### PR TITLE
refact: Refactor project package logic

### DIFF
--- a/alcedo_studio/src/app/project_package_backend.cpp
+++ b/alcedo_studio/src/app/project_package_backend.cpp
@@ -591,18 +591,39 @@ auto WritePackedProject(const std::filesystem::path& packedPath,
     }
     return false;
   }
-  const uint64_t db_checksum = XXH3_64bits(db_bytes.data(), db_bytes.size());
+  const uint64_t meta_size = static_cast<uint64_t>(meta_bytes.size());
+  const uint64_t db_size   = static_cast<uint64_t>(db_bytes.size());
 
-  try {
-    nlohmann::json metadata = nlohmann::json::parse(meta_bytes);
-    metadata["db_checksum_xxh3_64"] = FormatChecksum(db_checksum);
-    meta_bytes = metadata.dump(4);
-  } catch (...) {
-    if (errorOut) {
-      *errorOut = Tr("Project metadata JSON is invalid.");
-    }
-    return false;
+  // Build the fixed-width header prefix for checksum computation:
+  //   magic (8B) || version (4B LE) || meta_size (8B LE) || db_size (8B LE)
+  // The checksum covers this prefix plus meta_bytes, but not db_bytes.
+  std::string hash_input;
+  hash_input.reserve(kPackedProjectMagic.size() + 4 + 8 + 8 + meta_bytes.size());
+  hash_input.append(kPackedProjectMagic.data(), kPackedProjectMagic.size());
+  {
+    std::array<unsigned char, 4> bytes{};
+    bytes[0] = static_cast<unsigned char>(kPackedProjectVersion & 0xFFU);
+    bytes[1] = static_cast<unsigned char>((kPackedProjectVersion >> 8U) & 0xFFU);
+    bytes[2] = static_cast<unsigned char>((kPackedProjectVersion >> 16U) & 0xFFU);
+    bytes[3] = static_cast<unsigned char>((kPackedProjectVersion >> 24U) & 0xFFU);
+    hash_input.append(reinterpret_cast<const char*>(bytes.data()), bytes.size());
   }
+  {
+    std::array<unsigned char, 8> bytes{};
+    for (size_t i = 0; i < bytes.size(); ++i) {
+      bytes[i] = static_cast<unsigned char>((meta_size >> (i * 8ULL)) & 0xFFULL);
+    }
+    hash_input.append(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+  }
+  {
+    std::array<unsigned char, 8> bytes{};
+    for (size_t i = 0; i < bytes.size(); ++i) {
+      bytes[i] = static_cast<unsigned char>((db_size >> (i * 8ULL)) & 0xFFULL);
+    }
+    hash_input.append(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+  }
+  hash_input.append(meta_bytes);
+  const uint64_t checksum = XXH3_64bits(hash_input.data(), hash_input.size());
 
   if (!album_util::EnsureDirectoryExists(packedPath.parent_path())) {
     if (errorOut) {
@@ -623,11 +644,9 @@ auto WritePackedProject(const std::filesystem::path& packedPath,
 
   out.write(kPackedProjectMagic.data(),
             static_cast<std::streamsize>(kPackedProjectMagic.size()));
-  const uint64_t meta_checksum = XXH3_64bits(meta_bytes.data(), meta_bytes.size());
   if (!WriteU32Le(out, kPackedProjectVersion) ||
-      !WriteU64Le(out, static_cast<uint64_t>(meta_bytes.size())) ||
-      !WriteU64Le(out, static_cast<uint64_t>(db_bytes.size())) ||
-      !WriteU64Le(out, meta_checksum) || !WriteU64Le(out, db_checksum)) {
+      !WriteU64Le(out, meta_size) || !WriteU64Le(out, db_size) ||
+      !WriteU64Le(out, checksum)) {
     if (errorOut) {
       *errorOut = Tr("Failed to write packed project header.");
     }
@@ -706,10 +725,9 @@ auto ReadPackedProject(const std::filesystem::path& packedPath,
 
   uint64_t meta_size = 0;
   uint64_t db_size   = 0;
-  uint64_t meta_checksum = 0;
-  uint64_t db_checksum   = 0;
+  uint64_t checksum  = 0;
   if (!ReadU64Le(in, &meta_size) || !ReadU64Le(in, &db_size) ||
-      !ReadU64Le(in, &meta_checksum) || !ReadU64Le(in, &db_checksum)) {
+      !ReadU64Le(in, &checksum)) {
     if (errorOut) {
       *errorOut = Tr("Packed project header is corrupted.");
     }
@@ -752,8 +770,36 @@ auto ReadPackedProject(const std::filesystem::path& packedPath,
     return false;
   }
 
-  if (XXH3_64bits(metaBytes->data(), metaBytes->size()) != meta_checksum ||
-      XXH3_64bits(dbBytes->data(), dbBytes->size()) != db_checksum) {
+  // Rebuild the same hash input used during WritePackedProject:
+  //   magic (8B) || version (4B LE) || meta_size (8B LE) || db_size (8B LE) || meta_bytes
+  std::string hash_input;
+  hash_input.reserve(kPackedProjectMagic.size() + 4 + 8 + 8 + metaBytes->size());
+  hash_input.append(magic.data(), magic.size());
+  {
+    std::array<unsigned char, 4> bytes{};
+    bytes[0] = static_cast<unsigned char>(version & 0xFFU);
+    bytes[1] = static_cast<unsigned char>((version >> 8U) & 0xFFU);
+    bytes[2] = static_cast<unsigned char>((version >> 16U) & 0xFFU);
+    bytes[3] = static_cast<unsigned char>((version >> 24U) & 0xFFU);
+    hash_input.append(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+  }
+  {
+    std::array<unsigned char, 8> bytes{};
+    for (size_t i = 0; i < bytes.size(); ++i) {
+      bytes[i] = static_cast<unsigned char>((meta_size >> (i * 8ULL)) & 0xFFULL);
+    }
+    hash_input.append(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+  }
+  {
+    std::array<unsigned char, 8> bytes{};
+    for (size_t i = 0; i < bytes.size(); ++i) {
+      bytes[i] = static_cast<unsigned char>((db_size >> (i * 8ULL)) & 0xFFULL);
+    }
+    hash_input.append(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+  }
+  hash_input.append(*metaBytes);
+
+  if (XXH3_64bits(hash_input.data(), hash_input.size()) != checksum) {
     if (errorOut) {
       *errorOut = Tr("Packed project checksum verification failed.");
     }

--- a/alcedo_studio/src/app/project_service.cpp
+++ b/alcedo_studio/src/app/project_service.cpp
@@ -5,9 +5,9 @@
 #include "app/project_service.hpp"
 
 #include <array>
-#include <chrono>
 #include <fstream>
-#include <random>
+#include <iostream>
+#include <optional>
 #include <stdexcept>
 #include <string_view>
 
@@ -62,120 +62,69 @@ auto IsSupportedProjectVersion(std::string_view version) -> bool {
          parsed >= min_supported && parsed <= max_supported;
 }
 
-auto BuildChecksumSnapshotPath() -> std::filesystem::path {
-  const auto temp_dir = std::filesystem::temp_directory_path() / "alcedo_main";
-  std::error_code ec;
-  std::filesystem::create_directories(temp_dir, ec);
-  if (ec) {
-    throw std::runtime_error("Failed to create temp directory for project checksum");
-  }
+// Collects lightweight diagnostic summary of the project database:
+// per-table row counts and min/max primary key ranges. This is NOT
+// a strong integrity check — mismatches produce a warning, not a
+// load failure. Use data_fingerprint (L3) for semantic verification.
+auto ComputeProjectDataSummary(StorageService& storage_service) -> nlohmann::json {
+  auto guard = storage_service.GetDBController().GetConnectionGuard();
 
-  const auto now =
-      static_cast<unsigned long long>(std::chrono::steady_clock::now().time_since_epoch().count());
-  std::mt19937_64 rng{std::random_device{}()};
-  for (int attempt = 0; attempt < 128; ++attempt) {
-    const auto candidate =
-        temp_dir / ("project_checksum_" + std::to_string(now) + "_" +
-                    std::to_string(rng() + static_cast<unsigned long long>(attempt)) + ".db");
-    if (!std::filesystem::exists(candidate, ec) || ec) {
-      return candidate;
+  auto query_int64 = [&](const std::string& sql) -> std::optional<int64_t> {
+    duckdb_result result;
+    if (duckdb_query(guard.conn_, sql.c_str(), &result) != DuckDBSuccess) {
+      duckdb_destroy_result(&result);
+      return std::nullopt;
     }
-  }
-  throw std::runtime_error("Failed to allocate temp project checksum path");
-}
-
-auto QueryCurrentCatalog(duckdb_connection conn) -> std::string {
-  duckdb_result result;
-  if (duckdb_query(conn, "SELECT current_catalog();", &result) != DuckDBSuccess) {
-    const char* err = duckdb_result_error(&result);
-    std::string msg = std::string("current_catalog query failed: ") + (err ? err : "unknown");
+    std::optional<int64_t> value;
+    if (duckdb_row_count(&result) > 0 && duckdb_column_count(&result) > 0) {
+      if (!duckdb_value_is_null(&result, 0, 0)) {
+        value = duckdb_value_int64(&result, 0, 0);
+      }
+    }
     duckdb_destroy_result(&result);
-    throw std::runtime_error(msg);
-  }
-  if (duckdb_row_count(&result) == 0 || duckdb_column_count(&result) == 0) {
-    duckdb_destroy_result(&result);
-    throw std::runtime_error("current_catalog query returned no rows");
-  }
-  const char* value = duckdb_value_varchar(&result, 0, 0);
-  if (value == nullptr || value[0] == '\0') {
-    if (value != nullptr) duckdb_free(const_cast<char*>(value));
-    duckdb_destroy_result(&result);
-    throw std::runtime_error("current_catalog query returned empty value");
-  }
-  std::string catalog = value;
-  duckdb_free(const_cast<char*>(value));
-  duckdb_destroy_result(&result);
-  return catalog;
-}
+    return value;
+  };
 
-void RunDuckDbQuery(duckdb_connection conn, const std::string& sql, const char* stage) {
-  duckdb_result result;
-  if (duckdb_query(conn, sql.c_str(), &result) != DuckDBSuccess) {
-    const char* err = duckdb_result_error(&result);
-    std::string msg = std::string(stage) + " failed: " + (err ? err : "unknown");
-    duckdb_destroy_result(&result);
-    throw std::runtime_error(msg);
-  }
-  duckdb_destroy_result(&result);
-}
+  struct TableInfo {
+    const char* name;
+    const char* pk_column;  // nullptr if no meaningful single numeric PK
+  };
+  static constexpr TableInfo kTables[] = {
+      {"Sleeve", "id"},         {"Image", "id"},        {"SleeveRoot", "id"},
+      {"Element", "id"},        {"FolderContent", nullptr}, {"FileImage", "file_id"},
+      {"ComboFolder", "combo_id"}, {"Filter", "combo_id"},  {"EditHistory", "file_id"},
+      {"Version", "hash"},      {"PipelineParam", "file_id"},
+  };
 
-// Computes the checksum of a live DuckDB database by creating a
-// logical snapshot (COPY FROM DATABASE) and hashing the snapshot file.
-// This avoids reading the live database file directly, which may be
-// locked on some platforms. LoadProject uses the same mechanism so
-// that the checksums are comparable.
-auto ComputeDatabaseChecksum(StorageService& storage_service) -> uint64_t {
-  const auto snapshot_path = BuildChecksumSnapshotPath();
-  std::error_code ec;
-  std::filesystem::remove(snapshot_path, ec);
+  nlohmann::json summary;
+  summary["version"] = 1;
+  nlohmann::json tables = nlohmann::json::object();
 
-  try {
-    auto guard = storage_service.GetDBController().GetConnectionGuard();
+  for (const auto& table : kTables) {
+    nlohmann::json entry;
 
-    RunDuckDbQuery(guard.conn_, "CHECKPOINT;", "CHECKPOINT");
+    auto count = query_int64(
+        std::string("SELECT COUNT(*) FROM \"") + table.name + "\"");
+    if (!count.has_value()) continue;
+    entry["rows"] = *count;
 
-    const std::string source_catalog = QueryCurrentCatalog(guard.conn_);
-    const std::string snapshot_utf8 = conv::ToBytes(snapshot_path.generic_wstring());
-
-    // Escape single-quotes by doubling them for DuckDB SQL string literals.
-    std::string escaped_path;
-    escaped_path.reserve(snapshot_utf8.size());
-    for (const char ch : snapshot_utf8) {
-      if (ch == '\'') escaped_path += "''";
-      else escaped_path += ch;
+    if (table.pk_column != nullptr) {
+      const std::string pk_str(table.pk_column);
+      auto min_val = query_int64(
+          std::string("SELECT MIN(\"") + pk_str + "\") FROM \"" + table.name + "\"");
+      auto max_val = query_int64(
+          std::string("SELECT MAX(\"") + pk_str + "\") FROM \"" + table.name + "\"");
+      if (min_val.has_value() && max_val.has_value()) {
+        entry["min_id"] = *min_val;
+        entry["max_id"] = *max_val;
+      }
     }
 
-    // Escape the catalog name as a SQL identifier (double-quotes).
-    std::string escaped_catalog;
-    escaped_catalog.reserve(source_catalog.size());
-    for (const char ch : source_catalog) {
-      if (ch == '"') escaped_catalog += "\"\"";
-      else escaped_catalog += ch;
-    }
-
-    RunDuckDbQuery(guard.conn_,
-                   "ATTACH '" + escaped_path + "' AS checksum_snapshot;",
-                   "ATTACH snapshot");
-    RunDuckDbQuery(guard.conn_,
-                   "COPY FROM DATABASE \"" + escaped_catalog + "\" TO checksum_snapshot;",
-                   "COPY FROM DATABASE");
-    RunDuckDbQuery(guard.conn_,
-                   "CHECKPOINT checksum_snapshot;",
-                   "CHECKPOINT snapshot");
-    RunDuckDbQuery(guard.conn_,
-                   "DETACH checksum_snapshot;",
-                   "DETACH snapshot");
-
-    uint64_t checksum = 0;
-    if (!project_pack::ComputeFileChecksum(snapshot_path, &checksum)) {
-      throw std::runtime_error("Failed to compute project database checksum");
-    }
-    std::filesystem::remove(snapshot_path, ec);
-    return checksum;
-  } catch (...) {
-    std::filesystem::remove(snapshot_path, ec);
-    throw;
+    tables[table.name] = entry;
   }
+
+  summary["tables"] = tables;
+  return summary;
 }
 
 }  // namespace
@@ -242,8 +191,7 @@ void ProjectService::SaveProject(const std::filesystem::path& meta_path) {
       std::string(project_pack::kMaxSupportedProjectFileVersion);
   metadata["start_id"]            = sleeve_service_->GetCurrentID();
   metadata["image_pool_start_id"] = pool_service_->GetCurrentID();
-  metadata["db_checksum_xxh3_64"] = project_pack::FormatChecksum(
-      ComputeDatabaseChecksum(*storage_service_));
+  metadata["data_summary"]        = ComputeProjectDataSummary(*storage_service_);
 
   std::ofstream file(meta_path_);
   if (!file.is_open()) {
@@ -291,11 +239,12 @@ void ProjectService::LoadProject(const std::filesystem::path& meta_path) {
     throw std::runtime_error("Project database file does not exist");
   }
 
-  bool has_checksum = metadata.contains("db_checksum_xxh3_64") &&
-                      metadata.at("db_checksum_xxh3_64").is_string();
-  std::string expected_checksum;
-  if (has_checksum) {
-    expected_checksum = metadata.at("db_checksum_xxh3_64").get<std::string>();
+  // Parse data_summary for diagnostic purposes — mismatch is a
+  // warning, not a load failure. Old projects carry db_checksum_xxh3_64
+  // instead; that field is silently ignored here.
+  std::optional<nlohmann::json> expected_summary;
+  if (metadata.contains("data_summary") && metadata.at("data_summary").is_object()) {
+    expected_summary = metadata.at("data_summary");
   }
 
   sl_element_id_t start_id = 0;
@@ -308,22 +257,20 @@ void ProjectService::LoadProject(const std::filesystem::path& meta_path) {
           ? static_cast<sl_element_id_t>(metadata.at("image_pool_start_id"))
           : 0;
 
-  // Open the database first so we can create a snapshot for checksum
-  // verification — matching how SaveProject computed the checksum.
   storage_service_ = std::make_shared<StorageService>(db_path_);
 
-  if (has_checksum) {
-    bool checksum_ok = false;
+  if (expected_summary.has_value()) {
     try {
-      const uint64_t db_checksum = ComputeDatabaseChecksum(*storage_service_);
-      checksum_ok = (project_pack::FormatChecksum(db_checksum) == expected_checksum);
+      nlohmann::json actual_summary = ComputeProjectDataSummary(*storage_service_);
+      if (actual_summary != *expected_summary) {
+        std::cerr << "[Alcedo] Project data summary differs from saved metadata. "
+                     "This may indicate data changes since the project was saved.\n";
+      }
+    } catch (const std::exception& e) {
+      std::cerr << "[Alcedo] Unable to compute project data summary for comparison: "
+                << e.what() << "\n";
     } catch (...) {
-      storage_service_.reset();
-      throw;
-    }
-    if (!checksum_ok) {
-      storage_service_.reset();
-      throw std::runtime_error("Project database checksum verification failed");
+      std::cerr << "[Alcedo] Unable to compute project data summary for comparison.\n";
     }
   }
 

--- a/alcedo_studio/src/include/app/project_package_backend.hpp
+++ b/alcedo_studio/src/include/app/project_package_backend.hpp
@@ -25,7 +25,7 @@ namespace alcedo::project_pack {
 constexpr std::wstring_view kPackedProjectExtension = L".alcd";
 constexpr std::array<char, 8> kPackedProjectMagic{
     {'P', 'U', 'E', 'R', 'H', 'P', 'K', '1'}};
-constexpr uint32_t kPackedProjectVersion = 2;
+constexpr uint32_t kPackedProjectVersion = 3;
 constexpr uint64_t kMaxPackedComponentBytes = 2ULL * 1024ULL * 1024ULL * 1024ULL;
 constexpr std::string_view kProjectFileVersion = "0.2.4";
 constexpr std::string_view kMinSupportedProjectFileVersion = "0.2.4";

--- a/alcedo_studio/tests/ui/album_backend_project_test.cpp
+++ b/alcedo_studio/tests/ui/album_backend_project_test.cpp
@@ -5,8 +5,9 @@
 /// @file album_backend_project_test.cpp
 /// @brief Project lifecycle tests for AlbumBackend.
 ///
-/// Covers: create project, load project (valid/invalid), save project, and
-/// initial service state.
+/// Covers: create project, load project (valid/invalid), save project,
+/// pack/unpack integrity, data_summary diagnostics, and initial service
+/// state.
 
 #include "ui/album_backend_test_fixture.hpp"
 
@@ -15,12 +16,17 @@
 #include <array>
 #include <chrono>
 #include <fstream>
+#include <memory>
 #include <optional>
+#include <sstream>
+#include <string>
 
+#include <duckdb.h>
 #include <json.hpp>
 
 #include "app/project_package_backend.hpp"
 #include "app/project_service.hpp"
+#include "sleeve/storage_service.hpp"
 
 namespace alcedo::ui::test {
 namespace {
@@ -261,6 +267,237 @@ TEST_F(ProjectTests, SaveProject_AfterCreate_Succeeds) {
 
   const bool ok = backend.SaveProject();
   EXPECT_TRUE(ok);
+}
+
+// ── Stderr capture for warning verification ─────────────────────────────────
+
+class ScopedStderrCapture {
+ public:
+  ScopedStderrCapture() : old_(std::cerr.rdbuf(ss_.rdbuf())) {}
+  ~ScopedStderrCapture() { std::cerr.rdbuf(old_); }
+  auto str() const -> std::string { return ss_.str(); }
+
+ private:
+  std::stringstream ss_;
+  std::streambuf*   old_;
+};
+
+// ── Pack/Unpack round-trip ──────────────────────────────────────────────────
+
+TEST_F(ProjectTests, PackUnpack_RoundTrip_Succeeds) {
+  const auto dbPath   = temp_dir_ / "roundtrip.db";
+  const auto metaPath = temp_dir_ / "roundtrip.json";
+  CreateMetadataProject(dbPath, metaPath);
+
+  auto project =
+      std::make_shared<ProjectService>(dbPath, metaPath, ProjectOpenMode::kLoadExisting);
+
+  std::filesystem::path snapshotPath;
+  ASSERT_TRUE(project_pack::BuildTempDbSnapshotPath(&snapshotPath, nullptr));
+  ASSERT_TRUE(project_pack::CreateLiveDbSnapshot(project, snapshotPath, nullptr));
+
+  const auto packedPath = temp_dir_ / "roundtrip.alcd";
+  ASSERT_TRUE(project_pack::WritePackedProject(packedPath, metaPath, snapshotPath, nullptr));
+
+  // Read back and verify the binary header.
+  std::string metaBytes, dbBytes;
+  ASSERT_TRUE(project_pack::ReadPackedProject(packedPath, &metaBytes, &dbBytes, nullptr));
+  EXPECT_FALSE(metaBytes.empty());
+  EXPECT_FALSE(dbBytes.empty());
+
+  // Unpack to workspace and verify the project loads without warnings.
+  std::filesystem::path workspaceDir;
+  ASSERT_TRUE(project_pack::CreateProjectWorkspace("roundtrip_test", &workspaceDir, nullptr));
+  std::filesystem::path unpackedDbPath, unpackedMetaPath;
+  ASSERT_TRUE(project_pack::UnpackProjectToWorkspace(packedPath, workspaceDir,
+                                                      "roundtrip_test", &unpackedDbPath,
+                                                      &unpackedMetaPath, nullptr));
+
+  {
+    ScopedStderrCapture capture;
+    EXPECT_NO_THROW({
+      ProjectService(unpackedDbPath, unpackedMetaPath, ProjectOpenMode::kLoadExisting);
+    });
+    // No data summary warning expected for a clean round-trip.
+    std::string output = capture.str();
+    EXPECT_TRUE(output.empty()) << "Unexpected stderr: " << output;
+  }
+
+  // Metadata should contain the expected fields.
+  std::ifstream metaFile(unpackedMetaPath);
+  ASSERT_TRUE(metaFile.is_open());
+  nlohmann::json meta;
+  metaFile >> meta;
+  EXPECT_TRUE(meta.contains("project_file_version"));
+  EXPECT_TRUE(meta.contains("data_summary"));
+  EXPECT_TRUE(meta["data_summary"].contains("tables"));
+
+  std::error_code ec;
+  std::filesystem::remove_all(workspaceDir, ec);
+  std::filesystem::remove(snapshotPath, ec);
+}
+
+// ── Header corruption detection ──────────────────────────────────────────────
+
+TEST_F(ProjectTests, PackUnpack_CorruptHeader_Detected) {
+  const auto dbPath   = temp_dir_ / "corrupt_hdr.db";
+  const auto metaPath = temp_dir_ / "corrupt_hdr.json";
+  CreateMetadataProject(dbPath, metaPath);
+
+  auto project =
+      std::make_shared<ProjectService>(dbPath, metaPath, ProjectOpenMode::kLoadExisting);
+
+  std::filesystem::path snapshotPath;
+  ASSERT_TRUE(project_pack::BuildTempDbSnapshotPath(&snapshotPath, nullptr));
+  ASSERT_TRUE(project_pack::CreateLiveDbSnapshot(project, snapshotPath, nullptr));
+
+  const auto packedPath = temp_dir_ / "corrupt_hdr.alcd";
+  ASSERT_TRUE(project_pack::WritePackedProject(packedPath, metaPath, snapshotPath, nullptr));
+
+  // Corrupt the version field (offset 8, byte 0) — the version is stored as
+  // 4-byte LE right after the 8-byte magic.
+  {
+    std::fstream f(packedPath, std::ios::binary | std::ios::in | std::ios::out);
+    ASSERT_TRUE(f.is_open());
+    f.seekp(8);  // first byte of version
+    char corrupt = 0xFF;
+    f.write(&corrupt, 1);
+    f.close();
+  }
+
+  std::string metaBytes, dbBytes;
+  EXPECT_FALSE(project_pack::ReadPackedProject(packedPath, &metaBytes, &dbBytes, nullptr));
+
+  std::error_code ec;
+  std::filesystem::remove(snapshotPath, ec);
+}
+
+TEST_F(ProjectTests, PackUnpack_CorruptChecksum_Detected) {
+  const auto dbPath   = temp_dir_ / "corrupt_cs.db";
+  const auto metaPath = temp_dir_ / "corrupt_cs.json";
+  CreateMetadataProject(dbPath, metaPath);
+
+  auto project =
+      std::make_shared<ProjectService>(dbPath, metaPath, ProjectOpenMode::kLoadExisting);
+
+  std::filesystem::path snapshotPath;
+  ASSERT_TRUE(project_pack::BuildTempDbSnapshotPath(&snapshotPath, nullptr));
+  ASSERT_TRUE(project_pack::CreateLiveDbSnapshot(project, snapshotPath, nullptr));
+
+  const auto packedPath = temp_dir_ / "corrupt_cs.alcd";
+  ASSERT_TRUE(project_pack::WritePackedProject(packedPath, metaPath, snapshotPath, nullptr));
+
+  // Corrupt a metadata byte so the checksum won't match.  Metadata starts at
+  // offset 8 (magic) + 4 (version) + 8 (meta_size) + 8 (db_size) + 8 (checksum) = 36.
+  {
+    std::fstream f(packedPath, std::ios::binary | std::ios::in | std::ios::out);
+    ASSERT_TRUE(f.is_open());
+    f.seekp(36);  // first byte of meta payload
+    char corrupt = 0xCC;
+    f.write(&corrupt, 1);
+    f.close();
+  }
+
+  std::string metaBytes, dbBytes;
+  EXPECT_FALSE(project_pack::ReadPackedProject(packedPath, &metaBytes, &dbBytes, nullptr));
+
+  std::error_code ec2;
+  std::filesystem::remove(snapshotPath, ec2);
+}
+
+// ── data_summary diagnostics: tampered metadata ──────────────────────────────
+
+TEST_F(ProjectTests, DataSummary_WarnsOnTamperedMetadata) {
+  const auto dbPath   = temp_dir_ / "tamper_meta.db";
+  const auto metaPath = temp_dir_ / "tamper_meta.json";
+  CreateMetadataProject(dbPath, metaPath);
+
+  // Modify the saved data_summary to claim more rows than exist.
+  nlohmann::json metadata;
+  {
+    std::ifstream f(metaPath);
+    ASSERT_TRUE(f.is_open());
+    f >> metadata;
+  }
+  ASSERT_TRUE(metadata.contains("data_summary"));
+  metadata["data_summary"]["tables"]["Element"]["rows"] = 999999;
+  {
+    std::ofstream f(metaPath, std::ios::trunc);
+    ASSERT_TRUE(f.is_open());
+    f << metadata.dump(4);
+  }
+
+  // Repack so the checksum covers the modified metadata.
+  auto project =
+      std::make_shared<ProjectService>(dbPath, metaPath, ProjectOpenMode::kLoadExisting);
+
+  std::filesystem::path snapshotPath;
+  ASSERT_TRUE(project_pack::BuildTempDbSnapshotPath(&snapshotPath, nullptr));
+  ASSERT_TRUE(project_pack::CreateLiveDbSnapshot(project, snapshotPath, nullptr));
+
+  const auto packedPath = temp_dir_ / "tamper_meta.alcd";
+  ASSERT_TRUE(project_pack::WritePackedProject(packedPath, metaPath, snapshotPath, nullptr));
+
+  // Unpack to workspace.
+  std::filesystem::path workspaceDir;
+  ASSERT_TRUE(project_pack::CreateProjectWorkspace("tamper_test", &workspaceDir, nullptr));
+  std::filesystem::path unpackedDbPath, unpackedMetaPath;
+  ASSERT_TRUE(project_pack::UnpackProjectToWorkspace(packedPath, workspaceDir,
+                                                      "tamper_test", &unpackedDbPath,
+                                                      &unpackedMetaPath, nullptr));
+
+  // Loading should succeed but emit a data_summary warning.
+  {
+    ScopedStderrCapture capture;
+    EXPECT_NO_THROW({
+      ProjectService(unpackedDbPath, unpackedMetaPath, ProjectOpenMode::kLoadExisting);
+    });
+    std::string output = capture.str();
+    EXPECT_FALSE(output.empty()) << "Expected a data-summary warning on stderr";
+    EXPECT_NE(output.find("[Alcedo] Project data summary differs"),
+              std::string::npos)
+        << "stderr: " << output;
+  }
+
+  std::error_code ec;
+  std::filesystem::remove_all(workspaceDir, ec);
+  std::filesystem::remove(snapshotPath, ec);
+}
+
+// ── data_summary diagnostics: DB modified after save ─────────────────────────
+
+TEST_F(ProjectTests, DataSummary_WarnsOnDbChanged) {
+  const auto dbPath   = temp_dir_ / "db_mod.db";
+  const auto metaPath = temp_dir_ / "db_mod.json";
+  CreateMetadataProject(dbPath, metaPath);
+
+  // Modify the database outside of the project so the stored data_summary
+  // no longer matches.
+  {
+    StorageService storage(dbPath);
+    auto           guard = storage.GetDBController().GetConnectionGuard();
+    duckdb_result  result;
+    ASSERT_EQ(duckdb_query(guard.conn_,
+                           "INSERT INTO Element (id, type, element_name, "
+                           "added_time, modified_time, ref_count) "
+                           "VALUES (88888, 1, 'extra_elem', NOW(), NOW(), 0);",
+                           &result),
+              DuckDBSuccess);
+    duckdb_destroy_result(&result);
+  }
+
+  // Load — should succeed but warn about mismatched summary.
+  {
+    ScopedStderrCapture capture;
+    EXPECT_NO_THROW({
+      ProjectService(dbPath, metaPath, ProjectOpenMode::kLoadExisting);
+    });
+    std::string output = capture.str();
+    EXPECT_FALSE(output.empty()) << "Expected a data-summary warning on stderr";
+    EXPECT_NE(output.find("[Alcedo] Project data summary differs"),
+              std::string::npos)
+        << "stderr: " << output;
+  }
 }
 
 // ── Create project with default name via convenience overload ──────────────


### PR DESCRIPTION
- Removed the BuildChecksumSnapshotPath and ComputeDatabaseChecksum functions, replacing them with ComputeProjectDataSummary for lightweight project diagnostics.
- Updated SaveProject and LoadProject methods to utilize the new data summary instead of checksum for integrity verification.
- Introduced detailed logging for data summary mismatches during project loading.
- Added unit tests for pack/unpack integrity, including scenarios for corrupted headers and checksums.
- Enhanced metadata handling to include data summary diagnostics, ensuring backward compatibility with existing project formats.