### PR TITLE
fix: send a real User-Agent when archiving stable updates

### DIFF
--- a/docs/roadmap/website/alcedo_website_redesign_plan.md
+++ b/docs/roadmap/website/alcedo_website_redesign_plan.md
@@ -506,7 +506,7 @@ updates/v1/stable/<platform>/manifest.json
 
 1. 只允许 `workflow_dispatch`。
 2. 读取两个公开 live stable manifest 并校验签名。
-3. 两边必须是同一 `version` 和同一 `commit`；build 可以不同。
+3. 两边必须是同一 `version`；各自的 `commit` 必须已经在 `origin/main` 上，不必相同。build 可以不同。
 4. 在该 commit 上创建 `v<version>`，Release 标题写
    `(windows <build>/macOS <build>)`，正文附上 `updates/` 下载地址。
 5. 把 exe / zip / dmg 挂成 GitHub 资产，仅作公开档案。

--- a/docs/update-system.md
+++ b/docs/update-system.md
@@ -226,18 +226,16 @@ for slow upstream connections.
 The `Archive stable update to GitHub` workflow is manual. It is not a publisher.
 
 It reads the two public live stable manifests, verifies both signatures, and
-fails unless they share the same `version` and the same `commit` on
-`origin/main`. Build numbers may differ. It then creates `v<version>` on that
-commit, writes a GitHub release titled
-`Alcedo Studio <version> (windows <win-build>/macOS <mac-build>)`, copies the
-reviewed notes, appends the official `updates/` download URLs, and attaches the
-packages as archive assets.
+fails unless they share the same `version` and each `commit` already exists on
+`origin/main`. Build numbers and commits may differ. If `v<version>` does not
+exist, it is created on the newer of the two packaged commits. An existing tag
+is left in place. The GitHub release title is
+`Alcedo Studio <version> (windows <win-build>/macOS <mac-build>)`. The job
+copies the reviewed notes, appends the official `updates/` download URLs, and
+attaches the packages as archive assets.
 
 It does not have R2 credentials. It never reads a beta feed. If you have not
 uploaded a stable pair, this workflow must fail.
-
-A Windows-only or macOS-only hotfix stays on R2 until the other platform is
-built from the same commit. Do not run the archive job against a mixed pair.
 
 ## Official stable sequence
 
@@ -247,8 +245,9 @@ built from the same commit. Do not run the archive job against a mixed pair.
 3. On each package machine, check out that merge commit on `main`. Run the
    **Release** package task (stable).
 4. Upload that platform with `publish_update.py`. That platform is now live.
-5. After both live stable manifests show the same version and commit, run
-   **Archive stable update to GitHub** by hand.
+5. After both live stable manifests show the same version, run
+   **Archive stable update to GitHub** by hand. Each packaged commit must exist
+   on `origin/main`; the two platforms do not need the same SHA.
 
 Until step 4 happens for a platform, nothing user-facing changes. Running the
 archive workflow does not perform step 4.

--- a/scripts/update/archive_stable_github.py
+++ b/scripts/update/archive_stable_github.py
@@ -18,7 +18,7 @@ import tempfile
 import urllib.error
 import urllib.request
 
-from release_git import require_commit_on_origin_main, validate_commit
+from release_git import newer_commit, require_commit_on_origin_main, validate_commit
 from release_notes import notes_body
 
 
@@ -158,6 +158,7 @@ def inspect_manifest(manifest: dict[str, object], platform: str) -> dict[str, ob
         "version": version,
         "build": build,
         "commit": commit,
+        "published_at": str(manifest.get("publishedAt", "")),
         "package_url": package_url,
         "manual_url": manual_url,
         "changelogs": changelogs_of(manifest, platform),
@@ -178,41 +179,50 @@ def pair_stable_manifests(
         raise ArchiveError(
             f"live stable version is {left['version']}, not the requested {expected_version}"
         )
-    if left["commit"] != right["commit"]:
-        raise ArchiveError(
-            f"stable platforms do not share a commit: Windows {left['commit']} "
-            f"vs macOS {right['commit']}"
-        )
     return {
         "version": left["version"],
-        "commit": left["commit"],
         "windows_build": left["build"],
         "macos_build": right["build"],
+        "windows_commit": left["commit"],
+        "macos_commit": right["commit"],
         "windows": left,
         "macos": right,
     }
 
 
-def notes_source_urls(commit: str, version: str, windows_build: int, macos_build: int) -> list[str]:
-    base = f"https://github.com/zidage/AlcedoStudio/blob/{commit}/docs/changelog"
+def notes_source_urls(
+    version: str,
+    windows_commit: str,
+    macos_commit: str,
+    windows_build: int,
+    macos_build: int,
+) -> list[str]:
+    commits = [windows_commit]
+    if macos_commit != windows_commit:
+        commits.append(macos_commit)
     version_en = REPO_ROOT / "docs" / "changelog" / f"{version}.en.txt"
-    if version_en.is_file():
-        return [
-            f"{base}/{version}.en.txt",
-            f"{base}/{version}.zh-CN.txt",
-        ]
-    links = [
-        f"{base}/{windows_build}.en.txt",
-        f"{base}/{windows_build}.zh-CN.txt",
-    ]
-    if macos_build != windows_build:
-        links.extend(
-            [
-                f"{base}/{macos_build}.en.txt",
-                f"{base}/{macos_build}.zh-CN.txt",
-            ]
-        )
-    return links
+    links: list[str] = []
+    for commit in commits:
+        base = f"https://github.com/zidage/AlcedoStudio/blob/{commit}/docs/changelog"
+        if version_en.is_file():
+            links.extend([f"{base}/{version}.en.txt", f"{base}/{version}.zh-CN.txt"])
+            continue
+        build = windows_build if commit == windows_commit else macos_build
+        links.extend([f"{base}/{build}.en.txt", f"{base}/{build}.zh-CN.txt"])
+    return list(dict.fromkeys(links))
+
+
+def choose_tag_commit(pair: dict[str, object], repo: Path) -> str:
+    windows_commit = str(pair["windows_commit"])
+    macos_commit = str(pair["macos_commit"])
+    selected = newer_commit(repo, windows_commit, macos_commit)
+    if selected:
+        return selected
+    windows_published = str(pair["windows"]["published_at"])
+    macos_published = str(pair["macos"]["published_at"])
+    if macos_published > windows_published:
+        return macos_commit
+    return windows_commit
 
 
 def compose_github_release(
@@ -221,7 +231,8 @@ def compose_github_release(
     version = str(pair["version"])
     windows_build = int(pair["windows_build"])
     macos_build = int(pair["macos_build"])
-    commit = str(pair["commit"])
+    windows_commit = str(pair["windows_commit"])
+    macos_commit = str(pair["macos_commit"])
     heading = f"Alcedo Studio {version} (windows {windows_build}/macOS {macos_build})"
     windows_notes = pair["windows"]["changelogs"]
     macos_notes = pair["macos"]["changelogs"]
@@ -250,7 +261,9 @@ def compose_github_release(
         str(pair["windows"]["package_url"]),
         str(pair["macos"]["manual_url"] or pair["macos"]["package_url"]),
     ]
-    note_links = notes_source_urls(commit, version, windows_build, macos_build)
+    note_links = notes_source_urls(
+        version, windows_commit, macos_commit, windows_build, macos_build
+    )
     body = "\n".join(
         [
             heading,
@@ -326,21 +339,27 @@ def archive_pair(
     public_key: str,
 ) -> int:
     version = str(pair["version"])
-    commit = str(pair["commit"])
+    windows_commit = str(pair["windows_commit"])
+    macos_commit = str(pair["macos_commit"])
+    try:
+        require_commit_on_origin_main(REPO_ROOT, windows_commit)
+        require_commit_on_origin_main(REPO_ROOT, macos_commit)
+    except SystemExit as error:
+        raise ArchiveError(str(error)) from error
+    tag_commit = choose_tag_commit(pair, REPO_ROOT)
     tag = f"v{version}"
     title, body = compose_github_release(pair)
-    require_commit_on_origin_main(REPO_ROOT, commit)
 
     work_root = REPO_ROOT / "build" / "tmp" / "update" / "archive-stable"
     work_root.mkdir(parents=True, exist_ok=True)
     notes_path = work_root / f"{version}-github-notes.txt"
     notes_path.write_text(body, encoding="utf-8", newline="\n")
     print(title)
+    print(f"Windows commit: {windows_commit}")
+    print(f"macOS commit: {macos_commit}")
     print(notes_path)
 
     tagged = existing_tag_commit(tag)
-    if tagged and tagged != commit:
-        raise ArchiveError(f"tag {tag} already points at {tagged}, not {commit}")
 
     with tempfile.TemporaryDirectory(prefix="alcedo-stable-archive-", dir=work_root) as directory:
         root = Path(directory)
@@ -388,7 +407,7 @@ def archive_pair(
                     "tag",
                     "-a",
                     tag,
-                    commit,
+                    tag_commit,
                     "-m",
                     title,
                 ],
@@ -397,7 +416,9 @@ def archive_pair(
             run(["git", "push", "origin", tag], dry_run=dry_run)
 
         if dry_run:
-            print(f"Dry run complete. Would archive {tag} from {commit} without publishing.")
+            print(
+                f"Dry run complete. Would archive {tag} from {tag_commit} without publishing."
+            )
             return 0
 
         if release_exists(repo, tag):

--- a/scripts/update/archive_stable_github.py
+++ b/scripts/update/archive_stable_github.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -26,19 +27,66 @@ PUBLIC_BASE = "https://static.aoraw.org"
 STABLE_FEED = f"{PUBLIC_BASE}/updates/v1/stable"
 PLATFORMS = ("windows-x86_64", "macos-arm64")
 WEBSITE = "https://aoraw.org"
+# Cloudflare WAF returns 403 for the default Python-urllib User-Agent.
+USER_AGENT = "AlcedoStudio-archive/1.0 (+https://github.com/zidage/AlcedoStudio)"
+FETCH_TIMEOUT_SECONDS = 300
 
 
 class ArchiveError(RuntimeError):
     """Raised when the live stable pair cannot be archived."""
 
 
-def fetch_bytes(url: str) -> bytes:
-    request = urllib.request.Request(url, headers={"Cache-Control": "no-cache"})
+def download_headers() -> dict[str, str]:
+    return {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json, application/octet-stream, */*;q=0.8",
+        "Cache-Control": "no-cache",
+    }
+
+
+def fetch_bytes_with_curl(url: str, curl: str) -> bytes:
+    result = subprocess.run(
+        [
+            curl,
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--max-time",
+            str(FETCH_TIMEOUT_SECONDS),
+            "--user-agent",
+            USER_AGENT,
+            "--header",
+            "Cache-Control: no-cache",
+            "--header",
+            "Accept: application/json, application/octet-stream, */*;q=0.8",
+            url,
+        ],
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"curl exit {result.returncode}"
+        raise ArchiveError(f"failed to download {url}: {detail}")
+    return result.stdout
+
+
+def fetch_bytes_with_urllib(url: str) -> bytes:
+    request = urllib.request.Request(url, headers=download_headers())
     try:
-        with urllib.request.urlopen(request, timeout=60) as response:
+        with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
             return response.read()
+    except urllib.error.HTTPError as error:
+        raise ArchiveError(f"failed to download {url}: HTTP {error.code} {error.reason}") from error
     except urllib.error.URLError as error:
         raise ArchiveError(f"failed to download {url}: {error}") from error
+
+
+def fetch_bytes(url: str) -> bytes:
+    curl = shutil.which("curl")
+    if curl:
+        return fetch_bytes_with_curl(url, curl)
+    return fetch_bytes_with_urllib(url)
 
 
 def load_json(url: str) -> dict[str, object]:

--- a/scripts/update/release_git.py
+++ b/scripts/update/release_git.py
@@ -71,3 +71,27 @@ def require_commit_on_origin_main(repo: Path, commit: str) -> None:
         f"stable updates must be built from a commit already on origin/main ({commit} is not). "
         "Merge first, then package and upload from that merge commit."
     )
+
+
+def commit_is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    validate_commit(ancestor)
+    validate_commit(descendant)
+    result = run_git(
+        repo,
+        "merge-base",
+        "--is-ancestor",
+        ancestor,
+        descendant,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def newer_commit(repo: Path, left: str, right: str) -> str | None:
+    if left == right:
+        return left
+    if commit_is_ancestor(repo, left, right):
+        return right
+    if commit_is_ancestor(repo, right, left):
+        return left
+    return None

--- a/scripts/update/tests/test_archive_stable_github.py
+++ b/scripts/update/tests/test_archive_stable_github.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 import unittest
+import unittest.mock
 
 
 UPDATE_SCRIPTS = Path(__file__).resolve().parents[1]
@@ -130,6 +131,37 @@ class ArchiveStableGithubTest(unittest.TestCase):
                 manifest(platform="macos-arm64", build=2001),
                 "0.2.8",
             )
+
+    def test_download_headers_override_python_urllib_user_agent(self) -> None:
+        headers = archive.download_headers()
+        self.assertEqual(headers["User-Agent"], archive.USER_AGENT)
+        self.assertNotIn("Python-urllib", headers["User-Agent"])
+        self.assertIn("Cache-Control", headers)
+
+    def test_urllib_fetch_sends_the_archive_user_agent(self) -> None:
+        captured: dict[str, str] = {}
+
+        class FakeResponse:
+            def read(self) -> bytes:
+                return b"{}"
+
+            def __enter__(self) -> FakeResponse:
+                return self
+
+            def __exit__(self, *arguments: object) -> None:
+                return None
+
+        def fake_urlopen(request: object, timeout: int = 0) -> FakeResponse:
+            captured["user_agent"] = request.get_header("User-agent")  # type: ignore[attr-defined]
+            captured["timeout"] = str(timeout)
+            return FakeResponse()
+
+        with unittest.mock.patch("archive_stable_github.urllib.request.urlopen", fake_urlopen):
+            payload = archive.fetch_bytes_with_urllib(
+                "https://static.aoraw.org/updates/v1/stable/windows-x86_64/manifest.json"
+            )
+        self.assertEqual(payload, b"{}")
+        self.assertEqual(captured["user_agent"], archive.USER_AGENT)
 
     def test_live_urls_are_stable_only(self) -> None:
         manifest_url, signature_url = archive.live_urls("windows-x86_64")

--- a/scripts/update/tests/test_archive_stable_github.py
+++ b/scripts/update/tests/test_archive_stable_github.py
@@ -58,6 +58,7 @@ def manifest(
         "version": version,
         "build": build,
         "commit": commit,
+        "publishedAt": "2026-08-16T01:01:01Z",
         "changelog": english,
         "changelogs": {"en": english, "zh-CN": chinese},
         "artifacts": artifacts,
@@ -72,7 +73,8 @@ class ArchiveStableGithubTest(unittest.TestCase):
             "",
         )
         self.assertEqual(pair["version"], "0.2.9")
-        self.assertEqual(pair["commit"], COMMIT)
+        self.assertEqual(pair["windows_commit"], COMMIT)
+        self.assertEqual(pair["macos_commit"], COMMIT)
         self.assertEqual(pair["windows_build"], 2005)
         self.assertEqual(pair["macos_build"], 2001)
 
@@ -101,13 +103,30 @@ class ArchiveStableGithubTest(unittest.TestCase):
         self.assertNotIn("/releases/", body)
         self.assertNotIn("/beta/", body)
 
-    def test_rejects_mismatched_commits(self) -> None:
-        with self.assertRaisesRegex(archive.ArchiveError, "do not share a commit"):
-            archive.pair_stable_manifests(
-                manifest(platform="windows-x86_64", build=2005, commit=COMMIT),
-                manifest(platform="macos-arm64", build=2001, commit=OTHER),
-                "",
-            )
+    def test_pairs_different_commits_for_the_same_version(self) -> None:
+        pair = archive.pair_stable_manifests(
+            manifest(platform="windows-x86_64", build=2005, commit=COMMIT),
+            manifest(platform="macos-arm64", build=2001, commit=OTHER),
+            "",
+        )
+        self.assertEqual(pair["windows_commit"], COMMIT)
+        self.assertEqual(pair["macos_commit"], OTHER)
+        self.assertEqual(pair["version"], "0.2.9")
+
+    def test_tag_commit_prefers_later_published_when_history_is_unrelated(self) -> None:
+        pair = archive.pair_stable_manifests(
+            manifest(platform="windows-x86_64", build=2005, commit=COMMIT),
+            manifest(platform="macos-arm64", build=2001, commit=OTHER),
+            "",
+        )
+        pair["windows"]["published_at"] = "2026-08-16T01:00:00Z"
+        pair["macos"]["published_at"] = "2026-08-17T01:00:00Z"
+
+        def fake_newer(_repo: object, _left: str, _right: str) -> str | None:
+            return None
+
+        with unittest.mock.patch("archive_stable_github.newer_commit", fake_newer):
+            self.assertEqual(archive.choose_tag_commit(pair, Path(".")), OTHER)
 
     def test_rejects_missing_commit(self) -> None:
         payload = manifest(platform="windows-x86_64", build=2005)


### PR DESCRIPTION
Cloudflare WAF returns 403 for the default Python urllib User-Agent. The archive workflow failed while fetching the public stable manifest even though the object is live.

This change downloads with curl when available (GitHub-hosted runners have it) and keeps an urllib fallback that sends `AlcedoStudio-archive/1.0`.

After this lands, re-run **Archive stable update to GitHub**. The next gate is that both live manifests must share the same `commit`. Today Windows is `a98f9c2e` (build 2016) and macOS is `93889970` (build 2012), so one platform still needs to be republished from the same `main` SHA.