### PR TITLE
fix: Fix bugs before v0.2.5 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1074,6 +1074,7 @@ alcedo_studio/src/third_party/*
 !alcedo_studio/src/third_party/CMakeLists.txt
 !alcedo_studio/src/third_party/cmake/
 !alcedo_studio/src/third_party/cmake/FindGLIB2.cmake
+!alcedo_studio/src/third_party/libultrahdr/
 !alcedo_studio/src/third_party/include/
 !alcedo_studio/src/third_party/include/alcedo/
 !alcedo_studio/src/third_party/include/alcedo/metal/

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,9 +12,10 @@
 [submodule "alcedo/src/third_party/metal-cpp"]
 	path = alcedo/src/third_party/metal-cpp
 	url = https://github.com/bkaradzic/metal-cpp
-[submodule "alcedo/src/third_party/libultrahdr"]
-	path = alcedo/src/third_party/libultrahdr
-	url = https://github.com/google/libultrahdr.git
+[submodule "alcedo_studio/src/third_party/libultrahdr"]
+	path = alcedo_studio/src/third_party/libultrahdr
+	url = https://github.com/zidage/libultrahdr.git
+	branch = alcedo-v1.4.0-dither
 [submodule "alcedo_studio/third_party/dawn"]
 	path = alcedo_studio/third_party/dawn
 	url = https://dawn.googlesource.com/dawn

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -142,6 +142,14 @@
       "jobs": 8
     },
     {
+      "name": "win_debug_app",
+      "configurePreset": "win_debug",
+      "jobs": 8,
+      "targets": [
+        "alcedo_main"
+      ]
+    },
+    {
       "name": "win_release",
       "configurePreset": "win_release",
       "jobs": 8,

--- a/alcedo_studio/src/app/adjustment_transfer_service.cpp
+++ b/alcedo_studio/src/app/adjustment_transfer_service.cpp
@@ -337,13 +337,14 @@ auto ApplyAsTransactions(PipelineExecutor& target, WorkingVersion& working_versi
   return changed;
 }
 
-auto UniqueVersionDisplayName(const EditHistory& history, const std::string& requested_name)
-    -> std::string {
-  const std::string base_name = requested_name.empty() ? "Pasted Adjustments" : requested_name;
+auto UniqueVersionDisplayName(const EditHistory& history, const std::string& requested_name,
+                              std::string_view fallback_name) -> std::string {
+  const std::string base_name =
+      requested_name.empty() ? std::string{fallback_name} : requested_name;
   bool              base_exists = false;
   int               max_suffix  = 1;
 
-  const std::string prefix = base_name + " (";
+  const std::string prefix      = base_name + " (";
   for (const auto& node : history.GetVersions()) {
     const std::string& existing_name = node.ver_ref_.GetDisplayName();
     if (existing_name == base_name) {
@@ -360,7 +361,7 @@ auto UniqueVersionDisplayName(const EditHistory& history, const std::string& req
     try {
       const int parsed = std::stoi(suffix);
       if (parsed > 1) {
-        max_suffix = std::max(max_suffix, parsed);
+        max_suffix  = std::max(max_suffix, parsed);
         base_exists = true;
       }
     } catch (...) {
@@ -572,8 +573,8 @@ auto AdjustmentTransferService::Apply(PipelineMgmtService&             pipeline_
                                       EditHistoryMgmtService&          history_service,
                                       std::span<const sl_element_id_t> target_ids,
                                       const AdjustmentTransferPackage& package,
-                                      std::string                     version_display_name)
-    -> AdjustmentApplyResult {
+                                      std::string                      version_display_name,
+                                      AdjustmentVersionApplyMode mode) -> AdjustmentApplyResult {
   AdjustmentApplyResult result;
   if (package.Empty()) {
     result.unchanged_ids_.assign(target_ids.begin(), target_ids.end());
@@ -603,17 +604,29 @@ auto AdjustmentTransferService::Apply(PipelineMgmtService&             pipeline_
       bool changed = false;
       {
         std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
-        const auto                   base_params = pipeline_guard->pipeline_->ExportPipelineParams();
-        Version pasted_version = Version::Empty(
-            target_id, UniqueVersionDisplayName(*history_guard->history_, version_display_name),
-            base_params);
-        WorkingVersion working_version{target_id, pasted_version.GetVersionID(), base_params};
+        const auto        base_params  = pipeline_guard->pipeline_->ExportPipelineParams();
+        const std::string display_name = UniqueVersionDisplayName(
+            *history_guard->history_, version_display_name,
+            mode == AdjustmentVersionApplyMode::kMerge ? "Merged Adjustments"
+                                                       : "Pasted Adjustments");
 
-        changed = ApplyAsTransactions(*pipeline_guard->pipeline_, working_version, package);
-        if (changed) {
-          pasted_version.UpdateFromWorkingVersion(working_version,
-                                                  pipeline_guard->pipeline_->ExportPipelineParams());
-          history_service.CommitVersion(history_guard, std::move(pasted_version));
+        if (mode == AdjustmentVersionApplyMode::kMerge) {
+          changed = Apply(*pipeline_guard->pipeline_, package);
+          if (changed) {
+            Version merged_version = Version::Empty(
+                target_id, display_name, pipeline_guard->pipeline_->ExportPipelineParams());
+            history_service.CommitVersion(history_guard, std::move(merged_version));
+          }
+        } else {
+          Version        pasted_version = Version::Empty(target_id, display_name, base_params);
+          WorkingVersion working_version{target_id, pasted_version.GetVersionID(), base_params};
+
+          changed = ApplyAsTransactions(*pipeline_guard->pipeline_, working_version, package);
+          if (changed) {
+            pasted_version.UpdateFromWorkingVersion(
+                working_version, pipeline_guard->pipeline_->ExportPipelineParams());
+            history_service.CommitVersion(history_guard, std::move(pasted_version));
+          }
         }
       }
 

--- a/alcedo_studio/src/app/export_service.cpp
+++ b/alcedo_studio/src/app/export_service.cpp
@@ -26,27 +26,31 @@ auto ResolveExportColorProfileConfig(const OperatorParams& params) -> ExportColo
                                   params.to_output_params_.peak_luminance_};
 }
 
-auto RatedValueOrNull(int rating) -> std::optional<int> {
-  const int normalized_rating = ExifDisplayMetaData::NormalizeRating(rating);
-  if (normalized_rating <= 0) {
-    return std::nullopt;
-  }
-  return normalized_rating;
+auto HasExportMetadata(const ExifDisplayMetaData& metadata) -> bool {
+  return !metadata.make_.empty() || !metadata.model_.empty() || !metadata.lens_.empty() ||
+         !metadata.lens_make_.empty() || !metadata.date_time_str_.empty() ||
+         metadata.aperture_ > 0.0f || metadata.focal_ > 0.0f || metadata.focal_35mm_ > 0.0f ||
+         metadata.focus_distance_m_ > 0.0f || metadata.iso_ > 0 ||
+         (metadata.shutter_speed_.first > 0 && metadata.shutter_speed_.second > 0) ||
+         ExifDisplayMetaData::NormalizeRating(metadata.rating_) > 0;
 }
 
-auto ResolveImageRating(const std::shared_ptr<Image>& image) -> std::optional<int> {
+auto ResolveImageExportMetadata(const std::shared_ptr<Image>& image)
+    -> std::optional<ExifDisplayMetaData> {
   if (!image) {
     return std::nullopt;
   }
+  ExifDisplayMetaData metadata;
   if (image->has_exif_display_.load()) {
-    return RatedValueOrNull(image->exif_display_.rating_);
-  }
-  if (image->has_exif_json_.load()) {
-    ExifDisplayMetaData metadata;
+    metadata = image->exif_display_;
+  } else if (image->has_exif_json_.load()) {
     metadata.FromJson(image->exif_json_);
-    return RatedValueOrNull(metadata.rating_);
+  } else {
+    return std::nullopt;
   }
-  return std::nullopt;
+  metadata.rating_ = ExifDisplayMetaData::NormalizeRating(metadata.rating_);
+  return HasExportMetadata(metadata) ? std::optional<ExifDisplayMetaData>(std::move(metadata))
+                                     : std::nullopt;
 }
 
 }  // namespace
@@ -68,7 +72,7 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
                              std::to_string(task.image_id_));
   }
   auto img_src_path = source_img->image_path_;
-  const auto export_rating = ResolveImageRating(source_img);
+  const auto export_metadata = ResolveImageExportMetadata(source_img);
 
   // Create a pipeline task for export
   PipelineTask render_task;
@@ -113,16 +117,13 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
   const auto export_profile =
       ResolveExportColorProfileConfig(pipeline_guard->pipeline_->GetGlobalParams());
   const bool wrote_ultra_hdr = ImageWriter::ShouldWriteUltraHdr(task.options_, export_profile);
-  const bool requested_ultra_hdr =
-      task.options_.hdr_export_mode_ == ExportFormatOptions::HDR_EXPORT_MODE::ULTRA_HDR &&
-      task.options_.format_ == ImageFormatType::JPEG;
   pipeline_service_->SavePipeline(pipeline_guard);
   // Use ImageWriter to write the image to disk
   ImageWriter::WriteImageToPath(img_src_path, rendered_image, task.options_, export_profile,
-                                export_rating);
+                                export_metadata);
   result.success_ = true;
   result.wrote_ultra_hdr_ = wrote_ultra_hdr;
-  result.used_embedded_profile_fallback_ = requested_ultra_hdr && !wrote_ultra_hdr;
+  result.used_embedded_profile_fallback_ = false;
   return result;
 }
 

--- a/alcedo_studio/src/edit/operators/cst/odt_op.cpp
+++ b/alcedo_studio/src/edit/operators/cst/odt_op.cpp
@@ -266,7 +266,8 @@ void ODT_Op::RebuildRuntime() {
         odt_cpu::ResolveACESODTRuntime(limiting_space_, peak_luminance_);
     to_output_params_.limit_to_display_matx_ =
         ColorUtils::RGB_TO_XYZ_f33(limiting_space_) * ColorUtils::XYZ_TO_RGB_f33(encoding_space_);
-    to_output_params_.display_linear_scale_ = 1.0f;
+    to_output_params_.display_linear_scale_ =
+        (encoding_eotf_ == ColorUtils::EOTF::ST2084) ? ColorUtils::ref_lum : 1.0f;
     return;
   }
 

--- a/alcedo_studio/src/edit/pipeline/pipeline_metal_impl.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_metal_impl.cpp
@@ -172,7 +172,8 @@ auto UploadStageParams(const MetalNeighborStageParams& params) -> NS::SharedPtr<
 
 auto ResolveViewerDisplayConfig(const OperatorParams& params) -> ViewerDisplayConfig {
   return ViewerDisplayConfig{params.to_output_params_.encoding_space_,
-                             params.to_output_params_.eotf_};
+                             params.to_output_params_.eotf_,
+                             params.to_output_params_.peak_luminance_};
 }
 
 auto BuildGaussianWeights(float sigma, uint32_t radius)

--- a/alcedo_studio/src/edit/pipeline/pipeline_opencl_impl.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_opencl_impl.cpp
@@ -56,7 +56,8 @@ struct OpenClNeighborStage {
 
 auto ResolveViewerDisplayConfig(const OperatorParams& params) -> ViewerDisplayConfig {
   return ViewerDisplayConfig{params.to_output_params_.encoding_space_,
-                             params.to_output_params_.eotf_};
+                             params.to_output_params_.eotf_,
+                             params.to_output_params_.peak_luminance_};
 }
 
 auto BuildGaussianWeights(float sigma, uint32_t radius)

--- a/alcedo_studio/src/image/image.cpp
+++ b/alcedo_studio/src/image/image.cpp
@@ -223,6 +223,19 @@ void Image::SetExifDisplayMetaData(ExifDisplayMetaData&& exif_display) {
   }
 }
 
+void Image::SetHdrDisplayMetadata(bool is_hdr) {
+  if (has_exif_json_ && exif_json_.is_object() && !has_exif_display_) {
+    exif_display_.FromJson(exif_json_);
+    has_exif_display_ = true;
+  }
+  exif_display_.is_hdr_ = is_hdr;
+  has_exif_display_    = true;
+  has_exif_json_       = false;
+  if (sync_state_.load() == ImageSyncState::SYNCED) {
+    sync_state_ = ImageSyncState::MODIFIED;
+  }
+}
+
 void Image::SetRawColorContext(RawRuntimeColorContext&& ctx) {
   raw_color_context_     = std::move(ctx);
   has_raw_color_context_ = true;

--- a/alcedo_studio/src/image/metadata_extractor.cpp
+++ b/alcedo_studio/src/image/metadata_extractor.cpp
@@ -22,6 +22,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -123,6 +124,22 @@ auto ResolveCropFactorHint(float focal_mm, float focal_35mm_mm) -> float {
 auto PathToUtf8(const std::filesystem::path& path) -> std::string {
   const auto u8 = path.u8string();
   return std::string(reinterpret_cast<const char*>(u8.data()), u8.size());
+}
+
+auto ToLowerAscii(std::string value) -> std::string {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+auto ContainsAny(const std::string& text, const std::initializer_list<std::string_view>& patterns)
+    -> bool {
+  for (const auto pattern : patterns) {
+    if (text.find(pattern) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
 }
 
 auto ExtractDngGeometryMetadataFromFile(const std::filesystem::path& path)
@@ -1019,6 +1036,76 @@ auto PopulateDisplayDimensionsFromOiio(const image_path_t& image_path,
   }
 }
 
+auto OiioMetadataSuggestsHdr(const ImageSpec& spec) -> bool {
+  const auto inspect = [](std::string text) {
+    text = ToLowerAscii(std::move(text));
+    return ContainsAny(text, {"ultrahdr", "ultra hdr", "hdrgm", "gainmap", "gain map",
+                              "iso 21496", "iso:ts:21496", "rec2100", "rec.2100", "bt2100",
+                              "bt.2100", "itur_2100", "itur-2100", "st2084", "st 2084",
+                              "smpte2084", "smpte 2084", "hlg"});
+  };
+
+  if (inspect(spec.get_string_attribute("oiio:ColorSpace")) ||
+      inspect(spec.get_string_attribute("colorspace")) ||
+      inspect(spec.get_string_attribute("jpeg:subimages"))) {
+    return true;
+  }
+
+  for (const auto& param : spec.extra_attribs) {
+    const std::string key = param.name().string();
+    if (inspect(key) || inspect(param.get_string(0))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto FileSignaturesSuggestHdr(const image_path_t& image_path) -> bool {
+  std::ifstream ifs(image_path, std::ios::binary);
+  if (!ifs.is_open()) {
+    return false;
+  }
+
+  constexpr size_t kMaxProbeBytes = 4 * 1024 * 1024;
+  std::string      bytes(kMaxProbeBytes, '\0');
+  ifs.read(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+  bytes.resize(static_cast<size_t>(std::max<std::streamsize>(0, ifs.gcount())));
+  if (bytes.empty()) {
+    return false;
+  }
+
+  const std::string text = ToLowerAscii(std::move(bytes));
+  return ContainsAny(text, {"http://ns.adobe.com/hdr-gain-map", "hdrgm:version",
+                            "hdrgm:gainmapmin", "gainmap:version", "ultrahdr",
+                            "ultra hdr", "iso 21496", "iso:ts:21496",
+                            "urn:iso:std:iso:ts:21496", "gain map"});
+}
+
+auto DetectHdrMetadata(const image_path_t& image_path, const Exiv2::Image* exif_image = nullptr)
+    -> bool {
+  if (exif_image) {
+    for (const auto& datum : exif_image->xmpData()) {
+      const std::string text = ToLowerAscii(datum.key() + " " + datum.toString());
+      if (ContainsAny(text, {"ultrahdr", "ultra hdr", "hdrgm", "gainmap", "gain map",
+                             "iso 21496", "iso:ts:21496", "rec2100", "rec.2100", "bt2100",
+                             "bt.2100", "st2084", "st 2084", "smpte2084", "smpte 2084",
+                             "hlg"})) {
+        return true;
+      }
+    }
+  }
+
+  try {
+    auto input = ImageInput::open(PathToUtf8(image_path));
+    if (input && OiioMetadataSuggestsHdr(input->spec())) {
+      return true;
+    }
+  } catch (...) {
+  }
+
+  return FileSignaturesSuggestHdr(image_path);
+}
+
 void PopulateDngMetadataHintFromOpenLibRaw(LibRaw& raw_processor, ExifDisplayMetaData& display,
                                            RawRuntimeColorContext& ctx) {
   const std::string raw_make       = TrimAscii(raw_processor.imgdata.idata.make);
@@ -1175,6 +1262,7 @@ auto ExtractDngMetadataToImageFast(const image_path_t& image_path, Image& image)
     // only as a last-resort size probe if LibRaw open_file did not expose it.
     PopulateDisplayDimensionsFromOiio(image_path, display);
   }
+  display.is_hdr_ = DetectHdrMetadata(image_path, exif_image.get());
 
   image.SetExifDisplayMetaData(std::move(display));
   image.SetRawColorContext(std::move(ctx));
@@ -1535,6 +1623,7 @@ void MetadataExtractor::ExtractEXIF_ToImage(const image_path_t& image_path, Imag
     GetDisplayMetadataFromExif(exif_data->exifData(), display_metadata);
   }
   PopulateStandardRating(*exif_data, display_metadata);
+  display_metadata.is_hdr_ = DetectHdrMetadata(image_path, exif_data.get());
   image.SetExifDisplayMetaData(std::move(display_metadata));
 }
 
@@ -1601,6 +1690,7 @@ auto MetadataExtractor::ExtractRawMetadata_ToImage(const image_path_t& image_pat
 
   ExifDisplayMetaData display{};
   PopulateDisplayMetadataFromLibRaw(*raw_processor, ctx, display);
+  display.is_hdr_ = DetectHdrMetadata(image_path);
 
   raw_processor->recycle();
 

--- a/alcedo_studio/src/include/app/adjustment_transfer_service.hpp
+++ b/alcedo_studio/src/include/app/adjustment_transfer_service.hpp
@@ -64,6 +64,11 @@ struct AdjustmentApplyResult {
   std::vector<AdjustmentApplyFailure> failures_;
 };
 
+enum class AdjustmentVersionApplyMode {
+  kPaste,
+  kMerge,
+};
+
 class AdjustmentTransferService final {
  public:
   AdjustmentTransferService() = delete;
@@ -92,14 +97,14 @@ class AdjustmentTransferService final {
                                   const AdjustmentTransferPackage& package)
       -> AdjustmentApplyResult;
 
-  // Creates a new active version for each changed target, appends one edit transaction per applied
-  // transfer entry, and checkouts the target image to that new version. This is the project-level
-  // paste semantic used by the album UI and external batch/CLI callers.
-  [[nodiscard]] static auto Apply(PipelineMgmtService&             pipeline_service,
-                                  EditHistoryMgmtService&          history_service,
-                                  std::span<const sl_element_id_t> target_ids,
-                                  const AdjustmentTransferPackage& package,
-                                  std::string version_display_name = "Pasted Adjustments")
+  // Creates a new active version for each changed target and checkouts the target image to that
+  // version. kPaste records one edit transaction per applied transfer entry. kMerge materializes
+  // the merged final pipeline params into a transaction-free version.
+  [[nodiscard]] static auto Apply(
+      PipelineMgmtService& pipeline_service, EditHistoryMgmtService& history_service,
+      std::span<const sl_element_id_t> target_ids, const AdjustmentTransferPackage& package,
+      std::string                version_display_name = "",
+      AdjustmentVersionApplyMode mode                 = AdjustmentVersionApplyMode::kPaste)
       -> AdjustmentApplyResult;
 };
 

--- a/alcedo_studio/src/include/image/image.hpp
+++ b/alcedo_studio/src/include/image/image.hpp
@@ -81,6 +81,7 @@ class Image {
 
   void                  SetId(image_id_t image_id);
   void                  SetExifDisplayMetaData(ExifDisplayMetaData&& exif_display);
+  void                  SetHdrDisplayMetadata(bool is_hdr);
   void                  SetRawColorContext(RawRuntimeColorContext&& ctx);
   auto                  GetRawColorContext() const -> const RawRuntimeColorContext&;
   auto                  HasRawColorContext() const -> bool;

--- a/alcedo_studio/src/include/image/metadata.hpp
+++ b/alcedo_studio/src/include/image/metadata.hpp
@@ -34,6 +34,7 @@ class ExifDisplayMetaData {
 
   // Other
   int                 rating_        = 0;
+  bool                is_hdr_        = false;
 
   ExifDisplayMetaData()             = default;
   ExifDisplayMetaData(nlohmann::json exif_json);
@@ -65,6 +66,7 @@ class ExifDisplayMetaData {
     ss << "Image Size: " << width_ << " x " << height_ << "\n";
     ss << "Date Time: " << date_time_str_ << "\n";
     ss << "Rating: " << rating_ << "\n";
+    ss << "HDR: " << (is_hdr_ ? "true" : "false") << "\n";
     return ss.str();
   }
 
@@ -90,6 +92,7 @@ class ExifDisplayMetaData {
 
     // Other
     exif_json["Rating"]         = NormalizeRating(rating_);
+    exif_json["IsHDR"]          = is_hdr_;
     return exif_json;
   }
 
@@ -120,6 +123,7 @@ class ExifDisplayMetaData {
     date_time_str_ = exif_json.value("DateTimeString", "");
     // Other
     rating_        = NormalizeRating(exif_json.value("Rating", 0));
+    is_hdr_        = exif_json.value("IsHDR", false);
   }
 };
 };  // namespace alcedo

--- a/alcedo_studio/src/include/io/image/image_writer.hpp
+++ b/alcedo_studio/src/include/io/image/image_writer.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include "image/image_buffer.hpp"
+#include "image/metadata.hpp"
 #include "io/image/export_color_profile_config.hpp"
 #include "type/supported_file_type.hpp"
 #include "type/type.hpp"
@@ -24,6 +25,6 @@ class ImageWriter {
                                std::shared_ptr<ImageBuffer> image_data,
                                ExportFormatOptions          options,
                                std::optional<ExportColorProfileConfig> color_profile = std::nullopt,
-                               std::optional<int> rating = std::nullopt);
+                               std::optional<ExifDisplayMetaData> export_metadata = std::nullopt);
 };
 };  // namespace alcedo

--- a/alcedo_studio/src/include/io/image/ultra_hdr_writer.hpp
+++ b/alcedo_studio/src/include/io/image/ultra_hdr_writer.hpp
@@ -22,12 +22,13 @@ class UltraHdrWriter {
                                const cv::Mat&                  rgba32f,
                                const ExportFormatOptions&      options,
                                const ExportColorProfileConfig& color_profile,
-                               std::optional<int> rating = std::nullopt);
+                               std::optional<ExifDisplayMetaData> export_metadata = std::nullopt);
 
   static auto BuildSanitizedExifData(const image_path_t& source_path, int width, int height)
       -> std::vector<uint8_t>;
   static auto BuildSanitizedExifData(const image_path_t& source_path, int width, int height,
-                                     std::optional<int> rating) -> std::vector<uint8_t>;
+                                     const std::optional<ExifDisplayMetaData>& export_metadata)
+      -> std::vector<uint8_t>;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/type/supported_file_type.hpp
+++ b/alcedo_studio/src/include/type/supported_file_type.hpp
@@ -52,6 +52,8 @@ struct ExportFormatOptions {
   int                   compression_level_ = 5;                    // For PNG
   TIFF_COMPRESS         tiff_compress_     = TIFF_COMPRESS::NONE;  // For TIFF
   HDR_EXPORT_MODE       hdr_export_mode_   = HDR_EXPORT_MODE::ULTRA_HDR;
+  int                   ultra_hdr_quality_ = 95;  // Gain map quality for Ultra HDR
+  bool                  ultra_hdr_dither_enabled_ = true;
 };
 
 static const std::unordered_set<std::wstring> supported_extensions = {

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/adjustment_transfer_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/adjustment_transfer_controller.hpp
@@ -32,7 +32,7 @@ class AdjustmentTransferController final : public QObject {
 
   Q_INVOKABLE QVariantMap PrepareCopy(uint elementId);
   Q_INVOKABLE QVariantMap Copy(uint elementId, const QVariantList& selectedKeys);
-  Q_INVOKABLE QVariantMap Paste(const QVariantList& targetEntries);
+  Q_INVOKABLE QVariantMap Paste(const QVariantList& targetEntries, const QString& strategy);
   Q_INVOKABLE void        Discard();
 
  signals:

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/album_backend.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/album_backend.hpp
@@ -241,6 +241,12 @@ class AlbumBackend final : public QObject {
              const QString& outputDirUrlOrPath, const QString& formatName, const QString& hdrExportMode,
              bool resizeEnabled, int maxLengthSide, int quality, int bitDepth, int pngCompressionLevel,
              const QString& tiffCompression, const QVariantList& targetEntries);
+  Q_INVOKABLE void        StartExportWithSplitOptionsForTargets(
+             const QString& outputDirUrlOrPath, bool sdrResizeEnabled, int sdrMaxLengthSide,
+             int ultraHdrMaxLengthSide,
+             const QString& sdrFormatName, int sdrQuality, int sdrBitDepth,
+             int sdrPngCompressionLevel, const QString& sdrTiffCompression,
+             int ultraHdrQuality, bool ultraHdrDitherEnabled, const QVariantList& targetEntries);
   Q_INVOKABLE void         ResetExportState();
   Q_INVOKABLE bool         CanUseHdrExportForTargets(const QVariantList& targetEntries) const;
   Q_INVOKABLE void         BrowseNikonHeConverter();
@@ -345,6 +351,8 @@ class AlbumBackend final : public QObject {
   void AddOrUpdateAlbumItem(sl_element_id_t elementId, image_id_t imageId, sl_element_id_t folderId,
                             const QString& scopeType, const file_name_t& fallbackName,
                             const std::filesystem::path& filePath);
+  void SetAlbumItemHdrFlag(sl_element_id_t elementId, image_id_t imageId, bool isHdr);
+  void PersistImageHdrFlag(sl_element_id_t elementId, image_id_t imageId, bool isHdr);
   auto FindAlbumItem(sl_element_id_t elementId) -> AlbumItem*;
   auto FindAlbumItem(sl_element_id_t elementId) const -> const AlbumItem*;
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/album_thumbnail_model.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/album_thumbnail_model.hpp
@@ -73,6 +73,9 @@ class AlbumThumbnailModel : public QAbstractListModel {
   void updateThumbnailState(sl_element_id_t elementId, const QString& dataUrl,
                             bool loading, bool missingSource, const QString& errorText);
 
+  /// Patch rating for the currently loaded row — emits dataChanged for Rating only.
+  bool updateRating(sl_element_id_t elementId, image_id_t imageId, int rating);
+
   /// QML helper: return a QVariantMap for the row at @p index, or empty map.
   Q_INVOKABLE QVariantMap getItemAt(int index) const;
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/album_thumbnail_model.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/album_thumbnail_model.hpp
@@ -41,6 +41,7 @@ class AlbumThumbnailModel : public QAbstractListModel {
     CaptureDate,
     ImportDate,
     Rating,
+    IsHdr,
     Tags,
     Accent,
     ThumbUrl,
@@ -75,6 +76,9 @@ class AlbumThumbnailModel : public QAbstractListModel {
 
   /// Patch rating for the currently loaded row — emits dataChanged for Rating only.
   bool updateRating(sl_element_id_t elementId, image_id_t imageId, int rating);
+
+  /// Patch HDR export marker for the currently loaded row — emits dataChanged for IsHdr only.
+  bool updateHdrFlag(sl_element_id_t elementId, image_id_t imageId, bool isHdr);
 
   /// QML helper: return a QVariantMap for the row at @p index, or empty map.
   Q_INVOKABLE QVariantMap getItemAt(int index) const;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/album_types.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/album_types.hpp
@@ -34,6 +34,7 @@ struct AlbumItem {
   QDate                 capture_date{};
   QDate                 import_date{};
   int                   rating = 0;
+  bool                  is_hdr = false;
   QString               tags{};
   QString               accent{};
   QString               thumb_data_url{};

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/import_export.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/import_export.hpp
@@ -42,6 +42,14 @@ class ImportExportHandler {
                                         int bitDepth, int pngCompressionLevel,
                                         const QString& tiffCompression,
                                         const QVariantList& targetEntries);
+  void StartExportWithSplitOptionsForTargets(const QString& outputDirUrlOrPath,
+                                             bool sdrResizeEnabled, int sdrMaxLengthSide,
+                                             int ultraHdrMaxLengthSide,
+                                             const QString& sdrFormatName, int sdrQuality,
+                                             int sdrBitDepth, int sdrPngCompressionLevel,
+                                             const QString& sdrTiffCompression,
+                                             int ultraHdrQuality, bool ultraHdrDitherEnabled,
+                                             const QVariantList& targetEntries);
   void ResetExportState();
 
   void FinishImport(const ImportResult& result);
@@ -51,11 +59,12 @@ class ImportExportHandler {
   [[nodiscard]] auto CollectExportTargets(const QVariantList& targetEntries) const
       -> std::vector<ExportTarget>;
   auto BuildExportQueue(const std::vector<ExportTarget>& targets,
-                        const std::filesystem::path& outputDir, ImageFormatType format,
-                        ExportFormatOptions::HDR_EXPORT_MODE hdrExportMode, bool resizeEnabled,
-                        int maxLengthSide, int quality, ExportFormatOptions::BIT_DEPTH bitDepth,
-                        int pngCompressionLevel,
-                        ExportFormatOptions::TIFF_COMPRESS tiffCompression)
+                        const std::filesystem::path& outputDir, bool sdrResizeEnabled,
+                        int sdrMaxLengthSide, int ultraHdrMaxLengthSide,
+                        ImageFormatType sdrFormat, int sdrQuality,
+                        ExportFormatOptions::BIT_DEPTH sdrBitDepth, int sdrPngCompressionLevel,
+                        ExportFormatOptions::TIFF_COMPRESS sdrTiffCompression,
+                        int ultraHdrQuality, bool ultraHdrDitherEnabled)
       -> ExportQueueBuildResult;
 
   [[nodiscard]] bool export_inflight() const { return export_inflight_; }

--- a/alcedo_studio/src/include/ui/alcedo_main/editor_dialog/frame/editor_frame_manager.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/editor_dialog/frame/editor_frame_manager.hpp
@@ -34,7 +34,8 @@ class EditorFrameManager final {
   auto CurrentFrameSink() -> IFrameSink*;
 
   void SyncViewerDisplayEncoding(ColorUtils::ColorSpace encoding_space,
-                                 ColorUtils::EOTF       encoding_eotf);
+                                 ColorUtils::EOTF       encoding_eotf,
+                                 float                  peak_luminance);
 
   void MarkNeedsFullFramePreviewAfterGeometryCommit();
   void ClearNeedsFullFramePreviewAfterGeometryCommit();

--- a/alcedo_studio/src/include/ui/alcedo_main/editor_dialog/widgets/display_transform_panel_widget.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/editor_dialog/widgets/display_transform_panel_widget.hpp
@@ -39,7 +39,7 @@ class DisplayTransformPanelWidget final : public AdjustmentPanelWidget {
     std::function<bool()>                                         is_global_syncing;
     std::function<void()>                                         request_render;
     std::function<const AdjustmentState&()>                       default_adjustment_state;
-    std::function<void(ColorUtils::ColorSpace, ColorUtils::EOTF)> sync_display_encoding;
+    std::function<void(ColorUtils::ColorSpace, ColorUtils::EOTF, float)> sync_display_encoding;
     std::function<std::optional<DisplayTransformAdjustmentState>(
         const DisplayTransformAdjustmentState&)>
         load_from_pipeline;

--- a/alcedo_studio/src/include/ui/alcedo_main/editor_dialog/widgets/tone_control_panel_widget.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/editor_dialog/widgets/tone_control_panel_widget.hpp
@@ -8,6 +8,7 @@
 #include <QEvent>
 #include <QLabel>
 #include <QSlider>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <QWidget>
 #include <functional>
@@ -90,6 +91,9 @@ class ToneControlPanelWidget final : public AdjustmentPanelWidget {
   auto IsSyncing() const -> bool;
   bool eventFilter(QObject* obj, QEvent* event) override;
   void RegisterSliderReset(QSlider* slider, std::function<void()> on_reset);
+  void RegisterSliderSettled(QSlider* slider, std::function<void()> on_settled);
+  void ScheduleWheelSliderSettled(QSlider* slider);
+  void EnsureWheelSliderSettledTimer();
   void RegisterCurveReset(ToneCurveWidget* widget, std::function<void()> on_reset);
   void RequestPipelineRender();
   auto SessionPreviewParamsForTone(AdjustmentField field) -> nlohmann::json;
@@ -114,6 +118,9 @@ class ToneControlPanelWidget final : public AdjustmentPanelWidget {
   float                                     last_known_as_shot_tint_           = 0.0f;
   bool                                      has_last_known_as_shot_color_temp_ = false;
   std::map<QSlider*, std::function<void()>> slider_reset_callbacks_{};
+  std::map<QSlider*, std::function<void()>> slider_settled_callbacks_{};
+  QTimer*                                   wheel_slider_settled_timer_ = nullptr;
+  QSlider*                                  pending_wheel_slider_       = nullptr;
   std::function<void()>                     curve_reset_callback_{};
 
   QSlider*                                  exposure_slider_              = nullptr;

--- a/alcedo_studio/src/include/ui/edit_viewer/edit_viewer.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/edit_viewer.hpp
@@ -52,7 +52,8 @@ class QtEditViewer : public QWidget, public alcedo::IFrameSink {
   auto GetViewZoom() const -> float;
   auto IsViewInteractionActive() const -> bool;
   void SetDisplayEncoding(ColorUtils::ColorSpace encoding_space,
-                          ColorUtils::EOTF       encoding_eotf);
+                          ColorUtils::EOTF       encoding_eotf,
+                          float                  peak_luminance);
   void SyncPendingFrameStateForScheduling();
   void SetExpectedDetailToken(std::uint64_t preview_generation, std::uint64_t detail_serial);
   void ClearExpectedDetailToken();

--- a/alcedo_studio/src/include/ui/edit_viewer/frame_sink.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/frame_sink.hpp
@@ -19,6 +19,7 @@ struct FinalDisplayFrameView;
 struct ViewerDisplayConfig {
   ColorUtils::ColorSpace encoding_space = ColorUtils::ColorSpace::REC709;
   ColorUtils::EOTF       encoding_eotf  = ColorUtils::EOTF::GAMMA_2_2;
+  float                  peak_luminance = 100.0f;
 
   auto operator==(const ViewerDisplayConfig& other) const -> bool = default;
 };

--- a/alcedo_studio/src/io/image/image_writer.cpp
+++ b/alcedo_studio/src/io/image/image_writer.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
@@ -46,6 +47,43 @@ auto RatingPercentFor(int rating) -> uint16_t {
     default:
       return 0;
   }
+}
+
+auto HasMeaningfulExportMetadata(const ExifDisplayMetaData& metadata) -> bool {
+  return !metadata.make_.empty() || !metadata.model_.empty() || !metadata.lens_.empty() ||
+         !metadata.lens_make_.empty() || !metadata.date_time_str_.empty() ||
+         metadata.aperture_ > 0.0f || metadata.focal_ > 0.0f || metadata.focal_35mm_ > 0.0f ||
+         metadata.focus_distance_m_ > 0.0f || metadata.iso_ > 0 ||
+         (metadata.shutter_speed_.first > 0 && metadata.shutter_speed_.second > 0) ||
+         ExifDisplayMetaData::NormalizeRating(metadata.rating_) > 0;
+}
+
+auto RationalFromFloat(float value, int denominator) -> Exiv2::Rational {
+  if (!std::isfinite(value) || value <= 0.0f || denominator <= 0) {
+    return {0, 1};
+  }
+  return {std::max(1, static_cast<int>(std::lround(value * denominator))), denominator};
+}
+
+auto ExifDateTimeString(std::string value) -> std::optional<std::string> {
+  if (value.size() < 19) {
+    return std::nullopt;
+  }
+  value = value.substr(0, 19);
+  if (value[4] == '-') value[4] = ':';
+  if (value[7] == '-') value[7] = ':';
+  return value;
+}
+
+auto XmpDateTimeString(const std::string& value) -> std::optional<std::string> {
+  if (value.size() < 19) {
+    return std::nullopt;
+  }
+  std::string out = value.substr(0, 19);
+  if (out[4] == ':') out[4] = '-';
+  if (out[7] == ':') out[7] = '-';
+  if (out[10] == ' ') out[10] = 'T';
+  return out;
 }
 
 auto ShouldResize(const ExportFormatOptions& options) -> bool {
@@ -219,6 +257,20 @@ void RemoveEmbeddedColorProfileMetadata(ImageSpec& spec) {
   spec.extra_attribs.remove("exif:ColorSpace", TypeDesc::UNKNOWN, false);
 }
 
+void EraseExifKey(Exiv2::ExifData& exif_data, const char* key) {
+  const auto it = exif_data.findKey(Exiv2::ExifKey(key));
+  if (it != exif_data.end()) {
+    exif_data.erase(it);
+  }
+}
+
+void RemoveConflictingExifColorTags(Exiv2::ExifData& exif_data) {
+  EraseExifKey(exif_data, "Exif.Photo.ColorSpace");
+  EraseExifKey(exif_data, "Exif.Image.ColorSpace");
+  EraseExifKey(exif_data, "Exif.Iop.InteroperabilityIndex");
+  EraseExifKey(exif_data, "Exif.Iop.InteroperabilityVersion");
+}
+
 void ApplyExportColorProfile(ImageSpec& spec,
                              const std::optional<ExportColorProfileConfig>& color_profile) {
   if (!color_profile.has_value()) {
@@ -241,47 +293,415 @@ void ApplyExportColorProfile(ImageSpec& spec,
                  icc_bytes.data());
 }
 
-void ApplyRatingMetadata(const std::filesystem::path& export_path, std::optional<int> rating) {
-  if (!rating.has_value()) {
+void ApplyExportMetadataToOIIO(ImageSpec& spec,
+                               const std::optional<ExifDisplayMetaData>& export_metadata) {
+  if (!export_metadata.has_value() || !HasMeaningfulExportMetadata(*export_metadata)) {
     return;
   }
 
-  try {
-    auto image = Exiv2::ImageFactory::open(PathToUtf8(export_path));
-    if (!image) {
-      return;
-    }
+  const ExifDisplayMetaData& metadata = *export_metadata;
+  if (!metadata.make_.empty()) {
+    spec.attribute("Exif:Make", metadata.make_);
+  }
+  if (!metadata.model_.empty()) {
+    spec.attribute("Exif:Model", metadata.model_);
+  }
+  if (!metadata.lens_.empty()) {
+    spec.attribute("Exif:LensModel", metadata.lens_);
+  }
+  if (!metadata.lens_make_.empty()) {
+    spec.attribute("Exif:LensMake", metadata.lens_make_);
+  }
+  if (const auto exif_dt = ExifDateTimeString(metadata.date_time_str_); exif_dt.has_value()) {
+    spec.attribute("Exif:DateTime", *exif_dt);
+    spec.attribute("Exif:DateTimeOriginal", *exif_dt);
+    spec.attribute("Exif:DateTimeDigitized", *exif_dt);
+  }
 
-    const int normalized_rating = ExifDisplayMetaData::NormalizeRating(*rating);
-    image->readMetadata();
+  const int normalized_rating = ExifDisplayMetaData::NormalizeRating(metadata.rating_);
+  if (normalized_rating > 0) {
+    spec.attribute("Exif:Rating", normalized_rating);
+    spec.attribute("Exif:RatingPercent", static_cast<int>(RatingPercentFor(normalized_rating)));
+    spec.attribute("XMP:xmp:Rating", normalized_rating);
+  }
+}
 
+void ApplyDisplayMetadataToExif(Exiv2::ExifData& exif_data,
+                                const ExifDisplayMetaData& metadata) {
+  if (!metadata.make_.empty()) {
     try {
-      Exiv2::XmpData xmp_data = image->xmpData();
-      xmp_data["Xmp.xmp.Rating"] = normalized_rating;
-      image->setXmpData(xmp_data);
+      exif_data["Exif.Image.Make"] = metadata.make_;
     } catch (...) {
     }
-
+  }
+  if (!metadata.model_.empty()) {
     try {
-      Exiv2::ExifData exif_data = image->exifData();
+      exif_data["Exif.Image.Model"] = metadata.model_;
+    } catch (...) {
+    }
+  }
+  if (!metadata.lens_.empty()) {
+    try {
+      exif_data["Exif.Photo.LensModel"] = metadata.lens_;
+    } catch (...) {
+    }
+  }
+  if (!metadata.lens_make_.empty()) {
+    try {
+      exif_data["Exif.Photo.LensMake"] = metadata.lens_make_;
+    } catch (...) {
+    }
+  }
+  if (metadata.aperture_ > 0.0f) {
+    try {
+      exif_data["Exif.Photo.FNumber"] = RationalFromFloat(metadata.aperture_, 100);
+    } catch (...) {
+    }
+  }
+  if (metadata.focal_ > 0.0f) {
+    try {
+      exif_data["Exif.Photo.FocalLength"] = RationalFromFloat(metadata.focal_, 100);
+    } catch (...) {
+    }
+  }
+  if (metadata.focal_35mm_ > 0.0f) {
+    try {
+      exif_data["Exif.Photo.FocalLengthIn35mmFilm"] =
+          static_cast<uint16_t>(std::lround(metadata.focal_35mm_));
+    } catch (...) {
+    }
+  }
+  if (metadata.focus_distance_m_ > 0.0f) {
+    try {
+      exif_data["Exif.Photo.SubjectDistance"] = RationalFromFloat(metadata.focus_distance_m_, 1000);
+    } catch (...) {
+    }
+  }
+  if (metadata.iso_ > 0) {
+    try {
+      exif_data["Exif.Photo.ISOSpeedRatings"] = static_cast<uint16_t>(
+          std::min<uint64_t>(metadata.iso_, std::numeric_limits<uint16_t>::max()));
+    } catch (...) {
+    }
+  }
+  if (metadata.shutter_speed_.first > 0 && metadata.shutter_speed_.second > 0) {
+    try {
+      exif_data["Exif.Photo.ExposureTime"] = Exiv2::Rational(metadata.shutter_speed_.first,
+                                                             metadata.shutter_speed_.second);
+    } catch (...) {
+    }
+  }
+  if (const auto exif_dt = ExifDateTimeString(metadata.date_time_str_); exif_dt.has_value()) {
+    try {
+      exif_data["Exif.Image.DateTime"] = *exif_dt;
+    } catch (...) {
+    }
+    try {
+      exif_data["Exif.Photo.DateTimeOriginal"] = *exif_dt;
+    } catch (...) {
+    }
+    try {
+      exif_data["Exif.Photo.DateTimeDigitized"] = *exif_dt;
+    } catch (...) {
+    }
+  }
+
+  const int normalized_rating = ExifDisplayMetaData::NormalizeRating(metadata.rating_);
+  if (normalized_rating > 0) {
+    try {
       exif_data["Exif.Image.Rating"] = static_cast<uint16_t>(normalized_rating);
+    } catch (...) {
+    }
+    try {
+      exif_data["Exif.Image.RatingPercent"] = RatingPercentFor(normalized_rating);
+    } catch (...) {
+    }
+  }
+}
+
+void ApplyDisplayMetadataToXmp(Exiv2::XmpData& xmp_data, const ExifDisplayMetaData& metadata) {
+  if (!metadata.lens_.empty()) {
+    try {
+      xmp_data["Xmp.exif.LensModel"] = metadata.lens_;
+    } catch (...) {
+    }
+  }
+  if (const auto xmp_dt = XmpDateTimeString(metadata.date_time_str_); xmp_dt.has_value()) {
+    try {
+      xmp_data["Xmp.xmp.CreateDate"] = *xmp_dt;
+    } catch (...) {
+    }
+    try {
+      xmp_data["Xmp.photoshop.DateCreated"] = *xmp_dt;
+    } catch (...) {
+    }
+    try {
+      xmp_data["Xmp.exif.DateTimeOriginal"] = *xmp_dt;
+    } catch (...) {
+    }
+  }
+
+  const int normalized_rating = ExifDisplayMetaData::NormalizeRating(metadata.rating_);
+  if (normalized_rating > 0) {
+    try {
+      xmp_data["Xmp.xmp.Rating"] = normalized_rating;
+    } catch (...) {
+    }
+  }
+}
+
+void SetIccProfileBytes(Exiv2::Image& image, const std::vector<uint8_t>& icc_bytes) {
+  if (icc_bytes.empty()) {
+    return;
+  }
+
+  Exiv2::DataBuf profile(reinterpret_cast<const Exiv2::byte*>(icc_bytes.data()),
+                         icc_bytes.size());
+  try {
+    image.setIccProfile(std::move(profile));
+  } catch (...) {
+    Exiv2::DataBuf unchecked(reinterpret_cast<const Exiv2::byte*>(icc_bytes.data()),
+                             icc_bytes.size());
+    image.setIccProfile(std::move(unchecked), false);
+  }
+}
+
+auto EmbeddedIccMatches(Exiv2::Image& image, const std::vector<uint8_t>& icc_bytes) -> bool {
+  if (icc_bytes.empty()) {
+    return true;
+  }
+  const auto& profile = image.iccProfile();
+  return profile.size() == icc_bytes.size() &&
+         std::equal(profile.cbegin(), profile.cend(), icc_bytes.begin());
+}
+
+auto ReadFileBytes(const std::filesystem::path& path) -> std::vector<uint8_t> {
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open()) {
+    return {};
+  }
+  return std::vector<uint8_t>(std::istreambuf_iterator<char>(input), {});
+}
+
+auto WriteFileBytes(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) -> bool {
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  if (!output.is_open()) {
+    return false;
+  }
+  output.write(reinterpret_cast<const char*>(bytes.data()),
+               static_cast<std::streamsize>(bytes.size()));
+  return output.good();
+}
+
+auto IsJpegBytes(const std::vector<uint8_t>& bytes) -> bool {
+  return bytes.size() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xD8;
+}
+
+auto IsExifApp1Segment(const std::vector<uint8_t>& bytes, size_t marker_pos,
+                       size_t segment_length) -> bool {
+  constexpr uint8_t kExifPrefix[] = {'E', 'x', 'i', 'f', 0, 0};
+  const size_t      payload_pos   = marker_pos + 4;
+  return segment_length >= 2 + sizeof(kExifPrefix) &&
+         payload_pos + sizeof(kExifPrefix) <= bytes.size() &&
+         std::equal(std::begin(kExifPrefix), std::end(kExifPrefix), bytes.begin() + payload_pos);
+}
+
+auto BuildJpegExifPayload(const std::optional<ExifDisplayMetaData>& export_metadata)
+    -> std::vector<uint8_t> {
+  try {
+    Exiv2::ExifData exif_data;
+    if (export_metadata.has_value() && HasMeaningfulExportMetadata(*export_metadata)) {
+      ApplyDisplayMetadataToExif(exif_data, *export_metadata);
+    }
+    if (exif_data.empty()) {
+      return {};
+    }
+
+    Exiv2::Blob      blob;
+    Exiv2::ExifParser::encode(blob, Exiv2::littleEndian, exif_data);
+
+    constexpr uint8_t kExifPrefix[] = {'E', 'x', 'i', 'f', 0, 0};
+    std::vector<uint8_t> payload(std::begin(kExifPrefix), std::end(kExifPrefix));
+    payload.insert(payload.end(), blob.begin(), blob.end());
+    return payload;
+  } catch (...) {
+    return {};
+  }
+}
+
+auto ReplaceJpegExifSegment(const std::filesystem::path& export_path,
+                            const std::vector<uint8_t>&  exif_payload) -> bool {
+  if (exif_payload.empty() || exif_payload.size() > 65533) {
+    return false;
+  }
+
+  std::vector<uint8_t> bytes = ReadFileBytes(export_path);
+  if (!IsJpegBytes(bytes)) {
+    return false;
+  }
+
+  std::vector<uint8_t> segment;
+  const uint16_t segment_length = static_cast<uint16_t>(exif_payload.size() + 2);
+  segment.reserve(exif_payload.size() + 4);
+  segment.push_back(0xFF);
+  segment.push_back(0xE1);
+  segment.push_back(static_cast<uint8_t>((segment_length >> 8) & 0xFF));
+  segment.push_back(static_cast<uint8_t>(segment_length & 0xFF));
+  segment.insert(segment.end(), exif_payload.begin(), exif_payload.end());
+
+  size_t insert_pos = 2;
+  for (size_t pos = 2; pos + 4 <= bytes.size();) {
+    if (bytes[pos] != 0xFF) {
+      break;
+    }
+    while (pos < bytes.size() && bytes[pos] == 0xFF) {
+      ++pos;
+    }
+    if (pos >= bytes.size()) {
+      break;
+    }
+    const uint8_t marker = bytes[pos++];
+    if (marker == 0xDA || marker == 0xD9) {
+      insert_pos = pos - 2;
+      break;
+    }
+    if (marker == 0x01 || (marker >= 0xD0 && marker <= 0xD7)) {
+      insert_pos = pos;
+      continue;
+    }
+    if (pos + 2 > bytes.size()) {
+      break;
+    }
+    const size_t length = (static_cast<size_t>(bytes[pos]) << 8) | bytes[pos + 1];
+    if (length < 2 || pos + length > bytes.size()) {
+      break;
+    }
+    const size_t marker_pos = pos - 2;
+    const size_t next_pos   = pos + length;
+    if (marker == 0xE1 && IsExifApp1Segment(bytes, marker_pos, length)) {
+      std::vector<uint8_t> out;
+      out.reserve(bytes.size() - (next_pos - marker_pos) + segment.size());
+      out.insert(out.end(), bytes.begin(), bytes.begin() + marker_pos);
+      out.insert(out.end(), segment.begin(), segment.end());
+      out.insert(out.end(), bytes.begin() + next_pos, bytes.end());
+      return WriteFileBytes(export_path, out);
+    }
+    if (marker == 0xE0 && insert_pos == marker_pos) {
+      insert_pos = next_pos;
+    }
+    pos = next_pos;
+  }
+
+  std::vector<uint8_t> out;
+  out.reserve(bytes.size() + segment.size());
+  out.insert(out.end(), bytes.begin(), bytes.begin() + insert_pos);
+  out.insert(out.end(), segment.begin(), segment.end());
+  out.insert(out.end(), bytes.begin() + insert_pos, bytes.end());
+  return WriteFileBytes(export_path, out);
+}
+
+void ApplyExportMetadata(
+    const std::filesystem::path& export_path,
+    const std::optional<ExportColorProfileConfig>& color_profile,
+    const std::optional<ExifDisplayMetaData>& export_metadata) {
+  const bool has_metadata =
+      export_metadata.has_value() && HasMeaningfulExportMetadata(*export_metadata);
+  const std::vector<uint8_t> icc_bytes =
+      color_profile.has_value() ? ExportIccProfileResolver::ResolveIccProfileBytes(*color_profile)
+                                : std::vector<uint8_t>{};
+  if (!has_metadata && icc_bytes.empty()) {
+    return;
+  }
+
+  bool icc_needs_repair = !icc_bytes.empty();
+  if (!icc_bytes.empty()) {
+    const std::vector<uint8_t> exif_payload = BuildJpegExifPayload(export_metadata);
+    if (ReplaceJpegExifSegment(export_path, exif_payload)) {
       try {
-        exif_data["Exif.Image.RatingPercent"] = RatingPercentFor(normalized_rating);
+        auto image = Exiv2::ImageFactory::open(PathToUtf8(export_path));
+        if (image) {
+          image->readMetadata();
+          if (!icc_bytes.empty()) {
+            icc_needs_repair = !EmbeddedIccMatches(*image, icc_bytes);
+          }
+        }
       } catch (...) {
       }
-      image->setExifData(exif_data);
-    } catch (...) {
+      if (icc_needs_repair) {
+        try {
+          auto image = Exiv2::ImageFactory::open(PathToUtf8(export_path));
+          if (!image) {
+            return;
+          }
+          image->readMetadata();
+          SetIccProfileBytes(*image, icc_bytes);
+          image->writeMetadata();
+        } catch (...) {
+        }
+      }
+      return;
     }
+  }
 
-    image->writeMetadata();
-  } catch (...) {
-    // Metadata injection is best-effort; pixel export should not fail for unsupported tags/formats.
+  if (has_metadata || !icc_bytes.empty()) {
+    try {
+      auto image = Exiv2::ImageFactory::open(PathToUtf8(export_path));
+      if (!image) {
+        return;
+      }
+
+      image->readMetadata();
+      if (!icc_bytes.empty()) {
+        icc_needs_repair = !EmbeddedIccMatches(*image, icc_bytes);
+      }
+
+      try {
+        Exiv2::ExifData exif_data = image->exifData();
+        if (!icc_bytes.empty()) {
+          RemoveConflictingExifColorTags(exif_data);
+        }
+        if (has_metadata) {
+          ApplyDisplayMetadataToExif(exif_data, *export_metadata);
+        }
+        image->setExifData(exif_data);
+      } catch (...) {
+      }
+
+      if (has_metadata) {
+        try {
+          Exiv2::XmpData xmp_data = image->xmpData();
+          ApplyDisplayMetadataToXmp(xmp_data, *export_metadata);
+          image->setXmpData(xmp_data);
+        } catch (...) {
+        }
+      }
+
+      image->writeMetadata();
+    } catch (...) {
+      // Metadata injection is best-effort; pixel export should not fail for unsupported tags/formats.
+    }
+  }
+
+  if (icc_needs_repair) {
+    try {
+      auto image = Exiv2::ImageFactory::open(PathToUtf8(export_path));
+      if (!image) {
+        return;
+      }
+
+      image->readMetadata();
+      SetIccProfileBytes(*image, icc_bytes);
+      image->writeMetadata();
+    } catch (...) {
+      // ICC repair is best-effort; OIIO may already have embedded the profile.
+    }
   }
 }
 
 auto TryWriteWithOpenImageIO(const image_path_t& src_path, const std::filesystem::path& export_path,
                              const cv::Mat& rgba32f, const ExportFormatOptions& options,
                              const std::optional<ExportColorProfileConfig>& color_profile,
+                             const std::optional<ExifDisplayMetaData>& export_metadata,
                              std::string& out_error) -> bool {
   const std::string dst          = PathToUtf8(export_path);
 
@@ -307,6 +727,7 @@ auto TryWriteWithOpenImageIO(const image_path_t& src_path, const std::filesystem
 
   ForceUprightOrientation(outspec);
   ApplyOIIOFormatOptions(outspec, options);
+  ApplyExportMetadataToOIIO(outspec, export_metadata);
   ApplyExportColorProfile(outspec, color_profile);
 
   // OIIO v3 exports ImageOutput::create(string_view, ...) (and a UTF-16 helper).
@@ -412,7 +833,7 @@ void ImageWriter::WriteImageToPath(const image_path_t&          src_path,
                                    std::shared_ptr<ImageBuffer> image_data,
                                    ExportFormatOptions          options,
                                    std::optional<ExportColorProfileConfig> color_profile,
-                                   std::optional<int> rating) {
+                                   std::optional<ExifDisplayMetaData> export_metadata) {
   if (!image_data) {
     throw std::runtime_error("ImageWriter: image_data is null");
   }
@@ -447,7 +868,7 @@ void ImageWriter::WriteImageToPath(const image_path_t&          src_path,
   if (ShouldWriteUltraHdr(options, color_profile)) {
 #if defined(ALCEDO_HAS_ULTRAHDR)
     UltraHdrWriter::WriteImageToPath(src_path, export_path, working, options, *color_profile,
-                                     rating);
+                                     export_metadata);
     return;
 #else
     throw std::runtime_error(
@@ -455,11 +876,15 @@ void ImageWriter::WriteImageToPath(const image_path_t&          src_path,
 #endif
   }
 
+  if (color_profile.has_value() && IsUltraHdrTransfer(color_profile->encoding_eotf)) {
+    throw std::runtime_error("ImageWriter: HDR export requires Ultra HDR JPEG output.");
+  }
+
   std::string oiio_err;
   try {
     if (TryWriteWithOpenImageIO(src_path, export_path, working, options, color_profile,
-                                oiio_err)) {
-      ApplyRatingMetadata(export_path, rating);
+                                export_metadata, oiio_err)) {
+      ApplyExportMetadata(export_path, color_profile, export_metadata);
       return;
     }
   } catch (const std::exception& e) {
@@ -468,7 +893,7 @@ void ImageWriter::WriteImageToPath(const image_path_t&          src_path,
 
   std::string cv_err;
   if (TryWriteWithOpenCV(export_path, working, options, cv_err)) {
-    ApplyRatingMetadata(export_path, rating);
+    ApplyExportMetadata(export_path, color_profile, export_metadata);
     return;
   }
 

--- a/alcedo_studio/src/io/image/ultra_hdr_writer.cpp
+++ b/alcedo_studio/src/io/image/ultra_hdr_writer.cpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -30,6 +31,25 @@ OIIO_NAMESPACE_USING
 constexpr float kSdrWhiteNits = 203.0f;
 constexpr float kHlgReferencePeakNits = 1000.0f;
 constexpr float kPqReferencePeakNits = 10000.0f;
+constexpr int   kUltraHdrGainMapScaleFactor = 1;
+
+auto OrderedDither8x8(int x, int y, int channel) -> float {
+  static constexpr int kBayer8x8[8][8] = {
+      {0, 48, 12, 60, 3, 51, 15, 63},     {32, 16, 44, 28, 35, 19, 47, 31},
+      {8, 56, 4, 52, 11, 59, 7, 55},      {40, 24, 36, 20, 43, 27, 39, 23},
+      {2, 50, 14, 62, 1, 49, 13, 61},     {34, 18, 46, 30, 33, 17, 45, 29},
+      {10, 58, 6, 54, 9, 57, 5, 53},      {42, 26, 38, 22, 41, 25, 37, 21},
+  };
+  const int sample = kBayer8x8[(y + channel * 3) & 7][(x + channel * 5) & 7];
+  return (static_cast<float>(sample) + 0.5f) / 64.0f - 0.5f;
+}
+
+auto QuantizeToU8WithDither(float value, int x, int y, int channel) -> uint8_t {
+  const float scaled = std::clamp(value, 0.0f, 1.0f) * 255.0f;
+  const int quantized =
+      static_cast<int>(std::floor(scaled + 0.5f + OrderedDither8x8(x, y, channel)));
+  return static_cast<uint8_t>(std::clamp(quantized, 0, 255));
+}
 
 auto PathToUtf8(const std::filesystem::path& path) -> std::string {
   auto u8 = path.u8string();
@@ -145,7 +165,13 @@ auto ConvertHdrIntentToLinear(const cv::Mat& rgba32f, ColorUtils::EOTF eotf) -> 
   return linear;
 }
 
-auto BuildSdrBaseRgb8(const cv::Mat& linear_rgba32f) -> cv::Mat {
+auto QuantizeToU8(float value) -> uint8_t {
+  return static_cast<uint8_t>(
+      std::clamp(static_cast<int>(std::floor(std::clamp(value, 0.0f, 1.0f) * 255.0f + 0.5f)), 0,
+                 255));
+}
+
+auto BuildSdrBaseRgb8(const cv::Mat& linear_rgba32f, bool dither_enabled) -> cv::Mat {
   cv::Mat rgb8(linear_rgba32f.rows, linear_rgba32f.cols, CV_8UC3);
   for (int y = 0; y < linear_rgba32f.rows; ++y) {
     const auto* src_row = linear_rgba32f.ptr<cv::Vec4f>(y);
@@ -153,8 +179,9 @@ auto BuildSdrBaseRgb8(const cv::Mat& linear_rgba32f) -> cv::Mat {
     for (int x = 0; x < linear_rgba32f.cols; ++x) {
       for (int c = 0; c < 3; ++c) {
         const float base_linear = std::clamp(src_row[x][c], 0.0f, 1.0f);
-        dst_row[x][c] =
-            static_cast<uint8_t>(std::lround(EncodeSrgb(base_linear) * 255.0f));
+        const float encoded = EncodeSrgb(base_linear);
+        dst_row[x][c] = dither_enabled ? QuantizeToU8WithDither(encoded, x, y, c)
+                                       : QuantizeToU8(encoded);
       }
     }
   }
@@ -198,16 +225,127 @@ auto RatingPercentFor(int rating) -> uint16_t {
   }
 }
 
-void ApplyExifRating(Exiv2::ExifData& exif_data, std::optional<int> rating) {
-  if (!rating.has_value()) {
+auto HasMeaningfulExportMetadata(const ExifDisplayMetaData& metadata) -> bool {
+  return !metadata.make_.empty() || !metadata.model_.empty() || !metadata.lens_.empty() ||
+         !metadata.lens_make_.empty() || !metadata.date_time_str_.empty() ||
+         metadata.aperture_ > 0.0f || metadata.focal_ > 0.0f || metadata.focal_35mm_ > 0.0f ||
+         metadata.focus_distance_m_ > 0.0f || metadata.iso_ > 0 ||
+         (metadata.shutter_speed_.first > 0 && metadata.shutter_speed_.second > 0) ||
+         ExifDisplayMetaData::NormalizeRating(metadata.rating_) > 0;
+}
+
+auto RationalFromFloat(float value, int denominator) -> Exiv2::Rational {
+  if (!std::isfinite(value) || value <= 0.0f || denominator <= 0) {
+    return {0, 1};
+  }
+  return {std::max(1, static_cast<int>(std::lround(value * denominator))), denominator};
+}
+
+auto ExifDateTimeString(std::string value) -> std::optional<std::string> {
+  if (value.size() < 19) {
+    return std::nullopt;
+  }
+  value = value.substr(0, 19);
+  if (value[4] == '-') value[4] = ':';
+  if (value[7] == '-') value[7] = ':';
+  return value;
+}
+
+void ApplyExportMetadataToExif(Exiv2::ExifData& exif_data,
+                               const std::optional<ExifDisplayMetaData>& export_metadata) {
+  if (!export_metadata.has_value() || !HasMeaningfulExportMetadata(*export_metadata)) {
     return;
   }
 
-  const int normalized_rating = ExifDisplayMetaData::NormalizeRating(*rating);
-  exif_data["Exif.Image.Rating"] = static_cast<uint16_t>(normalized_rating);
-  try {
-    exif_data["Exif.Image.RatingPercent"] = RatingPercentFor(normalized_rating);
-  } catch (...) {
+  const ExifDisplayMetaData& metadata = *export_metadata;
+  if (!metadata.make_.empty()) {
+    try {
+      exif_data["Exif.Image.Make"] = metadata.make_;
+    } catch (...) {
+    }
+  }
+  if (!metadata.model_.empty()) {
+    try {
+      exif_data["Exif.Image.Model"] = metadata.model_;
+    } catch (...) {
+    }
+  }
+  if (!metadata.lens_.empty()) {
+    try {
+      exif_data["Exif.Photo.LensModel"] = metadata.lens_;
+    } catch (...) {
+    }
+  }
+  if (!metadata.lens_make_.empty()) {
+    try {
+      exif_data["Exif.Photo.LensMake"] = metadata.lens_make_;
+    } catch (...) {
+    }
+  }
+  if (metadata.aperture_ > 0.0f) {
+    try {
+      exif_data["Exif.Photo.FNumber"] = RationalFromFloat(metadata.aperture_, 100);
+    } catch (...) {
+    }
+  }
+  if (metadata.focal_ > 0.0f) {
+    try {
+      exif_data["Exif.Photo.FocalLength"] = RationalFromFloat(metadata.focal_, 100);
+    } catch (...) {
+    }
+  }
+  if (metadata.focal_35mm_ > 0.0f) {
+    try {
+      exif_data["Exif.Photo.FocalLengthIn35mmFilm"] =
+          static_cast<uint16_t>(std::lround(metadata.focal_35mm_));
+    } catch (...) {
+    }
+  }
+  if (metadata.focus_distance_m_ > 0.0f) {
+    try {
+      exif_data["Exif.Photo.SubjectDistance"] = RationalFromFloat(metadata.focus_distance_m_, 1000);
+    } catch (...) {
+    }
+  }
+  if (metadata.iso_ > 0) {
+    try {
+      exif_data["Exif.Photo.ISOSpeedRatings"] = static_cast<uint16_t>(
+          std::min<uint64_t>(metadata.iso_, std::numeric_limits<uint16_t>::max()));
+    } catch (...) {
+    }
+  }
+  if (metadata.shutter_speed_.first > 0 && metadata.shutter_speed_.second > 0) {
+    try {
+      exif_data["Exif.Photo.ExposureTime"] = Exiv2::Rational(metadata.shutter_speed_.first,
+                                                             metadata.shutter_speed_.second);
+    } catch (...) {
+    }
+  }
+  if (const auto exif_dt = ExifDateTimeString(metadata.date_time_str_); exif_dt.has_value()) {
+    try {
+      exif_data["Exif.Image.DateTime"] = *exif_dt;
+    } catch (...) {
+    }
+    try {
+      exif_data["Exif.Photo.DateTimeOriginal"] = *exif_dt;
+    } catch (...) {
+    }
+    try {
+      exif_data["Exif.Photo.DateTimeDigitized"] = *exif_dt;
+    } catch (...) {
+    }
+  }
+
+  const int normalized_rating = ExifDisplayMetaData::NormalizeRating(metadata.rating_);
+  if (normalized_rating > 0) {
+    try {
+      exif_data["Exif.Image.Rating"] = static_cast<uint16_t>(normalized_rating);
+    } catch (...) {
+    }
+    try {
+      exif_data["Exif.Image.RatingPercent"] = RatingPercentFor(normalized_rating);
+    } catch (...) {
+    }
   }
 }
 
@@ -306,10 +444,11 @@ auto BuildBaseJpegBytes(const cv::Mat&                  linear_rgba32f,
                         const ExportFormatOptions&      options,
                         const ExportColorProfileConfig& color_profile,
                         const std::vector<uint8_t>&     exif_bytes) -> std::vector<uint8_t> {
-  const cv::Mat                   base_rgb8 = BuildSdrBaseRgb8(linear_rgba32f);
+  const cv::Mat                   base_rgb8 =
+      BuildSdrBaseRgb8(linear_rgba32f, options.ultra_hdr_dither_enabled_);
   const TempFileGuard             temp_file(MakeTempBaseJpegPath());
   const ExportColorProfileConfig  base_profile = MakeSdrBaseColorProfile(color_profile);
-  WriteBaseJpeg(temp_file.path(), base_rgb8, options.quality_, base_profile);
+  WriteBaseJpeg(temp_file.path(), base_rgb8, options.ultra_hdr_quality_, base_profile);
   AttachExifToJpeg(temp_file.path(), exif_bytes);
   return ReadFileBytes(temp_file.path());
 }
@@ -322,7 +461,8 @@ auto UltraHdrWriter::BuildSanitizedExifData(const image_path_t& source_path, int
 }
 
 auto UltraHdrWriter::BuildSanitizedExifData(const image_path_t& source_path, int width, int height,
-                                            std::optional<int> rating) -> std::vector<uint8_t> {
+                                            const std::optional<ExifDisplayMetaData>&
+                                                export_metadata) -> std::vector<uint8_t> {
   try {
     auto image = Exiv2::ImageFactory::open(PathToUtf8(source_path));
     if (!image) {
@@ -331,12 +471,13 @@ auto UltraHdrWriter::BuildSanitizedExifData(const image_path_t& source_path, int
 
     image->readMetadata();
     Exiv2::ExifData exif_data = image->exifData();
-    if (exif_data.empty() && !rating.has_value()) {
+    if (exif_data.empty() &&
+        (!export_metadata.has_value() || !HasMeaningfulExportMetadata(*export_metadata))) {
       return {};
     }
 
     SanitizeExifData(exif_data, width, height);
-    ApplyExifRating(exif_data, rating);
+    ApplyExportMetadataToExif(exif_data, export_metadata);
 
     Exiv2::Blob blob;
     Exiv2::ByteOrder byte_order = image->byteOrder();
@@ -355,14 +496,15 @@ void UltraHdrWriter::WriteImageToPath(const image_path_t&             src_path,
                                       const cv::Mat&                  rgba32f,
                                       const ExportFormatOptions&      options,
                                       const ExportColorProfileConfig& color_profile,
-                                      std::optional<int>              rating) {
+                                      std::optional<ExifDisplayMetaData> export_metadata) {
   if (rgba32f.empty() || rgba32f.type() != CV_32FC4) {
     throw std::runtime_error("UltraHdrWriter: expected non-empty CV_32FC4 image.");
   }
 
   cv::Mat linear_rgba32f = ConvertHdrIntentToLinear(rgba32f, color_profile.encoding_eotf);
   std::vector<uint8_t> exif_bytes =
-      BuildSanitizedExifData(src_path, linear_rgba32f.cols, linear_rgba32f.rows, rating);
+      BuildSanitizedExifData(src_path, linear_rgba32f.cols, linear_rgba32f.rows,
+                             export_metadata);
   std::vector<uint8_t> base_jpeg_bytes =
       BuildBaseJpegBytes(linear_rgba32f, options, color_profile, exif_bytes);
 
@@ -402,8 +544,15 @@ void UltraHdrWriter::WriteImageToPath(const image_path_t&             src_path,
                    "uhdr_enc_set_compressed_image");
   ThrowIfUhdrError(uhdr_enc_set_output_format(encoder.get(), UHDR_CODEC_JPG),
                    "uhdr_enc_set_output_format");
-  ThrowIfUhdrError(uhdr_enc_set_quality(encoder.get(), options.quality_, UHDR_GAIN_MAP_IMG),
+  ThrowIfUhdrError(uhdr_enc_set_quality(encoder.get(), options.ultra_hdr_quality_,
+                                        UHDR_GAIN_MAP_IMG),
                    "uhdr_enc_set_quality(gainmap)");
+  ThrowIfUhdrError(
+      uhdr_enc_set_using_gainmap_dithering(encoder.get(),
+                                           options.ultra_hdr_dither_enabled_ ? 1 : 0),
+      "uhdr_enc_set_using_gainmap_dithering");
+  ThrowIfUhdrError(uhdr_enc_set_gainmap_scale_factor(encoder.get(), kUltraHdrGainMapScaleFactor),
+                   "uhdr_enc_set_gainmap_scale_factor");
   ThrowIfUhdrError(uhdr_enc_set_using_multi_channel_gainmap(encoder.get(), 1),
                    "uhdr_enc_set_using_multi_channel_gainmap");
   ThrowIfUhdrError(uhdr_enc_set_preset(encoder.get(), UHDR_USAGE_BEST_QUALITY),

--- a/alcedo_studio/src/third_party/CMakeLists.txt
+++ b/alcedo_studio/src/third_party/CMakeLists.txt
@@ -191,7 +191,7 @@ set(PUERHLAB_ULTRAHDR_SOURCE_DIR
 if(NOT EXISTS "${PUERHLAB_ULTRAHDR_SOURCE_DIR}/CMakeLists.txt")
     message(FATAL_ERROR
         "libultrahdr source was not found at ${PUERHLAB_ULTRAHDR_SOURCE_DIR}. "
-        "Run `git submodule update --init --recursive pu-erh_lab/src/third_party/libultrahdr` "
+        "Run `git submodule update --init --recursive alcedo_studio/src/third_party/libultrahdr` "
         "and re-configure.")
 endif()
 
@@ -240,7 +240,7 @@ if(EXISTS "${PUERHLAB_ULTRAHDR_IMAGE_IO_HEADER}")
 else()
     message(WARNING
         "libultrahdr checkout is incomplete: missing ${PUERHLAB_ULTRAHDR_IMAGE_IO_HEADER}. "
-        "Run `git submodule update --init --recursive pu-erh_lab/src/third_party/libultrahdr` "
+        "Run `git submodule update --init --recursive alcedo_studio/src/third_party/libultrahdr` "
         "and re-configure. Ultra HDR support will be disabled for this build.")
 endif()
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/adjustment_transfer_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/adjustment_transfer_controller.cpp
@@ -435,7 +435,8 @@ auto AdjustmentTransferController::Copy(uint elementId, const QVariantList& sele
   }
 }
 
-auto AdjustmentTransferController::Paste(const QVariantList& targetEntries) -> QVariantMap {
+auto AdjustmentTransferController::Paste(const QVariantList& targetEntries, const QString& strategy)
+    -> QVariantMap {
   if (!copied_package_.has_value()) {
     return ErrorResult(Tr("No copied adjustments."));
   }
@@ -456,9 +457,11 @@ auto AdjustmentTransferController::Paste(const QVariantList& targetEntries) -> Q
   }
 
   try {
-    const auto result = AdjustmentTransferService::Apply(
+    const bool merge_strategy = strategy != QStringLiteral("paste");
+    const auto result         = AdjustmentTransferService::Apply(
         *pipeline_service, *history_service, ids, *copied_package_,
-        Tr("Pasted Adjustments").toStdString());
+        (merge_strategy ? Tr("Merged Adjustments") : Tr("Pasted Adjustments")).toStdString(),
+        merge_strategy ? AdjustmentVersionApplyMode::kMerge : AdjustmentVersionApplyMode::kPaste);
     auto thumbnail_service = backend_.project_handler_.thumbnail_service();
     for (sl_element_id_t element_id : result.applied_ids_) {
       const auto*      item     = backend_.FindAlbumItem(element_id);
@@ -482,7 +485,8 @@ auto AdjustmentTransferController::Paste(const QVariantList& targetEntries) -> Q
                                      {"message", QString::fromStdString(failure.message_)}});
     }
 
-    QVariantMap response = SuccessResult(Tr("Adjustments pasted."));
+    QVariantMap response =
+        SuccessResult(merge_strategy ? Tr("Adjustments merged.") : Tr("Adjustments pasted."));
     response.insert("appliedCount", static_cast<int>(result.applied_ids_.size()));
     response.insert("unchangedCount", static_cast<int>(result.unchanged_ids_.size()));
     response.insert("failureCount", static_cast<int>(result.failures_.size()));

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/adjustment_transfer_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/adjustment_transfer_controller.cpp
@@ -13,6 +13,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "edit/operators/utils/color_utils.hpp"
 #include "edit/pipeline/pipeline_cpu.hpp"
 #include "ui/alcedo_main/album_backend/album_backend.hpp"
 #include "ui/alcedo_main/album_backend/path_utils.hpp"
@@ -126,6 +127,10 @@ auto OperatorEnabledFor(CPUPipelineExecutor& pipeline, const AdjustmentItemSpec&
 }
 
 auto BoolText(bool value) -> QString { return value ? Tr("On") : Tr("Off"); }
+
+auto IsHdrExportEotf(const ColorUtils::EOTF eotf) -> bool {
+  return eotf == ColorUtils::EOTF::ST2084 || eotf == ColorUtils::EOTF::HLG;
+}
 
 auto JsonNumberText(const nlohmann::json& params, const char* key, int precision = 2) -> QString {
   if (!params.contains(key) || !params[key].is_number()) {
@@ -463,9 +468,23 @@ auto AdjustmentTransferController::Paste(const QVariantList& targetEntries, cons
         (merge_strategy ? Tr("Merged Adjustments") : Tr("Pasted Adjustments")).toStdString(),
         merge_strategy ? AdjustmentVersionApplyMode::kMerge : AdjustmentVersionApplyMode::kPaste);
     auto thumbnail_service = backend_.project_handler_.thumbnail_service();
+    bool hdr_metadata_dirty = false;
     for (sl_element_id_t element_id : result.applied_ids_) {
       const auto*      item     = backend_.FindAlbumItem(element_id);
       const image_id_t image_id = item != nullptr ? item->image_id : 0;
+      if (image_id != 0) {
+        try {
+          auto guard = pipeline_service->LoadPipeline(element_id);
+          if (guard && guard->pipeline_) {
+            const bool is_hdr = IsHdrExportEotf(
+                guard->pipeline_->GetGlobalParams().to_output_params_.eotf_);
+            pipeline_service->SavePipeline(guard);
+            backend_.PersistImageHdrFlag(element_id, image_id, is_hdr);
+            hdr_metadata_dirty = true;
+          }
+        } catch (...) {
+        }
+      }
       if (thumbnail_service) {
         try {
           thumbnail_service->InvalidateThumbnail(element_id);
@@ -475,6 +494,15 @@ auto AdjustmentTransferController::Paste(const QVariantList& targetEntries, cons
       if (image_id != 0) {
         if (!backend_.thumb_.RefreshCurrentThumbnail(element_id, image_id)) {
           backend_.thumb_.UpdateThumbnailState(element_id, QString(), false, false);
+        }
+      }
+    }
+    if (hdr_metadata_dirty) {
+      if (auto project = backend_.project_handler_.project()) {
+        try {
+          project->GetImagePoolService()->SyncWithStorage();
+          project->SaveProject(backend_.project_handler_.meta_path());
+        } catch (...) {
         }
       }
     }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/album_backend.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/album_backend.cpp
@@ -28,7 +28,6 @@
 
 #include "app/album_browse_service.hpp"
 #include "app/project_package_service.hpp"
-#include "edit/operators/utils/color_utils.hpp"
 #include "image/image.hpp"
 #ifdef HAVE_OPENCL
 #include "opencl/opencl_runtime.hpp"
@@ -188,10 +187,6 @@ auto FindOptionIndex(const QVariantList& options, const QString& backendKey) -> 
     }
   }
   return -1;
-}
-
-auto IsHdrExportEotf(const ColorUtils::EOTF eotf) -> bool {
-  return eotf == ColorUtils::EOTF::ST2084 || eotf == ColorUtils::EOTF::HLG;
 }
 
 auto NormalizeRecentProjectPath(const std::filesystem::path& projectPath) -> QString {
@@ -621,45 +616,33 @@ void AlbumBackend::StartExportWithOptionsForTargets(
       bitDepth, pngCompressionLevel, tiffCompression, targetEntries);
 }
 
+void AlbumBackend::StartExportWithSplitOptionsForTargets(
+    const QString& outputDirUrlOrPath, bool sdrResizeEnabled, int sdrMaxLengthSide,
+    int ultraHdrMaxLengthSide,
+    const QString& sdrFormatName, int sdrQuality, int sdrBitDepth, int sdrPngCompressionLevel,
+    const QString& sdrTiffCompression, int ultraHdrQuality, bool ultraHdrDitherEnabled,
+    const QVariantList& targetEntries) {
+  import_export_.StartExportWithSplitOptionsForTargets(
+      outputDirUrlOrPath, sdrResizeEnabled, sdrMaxLengthSide, ultraHdrMaxLengthSide, sdrFormatName,
+      sdrQuality, sdrBitDepth, sdrPngCompressionLevel, sdrTiffCompression, ultraHdrQuality,
+      ultraHdrDitherEnabled, targetEntries);
+}
+
 void AlbumBackend::ResetExportState() { import_export_.ResetExportState(); }
 bool AlbumBackend::CanUseHdrExportForTargets(const QVariantList& targetEntries) const {
-  if (project_handler_.project_loading()) {
-    return false;
-  }
-
-  const auto& psvc = project_handler_.pipeline_service();
-  auto        proj = project_handler_.project();
-  if (!psvc || !proj) {
-    return false;
-  }
-
   const auto targets = import_export_.CollectExportTargets(targetEntries);
   if (targets.empty()) {
     return false;
   }
 
   for (const auto& [elementId, imageId] : targets) {
-    (void)imageId;
-
-    bool hdr_eotf = false;
-    try {
-      auto pipeline_guard = psvc->LoadPipeline(elementId);
-      if (!pipeline_guard || !pipeline_guard->pipeline_) {
-        return false;
-      }
-      hdr_eotf =
-          IsHdrExportEotf(pipeline_guard->pipeline_->GetGlobalParams().to_output_params_.eotf_);
-      psvc->SavePipeline(pipeline_guard);
-    } catch (...) {
-      return false;
-    }
-
-    if (!hdr_eotf) {
-      return false;
+    if (const auto* item = FindAlbumItem(elementId);
+        item != nullptr && (imageId == 0 || item->image_id == imageId) && item->is_hdr) {
+      return true;
     }
   }
 
-  return true;
+  return false;
 }
 void AlbumBackend::BrowseNikonHeConverter() { nikon_he_recovery_.BrowseConverter(); }
 void AlbumBackend::StartNikonHeConversion() { nikon_he_recovery_.StartConversion(); }
@@ -1260,6 +1243,7 @@ void AlbumBackend::AddOrUpdateAlbumItem(sl_element_id_t elementId, image_id_t im
         item->aperture          = static_cast<double>(exif.aperture_);
         item->focal_length      = static_cast<double>(exif.focal_);
         item->rating            = exif.rating_;
+        item->is_hdr            = exif.is_hdr_;
         const QDate captureDate = DateFromExifString(exif.date_time_str_);
         if (captureDate.isValid()) {
           item->capture_date = captureDate;
@@ -1274,6 +1258,32 @@ void AlbumBackend::AddOrUpdateAlbumItem(sl_element_id_t elementId, image_id_t im
   }
   if (item->extension.isEmpty()) {
     item->extension = ExtensionFromFileName(item->file_name);
+  }
+}
+
+void AlbumBackend::SetAlbumItemHdrFlag(sl_element_id_t elementId, image_id_t imageId, bool isHdr) {
+  if (auto* item = FindAlbumItem(elementId);
+      item != nullptr && (imageId == 0 || item->image_id == imageId)) {
+    item->is_hdr = isHdr;
+  }
+  thumbnail_model_.updateHdrFlag(elementId, imageId, isHdr);
+}
+
+void AlbumBackend::PersistImageHdrFlag(sl_element_id_t elementId, image_id_t imageId, bool isHdr) {
+  auto proj = project_handler_.project();
+  if (!proj || imageId == 0) {
+    return;
+  }
+
+  try {
+    proj->GetImagePoolService()->Write_NoSync<void>(
+        imageId, [isHdr](const std::shared_ptr<Image>& image) {
+          if (image) {
+            image->SetHdrDisplayMetadata(isHdr);
+          }
+        });
+    SetAlbumItemHdrFlag(elementId, imageId, isHdr);
+  } catch (...) {
   }
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/album_thumbnail_model.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/album_thumbnail_model.cpp
@@ -67,6 +67,8 @@ QVariant AlbumThumbnailModel::roleValue(const AlbumItem& item, int role) const {
                                         : QStringLiteral("--");
     case Rating:
       return item.rating;
+    case IsHdr:
+      return item.is_hdr;
     case Tags:
       return item.tags;
     case Accent:
@@ -100,6 +102,7 @@ QHash<int, QByteArray> AlbumThumbnailModel::roleNames() const {
       {CaptureDate, "captureDate"},
       {ImportDate, "importDate"},
       {Rating, "rating"},
+      {IsHdr, "isHdr"},
       {Tags, "tags"},
       {Accent, "accent"},
       {ThumbUrl, "thumbUrl"},
@@ -207,6 +210,21 @@ bool AlbumThumbnailModel::updateRating(sl_element_id_t elementId, image_id_t ima
   return updated;
 }
 
+bool AlbumThumbnailModel::updateHdrFlag(sl_element_id_t elementId, image_id_t imageId,
+                                        bool isHdr) {
+  const int row = rowByElementId(elementId);
+  if (row < 0) return false;
+
+  auto& item = rows_[static_cast<size_t>(row)];
+  if (imageId != 0 && item.image_id != imageId) return false;
+  if (item.is_hdr == isHdr) return false;
+
+  item.is_hdr = isHdr;
+  const QModelIndex idx = index(row);
+  emit dataChanged(idx, idx, {IsHdr});
+  return true;
+}
+
 QVariantMap AlbumThumbnailModel::getItemAt(int idx) const {
   if (idx < 0 || idx >= static_cast<int>(rows_.size())) return {};
   const auto& item = rows_[static_cast<size_t>(idx)];
@@ -215,6 +233,7 @@ QVariantMap AlbumThumbnailModel::getItemAt(int idx) const {
       {"imageId", static_cast<uint>(item.image_id)},
       {"fileName", item.file_name.isEmpty() ? QStringLiteral("(unnamed)") : item.file_name},
       {"rating", item.rating},
+      {"isHdr", item.is_hdr},
   };
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/album_thumbnail_model.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/album_thumbnail_model.cpp
@@ -172,6 +172,41 @@ void AlbumThumbnailModel::updateThumbnailState(sl_element_id_t elementId, const 
   emit thumbnailUpdated(static_cast<uint>(elementId), dataUrl, loading, missingSource, errorText);
 }
 
+bool AlbumThumbnailModel::updateRating(sl_element_id_t elementId, image_id_t imageId, int rating) {
+  bool updated = false;
+
+  auto update_row = [&](int row) {
+    if (row < 0 || row >= static_cast<int>(rows_.size())) {
+      return;
+    }
+    auto& item = rows_[static_cast<size_t>(row)];
+    if (imageId != 0 && item.image_id != imageId) {
+      return;
+    }
+    if (item.rating == rating) {
+      return;
+    }
+
+    item.rating = rating;
+    const QModelIndex idx = index(row);
+    emit dataChanged(idx, idx, {Rating});
+    updated = true;
+  };
+
+  if (elementId != 0) {
+    update_row(rowByElementId(static_cast<uint>(elementId)));
+    return updated;
+  }
+
+  if (imageId == 0) {
+    return false;
+  }
+  for (int row = 0; row < static_cast<int>(rows_.size()); ++row) {
+    update_row(row);
+  }
+  return updated;
+}
+
 QVariantMap AlbumThumbnailModel::getItemAt(int idx) const {
   if (idx < 0 || idx >= static_cast<int>(rows_.size())) return {};
   const auto& item = rows_[static_cast<size_t>(idx)];

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_controller.cpp
@@ -10,6 +10,7 @@
 #include "app/pipeline_service.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
 #include "io/image/image_loader.hpp"
+#include "edit/operators/utils/color_utils.hpp"
 #include "ui/alcedo_main/editor_dialog/editor_dialog.hpp"
 
 #include <QApplication>
@@ -40,6 +41,10 @@ auto Utf8OrNativeToPath(const std::string& raw_path) -> std::filesystem::path {
   } catch (...) {
     return std::filesystem::path(raw_path);
   }
+}
+
+auto IsHdrExportEotf(const ColorUtils::EOTF eotf) -> bool {
+  return eotf == ColorUtils::EOTF::ST2084 || eotf == ColorUtils::EOTF::HLG;
 }
 
 }  // namespace
@@ -110,6 +115,9 @@ void EditorController::OpenEditor(sl_element_id_t elementId, image_id_t imageId)
       psvc->Sync();
       hsvc->SaveHistory(history_guard);
       hsvc->Sync();
+      backend_.PersistImageHdrFlag(
+          elementId, imageId,
+          IsHdrExportEotf(pipeline_guard->pipeline_->GetGlobalParams().to_output_params_.eotf_));
       proj->GetImagePoolService()->SyncWithStorage();
       proj->SaveProject(backend_.project_handler_.meta_path());
 
@@ -539,11 +547,16 @@ void EditorController::FinalizeEditorSession(bool persistChanges) {
   const auto finishedImage   = editor_image_id_;
 
   const auto& psvc = backend_.project_handler_.pipeline_service();
+  bool        update_hdr_flag = false;
+  bool        is_hdr_export   = false;
   if (psvc) {
     try {
       if (persistChanges) {
         ApplyEditorStateToPipeline();
         editor_pipeline_guard_->dirty_ = true;
+        is_hdr_export = IsHdrExportEotf(
+            editor_pipeline_guard_->pipeline_->GetGlobalParams().to_output_params_.eotf_);
+        update_hdr_flag = true;
       } else {
         editor_pipeline_guard_->dirty_ = false;
       }
@@ -558,6 +571,9 @@ void EditorController::FinalizeEditorSession(bool persistChanges) {
   auto proj = backend_.project_handler_.project();
   if (persistChanges && proj) {
     try {
+      if (update_hdr_flag) {
+        backend_.PersistImageHdrFlag(finishedElement, finishedImage, is_hdr_export);
+      }
       proj->GetImagePoolService()->SyncWithStorage();
       proj->SaveProject(backend_.project_handler_.meta_path());
     } catch (...) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/image_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/image_controller.cpp
@@ -912,19 +912,14 @@ auto ImageController::SetImageRating(uint elementId, uint imageId, int rating) -
       return result;
     }
 
-    if (target.element_id_ != 0) {
-      if (auto* item = backend_.FindAlbumItem(target.element_id_);
-          item && item->image_id == target.image_id_) {
-        item->rating = rating;
-      }
-    } else {
-      for (auto& item : backend_.view_state_.all_images_) {
-        if (item.image_id == target.image_id_) {
-          item.rating = rating;
-        }
+    for (auto& item : backend_.view_state_.all_images_) {
+      if ((target.element_id_ != 0 && item.element_id == target.element_id_) ||
+          (target.element_id_ == 0 && item.image_id == target.image_id_)) {
+        item.rating = rating;
       }
     }
-    backend_.stats_.RebuildThumbnailView();
+    backend_.thumbnail_model_.updateRating(target.element_id_, target.image_id_, rating);
+    backend_.stats_.RefreshStats();
 
     bool save_ok = true;
     try {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/import_export.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/import_export.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <thread>
+#include <tuple>
 #include <unordered_set>
 #include <utility>
 
@@ -27,14 +28,6 @@ using namespace album_util;
                               __VA_OPT__(, ) __VA_ARGS__)
 
 namespace {
-
-auto EffectiveExportFormat(ImageFormatType format,
-                           ExportFormatOptions::HDR_EXPORT_MODE hdrExportMode) -> ImageFormatType {
-  if (hdrExportMode == ExportFormatOptions::HDR_EXPORT_MODE::ULTRA_HDR) {
-    return ImageFormatType::JPEG;
-  }
-  return format;
-}
 
 auto SanitizeBitDepth(ImageFormatType format,
                       ExportFormatOptions::BIT_DEPTH requested) -> ExportFormatOptions::BIT_DEPTH {
@@ -222,8 +215,8 @@ void ImportExportHandler::CancelImport() {
 }
 
 void ImportExportHandler::StartExport(const QString& outputDirUrlOrPath) {
-  StartExportWithOptionsForTargets(outputDirUrlOrPath, "JPEG", "ULTRA_HDR", false, 4096, 95, 16,
-                                   5, "NONE", {});
+  StartExportWithSplitOptionsForTargets(outputDirUrlOrPath, false, 0, 8192, "JPEG", 95, 16, 5,
+                                        "NONE", 95, true, {});
 }
 
 void ImportExportHandler::StartExportWithOptions(const QString& outputDirUrlOrPath,
@@ -243,6 +236,17 @@ void ImportExportHandler::StartExportWithOptionsForTargets(
     bool resizeEnabled, int maxLengthSide, int quality, int bitDepth,
     int pngCompressionLevel, const QString& tiffCompression,
     const QVariantList& targetEntries) {
+  (void)hdrExportMode;
+  StartExportWithSplitOptionsForTargets(outputDirUrlOrPath, resizeEnabled, maxLengthSide, 8192,
+                                        formatName, quality, bitDepth, pngCompressionLevel,
+                                        tiffCompression, quality, true, targetEntries);
+}
+
+void ImportExportHandler::StartExportWithSplitOptionsForTargets(
+    const QString& outputDirUrlOrPath, bool sdrResizeEnabled, int sdrMaxLengthSide,
+    int ultraHdrMaxLengthSide, const QString& sdrFormatName, int sdrQuality, int sdrBitDepth,
+    int sdrPngCompressionLevel, const QString& sdrTiffCompression, int ultraHdrQuality,
+    bool ultraHdrDitherEnabled, const QVariantList& targetEntries) {
   if (backend_.project_handler_.project_loading()) {
     SetExportFailureState(PL_TEXT("Project is loading. Please wait."));
     return;
@@ -282,19 +286,24 @@ void ImportExportHandler::StartExportWithOptionsForTargets(
     return;
   }
 
-  const ImageFormatType requested_format = FormatFromName(formatName);
-  const auto            hdr_mode         = HdrExportModeFromName(hdrExportMode);
-  const int             clamped_max   = std::clamp(maxLengthSide, 256, 16384);
-  const int             clamped_q     = std::clamp(quality, 1, 100);
-  const ImageFormatType effective_format = EffectiveExportFormat(requested_format, hdr_mode);
-  const auto            bit_depth        = SanitizeBitDepth(effective_format, BitDepthFromInt(bitDepth));
-  const int             clamped_png   = std::clamp(pngCompressionLevel, 0, 9);
-  const auto            tiff_compress = TiffCompressFromName(tiffCompression);
+  const ImageFormatType sdr_format = FormatFromName(sdrFormatName);
+  const int             clamped_sdr_max =
+      sdrResizeEnabled ? std::clamp(sdrMaxLengthSide, 256, 16384) : 0;
+  const int             clamped_ultra_hdr_max =
+      std::clamp(ultraHdrMaxLengthSide > 0 ? ultraHdrMaxLengthSide : 8192, 256, 8192);
+  const int             clamped_sdr_quality = std::clamp(sdrQuality, 1, 100);
+  const int             clamped_ultra_hdr_quality = std::clamp(ultraHdrQuality, 1, 100);
+  const auto            sdr_bit_depth =
+      SanitizeBitDepth(sdr_format, BitDepthFromInt(sdrBitDepth));
+  const int             clamped_png = std::clamp(sdrPngCompressionLevel, 0, 9);
+  const auto            tiff_compress = TiffCompressFromName(sdrTiffCompression);
 
   esvc->ClearAllExportTasks();
-  const auto queue_result =
-      BuildExportQueue(targets, outDirOpt.value(), effective_format, hdr_mode, resizeEnabled, clamped_max,
-                       clamped_q, bit_depth, clamped_png, tiff_compress);
+  const auto queue_result = BuildExportQueue(
+      targets, outDirOpt.value(), sdrResizeEnabled, clamped_sdr_max, clamped_ultra_hdr_max,
+      sdr_format, clamped_sdr_quality, sdr_bit_depth, clamped_png, tiff_compress,
+      clamped_ultra_hdr_quality,
+      ultraHdrDitherEnabled);
 
   if (queue_result.queued_count_ == 0) {
     export_status_text_ = PL_TEXT("No export tasks were queued.");
@@ -480,15 +489,11 @@ void ImportExportHandler::FinishExport(
 
   int         ok   = 0;
   int         fail = 0;
-  int         ultra_hdr_fallbacks = 0;
   QStringList errors;
   if (results) {
     for (const auto& r : *results) {
       if (r.success_) {
         ++ok;
-        if (r.used_embedded_profile_fallback_) {
-          ++ultra_hdr_fallbacks;
-        }
       } else {
         ++fail;
         if (!r.message_.empty() && errors.size() < 8) {
@@ -515,16 +520,6 @@ void ImportExportHandler::FinishExport(
     export_status_text_ = PL_TEXT(
         "Export complete. Written %1/%2 image(s), failed %3. Skipped %4 invalid item(s).", ok,
         total, fail, skippedCount);
-  }
-  if (ultra_hdr_fallbacks > 0) {
-    export_status_text_ = PL_TEXT(
-        "Export complete. Written %1/%2 image(s), failed %3. %4 item(s) used embedded ICC fallback instead of Ultra HDR.",
-        ok, total, fail, ultra_hdr_fallbacks);
-    if (skippedCount > 0) {
-      export_status_text_ = PL_TEXT(
-          "Export complete. Written %1/%2 image(s), failed %3. Skipped %4 invalid item(s). %5 item(s) used embedded ICC fallback instead of Ultra HDR.",
-          ok, total, fail, skippedCount, ultra_hdr_fallbacks);
-    }
   }
   emit backend_.ExportStateChanged();
   emit backend_.exportStateChanged();
@@ -573,10 +568,11 @@ auto ImportExportHandler::CollectExportTargets(const QVariantList& targetEntries
 
 auto ImportExportHandler::BuildExportQueue(
     const std::vector<ExportTarget>& targets, const std::filesystem::path& outputDir,
-    ImageFormatType format, ExportFormatOptions::HDR_EXPORT_MODE hdrExportMode,
-    bool resizeEnabled, int maxLengthSide, int quality, ExportFormatOptions::BIT_DEPTH bitDepth,
-    int pngCompressionLevel,
-    ExportFormatOptions::TIFF_COMPRESS tiffCompression) -> ExportQueueBuildResult {
+    bool sdrResizeEnabled, int sdrMaxLengthSide, int ultraHdrMaxLengthSide,
+    ImageFormatType sdrFormat, int sdrQuality,
+    ExportFormatOptions::BIT_DEPTH sdrBitDepth, int sdrPngCompressionLevel,
+    ExportFormatOptions::TIFF_COMPRESS sdrTiffCompression, int ultraHdrQuality,
+    bool ultraHdrDitherEnabled) -> ExportQueueBuildResult {
   ExportQueueBuildResult summary;
   auto                   proj = backend_.project_handler_.project();
   const auto&            esvc = backend_.project_handler_.export_service();
@@ -591,18 +587,24 @@ auto ImportExportHandler::BuildExportQueue(
   for (const auto& [elementId, imageId] : targets) {
     try {
       const auto source_info =
-          proj->GetImagePoolService()->Read<std::pair<std::filesystem::path, std::wstring>>(
+          proj->GetImagePoolService()->Read<std::tuple<std::filesystem::path, std::wstring, bool>>(
               imageId, [](const std::shared_ptr<Image>& image) {
                 if (!image) {
-                  return std::pair<std::filesystem::path, std::wstring>{};
+                  return std::tuple<std::filesystem::path, std::wstring, bool>{};
                 }
                 std::wstring image_name = image->image_name_;
                 if (image_name.empty() && !image->image_path_.empty()) {
                   image_name = image->image_path_.filename().wstring();
                 }
-                return std::make_pair(image->image_path_, std::move(image_name));
+                bool is_hdr = image->exif_display_.is_hdr_;
+                if (!image->has_exif_display_.load() && image->has_exif_json_.load()) {
+                  ExifDisplayMetaData metadata;
+                  metadata.FromJson(image->exif_json_);
+                  is_hdr = metadata.is_hdr_;
+                }
+                return std::make_tuple(image->image_path_, std::move(image_name), is_hdr);
               });
-      const auto& srcPath = source_info.first;
+      const auto& srcPath = std::get<0>(source_info);
       if (srcPath.empty()) {
         ++summary.skipped_count_;
         if (summary.first_error_.isEmpty()) {
@@ -612,8 +614,8 @@ auto ImportExportHandler::BuildExportQueue(
       }
 
       std::filesystem::path name_source_path;
-      if (!source_info.second.empty()) {
-        name_source_path = std::filesystem::path(source_info.second).filename();
+      if (!std::get<1>(source_info).empty()) {
+        name_source_path = std::filesystem::path(std::get<1>(source_info)).filename();
       }
       if (name_source_path.empty()) {
         name_source_path = srcPath.filename();
@@ -622,7 +624,11 @@ auto ImportExportHandler::BuildExportQueue(
         name_source_path = std::filesystem::path(L"image");
       }
 
-      auto       export_path = ExportPathForOptions(name_source_path, outputDir, elementId, imageId, format);
+      const bool is_hdr_export = std::get<2>(source_info);
+
+      const ImageFormatType task_format = is_hdr_export ? ImageFormatType::JPEG : sdrFormat;
+      auto       export_path =
+          ExportPathForOptions(name_source_path, outputDir, elementId, imageId, task_format);
       const auto path_exists = [](const std::filesystem::path& p) {
         std::error_code ec;
         return std::filesystem::exists(p, ec);
@@ -646,14 +652,18 @@ auto ImportExportHandler::BuildExportQueue(
       ExportTask task;
       task.sleeve_id_                  = elementId;
       task.image_id_                   = imageId;
-      task.options_.format_            = format;
-      task.options_.resize_enabled_    = resizeEnabled;
-      task.options_.max_length_side_   = resizeEnabled ? maxLengthSide : 0;
-      task.options_.quality_           = quality;
-      task.options_.bit_depth_         = bitDepth;
-      task.options_.compression_level_ = pngCompressionLevel;
-      task.options_.tiff_compress_     = tiffCompression;
-      task.options_.hdr_export_mode_   = hdrExportMode;
+      task.options_.format_            = task_format;
+      task.options_.resize_enabled_    = is_hdr_export ? true : sdrResizeEnabled;
+      task.options_.max_length_side_ =
+          is_hdr_export ? ultraHdrMaxLengthSide : (sdrResizeEnabled ? sdrMaxLengthSide : 0);
+      task.options_.quality_           = is_hdr_export ? ultraHdrQuality : sdrQuality;
+      task.options_.bit_depth_         = is_hdr_export ? ExportFormatOptions::BIT_DEPTH::BIT_8
+                                                       : sdrBitDepth;
+      task.options_.compression_level_ = sdrPngCompressionLevel;
+      task.options_.tiff_compress_     = sdrTiffCompression;
+      task.options_.hdr_export_mode_   = ExportFormatOptions::HDR_EXPORT_MODE::ULTRA_HDR;
+      task.options_.ultra_hdr_quality_ = ultraHdrQuality;
+      task.options_.ultra_hdr_dither_enabled_ = ultraHdrDitherEnabled;
       task.options_.export_path_       = std::move(export_path);
 
       esvc->EnqueueExportTask(task);

--- a/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
@@ -739,7 +739,7 @@ auto AppTheme::EditorCheckBoxStyle() -> QString {
 
 auto AppTheme::EditorScrollAreaStyle() -> QString {
   const auto& theme       = AppTheme::Instance();
-  const QString bg_base   = Rgba(WithAlpha(theme.bgBaseColor(), 236));
+  const QString bg_panel  = Hex(theme.bgPanelColor());
   const QString bg_canvas = Rgba(WithAlpha(theme.bgCanvasColor(), 170));
   const QString accent    = Hex(theme.accentColor());
 
@@ -760,7 +760,7 @@ auto AppTheme::EditorScrollAreaStyle() -> QString {
                         "}"
                         "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0px; }"
                         "QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical { background: transparent; }")
-      .arg(bg_base, bg_canvas, accent);
+      .arg(bg_panel, bg_canvas, accent);
 }
 
 auto AppTheme::EditorListWidgetStyle() -> QString {

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_core.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_core.cpp
@@ -709,7 +709,8 @@ void EditorDialog::BuildRawDecodePanel() {
       .request_render =
           [this]() {
             if (render_coordinator_) {
-              render_coordinator_->RequestRender();
+              render_coordinator_->RequestRender(/*use_viewport_region=*/true,
+                                                 /*bump_preview_generation=*/false);
             }
           },
       .load_from_pipeline =

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_core.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_core.cpp
@@ -507,7 +507,12 @@ void EditorDialog::BuildToneControlPanel() {
 
   const auto default_lut_path = look_panel_ ? look_panel_->DefaultLutPath() : std::string{};
 
-  // If the pipeline already has operator params (loaded from PipelineService/storage),
+  // Seed a working version from the latest committed one (if any) before reading panel state.
+  if (history_coordinator_) {
+    history_coordinator_->SeedWorkingVersionFromActive();
+  }
+
+  // If the pipeline already has operator params (loaded from PipelineService/storage or history),
   // initialize UI state from those params rather than overwriting them.
   const bool loaded_state_from_pipeline = LoadStateFromPipelineIfPresent();
   if (!loaded_state_from_pipeline) {
@@ -516,11 +521,6 @@ void EditorDialog::BuildToneControlPanel() {
     UpdateAllCdlWheelDerivedColors(state_);
   }
   committed_state_ = state_;
-
-  // Seed a working version from the latest committed one (if any).
-  if (history_coordinator_) {
-    history_coordinator_->SeedWorkingVersionFromActive();
-  }
   ToneControlPanelWidget::Dependencies deps{
       .session                = adjustment_session_.get(),
       .panel_layout           = controls_layout_,

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_core.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_core.cpp
@@ -609,8 +609,10 @@ void EditorDialog::BuildDisplayTransformPanel() {
         return DefaultAdjustmentState();
       },
       .sync_display_encoding =
-          [this](ColorUtils::ColorSpace encoding_space, ColorUtils::EOTF encoding_eotf) {
-            frame_manager_.SyncViewerDisplayEncoding(encoding_space, encoding_eotf);
+          [this](ColorUtils::ColorSpace encoding_space, ColorUtils::EOTF encoding_eotf,
+                 float peak_luminance) {
+            frame_manager_.SyncViewerDisplayEncoding(encoding_space, encoding_eotf,
+                                                     peak_luminance);
           },
       .load_from_pipeline = [this](const DisplayTransformAdjustmentState& base)
           -> std::optional<DisplayTransformAdjustmentState> {

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_pipeline.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_pipeline.cpp
@@ -28,7 +28,8 @@ void EditorDialog::SetupPipeline() {
   auto exec                     = pipeline_guard_->pipeline_;
   controllers::EnsureLoadingOperatorDefaults(exec);
   frame_manager_.AttachExecutionStages(exec);
-  frame_manager_.SyncViewerDisplayEncoding(state_.odt_.encoding_space_, state_.odt_.encoding_eotf_);
+  frame_manager_.SyncViewerDisplayEncoding(state_.odt_.encoding_space_, state_.odt_.encoding_eotf_,
+                                           state_.odt_.peak_luminance_);
 
   // Inject pre-extracted raw metadata from the Image so downstream operators
   // (ColorTemp, LensCalib) resolve eagerly.

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_ui_state.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/dialog_ui_state.cpp
@@ -136,7 +136,8 @@ void EditorDialog::SyncControlsFromState() {
   }
   if (viewer_) {
     frame_manager_.SyncViewerDisplayEncoding(state_.odt_.encoding_space_,
-                                             state_.odt_.encoding_eotf_);
+                                             state_.odt_.encoding_eotf_,
+                                             state_.odt_.peak_luminance_);
     const bool geometry_active = (active_panel_ == ControlPanelKind::Geometry);
     viewer_->SetCropOverlayVisible(geometry_active);
     viewer_->SetCropToolEnabled(geometry_active);

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/frame/editor_frame_manager.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/frame/editor_frame_manager.cpp
@@ -104,11 +104,12 @@ auto EditorFrameManager::CurrentFrameSink() -> IFrameSink* {
 }
 
 void EditorFrameManager::SyncViewerDisplayEncoding(ColorUtils::ColorSpace encoding_space,
-                                                   ColorUtils::EOTF       encoding_eotf) {
+                                                   ColorUtils::EOTF       encoding_eotf,
+                                                   float                  peak_luminance) {
   if (!viewer_) {
     return;
   }
-  viewer_->SetDisplayEncoding(encoding_space, encoding_eotf);
+  viewer_->SetDisplayEncoding(encoding_space, encoding_eotf, peak_luminance);
 }
 
 void EditorFrameManager::MarkNeedsFullFramePreviewAfterGeometryCommit() {

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/history/editor_history_coordinator.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/history/editor_history_coordinator.cpp
@@ -39,6 +39,17 @@ void EditorHistoryCoordinator::SeedWorkingVersionFromActive() {
       history.SetImportPipelineParams(dependencies_.pipeline_guard->pipeline_->ExportPipelineParams());
       dependencies_.history_guard->dirty_ = true;
     }
+
+    const auto active_params =
+        history.ReconstructPipelineParamsForVersion(history.GetActiveVersionID());
+    if (active_params.has_value() &&
+        dependencies_.pipeline_guard->pipeline_->ExportPipelineParams() != *active_params) {
+      dependencies_.pipeline_guard->pipeline_->ImportPipelineParams(*active_params);
+      dependencies_.pipeline_guard->dirty_ = true;
+      if (callbacks_.after_pipeline_params_imported) {
+        callbacks_.after_pipeline_params_imported();
+      }
+    }
   }
   working_version_ =
       controllers::SeedWorkingVersionFromActive(dependencies_.element_id,

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/session/editor_adjustment_session.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/session/editor_adjustment_session.cpp
@@ -5,6 +5,7 @@
 #include "ui/alcedo_main/editor_dialog/session/editor_adjustment_session.hpp"
 
 #include <exception>
+#include <mutex>
 #include <utility>
 
 #include "edit/history/edit_transaction.hpp"
@@ -44,7 +45,9 @@ auto EditorAdjustmentSession::Commit(const AdjustmentCommit& commit) -> CommitRe
 
   EditTransaction tx{tx_type, op_type, stage_name, before_params, new_params, before_enabled, true};
   try {
+    std::unique_lock<std::mutex> render_guard(exec->GetRenderLock());
     (void)tx.ApplyForward(*exec);
+    dependencies_.working_version->SetHeadPipelineParams(exec->ExportPipelineParams());
   } catch (const std::exception& e) {
     return {.status = CommitStatus::Failed, .error = QString::fromUtf8(e.what())};
   } catch (...) {
@@ -52,7 +55,6 @@ auto EditorAdjustmentSession::Commit(const AdjustmentCommit& commit) -> CommitRe
   }
 
   dependencies_.working_version->AppendEditTransaction(std::move(tx));
-  dependencies_.working_version->SetHeadPipelineParams(exec->ExportPipelineParams());
   dependencies_.pipeline_guard->dirty_ = true;
 
   CopyFieldState(commit.field, *dependencies_.state, *dependencies_.committed_state);

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/display_transform_panel_widget.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/display_transform_panel_widget.cpp
@@ -5,6 +5,7 @@
 #include "ui/alcedo_main/editor_dialog/widgets/display_transform_panel_widget.hpp"
 
 #include <QKeyEvent>
+#include <QLayout>
 #include <QSignalBlocker>
 #include <algorithm>
 #include <cmath>
@@ -192,6 +193,38 @@ class AccordionHeader final : public QFrame {
   std::function<void()> on_activated_{};
 };
 
+auto OpenDrtDetailSpinBoxStyle() -> QString {
+  const auto&  theme  = AppTheme::Instance();
+  const QColor bg     = theme.bgPanelColor();
+  const QColor text   = theme.textColor();
+  const QColor muted  = theme.textMutedColor();
+  const QColor border = theme.glassStrokeColor();
+  const QColor accent = theme.accentColor();
+  return QStringLiteral("QDoubleSpinBox {"
+                        "  background: %1;"
+                        "  color: %2;"
+                        "  border: 1px solid %3;"
+                        "  border-radius: 7px;"
+                        "  padding: 3px 7px;"
+                        "}"
+                        "QDoubleSpinBox:hover {"
+                        "  border-color: %4;"
+                        "}"
+                        "QDoubleSpinBox:focus {"
+                        "  border: 1px solid %5;"
+                        "}"
+                        "QDoubleSpinBox:disabled {"
+                        "  color: %6;"
+                        "}"
+                        "QDoubleSpinBox::up-button, QDoubleSpinBox::down-button {"
+                        "  width: 0px;"
+                        "}")
+      .arg(bg.name(QColor::HexArgb), text.name(QColor::HexRgb), border.name(QColor::HexArgb),
+           QColor(border.red(), border.green(), border.blue(), 196).name(QColor::HexArgb),
+           QColor(accent.red(), accent.green(), accent.blue(), 224).name(QColor::HexArgb),
+           muted.name(QColor::HexRgb));
+}
+
 }  // namespace
 
 void DisplayTransformPanelWidget::Build() {
@@ -281,10 +314,9 @@ void DisplayTransformPanelWidget::Build() {
     auto* spin = new QSpinBox(this);
     spin->setRange(min, max);
     spin->setValue(value);
-    spin->setSuffix(suffix);
     spin->setStyleSheet(AppTheme::EditorSpinBoxStyle());
     AppTheme::MarkFontRole(spin, AppTheme::FontRole::DataBody);
-    spin->setFixedWidth(80);
+    spin->setFixedWidth(58);
     spin->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 
     QObject::connect(slider, &QSlider::valueChanged, this, [this, spin, onChange](int v) {
@@ -341,6 +373,14 @@ void DisplayTransformPanelWidget::Build() {
     value_row_layout->setSpacing(8);
     value_row_layout->addWidget(slider, 1);
     value_row_layout->addWidget(spin, 0);
+    const QString unit_text = suffix.trimmed().toUpper();
+    if (!unit_text.isEmpty()) {
+      auto* unit_label = new QLabel(unit_text, value_row);
+      unit_label->setStyleSheet(AppTheme::EditorLabelStyle(AppTheme::Instance().textMutedColor()));
+      AppTheme::MarkFontRole(unit_label, AppTheme::FontRole::DataCaption);
+      unit_label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+      value_row_layout->addWidget(unit_label, 0);
+    }
     rowLayout->addWidget(value_row, 1);
 
     deps_.panel_layout->insertWidget(deps_.panel_layout->count() - 1, row);
@@ -375,7 +415,7 @@ void DisplayTransformPanelWidget::Build() {
     spin->setSingleStep(static_cast<double>(step));
     spin->setValue(value);
     spin->setSuffix(suffix);
-    spin->setStyleSheet(AppTheme::EditorSpinBoxStyle());
+    spin->setStyleSheet(OpenDrtDetailSpinBoxStyle());
     AppTheme::MarkFontRole(spin, AppTheme::FontRole::DataCaption);
     spin->setFixedSize(82, 24);
     spin->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
@@ -507,13 +547,18 @@ void DisplayTransformPanelWidget::Build() {
       " nits");
 
   {
-    auto* frame = new QFrame(this);
-    frame->setObjectName("EditorSection");
+    auto* frame = new QWidget(this);
+    frame->setObjectName("EditorMethodSection");
+    frame->setAttribute(Qt::WA_StyledBackground, true);
+    frame->setStyleSheet(QStringLiteral("QWidget#EditorMethodSection {"
+                                        "  background: transparent;"
+                                        "  border: none;"
+                                        "}"));
     auto* layout = new QVBoxLayout(frame);
-    layout->setContentsMargins(12, 12, 12, 12);
-    layout->setSpacing(10);
+    layout->setContentsMargins(0, 8, 0, 2);
+    layout->setSpacing(8);
 
-    auto* title = NewLocalizedLabel("Rendering Method", frame);
+    auto* title = NewLocalizedLabel("Rendering Method", frame, true);
     title->setObjectName("EditorSectionTitle");
     auto* sub = NewLocalizedLabel(
         "Choose the transform family. Shared encoding settings stay above; method-specific "
@@ -523,6 +568,16 @@ void DisplayTransformPanelWidget::Build() {
     sub->setWordWrap(true);
     layout->addWidget(title, 0);
     layout->addWidget(sub, 0);
+
+    auto* divider = new QFrame(frame);
+    divider->setFrameShape(QFrame::HLine);
+    divider->setFixedHeight(1);
+    const QColor divider_color = AppTheme::Instance().dividerColor();
+    divider->setStyleSheet(
+        QStringLiteral("QFrame { background: %1; border: none; }")
+            .arg(QColor(divider_color.red(), divider_color.green(), divider_color.blue(), 110)
+                     .name(QColor::HexArgb)));
+    layout->addWidget(divider, 0);
 
     auto* cards_row    = new QWidget(frame);
     auto* cards_layout = new QVBoxLayout(cards_row);
@@ -955,8 +1010,18 @@ void DisplayTransformPanelWidget::RefreshOdtMethodUi() {
   if (odt_method_stack_) {
     odt_method_stack_->setCurrentIndex(aces_active ? 0 : 1);
     if (QWidget* current_page = odt_method_stack_->currentWidget()) {
+      current_page->ensurePolished();
+      if (QLayout* page_layout = current_page->layout()) {
+        page_layout->activate();
+      }
       current_page->adjustSize();
-      const int page_height = std::max(1, current_page->sizeHint().height());
+      int page_height =
+          std::max(current_page->sizeHint().height(), current_page->minimumSizeHint().height());
+      if (QLayout* page_layout = current_page->layout()) {
+        page_height = std::max(page_height, page_layout->sizeHint().height());
+        page_height = std::max(page_height, page_layout->minimumSize().height());
+      }
+      page_height = std::max(1, page_height + 6);
       odt_method_stack_->setMinimumHeight(page_height);
       odt_method_stack_->setMaximumHeight(page_height);
     }

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/display_transform_panel_widget.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/display_transform_panel_widget.cpp
@@ -66,7 +66,8 @@ void DisplayTransformPanelWidget::RequestPipelineRender() {
 void DisplayTransformPanelWidget::SyncViewerDisplayEncoding() {
   if (callbacks_.sync_display_encoding) {
     callbacks_.sync_display_encoding(display_state_.odt_.encoding_space_,
-                                     display_state_.odt_.encoding_eotf_);
+                                     display_state_.odt_.encoding_eotf_,
+                                     display_state_.odt_.peak_luminance_);
   }
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/editor_control_panel_widget.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/editor_control_panel_widget.cpp
@@ -7,6 +7,33 @@
 #include "ui/alcedo_main/editor_dialog/dialog_internal.hpp"
 
 namespace alcedo::ui {
+namespace {
+
+auto EditorPanelStageStyle(const QString& selector) -> QString {
+  return QStringLiteral("%1 { background: %2; border: none; }")
+      .arg(selector, AppTheme::Instance().bgPanelColor().name(QColor::HexArgb));
+}
+
+void ApplyEditorPanelStageBackground(QWidget* widget) {
+  if (!widget) {
+    return;
+  }
+  widget->setObjectName(QStringLiteral("EditorPanelStage"));
+  widget->setAttribute(Qt::WA_StyledBackground, true);
+  widget->setStyleSheet(EditorPanelStageStyle(QStringLiteral("QWidget#EditorPanelStage")));
+}
+
+void ApplyEditorScrollViewportBackground(QScrollArea* scroll_area) {
+  if (!scroll_area || !scroll_area->viewport()) {
+    return;
+  }
+  scroll_area->viewport()->setObjectName(QStringLiteral("EditorPanelViewport"));
+  scroll_area->viewport()->setAttribute(Qt::WA_StyledBackground, true);
+  scroll_area->viewport()->setStyleSheet(
+      EditorPanelStageStyle(QStringLiteral("QWidget#EditorPanelViewport")));
+}
+
+}  // namespace
 
 EditorControlPanelWidget::EditorControlPanelWidget(QWidget* parent) : QWidget(parent) {}
 
@@ -18,8 +45,10 @@ void EditorDialog::BuildLookControlPanel(EditorControlPanelWidget* controls_pane
   look_controls_scroll_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   look_controls_scroll_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   look_controls_scroll_->setStyleSheet(scroll_style);
+  ApplyEditorScrollViewportBackground(look_controls_scroll_);
 
   look_panel_ = new LookControlPanelWidget(look_controls_scroll_);
+  ApplyEditorPanelStageBackground(look_panel_);
   look_controls_scroll_->setWidget(look_panel_);
 }
 
@@ -44,10 +73,12 @@ auto EditorDialog::BuildControlPanelShell(const QString& panel_style) -> EditorC
   tone_controls_scroll_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   tone_controls_scroll_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   tone_controls_scroll_->setStyleSheet(scroll_style);
+  ApplyEditorScrollViewportBackground(tone_controls_scroll_);
 
   tone_panel_    = new ToneControlPanelWidget(tone_controls_scroll_);
   tone_controls_ = tone_panel_;
   controls_      = tone_controls_;
+  ApplyEditorPanelStageBackground(tone_controls_);
   tone_controls_->setMinimumWidth(0);
   tone_controls_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   controls_layout_ = new QVBoxLayout(tone_controls_);
@@ -64,9 +95,11 @@ auto EditorDialog::BuildControlPanelShell(const QString& panel_style) -> EditorC
   drt_controls_scroll_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   drt_controls_scroll_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   drt_controls_scroll_->setStyleSheet(scroll_style);
+  ApplyEditorScrollViewportBackground(drt_controls_scroll_);
 
   drt_panel_    = new DisplayTransformPanelWidget(drt_controls_scroll_);
   drt_controls_ = drt_panel_;
+  ApplyEditorPanelStageBackground(drt_controls_);
   drt_controls_->setMinimumWidth(0);
   drt_controls_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   drt_controls_layout_ = new QVBoxLayout(drt_controls_);
@@ -81,9 +114,11 @@ auto EditorDialog::BuildControlPanelShell(const QString& panel_style) -> EditorC
   geometry_controls_scroll_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   geometry_controls_scroll_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   geometry_controls_scroll_->setStyleSheet(scroll_style);
+  ApplyEditorScrollViewportBackground(geometry_controls_scroll_);
 
   geometry_panel_    = new GeometryPanelWidget(geometry_controls_scroll_);
   geometry_controls_ = geometry_panel_;
+  ApplyEditorPanelStageBackground(geometry_controls_);
   geometry_controls_->setMinimumWidth(0);
   geometry_controls_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   geometry_controls_layout_ = new QVBoxLayout(geometry_controls_);
@@ -98,9 +133,11 @@ auto EditorDialog::BuildControlPanelShell(const QString& panel_style) -> EditorC
   raw_controls_scroll_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   raw_controls_scroll_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   raw_controls_scroll_->setStyleSheet(scroll_style);
+  ApplyEditorScrollViewportBackground(raw_controls_scroll_);
 
   raw_panel_    = new RawDecodePanelWidget(raw_controls_scroll_);
   raw_controls_ = raw_panel_;
+  ApplyEditorPanelStageBackground(raw_controls_);
   raw_controls_->setMinimumWidth(0);
   raw_controls_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   raw_controls_layout_ = new QVBoxLayout(raw_controls_);
@@ -110,6 +147,10 @@ auto EditorDialog::BuildControlPanelShell(const QString& panel_style) -> EditorC
   raw_controls_scroll_->setWidget(raw_controls_);
 
   control_panels_stack_ = new QStackedWidget(controls_panel);
+  control_panels_stack_->setObjectName(QStringLiteral("EditorControlPanelsStack"));
+  control_panels_stack_->setAttribute(Qt::WA_StyledBackground, true);
+  control_panels_stack_->setStyleSheet(
+      EditorPanelStageStyle(QStringLiteral("QStackedWidget#EditorControlPanelsStack")));
   control_panels_stack_->addWidget(tone_controls_scroll_);
   control_panels_stack_->addWidget(look_controls_scroll_);
   control_panels_stack_->addWidget(drt_controls_scroll_);

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/editor_viewer_pane.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/editor_viewer_pane.cpp
@@ -44,6 +44,11 @@ EditorViewerPane::EditorViewerPane(QWidget* parent) : QWidget(parent) {}
 
 void EditorDialog::BuildViewerAndPanelShell() {
     const auto& theme = AppTheme::Instance();
+    setObjectName(QStringLiteral("EditorDialog"));
+    setAttribute(Qt::WA_StyledBackground, true);
+    setStyleSheet(QStringLiteral("QDialog#EditorDialog { background: %1; }")
+                      .arg(theme.bgCanvasColor().name(QColor::HexArgb)));
+
     const QString borderless_panel_style = QStringLiteral(
         "#EditorControlsPanel {"
         "  background: %1;"
@@ -74,10 +79,14 @@ void EditorDialog::BuildViewerAndPanelShell() {
     main_splitter->setObjectName("EditorMainSplitter");
     main_splitter->setChildrenCollapsible(false);
     main_splitter->setHandleWidth(kEditorOuterMargin);
-    main_splitter->setStyleSheet(
+    main_splitter->setStyleSheet(QStringLiteral(
+        "QSplitter#EditorMainSplitter {"
+        "  background: %1;"
+        "  border: none;"
+        "}"
         "QSplitter#EditorMainSplitter::handle {"
-        "  background: transparent;"
-        "}");
+        "  background: %1;"
+        "}").arg(theme.bgCanvasColor().name(QColor::HexArgb)));
     main_splitter_ = main_splitter;
 
     viewer_ = new QtEditViewer(this);

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/geometry_panel_widget.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/geometry_panel_widget.cpp
@@ -292,6 +292,38 @@ auto AddGeometrySection(QWidget* parent, QVBoxLayout& layout, const char* title_
   return v;
 }
 
+auto GeometryRatioSpinStyle() -> QString {
+  const auto&  theme  = AppTheme::Instance();
+  const QColor bg     = theme.bgPanelColor();
+  const QColor text   = theme.textColor();
+  const QColor muted  = theme.textMutedColor();
+  const QColor border = theme.glassStrokeColor();
+  const QColor accent = theme.accentColor();
+  return QStringLiteral("QDoubleSpinBox {"
+                        "  background: %1;"
+                        "  color: %2;"
+                        "  border: 1px solid %3;"
+                        "  border-radius: 8px;"
+                        "  padding: 4px 8px;"
+                        "}"
+                        "QDoubleSpinBox:hover {"
+                        "  border-color: %4;"
+                        "}"
+                        "QDoubleSpinBox:focus {"
+                        "  border: 1px solid %5;"
+                        "}"
+                        "QDoubleSpinBox:disabled {"
+                        "  color: %6;"
+                        "}"
+                        "QDoubleSpinBox::up-button, QDoubleSpinBox::down-button {"
+                        "  width: 0px;"
+                        "}")
+      .arg(bg.name(QColor::HexArgb), text.name(QColor::HexRgb), border.name(QColor::HexArgb),
+           QColor(border.red(), border.green(), border.blue(), 196).name(QColor::HexArgb),
+           QColor(accent.red(), accent.green(), accent.blue(), 224).name(QColor::HexArgb),
+           muted.name(QColor::HexRgb));
+}
+
 }  // namespace
 
 void GeometryPanelWidget::BuildCropAspectSection() {
@@ -428,7 +460,7 @@ void GeometryPanelWidget::BuildCropAspectSection() {
     spin->setValue(value);
     spin->setPrefix(prefix);
     spin->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    spin->setStyleSheet(AppTheme::EditorSpinBoxStyle());
+    spin->setStyleSheet(GeometryRatioSpinStyle());
     spin->setButtonSymbols(QAbstractSpinBox::NoButtons);
     spin->setFixedHeight(kControlHeight);
     spin->setMinimumWidth(0);

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/raw_decode_panel_widget.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/raw_decode_panel_widget.cpp
@@ -131,7 +131,6 @@ void RawDecodePanelWidget::PullCommittedRawStateFromDialog() {
 
 void RawDecodePanelWidget::PreviewRawField(AdjustmentField field) {
   ProjectRawStateToDialog();
-  RequestPipelineRender();
   if (!deps_.session) {
     return;
   }
@@ -146,12 +145,14 @@ void RawDecodePanelWidget::CommitRawField(AdjustmentField field) {
   ProjectRawStateToDialog();
   if (!deps_.session) {
     PullCommittedRawStateFromDialog();
+    RequestPipelineRender();
     return;
   }
 
   if (!RawPipelineAdapter::FieldChanged(field, raw_state_, committed_raw_state_)) {
     deps_.session->Commit(field);
     PullCommittedRawStateFromDialog();
+    RequestPipelineRender();
     return;
   }
 
@@ -161,6 +162,7 @@ void RawDecodePanelWidget::CommitRawField(AdjustmentField field) {
       .new_params = RawPipelineAdapter::ParamsFor(field, raw_state_),
   });
   PullCommittedRawStateFromDialog();
+  RequestPipelineRender();
 }
 
 void RawDecodePanelWidget::Build() {

--- a/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/tone_control_panel_widget.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/editor_dialog/widgets/tone_control_panel_widget.cpp
@@ -31,6 +31,7 @@ namespace {
 constexpr char kLocalizedTextProperty[]      = "puerhlabI18nText";
 constexpr char kLocalizedTextUpperProperty[] = "puerhlabI18nTextUpper";
 constexpr char kLocalizedToolTipProperty[]   = "puerhlabI18nToolTip";
+constexpr int  kWheelSliderSettledMs         = 180;
 
 void           SetLocalizedText(QObject* object, const char* source, bool uppercase = false) {
   if (!object || source == nullptr) {
@@ -195,7 +196,18 @@ void ToneControlPanelWidget::PullCommittedColorTempStateFromDialog() {
 }
 
 bool ToneControlPanelWidget::eventFilter(QObject* obj, QEvent* event) {
-  if (event && event->type() == QEvent::MouseButtonDblClick) {
+  if (!event) {
+    return AdjustmentPanelWidget::eventFilter(obj, event);
+  }
+
+  if (event->type() == QEvent::Wheel) {
+    if (auto* slider = qobject_cast<QSlider*>(obj);
+        slider != nullptr && slider_settled_callbacks_.contains(slider)) {
+      ScheduleWheelSliderSettled(slider);
+    }
+  }
+
+  if (event->type() == QEvent::MouseButtonDblClick) {
     if (auto* slider = qobject_cast<QSlider*>(obj)) {
       const auto it = slider_reset_callbacks_.find(slider);
       if (it != slider_reset_callbacks_.end()) {
@@ -221,6 +233,43 @@ void ToneControlPanelWidget::RegisterSliderReset(QSlider* slider, std::function<
   }
   slider->installEventFilter(this);
   slider_reset_callbacks_[slider] = std::move(on_reset);
+}
+
+void ToneControlPanelWidget::RegisterSliderSettled(QSlider* slider,
+                                                   std::function<void()> on_settled) {
+  if (!slider || !on_settled) {
+    return;
+  }
+  slider->installEventFilter(this);
+  slider_settled_callbacks_[slider] = std::move(on_settled);
+}
+
+void ToneControlPanelWidget::ScheduleWheelSliderSettled(QSlider* slider) {
+  if (!slider || IsSyncing()) {
+    return;
+  }
+  pending_wheel_slider_ = slider;
+  EnsureWheelSliderSettledTimer();
+  wheel_slider_settled_timer_->start(kWheelSliderSettledMs);
+}
+
+void ToneControlPanelWidget::EnsureWheelSliderSettledTimer() {
+  if (wheel_slider_settled_timer_) {
+    return;
+  }
+  wheel_slider_settled_timer_ = new QTimer(this);
+  wheel_slider_settled_timer_->setSingleShot(true);
+  QObject::connect(wheel_slider_settled_timer_, &QTimer::timeout, this, [this]() {
+    auto* slider = pending_wheel_slider_;
+    pending_wheel_slider_ = nullptr;
+    if (IsSyncing() || !slider) {
+      return;
+    }
+    const auto it = slider_settled_callbacks_.find(slider);
+    if (it != slider_settled_callbacks_.end() && it->second) {
+      it->second();
+    }
+  });
 }
 
 void ToneControlPanelWidget::RegisterCurveReset(ToneCurveWidget*      widget,
@@ -555,6 +604,13 @@ void ToneControlPanelWidget::BuildToneSection() {
       on_release();
     });
 
+    RegisterSliderSettled(slider, [this, on_release]() {
+      if (IsSyncing()) {
+        return;
+      }
+      on_release();
+    });
+
     RegisterSliderReset(slider, [this, on_reset]() {
       if (IsSyncing()) {
         return;
@@ -831,6 +887,13 @@ void ToneControlPanelWidget::BuildColorSection() {
       on_release();
     });
 
+    RegisterSliderSettled(slider, [this, on_release]() {
+      if (IsSyncing()) {
+        return;
+      }
+      on_release();
+    });
+
     RegisterSliderReset(slider, [this, on_reset]() {
       if (IsSyncing()) {
         return;
@@ -1074,6 +1137,13 @@ void ToneControlPanelWidget::BuildDetailSection() {
                      });
 
     QObject::connect(slider, &QSlider::sliderReleased, parent_widget, [this, on_release]() {
+      if (IsSyncing()) {
+        return;
+      }
+      on_release();
+    });
+
+    RegisterSliderSettled(slider, [this, on_release]() {
       if (IsSyncing()) {
         return;
       }

--- a/alcedo_studio/src/ui/alcedo_main/i18n/alcedo_main_en.ts
+++ b/alcedo_studio/src/ui/alcedo_main/i18n/alcedo_main_en.ts
@@ -2015,6 +2015,94 @@ Original source files on disk will be kept.</source>
     </message>
 </context>
 <context>
+    <name>AdjustmentTransferDialog</name>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="108"/>
+        <source>Copy Adjustments</source>
+        <translation>Copy Adjustments</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="108"/>
+        <source>Paste Adjustments</source>
+        <translation>Paste Adjustments</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="114"/>
+        <source>Choose the adjustments to copy from %1.</source>
+        <translation>Choose the adjustments to copy from %1.</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="115"/>
+        <source>Choose the adjustments to copy.</source>
+        <translation>Choose the adjustments to copy.</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="117"/>
+        <source>Apply these copied adjustments to %1 selected images?</source>
+        <translation>Apply these copied adjustments to %1 selected images?</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="204"/>
+        <source>Strategy</source>
+        <translation>Strategy</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="251"/>
+        <source>Merge</source>
+        <translation>Merge</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="272"/>
+        <source>Paste</source>
+        <translation>Paste</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="297"/>
+        <source>Merge creates a clean merged version from the target's current adjustments plus the copied adjustments, with copied values taking priority. Paste keeps the copied adjustments as new edit steps in a pasted version.</source>
+        <translation>Merge creates a clean merged version from the target's current adjustments plus the copied adjustments, with copied values taking priority. Paste keeps the copied adjustments as new edit steps in a pasted version.</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="406"/>
+        <source>%1 selected</source>
+        <translation>%1 selected</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="407"/>
+        <source>%1 adjustments</source>
+        <translation>%1 adjustments</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="415"/>
+        <source>Select all</source>
+        <translation>Select all</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="423"/>
+        <source>Unselect all</source>
+        <translation>Unselect all</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="429"/>
+        <source>Cancel</source>
+        <translation>Cancel</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="429"/>
+        <source>No</source>
+        <translation>No</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="439"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="439"/>
+        <source>Yes</source>
+        <translation>Yes</translation>
+    </message>
+</context>
+<context>
     <name>alcedo::ui::AppTheme</name>
     <message>
         <location filename="../app_theme.cpp" line="940"/>

--- a/alcedo_studio/src/ui/alcedo_main/i18n/alcedo_main_zh_CN.ts
+++ b/alcedo_studio/src/ui/alcedo_main/i18n/alcedo_main_zh_CN.ts
@@ -3072,6 +3072,94 @@ Original source files on disk will be kept.</source>
     </message>
 </context>
 <context>
+    <name>AdjustmentTransferDialog</name>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="108"/>
+        <source>Copy Adjustments</source>
+        <translation>复制调整</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="108"/>
+        <source>Paste Adjustments</source>
+        <translation>粘贴调整</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="114"/>
+        <source>Choose the adjustments to copy from %1.</source>
+        <translation>选择要从 %1 复制的调整。</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="115"/>
+        <source>Choose the adjustments to copy.</source>
+        <translation>选择要复制的调整。</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="117"/>
+        <source>Apply these copied adjustments to %1 selected images?</source>
+        <translation>将这些复制的调整应用到 %1 张已选图像？</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="204"/>
+        <source>Strategy</source>
+        <translation>策略</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="251"/>
+        <source>Merge</source>
+        <translation>合并</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="272"/>
+        <source>Paste</source>
+        <translation>粘贴</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="297"/>
+        <source>Merge creates a clean merged version from the target's current adjustments plus the copied adjustments, with copied values taking priority. Paste keeps the copied adjustments as new edit steps in a pasted version.</source>
+        <translation>合并会基于目标当前调整和复制来的调整创建一个干净的合并版本，复制来的同名参数优先。粘贴会把复制来的调整作为新的编辑步骤写入一个粘贴版本。</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="406"/>
+        <source>%1 selected</source>
+        <translation>已选择 %1 项</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="407"/>
+        <source>%1 adjustments</source>
+        <translation>%1 项调整</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="415"/>
+        <source>Select all</source>
+        <translation>全选</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="423"/>
+        <source>Unselect all</source>
+        <translation>取消全选</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="429"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="429"/>
+        <source>No</source>
+        <translation>否</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="439"/>
+        <source>OK</source>
+        <translation>确定</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdjustmentTransferDialog.qml" line="439"/>
+        <source>Yes</source>
+        <translation>是</translation>
+    </message>
+</context>
+<context>
     <name>alcedo::ui::AppTheme</name>
     <message>
         <location filename="../app_theme.cpp" line="940"/>

--- a/alcedo_studio/src/ui/alcedo_main/qml/AdjustmentTransferDialog.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/AdjustmentTransferDialog.qml
@@ -18,6 +18,7 @@ Dialog {
     y: parent ? Math.round((parent.height - height) / 2) : 0
 
     property string mode: "copy"
+    property string pasteStrategy: "merge"
     property string sourceTitle: ""
     property int targetCount: 0
     property var adjustmentRows: []
@@ -25,7 +26,7 @@ Dialog {
     property real cornerRadius: 0
 
     signal copyAccepted(var selectedKeys)
-    signal pasteAccepted()
+    signal pasteAccepted(string strategy)
     signal pasteDiscarded()
 
     readonly property bool copyMode: mode === "copy"
@@ -37,6 +38,7 @@ Dialog {
     readonly property color textColor: appTheme.textColor
     readonly property color mutedTextColor: appTheme.textMutedColor
     readonly property color accentColor: appTheme.accentColor
+    readonly property color selectedStrategyTextColor: appTheme.bgBaseColor
     readonly property int selectedCount: {
         let count = 0
         for (let i = 0; i < adjustmentRows.length; ++i) {
@@ -58,6 +60,23 @@ Dialog {
         return keys
     }
 
+    function restoreListScroll(contentY) {
+        Qt.callLater(function() {
+            if (!listView) {
+                return
+            }
+            const minY = listView.originY
+            const maxY = Math.max(minY, listView.contentHeight - listView.height)
+            listView.contentY = Math.max(minY, Math.min(contentY, maxY))
+        })
+    }
+
+    function setRowsPreservingScroll(rows) {
+        const contentY = listView ? listView.contentY : 0
+        adjustmentRows = rows
+        restoreListScroll(contentY)
+    }
+
     function setRowChecked(index, checked) {
         if (index < 0 || index >= adjustmentRows.length) {
             return
@@ -66,7 +85,23 @@ Dialog {
         const row = Object.assign({}, next[index])
         row.checked = checked
         next[index] = row
-        adjustmentRows = next
+        setRowsPreservingScroll(next)
+    }
+
+    function setAllRowsChecked(checked) {
+        const next = []
+        let changed = false
+        for (let i = 0; i < adjustmentRows.length; ++i) {
+            const row = Object.assign({}, adjustmentRows[i])
+            if (row.checked !== checked) {
+                row.checked = checked
+                changed = true
+            }
+            next.push(row)
+        }
+        if (changed) {
+            setRowsPreservingScroll(next)
+        }
     }
 
     function titleText() {
@@ -152,6 +187,117 @@ Dialog {
                 text: dialog.subtitleText()
                 color: dialog.mutedTextColor
                 font.pixelSize: 12
+                wrapMode: Text.WordWrap
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: !dialog.copyMode
+            spacing: 6
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: qsTr("Strategy")
+                    color: dialog.mutedTextColor
+                    font.pixelSize: 12
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                Rectangle {
+                    id: strategySwitch
+                    Layout.preferredWidth: 230
+                    Layout.preferredHeight: 34
+                    radius: height / 2
+                    color: Qt.rgba(0, 0, 0, 0.18)
+                    border.width: 1
+                    border.color: dialog.borderColor
+                    clip: true
+
+                    HoverHandler {
+                        id: strategyHover
+                    }
+
+                    Rectangle {
+                        width: (strategySwitch.width - 4) / 2
+                        height: strategySwitch.height - 4
+                        x: dialog.pasteStrategy === "merge" ? 2 : strategySwitch.width / 2
+                        y: 2
+                        radius: height / 2
+                        color: dialog.accentColor
+
+                        Behavior on x {
+                            NumberAnimation {
+                                duration: 160
+                                easing.type: Easing.OutCubic
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.margins: 2
+                        spacing: 0
+
+                        Item {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+
+                            Label {
+                                anchors.centerIn: parent
+                                text: qsTr("Merge")
+                                color: dialog.pasteStrategy === "merge"
+                                       ? dialog.selectedStrategyTextColor
+                                       : dialog.textColor
+                                font.pixelSize: 12
+                                font.weight: dialog.pasteStrategy === "merge" ? 700 : 500
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: dialog.pasteStrategy = "merge"
+                            }
+                        }
+
+                        Item {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+
+                            Label {
+                                anchors.centerIn: parent
+                                text: qsTr("Paste")
+                                color: dialog.pasteStrategy === "paste"
+                                       ? dialog.selectedStrategyTextColor
+                                       : dialog.textColor
+                                font.pixelSize: 12
+                                font.weight: dialog.pasteStrategy === "paste" ? 700 : 500
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: dialog.pasteStrategy = "paste"
+                            }
+                        }
+                    }
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+            }
+
+            Label {
+                Layout.fillWidth: true
+                visible: strategyHover.hovered
+                text: qsTr("Merge creates a clean merged version from the target's current adjustments plus the copied adjustments, with copied values taking priority. Paste keeps the copied adjustments as new edit steps in a pasted version.")
+                color: dialog.mutedTextColor
+                font.pixelSize: 11
+                lineHeight: 1.25
                 wrapMode: Text.WordWrap
             }
         }
@@ -265,6 +411,21 @@ Dialog {
             }
 
             Button {
+                visible: dialog.copyMode
+                text: qsTr("Select all")
+                enabled: dialog.adjustmentRows.length > 0
+                         && dialog.selectedCount < dialog.adjustmentRows.length
+                onClicked: dialog.setAllRowsChecked(true)
+            }
+
+            Button {
+                visible: dialog.copyMode
+                text: qsTr("Unselect all")
+                enabled: dialog.selectedCount > 0
+                onClicked: dialog.setAllRowsChecked(false)
+            }
+
+            Button {
                 text: dialog.copyMode ? qsTr("Cancel") : qsTr("No")
                 onClicked: {
                     if (!dialog.copyMode) {
@@ -281,7 +442,7 @@ Dialog {
                     if (dialog.copyMode) {
                         dialog.copyAccepted(dialog.selectedKeys())
                     } else {
-                        dialog.pasteAccepted()
+                        dialog.pasteAccepted(dialog.pasteStrategy)
                     }
                     dialog.close()
                 }

--- a/alcedo_studio/src/ui/alcedo_main/qml/AlbumExportDialog.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/AlbumExportDialog.qml
@@ -66,20 +66,18 @@ Dialog {
     signal ensurePreviewRequested()
     signal startExportRequested(
         string outDir,
-        string format,
-        string hdrExportMode,
-        bool resizeEnabled,
-        int maxSide,
-        int quality,
-        int bitDepth,
-        int pngLevel,
-        string tiffCompression)
+        bool sdrResizeEnabled,
+        int sdrMaxSide,
+        int ultraHdrMaxSide,
+        string sdrFormat,
+        int sdrQuality,
+        int sdrBitDepth,
+        int sdrPngLevel,
+        string sdrTiffCompression,
+        int ultraHdrQuality,
+        bool ultraHdrDitherEnabled)
 
-    readonly property bool ultraHdrSelected: hdrExportAvailable
-                                             && hdrExportMode.currentValue === "ULTRA_HDR"
-    readonly property string effectiveExportFormat: root.ultraHdrSelected
-                                                    ? "JPEG"
-                                                    : exportFormat.currentValue
+    readonly property string sdrExportFormat: exportFormat.currentValue
     readonly property string effectiveOutDir: {
         if (!subfolderCheck.checked || subfolderName.text.trim().length === 0)
             return exportOutDir.text
@@ -172,12 +170,12 @@ Dialog {
     }
 
     function ensureValidBitDepthSelection() {
-        const options = root.bitDepthOptionsFor(root.effectiveExportFormat)
+        const options = root.bitDepthOptionsFor(root.sdrExportFormat)
         const current = Number(exportBitDepth.currentValue)
         for (let i = 0; i < options.length; ++i) {
             if (Number(options[i].value) === current) return
         }
-        const preferred = root.preferredBitDepthFor(root.effectiveExportFormat)
+        const preferred = root.preferredBitDepthFor(root.sdrExportFormat)
         for (let i = 0; i < options.length; ++i) {
             if (Number(options[i].value) === preferred) {
                 exportBitDepth.currentIndex = i
@@ -187,11 +185,32 @@ Dialog {
         exportBitDepth.currentIndex = 0
     }
 
+    function normalizeUltraHdrMaxSide() {
+        const raw = ultraHdrMaxSideField.text.trim()
+        if (raw.length === 0) {
+            ultraHdrMaxSideField.text = "8192"
+            return
+        }
+        const v = parseInt(raw)
+        if (isNaN(v)) {
+            ultraHdrMaxSideField.text = "8192"
+        } else if (v > 8192) {
+            ultraHdrMaxSideField.text = "8192"
+        } else if (v < 256) {
+            ultraHdrMaxSideField.text = "256"
+        }
+    }
+
+    function clearSizeLimitFocus() {
+        if (sdrMaxSideField.activeFocus || ultraHdrMaxSideField.activeFocus) {
+            root.forceActiveFocus()
+        }
+    }
+
     onOpened: {
         if (exportOutDir.text.length === 0)
             exportOutDir.text = albumBackend.defaultExportFolder
-        if (!hdrExportAvailable)
-            hdrExportMode.currentIndex = 1
+        normalizeUltraHdrMaxSide()
         ensureValidBitDepthSelection()
         ensurePreviewRequested()
         albumBackend.ResetExportState()
@@ -199,22 +218,11 @@ Dialog {
     }
     onClosed: exportTriggered = false
     onHdrExportAvailableChanged: {
-        if (!hdrExportAvailable)
-            hdrExportMode.currentIndex = 1
         ensureValidBitDepthSelection()
+        if (hdrExportAvailable)
+            normalizeUltraHdrMaxSide()
     }
-    onEffectiveExportFormatChanged: ensureValidBitDepthSelection()
-    onUltraHdrSelectedChanged: {
-        if (ultraHdrSelected) {
-            if (exportMaxSideField.text.length === 0) {
-                exportMaxSideField.text = "8192"
-            } else {
-                const v = parseInt(exportMaxSideField.text)
-                if (!isNaN(v) && v > 8192)
-                    exportMaxSideField.text = "8192"
-            }
-        }
-    }
+    onSdrExportFormatChanged: ensureValidBitDepthSelection()
 
     FolderDialog {
         id: exportFolderDialog
@@ -305,6 +313,12 @@ Dialog {
                         radius: 8
                         color: root.cardColor
 
+                        MouseArea {
+                            anchors.fill: parent
+                            enabled: !albumBackend.exportInFlight
+                            onClicked: root.clearSizeLimitFocus()
+                        }
+
                         ColumnLayout {
                             id: destCol
                             y: 14; x: 16
@@ -373,27 +387,138 @@ Dialog {
                         }
                     }
 
-                    // ── Cards: File Settings + Quality (side by side) ──
+                    // ── Cards: HDR + SDR Settings ──────────────
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: 10
 
-                        // Card: File Settings
+                        // Card: HDR Export Settings
                         Rectangle {
                             Layout.fillWidth: true
-                            Layout.preferredHeight: Math.max(fileSettingsCol.implicitHeight,
-                                                            qualityCol.implicitHeight) + 28
+                            Layout.preferredHeight: Math.max(hdrSettingsCol.implicitHeight,
+                                                            sdrSettingsCol.implicitHeight) + 28
                             radius: 8
                             color: root.cardColor
 
+                            MouseArea {
+                                anchors.fill: parent
+                                enabled: !albumBackend.exportInFlight
+                                onClicked: root.clearSizeLimitFocus()
+                            }
+
                             ColumnLayout {
-                                id: fileSettingsCol
+                                id: hdrSettingsCol
+                                y: 14; x: 16
+                                width: parent.width - 32
+                                spacing: 10
+
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    Label {
+                                        text: qsTr("HDR Export Settings")
+                                        font.pixelSize: 13
+                                        font.weight: Font.DemiBold
+                                        color: root.textColor
+                                    }
+                                    Item { Layout.fillWidth: true }
+                                    Label {
+                                        text: qsTr("Ultra HDR")
+                                        color: root.hdrExportAvailable ? root.accentColor : root.mutedTextColor
+                                        font.family: root.dataFontFamily
+                                        font.pixelSize: 11
+                                    }
+                                }
+
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 8
+                                    enabled: root.hdrExportAvailable && !albumBackend.exportInFlight
+                                    opacity: root.hdrExportAvailable ? 1.0 : 0.45
+
+                                    Label {
+                                        text: qsTr("HDR quality")
+                                        color: root.mutedTextColor
+                                        font.pixelSize: 11
+                                    }
+                                    Item { Layout.fillWidth: true }
+                                    Label {
+                                        text: Math.round(ultraHdrQualitySlider.value) + "%"
+                                        font.family: root.dataFontFamily
+                                        font.pixelSize: 13
+                                        font.weight: Font.DemiBold
+                                        color: root.accentColor
+                                    }
+                                }
+
+                                Slider {
+                                    id: ultraHdrQualitySlider
+                                    Layout.fillWidth: true
+                                    from: 1; to: 100; value: 95; stepSize: 1
+                                    enabled: root.hdrExportAvailable && !albumBackend.exportInFlight
+                                    opacity: root.hdrExportAvailable ? 1.0 : 0.45
+                                }
+
+                                ColumnLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 5
+                                    enabled: root.hdrExportAvailable && !albumBackend.exportInFlight
+                                    opacity: root.hdrExportAvailable ? 1.0 : 0.45
+                                    Label {
+                                        text: qsTr("Encoding longest edge (px)")
+                                        color: root.mutedTextColor
+                                        font.pixelSize: 11
+                                    }
+                                    TextField {
+                                        id: ultraHdrMaxSideField
+                                        Layout.fillWidth: true
+                                        text: "8192"
+                                        placeholderText: "8192"
+                                        validator: IntValidator {
+                                            bottom: 256
+                                            top: 8192
+                                        }
+                                        inputMethodHints: Qt.ImhDigitsOnly
+                                        font.family: root.dataFontFamily
+                                        font.pixelSize: 12
+                                        enabled: root.hdrExportAvailable && !albumBackend.exportInFlight
+                                        onEditingFinished: root.normalizeUltraHdrMaxSide()
+                                    }
+                                }
+
+                                CheckBox {
+                                    id: ultraHdrDitherCheck
+                                    Layout.fillWidth: true
+                                    text: qsTr("Dithering")
+                                    checked: true
+                                    font.pixelSize: 12
+                                    enabled: root.hdrExportAvailable && !albumBackend.exportInFlight
+                                    opacity: root.hdrExportAvailable ? 1.0 : 0.45
+                                }
+                            }
+                        }
+
+                        // Card: SDR Export Settings
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: Math.max(hdrSettingsCol.implicitHeight,
+                                                            sdrSettingsCol.implicitHeight) + 28
+                            radius: 8
+                            color: root.cardColor
+
+                            MouseArea {
+                                anchors.fill: parent
+                                enabled: !albumBackend.exportInFlight
+                                onClicked: root.clearSizeLimitFocus()
+                            }
+
+                            ColumnLayout {
+                                id: sdrSettingsCol
                                 y: 14; x: 16
                                 width: parent.width - 32
                                 spacing: 10
 
                                 Label {
-                                    text: qsTr("File Settings")
+                                    text: qsTr("SDR Export Settings")
                                     font.pixelSize: 13
                                     font.weight: Font.DemiBold
                                     color: root.textColor
@@ -410,7 +535,7 @@ Dialog {
                                     ComboBox {
                                         id: exportFormat
                                         Layout.fillWidth: true
-                                        enabled: !root.ultraHdrSelected && !albumBackend.exportInFlight
+                                        enabled: !albumBackend.exportInFlight
                                         model: [
                                             { text: "JPEG", value: "JPEG" },
                                             { text: "PNG",  value: "PNG"  },
@@ -427,49 +552,37 @@ Dialog {
                                     Layout.fillWidth: true
                                     spacing: 5
                                     Label {
-                                        text: qsTr("Bit Depth")
+                                        text: qsTr("Limit longest edge (px)")
                                         color: root.mutedTextColor
                                         font.pixelSize: 11
                                     }
-                                    ComboBox {
-                                        id: exportBitDepth
+                                    TextField {
+                                        id: sdrMaxSideField
                                         Layout.fillWidth: true
-                                        enabled: root.bitDepthOptionsFor(root.effectiveExportFormat).length > 1
-                                                 && !albumBackend.exportInFlight
-                                        model: root.bitDepthOptionsFor(root.effectiveExportFormat)
-                                        textRole: "text"
-                                        valueRole: "value"
+                                        placeholderText: qsTr("No limit")
+                                        validator: IntValidator {
+                                            bottom: 256
+                                            top: 16384
+                                        }
+                                        inputMethodHints: Qt.ImhDigitsOnly
+                                        font.family: root.dataFontFamily
+                                        font.pixelSize: 12
+                                        enabled: !albumBackend.exportInFlight
                                     }
                                 }
-                            }
-                        }
-
-                        // Card: Quality & Resize
-                        Rectangle {
-                            Layout.fillWidth: true
-                            Layout.preferredHeight: Math.max(fileSettingsCol.implicitHeight,
-                                                            qualityCol.implicitHeight) + 28
-                            radius: 8
-                            color: root.cardColor
-
-                            ColumnLayout {
-                                id: qualityCol
-                                y: 14; x: 16
-                                width: parent.width - 32
-                                spacing: 10
 
                                 RowLayout {
                                     Layout.fillWidth: true
+                                    visible: root.sdrExportFormat === "JPEG"
+                                             || root.sdrExportFormat === "WEBP"
+                                    spacing: 8
                                     Label {
                                         text: qsTr("Quality")
-                                        font.pixelSize: 13
-                                        font.weight: Font.DemiBold
-                                        color: root.textColor
+                                        color: root.mutedTextColor
+                                        font.pixelSize: 11
                                     }
                                     Item { Layout.fillWidth: true }
                                     Label {
-                                        visible: root.effectiveExportFormat === "JPEG"
-                                                 || root.effectiveExportFormat === "WEBP"
                                         text: Math.round(exportQualitySlider.value) + "%"
                                         font.family: root.dataFontFamily
                                         font.pixelSize: 13
@@ -481,15 +594,34 @@ Dialog {
                                 Slider {
                                     id: exportQualitySlider
                                     Layout.fillWidth: true
-                                    visible: root.effectiveExportFormat === "JPEG"
-                                             || root.effectiveExportFormat === "WEBP"
+                                    visible: root.sdrExportFormat === "JPEG"
+                                             || root.sdrExportFormat === "WEBP"
                                     from: 1; to: 100; value: 90; stepSize: 1
                                     enabled: !albumBackend.exportInFlight
                                 }
 
+                                ColumnLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 5
+                                    Label {
+                                        text: qsTr("Bit Depth")
+                                        color: root.mutedTextColor
+                                        font.pixelSize: 11
+                                    }
+                                    ComboBox {
+                                        id: exportBitDepth
+                                        Layout.fillWidth: true
+                                        enabled: root.bitDepthOptionsFor(root.sdrExportFormat).length > 1
+                                                 && !albumBackend.exportInFlight
+                                        model: root.bitDepthOptionsFor(root.sdrExportFormat)
+                                        textRole: "text"
+                                        valueRole: "value"
+                                    }
+                                }
+
                                 RowLayout {
                                     Layout.fillWidth: true
-                                    visible: root.effectiveExportFormat === "PNG"
+                                    visible: root.sdrExportFormat === "PNG"
                                     spacing: 8
                                     Label {
                                         text: qsTr("PNG level")
@@ -507,7 +639,7 @@ Dialog {
 
                                 RowLayout {
                                     Layout.fillWidth: true
-                                    visible: root.effectiveExportFormat === "TIFF"
+                                    visible: root.sdrExportFormat === "TIFF"
                                     spacing: 8
                                     Label {
                                         text: qsTr("Compression")
@@ -529,107 +661,6 @@ Dialog {
                                         enabled: !albumBackend.exportInFlight
                                     }
                                 }
-
-                                ColumnLayout {
-                                    Layout.fillWidth: true
-                                    spacing: 5
-                                    Label {
-                                        text: qsTr("Limit Longest Edge (px)")
-                                        color: root.mutedTextColor
-                                        font.pixelSize: 11
-                                    }
-                                    TextField {
-                                        id: exportMaxSideField
-                                        Layout.fillWidth: true
-                                        placeholderText: "e.g. 2048"
-                                        validator: IntValidator {
-                                            bottom: 256
-                                            top: root.ultraHdrSelected ? 8192 : 16384
-                                        }
-                                        inputMethodHints: Qt.ImhDigitsOnly
-                                        font.family: root.dataFontFamily
-                                        font.pixelSize: 12
-                                        enabled: !albumBackend.exportInFlight
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // ── Card: Metadata & Output ────────────────
-                    Rectangle {
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: metadataCol.implicitHeight + 28
-                        radius: 8
-                        color: root.cardColor
-
-                        ColumnLayout {
-                            id: metadataCol
-                            y: 14; x: 16
-                            width: parent.width - 32
-                            spacing: 10
-
-                            Label {
-                                text: qsTr("Metadata & Output")
-                                font.pixelSize: 13
-                                font.weight: Font.DemiBold
-                                color: root.textColor
-                            }
-
-                            RowLayout {
-                                id: metadataRow
-                                Layout.fillWidth: true
-                                spacing: 12
-
-                                // HDR Export
-                                ColumnLayout {
-                                    Layout.fillWidth: true
-                                    Layout.preferredWidth: (metadataRow.width - metadataRow.spacing) / 2
-                                    spacing: 4
-
-                                    Label {
-                                        text: qsTr("HDR Export")
-                                        color: root.mutedTextColor
-                                        font.pixelSize: 11
-                                    }
-
-                                    ComboBox {
-                                        id: hdrExportMode
-                                        Layout.fillWidth: true
-                                        enabled: root.hdrExportAvailable && !albumBackend.exportInFlight
-                                        model: [
-                                            { text: qsTr("Ultra HDR"),        value: "ULTRA_HDR"            },
-                                            { text: qsTr("ICC Profile"),      value: "EMBEDDED_PROFILE_ONLY" }
-                                        ]
-                                        textRole: "text"
-                                        valueRole: "value"
-                                        onCurrentValueChanged: {
-                                            if (currentValue === "ULTRA_HDR")
-                                                exportFormat.currentIndex = 0
-                                        }
-                                    }
-                                }
-
-                                // SDR Export
-                                ColumnLayout {
-                                    Layout.fillWidth: true
-                                    Layout.preferredWidth: (metadataRow.width - metadataRow.spacing) / 2
-                                    spacing: 4
-
-                                    Label {
-                                        text: qsTr("SDR Export")
-                                        color: root.mutedTextColor
-                                        font.pixelSize: 11
-                                    }
-
-                                    CheckBox {
-                                        id: embedColorProfileCheck
-                                        text: qsTr("Embed ICC Profile")
-                                        checked: true
-                                        enabled: !root.ultraHdrSelected && !albumBackend.exportInFlight
-                                        font.pixelSize: 12
-                                    }
-                                }
                             }
                         }
                     }
@@ -642,6 +673,12 @@ Dialog {
                 Layout.fillHeight: true
                 radius: 8
                 color: root.cardColor
+
+                MouseArea {
+                    anchors.fill: parent
+                    enabled: !albumBackend.exportInFlight
+                    onClicked: root.clearSizeLimitFocus()
+                }
 
                 ColumnLayout {
                     anchors.fill: parent
@@ -750,14 +787,41 @@ Dialog {
                                 ColumnLayout {
                                     Layout.fillWidth: true
                                     spacing: 2
-                                    Label {
+
+                                    RowLayout {
                                         Layout.fillWidth: true
-                                        text: modelData.label
-                                        elide: Text.ElideRight
-                                        color: root.textColor
-                                        font.family: root.dataFontFamily
-                                        font.pixelSize: 12
+                                        spacing: 6
+
+                                        Label {
+                                            Layout.fillWidth: true
+                                            text: modelData.label
+                                            elide: Text.ElideRight
+                                            color: root.textColor
+                                            font.family: root.dataFontFamily
+                                            font.pixelSize: 12
+                                        }
+
+                                        Rectangle {
+                                            visible: !summaryRow && modelData.isHdr === true
+                                            Layout.preferredWidth: hdrQueueTagText.implicitWidth + 10
+                                            Layout.preferredHeight: 18
+                                            radius: 4
+                                            color: "#3A3020"
+                                            border.width: 1
+                                            border.color: "#D8A93B"
+
+                                            Label {
+                                                id: hdrQueueTagText
+                                                anchors.centerIn: parent
+                                                text: "HDR"
+                                                color: "#F2C766"
+                                                font.family: root.dataFontFamily
+                                                font.pixelSize: 10
+                                                font.weight: Font.DemiBold
+                                            }
+                                        }
                                     }
+
                                     RowLayout {
                                         spacing: 5
                                         Rectangle {
@@ -881,18 +945,22 @@ Dialog {
                 }
                 onClicked: {
                     root.exportTriggered = true
-                    const hasResize = exportMaxSideField.text.trim().length > 0
-                    const maxSide   = hasResize ? parseInt(exportMaxSideField.text) : 0
+                    root.normalizeUltraHdrMaxSide()
+                    const hasSdrResize = sdrMaxSideField.text.trim().length > 0
+                    const sdrMaxSide   = hasSdrResize ? parseInt(sdrMaxSideField.text) : 0
+                    const ultraHdrMaxSide = parseInt(ultraHdrMaxSideField.text)
                     root.startExportRequested(
                         root.effectiveOutDir,
+                        hasSdrResize,
+                        sdrMaxSide,
+                        isNaN(ultraHdrMaxSide) ? 8192 : ultraHdrMaxSide,
                         exportFormat.currentValue,
-                        hdrExportMode.currentValue,
-                        hasResize,
-                        maxSide,
                         Math.round(exportQualitySlider.value),
                         Number(exportBitDepth.currentValue),
                         exportPngLevel.value,
-                        exportTiffComp.currentValue)
+                        exportTiffComp.currentValue,
+                        Math.round(ultraHdrQualitySlider.value),
+                        ultraHdrDitherCheck.checked)
                 }
             }
         }

--- a/alcedo_studio/src/ui/alcedo_main/qml/ExportQueueState.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/ExportQueueState.qml
@@ -26,7 +26,8 @@ QtObject {
             next[keyForElement(item.elementId)] = {
                 elementId: Number(item.elementId),
                 imageId: Number(item.imageId),
-                fileName: item.fileName ? item.fileName : qsTr("(unnamed)")
+                fileName: item.fileName ? item.fileName : qsTr("(unnamed)"),
+                isHdr: item.isHdr === true
             }
         }
         exportQueueById = next
@@ -95,10 +96,21 @@ QtObject {
         for (let i = 0; i < rows.length; ++i) {
             targets.push({
                 elementId: rows[i].elementId,
-                imageId: rows[i].imageId
+                imageId: rows[i].imageId,
+                isHdr: rows[i].isHdr === true
             })
         }
         return targets
+    }
+
+    function hasHdrItems() {
+        const rows = Object.values(exportQueueById)
+        for (let i = 0; i < rows.length; ++i) {
+            if (rows[i].isHdr === true) {
+                return true
+            }
+        }
+        return false
     }
 
     function refreshExportPreview() {
@@ -112,7 +124,8 @@ QtObject {
             next.push({
                 statusKey: exportStatusKey(item.elementId, item.imageId),
                 summaryRow: false,
-                label: item.fileName ? item.fileName : qsTr("(unnamed)")
+                label: item.fileName ? item.fileName : qsTr("(unnamed)"),
+                isHdr: item.isHdr === true
             })
         }
         exportPreviewRows = next

--- a/alcedo_studio/src/ui/alcedo_main/qml/Main.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/Main.qml
@@ -484,6 +484,7 @@ ApplicationWindow {
             return
         }
         adjustmentTransferDialog.mode = "paste"
+        adjustmentTransferDialog.pasteStrategy = "merge"
         adjustmentTransferDialog.sourceTitle =
                 albumBackend.adjustmentTransferController.packageSourceTitle
         adjustmentTransferDialog.targetCount = root.pendingAdjustmentPasteTargets.length
@@ -647,9 +648,10 @@ ApplicationWindow {
                 root.showSnackbar(result.message)
             }
         }
-        onPasteAccepted: {
+        onPasteAccepted: function(strategy) {
             const result = albumBackend.adjustmentTransferController.Paste(
-                root.pendingAdjustmentPasteTargets)
+                root.pendingAdjustmentPasteTargets,
+                strategy)
             if (result && result.message) {
                 root.showSnackbar(result.message)
             }

--- a/alcedo_studio/src/ui/alcedo_main/qml/Main.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/Main.qml
@@ -278,7 +278,8 @@ ApplicationWindow {
             elementId: elementId,
             imageId: Number(row.imageId),
             fileName: row.fileName ? row.fileName : qsTr("(unnamed)"),
-            rating: Number(row.rating)
+            rating: Number(row.rating),
+            isHdr: row.isHdr === true
         }
     }
 
@@ -506,7 +507,7 @@ ApplicationWindow {
             return String(Number(elementId))
         }
 
-        function setImageSelected(elementId, imageId, fileName, selected) {
+        function setImageSelected(elementId, imageId, fileName, isHdr, selected) {
             const key = keyForElement(elementId)
             const already = Object.prototype.hasOwnProperty.call(selectedImagesById, key)
             if (selected === already) {
@@ -518,7 +519,8 @@ ApplicationWindow {
                 next[key] = {
                     elementId: Number(elementId),
                     imageId: Number(imageId),
-                    fileName: fileName ? fileName : qsTr("(unnamed)")
+                    fileName: fileName ? fileName : qsTr("(unnamed)"),
+                    isHdr: isHdr === true
                 }
             } else {
                 delete next[key]
@@ -538,10 +540,39 @@ ApplicationWindow {
                 next[key] = {
                     elementId: Number(item.elementId),
                     imageId: Number(item.imageId),
-                    fileName: item.fileName ? item.fileName : qsTr("(unnamed)")
+                    fileName: item.fileName ? item.fileName : qsTr("(unnamed)"),
+                    isHdr: item.isHdr === true
                 }
             }
             selectedImagesById = next
+        }
+
+        function currentSelectedItems() {
+            const rows = Object.values(selectedImagesById)
+            const items = []
+            for (let i = 0; i < rows.length; ++i) {
+                const item = rows[i]
+                const rowIndex = albumBackend.thumbnailModel.rowByElementId(Number(item.elementId))
+                if (rowIndex >= 0) {
+                    const current = albumBackend.thumbnailModel.getItemAt(rowIndex)
+                    if (current && Number(current.elementId) === Number(item.elementId)) {
+                        items.push({
+                            elementId: Number(current.elementId),
+                            imageId: Number(current.imageId),
+                            fileName: current.fileName ? current.fileName : qsTr("(unnamed)"),
+                            isHdr: current.isHdr === true
+                        })
+                        continue
+                    }
+                }
+                items.push({
+                    elementId: Number(item.elementId),
+                    imageId: Number(item.imageId),
+                    fileName: item.fileName ? item.fileName : qsTr("(unnamed)"),
+                    isHdr: item.isHdr === true
+                })
+            }
+            return items
         }
 
         function pruneDeletedElements(elementIds) {
@@ -590,25 +621,26 @@ ApplicationWindow {
         selectedCount: root.selectedCount
         exportQueueCount: root.exportQueueCount
         exportPreviewRows: root.exportPreviewRows
-        hdrExportAvailable: root.exportQueueCount > 0
-            && albumBackend.CanUseHdrExportForTargets(Object.values(root.exportQueueById))
+        hdrExportAvailable: exportQueueState.hasHdrItems()
         onAddSelectedToQueueRequested: {
-            exportQueueState.addTargets(Object.values(selectionState.selectedImagesById))
+            exportQueueState.addTargets(selectionState.currentSelectedItems())
             selectionState.clearSelectedImages()
         }
         onClearQueueRequested: exportQueueState.clearQueue()
         onEnsurePreviewRequested: exportQueueState.refreshExportPreview()
-        onStartExportRequested: function(outDir, format, hdrExportMode, resizeEnabled, maxSide, quality, bitDepth, pngLevel, tiffComp) {
-            albumBackend.StartExportWithOptionsForTargets(
+        onStartExportRequested: function(outDir, sdrResizeEnabled, sdrMaxSide, ultraHdrMaxSide, sdrFormat, sdrQuality, sdrBitDepth, sdrPngLevel, sdrTiffComp, ultraHdrQuality, ultraHdrDitherEnabled) {
+            albumBackend.StartExportWithSplitOptionsForTargets(
                 outDir,
-                format,
-                hdrExportMode,
-                resizeEnabled,
-                maxSide,
-                quality,
-                bitDepth,
-                pngLevel,
-                tiffComp,
+                sdrResizeEnabled,
+                sdrMaxSide,
+                ultraHdrMaxSide,
+                sdrFormat,
+                sdrQuality,
+                sdrBitDepth,
+                sdrPngLevel,
+                sdrTiffComp,
+                ultraHdrQuality,
+                ultraHdrDitherEnabled,
                 exportQueueState.exportQueueTargets())
         }
     }
@@ -1551,7 +1583,7 @@ ApplicationWindow {
                             scale: addSelectedBtn.hovered && enabled ? 1.03 : 1.0
                             Behavior on scale { NumberAnimation { duration: 100; easing.type: Easing.OutCubic } }
                             onClicked: {
-                                exportQueueState.addTargets(Object.values(selectionState.selectedImagesById))
+                                exportQueueState.addTargets(selectionState.currentSelectedItems())
                                 selectionState.clearSelectedImages()
                             }
                         }
@@ -2148,8 +2180,8 @@ ApplicationWindow {
             onZoomLevelChanged: root.gridZoomLevel = zoomLevel
             selectedImagesById: root.selectedImagesById
             exportQueueById: root.exportQueueById
-            onImageSelectionChanged: function(elementId, imageId, fileName, selected) {
-                selectionState.setImageSelected(elementId, imageId, fileName, selected)
+            onImageSelectionChanged: function(elementId, imageId, fileName, isHdr, selected) {
+                selectionState.setImageSelected(elementId, imageId, fileName, isHdr, selected)
             }
             onReplaceSelection: function(items) {
                 selectionState.replaceSelectedImages(items)
@@ -2165,8 +2197,8 @@ ApplicationWindow {
         ThumbnailListView {
             selectedImagesById: root.selectedImagesById
             exportQueueById: root.exportQueueById
-            onImageSelectionChanged: function(elementId, imageId, fileName, selected) {
-                selectionState.setImageSelected(elementId, imageId, fileName, selected)
+            onImageSelectionChanged: function(elementId, imageId, fileName, isHdr, selected) {
+                selectionState.setImageSelected(elementId, imageId, fileName, isHdr, selected)
             }
             onReplaceSelection: function(items) {
                 selectionState.replaceSelectedImages(items)

--- a/alcedo_studio/src/ui/alcedo_main/qml/ThumbnailGridView.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/ThumbnailGridView.qml
@@ -61,7 +61,8 @@ Item {
     readonly property real delegateReflowTravelDamping: 0.32
     readonly property real delegateReflowMaxTravel: 44
 
-    signal imageSelectionChanged(int elementId, int imageId, string fileName, bool selected)
+    signal imageSelectionChanged(int elementId, int imageId, string fileName, bool isHdr,
+                                 bool selected)
     signal replaceSelection(var items)
     signal contextMenuRequested(var item, real sceneX, real sceneY)
     signal zoomChanged(int zoomLevel)
@@ -580,7 +581,8 @@ Item {
             elementId: elementId,
             imageId: Number(row.imageId),
             fileName: row.fileName ? row.fileName : qsTr("(unnamed)"),
-            rating: Number(row.rating)
+            rating: Number(row.rating),
+            isHdr: row.isHdr === true
         }
     }
 
@@ -600,7 +602,8 @@ Item {
                 elementId: elementId,
                 imageId: Number(row.imageId),
                 fileName: row.fileName ? row.fileName : qsTr("(unnamed)"),
-                rating: Number(row.rating)
+                rating: Number(row.rating),
+                isHdr: row.isHdr === true
             })
         }
         return items
@@ -666,6 +669,7 @@ Item {
         required property string aperture
         required property string captureDate
         required property int rating
+        required property bool isHdr
         required property string accent
         required property string thumbUrl
         required property bool thumbLoading
@@ -1014,16 +1018,46 @@ Item {
                 elide: Text.ElideRight
                 width: parent.width
             }
-            Label {
+            Row {
                 visible: !root.hideMetadata
-                text: qsTr("%1 | Rating %2/5").arg(captureDate).arg(rating)
-                color: root.cardMuted
-                font.family: appTheme.dataFontFamily
-                font.pixelSize: root.metadataFontSize
-                font.weight: root.dataFontWeight
-                font.letterSpacing: root.dataLetterSpacing
-                elide: Text.ElideRight
                 width: parent.width
+                height: Math.max(ratingLabel.implicitHeight, hdrGridTag.height)
+                spacing: 5
+
+                Label {
+                    id: ratingLabel
+                    text: qsTr("%1 | Rating %2/5").arg(captureDate).arg(rating)
+                    color: root.cardMuted
+                    font.family: appTheme.dataFontFamily
+                    font.pixelSize: root.metadataFontSize
+                    font.weight: root.dataFontWeight
+                    font.letterSpacing: root.dataLetterSpacing
+                    elide: Text.ElideRight
+                    width: isHdr ? Math.max(0, parent.width - hdrGridTag.width - parent.spacing)
+                                 : parent.width
+                    anchors.bottom: parent.bottom
+                }
+
+                Rectangle {
+                    id: hdrGridTag
+                    visible: isHdr
+                    width: hdrGridTagText.implicitWidth + 8
+                    height: Math.max(13, hdrGridTagText.implicitHeight + 2)
+                    radius: 3
+                    color: "#3A3020"
+                    border.width: 1
+                    border.color: "#D8A93B"
+                    anchors.bottom: parent.bottom
+                    Label {
+                        id: hdrGridTagText
+                        anchors.centerIn: parent
+                        text: "HDR"
+                        color: "#F2C766"
+                        font.family: appTheme.dataFontFamily
+                        font.pixelSize: Math.max(8, root.metadataFontSize - 1)
+                        font.weight: Font.DemiBold
+                    }
+                }
             }
         }
 
@@ -1204,7 +1238,8 @@ Item {
                             root.selectRangeToIndex(idx, mouse.modifiers & Qt.ControlModifier)
                         } else if (mouse.modifiers & Qt.ControlModifier) {
                             const next = !root.isImageSelected(item.elementId)
-                            root.imageSelectionChanged(item.elementId, item.imageId, item.fileName, next)
+                            root.imageSelectionChanged(item.elementId, item.imageId, item.fileName,
+                                                       item.isHdr === true, next)
                             root.updateSelectionAnchor(idx)
                         } else {
                             root.replaceSelection([item])

--- a/alcedo_studio/src/ui/alcedo_main/qml/ThumbnailListView.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/ThumbnailListView.qml
@@ -23,7 +23,8 @@ ListView {
     property var selectedImagesById: ({})
     property var exportQueueById: ({})
 
-    signal imageSelectionChanged(int elementId, int imageId, string fileName, bool selected)
+    signal imageSelectionChanged(int elementId, int imageId, string fileName, bool isHdr,
+                                 bool selected)
     signal replaceSelection(var items)
     signal contextMenuRequested(var item, real sceneX, real sceneY)
 
@@ -79,6 +80,7 @@ ListView {
         required property string focalLength
         required property string captureDate
         required property int rating
+        required property bool isHdr
         required property string tags
         required property string accent
         required property string thumbUrl
@@ -316,7 +318,8 @@ ListView {
                     elementId: elementId,
                     imageId: imageId,
                     fileName: fileName,
-                    rating: rating
+                    rating: rating,
+                    isHdr: isHdr
                 }, scenePoint.x, scenePoint.y)
             }
             onClicked: function(mouse) {
@@ -325,13 +328,14 @@ ListView {
                 }
                 if (root.hasMultiSelectModifier(mouse.modifiers)) {
                     const nextSelected = !root.isImageSelected(elementId)
-                    root.imageSelectionChanged(elementId, imageId, fileName, nextSelected)
+                    root.imageSelectionChanged(elementId, imageId, fileName, isHdr, nextSelected)
                 } else {
                     root.replaceSelection([{
                         elementId: elementId,
                         imageId: imageId,
                         fileName: fileName,
-                        rating: rating
+                        rating: rating,
+                        isHdr: isHdr
                     }])
                 }
             }

--- a/alcedo_studio/src/ui/edit_viewer/color_manager.mm
+++ b/alcedo_studio/src/ui/edit_viewer/color_manager.mm
@@ -13,6 +13,8 @@
 #include <QtCore/qlogging.h>
 #include <QDebug>
 #include <QString>
+#include <algorithm>
+#include <cmath>
 
 namespace alcedo {
 namespace {
@@ -162,6 +164,28 @@ void LogFallbackColorSpace(const ViewerDisplayConfig& config, CFStringRef resolv
                   QString::fromStdString(ColorUtils::EOTFToString(config.encoding_eotf)));
 }
 
+auto ClampHdrPeakLuminance(float peak_luminance) -> float {
+  if (!std::isfinite(peak_luminance)) {
+    return 100.0f;
+  }
+  return std::clamp(peak_luminance, 100.0f, 10000.0f);
+}
+
+auto ResolveEDRMetadata(const ViewerDisplayConfig& config) -> CAEDRMetadata* {
+  if (@available(macOS 10.15, *)) {
+    if (config.encoding_eotf == ColorUtils::EOTF::ST2084) {
+      const float peak_luminance = ClampHdrPeakLuminance(config.peak_luminance);
+      return [CAEDRMetadata HDR10MetadataWithMinLuminance:0.0001f
+                                             maxLuminance:peak_luminance
+                                       opticalOutputScale:10000.0f];
+    }
+    if (config.encoding_eotf == ColorUtils::EOTF::HLG) {
+      return [CAEDRMetadata HLGMetadata];
+    }
+  }
+  return nil;
+}
+
 }  // namespace
 
 auto ColorManager::ApplyWindowColorSpace(void*                      native_view_or_window,
@@ -201,12 +225,20 @@ auto ColorManager::ApplyWindowColorSpace(void*                      native_view_
     return false;
   }
 
+  const bool uses_hdr_transfer = config.encoding_eotf == ColorUtils::EOTF::ST2084 ||
+                                 config.encoding_eotf == ColorUtils::EOTF::HLG;
+  metal_layer.wantsExtendedDynamicRangeContent = uses_hdr_transfer;
+  if (@available(macOS 10.15, *)) {
+    metal_layer.EDRMetadata = uses_hdr_transfer ? ResolveEDRMetadata(config) : nil;
+  }
+
   CGColorSpaceRef color_space = CGColorSpaceCreateWithName(color_name);
   if (!color_space) {
     return false;
   }
 
   metal_layer.colorspace = color_space;
+
   CGColorSpaceRelease(color_space);
 
   if (!exact_match) {

--- a/alcedo_studio/src/ui/edit_viewer/edit_viewer.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/edit_viewer.cpp
@@ -353,10 +353,12 @@ auto QtEditViewer::GetViewZoom() const -> float { return viewer_state_.GetViewZo
 auto QtEditViewer::IsViewInteractionActive() const -> bool { return view_interaction_active_; }
 
 void QtEditViewer::SetDisplayEncoding(ColorUtils::ColorSpace encoding_space,
-                                      ColorUtils::EOTF       encoding_eotf) {
+                                      ColorUtils::EOTF       encoding_eotf,
+                                      float                  peak_luminance) {
   {
     std::lock_guard<std::mutex> lock(host_frame_mutex_);
-    pending_display_config_       = ViewerDisplayConfig{encoding_space, encoding_eotf};
+    pending_display_config_       = ViewerDisplayConfig{encoding_space, encoding_eotf,
+                                                        peak_luminance};
     pending_display_config_valid_ = true;
   }
   emit RequestUpdate();

--- a/alcedo_studio/tests/CMakeLists.txt
+++ b/alcedo_studio/tests/CMakeLists.txt
@@ -656,7 +656,8 @@ endif()
 add_executable(ImageWriterTest io/image_writer_test.cpp)
 target_include_directories(ImageWriterTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(ImageWriterTest PRIVATE GTest::gtest_main ImageWriter ${ALCEDO_TEST_OPENCV_MIN_DEPS})
-gtest_discover_tests(ImageWriterTest TEST_PREFIX "ImageWriterTest.")
+gtest_discover_tests(ImageWriterTest TEST_PREFIX "ImageWriterTest."
+  PROPERTIES LABELS "ci_core_flow")
 
 add_executable(MetadataExtractorTest image/metadata_extractor_test.cpp)
 target_include_directories(MetadataExtractorTest PUBLIC ${ALCEDO_INCLUDE_DIR})
@@ -735,6 +736,12 @@ target_link_libraries(CiRawWorkflowTest
 gtest_discover_tests(CiRawWorkflowTest TEST_PREFIX "CiRawWorkflowTest."
   PROPERTIES LABELS "ci_raw_flow")
 
+add_executable(SleeveFilesystemCiTest ci/sleeve_filesystem_ci_test.cpp)
+target_include_directories(SleeveFilesystemCiTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(SleeveFilesystemCiTest PRIVATE GTest::gtest_main SleeveFS StrConv)
+gtest_discover_tests(SleeveFilesystemCiTest TEST_PREFIX "SleeveFilesystemCiTest."
+  PROPERTIES LABELS "ci_core_flow")
+
 add_executable(ThumbnailAlbumQtDemo app/thumbnail_album_qt_demo.cpp)
 target_include_directories(ThumbnailAlbumQtDemo PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(ThumbnailAlbumQtDemo PRIVATE ThumbnailService ProjectService ImportService Qt6::Widgets SleeveFilterService)
@@ -807,9 +814,9 @@ macro(def_ui_test TARGET_NAME SOURCE_FILE)
             Qt6::Core
     )
     include(GoogleTest)
-    if(ARGN)
+    if(NOT "${ARGN}" STREQUAL "")
         gtest_discover_tests(${TARGET_NAME} TEST_PREFIX "${TARGET_NAME}."
-            PROPERTIES LABELS "${ARGN}")
+            PROPERTIES LABELS ${ARGN})
     else()
         gtest_discover_tests(${TARGET_NAME} TEST_PREFIX "${TARGET_NAME}.")
     endif()
@@ -820,7 +827,7 @@ def_ui_test(AlbumBackendProjectTest  album_backend_project_test.cpp)
 def_ui_test(AlbumBackendFolderTest   album_backend_folder_test.cpp)
 def_ui_test(AlbumBackendImageDeleteTest album_backend_image_delete_test.cpp)
 def_ui_test(AlbumBackendImageDetailsTest album_backend_image_details_test.cpp)
-def_ui_test(AlbumBackendRatingTest album_backend_rating_test.cpp)
+def_ui_test(AlbumBackendRatingTest album_backend_rating_test.cpp "ci_raw_flow")
 def_ui_test(AlbumBackendThumbnailTest album_backend_thumbnail_test.cpp)
 def_ui_test(AlbumBackendI18nTest album_backend_i18n_test.cpp)
 def_ui_test(AlbumBackendCiWorkflowTest album_backend_ci_workflow_test.cpp "ci_raw_flow")
@@ -969,6 +976,8 @@ alcedo_assign_test_category(demos ALCEDO_BUILD_DEMO_TARGETS alcedo_tests_demos
 )
 
 alcedo_assign_test_category(ci_core ALCEDO_BUILD_CI_TESTS alcedo_tests_ci_core
+  ImageWriterTest
+  SleeveFilesystemCiTest
   PipelineServiceTest
   EditHistoryMgmtServiceTest
   CropRotateOpTest
@@ -976,6 +985,7 @@ alcedo_assign_test_category(ci_core ALCEDO_BUILD_CI_TESTS alcedo_tests_ci_core
 
 alcedo_assign_test_category(ci_raw ALCEDO_BUILD_CI_TESTS alcedo_tests_ci_raw
   CiRawWorkflowTest
+  AlbumBackendRatingTest
   AlbumBackendCiWorkflowTest
 )
 

--- a/alcedo_studio/tests/app/adjustment_transfer_service_test.cpp
+++ b/alcedo_studio/tests/app/adjustment_transfer_service_test.cpp
@@ -40,6 +40,25 @@ auto PackageContainsOperator(const AdjustmentTransferPackage& package, OperatorT
   return false;
 }
 
+auto MakeCustomOdtParams() -> nlohmann::json {
+  auto params = pipeline_defaults::MakeDefaultODTParams();
+  auto& odt   = params["odt"];
+  odt["method"]                                        = "open_drt";
+  odt["encoding_space"]                                = "rec2020";
+  odt["encoding_eotf"]                                 = "st2084";
+  odt["peak_luminance"]                                = 400.0f;
+  odt["open_drt"]["look_preset"]                       = "umbra";
+  odt["open_drt"]["tonescale_preset"]                  = "aces_2_0";
+  odt["open_drt"]["creative_white"]                    = "d60";
+  odt["open_drt"]["creative_white_limit"]              = 0.42f;
+  odt["open_drt"]["display_grey_luminance"]            = 14.0f;
+  odt["open_drt"]["hdr_grey_boost"]                    = 0.25f;
+  odt["open_drt"]["hdr_purity"]                        = 0.7f;
+  odt["open_drt"]["parameters"]["tn_con"]              = 1.85f;
+  odt["open_drt"]["parameters"]["ptm_high"]            = -0.65f;
+  return params;
+}
+
 class AdjustmentTransferServiceTest : public ::testing::Test {
  protected:
   std::filesystem::path db_path_;
@@ -325,6 +344,99 @@ TEST_F(AdjustmentTransferServiceTest, VersionedApplyCreatesActiveCheckoutVersion
   EXPECT_EQ(second_active.GetDisplayName(), "Pasted Adjustments (2)");
   EXPECT_EQ(second_active.GetAllEditTransactions().size(), 2u);
   history_service.SaveHistory(second_history);
+}
+
+TEST_F(AdjustmentTransferServiceTest, VersionedApplyPersistsOutputTransformForEditorReopen) {
+  constexpr sl_element_id_t source_id = 41;
+  constexpr sl_element_id_t target_id = 42;
+
+  ProjectService         project(db_path_, meta_path_, ProjectOpenMode::kCreateNew);
+  PipelineMgmtService    pipeline_service(project.GetStorageService());
+  EditHistoryMgmtService history_service(project.GetStorageService());
+
+  {
+    auto source_pipeline = pipeline_service.LoadPipeline(source_id);
+    ASSERT_NE(source_pipeline, nullptr);
+    ASSERT_NE(source_pipeline->pipeline_, nullptr);
+    auto& global = source_pipeline->pipeline_->GetGlobalParams();
+    source_pipeline->pipeline_->GetStage(PipelineStageName::Output_Transform)
+        .SetOperator(OperatorType::ODT, MakeCustomOdtParams(), global);
+    source_pipeline->pipeline_->GetStage(PipelineStageName::Output_Transform)
+        .EnableOperator(OperatorType::ODT, true, global);
+    source_pipeline->dirty_ = true;
+    pipeline_service.SavePipeline(source_pipeline);
+  }
+
+  {
+    auto target_pipeline = pipeline_service.LoadPipeline(target_id);
+    ASSERT_NE(target_pipeline, nullptr);
+    ASSERT_NE(target_pipeline->pipeline_, nullptr);
+    target_pipeline->dirty_ = true;
+    pipeline_service.SavePipeline(target_pipeline);
+  }
+  pipeline_service.Sync();
+
+  auto source_pipeline = pipeline_service.LoadPipeline(source_id);
+  ASSERT_NE(source_pipeline, nullptr);
+  ASSERT_NE(source_pipeline->pipeline_, nullptr);
+  const auto package = AdjustmentTransferService::Capture(*source_pipeline->pipeline_);
+  ASSERT_TRUE(PackageContainsOperator(package, OperatorType::ODT));
+  pipeline_service.SavePipeline(source_pipeline);
+
+  const sl_element_id_t ids[] = {target_id};
+  const auto result = AdjustmentTransferService::Apply(
+      pipeline_service, history_service, std::span<const sl_element_id_t>(ids), package,
+      "Pasted Adjustments");
+  ASSERT_EQ(result.failures_.size(), 0u);
+  ASSERT_EQ(result.applied_ids_.size(), 1u);
+
+  auto target_pipeline = pipeline_service.LoadPipeline(target_id);
+  ASSERT_NE(target_pipeline, nullptr);
+  ASSERT_NE(target_pipeline->pipeline_, nullptr);
+  const auto live_odt =
+      OperatorParamsFor(*target_pipeline->pipeline_, PipelineStageName::Output_Transform,
+                        OperatorType::ODT);
+  EXPECT_EQ(live_odt["odt"]["encoding_space"], "rec2020");
+  EXPECT_EQ(live_odt["odt"]["encoding_eotf"], "st2084");
+  EXPECT_DOUBLE_EQ(live_odt["odt"]["peak_luminance"].get<double>(), 400.0);
+  EXPECT_EQ(live_odt["odt"]["open_drt"]["look_preset"], "umbra");
+  EXPECT_EQ(live_odt["odt"]["open_drt"]["tonescale_preset"], "aces_2_0");
+  EXPECT_EQ(live_odt["odt"]["open_drt"]["creative_white"], "d60");
+  EXPECT_NEAR(live_odt["odt"]["open_drt"]["parameters"]["tn_con"].get<double>(), 1.85, 1e-6);
+  pipeline_service.SavePipeline(target_pipeline);
+
+  auto history = history_service.LoadHistory(target_id);
+  ASSERT_NE(history, nullptr);
+  ASSERT_NE(history->history_, nullptr);
+  const auto reconstructed =
+      history->history_->ReconstructPipelineParamsForVersion(history->history_->GetActiveVersionID());
+  ASSERT_TRUE(reconstructed.has_value());
+  CPUPipelineExecutor reconstructed_pipeline;
+  reconstructed_pipeline.ImportPipelineParams(*reconstructed);
+  const auto reconstructed_odt =
+      OperatorParamsFor(reconstructed_pipeline, PipelineStageName::Output_Transform,
+                        OperatorType::ODT);
+  EXPECT_EQ(reconstructed_odt["odt"]["encoding_space"], "rec2020");
+  EXPECT_EQ(reconstructed_odt["odt"]["encoding_eotf"], "st2084");
+  EXPECT_DOUBLE_EQ(reconstructed_odt["odt"]["peak_luminance"].get<double>(), 400.0);
+  EXPECT_EQ(reconstructed_odt["odt"]["open_drt"]["look_preset"], "umbra");
+  history_service.SaveHistory(history);
+
+  pipeline_service.Sync();
+  history_service.Sync();
+
+  PipelineMgmtService reopened_pipeline_service(project.GetStorageService());
+  auto reopened_pipeline = reopened_pipeline_service.LoadPipeline(target_id);
+  ASSERT_NE(reopened_pipeline, nullptr);
+  ASSERT_NE(reopened_pipeline->pipeline_, nullptr);
+  const auto reopened_odt =
+      OperatorParamsFor(*reopened_pipeline->pipeline_, PipelineStageName::Output_Transform,
+                        OperatorType::ODT);
+  EXPECT_EQ(reopened_odt["odt"]["encoding_space"], "rec2020");
+  EXPECT_EQ(reopened_odt["odt"]["encoding_eotf"], "st2084");
+  EXPECT_DOUBLE_EQ(reopened_odt["odt"]["peak_luminance"].get<double>(), 400.0);
+  EXPECT_EQ(reopened_odt["odt"]["open_drt"]["look_preset"], "umbra");
+  reopened_pipeline_service.SavePipeline(reopened_pipeline);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/app/adjustment_transfer_service_test.cpp
+++ b/alcedo_studio/tests/app/adjustment_transfer_service_test.cpp
@@ -346,6 +346,81 @@ TEST_F(AdjustmentTransferServiceTest, VersionedApplyCreatesActiveCheckoutVersion
   history_service.SaveHistory(second_history);
 }
 
+TEST_F(AdjustmentTransferServiceTest, VersionedMergeMaterializesCombinedParamsWithoutEdits) {
+  constexpr sl_element_id_t target_id = 42;
+
+  ProjectService         project(db_path_, meta_path_, ProjectOpenMode::kCreateNew);
+  PipelineMgmtService    pipeline_service(project.GetStorageService());
+  EditHistoryMgmtService history_service(project.GetStorageService());
+
+  const sl_element_id_t ids[] = {target_id};
+  const nlohmann::json  initial_package_json = {
+      {"schema", "alcedo.adjustment_transfer.v1"},
+      {"operators",
+       {{{"operator", "exposure"}, {"enabled", true}, {"params", {{"exposure", 0.5f}}}},
+        {{"operator", "contrast"}, {"enabled", true}, {"params", {{"contrast", 2.0f}}}},
+        {{"operator", "saturation"}, {"enabled", true}, {"params", {{"saturation", 12.0f}}}}}}};
+  const auto initial_package = AdjustmentTransferService::ImportPackage(initial_package_json);
+  const auto initial_result  = AdjustmentTransferService::Apply(
+      pipeline_service, history_service, std::span<const sl_element_id_t>(ids), initial_package,
+      "Pasted Adjustments");
+  ASSERT_EQ(initial_result.failures_.size(), 0u);
+  ASSERT_EQ(initial_result.applied_ids_.size(), 1u);
+
+  auto pasted_history = history_service.LoadHistory(target_id);
+  ASSERT_NE(pasted_history, nullptr);
+  ASSERT_NE(pasted_history->history_, nullptr);
+  const auto pasted_version_id = pasted_history->history_->GetActiveVersionID();
+  EXPECT_EQ(pasted_history->history_->GetActiveVersion().GetDisplayName(), "Pasted Adjustments");
+  EXPECT_EQ(pasted_history->history_->GetActiveVersion().GetAllEditTransactions().size(), 3u);
+  history_service.SaveHistory(pasted_history);
+
+  const nlohmann::json merge_package_json = {
+      {"schema", "alcedo.adjustment_transfer.v1"},
+      {"operators",
+       {{{"operator", "exposure"}, {"enabled", true}, {"params", {{"exposure", 1.5f}}}},
+        {{"operator", "contrast"}, {"enabled", true}, {"params", {{"contrast", -0.25f}}}}}}};
+  const auto merge_package = AdjustmentTransferService::ImportPackage(merge_package_json);
+  const auto merge_result  = AdjustmentTransferService::Apply(
+      pipeline_service, history_service, std::span<const sl_element_id_t>(ids), merge_package,
+      "Merged Adjustments", AdjustmentVersionApplyMode::kMerge);
+  ASSERT_EQ(merge_result.failures_.size(), 0u);
+  ASSERT_EQ(merge_result.applied_ids_.size(), 1u);
+
+  auto history = history_service.LoadHistory(target_id);
+  ASSERT_NE(history, nullptr);
+  ASSERT_NE(history->history_, nullptr);
+  EXPECT_EQ(history->history_->GetVersions().size(), 3u);
+
+  auto& merged = history->history_->GetActiveVersion();
+  EXPECT_EQ(merged.GetDisplayName(), "Merged Adjustments");
+  EXPECT_EQ(merged.GetAllEditTransactions().size(), 0u);
+  EXPECT_EQ(merged.GetCursor(), 0u);
+  EXPECT_EQ(merged.GetTransactionCount(), 0u);
+  EXPECT_TRUE(merged.GetFinalPipelineParams().has_value());
+
+  const auto reconstructed = history->history_->ReconstructPipelineParamsForVersion(
+      history->history_->GetActiveVersionID());
+  ASSERT_TRUE(reconstructed.has_value());
+  CPUPipelineExecutor reconstructed_pipeline;
+  reconstructed_pipeline.ImportPipelineParams(*reconstructed);
+
+  const auto exposure = OperatorParamsFor(
+      reconstructed_pipeline, PipelineStageName::Basic_Adjustment, OperatorType::EXPOSURE);
+  const auto contrast = OperatorParamsFor(
+      reconstructed_pipeline, PipelineStageName::Basic_Adjustment, OperatorType::CONTRAST);
+  const auto saturation = OperatorParamsFor(
+      reconstructed_pipeline, PipelineStageName::Color_Adjustment, OperatorType::SATURATION);
+  EXPECT_DOUBLE_EQ(exposure["exposure"].get<double>(), 1.5);
+  EXPECT_DOUBLE_EQ(contrast["contrast"].get<double>(), -0.25);
+  EXPECT_DOUBLE_EQ(saturation["saturation"].get<double>(), 12.0);
+
+  auto& pasted = history->history_->GetVersion(pasted_version_id);
+  EXPECT_EQ(pasted.GetDisplayName(), "Pasted Adjustments");
+  EXPECT_EQ(pasted.GetAllEditTransactions().size(), 3u);
+  history_service.SaveHistory(history);
+}
+
 TEST_F(AdjustmentTransferServiceTest, VersionedApplyPersistsOutputTransformForEditorReopen) {
   constexpr sl_element_id_t source_id = 41;
   constexpr sl_element_id_t target_id = 42;

--- a/alcedo_studio/tests/ci/sleeve_filesystem_ci_test.cpp
+++ b/alcedo_studio/tests/ci/sleeve_filesystem_ci_test.cpp
@@ -1,0 +1,122 @@
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "sleeve/sleeve_element/sleeve_file.hpp"
+#include "sleeve/sleeve_filesystem.hpp"
+
+namespace alcedo {
+namespace {
+
+auto ContainsId(const std::vector<sl_element_id_t>& ids, sl_element_id_t id) -> bool {
+  return std::find(ids.begin(), ids.end(), id) != ids.end();
+}
+
+class SleeveFilesystemCiTest : public ::testing::Test {
+ protected:
+  std::filesystem::path temp_dir_;
+  std::filesystem::path db_path_;
+  std::filesystem::path meta_path_;
+
+  void SetUp() override {
+    temp_dir_ = std::filesystem::temp_directory_path() /
+                ("alcedo_sleeve_fs_ci_" +
+                 std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::filesystem::create_directories(temp_dir_);
+    db_path_ = temp_dir_ / "sleeve_ci.db";
+    meta_path_ = temp_dir_ / "sleeve_ci.json";
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove_all(temp_dir_, ec);
+  }
+};
+
+TEST_F(SleeveFilesystemCiTest, AlbumMembershipPersistsWithoutDuplicatingLibraryFile) {
+  sl_element_id_t album_id = 0;
+  sl_element_id_t file_id = 0;
+
+  {
+    StorageService storage_service{db_path_};
+    FileSystem     fs{db_path_, storage_service, 0};
+    fs.InitRoot();
+
+    const auto album = fs.Create(L"", L"Album", ElementType::FOLDER);
+    const auto file = fs.CreateFileInLibrary(L"Shared.arw");
+    ASSERT_NE(album, nullptr);
+    ASSERT_NE(file, nullptr);
+
+    album_id = album->element_id_;
+    file_id = file->element_id_;
+    fs.LinkFileToFolder(file_id, album_id);
+    fs.LinkFileToFolder(file_id, album_id);
+
+    fs.SyncToDB();
+    fs.WriteSleeveMeta(meta_path_);
+  }
+
+  {
+    StorageService storage_service{db_path_};
+    FileSystem     fs{db_path_, storage_service, 0};
+    fs.ReadSleeveMeta(meta_path_);
+    fs.InitRoot();
+
+    const auto root_ids = fs.ListFolderContent(0);
+    const auto album_ids = fs.ListFolderContent(album_id);
+    EXPECT_TRUE(ContainsId(root_ids, file_id));
+    EXPECT_TRUE(ContainsId(album_ids, file_id));
+
+    const auto from_root =
+        std::static_pointer_cast<SleeveFile>(fs.Get(L"/Shared.arw", false));
+    const auto from_album =
+        std::static_pointer_cast<SleeveFile>(fs.Get(L"/Album/Shared.arw", false));
+    ASSERT_NE(from_root, nullptr);
+    ASSERT_NE(from_album, nullptr);
+    EXPECT_EQ(from_root->element_id_, file_id);
+    EXPECT_EQ(from_album->element_id_, file_id);
+    EXPECT_EQ(from_root->ref_count_, 1u);
+  }
+}
+
+TEST_F(SleeveFilesystemCiTest, AlbumDeleteUnlinksButRootDeleteRemovesEveryMembership) {
+  sl_element_id_t album_id = 0;
+  sl_element_id_t file_id = 0;
+
+  {
+    StorageService storage_service{db_path_};
+    FileSystem     fs{db_path_, storage_service, 0};
+    fs.InitRoot();
+
+    const auto album = fs.Create(L"", L"Album", ElementType::FOLDER);
+    const auto file = fs.CreateFileInLibrary(L"DeleteScope.arw");
+    ASSERT_NE(album, nullptr);
+    ASSERT_NE(file, nullptr);
+
+    album_id = album->element_id_;
+    file_id = file->element_id_;
+    fs.LinkFileToFolder(file_id, album_id);
+
+    fs.Delete(L"/Album/DeleteScope.arw");
+    EXPECT_TRUE(ContainsId(fs.ListFolderContent(0), file_id));
+    EXPECT_FALSE(ContainsId(fs.ListFolderContent(album_id), file_id));
+
+    fs.LinkFileToFolder(file_id, album_id);
+    fs.Delete(L"/DeleteScope.arw");
+    EXPECT_FALSE(ContainsId(fs.ListFolderContent(0), file_id));
+    EXPECT_FALSE(ContainsId(fs.ListFolderContent(album_id), file_id));
+    EXPECT_THROW(fs.Get(L"/Album/DeleteScope.arw", false), std::runtime_error);
+  }
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/operators/cst/odt_op_test.cpp
+++ b/alcedo_studio/tests/edit/operators/cst/odt_op_test.cpp
@@ -36,6 +36,38 @@ TEST(ODTOpTests, MethodSwitchesToACES2) {
   EXPECT_EQ(op.GetParams()["odt"]["limiting_space"], "rec709");
 }
 
+TEST(ODTOpTests, ACES2St2084UsesReferenceLuminanceScale) {
+  nlohmann::json params           = pipeline_defaults::MakeDefaultODTParams();
+  params["odt"]["method"]         = "aces_2_0";
+  params["odt"]["encoding_space"] = "rec2020";
+  params["odt"]["encoding_eotf"]  = "st2084";
+  params["odt"]["limiting_space"] = "rec2020";
+  params["odt"]["peak_luminance"] = 600.0f;
+
+  ODT_Op         op(params);
+  OperatorParams global_params;
+  op.SetGlobalParams(global_params);
+
+  EXPECT_EQ(global_params.to_output_params_.method_, ColorUtils::ODTMethod::ACES_2_0);
+  EXPECT_EQ(global_params.to_output_params_.eotf_, ColorUtils::EOTF::ST2084);
+  EXPECT_FLOAT_EQ(global_params.to_output_params_.display_linear_scale_, ColorUtils::ref_lum);
+}
+
+TEST(ODTOpTests, ACES2GammaOutputKeepsUnitScale) {
+  nlohmann::json params           = pipeline_defaults::MakeDefaultODTParams();
+  params["odt"]["method"]         = "aces_2_0";
+  params["odt"]["encoding_space"] = "rec709";
+  params["odt"]["encoding_eotf"]  = "gamma_2_2";
+  params["odt"]["limiting_space"] = "rec709";
+
+  ODT_Op         op(params);
+  OperatorParams global_params;
+  op.SetGlobalParams(global_params);
+
+  EXPECT_EQ(global_params.to_output_params_.method_, ColorUtils::ODTMethod::ACES_2_0);
+  EXPECT_FLOAT_EQ(global_params.to_output_params_.display_linear_scale_, 1.0f);
+}
+
 TEST(ODTOpTests, UnsupportedOpenDRTOutputCombinationThrows) {
   nlohmann::json params           = pipeline_defaults::MakeDefaultODTParams();
   params["odt"]["encoding_space"] = "prophoto";

--- a/alcedo_studio/tests/io/image_writer_test.cpp
+++ b/alcedo_studio/tests/io/image_writer_test.cpp
@@ -10,16 +10,12 @@
 #include <exiv2/exiv2.hpp>
 
 #include <filesystem>
-#include <fstream>
 #include <memory>
 #include <opencv2/imgcodecs.hpp>
 #include <vector>
 
-#if defined(ALCEDO_HAS_ULTRAHDR)
-#include <ultrahdr_api.h>
-#endif
-
 #include "image/image_buffer.hpp"
+#include "image/metadata.hpp"
 
 namespace alcedo {
 namespace {
@@ -45,21 +41,6 @@ auto MakeColorProfile(ColorUtils::ColorSpace color_space, ColorUtils::EOTF eotf)
   return ExportColorProfileConfig{color_space, eotf, 600.0f};
 }
 
-auto HasEmbeddedIccProfile(const std::filesystem::path& path) -> bool {
-  OIIO_NAMESPACE_USING
-
-  auto input = ImageInput::open(path.string());
-  if (!input) {
-    return false;
-  }
-
-  const auto& spec = input->spec();
-  const auto* attr = spec.find_attribute("ICCProfile");
-  const bool  has_icc = attr != nullptr;
-  input->close();
-  return has_icc;
-}
-
 auto ReadXmpRating(const std::filesystem::path& path) -> int {
   auto image = Exiv2::ImageFactory::open(path.string());
   if (!image) {
@@ -80,6 +61,28 @@ auto ReadExifRating(const std::filesystem::path& path) -> int {
   const auto& exif_data = image->exifData();
   const auto  rating    = exif_data.findKey(Exiv2::ExifKey("Exif.Image.Rating"));
   return rating == exif_data.end() ? -1 : static_cast<int>(rating->toInt64());
+}
+
+auto ReadExifString(const std::filesystem::path& path, const char* key) -> std::string {
+  auto image = Exiv2::ImageFactory::open(path.string());
+  if (!image) {
+    return {};
+  }
+  image->readMetadata();
+  const auto& exif_data = image->exifData();
+  const auto  it        = exif_data.findKey(Exiv2::ExifKey(key));
+  return it == exif_data.end() ? std::string{} : it->toString();
+}
+
+auto ReadXmpString(const std::filesystem::path& path, const char* key) -> std::string {
+  auto image = Exiv2::ImageFactory::open(path.string());
+  if (!image) {
+    return {};
+  }
+  image->readMetadata();
+  const auto& xmp_data = image->xmpData();
+  const auto  it       = xmp_data.findKey(Exiv2::XmpKey(key));
+  return it == xmp_data.end() ? std::string{} : it->toString();
 }
 
 void WriteTestJpeg(const std::filesystem::path& path, const std::vector<uint8_t>& rgb,
@@ -183,7 +186,7 @@ TEST_F(ImageWriterTests, LegacyJpegExportForcesUprightOrientation) {
   }
 }
 
-TEST_F(ImageWriterTests, EmbeddedHdrIccModeWritesRegularJpegWithProfile) {
+TEST_F(ImageWriterTests, EmbeddedHdrIccModeRejectsHdrJpegExport) {
   const auto src_path = temp_dir_ / "hdr_source.jpg";
   const auto dst_path = temp_dir_ / "embedded_hdr.jpg";
 
@@ -203,19 +206,49 @@ TEST_F(ImageWriterTests, EmbeddedHdrIccModeWritesRegularJpegWithProfile) {
   const auto hdr_profile =
       MakeColorProfile(ColorUtils::ColorSpace::REC2020, ColorUtils::EOTF::ST2084);
 
-  ImageWriter::WriteImageToPath(src_path, image_data, options, hdr_profile);
+  EXPECT_THROW(ImageWriter::WriteImageToPath(src_path, image_data, options, hdr_profile),
+               std::runtime_error);
+  EXPECT_FALSE(std::filesystem::exists(dst_path));
+}
 
-  ASSERT_TRUE(std::filesystem::exists(dst_path));
-  EXPECT_TRUE(HasEmbeddedIccProfile(dst_path));
+TEST_F(ImageWriterTests, EmbeddedHdrIccModeRejectsMetadataInjectedHdrJpegExport) {
+  const auto src_path = temp_dir_ / "hdr_metadata_source.jpg";
+  const auto dst_path = temp_dir_ / "embedded_hdr_metadata.jpg";
 
-#if defined(ALCEDO_HAS_ULTRAHDR)
-  std::ifstream in(dst_path, std::ios::binary);
-  ASSERT_TRUE(in.is_open());
-  const auto bytes =
-      std::vector<uint8_t>(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
-  ASSERT_FALSE(bytes.empty());
-  EXPECT_EQ(is_uhdr_image(const_cast<uint8_t*>(bytes.data()), static_cast<int>(bytes.size())), 0);
-#endif
+  WriteTestJpeg(src_path, {
+                           64, 32, 16, 64, 32, 16,
+                           64, 32, 16, 64, 32, 16,
+                         }, 2, 2);
+
+  {
+    auto image = Exiv2::ImageFactory::open(src_path.string());
+    ASSERT_TRUE(image != nullptr);
+    image->readMetadata();
+    Exiv2::ExifData exif_data = image->exifData();
+    exif_data["Exif.Photo.ColorSpace"] = static_cast<uint16_t>(1);
+    image->setExifData(exif_data);
+    image->writeMetadata();
+  }
+
+  cv::Mat rgba32f(2, 2, CV_32FC4, cv::Scalar(0.62f, 0.41f, 0.21f, 1.0f));
+  auto    image_data = std::make_shared<ImageBuffer>(std::move(rgba32f));
+
+  ExportFormatOptions options;
+  options.format_ = ImageFormatType::JPEG;
+  options.export_path_ = dst_path;
+  options.hdr_export_mode_ = ExportFormatOptions::HDR_EXPORT_MODE::EMBEDDED_PROFILE_ONLY;
+
+  const auto hdr_profile =
+      MakeColorProfile(ColorUtils::ColorSpace::REC2020, ColorUtils::EOTF::ST2084);
+
+  ExifDisplayMetaData metadata;
+  metadata.lens_ = "Alcedo Test 35mm F1.8";
+  metadata.date_time_str_ = "2024-05-06 07:08:09";
+  metadata.rating_ = 5;
+
+  EXPECT_THROW(ImageWriter::WriteImageToPath(src_path, image_data, options, hdr_profile, metadata),
+               std::runtime_error);
+  EXPECT_FALSE(std::filesystem::exists(dst_path));
 }
 
 TEST_F(ImageWriterTests, ExportWritesCurrentRatingMetadata) {
@@ -246,13 +279,55 @@ TEST_F(ImageWriterTests, ExportWritesCurrentRatingMetadata) {
   options.format_ = ImageFormatType::JPEG;
   options.export_path_ = dst_path;
 
-  ImageWriter::WriteImageToPath(src_path, image_data, options, std::nullopt, 4);
+  ExifDisplayMetaData metadata;
+  metadata.rating_ = 4;
+
+  ImageWriter::WriteImageToPath(src_path, image_data, options, std::nullopt, metadata);
 
   ASSERT_TRUE(std::filesystem::exists(dst_path));
   EXPECT_EQ(ReadExifRating(dst_path), 4);
   const int xmp_rating = ReadXmpRating(dst_path);
   if (xmp_rating >= 0) {
     EXPECT_EQ(xmp_rating, 4);
+  }
+}
+
+TEST_F(ImageWriterTests, ExportWritesCurrentLensAndCaptureDateMetadata) {
+  const auto src_path = temp_dir_ / "metadata_source.jpg";
+  const auto dst_path = temp_dir_ / "metadata_exported.jpg";
+
+  WriteTestJpeg(src_path, {128, 96, 64, 64, 96, 128}, 2, 1);
+
+  cv::Mat rgba32f(1, 2, CV_32FC4);
+  rgba32f.at<cv::Vec4f>(0, 0) = cv::Vec4f(0.5f, 0.4f, 0.3f, 1.0f);
+  rgba32f.at<cv::Vec4f>(0, 1) = cv::Vec4f(0.3f, 0.4f, 0.5f, 1.0f);
+  auto image_data = std::make_shared<ImageBuffer>(std::move(rgba32f));
+
+  ExportFormatOptions options;
+  options.format_ = ImageFormatType::JPEG;
+  options.export_path_ = dst_path;
+
+  ExifDisplayMetaData metadata;
+  metadata.make_ = "AlcedoCam";
+  metadata.model_ = "Model T";
+  metadata.lens_make_ = "Alcedo Optics";
+  metadata.lens_ = "Alcedo Optics 50mm F2";
+  metadata.date_time_str_ = "2023-12-31 23:59:58";
+  metadata.focal_ = 50.0f;
+  metadata.aperture_ = 2.0f;
+  metadata.iso_ = 400;
+
+  ImageWriter::WriteImageToPath(src_path, image_data, options, std::nullopt, metadata);
+
+  ASSERT_TRUE(std::filesystem::exists(dst_path));
+  EXPECT_EQ(ReadExifString(dst_path, "Exif.Image.Make"), metadata.make_);
+  EXPECT_EQ(ReadExifString(dst_path, "Exif.Image.Model"), metadata.model_);
+  EXPECT_EQ(ReadExifString(dst_path, "Exif.Photo.LensMake"), metadata.lens_make_);
+  EXPECT_EQ(ReadExifString(dst_path, "Exif.Photo.LensModel"), metadata.lens_);
+  EXPECT_EQ(ReadExifString(dst_path, "Exif.Photo.DateTimeOriginal"), "2023:12:31 23:59:58");
+  const auto xmp_create_date = ReadXmpString(dst_path, "Xmp.xmp.CreateDate");
+  if (!xmp_create_date.empty()) {
+    EXPECT_EQ(xmp_create_date, "2023-12-31T23:59:58");
   }
 }
 

--- a/alcedo_studio/tests/io/image_writer_test.cpp
+++ b/alcedo_studio/tests/io/image_writer_test.cpp
@@ -8,8 +8,13 @@
 #include <gtest/gtest.h>
 
 #include <exiv2/exiv2.hpp>
+#if defined(ALCEDO_HAS_ULTRAHDR)
+#include <ultrahdr_api.h>
+#endif
 
 #include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <memory>
 #include <opencv2/imgcodecs.hpp>
 #include <vector>
@@ -96,6 +101,14 @@ void WriteTestJpeg(const std::filesystem::path& path, const std::vector<uint8_t>
   ASSERT_TRUE(output->open(path.string(), spec));
   ASSERT_TRUE(output->write_image(TypeDesc::UINT8, rgb.data()));
   ASSERT_TRUE(output->close());
+}
+
+auto ReadFileBytes(const std::filesystem::path& path) -> std::vector<uint8_t> {
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open()) {
+    return {};
+  }
+  return std::vector<uint8_t>(std::istreambuf_iterator<char>(input), {});
 }
 
 }  // namespace
@@ -249,6 +262,51 @@ TEST_F(ImageWriterTests, EmbeddedHdrIccModeRejectsMetadataInjectedHdrJpegExport)
   EXPECT_THROW(ImageWriter::WriteImageToPath(src_path, image_data, options, hdr_profile, metadata),
                std::runtime_error);
   EXPECT_FALSE(std::filesystem::exists(dst_path));
+}
+
+TEST_F(ImageWriterTests, UltraHdrExportSupportsGainMapDitherToggle) {
+#if !defined(ALCEDO_HAS_ULTRAHDR)
+  GTEST_SKIP() << "Ultra HDR support is not enabled in this build.";
+#else
+  const auto src_path = temp_dir_ / "ultra_hdr_source.jpg";
+  std::vector<uint8_t> source_rgb;
+  source_rgb.reserve(8 * 8 * 3);
+  for (int y = 0; y < 8; ++y) {
+    for (int x = 0; x < 8; ++x) {
+      const auto v = static_cast<uint8_t>(16 + (x + y) * 12);
+      source_rgb.insert(source_rgb.end(), {v, v, v});
+    }
+  }
+  WriteTestJpeg(src_path, source_rgb, 8, 8);
+
+  cv::Mat rgba32f(8, 8, CV_32FC4);
+  for (int y = 0; y < rgba32f.rows; ++y) {
+    for (int x = 0; x < rgba32f.cols; ++x) {
+      const float v = 0.08f + 0.025f * static_cast<float>(x + y);
+      rgba32f.at<cv::Vec4f>(y, x) = cv::Vec4f(v, v * 0.85f, v * 0.65f, 1.0f);
+    }
+  }
+  auto image_data = std::make_shared<ImageBuffer>(std::move(rgba32f));
+
+  const auto hdr_profile =
+      MakeColorProfile(ColorUtils::ColorSpace::REC2020, ColorUtils::EOTF::ST2084);
+
+  for (const bool dither_enabled : {false, true}) {
+    ExportFormatOptions options;
+    options.format_ = ImageFormatType::JPEG;
+    options.export_path_ =
+        temp_dir_ / (dither_enabled ? "ultra_hdr_dither_on.jpg" : "ultra_hdr_dither_off.jpg");
+    options.hdr_export_mode_ = ExportFormatOptions::HDR_EXPORT_MODE::ULTRA_HDR;
+    options.ultra_hdr_dither_enabled_ = dither_enabled;
+
+    ImageWriter::WriteImageToPath(src_path, image_data, options, hdr_profile);
+
+    const std::vector<uint8_t> bytes = ReadFileBytes(options.export_path_);
+    ASSERT_FALSE(bytes.empty());
+    EXPECT_EQ(is_uhdr_image(const_cast<uint8_t*>(bytes.data()), static_cast<int>(bytes.size())), 1)
+        << "dither_enabled=" << dither_enabled;
+  }
+#endif
 }
 
 TEST_F(ImageWriterTests, ExportWritesCurrentRatingMetadata) {

--- a/alcedo_studio/tests/ui/album_backend_rating_test.cpp
+++ b/alcedo_studio/tests/ui/album_backend_rating_test.cpp
@@ -189,11 +189,20 @@ TEST_F(RatingTests, SetImageRating_UpdatesLoadedThumbnailWithoutModelReset) {
   auto* model = qobject_cast<AlbumThumbnailModel*>(backend.ThumbnailModel());
   ASSERT_NE(model, nullptr);
   QSignalSpy model_reset_spy(model, SIGNAL(modelReset()));
+  QSignalSpy data_changed_spy(model, &QAbstractItemModel::dataChanged);
 
   const QVariantMap result = backend.SetImageRating(seeded->element_id_, seeded->image_id_, 4);
   ASSERT_TRUE(result.value("success").toBool()) << result.value("message").toString().toStdString();
 
   EXPECT_EQ(model_reset_spy.count(), 0);
+  ASSERT_EQ(data_changed_spy.count(), 1);
+  const QList<QVariant> changed_args = data_changed_spy.takeFirst();
+  const QModelIndex     top_left = changed_args.at(0).value<QModelIndex>();
+  const QModelIndex     bottom_right = changed_args.at(1).value<QModelIndex>();
+  const auto            roles = qvariant_cast<QList<int>>(changed_args.at(2));
+  EXPECT_EQ(top_left.row(), 0);
+  EXPECT_EQ(bottom_right.row(), 0);
+  EXPECT_TRUE(roles.contains(AlbumThumbnailModel::Rating));
   ASSERT_EQ(model->count(), 1);
   EXPECT_EQ(model->getItemAt(0).value("rating").toInt(), 4);
 }

--- a/alcedo_studio/tests/ui/album_backend_rating_test.cpp
+++ b/alcedo_studio/tests/ui/album_backend_rating_test.cpp
@@ -179,6 +179,25 @@ TEST_F(RatingTests, GetImageRating_ReflectsCurrentRatingForContextMenuState) {
   EXPECT_EQ(thumbs.front().toMap().value("rating").toInt(), 3);
 }
 
+TEST_F(RatingTests, SetImageRating_UpdatesLoadedThumbnailWithoutModelReset) {
+  const auto seeded = CreateSeededPackedProject(temp_dir_, 0);
+  ASSERT_TRUE(seeded.has_value());
+
+  AlbumBackend backend;
+  ASSERT_TRUE(LoadPackedProject(backend, seeded->packed_path_));
+
+  auto* model = qobject_cast<AlbumThumbnailModel*>(backend.ThumbnailModel());
+  ASSERT_NE(model, nullptr);
+  QSignalSpy model_reset_spy(model, SIGNAL(modelReset()));
+
+  const QVariantMap result = backend.SetImageRating(seeded->element_id_, seeded->image_id_, 4);
+  ASSERT_TRUE(result.value("success").toBool()) << result.value("message").toString().toStdString();
+
+  EXPECT_EQ(model_reset_spy.count(), 0);
+  ASSERT_EQ(model->count(), 1);
+  EXPECT_EQ(model->getItemAt(0).value("rating").toInt(), 4);
+}
+
 TEST_F(RatingTests, ImageMetadata_NormalizesRatingToFiveStarStandard) {
   ExifDisplayMetaData metadata;
   metadata.FromJson({{"Rating", 99}});

--- a/scripts/ci_prepare_third_party.sh
+++ b/scripts/ci_prepare_third_party.sh
@@ -41,11 +41,10 @@ clone_if_missing \
   "CMakeLists.txt" \
   "https://github.com/lensfun/lensfun.git"
 
-clone_if_missing \
-  "alcedo_studio/src/third_party/libultrahdr" \
-  "third_party/image_io/includes/image_io/base/data_segment_data_source.h" \
-  "https://github.com/google/libultrahdr.git" \
-  --recurse-submodules
+if [[ ! -e "alcedo_studio/src/third_party/libultrahdr/third_party/image_io/includes/image_io/base/data_segment_data_source.h" ]]; then
+  git submodule sync -- "alcedo_studio/src/third_party/libultrahdr"
+  git submodule update --init --recursive --depth 1 "alcedo_studio/src/third_party/libultrahdr"
+fi
 
 clone_if_missing \
   "alcedo_studio/src/third_party/metal-cpp" \


### PR DESCRIPTION
This pull request introduces enhancements to HDR metadata detection and handling, refactors adjustment transfer operations, and improves export metadata propagation throughout the application. The most significant changes are grouped below:

**HDR Metadata Detection and Propagation:**

* Added robust HDR detection logic in `metadata_extractor.cpp` that inspects image metadata, file signatures, and OIIO attributes to determine HDR status. This status is now stored in the `ExifDisplayMetaData` struct as the `is_hdr_` field, and is extracted for all supported image types. 
* Updated the `Image` class and `ExifDisplayMetaData` to support setting and serializing the HDR flag, including new helper methods for setting HDR display metadata. 

**Export Metadata Handling:**

* Refactored export logic to propagate the complete `ExifDisplayMetaData` (including HDR status and other metadata) to the `ImageWriter` during export, replacing the previous rating-only approach. 
* Improved the logic for determining whether export metadata should be included, ensuring metadata is only attached if meaningful fields are present. 

**Adjustment Transfer Service Refactor:**

* Introduced `AdjustmentVersionApplyMode` (with `kPaste` and `kMerge` options) to the adjustment transfer service, allowing for more flexible application of adjustment versions (either as a transaction-per-edit or as a merged, transaction-free version). 
* Updated method signatures and logic in `adjustment_transfer_service.cpp` to support the new apply modes and improved version naming with customizable fallback names. 

**Color Management and Miscellaneous:**

* Improved color management in `odt_op.cpp` by setting `display_linear_scale_` according to encoding EOTF, ensuring correct luminance scaling for ST2084. 
* Added string utility functions for case-insensitive metadata inspection and pattern matching in `metadata_extractor.cpp` to support robust HDR detection. 

**Build System:**

* Added a new CMake build preset `win_debug_app` to facilitate targeted builds for the `alcedo_main` application. 