### PR TITLE
feat(edit): add GPU-free pipeline document and three-node DAG

### DIFF
--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -19,3 +19,27 @@ def_library(EditHistory
     SOURCES ${HISTORY_SRCS}
     PUBLIC_DEPS Image TimeProvider JSON EditPipeline
 )
+
+# GPU DAG document/graph/models. No ImageBuffer, Operators, or GPU backends.
+set(EDIT_GRAPH_SRCS
+    ${ALCEDO_SRC_ROOT}/edit/operators/models/adjustment_catalog.cpp
+    ${ALCEDO_SRC_ROOT}/edit/operators/models/cat02_white_balance_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/operators/models/color_wheel_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/operators/models/curve_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/operators/models/hls_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/operators/models/lmt_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/operators/models/sharpen_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/graph/analytic_mask_node_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/graph/color_grade_node_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/graph/develop_node_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/graph/drt_node_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/graph/legacy_pipeline_importer.cpp
+    ${ALCEDO_SRC_ROOT}/edit/graph/pipeline_document.cpp
+    ${ALCEDO_SRC_ROOT}/edit/graph/pipeline_graph.cpp
+    ${ALCEDO_SRC_ROOT}/edit/graph/raster_mask_node_model.cpp
+)
+
+def_library(EditGraph
+    SOURCES ${EDIT_GRAPH_SRCS}
+    PUBLIC_DEPS JSON
+)

--- a/alcedo_studio/src/edit/graph/analytic_mask_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/analytic_mask_node_model.cpp
@@ -1,0 +1,86 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/analytic_mask_node_model.hpp"
+
+#include "edit/operators/models/json_read.hpp"
+
+namespace alcedo {
+
+AnalyticMaskNodeModel::AnalyticMaskNodeModel(NodeId id, AnalyticMaskKind kind)
+    : id_(std::move(id)), kind_(kind) {
+  outputs_[0] = PortDescriptor{PortId{"mask"}, PortDataType::Mask, true};
+}
+
+auto AnalyticMaskNodeModel::InputPorts() const -> std::span<const PortDescriptor> { return {}; }
+
+auto AnalyticMaskNodeModel::OutputPorts() const -> std::span<const PortDescriptor> { return outputs_; }
+
+auto AnalyticMaskNodeModel::ToJson() const -> nlohmann::json {
+  nlohmann::json params;
+  if (kind_ == AnalyticMaskKind::Radial) {
+    params = {{"kind", "radial"},
+              {"center_x", radial_.center_x},
+              {"center_y", radial_.center_y},
+              {"major_radius", radial_.major_radius},
+              {"minor_radius", radial_.minor_radius},
+              {"rotation", radial_.rotation},
+              {"inner_feather", radial_.inner_feather},
+              {"outer_feather", radial_.outer_feather},
+              {"invert", radial_.invert}};
+  } else {
+    params = {{"kind", "graduated_nd"},
+              {"origin_x", graduated_.origin_x},
+              {"origin_y", graduated_.origin_y},
+              {"normal_x", graduated_.normal_x},
+              {"normal_y", graduated_.normal_y},
+              {"transition_distance", graduated_.transition_distance},
+              {"start_value", graduated_.start_value},
+              {"end_value", graduated_.end_value},
+              {"invert", graduated_.invert}};
+  }
+  return {{"id", std::string{id_.Value()}},
+          {"type", std::string{Type().Text()}},
+          {"params", std::move(params)}};
+}
+
+auto AnalyticMaskNodeModel::FromJson(const nlohmann::json& json)
+    -> std::unique_ptr<AnalyticMaskNodeModel> {
+  const auto kind_text =
+      json.contains("params") ? json_util::ReadString(json["params"], "kind", "radial") : "radial";
+  const auto kind =
+      kind_text == "graduated_nd" ? AnalyticMaskKind::GraduatedNd : AnalyticMaskKind::Radial;
+  auto node = std::make_unique<AnalyticMaskNodeModel>(NodeId{json.at("id").get<std::string>()}, kind);
+  if (!json.contains("params") || !json["params"].is_object()) {
+    return node;
+  }
+  const auto& params = json["params"];
+  if (kind == AnalyticMaskKind::Radial) {
+    RadialMaskParams radial;
+    radial.center_x      = json_util::ReadFloat(params, "center_x", radial.center_x);
+    radial.center_y      = json_util::ReadFloat(params, "center_y", radial.center_y);
+    radial.major_radius  = json_util::ReadFloat(params, "major_radius", radial.major_radius);
+    radial.minor_radius  = json_util::ReadFloat(params, "minor_radius", radial.minor_radius);
+    radial.rotation      = json_util::ReadFloat(params, "rotation", radial.rotation);
+    radial.inner_feather = json_util::ReadFloat(params, "inner_feather", radial.inner_feather);
+    radial.outer_feather = json_util::ReadFloat(params, "outer_feather", radial.outer_feather);
+    radial.invert        = json_util::ReadBool(params, "invert", radial.invert);
+    node->SetRadial(radial);
+  } else {
+    GraduatedNdMaskParams graduated;
+    graduated.origin_x            = json_util::ReadFloat(params, "origin_x", graduated.origin_x);
+    graduated.origin_y            = json_util::ReadFloat(params, "origin_y", graduated.origin_y);
+    graduated.normal_x            = json_util::ReadFloat(params, "normal_x", graduated.normal_x);
+    graduated.normal_y            = json_util::ReadFloat(params, "normal_y", graduated.normal_y);
+    graduated.transition_distance =
+        json_util::ReadFloat(params, "transition_distance", graduated.transition_distance);
+    graduated.start_value = json_util::ReadFloat(params, "start_value", graduated.start_value);
+    graduated.end_value   = json_util::ReadFloat(params, "end_value", graduated.end_value);
+    graduated.invert      = json_util::ReadBool(params, "invert", graduated.invert);
+    node->SetGraduatedNd(graduated);
+  }
+  return node;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
@@ -1,0 +1,188 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/color_grade_node_model.hpp"
+
+#include <algorithm>
+#include <array>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "edit/operators/models/adjustment_catalog.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+
+namespace alcedo {
+
+namespace {
+
+auto DefaultAdjustmentTypes() -> std::array<OperatorTypeId, 17> {
+  return {type_ids::Cat02WhiteBalance(), type_ids::Exposure(),   type_ids::Contrast(),
+          type_ids::White(),             type_ids::Black(),      type_ids::Shadows(),
+          type_ids::Highlights(),        type_ids::Curve(),      type_ids::Hls(),
+          type_ids::Saturation(),        type_ids::Vibrance(),   type_ids::ColorWheel(),
+          type_ids::Lmt(),               type_ids::Clarity(),    type_ids::Sharpen(),
+          type_ids::Halation(),          type_ids::FilmGrain()};
+}
+
+auto InstanceSuffixFor(const OperatorTypeId& type) -> std::string {
+  const std::string text{type.Text()};
+  const auto        pos = text.rfind('.');
+  if (pos == std::string::npos || pos + 1 >= text.size()) {
+    return text;
+  }
+  return text.substr(pos + 1);
+}
+
+}  // namespace
+
+ColorGradeNodeModel::ColorGradeNodeModel(NodeId id) : id_(std::move(id)) {
+  inputs_[0]  = PortDescriptor{PortId{"image"}, PortDataType::SceneImage, true};
+  inputs_[1]  = PortDescriptor{PortId{"mask"}, PortDataType::Mask, false};
+  outputs_[0] = PortDescriptor{PortId{"image"}, PortDataType::SceneImage, true};
+}
+
+auto ColorGradeNodeModel::InputPorts() const -> std::span<const PortDescriptor> { return inputs_; }
+
+auto ColorGradeNodeModel::OutputPorts() const -> std::span<const PortDescriptor> { return outputs_; }
+
+auto ColorGradeNodeModel::ToJson() const -> nlohmann::json {
+  nlohmann::json adjustments = nlohmann::json::array();
+  for (const auto& entry : adjustments_) {
+    adjustments.push_back({{"id", std::string{entry.instance_id.Value()}},
+                           {"type", std::string{entry.model->Type().Text()}},
+                           {"params", entry.model->ToJson()}});
+  }
+  return {{"id", std::string{id_.Value()}},
+          {"type", std::string{Type().Text()}},
+          {"enabled", enabled_},
+          {"mix", mix_},
+          {"adjustments", std::move(adjustments)}};
+}
+
+auto ColorGradeNodeModel::MakeDefault(NodeId id) -> std::unique_ptr<ColorGradeNodeModel> {
+  auto        node   = std::make_unique<ColorGradeNodeModel>(std::move(id));
+  const auto  types   = DefaultAdjustmentTypes();
+  const auto& catalog = BuiltinAdjustmentCatalog::Instance();
+  const std::string prefix = std::string{node->Id().Value()} + ".";
+  for (const auto& type : types) {
+    auto model = catalog.CreateDefault(type);
+    if (model == nullptr) {
+      throw std::logic_error("Missing default adjustment factory for " + std::string{type.Text()});
+    }
+    std::string suffix = InstanceSuffixFor(type);
+    if (type == type_ids::Cat02WhiteBalance()) {
+      suffix = "cat02_wb";
+    } else if (type == type_ids::Hls()) {
+      suffix = "hls";
+    }
+    node->InsertAdjustment(node->AdjustmentCount(), AdjustmentInstanceId{prefix + suffix},
+                           std::move(model));
+  }
+  return node;
+}
+
+auto ColorGradeNodeModel::FromJson(const nlohmann::json& json) -> std::unique_ptr<ColorGradeNodeModel> {
+  auto        node    = std::make_unique<ColorGradeNodeModel>(NodeId{json.at("id").get<std::string>()});
+  const auto& catalog = BuiltinAdjustmentCatalog::Instance();
+  node->enabled_      = json.value("enabled", true);
+  node->mix_          = json.value("mix", 1.0f);
+  if (json.contains("adjustments") && json["adjustments"].is_array()) {
+    for (const auto& item : json["adjustments"]) {
+      const auto type_text = item.at("type").get<std::string>();
+      auto       model     = catalog.CreateDefault(OperatorTypeId{type_text});
+      if (model == nullptr) {
+        throw std::runtime_error("Unknown adjustment type: " + type_text);
+      }
+      if (item.contains("params") && item["params"].is_object()) {
+        model->LoadJson(item["params"]);
+      }
+      node->InsertAdjustment(node->AdjustmentCount(),
+                             AdjustmentInstanceId{item.at("id").get<std::string>()}, std::move(model));
+    }
+  }
+  return node;
+}
+
+void ColorGradeNodeModel::SetEnabled(bool enabled) { enabled_ = enabled; }
+
+void ColorGradeNodeModel::SetMix(float mix) { mix_ = std::clamp(mix, 0.0f, 1.0f); }
+
+auto ColorGradeNodeModel::AdjustmentIdAt(std::size_t index) const -> const AdjustmentInstanceId& {
+  return adjustments_.at(index).instance_id;
+}
+
+auto ColorGradeNodeModel::AdjustmentAt(std::size_t index) -> IOperatorModel& {
+  return *adjustments_.at(index).model;
+}
+
+auto ColorGradeNodeModel::AdjustmentAt(std::size_t index) const -> const IOperatorModel& {
+  return *adjustments_.at(index).model;
+}
+
+auto ColorGradeNodeModel::FindAdjustment(const AdjustmentInstanceId& id) -> IOperatorModel* {
+  for (auto& entry : adjustments_) {
+    if (entry.instance_id == id) {
+      return entry.model.get();
+    }
+  }
+  return nullptr;
+}
+
+auto ColorGradeNodeModel::FindAdjustmentByType(const OperatorTypeId& type) -> IOperatorModel* {
+  for (auto& entry : adjustments_) {
+    if (entry.model->Type() == type) {
+      return entry.model.get();
+    }
+  }
+  return nullptr;
+}
+
+auto ColorGradeNodeModel::FindAdjustmentByType(const OperatorTypeId& type) const
+    -> const IOperatorModel* {
+  for (const auto& entry : adjustments_) {
+    if (entry.model->Type() == type) {
+      return entry.model.get();
+    }
+  }
+  return nullptr;
+}
+
+void ColorGradeNodeModel::InsertAdjustment(std::size_t index, AdjustmentInstanceId id,
+                                           std::unique_ptr<IOperatorModel> model) {
+  if (model == nullptr) {
+    throw std::invalid_argument("InsertAdjustment requires a Model");
+  }
+  if (index > adjustments_.size()) {
+    index = adjustments_.size();
+  }
+  AdjustmentModelEntry entry;
+  entry.instance_id = std::move(id);
+  entry.model       = std::move(model);
+  adjustments_.insert(adjustments_.begin() + static_cast<std::ptrdiff_t>(index), std::move(entry));
+}
+
+void ColorGradeNodeModel::RemoveAdjustment(const AdjustmentInstanceId& id) {
+  const auto it = std::find_if(adjustments_.begin(), adjustments_.end(),
+                               [&id](const AdjustmentModelEntry& entry) { return entry.instance_id == id; });
+  if (it != adjustments_.end()) {
+    adjustments_.erase(it);
+  }
+}
+
+void ColorGradeNodeModel::MoveAdjustment(const AdjustmentInstanceId& id, std::size_t index) {
+  const auto it = std::find_if(adjustments_.begin(), adjustments_.end(),
+                               [&id](const AdjustmentModelEntry& entry) { return entry.instance_id == id; });
+  if (it == adjustments_.end()) {
+    return;
+  }
+  AdjustmentModelEntry entry = std::move(*it);
+  adjustments_.erase(it);
+  if (index > adjustments_.size()) {
+    index = adjustments_.size();
+  }
+  adjustments_.insert(adjustments_.begin() + static_cast<std::ptrdiff_t>(index), std::move(entry));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/develop_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/develop_node_model.cpp
@@ -1,0 +1,96 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/develop_node_model.hpp"
+
+#include "edit/operators/models/json_read.hpp"
+
+namespace alcedo {
+
+auto DevelopParamsModel::IsDefault() const -> bool {
+  const auto payload = PayloadCopy();
+  return payload.demosaic_method == "default" && payload.highlights_reconstruct &&
+         payload.use_camera_wb && payload.user_wb == 7600.0f && payload.wb_mode == "as_shot" &&
+         !payload.lens_enabled;
+}
+
+auto DevelopParamsModel::ToJson() const -> nlohmann::json {
+  const auto payload = PayloadCopy();
+  return {{"demosaic_method", payload.demosaic_method},
+          {"highlights_reconstruct", payload.highlights_reconstruct},
+          {"use_camera_wb", payload.use_camera_wb},
+          {"user_wb", payload.user_wb},
+          {"wb_mode", payload.wb_mode},
+          {"custom_cct", payload.custom_cct},
+          {"custom_tint", payload.custom_tint},
+          {"as_shot_cct", payload.as_shot_cct},
+          {"as_shot_tint", payload.as_shot_tint},
+          {"lens_enabled", payload.lens_enabled},
+          {"apply_vignetting", payload.apply_vignetting},
+          {"apply_distortion", payload.apply_distortion},
+          {"apply_tca", payload.apply_tca},
+          {"apply_crop", payload.apply_crop},
+          {"auto_scale", payload.auto_scale},
+          {"use_user_scale", payload.use_user_scale},
+          {"user_scale", payload.user_scale},
+          {"projection_enabled", payload.projection_enabled},
+          {"target_projection", payload.target_projection},
+          {"lens_profile_db_path", payload.lens_profile_db_path}};
+}
+
+void DevelopParamsModel::LoadJson(const nlohmann::json& json) {
+  Mutate(DevelopDirty::All, [&json](DevelopPayload& payload) {
+    payload.demosaic_method        = json_util::ReadString(json, "demosaic_method", payload.demosaic_method);
+    payload.highlights_reconstruct = json_util::ReadBool(json, "highlights_reconstruct", payload.highlights_reconstruct);
+    payload.use_camera_wb          = json_util::ReadBool(json, "use_camera_wb", payload.use_camera_wb);
+    payload.user_wb                = json_util::ReadFloat(json, "user_wb", payload.user_wb);
+    payload.wb_mode                = json_util::ReadString(json, "wb_mode", payload.wb_mode);
+    payload.custom_cct             = json_util::ReadFloat(json, "custom_cct", payload.custom_cct);
+    payload.custom_tint            = json_util::ReadFloat(json, "custom_tint", payload.custom_tint);
+    payload.as_shot_cct            = json_util::ReadFloat(json, "as_shot_cct", payload.as_shot_cct);
+    payload.as_shot_tint           = json_util::ReadFloat(json, "as_shot_tint", payload.as_shot_tint);
+    payload.lens_enabled           = json_util::ReadBool(json, "lens_enabled", payload.lens_enabled);
+    payload.apply_vignetting       = json_util::ReadBool(json, "apply_vignetting", payload.apply_vignetting);
+    payload.apply_distortion       = json_util::ReadBool(json, "apply_distortion", payload.apply_distortion);
+    payload.apply_tca              = json_util::ReadBool(json, "apply_tca", payload.apply_tca);
+    payload.apply_crop             = json_util::ReadBool(json, "apply_crop", payload.apply_crop);
+    payload.auto_scale             = json_util::ReadBool(json, "auto_scale", payload.auto_scale);
+    payload.use_user_scale         = json_util::ReadBool(json, "use_user_scale", payload.use_user_scale);
+    payload.user_scale             = json_util::ReadFloat(json, "user_scale", payload.user_scale);
+    payload.projection_enabled     = json_util::ReadBool(json, "projection_enabled", payload.projection_enabled);
+    payload.target_projection = json_util::ReadString(json, "target_projection", payload.target_projection);
+    payload.lens_profile_db_path =
+        json_util::ReadString(json, "lens_profile_db_path", payload.lens_profile_db_path);
+  });
+}
+
+void DevelopParamsModel::ReplaceParams(DevelopPayload payload) {
+  Mutate(DevelopDirty::All, [payload = std::move(payload)](DevelopPayload& dest) mutable {
+    dest = std::move(payload);
+  });
+}
+
+DevelopNodeModel::DevelopNodeModel(NodeId id) : id_(std::move(id)) {
+  outputs_[0] = PortDescriptor{PortId{"image"}, PortDataType::SceneImage, true};
+}
+
+auto DevelopNodeModel::InputPorts() const -> std::span<const PortDescriptor> { return {}; }
+
+auto DevelopNodeModel::OutputPorts() const -> std::span<const PortDescriptor> { return outputs_; }
+
+auto DevelopNodeModel::ToJson() const -> nlohmann::json {
+  return {{"id", std::string{id_.Value()}},
+          {"type", std::string{Type().Text()}},
+          {"params", params_.ToJson()}};
+}
+
+auto DevelopNodeModel::FromJson(const nlohmann::json& json) -> std::unique_ptr<DevelopNodeModel> {
+  auto node = std::make_unique<DevelopNodeModel>(NodeId{json.at("id").get<std::string>()});
+  if (json.contains("params") && json["params"].is_object()) {
+    node->params_.LoadJson(json["params"]);
+  }
+  return node;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/drt_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/drt_node_model.cpp
@@ -1,0 +1,258 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/drt_node_model.hpp"
+
+#include <string_view>
+
+#include "edit/operators/models/json_read.hpp"
+
+namespace alcedo {
+
+namespace {
+
+auto MethodToString(DrtMethod method) -> const char* {
+  return method == DrtMethod::Aces20 ? "aces_2_0" : "open_drt";
+}
+
+auto MethodFromString(std::string_view text) -> DrtMethod {
+  return text == "aces_2_0" ? DrtMethod::Aces20 : DrtMethod::OpenDrt;
+}
+
+auto SpaceToString(DrtColorSpace space) -> const char* {
+  switch (space) {
+    case DrtColorSpace::Rec2020:
+      return "rec2020";
+    case DrtColorSpace::P3D65:
+      return "p3_d65";
+    case DrtColorSpace::Rec709:
+    default:
+      return "rec709";
+  }
+}
+
+auto SpaceFromString(std::string_view text) -> DrtColorSpace {
+  if (text == "rec2020") {
+    return DrtColorSpace::Rec2020;
+  }
+  if (text == "p3_d65") {
+    return DrtColorSpace::P3D65;
+  }
+  return DrtColorSpace::Rec709;
+}
+
+auto EotfToString(DrtEotf eotf) -> const char* {
+  switch (eotf) {
+    case DrtEotf::Linear:
+      return "linear";
+    case DrtEotf::St2084:
+      return "st2084";
+    case DrtEotf::Hlg:
+      return "hlg";
+    case DrtEotf::Gamma26:
+      return "gamma_2_6";
+    case DrtEotf::Bt1886:
+      return "bt1886";
+    case DrtEotf::Gamma18:
+      return "gamma_1_8";
+    case DrtEotf::Gamma22:
+    default:
+      return "gamma_2_2";
+  }
+}
+
+auto EotfFromString(std::string_view text) -> DrtEotf {
+  if (text == "linear") {
+    return DrtEotf::Linear;
+  }
+  if (text == "st2084") {
+    return DrtEotf::St2084;
+  }
+  if (text == "hlg") {
+    return DrtEotf::Hlg;
+  }
+  if (text == "gamma_2_6") {
+    return DrtEotf::Gamma26;
+  }
+  if (text == "bt1886") {
+    return DrtEotf::Bt1886;
+  }
+  if (text == "gamma_1_8") {
+    return DrtEotf::Gamma18;
+  }
+  return DrtEotf::Gamma22;
+}
+
+auto DetailedToJson(const OpenDrtDetailedParams& params) -> nlohmann::json {
+  return {{"tn_con", params.tn_con},       {"tn_sh", params.tn_sh},
+          {"tn_toe", params.tn_toe},       {"tn_off", params.tn_off},
+          {"tn_hcon", params.tn_hcon},     {"tn_hcon_pv", params.tn_hcon_pv},
+          {"tn_hcon_st", params.tn_hcon_st}, {"tn_lcon", params.tn_lcon},
+          {"tn_lcon_w", params.tn_lcon_w}, {"cwp_lm", params.cwp_lm},
+          {"rs_sa", params.rs_sa},         {"rs_rw", params.rs_rw},
+          {"rs_bw", params.rs_bw},         {"pt_lml", params.pt_lml},
+          {"pt_lml_r", params.pt_lml_r},   {"pt_lml_g", params.pt_lml_g},
+          {"pt_lml_b", params.pt_lml_b},   {"pt_lmh", params.pt_lmh},
+          {"pt_lmh_r", params.pt_lmh_r},   {"pt_lmh_b", params.pt_lmh_b},
+          {"ptl_c", params.ptl_c},         {"ptl_m", params.ptl_m},
+          {"ptl_y", params.ptl_y},         {"ptm_low", params.ptm_low},
+          {"ptm_low_rng", params.ptm_low_rng}, {"ptm_low_st", params.ptm_low_st},
+          {"ptm_high", params.ptm_high},   {"ptm_high_rng", params.ptm_high_rng},
+          {"ptm_high_st", params.ptm_high_st}, {"brl", params.brl},
+          {"brl_r", params.brl_r},         {"brl_g", params.brl_g},
+          {"brl_b", params.brl_b},         {"brl_rng", params.brl_rng},
+          {"brl_st", params.brl_st},       {"brlp", params.brlp},
+          {"brlp_r", params.brlp_r},       {"brlp_g", params.brlp_g},
+          {"brlp_b", params.brlp_b},       {"hc_r", params.hc_r},
+          {"hc_r_rng", params.hc_r_rng},   {"hs_r", params.hs_r},
+          {"hs_r_rng", params.hs_r_rng},   {"hs_g", params.hs_g},
+          {"hs_g_rng", params.hs_g_rng},   {"hs_b", params.hs_b},
+          {"hs_b_rng", params.hs_b_rng},   {"hs_c", params.hs_c},
+          {"hs_c_rng", params.hs_c_rng},   {"hs_m", params.hs_m},
+          {"hs_m_rng", params.hs_m_rng},   {"hs_y", params.hs_y},
+          {"hs_y_rng", params.hs_y_rng}};
+}
+
+void DetailedFromJson(const nlohmann::json& json, OpenDrtDetailedParams& params) {
+  if (!json.is_object()) {
+    return;
+  }
+#define ALCEDO_READ_ODRT(field) params.field = json_util::ReadFloat(json, #field, params.field)
+  ALCEDO_READ_ODRT(tn_con);
+  ALCEDO_READ_ODRT(tn_sh);
+  ALCEDO_READ_ODRT(tn_toe);
+  ALCEDO_READ_ODRT(tn_off);
+  ALCEDO_READ_ODRT(tn_hcon);
+  ALCEDO_READ_ODRT(tn_hcon_pv);
+  ALCEDO_READ_ODRT(tn_hcon_st);
+  ALCEDO_READ_ODRT(tn_lcon);
+  ALCEDO_READ_ODRT(tn_lcon_w);
+  ALCEDO_READ_ODRT(cwp_lm);
+  ALCEDO_READ_ODRT(rs_sa);
+  ALCEDO_READ_ODRT(rs_rw);
+  ALCEDO_READ_ODRT(rs_bw);
+  ALCEDO_READ_ODRT(pt_lml);
+  ALCEDO_READ_ODRT(pt_lml_r);
+  ALCEDO_READ_ODRT(pt_lml_g);
+  ALCEDO_READ_ODRT(pt_lml_b);
+  ALCEDO_READ_ODRT(pt_lmh);
+  ALCEDO_READ_ODRT(pt_lmh_r);
+  ALCEDO_READ_ODRT(pt_lmh_b);
+  ALCEDO_READ_ODRT(ptl_c);
+  ALCEDO_READ_ODRT(ptl_m);
+  ALCEDO_READ_ODRT(ptl_y);
+  ALCEDO_READ_ODRT(ptm_low);
+  ALCEDO_READ_ODRT(ptm_low_rng);
+  ALCEDO_READ_ODRT(ptm_low_st);
+  ALCEDO_READ_ODRT(ptm_high);
+  ALCEDO_READ_ODRT(ptm_high_rng);
+  ALCEDO_READ_ODRT(ptm_high_st);
+  ALCEDO_READ_ODRT(brl);
+  ALCEDO_READ_ODRT(brl_r);
+  ALCEDO_READ_ODRT(brl_g);
+  ALCEDO_READ_ODRT(brl_b);
+  ALCEDO_READ_ODRT(brl_rng);
+  ALCEDO_READ_ODRT(brl_st);
+  ALCEDO_READ_ODRT(brlp);
+  ALCEDO_READ_ODRT(brlp_r);
+  ALCEDO_READ_ODRT(brlp_g);
+  ALCEDO_READ_ODRT(brlp_b);
+  ALCEDO_READ_ODRT(hc_r);
+  ALCEDO_READ_ODRT(hc_r_rng);
+  ALCEDO_READ_ODRT(hs_r);
+  ALCEDO_READ_ODRT(hs_r_rng);
+  ALCEDO_READ_ODRT(hs_g);
+  ALCEDO_READ_ODRT(hs_g_rng);
+  ALCEDO_READ_ODRT(hs_b);
+  ALCEDO_READ_ODRT(hs_b_rng);
+  ALCEDO_READ_ODRT(hs_c);
+  ALCEDO_READ_ODRT(hs_c_rng);
+  ALCEDO_READ_ODRT(hs_m);
+  ALCEDO_READ_ODRT(hs_m_rng);
+  ALCEDO_READ_ODRT(hs_y);
+  ALCEDO_READ_ODRT(hs_y_rng);
+#undef ALCEDO_READ_ODRT
+}
+
+}  // namespace
+
+auto DrtParamsModel::IsDefault() const -> bool {
+  return Read([](const DrtPayload& payload) {
+    return payload.method == DrtMethod::OpenDrt && payload.encoding_space == DrtColorSpace::Rec709 &&
+           payload.encoding_eotf == DrtEotf::Gamma22 && payload.peak_luminance == 100.0f;
+  });
+}
+
+auto DrtParamsModel::ToJson() const -> nlohmann::json {
+  const auto payload = PayloadCopy();
+  return {{"method", MethodToString(payload.method)},
+          {"encoding_space", SpaceToString(payload.encoding_space)},
+          {"encoding_eotf", EotfToString(payload.encoding_eotf)},
+          {"limiting_space", SpaceToString(payload.limiting_space)},
+          {"peak_luminance", payload.peak_luminance},
+          {"open_drt",
+           {{"look_preset", payload.look_preset},
+            {"tonescale_preset", payload.tonescale_preset},
+            {"creative_white", payload.creative_white},
+            {"creative_white_limit", payload.creative_white_limit},
+            {"display_grey_luminance", payload.display_grey_luminance},
+            {"hdr_grey_boost", payload.hdr_grey_boost},
+            {"hdr_purity", payload.hdr_purity},
+            {"parameters", DetailedToJson(payload.parameters)}}}};
+}
+
+void DrtParamsModel::LoadJson(const nlohmann::json& json) {
+  Mutate(DrtDirty::All, [&json](DrtPayload& payload) {
+    payload.method         = MethodFromString(json_util::ReadString(json, "method", "open_drt"));
+    payload.encoding_space = SpaceFromString(json_util::ReadString(json, "encoding_space", "rec709"));
+    payload.encoding_eotf  = EotfFromString(json_util::ReadString(json, "encoding_eotf", "gamma_2_2"));
+    payload.limiting_space = SpaceFromString(json_util::ReadString(json, "limiting_space", "rec709"));
+    payload.peak_luminance = json_util::ReadFloat(json, "peak_luminance", payload.peak_luminance);
+    if (json.contains("open_drt") && json["open_drt"].is_object()) {
+      const auto& open_drt       = json["open_drt"];
+      payload.look_preset        = json_util::ReadString(open_drt, "look_preset", payload.look_preset);
+      payload.tonescale_preset   = json_util::ReadString(open_drt, "tonescale_preset", payload.tonescale_preset);
+      payload.creative_white     = json_util::ReadString(open_drt, "creative_white", payload.creative_white);
+      payload.creative_white_limit =
+          json_util::ReadFloat(open_drt, "creative_white_limit", payload.creative_white_limit);
+      payload.display_grey_luminance =
+          json_util::ReadFloat(open_drt, "display_grey_luminance", payload.display_grey_luminance);
+      payload.hdr_grey_boost = json_util::ReadFloat(open_drt, "hdr_grey_boost", payload.hdr_grey_boost);
+      payload.hdr_purity     = json_util::ReadFloat(open_drt, "hdr_purity", payload.hdr_purity);
+      if (open_drt.contains("parameters")) {
+        DetailedFromJson(open_drt["parameters"], payload.parameters);
+      }
+    }
+  });
+}
+
+void DrtParamsModel::ReplaceParams(DrtPayload payload) {
+  Mutate(DrtDirty::All,
+         [payload = std::move(payload)](DrtPayload& dest) mutable { dest = std::move(payload); });
+}
+
+DrtNodeModel::DrtNodeModel(NodeId id) : id_(std::move(id)) {
+  inputs_[0]  = PortDescriptor{PortId{"image"}, PortDataType::SceneImage, true};
+  outputs_[0] = PortDescriptor{PortId{"display"}, PortDataType::DisplayImage, true};
+}
+
+auto DrtNodeModel::InputPorts() const -> std::span<const PortDescriptor> { return inputs_; }
+
+auto DrtNodeModel::OutputPorts() const -> std::span<const PortDescriptor> { return outputs_; }
+
+auto DrtNodeModel::ToJson() const -> nlohmann::json {
+  return {{"id", std::string{id_.Value()}},
+          {"type", std::string{Type().Text()}},
+          {"params", params_.ToJson()}};
+}
+
+auto DrtNodeModel::FromJson(const nlohmann::json& json) -> std::unique_ptr<DrtNodeModel> {
+  auto node = std::make_unique<DrtNodeModel>(NodeId{json.at("id").get<std::string>()});
+  if (json.contains("params") && json["params"].is_object()) {
+    node->params_.LoadJson(json["params"]);
+  }
+  return node;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
+++ b/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
@@ -1,0 +1,329 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/legacy_pipeline_importer.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/json_read.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+
+namespace alcedo {
+
+namespace {
+
+constexpr int kLegacyRawDecode         = 0;
+constexpr int kLegacyResize            = 1;
+constexpr int kLegacyExposure          = 2;
+constexpr int kLegacyContrast          = 3;
+constexpr int kLegacyWhite             = 4;
+constexpr int kLegacyBlack             = 5;
+constexpr int kLegacyShadows           = 6;
+constexpr int kLegacyHighlights        = 7;
+constexpr int kLegacyCurve             = 8;
+constexpr int kLegacyHls               = 9;
+constexpr int kLegacySaturation        = 10;
+constexpr int kLegacyTint              = 11;
+constexpr int kLegacyVibrance          = 12;
+constexpr int kLegacyCst               = 13;
+constexpr int kLegacyToWs              = 14;
+constexpr int kLegacyToOutput          = 15;
+constexpr int kLegacyLmt               = 16;
+constexpr int kLegacyOdt               = 17;
+constexpr int kLegacyClarity           = 18;
+constexpr int kLegacySharpen           = 19;
+constexpr int kLegacyColorWheel        = 20;
+constexpr int kLegacyAcesToneMapping   = 21;
+constexpr int kLegacyAutoExposure      = 22;
+constexpr int kLegacyUnknown           = 23;
+constexpr int kLegacyCropRotate        = 24;
+constexpr int kLegacyLensCalibration   = 25;
+constexpr int kLegacyColorTemp         = 26;
+constexpr int kLegacyFilmGrain         = 27;
+constexpr int kLegacyHalation          = 28;
+
+struct LegacyOperator {
+  int            type    = -1;
+  bool           enable  = true;
+  nlohmann::json params  = nlohmann::json::object();
+};
+
+auto IsSkippedType(int type) -> bool {
+  return type == kLegacyResize || type == kLegacyCst || type == kLegacyToWs ||
+         type == kLegacyToOutput || type == kLegacyUnknown;
+}
+
+auto IsFatalUnknown(int type) -> bool {
+  return type == kLegacyAcesToneMapping || type == kLegacyAutoExposure || type < 0 || type > 28;
+}
+
+auto NestedOrSelf(const nlohmann::json& params, const char* key) -> nlohmann::json {
+  if (params.contains(key)) {
+    return params[key];
+  }
+  return params;
+}
+
+void CollectFromObject(const nlohmann::json& object, std::vector<LegacyOperator>& out) {
+  if (!object.is_object()) {
+    return;
+  }
+  for (auto it = object.begin(); it != object.end(); ++it) {
+    const auto& value = it.value();
+    if (!value.is_object()) {
+      continue;
+    }
+    if (value.contains("type")) {
+      LegacyOperator op;
+      op.type   = value["type"].is_number_integer() ? value["type"].get<int>() : -1;
+      op.enable = value.value("enable", true);
+      op.params = value.contains("params") ? value["params"] : nlohmann::json::object();
+      out.push_back(std::move(op));
+    } else {
+      CollectFromObject(value, out);
+    }
+  }
+}
+
+auto CollectOperators(const nlohmann::json& stage_json) -> std::vector<LegacyOperator> {
+  std::vector<LegacyOperator> operators;
+  CollectFromObject(stage_json, operators);
+  return operators;
+}
+
+auto FindOp(const std::vector<LegacyOperator>& operators, int type) -> const LegacyOperator* {
+  for (const auto& op : operators) {
+    if (op.type == type) {
+      return &op;
+    }
+  }
+  return nullptr;
+}
+
+void ApplyScalar(IOperatorModel* model, const nlohmann::json& value, const char* new_key) {
+  if (model == nullptr) {
+    return;
+  }
+  nlohmann::json json;
+  if (value.is_number()) {
+    json[new_key] = value.get<float>();
+  } else if (value.is_object() && value.contains(new_key)) {
+    json[new_key] = value[new_key];
+  } else if (value.is_object()) {
+    json = value;
+  }
+  if (!json.empty()) {
+    model->LoadJson(json);
+  }
+}
+
+void ApplyCrop(ImageGeometryModel& geometry, const LegacyOperator& op) {
+  const auto crop = NestedOrSelf(op.params, "crop_rotate");
+  if (!op.enable || (crop.contains("enabled") && crop["enabled"].is_boolean() && !crop["enabled"].get<bool>())) {
+    geometry.SetCropRect(NormalizedRect{});
+    geometry.SetRotationDegrees(0.0f);
+    geometry.SetExpandToFit(json_util::ReadBool(crop, "expand_to_fit", true));
+    return;
+  }
+  geometry.SetRotationDegrees(json_util::ReadFloat(crop, "angle_degrees", 0.0f));
+  geometry.SetExpandToFit(json_util::ReadBool(crop, "expand_to_fit", true));
+  const bool enable_crop = json_util::ReadBool(crop, "enable_crop", true);
+  if (!enable_crop || !crop.contains("crop_rect")) {
+    geometry.SetCropRect(NormalizedRect{});
+    return;
+  }
+  const auto& rect = crop["crop_rect"];
+  NormalizedRect crop_rect;
+  crop_rect.x = json_util::ReadFloat(rect, "x", 0.0f);
+  crop_rect.y = json_util::ReadFloat(rect, "y", 0.0f);
+  crop_rect.w = json_util::ReadFloat(rect, "w", 1.0f);
+  crop_rect.h = json_util::ReadFloat(rect, "h", 1.0f);
+  geometry.SetCropRect(crop_rect);
+}
+
+void ApplyDevelop(DevelopParamsModel& develop, const std::vector<LegacyOperator>& operators) {
+  auto payload = develop.Params();
+  if (const auto* raw = FindOp(operators, kLegacyRawDecode)) {
+    const auto raw_params          = NestedOrSelf(raw->params, "raw");
+    payload.demosaic_method        = json_util::ReadString(raw_params, "method", payload.demosaic_method);
+    payload.highlights_reconstruct =
+        json_util::ReadBool(raw_params, "highlights_reconstruct", payload.highlights_reconstruct);
+    payload.use_camera_wb = json_util::ReadBool(raw_params, "use_camera_wb", payload.use_camera_wb);
+    payload.user_wb       = json_util::ReadFloat(raw_params, "user_wb", payload.user_wb);
+  }
+  if (const auto* lens = FindOp(operators, kLegacyLensCalibration)) {
+    const auto lens_params         = NestedOrSelf(lens->params, "lens_calib");
+    payload.lens_enabled           = lens->enable && json_util::ReadBool(lens_params, "enabled", false);
+    payload.apply_vignetting       = json_util::ReadBool(lens_params, "apply_vignetting", true);
+    payload.apply_distortion       = json_util::ReadBool(lens_params, "apply_distortion", true);
+    payload.apply_tca              = json_util::ReadBool(lens_params, "apply_tca", true);
+    payload.apply_crop             = json_util::ReadBool(lens_params, "apply_crop", true);
+    payload.auto_scale             = json_util::ReadBool(lens_params, "auto_scale", true);
+    payload.use_user_scale         = json_util::ReadBool(lens_params, "use_user_scale", false);
+    payload.user_scale             = json_util::ReadFloat(lens_params, "user_scale", 1.0f);
+    payload.projection_enabled     = json_util::ReadBool(lens_params, "projection_enabled", false);
+    payload.target_projection      = json_util::ReadString(lens_params, "target_projection", "unknown");
+    payload.lens_profile_db_path =
+        json_util::ReadString(lens_params, "lens_profile_db_path", payload.lens_profile_db_path);
+  }
+  if (const auto* temp = FindOp(operators, kLegacyColorTemp)) {
+    const auto color_temp   = NestedOrSelf(temp->params, "color_temp");
+    payload.wb_mode         = json_util::ReadString(color_temp, "mode", payload.wb_mode);
+    payload.custom_cct      = json_util::ReadFloat(color_temp, "custom_cct", payload.custom_cct);
+    if (color_temp.contains("cct")) {
+      payload.custom_cct = json_util::ReadFloat(color_temp, "cct", payload.custom_cct);
+    }
+    payload.custom_tint  = json_util::ReadFloat(color_temp, "custom_tint", payload.custom_tint);
+    if (color_temp.contains("tint")) {
+      payload.custom_tint = json_util::ReadFloat(color_temp, "tint", payload.custom_tint);
+    }
+    payload.as_shot_cct  = json_util::ReadFloat(color_temp, "as_shot_cct", payload.as_shot_cct);
+    payload.as_shot_tint = json_util::ReadFloat(color_temp, "as_shot_tint", payload.as_shot_tint);
+  }
+  develop.ReplaceParams(std::move(payload));
+}
+
+void ApplyGradeScalar(ColorGradeNodeModel& grade, const OperatorTypeId& type,
+                      const LegacyOperator* op, const char* old_key, const char* new_key,
+                      bool convert_saturation) {
+  if (op == nullptr) {
+    return;
+  }
+  auto* model = grade.FindAdjustmentByType(type);
+  if (model == nullptr) {
+    return;
+  }
+  const auto value = NestedOrSelf(op->params, old_key);
+  if (convert_saturation && value.is_number()) {
+    const float offset     = value.get<float>();
+    const float multiplier = std::max(0.0f, 1.0f + offset / 100.0f);
+    nlohmann::json json;
+    json[new_key] = multiplier;
+    model->LoadJson(json);
+    return;
+  }
+  ApplyScalar(model, value, new_key);
+}
+
+}  // namespace
+
+auto LegacyPipelineImporter::Import(const nlohmann::json& stage_json) -> LegacyImportResult {
+  LegacyImportResult result;
+  const auto         operators = CollectOperators(stage_json);
+  for (const auto& op : operators) {
+    if (IsFatalUnknown(op.type)) {
+      result.error = "Unknown legacy operator type: " + std::to_string(op.type);
+      return result;
+    }
+    if (!IsSkippedType(op.type) && op.type != kLegacyRawDecode && op.type != kLegacyExposure &&
+        op.type != kLegacyContrast && op.type != kLegacyWhite && op.type != kLegacyBlack &&
+        op.type != kLegacyShadows && op.type != kLegacyHighlights && op.type != kLegacyCurve &&
+        op.type != kLegacyHls && op.type != kLegacySaturation && op.type != kLegacyTint &&
+        op.type != kLegacyVibrance && op.type != kLegacyLmt && op.type != kLegacyOdt &&
+        op.type != kLegacyClarity && op.type != kLegacySharpen && op.type != kLegacyColorWheel &&
+        op.type != kLegacyCropRotate && op.type != kLegacyLensCalibration &&
+        op.type != kLegacyColorTemp && op.type != kLegacyFilmGrain && op.type != kLegacyHalation) {
+      result.error = "Unknown legacy operator type: " + std::to_string(op.type);
+      return result;
+    }
+  }
+
+  auto document = CreateDefaultPipelineDocument();
+  if (const auto* crop = FindOp(operators, kLegacyCropRotate)) {
+    ApplyCrop(document.Geometry(), *crop);
+  }
+  if (auto* develop = document.Develop()) {
+    ApplyDevelop(develop->Params(), operators);
+  }
+  auto* grade = document.PrimaryGrade();
+  auto* drt   = document.Drt();
+  if (grade == nullptr || drt == nullptr) {
+    result.error = "Default document is missing grade or DRT";
+    return result;
+  }
+
+  ApplyGradeScalar(*grade, type_ids::Exposure(), FindOp(operators, kLegacyExposure), "exposure",
+                   "exposure_ev", false);
+  ApplyGradeScalar(*grade, type_ids::Contrast(), FindOp(operators, kLegacyContrast), "contrast",
+                   "contrast", false);
+  ApplyGradeScalar(*grade, type_ids::White(), FindOp(operators, kLegacyWhite), "white", "white", false);
+  ApplyGradeScalar(*grade, type_ids::Black(), FindOp(operators, kLegacyBlack), "black", "black", false);
+  ApplyGradeScalar(*grade, type_ids::Shadows(), FindOp(operators, kLegacyShadows), "shadows", "shadows",
+                   false);
+  ApplyGradeScalar(*grade, type_ids::Highlights(), FindOp(operators, kLegacyHighlights), "highlights",
+                   "highlights", false);
+  ApplyGradeScalar(*grade, type_ids::Saturation(), FindOp(operators, kLegacySaturation), "saturation",
+                   "saturation", true);
+  ApplyGradeScalar(*grade, type_ids::Vibrance(), FindOp(operators, kLegacyVibrance), "vibrance",
+                   "vibrance", false);
+  ApplyGradeScalar(*grade, type_ids::Clarity(), FindOp(operators, kLegacyClarity), "clarity", "clarity",
+                   false);
+
+  if (const auto* curve = FindOp(operators, kLegacyCurve)) {
+    if (auto* model = grade->FindAdjustmentByType(type_ids::Curve())) {
+      const auto nested = NestedOrSelf(curve->params, "curve");
+      model->LoadJson(nested.is_object() ? nested : curve->params);
+    }
+  }
+  if (const auto* hls = FindOp(operators, kLegacyHls)) {
+    if (auto* model = grade->FindAdjustmentByType(type_ids::Hls())) {
+      model->LoadJson(NestedOrSelf(hls->params, "HLS"));
+    }
+  }
+  if (const auto* wheel = FindOp(operators, kLegacyColorWheel)) {
+    if (auto* model = grade->FindAdjustmentByType(type_ids::ColorWheel())) {
+      model->LoadJson(NestedOrSelf(wheel->params, "color_wheel"));
+    }
+  }
+  if (const auto* lmt = FindOp(operators, kLegacyLmt)) {
+    if (auto* model = grade->FindAdjustmentByType(type_ids::Lmt())) {
+      nlohmann::json json;
+      if (lmt->params.contains("ocio_lmt") && lmt->params["ocio_lmt"].is_string()) {
+        json["cube_path"] = lmt->params["ocio_lmt"].get<std::string>();
+      } else {
+        json["cube_path"] = json_util::ReadString(lmt->params, "cube_path", {});
+      }
+      model->LoadJson(json);
+    }
+  }
+  if (const auto* sharpen = FindOp(operators, kLegacySharpen)) {
+    if (auto* model = grade->FindAdjustmentByType(type_ids::Sharpen())) {
+      const auto nested = NestedOrSelf(sharpen->params, "sharpen");
+      nlohmann::json json;
+      json["amount"]    = json_util::ReadFloat(nested, "offset", json_util::ReadFloat(nested, "amount", 0.0f));
+      json["radius"]    = json_util::ReadFloat(nested, "radius", 3.0f);
+      json["threshold"] = json_util::ReadFloat(nested, "threshold", 0.0f);
+      model->LoadJson(json);
+    }
+  }
+  if (const auto* grain = FindOp(operators, kLegacyFilmGrain)) {
+    if (auto* model = grade->FindAdjustmentByType(type_ids::FilmGrain())) {
+      const auto nested = NestedOrSelf(grain->params, "film_grain");
+      ApplyScalar(model, nested, "strength");
+    }
+  }
+  if (const auto* halo = FindOp(operators, kLegacyHalation)) {
+    if (auto* model = grade->FindAdjustmentByType(type_ids::Halation())) {
+      const auto nested = NestedOrSelf(halo->params, "halation");
+      ApplyScalar(model, nested, "strength");
+    }
+  }
+  if (const auto* tint = FindOp(operators, kLegacyTint)) {
+    auto model = std::make_unique<TintModel>();
+    const auto nested = NestedOrSelf(tint->params, "tint");
+    ApplyScalar(model.get(), nested, "tint");
+    document.InsertAdjustment(NodeId{"grade.primary"}, grade->AdjustmentCount(),
+                              AdjustmentInstanceId{"grade.primary.tint"}, std::move(model));
+  }
+  if (const auto* odt = FindOp(operators, kLegacyOdt)) {
+    drt->Params().LoadJson(NestedOrSelf(odt->params, "odt"));
+  }
+
+  result.document = std::move(document);
+  return result;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/pipeline_document.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_document.cpp
@@ -1,0 +1,143 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/pipeline_document.hpp"
+
+#include <stdexcept>
+#include <string>
+
+#include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+
+namespace alcedo {
+
+namespace {
+
+template <class T>
+auto Downcast(INodeModel* node) -> T* {
+  return dynamic_cast<T*>(node);
+}
+
+template <class T>
+auto Downcast(const INodeModel* node) -> const T* {
+  return dynamic_cast<const T*>(node);
+}
+
+auto NodeFromJson(const nlohmann::json& json) -> std::unique_ptr<INodeModel> {
+  const auto type = json.at("type").get<std::string>();
+  if (type == type_ids::DevelopNode().Text()) {
+    return DevelopNodeModel::FromJson(json);
+  }
+  if (type == type_ids::ColorGradeNode().Text()) {
+    return ColorGradeNodeModel::FromJson(json);
+  }
+  if (type == type_ids::DrtNode().Text()) {
+    return DrtNodeModel::FromJson(json);
+  }
+  if (type == type_ids::AnalyticMaskNode().Text()) {
+    return AnalyticMaskNodeModel::FromJson(json);
+  }
+  if (type == type_ids::RasterMaskNode().Text()) {
+    return RasterMaskNodeModel::FromJson(json);
+  }
+  throw std::runtime_error("Unknown node type: " + type);
+}
+
+}  // namespace
+
+auto PipelineDocument::Develop() -> DevelopNodeModel* {
+  return Downcast<DevelopNodeModel>(graph_.FindNode("develop"));
+}
+
+auto PipelineDocument::Develop() const -> const DevelopNodeModel* {
+  return Downcast<DevelopNodeModel>(graph_.FindNode("develop"));
+}
+
+auto PipelineDocument::PrimaryGrade() -> ColorGradeNodeModel* {
+  return Downcast<ColorGradeNodeModel>(graph_.FindNode("grade.primary"));
+}
+
+auto PipelineDocument::PrimaryGrade() const -> const ColorGradeNodeModel* {
+  return Downcast<ColorGradeNodeModel>(graph_.FindNode("grade.primary"));
+}
+
+auto PipelineDocument::Drt() -> DrtNodeModel* {
+  return Downcast<DrtNodeModel>(graph_.FindNode("drt"));
+}
+
+auto PipelineDocument::Drt() const -> const DrtNodeModel* {
+  return Downcast<DrtNodeModel>(graph_.FindNode("drt"));
+}
+
+void PipelineDocument::InsertAdjustment(const NodeId& grade_id, std::size_t index,
+                                        AdjustmentInstanceId instance_id,
+                                        std::unique_ptr<IOperatorModel> model) {
+  auto* grade = Downcast<ColorGradeNodeModel>(graph_.FindNode(grade_id));
+  if (grade == nullptr) {
+    throw std::invalid_argument("InsertAdjustment: node is not a ColorGrade");
+  }
+  grade->InsertAdjustment(index, std::move(instance_id), std::move(model));
+  MarkTopologyDirty();
+}
+
+auto PipelineDocument::ToJson() const -> nlohmann::json {
+  nlohmann::json nodes = nlohmann::json::array();
+  for (const auto& node : graph_.Nodes()) {
+    nodes.push_back(node->ToJson());
+  }
+  nlohmann::json edges = nlohmann::json::array();
+  for (const auto& edge : graph_.Edges()) {
+    edges.push_back({{"from", nlohmann::json::array({std::string{edge.from_node.Value()},
+                                                     std::string{edge.from_port.Value()}})},
+                     {"to", nlohmann::json::array({std::string{edge.to_node.Value()},
+                                                   std::string{edge.to_port.Value()}})}});
+  }
+  return {{"format_version", format_version_},
+          {"geometry", geometry_.ToJson()},
+          {"nodes", std::move(nodes)},
+          {"edges", std::move(edges)}};
+}
+
+auto PipelineDocument::FromJson(const nlohmann::json& json) -> PipelineDocument {
+  PipelineDocument document;
+  if (!json.contains("format_version") || json["format_version"].get<std::uint32_t>() !=
+                                              kPipelineDocumentFormatVersion) {
+    throw std::runtime_error("Unsupported pipeline document format_version");
+  }
+  document.format_version_ = kPipelineDocumentFormatVersion;
+  if (json.contains("geometry")) {
+    document.geometry_ = ImageGeometryModel::FromJson(json["geometry"]);
+  }
+  if (json.contains("nodes") && json["nodes"].is_array()) {
+    for (const auto& node_json : json["nodes"]) {
+      document.graph_.AddNode(NodeFromJson(node_json));
+    }
+  }
+  if (json.contains("edges") && json["edges"].is_array()) {
+    for (const auto& edge_json : json["edges"]) {
+      const auto from = edge_json.at("from");
+      const auto to   = edge_json.at("to");
+      document.graph_.Connect(NodeId{from.at(0).get<std::string>()},
+                              PortId{from.at(1).get<std::string>()},
+                              NodeId{to.at(0).get<std::string>()}, PortId{to.at(1).get<std::string>()});
+    }
+  }
+  document.topology_dirty_ = true;
+  return document;
+}
+
+auto CreateDefaultPipelineDocument() -> PipelineDocument {
+  PipelineDocument document;
+  document.Graph().AddNode(std::make_unique<DevelopNodeModel>(NodeId{"develop"}));
+  document.Graph().AddNode(ColorGradeNodeModel::MakeDefault(NodeId{"grade.primary"}));
+  document.Graph().AddNode(std::make_unique<DrtNodeModel>(NodeId{"drt"}));
+  document.Graph().Connect(NodeId{"develop"}, PortId{"image"}, NodeId{"grade.primary"},
+                           PortId{"image"});
+  document.Graph().Connect(NodeId{"grade.primary"}, PortId{"image"}, NodeId{"drt"}, PortId{"image"});
+  document.MarkTopologyDirty();
+  return document;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/pipeline_graph.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_graph.cpp
@@ -1,0 +1,205 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/pipeline_graph.hpp"
+
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+
+namespace alcedo {
+
+void PipelineGraph::AddNode(std::unique_ptr<INodeModel> node) {
+  if (node == nullptr) {
+    throw std::invalid_argument("AddNode requires a node");
+  }
+  if (FindNode(node->Id()) != nullptr) {
+    throw std::invalid_argument("Duplicate node id: " + std::string{node->Id().Value()});
+  }
+  nodes_.push_back(std::move(node));
+}
+
+void PipelineGraph::Connect(NodeId from_node, PortId from_port, NodeId to_node, PortId to_port) {
+  edges_.push_back(GraphEdge{std::move(from_node), std::move(from_port), std::move(to_node),
+                             std::move(to_port)});
+}
+
+auto PipelineGraph::FindNode(const NodeId& id) -> INodeModel* {
+  return const_cast<INodeModel*>(static_cast<const PipelineGraph*>(this)->FindNode(id));
+}
+
+auto PipelineGraph::FindNode(const NodeId& id) const -> const INodeModel* {
+  for (const auto& node : nodes_) {
+    if (node->Id() == id) {
+      return node.get();
+    }
+  }
+  return nullptr;
+}
+
+auto PipelineGraph::FindNode(std::string_view id) -> INodeModel* {
+  return FindNode(NodeId{std::string{id}});
+}
+
+auto PipelineGraph::FindNode(std::string_view id) const -> const INodeModel* {
+  return FindNode(NodeId{std::string{id}});
+}
+
+auto PipelineGraph::FindPort(const INodeModel& node, const PortId& id, bool input) const
+    -> const PortDescriptor* {
+  const auto ports = input ? node.InputPorts() : node.OutputPorts();
+  for (const auto& port : ports) {
+    if (port.id == id) {
+      return &port;
+    }
+  }
+  return nullptr;
+}
+
+auto PipelineGraph::Validate() const -> std::vector<GraphValidationError> {
+  std::vector<GraphValidationError> errors;
+  int develop_count = 0;
+  int drt_count     = 0;
+  for (const auto& node : nodes_) {
+    if (node->Type() == type_ids::DevelopNode()) {
+      ++develop_count;
+    }
+    if (node->Type() == type_ids::DrtNode()) {
+      ++drt_count;
+    }
+  }
+  if (develop_count == 0) {
+    errors.push_back({GraphValidationCode::MissingDevelopEndpoint, "Graph needs one Develop node"});
+  } else if (develop_count > 1) {
+    errors.push_back(
+        {GraphValidationCode::MultipleDevelopEndpoints, "Graph has more than one Develop node"});
+  }
+  if (drt_count == 0) {
+    errors.push_back({GraphValidationCode::MissingDrtEndpoint, "Graph needs one DRT node"});
+  } else if (drt_count > 1) {
+    errors.push_back({GraphValidationCode::MultipleDrtEndpoints, "Graph has more than one DRT node"});
+  }
+
+  std::unordered_map<std::string, int> incoming_count;
+  for (const auto& edge : edges_) {
+    const auto* from = FindNode(edge.from_node);
+    const auto* to   = FindNode(edge.to_node);
+    if (from == nullptr) {
+      errors.push_back({GraphValidationCode::UnknownNode,
+                        "Unknown from node: " + std::string{edge.from_node.Value()}});
+      continue;
+    }
+    if (to == nullptr) {
+      errors.push_back({GraphValidationCode::UnknownNode,
+                        "Unknown to node: " + std::string{edge.to_node.Value()}});
+      continue;
+    }
+    const auto* from_port = FindPort(*from, edge.from_port, false);
+    const auto* to_port   = FindPort(*to, edge.to_port, true);
+    if (from_port == nullptr) {
+      errors.push_back({GraphValidationCode::UnknownPort,
+                        "Unknown output port: " + std::string{edge.from_port.Value()}});
+      continue;
+    }
+    if (to_port == nullptr) {
+      errors.push_back({GraphValidationCode::UnknownPort,
+                        "Unknown input port: " + std::string{edge.to_port.Value()}});
+      continue;
+    }
+    if (from_port->data_type != to_port->data_type) {
+      errors.push_back({GraphValidationCode::PortTypeMismatch,
+                        "Port type mismatch: " + std::string{from->Id().Value()} + "." +
+                            std::string{from_port->id.Value()} + " -> " +
+                            std::string{to->Id().Value()} + "." + std::string{to_port->id.Value()}});
+    }
+    const std::string key =
+        std::string{to->Id().Value()} + "/" + std::string{to_port->id.Value()};
+    incoming_count[key] += 1;
+  }
+
+  for (const auto& node : nodes_) {
+    for (const auto& port : node->InputPorts()) {
+      const std::string key = std::string{node->Id().Value()} + "/" + std::string{port.id.Value()};
+      const int         count = incoming_count[key];
+      if (port.required && count == 0) {
+        errors.push_back({GraphValidationCode::MissingRequiredInput,
+                          "Missing required input: " + key});
+      }
+      if (count > 1) {
+        errors.push_back({GraphValidationCode::MultipleInputsOnPort, "Multiple inputs on " + key});
+      }
+    }
+  }
+
+  std::unordered_map<std::string, int> indegree;
+  std::unordered_map<std::string, std::vector<std::string>> adjacency;
+  for (const auto& node : nodes_) {
+    indegree[std::string{node->Id().Value()}] = 0;
+  }
+  for (const auto& edge : edges_) {
+    adjacency[std::string{edge.from_node.Value()}].push_back(std::string{edge.to_node.Value()});
+    indegree[std::string{edge.to_node.Value()}] += 1;
+  }
+  std::queue<std::string> ready;
+  for (const auto& [id, degree] : indegree) {
+    if (degree == 0) {
+      ready.push(id);
+    }
+  }
+  std::size_t visited = 0;
+  while (!ready.empty()) {
+    const auto id = ready.front();
+    ready.pop();
+    ++visited;
+    for (const auto& next : adjacency[id]) {
+      indegree[next] -= 1;
+      if (indegree[next] == 0) {
+        ready.push(next);
+      }
+    }
+  }
+  if (visited != nodes_.size()) {
+    errors.push_back({GraphValidationCode::Cycle, "PipelineGraph contains a cycle"});
+  }
+  return errors;
+}
+
+auto PipelineGraph::TopologicalOrder() const -> std::vector<NodeId> {
+  if (!Validate().empty()) {
+    throw std::runtime_error("TopologicalOrder requires a valid graph");
+  }
+  std::unordered_map<std::string, int> indegree;
+  std::unordered_map<std::string, std::vector<std::string>> adjacency;
+  for (const auto& node : nodes_) {
+    indegree[std::string{node->Id().Value()}] = 0;
+  }
+  for (const auto& edge : edges_) {
+    adjacency[std::string{edge.from_node.Value()}].push_back(std::string{edge.to_node.Value()});
+    indegree[std::string{edge.to_node.Value()}] += 1;
+  }
+  std::queue<std::string> ready;
+  for (const auto& node : nodes_) {
+    if (indegree[std::string{node->Id().Value()}] == 0) {
+      ready.push(std::string{node->Id().Value()});
+    }
+  }
+  std::vector<NodeId> order;
+  while (!ready.empty()) {
+    const auto id = ready.front();
+    ready.pop();
+    order.emplace_back(id);
+    for (const auto& next : adjacency[id]) {
+      indegree[next] -= 1;
+      if (indegree[next] == 0) {
+        ready.push(next);
+      }
+    }
+  }
+  return order;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/raster_mask_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/raster_mask_node_model.cpp
@@ -1,0 +1,52 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/raster_mask_node_model.hpp"
+
+#include "edit/operators/models/json_read.hpp"
+
+namespace alcedo {
+
+RasterMaskNodeModel::RasterMaskNodeModel(NodeId id) : id_(std::move(id)) {
+  outputs_[0] = PortDescriptor{PortId{"mask"}, PortDataType::Mask, true};
+}
+
+auto RasterMaskNodeModel::InputPorts() const -> std::span<const PortDescriptor> { return {}; }
+
+auto RasterMaskNodeModel::OutputPorts() const -> std::span<const PortDescriptor> { return outputs_; }
+
+auto RasterMaskNodeModel::ToJson() const -> nlohmann::json {
+  return {{"id", std::string{id_.Value()}},
+          {"type", std::string{Type().Text()}},
+          {"params",
+           {{"asset_key", asset_key_},
+            {"reference_bounds",
+             nlohmann::json::array({reference_bounds_.x, reference_bounds_.y, reference_bounds_.w,
+                                    reference_bounds_.h})},
+            {"feather_radius", feather_radius_},
+            {"invert", invert_}}}};
+}
+
+auto RasterMaskNodeModel::FromJson(const nlohmann::json& json) -> std::unique_ptr<RasterMaskNodeModel> {
+  auto node = std::make_unique<RasterMaskNodeModel>(NodeId{json.at("id").get<std::string>()});
+  if (!json.contains("params") || !json["params"].is_object()) {
+    return node;
+  }
+  const auto& params = json["params"];
+  node->SetAssetKey(json_util::ReadString(params, "asset_key", {}));
+  node->SetFeatherRadius(json_util::ReadFloat(params, "feather_radius", 0.0f));
+  node->SetInvert(json_util::ReadBool(params, "invert", false));
+  if (params.contains("reference_bounds") && params["reference_bounds"].is_array() &&
+      params["reference_bounds"].size() >= 4) {
+    NormalizedRect bounds;
+    bounds.x = params["reference_bounds"][0].get<float>();
+    bounds.y = params["reference_bounds"][1].get<float>();
+    bounds.w = params["reference_bounds"][2].get<float>();
+    bounds.h = params["reference_bounds"][3].get<float>();
+    node->SetReferenceBounds(bounds);
+  }
+  return node;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/operators/models/adjustment_catalog.cpp
+++ b/alcedo_studio/src/edit/operators/models/adjustment_catalog.cpp
@@ -1,0 +1,93 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/operators/models/adjustment_catalog.hpp"
+
+#include <stdexcept>
+
+#include "edit/operators/models/cat02_white_balance_model.hpp"
+#include "edit/operators/models/color_wheel_model.hpp"
+#include "edit/operators/models/curve_model.hpp"
+#include "edit/operators/models/hls_model.hpp"
+#include "edit/operators/models/lmt_model.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/operators/models/sharpen_model.hpp"
+
+namespace alcedo {
+
+namespace {
+
+template <class Model>
+auto MakeFactory() -> OperatorModelFactory {
+  return []() -> std::unique_ptr<IOperatorModel> { return std::make_unique<Model>(); };
+}
+
+}  // namespace
+
+auto BuiltinAdjustmentCatalog::Instance() -> const BuiltinAdjustmentCatalog& {
+  static const BuiltinAdjustmentCatalog catalog;
+  return catalog;
+}
+
+BuiltinAdjustmentCatalog::BuiltinAdjustmentCatalog() {
+  Register({type_ids::Cat02WhiteBalance(), "CAT02 White Balance", MakeFactory<Cat02WhiteBalanceModel>()});
+  Register({type_ids::Exposure(), "Exposure", MakeFactory<ExposureModel>()});
+  Register({type_ids::Contrast(), "Contrast", MakeFactory<ContrastModel>()});
+  Register({type_ids::White(), "White", MakeFactory<WhiteModel>()});
+  Register({type_ids::Black(), "Black", MakeFactory<BlackModel>()});
+  Register({type_ids::Shadows(), "Shadows", MakeFactory<ShadowsModel>()});
+  Register({type_ids::Highlights(), "Highlights", MakeFactory<HighlightsModel>()});
+  Register({type_ids::Curve(), "Curve", MakeFactory<CurveModel>()});
+  Register({type_ids::Hls(), "HLS", MakeFactory<HlsModel>()});
+  Register({type_ids::Saturation(), "Saturation", MakeFactory<SaturationModel>()});
+  Register({type_ids::Vibrance(), "Vibrance", MakeFactory<VibranceModel>()});
+  Register({type_ids::ColorWheel(), "Color Wheel", MakeFactory<ColorWheelModel>()});
+  Register({type_ids::Lmt(), "LMT", MakeFactory<LmtModel>()});
+  Register({type_ids::Clarity(), "Clarity", MakeFactory<ClarityModel>()});
+  Register({type_ids::Sharpen(), "Sharpen", MakeFactory<SharpenModel>()});
+  Register({type_ids::Halation(), "Halation", MakeFactory<HalationModel>()});
+  Register({type_ids::FilmGrain(), "Film Grain", MakeFactory<FilmGrainModel>()});
+  Register({type_ids::Tint(), "Tint", MakeFactory<TintModel>()});
+}
+
+void BuiltinAdjustmentCatalog::Register(AdjustmentDefinition definition) {
+  for (const auto& existing : definitions_) {
+    if (existing.type.Text() == definition.type.Text()) {
+      throw std::logic_error("Duplicate adjustment type text: " + std::string{definition.type.Text()});
+    }
+    if (existing.type.Hash() == definition.type.Hash()) {
+      throw std::logic_error("Duplicate adjustment type hash: " + std::string{definition.type.Text()});
+    }
+  }
+  definitions_.push_back(std::move(definition));
+}
+
+auto BuiltinAdjustmentCatalog::Find(const OperatorTypeId& type) const
+    -> const AdjustmentDefinition* {
+  return Find(type.Text());
+}
+
+auto BuiltinAdjustmentCatalog::Find(std::string_view text) const -> const AdjustmentDefinition* {
+  for (const auto& definition : definitions_) {
+    if (definition.type.Text() == text) {
+      return &definition;
+    }
+  }
+  return nullptr;
+}
+
+auto BuiltinAdjustmentCatalog::Definitions() const -> const std::vector<AdjustmentDefinition>& {
+  return definitions_;
+}
+
+auto BuiltinAdjustmentCatalog::CreateDefault(const OperatorTypeId& type) const
+    -> std::unique_ptr<IOperatorModel> {
+  const auto* definition = Find(type);
+  if (definition == nullptr) {
+    return nullptr;
+  }
+  return definition->create_default_model();
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/operators/models/cat02_white_balance_model.cpp
+++ b/alcedo_studio/src/edit/operators/models/cat02_white_balance_model.cpp
@@ -1,0 +1,62 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/operators/models/cat02_white_balance_model.hpp"
+
+#include <algorithm>
+
+#include "edit/operators/models/json_read.hpp"
+
+namespace alcedo {
+
+auto Cat02WhiteBalanceModel::IsDefault() const -> bool {
+  return Read([](const Cat02WhiteBalancePayload& payload) {
+    return payload.enabled && payload.temperature_offset == 0.0f && payload.tint_offset == 0.0f;
+  });
+}
+
+void Cat02WhiteBalanceModel::SetEnabled(bool enabled) {
+  Mutate(Cat02WhiteBalanceDirty::Enabled,
+         [enabled](Cat02WhiteBalancePayload& payload) { payload.enabled = enabled; });
+}
+
+void Cat02WhiteBalanceModel::SetTemperatureOffset(float offset) {
+  const float clamped = std::clamp(offset, -100.0f, 100.0f);
+  Mutate(Cat02WhiteBalanceDirty::Temperature, [clamped](Cat02WhiteBalancePayload& payload) {
+    payload.temperature_offset = clamped;
+  });
+}
+
+void Cat02WhiteBalanceModel::SetTintOffset(float offset) {
+  const float clamped = std::clamp(offset, -100.0f, 100.0f);
+  Mutate(Cat02WhiteBalanceDirty::Tint,
+         [clamped](Cat02WhiteBalancePayload& payload) { payload.tint_offset = clamped; });
+}
+
+auto Cat02WhiteBalanceModel::Enabled() const -> bool {
+  return Read([](const Cat02WhiteBalancePayload& payload) { return payload.enabled; });
+}
+
+auto Cat02WhiteBalanceModel::TemperatureOffset() const -> float {
+  return Read([](const Cat02WhiteBalancePayload& payload) { return payload.temperature_offset; });
+}
+
+auto Cat02WhiteBalanceModel::TintOffset() const -> float {
+  return Read([](const Cat02WhiteBalancePayload& payload) { return payload.tint_offset; });
+}
+
+auto Cat02WhiteBalanceModel::ToJson() const -> nlohmann::json {
+  const auto payload = PayloadCopy();
+  return nlohmann::json{{"enabled", payload.enabled},
+                        {"temperature_offset", payload.temperature_offset},
+                        {"tint_offset", payload.tint_offset}};
+}
+
+void Cat02WhiteBalanceModel::LoadJson(const nlohmann::json& json) {
+  SetEnabled(json_util::ReadBool(json, "enabled", true));
+  SetTemperatureOffset(json_util::ReadFloat(json, "temperature_offset", 0.0f));
+  SetTintOffset(json_util::ReadFloat(json, "tint_offset", 0.0f));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/operators/models/color_wheel_model.cpp
+++ b/alcedo_studio/src/edit/operators/models/color_wheel_model.cpp
@@ -1,0 +1,81 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/operators/models/color_wheel_model.hpp"
+
+#include "edit/operators/models/json_read.hpp"
+
+namespace alcedo {
+
+namespace {
+
+auto ControlToJson(const ColorWheelControl& control) -> nlohmann::json {
+  return {{"disc", {{"x", control.disc.x}, {"y", control.disc.y}}},
+          {"strength", control.strength},
+          {"color_offset",
+           {{"x", control.color_offset.x},
+            {"y", control.color_offset.y},
+            {"z", control.color_offset.z}}},
+          {"luminance_offset", control.luminance_offset}};
+}
+
+auto ControlFromJson(const nlohmann::json& json, ColorWheelControl fallback) -> ColorWheelControl {
+  if (!json.is_object()) {
+    return fallback;
+  }
+  ColorWheelControl control = fallback;
+  if (json.contains("disc") && json["disc"].is_object()) {
+    control.disc.x = json_util::ReadFloat(json["disc"], "x", control.disc.x);
+    control.disc.y = json_util::ReadFloat(json["disc"], "y", control.disc.y);
+  }
+  control.strength = json_util::ReadFloat(json, "strength", control.strength);
+  if (json.contains("color_offset") && json["color_offset"].is_object()) {
+    control.color_offset.x = json_util::ReadFloat(json["color_offset"], "x", control.color_offset.x);
+    control.color_offset.y = json_util::ReadFloat(json["color_offset"], "y", control.color_offset.y);
+    control.color_offset.z = json_util::ReadFloat(json["color_offset"], "z", control.color_offset.z);
+  }
+  control.luminance_offset =
+      json_util::ReadFloat(json, "luminance_offset", control.luminance_offset);
+  return control;
+}
+
+auto IsIdentity(const ColorWheelPayload& payload) -> bool {
+  const auto lift_ok = payload.lift.disc.x == 0.0f && payload.lift.disc.y == 0.0f &&
+                       payload.lift.color_offset.x == 0.0f && payload.lift.color_offset.y == 0.0f &&
+                       payload.lift.color_offset.z == 0.0f && payload.lift.luminance_offset == 0.0f;
+  const auto gamma_ok = payload.gamma.color_offset.x == 1.0f && payload.gamma.color_offset.y == 1.0f &&
+                        payload.gamma.color_offset.z == 1.0f;
+  const auto gain_ok = payload.gain.color_offset.x == 1.0f && payload.gain.color_offset.y == 1.0f &&
+                       payload.gain.color_offset.z == 1.0f;
+  return lift_ok && gamma_ok && gain_ok;
+}
+
+}  // namespace
+
+auto ColorWheelModel::IsDefault() const -> bool {
+  return Read([](const ColorWheelPayload& payload) { return IsIdentity(payload); });
+}
+
+auto ColorWheelModel::ToJson() const -> nlohmann::json {
+  const auto payload = PayloadCopy();
+  return {{"lift", ControlToJson(payload.lift)},
+          {"gamma", ControlToJson(payload.gamma)},
+          {"gain", ControlToJson(payload.gain)}};
+}
+
+void ColorWheelModel::LoadJson(const nlohmann::json& json) {
+  Mutate(ColorWheelDirty::Wheels, [&json](ColorWheelPayload& payload) {
+    if (json.contains("lift")) {
+      payload.lift = ControlFromJson(json["lift"], payload.lift);
+    }
+    if (json.contains("gamma")) {
+      payload.gamma = ControlFromJson(json["gamma"], payload.gamma);
+    }
+    if (json.contains("gain")) {
+      payload.gain = ControlFromJson(json["gain"], payload.gain);
+    }
+  });
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/operators/models/curve_model.cpp
+++ b/alcedo_studio/src/edit/operators/models/curve_model.cpp
@@ -1,0 +1,57 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/operators/models/curve_model.hpp"
+
+#include <algorithm>
+
+namespace alcedo {
+
+namespace {
+
+auto IsIdentityPoints(const std::vector<CurvePoint>& points) -> bool {
+  return points.size() == 2 && points[0].x == 0.0f && points[0].y == 0.0f && points[1].x == 1.0f &&
+         points[1].y == 1.0f;
+}
+
+}  // namespace
+
+auto CurveModel::IsDefault() const -> bool {
+  return Read([](const CurvePayload& payload) { return IsIdentityPoints(payload.points); });
+}
+
+void CurveModel::SetPoints(std::vector<CurvePoint> points) {
+  if (points.size() < 2) {
+    points = {{0.0f, 0.0f}, {1.0f, 1.0f}};
+  }
+  Mutate(CurveDirty::Points,
+         [points = std::move(points)](CurvePayload& payload) mutable { payload.points = std::move(points); });
+}
+
+auto CurveModel::Points() const -> std::vector<CurvePoint> {
+  return Read([](const CurvePayload& payload) { return payload.points; });
+}
+
+auto CurveModel::ToJson() const -> nlohmann::json {
+  nlohmann::json points = nlohmann::json::array();
+  for (const auto& point : Points()) {
+    points.push_back({{"x", point.x}, {"y", point.y}});
+  }
+  return {{"points", std::move(points)}};
+}
+
+void CurveModel::LoadJson(const nlohmann::json& json) {
+  std::vector<CurvePoint> points;
+  if (json.contains("points") && json["points"].is_array()) {
+    for (const auto& item : json["points"]) {
+      CurvePoint point;
+      point.x = item.value("x", 0.0f);
+      point.y = item.value("y", 0.0f);
+      points.push_back(point);
+    }
+  }
+  SetPoints(std::move(points));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/operators/models/hls_model.cpp
+++ b/alcedo_studio/src/edit/operators/models/hls_model.cpp
@@ -1,0 +1,98 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/operators/models/hls_model.hpp"
+
+#include "edit/operators/models/json_read.hpp"
+
+namespace alcedo {
+
+namespace {
+
+auto TablesAreIdentity(const HlsPayload& payload) -> bool {
+  for (const auto& adj : payload.hls_adj_table) {
+    if (adj.h != 0.0f || adj.l != 0.0f || adj.s != 0.0f) {
+      return false;
+    }
+  }
+  return payload.hls_adj.h == 0.0f && payload.hls_adj.l == 0.0f && payload.hls_adj.s == 0.0f;
+}
+
+auto VecToJson(const HlsVec3& vec) -> nlohmann::json { return nlohmann::json::array({vec.h, vec.l, vec.s}); }
+
+auto VecFromJson(const nlohmann::json& json, HlsVec3 fallback) -> HlsVec3 {
+  if (!json.is_array() || json.size() < 3) {
+    return fallback;
+  }
+  HlsVec3 vec;
+  vec.h = json[0].is_number() ? json[0].get<float>() : fallback.h;
+  vec.l = json[1].is_number() ? json[1].get<float>() : fallback.l;
+  vec.s = json[2].is_number() ? json[2].get<float>() : fallback.s;
+  return vec;
+}
+
+}  // namespace
+
+auto HlsModel::IsDefault() const -> bool {
+  return Read([](const HlsPayload& payload) { return TablesAreIdentity(payload); });
+}
+
+auto HlsModel::ToJson() const -> nlohmann::json {
+  const auto     payload = PayloadCopy();
+  nlohmann::json hue_bins = nlohmann::json::array();
+  nlohmann::json adj_table = nlohmann::json::array();
+  nlohmann::json range_table = nlohmann::json::array();
+  for (int i = 0; i < kHlsHueBinCount; ++i) {
+    hue_bins.push_back(payload.hue_bins[static_cast<std::size_t>(i)]);
+    adj_table.push_back(VecToJson(payload.hls_adj_table[static_cast<std::size_t>(i)]));
+    range_table.push_back(payload.h_range_table[static_cast<std::size_t>(i)]);
+  }
+  return {{"hue_bins", std::move(hue_bins)},
+          {"hls_adj_table", std::move(adj_table)},
+          {"h_range_table", std::move(range_table)},
+          {"target_hls", VecToJson(payload.target_hls)},
+          {"hls_adj", VecToJson(payload.hls_adj)},
+          {"h_range", payload.h_range},
+          {"l_range", payload.l_range},
+          {"s_range", payload.s_range}};
+}
+
+void HlsModel::LoadJson(const nlohmann::json& json) {
+  Mutate(HlsDirty::Table, [&json](HlsPayload& payload) {
+    if (json.contains("hue_bins") && json["hue_bins"].is_array()) {
+      const auto& bins = json["hue_bins"];
+      for (int i = 0; i < kHlsHueBinCount && i < static_cast<int>(bins.size()); ++i) {
+        if (bins[i].is_number()) {
+          payload.hue_bins[static_cast<std::size_t>(i)] = bins[i].get<float>();
+        }
+      }
+    }
+    if (json.contains("hls_adj_table") && json["hls_adj_table"].is_array()) {
+      const auto& table = json["hls_adj_table"];
+      for (int i = 0; i < kHlsHueBinCount && i < static_cast<int>(table.size()); ++i) {
+        payload.hls_adj_table[static_cast<std::size_t>(i)] =
+            VecFromJson(table[i], payload.hls_adj_table[static_cast<std::size_t>(i)]);
+      }
+    }
+    if (json.contains("h_range_table") && json["h_range_table"].is_array()) {
+      const auto& table = json["h_range_table"];
+      for (int i = 0; i < kHlsHueBinCount && i < static_cast<int>(table.size()); ++i) {
+        if (table[i].is_number()) {
+          payload.h_range_table[static_cast<std::size_t>(i)] = table[i].get<float>();
+        }
+      }
+    }
+    if (json.contains("target_hls")) {
+      payload.target_hls = VecFromJson(json["target_hls"], payload.target_hls);
+    }
+    if (json.contains("hls_adj")) {
+      payload.hls_adj = VecFromJson(json["hls_adj"], payload.hls_adj);
+    }
+    payload.h_range = json_util::ReadFloat(json, "h_range", payload.h_range);
+    payload.l_range = json_util::ReadFloat(json, "l_range", payload.l_range);
+    payload.s_range = json_util::ReadFloat(json, "s_range", payload.s_range);
+  });
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/operators/models/lmt_model.cpp
+++ b/alcedo_studio/src/edit/operators/models/lmt_model.cpp
@@ -1,0 +1,31 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/operators/models/lmt_model.hpp"
+
+#include "edit/operators/models/json_read.hpp"
+
+namespace alcedo {
+
+auto LmtModel::IsDefault() const -> bool {
+  return Read([](const LmtPayload& payload) { return payload.cube_path.empty(); });
+}
+
+void LmtModel::SetCubePath(std::string path) {
+  Mutate(LmtDirty::Path, [path = std::move(path)](LmtPayload& payload) mutable {
+    payload.cube_path = std::move(path);
+  });
+}
+
+auto LmtModel::CubePath() const -> std::string {
+  return Read([](const LmtPayload& payload) { return payload.cube_path; });
+}
+
+auto LmtModel::ToJson() const -> nlohmann::json { return {{"cube_path", CubePath()}}; }
+
+void LmtModel::LoadJson(const nlohmann::json& json) {
+  SetCubePath(json_util::ReadString(json, "cube_path", {}));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/operators/models/sharpen_model.cpp
+++ b/alcedo_studio/src/edit/operators/models/sharpen_model.cpp
@@ -1,0 +1,58 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/operators/models/sharpen_model.hpp"
+
+#include <algorithm>
+
+#include "edit/operators/models/json_read.hpp"
+
+namespace alcedo {
+
+auto SharpenModel::IsDefault() const -> bool {
+  return Read([](const SharpenPayload& payload) {
+    return payload.amount == 0.0f && payload.radius == 3.0f && payload.threshold == 0.0f;
+  });
+}
+
+void SharpenModel::SetAmount(float amount) {
+  const float clamped = std::clamp(amount, 0.0f, 100.0f);
+  Mutate(SharpenDirty::Amount, [clamped](SharpenPayload& payload) { payload.amount = clamped; });
+}
+
+void SharpenModel::SetRadius(float radius) {
+  const float clamped = std::clamp(radius, 0.1f, 64.0f);
+  Mutate(SharpenDirty::Radius, [clamped](SharpenPayload& payload) { payload.radius = clamped; });
+}
+
+void SharpenModel::SetThreshold(float threshold) {
+  const float clamped = std::clamp(threshold, 0.0f, 1.0f);
+  Mutate(SharpenDirty::Threshold,
+         [clamped](SharpenPayload& payload) { payload.threshold = clamped; });
+}
+
+auto SharpenModel::Amount() const -> float {
+  return Read([](const SharpenPayload& payload) { return payload.amount; });
+}
+
+auto SharpenModel::Radius() const -> float {
+  return Read([](const SharpenPayload& payload) { return payload.radius; });
+}
+
+auto SharpenModel::Threshold() const -> float {
+  return Read([](const SharpenPayload& payload) { return payload.threshold; });
+}
+
+auto SharpenModel::ToJson() const -> nlohmann::json {
+  const auto payload = PayloadCopy();
+  return {{"amount", payload.amount}, {"radius", payload.radius}, {"threshold", payload.threshold}};
+}
+
+void SharpenModel::LoadJson(const nlohmann::json& json) {
+  SetAmount(json_util::ReadFloat(json, "amount", 0.0f));
+  SetRadius(json_util::ReadFloat(json, "radius", 3.0f));
+  SetThreshold(json_util::ReadFloat(json, "threshold", 0.0f));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/analytic_mask_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/analytic_mask_node_model.hpp
@@ -1,0 +1,76 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <span>
+
+#include "edit/graph/i_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+
+namespace alcedo {
+
+enum class AnalyticMaskKind {
+  Radial,
+  GraduatedNd,
+};
+
+struct RadialMaskParams {
+  float center_x      = 0.5f;
+  float center_y      = 0.5f;
+  float major_radius  = 0.5f;
+  float minor_radius  = 0.5f;
+  float rotation      = 0.0f;
+  float inner_feather = 0.0f;
+  float outer_feather = 0.0f;
+  bool  invert        = false;
+};
+
+struct GraduatedNdMaskParams {
+  float origin_x             = 0.5f;
+  float origin_y             = 0.5f;
+  float normal_x             = 0.0f;
+  float normal_y             = 1.0f;
+  float transition_distance  = 0.2f;
+  float start_value          = 1.0f;
+  float end_value            = 0.0f;
+  bool  invert               = false;
+};
+
+/**
+ * @brief Analytic mask node. Produces a Mask port; not created in the default graph.
+ */
+class AnalyticMaskNodeModel final : public INodeModel {
+ public:
+  explicit AnalyticMaskNodeModel(NodeId id, AnalyticMaskKind kind = AnalyticMaskKind::Radial);
+
+  [[nodiscard]] auto Id() const -> const NodeId& override { return id_; }
+  [[nodiscard]] auto Type() const -> const OperatorTypeId& override {
+    return type_ids::AnalyticMaskNode();
+  }
+  [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+
+  [[nodiscard]] auto Kind() const -> AnalyticMaskKind { return kind_; }
+  [[nodiscard]] auto Radial() const -> const RadialMaskParams& { return radial_; }
+  [[nodiscard]] auto GraduatedNd() const -> const GraduatedNdMaskParams& { return graduated_; }
+
+  void SetKind(AnalyticMaskKind kind) { kind_ = kind; }
+  void SetRadial(RadialMaskParams params) { radial_ = params; }
+  void SetGraduatedNd(GraduatedNdMaskParams params) { graduated_ = params; }
+
+  static auto FromJson(const nlohmann::json& json) -> std::unique_ptr<AnalyticMaskNodeModel>;
+
+ private:
+  NodeId                 id_;
+  AnalyticMaskKind       kind_ = AnalyticMaskKind::Radial;
+  RadialMaskParams       radial_{};
+  GraduatedNdMaskParams  graduated_{};
+  std::array<PortDescriptor, 1> outputs_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
@@ -1,0 +1,79 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "edit/graph/i_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/i_operator_model.hpp"
+
+namespace alcedo {
+
+struct AdjustmentModelEntry {
+  AdjustmentInstanceId           instance_id;
+  std::unique_ptr<IOperatorModel> model;
+};
+
+/**
+ * @brief Color grade node with an ordered adjustment list, mix, and optional mask input.
+ *
+ * Adjustment list order is user data. GraphCompiler must not reorder Models.
+ */
+class ColorGradeNodeModel final : public INodeModel {
+ public:
+  explicit ColorGradeNodeModel(NodeId id);
+
+  [[nodiscard]] auto Id() const -> const NodeId& override { return id_; }
+  [[nodiscard]] auto Type() const -> const OperatorTypeId& override {
+    return type_ids::ColorGradeNode();
+  }
+  [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+
+  /**
+   * @brief Default primary grade: CAT02 through film grain in the documented order.
+   * @param id Node id, typically "grade.primary".
+   */
+  static auto MakeDefault(NodeId id) -> std::unique_ptr<ColorGradeNodeModel>;
+  static auto FromJson(const nlohmann::json& json) -> std::unique_ptr<ColorGradeNodeModel>;
+
+  void SetEnabled(bool enabled);
+  void SetMix(float mix);
+
+  [[nodiscard]] auto Enabled() const -> bool { return enabled_; }
+  [[nodiscard]] auto Mix() const -> float { return mix_; }
+
+  [[nodiscard]] auto AdjustmentCount() const -> std::size_t { return adjustments_.size(); }
+  [[nodiscard]] auto AdjustmentIdAt(std::size_t index) const -> const AdjustmentInstanceId&;
+  [[nodiscard]] auto AdjustmentAt(std::size_t index) -> IOperatorModel&;
+  [[nodiscard]] auto AdjustmentAt(std::size_t index) const -> const IOperatorModel&;
+  [[nodiscard]] auto FindAdjustment(const AdjustmentInstanceId& id) -> IOperatorModel*;
+  [[nodiscard]] auto FindAdjustmentByType(const OperatorTypeId& type) -> IOperatorModel*;
+  [[nodiscard]] auto FindAdjustmentByType(const OperatorTypeId& type) const -> const IOperatorModel*;
+
+  /**
+   * @brief Insert an adjustment instance. Caller must mark topology_dirty on the document.
+   */
+  void InsertAdjustment(std::size_t index, AdjustmentInstanceId id,
+                        std::unique_ptr<IOperatorModel> model);
+  void RemoveAdjustment(const AdjustmentInstanceId& id);
+  void MoveAdjustment(const AdjustmentInstanceId& id, std::size_t index);
+
+ private:
+  NodeId id_;
+  std::vector<AdjustmentModelEntry> adjustments_;
+  bool  enabled_ = true;
+  float mix_     = 1.0f;
+  std::array<PortDescriptor, 2> inputs_;
+  std::array<PortDescriptor, 1> outputs_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/develop_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/develop_node_model.hpp
@@ -1,0 +1,92 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <array>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "edit/graph/i_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_model_base.hpp"
+
+namespace alcedo {
+
+struct DevelopPayload {
+  std::string demosaic_method          = "default";
+  bool        highlights_reconstruct   = true;
+  bool        use_camera_wb            = true;
+  float       user_wb                  = 7600.0f;
+  std::string wb_mode                  = "as_shot";
+  float       custom_cct               = 6500.0f;
+  float       custom_tint              = 0.0f;
+  float       as_shot_cct              = 6500.0f;
+  float       as_shot_tint             = 0.0f;
+  bool        lens_enabled             = false;
+  bool        apply_vignetting         = true;
+  bool        apply_distortion         = true;
+  bool        apply_tca                = true;
+  bool        apply_crop               = true;
+  bool        auto_scale               = true;
+  bool        use_user_scale           = false;
+  float       user_scale               = 1.0f;
+  bool        projection_enabled       = false;
+  std::string target_projection        = "unknown";
+  std::string lens_profile_db_path     = "src/config/lens_calib";
+};
+
+enum class DevelopDirty : std::uint32_t {
+  None        = 0,
+  Demosaic    = 1U << 0,
+  Highlights  = 1U << 1,
+  WhiteBalance = 1U << 2,
+  Lens        = 1U << 3,
+  All         = Demosaic | Highlights | WhiteBalance | Lens,
+};
+
+/**
+ * @brief Develop endpoint parameters. LibRaw unpack stays outside the graph.
+ */
+class DevelopParamsModel final
+    : public OperatorModelBase<DevelopParamsModel, DevelopPayload, DevelopDirty> {
+ public:
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::DevelopNode(); }
+
+  [[nodiscard]] auto IsDefault() const -> bool override;
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+  void               LoadJson(const nlohmann::json& json) override;
+
+  [[nodiscard]] auto Params() const -> DevelopPayload { return PayloadCopy(); }
+  void               ReplaceParams(DevelopPayload payload);
+};
+
+/**
+ * @brief Develop root node. No image input; one scene-image output.
+ */
+class DevelopNodeModel final : public INodeModel {
+ public:
+  explicit DevelopNodeModel(NodeId id);
+
+  [[nodiscard]] auto Id() const -> const NodeId& override { return id_; }
+  [[nodiscard]] auto Type() const -> const OperatorTypeId& override { return type_ids::DevelopNode(); }
+  [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+
+  [[nodiscard]] auto Params() -> DevelopParamsModel& { return params_; }
+  [[nodiscard]] auto Params() const -> const DevelopParamsModel& { return params_; }
+
+  static auto FromJson(const nlohmann::json& json) -> std::unique_ptr<DevelopNodeModel>;
+
+ private:
+  NodeId             id_;
+  DevelopParamsModel params_;
+  std::array<PortDescriptor, 1> outputs_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/drt_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/drt_node_model.hpp
@@ -1,0 +1,158 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+
+#include "edit/graph/i_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_model_base.hpp"
+
+namespace alcedo {
+
+enum class DrtMethod : int {
+  Aces20  = 0,
+  OpenDrt = 1,
+};
+
+enum class DrtColorSpace : int {
+  Rec709  = 0,
+  Rec2020 = 1,
+  P3D65   = 2,
+};
+
+enum class DrtEotf : int {
+  Linear   = 0,
+  St2084   = 1,
+  Hlg      = 2,
+  Gamma26  = 3,
+  Bt1886   = 4,
+  Gamma22  = 5,
+  Gamma18  = 6,
+};
+
+struct OpenDrtDetailedParams {
+  float tn_con       = 1.66f;
+  float tn_sh        = 0.5f;
+  float tn_toe       = 0.003f;
+  float tn_off       = 0.005f;
+  float tn_hcon      = 0.0f;
+  float tn_hcon_pv   = 1.0f;
+  float tn_hcon_st   = 4.0f;
+  float tn_lcon      = 0.0f;
+  float tn_lcon_w    = 0.5f;
+  float cwp_lm       = 0.25f;
+  float rs_sa        = 0.35f;
+  float rs_rw        = 0.25f;
+  float rs_bw        = 0.55f;
+  float pt_lml       = 0.25f;
+  float pt_lml_r     = 0.5f;
+  float pt_lml_g     = 0.0f;
+  float pt_lml_b     = 0.1f;
+  float pt_lmh       = 0.25f;
+  float pt_lmh_r     = 0.5f;
+  float pt_lmh_b     = 0.0f;
+  float ptl_c        = 0.06f;
+  float ptl_m        = 0.08f;
+  float ptl_y        = 0.06f;
+  float ptm_low      = 0.4f;
+  float ptm_low_rng  = 0.25f;
+  float ptm_low_st   = 0.5f;
+  float ptm_high     = -0.8f;
+  float ptm_high_rng = 0.35f;
+  float ptm_high_st  = 0.4f;
+  float brl          = 0.0f;
+  float brl_r        = -2.5f;
+  float brl_g        = -1.5f;
+  float brl_b        = -1.5f;
+  float brl_rng      = 0.5f;
+  float brl_st       = 0.35f;
+  float brlp         = -0.5f;
+  float brlp_r       = -1.25f;
+  float brlp_g       = -1.25f;
+  float brlp_b       = -0.25f;
+  float hc_r         = 1.0f;
+  float hc_r_rng     = 0.3f;
+  float hs_r         = 0.6f;
+  float hs_r_rng     = 0.6f;
+  float hs_g         = 0.35f;
+  float hs_g_rng     = 1.0f;
+  float hs_b         = 0.66f;
+  float hs_b_rng     = 1.0f;
+  float hs_c         = 0.25f;
+  float hs_c_rng     = 1.0f;
+  float hs_m         = 0.0f;
+  float hs_m_rng     = 1.0f;
+  float hs_y         = 0.0f;
+  float hs_y_rng     = 1.0f;
+};
+
+struct DrtPayload {
+  DrtMethod     method          = DrtMethod::OpenDrt;
+  DrtColorSpace encoding_space  = DrtColorSpace::Rec709;
+  DrtEotf       encoding_eotf   = DrtEotf::Gamma22;
+  DrtColorSpace limiting_space  = DrtColorSpace::Rec709;
+  float         peak_luminance  = 100.0f;
+  std::string   look_preset     = "standard";
+  std::string   tonescale_preset = "use_look_preset";
+  std::string   creative_white  = "use_look_preset";
+  float         creative_white_limit     = 0.25f;
+  float         display_grey_luminance   = 10.0f;
+  float         hdr_grey_boost           = 0.13f;
+  float         hdr_purity               = 0.5f;
+  OpenDrtDetailedParams parameters{};
+};
+
+enum class DrtDirty : std::uint32_t {
+  None       = 0,
+  Method     = 1U << 0,
+  Encoding   = 1U << 1,
+  OpenDrt    = 1U << 2,
+  All        = Method | Encoding | OpenDrt,
+};
+
+class DrtParamsModel final : public OperatorModelBase<DrtParamsModel, DrtPayload, DrtDirty> {
+ public:
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::DrtNode(); }
+
+  [[nodiscard]] auto IsDefault() const -> bool override;
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+  void               LoadJson(const nlohmann::json& json) override;
+
+  [[nodiscard]] auto Params() const -> DrtPayload { return PayloadCopy(); }
+  void               ReplaceParams(DrtPayload payload);
+};
+
+/**
+ * @brief Display-referred endpoint. One scene-image input; display output is not
+ * a scene graph port.
+ */
+class DrtNodeModel final : public INodeModel {
+ public:
+  explicit DrtNodeModel(NodeId id);
+
+  [[nodiscard]] auto Id() const -> const NodeId& override { return id_; }
+  [[nodiscard]] auto Type() const -> const OperatorTypeId& override { return type_ids::DrtNode(); }
+  [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+
+  [[nodiscard]] auto Params() -> DrtParamsModel& { return params_; }
+  [[nodiscard]] auto Params() const -> const DrtParamsModel& { return params_; }
+
+  static auto FromJson(const nlohmann::json& json) -> std::unique_ptr<DrtNodeModel>;
+
+ private:
+  NodeId         id_;
+  DrtParamsModel params_;
+  std::array<PortDescriptor, 1> inputs_;
+  std::array<PortDescriptor, 1> outputs_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/graph_ids.hpp
+++ b/alcedo_studio/src/include/edit/graph/graph_ids.hpp
@@ -1,0 +1,98 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace alcedo {
+
+/**
+ * @brief Stable identifier for a node in a PipelineGraph.
+ *
+ * Default document uses "develop", "grade.primary", and "drt".
+ */
+class NodeId {
+ public:
+  NodeId() = default;
+  explicit NodeId(std::string value) : value_(std::move(value)) {}
+
+  [[nodiscard]] auto Value() const -> std::string_view { return value_; }
+  [[nodiscard]] auto Empty() const -> bool { return value_.empty(); }
+
+  friend auto operator==(const NodeId& lhs, const NodeId& rhs) -> bool {
+    return lhs.value_ == rhs.value_;
+  }
+  friend auto operator!=(const NodeId& lhs, const NodeId& rhs) -> bool { return !(lhs == rhs); }
+  friend auto operator<(const NodeId& lhs, const NodeId& rhs) -> bool {
+    return lhs.value_ < rhs.value_;
+  }
+
+ private:
+  std::string value_;
+};
+
+/**
+ * @brief Named port on a node ("image", "mask", "display").
+ */
+class PortId {
+ public:
+  PortId() = default;
+  explicit PortId(std::string value) : value_(std::move(value)) {}
+
+  [[nodiscard]] auto Value() const -> std::string_view { return value_; }
+  [[nodiscard]] auto Empty() const -> bool { return value_.empty(); }
+
+  friend auto operator==(const PortId& lhs, const PortId& rhs) -> bool {
+    return lhs.value_ == rhs.value_;
+  }
+  friend auto operator!=(const PortId& lhs, const PortId& rhs) -> bool { return !(lhs == rhs); }
+
+ private:
+  std::string value_;
+};
+
+/**
+ * @brief Identity of one adjustment instance inside a ColorGrade node.
+ *
+ * Distinct from OperatorTypeId so the same adjustment type can appear twice.
+ */
+class AdjustmentInstanceId {
+ public:
+  AdjustmentInstanceId() = default;
+  explicit AdjustmentInstanceId(std::string value) : value_(std::move(value)) {}
+
+  [[nodiscard]] auto Value() const -> std::string_view { return value_; }
+  [[nodiscard]] auto Empty() const -> bool { return value_.empty(); }
+
+  friend auto operator==(const AdjustmentInstanceId& lhs, const AdjustmentInstanceId& rhs)
+      -> bool {
+    return lhs.value_ == rhs.value_;
+  }
+  friend auto operator!=(const AdjustmentInstanceId& lhs, const AdjustmentInstanceId& rhs)
+      -> bool {
+    return !(lhs == rhs);
+  }
+
+ private:
+  std::string value_;
+};
+
+/**
+ * @brief Identity of a produced graph value: producer node plus output port.
+ *
+ * Workspace KV cache (later phases) keys results by this id.
+ */
+struct GraphValueId {
+  NodeId producer;
+  PortId output_port;
+
+  friend auto operator==(const GraphValueId& lhs, const GraphValueId& rhs) -> bool {
+    return lhs.producer == rhs.producer && lhs.output_port == rhs.output_port;
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/graph_validation.hpp
+++ b/alcedo_studio/src/include/edit/graph/graph_validation.hpp
@@ -1,0 +1,31 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <string>
+
+namespace alcedo {
+
+enum class GraphValidationCode {
+  Ok = 0,
+  DuplicateNodeId,
+  MissingDevelopEndpoint,
+  MissingDrtEndpoint,
+  MultipleDevelopEndpoints,
+  MultipleDrtEndpoints,
+  UnknownNode,
+  UnknownPort,
+  PortTypeMismatch,
+  Cycle,
+  MissingRequiredInput,
+  MultipleInputsOnPort,
+};
+
+struct GraphValidationError {
+  GraphValidationCode code = GraphValidationCode::Ok;
+  std::string         message;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/i_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/i_node_model.hpp
@@ -1,0 +1,34 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <span>
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/graph/port.hpp"
+#include "edit/operators/models/operator_type_id.hpp"
+#include "json.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief User-assemblable graph node. Does not execute GPU work.
+ */
+class INodeModel {
+ public:
+  virtual ~INodeModel() = default;
+
+  [[nodiscard]] virtual auto Id() const -> const NodeId&                 = 0;
+  [[nodiscard]] virtual auto Type() const -> const OperatorTypeId&       = 0;
+  [[nodiscard]] virtual auto InputPorts() const -> std::span<const PortDescriptor>  = 0;
+  [[nodiscard]] virtual auto OutputPorts() const -> std::span<const PortDescriptor> = 0;
+
+  /**
+   * @brief Serialize node identity, type, and parameters. Does not include edges.
+   */
+  [[nodiscard]] virtual auto ToJson() const -> nlohmann::json = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/image_geometry_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/image_geometry_model.hpp
@@ -1,0 +1,68 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "json.hpp"
+
+namespace alcedo {
+
+struct NormalizedRect {
+  float x = 0.0f;
+  float y = 0.0f;
+  float w = 1.0f;
+  float h = 1.0f;
+
+  [[nodiscard]] auto IsFullFrame() const -> bool {
+    return x == 0.0f && y == 0.0f && w == 1.0f && h == 1.0f;
+  }
+};
+
+/**
+ * @brief Document-level crop and rotation. Not a user-visible graph node.
+ *
+ * Viewport ROI and dynamic resolution are render-request data and are not stored.
+ */
+class ImageGeometryModel {
+ public:
+  ImageGeometryModel() = default;
+
+  [[nodiscard]] auto CropRect() const -> NormalizedRect { return crop_rect_; }
+  [[nodiscard]] auto RotationDegrees() const -> float { return rotation_degrees_; }
+  [[nodiscard]] auto ExpandToFit() const -> bool { return expand_to_fit_; }
+
+  void SetCropRect(NormalizedRect rect) { crop_rect_ = rect; }
+  void SetRotationDegrees(float degrees) { rotation_degrees_ = degrees; }
+  void SetExpandToFit(bool expand) { expand_to_fit_ = expand; }
+
+  [[nodiscard]] auto ToJson() const -> nlohmann::json {
+    return {{"crop_rect", nlohmann::json::array({crop_rect_.x, crop_rect_.y, crop_rect_.w, crop_rect_.h})},
+            {"rotation_degrees", rotation_degrees_},
+            {"expand_to_fit", expand_to_fit_}};
+  }
+
+  static auto FromJson(const nlohmann::json& json) -> ImageGeometryModel {
+    ImageGeometryModel model;
+    if (json.contains("crop_rect") && json["crop_rect"].is_array() && json["crop_rect"].size() >= 4) {
+      model.crop_rect_.x = json["crop_rect"][0].get<float>();
+      model.crop_rect_.y = json["crop_rect"][1].get<float>();
+      model.crop_rect_.w = json["crop_rect"][2].get<float>();
+      model.crop_rect_.h = json["crop_rect"][3].get<float>();
+    }
+    if (json.contains("rotation_degrees") && json["rotation_degrees"].is_number()) {
+      model.rotation_degrees_ = json["rotation_degrees"].get<float>();
+    }
+    if (json.contains("expand_to_fit") && json["expand_to_fit"].is_boolean()) {
+      model.expand_to_fit_ = json["expand_to_fit"].get<bool>();
+    }
+    return model;
+  }
+
+ private:
+  NormalizedRect crop_rect_{};
+  float          rotation_degrees_ = 0.0f;
+  bool           expand_to_fit_    = true;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/legacy_pipeline_importer.hpp
+++ b/alcedo_studio/src/include/edit/graph/legacy_pipeline_importer.hpp
@@ -1,0 +1,35 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "edit/graph/pipeline_document.hpp"
+
+namespace alcedo {
+
+struct LegacyImportResult {
+  std::optional<PipelineDocument> document;
+  std::string                     error;
+
+  [[nodiscard]] auto Ok() const -> bool { return document.has_value(); }
+};
+
+/**
+ * @brief One-way importer from old stage JSON to PipelineDocument.
+ *
+ * Does not switch the product read path. Unknown operator types fail the import.
+ */
+class LegacyPipelineImporter {
+ public:
+  /**
+   * @param stage_json CPUPipelineExecutor::ExportPipelineParams shape.
+   * @return Document on success; error string and empty document on failure.
+   */
+  [[nodiscard]] static auto Import(const nlohmann::json& stage_json) -> LegacyImportResult;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
@@ -1,0 +1,67 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/develop_node_model.hpp"
+#include "edit/graph/drt_node_model.hpp"
+#include "edit/graph/image_geometry_model.hpp"
+#include "edit/graph/pipeline_graph.hpp"
+
+namespace alcedo {
+
+inline constexpr std::uint32_t kPipelineDocumentFormatVersion = 2;
+
+/**
+ * @brief Serializable pipeline: geometry plus DAG. Does not own a GPU workspace.
+ *
+ * Graph edits set topology_dirty. Parameter Model setters do not.
+ */
+class PipelineDocument {
+ public:
+  PipelineDocument() = default;
+
+  [[nodiscard]] auto FormatVersion() const -> std::uint32_t { return format_version_; }
+  [[nodiscard]] auto Geometry() -> ImageGeometryModel& { return geometry_; }
+  [[nodiscard]] auto Geometry() const -> const ImageGeometryModel& { return geometry_; }
+  [[nodiscard]] auto Graph() -> PipelineGraph& { return graph_; }
+  [[nodiscard]] auto Graph() const -> const PipelineGraph& { return graph_; }
+
+  [[nodiscard]] auto TopologyDirty() const -> bool { return topology_dirty_; }
+  void               MarkTopologyDirty() { topology_dirty_ = true; }
+  void               ClearTopologyDirty() { topology_dirty_ = false; }
+
+  [[nodiscard]] auto Develop() -> DevelopNodeModel*;
+  [[nodiscard]] auto Develop() const -> const DevelopNodeModel*;
+  [[nodiscard]] auto PrimaryGrade() -> ColorGradeNodeModel*;
+  [[nodiscard]] auto PrimaryGrade() const -> const ColorGradeNodeModel*;
+  [[nodiscard]] auto Drt() -> DrtNodeModel*;
+  [[nodiscard]] auto Drt() const -> const DrtNodeModel*;
+
+  /**
+   * @brief Insert an adjustment on a ColorGrade node and set topology_dirty.
+   */
+  void InsertAdjustment(const NodeId& grade_id, std::size_t index, AdjustmentInstanceId instance_id,
+                        std::unique_ptr<IOperatorModel> model);
+
+  [[nodiscard]] auto ToJson() const -> nlohmann::json;
+  static auto        FromJson(const nlohmann::json& json) -> PipelineDocument;
+
+ private:
+  std::uint32_t       format_version_ = kPipelineDocumentFormatVersion;
+  ImageGeometryModel  geometry_{};
+  PipelineGraph       graph_{};
+  bool                topology_dirty_ = true;
+};
+
+/**
+ * @brief Three-node default: Develop -> Primary Color Grade -> DRT.
+ */
+[[nodiscard]] auto CreateDefaultPipelineDocument() -> PipelineDocument;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/pipeline_graph.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_graph.hpp
@@ -1,0 +1,61 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "edit/graph/graph_validation.hpp"
+#include "edit/graph/i_node_model.hpp"
+
+namespace alcedo {
+
+struct GraphEdge {
+  NodeId from_node;
+  PortId from_port;
+  NodeId to_node;
+  PortId to_port;
+};
+
+/**
+ * @brief Simple directed graph of INodeModel instances.
+ *
+ * Does not own GPU resources. Validate reports endpoint, port-type, and cycle errors.
+ */
+class PipelineGraph {
+ public:
+  void AddNode(std::unique_ptr<INodeModel> node);
+  void Connect(NodeId from_node, PortId from_port, NodeId to_node, PortId to_port);
+
+  [[nodiscard]] auto Validate() const -> std::vector<GraphValidationError>;
+  /**
+   * @brief Topological node order.
+   * @pre Validate() is empty; otherwise throws std::runtime_error.
+   */
+  [[nodiscard]] auto TopologicalOrder() const -> std::vector<NodeId>;
+
+  [[nodiscard]] auto NodeCount() const -> std::size_t { return nodes_.size(); }
+  [[nodiscard]] auto Edges() const -> const std::vector<GraphEdge>& { return edges_; }
+
+  [[nodiscard]] auto FindNode(const NodeId& id) -> INodeModel*;
+  [[nodiscard]] auto FindNode(const NodeId& id) const -> const INodeModel*;
+  [[nodiscard]] auto FindNode(std::string_view id) -> INodeModel*;
+  [[nodiscard]] auto FindNode(std::string_view id) const -> const INodeModel*;
+
+  [[nodiscard]] auto Nodes() -> std::vector<std::unique_ptr<INodeModel>>& { return nodes_; }
+  [[nodiscard]] auto Nodes() const -> const std::vector<std::unique_ptr<INodeModel>>& {
+    return nodes_;
+  }
+
+ private:
+  [[nodiscard]] auto FindPort(const INodeModel& node, const PortId& id, bool input) const
+      -> const PortDescriptor*;
+
+  std::vector<std::unique_ptr<INodeModel>> nodes_;
+  std::vector<GraphEdge>                   edges_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/port.hpp
+++ b/alcedo_studio/src/include/edit/graph/port.hpp
@@ -1,0 +1,29 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/graph/graph_ids.hpp"
+
+namespace alcedo {
+
+enum class PortDataType {
+  SceneImage,
+  DisplayImage,
+  Mask,
+};
+
+/**
+ * @brief Static description of one node port.
+ *
+ * @param required Incoming required ports must have exactly one edge. Optional
+ *        ports (ColorGrade mask) may have zero or one edge.
+ */
+struct PortDescriptor {
+  PortId       id;
+  PortDataType data_type  = PortDataType::SceneImage;
+  bool         required   = true;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/raster_mask_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/raster_mask_node_model.hpp
@@ -1,0 +1,56 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <span>
+#include <string>
+
+#include <string_view>
+
+#include "edit/graph/i_node_model.hpp"
+#include "edit/graph/image_geometry_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Raster mask node referencing a MaskAssetKey. GPU textures are not stored here.
+ */
+class RasterMaskNodeModel final : public INodeModel {
+ public:
+  explicit RasterMaskNodeModel(NodeId id);
+
+  [[nodiscard]] auto Id() const -> const NodeId& override { return id_; }
+  [[nodiscard]] auto Type() const -> const OperatorTypeId& override {
+    return type_ids::RasterMaskNode();
+  }
+  [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+
+  [[nodiscard]] auto AssetKey() const -> std::string_view { return asset_key_; }
+  [[nodiscard]] auto ReferenceBounds() const -> NormalizedRect { return reference_bounds_; }
+  [[nodiscard]] auto FeatherRadius() const -> float { return feather_radius_; }
+  [[nodiscard]] auto Invert() const -> bool { return invert_; }
+
+  void SetAssetKey(std::string key) { asset_key_ = std::move(key); }
+  void SetReferenceBounds(NormalizedRect bounds) { reference_bounds_ = bounds; }
+  void SetFeatherRadius(float radius) { feather_radius_ = radius; }
+  void SetInvert(bool invert) { invert_ = invert; }
+
+  static auto FromJson(const nlohmann::json& json) -> std::unique_ptr<RasterMaskNodeModel>;
+
+ private:
+  NodeId         id_;
+  std::string    asset_key_;
+  NormalizedRect reference_bounds_{};
+  float          feather_radius_ = 0.0f;
+  bool           invert_         = false;
+  std::array<PortDescriptor, 1> outputs_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/adjustment_catalog.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/adjustment_catalog.hpp
@@ -1,0 +1,53 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "edit/operators/models/i_operator_model.hpp"
+
+namespace alcedo {
+
+using OperatorModelFactory = std::function<std::unique_ptr<IOperatorModel>()>;
+
+struct AdjustmentDefinition {
+  OperatorTypeId       type;
+  std::string_view     display_name;
+  OperatorModelFactory create_default_model;
+};
+
+/**
+ * @brief Built-in adjustment Model factories. Backend GPU factories are added in
+ * later phases.
+ *
+ * Registration rejects duplicate type text and duplicate FNV-1a hashes.
+ * Thread-safe after construction: the catalog is immutable following static init.
+ */
+class BuiltinAdjustmentCatalog {
+ public:
+  static auto Instance() -> const BuiltinAdjustmentCatalog&;
+
+  [[nodiscard]] auto Find(const OperatorTypeId& type) const -> const AdjustmentDefinition*;
+  [[nodiscard]] auto Find(std::string_view text) const -> const AdjustmentDefinition*;
+  [[nodiscard]] auto Definitions() const -> const std::vector<AdjustmentDefinition>&;
+
+  /**
+   * @brief Create a default Model for @p type.
+   * @return nullptr when the type is not registered.
+   */
+  [[nodiscard]] auto CreateDefault(const OperatorTypeId& type) const
+      -> std::unique_ptr<IOperatorModel>;
+
+ private:
+  BuiltinAdjustmentCatalog();
+  void Register(AdjustmentDefinition definition);
+
+  std::vector<AdjustmentDefinition> definitions_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/builtin_type_ids.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/builtin_type_ids.hpp
@@ -1,0 +1,105 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/operators/models/operator_type_id.hpp"
+
+namespace alcedo::type_ids {
+
+inline auto Exposure() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.exposure"};
+  return id;
+}
+inline auto Contrast() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.contrast"};
+  return id;
+}
+inline auto White() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.white"};
+  return id;
+}
+inline auto Black() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.black"};
+  return id;
+}
+inline auto Shadows() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.shadows"};
+  return id;
+}
+inline auto Highlights() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.highlights"};
+  return id;
+}
+inline auto Saturation() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.saturation"};
+  return id;
+}
+inline auto Vibrance() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.vibrance"};
+  return id;
+}
+inline auto Clarity() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.clarity"};
+  return id;
+}
+inline auto Halation() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.halation"};
+  return id;
+}
+inline auto FilmGrain() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.film_grain"};
+  return id;
+}
+inline auto Tint() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.tint"};
+  return id;
+}
+inline auto Cat02WhiteBalance() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.cat02_white_balance"};
+  return id;
+}
+inline auto Curve() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.curve"};
+  return id;
+}
+inline auto Hls() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.hls"};
+  return id;
+}
+inline auto ColorWheel() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.color_wheel"};
+  return id;
+}
+inline auto Lmt() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.lmt"};
+  return id;
+}
+inline auto Sharpen() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.adjustment.sharpen"};
+  return id;
+}
+
+inline auto DevelopNode() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.node.develop"};
+  return id;
+}
+inline auto ColorGradeNode() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.node.color_grade"};
+  return id;
+}
+inline auto DrtNode() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.node.drt"};
+  return id;
+}
+inline auto AnalyticMaskNode() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.node.analytic_mask"};
+  return id;
+}
+inline auto RasterMaskNode() -> const OperatorTypeId& {
+  static const OperatorTypeId id{"alcedo.node.raster_mask"};
+  return id;
+}
+
+}  // namespace alcedo::type_ids

--- a/alcedo_studio/src/include/edit/operators/models/cat02_white_balance_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/cat02_white_balance_model.hpp
@@ -1,0 +1,55 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_model_base.hpp"
+
+namespace alcedo {
+
+struct Cat02WhiteBalancePayload {
+  bool  enabled             = true;
+  float temperature_offset  = 0.0f;
+  float tint_offset         = 0.0f;
+};
+
+enum class Cat02WhiteBalanceDirty : std::uint32_t {
+  None        = 0,
+  Enabled     = 1U << 0,
+  Temperature = 1U << 1,
+  Tint        = 1U << 2,
+  All         = Enabled | Temperature | Tint,
+};
+
+/**
+ * @brief Scene-referred CAT02 white-balance offsets on a ColorGrade node.
+ *
+ * Default offsets are zero (identity). RAW camera WB lives on DevelopNodeModel.
+ */
+class Cat02WhiteBalanceModel final
+    : public OperatorModelBase<Cat02WhiteBalanceModel, Cat02WhiteBalancePayload,
+                               Cat02WhiteBalanceDirty> {
+ public:
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Cat02WhiteBalance(); }
+
+  static constexpr std::string_view kInstanceSuffix = "cat02_wb";
+
+  [[nodiscard]] auto IsDefault() const -> bool override;
+
+  void SetEnabled(bool enabled);
+  void SetTemperatureOffset(float offset);
+  void SetTintOffset(float offset);
+
+  [[nodiscard]] auto Enabled() const -> bool;
+  [[nodiscard]] auto TemperatureOffset() const -> float;
+  [[nodiscard]] auto TintOffset() const -> float;
+
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+  void               LoadJson(const nlohmann::json& json) override;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/color_wheel_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/color_wheel_model.hpp
@@ -1,0 +1,59 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_model_base.hpp"
+
+namespace alcedo {
+
+struct Vec2f {
+  float x = 0.0f;
+  float y = 0.0f;
+};
+
+struct Vec3f {
+  float x = 0.0f;
+  float y = 0.0f;
+  float z = 0.0f;
+};
+
+struct ColorWheelControl {
+  Vec2f disc{};
+  float strength = 1.0f;
+  Vec3f color_offset{};
+  float luminance_offset = 0.0f;
+};
+
+struct ColorWheelPayload {
+  ColorWheelControl lift{};
+  ColorWheelControl gamma{Vec2f{}, 1.0f, Vec3f{1.0f, 1.0f, 1.0f}, 0.0f};
+  ColorWheelControl gain{Vec2f{}, 1.0f, Vec3f{1.0f, 1.0f, 1.0f}, 0.0f};
+};
+
+enum class ColorWheelDirty : std::uint32_t {
+  None  = 0,
+  Wheels = 1U << 0,
+  All    = Wheels,
+};
+
+/**
+ * @brief Lift / gamma / gain color wheels. Identity uses zero lift and unity gamma/gain.
+ */
+class ColorWheelModel final
+    : public OperatorModelBase<ColorWheelModel, ColorWheelPayload, ColorWheelDirty> {
+ public:
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::ColorWheel(); }
+  static constexpr std::string_view kInstanceSuffix = "color_wheel";
+
+  [[nodiscard]] auto IsDefault() const -> bool override;
+
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+  void               LoadJson(const nlohmann::json& json) override;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/curve_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/curve_model.hpp
@@ -1,0 +1,47 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_model_base.hpp"
+
+namespace alcedo {
+
+struct CurvePoint {
+  float x = 0.0f;
+  float y = 0.0f;
+};
+
+struct CurvePayload {
+  std::vector<CurvePoint> points{{0.0f, 0.0f}, {1.0f, 1.0f}};
+};
+
+enum class CurveDirty : std::uint32_t {
+  None   = 0,
+  Points = 1U << 0,
+  All    = Points,
+};
+
+/**
+ * @brief Tone curve control points in unit square. Identity is (0,0)-(1,1).
+ */
+class CurveModel final : public OperatorModelBase<CurveModel, CurvePayload, CurveDirty> {
+ public:
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Curve(); }
+  static constexpr std::string_view kInstanceSuffix = "curve";
+
+  [[nodiscard]] auto IsDefault() const -> bool override;
+
+  void SetPoints(std::vector<CurvePoint> points);
+  [[nodiscard]] auto Points() const -> std::vector<CurvePoint>;
+
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+  void               LoadJson(const nlohmann::json& json) override;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/dirty_field_mask.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/dirty_field_mask.hpp
@@ -1,0 +1,58 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+namespace alcedo {
+
+/**
+ * @brief Bit mask of dirty parameter fields. A field is clean or dirty; there is
+ * no write counter.
+ *
+ * Combine with bitwise or. Empty mask means no dirty fields.
+ */
+class DirtyFieldMask {
+ public:
+  constexpr DirtyFieldMask() = default;
+
+  constexpr explicit DirtyFieldMask(std::uint64_t bits) : bits_(bits) {}
+
+  template <typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
+  constexpr DirtyFieldMask(Enum bit) : bits_(static_cast<std::uint64_t>(bit)) {}
+
+  [[nodiscard]] constexpr auto Bits() const -> std::uint64_t { return bits_; }
+  [[nodiscard]] constexpr auto Any() const -> bool { return bits_ != 0; }
+  [[nodiscard]] constexpr auto Contains(DirtyFieldMask other) const -> bool {
+    return (bits_ & other.bits_) == other.bits_ && other.bits_ != 0;
+  }
+
+  constexpr auto operator|=(DirtyFieldMask other) -> DirtyFieldMask& {
+    bits_ |= other.bits_;
+    return *this;
+  }
+
+  friend constexpr auto operator|(DirtyFieldMask lhs, DirtyFieldMask rhs) -> DirtyFieldMask {
+    return DirtyFieldMask{lhs.bits_ | rhs.bits_};
+  }
+
+  friend constexpr auto operator&(DirtyFieldMask lhs, DirtyFieldMask rhs) -> DirtyFieldMask {
+    return DirtyFieldMask{lhs.bits_ & rhs.bits_};
+  }
+
+  friend constexpr auto operator==(DirtyFieldMask lhs, DirtyFieldMask rhs) -> bool {
+    return lhs.bits_ == rhs.bits_;
+  }
+
+  friend constexpr auto operator!=(DirtyFieldMask lhs, DirtyFieldMask rhs) -> bool {
+    return lhs.bits_ != rhs.bits_;
+  }
+
+ private:
+  std::uint64_t bits_ = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/hls_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/hls_model.hpp
@@ -1,0 +1,56 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_model_base.hpp"
+
+namespace alcedo {
+
+inline constexpr int kHlsHueBinCount = 8;
+
+struct HlsVec3 {
+  float h = 0.0f;
+  float l = 0.0f;
+  float s = 0.0f;
+};
+
+struct HlsPayload {
+  std::array<float, kHlsHueBinCount>   hue_bins{0.0f, 45.0f, 90.0f, 135.0f,
+                                                180.0f, 225.0f, 270.0f, 315.0f};
+  std::array<HlsVec3, kHlsHueBinCount> hls_adj_table{};
+  std::array<float, kHlsHueBinCount>   h_range_table{45.0f, 45.0f, 45.0f, 45.0f,
+                                                     45.0f, 45.0f, 45.0f, 45.0f};
+  HlsVec3                              target_hls{0.0f, 0.5f, 1.0f};
+  HlsVec3                              hls_adj{};
+  float                                h_range = 45.0f;
+  float                                l_range = 0.1f;
+  float                                s_range = 0.1f;
+};
+
+enum class HlsDirty : std::uint32_t {
+  None  = 0,
+  Table = 1U << 0,
+  All   = Table,
+};
+
+/**
+ * @brief Eight-bin HLS adjustment tables. Default tables are zero (identity).
+ */
+class HlsModel final : public OperatorModelBase<HlsModel, HlsPayload, HlsDirty> {
+ public:
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Hls(); }
+  static constexpr std::string_view kInstanceSuffix = "hls";
+
+  [[nodiscard]] auto IsDefault() const -> bool override;
+
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+  void               LoadJson(const nlohmann::json& json) override;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/i_operator_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/i_operator_model.hpp
@@ -1,0 +1,51 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <optional>
+
+#include "edit/operators/models/dirty_field_mask.hpp"
+#include "edit/operators/models/operator_param_dto.hpp"
+#include "edit/operators/models/operator_type_id.hpp"
+#include "json.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Pure parameter Model. Does not receive images, allocate GPU memory, or
+ * apply pixels.
+ *
+ * Setters mark dirty field bits. @ref TakeDirtyPatch copies the current payload
+ * and clears taken bits under a short lock. Failed uploads call @ref RestoreDirty.
+ *
+ * Thread-safe: setters, take, restore, and JSON load serialize on an internal mutex
+ * in OperatorModelBase.
+ */
+class IOperatorModel {
+ public:
+  virtual ~IOperatorModel() = default;
+
+  [[nodiscard]] virtual auto Type() const -> OperatorTypeId = 0;
+  [[nodiscard]] virtual auto IsDefault() const -> bool      = 0;
+  [[nodiscard]] virtual auto IsDirty() const -> bool        = 0;
+
+  /// Full payload snapshot. Ignores dirty bits.
+  [[nodiscard]] virtual auto MakeFullDto() const -> OperatorParamDto = 0;
+
+  /**
+   * @brief Copy current payload and clear taken dirty bits.
+   * @return nullopt when no field is dirty.
+   */
+  virtual auto TakeDirtyPatch() -> std::optional<OperatorParamPatchDto> = 0;
+
+  /// Re-set dirty bits after a cancelled or failed parameter transfer.
+  virtual void RestoreDirty(DirtyFieldMask fields) = 0;
+  virtual void MarkAllDirty()                      = 0;
+
+  [[nodiscard]] virtual auto ToJson() const -> nlohmann::json     = 0;
+  virtual void               LoadJson(const nlohmann::json& json) = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/json_read.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/json_read.hpp
@@ -1,0 +1,35 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <string>
+
+#include "json.hpp"
+
+namespace alcedo::json_util {
+
+inline auto ReadFloat(const nlohmann::json& json, const char* key, float fallback) -> float {
+  if (!json.contains(key) || !json[key].is_number()) {
+    return fallback;
+  }
+  return json[key].get<float>();
+}
+
+inline auto ReadBool(const nlohmann::json& json, const char* key, bool fallback) -> bool {
+  if (!json.contains(key) || !json[key].is_boolean()) {
+    return fallback;
+  }
+  return json[key].get<bool>();
+}
+
+inline auto ReadString(const nlohmann::json& json, const char* key, std::string fallback)
+    -> std::string {
+  if (!json.contains(key) || !json[key].is_string()) {
+    return fallback;
+  }
+  return json[key].get<std::string>();
+}
+
+}  // namespace alcedo::json_util

--- a/alcedo_studio/src/include/edit/operators/models/lmt_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/lmt_model.hpp
@@ -1,0 +1,42 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_model_base.hpp"
+
+namespace alcedo {
+
+struct LmtPayload {
+  std::string cube_path;
+};
+
+enum class LmtDirty : std::uint32_t {
+  None = 0,
+  Path = 1U << 0,
+  All  = Path,
+};
+
+/**
+ * @brief Look Modification Transform / LUT path. Empty path is identity.
+ */
+class LmtModel final : public OperatorModelBase<LmtModel, LmtPayload, LmtDirty> {
+ public:
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Lmt(); }
+  static constexpr std::string_view kInstanceSuffix = "lmt";
+
+  [[nodiscard]] auto IsDefault() const -> bool override;
+
+  void SetCubePath(std::string path);
+  [[nodiscard]] auto CubePath() const -> std::string;
+
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+  void               LoadJson(const nlohmann::json& json) override;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/operator_model_base.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/operator_model_base.hpp
@@ -1,0 +1,100 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <mutex>
+#include <utility>
+
+#include "edit/operators/models/i_operator_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief CRTP helper that owns payload, dirty mask, and the take/restore lock.
+ *
+ * Derived must provide `static auto TypeId() -> const OperatorTypeId&` and a
+ * Dirty enum with `All`. New instances start with All dirty so the first patch
+ * can upload every field.
+ *
+ * @tparam Derived CRTP type.
+ * @tparam Payload Copyable parameter struct stored in DTOs.
+ * @tparam DirtyEnum Bit flags convertible to DirtyFieldMask.
+ */
+template <class Derived, class Payload, class DirtyEnum>
+class OperatorModelBase : public IOperatorModel {
+ public:
+  [[nodiscard]] auto Type() const -> OperatorTypeId override { return Derived::TypeId(); }
+
+  [[nodiscard]] auto IsDirty() const -> bool override {
+    std::lock_guard lock(mutex_);
+    return dirty_.Any();
+  }
+
+  [[nodiscard]] auto MakeFullDto() const -> OperatorParamDto override {
+    std::lock_guard lock(mutex_);
+    return MakeDtoLocked();
+  }
+
+  auto TakeDirtyPatch() -> std::optional<OperatorParamPatchDto> override {
+    std::lock_guard lock(mutex_);
+    if (!dirty_.Any()) {
+      return std::nullopt;
+    }
+    OperatorParamPatchDto patch;
+    patch.type         = Derived::TypeId();
+    patch.dirty_fields = dirty_;
+    patch.payload      = std::make_shared<TypedOperatorParamPayload<Payload>>(
+        Derived::TypeId(), kDataVersion, payload_);
+    dirty_ = DirtyFieldMask{};
+    return patch;
+  }
+
+  void RestoreDirty(DirtyFieldMask fields) override {
+    std::lock_guard lock(mutex_);
+    dirty_ |= fields;
+  }
+
+  void MarkAllDirty() override {
+    std::lock_guard lock(mutex_);
+    dirty_ = DirtyFieldMask{DirtyEnum::All};
+  }
+
+ protected:
+  static constexpr std::uint32_t kDataVersion = 1;
+
+  template <class Fn>
+  void Mutate(DirtyEnum bit, Fn&& fn) {
+    std::lock_guard lock(mutex_);
+    fn(payload_);
+    dirty_ |= DirtyFieldMask{bit};
+  }
+
+  template <class Fn>
+  auto Read(Fn&& fn) const {
+    std::lock_guard lock(mutex_);
+    return fn(payload_);
+  }
+
+  [[nodiscard]] auto PayloadCopy() const -> Payload {
+    std::lock_guard lock(mutex_);
+    return payload_;
+  }
+
+  Payload                  payload_{};
+  DirtyFieldMask           dirty_{DirtyEnum::All};
+  mutable std::mutex       mutex_;
+
+ private:
+  [[nodiscard]] auto MakeDtoLocked() const -> OperatorParamDto {
+    OperatorParamDto dto;
+    dto.type          = Derived::TypeId();
+    dto.data_version  = kDataVersion;
+    dto.payload       = std::make_shared<TypedOperatorParamPayload<Payload>>(
+        Derived::TypeId(), kDataVersion, payload_);
+    return dto;
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/operator_param_dto.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/operator_param_dto.hpp
@@ -1,0 +1,76 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/operators/models/dirty_field_mask.hpp"
+#include "edit/operators/models/operator_type_id.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Type-erased immutable parameter payload. Contains no GPU or JSON types.
+ */
+class IOperatorParamPayload {
+ public:
+  virtual ~IOperatorParamPayload() = default;
+
+  [[nodiscard]] virtual auto Type() const -> OperatorTypeId        = 0;
+  [[nodiscard]] virtual auto DataVersion() const -> std::uint32_t = 0;
+};
+
+/**
+ * @brief Concrete payload box for one Model's parameter struct.
+ */
+template <class T>
+class TypedOperatorParamPayload final : public IOperatorParamPayload {
+ public:
+  TypedOperatorParamPayload(OperatorTypeId type, std::uint32_t version, T value)
+      : type_(std::move(type)), version_(version), value_(std::move(value)) {}
+
+  [[nodiscard]] auto Type() const -> OperatorTypeId override { return type_; }
+  [[nodiscard]] auto DataVersion() const -> std::uint32_t override { return version_; }
+  [[nodiscard]] auto Value() const -> const T& { return value_; }
+
+ private:
+  OperatorTypeId type_;
+  std::uint32_t  version_ = 1;
+  T              value_{};
+};
+
+/**
+ * @brief Full parameter snapshot used to build ParameterArena and recover devices.
+ *
+ * Independent of dirty state. payload is shared and immutable.
+ */
+struct OperatorParamDto {
+  OperatorTypeId                               type;
+  std::uint32_t                                data_version = 1;
+  std::shared_ptr<const IOperatorParamPayload> payload;
+};
+
+/**
+ * @brief Dirty-field patch taken from a Model. node_id and adjustment_id may be
+ * empty when taken directly from an IOperatorModel; ColorGrade fills them.
+ */
+struct OperatorParamPatchDto {
+  NodeId                                       node_id;
+  AdjustmentInstanceId                         adjustment_id;
+  OperatorTypeId                               type;
+  DirtyFieldMask                               dirty_fields;
+  std::shared_ptr<const IOperatorParamPayload> payload;
+};
+
+template <class T>
+[[nodiscard]] auto PayloadAs(const IOperatorParamPayload* payload) -> const T* {
+  const auto* typed = dynamic_cast<const TypedOperatorParamPayload<T>*>(payload);
+  return typed == nullptr ? nullptr : &typed->Value();
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/operator_type_id.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/operator_type_id.hpp
@@ -1,0 +1,59 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace alcedo {
+
+/// FNV-1a 64-bit hash used for stable OperatorTypeId lookup.
+/// @param text UTF-8 type string. Must be non-empty for registered types.
+/// @return Deterministic hash. Collisions are rejected at catalog registration.
+[[nodiscard]] constexpr auto Fnv1a64(std::string_view text) -> std::uint64_t {
+  constexpr std::uint64_t kOffset = 14695981039346656037ull;
+  constexpr std::uint64_t kPrime  = 1099511628211ull;
+  std::uint64_t           hash    = kOffset;
+  for (unsigned char byte : text) {
+    hash ^= static_cast<std::uint64_t>(byte);
+    hash *= kPrime;
+  }
+  return hash;
+}
+
+/**
+ * @brief Stable string type identifier for adjustments and nodes.
+ *
+ * JSON stores @ref Text. Runtime lookup may use @ref Hash; the catalog rejects
+ * duplicate text and duplicate hashes at registration.
+ *
+ * Thread-safe: immutable after construction.
+ */
+class OperatorTypeId {
+ public:
+  OperatorTypeId() = default;
+
+  explicit OperatorTypeId(std::string text)
+      : text_(std::move(text)), hash_(Fnv1a64(text_)) {}
+
+  [[nodiscard]] auto Text() const -> std::string_view { return text_; }
+  [[nodiscard]] auto Hash() const -> std::uint64_t { return hash_; }
+  [[nodiscard]] auto Empty() const -> bool { return text_.empty(); }
+
+  friend auto operator==(const OperatorTypeId& lhs, const OperatorTypeId& rhs) -> bool {
+    return lhs.hash_ == rhs.hash_ && lhs.text_ == rhs.text_;
+  }
+
+  friend auto operator!=(const OperatorTypeId& lhs, const OperatorTypeId& rhs) -> bool {
+    return !(lhs == rhs);
+  }
+
+ private:
+  std::string   text_;
+  std::uint64_t hash_ = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/pending_parameter_patch.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/pending_parameter_patch.hpp
@@ -1,0 +1,79 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include "edit/operators/models/i_operator_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief RAII guard for a taken dirty patch. Destructor restores dirty bits
+ * unless @ref Commit was called after a successful transfer.
+ *
+ * Does not own the Model. The Model must outlive this object.
+ */
+class PendingParameterPatch {
+ public:
+  PendingParameterPatch(IOperatorModel& model, OperatorParamPatchDto patch)
+      : model_(&model), patch_(std::move(patch)) {}
+
+  PendingParameterPatch(const PendingParameterPatch&)            = delete;
+  auto operator=(const PendingParameterPatch&) -> PendingParameterPatch& = delete;
+
+  PendingParameterPatch(PendingParameterPatch&& other) noexcept
+      : model_(other.model_), patch_(std::move(other.patch_)), committed_(other.committed_) {
+    other.model_     = nullptr;
+    other.committed_ = true;
+  }
+
+  auto operator=(PendingParameterPatch&& other) noexcept -> PendingParameterPatch& {
+    if (this == &other) {
+      return *this;
+    }
+    AbortIfNeeded();
+    model_           = other.model_;
+    patch_           = std::move(other.patch_);
+    committed_       = other.committed_;
+    other.model_     = nullptr;
+    other.committed_ = true;
+    return *this;
+  }
+
+  ~PendingParameterPatch() { AbortIfNeeded(); }
+
+  /// Marks the transfer successful so dirty bits stay clear.
+  void Commit() { committed_ = true; }
+
+  [[nodiscard]] auto Patch() const -> const OperatorParamPatchDto& { return patch_; }
+
+ private:
+  void AbortIfNeeded() {
+    if (model_ != nullptr && !committed_) {
+      model_->RestoreDirty(patch_.dirty_fields);
+    }
+  }
+
+  IOperatorModel*        model_     = nullptr;
+  OperatorParamPatchDto  patch_{};
+  bool                   committed_ = false;
+};
+
+/**
+ * @brief Take a dirty patch and wrap it for commit-or-restore.
+ * @return nullopt when the Model has no dirty fields.
+ */
+[[nodiscard]] inline auto TakePendingParameterPatch(IOperatorModel& model)
+    -> std::optional<PendingParameterPatch> {
+  auto patch = model.TakeDirtyPatch();
+  if (!patch.has_value()) {
+    return std::nullopt;
+  }
+  return PendingParameterPatch{model, std::move(*patch)};
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/scalar_operator_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/scalar_operator_model.hpp
@@ -1,0 +1,225 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <string_view>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_model_base.hpp"
+
+namespace alcedo {
+
+struct ScalarFloatPayload {
+  float value = 0.0f;
+};
+
+/**
+ * @brief Single-float adjustment Model parameterized by Traits.
+ *
+ * Traits provide TypeId, JSON key, default, min, max, and Dirty enum.
+ */
+template <class Traits>
+class ScalarOperatorModel final
+    : public OperatorModelBase<ScalarOperatorModel<Traits>, typename Traits::Payload,
+                               typename Traits::Dirty> {
+ public:
+  using Payload = typename Traits::Payload;
+  using Dirty   = typename Traits::Dirty;
+
+  ScalarOperatorModel() { this->payload_.value = Traits::kDefault; }
+
+  static auto TypeId() -> const OperatorTypeId& { return Traits::TypeId(); }
+
+  [[nodiscard]] auto IsDefault() const -> bool override {
+    return this->Read([](const Payload& payload) { return payload.value == Traits::kDefault; });
+  }
+
+  /**
+   * @brief Set the scalar parameter, clamped to Traits min/max, and mark dirty.
+   */
+  void SetValue(float value) {
+    const float clamped = std::clamp(value, Traits::kMin, Traits::kMax);
+    this->Mutate(Dirty::Value, [clamped](Payload& payload) { payload.value = clamped; });
+  }
+
+  [[nodiscard]] auto Value() const -> float {
+    return this->Read([](const Payload& payload) { return payload.value; });
+  }
+
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override {
+    nlohmann::json json;
+    json[std::string{Traits::kJsonKey}] = Value();
+    return json;
+  }
+
+  void LoadJson(const nlohmann::json& json) override {
+    float value = Traits::kDefault;
+    if (json.contains(Traits::kJsonKey) && json[Traits::kJsonKey].is_number()) {
+      value = json[Traits::kJsonKey].template get<float>();
+    }
+    SetValue(value);
+  }
+};
+
+struct ExposureTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Exposure(); }
+  static constexpr std::string_view kJsonKey    = "exposure_ev";
+  static constexpr std::string_view kDisplayName = "Exposure";
+  static constexpr std::string_view kInstanceSuffix = "exposure";
+  static constexpr float            kDefault     = 0.0f;
+  static constexpr float            kMin         = -16.0f;
+  static constexpr float            kMax         = 16.0f;
+};
+
+struct ContrastTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Contrast(); }
+  static constexpr std::string_view kJsonKey        = "contrast";
+  static constexpr std::string_view kDisplayName    = "Contrast";
+  static constexpr std::string_view kInstanceSuffix = "contrast";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = -100.0f;
+  static constexpr float            kMax            = 100.0f;
+};
+
+struct WhiteTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::White(); }
+  static constexpr std::string_view kJsonKey        = "white";
+  static constexpr std::string_view kDisplayName    = "White";
+  static constexpr std::string_view kInstanceSuffix = "white";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = -100.0f;
+  static constexpr float            kMax            = 100.0f;
+};
+
+struct BlackTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Black(); }
+  static constexpr std::string_view kJsonKey        = "black";
+  static constexpr std::string_view kDisplayName    = "Black";
+  static constexpr std::string_view kInstanceSuffix = "black";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = -100.0f;
+  static constexpr float            kMax            = 100.0f;
+};
+
+struct ShadowsTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Shadows(); }
+  static constexpr std::string_view kJsonKey        = "shadows";
+  static constexpr std::string_view kDisplayName    = "Shadows";
+  static constexpr std::string_view kInstanceSuffix = "shadows";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = -100.0f;
+  static constexpr float            kMax            = 100.0f;
+};
+
+struct HighlightsTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Highlights(); }
+  static constexpr std::string_view kJsonKey        = "highlights";
+  static constexpr std::string_view kDisplayName    = "Highlights";
+  static constexpr std::string_view kInstanceSuffix = "highlights";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = -100.0f;
+  static constexpr float            kMax            = 100.0f;
+};
+
+struct SaturationTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Saturation(); }
+  static constexpr std::string_view kJsonKey        = "saturation";
+  static constexpr std::string_view kDisplayName    = "Saturation";
+  static constexpr std::string_view kInstanceSuffix = "saturation";
+  static constexpr float            kDefault        = 1.0f;
+  static constexpr float            kMin            = 0.0f;
+  static constexpr float            kMax            = 4.0f;
+};
+
+struct VibranceTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Vibrance(); }
+  static constexpr std::string_view kJsonKey        = "vibrance";
+  static constexpr std::string_view kDisplayName    = "Vibrance";
+  static constexpr std::string_view kInstanceSuffix = "vibrance";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = -100.0f;
+  static constexpr float            kMax            = 100.0f;
+};
+
+struct ClarityTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Clarity(); }
+  static constexpr std::string_view kJsonKey        = "clarity";
+  static constexpr std::string_view kDisplayName    = "Clarity";
+  static constexpr std::string_view kInstanceSuffix = "clarity";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = -100.0f;
+  static constexpr float            kMax            = 100.0f;
+};
+
+struct HalationTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Halation(); }
+  static constexpr std::string_view kJsonKey        = "strength";
+  static constexpr std::string_view kDisplayName    = "Halation";
+  static constexpr std::string_view kInstanceSuffix = "halation";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = 0.0f;
+  static constexpr float            kMax            = 1.0f;
+};
+
+struct FilmGrainTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::FilmGrain(); }
+  static constexpr std::string_view kJsonKey        = "strength";
+  static constexpr std::string_view kDisplayName    = "Film Grain";
+  static constexpr std::string_view kInstanceSuffix = "film_grain";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = 0.0f;
+  static constexpr float            kMax            = 1.0f;
+};
+
+struct TintTraits {
+  using Payload = ScalarFloatPayload;
+  enum class Dirty : std::uint32_t { None = 0, Value = 1U << 0, All = Value };
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Tint(); }
+  static constexpr std::string_view kJsonKey        = "tint";
+  static constexpr std::string_view kDisplayName    = "Tint";
+  static constexpr std::string_view kInstanceSuffix = "tint";
+  static constexpr float            kDefault        = 0.0f;
+  static constexpr float            kMin            = -100.0f;
+  static constexpr float            kMax            = 100.0f;
+};
+
+using ExposureModel   = ScalarOperatorModel<ExposureTraits>;
+using ContrastModel   = ScalarOperatorModel<ContrastTraits>;
+using WhiteModel      = ScalarOperatorModel<WhiteTraits>;
+using BlackModel      = ScalarOperatorModel<BlackTraits>;
+using ShadowsModel    = ScalarOperatorModel<ShadowsTraits>;
+using HighlightsModel = ScalarOperatorModel<HighlightsTraits>;
+using SaturationModel = ScalarOperatorModel<SaturationTraits>;
+using VibranceModel   = ScalarOperatorModel<VibranceTraits>;
+using ClarityModel    = ScalarOperatorModel<ClarityTraits>;
+using HalationModel   = ScalarOperatorModel<HalationTraits>;
+using FilmGrainModel  = ScalarOperatorModel<FilmGrainTraits>;
+using TintModel       = ScalarOperatorModel<TintTraits>;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/models/sharpen_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/sharpen_model.hpp
@@ -1,0 +1,50 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_model_base.hpp"
+
+namespace alcedo {
+
+struct SharpenPayload {
+  float amount    = 0.0f;
+  float radius    = 3.0f;
+  float threshold = 0.0f;
+};
+
+enum class SharpenDirty : std::uint32_t {
+  None      = 0,
+  Amount    = 1U << 0,
+  Radius    = 1U << 1,
+  Threshold = 1U << 2,
+  All       = Amount | Radius | Threshold,
+};
+
+/**
+ * @brief Unsharp-mask parameters. Amount 0 is identity; radius defaults to 3.
+ */
+class SharpenModel final : public OperatorModelBase<SharpenModel, SharpenPayload, SharpenDirty> {
+ public:
+  static auto TypeId() -> const OperatorTypeId& { return type_ids::Sharpen(); }
+  static constexpr std::string_view kInstanceSuffix = "sharpen";
+
+  [[nodiscard]] auto IsDefault() const -> bool override;
+
+  void SetAmount(float amount);
+  void SetRadius(float radius);
+  void SetThreshold(float threshold);
+
+  [[nodiscard]] auto Amount() const -> float;
+  [[nodiscard]] auto Radius() const -> float;
+  [[nodiscard]] auto Threshold() const -> float;
+
+  [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+  void               LoadJson(const nlohmann::json& json) override;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -223,3 +223,20 @@ target_compile_definitions(EditorJournalFuzzFrameworkTest PRIVATE
 gtest_discover_tests(EditorJournalFuzzFrameworkTest TEST_PREFIX "EditorJournalFuzzFrameworkTest."
   PROPERTIES LABELS "ci_core_flow")
 alcedo_register_test_target(EditorJournalFuzzFrameworkTest edit)
+
+# GPU DAG Phase G1: Model, DTO, PipelineGraph, format v2 JSON, legacy import.
+add_executable(GpuDagModelGraphTest
+  ${ALCEDO_TEST_ROOT}/edit/graph/default_pipeline_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/graph/graph_validation_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/graph/dirty_patch_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/graph/json_roundtrip_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/graph/legacy_import_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/graph/header_hygiene_test.cpp)
+target_include_directories(GpuDagModelGraphTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(GpuDagModelGraphTest PRIVATE GTest::gtest_main EditGraph)
+target_compile_definitions(GpuDagModelGraphTest PRIVATE
+  ALCEDO_MODEL_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/operators/models"
+  ALCEDO_GRAPH_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/graph")
+gtest_discover_tests(GpuDagModelGraphTest TEST_PREFIX "GpuDagModelGraphTest."
+  PROPERTIES LABELS "ci_core_flow;edit;graph")
+alcedo_register_test_target(GpuDagModelGraphTest edit)

--- a/alcedo_studio/tests/edit/graph/default_pipeline_test.cpp
+++ b/alcedo_studio/tests/edit/graph/default_pipeline_test.cpp
@@ -1,0 +1,91 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <string>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/operators/models/adjustment_catalog.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+
+namespace alcedo {
+
+TEST(GpuDagModelGraph, DefaultPipelineHasDevelopGradeAndDrtNodes) {
+  const auto document = CreateDefaultPipelineDocument();
+  ASSERT_EQ(document.Graph().NodeCount(), 3u);
+  ASSERT_NE(document.Develop(), nullptr);
+  ASSERT_NE(document.PrimaryGrade(), nullptr);
+  ASSERT_NE(document.Drt(), nullptr);
+  EXPECT_EQ(document.Develop()->Type(), type_ids::DevelopNode());
+  EXPECT_EQ(document.PrimaryGrade()->Type(), type_ids::ColorGradeNode());
+  EXPECT_EQ(document.Drt()->Type(), type_ids::DrtNode());
+  EXPECT_TRUE(document.Graph().Validate().empty());
+}
+
+TEST(GpuDagModelGraph, DefaultPipelineConnectsDevelopThroughPrimaryGradeToDrt) {
+  const auto document = CreateDefaultPipelineDocument();
+  const auto& edges   = document.Graph().Edges();
+  ASSERT_EQ(edges.size(), 2u);
+  EXPECT_EQ(edges[0].from_node, NodeId{"develop"});
+  EXPECT_EQ(edges[0].from_port, PortId{"image"});
+  EXPECT_EQ(edges[0].to_node, NodeId{"grade.primary"});
+  EXPECT_EQ(edges[0].to_port, PortId{"image"});
+  EXPECT_EQ(edges[1].from_node, NodeId{"grade.primary"});
+  EXPECT_EQ(edges[1].from_port, PortId{"image"});
+  EXPECT_EQ(edges[1].to_node, NodeId{"drt"});
+  EXPECT_EQ(edges[1].to_port, PortId{"image"});
+
+  const auto order = document.Graph().TopologicalOrder();
+  ASSERT_EQ(order.size(), 3u);
+  EXPECT_EQ(order[0], NodeId{"develop"});
+  EXPECT_EQ(order[1], NodeId{"grade.primary"});
+  EXPECT_EQ(order[2], NodeId{"drt"});
+}
+
+TEST(GpuDagModelGraph, DefaultPrimaryGradeContainsOrderedSceneAdjustments) {
+  const auto document = CreateDefaultPipelineDocument();
+  const auto* grade   = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  ASSERT_EQ(grade->AdjustmentCount(), 17u);
+
+  const OperatorTypeId* expected[] = {
+      &type_ids::Cat02WhiteBalance(), &type_ids::Exposure(),   &type_ids::Contrast(),
+      &type_ids::White(),             &type_ids::Black(),      &type_ids::Shadows(),
+      &type_ids::Highlights(),        &type_ids::Curve(),      &type_ids::Hls(),
+      &type_ids::Saturation(),        &type_ids::Vibrance(),   &type_ids::ColorWheel(),
+      &type_ids::Lmt(),               &type_ids::Clarity(),    &type_ids::Sharpen(),
+      &type_ids::Halation(),          &type_ids::FilmGrain(),
+  };
+  for (std::size_t i = 0; i < 17; ++i) {
+    EXPECT_EQ(grade->AdjustmentAt(i).Type(), *expected[i]) << i;
+  }
+  EXPECT_EQ(std::string{grade->AdjustmentIdAt(0).Value()}, "grade.primary.cat02_wb");
+  EXPECT_EQ(std::string{grade->AdjustmentIdAt(1).Value()}, "grade.primary.exposure");
+}
+
+TEST(GpuDagModelGraph, DefaultPrimaryGradeUsesFullMixAndNoMask) {
+  const auto document = CreateDefaultPipelineDocument();
+  const auto* grade   = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  EXPECT_TRUE(grade->Enabled());
+  EXPECT_FLOAT_EQ(grade->Mix(), 1.0f);
+  for (const auto& edge : document.Graph().Edges()) {
+    EXPECT_NE(edge.to_port, PortId{"mask"});
+  }
+}
+
+TEST(GpuDagModelGraph, BuiltinCatalogTypeIdsAreUnique) {
+  const auto& definitions = BuiltinAdjustmentCatalog::Instance().Definitions();
+  ASSERT_GE(definitions.size(), 18u);
+  for (std::size_t i = 0; i < definitions.size(); ++i) {
+    for (std::size_t j = i + 1; j < definitions.size(); ++j) {
+      EXPECT_NE(definitions[i].type.Text(), definitions[j].type.Text());
+      EXPECT_NE(definitions[i].type.Hash(), definitions[j].type.Hash());
+    }
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/dirty_patch_test.cpp
+++ b/alcedo_studio/tests/edit/graph/dirty_patch_test.cpp
@@ -1,0 +1,80 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+
+namespace alcedo {
+
+TEST(GpuDagModelGraph, RepeatedExposureWritesCollapseIntoOneDirtyPatch) {
+  ExposureModel model;
+  model.SetValue(0.1f);
+  model.SetValue(0.2f);
+  model.SetValue(0.3f);
+
+  const auto patch = model.TakeDirtyPatch();
+  ASSERT_TRUE(patch.has_value());
+  const auto* payload = PayloadAs<ScalarFloatPayload>(patch->payload.get());
+  ASSERT_NE(payload, nullptr);
+  EXPECT_FLOAT_EQ(payload->value, 0.3f);
+  EXPECT_FALSE(model.IsDirty());
+  EXPECT_FALSE(model.TakeDirtyPatch().has_value());
+}
+
+TEST(GpuDagModelGraph, DirtyPatchTakenBeforeNewEditLeavesNewEditDirty) {
+  ExposureModel model;
+  model.SetValue(0.2f);
+  ASSERT_TRUE(model.TakeDirtyPatch().has_value());
+  EXPECT_FALSE(model.IsDirty());
+
+  model.SetValue(0.5f);
+  EXPECT_TRUE(model.IsDirty());
+  const auto patch = model.TakeDirtyPatch();
+  ASSERT_TRUE(patch.has_value());
+  const auto* payload = PayloadAs<ScalarFloatPayload>(patch->payload.get());
+  ASSERT_NE(payload, nullptr);
+  EXPECT_FLOAT_EQ(payload->value, 0.5f);
+}
+
+TEST(GpuDagModelGraph, CancelledParameterTransferRestoresDirtyFields) {
+  ExposureModel model;
+  model.SetValue(1.25f);
+  {
+    auto pending = TakePendingParameterPatch(model);
+    ASSERT_TRUE(pending.has_value());
+    EXPECT_FALSE(model.IsDirty());
+  }
+  EXPECT_TRUE(model.IsDirty());
+  const auto retry = model.TakeDirtyPatch();
+  ASSERT_TRUE(retry.has_value());
+  const auto* payload = PayloadAs<ScalarFloatPayload>(retry->payload.get());
+  ASSERT_NE(payload, nullptr);
+  EXPECT_FLOAT_EQ(payload->value, 1.25f);
+}
+
+TEST(GpuDagModelGraph, MakeFullDtoIgnoresDirtyState) {
+  ExposureModel model;
+  model.SetValue(0.75f);
+  ASSERT_TRUE(model.TakeDirtyPatch().has_value());
+  EXPECT_FALSE(model.IsDirty());
+  const auto dto      = model.MakeFullDto();
+  const auto* payload = PayloadAs<ScalarFloatPayload>(dto.payload.get());
+  ASSERT_NE(payload, nullptr);
+  EXPECT_FLOAT_EQ(payload->value, 0.75f);
+}
+
+TEST(GpuDagModelGraph, CommittedParameterTransferLeavesFieldsClean) {
+  ExposureModel model;
+  model.SetValue(0.4f);
+  {
+    auto pending = TakePendingParameterPatch(model);
+    ASSERT_TRUE(pending.has_value());
+    pending->Commit();
+  }
+  EXPECT_FALSE(model.IsDirty());
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/graph_validation_test.cpp
+++ b/alcedo_studio/tests/edit/graph/graph_validation_test.cpp
@@ -1,0 +1,62 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <vector>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
+
+namespace alcedo {
+
+namespace {
+
+auto HasCode(const std::vector<GraphValidationError>& errors, GraphValidationCode code) -> bool {
+  for (const auto& error : errors) {
+    if (error.code == code) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST(GpuDagModelGraph, PipelineGraphRejectsCycle) {
+  auto document = CreateDefaultPipelineDocument();
+  document.Graph().AddNode(ColorGradeNodeModel::MakeDefault(NodeId{"grade.b"}));
+  document.Graph().Connect(NodeId{"grade.primary"}, PortId{"image"}, NodeId{"grade.b"},
+                           PortId{"image"});
+  document.Graph().Connect(NodeId{"grade.b"}, PortId{"image"}, NodeId{"grade.primary"},
+                           PortId{"image"});
+  const auto errors = document.Graph().Validate();
+  EXPECT_TRUE(HasCode(errors, GraphValidationCode::Cycle));
+  EXPECT_THROW(
+      {
+        const auto order = document.Graph().TopologicalOrder();
+        (void)order;
+      },
+      std::runtime_error);
+}
+
+TEST(GpuDagModelGraph, PipelineGraphRejectsDisplayImageConnectedToSceneInput) {
+  auto document = CreateDefaultPipelineDocument();
+  document.Graph().Connect(NodeId{"drt"}, PortId{"display"}, NodeId{"grade.primary"},
+                           PortId{"image"});
+  const auto errors = document.Graph().Validate();
+  EXPECT_TRUE(HasCode(errors, GraphValidationCode::PortTypeMismatch));
+}
+
+TEST(GpuDagModelGraph, PipelineGraphRejectsMaskConnectedToImageInput) {
+  auto document = CreateDefaultPipelineDocument();
+  document.Graph().AddNode(std::make_unique<RasterMaskNodeModel>(NodeId{"mask.1"}));
+  document.Graph().Connect(NodeId{"mask.1"}, PortId{"mask"}, NodeId{"grade.primary"},
+                           PortId{"image"});
+  const auto errors = document.Graph().Validate();
+  EXPECT_TRUE(HasCode(errors, GraphValidationCode::PortTypeMismatch));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/header_hygiene_test.cpp
+++ b/alcedo_studio/tests/edit/graph/header_hygiene_test.cpp
@@ -1,0 +1,61 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace alcedo {
+
+namespace {
+
+auto FileContainsForbiddenToken(const std::filesystem::path& path) -> std::string {
+  std::ifstream input(path);
+  std::string   line;
+  int           line_number = 0;
+  while (std::getline(input, line)) {
+    ++line_number;
+    const char* tokens[] = {"image_buffer.hpp", "image_buffer.h", "cuda.h", "cuda_runtime",
+                            "OpenCL",           "opencl.h",       "Metal/", "metal.h"};
+    for (const char* token : tokens) {
+      if (line.find(token) != std::string::npos) {
+        return path.filename().string() + ":" + std::to_string(line_number) + " " + token;
+      }
+    }
+  }
+  return {};
+}
+
+void ScanDirectory(const std::filesystem::path& root, std::vector<std::string>* hits) {
+  if (!std::filesystem::exists(root)) {
+    hits->push_back("missing directory: " + root.string());
+    return;
+  }
+  for (const auto& entry : std::filesystem::directory_iterator(root)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    if (entry.path().extension() != ".hpp") {
+      continue;
+    }
+    const auto hit = FileContainsForbiddenToken(entry.path());
+    if (!hit.empty()) {
+      hits->push_back(hit);
+    }
+  }
+}
+
+}  // namespace
+
+TEST(GpuDagModelGraph, ModelAndGraphHeadersDoNotIncludeGpuOrImageBuffer) {
+  std::vector<std::string> hits;
+  ScanDirectory(std::filesystem::path{ALCEDO_MODEL_HEADER_ROOT}, &hits);
+  ScanDirectory(std::filesystem::path{ALCEDO_GRAPH_HEADER_ROOT}, &hits);
+  EXPECT_TRUE(hits.empty()) << (hits.empty() ? "" : hits.front());
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/json_roundtrip_test.cpp
+++ b/alcedo_studio/tests/edit/graph/json_roundtrip_test.cpp
@@ -1,0 +1,50 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+
+namespace alcedo {
+
+TEST(GpuDagModelGraph, PipelineDocumentRoundTripPreservesNodeIdsEdgesAndAdjustmentOrder) {
+  auto document = CreateDefaultPipelineDocument();
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(1.25f);
+  document.PrimaryGrade()->MoveAdjustment(AdjustmentInstanceId{"grade.primary.film_grain"}, 8);
+
+  const auto json     = document.ToJson();
+  EXPECT_EQ(json["format_version"], 2);
+  EXPECT_FALSE(json.dump().find("stage") != std::string::npos && json.contains("stage"));
+  EXPECT_FALSE(json.contains("priority"));
+  const std::string dumped = json.dump();
+  EXPECT_EQ(dumped.find("\"priority\""), std::string::npos);
+  EXPECT_EQ(dumped.find("Image Loading"), std::string::npos);
+
+  const auto restored = PipelineDocument::FromJson(json);
+  ASSERT_EQ(restored.Graph().NodeCount(), 3u);
+  ASSERT_NE(restored.Develop(), nullptr);
+  ASSERT_NE(restored.PrimaryGrade(), nullptr);
+  ASSERT_NE(restored.Drt(), nullptr);
+  ASSERT_EQ(restored.Graph().Edges().size(), 2u);
+  EXPECT_EQ(restored.Graph().Edges()[0].from_node, NodeId{"develop"});
+  EXPECT_EQ(restored.Graph().Edges()[1].to_node, NodeId{"drt"});
+
+  const auto* grade = restored.PrimaryGrade();
+  ASSERT_EQ(grade->AdjustmentCount(), 17u);
+  EXPECT_EQ(std::string{grade->AdjustmentIdAt(8).Value()}, "grade.primary.film_grain");
+  const auto* restored_exposure =
+      dynamic_cast<const ExposureModel*>(&grade->AdjustmentAt(1));
+  ASSERT_NE(restored_exposure, nullptr);
+  EXPECT_FLOAT_EQ(restored_exposure->Value(), 1.25f);
+  EXPECT_TRUE(restored.Graph().Validate().empty());
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
+++ b/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
@@ -1,0 +1,103 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "edit/graph/legacy_pipeline_importer.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+
+namespace alcedo {
+
+namespace {
+
+auto MakeLegacyStageJson() -> nlohmann::json {
+  nlohmann::json json;
+  json["Image Loading"]["Image Loading"]["raw_decode"] = {
+      {"type", 0},
+      {"enable", true},
+      {"params", {{"raw", {{"method", "legacy"}, {"highlights_reconstruct", false},
+                           {"use_camera_wb", false}, {"user_wb", 5200.0}}}}}};
+  json["Image Loading"]["Image Loading"]["lens_calib"] = {
+      {"type", 25},
+      {"enable", true},
+      {"params", {{"lens_calib", {{"enabled", true}, {"apply_distortion", false}}}}}};
+  json["Geometry Adjustment"]["Geometry Adjustment"]["crop_rotate"] = {
+      {"type", 24},
+      {"enable", true},
+      {"params",
+       {{"crop_rotate",
+         {{"enabled", true},
+          {"angle_degrees", 12.0},
+          {"enable_crop", true},
+          {"expand_to_fit", false},
+          {"crop_rect", {{"x", 0.1}, {"y", 0.2}, {"w", 0.5}, {"h", 0.6}}}}}}}};
+  json["To Working Space"]["To Working Space"]["color_temp"] = {
+      {"type", 26},
+      {"enable", true},
+      {"params",
+       {{"color_temp",
+         {{"mode", "custom"}, {"custom_cct", 7200.0}, {"custom_tint", 8.0}}}}}};
+  json["Basic Adjustment"]["Basic Adjustment"]["exposure"] = {
+      {"type", 2}, {"enable", true}, {"params", {{"exposure", 1.5}}}};
+  json["Color Adjustment"]["Color Adjustment"]["saturation"] = {
+      {"type", 10}, {"enable", true}, {"params", {{"saturation", 30.0}}}};
+  json["Output Transform"]["Output Transform"]["odt"] = {
+      {"type", 17},
+      {"enable", true},
+      {"params", {{"odt", {{"method", "aces_2_0"}, {"peak_luminance", 200.0}}}}}};
+  return json;
+}
+
+}  // namespace
+
+TEST(GpuDagModelGraph, LegacyStageJsonMapsRawGradeGeometryAndDrtToNewDocument) {
+  const auto result = LegacyPipelineImporter::Import(MakeLegacyStageJson());
+  ASSERT_TRUE(result.Ok()) << result.error;
+  const auto& document = *result.document;
+  ASSERT_NE(document.Develop(), nullptr);
+  ASSERT_NE(document.PrimaryGrade(), nullptr);
+  ASSERT_NE(document.Drt(), nullptr);
+
+  const auto develop = document.Develop()->Params().Params();
+  EXPECT_EQ(develop.demosaic_method, "legacy");
+  EXPECT_FALSE(develop.highlights_reconstruct);
+  EXPECT_FALSE(develop.use_camera_wb);
+  EXPECT_FLOAT_EQ(develop.user_wb, 5200.0f);
+  EXPECT_TRUE(develop.lens_enabled);
+  EXPECT_FALSE(develop.apply_distortion);
+  EXPECT_EQ(develop.wb_mode, "custom");
+  EXPECT_FLOAT_EQ(develop.custom_cct, 7200.0f);
+  EXPECT_FLOAT_EQ(develop.custom_tint, 8.0f);
+
+  EXPECT_FLOAT_EQ(document.Geometry().RotationDegrees(), 12.0f);
+  EXPECT_FALSE(document.Geometry().ExpandToFit());
+  EXPECT_FLOAT_EQ(document.Geometry().CropRect().x, 0.1f);
+  EXPECT_FLOAT_EQ(document.Geometry().CropRect().w, 0.5f);
+
+  const auto* exposure = dynamic_cast<const ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_FLOAT_EQ(exposure->Value(), 1.5f);
+
+  const auto* saturation = dynamic_cast<const SaturationModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Saturation()));
+  ASSERT_NE(saturation, nullptr);
+  EXPECT_FLOAT_EQ(saturation->Value(), 1.3f);
+
+  EXPECT_EQ(document.Drt()->Params().Params().method, DrtMethod::Aces20);
+  EXPECT_FLOAT_EQ(document.Drt()->Params().Params().peak_luminance, 200.0f);
+}
+
+TEST(GpuDagModelGraph, LegacyImportFailsOnUnknownOperatorType) {
+  auto json = MakeLegacyStageJson();
+  json["Basic Adjustment"]["Basic Adjustment"]["mystery"] = {
+      {"type", 21}, {"enable", true}, {"params", nlohmann::json::object()}};
+  const auto result = LegacyPipelineImporter::Import(json);
+  EXPECT_FALSE(result.Ok());
+  EXPECT_FALSE(result.error.empty());
+  EXPECT_FALSE(result.document.has_value());
+}
+
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: 设计阶段。实现尚未开始。
+Status: G1 complete (Model, DTO, PipelineGraph). G2 not started.
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -1886,6 +1886,94 @@ LegacyStageJsonMapsRawGradeGeometryAndDrtToNewDocument
 - 图修改只使用 `topology_dirty`；
 - JSON 中没有 stage 或 priority；
 - 旧产品执行路径仍然构建。
+
+##### Phase G1 completion record (2026-08-22)
+
+**Status:** complete — GPU-free Model/DTO/PipelineGraph, default three-node document, format v2 JSON, and one-way legacy importer. Product execution still uses PipelineStage.
+
+**Primary success call chain:**
+
+```text
+CreateDefaultPipelineDocument
+  -> DevelopNodeModel + ColorGradeNodeModel::MakeDefault + DrtNodeModel
+  -> PipelineGraph::AddNode / Connect
+  -> Validate + TopologicalOrder
+  -> PipelineDocument::ToJson  (format_version 2)
+```
+
+**Parameter dirty call chain:**
+
+```text
+ExposureModel::SetValue
+  -> dirty field bit
+  -> TakeDirtyPatch
+  -> OperatorParamPatchDto (latest value; bits cleared)
+```
+
+**Primary failure call chain:**
+
+```text
+Connect(display or mask output, scene image input) or cyclic edge
+  -> PipelineGraph::Validate
+  -> PortTypeMismatch or Cycle
+  -> TopologicalOrder throws; document graph left as constructed
+
+Unknown legacy OperatorType
+  -> LegacyPipelineImporter::Import
+  -> error string, no PipelineDocument
+```
+
+**Cancelled parameter transfer:**
+
+```text
+TakePendingParameterPatch
+  -> destructor without Commit
+  -> RestoreDirty
+  -> field remains dirty for retry
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `DefaultPipelineHasDevelopGradeAndDrtNodes` | `GpuDagModelGraphTest` | PASS |
+| `DefaultPipelineConnectsDevelopThroughPrimaryGradeToDrt` | `GpuDagModelGraphTest` | PASS |
+| `DefaultPrimaryGradeContainsOrderedSceneAdjustments` | `GpuDagModelGraphTest` | PASS |
+| `DefaultPrimaryGradeUsesFullMixAndNoMask` | `GpuDagModelGraphTest` | PASS |
+| `PipelineGraphRejectsCycle` | `GpuDagModelGraphTest` | PASS |
+| `PipelineGraphRejectsDisplayImageConnectedToSceneInput` | `GpuDagModelGraphTest` | PASS |
+| `PipelineGraphRejectsMaskConnectedToImageInput` | `GpuDagModelGraphTest` | PASS |
+| `RepeatedExposureWritesCollapseIntoOneDirtyPatch` | `GpuDagModelGraphTest` | PASS |
+| `DirtyPatchTakenBeforeNewEditLeavesNewEditDirty` | `GpuDagModelGraphTest` | PASS |
+| `CancelledParameterTransferRestoresDirtyFields` | `GpuDagModelGraphTest` | PASS |
+| `PipelineDocumentRoundTripPreservesNodeIdsEdgesAndAdjustmentOrder` | `GpuDagModelGraphTest` | PASS |
+| `LegacyStageJsonMapsRawGradeGeometryAndDrtToNewDocument` | `GpuDagModelGraphTest` | PASS |
+| Header hygiene (no GPU / ImageBuffer includes) | `GpuDagModelGraphTest` | PASS |
+| Unknown legacy operator fails import | `GpuDagModelGraphTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagModelGraphTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R GpuDagModelGraphTest
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target Operators EditPipeline --parallel 4
+```
+
+Suite totals: `17/17` GpuDagModelGraphTest PASS. Operators and EditPipeline still build.
+
+**Checklist / exit condition:** all G1 exit conditions met. Product `PipelineMgmtService` is unchanged.
+
+**LOC note (grill-code-review):** largest new file is `legacy_pipeline_importer.cpp` (~305 lines). No changed file exceeds 1000 LOC. `EditGraph` links JSON only.
+
+**Remaining gaps:** GraphCompiler, ExecutionPlan, CUDA workspace (G2); product path still reads old stage JSON (G7).
+
+**Files added:** `alcedo_studio/src/include/edit/graph/*`, `alcedo_studio/src/include/edit/operators/models/*`, matching `.cpp` under `edit/graph` and `edit/operators/models`, `tests/edit/graph/*`, CMake `EditGraph` + `GpuDagModelGraphTest`.
+
+**Files removed:** none.
+
+**Performance and allocation evidence:** not applicable; G1 has no GPU path.
+
+**Open work:** G2 CUDA workspace.
 
 ## 35. Phase G2 — CUDA workspace 和参数传输
 


### PR DESCRIPTION
## Summary

- Add GPU-independent operator models, DTOs, dirty-field tracking, and parameter patch retry behavior.
- Add the typed `PipelineGraph`, default Develop → Primary Grade → DRT document, JSON format v2, and the one-way legacy importer.
- Keep the product execution path unchanged while establishing the data model used by later GPU runtime layers.

## Stack

Layer G1 of GitHub stack #99.

- Base: #93
- Next layer: #95

## Validation

- `GpuDagModelGraphTest`: 17/17 passed.
- `Operators` and `EditPipeline` targets built successfully.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
