### PR TITLE
ci: configure R2 signing environment

### DIFF
--- a/.github/workflows/sync-release-to-r2.yml
+++ b/.github/workflows/sync-release-to-r2.yml
@@ -29,11 +29,13 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_REGION: auto
       AWS_DEFAULT_REGION: auto
       AWS_EC2_METADATA_DISABLED: "true"
       GH_TOKEN: ${{ github.token }}
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      AWS_ENDPOINT_URL: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
 
     steps:
       - name: Check R2 configuration


### PR DESCRIPTION
## What changed

Sets the R2-specific AWS CLI environment explicitly:

- `AWS_REGION=auto`
- `AWS_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com`

## Why

Cloudflare R2 uses AWS Signature Version 4 with the `auto` region. Making both settings explicit follows the R2 CLI guidance and avoids runner-specific AWS CLI configuration differences.

## Validation

- `git diff --check`
- Parsed the workflow YAML and asserted the R2 signing environment