### PR TITLE
docs: restore approved README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 **Alcedo Studio** is a free, open-source photography workstation for the day after a shoot.
 
-Import a card of RAW files and start browsing. Grade up to 150-megapixel frames in 32-bit float on the GPU.
+Import a card of RAW files and browse. Grade up to 150-megapixel frames in 32-bit float on the GPU.
 
-One file follows your photos. It's a [DuckDB](https://duckdb.org/) database with extra metadata, and it holds your album structure and the full edit history. Move it, back it up, put it where you want. No mess, and searches across a large library stay fast.
+One file follows your photos. It's a [DuckDB](https://duckdb.org/) database with extra metadata, and it holds your album structure and the full edit history. Move it, back it up, put it where you want. No mess, and lookups over a big library are still instant.
 
-What's more, it uses a film-industry workflow. In a DI suite, the colorist works on a scene-referred image in a log-like working space, and a fixed transform forms the final picture for the screen. That split is why modern color pipelines stay stable when shots, cameras, and deliverables change. Alcedo follows the same structure: your RAW becomes a scene-linear image, you grade in an ACEScc-style log space, film-emulation LUTs carry the look, and a display rendering transform makes the final picture. On macOS you can even watch HDR while you edit.
+What's more, it uses film industry workflow. In a DI suite, the colorist works on a scene-referred image in a log working space, and a fixed transform forms the final picture for the screen. That split is why modern color pipelines stay stable when shots, cameras, and deliverables change. Alcedo follows the same structure: your RAW becomes a scene-linear image, you grade in an ACEScc-style log space, film-emulation LUTs carry the look, and a display rendering transform makes the final picture. On macOS you can even watch HDR while you edit.
 
 Windows 10/11 x64 and Apple Silicon. Current release: [v0.2.9](https://github.com/zidage/AlcedoStudio/releases/tag/v0.2.9).
 
@@ -30,21 +30,21 @@ https://github.com/user-attachments/assets/ae0d9773-220e-4901-90f6-1989f58b0462
 
 **Work with most cameras.** Tested across Canon, Nikon, Sony, Fujifilm, Panasonic, OM System, Leica, Hasselblad, Phase One (including IQ4 150MP), Pentax, Sigma, and phone / drone DNG. Lists: [supported formats](docs/supported_raw_formats.md) and [supported cameras](docs/supported_cameras.md). Nikon HE and HE★ NEFs from the Z 8, Z 9, Z 6 III, and Z 50 II decode through the project's [LibRaw fork](https://github.com/zidage/LibRaw). You can also pick the demosaic: Default, RCD, or Neural Engine (a distilled [DemosaicNet](https://groups.csail.mit.edu/graphics/demosaicnet/) on the GPU, Bayer and X-Trans). Highlight reconstruction comes from an improved inpaint-opposed method, adapted from darktable and RawTherapee.
 
-**High-performance processing core.** Drag a slider and the preview holds 2.5K at 60 frames per second. When you stop, the preview sharpens to 4K, so your high-megapixel camera still shows what it captured. An RGB histogram and waveform follow the image. CUDA on NVIDIA, OpenCL on other Windows GPUs, Metal on macOS. A tuned cache keeps interactions fast and memory use low. It also provides a wide range of adjustment tools, from local tone mapping (highlights and shadows) to CDL color wheels, all carefully tuned for photography.
+**High-performance processing core.** Drag a slider and the preview holds 2.5K at 60 frames per second. When you stop, the preview sharpens to 4K, so your high-megapixel camera still shows what it captured. An RGB histogram and waveform follow the image. CUDA on NVIDIA, OpenCL on other Windows GPUs, Metal on macOS. A tuned cache keeps the interaction fast and the memory low. It also provides a wide range of adjustment tools, from local tone mapping (highlights and shadows) to CDL color wheels, all carefully tuned for photography use.
 
 **A display rendering transform forms the picture.** Scene-linear RAW holds colors and dynamic range a monitor can't show on its own. A DRT (Display Rendering Transform) is the look decision that maps that range onto the screen. That transform sits at the heart of modern film pipelines, and there's a good public write-up in [Chris Brejon's article on picture formation](https://chrisbrejon.com/articles/what-makes-a-good-picture-formation/). Alcedo provides ACES 2.0 and OpenDRT. Grade toward sRGB, wide-gamut, or HDR. You pick the target color space, the EOTF, and the HDR peak luminance. On macOS, the preview supports HDR while you edit.
 
 **Film-emulation LUTs.** [CUBE LUTs generated from real film-stock spectral response](https://github.com/JanLohse/spectral_film_lut), plus grain and halation with a physical model behind them.
 
-**Looks you keep, copy, and walk back.** A photo can hold several named looks, so you can compare and come back. You can copy a look onto another photo, or merge parts of one look into another. Every adjustment leaves a record, and you can return to every step. That whole history stays with the project file, so the undo trail is still there next month. The edit history is backed by a Git-like version control system. For more information, see [Edit History](https://zidage.github.io/AlcedoStudio_docs/en/docs/developer/edit-history-architecture).
+**Looks you keep, copy, and walk back.** A photo can hold several named looks, so you can compare and come back. You can copy a look onto another photo, or merge parts of one look into another. Every adjustment leaves a record, and every step can go back. That whole history stays with the project file, so the undo trail is still there next month. The edit history is backed by a Git-like version control system. For more information, see [Edit History](https://zidage.github.io/AlcedoStudio_docs/en/docs/developer/edit-history-architecture).
 
 **Export with highly customizable configurations.** Configure format, size, naming, metadata, and ICC profile. JPEG, PNG, TIFF, or EXR up to 32-bit. Original pixels, a longest edge, pixel bounds, or a print size at a set DPI. File names can draw from the source name, capture date, camera, lens, exposure, rating, and a running sequence.
 
-**Describe, review, and rate.** Connect an LLM provider you already use, and it writes a description, a 1–5 star rating, and a short rating reason. You control how strict the review is. You can also run this analysis in the background while you browse or edit images.
+**Describe, review, and rate.** Set up an LLM provider API key you already have access to (OpenCode Go, ChatGPT subscription, etc.), and it writes a description, a 1–5 star rating, and a short rating reason. You control how strict the review is. You can also run this analysis in the background while browsing or editing the images.
 
 **Tag it. Find it.** The library supports semantic tagging. Multilingual CLIP models run locally and tag every photo, so a scene, a subject, or a phrase becomes a query — no manual keywording. Global search mixes field filters (camera, date, lens) with natural-language search by meaning, and the album inspector maps the same library by capture date, camera, lens, labels, and rating. You can also manage models and configure auto tagging after import.
 
-**The library stays fast.** The library uses an inode-like file system stored in a DuckDB database. Full-text search lets the words in an LLM description work as a query: "red umbrella" matches the description, not only the filename. HNSW vector search keeps similar photos close, so a phrase can find images by their content.
+**The library stays fast.** Library is stored as a inode-like file system in a duckdb database. FTS is enabled to allow the words in a LLM description to work as a query: "red umbrella" hits the description, not only the filename. HNSW vector search is there so photos that look alike sit near each other: a phrase finds images by contents.
 
 ## System requirements
 


### PR DESCRIPTION
## Summary

- Restore the README wording that the author approved.
- Keep only the spelling fixes for `film`, `photography`, and `description`.
- Use the requested term `log working space`.
- Restore the ChatGPT subscription and OAuth-capable provider wording.

## Validation

- Ran `git diff --check`.
- Confirmed that this PR changes only `README.md`.

This change only corrects the wording introduced by PR #90.