### PR TITLE
feat(edit): add CUDA DAG workspace and lift TransientBufferArena

### DIFF
--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -43,3 +43,17 @@ def_library(EditGraph
     SOURCES ${EDIT_GRAPH_SRCS}
     PUBLIC_DEPS JSON
 )
+
+# GPU-agnostic DAG runtime (parameter arena, texture LRU, KV cache). No CUDA headers.
+def_library(EditRuntime
+    SOURCES ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
+    PUBLIC_DEPS EditGraph
+)
+
+if(ALCEDO_CUDA_ENABLED)
+    def_cuda_library(EditRuntimeCuda
+        SOURCES ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_backend.cpp
+        PUBLIC_DEPS EditRuntime CUDA::cudart
+    )
+    target_compile_definitions(EditRuntimeCuda PUBLIC HAVE_CUDA)
+endif()

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -1,0 +1,251 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/cuda/cuda_backend.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+#include "cuda/cuda_check.hpp"
+
+namespace alcedo {
+
+CudaCommandContext::CudaCommandContext() {
+  cuda::CheckCuda(::cudaStreamCreate(&stream_), "CudaCommandContext::cudaStreamCreate");
+  cuda::CheckCuda(::cudaEventCreateWithFlags(&event_, cudaEventDisableTiming),
+                  "CudaCommandContext::cudaEventCreate");
+}
+
+CudaCommandContext::~CudaCommandContext() { Destroy(); }
+
+CudaCommandContext::CudaCommandContext(CudaCommandContext&& other) noexcept
+    : stream_(other.stream_), event_(other.event_), submission_id_(other.submission_id_) {
+  other.stream_        = nullptr;
+  other.event_         = nullptr;
+  other.submission_id_ = 0;
+}
+
+auto CudaCommandContext::operator=(CudaCommandContext&& other) noexcept -> CudaCommandContext& {
+  if (this != &other) {
+    Destroy();
+    stream_            = other.stream_;
+    event_             = other.event_;
+    submission_id_     = other.submission_id_;
+    other.stream_      = nullptr;
+    other.event_       = nullptr;
+    other.submission_id_ = 0;
+  }
+  return *this;
+}
+
+void CudaCommandContext::Destroy() noexcept {
+  if (event_ != nullptr) {
+    ::cudaEventDestroy(event_);
+    event_ = nullptr;
+  }
+  if (stream_ != nullptr) {
+    ::cudaStreamDestroy(stream_);
+    stream_ = nullptr;
+  }
+}
+
+CudaBackend::Buffer::Buffer(CudaBackend* owner, void* ptr, std::size_t bytes, std::uint64_t id)
+    : owner_(owner), ptr_(ptr), bytes_(bytes), resource_id_(id) {}
+
+CudaBackend::Buffer::~Buffer() { Reset(); }
+
+CudaBackend::Buffer::Buffer(Buffer&& other) noexcept
+    : owner_(other.owner_),
+      ptr_(other.ptr_),
+      bytes_(other.bytes_),
+      resource_id_(other.resource_id_) {
+  other.owner_       = nullptr;
+  other.ptr_         = nullptr;
+  other.bytes_       = 0;
+  other.resource_id_ = 0;
+}
+
+auto CudaBackend::Buffer::operator=(Buffer&& other) noexcept -> Buffer& {
+  if (this != &other) {
+    Reset();
+    owner_             = other.owner_;
+    ptr_               = other.ptr_;
+    bytes_             = other.bytes_;
+    resource_id_       = other.resource_id_;
+    other.owner_       = nullptr;
+    other.ptr_         = nullptr;
+    other.bytes_       = 0;
+    other.resource_id_ = 0;
+  }
+  return *this;
+}
+
+void CudaBackend::Buffer::Reset() noexcept {
+  if (ptr_ != nullptr) {
+    if (owner_ != nullptr) {
+      owner_->NoteFree();
+    }
+    ::cudaFree(ptr_);
+    ptr_ = nullptr;
+  }
+  owner_       = nullptr;
+  bytes_       = 0;
+  resource_id_ = 0;
+}
+
+CudaBackend::Texture2D::Texture2D(CudaBackend* owner, void* ptr, std::size_t bytes,
+                                  std::uint32_t width, std::uint32_t height, TextureFormat format,
+                                  std::uint64_t id)
+    : owner_(owner),
+      ptr_(ptr),
+      bytes_(bytes),
+      width_(width),
+      height_(height),
+      format_(format),
+      resource_id_(id) {}
+
+CudaBackend::Texture2D::~Texture2D() { Reset(); }
+
+CudaBackend::Texture2D::Texture2D(Texture2D&& other) noexcept
+    : owner_(other.owner_),
+      ptr_(other.ptr_),
+      bytes_(other.bytes_),
+      width_(other.width_),
+      height_(other.height_),
+      format_(other.format_),
+      resource_id_(other.resource_id_) {
+  other.owner_       = nullptr;
+  other.ptr_         = nullptr;
+  other.bytes_       = 0;
+  other.width_       = 0;
+  other.height_      = 0;
+  other.resource_id_ = 0;
+}
+
+auto CudaBackend::Texture2D::operator=(Texture2D&& other) noexcept -> Texture2D& {
+  if (this != &other) {
+    Reset();
+    owner_             = other.owner_;
+    ptr_               = other.ptr_;
+    bytes_             = other.bytes_;
+    width_             = other.width_;
+    height_            = other.height_;
+    format_            = other.format_;
+    resource_id_       = other.resource_id_;
+    other.owner_       = nullptr;
+    other.ptr_         = nullptr;
+    other.bytes_       = 0;
+    other.width_       = 0;
+    other.height_      = 0;
+    other.resource_id_ = 0;
+  }
+  return *this;
+}
+
+void CudaBackend::Texture2D::Reset() noexcept {
+  if (ptr_ != nullptr) {
+    if (owner_ != nullptr) {
+      owner_->NoteFree();
+    }
+    ::cudaFree(ptr_);
+    ptr_ = nullptr;
+  }
+  owner_       = nullptr;
+  bytes_       = 0;
+  width_       = 0;
+  height_      = 0;
+  resource_id_ = 0;
+}
+
+auto CudaBackend::CreateBuffer(std::size_t bytes) -> Buffer {
+  if (bytes == 0) {
+    return {};
+  }
+  void* ptr = nullptr;
+  cuda::CheckCuda(::cudaMalloc(&ptr, bytes), "CudaBackend::CreateBuffer");
+  NoteMalloc();
+  return Buffer{this, ptr, bytes, next_resource_id_++};
+}
+
+auto CudaBackend::CreateTexture2D(std::uint32_t width, std::uint32_t height, TextureFormat format)
+    -> Texture2D {
+  const auto bytes =
+      static_cast<std::size_t>(width) * height * TextureFormatBytesPerPixel(format);
+  if (bytes == 0) {
+    return {};
+  }
+  void* ptr = nullptr;
+  cuda::CheckCuda(::cudaMalloc(&ptr, bytes), "CudaBackend::CreateTexture2D");
+  NoteMalloc();
+  return Texture2D{this, ptr, bytes, width, height, format, next_resource_id_++};
+}
+
+void CudaBackend::UploadBufferRange(Buffer& buffer, std::uint32_t offset,
+                                    std::span<const std::byte> bytes,
+                                    CommandContext& command_context) {
+  if (fail_next_upload_) {
+    fail_next_upload_ = false;
+    throw std::runtime_error("CudaBackend::UploadBufferRange: injected failure");
+  }
+  if (bytes.empty()) {
+    return;
+  }
+  if (buffer.Empty() || static_cast<std::size_t>(offset) + bytes.size() > buffer.Bytes()) {
+    throw std::runtime_error("CudaBackend::UploadBufferRange: range exceeds buffer");
+  }
+  auto* dst = static_cast<std::byte*>(buffer.DevicePointer()) + offset;
+  cuda::CheckCuda(::cudaMemcpyAsync(dst, bytes.data(), bytes.size(), cudaMemcpyHostToDevice,
+                                    command_context.Stream()),
+                  "CudaBackend::UploadBufferRange");
+  ++h2d_copy_count_;
+  h2d_bytes_ += bytes.size();
+  last_h2d_ranges_.push_back(
+      ByteRange{offset, static_cast<std::uint32_t>(bytes.size())});
+}
+
+void CudaBackend::DownloadBufferRange(const Buffer& buffer, std::uint32_t offset,
+                                      std::span<std::byte> out,
+                                      CommandContext& command_context) const {
+  if (out.empty()) {
+    return;
+  }
+  if (buffer.Empty() || static_cast<std::size_t>(offset) + out.size() > buffer.Bytes()) {
+    throw std::runtime_error("CudaBackend::DownloadBufferRange: range exceeds buffer");
+  }
+  const auto* src = static_cast<const std::byte*>(buffer.DevicePointer()) + offset;
+  cuda::CheckCuda(::cudaMemcpyAsync(out.data(), src, out.size(), cudaMemcpyDeviceToHost,
+                                    command_context.Stream()),
+                  "CudaBackend::DownloadBufferRange");
+  cuda::CheckCuda(::cudaStreamSynchronize(command_context.Stream()),
+                  "CudaBackend::DownloadBufferRange sync");
+}
+
+void CudaBackend::GenerateMaskMipLevels(Texture2D&) {}
+
+void CudaBackend::Submit(CommandContext& command_context) {
+  cuda::CheckCuda(::cudaEventRecord(command_context.Event(), command_context.Stream()),
+                  "CudaBackend::Submit");
+  in_flight_submission_ = command_context.SubmissionId();
+}
+
+void CudaBackend::Wait(CommandContext& command_context) {
+  if (in_flight_submission_ == 0) {
+    return;
+  }
+  cuda::CheckCuda(::cudaEventSynchronize(command_context.Event()), "CudaBackend::Wait");
+  completed_submission_ = in_flight_submission_;
+  in_flight_submission_ = 0;
+}
+
+void CudaBackend::ResetCounters() {
+  malloc_count_   = 0;
+  free_count_     = 0;
+  h2d_copy_count_ = 0;
+  h2d_bytes_      = 0;
+  last_h2d_ranges_.clear();
+}
+
+void CudaBackend::FailNextUpload() { fail_next_upload_ = true; }
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/edit_runtime.cpp
+++ b/alcedo_studio/src/edit/runtime/edit_runtime.cpp
@@ -1,0 +1,11 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/byte_range.hpp"
+
+namespace alcedo {
+
+void EditRuntimeLinkAnchor() {}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/cuda/cuda_check.hpp
+++ b/alcedo_studio/src/include/cuda/cuda_check.hpp
@@ -1,0 +1,20 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include <cuda_runtime.h>
+
+namespace alcedo::cuda {
+
+inline void CheckCuda(cudaError_t status, const char* what) {
+  if (status != cudaSuccess) {
+    throw std::runtime_error(std::string(what) + ": " + cudaGetErrorString(status));
+  }
+}
+
+}  // namespace alcedo::cuda

--- a/alcedo_studio/src/include/cuda/cuda_slab_backend.hpp
+++ b/alcedo_studio/src/include/cuda/cuda_slab_backend.hpp
@@ -1,0 +1,74 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include <cuda_runtime.h>
+
+#include "cuda/cuda_check.hpp"
+
+namespace alcedo::cuda {
+
+/**
+ * @brief CUDA slab factory for @ref TransientBufferArena. Independent of edit runtime.
+ *
+ * CreateSlab calls cudaMalloc. Slab destructor calls cudaFree. Not thread-safe.
+ */
+struct CudaSlabBackend {
+  class Slab {
+   public:
+    Slab() = default;
+    Slab(void* ptr, std::size_t bytes) : ptr_(ptr), bytes_(bytes) {}
+
+    Slab(const Slab&)            = delete;
+    auto operator=(const Slab&) -> Slab& = delete;
+
+    Slab(Slab&& other) noexcept : ptr_(other.ptr_), bytes_(other.bytes_) {
+      other.ptr_   = nullptr;
+      other.bytes_ = 0;
+    }
+
+    auto operator=(Slab&& other) noexcept -> Slab& {
+      if (this != &other) {
+        Reset();
+        ptr_         = other.ptr_;
+        bytes_       = other.bytes_;
+        other.ptr_   = nullptr;
+        other.bytes_ = 0;
+      }
+      return *this;
+    }
+
+    ~Slab() { Reset(); }
+
+    void Reset() noexcept {
+      if (ptr_ != nullptr) {
+        ::cudaFree(ptr_);
+        ptr_ = nullptr;
+      }
+      bytes_ = 0;
+    }
+
+    [[nodiscard]] auto DevicePointer() const -> void* { return ptr_; }
+    [[nodiscard]] auto Bytes() const -> std::size_t { return bytes_; }
+
+   private:
+    void*       ptr_   = nullptr;
+    std::size_t bytes_ = 0;
+  };
+
+  [[nodiscard]] auto CreateSlab(std::size_t bytes) -> Slab {
+    if (bytes == 0) {
+      return {};
+    }
+    void* ptr = nullptr;
+    CheckCuda(::cudaMalloc(&ptr, bytes), "CudaSlabBackend::CreateSlab");
+    return Slab{ptr, bytes};
+  }
+};
+
+}  // namespace alcedo::cuda

--- a/alcedo_studio/src/include/cuda/nn/workspace.hpp
+++ b/alcedo_studio/src/include/cuda/nn/workspace.hpp
@@ -8,131 +8,31 @@
 #include <cstdint>
 #include <initializer_list>
 #include <stdexcept>
-#include <utility>
 #include <vector>
 
-#include <cuda_runtime.h>
-
-#include "cuda/nn/common.hpp"
+#include "cuda/cuda_slab_backend.hpp"
 #include "cuda/nn/tensor.hpp"
+#include "gpu/transient_buffer_arena.hpp"
+#include "gpu/transient_buffer_scope.hpp"
 
 namespace alcedo::cuda::nn {
 
-// Grow-only device workspace for ephemeral CNN intermediates.
-//
-// Design (steady-state forward must not call cudaMalloc):
-// - One (or, after Reserve, a larger) device slab owned by the pool.
-// - Bump allocator: Allocate advances an offset; Reset() rewinds to zero.
-// - Nested scopes: WorkspaceScope captures the offset and rewinds on destroy
-//   (LIFO). Prefer Reset() once at the end of each model forward.
-// - Capacity grows only when the bump offset is zero (no live pointers), or via
-//   an explicit Reserve() before a forward. Callers should Reserve the peak
-//   workspace once at model / tile setup.
-//
-// Not thread-safe. One pool per stream or serialize access.
-class WorkspacePool {
+/**
+ * @brief CNN-facing bump workspace. Same slab policy as edit TransientBufferArena.
+ *
+ * AllocateTensor / AllocateFloats stay here because they need DeviceTensor.
+ * Not thread-safe. One pool per stream or serialize access.
+ */
+class WorkspacePool : public TransientBufferArena<cuda::CudaSlabBackend> {
  public:
-  // Default CUDA alignment for activations (good for float4 / vector paths).
-  static constexpr std::size_t kDefaultAlignment = 256;
-
-  WorkspacePool() = default;
-
-  explicit WorkspacePool(std::size_t initial_capacity_bytes) { Reserve(initial_capacity_bytes); }
-
-  WorkspacePool(const WorkspacePool&)            = delete;
-  WorkspacePool& operator=(const WorkspacePool&) = delete;
-
-  WorkspacePool(WorkspacePool&& other) noexcept
-      : base_(other.base_), capacity_(other.capacity_), offset_(other.offset_) {
-    other.base_     = nullptr;
-    other.capacity_ = 0;
-    other.offset_   = 0;
-  }
-
-  auto operator=(WorkspacePool&& other) noexcept -> WorkspacePool& {
-    if (this != &other) {
-      FreeDevice();
-      base_           = other.base_;
-      capacity_       = other.capacity_;
-      offset_         = other.offset_;
-      other.base_     = nullptr;
-      other.capacity_ = 0;
-      other.offset_   = 0;
-    }
-    return *this;
-  }
-
-  ~WorkspacePool() { FreeDevice(); }
-
-  // Ensure capacity >= bytes. Grow-only. Fails if bump allocations are live
-  // (offset_ != 0), because live pointers would dangle after reallocation.
-  void Reserve(std::size_t bytes) {
-    if (bytes <= capacity_) {
-      return;
-    }
-    if (offset_ != 0) {
-      throw std::runtime_error(
-          "WorkspacePool::Reserve: cannot grow while allocations are live; "
-          "Reset() first or Reserve peak size before Allocate");
-    }
-    void* new_base = nullptr;
-    CheckCuda(::cudaMalloc(&new_base, bytes), "WorkspacePool::Reserve");
-    if (base_ != nullptr) {
-      ::cudaFree(base_);
-    }
-    base_     = new_base;
-    capacity_ = bytes;
-  }
-
-  // Bump-allocate `bytes` (may be 0 → returns nullptr). Grows capacity only when
-  // the pool is empty (offset_ == 0). Otherwise throws if capacity is insufficient
-  // so callers learn to Reserve peak usage up front.
-  [[nodiscard]] auto Allocate(std::size_t bytes, std::size_t alignment = kDefaultAlignment)
-      -> void* {
-    if (bytes == 0) {
-      return nullptr;
-    }
-    if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
-      throw std::runtime_error("WorkspacePool::Allocate: alignment must be a power of two");
-    }
-
-    const std::size_t aligned_offset = AlignUp(offset_, alignment);
-    const std::size_t end            = aligned_offset + bytes;
-
-    if (end > capacity_) {
-      if (offset_ != 0) {
-        throw std::runtime_error(
-            "WorkspacePool::Allocate: insufficient capacity with live allocations; "
-            "call Reserve() with the peak workspace size before forward");
-      }
-      // Empty pool: grow with modest headroom so repeated small allocs do not thrash.
-      std::size_t new_cap = capacity_ == 0 ? end : capacity_;
-      while (new_cap < end) {
-        const std::size_t doubled = new_cap > (std::size_t{1} << 62) ? end : new_cap * 2;
-        new_cap                   = doubled < end ? end : doubled;
-      }
-      Reserve(new_cap);
-      // offset_ still 0; recompute (aligned_offset was 0).
-      offset_ = bytes;
-      return base_;
-    }
-
-    offset_ = end;
-    return static_cast<char*>(base_) + aligned_offset;
-  }
-
-  // Typed convenience: allocate `count` elements of T (default-aligned).
-  template <typename T>
-  [[nodiscard]] auto Allocate(std::size_t count, std::size_t alignment = kDefaultAlignment) -> T* {
-    return static_cast<T*>(Allocate(count * sizeof(T), alignment));
-  }
+  using Base = TransientBufferArena<cuda::CudaSlabBackend>;
+  using Base::Base;
 
   [[nodiscard]] auto AllocateFloats(std::size_t count,
                                     std::size_t alignment = kDefaultAlignment) -> float* {
     return Allocate<float>(count, alignment);
   }
 
-  // Contiguous NCHW (or any rank) tensor backed by the bump allocator.
   [[nodiscard]] auto AllocateTensor(std::initializer_list<std::int64_t> dims,
                                     std::size_t alignment = kDefaultAlignment) -> DeviceTensor {
     return AllocateTensor(dims.begin(), static_cast<int>(dims.size()), alignment);
@@ -142,30 +42,6 @@ class WorkspacePool {
                                     std::size_t alignment = kDefaultAlignment) -> DeviceTensor {
     return AllocateTensor(dims.data(), static_cast<int>(dims.size()), alignment);
   }
-
-  // Rewind bump pointer to zero. Does not free device memory.
-  void Reset() noexcept { offset_ = 0; }
-
-  // Rewind to a previously recorded mark (from used_bytes()). LIFO only.
-  void Rewind(std::size_t mark_bytes) {
-    if (mark_bytes > offset_) {
-      throw std::runtime_error("WorkspacePool::Rewind: mark is past current offset");
-    }
-    offset_ = mark_bytes;
-  }
-
-  // Non-throwing rewind for RAII scopes (clamps to current offset).
-  void RewindUnchecked(std::size_t mark_bytes) noexcept {
-    offset_ = mark_bytes < offset_ ? mark_bytes : offset_;
-  }
-
-  [[nodiscard]] auto capacity_bytes() const noexcept -> std::size_t { return capacity_; }
-  [[nodiscard]] auto used_bytes() const noexcept -> std::size_t { return offset_; }
-  [[nodiscard]] auto remaining_bytes() const noexcept -> std::size_t {
-    return capacity_ > offset_ ? capacity_ - offset_ : 0;
-  }
-  [[nodiscard]] auto base() const noexcept -> void* { return base_; }
-  [[nodiscard]] auto empty() const noexcept -> bool { return offset_ == 0; }
 
  private:
   [[nodiscard]] auto AllocateTensor(const std::int64_t* dims, int rank,
@@ -180,63 +56,8 @@ class WorkspacePool {
     float* ptr = AllocateFloats(static_cast<std::size_t>(numel), alignment);
     return DeviceTensor::Contiguous(ptr, dims, rank);
   }
-
-  static auto AlignUp(std::size_t value, std::size_t alignment) -> std::size_t {
-    return (value + alignment - 1) & ~(alignment - 1);
-  }
-
-  void FreeDevice() noexcept {
-    if (base_ != nullptr) {
-      ::cudaFree(base_);
-      base_ = nullptr;
-    }
-    capacity_ = 0;
-    offset_   = 0;
-  }
-
-  void*       base_     = nullptr;
-  std::size_t capacity_ = 0;
-  std::size_t offset_   = 0;
 };
 
-// RAII nested scope: rewinds the pool offset to the mark taken at construction.
-// Allocations made inside the scope become invalid when the scope ends.
-class WorkspaceScope {
- public:
-  explicit WorkspaceScope(WorkspacePool& pool) : pool_(&pool), mark_(pool.used_bytes()) {}
-
-  WorkspaceScope(const WorkspaceScope&)            = delete;
-  WorkspaceScope& operator=(const WorkspaceScope&) = delete;
-
-  WorkspaceScope(WorkspaceScope&& other) noexcept : pool_(other.pool_), mark_(other.mark_) {
-    other.pool_ = nullptr;
-  }
-
-  auto operator=(WorkspaceScope&& other) noexcept -> WorkspaceScope& {
-    if (this != &other) {
-      Release();
-      pool_       = other.pool_;
-      mark_       = other.mark_;
-      other.pool_ = nullptr;
-    }
-    return *this;
-  }
-
-  ~WorkspaceScope() { Release(); }
-
-  // Early rewind (idempotent).
-  void Release() noexcept {
-    if (pool_ != nullptr) {
-      pool_->RewindUnchecked(mark_);
-      pool_ = nullptr;
-    }
-  }
-
-  [[nodiscard]] auto mark() const noexcept -> std::size_t { return mark_; }
-
- private:
-  WorkspacePool* pool_ = nullptr;
-  std::size_t    mark_ = 0;
-};
+using WorkspaceScope = TransientBufferScope<cuda::CudaSlabBackend>;
 
 }  // namespace alcedo::cuda::nn

--- a/alcedo_studio/src/include/edit/graph/graph_ids.hpp
+++ b/alcedo_studio/src/include/edit/graph/graph_ids.hpp
@@ -50,6 +50,9 @@ class PortId {
     return lhs.value_ == rhs.value_;
   }
   friend auto operator!=(const PortId& lhs, const PortId& rhs) -> bool { return !(lhs == rhs); }
+  friend auto operator<(const PortId& lhs, const PortId& rhs) -> bool {
+    return lhs.value_ < rhs.value_;
+  }
 
  private:
   std::string value_;
@@ -76,6 +79,10 @@ class AdjustmentInstanceId {
       -> bool {
     return !(lhs == rhs);
   }
+  friend auto operator<(const AdjustmentInstanceId& lhs, const AdjustmentInstanceId& rhs)
+      -> bool {
+    return lhs.value_ < rhs.value_;
+  }
 
  private:
   std::string value_;
@@ -84,7 +91,7 @@ class AdjustmentInstanceId {
 /**
  * @brief Identity of a produced graph value: producer node plus output port.
  *
- * Workspace KV cache (later phases) keys results by this id.
+ * Workspace KV cache keys results by this id.
  */
 struct GraphValueId {
   NodeId producer;
@@ -92,6 +99,12 @@ struct GraphValueId {
 
   friend auto operator==(const GraphValueId& lhs, const GraphValueId& rhs) -> bool {
     return lhs.producer == rhs.producer && lhs.output_port == rhs.output_port;
+  }
+  friend auto operator<(const GraphValueId& lhs, const GraphValueId& rhs) -> bool {
+    if (lhs.producer != rhs.producer) {
+      return lhs.producer < rhs.producer;
+    }
+    return lhs.output_port < rhs.output_port;
   }
 };
 

--- a/alcedo_studio/src/include/edit/operators/models/operator_param_dto.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/operator_param_dto.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <utility>
 
 #include "edit/graph/graph_ids.hpp"
@@ -23,6 +25,9 @@ class IOperatorParamPayload {
 
   [[nodiscard]] virtual auto Type() const -> OperatorTypeId        = 0;
   [[nodiscard]] virtual auto DataVersion() const -> std::uint32_t = 0;
+
+  /// Immutable byte view of the payload struct. Used by ParameterArena field copies.
+  [[nodiscard]] virtual auto Bytes() const -> std::span<const std::byte> = 0;
 };
 
 /**
@@ -37,6 +42,9 @@ class TypedOperatorParamPayload final : public IOperatorParamPayload {
   [[nodiscard]] auto Type() const -> OperatorTypeId override { return type_; }
   [[nodiscard]] auto DataVersion() const -> std::uint32_t override { return version_; }
   [[nodiscard]] auto Value() const -> const T& { return value_; }
+  [[nodiscard]] auto Bytes() const -> std::span<const std::byte> override {
+    return std::span<const std::byte>(reinterpret_cast<const std::byte*>(&value_), sizeof(T));
+  }
 
  private:
   OperatorTypeId type_;

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -1,0 +1,90 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <stdexcept>
+
+#include "edit/runtime/node_result_cache.hpp"
+#include "edit/runtime/parameter_arena.hpp"
+#include "edit/runtime/texture_pool.hpp"
+#include "gpu/transient_buffer_arena.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Per-device GPU workspace: parameters, transients, textures, node values.
+ *
+ * Owned by a render device, not by PipelineDocument or ExecutionPlan. Grows
+ * only when no GPU submission is in flight. One in-flight frame.
+ *
+ * @tparam Backend Resource factory. CUDA is first; other GPU APIs follow.
+ */
+template <class Backend>
+class BasicRenderWorkspace {
+ public:
+  using Buffer          = typename Backend::Buffer;
+  using Texture2D       = typename Backend::Texture2D;
+  using CommandContext  = typename Backend::CommandContext;
+
+  BasicRenderWorkspace()
+      : parameters_(backend_),
+        transients_(backend_),
+        textures_(backend_),
+        mask_textures_(backend_) {}
+
+  BasicRenderWorkspace(const BasicRenderWorkspace&)            = delete;
+  auto operator=(const BasicRenderWorkspace&) -> BasicRenderWorkspace& = delete;
+
+  [[nodiscard]] auto Device() -> Backend& { return backend_; }
+  [[nodiscard]] auto Device() const -> const Backend& { return backend_; }
+
+  [[nodiscard]] auto Parameters() -> ParameterArena<Backend>& { return parameters_; }
+  [[nodiscard]] auto TransientBuffers() -> TransientBufferArena<Backend>& { return transients_; }
+  [[nodiscard]] auto Textures() -> TexturePool<Backend>& { return textures_; }
+  [[nodiscard]] auto MaskTextures() -> TexturePool<Backend>& { return mask_textures_; }
+  [[nodiscard]] auto Values() -> NodeResultCache<Backend>& { return values_; }
+
+  /**
+   * @brief Wait the previous submission, rewind transients, start a new submission id.
+   * @throws std::runtime_error if called re-entrantly.
+   */
+  void BeginRender(CommandContext& command_context) {
+    if (rendering_) {
+      throw std::runtime_error("BasicRenderWorkspace::BeginRender: already rendering");
+    }
+    backend_.Wait(command_context);
+    transients_.Reset();
+    textures_.BeginFrame();
+    mask_textures_.BeginFrame();
+    command_context.SetSubmissionId(backend_.NextSubmissionId());
+    rendering_ = true;
+  }
+
+  /**
+   * @brief Record completion of the current command buffer. Does not wait.
+   */
+  void EndRender(CommandContext& command_context) {
+    if (!rendering_) {
+      throw std::runtime_error("BasicRenderWorkspace::EndRender: not rendering");
+    }
+    textures_.MarkSubmitted(command_context.SubmissionId());
+    mask_textures_.MarkSubmitted(command_context.SubmissionId());
+    backend_.Submit(command_context);
+    rendering_ = false;
+  }
+
+  [[nodiscard]] auto IsRendering() const -> bool { return rendering_; }
+
+ private:
+  Backend                        backend_{};
+  ParameterArena<Backend>        parameters_;
+  TransientBufferArena<Backend>  transients_;
+  TexturePool<Backend>           textures_;
+  TexturePool<Backend>           mask_textures_;
+  NodeResultCache<Backend>       values_{};
+  bool                           rendering_ = false;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/byte_range.hpp
+++ b/alcedo_studio/src/include/edit/runtime/byte_range.hpp
@@ -1,0 +1,46 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace alcedo {
+
+/// Half-open byte interval in a ParameterArena device buffer.
+struct ByteRange {
+  std::uint32_t offset = 0;
+  std::uint32_t size   = 0;
+
+  [[nodiscard]] auto End() const -> std::uint32_t { return offset + size; }
+};
+
+/**
+ * @brief Sort ranges by offset and merge overlapping or adjacent intervals.
+ * @param ranges Input ranges; may be empty or unsorted.
+ * @return Non-overlapping ranges in offset order.
+ */
+inline auto MergeAdjacentRanges(std::vector<ByteRange> ranges) -> std::vector<ByteRange> {
+  if (ranges.empty()) {
+    return ranges;
+  }
+  std::sort(ranges.begin(), ranges.end(),
+            [](const ByteRange& lhs, const ByteRange& rhs) { return lhs.offset < rhs.offset; });
+  std::vector<ByteRange> merged;
+  merged.push_back(ranges.front());
+  for (std::size_t i = 1; i < ranges.size(); ++i) {
+    ByteRange& last = merged.back();
+    if (ranges[i].offset <= last.End()) {
+      const auto end = (std::max)(last.End(), ranges[i].End());
+      last.size      = end - last.offset;
+    } else {
+      merged.push_back(ranges[i]);
+    }
+  }
+  return merged;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -1,0 +1,176 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "edit/runtime/byte_range.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief CUDA stream plus a recorded completion event for one in-flight submission.
+ *
+ * Owns the stream and event. Not thread-safe.
+ */
+class CudaCommandContext {
+ public:
+  CudaCommandContext();
+  ~CudaCommandContext();
+
+  CudaCommandContext(const CudaCommandContext&)            = delete;
+  auto operator=(const CudaCommandContext&) -> CudaCommandContext& = delete;
+  CudaCommandContext(CudaCommandContext&& other) noexcept;
+  auto operator=(CudaCommandContext&& other) noexcept -> CudaCommandContext&;
+
+  [[nodiscard]] auto Stream() const -> cudaStream_t { return stream_; }
+  [[nodiscard]] auto Event() const -> cudaEvent_t { return event_; }
+  [[nodiscard]] auto SubmissionId() const -> std::uint64_t { return submission_id_; }
+  void               SetSubmissionId(std::uint64_t id) { submission_id_ = id; }
+
+ private:
+  void Destroy() noexcept;
+
+  cudaStream_t  stream_        = nullptr;
+  cudaEvent_t   event_         = nullptr;
+  std::uint64_t submission_id_ = 0;
+};
+
+/**
+ * @brief CUDA resource factory and allocation/H2D counters for the DAG workspace.
+ *
+ * All cudaMalloc / cudaFree for this device go through CreateBuffer / CreateTexture2D
+ * and Buffer/Texture2D destructors. Not thread-safe. One in-flight submission.
+ */
+class CudaBackend {
+ public:
+  class Buffer {
+   public:
+    Buffer() = default;
+    Buffer(CudaBackend* owner, void* ptr, std::size_t bytes, std::uint64_t id);
+    ~Buffer();
+
+    Buffer(const Buffer&)            = delete;
+    auto operator=(const Buffer&) -> Buffer& = delete;
+    Buffer(Buffer&& other) noexcept;
+    auto operator=(Buffer&& other) noexcept -> Buffer&;
+
+    [[nodiscard]] auto DevicePointer() const -> void* { return ptr_; }
+    [[nodiscard]] auto Bytes() const -> std::size_t { return bytes_; }
+    [[nodiscard]] auto ResourceId() const -> std::uint64_t { return resource_id_; }
+    [[nodiscard]] auto Empty() const -> bool { return ptr_ == nullptr; }
+
+    void Reset() noexcept;
+
+   private:
+    CudaBackend*  owner_       = nullptr;
+    void*         ptr_         = nullptr;
+    std::size_t   bytes_       = 0;
+    std::uint64_t resource_id_ = 0;
+  };
+
+  class Texture2D {
+   public:
+    Texture2D() = default;
+    Texture2D(CudaBackend* owner, void* ptr, std::size_t bytes, std::uint32_t width,
+              std::uint32_t height, TextureFormat format, std::uint64_t id);
+    ~Texture2D();
+
+    Texture2D(const Texture2D&)            = delete;
+    auto operator=(const Texture2D&) -> Texture2D& = delete;
+    Texture2D(Texture2D&& other) noexcept;
+    auto operator=(Texture2D&& other) noexcept -> Texture2D&;
+
+    [[nodiscard]] auto DevicePointer() const -> void* { return ptr_; }
+    [[nodiscard]] auto Bytes() const -> std::size_t { return bytes_; }
+    [[nodiscard]] auto Width() const -> std::uint32_t { return width_; }
+    [[nodiscard]] auto Height() const -> std::uint32_t { return height_; }
+    [[nodiscard]] auto Format() const -> TextureFormat { return format_; }
+    [[nodiscard]] auto ResourceId() const -> std::uint64_t { return resource_id_; }
+
+    void Reset() noexcept;
+
+   private:
+    CudaBackend*  owner_       = nullptr;
+    void*         ptr_         = nullptr;
+    std::size_t   bytes_       = 0;
+    std::uint32_t width_       = 0;
+    std::uint32_t height_      = 0;
+    TextureFormat format_      = TextureFormat::R8;
+    std::uint64_t resource_id_ = 0;
+  };
+
+  using Slab            = Buffer;
+  using CommandContext  = CudaCommandContext;
+
+  CudaBackend()  = default;
+  ~CudaBackend() = default;
+
+  CudaBackend(const CudaBackend&)            = delete;
+  auto operator=(const CudaBackend&) -> CudaBackend& = delete;
+
+  [[nodiscard]] auto CreateBuffer(std::size_t bytes) -> Buffer;
+  [[nodiscard]] auto CreateSlab(std::size_t bytes) -> Buffer { return CreateBuffer(bytes); }
+  [[nodiscard]] auto CreateTexture2D(std::uint32_t width, std::uint32_t height,
+                                     TextureFormat format) -> Texture2D;
+
+  void UploadBufferRange(Buffer& buffer, std::uint32_t offset, std::span<const std::byte> bytes,
+                         CommandContext& command_context);
+  void DownloadBufferRange(const Buffer& buffer, std::uint32_t offset, std::span<std::byte> out,
+                           CommandContext& command_context) const;
+
+  /// G6 will generate mips. G2 keeps the entry and does nothing.
+  void GenerateMaskMipLevels(Texture2D& texture);
+
+  void Submit(CommandContext& command_context);
+  void Wait(CommandContext& command_context);
+
+  [[nodiscard]] auto HasInFlightSubmission() const -> bool {
+    return in_flight_submission_ != 0;
+  }
+  [[nodiscard]] auto IsResourceBusy(std::uint64_t submitted_on) const -> bool {
+    return submitted_on != 0 && submitted_on > completed_submission_;
+  }
+  [[nodiscard]] auto NextSubmissionId() -> std::uint64_t { return ++next_submission_; }
+
+  void NoteFree() noexcept { ++free_count_; }
+
+  void ResetCounters();
+  void FailNextUpload();
+  void NoteHostToDeviceBegin() { last_h2d_ranges_.clear(); }
+
+  [[nodiscard]] auto MallocCount() const -> std::uint64_t { return malloc_count_; }
+  [[nodiscard]] auto FreeCount() const -> std::uint64_t { return free_count_; }
+  [[nodiscard]] auto HostToDeviceCopyCount() const -> std::uint64_t { return h2d_copy_count_; }
+  [[nodiscard]] auto HostToDeviceBytes() const -> std::uint64_t { return h2d_bytes_; }
+  [[nodiscard]] auto LastHostToDeviceRanges() const -> const std::vector<ByteRange>& {
+    return last_h2d_ranges_;
+  }
+
+ private:
+  friend class Buffer;
+  friend class Texture2D;
+
+  void NoteMalloc() noexcept { ++malloc_count_; }
+
+  std::uint64_t         malloc_count_          = 0;
+  std::uint64_t         free_count_            = 0;
+  std::uint64_t         h2d_copy_count_        = 0;
+  std::uint64_t         h2d_bytes_             = 0;
+  std::uint64_t         next_resource_id_      = 1;
+  std::uint64_t         next_submission_       = 0;
+  std::uint64_t         in_flight_submission_  = 0;
+  std::uint64_t         completed_submission_  = 0;
+  bool                  fail_next_upload_      = false;
+  std::vector<ByteRange> last_h2d_ranges_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
@@ -1,0 +1,41 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/runtime/basic_render_workspace.hpp"
+#include "edit/runtime/cuda/cuda_backend.hpp"
+
+namespace alcedo {
+
+using CudaRenderWorkspace = BasicRenderWorkspace<CudaBackend>;
+
+/**
+ * @brief Owns a CUDA workspace and one command context. Does not own a graph or plan.
+ *
+ * Device loss is the only reason to destroy this object. Not thread-safe.
+ */
+class CudaRenderDevice {
+ public:
+  [[nodiscard]] auto Workspace() -> CudaRenderWorkspace& { return workspace_; }
+  [[nodiscard]] auto Workspace() const -> const CudaRenderWorkspace& { return workspace_; }
+  [[nodiscard]] auto CommandContext() -> CudaCommandContext& { return command_context_; }
+
+  void BeginRender() { workspace_.BeginRender(command_context_); }
+  void EndRender() { workspace_.EndRender(command_context_); }
+  void WaitIdle() { workspace_.Device().Wait(command_context_); }
+
+  ~CudaRenderDevice() {
+    try {
+      WaitIdle();
+    } catch (...) {
+    }
+  }
+
+ private:
+  CudaRenderWorkspace workspace_;
+  CudaCommandContext  command_context_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/node_result_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/node_result_cache.hpp
@@ -1,0 +1,51 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <utility>
+
+#include "edit/graph/graph_ids.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief KV cache of node outputs keyed by producer node and output port.
+ *
+ * Values are owning backend buffers. Not thread-safe.
+ */
+template <class Backend>
+class NodeResultCache {
+ public:
+  void Store(GraphValueId id, typename Backend::Buffer buffer) {
+    values_.insert_or_assign(std::move(id), std::move(buffer));
+  }
+
+  [[nodiscard]] auto Find(const GraphValueId& id) -> typename Backend::Buffer* {
+    const auto it = values_.find(id);
+    return it == values_.end() ? nullptr : &it->second;
+  }
+
+  [[nodiscard]] auto Find(const GraphValueId& id) const -> const typename Backend::Buffer* {
+    const auto it = values_.find(id);
+    return it == values_.end() ? nullptr : &it->second;
+  }
+
+  [[nodiscard]] auto Find(const NodeId& producer, const PortId& output_port)
+      -> typename Backend::Buffer* {
+    return Find(GraphValueId{producer, output_port});
+  }
+
+  void Erase(const GraphValueId& id) { values_.erase(id); }
+  void Clear() { values_.clear(); }
+  [[nodiscard]] auto Size() const -> std::size_t { return values_.size(); }
+
+ private:
+  std::map<GraphValueId, typename Backend::Buffer> values_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/parameter_arena.hpp
+++ b/alcedo_studio/src/include/edit/runtime/parameter_arena.hpp
@@ -1,0 +1,180 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "edit/operators/models/operator_param_dto.hpp"
+#include "edit/runtime/byte_range.hpp"
+#include "edit/runtime/parameter_binding.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Grow-only host+device parameter buffer with dirty-range H2D copies.
+ *
+ * Offsets assigned by BindSlot stay stable across renders. Grows only when the
+ * backend has no in-flight GPU submission. Not thread-safe.
+ *
+ * @tparam Backend Must provide Buffer, CreateBuffer, UploadBufferRange,
+ *         DownloadBufferRange, and HasInFlightSubmission.
+ */
+template <class Backend>
+class ParameterArena {
+ public:
+  static constexpr std::uint32_t kSlotAlignment = 16;
+
+  explicit ParameterArena(Backend& backend) : backend_(&backend) {}
+
+  ParameterArena(const ParameterArena&)            = delete;
+  auto operator=(const ParameterArena&) -> ParameterArena& = delete;
+
+  /**
+   * @brief Pre-size host mirror and device buffer. No-op if @p bytes <= capacity.
+   * @throws std::runtime_error if a GPU submission is still in flight.
+   */
+  void Reserve(std::size_t bytes) {
+    if (bytes <= capacity_) {
+      return;
+    }
+    ThrowIfBusy();
+    auto new_device = backend_->CreateBuffer(bytes);
+    host_.resize(bytes, std::byte{0});
+    device_   = std::move(new_device);
+    capacity_ = bytes;
+  }
+
+  /**
+   * @brief Assign the next aligned slot. Field destination_offset is relative to the slot.
+   * @return Binding with absolute field destinations.
+   */
+  auto BindSlot(ParameterSlotKey key, std::uint32_t size,
+                std::span<const ParameterFieldBinding> fields) -> ParameterBinding {
+    const auto offset = static_cast<std::uint32_t>(AlignUp(used_, kSlotAlignment));
+    const auto end    = static_cast<std::size_t>(offset) + size;
+    if (end > capacity_) {
+      Reserve(end);
+    }
+    ParameterBinding binding;
+    binding.offset = offset;
+    binding.size   = size;
+    binding.fields.reserve(fields.size());
+    for (const auto& field : fields) {
+      ParameterFieldBinding absolute = field;
+      absolute.destination_offset    = offset + field.destination_offset;
+      binding.fields.push_back(absolute);
+    }
+    used_         = end;
+    slots_[key]   = binding;
+    return slots_[key];
+  }
+
+  [[nodiscard]] auto Binding(const ParameterSlotKey& key) const -> const ParameterBinding& {
+    const auto it = slots_.find(key);
+    if (it == slots_.end()) {
+      throw std::runtime_error("ParameterArena: unknown slot");
+    }
+    return it->second;
+  }
+
+  /**
+   * @brief Copy every bound field from a full DTO. Does not read dirty bits.
+   * Queues the whole slot for upload.
+   */
+  void InitializeFromFullDto(const ParameterSlotKey& key, const OperatorParamDto& dto) {
+    const auto& binding = Binding(key);
+    CopyFields(binding, dto.payload.get(), /*dirty_only=*/false, {});
+    pending_.push_back(ByteRange{binding.offset, binding.size});
+  }
+
+  /**
+   * @brief Copy dirty fields from a patch into the host mirror and queue ranges.
+   */
+  void ApplyPatch(const ParameterSlotKey& key, const OperatorParamPatchDto& patch) {
+    const auto& binding = Binding(key);
+    CopyFields(binding, patch.payload.get(), /*dirty_only=*/true, patch.dirty_fields);
+  }
+
+  /**
+   * @brief Merge queued dirty ranges and upload them. No copy when nothing is dirty.
+   */
+  void UploadDirty(typename Backend::CommandContext& command_context) {
+    backend_->NoteHostToDeviceBegin();
+    if (pending_.empty()) {
+      return;
+    }
+    const auto merged = MergeAdjacentRanges(std::move(pending_));
+    pending_.clear();
+    for (const auto& range : merged) {
+      if (range.size == 0) {
+        continue;
+      }
+      backend_->UploadBufferRange(device_, range.offset,
+                                  std::span<const std::byte>(host_.data() + range.offset, range.size),
+                                  command_context);
+    }
+  }
+
+  void Download(std::uint32_t offset, std::span<std::byte> out,
+                typename Backend::CommandContext& command_context) const {
+    backend_->DownloadBufferRange(device_, offset, out, command_context);
+  }
+
+  [[nodiscard]] auto HostSpan() const -> std::span<const std::byte> { return host_; }
+  [[nodiscard]] auto capacity_bytes() const -> std::size_t { return capacity_; }
+  [[nodiscard]] auto used_bytes() const -> std::size_t { return used_; }
+  [[nodiscard]] auto DeviceBuffer() const -> const typename Backend::Buffer& { return device_; }
+
+ private:
+  static auto AlignUp(std::size_t value, std::uint32_t alignment) -> std::size_t {
+    return (value + alignment - 1) & ~(static_cast<std::size_t>(alignment) - 1);
+  }
+
+  void ThrowIfBusy() const {
+    if (backend_->HasInFlightSubmission()) {
+      throw std::runtime_error("ParameterArena: cannot grow while a GPU submission is in flight");
+    }
+  }
+
+  void CopyFields(const ParameterBinding& binding, const IOperatorParamPayload* payload,
+                  bool dirty_only, DirtyFieldMask dirty) {
+    if (payload == nullptr) {
+      throw std::runtime_error("ParameterArena: missing payload");
+    }
+    const auto bytes = payload->Bytes();
+    for (const auto& field : binding.fields) {
+      if (dirty_only && !dirty.Contains(field.dirty_bit)) {
+        continue;
+      }
+      if (static_cast<std::size_t>(field.source_offset) + field.size > bytes.size()) {
+        throw std::runtime_error("ParameterArena: field exceeds payload");
+      }
+      if (static_cast<std::size_t>(field.destination_offset) + field.size > host_.size()) {
+        throw std::runtime_error("ParameterArena: field exceeds arena");
+      }
+      std::memcpy(host_.data() + field.destination_offset, bytes.data() + field.source_offset,
+                  field.size);
+      if (dirty_only) {
+        pending_.push_back(ByteRange{field.destination_offset, field.size});
+      }
+    }
+  }
+
+  Backend*                             backend_ = nullptr;
+  typename Backend::Buffer             device_{};
+  std::vector<std::byte>               host_;
+  std::size_t                          capacity_ = 0;
+  std::size_t                          used_     = 0;
+  std::map<ParameterSlotKey, ParameterBinding> slots_;
+  std::vector<ByteRange>               pending_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/parameter_binding.hpp
+++ b/alcedo_studio/src/include/edit/runtime/parameter_binding.hpp
@@ -1,0 +1,51 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/operators/models/dirty_field_mask.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief One field copy from a DTO payload into the ParameterArena.
+ *
+ * destination_offset is relative to the slot start when passed to BindSlot;
+ * the arena stores the absolute arena offset after bind.
+ */
+struct ParameterFieldBinding {
+  DirtyFieldMask dirty_bit;
+  std::uint32_t  source_offset      = 0;
+  std::uint32_t  destination_offset = 0;
+  std::uint32_t  size               = 0;
+};
+
+/// Stable ParameterArena placement for one adjustment instance.
+struct ParameterBinding {
+  std::uint32_t                       offset = 0;
+  std::uint32_t                       size   = 0;
+  std::vector<ParameterFieldBinding>  fields;
+};
+
+/// Lookup key for a bound parameter slot.
+struct ParameterSlotKey {
+  NodeId               node_id;
+  AdjustmentInstanceId adjustment_id;
+
+  friend auto operator==(const ParameterSlotKey& lhs, const ParameterSlotKey& rhs) -> bool {
+    return lhs.node_id == rhs.node_id && lhs.adjustment_id == rhs.adjustment_id;
+  }
+  friend auto operator<(const ParameterSlotKey& lhs, const ParameterSlotKey& rhs) -> bool {
+    if (lhs.node_id != rhs.node_id) {
+      return lhs.node_id < rhs.node_id;
+    }
+    return lhs.adjustment_id < rhs.adjustment_id;
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/texture_format.hpp
+++ b/alcedo_studio/src/include/edit/runtime/texture_format.hpp
@@ -1,0 +1,30 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace alcedo {
+
+enum class TextureFormat : std::uint8_t {
+  R8      = 0,
+  Rgba8   = 1,
+  Rgba32f = 2,
+};
+
+[[nodiscard]] inline auto TextureFormatBytesPerPixel(TextureFormat format) -> std::size_t {
+  switch (format) {
+    case TextureFormat::R8:
+      return 1;
+    case TextureFormat::Rgba8:
+      return 4;
+    case TextureFormat::Rgba32f:
+      return 16;
+  }
+  return 1;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/texture_pool.hpp
+++ b/alcedo_studio/src/include/edit/runtime/texture_pool.hpp
@@ -1,0 +1,291 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+
+template <class Backend>
+class TexturePool;
+
+/**
+ * @brief RAII pin on a TexturePool entry. Prevents LRU eviction while held.
+ *
+ * The pool and its backend must outlive this object. Move-only.
+ */
+template <class Backend>
+class ResourceLease {
+ public:
+  ResourceLease() = default;
+  ResourceLease(TexturePool<Backend>* pool, std::uint64_t handle)
+      : pool_(pool), handle_(handle) {}
+
+  ResourceLease(const ResourceLease&)            = delete;
+  auto operator=(const ResourceLease&) -> ResourceLease& = delete;
+
+  ResourceLease(ResourceLease&& other) noexcept : pool_(other.pool_), handle_(other.handle_) {
+    other.pool_   = nullptr;
+    other.handle_ = 0;
+  }
+
+  auto operator=(ResourceLease&& other) noexcept -> ResourceLease& {
+    if (this != &other) {
+      Release();
+      pool_         = other.pool_;
+      handle_       = other.handle_;
+      other.pool_   = nullptr;
+      other.handle_ = 0;
+    }
+    return *this;
+  }
+
+  ~ResourceLease() { Release(); }
+
+  void Release();
+
+  [[nodiscard]] auto Empty() const -> bool { return pool_ == nullptr; }
+  [[nodiscard]] auto Handle() const -> std::uint64_t { return handle_; }
+  [[nodiscard]] auto Texture() -> typename Backend::Texture2D&;
+  [[nodiscard]] auto Texture() const -> const typename Backend::Texture2D&;
+
+ private:
+  TexturePool<Backend>* pool_   = nullptr;
+  std::uint64_t         handle_ = 0;
+};
+
+struct TextureRequest {
+  std::uint32_t width  = 0;
+  std::uint32_t height = 0;
+  TextureFormat format = TextureFormat::R8;
+};
+
+/**
+ * @brief Byte-budget LRU of GPU textures. Evicts only unleased, non-busy entries.
+ *
+ * Not thread-safe. @p Backend must provide Texture2D, CreateTexture2D, and
+ * IsResourceBusy(submitted_on_submission_id).
+ */
+template <class Backend>
+class TexturePool {
+ public:
+  explicit TexturePool(Backend& backend) : backend_(&backend) {}
+
+  TexturePool(const TexturePool&)            = delete;
+  auto operator=(const TexturePool&) -> TexturePool& = delete;
+
+  void SetByteBudget(std::size_t bytes) { budget_bytes_ = bytes; }
+  [[nodiscard]] auto ByteBudget() const -> std::size_t { return budget_bytes_; }
+  [[nodiscard]] auto UsedBytes() const -> std::size_t { return used_bytes_; }
+
+  void BeginFrame() {
+    for (auto& entry : entries_) {
+      if (entry.alive) {
+        entry.used_this_frame = false;
+      }
+    }
+  }
+
+  /**
+   * @brief Reuse a matching free texture or allocate one. Increments the lease count.
+   */
+  [[nodiscard]] auto Acquire(const TextureRequest& request) -> ResourceLease<Backend> {
+    if (request.width == 0 || request.height == 0) {
+      throw std::runtime_error("TexturePool::Acquire: invalid size");
+    }
+    const auto bytes = TextureBytes(request);
+    if (auto* reusable = FindReusable(request)) {
+      return TakeLease(*reusable);
+    }
+    EvictUntil(bytes);
+    auto texture = backend_->CreateTexture2D(request.width, request.height, request.format);
+    Entry entry;
+    entry.texture         = std::move(texture);
+    entry.request         = request;
+    entry.bytes           = bytes;
+    entry.handle          = next_handle_++;
+    entry.alive           = true;
+    entries_.push_back(std::move(entry));
+    used_bytes_ += bytes;
+    return TakeLease(entries_.back());
+  }
+
+  void MarkSubmitted(std::uint64_t submission_id) {
+    for (auto& entry : entries_) {
+      if (entry.alive && (entry.used_this_frame || entry.lease_count > 0)) {
+        entry.submitted_on = submission_id;
+      }
+    }
+  }
+
+  [[nodiscard]] auto Contains(std::uint64_t handle) const -> bool {
+    return Find(handle) != nullptr;
+  }
+
+  [[nodiscard]] auto EntryCount() const -> std::size_t {
+    std::size_t count = 0;
+    for (const auto& entry : entries_) {
+      if (entry.alive) {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  void ReleaseLease(std::uint64_t handle) {
+    auto* entry = Find(handle);
+    if (entry == nullptr || entry->lease_count == 0) {
+      return;
+    }
+    --entry->lease_count;
+  }
+
+  auto TextureAt(std::uint64_t handle) -> typename Backend::Texture2D& {
+    auto* entry = Find(handle);
+    if (entry == nullptr) {
+      throw std::runtime_error("TexturePool: invalid lease handle");
+    }
+    return entry->texture;
+  }
+
+  auto TextureAt(std::uint64_t handle) const -> const typename Backend::Texture2D& {
+    const auto* entry = Find(handle);
+    if (entry == nullptr) {
+      throw std::runtime_error("TexturePool: invalid lease handle");
+    }
+    return entry->texture;
+  }
+
+  /**
+   * @brief Drop unleased, idle textures until used + needed fits the budget, if possible.
+   */
+  void EvictUntil(std::size_t needed_bytes) {
+    if (budget_bytes_ == 0) {
+      return;
+    }
+    while (used_bytes_ + needed_bytes > budget_bytes_) {
+      Entry* victim = nullptr;
+      std::uint64_t oldest = (std::numeric_limits<std::uint64_t>::max)();
+      for (auto& entry : entries_) {
+        if (!entry.alive || entry.lease_count > 0) {
+          continue;
+        }
+        if (backend_->IsResourceBusy(entry.submitted_on)) {
+          continue;
+        }
+        if (entry.lru_tick < oldest) {
+          oldest = entry.lru_tick;
+          victim = &entry;
+        }
+      }
+      if (victim == nullptr) {
+        break;
+      }
+      used_bytes_ -= victim->bytes;
+      victim->texture = {};
+      victim->alive   = false;
+    }
+  }
+
+ private:
+  friend class ResourceLease<Backend>;
+
+  struct Entry {
+    typename Backend::Texture2D texture{};
+    TextureRequest              request{};
+    std::size_t                 bytes           = 0;
+    std::uint64_t               handle          = 0;
+    std::uint32_t               lease_count     = 0;
+    std::uint64_t               submitted_on    = 0;
+    std::uint64_t               lru_tick        = 0;
+    bool                        used_this_frame = false;
+    bool                        alive           = false;
+  };
+
+  static auto TextureBytes(const TextureRequest& request) -> std::size_t {
+    return static_cast<std::size_t>(request.width) * request.height *
+           TextureFormatBytesPerPixel(request.format);
+  }
+
+  auto Find(std::uint64_t handle) -> Entry* {
+    for (auto& entry : entries_) {
+      if (entry.alive && entry.handle == handle) {
+        return &entry;
+      }
+    }
+    return nullptr;
+  }
+
+  auto Find(std::uint64_t handle) const -> const Entry* {
+    for (const auto& entry : entries_) {
+      if (entry.alive && entry.handle == handle) {
+        return &entry;
+      }
+    }
+    return nullptr;
+  }
+
+  auto FindReusable(const TextureRequest& request) -> Entry* {
+    for (auto& entry : entries_) {
+      if (!entry.alive || entry.lease_count > 0) {
+        continue;
+      }
+      if (entry.request.width != request.width || entry.request.height != request.height ||
+          entry.request.format != request.format) {
+        continue;
+      }
+      return &entry;
+    }
+    return nullptr;
+  }
+
+  auto TakeLease(Entry& entry) -> ResourceLease<Backend> {
+    ++entry.lease_count;
+    entry.used_this_frame = true;
+    entry.lru_tick        = ++lru_clock_;
+    return ResourceLease<Backend>{this, entry.handle};
+  }
+
+  Backend*             backend_      = nullptr;
+  std::vector<Entry>   entries_;
+  std::size_t          budget_bytes_ = 0;
+  std::size_t          used_bytes_   = 0;
+  std::uint64_t        next_handle_  = 1;
+  std::uint64_t        lru_clock_    = 0;
+};
+
+template <class Backend>
+void ResourceLease<Backend>::Release() {
+  if (pool_ != nullptr) {
+    pool_->ReleaseLease(handle_);
+    pool_   = nullptr;
+    handle_ = 0;
+  }
+}
+
+template <class Backend>
+auto ResourceLease<Backend>::Texture() -> typename Backend::Texture2D& {
+  if (pool_ == nullptr) {
+    throw std::runtime_error("ResourceLease: empty");
+  }
+  return pool_->TextureAt(handle_);
+}
+
+template <class Backend>
+auto ResourceLease<Backend>::Texture() const -> const typename Backend::Texture2D& {
+  if (pool_ == nullptr) {
+    throw std::runtime_error("ResourceLease: empty");
+  }
+  return pool_->TextureAt(handle_);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
@@ -1,0 +1,180 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+namespace alcedo {
+
+/**
+ * @brief Grow-only bump allocator over one device slab supplied by @p Backend.
+ *
+ * Backend must provide:
+ * - `class Slab` with `DevicePointer()`, `Bytes()`, move-only RAII free
+ * - `CreateSlab(std::size_t bytes) -> Slab`
+ *
+ * Capacity grows only when no bump allocations are live (`used_bytes() == 0`).
+ * `Reset()` / `Rewind` do not free the slab. Not thread-safe.
+ *
+ * @tparam Backend Slab factory. Must outlive this arena when passed by reference.
+ */
+template <class Backend>
+class TransientBufferArena {
+ public:
+  static constexpr std::size_t kDefaultAlignment = 256;
+
+  TransientBufferArena() : owned_(std::in_place), backend_(&*owned_) {}
+
+  explicit TransientBufferArena(std::size_t initial_capacity_bytes) : TransientBufferArena() {
+    Reserve(initial_capacity_bytes);
+  }
+
+  /**
+   * @brief Borrow an existing backend so allocation counters stay on one device.
+   * @pre backend outlives this arena.
+   */
+  explicit TransientBufferArena(Backend& backend) : backend_(&backend) {}
+
+  TransientBufferArena(Backend& backend, std::size_t initial_capacity_bytes)
+      : backend_(&backend) {
+    Reserve(initial_capacity_bytes);
+  }
+
+  TransientBufferArena(const TransientBufferArena&)            = delete;
+  auto operator=(const TransientBufferArena&) -> TransientBufferArena& = delete;
+
+  TransientBufferArena(TransientBufferArena&& other) noexcept { MoveFrom(other); }
+
+  auto operator=(TransientBufferArena&& other) noexcept -> TransientBufferArena& {
+    if (this != &other) {
+      ResetSlab();
+      MoveFrom(other);
+    }
+    return *this;
+  }
+
+  ~TransientBufferArena() { ResetSlab(); }
+
+  /**
+   * @brief Ensure slab capacity is at least @p bytes. Grows only when unused.
+   * @throws std::runtime_error if bump allocations are live.
+   */
+  void Reserve(std::size_t bytes) {
+    if (bytes <= capacity_) {
+      return;
+    }
+    if (offset_ != 0) {
+      throw std::runtime_error(
+          "TransientBufferArena::Reserve: cannot grow while allocations are live; "
+          "Reset() first or Reserve peak size before Allocate");
+    }
+    auto new_slab = backend_->CreateSlab(bytes);
+    slab_         = std::move(new_slab);
+    capacity_     = bytes;
+  }
+
+  /**
+   * @brief Bump-allocate @p bytes. Zero returns nullptr.
+   * @throws std::runtime_error on bad alignment, or if capacity is short while live.
+   */
+  [[nodiscard]] auto Allocate(std::size_t bytes, std::size_t alignment = kDefaultAlignment)
+      -> void* {
+    if (bytes == 0) {
+      return nullptr;
+    }
+    if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
+      throw std::runtime_error("TransientBufferArena::Allocate: alignment must be a power of two");
+    }
+
+    const std::size_t aligned_offset = AlignUp(offset_, alignment);
+    const std::size_t end            = aligned_offset + bytes;
+
+    if (end > capacity_) {
+      if (offset_ != 0) {
+        throw std::runtime_error(
+            "TransientBufferArena::Allocate: insufficient capacity with live allocations; "
+            "call Reserve() with the peak workspace size before forward");
+      }
+      std::size_t new_cap = capacity_ == 0 ? end : capacity_;
+      while (new_cap < end) {
+        const std::size_t doubled = new_cap > (std::size_t{1} << 62) ? end : new_cap * 2;
+        new_cap                   = doubled < end ? end : doubled;
+      }
+      Reserve(new_cap);
+      offset_ = bytes;
+      return base();
+    }
+
+    offset_ = end;
+    return static_cast<char*>(base()) + aligned_offset;
+  }
+
+  template <typename T>
+  [[nodiscard]] auto Allocate(std::size_t count, std::size_t alignment = kDefaultAlignment) -> T* {
+    return static_cast<T*>(Allocate(count * sizeof(T), alignment));
+  }
+
+  /// Rewind bump pointer to zero. Does not free device memory.
+  void Reset() noexcept { offset_ = 0; }
+
+  void Rewind(std::size_t mark_bytes) {
+    if (mark_bytes > offset_) {
+      throw std::runtime_error("TransientBufferArena::Rewind: mark is past current offset");
+    }
+    offset_ = mark_bytes;
+  }
+
+  void RewindUnchecked(std::size_t mark_bytes) noexcept {
+    offset_ = mark_bytes < offset_ ? mark_bytes : offset_;
+  }
+
+  [[nodiscard]] auto capacity_bytes() const noexcept -> std::size_t { return capacity_; }
+  [[nodiscard]] auto used_bytes() const noexcept -> std::size_t { return offset_; }
+  [[nodiscard]] auto remaining_bytes() const noexcept -> std::size_t {
+    return capacity_ > offset_ ? capacity_ - offset_ : 0;
+  }
+  [[nodiscard]] auto base() const noexcept -> void* {
+    return slab_.DevicePointer();
+  }
+  [[nodiscard]] auto empty() const noexcept -> bool { return offset_ == 0; }
+
+ private:
+  static auto AlignUp(std::size_t value, std::size_t alignment) -> std::size_t {
+    return (value + alignment - 1) & ~(alignment - 1);
+  }
+
+  void ResetSlab() noexcept {
+    slab_     = {};
+    capacity_ = 0;
+    offset_   = 0;
+  }
+
+  void MoveFrom(TransientBufferArena& other) noexcept {
+    owned_ = std::move(other.owned_);
+    if (owned_.has_value()) {
+      backend_       = &*owned_;
+      other.backend_ = nullptr;
+    } else {
+      backend_       = other.backend_;
+      other.backend_ = nullptr;
+    }
+    slab_           = std::move(other.slab_);
+    capacity_       = other.capacity_;
+    offset_         = other.offset_;
+    other.capacity_ = 0;
+    other.offset_   = 0;
+  }
+
+  std::optional<Backend> owned_;
+  Backend*               backend_ = nullptr;
+  typename Backend::Slab slab_{};
+  std::size_t            capacity_ = 0;
+  std::size_t            offset_   = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/gpu/transient_buffer_scope.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_scope.hpp
@@ -1,0 +1,60 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "gpu/transient_buffer_arena.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief RAII nested bump scope. Rewinds @ref TransientBufferArena to the mark
+ * taken at construction. Allocations inside the scope are invalid after Release.
+ *
+ * LIFO only. Not thread-safe.
+ */
+template <class Backend>
+class TransientBufferScope {
+ public:
+  explicit TransientBufferScope(TransientBufferArena<Backend>& arena)
+      : arena_(&arena), mark_(arena.used_bytes()) {}
+
+  TransientBufferScope(const TransientBufferScope&)            = delete;
+  auto operator=(const TransientBufferScope&) -> TransientBufferScope& = delete;
+
+  TransientBufferScope(TransientBufferScope&& other) noexcept
+      : arena_(other.arena_), mark_(other.mark_) {
+    other.arena_ = nullptr;
+  }
+
+  auto operator=(TransientBufferScope&& other) noexcept -> TransientBufferScope& {
+    if (this != &other) {
+      Release();
+      arena_       = other.arena_;
+      mark_        = other.mark_;
+      other.arena_ = nullptr;
+    }
+    return *this;
+  }
+
+  ~TransientBufferScope() { Release(); }
+
+  void Release() noexcept {
+    if (arena_ != nullptr) {
+      arena_->RewindUnchecked(mark_);
+      arena_ = nullptr;
+    }
+  }
+
+  [[nodiscard]] auto mark() const noexcept -> std::size_t { return mark_; }
+
+ private:
+  TransientBufferArena<Backend>* arena_ = nullptr;
+  std::size_t                    mark_  = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -240,3 +240,20 @@ target_compile_definitions(GpuDagModelGraphTest PRIVATE
 gtest_discover_tests(GpuDagModelGraphTest TEST_PREFIX "GpuDagModelGraphTest."
   PROPERTIES LABELS "ci_core_flow;edit;graph")
 alcedo_register_test_target(GpuDagModelGraphTest edit)
+
+# GPU DAG Phase G2: CUDA workspace, ParameterArena, transient bump, texture lease.
+if(ALCEDO_CUDA_ENABLED)
+  add_executable(GpuDagCudaWorkspaceTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/parameter_arena_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/transient_and_cache_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/texture_lease_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/header_hygiene_test.cpp)
+  target_include_directories(GpuDagCudaWorkspaceTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagCudaWorkspaceTest PRIVATE GTest::gtest_main EditRuntimeCuda)
+  target_compile_definitions(GpuDagCudaWorkspaceTest PRIVATE
+    ALCEDO_GPU_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/gpu"
+    ALCEDO_RUNTIME_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/runtime")
+  gtest_discover_tests(GpuDagCudaWorkspaceTest TEST_PREFIX "GpuDagCudaWorkspaceTest."
+    PROPERTIES LABELS "gpu;edit;runtime")
+  alcedo_register_test_target(GpuDagCudaWorkspaceTest gpu)
+endif()

--- a/alcedo_studio/tests/edit/runtime/cuda_workspace_test_support.hpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_workspace_test_support.hpp
@@ -1,0 +1,72 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/operators/models/sharpen_model.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/parameter_binding.hpp"
+
+namespace alcedo {
+namespace cuda_workspace_test {
+
+inline auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+class CudaWorkspaceFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasCudaDevice()) {
+      GTEST_SKIP() << "No CUDA device available.";
+    }
+  }
+};
+
+inline auto SharpenFieldBindings() -> std::vector<ParameterFieldBinding> {
+  return {
+      ParameterFieldBinding{DirtyFieldMask{SharpenDirty::Amount},
+                            static_cast<std::uint32_t>(offsetof(SharpenPayload, amount)), 0, 4},
+      ParameterFieldBinding{DirtyFieldMask{SharpenDirty::Radius},
+                            static_cast<std::uint32_t>(offsetof(SharpenPayload, radius)), 4, 4},
+      ParameterFieldBinding{DirtyFieldMask{SharpenDirty::Threshold},
+                            static_cast<std::uint32_t>(offsetof(SharpenPayload, threshold)), 8, 4},
+  };
+}
+
+inline auto ExposureFieldBindings() -> std::vector<ParameterFieldBinding> {
+  return {ParameterFieldBinding{DirtyFieldMask{ExposureTraits::Dirty::Value}, 0, 0, 4}};
+}
+
+inline auto BindSharpen(ParameterArena<CudaBackend>& arena, ParameterSlotKey key)
+    -> ParameterBinding {
+  const auto fields = SharpenFieldBindings();
+  return arena.BindSlot(key, static_cast<std::uint32_t>(sizeof(SharpenPayload)), fields);
+}
+
+inline auto UploadFullAndClearDirty(CudaRenderDevice& device, ParameterSlotKey key,
+                                    IOperatorModel& model) -> bool {
+  auto& arena = device.Workspace().Parameters();
+  arena.InitializeFromFullDto(key, model.MakeFullDto());
+  arena.UploadDirty(device.CommandContext());
+  auto pending = TakePendingParameterPatch(model);
+  if (!pending.has_value()) {
+    return false;
+  }
+  pending->Commit();
+  return true;
+}
+
+}  // namespace cuda_workspace_test
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/header_hygiene_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/header_hygiene_test.cpp
@@ -1,0 +1,60 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace alcedo {
+namespace {
+
+auto FileContainsForbiddenToken(const std::filesystem::path& path) -> std::string {
+  std::ifstream input(path);
+  std::string   line;
+  int           line_number = 0;
+  while (std::getline(input, line)) {
+    ++line_number;
+    const char* tokens[] = {"image_buffer.hpp", "image_buffer.h", "cuda.h", "cuda_runtime",
+                            "OpenCL",           "opencl.h",       "Metal/", "metal.h"};
+    for (const char* token : tokens) {
+      if (line.find(token) != std::string::npos) {
+        return path.filename().string() + ":" + std::to_string(line_number) + " " + token;
+      }
+    }
+  }
+  return {};
+}
+
+void ScanDirectory(const std::filesystem::path& root, std::vector<std::string>* hits) {
+  if (!std::filesystem::exists(root)) {
+    hits->push_back("missing directory: " + root.string());
+    return;
+  }
+  for (const auto& entry : std::filesystem::directory_iterator(root)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    if (entry.path().extension() != ".hpp") {
+      continue;
+    }
+    const auto hit = FileContainsForbiddenToken(entry.path());
+    if (!hit.empty()) {
+      hits->push_back(hit);
+    }
+  }
+}
+
+}  // namespace
+
+TEST(GpuDagCudaWorkspace, GpuAndRuntimeHeadersDoNotIncludeCudaOrImageBuffer) {
+  std::vector<std::string> hits;
+  ScanDirectory(std::filesystem::path{ALCEDO_GPU_HEADER_ROOT}, &hits);
+  ScanDirectory(std::filesystem::path{ALCEDO_RUNTIME_HEADER_ROOT}, &hits);
+  EXPECT_TRUE(hits.empty()) << (hits.empty() ? "" : hits.front());
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/parameter_arena_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/parameter_arena_test.cpp
@@ -1,0 +1,158 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "cuda_workspace_test_support.hpp"
+
+#include <cstring>
+#include <span>
+#include <stdexcept>
+
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+
+namespace alcedo {
+namespace {
+
+using cuda_workspace_test::BindSharpen;
+using cuda_workspace_test::CudaWorkspaceFixture;
+using cuda_workspace_test::ExposureFieldBindings;
+using cuda_workspace_test::UploadFullAndClearDirty;
+
+TEST_F(CudaWorkspaceFixture, ParameterArenaKeepsStableOffsetsAcrossRenders) {
+  CudaRenderDevice device;
+  ParameterSlotKey key{NodeId{"grade.primary"}, AdjustmentInstanceId{"sharpen"}};
+  const auto first = BindSharpen(device.Workspace().Parameters(), key);
+
+  device.BeginRender();
+  device.EndRender();
+  device.BeginRender();
+  device.EndRender();
+  device.WaitIdle();
+
+  const auto& again = device.Workspace().Parameters().Binding(key);
+  EXPECT_EQ(again.offset, first.offset);
+  EXPECT_EQ(again.size, first.size);
+  ASSERT_EQ(again.fields.size(), 3U);
+  EXPECT_EQ(again.fields[0].destination_offset, first.fields[0].destination_offset);
+}
+
+TEST_F(CudaWorkspaceFixture, ParameterArenaUploadsOnlyDirtyFieldRanges) {
+  CudaRenderDevice device;
+  ParameterSlotKey key{NodeId{"grade.primary"}, AdjustmentInstanceId{"sharpen"}};
+  SharpenModel     model;
+  BindSharpen(device.Workspace().Parameters(), key);
+  ASSERT_TRUE(UploadFullAndClearDirty(device, key, model));
+
+  model.SetAmount(12.0f);
+  auto pending = TakePendingParameterPatch(model);
+  ASSERT_TRUE(pending.has_value());
+
+  auto& backend = device.Workspace().Device();
+  backend.ResetCounters();
+  device.Workspace().Parameters().ApplyPatch(key, pending->Patch());
+  device.Workspace().Parameters().UploadDirty(device.CommandContext());
+  device.WaitIdle();
+  pending->Commit();
+
+  ASSERT_EQ(backend.LastHostToDeviceRanges().size(), 1U);
+  EXPECT_EQ(backend.LastHostToDeviceRanges().front().size, 4U);
+  EXPECT_EQ(backend.HostToDeviceBytes(), 4U);
+  EXPECT_LT(backend.HostToDeviceBytes(), sizeof(SharpenPayload));
+}
+
+TEST_F(CudaWorkspaceFixture, AdjacentDirtyParameterRangesMergeBeforeCudaCopy) {
+  CudaRenderDevice device;
+  ParameterSlotKey key{NodeId{"grade.primary"}, AdjustmentInstanceId{"sharpen"}};
+  SharpenModel     model;
+  BindSharpen(device.Workspace().Parameters(), key);
+  ASSERT_TRUE(UploadFullAndClearDirty(device, key, model));
+
+  model.SetAmount(8.0f);
+  model.SetRadius(5.0f);
+  auto pending = TakePendingParameterPatch(model);
+  ASSERT_TRUE(pending.has_value());
+
+  auto& backend = device.Workspace().Device();
+  backend.ResetCounters();
+  device.Workspace().Parameters().ApplyPatch(key, pending->Patch());
+  device.Workspace().Parameters().UploadDirty(device.CommandContext());
+  device.WaitIdle();
+  pending->Commit();
+
+  ASSERT_EQ(backend.LastHostToDeviceRanges().size(), 1U);
+  EXPECT_EQ(backend.LastHostToDeviceRanges().front().size, 8U);
+  EXPECT_EQ(backend.HostToDeviceCopyCount(), 1U);
+  EXPECT_EQ(backend.HostToDeviceBytes(), 8U);
+}
+
+TEST_F(CudaWorkspaceFixture, RepeatedDirtyWritesUseLatestValue) {
+  CudaRenderDevice device;
+  ParameterSlotKey key{NodeId{"grade.primary"}, AdjustmentInstanceId{"exposure"}};
+  ExposureModel    model;
+  const auto       fields = ExposureFieldBindings();
+  device.Workspace().Parameters().BindSlot(key, 4, fields);
+
+  model.SetValue(0.25f);
+  model.SetValue(1.5f);
+  auto pending = TakePendingParameterPatch(model);
+  ASSERT_TRUE(pending.has_value());
+  device.Workspace().Parameters().ApplyPatch(key, pending->Patch());
+  device.Workspace().Parameters().UploadDirty(device.CommandContext());
+  device.WaitIdle();
+  pending->Commit();
+
+  float gpu_value = 0.0f;
+  std::byte storage[4];
+  device.Workspace().Parameters().Download(device.Workspace().Parameters().Binding(key).offset,
+                                           std::span<std::byte>(storage, 4),
+                                           device.CommandContext());
+  std::memcpy(&gpu_value, storage, sizeof(gpu_value));
+  EXPECT_FLOAT_EQ(gpu_value, 1.5f);
+}
+
+TEST_F(CudaWorkspaceFixture, CancelledCudaParameterCopyRestoresDirtyFields) {
+  CudaRenderDevice device;
+  ParameterSlotKey key{NodeId{"grade.primary"}, AdjustmentInstanceId{"exposure"}};
+  ExposureModel    model;
+  const auto       fields = ExposureFieldBindings();
+  device.Workspace().Parameters().BindSlot(key, 4, fields);
+  ASSERT_TRUE(UploadFullAndClearDirty(device, key, model));
+
+  model.SetValue(0.75f);
+  {
+    auto pending = TakePendingParameterPatch(model);
+    ASSERT_TRUE(pending.has_value());
+    device.Workspace().Device().FailNextUpload();
+    device.Workspace().Parameters().ApplyPatch(key, pending->Patch());
+    EXPECT_THROW(device.Workspace().Parameters().UploadDirty(device.CommandContext()),
+                 std::runtime_error);
+  }
+  EXPECT_TRUE(model.IsDirty());
+
+  auto retry = TakePendingParameterPatch(model);
+  ASSERT_TRUE(retry.has_value());
+  device.Workspace().Parameters().ApplyPatch(key, retry->Patch());
+  device.Workspace().Parameters().UploadDirty(device.CommandContext());
+  device.WaitIdle();
+  retry->Commit();
+  EXPECT_FALSE(model.IsDirty());
+}
+
+TEST_F(CudaWorkspaceFixture, UnchangedParametersIssueNoHostToDeviceCopy) {
+  CudaRenderDevice device;
+  ParameterSlotKey key{NodeId{"grade.primary"}, AdjustmentInstanceId{"exposure"}};
+  ExposureModel    model;
+  const auto       fields = ExposureFieldBindings();
+  device.Workspace().Parameters().BindSlot(key, 4, fields);
+  ASSERT_TRUE(UploadFullAndClearDirty(device, key, model));
+
+  auto& backend = device.Workspace().Device();
+  backend.ResetCounters();
+  device.Workspace().Parameters().UploadDirty(device.CommandContext());
+  EXPECT_EQ(backend.HostToDeviceCopyCount(), 0U);
+  EXPECT_EQ(backend.HostToDeviceBytes(), 0U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/texture_lease_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/texture_lease_test.cpp
@@ -1,0 +1,38 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "cuda_workspace_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+using cuda_workspace_test::CudaWorkspaceFixture;
+
+TEST_F(CudaWorkspaceFixture, TextureLeasePreventsEvictionUntilCudaSubmissionCompletes) {
+  CudaRenderDevice device;
+  auto&            textures = device.Workspace().Textures();
+  constexpr std::uint32_t kSize = 64;
+  textures.SetByteBudget(static_cast<std::size_t>(kSize) * kSize);
+
+  device.BeginRender();
+  auto lease_a = textures.Acquire({kSize, kSize, TextureFormat::R8});
+  const auto handle_a = lease_a.Handle();
+  auto lease_b = textures.Acquire({kSize, kSize, TextureFormat::R8});
+  EXPECT_TRUE(textures.Contains(handle_a));
+  device.EndRender();
+
+  lease_a.Release();
+  lease_b.Release();
+  textures.EvictUntil(static_cast<std::size_t>(kSize) * kSize);
+  EXPECT_TRUE(textures.Contains(handle_a));
+
+  device.BeginRender();
+  textures.EvictUntil(static_cast<std::size_t>(kSize) * kSize);
+  EXPECT_FALSE(textures.Contains(handle_a));
+  device.EndRender();
+  device.WaitIdle();
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/transient_and_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/transient_and_cache_test.cpp
@@ -1,0 +1,91 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "cuda_workspace_test_support.hpp"
+
+#include <stdexcept>
+
+#include "edit/graph/graph_ids.hpp"
+
+namespace alcedo {
+namespace {
+
+using cuda_workspace_test::CudaWorkspaceFixture;
+
+TEST_F(CudaWorkspaceFixture, WorkspaceResetRewindsTransientMemoryWithoutFreeingCudaAllocation) {
+  CudaRenderDevice device;
+  auto&            transients = device.Workspace().TransientBuffers();
+  transients.Reserve(4096);
+  device.Workspace().Device().ResetCounters();
+
+  void* first = transients.Allocate(512);
+  ASSERT_NE(first, nullptr);
+  const auto capacity = transients.capacity_bytes();
+  transients.Reset();
+  EXPECT_EQ(transients.used_bytes(), 0U);
+  EXPECT_EQ(transients.capacity_bytes(), capacity);
+  void* second = transients.Allocate(512);
+  EXPECT_EQ(second, first);
+  EXPECT_EQ(device.Workspace().Device().MallocCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().FreeCount(), 0U);
+}
+
+TEST_F(CudaWorkspaceFixture, WorkspaceCannotGrowWhileTransientPointersAreLive) {
+  CudaRenderDevice device;
+  auto&            transients = device.Workspace().TransientBuffers();
+  transients.Reserve(256);
+  void* live = transients.Allocate(64);
+  ASSERT_NE(live, nullptr);
+  EXPECT_THROW(transients.Reserve(1024), std::runtime_error);
+  EXPECT_THROW((void)transients.Allocate(transients.capacity_bytes()), std::runtime_error);
+}
+
+TEST_F(CudaWorkspaceFixture, NodeResultCacheReturnsValueByProducerNodeAndPort) {
+  CudaRenderDevice device;
+  auto             buffer = device.Workspace().Device().CreateBuffer(32);
+  ASSERT_FALSE(buffer.Empty());
+  const void* ptr = buffer.DevicePointer();
+  const GraphValueId id{NodeId{"develop"}, PortId{"image"}};
+  device.Workspace().Values().Store(id, std::move(buffer));
+
+  auto* found = device.Workspace().Values().Find(NodeId{"develop"}, PortId{"image"});
+  ASSERT_NE(found, nullptr);
+  EXPECT_EQ(found->DevicePointer(), ptr);
+
+  EXPECT_EQ(device.Workspace().Values().Find(NodeId{"develop"}, PortId{"mask"}), nullptr);
+  EXPECT_EQ(device.Workspace().Values().Find(NodeId{"drt"}, PortId{"image"}), nullptr);
+}
+
+TEST_F(CudaWorkspaceFixture, SecondRenderUsesNoCudaAllocationAfterPeakReserve) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  workspace.Parameters().Reserve(256);
+  workspace.TransientBuffers().Reserve(1 << 20);
+  workspace.Textures().SetByteBudget(64 * 64);
+
+  device.BeginRender();
+  {
+    auto lease = workspace.Textures().Acquire({64, 64, TextureFormat::R8});
+    ASSERT_FALSE(lease.Empty());
+    ASSERT_NE(workspace.TransientBuffers().Allocate(2048), nullptr);
+    device.EndRender();
+  }
+  device.WaitIdle();
+  workspace.Device().ResetCounters();
+
+  device.BeginRender();
+  {
+    auto lease = workspace.Textures().Acquire({64, 64, TextureFormat::R8});
+    ASSERT_FALSE(lease.Empty());
+    ASSERT_NE(workspace.TransientBuffers().Allocate(2048), nullptr);
+    device.EndRender();
+  }
+  device.WaitIdle();
+
+  EXPECT_EQ(workspace.Device().MallocCount(), 0U);
+  EXPECT_EQ(workspace.Device().FreeCount(), 0U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G1 complete (Model, DTO, PipelineGraph). G2 not started.
+Status: G2 complete (CUDA workspace, ParameterArena, lifted TransientBufferArena). G3 not started.
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2026,6 +2026,85 @@ SecondRenderUsesNoCudaAllocationAfterPeakReserve
 - 未改变参数时不执行参数 H2D copy；
 - 一个字段改变时不上传完整参数区；
 - workspace 生命周期独立于 ExecutionPlan。
+
+##### Phase G2 completion record (2026-08-22)
+
+**Status:** complete — templated CUDA render workspace, grow-only ParameterArena with dirty-range H2D, TransientBufferArena lifted from `cuda::nn::WorkspacePool`, texture LRU with leases, node-result KV cache. No grading kernels. No ExecutionPlan.
+
+**Primary success call chain:**
+
+```text
+CudaRenderDevice::BeginRender
+  -> CudaBackend::Wait (previous submission)
+  -> TransientBufferArena::Reset
+  -> TakePendingParameterPatch
+  -> ParameterArena host-mirror field copy
+  -> MergeAdjacentRanges
+  -> CudaBackend::UploadBufferRange
+  -> PendingParameterPatch::Commit
+  -> EndRender (cudaEventRecord)
+```
+
+**Primary failure call chain:**
+
+```text
+CudaBackend::FailNextUpload / UploadBufferRange throws
+  -> PendingParameterPatch destructor
+  -> RestoreDirty
+  -> no Commit; next TakePending retries the latest payload
+```
+
+**Transient grow failure:**
+
+```text
+Allocate while used_bytes() != 0 and capacity short
+  -> TransientBufferArena throws
+  -> existing slab and live pointers unchanged
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `ParameterArenaKeepsStableOffsetsAcrossRenders` | `GpuDagCudaWorkspaceTest` | PASS |
+| `ParameterArenaUploadsOnlyDirtyFieldRanges` | `GpuDagCudaWorkspaceTest` | PASS |
+| `AdjacentDirtyParameterRangesMergeBeforeCudaCopy` | `GpuDagCudaWorkspaceTest` | PASS |
+| `RepeatedDirtyWritesUseLatestValue` | `GpuDagCudaWorkspaceTest` | PASS |
+| `CancelledCudaParameterCopyRestoresDirtyFields` | `GpuDagCudaWorkspaceTest` | PASS |
+| `WorkspaceResetRewindsTransientMemoryWithoutFreeingCudaAllocation` | `GpuDagCudaWorkspaceTest` | PASS |
+| `WorkspaceCannotGrowWhileTransientPointersAreLive` | `GpuDagCudaWorkspaceTest` | PASS |
+| `NodeResultCacheReturnsValueByProducerNodeAndPort` | `GpuDagCudaWorkspaceTest` | PASS |
+| `TextureLeasePreventsEvictionUntilCudaSubmissionCompletes` | `GpuDagCudaWorkspaceTest` | PASS |
+| `SecondRenderUsesNoCudaAllocationAfterPeakReserve` | `GpuDagCudaWorkspaceTest` | PASS |
+| `UnchangedParametersIssueNoHostToDeviceCopy` | `GpuDagCudaWorkspaceTest` | PASS |
+| Header hygiene (`include/gpu`, `include/edit/runtime` non-cuda) | `GpuDagCudaWorkspaceTest` | PASS |
+| G1 `GpuDagModelGraphTest` regression | `GpuDagModelGraphTest` | PASS |
+| Lifted `WorkspacePool` (`MlOpsWorkspaceTest`) | `MlOpsTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagCudaWorkspaceTest GpuDagModelGraphTest --parallel 4
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target MlOpsTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "GpuDagCudaWorkspaceTest|GpuDagModelGraphTest"
+ctest --test-dir build/debug --output-on-failure -R "GpuDagCudaWorkspaceTest|MlOpsTest.MlOpsWorkspaceTest"
+```
+
+Suite totals: `12/12` GpuDagCudaWorkspaceTest PASS. `17/17` GpuDagModelGraphTest PASS. `12/12` MlOpsWorkspaceTest PASS.
+
+**Checklist / exit condition:** all G2 exit conditions met. Product `PipelineMgmtService` and old `GPUPipelineWrapper` are unchanged. Workspace is owned by `CudaRenderDevice`, not by a plan.
+
+**LOC note (grill-code-review):** largest new file is `texture_pool.hpp` (291 lines). `cuda_backend.cpp` is 251 lines. No changed file exceeds 1000 LOC.
+
+**Remaining gaps:** GraphCompiler / ExecutionPlan / `IRenderDevice::Execute` (G4+). RenderGeometryResolver (G3). Develop/grade/DRT kernels (G4–G7). MaskStore and feather (G6). OpenCL `WorkspacePool` still a separate copy until G8. DemosaicNet still uses its own `WorkspacePool` instance, not `CudaRenderWorkspace`.
+
+**Files added:** `alcedo_studio/src/include/gpu/transient_buffer_arena.hpp`, `transient_buffer_scope.hpp`, `include/cuda/cuda_check.hpp`, `cuda_slab_backend.hpp`, `include/edit/runtime/*`, `src/edit/runtime/*`, `tests/edit/runtime/*`. CMake `EditRuntime` + `EditRuntimeCuda` + `GpuDagCudaWorkspaceTest`.
+
+**Files removed:** none. `cuda/nn/workspace.hpp` is now a facade over `TransientBufferArena<CudaSlabBackend>`.
+
+**Performance and allocation evidence:** `SecondRenderUsesNoCudaAllocationAfterPeakReserve` asserts malloc/free counts stay 0 after peak reserve. `UnchangedParametersIssueNoHostToDeviceCopy` asserts H2D bytes 0. `ParameterArenaUploadsOnlyDirtyFieldRanges` asserts a 4-byte copy. `AdjacentDirtyParameterRangesMergeBeforeCudaCopy` asserts one 8-byte copy.
+
+**Open work:** G3 RenderGeometryResolver.
 
 ## 36. Phase G3 — RenderGeometryResolver
 


### PR DESCRIPTION
## Summary

- Add the CUDA render workspace, stable parameter arena, dirty-range uploads, and retry-safe parameter transfer.
- Lift `TransientBufferArena` into shared GPU infrastructure and add texture leases plus the node-result cache.
- Reuse peak allocations across renders and avoid host-to-device copies when parameters are unchanged.

## Stack

Layer G2 of GitHub stack #99.

- Base: #94
- Next layer: #96

## Validation

- `GpuDagCudaWorkspaceTest`: 12/12 passed.
- G1 regression: 17/17 passed.
- `MlOpsWorkspaceTest`: 12/12 passed.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
