### PR TITLE
docs: update README product positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@
 ![License](https://img.shields.io/badge/License-GPLv3-blue)
 ![CUDA](https://img.shields.io/badge/CUDA-12.8-76B900)
 ![C++](https://img.shields.io/badge/C++-20-blue)
-![AI](https://img.shields.io/badge/AI-CLIP%20%2B%20VLM-ff6f00)
 
-**Alcedo Studio** is a RAW photo editor and photo library manager. Image processing runs on a GPU-accelerated pipeline. Tagging and search run locally on your machine, while the culling assist uses LLM APIs (OpenAI-compatible, Anthropic, or Volcengine Ark) that may be cloud-hosted. The library is stored in a single DuckDB-backed file next to your photos, so there is no separate catalog to migrate.
+**Alcedo Studio** is a free, open-source photography workstation for the day after a shoot.
+
+Import a card of RAWs and the library is ready to browse. Grade files up to 150 megapixels in 32-bit float on the GPU.
+
+The project is one [DuckDB](https://duckdb.org/) file with extra metadata. Album structure and the full edit history live inside it. One file to move and keep. No mess.
+
+What's more, the grade follows a film-industry picture pipeline. Camera RAW becomes a scene-referred image. You work in a log space the way a DI suite grades ACEScc. Looks arrive as film-emulation LUTs. A display rendering transform then forms the picture for the monitor.
+
+Windows 10/11 x64 and Apple Silicon. Current release: [v0.2.9](https://github.com/zidage/AlcedoStudio/releases/tag/v0.2.9).
 
 ---
 
@@ -19,148 +26,54 @@ https://github.com/user-attachments/assets/d70cd10d-2045-42f3-a67d-97ab3ef9874b
 
 https://github.com/user-attachments/assets/ae0d9773-220e-4901-90f6-1989f58b0462
 
+## Features
 
-## Core Features
+**Cameras, then RAW quality.** Tested across Canon, Nikon, Sony, Fujifilm, Panasonic, OM System, Leica, Hasselblad, Phase One (including IQ4 150MP), Pentax, Sigma, and phone / drone DNG. Lists: [supported formats](docs/supported_raw_formats.md) and [supported cameras](docs/supported_cameras.md). Nikon HE and HE★ NEFs from the Z 8, Z 9, Z 6 III, and Z 50 II decode through the project's [LibRaw fork](https://github.com/zidage/LibRaw) with special performance optimization.
 
-### 1. 32-Bit Float Pipeline, Dual Color Science, and HDR Output
+Pick the demosaic: Default, RCD, or Neural Engine (a distilled [DemosaicNet](https://groups.csail.mit.edu/graphics/demosaicnet/) on the GPU, Bayer and X-Trans). Highlight reconstruction uses an improved inpaint-opposed method originally from darktable and RawTherapee.
 
-The processing pipeline works in 32-bit float. Demosaicing, adjustments, and output transforms all operate on float data, and the pipeline runs on the GPU where one is available.
+**Smooth at 2.5K@60.** Drag a slider and the preview holds 2.5K at 60 FPS. When you stop, it can reach 4K, so your high-megapixel camera still looks like itself. An RGB histogram and a waveform update with the picture and guide the next move. CUDA on NVIDIA, OpenCL on other Windows GPUs, Metal on macOS. A cache keeps that performance with low memory. You set the thumbnail disk cache: location, size, quality, on or off, no mysterious disk space occupancy.
 
-* **32-Bit Floating-Point Precision**: The pipeline, from raw demosaicing with the RCD algorithm through highlight reconstruction, operates in 32-bit float per channel to preserve shadow and highlight detail.
-* **Dual Color Science**: Output rendering uses ACES 2.0 and OpenDRT, with custom target color spaces, peak-luminance control, and EOTF mapping.
-* **HDR and UltraHDR Output**: HDR display output is not a post-processing effect. Alcedo Studio maps the dynamic range of the RAW file to HDR displays (HDR preview is macOS-only) and can export standard-compliant **UltraHDR gain-map JPEGs**, which reproduce the original luminance range on HDR screens.
-* **GPU Backends**: The pipeline is implemented natively for CUDA and OpenCL on Windows and for Metal on macOS. On modern GPUs, exposure and grading adjustments update in real time.
+**A display rendering transform forms the picture.** Scene-linear RAW holds color and dynamic range a monitor can't show as-is. A DRT (picture formation) is the look decision that maps that range onto the display. See [Chris Brejon on picture formation](https://chrisbrejon.com/articles/what-makes-a-good-picture-formation/) for more information about DRT. You can use ACES 2.0 or OpenDRT, grading toward sRGB, wide-gamut, or HDR: choose the encoding color space, the EOTF, and HDR peak luminance. On macOS you even get an HDR preview while you edit.
 
-### 2. Native Nikon High-Efficiency (HE/HE*) Support
+**Film-emulation LUTs.** [CUBE LUTs generated from real film-stock spectral response](https://github.com/JanLohse/spectral_film_lut), plus grain and halation designed with physical properties.
 
-Nikon's High-Efficiency (`HE`) and High-Efficiency★ (`HE*`) formats are not supported by upstream LibRaw. Alcedo Studio decodes them directly, so these files can be imported and edited without converting them to DNG first.
+**Looks you can keep, copy, and walk back.** Named versions hold different looks on a photo so you can compare. Copy a look onto another photo, or merge fields from one look into another. Every adjustment is a step you can undo. That history stays in the project file, so the undo trail is still there next month.
 
-* **Direct Import**: Import and edit compressed RAW files from Nikon Z 8, Z 9, Z 6 III, Z f, and Z 50 II cameras.
-* **Patched LibRaw**: The project ships a custom-patched fork of LibRaw for decoding these formats.
+**Export with highly customizable configurations.** Format, size, naming, metadata, ICC, and alpha, from the inspector. JPEG, PNG, TIFF, or EXR (up to 32-bit). Original pixels, longest edge, pixel bounds, or print size with DPI. File names can use source name, capture date, camera, lens, exposure, rating, and sequence.
 
-### 3. On-Device Semantic Search
+**Review and rate.** Connect an LLM you already use (OpenAI-compatible, Anthropic, or Volcengine Ark). It writes a description, a 1–5 star rating, and a short reason into EXIF. You set how strict the review is.
 
-Alcedo Studio includes a local vector search engine. Vision models (CLIP / SigLIP) run on your machine and index the library without sending images anywhere.
+**Tag it. Find it.** Local multilingual CLIP models label the library. Type a scene, a camera, a date, or a phrase. The inspector maps the same library by capture date, camera, lens, labels, and rating. You can manage the CLIP models yourself by downloading a new model, activating an existing model for your library, and deleting a downloaded model to free up space.
 
-* **Semantic Queries**: Type a description such as *"portrait at sunset by the ocean"*. The query is converted to an embedding and ranked against the library locally.
-* **Local and Private**: Images and queries stay on your hard drive. No API keys are required for tagging and searching.
-* **Model Isolation**: Switch between models (MobileCLIP2, SigLIP2, Jina CLIP v2, or macOS CoreML profiles). Labels produced by different models are kept separate, so tags from one model do not mix with another's.
+**The library stays fast on a big shoot.** DuckDB is built so a whole card of photos can answer at once. Filter by Saturday, a 35mm, and five stars, and the grid updates. The inspector can tell you how many frames you shot on each body that week.
 
-### 4. LLM-Assisted Culling and EXIF Metadata Writeback
+FTS is there so the words in a description or tag work as a query: "red umbrella" hits the caption, not only the filename. HNSW is there so photos that look alike sit near each other: a phrase finds frames by meaning, even when nobody typed that filename.
 
-The culling assist batch-analyzes candidate photos through standard APIs (OpenAI-compatible, Anthropic, or Volcengine Ark) before you start editing them.
+Put the file where you want. Move it. Back it up.
 
-* **Issue Detection**: The analysis flags technical and aesthetic issues — missed focus, motion blur, and poor composition.
-* **1-5 Star Ratings**: Each photo receives a rating from 1 to 5 stars based on the configured strictness. Ratings are written back to standard EXIF metadata, so other photo managers can read them.
-* **Keys and Strictness**: API keys are stored in the OS keychain. A strictness setting controls how critical the analysis is.
+## System requirements
 
-### 5. Single-File Project Management
+- **Windows**: 10/11 x64. NVIDIA GPU (compute capability 6.0+) for CUDA; other GPUs use OpenCL.
+- **macOS**: Apple Silicon (M1 or newer), macOS 13.3 or later, Metal.
+- 8GB RAM minimum (16GB+ for large libraries).
+- Release builds install signed updates from Settings → Updates.
 
-Projects use a physical-first layout: the library is described by a single file in the photo directory, and there is no separate catalog to migrate or rebuild.
+## Documentation
 
-* **Single `.alcd` File**: All edit history, version metadata, semantic tags, and folder organization are stored in a DuckDB-backed `.alcd` file located in the photo directory.
-* **Portability**: Backing up or moving a library means copying the `.alcd` file.
-* **Separate Thumbnail Cache**: The disk-backed thumbnail cache and metadata are stored independently, so project files stay small.
-
----
-
-## Additional Features
-
-### Non-Destructive Versioning (Mini-Git Edit History)
-
-Alcedo Studio does not modify the original RAW files. Edits for each photo are stored as a small Git-like commit graph in the project's `.alcd` file.
-
-* **Versions and Edit History**: The editor's left rail has two panels. **Versions** lists named branches for a photo (for example “High-contrast B&W” and “Warm film look”). **Edit History** shows the commit graph for the currently checked-out Version, with undo and redo.
-* **Branch management**: A Version is a named branch that points at a commit (or at the image root). Multiple Versions may share ancestry; shared commits are stored once.
-* **Commits**: When you release the slider, one immutable edit commit is recorded on the active Version. Undo and redo move the working head along that Version's graph.
-* **Branch, fork, paste, and merge**:
-  - **Branch from current** creates a new Version from the current head.
-  - **Fork from root** creates a new Version from the image's import baseline.
-  - **Paste adjustments** creates a new Version on the target photo from another photo's adjustments, so you can try the other photo's look without changing the existing Version.
-  - **Merge adjustments** folds another photo's adjustments into the Version you are already using — useful when you want to keep local work (crop, exposure, and so on) and still take color or style from elsewhere. Conflicting fields are resolved in a preview dialog; the result is one merge commit.
-* **Write-ahead log (WAL)**: Finalized edits are first appended to a per-image recovery journal (a write-ahead log). Before switching photos, checking out another Version, leaving the editor, or shutting down, that journal is materialized into DuckDB so the live pipeline, panel state, and stored project agree.
-
-> How to use the **Versions** and **Edit History** panels: [user guide](https://zidage.github.io/AlcedoStudio_docs/en/docs/getting-started/edit-history-and-versions).  
-> Commit graph, journal, and storage layout: [developer documentation](https://zidage.github.io/AlcedoStudio_docs/en/docs/developer/edit-history-architecture).
-
-### RAW Processing & Styling
-* **Demosaicing**: The RCD demosaic algorithm produces clean, artifact-free RAW decoding with sharp detail.
-* **Styling & Film Emulation**: Curated spectral film LUTs (CUBE format) tuned for ACEScc/ACEScct, with GPU-backed film grain and halation simulation.
-
-### Export Workflow
-* **Flexible formats**: Batch export to JPEG, PNG, TIFF, and WebP, at 8/16/32-bit depths.
-* **UltraHDR & HDR Gain-Maps**: Export gain-map JPEGs for HDR display on modern platforms (for example, mobile devices and HDR screens).
-* **Metadata & ICC Options**: Control metadata stripping and embed ICC profiles per batch.
-
-> [!TIP]
-> For edit history and versioning, see the [Alcedo Studio documentation site](https://zidage.github.io/AlcedoStudio_docs/docs/intro).
-
----
-
-## RAW and Camera Support
-
-Alcedo Studio imports all major RAW formats through a patched fork of [LibRaw](https://github.com/zidage/LibRaw):
-
-- Canon CR2 / CR3
-- Nikon NEF
-- Sony ARW
-- Fujifilm RAF
-- Panasonic RW2
-- Olympus / OM System ORF
-- Leica, Hasselblad, Phase One, Pentax, Sigma, Samsung
-- DNG, including smartphone and drone DNGs
-
-See the full format list in [docs/supported_raw_formats.md](docs/supported_raw_formats.md) and the camera list in [docs/supported_cameras.md](docs/supported_cameras.md).
-
-### Nikon HE / HE\* support
-Nikon High-Efficiency (`HE`) and High-Efficiency★ (`HE*`) NEFs are still unsupported in upstream LibRaw 0.22. Alcedo Studio ships a patched LibRaw fork that decodes these files directly — no conversion to DNG required. Validated cameras include:
-- Nikon Z 8
-- Nikon Z 9
-- Nikon Z 6 III
-- Nikon Z f
-- Nikon Z 50 II
-
-The decoder lives in the project's LibRaw fork: **https://github.com/zidage/LibRaw**
-
----
-
-## System Requirements
-
-- **Windows**: Windows 10/11 x64. CUDA-capable NVIDIA GPU (minimum compute capability 6.0 / 10-series, recommended 7.0+ / 20-series) with 6GB+ VRAM for 40MP+ RAW files. OpenCL fallback available for non-NVIDIA GPUs.
-- **macOS**: Apple Silicon Mac (M1/M2/M3/M4 series) running native Metal execution paths.
-- **Memory**: Minimum 8GB system RAM (16GB+ recommended for large libraries).
-- **Disk Space**: 500MB free disk space for installation; 60MB+ package footprint.
-
----
-
-## Build from Source
-
-Build instructions are maintained separately in [docs/build_from_source.md](docs/build_from_source.md) (English and Chinese).
-
----
-
-## Roadmap
-
-Roadmap and ongoing milestones are tracked in [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md).
-
----
+User guides and build notes: [documentation site](https://zidage.github.io/AlcedoStudio_docs/docs/intro). Source build: [docs/build_from_source.md](docs/build_from_source.md). Development plans made by AI agents: [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md). Change logs: [docs/changelog/](docs/changelog/).
 
 ## Acknowledgements
 
-Alcedo Studio builds on research, open-source implementations, and community data from the wider imaging ecosystem:
-
-- Distributed film-emulation LUTs are from [JanLohse/spectral_film_lut](https://github.com/JanLohse/spectral_film_lut).
-- Some camera color matrices are from [AcademySoftwareFoundation/rawtoaces-data](https://github.com/AcademySoftwareFoundation/rawtoaces-data).
-- The highlight reconstruction algorithm is adapted from RawTherapee's [hilite_recon.cc](https://github.com/RawTherapee/RawTherapee/blob/dev/rtengine/hilite_recon.cc).
-- The RCD demosaic algorithm is from [LuisSR/RCD-Demosaicing](https://github.com/LuisSR/RCD-Demosaicing).
-- OpenDRT is ported from [OpenDRT.dctl](https://github.com/jedypod/open-display-transform/blob/main/display-transforms/opendrt/OpenDRT.dctl).
-- ACES 2.0 support is ported from [aces-aswf/aces-core](https://github.com/aces-aswf/aces-core).
-- The film grain renderer is based on Alasdair Newson, Noura Faraj, Bruno Galerne, and Julie Delon's [Realistic Film Grain Rendering](https://doi.org/10.5201/ipol.2017.192).
-
----
+- Film LUTs from [JanLohse/spectral_film_lut](https://github.com/JanLohse/spectral_film_lut).
+- Camera color matrices from [rawtoaces-data](https://github.com/AcademySoftwareFoundation/rawtoaces-data).
+- Neural demosaic student models distilled from [mgharbi/demosaicnet](https://github.com/mgharbi/demosaicnet) ([Gharbi et al., 2016](https://groups.csail.mit.edu/graphics/demosaicnet/)).
+- Inpaint-opposed highlight reconstruction adapted from [darktable opposed.c](https://github.com/darktable-org/darktable/blob/master/src/iop/hlreconstruct/opposed.c) and [RawTherapee](https://github.com/RawTherapee/RawTherapee/blob/dev/rtengine/hilite_recon.cc).
+- RCD demosaic from [LuisSR/RCD-Demosaicing](https://github.com/LuisSR/RCD-Demosaicing).
+- OpenDRT ported from [jedypod/open-display-transform](https://github.com/jedypod/open-display-transform).
+- ACES 2.0 from [aces-aswf/aces-core](https://github.com/aces-aswf/aces-core).
+- Film grain based on [Realistic Film Grain Rendering](https://doi.org/10.5201/ipol.2017.192) (IPOL 2017).
 
 ## License
 
-The `v0.1.1` tag and earlier releases remain under Apache-2.0.
-Development after `v0.1.1` is licensed under `GPL-3.0-only`, with an additional permission under GPLv3 section 7 for combining/distributing required NVIDIA CUDA components.
-See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+Alcedo Studio is licensed under GPL-3.0-only. See [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,228 +1,79 @@
-# Alcedo Studio
+<p align="center">
+  <img src="docs/header.png" alt="Alcedo Studio" width="25%"/>
+</p>
 
-项目网站：[English](https://aoraw.org/) | [简体中文](https://aoraw.org/zh-cn/)
+[项目网站](https://aoraw.org/zh-cn/) | [Project website](https://aoraw.org/)
 
 <p align="right"><a href="./README.md">English</a> | <a href="./README.zh-CN.md"><strong>简体中文</strong></a></p>
 
 ![License](https://img.shields.io/badge/License-GPLv3-blue)
 ![CUDA](https://img.shields.io/badge/CUDA-12.8-76B900)
 ![C++](https://img.shields.io/badge/C++-20-blue)
-![AI](https://img.shields.io/badge/AI-CLIP%20%2B%20VLM-ff6f00)
 
-**Alcedo Studio** 是一款专为追求极致速度、完全隐私和本地 AI 体验的摄影师打造的次世代 RAW 图像处理与影集管理系统。它不模仿任何传统软件的臃肿，而是以全新的 GPU 加速管线与本地端侧 AI，重新定义从导入、智能检索到创意调色的完整工作流。
+**Alcedo Studio** 是一款免费、开源的摄影工作站，为拍摄完成后的工作而生。
 
----
+导入存储卡中的 RAW，图库随即就能浏览。通过 GPU 上的 32 位浮点管线，为高达 1.5 亿像素的照片调色。
 
-## 早期演示与截图
+每个项目都是一个带有额外元数据的 [DuckDB](https://duckdb.org/) 文件。相册结构和完整编辑历史都保存在其中。只需移动和保存一个文件，整洁，没有散落的数据。
 
-视频演示1：[BiliBili](https://www.bilibili.com/video/BV1bPcxzzEeM)
+更进一步，调色遵循电影工业的成像流程。相机 RAW 首先成为场景参照图像。你在对数空间中工作，就像 DI 调色系统处理 ACEScc 一样。胶片模拟 LUT 带来不同风格，最后由显示渲染变换为显示器形成画面。
 
-视频演示2 (带解说)：[BiliBili](https://www.bilibili.com/video/BV1sFfjBeE3n)
-
-<table>
-  <colgroup>
-    <col style="width: 76%" />
-    <col style="width: 24%" />
-  </colgroup>
-  <tbody>
-    <tr>
-      <td><img src="docs/screenshots/1-主界面.png" alt="Alcedo Studio 图库浏览器" width="100%" /></td>
-      <td><strong>图库影集浏览器</strong> —— 极速加载的缩略图网格、物理文件夹树、活跃搜索维度、星标过滤器与 AI 语义标签集成。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/7-高级筛选.png" alt="高级筛选与过滤" width="100%" /></td>
-      <td><strong>高级筛选与过滤</strong> —— 结合 EXIF 元数据、星标和 AI 语义标签，在庞大的库中进行精准的组合搜索与筛选。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/8-AI内容识别.png" alt="本地 AI 视觉引擎" width="100%" /></td>
-      <td><strong>本地 AI 视觉引擎</strong> —— 自由开启与管理本地 CLIP 或 SigLIP 端侧模型， 100% 数据隐私安全。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/9-AI内容过滤.png" alt="AI 语义标签过滤" width="100%" /></td>
-      <td><strong>AI 语义标签过滤</strong> —— 本地 AI 自动生成的语义标签会作为一级属性融入过滤器面板，与其他参数无缝组合。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/10-AI自然语言搜索.png" alt="自然语言智能搜索" width="100%" /></td>
-      <td><strong>自然语言智能搜索</strong> —— 像与人对话一样输入画面描述（如“海边日落人像”），在本地向量索引中实现即时的高匹配度排序。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/2-色彩科学.png" alt="电影级色彩科学" width="100%" /></td>
-      <td><strong>电影级双色彩科学</strong> —— 提供 ACES 2.0 和 OpenDRT 规范的输出渲染，带显示色彩空间与峰值亮度调整。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/3-基础调整.png" alt="实时影调基础调整" width="100%" /></td>
-      <td><strong>实时影调基础调整</strong> —— 支持曝光、对比度、白平衡、色调曲线和局部高光/阴影（LLF）微调，带实时直方图反馈。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/4-高级色彩.png" alt="创意调色板" width="100%" /></td>
-      <td><strong>创意调色板</strong> —— 精准控制 HSL 调整、色彩轮（Lift, Gamma, Gain）创意分级与实时示波器。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/5-几何调整.png" alt="几何畸变与透视修复" width="100%" /></td>
-      <td><strong>几何畸变与透视修复</strong> —— 包含裁剪、旋转、镜头畸变与透视修复等基本工具。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/Portra 400.png" alt="胶片模拟与配方" width="100%" /></td>
-      <td><strong>胶片模拟与配方</strong> —— 原生支持针对 ACEScc/ACEScct 流程优化的 Kodak、Fuji 和 Agfa 预设（.cube 格式 3D LUT）。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/5-胶片颗粒与Halation模拟.png" alt="真实胶片质感模拟" width="100%" /></td>
-      <td><strong>真实胶片质感模拟</strong> —— 基于物理模型的颗粒与光晕（Halation）仿真，在 CPU/GPU 混合管线上高效渲染。</td>
-    </tr>
-    <tr>
-      <td><img src="docs/screenshots/6-导出界面.png" alt="高级批量导出" width="100%" /></td>
-      <td><strong>高级批量导出</strong> —— 支持多格式并行队列，带精细位深控制、ICC 元数据选择和 UltraHDR 增益图写入。</td>
-    </tr>
-  </tbody>
-</table>
-
-> 项目使用的一部分演示 RAW 文件来自 [signatureedits](https://www.signatureedits.com/free-raw-photos/) 的 100% 免费 RAW 文件。
+支持 Windows 10/11 x64 和 Apple Silicon。当前版本：[v0.2.9](https://github.com/zidage/AlcedoStudio/releases/tag/v0.2.9)。
 
 ---
 
-## 自 v0.2.3 以来的主要变化
+https://github.com/user-attachments/assets/d70cd10d-2045-42f3-a67d-97ab3ef9874b
 
-自 v0.2.3 启用新品牌 Alcedo Studio 以来，项目逐步从原型探索过渡到实用的专业 RAW 编辑与资产管理系统。
+https://github.com/user-attachments/assets/ae0d9773-220e-4901-90f6-1989f58b0462
 
-| 版本周期 | 核心更新亮点 |
-| --- | --- |
-| **v0.2.4** | 迁移 GPU 后端至 OpenCL，新增 OpenCL 图像容器、镜头校正、透视修复、DNG 扭曲校正及示波器分析。Sleeve 虚拟文件系统引入了影集分组、分页、星级标记与全局索引搜索。 |
-| **v0.2.5** | 基于 LLF（局部拉普拉斯滤波器）重构高光/阴影局部影调处理；优化 OKLCh 与 HLS 调色空间；增加批量复制/粘贴修图参数；新增交互式裁剪叠加层及 UltraHDR 增益图导出。 |
-| **v0.2.6** | 全面落地 AI 原生工作流：内置本地语义搜索、本地 CLIP/SigLIP 影库扫描、HNSW 向量索引及异步模型下载。新增 CPU/GPU 胶片颗粒与光晕（Halation）模拟。修补 LibRaw 分支以原生解码尼康 HE/HE* 压缩格式。 |
+## 功能
 
----
+**先看相机支持，再谈 RAW 质量。** 已测试 Canon、Nikon、Sony、Fujifilm、Panasonic、OM System、Leica、Hasselblad、Phase One（包括 IQ4 150MP）、Pentax、Sigma，以及手机和无人机生成的 DNG。完整列表：[支持的格式](docs/supported_raw_formats.md)和[支持的相机](docs/supported_cameras.md)。来自 Z 8、Z 9、Z 6 III 和 Z 50 II 的 Nikon HE 与 HE★ NEF 文件通过项目的 [LibRaw 分支](https://github.com/zidage/LibRaw)解码，并针对性能进行了特别优化。
 
-## 五大核心支柱
+你可以选择去马赛克方法：Default、RCD 或 Neural Engine。Neural Engine 是在 GPU 上运行的精简版 [DemosaicNet](https://groups.csail.mit.edu/graphics/demosaicnet/)，支持 Bayer 和 X-Trans。高光重建使用改进的 inpaint-opposed 方法，其原始实现来自 darktable 和 RawTherapee。
 
-### 1. 专业级 32 位浮点、双色彩科学与 HDR 工作流管线
-编辑是 Alcedo Studio 的灵魂。为了保证极致的画质、精准的色彩与流畅度，我们绝不在计算精度和渲染性能上妥协。
-* **32 位浮点与高保真解码**：从使用高质量 **RCD 算法** 执行 RAW 去马赛克（demosaic），到高光重建，全流程均在 32 位单通道浮点精度下运算，完整保留阴影与高光里的每一丝细节。
-* **原生双色彩科学**：原生内置 ACES 2.0 与 OpenDRT 色彩科学渲染，完美匹配不同物理设备的色彩空间、EOTF 曲线和峰值亮度。
-* **真 HDR 与 UltraHDR 工作流**：这绝非市面上那种靠算法强行拉曝、暴力提亮的假 HDR 滤镜，而是**对 RAW 传感器捕获到的宽广动态范围进行完整、忠实的还原与再现**。配合 ACES 2.0/OpenDRT 映射，将高动态光影无损呈现于 HDR 监视器（仅 macOS 支持应用内实时预览），并支持导出标准 **UltraHDR Gain-map 增益图 JPEG**，在现代 HDR 屏幕和社交媒体平台上完美再现拍摄现场的真实光强。
-* **GPU 硬件级百帧级流畅**：Windows 下运行 **CUDA** 与 **OpenCL** 内核，macOS 下原生运行 **Metal** 渲染器，现代显卡下预览可达 **数百帧/秒**，拉动调整滑块完全没有延迟。
+**2.5K@60，保持流畅。** 拖动滑块时，预览以 2.5K 分辨率保持 60 FPS。停止调整后，预览最高可达 4K，让高像素相机的表现完整呈现。RGB 直方图和波形图随画面同步更新，为下一步调整提供参考。NVIDIA 使用 CUDA，其他 Windows GPU 使用 OpenCL，macOS 使用 Metal。缓存机制在保持性能的同时降低内存占用。缩略图磁盘缓存的位置、大小、质量以及是否启用，都由你决定，不会出现来源不明的磁盘占用。
 
-### 2. 独家原生支持尼康高效率压缩 (HE/HE*) RAW
-尼康特有的高效率压缩（`HE`）和高效率压缩★（`HE*`）NEF 格式在 LibRaw 0.22 中至今未被支持。Alcedo Studio 为此独立编写了解码补丁，免除了将大批照片转为 DNG 的繁杂步骤。
-* **告别格式转换瓶颈**：直接导入并极速编辑来自尼康 Z 8、Z 9、Z 6 III、Z f、以及 Z 50 II 的高压缩 RAW 照片。
-* **高度优化的补丁分支**：内置针对多线程 and 硬件指令集深度优化的 LibRaw 解码器，实现流畅的无感导入。
+**显示渲染变换决定画面如何呈现。** 场景线性 RAW 包含显示器无法直接呈现的色彩和动态范围。DRT，也就是画面形成，是把这些内容映射到显示设备时所做的视觉决策。关于 DRT 的更多信息，请参阅 [Chris Brejon 对画面形成的介绍](https://chrisbrejon.com/articles/what-makes-a-good-picture-formation/)。你可以使用 ACES 2.0 或 OpenDRT，面向 sRGB、广色域或 HDR 进行调色，并选择编码色彩空间、EOTF 和 HDR 峰值亮度。在 macOS 上，编辑时还能直接预览 HDR 效果。
 
-### 3. 完全本地化的端侧 AI 语义搜索与打标
-告别机械的文件名检索与繁琐的手动整理。Alcedo Studio 拥有完全运行于本机的向量搜索引擎，基于先进的端侧视觉模型（CLIP / SigLIP）。
-* **自然语言检索**：只需在搜索框中输入“海边日落人像”或“森林中的越野车”，本地向量索引即可在毫秒级内给出语义匹配度最高的照片列表。
-* **100% 数据隐私安全**：所有图像处理与向量化过程均在本地 GPU 运行，照片绝不上云，保护创作者的绝对隐私，且无需支付任何 API 密钥或订阅费用。
-* **模型独立隔离**：支持灵活切换 MobileCLIP2、SigLIP2、Jina CLIP v2 或 macOS CoreML 模型，不同模型的语义标签包彼此隔离，防止标签混淆与污染。
+**胶片模拟 LUT。** [CUBE LUT 根据真实胶片的光谱响应生成](https://github.com/JanLohse/spectral_film_lut)，并搭配依据物理特性设计的颗粒和光晕效果。
 
-### 4. 多模态大模型智能评片与选片
-让 AI 成为你的专业“第二审核人”，帮你在海量废片中快速筛选出合格的照片。通过接入标准大模型接口（兼容 OpenAI 格式、Anthropic 或火山方舟豆包），可在后台开启智能助理。
-* **精准揪出废片痛点**：AI 助理能自动识别画面中常见的技术与美学缺陷，例如**拍摄失焦（脱焦）、手抖模糊（运动抖动）以及构图失误**，在开始精修前直接过滤废片。
-* **1-5 星智能打分**：基于定制的审美逻辑对候选片自动评级，**打分将直接写入图像标准的 EXIF 元数据**，这意味着你的评分在任意看图或管理软件中都能同步读取。
-* **安全与个性化**：API Key 安全保存在操作系统密钥串（Keychain）中，绝不记录到日志或项目文件。可调的“严格度人设”（从宽容到挑剔）可满足不同的挑选要求。
+**保留、复制，也能随时回退的 Look。** 命名版本可以为同一张照片保存不同 Look，方便直接比较。你可以把 Look 复制到另一张照片，也可以把一个 Look 中的字段合并到另一个 Look。每一次调整都是可以撤销的步骤。完整历史保存在项目文件中，即使下个月重新打开项目，撤销路径依然存在。
 
-### 5. 极简轻量、即开即走的单文件项目管理
-彻底告别传统修图软件臃肿的集中式数据库，消除多机同步时数据库损坏或迁移困难的烦恼。
-* **单文件 `.alcd` 设计**：一个项目，一个文件。所有的修图历史、多版本参数、AI 语义标签和虚拟目录结构，都保存在项目文件夹下一个小巧的 DuckDB 数据库文件（.alcd）中。
-* **完美的便携性**：只需将包含照片和 `.alcd` 的文件夹整体复制、剪切或备份到外置硬盘/云盘，即可瞬间在另一台设备上无缝继续工作。
-* **缩略图缓存解耦**：磁盘缩略图缓存与核心元数据完全独立，确保项目主体文件始终轻量小巧。
+**使用高度可定制的配置导出。** 在检查器中设置格式、尺寸、命名、元数据、ICC 和 Alpha 通道。支持 JPEG、PNG、TIFF 和最高 32 位的 EXR。尺寸可以使用原始像素、最长边、像素边界，或带 DPI 的打印尺寸。文件名可以包含源文件名、拍摄日期、相机、镜头、曝光、评分和序号。
 
----
+**评片与评分。** 接入你已经使用的 LLM，支持兼容 OpenAI 的服务、Anthropic 和 Volcengine Ark。它可以把描述、1–5 星评分和简短理由写入 EXIF。你可以设置评片的严格程度。
 
-## 更多核心功能
+**打上标签，马上找到。** 本地多语言 CLIP 模型为图库生成标签。输入一个场景、一台相机、一个日期或一句描述即可搜索。检查器也会按拍摄日期、相机、镜头、标签和评分整理同一个图库。你可以自行管理 CLIP 模型：下载新模型、为当前图库启用已有模型，或删除已下载的模型以释放空间。
 
-### 无损版本管理（Mini-Git 编辑历史）
+**大型拍摄项目也能保持快速。** DuckDB 可以让整张存储卡中的照片同时参与查询。筛选某个星期六、35mm 镜头和五星照片，网格会立即更新。检查器还能告诉你，那一周每台机身分别拍摄了多少张照片。
 
-Alcedo Studio 不会修改原始 RAW 文件。每张照片的编辑记录以类似 Git 的小型提交图保存在项目的 `.alcd` 文件中。
+FTS 让描述或标签中的文字直接成为查询条件。搜索“红色雨伞”时，它匹配的是画面描述，而不只是文件名。HNSW 则让画面相似的照片在向量空间中彼此接近。即使没有人把那句话写进文件名，一段描述也能按含义找到对应画面。
 
-* **Versions 与 Edit History**：编辑器左侧栏有两个面板。**Versions** 列出同一张照片上的命名分支（例如「高反差黑白」与「暖调胶片」）。**Edit History** 显示当前正在使用的 Version 上的提交图，并提供撤销与重做。
-* **分支管理**：一个 Version 是指向某个提交（或图像根）的命名分支。多个 Version 可以共享祖先；共享的提交只存储一份。
-* **提交**：松开滑块时，会在当前 Version 上记录一条不可变的编辑提交。撤销与重做在该 Version 的提交图上移动工作头。
-* **分支、分叉、粘贴与合并**：
-  - **Branch from current** 从当前 head 创建新的 Version。
-  - **Fork from root** 从导入后的图像根创建新的 Version。
-  - **Paste adjustments** 在目标照片上根据另一张照片的调整**新建 Version**，方便整套试用，而不覆盖你已有的 Version。
-  - **Merge adjustments** 把另一张照片的调整合进**当前正在使用的 Version**——适合本地已有裁切、曝光等修改，又想沿用别处的色彩或风格。两边都改过的字段在预览对话框里选择；确认后写入一条合并提交。
-* **预写日志（WAL）**：已确认的编辑先追加到每张照片的恢复日志（write-ahead log）。在切换照片、改用其他 Version、离开编辑器或退出应用之前，该日志会物化写入 DuckDB，使实时流水线、参数面板与项目存储保持一致。
-
-> **Versions** 与 **Edit History** 面板的用法见 [用户指南](https://zidage.github.io/AlcedoStudio_docs/docs/getting-started/edit-history-and-versions)。  
-> 提交图、恢复日志与存储结构见 [开发者文档](https://zidage.github.io/AlcedoStudio_docs/docs/developer/edit-history-architecture)。
-
-### RAW 处理与风格化
-* **高保真去马赛克**：原生内置 **RCD demosaic 算法**，提供精细、清晰的 RAW 文件解码并有效抑制伪影。
-* **胶片模拟与风格化**：支持针对 ACEScc/ACEScct 色彩空间优化的 CUBE 格式 LUT，内置基于 GPU 加速的真实物理颗粒与光晕（Halation）模拟渲染器。
-
-### 批量导出队列
-* **多格式输出**：支持批量并行将 RAW 渲染导出为 JPEG、PNG、TIFF 及 WebP 格式，支持 8/16/32 位深度。
-* **UltraHDR 增益图与 HDR 格式**：完美支持 UltraHDR Gain-map 增益图 JPEG 导出，在现代 HDR 屏幕或移动设备上可呈现高亮度、高动态范围的绚丽视觉效果。
-* **元数据及 ICC 配置文件**：可自由控制 EXIF/IPTC 信息的剥离或保留，并为每批导出任务嵌入专属的 ICC 颜色配置文件。
-
-> [!TIP]
-> 编辑历史与版本管理请参阅 [Alcedo Studio 文档站](https://zidage.github.io/AlcedoStudio_docs/docs/intro)。
-
----
-
-## RAW 与相机支持
-
-Alcedo Studio 通过补丁版 [LibRaw](https://github.com/zidage/LibRaw) 分支支持导入目前绝大多数主流相机的 RAW 格式：
-
-- Canon CR2 / CR3
-- Nikon NEF
-- Sony ARW
-- Fujifilm RAF
-- Panasonic RW2
-- Olympus / OM System ORF
-- Leica、Hasselblad、Phase One、Pentax、Sigma、Samsung
-- DNG，包括主流智能手机和航拍无人机生成的 DNG 文件
-
-完整格式列表见 [docs/supported_raw_formats.md](docs/supported_raw_formats.md)，已验证支持相机列表见 [docs/supported_cameras.md](docs/supported_cameras.md)。
-
-### 独家支持：尼康 HE / HE\* RAW 压缩格式
-对于目前在 LibRaw 0.22 官方上游仍未提供支持的 Nikon High-Efficiency (`HE`) 与 High-Efficiency★ (`HE*`) NEF 文件，Alcedo Studio 自带的 Patched LibRaw 提供了原生的直接解码能力，无需转为 DNG。已通过实机照片测试的机型包括：
-- Nikon Z 8
-- Nikon Z 9
-- Nikon Z 6 III
-- Nikon Z f
-- Nikon Z 50 II
-
-解码补丁开源在：**https://github.com/zidage/LibRaw**
-
----
+把项目文件放在你需要的位置。移动它，备份它。
 
 ## 系统要求
 
-- **Windows 10/11 x64**：建议搭配支持 CUDA 的 NVIDIA GPU（最低计算能力 6.0，即 10 系列或更高；推荐 7.0+，即 20 系列或更高），配备 6GB+ VRAM 以流畅处理 40MP+ 的高像素 RAW 文件。非 NVIDIA 显卡可使用 OpenCL 执行加速。
-- **macOS**：支持 Apple Silicon 芯片（M1/M2/M3/M4 系列）的 Mac 硬件，原生运行 Metal 图像管线。
-- **系统内存**：最少 8GB RAM（推荐 16GB+ 以保证大型图库浏览的顺畅度）。
-- **硬盘空间**：至少 600MB 可用空间用于程序安装及工作缓存，安装包大小约为 130MB+。
+- **Windows**：Windows 10/11 x64。NVIDIA GPU（计算能力 6.0 或更高）使用 CUDA；其他 GPU 使用 OpenCL。
+- **macOS**：Apple Silicon（M1 或更新），macOS 13.3 或更新，使用 Metal。
+- 最少 8GB RAM，大型图库建议使用 16GB 或更多内存。
+- 正式版本可以在“设置 → 更新”中安装经过签名的更新。
 
----
+## 文档
 
-## 源码构建
-
-源码构建与依赖配置（中英文对照）请参考 [docs/build_from_source.md](docs/build_from_source.md)。
-
----
-
-## 开发路线图
-
-开发路线图与当前里程碑规划可以在 [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md) 中查看。
-
----
+用户指南和构建说明：[文档网站](https://zidage.github.io/AlcedoStudio_docs/docs/intro)。源码构建：[docs/build_from_source.md](docs/build_from_source.md)。由 AI 智能体制定的开发计划：[docs/roadmap/roadmap.md](docs/roadmap/roadmap.md)。变更日志：[docs/changelog/](docs/changelog/)。
 
 ## 致谢
 
-Alcedo Studio 建立在开源生态与图像学领域众多杰出研究的基础之上：
-
-- 胶片模拟 LUT 配方来源于 [JanLohse/spectral_film_lut](https://github.com/JanLohse/spectral_film_lut)。
-- 相机色彩矩阵参数来源于 [AcademySoftwareFoundation/rawtoaces-data](https://github.com/AcademySoftwareFoundation/rawtoaces-data).
-- 高光重建算法改编自 RawTherapee 中的 [hilite_recon.cc](https://github.com/RawTherapee/RawTherapee/blob/dev/rtengine/hilite_recon.cc).
-- Demosaic RCD 算法来源于 [LuisSR/RCD-Demosaicing](https://github.com/LuisSR/RCD-Demosaicing).
-- OpenDRT 色彩科学移植自 [OpenDRT.dctl](https://github.com/jedypod/open-display-transform/blob/main/display-transforms/opendrt/OpenDRT.dctl).
-- ACES 2.0 色彩管理移植自 [aces-aswf/aces-core](https://github.com/aces-aswf/aces-core).
-- 胶片物理颗粒算法基于 Alasdair Newson 等人的论文 *[Realistic Film Grain Rendering](https://doi.org/10.5201/ipol.2017.192)* 实现。
-
----
+- 胶片 LUT 来自 [JanLohse/spectral_film_lut](https://github.com/JanLohse/spectral_film_lut)。
+- 相机色彩矩阵来自 [rawtoaces-data](https://github.com/AcademySoftwareFoundation/rawtoaces-data)。
+- Neural demosaic student models 蒸馏自 [mgharbi/demosaicnet](https://github.com/mgharbi/demosaicnet)（[Gharbi 等，2016](https://groups.csail.mit.edu/graphics/demosaicnet/)）。
+- Inpaint-opposed 高光重建改编自 [darktable opposed.c](https://github.com/darktable-org/darktable/blob/master/src/iop/hlreconstruct/opposed.c) 和 [RawTherapee](https://github.com/RawTherapee/RawTherapee/blob/dev/rtengine/hilite_recon.cc)。
+- RCD 去马赛克来自 [LuisSR/RCD-Demosaicing](https://github.com/LuisSR/RCD-Demosaicing)。
+- OpenDRT 移植自 [jedypod/open-display-transform](https://github.com/jedypod/open-display-transform)。
+- ACES 2.0 来自 [aces-aswf/aces-core](https://github.com/aces-aswf/aces-core)。
+- 胶片颗粒基于 [Realistic Film Grain Rendering](https://doi.org/10.5201/ipol.2017.192)（IPOL 2017）。
 
 ## 许可证
 
-项目在 `v0.1.1` tag（含）以前的版本继续遵循 Apache-2.0 协议。
-`v0.1.1` 以后的开发版本遵循 `GPL-3.0-only`，并在根目录 [LICENSE](LICENSE) 中根据 GPLv3 第 7 条附带一项针对合并和分发 NVIDIA CUDA 组件的补充许可说明。
-详情请见 [LICENSE](LICENSE) 及 [NOTICE](NOTICE) 文件。
+Alcedo Studio 使用 GPL-3.0-only 许可证。请参阅 [LICENSE](LICENSE) 和 [NOTICE](NOTICE)。


### PR DESCRIPTION
## Summary

- Rewrite the English README as a product-facing overview.
- Add a matching Simplified Chinese translation with the same structure, facts, links, and feature order.
- Explain the film-industry image workflow, 2.5K 60 FPS preview, and 4K settled preview.
- Describe DuckDB library queries, FTS text search, and HNSW vector search.
- Clarify RAW support, local CLIP search, LLM review, persistent edit history, HDR output, film emulation, and export options.
- State the GPLv3 license in both files.

## Why

The previous READMEs mixed product value with implementation details. They also gave English and Simplified Chinese readers different product descriptions.

These versions start with the work that photographers need to complete. Both languages now present the same product position and technical evidence.

## Validation

- Checked every relative link in both README files.
- Confirmed that both files have the same heading and feature structure.
- Ran git diff --check.
- Confirmed that this branch changes only README.md and README.zh-CN.md.

This change only updates documentation. It does not change application code.