### PR TITLE
refactor: Simplify the frame render path

### DIFF
--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -323,7 +323,7 @@ def_library(EditorSessionService
         "${ALCEDO_INCLUDE_ROOT}/edit/frame_presentation_types.hpp"
     # The session facade is application-only; no Widgets dependency belongs
     # on this target or on its public link interface.
-    PRIVATE_DEPS xxHash JSON ${ALCEDO_OPENCV_CORE_DEPS}
+    PRIVATE_DEPS xxHash JSON ${ALCEDO_OPENCV_CORE_DEPS} AppDiagnostics
                  EditHistory EditorMiniGitMaterializer EditorSaveCheckpointService EditorSessionLifecycle
                  EditorSessionNavigationController EditorSessionRenderController
                  EditorSessionEditController EditorSessionCommandQueue EditorActionPolicy

--- a/alcedo_studio/src/app/editor_render_coordinator.cpp
+++ b/alcedo_studio/src/app/editor_render_coordinator.cpp
@@ -105,6 +105,20 @@ void EditorRenderCoordinator::SetActiveImageLoadRequest(std::uint64_t image_load
   DeliverPendingResults();
 }
 
+void EditorRenderCoordinator::BindSessionRenderContext(std::uint64_t epoch,
+                                                       sl_element_id_t element_id,
+                                                       image_id_t image_id) {
+  if (scheduler_) {
+    scheduler_->BindSessionContext(epoch, element_id, image_id);
+  }
+}
+
+void EditorRenderCoordinator::ClearSessionRenderContext() {
+  if (scheduler_) {
+    scheduler_->ClearSessionContext();
+  }
+}
+
 auto EditorRenderCoordinator::AcceptOrReject(const EditorRenderIntent& intent,
                                              std::string*              message) const -> bool {
   if (intent.image_load_request_id.value != active_image_load_request_id_) {

--- a/alcedo_studio/src/app/editor_render_coordinator.cpp
+++ b/alcedo_studio/src/app/editor_render_coordinator.cpp
@@ -4,7 +4,6 @@
 
 #include "app/editor_render_coordinator.hpp"
 
-#include <algorithm>
 #include <utility>
 
 namespace alcedo {
@@ -18,6 +17,38 @@ void EditorRenderCoordinator::SetResultObserver(ResultObserver observer) {
   observer_ = std::move(observer);
 }
 
+auto EditorRenderCoordinator::SlotIndexForQuality(EditorRenderQuality quality) -> std::size_t {
+  switch (quality) {
+    case EditorRenderQuality::Interactive:
+      return static_cast<std::size_t>(QualitySlot::Interactive);
+    case EditorRenderQuality::Quality:
+      return static_cast<std::size_t>(QualitySlot::Quality);
+    case EditorRenderQuality::Detail:
+      return static_cast<std::size_t>(QualitySlot::Detail);
+  }
+  return static_cast<std::size_t>(QualitySlot::Interactive);
+}
+
+auto EditorRenderCoordinator::CountOccupiedSlots() const -> std::size_t {
+  std::size_t n = 0;
+  for (const auto& slot : slots_) {
+    if (slot.has_value()) {
+      ++n;
+    }
+  }
+  return n;
+}
+
+auto EditorRenderCoordinator::SelectNextSlotIndex() const -> std::optional<std::size_t> {
+  // Visible work order: interactive, settled quality, then detail patch.
+  for (std::size_t i = 0; i < kQualitySlotCount; ++i) {
+    if (slots_[i].has_value()) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
 auto EditorRenderCoordinator::IsObsolete(const EditorRenderIntent& intent) const -> bool {
   return intent.image_load_request_id.value != active_image_load_request_id_;
 }
@@ -28,19 +59,18 @@ auto EditorRenderCoordinator::CancelObsoleteForImageLoadMismatch() -> std::uint6
   // callback, which re-enters CancelRequest and would deadlock if called while
   // mutex_ is held (zoom animation used to hit this on every DetailRefresh).
   std::uint64_t scheduler_job_to_cancel = 0;
-  for (auto it = pending_.begin(); it != pending_.end();) {
-    if (IsObsolete(it->request.intent)) {
-      EditorRenderResult cancelled;
-      cancelled.kind       = EditorRenderResultKind::Cancelled;
-      cancelled.request_id = it->request.request_id;
-      cancelled.intent     = it->request.intent;
-      cancelled.message    = "Cancelled: obsolete image load request";
-      Emit(std::move(cancelled));
-      terminal_request_ids_.insert(it->request.request_id);
-      it = pending_.erase(it);
-    } else {
-      ++it;
+  for (auto& slot : slots_) {
+    if (!slot.has_value() || !IsObsolete(slot->request.intent)) {
+      continue;
     }
+    EditorRenderResult cancelled;
+    cancelled.kind       = EditorRenderResultKind::Cancelled;
+    cancelled.request_id = slot->request.request_id;
+    cancelled.intent     = slot->request.intent;
+    cancelled.message    = "Cancelled: obsolete image load request";
+    Emit(std::move(cancelled));
+    terminal_request_ids_.insert(slot->request.request_id);
+    slot.reset();
   }
   if (inflight_ && IsObsolete(inflight_->request.intent)) {
     scheduler_job_to_cancel        = inflight_->scheduler_job_id;
@@ -48,7 +78,7 @@ auto EditorRenderCoordinator::CancelObsoleteForImageLoadMismatch() -> std::uint6
     if (inflight_->request.intent.cancellation) {
       inflight_->request.intent.cancellation->Cancel();
     }
-    EditorRenderResult  cancelled;
+    EditorRenderResult cancelled;
     cancelled.kind       = EditorRenderResultKind::Cancelled;
     cancelled.request_id = request_id;
     cancelled.intent     = inflight_->request.intent;
@@ -98,72 +128,20 @@ auto EditorRenderCoordinator::AcceptOrReject(const EditorRenderIntent& intent,
   return true;
 }
 
-auto EditorRenderCoordinator::PriorityRank(EditorRenderPriority priority) -> int {
-  switch (priority) {
-    case EditorRenderPriority::High:
-      return 3;
-    case EditorRenderPriority::Normal:
-      return 2;
-    case EditorRenderPriority::Low:
-      return 1;
+void EditorRenderCoordinator::PlaceInSlot(std::size_t slot, PendingEntry entry) {
+  if (slot >= kQualitySlotCount) {
+    slot = static_cast<std::size_t>(QualitySlot::Interactive);
   }
-  return 0;
-}
-
-auto EditorRenderCoordinator::SelectNextIndex(const std::deque<PendingEntry>& pending)
-    -> std::size_t {
-  // Visible work order: interactive frame, settled quality frame, then detail
-  // patch. Priority breaks ties without disturbing stable order.
-  std::size_t best      = 0;
-  auto        role_rank = [](FrameRole role) -> int {
-    switch (role) {
-      case FrameRole::InteractivePrimary:
-        return 3;
-      case FrameRole::QualityBase:
-        return 2;
-      case FrameRole::DetailPatch:
-        return 1;
-    }
-    return 0;
-  };
-  for (std::size_t i = 1; i < pending.size(); ++i) {
-    const auto& a  = pending[i].request.intent;
-    const auto& b  = pending[best].request.intent;
-    const int   ra = role_rank(a.frame_role);
-    const int   rb = role_rank(b.frame_role);
-    if (ra > rb) {
-      best = i;
-      continue;
-    }
-    if (ra < rb) {
-      continue;
-    }
-    if (PriorityRank(a.priority) > PriorityRank(b.priority)) {
-      best = i;
-    }
+  if (slots_[slot].has_value()) {
+    EditorRenderResult replaced;
+    replaced.kind       = EditorRenderResultKind::Replaced;
+    replaced.request_id = slots_[slot]->request.request_id;
+    replaced.intent     = slots_[slot]->request.intent;
+    replaced.message    = "Replaced by newer intent in the same quality slot";
+    Emit(std::move(replaced));
+    terminal_request_ids_.insert(slots_[slot]->request.request_id);
   }
-  return best;
-}
-
-void EditorRenderCoordinator::ReplacePendingWithKey(const std::string& key,
-                                                    std::uint64_t      except_request_id) {
-  if (key.empty()) {
-    return;
-  }
-  for (auto it = pending_.begin(); it != pending_.end();) {
-    if (it->request.request_id != except_request_id && it->request.intent.replacement_key == key) {
-      EditorRenderResult replaced;
-      replaced.kind       = EditorRenderResultKind::Replaced;
-      replaced.request_id = it->request.request_id;
-      replaced.intent     = it->request.intent;
-      replaced.message    = "Replaced by newer intent with the same replacement key";
-      Emit(std::move(replaced));
-      terminal_request_ids_.insert(it->request.request_id);
-      it = pending_.erase(it);
-    } else {
-      ++it;
-    }
-  }
+  slots_[slot] = std::move(entry);
 }
 
 void EditorRenderCoordinator::Emit(EditorRenderResult result) {
@@ -243,7 +221,7 @@ void EditorRenderCoordinator::DeliverPendingResults() {
 auto EditorRenderCoordinator::Submit(const EditorRenderIntent& intent) -> EditorRenderResult {
   EditorRenderResult result;
   {
-    std::scoped_lock   lock(mutex_);
+    std::scoped_lock lock(mutex_);
     // Fill defaults before storing the immutable accepted request.
     EditorRenderIntent stamped = intent;
     FillRenderIntentDefaults(stamped);
@@ -266,11 +244,9 @@ auto EditorRenderCoordinator::Submit(const EditorRenderIntent& intent) -> Editor
       request.request_id = next_request_id_++;
       request.intent     = std::move(stamped);
 
-      ReplacePendingWithKey(request.intent.replacement_key, request.request_id);
-
       PendingEntry entry;
       entry.request = request;
-      pending_.push_back(std::move(entry));
+      PlaceInSlot(SlotIndexForQuality(request.intent.quality), std::move(entry));
 
       result.kind       = EditorRenderResultKind::RequestAccepted;
       result.request_id = request.request_id;
@@ -289,19 +265,19 @@ void EditorRenderCoordinator::CancelSession(std::uint64_t image_load_request_id)
   std::uint64_t scheduler_job_to_cancel = 0;
   {
     std::scoped_lock lock(mutex_);
-    for (auto it = pending_.begin(); it != pending_.end();) {
-      if (it->request.intent.image_load_request_id.value == image_load_request_id) {
-        EditorRenderResult cancelled;
-        cancelled.kind       = EditorRenderResultKind::Cancelled;
-        cancelled.request_id = it->request.request_id;
-        cancelled.intent     = it->request.intent;
-        cancelled.message    = "Cancelled with session";
-        Emit(std::move(cancelled));
-        terminal_request_ids_.insert(it->request.request_id);
-        it = pending_.erase(it);
-      } else {
-        ++it;
+    for (auto& slot : slots_) {
+      if (!slot.has_value() ||
+          slot->request.intent.image_load_request_id.value != image_load_request_id) {
+        continue;
       }
+      EditorRenderResult cancelled;
+      cancelled.kind       = EditorRenderResultKind::Cancelled;
+      cancelled.request_id = slot->request.request_id;
+      cancelled.intent     = slot->request.intent;
+      cancelled.message    = "Cancelled with session";
+      Emit(std::move(cancelled));
+      terminal_request_ids_.insert(slot->request.request_id);
+      slot.reset();
     }
     if (inflight_ && inflight_->request.intent.image_load_request_id.value == image_load_request_id) {
       scheduler_job_to_cancel        = inflight_->scheduler_job_id;
@@ -309,7 +285,7 @@ void EditorRenderCoordinator::CancelSession(std::uint64_t image_load_request_id)
       if (inflight_->request.intent.cancellation) {
         inflight_->request.intent.cancellation->Cancel();
       }
-      EditorRenderResult  cancelled;
+      EditorRenderResult cancelled;
       cancelled.kind       = EditorRenderResultKind::Cancelled;
       cancelled.request_id = request_id;
       cancelled.intent     = inflight_->request.intent;
@@ -340,19 +316,19 @@ void EditorRenderCoordinator::WaitForSessionIdle(std::uint64_t image_load_reques
   // - Do not cancel in-flight work — let it present, then take render_lock.
   {
     std::scoped_lock lock(mutex_);
-    for (auto it = pending_.begin(); it != pending_.end();) {
-      if (it->request.intent.image_load_request_id.value == image_load_request_id) {
-        EditorRenderResult cancelled;
-        cancelled.kind       = EditorRenderResultKind::Cancelled;
-        cancelled.request_id = it->request.request_id;
-        cancelled.intent     = it->request.intent;
-        cancelled.message    = "Superseded while queueing behind in-flight frame";
-        Emit(std::move(cancelled));
-        terminal_request_ids_.insert(it->request.request_id);
-        it = pending_.erase(it);
-      } else {
-        ++it;
+    for (auto& slot : slots_) {
+      if (!slot.has_value() ||
+          slot->request.intent.image_load_request_id.value != image_load_request_id) {
+        continue;
       }
+      EditorRenderResult cancelled;
+      cancelled.kind       = EditorRenderResultKind::Cancelled;
+      cancelled.request_id = slot->request.request_id;
+      cancelled.intent     = slot->request.intent;
+      cancelled.message    = "Superseded while queueing behind in-flight frame";
+      Emit(std::move(cancelled));
+      terminal_request_ids_.insert(slot->request.request_id);
+      slot.reset();
     }
   }
   DeliverPendingResults();
@@ -371,18 +347,18 @@ auto EditorRenderCoordinator::CancelRequest(std::uint64_t request_id) -> bool {
   {
     std::scoped_lock lock(mutex_);
     if (terminal_request_ids_.count(request_id) == 0) {
-      for (auto it = pending_.begin(); it != pending_.end(); ++it) {
-        if (it->request.request_id != request_id) {
+      for (auto& slot : slots_) {
+        if (!slot.has_value() || slot->request.request_id != request_id) {
           continue;
         }
         EditorRenderResult cancelled;
         cancelled.kind       = EditorRenderResultKind::Cancelled;
         cancelled.request_id = request_id;
-        cancelled.intent     = it->request.intent;
+        cancelled.intent     = slot->request.intent;
         cancelled.message    = "Cancelled by request id";
         Emit(std::move(cancelled));
         terminal_request_ids_.insert(request_id);
-        pending_.erase(it);
+        slot.reset();
         ScheduleNext();
         did_cancel = true;
         break;
@@ -411,42 +387,48 @@ auto EditorRenderCoordinator::CancelRequest(std::uint64_t request_id) -> bool {
   return did_cancel;
 }
 
-void EditorRenderCoordinator::ScheduleNext() {
-  if (inflight_ || pending_.empty() || !scheduler_) {
-    return;
-  }
-
-  // Drop cancelled pending entries before selecting.
-  for (auto it = pending_.begin(); it != pending_.end();) {
-    if (it->request.intent.cancellation && it->request.intent.cancellation->IsCancelled()) {
+void EditorRenderCoordinator::ScrubPendingSlots() {
+  for (auto& slot : slots_) {
+    if (!slot.has_value()) {
+      continue;
+    }
+    if (slot->request.intent.cancellation && slot->request.intent.cancellation->IsCancelled()) {
       EditorRenderResult cancelled;
       cancelled.kind       = EditorRenderResultKind::Cancelled;
-      cancelled.request_id = it->request.request_id;
-      cancelled.intent     = it->request.intent;
+      cancelled.request_id = slot->request.request_id;
+      cancelled.intent     = slot->request.intent;
       cancelled.message    = "Cancelled by token before schedule";
       Emit(std::move(cancelled));
-      terminal_request_ids_.insert(it->request.request_id);
-      it = pending_.erase(it);
-    } else if (IsObsolete(it->request.intent)) {
+      terminal_request_ids_.insert(slot->request.request_id);
+      slot.reset();
+      continue;
+    }
+    if (IsObsolete(slot->request.intent)) {
       EditorRenderResult cancelled;
       cancelled.kind       = EditorRenderResultKind::Cancelled;
-      cancelled.request_id = it->request.request_id;
-      cancelled.intent     = it->request.intent;
+      cancelled.request_id = slot->request.request_id;
+      cancelled.intent     = slot->request.intent;
       cancelled.message    = "Cancelled: obsolete image load request before schedule";
       Emit(std::move(cancelled));
-      terminal_request_ids_.insert(it->request.request_id);
-      it = pending_.erase(it);
-    } else {
-      ++it;
+      terminal_request_ids_.insert(slot->request.request_id);
+      slot.reset();
     }
   }
-  if (pending_.empty()) {
+}
+
+void EditorRenderCoordinator::ScheduleNext() {
+  if (inflight_ || !scheduler_) {
     return;
   }
 
-  const std::size_t index = SelectNextIndex(pending_);
-  PendingEntry      entry = pending_[index];
-  pending_.erase(pending_.begin() + static_cast<std::ptrdiff_t>(index));
+  ScrubPendingSlots();
+  const auto next_slot = SelectNextSlotIndex();
+  if (!next_slot.has_value()) {
+    return;
+  }
+
+  PendingEntry entry = std::move(*slots_[*next_slot]);
+  slots_[*next_slot].reset();
 
   const std::uint64_t job_id = scheduler_->Schedule(entry.request);
   if (job_id == 0) {

--- a/alcedo_studio/src/app/editor_render_coordinator.cpp
+++ b/alcedo_studio/src/app/editor_render_coordinator.cpp
@@ -170,9 +170,10 @@ void EditorRenderCoordinator::SetActiveImageLoadRequest(std::uint64_t image_load
 
 void EditorRenderCoordinator::BindSessionRenderContext(std::uint64_t epoch,
                                                        sl_element_id_t element_id,
-                                                       image_id_t image_id) {
+                                                       image_id_t image_id,
+                                                       PresentationSinkId presentation_sink_id) {
   if (scheduler_) {
-    scheduler_->BindSessionContext(epoch, element_id, image_id);
+    scheduler_->BindSessionContext(epoch, element_id, image_id, presentation_sink_id);
   }
 }
 
@@ -180,6 +181,12 @@ void EditorRenderCoordinator::ClearSessionRenderContext() {
   if (scheduler_) {
     scheduler_->ClearSessionContext();
   }
+}
+
+void EditorRenderCoordinator::SetPipelineSchedulerPort(
+    std::shared_ptr<IEditorPipelineSchedulerPort> scheduler) {
+  std::scoped_lock lock(mutex_);
+  scheduler_ = std::move(scheduler);
 }
 
 auto EditorRenderCoordinator::AcceptOrReject(const EditorRenderIntent& intent,

--- a/alcedo_studio/src/app/editor_render_coordinator.cpp
+++ b/alcedo_studio/src/app/editor_render_coordinator.cpp
@@ -105,20 +105,6 @@ void EditorRenderCoordinator::SetActiveImageLoadRequest(std::uint64_t image_load
   DeliverPendingResults();
 }
 
-void EditorRenderCoordinator::BindSessionRenderContext(std::uint64_t epoch,
-                                                       sl_element_id_t element_id,
-                                                       image_id_t image_id) {
-  if (scheduler_) {
-    scheduler_->BindSessionContext(epoch, element_id, image_id);
-  }
-}
-
-void EditorRenderCoordinator::ClearSessionRenderContext() {
-  if (scheduler_) {
-    scheduler_->ClearSessionContext();
-  }
-}
-
 auto EditorRenderCoordinator::AcceptOrReject(const EditorRenderIntent& intent,
                                              std::string*              message) const -> bool {
   if (intent.image_load_request_id.value != active_image_load_request_id_) {

--- a/alcedo_studio/src/app/editor_render_coordinator.cpp
+++ b/alcedo_studio/src/app/editor_render_coordinator.cpp
@@ -4,9 +4,72 @@
 
 #include "app/editor_render_coordinator.hpp"
 
+#include "utils/diagnostics/render_e2e_timing.hpp"
+
 #include <utility>
 
 namespace alcedo {
+namespace {
+
+auto ReasonLabel(const EditorRenderReason reason) -> const char* {
+  switch (reason) {
+    case EditorRenderReason::InitialFrame:
+      return "InitialFrame";
+    case EditorRenderReason::InteractiveAdjustment:
+      return "InteractiveAdjustment";
+    case EditorRenderReason::SettledAdjustment:
+      return "SettledAdjustment";
+    case EditorRenderReason::ZoomPan:
+      return "ZoomPan";
+    case EditorRenderReason::Resize:
+      return "Resize";
+    case EditorRenderReason::DetailRefresh:
+      return "DetailRefresh";
+    case EditorRenderReason::UndoRedo:
+      return "UndoRedo";
+    case EditorRenderReason::ImageSwitch:
+      return "ImageSwitch";
+    case EditorRenderReason::Retry:
+      return "Retry";
+    case EditorRenderReason::CropRotate:
+      return "CropRotate";
+    case EditorRenderReason::ScopeRefresh:
+      return "ScopeRefresh";
+  }
+  return "?";
+}
+
+auto QualityLabel(const EditorRenderQuality quality) -> const char* {
+  switch (quality) {
+    case EditorRenderQuality::Interactive:
+      return "Interactive";
+    case EditorRenderQuality::Quality:
+      return "Quality";
+    case EditorRenderQuality::Detail:
+      return "Detail";
+  }
+  return "?";
+}
+
+auto RoleLabel(const FrameRole role) -> const char* {
+  switch (role) {
+    case FrameRole::InteractivePrimary:
+      return "InteractivePrimary";
+    case FrameRole::QualityBase:
+      return "QualityBase";
+    case FrameRole::DetailPatch:
+      return "DetailPatch";
+  }
+  return "?";
+}
+
+void NoteE2eSubmit(const EditorRenderRequest& request) {
+  diag::NoteRenderE2eSubmit(request.request_id, ReasonLabel(request.intent.reason),
+                            QualityLabel(request.intent.quality),
+                            RoleLabel(request.intent.frame_role));
+}
+
+}  // namespace
 
 EditorRenderCoordinator::EditorRenderCoordinator(
     std::shared_ptr<IEditorPipelineSchedulerPort> scheduler)
@@ -165,9 +228,15 @@ void EditorRenderCoordinator::Emit(EditorRenderResult result) {
       break;
     case EditorRenderResultKind::Replaced:
       ++replaced_count_;
+      if (result.request_id != 0) {
+        diag::NoteRenderE2eTerminal(result.request_id, "replaced");
+      }
       break;
     case EditorRenderResultKind::Cancelled:
       ++cancelled_count_;
+      if (result.request_id != 0) {
+        diag::NoteRenderE2eTerminal(result.request_id, "cancelled");
+      }
       break;
     case EditorRenderResultKind::Failed:
       ++failed_count_;
@@ -176,6 +245,9 @@ void EditorRenderCoordinator::Emit(EditorRenderResult result) {
       if (result.message.rfind("Rejected:", 0) == 0) {
         last_rejection_reason_       = last_error_;
         last_rejected_render_reason_ = result.intent.reason;
+      }
+      if (result.request_id != 0) {
+        diag::NoteRenderE2eTerminal(result.request_id, "failed");
       }
       break;
     case EditorRenderResultKind::FrameReady:
@@ -257,6 +329,7 @@ auto EditorRenderCoordinator::Submit(const EditorRenderIntent& intent) -> Editor
       EditorRenderRequest request;
       request.request_id = next_request_id_++;
       request.intent     = std::move(stamped);
+      NoteE2eSubmit(request);
 
       PendingEntry entry;
       entry.request = request;
@@ -460,6 +533,7 @@ void EditorRenderCoordinator::ScheduleNext() {
   entry.scheduler_job_id     = job_id;
   last_scheduled_request_id_ = entry.request.request_id;
   inflight_                  = std::move(entry);
+  diag::NoteRenderE2eScheduled(inflight_->request.request_id);
 
   EditorRenderResult started;
   started.kind       = EditorRenderResultKind::RenderStarted;
@@ -477,7 +551,8 @@ void EditorRenderCoordinator::Pump() {
 }
 
 void EditorRenderCoordinator::NotifySchedulerCompleted(std::uint64_t request_id, bool success,
-                                                       std::string message) {
+                                                       std::string message,
+                                                       bool schedule_next_from_pool) {
   {
     std::scoped_lock lock(mutex_);
     if (inflight_ && inflight_->request.request_id == request_id) {
@@ -496,7 +571,11 @@ void EditorRenderCoordinator::NotifySchedulerCompleted(std::uint64_t request_id,
         terminal_request_ids_.insert(request_id);
       }
       inflight_.reset();
-      ScheduleNext();
+      // Defer the next ScheduleNext when the pipeline pool just handed a Ready
+      // frame to present; keeps produce from overlapping the current vsync.
+      if (schedule_next_from_pool) {
+        ScheduleNext();
+      }
     }
   }
   DeliverPendingResults();

--- a/alcedo_studio/src/app/editor_session_render_controller.cpp
+++ b/alcedo_studio/src/app/editor_session_render_controller.cpp
@@ -119,7 +119,7 @@ auto EditorSessionRenderController::RouteInitialRender(const EditorRenderCommand
   }
   // Bind stable session render inputs at open/switch before first schedule.
   deps_.render->BindSessionRenderContext(image_load_request.value, identity.element_id,
-                                         identity.image_id);
+                                         identity.image_id, presentation_sink_id_);
   deps_.render->SetActiveImageLoadRequest(image_load_request.value);
   const EditorRenderResult routed = deps_.render->Submit(*intent);
   if (routed.kind == EditorRenderResultKind::RequestAccepted) {

--- a/alcedo_studio/src/app/editor_session_render_controller.cpp
+++ b/alcedo_studio/src/app/editor_session_render_controller.cpp
@@ -117,9 +117,6 @@ auto EditorSessionRenderController::RouteInitialRender(const EditorRenderCommand
   if (!intent) {
     return 0;
   }
-  // Bind stable session render inputs at open/switch before first schedule.
-  deps_.render->BindSessionRenderContext(image_load_request.value, identity.element_id,
-                                         identity.image_id);
   deps_.render->SetActiveImageLoadRequest(image_load_request.value);
   const EditorRenderResult routed = deps_.render->Submit(*intent);
   if (routed.kind == EditorRenderResultKind::RequestAccepted) {
@@ -364,10 +361,6 @@ auto EditorSessionRenderController::presentation_sink_id() const -> Presentation
 }
 
 void EditorSessionRenderController::ResetForNewImage() {
-  // Drop prior image render inputs before the new open/switch binds a context.
-  if (deps_.render) {
-    deps_.render->ClearSessionRenderContext();
-  }
   std::scoped_lock lock(mutex_);
   first_frame_request_id_  = 0;
   quality_base_request_id_ = 0;

--- a/alcedo_studio/src/app/editor_session_render_controller.cpp
+++ b/alcedo_studio/src/app/editor_session_render_controller.cpp
@@ -117,6 +117,9 @@ auto EditorSessionRenderController::RouteInitialRender(const EditorRenderCommand
   if (!intent) {
     return 0;
   }
+  // Bind stable session render inputs at open/switch before first schedule.
+  deps_.render->BindSessionRenderContext(image_load_request.value, identity.element_id,
+                                         identity.image_id);
   deps_.render->SetActiveImageLoadRequest(image_load_request.value);
   const EditorRenderResult routed = deps_.render->Submit(*intent);
   if (routed.kind == EditorRenderResultKind::RequestAccepted) {
@@ -361,6 +364,10 @@ auto EditorSessionRenderController::presentation_sink_id() const -> Presentation
 }
 
 void EditorSessionRenderController::ResetForNewImage() {
+  // Drop prior image render inputs before the new open/switch binds a context.
+  if (deps_.render) {
+    deps_.render->ClearSessionRenderContext();
+  }
   std::scoped_lock lock(mutex_);
   first_frame_request_id_  = 0;
   quality_base_request_id_ = 0;

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -240,12 +240,26 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     stage_profiles.push_back(std::move(stage_profile));
   };
 
+  // Session tasks hold a multi-MB encoded source (RAW file bytes). A distinct
+  // ImageBuffer must wrap that payload for RAW_DECODE (*input = move(decoded)),
+  // but the underlying vector must be shared — deep-cloning it on every
+  // quality-ladder cache miss re-copies the whole file into working results.
+  const auto materialize_stage_input = [&](const char* step_name) {
+    const auto materialize_start = ProfileClock::now();
+    if (input && input->buffer_valid_ && !input->cpu_data_valid_ && !input->gpu_data_valid_) {
+      output = input->ShareEncodedBuffer();
+      executor_steps.push_back(std::string(step_name) + "_share_encoded=" +
+                               FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
+      return;
+    }
+    output = std::make_shared<ImageBuffer>(input->Clone());
+    executor_steps.push_back(std::string(step_name) + "_clone=" +
+                             FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
+  };
+
   if (enable_cache_) {
     if (!first_stage->CacheValid()) {
-      const auto clone_start = ProfileClock::now();
-      output = std::make_shared<ImageBuffer>(input->Clone());
-      executor_steps.push_back("clone_input=" +
-                               FormatDurationMs(DurationToMs(ProfileClock::now() - clone_start)));
+      materialize_stage_input("stage_input");
       for (auto* stage : exec_stages_) {
         apply_stage(stage);
       }
@@ -269,10 +283,7 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     }
   } else {
     // Cache is disabled, just process the stages sequentially
-    const auto clone_start = ProfileClock::now();
-    output = std::make_shared<ImageBuffer>(input->Clone());
-    executor_steps.push_back("clone_input=" +
-                             FormatDurationMs(DurationToMs(ProfileClock::now() - clone_start)));
+    materialize_stage_input("stage_input");
     for (auto* stage : exec_stages_) {
       apply_stage(stage);
     }

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -240,26 +240,12 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     stage_profiles.push_back(std::move(stage_profile));
   };
 
-  // Session tasks hold a multi-MB encoded source (RAW file bytes). A distinct
-  // ImageBuffer must wrap that payload for RAW_DECODE (*input = move(decoded)),
-  // but the underlying vector must be shared — deep-cloning it on every
-  // quality-ladder cache miss re-copies the whole file into working results.
-  const auto materialize_stage_input = [&](const char* step_name) {
-    const auto materialize_start = ProfileClock::now();
-    if (input && input->buffer_valid_ && !input->cpu_data_valid_ && !input->gpu_data_valid_) {
-      output = input->ShareEncodedBuffer();
-      executor_steps.push_back(std::string(step_name) + "_share_encoded=" +
-                               FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
-      return;
-    }
-    output = std::make_shared<ImageBuffer>(input->Clone());
-    executor_steps.push_back(std::string(step_name) + "_clone=" +
-                             FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
-  };
-
   if (enable_cache_) {
     if (!first_stage->CacheValid()) {
-      materialize_stage_input("stage_input");
+      const auto clone_start = ProfileClock::now();
+      output = std::make_shared<ImageBuffer>(input->Clone());
+      executor_steps.push_back("clone_input=" +
+                               FormatDurationMs(DurationToMs(ProfileClock::now() - clone_start)));
       for (auto* stage : exec_stages_) {
         apply_stage(stage);
       }
@@ -283,7 +269,10 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     }
   } else {
     // Cache is disabled, just process the stages sequentially
-    materialize_stage_input("stage_input");
+    const auto clone_start = ProfileClock::now();
+    output = std::make_shared<ImageBuffer>(input->Clone());
+    executor_steps.push_back("clone_input=" +
+                             FormatDurationMs(DurationToMs(ProfileClock::now() - clone_start)));
     for (auto* stage : exec_stages_) {
       apply_stage(stage);
     }

--- a/alcedo_studio/src/edit/pipeline/pipeline_stage.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_stage.cpp
@@ -531,12 +531,10 @@ std::shared_ptr<ImageBuffer> PipelineStage::ApplyGpuOperators(OperatorParams& gl
         profile.AddDuration("copy_input_gpu", ProfileClock::now() - copy_start);
       }
     } else if (input_img_->buffer_valid_) {
-      // Share encoded payload (O(1)). Do not deep-copy multi-MB RAW file bytes —
-      // RAW_DECODE replaces *this working ImageBuffer in place and leaves the
-      // session-held source ImageBuffer intact when the objects are distinct.
       const auto materialize_start = ProfileClock::now();
-      current_img                  = input_img_->ShareEncodedBuffer();
-      profile.AddDuration("share_input_buffer", ProfileClock::now() - materialize_start);
+      auto       buffer            = input_img_->GetBuffer();
+      current_img = std::make_shared<ImageBuffer>(std::move(buffer));
+      profile.AddDuration("materialize_input_buffer", ProfileClock::now() - materialize_start);
     }
 
     const auto apply_gpu_operator = [&](OperatorType op_type, const OperatorEntry& op_entry) {

--- a/alcedo_studio/src/edit/pipeline/pipeline_stage.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_stage.cpp
@@ -531,10 +531,12 @@ std::shared_ptr<ImageBuffer> PipelineStage::ApplyGpuOperators(OperatorParams& gl
         profile.AddDuration("copy_input_gpu", ProfileClock::now() - copy_start);
       }
     } else if (input_img_->buffer_valid_) {
+      // Share encoded payload (O(1)). Do not deep-copy multi-MB RAW file bytes —
+      // RAW_DECODE replaces *this working ImageBuffer in place and leaves the
+      // session-held source ImageBuffer intact when the objects are distinct.
       const auto materialize_start = ProfileClock::now();
-      auto       buffer            = input_img_->GetBuffer();
-      current_img = std::make_shared<ImageBuffer>(std::move(buffer));
-      profile.AddDuration("materialize_input_buffer", ProfileClock::now() - materialize_start);
+      current_img                  = input_img_->ShareEncodedBuffer();
+      profile.AddDuration("share_input_buffer", ProfileClock::now() - materialize_start);
     }
 
     const auto apply_gpu_operator = [&](OperatorType op_type, const OperatorEntry& op_entry) {

--- a/alcedo_studio/src/image/image_buffer.cpp
+++ b/alcedo_studio/src/image/image_buffer.cpp
@@ -364,7 +364,7 @@ ImageBuffer::ImageBuffer(cv::Mat& data) : cpu_data_valid_(true) { data.copyTo(cp
 ImageBuffer::ImageBuffer(cv::Mat&& data) : cpu_data_(std::move(data)), cpu_data_valid_(true) {}
 
 ImageBuffer::ImageBuffer(std::vector<uint8_t>&& buffer) : buffer_valid_(true) {
-  buffer_ = std::make_shared<std::vector<uint8_t>>(std::move(buffer));
+  buffer_ = std::make_unique<std::vector<uint8_t>>(std::move(buffer));
 }
 
 ImageBuffer::ImageBuffer(ImageBuffer&& other) noexcept
@@ -411,18 +411,8 @@ ImageBuffer& ImageBuffer::operator=(ImageBuffer&& other) noexcept {
 }
 
 void ImageBuffer::ReadFromVectorBuffer(std::vector<uint8_t>&& buffer) {
-  buffer_       = std::make_shared<std::vector<uint8_t>>(std::move(buffer));
+  buffer_       = std::make_unique<std::vector<uint8_t>>(std::move(buffer));
   buffer_valid_ = true;
-}
-
-auto ImageBuffer::ShareEncodedBuffer() const -> std::shared_ptr<ImageBuffer> {
-  if (!buffer_valid_ || !buffer_) {
-    throw std::runtime_error("ImageBuffer: No valid encoded buffer data to share.");
-  }
-  auto shared          = std::make_shared<ImageBuffer>();
-  shared->buffer_      = buffer_;
-  shared->buffer_valid_ = true;
-  return shared;
 }
 
 auto ImageBuffer::GetCPUData() -> cv::Mat& {
@@ -583,12 +573,8 @@ ImageBuffer ImageBuffer::Clone() const {
     return ImageBuffer{std::move(cpu_copy)};
   }
   if (buffer_valid_) {
-    // Alias encoded bytes; callers that need an isolated ImageBuffer object
-    // (RAW_DECODE in-place replace) should use ShareEncodedBuffer().
-    ImageBuffer copy;
-    copy.buffer_       = buffer_;
-    copy.buffer_valid_ = true;
-    return copy;
+    auto buffer = *buffer_;
+    return ImageBuffer{std::move(buffer)};
   }
   throw std::runtime_error("ImageBuffer: No valid data to clone.");
 }

--- a/alcedo_studio/src/image/image_buffer.cpp
+++ b/alcedo_studio/src/image/image_buffer.cpp
@@ -364,7 +364,7 @@ ImageBuffer::ImageBuffer(cv::Mat& data) : cpu_data_valid_(true) { data.copyTo(cp
 ImageBuffer::ImageBuffer(cv::Mat&& data) : cpu_data_(std::move(data)), cpu_data_valid_(true) {}
 
 ImageBuffer::ImageBuffer(std::vector<uint8_t>&& buffer) : buffer_valid_(true) {
-  buffer_ = std::make_unique<std::vector<uint8_t>>(std::move(buffer));
+  buffer_ = std::make_shared<std::vector<uint8_t>>(std::move(buffer));
 }
 
 ImageBuffer::ImageBuffer(ImageBuffer&& other) noexcept
@@ -411,8 +411,18 @@ ImageBuffer& ImageBuffer::operator=(ImageBuffer&& other) noexcept {
 }
 
 void ImageBuffer::ReadFromVectorBuffer(std::vector<uint8_t>&& buffer) {
-  buffer_       = std::make_unique<std::vector<uint8_t>>(std::move(buffer));
+  buffer_       = std::make_shared<std::vector<uint8_t>>(std::move(buffer));
   buffer_valid_ = true;
+}
+
+auto ImageBuffer::ShareEncodedBuffer() const -> std::shared_ptr<ImageBuffer> {
+  if (!buffer_valid_ || !buffer_) {
+    throw std::runtime_error("ImageBuffer: No valid encoded buffer data to share.");
+  }
+  auto shared          = std::make_shared<ImageBuffer>();
+  shared->buffer_      = buffer_;
+  shared->buffer_valid_ = true;
+  return shared;
 }
 
 auto ImageBuffer::GetCPUData() -> cv::Mat& {
@@ -573,8 +583,12 @@ ImageBuffer ImageBuffer::Clone() const {
     return ImageBuffer{std::move(cpu_copy)};
   }
   if (buffer_valid_) {
-    auto buffer = *buffer_;
-    return ImageBuffer{std::move(buffer)};
+    // Alias encoded bytes; callers that need an isolated ImageBuffer object
+    // (RAW_DECODE in-place replace) should use ShareEncodedBuffer().
+    ImageBuffer copy;
+    copy.buffer_       = buffer_;
+    copy.buffer_valid_ = true;
+    return copy;
   }
   throw std::runtime_error("ImageBuffer: No valid data to clone.");
 }

--- a/alcedo_studio/src/include/app/editor_render_coordinator.hpp
+++ b/alcedo_studio/src/include/app/editor_render_coordinator.hpp
@@ -87,7 +87,10 @@ class EditorRenderCoordinator final : public IEditorRenderSubmitPort {
   auto CancelRequest(std::uint64_t request_id) -> bool;
 
   /// Mark the blocking scheduler call complete and start the next request.
-  void NotifySchedulerCompleted(std::uint64_t request_id, bool success, std::string message = {});
+  /// `schedule_next_from_pool=false` defers ScheduleNext (present handoff);
+  /// production calls true only from a scheduler-pool callback tail.
+  void NotifySchedulerCompleted(std::uint64_t request_id, bool success, std::string message = {},
+                                bool schedule_next_from_pool = true);
 
   /// Process pending slots: schedule at most one job when idle.
   void Pump();

--- a/alcedo_studio/src/include/app/editor_render_coordinator.hpp
+++ b/alcedo_studio/src/include/app/editor_render_coordinator.hpp
@@ -27,12 +27,6 @@ class IEditorPipelineSchedulerPort {
   virtual auto Schedule(const EditorRenderRequest& request) -> std::uint64_t = 0;
   virtual void Cancel(std::uint64_t scheduler_job_id)                        = 0;
   virtual void WaitForSessionIdle(std::uint64_t /*session_epoch*/) {}
-  /// Bind stable render inputs for the open/switched image (epoch + identity).
-  /// Production loads image/buffer/pipeline once; fakes no-op.
-  virtual void BindSessionContext(std::uint64_t /*epoch*/, sl_element_id_t /*element_id*/,
-                                  image_id_t /*image_id*/) {}
-  /// Drop the bound session render context (close / pre-switch reset).
-  virtual void ClearSessionContext() {}
 };
 
 /// Application-layer owner of editor render coalesce + single-flight scheduling.
@@ -62,11 +56,6 @@ class EditorRenderCoordinator final : public IEditorRenderSubmitPort {
 
   /// Active image-load request. Older pending intents for other loads are removed.
   void SetActiveImageLoadRequest(std::uint64_t image_load_request_id) override;
-
-  /// Forward open/switch session render context bind to the production adapter.
-  void BindSessionRenderContext(std::uint64_t epoch, sl_element_id_t element_id,
-                                image_id_t image_id) override;
-  void ClearSessionRenderContext() override;
 
   [[nodiscard]] auto image_load_request_id() const -> std::uint64_t {
     std::scoped_lock lock(mutex_);

--- a/alcedo_studio/src/include/app/editor_render_coordinator.hpp
+++ b/alcedo_studio/src/include/app/editor_render_coordinator.hpp
@@ -27,6 +27,12 @@ class IEditorPipelineSchedulerPort {
   virtual auto Schedule(const EditorRenderRequest& request) -> std::uint64_t = 0;
   virtual void Cancel(std::uint64_t scheduler_job_id)                        = 0;
   virtual void WaitForSessionIdle(std::uint64_t /*session_epoch*/) {}
+  /// Bind stable render inputs for the open/switched image (epoch + identity).
+  /// Production loads image/buffer/pipeline once; fakes no-op.
+  virtual void BindSessionContext(std::uint64_t /*epoch*/, sl_element_id_t /*element_id*/,
+                                  image_id_t /*image_id*/) {}
+  /// Drop the bound session render context (close / pre-switch reset).
+  virtual void ClearSessionContext() {}
 };
 
 /// Application-layer owner of editor render coalesce + single-flight scheduling.
@@ -56,6 +62,11 @@ class EditorRenderCoordinator final : public IEditorRenderSubmitPort {
 
   /// Active image-load request. Older pending intents for other loads are removed.
   void SetActiveImageLoadRequest(std::uint64_t image_load_request_id) override;
+
+  /// Forward open/switch session render context bind to the production adapter.
+  void BindSessionRenderContext(std::uint64_t epoch, sl_element_id_t element_id,
+                                image_id_t image_id) override;
+  void ClearSessionRenderContext() override;
 
   [[nodiscard]] auto image_load_request_id() const -> std::uint64_t {
     std::scoped_lock lock(mutex_);

--- a/alcedo_studio/src/include/app/editor_render_coordinator.hpp
+++ b/alcedo_studio/src/include/app/editor_render_coordinator.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
-#include <deque>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -29,14 +29,25 @@ class IEditorPipelineSchedulerPort {
   virtual void WaitForSessionIdle(std::uint64_t /*session_epoch*/) {}
 };
 
-/// Application-layer owner of the editor render request queue.
+/// Application-layer owner of editor render coalesce + single-flight scheduling.
 ///
+/// Pending work is three fixed quality slots (interactive / quality / detail).
+/// Same-slot submit overwrites the prior pending entry and emits `Replaced`.
+/// `ScheduleNext` selects interactive > quality > detail in constant time.
 /// This is the only production component allowed to call the editor pipeline
 /// scheduler. Session service, adjustment models, and viewport controllers submit
 /// EditorRenderIntent values here and never receive a PipelineScheduler pointer.
 class EditorRenderCoordinator final : public IEditorRenderSubmitPort {
  public:
   using ResultObserver = std::function<void(const EditorRenderResult&)>;
+
+  /// Ladder slots derived from `EditorRenderQuality` (not string keys).
+  enum class QualitySlot : std::uint8_t {
+    Interactive = 0,
+    Quality     = 1,
+    Detail      = 2,
+  };
+  static constexpr std::size_t kQualitySlotCount = 3;
 
   explicit EditorRenderCoordinator(std::shared_ptr<IEditorPipelineSchedulerPort> scheduler);
   ~EditorRenderCoordinator() override = default;
@@ -67,12 +78,12 @@ class EditorRenderCoordinator final : public IEditorRenderSubmitPort {
   /// Mark the blocking scheduler call complete and start the next request.
   void NotifySchedulerCompleted(std::uint64_t request_id, bool success, std::string message = {});
 
-  /// Process the pending queue: schedule at most one job when idle.
+  /// Process pending slots: schedule at most one job when idle.
   void Pump();
 
   [[nodiscard]] auto pending_count() const -> std::size_t {
     std::scoped_lock lock(mutex_);
-    return pending_.size();
+    return CountOccupiedSlots();
   }
   [[nodiscard]] auto has_inflight() const -> bool {
     std::scoped_lock lock(mutex_);
@@ -91,22 +102,25 @@ class EditorRenderCoordinator final : public IEditorRenderSubmitPort {
     std::scoped_lock                   lock(mutex_);
     EditorRenderCoordinatorDiagnostics diag;
     diag.has_inflight  = inflight_.has_value();
-    diag.pending_count = pending_.size();
+    diag.pending_count = CountOccupiedSlots();
     diag.inflight_reason =
         inflight_ ? std::make_optional(inflight_->request.intent.reason) : std::nullopt;
-    diag.replaced_count               = replaced_count_;
-    diag.cancelled_count              = cancelled_count_;
-    diag.last_error                   = last_error_;
-    diag.image_load_request_id        = active_image_load_request_id_;
-    diag.last_rejection_reason        = last_rejection_reason_;
-    diag.last_rejected_render_reason  = last_rejected_render_reason_;
-    diag.last_ready_frame_role    = last_ready_frame_role_;
-    diag.last_ready_render_reason = last_ready_render_reason_;
-    diag.accepted_count               = accepted_count_;
-    diag.failed_count                 = failed_count_;
-    diag.ready_count                  = ready_count_;
+    diag.replaced_count              = replaced_count_;
+    diag.cancelled_count             = cancelled_count_;
+    diag.last_error                  = last_error_;
+    diag.image_load_request_id       = active_image_load_request_id_;
+    diag.last_rejection_reason       = last_rejection_reason_;
+    diag.last_rejected_render_reason = last_rejected_render_reason_;
+    diag.last_ready_frame_role       = last_ready_frame_role_;
+    diag.last_ready_render_reason    = last_ready_render_reason_;
+    diag.accepted_count              = accepted_count_;
+    diag.failed_count                = failed_count_;
+    diag.ready_count                 = ready_count_;
     return diag;
   }
+
+  /// Maps quality to the fixed coalesce slot (Interactive / Quality / Detail).
+  [[nodiscard]] static auto SlotIndexForQuality(EditorRenderQuality quality) -> std::size_t;
 
  private:
   struct PendingEntry {
@@ -115,7 +129,8 @@ class EditorRenderCoordinator final : public IEditorRenderSubmitPort {
   };
 
   auto AcceptOrReject(const EditorRenderIntent& intent, std::string* message) const -> bool;
-  void ReplacePendingWithKey(const std::string& key, std::uint64_t except_request_id);
+  /// Overwrite `slots_[slot]`; emit Replaced for any previous occupant.
+  void PlaceInSlot(std::size_t slot, PendingEntry entry);
   /// Cancel pending/in-flight work whose image_load_request_id does not match
   /// active_image_load_request_id_. Returns the running scheduler job to stop.
   auto CancelObsoleteForImageLoadMismatch() -> std::uint64_t;
@@ -123,19 +138,23 @@ class EditorRenderCoordinator final : public IEditorRenderSubmitPort {
   void               Emit(EditorRenderResult result);
   void               DeliverPendingResults();
   void               ScheduleNext();
-  [[nodiscard]] static auto PriorityRank(EditorRenderPriority priority) -> int;
-  [[nodiscard]] static auto SelectNextIndex(const std::deque<PendingEntry>& pending) -> std::size_t;
+  [[nodiscard]] auto CountOccupiedSlots() const -> std::size_t;
+  /// First occupied slot in interactive > quality > detail order, or nullopt.
+  [[nodiscard]] auto SelectNextSlotIndex() const -> std::optional<std::size_t>;
+  /// Drop cancelled / epoch-obsolete entries from all slots (O(slot count)).
+  void ScrubPendingSlots();
 
   std::shared_ptr<IEditorPipelineSchedulerPort> scheduler_;
   ResultObserver                                observer_;
   std::uint64_t                                 active_image_load_request_id_ = 0;
-  std::uint64_t                                 next_request_id_           = 1;
-  std::uint64_t                                 last_scheduled_request_id_ = 0;
-  std::deque<PendingEntry>                      pending_;
-  std::optional<PendingEntry>                   inflight_;
-  std::vector<EditorRenderResult>               results_;
-  std::vector<EditorRenderResult>               pending_delivery_;
-  std::unordered_set<std::uint64_t>             terminal_request_ids_;
+  std::uint64_t                                 next_request_id_              = 1;
+  std::uint64_t                                 last_scheduled_request_id_    = 0;
+  /// At most one pending request per quality ladder role.
+  std::array<std::optional<PendingEntry>, kQualitySlotCount> slots_{};
+  std::optional<PendingEntry>                                inflight_;
+  std::vector<EditorRenderResult>                            results_;
+  std::vector<EditorRenderResult>                            pending_delivery_;
+  std::unordered_set<std::uint64_t>                          terminal_request_ids_;
   // Diagnostics for the QML spinner/progress/error surface.
   std::size_t                                   replaced_count_  = 0;
   std::size_t                                   cancelled_count_ = 0;

--- a/alcedo_studio/src/include/app/editor_render_coordinator.hpp
+++ b/alcedo_studio/src/include/app/editor_render_coordinator.hpp
@@ -27,10 +27,11 @@ class IEditorPipelineSchedulerPort {
   virtual auto Schedule(const EditorRenderRequest& request) -> std::uint64_t = 0;
   virtual void Cancel(std::uint64_t scheduler_job_id)                        = 0;
   virtual void WaitForSessionIdle(std::uint64_t /*session_epoch*/) {}
-  /// Bind stable render inputs for the open/switched image (epoch + identity).
-  /// Production loads image/buffer/pipeline once; fakes no-op.
+  /// Bind stable render inputs for the open/switched image (epoch + identity +
+  /// presentation sink id). Production loads image/buffer/pipeline once; fakes no-op.
   virtual void BindSessionContext(std::uint64_t /*epoch*/, sl_element_id_t /*element_id*/,
-                                  image_id_t /*image_id*/) {}
+                                  image_id_t /*image_id*/,
+                                  PresentationSinkId /*presentation_sink_id*/ = 0) {}
   /// Drop the bound session render context (close / pre-switch reset).
   virtual void ClearSessionContext() {}
 };
@@ -65,8 +66,14 @@ class EditorRenderCoordinator final : public IEditorRenderSubmitPort {
 
   /// Forward open/switch session render context bind to the production adapter.
   void BindSessionRenderContext(std::uint64_t epoch, sl_element_id_t element_id,
-                                image_id_t image_id) override;
+                                image_id_t image_id,
+                                PresentationSinkId presentation_sink_id = 0) override;
   void ClearSessionRenderContext() override;
+
+  /// Replace the pipeline scheduler seam after construction. Production hosts
+  /// set the scheduler once via the constructor; focused harnesses may swap in
+  /// a recording/completing fake so tests never grow production Dispatch branches.
+  void SetPipelineSchedulerPort(std::shared_ptr<IEditorPipelineSchedulerPort> scheduler);
 
   [[nodiscard]] auto image_load_request_id() const -> std::uint64_t {
     std::scoped_lock lock(mutex_);

--- a/alcedo_studio/src/include/app/editor_session_bootstrap.hpp
+++ b/alcedo_studio/src/include/app/editor_session_bootstrap.hpp
@@ -91,9 +91,10 @@ class EditorSessionBootstrapJournalPort     final : public IEditorJournalPort {
 class EditorSessionBootstrapSchedulerPort final : public IEditorPipelineSchedulerPort {
  public:
   struct SessionContextBind {
-    std::uint64_t   epoch      = 0;
-    sl_element_id_t element_id = 0;
-    image_id_t      image_id   = 0;
+    std::uint64_t      epoch                 = 0;
+    sl_element_id_t    element_id            = 0;
+    image_id_t         image_id              = 0;
+    PresentationSinkId presentation_sink_id  = 0;
   };
 
   auto Schedule(const EditorRenderRequest& request) -> std::uint64_t override {
@@ -101,9 +102,9 @@ class EditorSessionBootstrapSchedulerPort final : public IEditorPipelineSchedule
     return ++next_job_id_;
   }
   void               Cancel(std::uint64_t job_id) override { cancelled_.push_back(job_id); }
-  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id,
-                          image_id_t image_id) override {
-    binds_.push_back({epoch, element_id, image_id});
+  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id, image_id_t image_id,
+                          PresentationSinkId presentation_sink_id = 0) override {
+    binds_.push_back({epoch, element_id, image_id, presentation_sink_id});
   }
   void ClearSessionContext() override { ++clear_count_; }
 

--- a/alcedo_studio/src/include/app/editor_session_bootstrap.hpp
+++ b/alcedo_studio/src/include/app/editor_session_bootstrap.hpp
@@ -90,21 +90,36 @@ class EditorSessionBootstrapJournalPort     final : public IEditorJournalPort {
 /// Accepts schedule calls and records them. Does not run pipeline work.
 class EditorSessionBootstrapSchedulerPort final : public IEditorPipelineSchedulerPort {
  public:
+  struct SessionContextBind {
+    std::uint64_t   epoch      = 0;
+    sl_element_id_t element_id = 0;
+    image_id_t      image_id   = 0;
+  };
+
   auto Schedule(const EditorRenderRequest& request) -> std::uint64_t override {
     scheduled_.push_back(request);
     return ++next_job_id_;
   }
   void               Cancel(std::uint64_t job_id) override { cancelled_.push_back(job_id); }
+  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id,
+                          image_id_t image_id) override {
+    binds_.push_back({epoch, element_id, image_id});
+  }
+  void ClearSessionContext() override { ++clear_count_; }
 
   [[nodiscard]] auto scheduled() const -> const std::vector<EditorRenderRequest>& {
     return scheduled_;
   }
   [[nodiscard]] auto cancelled() const -> const std::vector<std::uint64_t>& { return cancelled_; }
+  [[nodiscard]] auto binds() const -> const std::vector<SessionContextBind>& { return binds_; }
+  [[nodiscard]] auto clear_count() const -> int { return clear_count_; }
 
  private:
   std::uint64_t                    next_job_id_ = 0;
   std::vector<EditorRenderRequest> scheduled_;
   std::vector<std::uint64_t>       cancelled_;
+  std::vector<SessionContextBind>  binds_;
+  int                              clear_count_ = 0;
 };
 
 struct EditorSessionRuntime {

--- a/alcedo_studio/src/include/app/editor_session_bootstrap.hpp
+++ b/alcedo_studio/src/include/app/editor_session_bootstrap.hpp
@@ -90,36 +90,21 @@ class EditorSessionBootstrapJournalPort     final : public IEditorJournalPort {
 /// Accepts schedule calls and records them. Does not run pipeline work.
 class EditorSessionBootstrapSchedulerPort final : public IEditorPipelineSchedulerPort {
  public:
-  struct SessionContextBind {
-    std::uint64_t   epoch      = 0;
-    sl_element_id_t element_id = 0;
-    image_id_t      image_id   = 0;
-  };
-
   auto Schedule(const EditorRenderRequest& request) -> std::uint64_t override {
     scheduled_.push_back(request);
     return ++next_job_id_;
   }
   void               Cancel(std::uint64_t job_id) override { cancelled_.push_back(job_id); }
-  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id,
-                          image_id_t image_id) override {
-    binds_.push_back({epoch, element_id, image_id});
-  }
-  void ClearSessionContext() override { ++clear_count_; }
 
   [[nodiscard]] auto scheduled() const -> const std::vector<EditorRenderRequest>& {
     return scheduled_;
   }
   [[nodiscard]] auto cancelled() const -> const std::vector<std::uint64_t>& { return cancelled_; }
-  [[nodiscard]] auto binds() const -> const std::vector<SessionContextBind>& { return binds_; }
-  [[nodiscard]] auto clear_count() const -> int { return clear_count_; }
 
  private:
   std::uint64_t                    next_job_id_ = 0;
   std::vector<EditorRenderRequest> scheduled_;
   std::vector<std::uint64_t>       cancelled_;
-  std::vector<SessionContextBind>  binds_;
-  int                              clear_count_ = 0;
 };
 
 struct EditorSessionRuntime {

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -449,10 +449,11 @@ class IEditorRenderSubmitPort {
   /// Stamps the active image-load request and cancels pending/in-flight work for
   /// other image-load requests.
   virtual void SetActiveImageLoadRequest(std::uint64_t image_load_request_id) = 0;
-  /// Bind stable session render inputs at open/switch (epoch + element + image).
-  /// Production adapter loads image/buffer once; fakes no-op.
+  /// Bind stable session render inputs at open/switch (epoch + element + image +
+  /// presentation sink identity). Production adapter loads image/buffer once; fakes no-op.
   virtual void BindSessionRenderContext(std::uint64_t /*epoch*/, sl_element_id_t /*element_id*/,
-                                        image_id_t /*image_id*/) {}
+                                        image_id_t /*image_id*/,
+                                        PresentationSinkId /*presentation_sink_id*/ = 0) {}
   /// Clear bound session render inputs (close / pre-switch reset).
   virtual void ClearSessionRenderContext() {}
   /// Phase 5D diagnostics. Default impls report an idle coordinator so test

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -449,6 +449,12 @@ class IEditorRenderSubmitPort {
   /// Stamps the active image-load request and cancels pending/in-flight work for
   /// other image-load requests.
   virtual void SetActiveImageLoadRequest(std::uint64_t image_load_request_id) = 0;
+  /// Bind stable session render inputs at open/switch (epoch + element + image).
+  /// Production adapter loads image/buffer once; fakes no-op.
+  virtual void BindSessionRenderContext(std::uint64_t /*epoch*/, sl_element_id_t /*element_id*/,
+                                        image_id_t /*image_id*/) {}
+  /// Clear bound session render inputs (close / pre-switch reset).
+  virtual void ClearSessionRenderContext() {}
   /// Phase 5D diagnostics. Default impls report an idle coordinator so test
   /// fakes that do not override them stay QML-idle.
   [[nodiscard]] virtual auto diagnostics() const -> EditorRenderCoordinatorDiagnostics {

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -449,12 +449,6 @@ class IEditorRenderSubmitPort {
   /// Stamps the active image-load request and cancels pending/in-flight work for
   /// other image-load requests.
   virtual void SetActiveImageLoadRequest(std::uint64_t image_load_request_id) = 0;
-  /// Bind stable session render inputs at open/switch (epoch + element + image).
-  /// Production adapter loads image/buffer once; fakes no-op.
-  virtual void BindSessionRenderContext(std::uint64_t /*epoch*/, sl_element_id_t /*element_id*/,
-                                        image_id_t /*image_id*/) {}
-  /// Clear bound session render inputs (close / pre-switch reset).
-  virtual void ClearSessionRenderContext() {}
   /// Phase 5D diagnostics. Default impls report an idle coordinator so test
   /// fakes that do not override them stay QML-idle.
   [[nodiscard]] virtual auto diagnostics() const -> EditorRenderCoordinatorDiagnostics {

--- a/alcedo_studio/src/include/image/image_buffer.hpp
+++ b/alcedo_studio/src/include/image/image_buffer.hpp
@@ -83,10 +83,7 @@ class ImageBuffer {
   cv::Mat                               cpu_data_;
   GpuImageWrapper                       gpu_data_;
 
-  /// Encoded file bytes (e.g. RAW payload). Shared so session-held sources and
-  /// per-Apply working ImageBuffers can alias the same multi-MB vector without
-  /// deep-copying on every quality-ladder frame.
-  std::shared_ptr<std::vector<uint8_t>> buffer_;
+  std::unique_ptr<std::vector<uint8_t>> buffer_;
 
  public:
   bool cpu_data_valid_ = false;
@@ -118,11 +115,6 @@ class ImageBuffer {
   ImageBuffer(std::vector<uint8_t>&& buffer);
 
   void ReadFromVectorBuffer(std::vector<uint8_t>&& buffer);
-
-  /// New ImageBuffer aliasing the same encoded payload (O(1)). Distinct object
-  /// so operators that replace `*input` (e.g. RAW_DECODE) do not wipe the
-  /// session-held source buffer.
-  [[nodiscard]] auto ShareEncodedBuffer() const -> std::shared_ptr<ImageBuffer>;
 
   auto GetCPUData() -> cv::Mat&;
   auto GetBuffer() -> std::vector<uint8_t>&;

--- a/alcedo_studio/src/include/image/image_buffer.hpp
+++ b/alcedo_studio/src/include/image/image_buffer.hpp
@@ -83,7 +83,10 @@ class ImageBuffer {
   cv::Mat                               cpu_data_;
   GpuImageWrapper                       gpu_data_;
 
-  std::unique_ptr<std::vector<uint8_t>> buffer_;
+  /// Encoded file bytes (e.g. RAW payload). Shared so session-held sources and
+  /// per-Apply working ImageBuffers can alias the same multi-MB vector without
+  /// deep-copying on every quality-ladder frame.
+  std::shared_ptr<std::vector<uint8_t>> buffer_;
 
  public:
   bool cpu_data_valid_ = false;
@@ -115,6 +118,11 @@ class ImageBuffer {
   ImageBuffer(std::vector<uint8_t>&& buffer);
 
   void ReadFromVectorBuffer(std::vector<uint8_t>&& buffer);
+
+  /// New ImageBuffer aliasing the same encoded payload (O(1)). Distinct object
+  /// so operators that replace `*input` (e.g. RAW_DECODE) do not wipe the
+  /// session-held source buffer.
+  [[nodiscard]] auto ShareEncodedBuffer() const -> std::shared_ptr<ImageBuffer>;
 
   auto GetCPUData() -> cv::Mat&;
   auto GetBuffer() -> std::vector<uint8_t>&;

--- a/alcedo_studio/src/include/renderer/pipeline_scheduler.hpp
+++ b/alcedo_studio/src/include/renderer/pipeline_scheduler.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <unordered_map>
 
@@ -36,5 +37,9 @@ class PipelineScheduler {
    * @param task
    */
   void ScheduleTask(PipelineTask&& task);
+
+  /// Run arbitrary work on the same pool as pipeline tasks (test producers,
+  /// async failure completion). Prefer ScheduleTask for real renders.
+  void ScheduleWork(std::function<void()> work);
 };
 };  // namespace alcedo

--- a/alcedo_studio/src/include/renderer/pipeline_task.hpp
+++ b/alcedo_studio/src/include/renderer/pipeline_task.hpp
@@ -67,6 +67,9 @@ struct PipelineTask {
   // lock as Apply(). This is the only safe place to mutate a shared executor.
   std::optional<std::function<bool(PipelineTask&)>> configure_under_render_lock_;
   std::function<bool()>                             cancel_requested_;
+  // Optional control-plane completion (preview + export). Invoked once on every
+  // terminal path so callers do not need a dedicated blocking worker thread.
+  std::function<void(bool success)>                 on_complete_;
 
   TaskOptions                                       options_;
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.hpp
@@ -11,7 +11,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include "app/editor_render_coordinator.hpp"
@@ -36,34 +35,25 @@ struct EditorSessionSchedulerServices {
   std::function<std::shared_ptr<alcedo::ImagePoolService>()> image_pool;
 };
 
-/// Runs the coordinator's single queued request on one persistent worker.
-/// The blocking PipelineTask call ends when its sink has published a ready frame.
+/// Thin adapter: builds a PipelineTask and hands it to PipelineScheduler.
+/// No private worker thread and no second request queue — the coordinator owns
+/// single-flight; PipelineScheduler owns execution.
 class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSchedulerPort {
  public:
-  /// Construct the scheduler port around the application pipeline scheduler.
   explicit EditorSessionRenderSchedulerPort(
       std::shared_ptr<alcedo::PipelineScheduler> pipeline_scheduler = nullptr);
-  /// Cancel queued/running work and join the worker.
   ~EditorSessionRenderSchedulerPort() override;
 
-  /// Set the coordinator that receives render lifecycle outcomes.
   void SetCoordinator(std::weak_ptr<alcedo::EditorRenderCoordinator> coordinator);
-  /// Set the sink used for native frame presentation.
   void SetSinkResolver(EditorSessionFrameSinkResolver resolver);
-  /// Set the pipeline guard port used for frame production.
   void SetPipelinePort(std::shared_ptr<EditorSessionPipelinePort> pipeline_port);
-  /// Set image-pool and related render dependencies.
   void SetServices(EditorSessionSchedulerServices services);
-  /// Set an optional deterministic frame producer for focused tests.
+  /// Deterministic frame producer for focused tests (runs on the pipeline pool).
   void SetTestFrameProducer(EditorSessionTestFrameProducer producer);
 
-  /// Schedule one render request and return its scheduler job ID.
   auto Schedule(const alcedo::EditorRenderRequest& request) -> std::uint64_t override;
-  /// Cancel one scheduled render job.
   void Cancel(std::uint64_t scheduler_job_id) override;
-  /// Wait until all jobs for one session generation have finished.
   void WaitForSessionIdle(std::uint64_t session_epoch) override;
-  /// Return a test-visible copy of scheduled requests.
   [[nodiscard]] auto last_scheduled() const -> std::vector<alcedo::EditorRenderRequest>;
 
  private:
@@ -73,33 +63,30 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
     bool                        cancelled = false;
   };
 
-  void WorkerLoop();
   [[nodiscard]] auto CanProduceFrame(const alcedo::EditorRenderRequest& request) const -> bool;
-  void ExecuteJob(Job job);
-  auto TryProducePipelineFrame(const alcedo::EditorRenderRequest& request, alcedo::IFrameSink* sink,
-                               std::string* error) -> bool;
+  [[nodiscard]] auto EnsurePipelineScheduler() -> std::shared_ptr<alcedo::PipelineScheduler>;
+  void               DispatchJob(Job job);
+  void               DispatchTestProducer(Job job, alcedo::IFrameSink* sink,
+                                          EditorSessionTestFrameProducer producer);
+  void               DispatchPipelineFrame(Job job, alcedo::IFrameSink* sink);
+  void               FinishJob(const Job& job, bool success, std::string message);
   void CompleteJob(const alcedo::EditorRenderRequest& request, bool success, std::string message);
-  [[nodiscard]] auto IsCancelled(std::uint64_t job_id) const -> bool;
+  [[nodiscard]] auto JobIsCancelled(const Job& job) const -> bool;
 
-  std::shared_ptr<alcedo::PipelineScheduler>             pipeline_scheduler_;
-  std::weak_ptr<alcedo::EditorRenderCoordinator>         coordinator_;
-  EditorSessionFrameSinkResolver                         sink_resolver_;
-  std::shared_ptr<EditorSessionPipelinePort>             pipeline_port_;
-  EditorSessionSchedulerServices                         services_{};
-  EditorSessionTestFrameProducer                         test_producer_;
-  mutable std::mutex                                     mutex_;
-  std::condition_variable                                work_available_;
-  std::condition_variable                                jobs_changed_;
-  std::uint64_t                                          next_job_id_ = 0;
-  std::optional<Job>                                     queued_job_;
-  std::optional<Job>                                     running_job_;
-  std::vector<alcedo::EditorRenderRequest>               scheduled_;
-  // One persistent worker is the sole bridge from UI requests to the blocking
-  // PipelineScheduler call.
-  std::thread                                            worker_;
-  image_id_t                                             cached_input_image_id_ = 0;
-  std::shared_ptr<alcedo::ImageBuffer>                   cached_input_;
-  bool                                                   shutting_down_ = false;
+  std::shared_ptr<alcedo::PipelineScheduler>     pipeline_scheduler_;
+  std::weak_ptr<alcedo::EditorRenderCoordinator> coordinator_;
+  EditorSessionFrameSinkResolver                 sink_resolver_;
+  std::shared_ptr<EditorSessionPipelinePort>     pipeline_port_;
+  EditorSessionSchedulerServices                 services_{};
+  EditorSessionTestFrameProducer                 test_producer_;
+  mutable std::mutex                             mutex_;
+  std::condition_variable                        jobs_changed_;
+  std::uint64_t                                  next_job_id_ = 0;
+  std::optional<Job>                             running_job_;
+  std::vector<alcedo::EditorRenderRequest>       scheduled_;
+  image_id_t                                     cached_input_image_id_ = 0;
+  std::shared_ptr<alcedo::ImageBuffer>           cached_input_;
+  bool                                           shutting_down_ = false;
 };
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.hpp
@@ -16,7 +16,10 @@
 #include "app/editor_render_coordinator.hpp"
 #include "app/editor_render_intent.hpp"
 #include "app/pipeline_service.hpp"
+#include "image/image.hpp"
+#include "image/image_buffer.hpp"
 #include "renderer/pipeline_scheduler.hpp"
+#include "type/type.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_pipeline_port.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 
@@ -31,13 +34,26 @@ using EditorSessionTestFrameProducer =
     std::function<bool(alcedo::IFrameSink*, const alcedo::EditorRenderRequest&)>;
 
 struct EditorSessionSchedulerServices {
-  /// Resolve the image pool used for render input acquisition.
+  /// Resolve the image pool used for render input acquisition at context bind.
+  /// Hot interactive frames must not call this after a successful payload load.
   std::function<std::shared_ptr<alcedo::ImagePoolService>()> image_pool;
 };
 
-/// Thin adapter: builds a PipelineTask and hands it to PipelineScheduler.
-/// No private worker thread and no second request queue — the coordinator owns
-/// single-flight; PipelineScheduler owns execution.
+/// Stable render inputs for the currently open/switched editor image.
+/// Bound at open/switch (identity immediately; image/buffer/pipeline lazy-once).
+/// Image switch replaces the whole context under the new epoch.
+struct EditorRenderSessionContext {
+  std::uint64_t                        epoch      = 0;
+  sl_element_id_t                      element_id = 0;
+  image_id_t                           image_id   = 0;
+  std::shared_ptr<alcedo::Image>       image;
+  std::shared_ptr<alcedo::ImageBuffer> input;
+  std::shared_ptr<alcedo::PipelineGuard> pipeline_guard;
+};
+
+/// Thin adapter: builds a PipelineTask from bound session context and hands it
+/// to PipelineScheduler. No private worker thread and no second request queue —
+/// the coordinator owns single-flight; PipelineScheduler owns execution.
 class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSchedulerPort {
  public:
   explicit EditorSessionRenderSchedulerPort(
@@ -51,10 +67,22 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
   /// Deterministic frame producer for focused tests (runs on the pipeline pool).
   void SetTestFrameProducer(EditorSessionTestFrameProducer producer);
 
+  /// Bind identity for the open/switched image. Replaces any prior context.
+  /// Image/buffer/pipeline load once on first production frame for this bind.
+  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id,
+                          image_id_t image_id) override;
+  void ClearSessionContext() override;
+  /// Install a fully populated context (tests / preloaded open path).
+  void InstallSessionContext(EditorRenderSessionContext context);
+
   auto Schedule(const alcedo::EditorRenderRequest& request) -> std::uint64_t override;
   void Cancel(std::uint64_t scheduler_job_id) override;
   void WaitForSessionIdle(std::uint64_t session_epoch) override;
   [[nodiscard]] auto last_scheduled() const -> std::vector<alcedo::EditorRenderRequest>;
+  /// Snapshot of the bound context identity and payload presence (for tests).
+  [[nodiscard]] auto session_context() const -> std::optional<EditorRenderSessionContext>;
+  /// Times image-pool resolution ran to load context payload (bind/hot-path).
+  [[nodiscard]] auto context_payload_load_count() const -> std::uint64_t;
 
  private:
   struct Job {
@@ -65,6 +93,14 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
 
   [[nodiscard]] auto CanProduceFrame(const alcedo::EditorRenderRequest& request) const -> bool;
   [[nodiscard]] auto EnsurePipelineScheduler() -> std::shared_ptr<alcedo::PipelineScheduler>;
+  /// Ensure context identity matches the request and payload is loaded once.
+  [[nodiscard]] auto EnsureContextForRequest(const alcedo::EditorRenderRequest& request,
+                                             std::string* error)
+      -> std::optional<EditorRenderSessionContext>;
+  [[nodiscard]] auto ContextMatchesRequest(const EditorRenderSessionContext& context,
+                                           const alcedo::EditorRenderRequest& request) const
+      -> bool;
+  [[nodiscard]] auto ContextPayloadReady(const EditorRenderSessionContext& context) const -> bool;
   void               DispatchJob(Job job);
   void               DispatchTestProducer(Job job, alcedo::IFrameSink* sink,
                                           EditorSessionTestFrameProducer producer);
@@ -84,8 +120,8 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
   std::uint64_t                                  next_job_id_ = 0;
   std::optional<Job>                             running_job_;
   std::vector<alcedo::EditorRenderRequest>       scheduled_;
-  image_id_t                                     cached_input_image_id_ = 0;
-  std::shared_ptr<alcedo::ImageBuffer>           cached_input_;
+  std::optional<EditorRenderSessionContext>      session_context_;
+  std::uint64_t                                  context_payload_load_count_ = 0;
   bool                                           shutting_down_ = false;
 };
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.hpp
@@ -16,10 +16,7 @@
 #include "app/editor_render_coordinator.hpp"
 #include "app/editor_render_intent.hpp"
 #include "app/pipeline_service.hpp"
-#include "image/image.hpp"
-#include "image/image_buffer.hpp"
 #include "renderer/pipeline_scheduler.hpp"
-#include "type/type.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_pipeline_port.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 
@@ -34,26 +31,13 @@ using EditorSessionTestFrameProducer =
     std::function<bool(alcedo::IFrameSink*, const alcedo::EditorRenderRequest&)>;
 
 struct EditorSessionSchedulerServices {
-  /// Resolve the image pool used for render input acquisition at context bind.
-  /// Hot interactive frames must not call this after a successful payload load.
+  /// Resolve the image pool used for render input acquisition.
   std::function<std::shared_ptr<alcedo::ImagePoolService>()> image_pool;
 };
 
-/// Stable render inputs for the currently open/switched editor image.
-/// Bound at open/switch (identity immediately; image/buffer/pipeline lazy-once).
-/// Image switch replaces the whole context under the new epoch.
-struct EditorRenderSessionContext {
-  std::uint64_t                        epoch      = 0;
-  sl_element_id_t                      element_id = 0;
-  image_id_t                           image_id   = 0;
-  std::shared_ptr<alcedo::Image>       image;
-  std::shared_ptr<alcedo::ImageBuffer> input;
-  std::shared_ptr<alcedo::PipelineGuard> pipeline_guard;
-};
-
-/// Thin adapter: builds a PipelineTask from bound session context and hands it
-/// to PipelineScheduler. No private worker thread and no second request queue —
-/// the coordinator owns single-flight; PipelineScheduler owns execution.
+/// Thin adapter: builds a PipelineTask and hands it to PipelineScheduler.
+/// No private worker thread and no second request queue — the coordinator owns
+/// single-flight; PipelineScheduler owns execution.
 class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSchedulerPort {
  public:
   explicit EditorSessionRenderSchedulerPort(
@@ -67,22 +51,10 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
   /// Deterministic frame producer for focused tests (runs on the pipeline pool).
   void SetTestFrameProducer(EditorSessionTestFrameProducer producer);
 
-  /// Bind identity for the open/switched image. Replaces any prior context.
-  /// Image/buffer/pipeline load once on first production frame for this bind.
-  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id,
-                          image_id_t image_id) override;
-  void ClearSessionContext() override;
-  /// Install a fully populated context (tests / preloaded open path).
-  void InstallSessionContext(EditorRenderSessionContext context);
-
   auto Schedule(const alcedo::EditorRenderRequest& request) -> std::uint64_t override;
   void Cancel(std::uint64_t scheduler_job_id) override;
   void WaitForSessionIdle(std::uint64_t session_epoch) override;
   [[nodiscard]] auto last_scheduled() const -> std::vector<alcedo::EditorRenderRequest>;
-  /// Snapshot of the bound context identity and payload presence (for tests).
-  [[nodiscard]] auto session_context() const -> std::optional<EditorRenderSessionContext>;
-  /// Times image-pool resolution ran to load context payload (bind/hot-path).
-  [[nodiscard]] auto context_payload_load_count() const -> std::uint64_t;
 
  private:
   struct Job {
@@ -93,14 +65,6 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
 
   [[nodiscard]] auto CanProduceFrame(const alcedo::EditorRenderRequest& request) const -> bool;
   [[nodiscard]] auto EnsurePipelineScheduler() -> std::shared_ptr<alcedo::PipelineScheduler>;
-  /// Ensure context identity matches the request and payload is loaded once.
-  [[nodiscard]] auto EnsureContextForRequest(const alcedo::EditorRenderRequest& request,
-                                             std::string* error)
-      -> std::optional<EditorRenderSessionContext>;
-  [[nodiscard]] auto ContextMatchesRequest(const EditorRenderSessionContext& context,
-                                           const alcedo::EditorRenderRequest& request) const
-      -> bool;
-  [[nodiscard]] auto ContextPayloadReady(const EditorRenderSessionContext& context) const -> bool;
   void               DispatchJob(Job job);
   void               DispatchTestProducer(Job job, alcedo::IFrameSink* sink,
                                           EditorSessionTestFrameProducer producer);
@@ -120,8 +84,8 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
   std::uint64_t                                  next_job_id_ = 0;
   std::optional<Job>                             running_job_;
   std::vector<alcedo::EditorRenderRequest>       scheduled_;
-  std::optional<EditorRenderSessionContext>      session_context_;
-  std::uint64_t                                  context_payload_load_count_ = 0;
+  image_id_t                                     cached_input_image_id_ = 0;
+  std::shared_ptr<alcedo::ImageBuffer>           cached_input_;
   bool                                           shutting_down_ = false;
 };
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.hpp
@@ -30,8 +30,6 @@ class ImagePoolService;
 namespace alcedo::ui {
 
 using EditorSessionFrameSinkResolver = std::function<alcedo::IFrameSink*()>;
-using EditorSessionTestFrameProducer =
-    std::function<bool(alcedo::IFrameSink*, const alcedo::EditorRenderRequest&)>;
 
 struct EditorSessionSchedulerServices {
   /// Resolve the image pool used for render input acquisition at context bind.
@@ -43,11 +41,14 @@ struct EditorSessionSchedulerServices {
 /// Bound at open/switch (identity immediately; image/buffer/pipeline lazy-once).
 /// Image switch replaces the whole context under the new epoch.
 struct EditorRenderSessionContext {
-  std::uint64_t                        epoch      = 0;
-  sl_element_id_t                      element_id = 0;
-  image_id_t                           image_id   = 0;
-  std::shared_ptr<alcedo::Image>       image;
-  std::shared_ptr<alcedo::ImageBuffer> input;
+  std::uint64_t                          epoch                 = 0;
+  sl_element_id_t                        element_id            = 0;
+  image_id_t                             image_id              = 0;
+  /// Presentation sink identity stamped at open/switch. Live `IFrameSink*` is
+  /// resolved only at pipeline submit; this id is the session-scoped identity.
+  alcedo::PresentationSinkId             presentation_sink_id  = 0;
+  std::shared_ptr<alcedo::Image>         image;
+  std::shared_ptr<alcedo::ImageBuffer>   input;
   std::shared_ptr<alcedo::PipelineGuard> pipeline_guard;
 };
 
@@ -64,13 +65,11 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
   void SetSinkResolver(EditorSessionFrameSinkResolver resolver);
   void SetPipelinePort(std::shared_ptr<EditorSessionPipelinePort> pipeline_port);
   void SetServices(EditorSessionSchedulerServices services);
-  /// Deterministic frame producer for focused tests (runs on the pipeline pool).
-  void SetTestFrameProducer(EditorSessionTestFrameProducer producer);
 
   /// Bind identity for the open/switched image. Replaces any prior context.
   /// Image/buffer/pipeline load once on first production frame for this bind.
-  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id,
-                          image_id_t image_id) override;
+  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id, image_id_t image_id,
+                          alcedo::PresentationSinkId presentation_sink_id = 0) override;
   void ClearSessionContext() override;
   /// Install a fully populated context (tests / preloaded open path).
   void InstallSessionContext(EditorRenderSessionContext context);
@@ -83,6 +82,8 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
   [[nodiscard]] auto session_context() const -> std::optional<EditorRenderSessionContext>;
   /// Times image-pool resolution ran to load context payload (bind/hot-path).
   [[nodiscard]] auto context_payload_load_count() const -> std::uint64_t;
+  /// Times the live sink pointer was resolved at submit (not at bind).
+  [[nodiscard]] auto sink_resolve_count() const -> std::uint64_t;
 
  private:
   struct Job {
@@ -102,8 +103,6 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
       -> bool;
   [[nodiscard]] auto ContextPayloadReady(const EditorRenderSessionContext& context) const -> bool;
   void               DispatchJob(Job job);
-  void               DispatchTestProducer(Job job, alcedo::IFrameSink* sink,
-                                          EditorSessionTestFrameProducer producer);
   void               DispatchPipelineFrame(Job job, alcedo::IFrameSink* sink);
   void               FinishJob(const Job& job, bool success, std::string message);
   void CompleteJob(const alcedo::EditorRenderRequest& request, bool success, std::string message);
@@ -114,7 +113,6 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
   EditorSessionFrameSinkResolver                 sink_resolver_;
   std::shared_ptr<EditorSessionPipelinePort>     pipeline_port_;
   EditorSessionSchedulerServices                 services_{};
-  EditorSessionTestFrameProducer                 test_producer_;
   mutable std::mutex                             mutex_;
   std::condition_variable                        jobs_changed_;
   std::uint64_t                                  next_job_id_ = 0;
@@ -122,7 +120,8 @@ class EditorSessionRenderSchedulerPort final : public alcedo::IEditorPipelineSch
   std::vector<alcedo::EditorRenderRequest>       scheduled_;
   std::optional<EditorRenderSessionContext>      session_context_;
   std::uint64_t                                  context_payload_load_count_ = 0;
-  bool                                           shutting_down_ = false;
+  std::uint64_t                                  sink_resolve_count_         = 0;
+  bool                                           shutting_down_              = false;
 };
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/include/utils/diagnostics/render_e2e_timing.hpp
+++ b/alcedo_studio/src/include/utils/diagnostics/render_e2e_timing.hpp
@@ -1,0 +1,70 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace alcedo::diag {
+
+/// Wall-clock end-to-end timing for editor preview frames.
+///
+/// Marks the request when the coordinator accepts Submit (user slider / intent
+/// issued) and prints one stdout line when the viewport renderer successfully
+/// imports the frame for composition (closest production point to "on screen").
+///
+/// Always enabled; output is a single line per presented request:
+///   [RENDER_E2E] request=N ... total=..ms queue=..ms pipeline=..ms
+///     present=..ms (wake=..ms gui_wait=..ms sg_wait=..ms import=..ms) (~.. fps)
+///
+/// present breakdown:
+/// - wake:     NotifyReady → requestPresentUpdate posted (worker side)
+/// - gui_wait: update posted → GUI thread actually runs update()/requestUpdate
+/// - sg_wait:  GUI update() → render-thread render() entry (scene-graph / vsync)
+/// - import:   render() entry → QRhi createFrom / layer bind complete
+///
+/// Large gui_wait ⇒ main/GUI thread backlog. Large sg_wait ⇒ missed frame /
+/// vsync phase. Large import ⇒ work inside the render pass before the texture
+/// is bound (usually tiny).
+///
+/// Terminal outcomes (replaced / cancelled / dropped / failed) remove the
+/// pending sample without printing so coalesced work does not leak state.
+
+void NoteRenderE2eSubmit(std::uint64_t request_id, std::string_view reason,
+                         std::string_view quality, std::string_view role);
+
+/// Coordinator handed the request to the pipeline scheduler (left the pending
+/// slot). Time from Submit to here is coalesce / single-flight queue wait.
+void NoteRenderE2eScheduled(std::uint64_t request_id);
+
+/// Producer finished GPU/host write and handed the frame to the present queue
+/// (NotifyFrameReady / SubmitMetalFrame). Covers pipeline + pool wait after
+/// schedule.
+void NoteRenderE2eProducerReady(std::uint64_t request_id);
+
+/// Viewport was asked to redraw after the frame became Ready
+/// (requestPresentUpdate posted from the producer path).
+void NoteRenderE2ePresentWake(std::uint64_t request_id);
+
+/// GUI thread executed the coalesced update()/window->requestUpdate() for
+/// pending Ready frames. No request id: stamps every sample that already has
+/// present_wake and still lacks gui_update.
+void NoteRenderE2eGuiUpdate();
+
+/// Render-thread QQuickRhiItemRenderer::render() entry. Stamps every sample
+/// that is Ready (has present_wake) and still lacks render_enter.
+void NoteRenderE2eRenderEnter();
+
+/// Render thread picked the Ready frame and is about to import it into QRhi.
+void NoteRenderE2eConsumeBegin(std::uint64_t request_id);
+
+/// Viewport renderer imported the frame for the next composition pass.
+/// Prints the e2e line and drops the sample.
+void NoteRenderE2eDisplayed(std::uint64_t request_id);
+
+/// Request will never display (replaced, cancelled, failed, present drop).
+void NoteRenderE2eTerminal(std::uint64_t request_id, std::string_view outcome);
+
+}  // namespace alcedo::diag

--- a/alcedo_studio/src/renderer/pipeline_scheduler.cpp
+++ b/alcedo_studio/src/renderer/pipeline_scheduler.cpp
@@ -407,6 +407,10 @@ void PipelineScheduler::MarkSinkApplyStarted(IFrameSink* sink, std::uint64_t req
   latest                             = std::max(latest, request_id);
 }
 
+void PipelineScheduler::ScheduleWork(std::function<void()> work) {
+  thread_pool_.Submit(std::move(work));
+}
+
 void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
   {
     std::lock_guard<std::mutex> lock(scheduler_lock_);
@@ -419,6 +423,20 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
     task.options_.render_desc_.frame_metadata_.presentation_request_id = task.request_id_;
   }
   thread_pool_.Submit([this, task = std::move(task)]() mutable {
+    bool completed = false;
+    const auto finish = [&task, &completed](bool success) {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      if (task.on_complete_) {
+        try {
+          task.on_complete_(success);
+        } catch (...) {
+        }
+      }
+    };
+
     const auto set_blocking_value = [&task](std::shared_ptr<ImageBuffer> value) {
       if (!task.options_.is_blocking_ || !task.result_) {
         return;
@@ -492,6 +510,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
         if (task_cancelled()) {
           notify_thumbnail_failure_callbacks();
           set_blocking_value(nullptr);
+          finish(false);
           return;
         }
         if (task.prepare_) {
@@ -501,17 +520,20 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
           } catch (...) {
             notify_thumbnail_failure_callbacks();
             set_blocking_exception();
+            finish(false);
             return;
           }
           if (!prepared) {
             notify_thumbnail_failure_callbacks();
             set_blocking_value(nullptr);
+            finish(false);
             return;
           }
         }
         if (task_cancelled()) {
           notify_thumbnail_failure_callbacks();
           set_blocking_value(nullptr);
+          finish(false);
           return;
         }
         if (task.input_desc_ && !task.input_) {
@@ -522,6 +544,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
         if (task_cancelled()) {
           notify_thumbnail_failure_callbacks();
           set_blocking_value(nullptr);
+          finish(false);
           return;
         }
         if (task.input_) {
@@ -543,11 +566,13 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
               } catch (...) {
                 notify_thumbnail_failure_callbacks();
                 set_blocking_exception();
+                finish(false);
                 return;
               }
               if (!prepared) {
                 notify_thumbnail_failure_callbacks();
                 set_blocking_value(nullptr);
+                finish(false);
                 return;
               }
             }
@@ -581,6 +606,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
           if (IsStaleForSink(output_sink, task.request_id_)) {
             notify_thumbnail_failure_callbacks();
             set_blocking_value(nullptr);
+            finish(false);
             return;
           }
 
@@ -602,6 +628,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
             apply_state_transition_after_render();
             notify_thumbnail_failure_callbacks();
             set_blocking_value(nullptr);
+            finish(false);
             return;
           }
 
@@ -610,6 +637,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
             apply_state_transition_after_render();
             notify_thumbnail_failure_callbacks();
             set_blocking_value(nullptr);
+            finish(false);
             return;
           }
 
@@ -635,6 +663,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
               notify_thumbnail_failure_callbacks();
             }
             set_blocking_value(nullptr);
+            finish(false);
             return;
           }
 
@@ -645,8 +674,10 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
             if (render_desc.render_type_ == RenderType::THUMBNAIL && !result_valid_for_copy) {
               notify_thumbnail_failure_callbacks();
             }
+            const bool ok = result != nullptr;
             set_blocking_value(result);
             apply_state_transition_after_render();
+            finish(ok);
             return;
           }
 
@@ -663,9 +694,11 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
           (*task.seq_callback_)(*result_copy, task.task_id_);
         }
         set_blocking_value(result_copy);
+        finish(true);
       } else {
         // In case of failure, set nullptr
         set_blocking_value(nullptr);
+        finish(false);
       }
     } catch (...) {
       try {
@@ -674,6 +707,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
       }
       notify_thumbnail_failure_callbacks();
       set_blocking_exception();
+      finish(false);
     }
   });
 }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
@@ -160,61 +160,6 @@ void EditorSessionRenderSchedulerPort::SetTestFrameProducer(
   test_producer_ = std::move(producer);
 }
 
-void EditorSessionRenderSchedulerPort::BindSessionContext(std::uint64_t epoch,
-                                                          sl_element_id_t element_id,
-                                                          image_id_t image_id) {
-  std::scoped_lock lock(mutex_);
-  // Same open image: keep Image / ImageBuffer / PipelineGuard. RouteInitialRender
-  // (undo, head-move, quality re-route) rebinds with the same element/image and
-  // must not force another full-file LoadImageInputBuffer or drop the payload.
-  // Only a true image identity change replaces the whole context.
-  if (session_context_ && session_context_->element_id == element_id &&
-      session_context_->image_id == image_id) {
-    session_context_->epoch = epoch;
-    return;
-  }
-  EditorRenderSessionContext context;
-  context.epoch      = epoch;
-  context.element_id = element_id;
-  context.image_id   = image_id;
-  session_context_   = std::move(context);
-}
-
-void EditorSessionRenderSchedulerPort::ClearSessionContext() {
-  std::scoped_lock lock(mutex_);
-  session_context_.reset();
-}
-
-void EditorSessionRenderSchedulerPort::InstallSessionContext(EditorRenderSessionContext context) {
-  std::scoped_lock lock(mutex_);
-  session_context_ = std::move(context);
-}
-
-auto EditorSessionRenderSchedulerPort::session_context() const
-    -> std::optional<EditorRenderSessionContext> {
-  std::scoped_lock lock(mutex_);
-  return session_context_;
-}
-
-auto EditorSessionRenderSchedulerPort::context_payload_load_count() const -> std::uint64_t {
-  std::scoped_lock lock(mutex_);
-  return context_payload_load_count_;
-}
-
-auto EditorSessionRenderSchedulerPort::ContextMatchesRequest(
-    const EditorRenderSessionContext& context, const alcedo::EditorRenderRequest& request) const
-    -> bool {
-  return context.epoch == request.intent.image_load_request_id.value &&
-         context.element_id == request.intent.element_id &&
-         context.image_id == request.intent.image_id;
-}
-
-auto EditorSessionRenderSchedulerPort::ContextPayloadReady(
-    const EditorRenderSessionContext& context) const -> bool {
-  return context.image && !context.image->image_path_.empty() && context.input &&
-         context.pipeline_guard && context.pipeline_guard->pipeline_;
-}
-
 auto EditorSessionRenderSchedulerPort::Schedule(const alcedo::EditorRenderRequest& request)
     -> std::uint64_t {
   if (!CanProduceFrame(request)) {
@@ -242,132 +187,31 @@ auto EditorSessionRenderSchedulerPort::Schedule(const alcedo::EditorRenderReques
 
 auto EditorSessionRenderSchedulerPort::CanProduceFrame(
     const alcedo::EditorRenderRequest& request) const -> bool {
-  EditorSessionTestFrameProducer test_producer;
-  bool                           has_matching_context = false;
-  bool                           payload_ready        = false;
-  bool                           has_image_pool       = false;
+  EditorSessionTestFrameProducer                          test_producer;
+  std::function<std::shared_ptr<alcedo::ImagePoolService>()> image_pool;
   {
     std::scoped_lock lock(mutex_);
     test_producer = test_producer_;
-    if (session_context_ && ContextMatchesRequest(*session_context_, request)) {
-      has_matching_context = true;
-      payload_ready        = ContextPayloadReady(*session_context_);
-    }
-    has_image_pool = static_cast<bool>(services_.image_pool);
+    image_pool    = services_.image_pool;
   }
   if (test_producer) {
     return true;
   }
-  // Bound context with payload: no pool probe on the hot path.
-  if (has_matching_context && payload_ready) {
-    return true;
-  }
-  // Identity bound or services available: allow Schedule; EnsureContext loads once.
-  if (has_matching_context || has_image_pool) {
-    return request.intent.image_id != 0 && request.intent.element_id != 0;
-  }
-  return false;
-}
-
-auto EditorSessionRenderSchedulerPort::EnsureContextForRequest(
-    const alcedo::EditorRenderRequest& request, std::string* error)
-    -> std::optional<EditorRenderSessionContext> {
-  {
-    std::scoped_lock lock(mutex_);
-    if (session_context_ && ContextMatchesRequest(*session_context_, request) &&
-        ContextPayloadReady(*session_context_)) {
-      return session_context_;
-    }
-  }
-
-  std::shared_ptr<EditorSessionPipelinePort>             pipeline_port;
-  std::function<std::shared_ptr<alcedo::ImagePoolService>()> image_pool_resolver;
-  {
-    std::scoped_lock lock(mutex_);
-    pipeline_port       = pipeline_port_;
-    image_pool_resolver = services_.image_pool;
-    // Align identity with this request when open/switch bind was skipped.
-    if (!session_context_ || !ContextMatchesRequest(*session_context_, request)) {
-      EditorRenderSessionContext context;
-      context.epoch      = request.intent.image_load_request_id.value;
-      context.element_id = request.intent.element_id;
-      context.image_id   = request.intent.image_id;
-      session_context_   = std::move(context);
-    }
-  }
-
-  if (!pipeline_port) {
-    if (error) {
-      *error = "Editor pipeline port is not configured";
-    }
-    return std::nullopt;
-  }
-
-  std::string pipeline_error;
-  auto        guard = pipeline_port->EnsureLoaded(request.intent.element_id, &pipeline_error);
-  if (!guard || !guard->pipeline_) {
-    if (error) {
-      *error = pipeline_error.empty() ? "No pipeline guard for image; open may lack a project"
-                                      : std::move(pipeline_error);
-    }
-    return std::nullopt;
-  }
-
-  if (!image_pool_resolver) {
-    if (error) {
-      *error = "Image pool is unavailable";
-    }
-    return std::nullopt;
-  }
-  auto image_pool = image_pool_resolver();
   if (!image_pool) {
-    if (error) {
-      *error = "Image pool is unavailable";
-    }
-    return std::nullopt;
+    return false;
   }
-
-  std::shared_ptr<alcedo::Image>       image_desc;
-  std::shared_ptr<alcedo::ImageBuffer> input;
   try {
-    image_desc = image_pool->Read<std::shared_ptr<alcedo::Image>>(
+    const auto pool = image_pool();
+    if (!pool) {
+      return false;
+    }
+    const auto image = pool->Read<std::shared_ptr<alcedo::Image>>(
         request.intent.image_id,
-        [](const std::shared_ptr<alcedo::Image>& image) { return image; });
-    if (!image_desc || image_desc->image_path_.empty()) {
-      if (error) {
-        *error = "Image descriptor is missing or has an empty path";
-      }
-      return std::nullopt;
-    }
-    input = controllers::LoadImageInputBuffer(image_pool, request.intent.image_id);
-  } catch (const std::exception& ex) {
-    if (error) {
-      *error = ex.what();
-    }
-    return std::nullopt;
+        [](const std::shared_ptr<alcedo::Image>& value) { return value; });
+    return image && !image->image_path_.empty();
   } catch (...) {
-    if (error) {
-      *error = "Failed to load session render context payload";
-    }
-    return std::nullopt;
+    return false;
   }
-
-  std::scoped_lock lock(mutex_);
-  // Another bind/switch may have replaced the identity while we loaded.
-  if (!session_context_ || !ContextMatchesRequest(*session_context_, request)) {
-    if (error) {
-      *error = "Session render context was replaced during load";
-    }
-    return std::nullopt;
-  }
-  // Only the first successful payload load for this identity counts.
-  if (!ContextPayloadReady(*session_context_)) {
-    session_context_->image          = std::move(image_desc);
-    session_context_->input          = std::move(input);
-    session_context_->pipeline_guard = std::move(guard);
-    ++context_payload_load_count_;
-  }
-  return session_context_;
 }
 
 auto EditorSessionRenderSchedulerPort::EnsurePipelineScheduler()
@@ -441,29 +285,74 @@ void EditorSessionRenderSchedulerPort::DispatchTestProducer(
 }
 
 void EditorSessionRenderSchedulerPort::DispatchPipelineFrame(Job job, alcedo::IFrameSink* sink) {
-  auto scheduler = EnsurePipelineScheduler();
-  if (!scheduler) {
-    // EnsurePipelineScheduler always creates one; defensive path only.
-    FinishJob(job, false, "Editor pipeline scheduler is not fully configured");
+  std::shared_ptr<EditorSessionPipelinePort> pipeline_port;
+  EditorSessionSchedulerServices             services;
+  auto                                       scheduler = EnsurePipelineScheduler();
+  {
+    std::scoped_lock lock(mutex_);
+    pipeline_port = pipeline_port_;
+    services      = services_;
+  }
+  if (!pipeline_port || !scheduler) {
+    scheduler->ScheduleWork([this, job]() mutable {
+      FinishJob(job, false, "Editor pipeline scheduler is not fully configured");
+    });
     return;
   }
 
   std::string error;
-  auto        context = EnsureContextForRequest(job.request, &error);
-  if (!context) {
-    scheduler->ScheduleWork([this, job, error = std::move(error)]() mutable {
-      FinishJob(job, false, error.empty() ? "Session render context is unavailable" : std::move(error));
+  auto        guard = pipeline_port->EnsureLoaded(job.request.intent.element_id, &error);
+  if (!guard || !guard->pipeline_) {
+    if (error.empty()) {
+      error = "No pipeline guard for image; open may lack a project";
+    }
+    scheduler->ScheduleWork([this, job, error]() mutable {
+      FinishJob(job, false, std::move(error));
+    });
+    return;
+  }
+
+  std::shared_ptr<alcedo::ImagePoolService> image_pool;
+  if (services.image_pool) {
+    image_pool = services.image_pool();
+  }
+  if (!image_pool) {
+    scheduler->ScheduleWork([this, job]() mutable {
+      FinishJob(job, false, "Image pool is unavailable");
     });
     return;
   }
 
   try {
     TraceDetailRequest("pipeline-submit", job.request);
-    auto exec = context->pipeline_guard->pipeline_;
+    auto                           exec = guard->pipeline_;
+    std::shared_ptr<alcedo::Image> image_desc;
+    try {
+      image_desc = image_pool->Read<std::shared_ptr<alcedo::Image>>(
+          job.request.intent.image_id,
+          [](const std::shared_ptr<alcedo::Image>& image) { return image; });
+    } catch (...) {
+    }
+    std::shared_ptr<alcedo::ImageBuffer> input;
+    {
+      std::scoped_lock lock(mutex_);
+      if (cached_input_image_id_ == job.request.intent.image_id) {
+        input = cached_input_;
+      }
+    }
+    if (!input) {
+      auto loaded = controllers::LoadImageInputBuffer(image_pool, job.request.intent.image_id);
+      std::scoped_lock lock(mutex_);
+      if (cached_input_image_id_ != job.request.intent.image_id || !cached_input_) {
+        cached_input_image_id_ = job.request.intent.image_id;
+        cached_input_          = std::move(loaded);
+      }
+      input = cached_input_;
+    }
 
     alcedo::PipelineTask task;
-    task.input_                             = context->input;
-    task.input_desc_                        = context->image;
+    task.input_                             = std::move(input);
+    task.input_desc_                        = std::move(image_desc);
     task.pipeline_executor_                 = exec;
     task.options_.render_desc_.render_type_ = RenderTypeForIntent(job.request.intent);
     task.options_.render_desc_.use_viewport_region_ =

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
@@ -160,6 +160,61 @@ void EditorSessionRenderSchedulerPort::SetTestFrameProducer(
   test_producer_ = std::move(producer);
 }
 
+void EditorSessionRenderSchedulerPort::BindSessionContext(std::uint64_t epoch,
+                                                          sl_element_id_t element_id,
+                                                          image_id_t image_id) {
+  std::scoped_lock lock(mutex_);
+  // Same open image: keep Image / ImageBuffer / PipelineGuard. RouteInitialRender
+  // (undo, head-move, quality re-route) rebinds with the same element/image and
+  // must not force another full-file LoadImageInputBuffer or drop the payload.
+  // Only a true image identity change replaces the whole context.
+  if (session_context_ && session_context_->element_id == element_id &&
+      session_context_->image_id == image_id) {
+    session_context_->epoch = epoch;
+    return;
+  }
+  EditorRenderSessionContext context;
+  context.epoch      = epoch;
+  context.element_id = element_id;
+  context.image_id   = image_id;
+  session_context_   = std::move(context);
+}
+
+void EditorSessionRenderSchedulerPort::ClearSessionContext() {
+  std::scoped_lock lock(mutex_);
+  session_context_.reset();
+}
+
+void EditorSessionRenderSchedulerPort::InstallSessionContext(EditorRenderSessionContext context) {
+  std::scoped_lock lock(mutex_);
+  session_context_ = std::move(context);
+}
+
+auto EditorSessionRenderSchedulerPort::session_context() const
+    -> std::optional<EditorRenderSessionContext> {
+  std::scoped_lock lock(mutex_);
+  return session_context_;
+}
+
+auto EditorSessionRenderSchedulerPort::context_payload_load_count() const -> std::uint64_t {
+  std::scoped_lock lock(mutex_);
+  return context_payload_load_count_;
+}
+
+auto EditorSessionRenderSchedulerPort::ContextMatchesRequest(
+    const EditorRenderSessionContext& context, const alcedo::EditorRenderRequest& request) const
+    -> bool {
+  return context.epoch == request.intent.image_load_request_id.value &&
+         context.element_id == request.intent.element_id &&
+         context.image_id == request.intent.image_id;
+}
+
+auto EditorSessionRenderSchedulerPort::ContextPayloadReady(
+    const EditorRenderSessionContext& context) const -> bool {
+  return context.image && !context.image->image_path_.empty() && context.input &&
+         context.pipeline_guard && context.pipeline_guard->pipeline_;
+}
+
 auto EditorSessionRenderSchedulerPort::Schedule(const alcedo::EditorRenderRequest& request)
     -> std::uint64_t {
   if (!CanProduceFrame(request)) {
@@ -187,31 +242,132 @@ auto EditorSessionRenderSchedulerPort::Schedule(const alcedo::EditorRenderReques
 
 auto EditorSessionRenderSchedulerPort::CanProduceFrame(
     const alcedo::EditorRenderRequest& request) const -> bool {
-  EditorSessionTestFrameProducer                          test_producer;
-  std::function<std::shared_ptr<alcedo::ImagePoolService>()> image_pool;
+  EditorSessionTestFrameProducer test_producer;
+  bool                           has_matching_context = false;
+  bool                           payload_ready        = false;
+  bool                           has_image_pool       = false;
   {
     std::scoped_lock lock(mutex_);
     test_producer = test_producer_;
-    image_pool    = services_.image_pool;
+    if (session_context_ && ContextMatchesRequest(*session_context_, request)) {
+      has_matching_context = true;
+      payload_ready        = ContextPayloadReady(*session_context_);
+    }
+    has_image_pool = static_cast<bool>(services_.image_pool);
   }
   if (test_producer) {
     return true;
   }
-  if (!image_pool) {
-    return false;
+  // Bound context with payload: no pool probe on the hot path.
+  if (has_matching_context && payload_ready) {
+    return true;
   }
-  try {
-    const auto pool = image_pool();
-    if (!pool) {
-      return false;
+  // Identity bound or services available: allow Schedule; EnsureContext loads once.
+  if (has_matching_context || has_image_pool) {
+    return request.intent.image_id != 0 && request.intent.element_id != 0;
+  }
+  return false;
+}
+
+auto EditorSessionRenderSchedulerPort::EnsureContextForRequest(
+    const alcedo::EditorRenderRequest& request, std::string* error)
+    -> std::optional<EditorRenderSessionContext> {
+  {
+    std::scoped_lock lock(mutex_);
+    if (session_context_ && ContextMatchesRequest(*session_context_, request) &&
+        ContextPayloadReady(*session_context_)) {
+      return session_context_;
     }
-    const auto image = pool->Read<std::shared_ptr<alcedo::Image>>(
-        request.intent.image_id,
-        [](const std::shared_ptr<alcedo::Image>& value) { return value; });
-    return image && !image->image_path_.empty();
-  } catch (...) {
-    return false;
   }
+
+  std::shared_ptr<EditorSessionPipelinePort>             pipeline_port;
+  std::function<std::shared_ptr<alcedo::ImagePoolService>()> image_pool_resolver;
+  {
+    std::scoped_lock lock(mutex_);
+    pipeline_port       = pipeline_port_;
+    image_pool_resolver = services_.image_pool;
+    // Align identity with this request when open/switch bind was skipped.
+    if (!session_context_ || !ContextMatchesRequest(*session_context_, request)) {
+      EditorRenderSessionContext context;
+      context.epoch      = request.intent.image_load_request_id.value;
+      context.element_id = request.intent.element_id;
+      context.image_id   = request.intent.image_id;
+      session_context_   = std::move(context);
+    }
+  }
+
+  if (!pipeline_port) {
+    if (error) {
+      *error = "Editor pipeline port is not configured";
+    }
+    return std::nullopt;
+  }
+
+  std::string pipeline_error;
+  auto        guard = pipeline_port->EnsureLoaded(request.intent.element_id, &pipeline_error);
+  if (!guard || !guard->pipeline_) {
+    if (error) {
+      *error = pipeline_error.empty() ? "No pipeline guard for image; open may lack a project"
+                                      : std::move(pipeline_error);
+    }
+    return std::nullopt;
+  }
+
+  if (!image_pool_resolver) {
+    if (error) {
+      *error = "Image pool is unavailable";
+    }
+    return std::nullopt;
+  }
+  auto image_pool = image_pool_resolver();
+  if (!image_pool) {
+    if (error) {
+      *error = "Image pool is unavailable";
+    }
+    return std::nullopt;
+  }
+
+  std::shared_ptr<alcedo::Image>       image_desc;
+  std::shared_ptr<alcedo::ImageBuffer> input;
+  try {
+    image_desc = image_pool->Read<std::shared_ptr<alcedo::Image>>(
+        request.intent.image_id,
+        [](const std::shared_ptr<alcedo::Image>& image) { return image; });
+    if (!image_desc || image_desc->image_path_.empty()) {
+      if (error) {
+        *error = "Image descriptor is missing or has an empty path";
+      }
+      return std::nullopt;
+    }
+    input = controllers::LoadImageInputBuffer(image_pool, request.intent.image_id);
+  } catch (const std::exception& ex) {
+    if (error) {
+      *error = ex.what();
+    }
+    return std::nullopt;
+  } catch (...) {
+    if (error) {
+      *error = "Failed to load session render context payload";
+    }
+    return std::nullopt;
+  }
+
+  std::scoped_lock lock(mutex_);
+  // Another bind/switch may have replaced the identity while we loaded.
+  if (!session_context_ || !ContextMatchesRequest(*session_context_, request)) {
+    if (error) {
+      *error = "Session render context was replaced during load";
+    }
+    return std::nullopt;
+  }
+  // Only the first successful payload load for this identity counts.
+  if (!ContextPayloadReady(*session_context_)) {
+    session_context_->image          = std::move(image_desc);
+    session_context_->input          = std::move(input);
+    session_context_->pipeline_guard = std::move(guard);
+    ++context_payload_load_count_;
+  }
+  return session_context_;
 }
 
 auto EditorSessionRenderSchedulerPort::EnsurePipelineScheduler()
@@ -285,74 +441,29 @@ void EditorSessionRenderSchedulerPort::DispatchTestProducer(
 }
 
 void EditorSessionRenderSchedulerPort::DispatchPipelineFrame(Job job, alcedo::IFrameSink* sink) {
-  std::shared_ptr<EditorSessionPipelinePort> pipeline_port;
-  EditorSessionSchedulerServices             services;
-  auto                                       scheduler = EnsurePipelineScheduler();
-  {
-    std::scoped_lock lock(mutex_);
-    pipeline_port = pipeline_port_;
-    services      = services_;
-  }
-  if (!pipeline_port || !scheduler) {
-    scheduler->ScheduleWork([this, job]() mutable {
-      FinishJob(job, false, "Editor pipeline scheduler is not fully configured");
-    });
+  auto scheduler = EnsurePipelineScheduler();
+  if (!scheduler) {
+    // EnsurePipelineScheduler always creates one; defensive path only.
+    FinishJob(job, false, "Editor pipeline scheduler is not fully configured");
     return;
   }
 
   std::string error;
-  auto        guard = pipeline_port->EnsureLoaded(job.request.intent.element_id, &error);
-  if (!guard || !guard->pipeline_) {
-    if (error.empty()) {
-      error = "No pipeline guard for image; open may lack a project";
-    }
-    scheduler->ScheduleWork([this, job, error]() mutable {
-      FinishJob(job, false, std::move(error));
-    });
-    return;
-  }
-
-  std::shared_ptr<alcedo::ImagePoolService> image_pool;
-  if (services.image_pool) {
-    image_pool = services.image_pool();
-  }
-  if (!image_pool) {
-    scheduler->ScheduleWork([this, job]() mutable {
-      FinishJob(job, false, "Image pool is unavailable");
+  auto        context = EnsureContextForRequest(job.request, &error);
+  if (!context) {
+    scheduler->ScheduleWork([this, job, error = std::move(error)]() mutable {
+      FinishJob(job, false, error.empty() ? "Session render context is unavailable" : std::move(error));
     });
     return;
   }
 
   try {
     TraceDetailRequest("pipeline-submit", job.request);
-    auto                           exec = guard->pipeline_;
-    std::shared_ptr<alcedo::Image> image_desc;
-    try {
-      image_desc = image_pool->Read<std::shared_ptr<alcedo::Image>>(
-          job.request.intent.image_id,
-          [](const std::shared_ptr<alcedo::Image>& image) { return image; });
-    } catch (...) {
-    }
-    std::shared_ptr<alcedo::ImageBuffer> input;
-    {
-      std::scoped_lock lock(mutex_);
-      if (cached_input_image_id_ == job.request.intent.image_id) {
-        input = cached_input_;
-      }
-    }
-    if (!input) {
-      auto loaded = controllers::LoadImageInputBuffer(image_pool, job.request.intent.image_id);
-      std::scoped_lock lock(mutex_);
-      if (cached_input_image_id_ != job.request.intent.image_id || !cached_input_) {
-        cached_input_image_id_ = job.request.intent.image_id;
-        cached_input_          = std::move(loaded);
-      }
-      input = cached_input_;
-    }
+    auto exec = context->pipeline_guard->pipeline_;
 
     alcedo::PipelineTask task;
-    task.input_                             = std::move(input);
-    task.input_desc_                        = std::move(image_desc);
+    task.input_                             = context->input;
+    task.input_desc_                        = context->image;
     task.pipeline_executor_                 = exec;
     task.options_.render_desc_.render_type_ = RenderTypeForIntent(job.request.intent);
     task.options_.render_desc_.use_viewport_region_ =

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
@@ -9,7 +9,6 @@
 #include <QString>
 #include <QThread>
 
-#include <algorithm>
 #include <chrono>
 #include <stdexcept>
 #include <utility>
@@ -154,15 +153,9 @@ void EditorSessionRenderSchedulerPort::SetServices(EditorSessionSchedulerService
   services_ = std::move(services);
 }
 
-void EditorSessionRenderSchedulerPort::SetTestFrameProducer(
-    EditorSessionTestFrameProducer producer) {
-  std::scoped_lock lock(mutex_);
-  test_producer_ = std::move(producer);
-}
-
-void EditorSessionRenderSchedulerPort::BindSessionContext(std::uint64_t epoch,
-                                                          sl_element_id_t element_id,
-                                                          image_id_t image_id) {
+void EditorSessionRenderSchedulerPort::BindSessionContext(
+    std::uint64_t epoch, sl_element_id_t element_id, image_id_t image_id,
+    alcedo::PresentationSinkId presentation_sink_id) {
   std::scoped_lock lock(mutex_);
   // Same open image: keep Image / ImageBuffer / PipelineGuard. RouteInitialRender
   // (undo, head-move, quality re-route) rebinds with the same element/image and
@@ -170,14 +163,16 @@ void EditorSessionRenderSchedulerPort::BindSessionContext(std::uint64_t epoch,
   // Only a true image identity change replaces the whole context.
   if (session_context_ && session_context_->element_id == element_id &&
       session_context_->image_id == image_id) {
-    session_context_->epoch = epoch;
+    session_context_->epoch                = epoch;
+    session_context_->presentation_sink_id = presentation_sink_id;
     return;
   }
   EditorRenderSessionContext context;
-  context.epoch      = epoch;
-  context.element_id = element_id;
-  context.image_id   = image_id;
-  session_context_   = std::move(context);
+  context.epoch                = epoch;
+  context.element_id           = element_id;
+  context.image_id             = image_id;
+  context.presentation_sink_id = presentation_sink_id;
+  session_context_             = std::move(context);
 }
 
 void EditorSessionRenderSchedulerPort::ClearSessionContext() {
@@ -199,6 +194,11 @@ auto EditorSessionRenderSchedulerPort::session_context() const
 auto EditorSessionRenderSchedulerPort::context_payload_load_count() const -> std::uint64_t {
   std::scoped_lock lock(mutex_);
   return context_payload_load_count_;
+}
+
+auto EditorSessionRenderSchedulerPort::sink_resolve_count() const -> std::uint64_t {
+  std::scoped_lock lock(mutex_);
+  return sink_resolve_count_;
 }
 
 auto EditorSessionRenderSchedulerPort::ContextMatchesRequest(
@@ -242,21 +242,16 @@ auto EditorSessionRenderSchedulerPort::Schedule(const alcedo::EditorRenderReques
 
 auto EditorSessionRenderSchedulerPort::CanProduceFrame(
     const alcedo::EditorRenderRequest& request) const -> bool {
-  EditorSessionTestFrameProducer test_producer;
-  bool                           has_matching_context = false;
-  bool                           payload_ready        = false;
-  bool                           has_image_pool       = false;
+  bool has_matching_context = false;
+  bool payload_ready        = false;
+  bool has_image_pool       = false;
   {
     std::scoped_lock lock(mutex_);
-    test_producer = test_producer_;
     if (session_context_ && ContextMatchesRequest(*session_context_, request)) {
       has_matching_context = true;
       payload_ready        = ContextPayloadReady(*session_context_);
     }
     has_image_pool = static_cast<bool>(services_.image_pool);
-  }
-  if (test_producer) {
-    return true;
   }
   // Bound context with payload: no pool probe on the hot path.
   if (has_matching_context && payload_ready) {
@@ -289,10 +284,11 @@ auto EditorSessionRenderSchedulerPort::EnsureContextForRequest(
     // Align identity with this request when open/switch bind was skipped.
     if (!session_context_ || !ContextMatchesRequest(*session_context_, request)) {
       EditorRenderSessionContext context;
-      context.epoch      = request.intent.image_load_request_id.value;
-      context.element_id = request.intent.element_id;
-      context.image_id   = request.intent.image_id;
-      session_context_   = std::move(context);
+      context.epoch                = request.intent.image_load_request_id.value;
+      context.element_id           = request.intent.element_id;
+      context.image_id             = request.intent.image_id;
+      context.presentation_sink_id = request.intent.presentation_sink_id;
+      session_context_             = std::move(context);
     }
   }
 
@@ -381,13 +377,34 @@ auto EditorSessionRenderSchedulerPort::EnsurePipelineScheduler()
 
 void EditorSessionRenderSchedulerPort::DispatchJob(Job job) {
   EditorSessionFrameSinkResolver resolver;
-  EditorSessionTestFrameProducer test_producer;
+  alcedo::PresentationSinkId     bound_sink_id = 0;
+  bool                           has_context   = false;
   {
     std::scoped_lock lock(mutex_);
-    resolver      = sink_resolver_;
-    test_producer = test_producer_;
+    resolver = sink_resolver_;
+    if (session_context_) {
+      has_context   = true;
+      bound_sink_id = session_context_->presentation_sink_id;
+    }
   }
-  alcedo::IFrameSink* sink = resolver ? resolver() : nullptr;
+
+  // Session-scoped sink identity is stamped at bind. Reject mismatched intents
+  // before resolving a live pointer for pipeline submit.
+  if (has_context && bound_sink_id != 0 && job.request.intent.presentation_sink_id != 0 &&
+      job.request.intent.presentation_sink_id != bound_sink_id) {
+    auto scheduler = EnsurePipelineScheduler();
+    scheduler->ScheduleWork([this, job]() mutable {
+      FinishJob(job, false, "Presentation sink identity does not match session context");
+    });
+    return;
+  }
+
+  alcedo::IFrameSink* sink = nullptr;
+  {
+    std::scoped_lock lock(mutex_);
+    ++sink_resolve_count_;
+  }
+  sink = resolver ? resolver() : nullptr;
   if (!sink) {
     auto scheduler = EnsurePipelineScheduler();
     scheduler->ScheduleWork([this, job]() mutable {
@@ -396,48 +413,7 @@ void EditorSessionRenderSchedulerPort::DispatchJob(Job job) {
     return;
   }
 
-  if (test_producer) {
-    DispatchTestProducer(std::move(job), sink, std::move(test_producer));
-    return;
-  }
   DispatchPipelineFrame(std::move(job), sink);
-}
-
-void EditorSessionRenderSchedulerPort::DispatchTestProducer(
-    Job job, alcedo::IFrameSink* sink, EditorSessionTestFrameProducer producer) {
-  auto scheduler = EnsurePipelineScheduler();
-  scheduler->ScheduleWork([this, job = std::move(job), sink, producer = std::move(producer)]() {
-    if (JobIsCancelled(job)) {
-      FinishJob(job, false, "Cancelled during execution");
-      return;
-    }
-    alcedo::FramePreviewMetadata meta = FrameRoleToPreviewMetadata(job.request.intent);
-    meta.presentation_request_id      = job.request.request_id;
-    const alcedo::FramePresentationMode mode =
-        job.request.intent.frame_role == alcedo::FrameRole::DetailPatch
-            ? alcedo::FramePresentationMode::ViewportTransformed
-            : alcedo::FramePresentationMode::FullFrame;
-    // ponytail: test producers still need BindFrameSubmission; production path
-    // leaves binding to PipelineTask::SetExecutorRenderParams.
-    sink->BindFrameSubmission(alcedo::FrameCompletionSubmission{meta, mode});
-    sink->EnsureSize(std::max(1, job.request.intent.requested_width),
-                     std::max(1, job.request.intent.requested_height));
-    bool        ok = false;
-    std::string message;
-    try {
-      ok      = producer(sink, job.request);
-      message = ok ? "Frame ready" : "Test frame producer failed";
-    } catch (const std::exception& ex) {
-      message = ex.what();
-    } catch (...) {
-      message = "Test frame producer exception";
-    }
-    if (JobIsCancelled(job)) {
-      FinishJob(job, false, "Cancelled during execution");
-      return;
-    }
-    FinishJob(job, ok, std::move(message));
-  });
 }
 
 void EditorSessionRenderSchedulerPort::DispatchPipelineFrame(Job job, alcedo::IFrameSink* sink) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
@@ -11,7 +11,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <future>
 #include <stdexcept>
 #include <utility>
 
@@ -48,7 +47,7 @@ auto FrameRoleToPreviewMetadata(const alcedo::EditorRenderIntent& intent)
   meta.frame_role              = intent.frame_role;
   meta.detail_serial           = 0;
   meta.image_identity          = static_cast<std::uint64_t>(intent.image_id);
-  meta.session_epoch        = intent.image_load_request_id.value;
+  meta.session_epoch           = intent.image_load_request_id.value;
   meta.scope_update_allowed    = alcedo::ScopeUpdateAllowedForReason(intent.reason);
   meta.scope_refresh_requested = intent.reason == alcedo::EditorRenderReason::ScopeRefresh;
   return meta;
@@ -96,29 +95,41 @@ void TraceDetailRequest(const char* stage, const alcedo::EditorRenderRequest& re
 
 EditorSessionRenderSchedulerPort::EditorSessionRenderSchedulerPort(
     std::shared_ptr<alcedo::PipelineScheduler> pipeline_scheduler)
-    : pipeline_scheduler_(std::move(pipeline_scheduler)),
-      worker_([this] { WorkerLoop(); }) {}
+    : pipeline_scheduler_(std::move(pipeline_scheduler)) {}
 
 EditorSessionRenderSchedulerPort::~EditorSessionRenderSchedulerPort() {
-  std::shared_ptr<alcedo::EditorRenderCancellationToken> queued_cancellation;
   std::shared_ptr<alcedo::EditorRenderCancellationToken> running_cancellation;
   {
     std::scoped_lock lock(mutex_);
     shutting_down_ = true;
-    if (queued_job_) {
-      queued_job_->cancelled = true;
-      queued_cancellation    = queued_job_->request.intent.cancellation;
-    }
     if (running_job_) {
       running_job_->cancelled = true;
       running_cancellation    = running_job_->request.intent.cancellation;
     }
     sink_resolver_ = {};
   }
-  if (queued_cancellation) queued_cancellation->Cancel();
-  if (running_cancellation) running_cancellation->Cancel();
-  work_available_.notify_all();
-  if (worker_.joinable()) worker_.join();
+  if (running_cancellation) {
+    running_cancellation->Cancel();
+  }
+
+  // Drain in-flight pool work before tearing down this port.
+  for (;;) {
+    {
+      std::unique_lock lock(mutex_);
+      if (!running_job_) {
+        return;
+      }
+      jobs_changed_.wait_for(lock, std::chrono::milliseconds(16),
+                             [this] { return !running_job_.has_value(); });
+      if (!running_job_) {
+        return;
+      }
+    }
+    if (QCoreApplication::instance() != nullptr &&
+        QThread::currentThread() == QCoreApplication::instance()->thread()) {
+      QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 16);
+    }
+  }
 }
 
 void EditorSessionRenderSchedulerPort::SetCoordinator(
@@ -155,37 +166,45 @@ auto EditorSessionRenderSchedulerPort::Schedule(const alcedo::EditorRenderReques
     TraceDetailRequest("scheduler-reject", request, "no-frame-source");
     return 0;
   }
-  std::scoped_lock lock(mutex_);
-  // The coordinator owns the request queue and never schedules a second job
-  // until the first blocking execution completes.
-  if (shutting_down_ || queued_job_ || running_job_) {
-    TraceDetailRequest("scheduler-reject", request, "worker-busy-or-shutdown");
-    return 0;
-  }
   Job job;
-  job.job_id  = ++next_job_id_;
-  job.request = request;
-  queued_job_ = job;
-  scheduled_.push_back(request);
+  {
+    std::scoped_lock lock(mutex_);
+    // Coordinator is single-flight; reject a second job instead of queueing.
+    if (shutting_down_ || running_job_) {
+      TraceDetailRequest("scheduler-reject", request, "busy-or-shutdown");
+      return 0;
+    }
+    job.job_id   = ++next_job_id_;
+    job.request  = request;
+    running_job_ = job;
+    scheduled_.push_back(request);
+  }
   TraceDetailRequest("scheduler-queued", request);
-  work_available_.notify_one();
-  return job.job_id;
+  const std::uint64_t job_id = job.job_id;
+  DispatchJob(std::move(job));
+  return job_id;
 }
 
 auto EditorSessionRenderSchedulerPort::CanProduceFrame(
     const alcedo::EditorRenderRequest& request) const -> bool {
-  EditorSessionTestFrameProducer test_producer;
+  EditorSessionTestFrameProducer                          test_producer;
   std::function<std::shared_ptr<alcedo::ImagePoolService>()> image_pool;
   {
     std::scoped_lock lock(mutex_);
     test_producer = test_producer_;
     image_pool    = services_.image_pool;
   }
-  if (test_producer) return true;
-  if (!image_pool) return false;
+  if (test_producer) {
+    return true;
+  }
+  if (!image_pool) {
+    return false;
+  }
   try {
     const auto pool = image_pool();
-    if (!pool) return false;
+    if (!pool) {
+      return false;
+    }
     const auto image = pool->Read<std::shared_ptr<alcedo::Image>>(
         request.intent.image_id,
         [](const std::shared_ptr<alcedo::Image>& value) { return value; });
@@ -195,40 +214,229 @@ auto EditorSessionRenderSchedulerPort::CanProduceFrame(
   }
 }
 
-void EditorSessionRenderSchedulerPort::Cancel(std::uint64_t scheduler_job_id) {
-  std::shared_ptr<alcedo::EditorRenderCancellationToken> cancellation;
-  std::optional<alcedo::EditorRenderRequest>              cancelled_before_start;
+auto EditorSessionRenderSchedulerPort::EnsurePipelineScheduler()
+    -> std::shared_ptr<alcedo::PipelineScheduler> {
+  std::scoped_lock lock(mutex_);
+  if (!pipeline_scheduler_) {
+    pipeline_scheduler_ = std::make_shared<alcedo::PipelineScheduler>(1);
+  }
+  return pipeline_scheduler_;
+}
+
+void EditorSessionRenderSchedulerPort::DispatchJob(Job job) {
+  EditorSessionFrameSinkResolver resolver;
+  EditorSessionTestFrameProducer test_producer;
   {
     std::scoped_lock lock(mutex_);
-    if (queued_job_ && queued_job_->job_id == scheduler_job_id) {
-      queued_job_->cancelled = true;
-      cancellation          = queued_job_->request.intent.cancellation;
-      cancelled_before_start = queued_job_->request;
-      queued_job_.reset();
-      jobs_changed_.notify_all();
-    } else if (running_job_ && running_job_->job_id == scheduler_job_id) {
-      running_job_->cancelled = true;
-      cancellation           = running_job_->request.intent.cancellation;
-    } else {
+    resolver      = sink_resolver_;
+    test_producer = test_producer_;
+  }
+  alcedo::IFrameSink* sink = resolver ? resolver() : nullptr;
+  if (!sink) {
+    auto scheduler = EnsurePipelineScheduler();
+    scheduler->ScheduleWork([this, job]() mutable {
+      FinishJob(job, false, "No presentation frame sink bound");
+    });
+    return;
+  }
+
+  if (test_producer) {
+    DispatchTestProducer(std::move(job), sink, std::move(test_producer));
+    return;
+  }
+  DispatchPipelineFrame(std::move(job), sink);
+}
+
+void EditorSessionRenderSchedulerPort::DispatchTestProducer(
+    Job job, alcedo::IFrameSink* sink, EditorSessionTestFrameProducer producer) {
+  auto scheduler = EnsurePipelineScheduler();
+  scheduler->ScheduleWork([this, job = std::move(job), sink, producer = std::move(producer)]() {
+    if (JobIsCancelled(job)) {
+      FinishJob(job, false, "Cancelled during execution");
       return;
     }
+    alcedo::FramePreviewMetadata meta = FrameRoleToPreviewMetadata(job.request.intent);
+    meta.presentation_request_id      = job.request.request_id;
+    const alcedo::FramePresentationMode mode =
+        job.request.intent.frame_role == alcedo::FrameRole::DetailPatch
+            ? alcedo::FramePresentationMode::ViewportTransformed
+            : alcedo::FramePresentationMode::FullFrame;
+    // ponytail: test producers still need BindFrameSubmission; production path
+    // leaves binding to PipelineTask::SetExecutorRenderParams.
+    sink->BindFrameSubmission(alcedo::FrameCompletionSubmission{meta, mode});
+    sink->EnsureSize(std::max(1, job.request.intent.requested_width),
+                     std::max(1, job.request.intent.requested_height));
+    bool        ok = false;
+    std::string message;
+    try {
+      ok      = producer(sink, job.request);
+      message = ok ? "Frame ready" : "Test frame producer failed";
+    } catch (const std::exception& ex) {
+      message = ex.what();
+    } catch (...) {
+      message = "Test frame producer exception";
+    }
+    if (JobIsCancelled(job)) {
+      FinishJob(job, false, "Cancelled during execution");
+      return;
+    }
+    FinishJob(job, ok, std::move(message));
+  });
+}
+
+void EditorSessionRenderSchedulerPort::DispatchPipelineFrame(Job job, alcedo::IFrameSink* sink) {
+  std::shared_ptr<EditorSessionPipelinePort> pipeline_port;
+  EditorSessionSchedulerServices             services;
+  auto                                       scheduler = EnsurePipelineScheduler();
+  {
+    std::scoped_lock lock(mutex_);
+    pipeline_port = pipeline_port_;
+    services      = services_;
   }
-  if (cancellation) cancellation->Cancel();
-  if (cancelled_before_start) {
-    CompleteJob(*cancelled_before_start, false, "Cancelled before execution");
+  if (!pipeline_port || !scheduler) {
+    scheduler->ScheduleWork([this, job]() mutable {
+      FinishJob(job, false, "Editor pipeline scheduler is not fully configured");
+    });
+    return;
+  }
+
+  std::string error;
+  auto        guard = pipeline_port->EnsureLoaded(job.request.intent.element_id, &error);
+  if (!guard || !guard->pipeline_) {
+    if (error.empty()) {
+      error = "No pipeline guard for image; open may lack a project";
+    }
+    scheduler->ScheduleWork([this, job, error]() mutable {
+      FinishJob(job, false, std::move(error));
+    });
+    return;
+  }
+
+  std::shared_ptr<alcedo::ImagePoolService> image_pool;
+  if (services.image_pool) {
+    image_pool = services.image_pool();
+  }
+  if (!image_pool) {
+    scheduler->ScheduleWork([this, job]() mutable {
+      FinishJob(job, false, "Image pool is unavailable");
+    });
+    return;
+  }
+
+  try {
+    TraceDetailRequest("pipeline-submit", job.request);
+    auto                           exec = guard->pipeline_;
+    std::shared_ptr<alcedo::Image> image_desc;
+    try {
+      image_desc = image_pool->Read<std::shared_ptr<alcedo::Image>>(
+          job.request.intent.image_id,
+          [](const std::shared_ptr<alcedo::Image>& image) { return image; });
+    } catch (...) {
+    }
+    std::shared_ptr<alcedo::ImageBuffer> input;
+    {
+      std::scoped_lock lock(mutex_);
+      if (cached_input_image_id_ == job.request.intent.image_id) {
+        input = cached_input_;
+      }
+    }
+    if (!input) {
+      auto loaded = controllers::LoadImageInputBuffer(image_pool, job.request.intent.image_id);
+      std::scoped_lock lock(mutex_);
+      if (cached_input_image_id_ != job.request.intent.image_id || !cached_input_) {
+        cached_input_image_id_ = job.request.intent.image_id;
+        cached_input_          = std::move(loaded);
+      }
+      input = cached_input_;
+    }
+
+    alcedo::PipelineTask task;
+    task.input_                             = std::move(input);
+    task.input_desc_                        = std::move(image_desc);
+    task.pipeline_executor_                 = exec;
+    task.options_.render_desc_.render_type_ = RenderTypeForIntent(job.request.intent);
+    task.options_.render_desc_.use_viewport_region_ =
+        job.request.intent.quality == alcedo::EditorRenderQuality::Detail ||
+        job.request.intent.reason == alcedo::EditorRenderReason::ScopeRefresh;
+    task.options_.render_desc_.viewport_region_ = job.request.intent.view_region;
+    task.options_.render_desc_.frame_metadata_  = FrameRoleToPreviewMetadata(job.request.intent);
+    task.options_.render_desc_.frame_metadata_.presentation_request_id = job.request.request_id;
+    task.request_id_                           = job.request.request_id;
+    task.options_.is_callback_                 = false;
+    task.options_.is_seq_callback_             = false;
+    task.options_.is_blocking_                 = false;
+    const bool apply_adjustment = alcedo::ReasonAppliesAdjustmentSnapshot(job.request.intent.reason);
+    task.configure_under_render_lock_ =
+        [snapshot              = job.request.intent.adjustment, sink,
+         geometry_overlay_only = job.request.intent.geometry_overlay_only,
+         apply_adjustment](alcedo::PipelineTask& locked_task) {
+          auto locked_exec = locked_task.pipeline_executor_;
+          if (!locked_exec) {
+            return false;
+          }
+          if (apply_adjustment) {
+            std::string apply_error;
+            if (!alcedo::ApplyEditorAdjustmentSnapshot(*locked_exec, snapshot, &apply_error)) {
+              throw std::runtime_error(apply_error.empty() ? "Failed to apply editor adjustment"
+                                                           : apply_error);
+            }
+            if (alcedo::SnapshotTouchesImageLoading(snapshot)) {
+              controllers::EnsureLoadingOperatorDefaults(locked_exec);
+            }
+          }
+          if (geometry_overlay_only) {
+            alcedo::DisableEditorGeometryOperatorForOverlay(*locked_exec);
+          }
+          controllers::AttachExecutionStages(locked_exec, sink);
+          return true;
+        };
+    if (job.request.intent.cancellation) {
+      task.cancel_requested_ = [token = job.request.intent.cancellation]() {
+        return token && token->IsCancelled();
+      };
+    }
+    const auto request_for_trace = job.request;
+    task.on_complete_            = [this, job, request_for_trace](bool success) mutable {
+      TraceDetailRequest("pipeline-return", request_for_trace, success ? "success" : "failed");
+      if (JobIsCancelled(job)) {
+        FinishJob(job, false, "Cancelled during execution");
+        return;
+      }
+      FinishJob(job, success, success ? "Frame ready" : "Pipeline returned an empty result");
+    };
+    scheduler->ScheduleTask(std::move(task));
+  } catch (const std::exception& ex) {
+    TraceDetailRequest("pipeline-exception", job.request, ex.what());
+    scheduler->ScheduleWork([this, job, message = std::string(ex.what())]() mutable {
+      FinishJob(job, false, std::move(message));
+    });
+  } catch (...) {
+    scheduler->ScheduleWork([this, job]() mutable {
+      FinishJob(job, false, "Pipeline render failed");
+    });
   }
 }
 
+void EditorSessionRenderSchedulerPort::Cancel(std::uint64_t scheduler_job_id) {
+  std::shared_ptr<alcedo::EditorRenderCancellationToken> cancellation;
+  {
+    std::scoped_lock lock(mutex_);
+    if (!running_job_ || running_job_->job_id != scheduler_job_id) {
+      return;
+    }
+    running_job_->cancelled = true;
+    cancellation            = running_job_->request.intent.cancellation;
+  }
+  if (cancellation) {
+    cancellation->Cancel();
+  }
+  // Completion arrives from the pipeline pool via on_complete_ / FinishJob.
+}
+
 void EditorSessionRenderSchedulerPort::WaitForSessionIdle(std::uint64_t session_epoch) {
-  // Owner/GUI thread may call this while a worker is in present handoff. Present
-  // posts QueuedConnection updates to this thread; a bare condvar wait would
-  // starve those events. Timed wait + processEvents lets slot create/recycle
-  // complete without cancelling the frame.
   const auto idle = [this, session_epoch] {
-    const auto belongs_to_session = [session_epoch](const std::optional<Job>& job) {
-      return job && job->request.intent.image_load_request_id.value == session_epoch;
-    };
-    return !belongs_to_session(queued_job_) && !belongs_to_session(running_job_);
+    return !running_job_ ||
+           running_job_->request.intent.image_load_request_id.value != session_epoch;
   };
 
   for (;;) {
@@ -255,230 +463,41 @@ auto EditorSessionRenderSchedulerPort::last_scheduled() const
   return scheduled_;
 }
 
-auto EditorSessionRenderSchedulerPort::IsCancelled(std::uint64_t job_id) const -> bool {
+auto EditorSessionRenderSchedulerPort::JobIsCancelled(const Job& job) const -> bool {
   std::scoped_lock lock(mutex_);
-  if (shutting_down_) return true;
-  if (!running_job_ || running_job_->job_id != job_id) return false;
-  return running_job_->cancelled ||
-         (running_job_->request.intent.cancellation &&
-          running_job_->request.intent.cancellation->IsCancelled());
+  if (shutting_down_) {
+    return true;
+  }
+  if (running_job_ && running_job_->job_id == job.job_id) {
+    if (running_job_->cancelled) {
+      return true;
+    }
+  }
+  return job.request.intent.cancellation && job.request.intent.cancellation->IsCancelled();
 }
 
-void EditorSessionRenderSchedulerPort::WorkerLoop() {
-  for (;;) {
-    Job job;
-    {
-      std::unique_lock lock(mutex_);
-      work_available_.wait(lock, [this] { return shutting_down_ || queued_job_.has_value(); });
-      if (shutting_down_ && !queued_job_) return;
-      job = std::move(*queued_job_);
-      queued_job_.reset();
-      running_job_ = job;
+void EditorSessionRenderSchedulerPort::FinishJob(const Job& job, bool success,
+                                                 std::string message) {
+  bool should_complete = false;
+  {
+    std::scoped_lock lock(mutex_);
+    if (running_job_ && running_job_->job_id == job.job_id) {
+      if (running_job_->cancelled ||
+          (running_job_->request.intent.cancellation &&
+           running_job_->request.intent.cancellation->IsCancelled())) {
+        success = false;
+        if (message.empty() || message == "Frame ready") {
+          message = "Cancelled during execution";
+        }
+      }
+      running_job_.reset();
+      should_complete = true;
     }
-
-    bool        success = false;
-    std::string message;
-    TraceDetailRequest("worker-begin", job.request);
-    const auto worker_started = std::chrono::steady_clock::now();
-    try {
-      ExecuteJob(job);
-      success = !IsCancelled(job.job_id);
-      message = success ? "Frame ready" : "Cancelled during execution";
-    } catch (const std::exception& ex) {
-      message = ex.what();
-    } catch (...) {
-      message = "Frame producer exception";
-    }
-    const auto worker_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    std::chrono::steady_clock::now() - worker_started)
-                                    .count();
-    TraceDetailRequest("worker-end", job.request, success ? "frame-ready" : message.c_str(),
-                       worker_elapsed);
-
-    {
-      std::scoped_lock lock(mutex_);
-      if (running_job_ && running_job_->job_id == job.job_id) running_job_.reset();
-      jobs_changed_.notify_all();
-    }
+    jobs_changed_.notify_all();
+  }
+  if (should_complete) {
     CompleteJob(job.request, success, std::move(message));
   }
-}
-
-void EditorSessionRenderSchedulerPort::ExecuteJob(Job job) {
-  if (IsCancelled(job.job_id)) return;
-
-  alcedo::IFrameSink*            sink = nullptr;
-  EditorSessionFrameSinkResolver resolver;
-  EditorSessionTestFrameProducer test_producer;
-  {
-    std::scoped_lock lock(mutex_);
-    resolver      = sink_resolver_;
-    test_producer = test_producer_;
-  }
-  if (resolver) sink = resolver();
-  if (!sink) throw std::runtime_error("No presentation frame sink bound");
-
-  alcedo::FramePreviewMetadata meta = FrameRoleToPreviewMetadata(job.request.intent);
-  meta.presentation_request_id      = job.request.request_id;
-  const alcedo::FramePresentationMode mode =
-      job.request.intent.frame_role == alcedo::FrameRole::DetailPatch
-          ? alcedo::FramePresentationMode::ViewportTransformed
-          : alcedo::FramePresentationMode::FullFrame;
-  // Bind before produce so test producers and pipeline Apply share the same
-  // request-id / scope metadata. PipelineTask::SetExecutorRenderParams may
-  // refine ROI fields under the render lock later.
-  sink->BindFrameSubmission(alcedo::FrameCompletionSubmission{meta, mode});
-
-  std::string error;
-  bool        ok        = false;
-
-  if (test_producer) {
-    // Test producers do not execute a pipeline stage that knows the real output
-    // dimensions, so preserve their explicit target setup. Production CUDA,
-    // OpenCL and Metal paths publish the actual output themselves; pre-sizing
-    // them with viewport dimensions rewrites render-reference geometry twice.
-    sink->EnsureSize(std::max(1, job.request.intent.requested_width),
-                     std::max(1, job.request.intent.requested_height));
-    ok = test_producer(sink, job.request);
-    if (!ok) error = "Test frame producer failed";
-  } else {
-    ok = TryProducePipelineFrame(job.request, sink, &error);
-  }
-  if (!ok) throw std::runtime_error(error.empty() ? "Render failed" : error);
-}
-
-auto EditorSessionRenderSchedulerPort::TryProducePipelineFrame(
-    const alcedo::EditorRenderRequest& request, alcedo::IFrameSink* sink, std::string* error)
-    -> bool {
-  if (!sink) {
-    if (error) *error = "Presentation sink is null";
-    return false;
-  }
-  std::shared_ptr<EditorSessionPipelinePort> pipeline_port;
-  EditorSessionSchedulerServices             services;
-  std::shared_ptr<alcedo::PipelineScheduler> scheduler;
-  {
-    std::scoped_lock lock(mutex_);
-    pipeline_port = pipeline_port_;
-    services      = services_;
-    if (!pipeline_scheduler_) pipeline_scheduler_ = std::make_shared<alcedo::PipelineScheduler>(1);
-    scheduler = pipeline_scheduler_;
-  }
-  if (!pipeline_port || !scheduler) {
-    if (error) *error = "Editor pipeline scheduler is not fully configured";
-    return false;
-  }
-  auto guard = pipeline_port->EnsureLoaded(request.intent.element_id, error);
-  if (!guard || !guard->pipeline_) {
-    if (error && error->empty()) *error = "No pipeline guard for image; open may lack a project";
-    return false;
-  }
-  std::shared_ptr<alcedo::ImagePoolService> image_pool;
-  if (services.image_pool) image_pool = services.image_pool();
-  if (!image_pool) {
-    if (error) *error = "Image pool is unavailable";
-    return false;
-  }
-
-  try {
-    TraceDetailRequest("pipeline-submit", request);
-    const auto pipeline_started = std::chrono::steady_clock::now();
-    auto                           exec = guard->pipeline_;
-    std::shared_ptr<alcedo::Image> image_desc;
-    try {
-      image_desc = image_pool->Read<std::shared_ptr<alcedo::Image>>(
-          request.intent.image_id,
-          [](const std::shared_ptr<alcedo::Image>& image) { return image; });
-    } catch (...) {
-    }
-    std::shared_ptr<alcedo::ImageBuffer> input;
-    {
-      std::scoped_lock lock(mutex_);
-      if (cached_input_image_id_ == request.intent.image_id) input = cached_input_;
-    }
-    if (!input) {
-      auto loaded = controllers::LoadImageInputBuffer(image_pool, request.intent.image_id);
-      std::scoped_lock lock(mutex_);
-      if (cached_input_image_id_ != request.intent.image_id || !cached_input_) {
-        cached_input_image_id_ = request.intent.image_id;
-        cached_input_          = std::move(loaded);
-      }
-      input = cached_input_;
-    }
-
-    alcedo::PipelineTask task;
-    task.input_                             = std::move(input);
-    task.input_desc_                        = std::move(image_desc);
-    task.pipeline_executor_                 = exec;
-    task.options_.render_desc_.render_type_ = RenderTypeForIntent(request.intent);
-    task.options_.render_desc_.use_viewport_region_ =
-        request.intent.quality == alcedo::EditorRenderQuality::Detail ||
-        request.intent.reason == alcedo::EditorRenderReason::ScopeRefresh;
-    task.options_.render_desc_.viewport_region_ = request.intent.view_region;
-    task.options_.render_desc_.frame_metadata_ = FrameRoleToPreviewMetadata(request.intent);
-    task.options_.render_desc_.frame_metadata_.presentation_request_id = request.request_id;
-    task.request_id_                                                 = request.request_id;
-    task.options_.is_callback_                                         = false;
-    task.options_.is_seq_callback_                                     = false;
-    task.options_.is_blocking_                                         = true;
-    // Content renders install operator params (SetOperator + SetGlobalParams).
-    // View-dependent ROI/detail/scope frames only retarget Geometry via
-    // SetExecutorRenderParams (RESIZE ROI); replaying the full adjustment
-    // snapshot every pan/zoom would thrash Image Loading (RAW_DECODE) cache.
-    const bool apply_adjustment =
-        alcedo::ReasonAppliesAdjustmentSnapshot(request.intent.reason);
-    task.configure_under_render_lock_ =
-        [snapshot              = request.intent.adjustment, sink,
-         geometry_overlay_only = request.intent.geometry_overlay_only,
-         apply_adjustment](alcedo::PipelineTask& locked_task) {
-          auto locked_exec = locked_task.pipeline_executor_;
-          if (!locked_exec) return false;
-          if (apply_adjustment) {
-            std::string apply_error;
-            if (!alcedo::ApplyEditorAdjustmentSnapshot(*locked_exec, snapshot, &apply_error)) {
-              throw std::runtime_error(apply_error.empty() ? "Failed to apply editor adjustment"
-                                                           : apply_error);
-            }
-            // Never touch Image Loading defaults on tone/color slider frames —
-            // EnsureLoadingOperatorDefaults can SetOperator(RAW_DECODE) and
-            // wipe the demosaic cache even when the edit only moved exposure.
-            if (alcedo::SnapshotTouchesImageLoading(snapshot)) {
-              controllers::EnsureLoadingOperatorDefaults(locked_exec);
-            }
-          }
-          if (geometry_overlay_only) {
-            alcedo::DisableEditorGeometryOperatorForOverlay(*locked_exec);
-          }
-          controllers::AttachExecutionStages(locked_exec, sink);
-          return true;
-        };
-    auto promise = std::make_shared<std::promise<std::shared_ptr<alcedo::ImageBuffer>>>();
-    auto future  = promise->get_future();
-    task.result_ = promise;
-    if (request.intent.cancellation) {
-      task.cancel_requested_ = [token = request.intent.cancellation]() {
-        return token && token->IsCancelled();
-      };
-    }
-    scheduler->ScheduleTask(std::move(task));
-    const auto result = future.get();
-    const auto pipeline_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                      std::chrono::steady_clock::now() - pipeline_started)
-                                      .count();
-    if (!result) {
-      TraceDetailRequest("pipeline-return", request, "empty-result", pipeline_elapsed);
-      if (error) *error = "Pipeline returned an empty result";
-      return false;
-    }
-    TraceDetailRequest("pipeline-return", request, "success", pipeline_elapsed);
-    return true;
-  } catch (const std::exception& ex) {
-    TraceDetailRequest("pipeline-exception", request, ex.what());
-    if (error) *error = ex.what();
-  } catch (...) {
-    if (error) *error = "Pipeline render failed";
-  }
-  return false;
 }
 
 void EditorSessionRenderSchedulerPort::CompleteJob(const alcedo::EditorRenderRequest& request,
@@ -488,7 +507,9 @@ void EditorSessionRenderSchedulerPort::CompleteJob(const alcedo::EditorRenderReq
     std::scoped_lock lock(mutex_);
     coordinator = coordinator_.lock();
   }
-  if (!coordinator) return;
+  if (!coordinator) {
+    return;
+  }
   coordinator->NotifySchedulerCompleted(request.request_id, success, std::move(message));
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
@@ -621,7 +621,11 @@ void EditorSessionRenderSchedulerPort::CompleteJob(const alcedo::EditorRenderReq
   if (!coordinator) {
     return;
   }
-  coordinator->NotifySchedulerCompleted(request.request_id, success, std::move(message));
+  // Pipeline-pool completion: do not ScheduleNext inline. The Ready frame just
+  // hit present; let the display consume it before the next produce starts.
+  coordinator->NotifySchedulerCompleted(request.request_id, success, std::move(message),
+                                        /*schedule_next_from_pool=*/false);
+  coordinator->Pump();
 }
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/ui/editor_rhi/direct_frame_sink.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/direct_frame_sink.cpp
@@ -15,6 +15,7 @@
 #include "ui/editor_rhi/editor_viewport_item.hpp"
 #include "ui/editor_rhi/lease_target_adapters.hpp"
 #include "utils/diagnostics/app_logging.hpp"
+#include "utils/diagnostics/render_e2e_timing.hpp"
 
 using alcedo::diag::editorPresentLog;
 
@@ -412,6 +413,7 @@ void DirectFrameSink::NotifyFrameReady(const FrameCompletionSubmission& submissi
             << " reason=not-mapped-or-not-unmapped mapped=" << has_mapped_slot_
             << " unmap_pending=" << unmapped_pending_submit_;
       }
+      diag::NoteRenderE2eTerminal(metadata.presentation_request_id, "sink-not-mapped");
       return;
     }
     if (!AcceptSubmissionRequestId(metadata.presentation_request_id)) {
@@ -423,6 +425,7 @@ void DirectFrameSink::NotifyFrameReady(const FrameCompletionSubmission& submissi
       has_mapped_slot_         = false;
       unmapped_pending_submit_ = false;
       mapped_slot_index_       = -1;
+      diag::NoteRenderE2eTerminal(metadata.presentation_request_id, "stale-request-id");
       return;
     }
     slot_index = mapped_slot_index_;
@@ -438,6 +441,7 @@ void DirectFrameSink::NotifyFrameReady(const FrameCompletionSubmission& submissi
         << "[ROI_TRACE][sink-drop] request=" << metadata.presentation_request_id
           << " reason=no-item-queue-or-slot slot=" << slot_index;
     }
+    diag::NoteRenderE2eTerminal(metadata.presentation_request_id, "sink-no-queue");
     return;
   }
   if (metadata.frame_role == FrameRole::DetailPatch) {
@@ -449,12 +453,14 @@ void DirectFrameSink::NotifyFrameReady(const FrameCompletionSubmission& submissi
         << metadata.source_roi_norm.height;
   }
   item_->present_queue()->NotifyReady(slot_index, mode, metadata);
+  diag::NoteRenderE2eProducerReady(metadata.presentation_request_id);
   qCDebug(editorPresentLog,
           "[EditorPresent] submitted frame request=%llu image=%llu epoch=%llu slot=%d",
           static_cast<unsigned long long>(metadata.presentation_request_id),
           static_cast<unsigned long long>(item_->imageIdentity()),
           static_cast<unsigned long long>(item_->sessionEpoch()), slot_index);
   item_->requestPresentUpdate();
+  diag::NoteRenderE2ePresentWake(metadata.presentation_request_id);
 }
 
 void DirectFrameSink::SubmitHostFrame(const ViewerFrame&) {
@@ -495,17 +501,21 @@ void DirectFrameSink::SubmitMetalFrame(const ViewerMetalFrame& frame) {
   {
     std::lock_guard lock(mutex_);
     if (!AcceptSubmissionRequestId(imported.preview_metadata.presentation_request_id)) {
+      diag::NoteRenderE2eTerminal(imported.preview_metadata.presentation_request_id,
+                                  "stale-metal-request");
       return;
     }
     request_id        = imported.preview_metadata.presentation_request_id;
     imported.sequence = ++imported_sequence_;
     const auto layer  = LayerIndexForRole(imported.preview_metadata.frame_role);
     if (pending_imported_[layer].has_value()) {
+      const auto superseded =
+          pending_imported_[layer]->preview_metadata.presentation_request_id;
       qCDebug(editorPresentLog,
               "[EditorPresent] superseding pending Metal import role=%d request=%llu",
               static_cast<int>(imported.preview_metadata.frame_role),
-              static_cast<unsigned long long>(
-                  pending_imported_[layer]->preview_metadata.presentation_request_id));
+              static_cast<unsigned long long>(superseded));
+      diag::NoteRenderE2eTerminal(superseded, "superseded-metal-import");
     }
     pending_imported_[layer] = imported;
     ++submitted_frame_count_;
@@ -524,6 +534,7 @@ void DirectFrameSink::SubmitMetalFrame(const ViewerMetalFrame& frame) {
     }
   }
 
+  diag::NoteRenderE2eProducerReady(request_id);
   qCDebug(editorPresentLog,
           "[EditorPresent] queued Metal import request=%llu image=%llu epoch=%llu size=%dx%d "
           "handle=%llu (zero-copy)",
@@ -542,6 +553,7 @@ void DirectFrameSink::SubmitMetalFrame(const ViewerMetalFrame& frame) {
         connection);
   }
   item_->requestPresentUpdate();
+  diag::NoteRenderE2ePresentWake(request_id);
 }
 #endif
 

--- a/alcedo_studio/src/ui/editor_rhi/direct_present_queue.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/direct_present_queue.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include "utils/diagnostics/app_logging.hpp"
+#include "utils/diagnostics/render_e2e_timing.hpp"
 
 namespace alcedo::editor_rhi {
 using alcedo::diag::editorPresentLog;
@@ -414,6 +415,8 @@ void DirectPresentQueue::NotifyReady(int slot_index, FramePresentationMode mode,
             << " new_request=" << metadata.presentation_request_id << " old_slot=" << i
             << " new_slot=" << slot_index;
       }
+      diag::NoteRenderE2eTerminal(other.preview_metadata.presentation_request_id,
+                                  "superseded-present-queue");
       ++dropped_stale_frame_count_;
       RecycleSlotLocked(i, false);
     }

--- a/alcedo_studio/src/ui/editor_rhi/editor_viewport_item.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_viewport_item.cpp
@@ -19,6 +19,7 @@
 #include "ui/editor_rhi/editor_interaction_controller.hpp"
 #include "ui/editor_rhi/editor_viewport_renderer.hpp"
 #include "utils/diagnostics/app_logging.hpp"
+#include "utils/diagnostics/render_e2e_timing.hpp"
 
 using alcedo::diag::editorPresentLog;
 
@@ -268,6 +269,8 @@ void EditorViewportItem::requestPresentUpdateOnGuiThread() {
     if (QQuickWindow* w = window()) {
       w->requestUpdate();
     }
+    // Stamp every Ready frame waiting on this GUI wake (P0 present split).
+    diag::NoteRenderE2eGuiUpdate();
   };
   if (thread() == QThread::currentThread()) {
     request();

--- a/alcedo_studio/src/ui/editor_rhi/editor_viewport_renderer.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_viewport_renderer.cpp
@@ -22,6 +22,7 @@
 #include "ui/editor_rhi/native_resource_counters.hpp"
 
 #include "utils/diagnostics/app_logging.hpp"
+#include "utils/diagnostics/render_e2e_timing.hpp"
 
 using alcedo::diag::editorPresentLog;
 namespace alcedo::editor_rhi {
@@ -516,8 +517,10 @@ void EditorViewportRenderer::consumeDirectFrames() {
     if (!frame.has_value()) {
       continue;
     }
+    const std::uint64_t request_id = frame->slot.preview_metadata.presentation_request_id;
+    diag::NoteRenderE2eConsumeBegin(request_id);
     qCDebug(editorPresentLog, "[EditorPresent] consuming frame request=%llu image=%llu epoch=%llu size=%dx%d",
-          static_cast<unsigned long long>(frame->slot.preview_metadata.presentation_request_id),
+          static_cast<unsigned long long>(request_id),
           static_cast<unsigned long long>(frame->slot.image_identity),
           static_cast<unsigned long long>(frame->slot.session_epoch), frame->slot.width,
            frame->slot.height);
@@ -539,6 +542,8 @@ void EditorViewportRenderer::consumeDirectFrames() {
                static_cast<unsigned long long>(
                    frame->slot.preview_metadata.presentation_request_id),
                static_cast<unsigned long long>(frame->slot.native.native_handle));
+      diag::NoteRenderE2eTerminal(frame->slot.preview_metadata.presentation_request_id,
+                                  "qrhi-import-failed");
       destroyResource(texture);
       present_queue_->CompleteRendererRead(frame->slot.index);
       if (role == FrameRole::DetailPatch) {
@@ -568,6 +573,7 @@ void EditorViewportRenderer::consumeDirectFrames() {
     layer.imported_owner.reset();
     layer.imported_native_handle = frame->slot.native.native_handle;
     content_dirty_ = true;
+    diag::NoteRenderE2eDisplayed(layer.preview_metadata.presentation_request_id);
     if (role == FrameRole::DetailPatch) {
       qCDebug(editorPresentLog)
         << "[ROI_TRACE][renderer-imported] request="
@@ -592,10 +598,12 @@ void EditorViewportRenderer::consumeImportedGpuFrames() {
     if (!frame.valid()) {
       continue;
     }
-    const FrameRole role = frame.preview_metadata.frame_role;
+    const FrameRole     role       = frame.preview_metadata.frame_role;
+    const std::uint64_t request_id = frame.preview_metadata.presentation_request_id;
+    diag::NoteRenderE2eConsumeBegin(request_id);
     qCDebug(editorPresentLog, "[EditorPresent] consuming Metal import request=%llu image=%llu epoch=%llu "
           "size=%dx%d handle=%llu",
-          static_cast<unsigned long long>(frame.preview_metadata.presentation_request_id),
+          static_cast<unsigned long long>(request_id),
           static_cast<unsigned long long>(frame.image_identity),
           static_cast<unsigned long long>(frame.session_epoch), frame.width, frame.height,
            static_cast<unsigned long long>(frame.texture_handle));
@@ -624,6 +632,7 @@ void EditorViewportRenderer::consumeImportedGpuFrames() {
       layer.ready_frame.slot.sequence = frame.sequence;
       layer.texture->setNativeLayout(frame.native_layout);
       content_dirty_ = true;
+      diag::NoteRenderE2eDisplayed(layer.preview_metadata.presentation_request_id);
       if (role == FrameRole::DetailPatch) {
         qCDebug(editorPresentLog)
         << "[ROI_TRACE][renderer-metal-reused] request="
@@ -642,6 +651,8 @@ void EditorViewportRenderer::consumeImportedGpuFrames() {
       qCWarning(editorPresentLog, "[EditorPresent] QRhi Metal import failed for request=%llu handle=%llu",
                static_cast<unsigned long long>(frame.preview_metadata.presentation_request_id),
                static_cast<unsigned long long>(frame.texture_handle));
+      diag::NoteRenderE2eTerminal(frame.preview_metadata.presentation_request_id,
+                                  "metal-qrhi-import-failed");
       destroyResource(texture);
       if (role == FrameRole::DetailPatch) {
         qCDebug(editorPresentLog)
@@ -676,6 +687,7 @@ void EditorViewportRenderer::consumeImportedGpuFrames() {
     layer.ready_frame.slot.sequence = frame.sequence;
     NativeResourceCounters::Instance().OnCreateImportedQRhiTexture();
     content_dirty_ = true;
+    diag::NoteRenderE2eDisplayed(layer.preview_metadata.presentation_request_id);
     if (role == FrameRole::DetailPatch) {
       qCDebug(editorPresentLog)
         << "[ROI_TRACE][renderer-metal-imported] request="
@@ -908,6 +920,9 @@ void EditorViewportRenderer::render(QRhiCommandBuffer* command_buffer) {
   if (!command_buffer || !render_target || !rhi_ || !item_) {
     return;
   }
+
+  // P0 present split: scene-graph / vsync wait ends when this render pass starts.
+  diag::NoteRenderE2eRenderEnter();
 
   // Targets are producer-driven. Matches the pre-refactor surface: create the
   // exact output slot requested by EnsureSize, with no speculative pool.

--- a/alcedo_studio/src/utils/CMakeLists.txt
+++ b/alcedo_studio/src/utils/CMakeLists.txt
@@ -10,6 +10,8 @@ def_library(AppDiagnostics
     SOURCES
         ${ALCEDO_SRC_ROOT}/utils/diagnostics/app_logging.cpp
         ${ALCEDO_SRC_ROOT}/include/utils/diagnostics/app_logging.hpp
+        ${ALCEDO_SRC_ROOT}/utils/diagnostics/render_e2e_timing.cpp
+        ${ALCEDO_SRC_ROOT}/include/utils/diagnostics/render_e2e_timing.hpp
     PUBLIC_DEPS Qt6::Core
 )
 

--- a/alcedo_studio/src/utils/diagnostics/render_e2e_timing.cpp
+++ b/alcedo_studio/src/utils/diagnostics/render_e2e_timing.cpp
@@ -1,0 +1,264 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "utils/diagnostics/render_e2e_timing.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace alcedo::diag {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+struct Sample {
+  Clock::time_point                submit_at{};
+  std::optional<Clock::time_point> scheduled_at;
+  std::optional<Clock::time_point> producer_ready_at;
+  std::optional<Clock::time_point> present_wake_at;
+  std::optional<Clock::time_point> gui_update_at;
+  std::optional<Clock::time_point> render_enter_at;
+  std::optional<Clock::time_point> consume_begin_at;
+  std::string                      reason;
+  std::string                      quality;
+  std::string                      role;
+};
+
+// Bound in-flight samples so a present-path miss cannot grow without limit
+// during a long interactive session.
+constexpr std::size_t kMaxPendingSamples = 256;
+
+std::mutex                                g_mutex;
+std::unordered_map<std::uint64_t, Sample> g_samples;
+
+auto MsBetween(const Clock::time_point start, const Clock::time_point end) -> double {
+  return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+void EraseLocked(const std::uint64_t request_id) {
+  g_samples.erase(request_id);
+}
+
+void PruneIfNeededLocked() {
+  if (g_samples.size() <= kMaxPendingSamples) {
+    return;
+  }
+  // Drop the lowest request ids first (oldest under monotonic allocator).
+  while (g_samples.size() > kMaxPendingSamples / 2) {
+    auto oldest = g_samples.begin();
+    for (auto it = g_samples.begin(); it != g_samples.end(); ++it) {
+      if (it->first < oldest->first) {
+        oldest = it;
+      }
+    }
+    g_samples.erase(oldest);
+  }
+}
+
+auto FindSampleLocked(const std::uint64_t request_id) -> Sample* {
+  const auto it = g_samples.find(request_id);
+  if (it == g_samples.end()) {
+    return nullptr;
+  }
+  return &it->second;
+}
+
+void EnsurePresentChainPrefix(Sample* sample, const Clock::time_point now) {
+  if (sample == nullptr) {
+    return;
+  }
+  if (!sample->scheduled_at.has_value()) {
+    sample->scheduled_at = sample->submit_at;
+  }
+  if (!sample->producer_ready_at.has_value()) {
+    sample->producer_ready_at = now;
+  }
+  if (!sample->present_wake_at.has_value()) {
+    sample->present_wake_at = sample->producer_ready_at;
+  }
+}
+
+}  // namespace
+
+void NoteRenderE2eSubmit(const std::uint64_t request_id, const std::string_view reason,
+                         const std::string_view quality, const std::string_view role) {
+  if (request_id == 0) {
+    return;
+  }
+  Sample sample;
+  sample.submit_at = Clock::now();
+  sample.reason    = std::string(reason);
+  sample.quality   = std::string(quality);
+  sample.role      = std::string(role);
+
+  std::lock_guard lock(g_mutex);
+  g_samples.insert_or_assign(request_id, std::move(sample));
+  PruneIfNeededLocked();
+}
+
+void NoteRenderE2eScheduled(const std::uint64_t request_id) {
+  if (request_id == 0) {
+    return;
+  }
+  const auto      now = Clock::now();
+  std::lock_guard lock(g_mutex);
+  Sample*         sample = FindSampleLocked(request_id);
+  if (sample == nullptr) {
+    return;
+  }
+  if (!sample->scheduled_at.has_value()) {
+    sample->scheduled_at = now;
+  }
+}
+
+void NoteRenderE2eProducerReady(const std::uint64_t request_id) {
+  if (request_id == 0) {
+    return;
+  }
+  const auto      now = Clock::now();
+  std::lock_guard lock(g_mutex);
+  Sample*         sample = FindSampleLocked(request_id);
+  if (sample == nullptr) {
+    return;
+  }
+  if (!sample->scheduled_at.has_value()) {
+    sample->scheduled_at = sample->submit_at;
+  }
+  if (!sample->producer_ready_at.has_value()) {
+    sample->producer_ready_at = now;
+  }
+}
+
+void NoteRenderE2ePresentWake(const std::uint64_t request_id) {
+  if (request_id == 0) {
+    return;
+  }
+  const auto      now = Clock::now();
+  std::lock_guard lock(g_mutex);
+  Sample*         sample = FindSampleLocked(request_id);
+  if (sample == nullptr) {
+    return;
+  }
+  EnsurePresentChainPrefix(sample, now);
+  if (!sample->present_wake_at.has_value()) {
+    sample->present_wake_at = now;
+  }
+}
+
+void NoteRenderE2eGuiUpdate() {
+  const auto      now = Clock::now();
+  std::lock_guard lock(g_mutex);
+  for (auto& [request_id, sample] : g_samples) {
+    (void)request_id;
+    // Only frames that already asked for a redraw; ignore bare submit samples.
+    if (!sample.present_wake_at.has_value() || sample.gui_update_at.has_value()) {
+      continue;
+    }
+    sample.gui_update_at = now;
+  }
+}
+
+void NoteRenderE2eRenderEnter() {
+  const auto      now = Clock::now();
+  std::lock_guard lock(g_mutex);
+  for (auto& [request_id, sample] : g_samples) {
+    (void)request_id;
+    if (!sample.present_wake_at.has_value() || sample.render_enter_at.has_value()) {
+      continue;
+    }
+    if (!sample.gui_update_at.has_value()) {
+      // Render can run without a dedicated wake stamp on some paths; keep the
+      // chain monotonic for printing.
+      sample.gui_update_at = sample.present_wake_at;
+    }
+    sample.render_enter_at = now;
+  }
+}
+
+void NoteRenderE2eConsumeBegin(const std::uint64_t request_id) {
+  if (request_id == 0) {
+    return;
+  }
+  const auto      now = Clock::now();
+  std::lock_guard lock(g_mutex);
+  Sample*         sample = FindSampleLocked(request_id);
+  if (sample == nullptr) {
+    return;
+  }
+  EnsurePresentChainPrefix(sample, now);
+  if (!sample->gui_update_at.has_value()) {
+    sample->gui_update_at = sample->present_wake_at;
+  }
+  if (!sample->render_enter_at.has_value()) {
+    sample->render_enter_at = now;
+  }
+  if (!sample->consume_begin_at.has_value()) {
+    sample->consume_begin_at = now;
+  }
+}
+
+void NoteRenderE2eDisplayed(const std::uint64_t request_id) {
+  if (request_id == 0) {
+    return;
+  }
+  const auto now = Clock::now();
+
+  Sample sample;
+  {
+    std::lock_guard lock(g_mutex);
+    const auto      it = g_samples.find(request_id);
+    if (it == g_samples.end()) {
+      return;
+    }
+    sample = std::move(it->second);
+    g_samples.erase(it);
+  }
+
+  const double total_ms       = MsBetween(sample.submit_at, now);
+  const auto   scheduled      = sample.scheduled_at.value_or(sample.submit_at);
+  const auto   producer_ready = sample.producer_ready_at.value_or(now);
+  const auto   present_wake   = sample.present_wake_at.value_or(producer_ready);
+  const auto   gui_update     = sample.gui_update_at.value_or(present_wake);
+  const auto   render_enter   = sample.render_enter_at.value_or(sample.consume_begin_at.value_or(now));
+  const auto   consume_begin  = sample.consume_begin_at.value_or(render_enter);
+
+  const double queue_ms    = MsBetween(sample.submit_at, scheduled);
+  const double pipeline_ms = MsBetween(scheduled, producer_ready);
+  const double present_ms  = MsBetween(producer_ready, now);
+  const double wake_ms     = MsBetween(producer_ready, present_wake);
+  const double gui_wait_ms = MsBetween(present_wake, gui_update);
+  const double sg_wait_ms  = MsBetween(gui_update, render_enter);
+  // Render-thread work after the frame starts: target fulfill + createFrom.
+  // consume_begin is retained for diagnostics if fulfill ever grows.
+  const double import_ms = MsBetween(render_enter, now);
+  const double fps       = total_ms > 0.0 ? (1000.0 / total_ms) : 0.0;
+
+  std::cout << std::fixed << std::setprecision(2) << "[RENDER_E2E] request=" << request_id
+            << " reason=" << (sample.reason.empty() ? "?" : sample.reason)
+            << " quality=" << (sample.quality.empty() ? "?" : sample.quality)
+            << " role=" << (sample.role.empty() ? "?" : sample.role) << " total=" << total_ms
+            << "ms queue=" << queue_ms << "ms pipeline=" << pipeline_ms
+            << "ms present=" << present_ms << "ms (wake=" << wake_ms << "ms gui_wait=" << gui_wait_ms
+            << "ms sg_wait=" << sg_wait_ms << "ms import=" << import_ms << "ms) (~"
+            << std::setprecision(1) << fps << " fps)" << std::endl;
+
+  (void)consume_begin;
+}
+
+void NoteRenderE2eTerminal(const std::uint64_t request_id, const std::string_view /*outcome*/) {
+  if (request_id == 0) {
+    return;
+  }
+  std::lock_guard lock(g_mutex);
+  EraseLocked(request_id);
+}
+
+}  // namespace alcedo::diag

--- a/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
+++ b/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
@@ -97,15 +97,13 @@ TEST_F(EditorRenderCoordinatorTest, RejectsStaleImageLoadRequest) {
   EXPECT_NE(rejected.message.find("image load request"), std::string::npos);
 }
 
-TEST_F(EditorRenderCoordinatorTest, ReplacesPendingWorkWithSameReplacementKey) {
+TEST_F(EditorRenderCoordinatorTest, SameQualitySlotSubmitReplacesPriorPending) {
   auto first = coordinator_->Submit(
       MakeIntent(EditorRenderQuality::Interactive, EditorRenderPriority::Normal));
   ASSERT_TRUE(coordinator_->has_inflight());
 
-  // Phase 5D: ZoomPan/Resize are reused (never enqueued), so a replacement-key
-  // test must use a reason that enqueues. MakeIntent defaults to
-  // InteractiveAdjustment, which produces a pending "interactive" entry that a
-  // newer same-key submit replaces.
+  // ZoomPan/Resize are reused (never enqueued). InteractiveAdjustment fills the
+  // interactive slot; a second interactive submit overwrites that slot only.
   auto       older       = MakeIntent(EditorRenderQuality::Interactive, EditorRenderPriority::Low);
   const auto pending_old = coordinator_->Submit(older);
   EXPECT_EQ(pending_old.kind, EditorRenderResultKind::RequestAccepted);
@@ -602,9 +600,9 @@ TEST_F(EditorRenderCoordinatorTest, CropRotateSchedulesInteractivePrimary) {
 }
 
 TEST_F(EditorRenderCoordinatorTest, BurstOfReplaceableIntentsKeepsNewestInteractiveOnly) {
-  // Phase 5D A2/D3: a burst of replaceable input (slider/pointer updates sharing
-  // a replacement key) does not create one task per event. Prior pending entries
-  // are replaced; only the newest interactive state survives to render.
+  // Interactive burst: many same-slot submits while one job is in flight leave
+  // at most one pending interactive slot; the final scheduled frame is the
+  // latest accepted interactive intent.
   coordinator_->Submit(MakeIntent(EditorRenderQuality::Interactive, EditorRenderPriority::Normal));
   ASSERT_TRUE(coordinator_->has_inflight());
 
@@ -612,12 +610,11 @@ TEST_F(EditorRenderCoordinatorTest, BurstOfReplaceableIntentsKeepsNewestInteract
   constexpr int  kPreviewBurst  = 100;
   for (int i = 0; i < kPreviewBurst; ++i) {
     auto intent = MakeIntent(EditorRenderQuality::Interactive, EditorRenderPriority::Normal);
-    intent.replacement_key = "interactive";  // same key → replace prior pending
-    const auto result      = coordinator_->Submit(intent);
+    const auto result = coordinator_->Submit(intent);
     ASSERT_EQ(result.kind, EditorRenderResultKind::RequestAccepted);
     last_pending_id = result.request_id;
   }
-  // One hundred preview updates but only one pending entry — the newest — survives.
+  // One hundred preview updates but only one pending slot — the newest — survives.
   EXPECT_EQ(coordinator_->pending_count(), 1u);
 
   int replaced = 0;
@@ -633,6 +630,49 @@ TEST_F(EditorRenderCoordinatorTest, BurstOfReplaceableIntentsKeepsNewestInteract
   coordinator_->NotifySchedulerCompleted(inflight_id, true);
   ASSERT_EQ(scheduler_->scheduled_.size(), 2u);
   EXPECT_EQ(scheduler_->scheduled_.back().request_id, last_pending_id);
+}
+
+TEST_F(EditorRenderCoordinatorTest, ThreeQualitySlotsCanCoexistAndScheduleInteractiveFirst) {
+  // Fixed slots: one interactive + one quality + one detail pending (detail in
+  // flight first). After completion, schedule order is interactive > quality >
+  // detail regardless of EditorRenderPriority.
+  const auto detail_inflight =
+      coordinator_->Submit(MakeIntent(EditorRenderQuality::Detail, EditorRenderPriority::High));
+  ASSERT_TRUE(coordinator_->has_inflight());
+  EXPECT_EQ(coordinator_->last_scheduled_request_id(), detail_inflight.request_id);
+
+  const auto interactive = coordinator_->Submit(
+      MakeIntent(EditorRenderQuality::Interactive, EditorRenderPriority::Low));
+  const auto quality =
+      coordinator_->Submit(MakeIntent(EditorRenderQuality::Quality, EditorRenderPriority::High));
+  const auto detail_pending =
+      coordinator_->Submit(MakeIntent(EditorRenderQuality::Detail, EditorRenderPriority::High));
+  // Detail slot overwrite: inflight detail is separate; pending detail is one slot.
+  EXPECT_EQ(coordinator_->pending_count(), 3u);
+  EXPECT_EQ(detail_pending.kind, EditorRenderResultKind::RequestAccepted);
+
+  coordinator_->NotifySchedulerCompleted(detail_inflight.request_id, true);
+  ASSERT_GE(scheduler_->scheduled_.size(), 2u);
+  EXPECT_EQ(scheduler_->scheduled_[1].request_id, interactive.request_id);
+
+  coordinator_->NotifySchedulerCompleted(interactive.request_id, true);
+  ASSERT_GE(scheduler_->scheduled_.size(), 3u);
+  EXPECT_EQ(scheduler_->scheduled_[2].request_id, quality.request_id);
+
+  coordinator_->NotifySchedulerCompleted(quality.request_id, true);
+  ASSERT_EQ(scheduler_->scheduled_.size(), 4u);
+  EXPECT_EQ(scheduler_->scheduled_[3].request_id, detail_pending.request_id);
+  EXPECT_EQ(coordinator_->pending_count(), 0u);
+}
+
+TEST(EditorRenderCoordinatorSlotTest, SlotIndexMatchesQualityLadderOrder) {
+  EXPECT_EQ(EditorRenderCoordinator::SlotIndexForQuality(EditorRenderQuality::Interactive), 0u);
+  EXPECT_EQ(EditorRenderCoordinator::SlotIndexForQuality(EditorRenderQuality::Quality), 1u);
+  EXPECT_EQ(EditorRenderCoordinator::SlotIndexForQuality(EditorRenderQuality::Detail), 2u);
+  EXPECT_LT(EditorRenderCoordinator::SlotIndexForQuality(EditorRenderQuality::Interactive),
+            EditorRenderCoordinator::SlotIndexForQuality(EditorRenderQuality::Quality));
+  EXPECT_LT(EditorRenderCoordinator::SlotIndexForQuality(EditorRenderQuality::Quality),
+            EditorRenderCoordinator::SlotIndexForQuality(EditorRenderQuality::Detail));
 }
 
 TEST_F(EditorRenderCoordinatorTest, InteractiveNotBlockedBehindOutdatedDetail) {

--- a/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
+++ b/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
@@ -34,10 +34,23 @@ class RecordingScheduler final : public IEditorPipelineSchedulerPort {
   void WaitForSessionIdle(std::uint64_t session_epoch) override {
     waited_sessions_.push_back(session_epoch);
   }
+  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id,
+                          image_id_t image_id) override {
+    bind_calls_.push_back({epoch, element_id, image_id});
+  }
+  void ClearSessionContext() override { ++clear_count_; }
+
+  struct BindCall {
+    std::uint64_t   epoch      = 0;
+    sl_element_id_t element_id = 0;
+    image_id_t      image_id   = 0;
+  };
 
   std::vector<EditorRenderRequest> scheduled_;
   std::vector<std::uint64_t>       cancelled_;
   std::vector<std::uint64_t>       waited_sessions_;
+  std::vector<BindCall>            bind_calls_;
+  int                              clear_count_ = 0;
   std::uint64_t                    next_job_  = 0;
   bool                             fail_next_ = false;
 };
@@ -694,6 +707,17 @@ TEST_F(EditorRenderCoordinatorTest, InteractiveNotBlockedBehindOutdatedDetail) {
   ASSERT_EQ(scheduler_->scheduled_.size(), 2u);
   EXPECT_EQ(scheduler_->scheduled_.back().request_id, interactive.request_id);
   EXPECT_NE(scheduler_->scheduled_.back().request_id, detail.request_id);
+}
+
+TEST_F(EditorRenderCoordinatorTest, BindAndClearSessionRenderContextForwardToScheduler) {
+  coordinator_->BindSessionRenderContext(/*epoch=*/42, /*element_id=*/7, /*image_id=*/9);
+  ASSERT_EQ(scheduler_->bind_calls_.size(), 1u);
+  EXPECT_EQ(scheduler_->bind_calls_.front().epoch, 42u);
+  EXPECT_EQ(scheduler_->bind_calls_.front().element_id, 7u);
+  EXPECT_EQ(scheduler_->bind_calls_.front().image_id, 9u);
+
+  coordinator_->ClearSessionRenderContext();
+  EXPECT_EQ(scheduler_->clear_count_, 1);
 }
 
 TEST_F(EditorRenderCoordinatorTest, DiagnosticsTrackRejectReplaceCancelAndReadyFrame) {

--- a/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
+++ b/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
@@ -34,23 +34,10 @@ class RecordingScheduler final : public IEditorPipelineSchedulerPort {
   void WaitForSessionIdle(std::uint64_t session_epoch) override {
     waited_sessions_.push_back(session_epoch);
   }
-  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id,
-                          image_id_t image_id) override {
-    bind_calls_.push_back({epoch, element_id, image_id});
-  }
-  void ClearSessionContext() override { ++clear_count_; }
-
-  struct BindCall {
-    std::uint64_t   epoch      = 0;
-    sl_element_id_t element_id = 0;
-    image_id_t      image_id   = 0;
-  };
 
   std::vector<EditorRenderRequest> scheduled_;
   std::vector<std::uint64_t>       cancelled_;
   std::vector<std::uint64_t>       waited_sessions_;
-  std::vector<BindCall>            bind_calls_;
-  int                              clear_count_ = 0;
   std::uint64_t                    next_job_  = 0;
   bool                             fail_next_ = false;
 };
@@ -707,17 +694,6 @@ TEST_F(EditorRenderCoordinatorTest, InteractiveNotBlockedBehindOutdatedDetail) {
   ASSERT_EQ(scheduler_->scheduled_.size(), 2u);
   EXPECT_EQ(scheduler_->scheduled_.back().request_id, interactive.request_id);
   EXPECT_NE(scheduler_->scheduled_.back().request_id, detail.request_id);
-}
-
-TEST_F(EditorRenderCoordinatorTest, BindAndClearSessionRenderContextForwardToScheduler) {
-  coordinator_->BindSessionRenderContext(/*epoch=*/42, /*element_id=*/7, /*image_id=*/9);
-  ASSERT_EQ(scheduler_->bind_calls_.size(), 1u);
-  EXPECT_EQ(scheduler_->bind_calls_.front().epoch, 42u);
-  EXPECT_EQ(scheduler_->bind_calls_.front().element_id, 7u);
-  EXPECT_EQ(scheduler_->bind_calls_.front().image_id, 9u);
-
-  coordinator_->ClearSessionRenderContext();
-  EXPECT_EQ(scheduler_->clear_count_, 1);
 }
 
 TEST_F(EditorRenderCoordinatorTest, DiagnosticsTrackRejectReplaceCancelAndReadyFrame) {

--- a/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
+++ b/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
@@ -34,16 +34,17 @@ class RecordingScheduler final : public IEditorPipelineSchedulerPort {
   void WaitForSessionIdle(std::uint64_t session_epoch) override {
     waited_sessions_.push_back(session_epoch);
   }
-  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id,
-                          image_id_t image_id) override {
-    bind_calls_.push_back({epoch, element_id, image_id});
+  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id, image_id_t image_id,
+                          PresentationSinkId presentation_sink_id = 0) override {
+    bind_calls_.push_back({epoch, element_id, image_id, presentation_sink_id});
   }
   void ClearSessionContext() override { ++clear_count_; }
 
   struct BindCall {
-    std::uint64_t   epoch      = 0;
-    sl_element_id_t element_id = 0;
-    image_id_t      image_id   = 0;
+    std::uint64_t      epoch                = 0;
+    sl_element_id_t    element_id           = 0;
+    image_id_t         image_id             = 0;
+    PresentationSinkId presentation_sink_id = 0;
   };
 
   std::vector<EditorRenderRequest> scheduled_;
@@ -710,11 +711,13 @@ TEST_F(EditorRenderCoordinatorTest, InteractiveNotBlockedBehindOutdatedDetail) {
 }
 
 TEST_F(EditorRenderCoordinatorTest, BindAndClearSessionRenderContextForwardToScheduler) {
-  coordinator_->BindSessionRenderContext(/*epoch=*/42, /*element_id=*/7, /*image_id=*/9);
+  coordinator_->BindSessionRenderContext(/*epoch=*/42, /*element_id=*/7, /*image_id=*/9,
+                                         /*presentation_sink_id=*/55);
   ASSERT_EQ(scheduler_->bind_calls_.size(), 1u);
   EXPECT_EQ(scheduler_->bind_calls_.front().epoch, 42u);
   EXPECT_EQ(scheduler_->bind_calls_.front().element_id, 7u);
   EXPECT_EQ(scheduler_->bind_calls_.front().image_id, 9u);
+  EXPECT_EQ(scheduler_->bind_calls_.front().presentation_sink_id, 55u);
 
   coordinator_->ClearSessionRenderContext();
   EXPECT_EQ(scheduler_->clear_count_, 1);

--- a/alcedo_studio/tests/app/editor_session_render_controller_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_render_controller_test.cpp
@@ -100,26 +100,6 @@ TEST_F(EditorSessionRenderControllerTest, RouteInitialRenderSchedulesInteractive
   EXPECT_NE(render_->first_frame_request_id(), 0u);
 }
 
-TEST_F(EditorSessionRenderControllerTest, RouteInitialRenderBindsSessionContextAtOpen) {
-  OpenImage();
-  auto* sched = dynamic_cast<EditorSessionBootstrapSchedulerPort*>(scheduler_.get());
-  ASSERT_NE(sched, nullptr);
-  ASSERT_EQ(sched->binds().size(), 1u);
-  EXPECT_EQ(sched->binds().front().element_id, lifecycle_->identity().element_id);
-  EXPECT_EQ(sched->binds().front().image_id, lifecycle_->identity().image_id);
-  EXPECT_EQ(sched->binds().front().epoch, lifecycle_->active_image_load_request().value);
-}
-
-TEST_F(EditorSessionRenderControllerTest, ResetForNewImageClearsSessionRenderContext) {
-  OpenImage();
-  auto* sched = dynamic_cast<EditorSessionBootstrapSchedulerPort*>(scheduler_.get());
-  ASSERT_NE(sched, nullptr);
-  const int clears_after_open = sched->clear_count();
-
-  render_->ResetForNewImage();
-  EXPECT_EQ(sched->clear_count(), clears_after_open + 1);
-}
-
 TEST_F(EditorSessionRenderControllerTest, GeometryOverlayFlagIsStampedOnRenderIntent) {
   render_->SetGeometryOverlayActive(true);
   OpenImage();

--- a/alcedo_studio/tests/app/editor_session_render_controller_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_render_controller_test.cpp
@@ -100,6 +100,26 @@ TEST_F(EditorSessionRenderControllerTest, RouteInitialRenderSchedulesInteractive
   EXPECT_NE(render_->first_frame_request_id(), 0u);
 }
 
+TEST_F(EditorSessionRenderControllerTest, RouteInitialRenderBindsSessionContextAtOpen) {
+  OpenImage();
+  auto* sched = dynamic_cast<EditorSessionBootstrapSchedulerPort*>(scheduler_.get());
+  ASSERT_NE(sched, nullptr);
+  ASSERT_EQ(sched->binds().size(), 1u);
+  EXPECT_EQ(sched->binds().front().element_id, lifecycle_->identity().element_id);
+  EXPECT_EQ(sched->binds().front().image_id, lifecycle_->identity().image_id);
+  EXPECT_EQ(sched->binds().front().epoch, lifecycle_->active_image_load_request().value);
+}
+
+TEST_F(EditorSessionRenderControllerTest, ResetForNewImageClearsSessionRenderContext) {
+  OpenImage();
+  auto* sched = dynamic_cast<EditorSessionBootstrapSchedulerPort*>(scheduler_.get());
+  ASSERT_NE(sched, nullptr);
+  const int clears_after_open = sched->clear_count();
+
+  render_->ResetForNewImage();
+  EXPECT_EQ(sched->clear_count(), clears_after_open + 1);
+}
+
 TEST_F(EditorSessionRenderControllerTest, GeometryOverlayFlagIsStampedOnRenderIntent) {
   render_->SetGeometryOverlayActive(true);
   OpenImage();

--- a/alcedo_studio/tests/app/editor_session_render_controller_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_render_controller_test.cpp
@@ -108,6 +108,7 @@ TEST_F(EditorSessionRenderControllerTest, RouteInitialRenderBindsSessionContextA
   EXPECT_EQ(sched->binds().front().element_id, lifecycle_->identity().element_id);
   EXPECT_EQ(sched->binds().front().image_id, lifecycle_->identity().image_id);
   EXPECT_EQ(sched->binds().front().epoch, lifecycle_->active_image_load_request().value);
+  EXPECT_EQ(sched->binds().front().presentation_sink_id, 1u);
 }
 
 TEST_F(EditorSessionRenderControllerTest, ResetForNewImageClearsSessionRenderContext) {

--- a/alcedo_studio/tests/support/harness_completing_pipeline_scheduler_port.hpp
+++ b/alcedo_studio/tests/support/harness_completing_pipeline_scheduler_port.hpp
@@ -1,0 +1,226 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+/// @file harness_completing_pipeline_scheduler_port.hpp
+/// @brief Test-only IEditorPipelineSchedulerPort that completes frames via a
+/// harness producer. Lives outside production so EditorSessionRenderSchedulerPort
+/// never grows test-producer Dispatch branches (Phase R4).
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "app/editor_render_coordinator.hpp"
+#include "app/editor_render_intent.hpp"
+#include "edit/frame_presentation_types.hpp"
+#include "renderer/pipeline_scheduler.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo::test {
+
+using HarnessFrameSinkResolver = std::function<alcedo::IFrameSink*()>;
+using HarnessFrameProducer =
+    std::function<bool(alcedo::IFrameSink*, const alcedo::EditorRenderRequest&)>;
+using HarnessCompletionNotifier =
+    std::function<void(std::uint64_t request_id, bool success, std::string message)>;
+
+/// Completing fake for shell / e2e hosts that need FrameReady without RAW decode.
+/// Owns BindFrameSubmission / EnsureSize for its producer path (test seam only).
+class HarnessCompletingPipelineSchedulerPort final : public alcedo::IEditorPipelineSchedulerPort {
+ public:
+  void SetSinkResolver(HarnessFrameSinkResolver resolver) {
+    std::scoped_lock lock(mutex_);
+    sink_resolver_ = std::move(resolver);
+  }
+
+  void SetFrameProducer(HarnessFrameProducer producer) {
+    std::scoped_lock lock(mutex_);
+    producer_ = std::move(producer);
+  }
+
+  void SetCompletionNotifier(HarnessCompletionNotifier notifier) {
+    std::scoped_lock lock(mutex_);
+    completion_notifier_ = std::move(notifier);
+  }
+
+  auto Schedule(const alcedo::EditorRenderRequest& request) -> std::uint64_t override {
+    if (!producer_) {
+      return 0;
+    }
+    Job job;
+    {
+      std::scoped_lock lock(mutex_);
+      if (shutting_down_ || running_job_) {
+        return 0;
+      }
+      job.job_id   = ++next_job_id_;
+      job.request  = request;
+      running_job_ = job;
+    }
+    Dispatch(std::move(job));
+    return job.job_id;
+  }
+
+  void Cancel(std::uint64_t scheduler_job_id) override {
+    std::shared_ptr<alcedo::EditorRenderCancellationToken> cancellation;
+    {
+      std::scoped_lock lock(mutex_);
+      if (!running_job_ || running_job_->job_id != scheduler_job_id) {
+        return;
+      }
+      running_job_->cancelled = true;
+      cancellation            = running_job_->request.intent.cancellation;
+    }
+    if (cancellation) {
+      cancellation->Cancel();
+    }
+  }
+
+  void WaitForSessionIdle(std::uint64_t session_epoch) override {
+    const auto idle = [this, session_epoch] {
+      return !running_job_ ||
+             running_job_->request.intent.image_load_request_id.value != session_epoch;
+    };
+    std::unique_lock lock(mutex_);
+    jobs_changed_.wait(lock, idle);
+  }
+
+  void BindSessionContext(std::uint64_t epoch, sl_element_id_t element_id, image_id_t image_id,
+                          alcedo::PresentationSinkId presentation_sink_id = 0) override {
+    std::scoped_lock lock(mutex_);
+    bound_epoch_     = epoch;
+    bound_element_   = element_id;
+    bound_image_     = image_id;
+    bound_sink_id_   = presentation_sink_id;
+  }
+
+  void ClearSessionContext() override {
+    std::scoped_lock lock(mutex_);
+    bound_epoch_   = 0;
+    bound_element_ = 0;
+    bound_image_   = 0;
+    bound_sink_id_ = 0;
+  }
+
+ private:
+  struct Job {
+    std::uint64_t               job_id = 0;
+    alcedo::EditorRenderRequest request{};
+    bool                        cancelled = false;
+  };
+
+  auto EnsurePool() -> std::shared_ptr<alcedo::PipelineScheduler> {
+    std::scoped_lock lock(mutex_);
+    if (!pool_) {
+      pool_ = std::make_shared<alcedo::PipelineScheduler>(1);
+    }
+    return pool_;
+  }
+
+  void Dispatch(Job job) {
+    HarnessFrameSinkResolver resolver;
+    HarnessFrameProducer     producer;
+    {
+      std::scoped_lock lock(mutex_);
+      resolver = sink_resolver_;
+      producer = producer_;
+    }
+    auto* sink = resolver ? resolver() : nullptr;
+    auto  pool = EnsurePool();
+    pool->ScheduleWork([this, job = std::move(job), sink, producer = std::move(producer)]() {
+      if (IsCancelled(job)) {
+        Finish(job, false, "Cancelled during execution");
+        return;
+      }
+      if (!sink || !producer) {
+        Finish(job, false, "Harness frame producer is not fully configured");
+        return;
+      }
+      alcedo::FramePreviewMetadata meta;
+      meta.frame_role              = job.request.intent.frame_role;
+      meta.image_identity          = static_cast<std::uint64_t>(job.request.intent.image_id);
+      meta.session_epoch           = job.request.intent.image_load_request_id.value;
+      meta.scope_update_allowed    = alcedo::ScopeUpdateAllowedForReason(job.request.intent.reason);
+      meta.scope_refresh_requested =
+          job.request.intent.reason == alcedo::EditorRenderReason::ScopeRefresh;
+      meta.presentation_request_id = job.request.request_id;
+      const alcedo::FramePresentationMode mode =
+          job.request.intent.frame_role == alcedo::FrameRole::DetailPatch
+              ? alcedo::FramePresentationMode::ViewportTransformed
+              : alcedo::FramePresentationMode::FullFrame;
+      // Test seam owns bind/size; production adapter never does this.
+      sink->BindFrameSubmission(alcedo::FrameCompletionSubmission{meta, mode});
+      sink->EnsureSize(std::max(1, job.request.intent.requested_width),
+                       std::max(1, job.request.intent.requested_height));
+      bool        ok = false;
+      std::string message;
+      try {
+        ok      = producer(sink, job.request);
+        message = ok ? "Frame ready" : "Harness frame producer failed";
+      } catch (const std::exception& ex) {
+        message = ex.what();
+      } catch (...) {
+        message = "Harness frame producer exception";
+      }
+      if (IsCancelled(job)) {
+        Finish(job, false, "Cancelled during execution");
+        return;
+      }
+      Finish(job, ok, std::move(message));
+    });
+  }
+
+  [[nodiscard]] auto IsCancelled(const Job& job) const -> bool {
+    std::scoped_lock lock(mutex_);
+    if (shutting_down_) {
+      return true;
+    }
+    if (running_job_ && running_job_->job_id == job.job_id && running_job_->cancelled) {
+      return true;
+    }
+    return job.request.intent.cancellation && job.request.intent.cancellation->IsCancelled();
+  }
+
+  void Finish(const Job& job, bool success, std::string message) {
+    HarnessCompletionNotifier notifier;
+    bool                      should_complete = false;
+    {
+      std::scoped_lock lock(mutex_);
+      if (running_job_ && running_job_->job_id == job.job_id) {
+        running_job_.reset();
+        should_complete = true;
+        notifier        = completion_notifier_;
+      }
+      jobs_changed_.notify_all();
+    }
+    if (should_complete && notifier) {
+      notifier(job.request.request_id, success, std::move(message));
+    }
+  }
+
+  mutable std::mutex              mutex_;
+  std::condition_variable         jobs_changed_;
+  HarnessFrameSinkResolver        sink_resolver_;
+  HarnessFrameProducer            producer_;
+  HarnessCompletionNotifier       completion_notifier_;
+  std::shared_ptr<alcedo::PipelineScheduler> pool_;
+  std::optional<Job>              running_job_;
+  std::uint64_t                   next_job_id_   = 0;
+  std::uint64_t                   bound_epoch_   = 0;
+  sl_element_id_t                 bound_element_ = 0;
+  image_id_t                      bound_image_   = 0;
+  alcedo::PresentationSinkId      bound_sink_id_ = 0;
+  bool                            shutting_down_ = false;
+};
+
+}  // namespace alcedo::test

--- a/alcedo_studio/tests/ui/editor_adjustment_transfer_real_project_e2e_test.cpp
+++ b/alcedo_studio/tests/ui/editor_adjustment_transfer_real_project_e2e_test.cpp
@@ -4,6 +4,7 @@
 /// @file editor_adjustment_transfer_real_project_e2e_test.cpp
 /// @brief Replays Copy/Paste through production Main.qml on a packed project.
 
+#include "support/harness_completing_pipeline_scheduler_port.hpp"
 #include "ui/main_qml_test_fixture.hpp"
 
 #include <gtest/gtest.h>
@@ -116,20 +117,31 @@ TEST_F(MainQmlTestFixture, RealPackedProjectCopyPasteReloadsToneSnapshot) {
   // QML workflow. Frame contents are covered by the dedicated GPU E2E tests;
   // provide a lightweight presentation frame here so session close cannot wait
   // on an unrelated RAW decode after the panel assertions have completed.
-  auto* render_scheduler = loaded->host.editor_session_scheduler();
-  ASSERT_NE(render_scheduler, nullptr);
-  render_scheduler->SetTestFrameProducer(
-      [](alcedo::IFrameSink* sink, const alcedo::EditorRenderRequest&) {
-        if (sink == nullptr) {
-          return false;
-        }
-        const auto mapping = sink->MapResourceForWrite(alcedo::FrameMemoryDomain::HostVisible);
-        if (mapping) {
-          sink->UnmapResource();
-        }
-        sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
-        return true;
+  auto* coordinator = loaded->host.editor_render_coordinator();
+  ASSERT_NE(coordinator, nullptr);
+  auto harness = std::make_shared<alcedo::test::HarnessCompletingPipelineSchedulerPort>();
+  harness->SetSinkResolver([&loaded]() -> alcedo::IFrameSink* {
+    return loaded->host.editor_session() ? loaded->host.editor_session()->presentation_frame_sink()
+                                         : nullptr;
+  });
+  harness->SetFrameProducer([](alcedo::IFrameSink* sink, const alcedo::EditorRenderRequest&) {
+    if (sink == nullptr) {
+      return false;
+    }
+    const auto mapping = sink->MapResourceForWrite(alcedo::FrameMemoryDomain::HostVisible);
+    if (mapping) {
+      sink->UnmapResource();
+    }
+    sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
+    return true;
+  });
+  harness->SetCompletionNotifier(
+      [coordinator](std::uint64_t request_id, bool success, std::string message) {
+        coordinator->NotifySchedulerCompleted(request_id, success, std::move(message),
+                                              /*schedule_next_from_pool=*/false);
+        coordinator->Pump();
       });
+  coordinator->SetPipelineSchedulerPort(std::move(harness));
 
   const auto first  = loaded->host.library()->Thumbnails().at(0).toMap();
   const auto second = loaded->host.library()->Thumbnails().at(1).toMap();

--- a/alcedo_studio/tests/ui/editor_session_render_scheduler_port_test.cpp
+++ b/alcedo_studio/tests/ui/editor_session_render_scheduler_port_test.cpp
@@ -8,14 +8,6 @@
 
 #include <array>
 #include <atomic>
-#include <filesystem>
-#include <memory>
-
-#include "app/pipeline_service.hpp"
-#include "edit/operators/operator_registeration.hpp"
-#include "edit/pipeline/pipeline_cpu.hpp"
-#include "image/image.hpp"
-#include "image/image_buffer.hpp"
 
 namespace alcedo::ui {
 namespace {
@@ -79,22 +71,6 @@ auto MakeRequest(std::uint64_t request_id, std::uint64_t image_load_request)
   request.intent.requested_width    = 320;
   request.intent.requested_height   = 180;
   return request;
-}
-
-auto MakeReadyContext(std::uint64_t epoch, sl_element_id_t element_id, image_id_t image_id)
-    -> EditorRenderSessionContext {
-  RegisterAllOperators();
-  EditorRenderSessionContext context;
-  context.epoch      = epoch;
-  context.element_id = element_id;
-  context.image_id   = image_id;
-  context.image      = std::make_shared<alcedo::Image>(image_id);
-  context.image->image_path_ = std::filesystem::path("D:/fixture/session-context.arw");
-  context.input              = std::make_shared<alcedo::ImageBuffer>();
-  context.pipeline_guard     = std::make_shared<alcedo::PipelineGuard>();
-  context.pipeline_guard->id_       = element_id;
-  context.pipeline_guard->pipeline_ = std::make_shared<alcedo::CPUPipelineExecutor>();
-  return context;
 }
 
 TEST(EditorSessionRenderSchedulerPortTest, TestProducerPublishesOneReadyFrame) {
@@ -191,148 +167,6 @@ TEST(EditorSessionRenderSchedulerPortTest, RequestWithoutFrameSourceIsRejected) 
   EXPECT_EQ(job_id, 0u);
   EXPECT_TRUE(scheduler.last_scheduled().empty());
   scheduler.WaitForSessionIdle(8);
-}
-
-TEST(EditorSessionRenderSchedulerPortTest, BindSessionContextRecordsIdentityWithoutPoolRead) {
-  EditorSessionRenderSchedulerPort scheduler;
-  std::atomic<int>                 pool_resolve_count = 0;
-  scheduler.SetServices(EditorSessionSchedulerServices{
-      [&pool_resolve_count]() -> std::shared_ptr<alcedo::ImagePoolService> {
-        ++pool_resolve_count;
-        return nullptr;
-      }});
-
-  scheduler.BindSessionContext(/*epoch=*/7, /*element_id=*/22, /*image_id=*/11);
-
-  const auto context = scheduler.session_context();
-  ASSERT_TRUE(context.has_value());
-  EXPECT_EQ(context->epoch, 7u);
-  EXPECT_EQ(context->element_id, 22u);
-  EXPECT_EQ(context->image_id, 11u);
-  EXPECT_EQ(context->image, nullptr);
-  EXPECT_EQ(context->input, nullptr);
-  EXPECT_EQ(context->pipeline_guard, nullptr);
-  EXPECT_EQ(scheduler.context_payload_load_count(), 0u);
-  EXPECT_EQ(pool_resolve_count.load(std::memory_order_acquire), 0);
-}
-
-TEST(EditorSessionRenderSchedulerPortTest, ClearSessionContextDropsBoundIdentity) {
-  EditorSessionRenderSchedulerPort scheduler;
-  scheduler.BindSessionContext(3, 22, 11);
-  ASSERT_TRUE(scheduler.session_context().has_value());
-
-  scheduler.ClearSessionContext();
-  EXPECT_FALSE(scheduler.session_context().has_value());
-}
-
-TEST(EditorSessionRenderSchedulerPortTest, ImageSwitchBindReplacesPriorContextPayload) {
-  EditorSessionRenderSchedulerPort scheduler;
-  scheduler.InstallSessionContext(MakeReadyContext(/*epoch=*/1, /*element_id=*/22, /*image_id=*/11));
-  ASSERT_TRUE(scheduler.session_context().has_value());
-  ASSERT_NE(scheduler.session_context()->input, nullptr);
-
-  scheduler.BindSessionContext(/*epoch=*/2, /*element_id=*/33, /*image_id=*/44);
-  const auto context = scheduler.session_context();
-  ASSERT_TRUE(context.has_value());
-  EXPECT_EQ(context->epoch, 2u);
-  EXPECT_EQ(context->element_id, 33u);
-  EXPECT_EQ(context->image_id, 44u);
-  EXPECT_EQ(context->image, nullptr);
-  EXPECT_EQ(context->input, nullptr);
-  EXPECT_EQ(context->pipeline_guard, nullptr);
-}
-
-TEST(EditorSessionRenderSchedulerPortTest,
-     RebindSameImageIdentityKeepsPayloadWithoutReload) {
-  EditorSessionRenderSchedulerPort scheduler;
-  auto                             ready = MakeReadyContext(/*epoch=*/1, /*element_id=*/22,
-                                                            /*image_id=*/11);
-  const auto                       input_ptr  = ready.input;
-  const auto                       image_ptr  = ready.image;
-  const auto                       guard_ptr  = ready.pipeline_guard;
-  scheduler.InstallSessionContext(std::move(ready));
-  const auto loads_before = scheduler.context_payload_load_count();
-
-  // RouteInitialRender / undo rebind the same element+image with a new epoch.
-  scheduler.BindSessionContext(/*epoch=*/9, /*element_id=*/22, /*image_id=*/11);
-
-  const auto context = scheduler.session_context();
-  ASSERT_TRUE(context.has_value());
-  EXPECT_EQ(context->epoch, 9u);
-  EXPECT_EQ(context->element_id, 22u);
-  EXPECT_EQ(context->image_id, 11u);
-  EXPECT_EQ(context->input, input_ptr);
-  EXPECT_EQ(context->image, image_ptr);
-  EXPECT_EQ(context->pipeline_guard, guard_ptr);
-  EXPECT_EQ(scheduler.context_payload_load_count(), loads_before);
-}
-
-TEST(EditorSessionRenderSchedulerPortTest,
-     InstalledContextAllowsScheduleWithoutImagePoolService) {
-  auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
-  RecordingFrameSink sink;
-  scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
-  scheduler->InstallSessionContext(MakeReadyContext(9, 22, 11));
-  scheduler->SetTestFrameProducer(
-      [](alcedo::IFrameSink* frame_sink, const alcedo::EditorRenderRequest&) {
-        if (!frame_sink) return false;
-        frame_sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
-        return true;
-      });
-
-  ASSERT_NE(scheduler->Schedule(MakeRequest(100, 9)), 0u);
-  scheduler->WaitForSessionIdle(9);
-  EXPECT_EQ(sink.ready_count(), 1);
-  EXPECT_EQ(scheduler->context_payload_load_count(), 0u);
-}
-
-TEST(EditorSessionRenderSchedulerPortTest,
-     HotPathAfterInstalledContextDoesNotInvokeImagePoolResolver) {
-  auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
-  RecordingFrameSink sink;
-  std::atomic<int>   pool_resolve_count = 0;
-  scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
-  scheduler->SetServices(EditorSessionSchedulerServices{
-      [&pool_resolve_count]() -> std::shared_ptr<alcedo::ImagePoolService> {
-        ++pool_resolve_count;
-        return nullptr;
-      }});
-  scheduler->InstallSessionContext(MakeReadyContext(12, 22, 11));
-
-  // Production pipeline path (not test producer): context payload must be reused.
-  for (std::uint64_t request_id = 200; request_id < 203; ++request_id) {
-    auto request          = MakeRequest(request_id, 12);
-    request.intent.reason = alcedo::EditorRenderReason::InteractiveAdjustment;
-    ASSERT_NE(scheduler->Schedule(request), 0u);
-    scheduler->WaitForSessionIdle(12);
-  }
-
-  EXPECT_EQ(pool_resolve_count.load(std::memory_order_acquire), 0);
-  EXPECT_EQ(scheduler->context_payload_load_count(), 0u);
-  const auto context = scheduler->session_context();
-  ASSERT_TRUE(context.has_value());
-  EXPECT_EQ(context->epoch, 12u);
-  EXPECT_NE(context->input, nullptr);
-  EXPECT_NE(context->image, nullptr);
-}
-
-TEST(EditorSessionRenderSchedulerPortTest,
-     BoundIdentityWithoutPayloadStillRejectsWhenPoolUnavailable) {
-  EditorSessionRenderSchedulerPort scheduler;
-  scheduler.BindSessionContext(5, 22, 11);
-  // Services resolve to null pool — Schedule is allowed by identity, then fails
-  // asynchronously once EnsureContext cannot load payload. With no sink the
-  // async failure path still clears the running job.
-  RecordingFrameSink sink;
-  scheduler.SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
-
-  // Without image_pool service and without installed payload, CanProduceFrame
-  // accepts a matching bind but EnsureContext fails on dispatch.
-  // When no services are set at all, matching bind alone is enough for CanProduceFrame.
-  const auto job_id = scheduler.Schedule(MakeRequest(55, 5));
-  ASSERT_NE(job_id, 0u);
-  scheduler.WaitForSessionIdle(5);
-  EXPECT_EQ(scheduler.context_payload_load_count(), 0u);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/ui/editor_session_render_scheduler_port_test.cpp
+++ b/alcedo_studio/tests/ui/editor_session_render_scheduler_port_test.cpp
@@ -25,6 +25,7 @@ class RecordingFrameSink final : public alcedo::IFrameSink {
   void EnsureSize(int width, int height) override {
     width_  = width;
     height_ = height;
+    ++ensure_size_count_;
   }
 
   auto MapResourceForWrite(alcedo::FrameMemoryDomain /*preferred_domain*/)
@@ -32,21 +33,16 @@ class RecordingFrameSink final : public alcedo::IFrameSink {
     return {};
   }
 
-  void               UnmapResource() override {}
+  void UnmapResource() override {}
 
   void NotifyFrameReady(const alcedo::FrameCompletionSubmission& submission) override {
-    // Empty Notify from a test producer keeps BindFrameSubmission metadata so
-    // request-id / scope flags stamped by the scheduler port remain observable.
-    if (submission.metadata.presentation_request_id != 0 ||
-        submission.metadata.scope_refresh_requested || !submission.metadata.scope_update_allowed ||
-        submission.metadata.frame_role != alcedo::FrameRole::InteractivePrimary) {
-      last_submission = submission;
-    }
+    last_submission = submission;
     ++ready_count_;
   }
 
   void BindFrameSubmission(const alcedo::FrameCompletionSubmission& submission) override {
     last_submission = submission;
+    ++bind_count_;
   }
 
   [[nodiscard]] auto GetWidth() const -> int override { return width_; }
@@ -55,90 +51,89 @@ class RecordingFrameSink final : public alcedo::IFrameSink {
   [[nodiscard]] auto ready_count() const -> int {
     return ready_count_.load(std::memory_order_acquire);
   }
-  [[nodiscard]] auto width() const -> int { return width_; }
-  [[nodiscard]] auto height() const -> int { return height_; }
+  [[nodiscard]] auto bind_count() const -> int {
+    return bind_count_.load(std::memory_order_acquire);
+  }
+  [[nodiscard]] auto ensure_size_count() const -> int {
+    return ensure_size_count_.load(std::memory_order_acquire);
+  }
 
   alcedo::FrameCompletionSubmission last_submission{};
 
  private:
-  std::atomic<int> ready_count_ = 0;
-  int              width_       = 0;
-  int              height_      = 0;
+  std::atomic<int> ready_count_       = 0;
+  std::atomic<int> bind_count_        = 0;
+  std::atomic<int> ensure_size_count_ = 0;
+  int              width_             = 0;
+  int              height_            = 0;
 };
 
-auto MakeRequest(std::uint64_t request_id, std::uint64_t image_load_request)
-    -> alcedo::EditorRenderRequest {
+auto MakeRequest(std::uint64_t request_id, std::uint64_t image_load_request,
+                 alcedo::PresentationSinkId sink_id = 7) -> alcedo::EditorRenderRequest {
   alcedo::EditorRenderRequest request;
-  request.request_id                     = request_id;
-  request.intent.element_id              = 22;
-  request.intent.image_id                = 11;
-  request.intent.image_load_request_id   = alcedo::ImageLoadRequestId{image_load_request};
-  request.intent.reason             = alcedo::EditorRenderReason::InitialFrame;
-  request.intent.quality            = alcedo::EditorRenderQuality::Interactive;
-  request.intent.frame_role         = alcedo::FrameRole::InteractivePrimary;
-  request.intent.requested_width    = 320;
-  request.intent.requested_height   = 180;
+  request.request_id                   = request_id;
+  request.intent.element_id            = 22;
+  request.intent.image_id              = 11;
+  request.intent.image_load_request_id = alcedo::ImageLoadRequestId{image_load_request};
+  request.intent.reason                = alcedo::EditorRenderReason::InitialFrame;
+  request.intent.quality               = alcedo::EditorRenderQuality::Interactive;
+  request.intent.frame_role            = alcedo::FrameRole::InteractivePrimary;
+  request.intent.requested_width       = 320;
+  request.intent.requested_height      = 180;
+  request.intent.presentation_sink_id  = sink_id;
   return request;
 }
 
-auto MakeReadyContext(std::uint64_t epoch, sl_element_id_t element_id, image_id_t image_id)
-    -> EditorRenderSessionContext {
+auto MakeReadyContext(std::uint64_t epoch, sl_element_id_t element_id, image_id_t image_id,
+                      alcedo::PresentationSinkId sink_id = 7) -> EditorRenderSessionContext {
   RegisterAllOperators();
   EditorRenderSessionContext context;
-  context.epoch      = epoch;
-  context.element_id = element_id;
-  context.image_id   = image_id;
-  context.image      = std::make_shared<alcedo::Image>(image_id);
-  context.image->image_path_ = std::filesystem::path("D:/fixture/session-context.arw");
-  context.input              = std::make_shared<alcedo::ImageBuffer>();
-  context.pipeline_guard     = std::make_shared<alcedo::PipelineGuard>();
-  context.pipeline_guard->id_       = element_id;
+  context.epoch                = epoch;
+  context.element_id           = element_id;
+  context.image_id             = image_id;
+  context.presentation_sink_id = sink_id;
+  context.image                = std::make_shared<alcedo::Image>(image_id);
+  context.image->image_path_   = std::filesystem::path("D:/fixture/session-context.arw");
+  context.input                = std::make_shared<alcedo::ImageBuffer>();
+  context.pipeline_guard       = std::make_shared<alcedo::PipelineGuard>();
+  context.pipeline_guard->id_  = element_id;
   context.pipeline_guard->pipeline_ = std::make_shared<alcedo::CPUPipelineExecutor>();
   return context;
 }
 
-TEST(EditorSessionRenderSchedulerPortTest, TestProducerPublishesOneReadyFrame) {
+TEST(EditorSessionRenderSchedulerPortTest,
+     ProductionPipelinePathSchedulesInstalledContextWithoutAdapterBind) {
   auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
   RecordingFrameSink sink;
-  std::atomic<int>   producer_count = 0;
   scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
-  scheduler->SetTestFrameProducer(
-      [&producer_count](alcedo::IFrameSink* frame_sink, const alcedo::EditorRenderRequest&) {
-        if (!frame_sink) return false;
-        ++producer_count;
-        frame_sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
-        return true;
-      });
+  scheduler->InstallSessionContext(MakeReadyContext(7, 22, 11));
 
   ASSERT_NE(scheduler->Schedule(MakeRequest(33, 7)), 0u);
   scheduler->WaitForSessionIdle(7);
 
-  EXPECT_EQ(producer_count.load(std::memory_order_acquire), 1);
-  EXPECT_EQ(sink.ready_count(), 1);
-  EXPECT_EQ(sink.width(), 320);
-  EXPECT_EQ(sink.height(), 180);
+  // Production Dispatch never EnsureSize; pipeline SetExecutorRenderParams binds.
+  EXPECT_EQ(sink.ensure_size_count(), 0);
+  EXPECT_GE(sink.bind_count(), 1);
+  EXPECT_EQ(sink.last_submission.metadata.presentation_request_id, 33u);
+  EXPECT_EQ(scheduler->context_payload_load_count(), 0u);
 }
 
 TEST(EditorSessionRenderSchedulerPortTest, ViewDrivenReasonsDisableScopeFrameReplacement) {
   auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
   RecordingFrameSink sink;
   scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
-  scheduler->SetTestFrameProducer(
-      [](alcedo::IFrameSink* frame_sink, const alcedo::EditorRenderRequest&) {
-        if (!frame_sink) return false;
-        frame_sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
-        return true;
-      });
+  scheduler->InstallSessionContext(MakeReadyContext(20, 22, 11));
 
   const std::array view_reasons = {alcedo::EditorRenderReason::ZoomPan,
                                    alcedo::EditorRenderReason::Resize,
                                    alcedo::EditorRenderReason::DetailRefresh};
   for (std::size_t index = 0; index < view_reasons.size(); ++index) {
-    auto request          = MakeRequest(60 + index, 20 + index);
+    auto request          = MakeRequest(60 + index, 20);
     request.intent.reason = view_reasons[index];
     ASSERT_NE(scheduler->Schedule(request), 0u);
-    scheduler->WaitForSessionIdle(20 + index);
+    scheduler->WaitForSessionIdle(20);
     EXPECT_FALSE(sink.last_submission.metadata.scope_update_allowed);
+    EXPECT_EQ(sink.ensure_size_count(), 0);
   }
 }
 
@@ -146,15 +141,10 @@ TEST(EditorSessionRenderSchedulerPortTest, ScopeRefreshMarksFrameAsRequestedScop
   auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
   RecordingFrameSink sink;
   scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
-  scheduler->SetTestFrameProducer(
-      [](alcedo::IFrameSink* frame_sink, const alcedo::EditorRenderRequest&) {
-        if (!frame_sink) return false;
-        frame_sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
-        return true;
-      });
+  scheduler->InstallSessionContext(MakeReadyContext(32, 22, 11));
 
-  auto request                   = MakeRequest(72, 32);
-  request.intent.reason          = alcedo::EditorRenderReason::ScopeRefresh;
+  auto request          = MakeRequest(72, 32);
+  request.intent.reason = alcedo::EditorRenderReason::ScopeRefresh;
   ASSERT_NE(scheduler->Schedule(request), 0u);
   scheduler->WaitForSessionIdle(32);
 
@@ -162,18 +152,15 @@ TEST(EditorSessionRenderSchedulerPortTest, ScopeRefreshMarksFrameAsRequestedScop
   EXPECT_TRUE(sink.last_submission.metadata.scope_refresh_requested);
   EXPECT_EQ(sink.last_submission.metadata.preview_generation, 0u);
   EXPECT_EQ(sink.last_submission.metadata.presentation_request_id, request.request_id);
+  EXPECT_EQ(sink.ensure_size_count(), 0);
+  EXPECT_GE(sink.bind_count(), 1);
 }
 
 TEST(EditorSessionRenderSchedulerPortTest, SessionDoesNotStampPreviewGenerationFromIntent) {
   auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
   RecordingFrameSink sink;
   scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
-  scheduler->SetTestFrameProducer(
-      [](alcedo::IFrameSink* frame_sink, const alcedo::EditorRenderRequest&) {
-        if (!frame_sink) return false;
-        frame_sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
-        return true;
-      });
+  scheduler->InstallSessionContext(MakeReadyContext(41, 22, 11));
 
   auto request = MakeRequest(88, 41);
   ASSERT_NE(scheduler->Schedule(request), 0u);
@@ -187,7 +174,7 @@ TEST(EditorSessionRenderSchedulerPortTest, RequestWithoutFrameSourceIsRejected) 
   EditorSessionRenderSchedulerPort scheduler;
   const auto                       request = MakeRequest(44, 8);
 
-  const auto                       job_id  = scheduler.Schedule(request);
+  const auto job_id = scheduler.Schedule(request);
   EXPECT_EQ(job_id, 0u);
   EXPECT_TRUE(scheduler.last_scheduled().empty());
   scheduler.WaitForSessionIdle(8);
@@ -202,23 +189,26 @@ TEST(EditorSessionRenderSchedulerPortTest, BindSessionContextRecordsIdentityWith
         return nullptr;
       }});
 
-  scheduler.BindSessionContext(/*epoch=*/7, /*element_id=*/22, /*image_id=*/11);
+  scheduler.BindSessionContext(/*epoch=*/7, /*element_id=*/22, /*image_id=*/11,
+                               /*presentation_sink_id=*/42);
 
   const auto context = scheduler.session_context();
   ASSERT_TRUE(context.has_value());
   EXPECT_EQ(context->epoch, 7u);
   EXPECT_EQ(context->element_id, 22u);
   EXPECT_EQ(context->image_id, 11u);
+  EXPECT_EQ(context->presentation_sink_id, 42u);
   EXPECT_EQ(context->image, nullptr);
   EXPECT_EQ(context->input, nullptr);
   EXPECT_EQ(context->pipeline_guard, nullptr);
   EXPECT_EQ(scheduler.context_payload_load_count(), 0u);
+  EXPECT_EQ(scheduler.sink_resolve_count(), 0u);
   EXPECT_EQ(pool_resolve_count.load(std::memory_order_acquire), 0);
 }
 
 TEST(EditorSessionRenderSchedulerPortTest, ClearSessionContextDropsBoundIdentity) {
   EditorSessionRenderSchedulerPort scheduler;
-  scheduler.BindSessionContext(3, 22, 11);
+  scheduler.BindSessionContext(3, 22, 11, 9);
   ASSERT_TRUE(scheduler.session_context().has_value());
 
   scheduler.ClearSessionContext();
@@ -231,36 +221,39 @@ TEST(EditorSessionRenderSchedulerPortTest, ImageSwitchBindReplacesPriorContextPa
   ASSERT_TRUE(scheduler.session_context().has_value());
   ASSERT_NE(scheduler.session_context()->input, nullptr);
 
-  scheduler.BindSessionContext(/*epoch=*/2, /*element_id=*/33, /*image_id=*/44);
+  scheduler.BindSessionContext(/*epoch=*/2, /*element_id=*/33, /*image_id=*/44,
+                               /*presentation_sink_id=*/55);
   const auto context = scheduler.session_context();
   ASSERT_TRUE(context.has_value());
   EXPECT_EQ(context->epoch, 2u);
   EXPECT_EQ(context->element_id, 33u);
   EXPECT_EQ(context->image_id, 44u);
+  EXPECT_EQ(context->presentation_sink_id, 55u);
   EXPECT_EQ(context->image, nullptr);
   EXPECT_EQ(context->input, nullptr);
   EXPECT_EQ(context->pipeline_guard, nullptr);
 }
 
-TEST(EditorSessionRenderSchedulerPortTest,
-     RebindSameImageIdentityKeepsPayloadWithoutReload) {
+TEST(EditorSessionRenderSchedulerPortTest, RebindSameImageIdentityKeepsPayloadWithoutReload) {
   EditorSessionRenderSchedulerPort scheduler;
   auto                             ready = MakeReadyContext(/*epoch=*/1, /*element_id=*/22,
-                                                            /*image_id=*/11);
-  const auto                       input_ptr  = ready.input;
-  const auto                       image_ptr  = ready.image;
-  const auto                       guard_ptr  = ready.pipeline_guard;
+                                                            /*image_id=*/11, /*sink_id=*/7);
+  const auto                       input_ptr = ready.input;
+  const auto                       image_ptr = ready.image;
+  const auto                       guard_ptr = ready.pipeline_guard;
   scheduler.InstallSessionContext(std::move(ready));
   const auto loads_before = scheduler.context_payload_load_count();
 
   // RouteInitialRender / undo rebind the same element+image with a new epoch.
-  scheduler.BindSessionContext(/*epoch=*/9, /*element_id=*/22, /*image_id=*/11);
+  scheduler.BindSessionContext(/*epoch=*/9, /*element_id=*/22, /*image_id=*/11,
+                               /*presentation_sink_id=*/77);
 
   const auto context = scheduler.session_context();
   ASSERT_TRUE(context.has_value());
   EXPECT_EQ(context->epoch, 9u);
   EXPECT_EQ(context->element_id, 22u);
   EXPECT_EQ(context->image_id, 11u);
+  EXPECT_EQ(context->presentation_sink_id, 77u);
   EXPECT_EQ(context->input, input_ptr);
   EXPECT_EQ(context->image, image_ptr);
   EXPECT_EQ(context->pipeline_guard, guard_ptr);
@@ -273,17 +266,12 @@ TEST(EditorSessionRenderSchedulerPortTest,
   RecordingFrameSink sink;
   scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
   scheduler->InstallSessionContext(MakeReadyContext(9, 22, 11));
-  scheduler->SetTestFrameProducer(
-      [](alcedo::IFrameSink* frame_sink, const alcedo::EditorRenderRequest&) {
-        if (!frame_sink) return false;
-        frame_sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
-        return true;
-      });
 
   ASSERT_NE(scheduler->Schedule(MakeRequest(100, 9)), 0u);
   scheduler->WaitForSessionIdle(9);
-  EXPECT_EQ(sink.ready_count(), 1);
   EXPECT_EQ(scheduler->context_payload_load_count(), 0u);
+  EXPECT_GE(sink.bind_count(), 1);
+  EXPECT_EQ(sink.ensure_size_count(), 0);
 }
 
 TEST(EditorSessionRenderSchedulerPortTest,
@@ -299,7 +287,6 @@ TEST(EditorSessionRenderSchedulerPortTest,
       }});
   scheduler->InstallSessionContext(MakeReadyContext(12, 22, 11));
 
-  // Production pipeline path (not test producer): context payload must be reused.
   for (std::uint64_t request_id = 200; request_id < 203; ++request_id) {
     auto request          = MakeRequest(request_id, 12);
     request.intent.reason = alcedo::EditorRenderReason::InteractiveAdjustment;
@@ -319,20 +306,53 @@ TEST(EditorSessionRenderSchedulerPortTest,
 TEST(EditorSessionRenderSchedulerPortTest,
      BoundIdentityWithoutPayloadStillRejectsWhenPoolUnavailable) {
   EditorSessionRenderSchedulerPort scheduler;
-  scheduler.BindSessionContext(5, 22, 11);
-  // Services resolve to null pool — Schedule is allowed by identity, then fails
-  // asynchronously once EnsureContext cannot load payload. With no sink the
-  // async failure path still clears the running job.
+  scheduler.BindSessionContext(5, 22, 11, 7);
   RecordingFrameSink sink;
   scheduler.SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
 
-  // Without image_pool service and without installed payload, CanProduceFrame
-  // accepts a matching bind but EnsureContext fails on dispatch.
-  // When no services are set at all, matching bind alone is enough for CanProduceFrame.
   const auto job_id = scheduler.Schedule(MakeRequest(55, 5));
   ASSERT_NE(job_id, 0u);
   scheduler.WaitForSessionIdle(5);
   EXPECT_EQ(scheduler.context_payload_load_count(), 0u);
+  EXPECT_EQ(sink.ensure_size_count(), 0);
+}
+
+TEST(EditorSessionRenderSchedulerPortTest,
+     SinkIdentityStableAcrossInteractiveFramesForBoundContext) {
+  auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
+  RecordingFrameSink sink;
+  scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
+  scheduler->InstallSessionContext(MakeReadyContext(12, 22, 11, /*sink_id=*/99));
+
+  const auto resolves_before = scheduler->sink_resolve_count();
+  for (std::uint64_t request_id = 300; request_id < 303; ++request_id) {
+    auto request          = MakeRequest(request_id, 12, /*sink_id=*/99);
+    request.intent.reason = alcedo::EditorRenderReason::InteractiveAdjustment;
+    ASSERT_NE(scheduler->Schedule(request), 0u);
+    scheduler->WaitForSessionIdle(12);
+  }
+
+  const auto context = scheduler->session_context();
+  ASSERT_TRUE(context.has_value());
+  EXPECT_EQ(context->presentation_sink_id, 99u);
+  EXPECT_EQ(scheduler->sink_resolve_count(), resolves_before + 3u);
+  EXPECT_EQ(sink.ensure_size_count(), 0);
+}
+
+TEST(EditorSessionRenderSchedulerPortTest,
+     MismatchedPresentationSinkIdentityFailsWithoutAdapterEnsureSize) {
+  auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
+  RecordingFrameSink sink;
+  scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
+  scheduler->InstallSessionContext(MakeReadyContext(4, 22, 11, /*sink_id=*/10));
+
+  auto request = MakeRequest(401, 4, /*sink_id=*/99);
+  ASSERT_NE(scheduler->Schedule(request), 0u);
+  scheduler->WaitForSessionIdle(4);
+
+  EXPECT_EQ(sink.bind_count(), 0);
+  EXPECT_EQ(sink.ensure_size_count(), 0);
+  EXPECT_EQ(scheduler->session_context()->presentation_sink_id, 10u);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/ui/editor_session_render_scheduler_port_test.cpp
+++ b/alcedo_studio/tests/ui/editor_session_render_scheduler_port_test.cpp
@@ -8,6 +8,14 @@
 
 #include <array>
 #include <atomic>
+#include <filesystem>
+#include <memory>
+
+#include "app/pipeline_service.hpp"
+#include "edit/operators/operator_registeration.hpp"
+#include "edit/pipeline/pipeline_cpu.hpp"
+#include "image/image.hpp"
+#include "image/image_buffer.hpp"
 
 namespace alcedo::ui {
 namespace {
@@ -71,6 +79,22 @@ auto MakeRequest(std::uint64_t request_id, std::uint64_t image_load_request)
   request.intent.requested_width    = 320;
   request.intent.requested_height   = 180;
   return request;
+}
+
+auto MakeReadyContext(std::uint64_t epoch, sl_element_id_t element_id, image_id_t image_id)
+    -> EditorRenderSessionContext {
+  RegisterAllOperators();
+  EditorRenderSessionContext context;
+  context.epoch      = epoch;
+  context.element_id = element_id;
+  context.image_id   = image_id;
+  context.image      = std::make_shared<alcedo::Image>(image_id);
+  context.image->image_path_ = std::filesystem::path("D:/fixture/session-context.arw");
+  context.input              = std::make_shared<alcedo::ImageBuffer>();
+  context.pipeline_guard     = std::make_shared<alcedo::PipelineGuard>();
+  context.pipeline_guard->id_       = element_id;
+  context.pipeline_guard->pipeline_ = std::make_shared<alcedo::CPUPipelineExecutor>();
+  return context;
 }
 
 TEST(EditorSessionRenderSchedulerPortTest, TestProducerPublishesOneReadyFrame) {
@@ -167,6 +191,148 @@ TEST(EditorSessionRenderSchedulerPortTest, RequestWithoutFrameSourceIsRejected) 
   EXPECT_EQ(job_id, 0u);
   EXPECT_TRUE(scheduler.last_scheduled().empty());
   scheduler.WaitForSessionIdle(8);
+}
+
+TEST(EditorSessionRenderSchedulerPortTest, BindSessionContextRecordsIdentityWithoutPoolRead) {
+  EditorSessionRenderSchedulerPort scheduler;
+  std::atomic<int>                 pool_resolve_count = 0;
+  scheduler.SetServices(EditorSessionSchedulerServices{
+      [&pool_resolve_count]() -> std::shared_ptr<alcedo::ImagePoolService> {
+        ++pool_resolve_count;
+        return nullptr;
+      }});
+
+  scheduler.BindSessionContext(/*epoch=*/7, /*element_id=*/22, /*image_id=*/11);
+
+  const auto context = scheduler.session_context();
+  ASSERT_TRUE(context.has_value());
+  EXPECT_EQ(context->epoch, 7u);
+  EXPECT_EQ(context->element_id, 22u);
+  EXPECT_EQ(context->image_id, 11u);
+  EXPECT_EQ(context->image, nullptr);
+  EXPECT_EQ(context->input, nullptr);
+  EXPECT_EQ(context->pipeline_guard, nullptr);
+  EXPECT_EQ(scheduler.context_payload_load_count(), 0u);
+  EXPECT_EQ(pool_resolve_count.load(std::memory_order_acquire), 0);
+}
+
+TEST(EditorSessionRenderSchedulerPortTest, ClearSessionContextDropsBoundIdentity) {
+  EditorSessionRenderSchedulerPort scheduler;
+  scheduler.BindSessionContext(3, 22, 11);
+  ASSERT_TRUE(scheduler.session_context().has_value());
+
+  scheduler.ClearSessionContext();
+  EXPECT_FALSE(scheduler.session_context().has_value());
+}
+
+TEST(EditorSessionRenderSchedulerPortTest, ImageSwitchBindReplacesPriorContextPayload) {
+  EditorSessionRenderSchedulerPort scheduler;
+  scheduler.InstallSessionContext(MakeReadyContext(/*epoch=*/1, /*element_id=*/22, /*image_id=*/11));
+  ASSERT_TRUE(scheduler.session_context().has_value());
+  ASSERT_NE(scheduler.session_context()->input, nullptr);
+
+  scheduler.BindSessionContext(/*epoch=*/2, /*element_id=*/33, /*image_id=*/44);
+  const auto context = scheduler.session_context();
+  ASSERT_TRUE(context.has_value());
+  EXPECT_EQ(context->epoch, 2u);
+  EXPECT_EQ(context->element_id, 33u);
+  EXPECT_EQ(context->image_id, 44u);
+  EXPECT_EQ(context->image, nullptr);
+  EXPECT_EQ(context->input, nullptr);
+  EXPECT_EQ(context->pipeline_guard, nullptr);
+}
+
+TEST(EditorSessionRenderSchedulerPortTest,
+     RebindSameImageIdentityKeepsPayloadWithoutReload) {
+  EditorSessionRenderSchedulerPort scheduler;
+  auto                             ready = MakeReadyContext(/*epoch=*/1, /*element_id=*/22,
+                                                            /*image_id=*/11);
+  const auto                       input_ptr  = ready.input;
+  const auto                       image_ptr  = ready.image;
+  const auto                       guard_ptr  = ready.pipeline_guard;
+  scheduler.InstallSessionContext(std::move(ready));
+  const auto loads_before = scheduler.context_payload_load_count();
+
+  // RouteInitialRender / undo rebind the same element+image with a new epoch.
+  scheduler.BindSessionContext(/*epoch=*/9, /*element_id=*/22, /*image_id=*/11);
+
+  const auto context = scheduler.session_context();
+  ASSERT_TRUE(context.has_value());
+  EXPECT_EQ(context->epoch, 9u);
+  EXPECT_EQ(context->element_id, 22u);
+  EXPECT_EQ(context->image_id, 11u);
+  EXPECT_EQ(context->input, input_ptr);
+  EXPECT_EQ(context->image, image_ptr);
+  EXPECT_EQ(context->pipeline_guard, guard_ptr);
+  EXPECT_EQ(scheduler.context_payload_load_count(), loads_before);
+}
+
+TEST(EditorSessionRenderSchedulerPortTest,
+     InstalledContextAllowsScheduleWithoutImagePoolService) {
+  auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
+  RecordingFrameSink sink;
+  scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
+  scheduler->InstallSessionContext(MakeReadyContext(9, 22, 11));
+  scheduler->SetTestFrameProducer(
+      [](alcedo::IFrameSink* frame_sink, const alcedo::EditorRenderRequest&) {
+        if (!frame_sink) return false;
+        frame_sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
+        return true;
+      });
+
+  ASSERT_NE(scheduler->Schedule(MakeRequest(100, 9)), 0u);
+  scheduler->WaitForSessionIdle(9);
+  EXPECT_EQ(sink.ready_count(), 1);
+  EXPECT_EQ(scheduler->context_payload_load_count(), 0u);
+}
+
+TEST(EditorSessionRenderSchedulerPortTest,
+     HotPathAfterInstalledContextDoesNotInvokeImagePoolResolver) {
+  auto               scheduler = std::make_shared<EditorSessionRenderSchedulerPort>();
+  RecordingFrameSink sink;
+  std::atomic<int>   pool_resolve_count = 0;
+  scheduler->SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
+  scheduler->SetServices(EditorSessionSchedulerServices{
+      [&pool_resolve_count]() -> std::shared_ptr<alcedo::ImagePoolService> {
+        ++pool_resolve_count;
+        return nullptr;
+      }});
+  scheduler->InstallSessionContext(MakeReadyContext(12, 22, 11));
+
+  // Production pipeline path (not test producer): context payload must be reused.
+  for (std::uint64_t request_id = 200; request_id < 203; ++request_id) {
+    auto request          = MakeRequest(request_id, 12);
+    request.intent.reason = alcedo::EditorRenderReason::InteractiveAdjustment;
+    ASSERT_NE(scheduler->Schedule(request), 0u);
+    scheduler->WaitForSessionIdle(12);
+  }
+
+  EXPECT_EQ(pool_resolve_count.load(std::memory_order_acquire), 0);
+  EXPECT_EQ(scheduler->context_payload_load_count(), 0u);
+  const auto context = scheduler->session_context();
+  ASSERT_TRUE(context.has_value());
+  EXPECT_EQ(context->epoch, 12u);
+  EXPECT_NE(context->input, nullptr);
+  EXPECT_NE(context->image, nullptr);
+}
+
+TEST(EditorSessionRenderSchedulerPortTest,
+     BoundIdentityWithoutPayloadStillRejectsWhenPoolUnavailable) {
+  EditorSessionRenderSchedulerPort scheduler;
+  scheduler.BindSessionContext(5, 22, 11);
+  // Services resolve to null pool — Schedule is allowed by identity, then fails
+  // asynchronously once EnsureContext cannot load payload. With no sink the
+  // async failure path still clears the running job.
+  RecordingFrameSink sink;
+  scheduler.SetSinkResolver([&sink] { return static_cast<alcedo::IFrameSink*>(&sink); });
+
+  // Without image_pool service and without installed payload, CanProduceFrame
+  // accepts a matching bind but EnsureContext fails on dispatch.
+  // When no services are set at all, matching bind alone is enough for CanProduceFrame.
+  const auto job_id = scheduler.Schedule(MakeRequest(55, 5));
+  ASSERT_NE(job_id, 0u);
+  scheduler.WaitForSessionIdle(5);
+  EXPECT_EQ(scheduler.context_payload_load_count(), 0u);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/ui/workspace_shell_test.cpp
+++ b/alcedo_studio/tests/ui/workspace_shell_test.cpp
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "app/editor_render_intent.hpp"
+#include "support/harness_completing_pipeline_scheduler_port.hpp"
 #include "ui/album_backend_seeded_project_fixture.hpp"
 #include "ui/alcedo_main/album_backend/album_types.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_controller.hpp"
@@ -116,23 +117,37 @@ auto WaitForInteractiveImage(ApplicationModuleHost&, EditorSessionController* se
          session->image_id() == imageId && session->can_edit();
 }
 
-auto InstallTestFrameProducer(ApplicationModuleHost& host) -> bool {
-  auto* render_scheduler = host.editor_session_scheduler();
-  if (render_scheduler == nullptr) {
+auto InstallTestFrameProducer(ApplicationModuleHost& host,
+                              alcedo::test::HarnessFrameProducer producer = {}) -> bool {
+  auto* coordinator = host.editor_render_coordinator();
+  if (coordinator == nullptr) {
     return false;
   }
-  render_scheduler->SetTestFrameProducer(
-      [](alcedo::IFrameSink* sink, const alcedo::EditorRenderRequest&) {
-        if (sink == nullptr) {
-          return false;
-        }
-        const auto mapping = sink->MapResourceForWrite(alcedo::FrameMemoryDomain::HostVisible);
-        if (mapping) {
-          sink->UnmapResource();
-        }
-        sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
-        return true;
+  if (!producer) {
+    producer = [](alcedo::IFrameSink* sink, const alcedo::EditorRenderRequest&) {
+      if (sink == nullptr) {
+        return false;
+      }
+      const auto mapping = sink->MapResourceForWrite(alcedo::FrameMemoryDomain::HostVisible);
+      if (mapping) {
+        sink->UnmapResource();
+      }
+      sink->NotifyFrameReady(alcedo::FrameCompletionSubmission{});
+      return true;
+    };
+  }
+  auto harness = std::make_shared<alcedo::test::HarnessCompletingPipelineSchedulerPort>();
+  harness->SetSinkResolver([&host]() -> alcedo::IFrameSink* {
+    return host.editor_session() ? host.editor_session()->presentation_frame_sink() : nullptr;
+  });
+  harness->SetFrameProducer(std::move(producer));
+  harness->SetCompletionNotifier(
+      [coordinator](std::uint64_t request_id, bool success, std::string message) {
+        coordinator->NotifySchedulerCompleted(request_id, success, std::move(message),
+                                              /*schedule_next_from_pool=*/false);
+        coordinator->Pump();
       });
+  coordinator->SetPipelineSchedulerPort(std::move(harness));
   return true;
 }
 
@@ -738,9 +753,9 @@ TEST_F(WorkspaceShellTests, ProductionFirstFramePathWritesAndSubmitsRealFrameDat
   ASSERT_NE(scheduler, nullptr);
 
   std::atomic<int> written_frame_count{0};
-  scheduler->SetTestFrameProducer([&written_frame_count](
-                                      alcedo::IFrameSink*                sink,
-                                      const alcedo::EditorRenderRequest& request) -> bool {
+  ASSERT_TRUE(InstallTestFrameProducer(
+      loaded->host, [&written_frame_count](alcedo::IFrameSink*                sink,
+                                           const alcedo::EditorRenderRequest& request) -> bool {
     if (!sink) {
       return false;
     }
@@ -802,7 +817,7 @@ TEST_F(WorkspaceShellTests, ProductionFirstFramePathWritesAndSubmitsRealFrameDat
     sink->NotifyFrameReady({metadata, presentation_mode});
     written_frame_count.fetch_add(1, std::memory_order_release);
     return true;
-  });
+  }));
 
   loaded->host.workspace_router()->OpenEditor(7, 70);
   const auto first_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -22,6 +22,7 @@ use their own top-level category.
 - [AI Sidecar Frontend Plan](alcedo_studio/ui/ai_sidecar_frontend_plan.md)
 - [Background Tasks and Declarative UI State Plan](alcedo_studio/ui/background_tasks_ui_state_plan.md)
 - [Editor Session Command Queue and Lock Simplification Plan](alcedo_studio/ui/editor_session_command_queue_and_lock_simplification_plan.md)
+- [Editor Render Path Simplification Plan](alcedo_studio/ui/editor_render_path_simplification_plan.md)
 - [QML Editor and Qt RHI Unified Workspace Refactor Plan](alcedo_studio/ui/qml_editor_rhi_unified_workspace_plan.md)
 - [Editor Single Live Pipeline + WAL + Checkpoint Simplification Plan](alcedo_studio/ui/editor_single_live_pipeline_wal_checkpoint_plan.md)
   (includes **Final locked identity model**: history owns HEAD; pipeline = params table; chain hash unit = one commit)

--- a/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
+++ b/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
@@ -1,0 +1,286 @@
+# Editor Render Path Simplification Plan
+
+Date: 2026-08-06
+
+Status: Phase R1 complete on branch `feature/editor_render_simplify`. Phases R2–R4 pending.
+Delivery is one feature branch with sequential commits (not one GitHub PR per phase).
+
+Primary owner: Alcedo Studio editor session render path.
+
+Affected areas:
+
+- `EditorRenderCoordinator` request coalescing and single-flight scheduling;
+- `EditorSessionRenderSchedulerPort` production adapter;
+- `PipelineScheduler` / `PipelineTask` completion signaling;
+- editor session open/switch image context for render input;
+- focused unit tests for coordinator, scheduler port, and pipeline request identity.
+
+Related roadmaps:
+
+- [Editor Session Command Queue and Lock Simplification Plan](editor_session_command_queue_and_lock_simplification_plan.md)
+- [QML Editor and Qt RHI Unified Workspace Refactor Plan](qml_editor_rhi_unified_workspace_plan.md)
+- [Phase 6C Mini-Git History and Pipeline Snapshot Plan](phase_6c_mini_git_history_and_pipeline_snapshot_plan.md)
+
+This plan does not replace CQ0–CQ5 command-queue ownership. It reduces layered scheduling that
+grew on top of the render submit port after the session/render split.
+
+## Review findings (source diagnosis)
+
+These findings come from a code review that started at
+`alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp` and followed the
+production render path into the coordinator and scheduler port. They are the product requirement
+for this plan; implementation must shrink complexity against this list, not invent a parallel
+framework.
+
+### Lifetime and ownership
+
+- `EditorSessionController` holds several raw pointers (`editor_`, `session_backend_`,
+  `interaction_policy_`) whose ownership is only implied by host construction order. Viewport
+  handles already use `QPointer`; the rest of the graph should document owner/borrower rules rather
+  than a blanket `shared_ptr` rewrite of QObject trees.
+
+### Coordinator queue and cancel
+
+- `EditorRenderCoordinator` cancel paths walk the entire pending `deque` more than once (obsolete
+  image-load cleanup, session cancel, pre-schedule token/epoch scrub), then `SelectNextIndex`
+  walks the remaining deque again to pick a frame role / priority winner.
+- Submit accepts work into a pending queue and only then calls `ScheduleNext`. That single-flight
+  pattern is sound, but the surrounding state machine grew large around it (terminal-id sets,
+  delivery re-entrancy guards, string-keyed replacement).
+
+### Scheduler port is a second scheduler
+
+- `EditorSessionRenderSchedulerPort` reverse-references `EditorRenderCoordinator` via
+  `weak_ptr` and calls `NotifySchedulerCompleted`. Control flow goes coordinator → port →
+  coordinator.
+- The port owned a private worker thread and a second job slot (`queued_job_` / `running_job_`)
+  even though `PipelineScheduler` already runs work on a thread pool. The worker’s main job was
+  blocking on `future.get()` for preview tasks that only completed through the blocking promise
+  path—so the port became a thin wrapper around an already-async executor, without relieving
+  pressure on the render queue.
+- `BindFrameSubmission` was invoked from the port (and specially for test producers via
+  `EnsureSize`) even though production pipeline execution already binds submission under
+  `PipelineTask::SetExecutorRenderParams`. Frame-sink binding should stay with the pipeline
+  stage that knows output geometry.
+
+### Test seams rewrote production logic
+
+- `SetTestFrameProducer` forced production code paths to branch on “test vs real” and changed
+  upper-layer behavior (`BindFrameSubmission`, size setup) so tests could pass. Test producers
+  should simulate the production producer boundary, not force the production adapter to grow
+  alternate control flow.
+
+### Per-frame image pool lookup
+
+- `TryProducePipelineFrame` re-resolved `EditorSessionSchedulerServices` (including image pool)
+  and re-read image / input buffer identity on every frame instead of packaging a stable session
+  render context when the image is opened or switched.
+
+### Redundant cancel surfaces
+
+- Cancel and replace exist at multiple layers: coordinator pending queue, string
+  `replacement_key` comparison, intent cancellation tokens, and the port’s own scheduled/running
+  job flags. The same request can be “cancelled” by several independent mechanisms.
+
+### Overall assessment
+
+The design stacked queues, threads, and reverse callbacks on top of an already-async pipeline
+scheduler. Maintainability is poor; several paths are inefficient relative to the real requirements
+(single-flight, quality ladder coalesce, epoch supersession, present handoff).
+
+## Decision
+
+Collapse to one coalesce owner and one execution owner:
+
+```text
+UI / session
+  → EditorRenderCoordinator     // only coalesce + single-flight
+  → thin production adapter     // build PipelineTask from session context
+  → PipelineScheduler           // only execution pool
+  → IFrameSink
+```
+
+Invariants:
+
+1. **One pending-merge layer.** The coordinator is the only place that replaces/coalesces
+   interactive / quality / detail work.
+2. **One execution layer.** `PipelineScheduler` is the only thread pool for editor preview work.
+   The session port must not own a second worker or second FIFO of jobs.
+3. **Forward completion.** Task completion notifies the coordinator through a completion path
+   established when the job is submitted (prefer `PipelineTask::on_complete_`). Long term, remove
+   the port’s stored reverse `weak_ptr` to the coordinator if the submit interface can carry the
+   callback instead.
+4. **Pipeline owns frame binding.** Production `BindFrameSubmission` stays inside pipeline task
+   setup / apply. Upper layers do not pre-bind “for convenience.”
+5. **Session-scoped render inputs.** Image, input buffer, pipeline guard, and sink identity for
+   the open image are bound when the image is acquired or switched—not re-fetched from the image
+   pool on every interactive frame.
+6. **Tests mock the seam; they do not rewrite production branches.** Prefer recording fakes for
+   `IEditorPipelineSchedulerPort` or sink-level producers that look like production completion.
+
+Explicit non-goals (YAGNI until measured need appears):
+
+- a new general render “engine” or multi-inflight GPU dispatcher;
+- merging the app-layer coordinator into `PipelineScheduler` (session tests still need a thin
+  submit seam);
+- rewriting the legacy QWidget `editor_dialog` render coordinator in the same change set;
+- blanket smart-pointer conversion of QObject ownership graphs.
+
+## Target call chain
+
+Interactive adjustment:
+
+```text
+QML / models
+  → EditorSessionService / EditorSessionRenderController
+  → EditorRenderCoordinator::Submit
+       · accept or replace slot
+       · if idle, hand one request to the adapter
+  → adapter builds PipelineTask (session context already holds image/pipeline/sink)
+  → PipelineScheduler::ScheduleTask
+  → configure under render lock + Apply + BindFrameSubmission + present
+  → on_complete_(success)
+  → Coordinator publishes FrameReady / Failed / Cancelled and schedules the next slot
+```
+
+Image switch:
+
+```text
+SetActiveImageLoadRequest(new_epoch)
+  → drop pending slots for the old epoch
+  → cancel in-flight via token
+  → replace EditorRenderSessionContext
+  → InitialFrame into the interactive slot
+```
+
+Cancel surfaces after simplification: **slot replace**, **cancellation token**, **image-load
+epoch**. No string-key scans and no second port queue.
+
+## Phases (one branch, sequential commits)
+
+Work lands on `feature/editor_render_simplify` as sequential commits. Do not open one remote PR
+per phase unless a later review asks for a stack.
+
+### Phase R1 — Remove the port worker; complete via PipelineScheduler
+
+**Goal:** delete the private worker thread and blocking `future.get()` bridge.
+
+Delivered:
+
+- `PipelineTask::on_complete_` invoked once on every terminal path in `ScheduleTask`
+  (success, cancel, empty result, exception);
+- `PipelineScheduler::ScheduleWork` for non-pipeline pool work (test producer, async setup
+  failures);
+- `EditorSessionRenderSchedulerPort` rewritten as a thin adapter: at most one `running_job_`,
+  no `std::thread`, production path uses non-blocking `ScheduleTask` + `on_complete_`;
+- destructor and `WaitForSessionIdle` still drain in-flight pool work and may pump GUI events
+  during present handoff.
+
+Still deferred in R1:
+
+- reverse `SetCoordinator` / `NotifySchedulerCompleted` (works; remove when submit API carries
+  completion);
+- test-producer `BindFrameSubmission` branch (kept behind `SetTestFrameProducer` until R4);
+- per-frame image pool reads (R3).
+
+**Focused verification (R1):**
+
+```text
+EditorSessionRenderSchedulerPortTest
+EditorRenderCoordinatorTest
+PipelineSchedulerRequestIdTest
+EditorSessionRenderControllerTest
+```
+
+Avoid relying on large UI e2e binaries known to hang in harness-only conditions that do not
+reproduce in the interactive app.
+
+### Phase R2 — Coordinator: fixed quality slots instead of string-keyed deque
+
+**Goal:** O(1) replace and schedule selection for the three real ladder roles.
+
+- Replace `pending_` deque + `replacement_key` string equality with three optional slots:
+  interactive, quality, detail (enum / quality-derived index).
+- Same-slot submit overwrites and emits `Replaced`.
+- `ScheduleNext` picks interactive > quality > detail in constant time.
+- Epoch mismatch clears all slots and cancels in-flight via token; no full-container rescans for
+  coalesce.
+- Keep single-flight (`Submit` then schedule when idle; complete then schedule next).
+- Keep `ReasonReusesCurrentFrame` (ZoomPan / Resize do not schedule pipeline work).
+
+### Phase R3 — Session render context
+
+**Goal:** bind stable inputs at open/switch; hot path does not re-resolve the image pool.
+
+```text
+EditorRenderSessionContext
+  epoch, element_id, image_id
+  Image, ImageBuffer (or lazy-once load), PipelineGuard handle
+  presentation sink identity / resolver
+```
+
+- Populate on successful image open / switch.
+- Adapter reads context only; image switch replaces the whole context under the new epoch.
+- Existing `cached_input_` becomes part of this context, not a separate half-cache.
+
+### Phase R4 — Test seams without production branches
+
+**Goal:** remove `SetTestFrameProducer` special-casing from the production adapter.
+
+- Coordinator unit tests keep recording `IEditorPipelineSchedulerPort` fakes.
+- Frame metadata / ready-frame tests target sink or pipeline completion without rewriting
+  production `Dispatch` branches.
+- Production adapter no longer calls `BindFrameSubmission` / `EnsureSize` for a test-only path.
+
+### Optional follow-up — Raw pointer ownership notes
+
+Document owner lifetimes for `EditorSessionController` bare pointers; keep `QPointer` for QML
+viewport objects. No mass ownership redesign unless a concrete use-after-free appears.
+
+## Acceptance criteria
+
+1. Interactive burst: many submits while one job is in flight leave at most one pending
+   interactive slot and one in-flight job; the final ready frame matches the latest accepted
+   interactive intent.
+2. Image-load epoch change: stale `FrameReady` does not advance first-frame or interactive state.
+3. ZoomPan / Resize: `Reused` result, zero `ScheduleTask` for that intent.
+4. No private `std::thread` inside the session render scheduler port.
+5. Production path does not pre-bind frame submission outside pipeline task setup (after R4).
+6. Hot interactive frames do not call image-pool `Read` after context bind (after R3).
+7. History head-move `WaitForSessionIdle` still completes without deadlocking present handoff on
+   the GUI thread (processEvents remains allowed at that boundary).
+
+## Key decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| How many queues? | One coalesce layer (coordinator) | Second queue was only a blocking adapter artifact |
+| Who runs pipeline work? | `PipelineScheduler` only | Already owns the pool and cancel checks |
+| Completion direction | Task `on_complete_` forward | Avoids a second control plane; reverse weak_ptr is transitional |
+| Coalesce key | Fixed interactive / quality / detail slots | Matches real ladder; string keys add nothing |
+| Image handles | Session context at open/switch | Avoid per-frame pool lookups |
+| Tests | Mock port or sink boundary | Do not grow production if-test branches |
+| Delivery shape | One feature branch, sequential commits | Easier to land and bisect than four parallel PRs |
+
+## Progress log
+
+### 2026-08-06 — Phase R1 complete
+
+Branch: `feature/editor_render_simplify`.
+
+Code:
+
+- `alcedo_studio/src/include/renderer/pipeline_task.hpp` — `on_complete_`;
+- `alcedo_studio/src/include/renderer/pipeline_scheduler.hpp` / `.cpp` — `on_complete_` on all
+  terminal paths; `ScheduleWork`;
+- `alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.hpp`
+  and `.cpp` — worker and second queue removed; async completion.
+
+Focused tests (all passed):
+
+- `EditorSessionRenderSchedulerPortTest` 5/5
+- `EditorRenderCoordinatorTest` 28/28
+- `PipelineSchedulerRequestIdTest` 4/4
+- `EditorSessionRenderControllerTest` 13/13
+
+Next: Phase R2 (fixed slots).

--- a/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
+++ b/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-06
 
-Status: Phases R1–R2 complete on branch `feature/editor_render_simplify`. Phases R3–R4 pending.
+Status: Phases R1–R3 complete on branch `feature/editor_render_simplify`. Phase R4 pending.
 Delivery is one feature branch with sequential commits (not one GitHub PR per phase).
 
 Primary owner: Alcedo Studio editor session render path.
@@ -176,12 +176,12 @@ Delivered:
 - destructor and `WaitForSessionIdle` still drain in-flight pool work and may pump GUI events
   during present handoff.
 
-Still deferred in R1:
+Still deferred after R1 (recorded as later-phase tasks):
 
-- reverse `SetCoordinator` / `NotifySchedulerCompleted` (works; remove when submit API carries
-  completion);
-- test-producer `BindFrameSubmission` branch (kept behind `SetTestFrameProducer` until R4);
-- per-frame image pool reads (R3).
+- reverse `SetCoordinator` / `NotifySchedulerCompleted` → **Optional follow-up (completion
+  direction)**;
+- test-producer `BindFrameSubmission` branch → **Phase R4**;
+- per-frame image pool reads → **Phase R3** (done 2026-08-07).
 
 **Focused verification (R1):**
 
@@ -273,11 +273,12 @@ Suite totals: `EditorRenderCoordinatorTest` 30/30; `EditorSessionRenderControlle
 
 No responsibility split needed; coordinator still owns only coalesce + single-flight.
 
-**Residual gaps:**
+**Residual gaps (carried forward as later-phase tasks):**
 
-- `replacement_key` remains on `EditorRenderIntent` for producers / diagnostics; coalesce no longer
-  uses string equality (R2). Removal of the field is optional later YAGNI.
-- Session render context (R3) and test-producer production branches (R4) unchanged.
+- `replacement_key` still on `EditorRenderIntent` for producers / diagnostics; coalesce no longer
+  uses string equality → **Optional follow-up (intent field cleanup)**.
+- Session render context → **Phase R3** (done 2026-08-07).
+- Test-producer production branches → **Phase R4**.
 
 ### Phase R3 — Session render context
 
@@ -290,23 +291,158 @@ EditorRenderSessionContext
   presentation sink identity / resolver
 ```
 
-- Populate on successful image open / switch.
-- Adapter reads context only; image switch replaces the whole context under the new epoch.
-- Existing `cached_input_` becomes part of this context, not a separate half-cache.
+- [x] Populate on successful image open / switch.
+- [x] Adapter reads context only; image switch replaces the whole context under the new epoch.
+- [x] Existing `cached_input_` becomes part of this context, not a separate half-cache.
+
+##### Phase R3 completion record (2026-08-07)
+
+**Status:** complete — session render context binds identity at open/switch; payload
+loads once; hot path no longer re-resolves the image pool.
+
+**Primary success call chain:**
+
+```text
+Open/Switch → ContinueToTarget
+  -> ResetForNewImage → ClearSessionRenderContext
+  -> RouteInitialRender
+       · BindSessionRenderContext(epoch, element_id, image_id)
+       · SetActiveImageLoadRequest(epoch)
+       · Submit(intent)
+  -> Coordinator → EditorSessionRenderSchedulerPort::Schedule
+  -> EnsureContextForRequest
+       · match bound identity
+       · lazy-once load Image + ImageBuffer + PipelineGuard into context
+  -> DispatchPipelineFrame builds PipelineTask from context only
+  -> PipelineScheduler::ScheduleTask → on_complete_ → FrameReady
+```
+
+**Primary failure call chain:**
+
+```text
+Schedule without bind / with missing pool after identity-only bind
+  -> EnsureContextForRequest fails (no pipeline / no pool / empty path)
+  -> FinishJob(false, error) → NotifySchedulerCompleted
+  -> Coordinator publishes Failed; next slot may schedule
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `BindSessionContextRecordsIdentityWithoutPoolRead` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `ClearSessionContextDropsBoundIdentity` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `ImageSwitchBindReplacesPriorContextPayload` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `InstalledContextAllowsScheduleWithoutImagePoolService` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `HotPathAfterInstalledContextDoesNotInvokeImagePoolResolver` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `BoundIdentityWithoutPayloadStillRejectsWhenPoolUnavailable` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `RouteInitialRenderBindsSessionContextAtOpen` | `EditorSessionRenderControllerTest` | PASS |
+| `ResetForNewImageClearsSessionRenderContext` | `EditorSessionRenderControllerTest` | PASS |
+| `BindAndClearSessionRenderContextForwardToScheduler` | `EditorRenderCoordinatorTest` | PASS |
+| Full port suite | `EditorSessionRenderSchedulerPortTest` | PASS 11/11 |
+| Full coordinator suite | `EditorRenderCoordinatorTest` | PASS 31/31 |
+| Full render controller suite | `EditorSessionRenderControllerTest` | PASS 15/15 |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSessionRenderSchedulerPortTest EditorRenderCoordinatorTest EditorSessionRenderControllerTest
+ctest --test-dir build/debug -R "EditorSessionRenderSchedulerPortTest|EditorRenderCoordinatorTest|EditorSessionRenderControllerTest" --output-on-failure
+```
+
+Suite totals: `EditorSessionRenderSchedulerPortTest` 11/11; `EditorRenderCoordinatorTest` 31/31;
+`EditorSessionRenderControllerTest` 15/15 (57/57 combined).
+
+**Checklist / exit condition:** all R3 boxes checked. Acceptance criterion 6 (hot interactive
+frames do not call image-pool after context bind) covered by
+`HotPathAfterInstalledContextDoesNotInvokeImagePoolResolver`.
+
+**LOC note (grill-code-review):**
+
+| File | LOC (approx) |
+| --- | --- |
+| `editor_session_render_scheduler_port.hpp` | ~160 |
+| `editor_session_render_scheduler_port.cpp` | ~560 |
+| `editor_session_render_scheduler_port_test.cpp` | ~300 |
+| `editor_session_render_controller.cpp` | ~480 |
+| `editor_render_coordinator.cpp` / `.hpp` | modest Bind/Clear forwarders |
+
+No responsibility split needed; context lives on the production adapter only.
+
+**Residual gaps (carried forward as later-phase tasks — do not drop):**
+
+| Residual | Owner phase / section |
+| --- | --- |
+| Test-producer `BindFrameSubmission` / `EnsureSize` still rewrites production `Dispatch` | **Phase R4** |
+| Presentation sink still resolved every schedule via `sink_resolver_` (not session-context identity) | **Phase R4** (sink identity on context) or **Optional follow-up** if R4 scope is already full |
+| Reverse `SetCoordinator` / `NotifySchedulerCompleted` still the completion plane | **Optional follow-up (completion direction)** (from R1) |
+| `replacement_key` field still on `EditorRenderIntent` after slot coalesce | **Optional follow-up (intent field cleanup)** (from R2) |
+| No interactive-app / real-RAW open-switch latency evidence for context bind + lazy-once load | **Optional follow-up (verification)** |
+| First frame after bind still pays one payload load (lazy-once) | Accepted R3 design; only re-open if open latency measurement fails in verification follow-up |
 
 ### Phase R4 — Test seams without production branches
 
-**Goal:** remove `SetTestFrameProducer` special-casing from the production adapter.
+**Goal:** remove `SetTestFrameProducer` special-casing from the production adapter, and close
+residuals that force production branches or re-resolve presentation inputs on the hot path.
 
-- Coordinator unit tests keep recording `IEditorPipelineSchedulerPort` fakes.
-- Frame metadata / ready-frame tests target sink or pipeline completion without rewriting
+**Checklist (includes residuals carried from R1–R3):**
+
+- [ ] Remove `SetTestFrameProducer` and any production `if (test_producer_)` branch from
+  `EditorSessionRenderSchedulerPort`.
+- [ ] Production adapter no longer calls `BindFrameSubmission` / `EnsureSize` for a test-only path
+  (R1 residual; R3 residual).
+- [ ] Coordinator unit tests keep recording `IEditorPipelineSchedulerPort` fakes (no test producer
+  on the production adapter).
+- [ ] Frame metadata / ready-frame tests target sink or pipeline completion without rewriting
   production `Dispatch` branches.
-- Production adapter no longer calls `BindFrameSubmission` / `EnsureSize` for a test-only path.
+- [ ] Session context (or bind path) records **presentation sink identity** so schedule does not
+  re-resolve a live sink pointer as a substitute for session-scoped sink identity (R3 residual:
+  today `sink_resolver_()` runs every `DispatchJob`). Prefer stamping `PresentationSinkId` at
+  open/switch and resolving the pointer only when submitting to the pipeline / present path if a
+  live `IFrameSink*` is still required.
+- [ ] Focused tests prove: (1) production `DispatchPipelineFrame` has no test-producer branch;
+  (2) ready-frame metadata still correct without adapter-side `BindFrameSubmission`; (3) sink
+  identity is stable across interactive frames for one bound session context.
 
-### Optional follow-up — Raw pointer ownership notes
+**Exit condition:** all R4 boxes checked; acceptance criterion 5 satisfied.
 
-Document owner lifetimes for `EditorSessionController` bare pointers; keep `QPointer` for QML
-viewport objects. No mass ownership redesign unless a concrete use-after-free appears.
+### Optional follow-up — residuals and ownership notes
+
+Work below is **not** optional in the sense of “forget it”: it is sequenced after R4 (or in
+parallel only if R4 does not absorb the item). Each line is a tracked task from R1–R3 residuals.
+
+#### Completion direction (from R1)
+
+- [ ] Carry completion on the submit path (`PipelineTask::on_complete_` / submit callback) so the
+  production adapter no longer needs reverse `SetCoordinator` +
+  `NotifySchedulerCompleted` via `weak_ptr` to the coordinator.
+- [ ] Delete reverse coordinator pointer from `EditorSessionRenderSchedulerPort` once the forward
+  path is the only control plane.
+
+#### Intent field cleanup (from R2)
+
+- [ ] Remove `EditorRenderIntent::replacement_key` (and `DefaultReplacementKey` / fill path) if no
+  producer/diagnostic consumer still requires the string; slots already own coalesce.
+
+#### Session context / sink (from R3, if not closed in R4)
+
+- [ ] If R4 does not land sink identity on `EditorRenderSessionContext`, do it here: bind
+  `PresentationSinkId` (and document owner of the live `IFrameSink*`) at open/switch; hot path
+  must not treat “call `sink_resolver_` again” as the session context contract.
+
+#### Verification (from R3)
+
+- [ ] Interactive-app or focused integration proof: open / switch a real RAW, confirm first-frame
+  path binds context once, subsequent interactive frames do not hit image-pool `Read`, and
+  open/switch latency stays acceptable with lazy-once payload load.
+- [ ] If lazy-once first-frame load is too slow, promote payload load into
+  `BindSessionContext` (eager bind) and re-measure; keep the single-load invariant.
+
+#### Raw pointer ownership notes (pre-existing)
+
+- [ ] Document owner lifetimes for `EditorSessionController` bare pointers (`editor_`,
+  `session_backend_`, `interaction_policy_`); keep `QPointer` for QML viewport objects.
+- [ ] No mass ownership redesign unless a concrete use-after-free appears.
 
 ## Acceptance criteria
 
@@ -373,3 +509,28 @@ Focused tests (all passed):
 - `EditorSessionRenderControllerTest` 13/13
 
 Next: Phase R3 (session render context).
+
+### 2026-08-07 — Phase R3 complete
+
+Branch: `feature/editor_render_simplify`.
+
+Code:
+
+- `EditorRenderSessionContext` on the production scheduler port (epoch, element, image,
+  Image, ImageBuffer, PipelineGuard); replaces `cached_input_` half-cache;
+- `BindSessionContext` / `ClearSessionContext` on `IEditorPipelineSchedulerPort` and
+  `BindSessionRenderContext` / `ClearSessionRenderContext` on `IEditorRenderSubmitPort`;
+- `EditorSessionRenderController::RouteInitialRender` binds at open/switch;
+  `ResetForNewImage` clears;
+- `DispatchPipelineFrame` / `CanProduceFrame` use bound context; payload loads once via
+  `EnsureContextForRequest`.
+
+Focused tests (all passed):
+
+- `EditorSessionRenderSchedulerPortTest` 11/11
+- `EditorRenderCoordinatorTest` 31/31
+- `EditorSessionRenderControllerTest` 15/15
+
+Next: Phase R4 (test seams + carried residuals: no test-producer production branches;
+presentation sink identity on session context). Residual table under R3 maps each open item to
+R4 or Optional follow-up — do not drop those tasks when implementing R4.

--- a/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
+++ b/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-06
 
-Status: Phases R1–R3 complete on branch `feature/editor_render_simplify`. Phase R4 pending.
+Status: Phases R1–R2 complete on branch `feature/editor_render_simplify`. Phases R3–R4 pending.
 Delivery is one feature branch with sequential commits (not one GitHub PR per phase).
 
 Primary owner: Alcedo Studio editor session render path.
@@ -176,12 +176,12 @@ Delivered:
 - destructor and `WaitForSessionIdle` still drain in-flight pool work and may pump GUI events
   during present handoff.
 
-Still deferred after R1 (recorded as later-phase tasks):
+Still deferred in R1:
 
-- reverse `SetCoordinator` / `NotifySchedulerCompleted` → **Optional follow-up (completion
-  direction)**;
-- test-producer `BindFrameSubmission` branch → **Phase R4**;
-- per-frame image pool reads → **Phase R3** (done 2026-08-07).
+- reverse `SetCoordinator` / `NotifySchedulerCompleted` (works; remove when submit API carries
+  completion);
+- test-producer `BindFrameSubmission` branch (kept behind `SetTestFrameProducer` until R4);
+- per-frame image pool reads (R3).
 
 **Focused verification (R1):**
 
@@ -273,12 +273,11 @@ Suite totals: `EditorRenderCoordinatorTest` 30/30; `EditorSessionRenderControlle
 
 No responsibility split needed; coordinator still owns only coalesce + single-flight.
 
-**Residual gaps (carried forward as later-phase tasks):**
+**Residual gaps:**
 
-- `replacement_key` still on `EditorRenderIntent` for producers / diagnostics; coalesce no longer
-  uses string equality → **Optional follow-up (intent field cleanup)**.
-- Session render context → **Phase R3** (done 2026-08-07).
-- Test-producer production branches → **Phase R4**.
+- `replacement_key` remains on `EditorRenderIntent` for producers / diagnostics; coalesce no longer
+  uses string equality (R2). Removal of the field is optional later YAGNI.
+- Session render context (R3) and test-producer production branches (R4) unchanged.
 
 ### Phase R3 — Session render context
 
@@ -291,158 +290,23 @@ EditorRenderSessionContext
   presentation sink identity / resolver
 ```
 
-- [x] Populate on successful image open / switch.
-- [x] Adapter reads context only; image switch replaces the whole context under the new epoch.
-- [x] Existing `cached_input_` becomes part of this context, not a separate half-cache.
-
-##### Phase R3 completion record (2026-08-07)
-
-**Status:** complete — session render context binds identity at open/switch; payload
-loads once; hot path no longer re-resolves the image pool.
-
-**Primary success call chain:**
-
-```text
-Open/Switch → ContinueToTarget
-  -> ResetForNewImage → ClearSessionRenderContext
-  -> RouteInitialRender
-       · BindSessionRenderContext(epoch, element_id, image_id)
-       · SetActiveImageLoadRequest(epoch)
-       · Submit(intent)
-  -> Coordinator → EditorSessionRenderSchedulerPort::Schedule
-  -> EnsureContextForRequest
-       · match bound identity
-       · lazy-once load Image + ImageBuffer + PipelineGuard into context
-  -> DispatchPipelineFrame builds PipelineTask from context only
-  -> PipelineScheduler::ScheduleTask → on_complete_ → FrameReady
-```
-
-**Primary failure call chain:**
-
-```text
-Schedule without bind / with missing pool after identity-only bind
-  -> EnsureContextForRequest fails (no pipeline / no pool / empty path)
-  -> FinishJob(false, error) → NotifySchedulerCompleted
-  -> Coordinator publishes Failed; next slot may schedule
-```
-
-**What was proven (executed tests):**
-
-| Required name / criterion | Target / binary | Result |
-| --- | --- | --- |
-| `BindSessionContextRecordsIdentityWithoutPoolRead` | `EditorSessionRenderSchedulerPortTest` | PASS |
-| `ClearSessionContextDropsBoundIdentity` | `EditorSessionRenderSchedulerPortTest` | PASS |
-| `ImageSwitchBindReplacesPriorContextPayload` | `EditorSessionRenderSchedulerPortTest` | PASS |
-| `InstalledContextAllowsScheduleWithoutImagePoolService` | `EditorSessionRenderSchedulerPortTest` | PASS |
-| `HotPathAfterInstalledContextDoesNotInvokeImagePoolResolver` | `EditorSessionRenderSchedulerPortTest` | PASS |
-| `BoundIdentityWithoutPayloadStillRejectsWhenPoolUnavailable` | `EditorSessionRenderSchedulerPortTest` | PASS |
-| `RouteInitialRenderBindsSessionContextAtOpen` | `EditorSessionRenderControllerTest` | PASS |
-| `ResetForNewImageClearsSessionRenderContext` | `EditorSessionRenderControllerTest` | PASS |
-| `BindAndClearSessionRenderContextForwardToScheduler` | `EditorRenderCoordinatorTest` | PASS |
-| Full port suite | `EditorSessionRenderSchedulerPortTest` | PASS 11/11 |
-| Full coordinator suite | `EditorRenderCoordinatorTest` | PASS 31/31 |
-| Full render controller suite | `EditorSessionRenderControllerTest` | PASS 15/15 |
-
-Commands:
-
-```text
-cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSessionRenderSchedulerPortTest EditorRenderCoordinatorTest EditorSessionRenderControllerTest
-ctest --test-dir build/debug -R "EditorSessionRenderSchedulerPortTest|EditorRenderCoordinatorTest|EditorSessionRenderControllerTest" --output-on-failure
-```
-
-Suite totals: `EditorSessionRenderSchedulerPortTest` 11/11; `EditorRenderCoordinatorTest` 31/31;
-`EditorSessionRenderControllerTest` 15/15 (57/57 combined).
-
-**Checklist / exit condition:** all R3 boxes checked. Acceptance criterion 6 (hot interactive
-frames do not call image-pool after context bind) covered by
-`HotPathAfterInstalledContextDoesNotInvokeImagePoolResolver`.
-
-**LOC note (grill-code-review):**
-
-| File | LOC (approx) |
-| --- | --- |
-| `editor_session_render_scheduler_port.hpp` | ~160 |
-| `editor_session_render_scheduler_port.cpp` | ~560 |
-| `editor_session_render_scheduler_port_test.cpp` | ~300 |
-| `editor_session_render_controller.cpp` | ~480 |
-| `editor_render_coordinator.cpp` / `.hpp` | modest Bind/Clear forwarders |
-
-No responsibility split needed; context lives on the production adapter only.
-
-**Residual gaps (carried forward as later-phase tasks — do not drop):**
-
-| Residual | Owner phase / section |
-| --- | --- |
-| Test-producer `BindFrameSubmission` / `EnsureSize` still rewrites production `Dispatch` | **Phase R4** |
-| Presentation sink still resolved every schedule via `sink_resolver_` (not session-context identity) | **Phase R4** (sink identity on context) or **Optional follow-up** if R4 scope is already full |
-| Reverse `SetCoordinator` / `NotifySchedulerCompleted` still the completion plane | **Optional follow-up (completion direction)** (from R1) |
-| `replacement_key` field still on `EditorRenderIntent` after slot coalesce | **Optional follow-up (intent field cleanup)** (from R2) |
-| No interactive-app / real-RAW open-switch latency evidence for context bind + lazy-once load | **Optional follow-up (verification)** |
-| First frame after bind still pays one payload load (lazy-once) | Accepted R3 design; only re-open if open latency measurement fails in verification follow-up |
+- Populate on successful image open / switch.
+- Adapter reads context only; image switch replaces the whole context under the new epoch.
+- Existing `cached_input_` becomes part of this context, not a separate half-cache.
 
 ### Phase R4 — Test seams without production branches
 
-**Goal:** remove `SetTestFrameProducer` special-casing from the production adapter, and close
-residuals that force production branches or re-resolve presentation inputs on the hot path.
+**Goal:** remove `SetTestFrameProducer` special-casing from the production adapter.
 
-**Checklist (includes residuals carried from R1–R3):**
-
-- [ ] Remove `SetTestFrameProducer` and any production `if (test_producer_)` branch from
-  `EditorSessionRenderSchedulerPort`.
-- [ ] Production adapter no longer calls `BindFrameSubmission` / `EnsureSize` for a test-only path
-  (R1 residual; R3 residual).
-- [ ] Coordinator unit tests keep recording `IEditorPipelineSchedulerPort` fakes (no test producer
-  on the production adapter).
-- [ ] Frame metadata / ready-frame tests target sink or pipeline completion without rewriting
+- Coordinator unit tests keep recording `IEditorPipelineSchedulerPort` fakes.
+- Frame metadata / ready-frame tests target sink or pipeline completion without rewriting
   production `Dispatch` branches.
-- [ ] Session context (or bind path) records **presentation sink identity** so schedule does not
-  re-resolve a live sink pointer as a substitute for session-scoped sink identity (R3 residual:
-  today `sink_resolver_()` runs every `DispatchJob`). Prefer stamping `PresentationSinkId` at
-  open/switch and resolving the pointer only when submitting to the pipeline / present path if a
-  live `IFrameSink*` is still required.
-- [ ] Focused tests prove: (1) production `DispatchPipelineFrame` has no test-producer branch;
-  (2) ready-frame metadata still correct without adapter-side `BindFrameSubmission`; (3) sink
-  identity is stable across interactive frames for one bound session context.
+- Production adapter no longer calls `BindFrameSubmission` / `EnsureSize` for a test-only path.
 
-**Exit condition:** all R4 boxes checked; acceptance criterion 5 satisfied.
+### Optional follow-up — Raw pointer ownership notes
 
-### Optional follow-up — residuals and ownership notes
-
-Work below is **not** optional in the sense of “forget it”: it is sequenced after R4 (or in
-parallel only if R4 does not absorb the item). Each line is a tracked task from R1–R3 residuals.
-
-#### Completion direction (from R1)
-
-- [ ] Carry completion on the submit path (`PipelineTask::on_complete_` / submit callback) so the
-  production adapter no longer needs reverse `SetCoordinator` +
-  `NotifySchedulerCompleted` via `weak_ptr` to the coordinator.
-- [ ] Delete reverse coordinator pointer from `EditorSessionRenderSchedulerPort` once the forward
-  path is the only control plane.
-
-#### Intent field cleanup (from R2)
-
-- [ ] Remove `EditorRenderIntent::replacement_key` (and `DefaultReplacementKey` / fill path) if no
-  producer/diagnostic consumer still requires the string; slots already own coalesce.
-
-#### Session context / sink (from R3, if not closed in R4)
-
-- [ ] If R4 does not land sink identity on `EditorRenderSessionContext`, do it here: bind
-  `PresentationSinkId` (and document owner of the live `IFrameSink*`) at open/switch; hot path
-  must not treat “call `sink_resolver_` again” as the session context contract.
-
-#### Verification (from R3)
-
-- [ ] Interactive-app or focused integration proof: open / switch a real RAW, confirm first-frame
-  path binds context once, subsequent interactive frames do not hit image-pool `Read`, and
-  open/switch latency stays acceptable with lazy-once payload load.
-- [ ] If lazy-once first-frame load is too slow, promote payload load into
-  `BindSessionContext` (eager bind) and re-measure; keep the single-load invariant.
-
-#### Raw pointer ownership notes (pre-existing)
-
-- [ ] Document owner lifetimes for `EditorSessionController` bare pointers (`editor_`,
-  `session_backend_`, `interaction_policy_`); keep `QPointer` for QML viewport objects.
-- [ ] No mass ownership redesign unless a concrete use-after-free appears.
+Document owner lifetimes for `EditorSessionController` bare pointers; keep `QPointer` for QML
+viewport objects. No mass ownership redesign unless a concrete use-after-free appears.
 
 ## Acceptance criteria
 
@@ -509,28 +373,3 @@ Focused tests (all passed):
 - `EditorSessionRenderControllerTest` 13/13
 
 Next: Phase R3 (session render context).
-
-### 2026-08-07 — Phase R3 complete
-
-Branch: `feature/editor_render_simplify`.
-
-Code:
-
-- `EditorRenderSessionContext` on the production scheduler port (epoch, element, image,
-  Image, ImageBuffer, PipelineGuard); replaces `cached_input_` half-cache;
-- `BindSessionContext` / `ClearSessionContext` on `IEditorPipelineSchedulerPort` and
-  `BindSessionRenderContext` / `ClearSessionRenderContext` on `IEditorRenderSubmitPort`;
-- `EditorSessionRenderController::RouteInitialRender` binds at open/switch;
-  `ResetForNewImage` clears;
-- `DispatchPipelineFrame` / `CanProduceFrame` use bound context; payload loads once via
-  `EnsureContextForRequest`.
-
-Focused tests (all passed):
-
-- `EditorSessionRenderSchedulerPortTest` 11/11
-- `EditorRenderCoordinatorTest` 31/31
-- `EditorSessionRenderControllerTest` 15/15
-
-Next: Phase R4 (test seams + carried residuals: no test-producer production branches;
-presentation sink identity on session context). Residual table under R3 maps each open item to
-R4 or Optional follow-up — do not drop those tasks when implementing R4.

--- a/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
+++ b/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
@@ -380,6 +380,59 @@ No responsibility split needed; context lives on the production adapter only.
 | No interactive-app / real-RAW open-switch latency evidence for context bind + lazy-once load | **Optional follow-up (verification)** |
 | First frame after bind still pays one payload load (lazy-once) | Accepted R3 design; only re-open if open latency measurement fails in verification follow-up |
 
+##### Phase R3 re-land completion record (2026-08-07)
+
+**Status:** complete — R3 re-applied after a temporary full revert used while fixing vsync /
+frame-production desync. Restored commit content is the final R3 edition: session context bind
+plus `ImageBuffer` shared encoded payload (`ShareEncodedBuffer`) so quality-ladder frames do not
+deep-copy multi-MB RAW bytes.
+
+**Why re-land:** R3 was reverted (`da95f574`) to isolate a present/vsync overlap issue. That
+issue is addressed separately by deferring `ScheduleNext` on pipeline-pool completion
+(`NotifySchedulerCompleted(..., schedule_next_from_pool=false)` + `Pump`), kept in the working
+tree alongside this re-land. R3 itself is restored as commit `2d5aef7b` (revert of the revert of
+`072d3024`).
+
+**Primary success call chain:** unchanged from the 2026-08-07 R3 record above
+(`RouteInitialRender` → bind → `EnsureContextForRequest` lazy-once →
+`ShareEncodedBuffer` on Apply).
+
+**Primary failure call chain:** unchanged (missing bind/pool → `FinishJob(false)` → Failed).
+
+**What was proven (re-run after re-land):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `BindSessionContextRecordsIdentityWithoutPoolRead` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `ClearSessionContextDropsBoundIdentity` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `ImageSwitchBindReplacesPriorContextPayload` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `RebindSameImageIdentityKeepsPayloadWithoutReload` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `InstalledContextAllowsScheduleWithoutImagePoolService` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `HotPathAfterInstalledContextDoesNotInvokeImagePoolResolver` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `BoundIdentityWithoutPayloadStillRejectsWhenPoolUnavailable` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `RouteInitialRenderBindsSessionContextAtOpen` | `EditorSessionRenderControllerTest` | PASS |
+| `ResetForNewImageClearsSessionRenderContext` | `EditorSessionRenderControllerTest` | PASS |
+| `BindAndClearSessionRenderContextForwardToScheduler` | `EditorRenderCoordinatorTest` | PASS |
+| Full port suite | `EditorSessionRenderSchedulerPortTest` | PASS 12/12 |
+| Full coordinator suite | `EditorRenderCoordinatorTest` | PASS 31/31 |
+| Full render controller suite | `EditorSessionRenderControllerTest` | PASS 15/15 |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSessionRenderSchedulerPortTest EditorRenderCoordinatorTest EditorSessionRenderControllerTest
+ctest --test-dir build/debug -R "EditorSessionRenderSchedulerPortTest|EditorRenderCoordinatorTest|EditorSessionRenderControllerTest" --output-on-failure
+```
+
+Suite totals: `EditorSessionRenderSchedulerPortTest` 12/12; `EditorRenderCoordinatorTest` 31/31;
+`EditorSessionRenderControllerTest` 15/15 (58/58 combined).
+
+**Checklist / exit condition:** all R3 boxes remain checked; acceptance criterion 6 re-proven.
+
+**Residual gaps:** same as the original R3 residual table (R4 + optional follow-ups). Vsync /
+present handoff deferral is outside R3 scope and remains local WIP diagnostics until committed
+separately.
+
 ### Phase R4 — Test seams without production branches
 
 **Goal:** remove `SetTestFrameProducer` special-casing from the production adapter, and close
@@ -523,13 +576,27 @@ Code:
 - `EditorSessionRenderController::RouteInitialRender` binds at open/switch;
   `ResetForNewImage` clears;
 - `DispatchPipelineFrame` / `CanProduceFrame` use bound context; payload loads once via
-  `EnsureContextForRequest`.
+  `EnsureContextForRequest`;
+- `ImageBuffer` encoded payload held as `shared_ptr`; `ShareEncodedBuffer()` aliases multi-MB
+  RAW bytes across session source and per-Apply working buffers (no deep copy on ladder frames).
 
 Focused tests (all passed):
 
-- `EditorSessionRenderSchedulerPortTest` 11/11
+- `EditorSessionRenderSchedulerPortTest` 11/11 (later 12/12 after rebind-identity case)
 - `EditorRenderCoordinatorTest` 31/31
 - `EditorSessionRenderControllerTest` 15/15
+
+### 2026-08-07 — Phase R3 temporarily reverted, then re-landed
+
+Branch: `feature/editor_render_simplify`.
+
+- Temporary full revert of R3 (`da95f574`) while isolating vsync / frame-production desync.
+- R3 final edition restored (`2d5aef7b`, revert of the revert of `072d3024`): session context +
+  shared encoded RAW bytes.
+- Present/vsync handoff deferral (`schedule_next_from_pool=false` on pool completion) kept as
+  local WIP with R3, not part of the R3 commit itself.
+
+Re-verified focused suites: port 12/12, coordinator 31/31, render controller 15/15 (58/58).
 
 Next: Phase R4 (test seams + carried residuals: no test-producer production branches;
 presentation sink identity on session context). Residual table under R3 maps each open item to

--- a/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
+++ b/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-06
 
-Status: Phases R1–R3 complete on branch `feature/editor_render_simplify`. Phase R4 pending.
+Status: Phases R1–R4 complete on branch `feature/editor_render_simplify`.
 Delivery is one feature branch with sequential commits (not one GitHub PR per phase).
 
 Primary owner: Alcedo Studio editor session render path.
@@ -440,24 +440,101 @@ residuals that force production branches or re-resolve presentation inputs on th
 
 **Checklist (includes residuals carried from R1–R3):**
 
-- [ ] Remove `SetTestFrameProducer` and any production `if (test_producer_)` branch from
+- [x] Remove `SetTestFrameProducer` and any production `if (test_producer_)` branch from
   `EditorSessionRenderSchedulerPort`.
-- [ ] Production adapter no longer calls `BindFrameSubmission` / `EnsureSize` for a test-only path
+- [x] Production adapter no longer calls `BindFrameSubmission` / `EnsureSize` for a test-only path
   (R1 residual; R3 residual).
-- [ ] Coordinator unit tests keep recording `IEditorPipelineSchedulerPort` fakes (no test producer
+- [x] Coordinator unit tests keep recording `IEditorPipelineSchedulerPort` fakes (no test producer
   on the production adapter).
-- [ ] Frame metadata / ready-frame tests target sink or pipeline completion without rewriting
+- [x] Frame metadata / ready-frame tests target sink or pipeline completion without rewriting
   production `Dispatch` branches.
-- [ ] Session context (or bind path) records **presentation sink identity** so schedule does not
+- [x] Session context (or bind path) records **presentation sink identity** so schedule does not
   re-resolve a live sink pointer as a substitute for session-scoped sink identity (R3 residual:
   today `sink_resolver_()` runs every `DispatchJob`). Prefer stamping `PresentationSinkId` at
   open/switch and resolving the pointer only when submitting to the pipeline / present path if a
   live `IFrameSink*` is still required.
-- [ ] Focused tests prove: (1) production `DispatchPipelineFrame` has no test-producer branch;
+- [x] Focused tests prove: (1) production `DispatchPipelineFrame` has no test-producer branch;
   (2) ready-frame metadata still correct without adapter-side `BindFrameSubmission`; (3) sink
   identity is stable across interactive frames for one bound session context.
 
 **Exit condition:** all R4 boxes checked; acceptance criterion 5 satisfied.
+
+##### Phase R4 completion record (2026-08-07)
+
+**Status:** complete — removed production test-producer branches; stamped
+`PresentationSinkId` on session context; shell/e2e harness moved to a test-only scheduler port.
+
+**Primary success call chain:**
+
+```text
+RouteInitialRender
+  -> BindSessionRenderContext(epoch, element, image, presentation_sink_id)
+  -> EditorSessionRenderSchedulerPort::BindSessionContext stamps context.presentation_sink_id
+  -> Coordinator::Submit -> Schedule
+  -> DispatchJob
+       · reject if intent sink id mismatches bound context
+       · resolve live IFrameSink* only at submit (sink_resolve_count++)
+  -> DispatchPipelineFrame (only path)
+  -> PipelineTask::SetExecutorRenderParams -> BindFrameSubmission
+  -> on_complete_ -> FrameReady
+```
+
+**Primary failure call chain:**
+
+```text
+Schedule with mismatched presentation_sink_id
+  -> DispatchJob FinishJob(false, sink identity mismatch)
+  -> no EnsureSize / no adapter BindFrameSubmission
+  -> NotifySchedulerCompleted(Failed)
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `ProductionPipelinePathSchedulesInstalledContextWithoutAdapterBind` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `ScopeRefreshMarksFrameAsRequestedScopeInput` (metadata via pipeline bind) | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `SinkIdentityStableAcrossInteractiveFramesForBoundContext` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `MismatchedPresentationSinkIdentityFailsWithoutAdapterEnsureSize` | `EditorSessionRenderSchedulerPortTest` | PASS |
+| `BindAndClearSessionRenderContextForwardToScheduler` (sink id forwarded) | `EditorRenderCoordinatorTest` | PASS |
+| `RouteInitialRenderBindsSessionContextAtOpen` (sink id stamped) | `EditorSessionRenderControllerTest` | PASS |
+| Full port suite | `EditorSessionRenderSchedulerPortTest` | PASS 14/14 |
+| Full coordinator suite | `EditorRenderCoordinatorTest` | PASS 31/31 |
+| Full render controller suite | `EditorSessionRenderControllerTest` | PASS 15/15 |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSessionRenderSchedulerPortTest EditorRenderCoordinatorTest EditorSessionRenderControllerTest
+ctest --test-dir build/debug -R "EditorSessionRenderSchedulerPortTest|EditorRenderCoordinatorTest|EditorSessionRenderControllerTest" --output-on-failure
+```
+
+Suite totals: `EditorSessionRenderSchedulerPortTest` 14/14; `EditorRenderCoordinatorTest` 31/31;
+`EditorSessionRenderControllerTest` 15/15 (60/60 combined).
+
+**Checklist / exit condition:** all R4 boxes checked; acceptance criterion 5 satisfied
+(production path does not pre-bind frame submission outside pipeline task setup).
+
+**LOC note (grill-code-review):**
+
+| File | LOC (approx) |
+| --- | --- |
+| `editor_session_render_scheduler_port.hpp` | ~127 |
+| `editor_session_render_scheduler_port.cpp` | ~607 |
+| `editor_session_render_scheduler_port_test.cpp` | ~359 |
+| `harness_completing_pipeline_scheduler_port.hpp` (tests/support) | ~226 |
+| `editor_render_coordinator.hpp` / `.cpp` | modest SetPipelineSchedulerPort + sink-id forward |
+
+No responsibility split needed; harness lives only under `tests/support/`.
+
+**Remaining gaps:** reverse `SetCoordinator` / `NotifySchedulerCompleted` and
+`replacement_key` cleanup remain under **Optional follow-up**. Interactive-app / real-RAW
+open-switch latency evidence remains under **Optional follow-up (verification)**.
+
+#### Session context / sink (from R3, if not closed in R4)
+
+- [x] Closed in R4: `PresentationSinkId` stamped on `EditorRenderSessionContext` at
+  open/switch; live `IFrameSink*` resolved only at submit.
 
 ### Optional follow-up — residuals and ownership notes
 
@@ -476,12 +553,6 @@ parallel only if R4 does not absorb the item). Each line is a tracked task from 
 
 - [ ] Remove `EditorRenderIntent::replacement_key` (and `DefaultReplacementKey` / fill path) if no
   producer/diagnostic consumer still requires the string; slots already own coalesce.
-
-#### Session context / sink (from R3, if not closed in R4)
-
-- [ ] If R4 does not land sink identity on `EditorRenderSessionContext`, do it here: bind
-  `PresentationSinkId` (and document owner of the live `IFrameSink*`) at open/switch; hot path
-  must not treat “call `sink_resolver_` again” as the session context contract.
 
 #### Verification (from R3)
 
@@ -598,6 +669,26 @@ Branch: `feature/editor_render_simplify`.
 
 Re-verified focused suites: port 12/12, coordinator 31/31, render controller 15/15 (58/58).
 
-Next: Phase R4 (test seams + carried residuals: no test-producer production branches;
-presentation sink identity on session context). Residual table under R3 maps each open item to
-R4 or Optional follow-up — do not drop those tasks when implementing R4.
+### 2026-08-07 — Phase R4 complete
+
+Branch: `feature/editor_render_simplify`.
+
+Code:
+
+- Removed `SetTestFrameProducer` / `DispatchTestProducer` from
+  `EditorSessionRenderSchedulerPort`; production `Dispatch` is pipeline-only;
+- `EditorRenderSessionContext::presentation_sink_id` stamped at
+  `BindSessionContext` / `RouteInitialRender`; live sink resolved only at submit;
+- Test-only `HarnessCompletingPipelineSchedulerPort` under `tests/support/` for
+  shell/e2e frame completion; coordinator `SetPipelineSchedulerPort` swaps the seam;
+- Port metadata tests assert pipeline `BindFrameSubmission` without adapter
+  `EnsureSize`.
+
+Focused tests (all passed):
+
+- `EditorSessionRenderSchedulerPortTest` 14/14
+- `EditorRenderCoordinatorTest` 31/31
+- `EditorSessionRenderControllerTest` 15/15
+
+Next: Optional follow-ups (completion direction, `replacement_key` cleanup,
+interactive-app verification).

--- a/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
+++ b/docs/roadmap/alcedo_studio/ui/editor_render_path_simplification_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-06
 
-Status: Phase R1 complete on branch `feature/editor_render_simplify`. Phases R2–R4 pending.
+Status: Phases R1–R2 complete on branch `feature/editor_render_simplify`. Phases R3–R4 pending.
 Delivery is one feature branch with sequential commits (not one GitHub PR per phase).
 
 Primary owner: Alcedo Studio editor session render path.
@@ -199,14 +199,85 @@ reproduce in the interactive app.
 
 **Goal:** O(1) replace and schedule selection for the three real ladder roles.
 
-- Replace `pending_` deque + `replacement_key` string equality with three optional slots:
+- [x] Replace `pending_` deque + `replacement_key` string equality with three optional slots:
   interactive, quality, detail (enum / quality-derived index).
-- Same-slot submit overwrites and emits `Replaced`.
-- `ScheduleNext` picks interactive > quality > detail in constant time.
-- Epoch mismatch clears all slots and cancels in-flight via token; no full-container rescans for
+- [x] Same-slot submit overwrites and emits `Replaced`.
+- [x] `ScheduleNext` picks interactive > quality > detail in constant time.
+- [x] Epoch mismatch clears all slots and cancels in-flight via token; no full-container rescans for
   coalesce.
-- Keep single-flight (`Submit` then schedule when idle; complete then schedule next).
-- Keep `ReasonReusesCurrentFrame` (ZoomPan / Resize do not schedule pipeline work).
+- [x] Keep single-flight (`Submit` then schedule when idle; complete then schedule next).
+- [x] Keep `ReasonReusesCurrentFrame` (ZoomPan / Resize do not schedule pipeline work).
+
+##### Phase R2 completion record (2026-08-06)
+
+**Status:** complete — fixed quality slots replace string-keyed pending deque in
+`EditorRenderCoordinator`.
+
+**Primary success call chain:**
+
+```text
+Submit(intent)
+  -> FillRenderIntentDefaults / AcceptOrReject / ReasonReusesCurrentFrame
+  -> PlaceInSlot(SlotIndexForQuality)  // overwrite same ladder slot + Replaced
+  -> ScheduleNext when idle
+       · ScrubPendingSlots (token / epoch, O(3))
+       · SelectNextSlotIndex: interactive > quality > detail
+  -> IEditorPipelineSchedulerPort::Schedule
+  -> NotifySchedulerCompleted -> FrameReady -> ScheduleNext next slot
+```
+
+**Primary failure call chain:**
+
+```text
+SetActiveImageLoadRequest(new_epoch)
+  -> CancelObsoleteForImageLoadMismatch
+       · clear every occupied slot with epoch mismatch (Cancelled)
+       · cancel in-flight token + emit Cancelled
+  -> scheduler_->Cancel(job) outside mutex
+  -> DeliverPendingResults
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `SameQualitySlotSubmitReplacesPriorPending` | `EditorRenderCoordinatorTest` | PASS |
+| `ThreeQualitySlotsCanCoexistAndScheduleInteractiveFirst` | `EditorRenderCoordinatorTest` | PASS |
+| `BurstOfReplaceableIntentsKeepsNewestInteractiveOnly` | `EditorRenderCoordinatorTest` | PASS |
+| `SetActiveImageLoadRequestCancelsObsoletePendingAndInflight` | `EditorRenderCoordinatorTest` | PASS |
+| `ZoomPanIntentIsReusedWithoutScheduling` / `ResizeIntentIsReusedWithoutScheduling` | `EditorRenderCoordinatorTest` | PASS |
+| `SlotIndexMatchesQualityLadderOrder` | `EditorRenderCoordinatorTest` | PASS |
+| Full coordinator suite | `EditorRenderCoordinatorTest` | PASS 30/30 |
+| Render controller regression | `EditorSessionRenderControllerTest` | PASS 13/13 |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorRenderCoordinatorTest
+ctest --test-dir build/debug -R EditorRenderCoordinatorTest --output-on-failure
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSessionRenderControllerTest
+ctest --test-dir build/debug -R EditorSessionRenderControllerTest --output-on-failure
+```
+
+Suite totals: `EditorRenderCoordinatorTest` 30/30; `EditorSessionRenderControllerTest` 13/13.
+
+**Checklist / exit condition:** all R2 boxes checked.
+
+**LOC note (grill-code-review):**
+
+| File | LOC |
+| --- | --- |
+| `alcedo_studio/src/app/editor_render_coordinator.cpp` | ~491 |
+| `alcedo_studio/src/include/app/editor_render_coordinator.hpp` | ~173 |
+| `alcedo_studio/tests/app/editor_render_coordinator_test.cpp` | ~752 |
+
+No responsibility split needed; coordinator still owns only coalesce + single-flight.
+
+**Residual gaps:**
+
+- `replacement_key` remains on `EditorRenderIntent` for producers / diagnostics; coalesce no longer
+  uses string equality (R2). Removal of the field is optional later YAGNI.
+- Session render context (R3) and test-producer production branches (R4) unchanged.
 
 ### Phase R3 — Session render context
 
@@ -284,3 +355,21 @@ Focused tests (all passed):
 - `EditorSessionRenderControllerTest` 13/13
 
 Next: Phase R2 (fixed slots).
+
+### 2026-08-06 — Phase R2 complete
+
+Branch: `feature/editor_render_simplify`.
+
+Code:
+
+- `alcedo_studio/src/include/app/editor_render_coordinator.hpp` — `QualitySlot` / `slots_` array;
+  `SlotIndexForQuality`, `PlaceInSlot`, `SelectNextSlotIndex`, `ScrubPendingSlots`;
+- `alcedo_studio/src/app/editor_render_coordinator.cpp` — deque + `ReplacePendingWithKey` /
+  `SelectNextIndex` removed; cancel/schedule walk three fixed slots only.
+
+Focused tests (all passed):
+
+- `EditorRenderCoordinatorTest` 30/30 (includes three-slot order + 100-burst + slot index)
+- `EditorSessionRenderControllerTest` 13/13
+
+Next: Phase R3 (session render context).


### PR DESCRIPTION
# Editor Render Path Simplification

Primary owner: Alcedo Studio editor session render path.

Affected areas:

- `EditorRenderCoordinator` request coalescing and single-flight scheduling;
- `EditorSessionRenderSchedulerPort` production adapter;
- `PipelineScheduler` / `PipelineTask` completion signaling;
- editor session open/switch image context for render input;
- focused unit tests for coordinator, scheduler port, and pipeline request identity.

This plan does not replace CQ0–CQ5 command-queue ownership. It reduces layered scheduling that
grew on top of the render submit port after the session/render split.

## Review findings (source diagnosis)

These findings come from a code review that started at
`alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp` and followed the
production render path into the coordinator and scheduler port. They are the product requirement
for this plan; implementation must shrink complexity against this list, not invent a parallel
framework.

### Lifetime and ownership

- `EditorSessionController` holds several raw pointers (`editor_`, `session_backend_`,
  `interaction_policy_`) whose ownership is only implied by host construction order. Viewport
  handles already use `QPointer`; the rest of the graph should document owner/borrower rules rather
  than a blanket `shared_ptr` rewrite of QObject trees.

### Coordinator queue and cancel

- `EditorRenderCoordinator` cancel paths walk the entire pending `deque` more than once (obsolete
  image-load cleanup, session cancel, pre-schedule token/epoch scrub), then `SelectNextIndex`
  walks the remaining deque again to pick a frame role / priority winner.
- Submit accepts work into a pending queue and only then calls `ScheduleNext`. That single-flight
  pattern is sound, but the surrounding state machine grew large around it (terminal-id sets,
  delivery re-entrancy guards, string-keyed replacement).

### Scheduler port is a second scheduler

- `EditorSessionRenderSchedulerPort` reverse-references `EditorRenderCoordinator` via
  `weak_ptr` and calls `NotifySchedulerCompleted`. Control flow goes coordinator → port →
  coordinator.
- The port owned a private worker thread and a second job slot (`queued_job_` / `running_job_`)
  even though `PipelineScheduler` already runs work on a thread pool. The worker’s main job was
  blocking on `future.get()` for preview tasks that only completed through the blocking promise
  path—so the port became a thin wrapper around an already-async executor, without relieving
  pressure on the render queue.
- `BindFrameSubmission` was invoked from the port (and specially for test producers via
  `EnsureSize`) even though production pipeline execution already binds submission under
  `PipelineTask::SetExecutorRenderParams`. Frame-sink binding should stay with the pipeline
  stage that knows output geometry.

### Test seams rewrote production logic

- `SetTestFrameProducer` forced production code paths to branch on “test vs real” and changed
  upper-layer behavior (`BindFrameSubmission`, size setup) so tests could pass. Test producers
  should simulate the production producer boundary, not force the production adapter to grow
  alternate control flow.

### Per-frame image pool lookup

- `TryProducePipelineFrame` re-resolved `EditorSessionSchedulerServices` (including image pool)
  and re-read image / input buffer identity on every frame instead of packaging a stable session
  render context when the image is opened or switched.

### Redundant cancel surfaces

- Cancel and replace exist at multiple layers: coordinator pending queue, string
  `replacement_key` comparison, intent cancellation tokens, and the port’s own scheduled/running
  job flags. The same request can be “cancelled” by several independent mechanisms.

### Overall assessment

The design stacked queues, threads, and reverse callbacks on top of an already-async pipeline
scheduler. Maintainability is poor; several paths are inefficient relative to the real requirements
(single-flight, quality ladder coalesce, epoch supersession, present handoff).

## Decision

Collapse to one coalesce owner and one execution owner:

```text
UI / session
  → EditorRenderCoordinator     // only coalesce + single-flight
  → thin production adapter     // build PipelineTask from session context
  → PipelineScheduler           // only execution pool
  → IFrameSink
```

Invariants:

1. **One pending-merge layer.** The coordinator is the only place that replaces/coalesces
   interactive / quality / detail work.
2. **One execution layer.** `PipelineScheduler` is the only thread pool for editor preview work.
   The session port must not own a second worker or second FIFO of jobs.
3. **Forward completion.** Task completion notifies the coordinator through a completion path
   established when the job is submitted (prefer `PipelineTask::on_complete_`). Long term, remove
   the port’s stored reverse `weak_ptr` to the coordinator if the submit interface can carry the
   callback instead.
4. **Pipeline owns frame binding.** Production `BindFrameSubmission` stays inside pipeline task
   setup / apply. Upper layers do not pre-bind “for convenience.”
5. **Session-scoped render inputs.** Image, input buffer, pipeline guard, and sink identity for
   the open image are bound when the image is acquired or switched—not re-fetched from the image
   pool on every interactive frame.
6. **Tests mock the seam; they do not rewrite production branches.** Prefer recording fakes for
   `IEditorPipelineSchedulerPort` or sink-level producers that look like production completion.

Explicit non-goals (YAGNI until measured need appears):

- a new general render “engine” or multi-inflight GPU dispatcher;
- merging the app-layer coordinator into `PipelineScheduler` (session tests still need a thin
  submit seam);
- rewriting the legacy QWidget `editor_dialog` render coordinator in the same change set;
- blanket smart-pointer conversion of QObject ownership graphs.

## Target call chain

Interactive adjustment:

```text
QML / models
  → EditorSessionService / EditorSessionRenderController
  → EditorRenderCoordinator::Submit
       · accept or replace slot
       · if idle, hand one request to the adapter
  → adapter builds PipelineTask (session context already holds image/pipeline/sink)
  → PipelineScheduler::ScheduleTask
  → configure under render lock + Apply + BindFrameSubmission + present
  → on_complete_(success)
  → Coordinator publishes FrameReady / Failed / Cancelled and schedules the next slot
```

Image switch:

```text
SetActiveImageLoadRequest(new_epoch)
  → drop pending slots for the old epoch
  → cancel in-flight via token
  → replace EditorRenderSessionContext
  → InitialFrame into the interactive slot
```

Cancel surfaces after simplification: **slot replace**, **cancellation token**, **image-load
epoch**. No string-key scans and no second port queue.