### PR TITLE
feat: add album inspector capture-date heatmap

### DIFF
--- a/alcedo_studio/src/config/panel_icons/calendar.svg
+++ b/alcedo_studio/src/config/panel_icons/calendar.svg
@@ -1,11 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#A7ABB3" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M7 3.5v3"/>
-  <path d="M17 3.5v3"/>
-  <rect x="3.5" y="5.5" width="17" height="15" rx="2.2"/>
-  <path d="M3.8 10h16.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M8 3v3"/>
+  <path d="M16 3v3"/>
+  <rect x="4" y="5" width="16" height="16" rx="2"/>
+  <path d="M4 10h16"/>
   <path d="M8 14h.01"/>
   <path d="M12 14h.01"/>
   <path d="M16 14h.01"/>
-  <path d="M8 17h.01"/>
-  <path d="M12 17h.01"/>
+  <path d="M8 18h.01"/>
+  <path d="M12 18h.01"/>
 </svg>

--- a/alcedo_studio/src/include/ui/alcedo_main/app_theme.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/app_theme.hpp
@@ -93,6 +93,10 @@ class AppTheme final : public QObject {
   Q_PROPERTY(int spaceMd READ spaceMd CONSTANT)
   Q_PROPERTY(int spaceLg READ spaceLg CONSTANT)
   Q_PROPERTY(int spaceXl READ spaceXl CONSTANT)
+  // Library date activity graph (GitHub-style capture heatmap).
+  Q_PROPERTY(int dateGraphCellMinSize READ dateGraphCellMinSize CONSTANT)
+  Q_PROPERTY(int dateGraphCellGap READ dateGraphCellGap CONSTANT)
+  Q_PROPERTY(int dateGraphCellRadius READ dateGraphCellRadius CONSTANT)
   Q_PROPERTY(int motionFoldOpenMs READ motionFoldOpenMs CONSTANT)
   Q_PROPERTY(int motionFoldCloseMs READ motionFoldCloseMs CONSTANT)
   Q_PROPERTY(int motionFadeMs READ motionFadeMs CONSTANT)
@@ -153,6 +157,11 @@ class AppTheme final : public QObject {
   Q_PROPERTY(QColor scopeHistogramRedColor READ scopeHistogramRedColor NOTIFY ThemeChanged)
   Q_PROPERTY(QColor scopeHistogramGreenColor READ scopeHistogramGreenColor NOTIFY ThemeChanged)
   Q_PROPERTY(QColor scopeHistogramBlueColor READ scopeHistogramBlueColor NOTIFY ThemeChanged)
+  Q_PROPERTY(QColor dateGraphLevel0Color READ dateGraphLevel0Color NOTIFY ThemeChanged)
+  Q_PROPERTY(QColor dateGraphLevel1Color READ dateGraphLevel1Color NOTIFY ThemeChanged)
+  Q_PROPERTY(QColor dateGraphLevel2Color READ dateGraphLevel2Color NOTIFY ThemeChanged)
+  Q_PROPERTY(QColor dateGraphLevel3Color READ dateGraphLevel3Color NOTIFY ThemeChanged)
+  Q_PROPERTY(QColor dateGraphLevel4Color READ dateGraphLevel4Color NOTIFY ThemeChanged)
 
  public:
   enum class FontRole : int {
@@ -266,6 +275,9 @@ class AppTheme final : public QObject {
   auto        spaceMd() const -> int;
   auto        spaceLg() const -> int;
   auto        spaceXl() const -> int;
+  auto        dateGraphCellMinSize() const -> int;
+  auto        dateGraphCellGap() const -> int;
+  auto        dateGraphCellRadius() const -> int;
   auto        motionFoldOpenMs() const -> int;
   auto        motionFoldCloseMs() const -> int;
   auto        motionFadeMs() const -> int;
@@ -308,6 +320,11 @@ class AppTheme final : public QObject {
   auto scopeHistogramRedColor() const -> QColor;
   auto scopeHistogramGreenColor() const -> QColor;
   auto scopeHistogramBlueColor() const -> QColor;
+  auto dateGraphLevel0Color() const -> QColor;
+  auto dateGraphLevel1Color() const -> QColor;
+  auto dateGraphLevel2Color() const -> QColor;
+  auto dateGraphLevel3Color() const -> QColor;
+  auto dateGraphLevel4Color() const -> QColor;
 
   auto currentThemeIndex() const -> int;
   void setCurrentThemeIndex(int index);

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -522,6 +522,8 @@ set(ALCEDO_MAIN_QML_FILES
     "${ALCEDO_UI_SHELL_ROOT}/qml/CollectionsPanel.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/GlobalSearchDialog.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/StatsCard.qml"
+    "${ALCEDO_UI_SHELL_ROOT}/qml/DateCommitGraph.qml"
+    "${ALCEDO_UI_SHELL_ROOT}/qml/DateFilterSection.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/StarRatingFilter.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/AppContextMenu.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/AppMenuItem.qml"

--- a/alcedo_studio/src/ui/alcedo_main/DESIGN.md
+++ b/alcedo_studio/src/ui/alcedo_main/DESIGN.md
@@ -8,6 +8,7 @@ Owner: `alcedo_studio/src/ui/alcedo_main`
 Implementation source of truth: `AppTheme` (`app_theme.hpp` / `app_theme.cpp`)  
 Shared components: `IconActionButton.qml`, `CollapsibleSection.qml`,
 `DialogActionButton.qml`, `IconButton.qml`, `SegmentedCardSwitcher.qml`,
+`SlidingIconNav.qml`, `DateFilterSection.qml`, `DateCommitGraph.qml`,
 `AdjustmentSlider.qml`, `ThemedProgressBar.qml`, `ThemeCheckBox.qml`
 
 This document freezes the visual system for the unified QML workspace (Phase 4C).
@@ -183,6 +184,34 @@ inside the card — not a nested second card of the same fill.
 | `spaceMd` | 12 | Default panel padding, desktop row gap |
 | `spaceLg` | 16 | Panel title margins |
 | `spaceXl` | 20 | Rare large separation |
+
+### Library date activity graph
+
+Capture-date heatmap in the album inspector (GitHub contribution-graph layout,
+week columns that wrap to the inspector width). Geometry is independent of the
+spacing ladder because the cells must stay dense enough for 365/366 days.
+
+| Token | px | Use |
+| --- | --- | --- |
+| `dateGraphCellMinSize` | 10 | Floor for a day square; cells grow to fill the wrap row |
+| `dateGraphCellGap` | 3 | Gap between day squares (GitHub pitch) |
+| `dateGraphCellRadius` | 2 | Day-square corner |
+
+Intensity uses `toneSteel` (same accent as the calendar date filter), not GitHub
+green and not ad-hoc QML alpha:
+
+| Token | Use |
+| --- | --- |
+| `dateGraphLevel0Color` | Empty / padding day (`bgBase` toward `textMuted`) |
+| `dateGraphLevel1Color` | Lowest non-zero bucket |
+| `dateGraphLevel2Color` | Mid-low bucket |
+| `dateGraphLevel3Color` | Mid-high bucket |
+| `dateGraphLevel4Color` | Peak bucket (`toneSteel`) |
+
+Selected day keeps its level fill and adds a 1 px `accentColor` outline so
+selection is not color-only. Month names sit above the week columns; there is
+no weekday gutter. Calendar / activity uses `SlidingIconNav`; the year
+picker reuses `AdjustmentCombo`. The day hover tip follows the pointer.
 
 ---
 

--- a/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
@@ -996,6 +996,26 @@ auto AppTheme::scopeHistogramBlueColor() const -> QColor {
   return Blend(QColor(0x8E, 0xB9, 0xE5), textColor(), 0.18);
 }
 
+auto AppTheme::dateGraphLevel0Color() const -> QColor {
+  return Blend(bgBaseColor(), textMutedColor(), 0.22);
+}
+
+auto AppTheme::dateGraphLevel1Color() const -> QColor {
+  return Blend(bgBaseColor(), toneSteel(), 0.30);
+}
+
+auto AppTheme::dateGraphLevel2Color() const -> QColor {
+  return Blend(bgBaseColor(), toneSteel(), 0.52);
+}
+
+auto AppTheme::dateGraphLevel3Color() const -> QColor {
+  return Blend(bgBaseColor(), toneSteel(), 0.74);
+}
+
+auto AppTheme::dateGraphLevel4Color() const -> QColor {
+  return toneSteel();
+}
+
 auto AppTheme::uiFontFamily() const -> QString {
   RegisterFonts();
   return ActiveUiFamily(FontState());
@@ -1090,6 +1110,9 @@ auto AppTheme::spaceSm() const -> int { return 8; }
 auto AppTheme::spaceMd() const -> int { return 12; }
 auto AppTheme::spaceLg() const -> int { return 16; }
 auto AppTheme::spaceXl() const -> int { return 20; }
+auto AppTheme::dateGraphCellMinSize() const -> int { return 10; }
+auto AppTheme::dateGraphCellGap() const -> int { return 3; }
+auto AppTheme::dateGraphCellRadius() const -> int { return 2; }
 auto AppTheme::motionFoldOpenMs() const -> int { return 200; }
 auto AppTheme::motionFoldCloseMs() const -> int { return 160; }
 auto AppTheme::motionFadeMs() const -> int { return 120; }

--- a/alcedo_studio/src/ui/alcedo_main/i18n/alcedo_main_en.ts
+++ b/alcedo_studio/src/ui/alcedo_main/i18n/alcedo_main_en.ts
@@ -944,6 +944,52 @@
     </message>
 </context>
 <context>
+    <name>DateCommitGraph</name>
+    <message>
+        <source>Last year</source>
+        <translation>Last year</translation>
+    </message>
+    <message>
+        <source>Capture activity</source>
+        <translation>Capture activity</translation>
+    </message>
+    <message>
+        <source>No photos on %1</source>
+        <translation>No photos on %1</translation>
+    </message>
+    <message>
+        <source>%1 photo on %2</source>
+        <translation>%1 photo on %2</translation>
+    </message>
+    <message>
+        <source>%1 photos on %2</source>
+        <translation>%1 photos on %2</translation>
+    </message>
+    <message>
+        <source>Less</source>
+        <translation>Less</translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation>More</translation>
+    </message>
+    <message>
+        <source>No capture dates</source>
+        <translation>No capture dates</translation>
+    </message>
+</context>
+<context>
+    <name>DateFilterSection</name>
+    <message>
+        <source>Calendar</source>
+        <translation>Calendar</translation>
+    </message>
+    <message>
+        <source>Activity</source>
+        <translation>Activity</translation>
+    </message>
+</context>
+<context>
     <name>Alcedo</name>
     <message>
         <location filename="../album_backend/image_controller.cpp" line="+51"/>

--- a/alcedo_studio/src/ui/alcedo_main/i18n/alcedo_main_zh_CN.ts
+++ b/alcedo_studio/src/ui/alcedo_main/i18n/alcedo_main_zh_CN.ts
@@ -944,6 +944,52 @@
     </message>
 </context>
 <context>
+    <name>DateCommitGraph</name>
+    <message>
+        <source>Last year</source>
+        <translation>近一年</translation>
+    </message>
+    <message>
+        <source>Capture activity</source>
+        <translation>拍摄活跃度</translation>
+    </message>
+    <message>
+        <source>No photos on %1</source>
+        <translation>%1 没有照片</translation>
+    </message>
+    <message>
+        <source>%1 photo on %2</source>
+        <translation>%2 有 %1 张照片</translation>
+    </message>
+    <message>
+        <source>%1 photos on %2</source>
+        <translation>%2 有 %1 张照片</translation>
+    </message>
+    <message>
+        <source>Less</source>
+        <translation>少</translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation>多</translation>
+    </message>
+    <message>
+        <source>No capture dates</source>
+        <translation>没有拍摄日期</translation>
+    </message>
+</context>
+<context>
+    <name>DateFilterSection</name>
+    <message>
+        <source>Calendar</source>
+        <translation>日历</translation>
+    </message>
+    <message>
+        <source>Activity</source>
+        <translation>热力图</translation>
+    </message>
+</context>
+<context>
     <name>Alcedo</name>
     <message>
         <location filename="../album_backend/image_controller.cpp" line="+51"/>

--- a/alcedo_studio/src/ui/alcedo_main/qml/AlbumInspectorPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/AlbumInspectorPanel.qml
@@ -93,14 +93,14 @@ ScrollView {
             Layout.bottomMargin: 20
             spacing: 24
 
-            StatsCard {
+            DateFilterSection {
                 Layout.fillWidth: true
                 title: qsTr("By Capture Date")
                 accentColor: appTheme.toneSteel
                 model: appModules.stats.dateStats
                 selectedLabel: appModules.stats.statsFilterDate
-                displayMode: "grouped"
-                onBarClicked: function(label) { appModules.stats.ToggleStatsFilter("date", label) }
+                folderKey: appModules.folders.currentFolderId
+                onDayClicked: function(label) { appModules.stats.ToggleStatsFilter("date", label) }
             }
 
             StatsCard {

--- a/alcedo_studio/src/ui/alcedo_main/qml/DateCommitGraph.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/DateCommitGraph.qml
@@ -1,0 +1,656 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// GitHub-style capture heatmap. Week columns (7 weekday rows) wrap to the
+// inspector width. The default window is one year ending on the latest dated
+// photo in `model` (dateStats {label, count}); calendar years are optional.
+// Reads the already-loaded stats list — no extra queries.
+Item {
+    id: root
+    objectName: "dateCommitGraph"
+
+    property var model: []
+    property string selectedLabel: ""
+    property var folderKey: 0
+    property color accentColor: appTheme.toneSteel
+    signal dayClicked(string label)
+
+    property string selectedYearKey: "rolling"
+    property var countsByDate: ({})
+    property string latestDate: ""
+    property var availableYears: []
+    property var histogramFolderKey
+
+    readonly property color textColor: appTheme.textColor
+    readonly property color mutedTextColor: appTheme.textMutedColor
+    readonly property int cellMinSize: appTheme.dateGraphCellMinSize
+    readonly property int cellGap: appTheme.dateGraphCellGap
+    readonly property int cellRadius: appTheme.dateGraphCellRadius
+    readonly property int monthLabelHeight: appTheme.lineHeightCaption
+    readonly property int wrapRowGap: appTheme.spaceSm
+    readonly property var levelColors: [
+        appTheme.dateGraphLevel0Color,
+        appTheme.dateGraphLevel1Color,
+        appTheme.dateGraphLevel2Color,
+        appTheme.dateGraphLevel3Color,
+        appTheme.dateGraphLevel4Color
+    ]
+
+    readonly property int gridInnerWidth: Math.max(cellMinSize, width)
+    readonly property int weeksPerRow: {
+        const pitch = cellMinSize + cellGap
+        return Math.max(1, Math.floor((gridInnerWidth + cellGap) / pitch))
+    }
+    readonly property int cellSize: {
+        const gaps = Math.max(0, weeksPerRow - 1) * cellGap
+        return Math.max(cellMinSize, Math.floor((gridInnerWidth - gaps) / weeksPerRow))
+    }
+    readonly property int weekPitch: cellSize + cellGap
+    readonly property int weekColumnHeight: 7 * cellSize + 6 * cellGap
+    readonly property int wrapRowHeight: monthLabelHeight + weekColumnHeight + wrapRowGap
+
+    readonly property var yearOptions: {
+        const opts = [{ value: "rolling", label: qsTr("Last year") }]
+        const years = availableYears
+        for (let i = 0; i < years.length; ++i)
+            opts.push({ value: years[i], label: String(years[i]) })
+        return opts
+    }
+
+    readonly property var dateWindow: {
+        const end = parseIso(latestDate)
+        if (!end)
+            return { startLabel: "", endLabel: "", dayCount: 0 }
+        let start = null
+        if (selectedYearKey !== "rolling") {
+            const year = Number(selectedYearKey)
+            if (year >= 1000) {
+                start = new Date(year, 0, 1)
+                end.setFullYear(year, 11, 31)
+            }
+        }
+        if (!start)
+            start = rollingStart(end)
+        let n = 0
+        const cursor = new Date(start.getFullYear(), start.getMonth(), start.getDate())
+        const last = new Date(end.getFullYear(), end.getMonth(), end.getDate())
+        while (cursor <= last) {
+            ++n
+            cursor.setDate(cursor.getDate() + 1)
+        }
+        return {
+            startLabel: formatIso(start),
+            endLabel: formatIso(end),
+            dayCount: n
+        }
+    }
+
+    readonly property int dayCount: dateWindow.dayCount
+    readonly property string startDate: dateWindow.startLabel
+    readonly property string endDate: dateWindow.endLabel
+    readonly property int histogramSize: Object.keys(countsByDate).length
+
+    readonly property var weeks: buildWeeks()
+    readonly property var wrapRows: {
+        const all = weeks
+        const per = weeksPerRow
+        const rows = []
+        for (let i = 0; i < all.length; i += per)
+            rows.push(all.slice(i, i + per))
+        return rows
+    }
+
+    property int hoverWeekIndex: -1
+    property int hoverDayIndex: -1
+    property string hoveredLabel: ""
+    property int hoveredCount: 0
+    property real hoverMouseX: 0
+    property real hoverMouseY: 0
+    property var lastCellInfo: ({ found: false, level: -1, count: 0, x: 0, y: 0 })
+    property string pendingFilterLabel: ""
+
+    implicitHeight: col.implicitHeight
+    implicitWidth: 200
+    width: parent ? parent.width : implicitWidth
+    Accessible.role: Accessible.Grouping
+    Accessible.name: qsTr("Capture activity")
+
+    QtObject {
+        id: yearComboModel
+        readonly property string label: ""
+        readonly property bool enabled: true
+        readonly property var entries: root.yearOptions
+        readonly property int currentIndex: {
+            const opts = root.yearOptions
+            for (let i = 0; i < opts.length; ++i) {
+                if (String(opts[i].value) === root.selectedYearKey)
+                    return i
+            }
+            return 0
+        }
+        function selectIndex(index) {
+            const opts = root.yearOptions
+            if (index >= 0 && index < opts.length)
+                root.selectYear(String(opts[index].value))
+        }
+    }
+
+    onModelChanged: ingestHistogram()
+    onSelectedLabelChanged: {
+        if (selectedLabel.length === 0)
+            ingestHistogram()
+    }
+    onFolderKeyChanged: ingestHistogram()
+    Component.onCompleted: ingestHistogram()
+
+    function isIsoDate(label) {
+        return typeof label === "string" && label.length === 10
+                && label.charCodeAt(4) === 45 && label.charCodeAt(7) === 45
+    }
+
+    function parseIso(label) {
+        if (!isIsoDate(label))
+            return null
+        const year = Number(label.slice(0, 4))
+        const month = Number(label.slice(5, 7))
+        const day = Number(label.slice(8, 10))
+        if (!year || month < 1 || month > 12 || day < 1)
+            return null
+        return new Date(year, month - 1, day)
+    }
+
+    function pad2(value) {
+        return value < 10 ? "0" + value : String(value)
+    }
+
+    function formatIso(date) {
+        return date.getFullYear() + "-" + pad2(date.getMonth() + 1) + "-" + pad2(date.getDate())
+    }
+
+    function rollingStart(end) {
+        const next = new Date(end.getFullYear(), end.getMonth(), end.getDate() + 1)
+        next.setFullYear(next.getFullYear() - 1)
+        return next
+    }
+
+    function levelFor(count, maxCount) {
+        if (count <= 0 || maxCount <= 0)
+            return 0
+        if (maxCount === 1)
+            return 4
+        const ratio = count / maxCount
+        if (ratio > 0.75)
+            return 4
+        if (ratio > 0.50)
+            return 3
+        if (ratio > 0.25)
+            return 2
+        return 1
+    }
+
+    function readIncomingHistogram() {
+        const next = {}
+        const yearSet = {}
+        let latest = ""
+        const rows = model || []
+        for (let i = 0; i < rows.length; ++i) {
+            const label = String(rows[i].label)
+            if (!isIsoDate(label))
+                continue
+            next[label] = Number(rows[i].count)
+            if (label > latest)
+                latest = label
+            yearSet[label.slice(0, 4)] = true
+        }
+        const years = Object.keys(yearSet)
+        years.sort()
+        years.reverse()
+        return { counts: next, latest: latest, years: years }
+    }
+
+    function incomingIsDateFilterEcho(incoming) {
+        if (latestDate.length === 0)
+            return false
+        const keys = Object.keys(incoming)
+        const cachedKeys = Object.keys(countsByDate)
+        if (keys.length === 0 || keys.length >= cachedKeys.length)
+            return false
+        for (let i = 0; i < keys.length; ++i) {
+            const label = keys[i]
+            if (!Object.prototype.hasOwnProperty.call(countsByDate, label))
+                return false
+            if (Number(incoming[label]) !== Number(countsByDate[label]))
+                return false
+        }
+        return true
+    }
+
+    function applyHistogram(parsed) {
+        countsByDate = parsed.counts
+        latestDate = parsed.latest
+        availableYears = parsed.years
+        histogramFolderKey = folderKey
+        if (selectedYearKey !== "rolling" && parsed.years.indexOf(selectedYearKey) < 0)
+            selectedYearKey = "rolling"
+    }
+
+    function ingestHistogram() {
+        const parsed = readIncomingHistogram()
+        const folderChanged = String(folderKey) !== String(histogramFolderKey)
+        if (folderChanged || latestDate.length === 0) {
+            pendingFilterLabel = ""
+            applyHistogram(parsed)
+            return
+        }
+
+        if (pendingFilterLabel.length > 0) {
+            pendingFilterLabel = ""
+            return
+        }
+
+        if (selectedLabel.length > 0 || incomingIsDateFilterEcho(parsed.counts))
+            return
+
+        applyHistogram(parsed)
+    }
+
+    function requestDayFilter(label) {
+        if (label.length === 0)
+            return
+        pendingFilterLabel = label
+        dayClicked(label)
+    }
+
+    function selectYear(key) {
+        if (key === "rolling") {
+            selectedYearKey = "rolling"
+            return
+        }
+        if (availableYears.indexOf(key) >= 0)
+            selectedYearKey = key
+    }
+
+    function cellInfo(label) {
+        const all = weeks
+        const per = weeksPerRow
+        for (let w = 0; w < all.length; ++w) {
+            const days = all[w].days
+            for (let d = 0; d < days.length; ++d) {
+                const cell = days[d]
+                if (!cell || !cell.inWindow || cell.label !== label)
+                    continue
+                const row = Math.floor(w / per)
+                const col = w % per
+                return {
+                    found: true,
+                    level: cell.level,
+                    count: cell.count,
+                    x: col * weekPitch + cellSize * 0.5,
+                    y: row * wrapRowHeight + monthLabelHeight + d * weekPitch + cellSize * 0.5
+                }
+            }
+        }
+        return { found: false, level: -1, count: 0, x: 0, y: 0 }
+    }
+
+    function inspectCell(label) {
+        lastCellInfo = cellInfo(label)
+    }
+
+    function emptyPadCell() {
+        return { label: "", count: 0, level: 0, inWindow: false, month: -1, day: 0 }
+    }
+
+    function buildWeeks() {
+        const win = dateWindow
+        const start = parseIso(win.startLabel)
+        if (!start)
+            return []
+
+        const counts = countsByDate
+        const days = []
+        let maxCount = 0
+        const cursor = new Date(start.getFullYear(), start.getMonth(), start.getDate())
+        for (let i = 0; i < win.dayCount; ++i) {
+            const label = formatIso(cursor)
+            const count = Number(counts[label] || 0)
+            if (count > maxCount)
+                maxCount = count
+            days.push({
+                label: label,
+                count: count,
+                level: 0,
+                inWindow: true,
+                month: cursor.getMonth(),
+                day: cursor.getDate()
+            })
+            cursor.setDate(cursor.getDate() + 1)
+        }
+        for (let i = 0; i < days.length; ++i)
+            days[i].level = levelFor(days[i].count, maxCount)
+
+        const loc = Qt.locale()
+        const firstDow = loc.firstDayOfWeek === 7 ? 0 : loc.firstDayOfWeek
+        const lead = (start.getDay() - firstDow + 7) % 7
+        const cells = []
+        for (let i = 0; i < lead; ++i)
+            cells.push(emptyPadCell())
+        for (let i = 0; i < days.length; ++i)
+            cells.push(days[i])
+        while (cells.length % 7 !== 0)
+            cells.push(emptyPadCell())
+
+        const out = []
+        for (let i = 0; i < cells.length; i += 7) {
+            const slice = cells.slice(i, i + 7)
+            let month = -1
+            let showMonth = false
+            for (let d = 0; d < 7; ++d) {
+                if (slice[d].inWindow) {
+                    month = slice[d].month
+                    break
+                }
+            }
+            if (month >= 0) {
+                if (i === 0) {
+                    showMonth = true
+                } else {
+                    const prev = cells[i - 1]
+                    showMonth = !prev.inWindow || prev.month !== month
+                }
+            }
+            out.push({
+                days: slice,
+                showMonth: showMonth,
+                monthLabel: month >= 0
+                            ? loc.standaloneMonthName(month, Locale.ShortFormat)
+                            : ""
+            })
+        }
+        return out
+    }
+
+    function monthSpan(rowWeeks, index) {
+        if (!rowWeeks || index < 0 || index >= rowWeeks.length)
+            return 0
+        const week = rowWeeks[index]
+        if (!week || (index > 0 && !week.showMonth))
+            return 0
+        let span = 1
+        for (let i = index + 1; i < rowWeeks.length; ++i) {
+            if (rowWeeks[i].showMonth)
+                break
+            ++span
+        }
+        return span
+    }
+
+    function cellAt(px, py) {
+        if (px < 0 || wrapRows.length === 0)
+            return null
+        const row = Math.floor(py / wrapRowHeight)
+        if (row < 0 || row >= wrapRows.length)
+            return null
+        const localY = py - row * wrapRowHeight - monthLabelHeight
+        if (localY < 0)
+            return null
+        const day = Math.floor(localY / weekPitch)
+        if (day < 0 || day > 6)
+            return null
+        const col = Math.floor(px / weekPitch)
+        const rowWeeks = wrapRows[row]
+        if (col < 0 || col >= rowWeeks.length)
+            return null
+        const cell = rowWeeks[col].days[day]
+        if (!cell || !cell.inWindow)
+            return null
+        return { cell: cell, weekIndex: row * weeksPerRow + col, dayIndex: day }
+    }
+
+    function hoverText() {
+        if (hoveredLabel.length === 0)
+            return ""
+        const date = parseIso(hoveredLabel)
+        const dateText = date ? Qt.formatDate(date, Locale.LongFormat) : hoveredLabel
+        if (hoveredCount <= 0)
+            return qsTr("No photos on %1").arg(dateText)
+        if (hoveredCount === 1)
+            return qsTr("%1 photo on %2").arg(hoveredCount).arg(dateText)
+        return qsTr("%1 photos on %2").arg(hoveredCount).arg(dateText)
+    }
+
+    ColumnLayout {
+        id: col
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: appTheme.spaceSm
+
+        AdjustmentCombo {
+            id: yearCombo
+            objectName: "dateCommitGraphYearRow"
+            visible: latestDate.length > 0
+            Layout.fillWidth: true
+            showResetButton: false
+            controlObjectName: "dateCommitGraphYearCombo"
+            model: yearComboModel
+        }
+
+        Label {
+            visible: latestDate.length > 0
+            Layout.fillWidth: true
+            text: root.startDate + " – " + root.endDate
+            color: root.mutedTextColor
+            font.family: appTheme.dataFontFamily
+            font.pixelSize: appTheme.fontSizeCaption
+            font.weight: appTheme.fontWeightRegular
+        }
+
+        Item {
+            id: graphGrid
+            objectName: "dateCommitGraphGrid"
+            visible: root.weeks.length > 0
+            Layout.fillWidth: true
+            implicitHeight: Math.max(0, root.wrapRows.length * root.wrapRowHeight
+                                     - (root.wrapRows.length > 0 ? root.wrapRowGap : 0))
+
+            Repeater {
+                model: root.wrapRows.length
+                delegate: Item {
+                    id: wrapRow
+                    required property int index
+                    readonly property var rowWeeks: root.wrapRows[index]
+                    width: graphGrid.width
+                    height: root.wrapRowHeight - root.wrapRowGap
+                    y: index * root.wrapRowHeight
+
+                    Repeater {
+                        model: wrapRow.rowWeeks.length
+                        delegate: Label {
+                            required property int index
+                            readonly property var week: wrapRow.rowWeeks[index]
+                            readonly property bool showLabel: index === 0
+                                    || (week && week.showMonth)
+                            readonly property int span: showLabel
+                                    ? root.monthSpan(wrapRow.rowWeeks, index) : 0
+                            x: index * root.weekPitch
+                            width: Math.max(root.cellSize, span * root.weekPitch - root.cellGap)
+                            height: root.monthLabelHeight
+                            visible: showLabel && week && week.monthLabel.length > 0
+                            text: week ? week.monthLabel : ""
+                            color: root.mutedTextColor
+                            font.family: appTheme.uiFontFamily
+                            font.pixelSize: appTheme.fontSizeCaption
+                            font.weight: appTheme.fontWeightRegular
+                            elide: Text.ElideRight
+                        }
+                    }
+
+                    Repeater {
+                        model: wrapRow.rowWeeks.length
+                        delegate: Item {
+                            id: weekCol
+                            required property int index
+                            readonly property var week: wrapRow.rowWeeks[index]
+                            readonly property int weekIndex: wrapRow.index * root.weeksPerRow + index
+                            x: index * root.weekPitch
+                            y: root.monthLabelHeight
+                            width: root.cellSize
+                            height: root.weekColumnHeight
+
+                            Repeater {
+                                model: 7
+                                delegate: Rectangle {
+                                    required property int index
+                                    readonly property var cell: weekCol.week
+                                                                ? weekCol.week.days[index] : null
+                                    readonly property bool inWindow: cell ? cell.inWindow : false
+                                    readonly property bool isSelected: inWindow
+                                            && cell.label === root.selectedLabel
+                                            && root.selectedLabel.length > 0
+                                    y: index * root.weekPitch
+                                    width: root.cellSize
+                                    height: root.cellSize
+                                    radius: root.cellRadius
+                                    objectName: inWindow && cell
+                                                ? "dateCommitGraphCell_" + cell.label : ""
+                                    color: cell ? (root.levelColors[cell.level] || root.levelColors[0])
+                                                : "transparent"
+                                    border.width: isSelected ? 1 : 0
+                                    border.color: root.accentColor
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                visible: root.hoverWeekIndex >= 0
+                x: (root.hoverWeekIndex % root.weeksPerRow) * root.weekPitch
+                y: Math.floor(root.hoverWeekIndex / root.weeksPerRow) * root.wrapRowHeight
+                   + root.monthLabelHeight + root.hoverDayIndex * root.weekPitch
+                width: root.cellSize
+                height: root.cellSize
+                radius: root.cellRadius
+                color: "transparent"
+                border.width: 1
+                border.color: root.textColor
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                cursorShape: Qt.PointingHandCursor
+                onPositionChanged: function(mouse) {
+                    root.hoverMouseX = mouse.x
+                    root.hoverMouseY = mouse.y
+                    const hit = root.cellAt(mouse.x, mouse.y)
+                    if (!hit) {
+                        root.hoverWeekIndex = -1
+                        root.hoverDayIndex = -1
+                        root.hoveredLabel = ""
+                        root.hoveredCount = 0
+                        return
+                    }
+                    root.hoverWeekIndex = hit.weekIndex
+                    root.hoverDayIndex = hit.dayIndex
+                    root.hoveredLabel = hit.cell.label
+                    root.hoveredCount = hit.cell.count
+                }
+                onExited: {
+                    root.hoverWeekIndex = -1
+                    root.hoverDayIndex = -1
+                    root.hoveredLabel = ""
+                    root.hoveredCount = 0
+                }
+                onClicked: function(mouse) {
+                    if (mouse.button === Qt.RightButton) {
+                        if (root.selectedLabel.length > 0)
+                            root.requestDayFilter(root.selectedLabel)
+                        return
+                    }
+                    const hit = root.cellAt(mouse.x, mouse.y)
+                    if (hit && hit.cell.count > 0)
+                        root.requestDayFilter(hit.cell.label)
+                }
+            }
+
+            ToolTip {
+                id: cellTip
+                parent: Overlay.overlay
+                visible: root.hoveredLabel.length > 0 && Overlay.overlay !== null
+                text: root.hoverText()
+                delay: 160
+                timeout: -1
+                x: {
+                    const layer = Overlay.overlay
+                    if (!layer)
+                        return 0
+                    const pad = appTheme.spaceSm
+                    const mapped = graphGrid.mapToItem(layer, root.hoverMouseX + pad, 0)
+                    return Math.min(mapped.x, Math.max(0, layer.width - implicitWidth))
+                }
+                y: {
+                    const layer = Overlay.overlay
+                    if (!layer)
+                        return 0
+                    const pad = appTheme.spaceSm
+                    const below = graphGrid.mapToItem(layer, 0, root.hoverMouseY + pad).y
+                    if (below + implicitHeight <= layer.height)
+                        return below
+                    return Math.max(0, graphGrid.mapToItem(layer, 0, root.hoverMouseY).y
+                                    - implicitHeight - pad)
+                }
+            }
+        }
+
+        RowLayout {
+            id: legend
+            objectName: "dateCommitGraphLegend"
+            visible: root.weeks.length > 0
+            Layout.fillWidth: true
+            spacing: appTheme.spaceXs
+
+            Label {
+                text: qsTr("Less")
+                color: root.mutedTextColor
+                font.family: appTheme.uiFontFamily
+                font.pixelSize: appTheme.fontSizeCaption
+            }
+
+            Repeater {
+                model: 5
+                delegate: Rectangle {
+                    required property int index
+                    Layout.preferredWidth: root.cellMinSize
+                    Layout.preferredHeight: root.cellMinSize
+                    radius: root.cellRadius
+                    color: root.levelColors[index]
+                }
+            }
+
+            Label {
+                text: qsTr("More")
+                color: root.mutedTextColor
+                font.family: appTheme.uiFontFamily
+                font.pixelSize: appTheme.fontSizeCaption
+            }
+
+            Item { Layout.fillWidth: true }
+        }
+
+        Label {
+            visible: latestDate.length === 0
+            Layout.fillWidth: true
+            Layout.topMargin: appTheme.spaceXs
+            horizontalAlignment: Text.AlignHCenter
+            text: qsTr("No capture dates")
+            color: root.mutedTextColor
+            font.family: appTheme.uiFontFamily
+            font.pixelSize: appTheme.fontSizeCaption
+            font.italic: true
+        }
+    }
+}

--- a/alcedo_studio/src/ui/alcedo_main/qml/DateFilterSection.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/DateFilterSection.qml
@@ -1,0 +1,122 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Album-inspector date filter: calendar tiles or a GitHub-style activity graph.
+// Style is local; both views consume the same dateStats list and emit one
+// day-clicked label for StatsEngine.ToggleStatsFilter("date", …).
+ColumnLayout {
+    id: section
+    objectName: "dateFilterSection"
+    spacing: appTheme.spaceSm
+
+    property string title: ""
+    property var model: []
+    property string selectedLabel: ""
+    property var folderKey: 0
+    property color accentColor: appTheme.toneSteel
+    property bool expanded: true
+    property string styleKey: "calendar"
+    signal dayClicked(string label)
+
+    readonly property var styleItems: [
+        {
+            key: "calendar",
+            icon: "qrc:/panel_icons/calendar.svg",
+            label: qsTr("Calendar"),
+            itemObjectName: "dateFilterStyleCalendar"
+        },
+        {
+            key: "activity",
+            icon: "qrc:/panel_icons/layout-grid.svg",
+            label: qsTr("Activity"),
+            itemObjectName: "dateFilterStyleActivity"
+        }
+    ]
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: appTheme.spaceXs
+
+        Label {
+            text: section.title.toUpperCase()
+            color: appTheme.textMutedColor
+            font.pixelSize: 10
+            font.weight: 700
+            font.letterSpacing: 1.6
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        Item { Layout.fillWidth: true }
+
+        Label {
+            text: section.expanded ? "▲" : "▼"
+            color: appTheme.textMutedColor
+            font.pixelSize: 9
+            Layout.alignment: Qt.AlignVCenter
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: section.expanded = !section.expanded
+            }
+        }
+    }
+
+    SlidingIconNav {
+        id: styleNav
+        objectName: "dateFilterStyleNav"
+        visible: section.expanded
+        Layout.alignment: Qt.AlignLeft
+        currentKey: section.styleKey
+        items: section.styleItems
+        thumbObjectName: "dateFilterStyleNavThumb"
+        onActivated: function(key) {
+            section.styleKey = key
+        }
+    }
+
+    Loader {
+        id: calendarLoader
+        objectName: "dateFilterCalendarLoader"
+        Layout.fillWidth: true
+        active: section.expanded && section.styleKey === "calendar"
+        visible: status === Loader.Ready
+        Layout.preferredHeight: (status === Loader.Ready && item) ? item.implicitHeight : 0
+        sourceComponent: calendarComponent
+    }
+
+    Loader {
+        id: graphLoader
+        objectName: "dateFilterGraphLoader"
+        Layout.fillWidth: true
+        active: section.expanded && section.styleKey === "activity"
+        asynchronous: true
+        visible: status === Loader.Ready
+        Layout.preferredHeight: (status === Loader.Ready && item) ? item.implicitHeight : 0
+        sourceComponent: graphComponent
+    }
+
+    Component {
+        id: calendarComponent
+        StatsCard {
+            title: section.title
+            showHeader: false
+            accentColor: section.accentColor
+            model: section.model
+            selectedLabel: section.selectedLabel
+            displayMode: "grouped"
+            onBarClicked: function(label) { section.dayClicked(label) }
+        }
+    }
+
+    Component {
+        id: graphComponent
+        DateCommitGraph {
+            model: section.model
+            selectedLabel: section.selectedLabel
+            folderKey: section.folderKey
+            accentColor: section.accentColor
+            onDayClicked: function(label) { section.dayClicked(label) }
+        }
+    }
+}

--- a/alcedo_studio/src/ui/alcedo_main/qml/StatsCard.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/StatsCard.qml
@@ -14,6 +14,7 @@ Item {
     readonly property int chipPreviewLimit: 3
     property string selectedLabel: ""
     property string displayMode: "bars"
+    property bool showHeader: true
     property var yearExpansion: ({})
     signal barClicked(string label)
 
@@ -164,6 +165,7 @@ Item {
 
         RowLayout {
             Layout.fillWidth: true
+            visible: card.showHeader
 
             Label {
                 text: card.title.toUpperCase()

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -1141,6 +1141,40 @@ target_link_libraries(EditorCdlTrackballGeometryTest
 alcedo_ui_gtest_discover_tests(EditorCdlTrackballGeometryTest TEST_PREFIX "EditorCdlTrackballGeometryTest.")
 alcedo_register_test_target(EditorCdlTrackballGeometryTest ui)
 
+# Library date activity graph: rolling year from latest photo, leap-year cells,
+# histogram cache across a date filter, and calendar/activity style switch.
+add_executable(DateCommitGraphQmlTest
+    ${ALCEDO_TEST_ROOT}/ui/date_commit_graph_qml_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
+    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
+    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
+    ${ALCEDO_SRC_DIR}/config/resource.qrc
+)
+target_include_directories(DateCommitGraphQmlTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR}
+)
+target_link_libraries(DateCommitGraphQmlTest
+    PRIVATE
+        GTest::gtest
+        Qt6::Core
+        Qt6::Test
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::Svg
+        Qt6::Widgets
+)
+target_compile_definitions(DateCommitGraphQmlTest
+    PRIVATE ALCEDO_TEST_SRC_DIR="${ALCEDO_SRC_DIR}"
+)
+set_target_properties(DateCommitGraphQmlTest PROPERTIES AUTOMOC ON)
+alcedo_ui_gtest_discover_tests(DateCommitGraphQmlTest
+    TEST_PREFIX "DateCommitGraphQmlTest."
+    PROPERTIES LABELS "workspace_qml;date_filter"
+)
+alcedo_register_test_target(DateCommitGraphQmlTest ui)
+
 # LUT panel QML: selection scroll contract, favorites, filter, appTheme VI tokens.
 add_executable(EditorLutPanelQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_lut_panel_qml_test.cpp

--- a/alcedo_studio/tests/ui/date_commit_graph_qml_test.cpp
+++ b/alcedo_studio/tests/ui/date_commit_graph_qml_test.cpp
@@ -1,0 +1,383 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <QEventLoop>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QQmlError>
+#include <QQmlExpression>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QSignalSpy>
+#include <QTest>
+#include <QTimer>
+#include <QUrl>
+#include <QVariantList>
+#include <QVariantMap>
+#include <chrono>
+#include <filesystem>
+#include <functional>
+
+#include "ui/alcedo_main/app_theme.hpp"
+
+namespace alcedo::ui::test {
+namespace {
+
+auto SrcQmlDir() -> QString {
+  return QString::fromStdString(
+      (std::filesystem::path(ALCEDO_TEST_SRC_DIR) / "ui" / "alcedo_main" / "qml").string());
+}
+
+void ProcessEvents(int ms) {
+  QEventLoop loop;
+  QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+  loop.exec();
+}
+
+auto WaitUntil(const std::function<bool()>& pred, int timeoutMs) -> bool {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (pred()) {
+      return true;
+    }
+    ProcessEvents(20);
+  }
+  return pred();
+}
+
+auto Row(const QString& label, int count) -> QVariantMap {
+  return QVariantMap{{QStringLiteral("label"), label}, {QStringLiteral("count"), count}};
+}
+
+constexpr char kGraphHarness[] = R"(
+import QtQuick
+import QtQuick.Controls
+
+ApplicationWindow {
+    id: root
+    objectName: "dateCommitGraphHarness"
+    width: 268
+    height: 820
+    visible: true
+    color: appTheme.bgCanvasColor
+    property var dateModel: []
+    property string selectedDate: ""
+    property int folderId: 0
+    property string lastClicked: ""
+    property var graphItem: host.item
+
+    Loader {
+        id: host
+        objectName: "dateCommitGraphLoader"
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        source: graphSourceUrl
+        onLoaded: {
+            if (!item)
+                return
+            item.model = Qt.binding(function() { return root.dateModel })
+            item.selectedLabel = Qt.binding(function() { return root.selectedDate })
+            item.folderKey = Qt.binding(function() { return root.folderId })
+            item.dayClicked.connect(function(label) { root.lastClicked = label })
+        }
+    }
+}
+)";
+
+constexpr char kSectionHarness[] = R"(
+import QtQuick
+import QtQuick.Controls
+
+ApplicationWindow {
+    id: root
+    objectName: "dateFilterSectionHarness"
+    width: 268
+    height: 820
+    visible: true
+    color: appTheme.bgCanvasColor
+    property var dateModel: []
+    property string selectedDate: ""
+    property int folderId: 0
+    property string lastClicked: ""
+    property var sectionItem: host.item
+
+    Loader {
+        id: host
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        source: sectionSourceUrl
+        onLoaded: {
+            if (!item)
+                return
+            item.title = "By Capture Date"
+            item.model = Qt.binding(function() { return root.dateModel })
+            item.selectedLabel = Qt.binding(function() { return root.selectedDate })
+            item.folderKey = Qt.binding(function() { return root.folderId })
+            item.dayClicked.connect(function(label) { root.lastClicked = label })
+        }
+    }
+}
+)";
+
+struct GraphHarness {
+  QQmlApplicationEngine engine;
+  QQuickWindow*         window = nullptr;
+  QQuickItem*           graph  = nullptr;
+  QStringList           warnings;
+
+  GraphHarness() {
+    QObject::connect(&engine, &QQmlEngine::warnings, [this](const QList<QQmlError>& ws) {
+      for (const auto& w : ws) {
+        warnings << w.toString();
+      }
+    });
+    AppTheme::Instance().setReduceMotion(true);
+    engine.addImportPath(QStringLiteral("qrc:/"));
+    engine.addImportPath(SrcQmlDir());
+    engine.rootContext()->setContextProperty(QStringLiteral("appTheme"), &AppTheme::Instance());
+    engine.rootContext()->setContextProperty(
+        QStringLiteral("graphSourceUrl"),
+        QUrl::fromLocalFile(SrcQmlDir() + QStringLiteral("/DateCommitGraph.qml")));
+    engine.loadData(QByteArray{kGraphHarness},
+                    QUrl(QStringLiteral("file:///DateCommitGraphHarness.qml")));
+    window = qobject_cast<QQuickWindow*>(engine.rootObjects().value(0, nullptr));
+    if (window != nullptr) {
+      window->show();
+      (void)QTest::qWaitForWindowExposed(window);
+      (void)WaitUntil([this] {
+        graph = window->findChild<QQuickItem*>(QStringLiteral("dateCommitGraph"));
+        return graph != nullptr;
+      }, 2000);
+      graph = window->findChild<QQuickItem*>(QStringLiteral("dateCommitGraph"));
+    }
+  }
+
+  void setModel(const QVariantList& rows) {
+    window->setProperty("dateModel", rows);
+    ProcessEvents(40);
+  }
+
+  void setSelected(const QString& label) {
+    window->setProperty("selectedDate", label);
+    ProcessEvents(20);
+  }
+
+  void setFolder(int folder_id) {
+    window->setProperty("folderId", folder_id);
+    ProcessEvents(20);
+  }
+
+  auto inspect(const QString& label) -> QVariantMap {
+    if (graph == nullptr) {
+      return {};
+    }
+    const QString expr =
+        QStringLiteral("inspectCell(\"%1\")").arg(label);
+    QQmlExpression qml_expr(qmlContext(graph), graph, expr);
+    (void)qml_expr.evaluate();
+    ProcessEvents(10);
+    return graph->property("lastCellInfo").toMap();
+  }
+};
+
+struct SectionHarness {
+  QQmlApplicationEngine engine;
+  QQuickWindow*         window  = nullptr;
+  QQuickItem*           section = nullptr;
+  QStringList           warnings;
+
+  SectionHarness() {
+    QObject::connect(&engine, &QQmlEngine::warnings, [this](const QList<QQmlError>& ws) {
+      for (const auto& w : ws) {
+        warnings << w.toString();
+      }
+    });
+    AppTheme::Instance().setReduceMotion(true);
+    engine.addImportPath(QStringLiteral("qrc:/"));
+    engine.addImportPath(SrcQmlDir());
+    engine.rootContext()->setContextProperty(QStringLiteral("appTheme"), &AppTheme::Instance());
+    engine.rootContext()->setContextProperty(
+        QStringLiteral("sectionSourceUrl"),
+        QUrl::fromLocalFile(SrcQmlDir() + QStringLiteral("/DateFilterSection.qml")));
+    engine.loadData(QByteArray{kSectionHarness},
+                    QUrl(QStringLiteral("file:///DateFilterSectionHarness.qml")));
+    window = qobject_cast<QQuickWindow*>(engine.rootObjects().value(0, nullptr));
+    if (window != nullptr) {
+      window->show();
+      (void)QTest::qWaitForWindowExposed(window);
+      (void)WaitUntil([this] {
+        section = window->findChild<QQuickItem*>(QStringLiteral("dateFilterSection"));
+        return section != nullptr;
+      }, 2000);
+      section = window->findChild<QQuickItem*>(QStringLiteral("dateFilterSection"));
+    }
+  }
+};
+
+}  // namespace
+
+TEST(DateCommitGraphQmlTest, TokensMatchAppTheme) {
+  auto& theme = AppTheme::Instance();
+  EXPECT_EQ(theme.dateGraphCellMinSize(), 10);
+  EXPECT_EQ(theme.dateGraphCellGap(), 3);
+  EXPECT_EQ(theme.dateGraphCellRadius(), 2);
+  EXPECT_EQ(theme.dateGraphLevel4Color(), theme.toneSteel());
+}
+
+TEST(DateCommitGraphQmlTest, RollingWindowEndsOnLatestPhotoAndHasYearOfDays) {
+  GraphHarness h;
+  ASSERT_NE(h.window, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+  ASSERT_NE(h.graph, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+
+  h.setModel(QVariantList{Row(QStringLiteral("(unknown)"), 3), Row(QStringLiteral("2024-02-29"), 1),
+                          Row(QStringLiteral("2026-05-25"), 4)});
+
+  EXPECT_EQ(h.graph->property("latestDate").toString(), QStringLiteral("2026-05-25"));
+  EXPECT_EQ(h.graph->property("selectedYearKey").toString(), QStringLiteral("rolling"));
+  EXPECT_EQ(h.graph->property("startDate").toString(), QStringLiteral("2025-05-26"));
+  EXPECT_EQ(h.graph->property("endDate").toString(), QStringLiteral("2026-05-25"));
+  EXPECT_EQ(h.graph->property("dayCount").toInt(), 365);
+  EXPECT_EQ(h.graph->property("histogramSize").toInt(), 2);
+}
+
+TEST(DateCommitGraphQmlTest, CalendarLeapYearExposesEveryDay) {
+  GraphHarness h;
+  ASSERT_NE(h.graph, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+
+  h.setModel(QVariantList{Row(QStringLiteral("2024-02-29"), 2),
+                          Row(QStringLiteral("2026-05-25"), 4)});
+  ASSERT_TRUE(h.graph->setProperty("selectedYearKey", QStringLiteral("2024")));
+  ProcessEvents(20);
+
+  EXPECT_EQ(h.graph->property("selectedYearKey").toString(), QStringLiteral("2024"));
+  EXPECT_EQ(h.graph->property("startDate").toString(), QStringLiteral("2024-01-01"));
+  EXPECT_EQ(h.graph->property("endDate").toString(), QStringLiteral("2024-12-31"));
+  EXPECT_EQ(h.graph->property("dayCount").toInt(), 366);
+  const auto leap = h.inspect(QStringLiteral("2024-02-29"));
+  EXPECT_TRUE(leap.value(QStringLiteral("found")).toBool());
+  EXPECT_EQ(leap.value(QStringLiteral("count")).toInt(), 2);
+}
+
+TEST(DateCommitGraphQmlTest, ClickingOccupiedDayEmitsIsoLabel) {
+  GraphHarness h;
+  ASSERT_NE(h.graph, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+  ASSERT_NE(h.window, nullptr);
+
+  h.setModel(QVariantList{Row(QStringLiteral("2026-05-25"), 5)});
+  auto* grid = h.window->findChild<QQuickItem*>(QStringLiteral("dateCommitGraphGrid"));
+  ASSERT_NE(grid, nullptr);
+  const auto info = h.inspect(QStringLiteral("2026-05-25"));
+  ASSERT_TRUE(info.value(QStringLiteral("found")).toBool());
+
+  QSignalSpy spy(h.graph, SIGNAL(dayClicked(QString)));
+  const QPointF local(info.value(QStringLiteral("x")).toReal(),
+                      info.value(QStringLiteral("y")).toReal());
+  QTest::mouseClick(h.window, Qt::LeftButton, Qt::NoModifier, grid->mapToScene(local).toPoint());
+  ProcessEvents(40);
+
+  EXPECT_GE(spy.count(), 1);
+  if (spy.count() > 0) {
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("2026-05-25"));
+  }
+  EXPECT_EQ(h.window->property("lastClicked").toString(), QStringLiteral("2026-05-25"));
+}
+
+TEST(DateCommitGraphQmlTest, DateFilterShrinkDoesNotDropCachedHistogram) {
+  GraphHarness h;
+  ASSERT_NE(h.graph, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+
+  h.setModel(QVariantList{Row(QStringLiteral("2025-01-02"), 1),
+                          Row(QStringLiteral("2026-05-25"), 4)});
+  EXPECT_EQ(h.graph->property("histogramSize").toInt(), 2);
+
+  h.setSelected(QStringLiteral("2026-05-25"));
+  h.setModel(QVariantList{Row(QStringLiteral("2026-05-25"), 4)});
+  EXPECT_EQ(h.graph->property("histogramSize").toInt(), 2);
+  EXPECT_EQ(h.graph->property("latestDate").toString(), QStringLiteral("2026-05-25"));
+}
+
+TEST(DateCommitGraphQmlTest, StatsRefreshBeforeSelectionKeepsYearHeatmap) {
+  GraphHarness h;
+  ASSERT_NE(h.graph, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+
+  h.setModel(QVariantList{Row(QStringLiteral("2025-06-01"), 1),
+                          Row(QStringLiteral("2026-05-25"), 4)});
+  EXPECT_EQ(h.graph->property("histogramSize").toInt(), 2);
+  EXPECT_EQ(h.graph->property("dayCount").toInt(), 365);
+
+  // StatsEngine emits StatsChanged (shrunk buckets) before StatsFilterChanged.
+  h.setModel(QVariantList{Row(QStringLiteral("2026-05-25"), 4)});
+  EXPECT_EQ(h.graph->property("histogramSize").toInt(), 2);
+  EXPECT_EQ(h.graph->property("latestDate").toString(), QStringLiteral("2026-05-25"));
+  EXPECT_EQ(h.graph->property("dayCount").toInt(), 365);
+  EXPECT_TRUE(h.inspect(QStringLiteral("2025-06-01")).value(QStringLiteral("found")).toBool());
+  EXPECT_EQ(h.inspect(QStringLiteral("2025-06-01")).value(QStringLiteral("count")).toInt(), 1);
+
+  h.setSelected(QStringLiteral("2026-05-25"));
+  EXPECT_EQ(h.graph->property("histogramSize").toInt(), 2);
+}
+
+TEST(DateCommitGraphQmlTest, FolderChangeRebuildsHistogramWhileDateFilterIsActive) {
+  GraphHarness h;
+  ASSERT_NE(h.graph, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+
+  h.setModel(QVariantList{Row(QStringLiteral("2025-01-02"), 1),
+                          Row(QStringLiteral("2026-05-25"), 4)});
+  h.setSelected(QStringLiteral("2026-05-25"));
+  h.setModel(QVariantList{Row(QStringLiteral("2023-08-10"), 2)});
+  h.setFolder(7);
+
+  EXPECT_EQ(h.graph->property("histogramSize").toInt(), 1);
+  EXPECT_EQ(h.graph->property("latestDate").toString(), QStringLiteral("2023-08-10"));
+  EXPECT_EQ(h.graph->property("endDate").toString(), QStringLiteral("2023-08-10"));
+}
+
+TEST(DateCommitGraphQmlTest, OccupiedPeakDayUsesLevelFourToken) {
+  GraphHarness h;
+  ASSERT_NE(h.graph, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+  ASSERT_NE(h.window, nullptr);
+
+  h.setModel(QVariantList{Row(QStringLiteral("2026-05-25"), 8)});
+  const auto info = h.inspect(QStringLiteral("2026-05-25"));
+  ASSERT_TRUE(info.value(QStringLiteral("found")).toBool());
+  EXPECT_EQ(info.value(QStringLiteral("level")).toInt(), 4);
+}
+
+TEST(DateFilterSectionQmlTest, StyleSwitchLoadsActivityGraphWithoutQueryingStatsEngine) {
+  SectionHarness h;
+  ASSERT_NE(h.window, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+  ASSERT_NE(h.section, nullptr) << h.warnings.join(QLatin1Char('\n')).toStdString();
+
+  h.window->setProperty("dateModel",
+                        QVariantList{Row(QStringLiteral("2026-05-25"), 3)});
+  ProcessEvents(40);
+
+  EXPECT_EQ(h.section->property("styleKey").toString(), QStringLiteral("calendar"));
+  auto* calendar = h.window->findChild<QQuickItem*>(QStringLiteral("dateFilterCalendarLoader"));
+  ASSERT_NE(calendar, nullptr);
+  EXPECT_TRUE(calendar->property("active").toBool());
+
+  ASSERT_TRUE(h.section->setProperty("styleKey", QStringLiteral("activity")));
+  ASSERT_TRUE(WaitUntil(
+      [this_window = h.window] {
+        auto* graph = this_window->findChild<QQuickItem*>(QStringLiteral("dateCommitGraph"));
+        return graph != nullptr && graph->property("dayCount").toInt() == 365;
+      },
+      2000));
+
+  auto* graph = h.window->findChild<QQuickItem*>(QStringLiteral("dateCommitGraph"));
+  ASSERT_NE(graph, nullptr);
+  EXPECT_EQ(graph->property("dayCount").toInt(), 365);
+  EXPECT_EQ(graph->property("endDate").toString(), QStringLiteral("2026-05-25"));
+  EXPECT_FALSE(h.window->findChild<QQuickItem*>(QStringLiteral("dateFilterCalendarLoader"))
+                   ->property("active")
+                   .toBool());
+}
+
+}  // namespace alcedo::ui::test


### PR DESCRIPTION
## Summary

- Add an Activity view beside the existing Calendar view in the capture-date inspector.
- Show the last year or a selected calendar year as a week-column heatmap.
- Wrap week columns to the inspector width.
- Use AppTheme tokens for cell geometry and five capture-density levels.
- Keep the full date histogram when an active date filter narrows the current stats response.
- Add English and Simplified Chinese UI text.
- Add focused QML tests for graph dates, filtering, selection, colors, and view switching.

## Why

The calendar view shows individual date groups. It does not show capture cadence or relative volume across a full year.

The activity graph adds that overview without a new backend query. It uses the existing dateStats model and the existing date-filter action.

***SLOP ALERT Regardless of all the B.S. generated by the LLM above, I just want to make this part cooler and be more like a "modern" software. SLOP ALERT***

## User impact

Users can switch between Calendar and Activity views. They can show the last year or one calendar year. A hover shows the date and photo count. A click applies the existing date filter.

The graph keeps its full-year context after a day is selected. It rebuilds the histogram when the active folder changes.

## Implementation notes

- DateFilterSection owns the view switch and loads only the selected view.
- DateCommitGraph builds ISO-date windows, week columns, wrapped rows, month labels, hover details, and intensity buckets.
- The graph caches the unfiltered histogram by folder and ignores the smaller response caused by its own date selection.
- AppTheme owns the cell size, gap, radius, and density colors.
- The QML module, design reference, resource icon, translations, and test target include the new components.

## Validation

- DateCommitGraphQmlTest and DateFilterSectionQmlTest: 9 of 9 tests passed.
- The tests cover theme tokens, rolling-year bounds, leap years, day clicks, filter-response caching, folder changes, peak colors, and view switching.
- git diff --check passed after the rebase.
- The feature diff contains no README changes.