### PR TITLE
feat(edit): add RenderGeometryResolver and CUDA GeometryResamplePass

### DIFF
--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -20,6 +20,13 @@ def_library(EditHistory
     PUBLIC_DEPS Image TimeProvider JSON EditPipeline
 )
 
+# GPU-free render geometry: coordinate spaces, resolver, sampling plans. No CUDA.
+def_library(EditGeometry
+    SOURCES
+        ${ALCEDO_SRC_ROOT}/edit/geometry/render_geometry_resolver.cpp
+        ${ALCEDO_SRC_ROOT}/edit/geometry/texture_sampling_plan.cpp
+)
+
 # GPU DAG document/graph/models. No ImageBuffer, Operators, or GPU backends.
 set(EDIT_GRAPH_SRCS
     ${ALCEDO_SRC_ROOT}/edit/operators/models/adjustment_catalog.cpp
@@ -41,18 +48,20 @@ set(EDIT_GRAPH_SRCS
 
 def_library(EditGraph
     SOURCES ${EDIT_GRAPH_SRCS}
-    PUBLIC_DEPS JSON
+    PUBLIC_DEPS JSON EditGeometry
 )
 
 # GPU-agnostic DAG runtime (parameter arena, texture LRU, KV cache). No CUDA headers.
 def_library(EditRuntime
     SOURCES ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
-    PUBLIC_DEPS EditGraph
+    PUBLIC_DEPS EditGraph EditGeometry
 )
 
 if(ALCEDO_CUDA_ENABLED)
     def_cuda_library(EditRuntimeCuda
-        SOURCES ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_backend.cpp
+        SOURCES
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_backend.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/geometry_resample.cu
         PUBLIC_DEPS EditRuntime CUDA::cudart
     )
     target_compile_definitions(EditRuntimeCuda PUBLIC HAVE_CUDA)

--- a/alcedo_studio/src/edit/geometry/render_geometry_resolver.cpp
+++ b/alcedo_studio/src/edit/geometry/render_geometry_resolver.cpp
@@ -1,0 +1,272 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/geometry/render_geometry_resolver.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+namespace alcedo {
+namespace {
+
+constexpr float kPi = 3.14159265358979323846f;
+
+void ThrowIfInvalidExtent(const Extent2D& extent, const char* name) {
+  if (extent.Empty()) {
+    throw std::runtime_error(std::string("ResolveRenderGeometry: ") + name + " must be positive");
+  }
+}
+
+auto ClampNormalizedRect(NormalizedRect rect, const char* name) -> NormalizedRect {
+  if (!std::isfinite(rect.x) || !std::isfinite(rect.y) || !std::isfinite(rect.w) ||
+      !std::isfinite(rect.h)) {
+    throw std::runtime_error(std::string("ResolveRenderGeometry: ") + name + " must be finite");
+  }
+  rect.w = std::clamp(rect.w, kGeometryMinNormalizedSize, 1.0f);
+  rect.h = std::clamp(rect.h, kGeometryMinNormalizedSize, 1.0f);
+  rect.x = std::clamp(rect.x, 0.0f, 1.0f - rect.w);
+  rect.y = std::clamp(rect.y, 0.0f, 1.0f - rect.h);
+  return rect;
+}
+
+auto NormalizeRotationDegrees(float degrees) -> float {
+  if (!std::isfinite(degrees)) {
+    return 0.0f;
+  }
+  degrees = std::fmod(degrees, 360.0f);
+  if (degrees > 180.0f) {
+    degrees -= 360.0f;
+  } else if (degrees < -180.0f) {
+    degrees += 360.0f;
+  }
+  return degrees;
+}
+
+auto RoundExtent(float width, float height) -> Extent2D {
+  if (!std::isfinite(width) || !std::isfinite(height) || width <= 0.0f || height <= 0.0f) {
+    throw std::runtime_error("ResolveRenderGeometry: extent components must be positive and finite");
+  }
+  const auto rounded_w = static_cast<std::uint32_t>(std::max(1L, std::lround(width)));
+  const auto rounded_h = static_cast<std::uint32_t>(std::max(1L, std::lround(height)));
+  return Extent2D{rounded_w, rounded_h};
+}
+
+auto ClampMaxEdge(Extent2D extent, std::uint32_t max_edge) -> Extent2D {
+  if (max_edge == 0) {
+    return extent;
+  }
+  const auto long_edge = std::max(extent.width, extent.height);
+  if (long_edge <= max_edge) {
+    return extent;
+  }
+  const float scale =
+      static_cast<float>(max_edge) / static_cast<float>(long_edge);
+  return RoundExtent(static_cast<float>(extent.width) * scale,
+                     static_cast<float>(extent.height) * scale);
+}
+
+struct Aabb {
+  float min_x = 0.0f;
+  float min_y = 0.0f;
+  float max_x = 0.0f;
+  float max_y = 0.0f;
+};
+
+auto AabbOfTransformedCorners(const Matrix3x3& matrix, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
+    -> Aabb {
+  const Vector2 p[4] = {TransformPoint(matrix, a), TransformPoint(matrix, b), TransformPoint(matrix, c),
+                        TransformPoint(matrix, d)};
+  Aabb          box{p[0].x, p[0].y, p[0].x, p[0].y};
+  for (int i = 1; i < 4; ++i) {
+    box.min_x = std::min(box.min_x, p[i].x);
+    box.min_y = std::min(box.min_y, p[i].y);
+    box.max_x = std::max(box.max_x, p[i].x);
+    box.max_y = std::max(box.max_y, p[i].y);
+  }
+  return box;
+}
+
+auto ClampRectI(std::int32_t x0, std::int32_t y0, std::int32_t x1, std::int32_t y1, Extent2D extent)
+    -> RectI {
+  const auto max_x = static_cast<std::int32_t>(extent.width);
+  const auto max_y = static_cast<std::int32_t>(extent.height);
+  x0               = std::clamp(x0, 0, max_x);
+  x1               = std::clamp(x1, 0, max_x);
+  y0               = std::clamp(y0, 0, max_y);
+  y1               = std::clamp(y1, 0, max_y);
+  if (x1 < x0) {
+    std::swap(x0, x1);
+  }
+  if (y1 < y0) {
+    std::swap(y0, y1);
+  }
+  if (x1 == x0) {
+    if (x0 > 0) {
+      --x0;
+    } else if (x1 < max_x) {
+      ++x1;
+    }
+  }
+  if (y1 == y0) {
+    if (y0 > 0) {
+      --y0;
+    } else if (y1 < max_y) {
+      ++y1;
+    }
+  }
+  return RectI{x0, y0, x1 - x0, y1 - y0};
+}
+
+auto RequiredRegionFromAabb(const Aabb& box, float radius_x, float radius_y, Extent2D extent)
+    -> RectI {
+  const auto x0 = static_cast<std::int32_t>(std::floor(box.min_x - radius_x));
+  const auto y0 = static_cast<std::int32_t>(std::floor(box.min_y - radius_y));
+  const auto x1 = static_cast<std::int32_t>(std::ceil(box.max_x + radius_x));
+  const auto y1 = static_cast<std::int32_t>(std::ceil(box.max_y + radius_y));
+  return ClampRectI(x0, y0, x1, y1, extent);
+}
+
+void FillGpuData(ResolvedRenderGeometry& geometry) {
+  for (int i = 0; i < 9; ++i) {
+    geometry.gpu_data.render_to_decoded[i] = geometry.render_to_decoded.m[i];
+  }
+  geometry.gpu_data.decoded_width  = geometry.decoded_extent.width;
+  geometry.gpu_data.decoded_height = geometry.decoded_extent.height;
+  geometry.gpu_data.render_width   = geometry.render_extent.width;
+  geometry.gpu_data.render_height  = geometry.render_extent.height;
+  geometry.gpu_data.border_rgba[0] = 0.0f;
+  geometry.gpu_data.border_rgba[1] = 0.0f;
+  geometry.gpu_data.border_rgba[2] = 0.0f;
+  geometry.gpu_data.border_rgba[3] = 1.0f;
+  geometry.gpu_data.filter         = static_cast<std::uint32_t>(geometry.filter);
+}
+
+}  // namespace
+
+auto ResolveRenderGeometry(const SourceGeometry& source, const ImageGeometryParams& image,
+                           const ViewRequest& view, const ResolutionRequest& resolution,
+                           const SamplingFootprint& footprint) -> ResolvedRenderGeometry {
+  ThrowIfInvalidExtent(source.decoded_extent, "decoded_extent");
+  ThrowIfInvalidExtent(source.full_reference_extent, "full_reference_extent");
+  if (!std::isfinite(resolution.render_scale) || resolution.render_scale <= 0.0f) {
+    throw std::runtime_error("ResolveRenderGeometry: render_scale must be positive and finite");
+  }
+  if (!std::isfinite(footprint.radius_x) || !std::isfinite(footprint.radius_y) ||
+      footprint.radius_x < 0.0f || footprint.radius_y < 0.0f) {
+    throw std::runtime_error("ResolveRenderGeometry: footprint radius must be finite and >= 0");
+  }
+
+  const auto crop = ClampNormalizedRect(image.crop_rect, "crop_rect");
+  const auto visible =
+      ClampNormalizedRect(view.visible_rect_in_edit_space, "visible_rect_in_edit_space");
+  const float theta =
+      NormalizeRotationDegrees(image.rotation_degrees) * (kPi / 180.0f);
+
+  const float full_w = static_cast<float>(source.full_reference_extent.width);
+  const float full_h = static_cast<float>(source.full_reference_extent.height);
+  const float left   = crop.x * full_w;
+  const float top    = crop.y * full_h;
+  const float right  = (crop.x + crop.w) * full_w;
+  const float bottom = (crop.y + crop.h) * full_h;
+  const float crop_w = right - left;
+  const float crop_h = bottom - top;
+  const float cx     = 0.5f * (left + right);
+  const float cy     = 0.5f * (top + bottom);
+
+  const auto to_center = Matrix3x3::Translate(-cx, -cy);
+  const auto rotate    = Matrix3x3::Rotate(theta);
+  const auto centered  = rotate * to_center;
+  const auto rotated_box =
+      AabbOfTransformedCorners(centered, Vector2{left, top}, Vector2{right, top},
+                               Vector2{right, bottom}, Vector2{left, bottom});
+  const float aabb_w = std::max(rotated_box.max_x - rotated_box.min_x, kGeometryMinNormalizedSize);
+  const float aabb_h = std::max(rotated_box.max_y - rotated_box.min_y, kGeometryMinNormalizedSize);
+
+  ResolvedRenderGeometry geometry;
+  geometry.decoded_extent        = source.decoded_extent;
+  geometry.full_reference_extent = source.full_reference_extent;
+  geometry.decoded_to_reference =
+      MakeDecodedToReference(source.decoded_extent, source.full_reference_extent);
+
+  if (image.expand_to_fit) {
+    geometry.edit_extent       = RoundExtent(aabb_w, aabb_h);
+    const float sx             = static_cast<float>(geometry.edit_extent.width) / aabb_w;
+    const float sy             = static_cast<float>(geometry.edit_extent.height) / aabb_h;
+    geometry.reference_to_edit = Matrix3x3::Scale(sx, sy) *
+                                 Matrix3x3::Translate(-rotated_box.min_x, -rotated_box.min_y) *
+                                 centered;
+  } else {
+    geometry.edit_extent       = RoundExtent(crop_w, crop_h);
+    const float sx             = static_cast<float>(geometry.edit_extent.width) / crop_w;
+    const float sy             = static_cast<float>(geometry.edit_extent.height) / crop_h;
+    geometry.reference_to_edit =
+        Matrix3x3::Translate(static_cast<float>(geometry.edit_extent.width) * 0.5f,
+                             static_cast<float>(geometry.edit_extent.height) * 0.5f) *
+        Matrix3x3::Scale(sx, sy) * centered;
+  }
+
+  const float edit_w   = static_cast<float>(geometry.edit_extent.width);
+  const float edit_h   = static_cast<float>(geometry.edit_extent.height);
+  const float v_left   = visible.x * edit_w;
+  const float v_top    = visible.y * edit_h;
+  const float v_right  = (visible.x + visible.w) * edit_w;
+  const float v_bottom = (visible.y + visible.h) * edit_h;
+  const float vis_w    = std::max(v_right - v_left, kGeometryMinNormalizedSize);
+  const float vis_h    = std::max(v_bottom - v_top, kGeometryMinNormalizedSize);
+
+  Extent2D target;
+  if (view.viewport_extent.width > 0 && view.viewport_extent.height > 0) {
+    target = view.viewport_extent;
+  } else {
+    target = RoundExtent(vis_w, vis_h);
+  }
+  geometry.render_extent = ClampMaxEdge(
+      RoundExtent(static_cast<float>(target.width) * resolution.render_scale,
+                  static_cast<float>(target.height) * resolution.render_scale),
+      resolution.max_edge);
+
+  const float rsx        = static_cast<float>(geometry.render_extent.width) / vis_w;
+  const float rsy        = static_cast<float>(geometry.render_extent.height) / vis_h;
+  geometry.edit_to_render = Matrix3x3::Scale(rsx, rsy) * Matrix3x3::Translate(-v_left, -v_top);
+
+  geometry.reference_to_render = geometry.edit_to_render * geometry.reference_to_edit;
+  geometry.render_to_reference = InvertAffine(geometry.reference_to_render);
+  geometry.render_to_decoded =
+      InvertAffine(geometry.decoded_to_reference) * geometry.render_to_reference;
+
+  geometry.filter =
+      resolution.quality == RenderQuality::Export ? TextureFilter::Bicubic : TextureFilter::Bilinear;
+
+  const float render_w = static_cast<float>(geometry.render_extent.width);
+  const float render_h = static_cast<float>(geometry.render_extent.height);
+  const auto  decoded_box =
+      AabbOfTransformedCorners(geometry.render_to_decoded, Vector2{0.0f, 0.0f},
+                               Vector2{render_w, 0.0f}, Vector2{render_w, render_h},
+                               Vector2{0.0f, render_h});
+  const auto reference_box =
+      AabbOfTransformedCorners(geometry.render_to_reference, Vector2{0.0f, 0.0f},
+                               Vector2{render_w, 0.0f}, Vector2{render_w, render_h},
+                               Vector2{0.0f, render_h});
+
+  if (footprint.requires_full_reference) {
+    geometry.required_decoded_region = RectI{
+        0, 0, static_cast<std::int32_t>(geometry.decoded_extent.width),
+        static_cast<std::int32_t>(geometry.decoded_extent.height)};
+    geometry.required_reference_region = RectI{
+        0, 0, static_cast<std::int32_t>(geometry.full_reference_extent.width),
+        static_cast<std::int32_t>(geometry.full_reference_extent.height)};
+  } else {
+    geometry.required_decoded_region = RequiredRegionFromAabb(
+        decoded_box, footprint.radius_x, footprint.radius_y, geometry.decoded_extent);
+    geometry.required_reference_region = RequiredRegionFromAabb(
+        reference_box, footprint.radius_x, footprint.radius_y, geometry.full_reference_extent);
+  }
+
+  FillGpuData(geometry);
+  return geometry;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/geometry/texture_sampling_plan.cpp
+++ b/alcedo_studio/src/edit/geometry/texture_sampling_plan.cpp
@@ -1,0 +1,74 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/geometry/texture_sampling_plan.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace alcedo {
+namespace {
+
+auto ClampBounds(NormalizedRect bounds) -> NormalizedRect {
+  if (!std::isfinite(bounds.x) || !std::isfinite(bounds.y) || !std::isfinite(bounds.w) ||
+      !std::isfinite(bounds.h)) {
+    throw std::runtime_error("MakeRasterMaskSamplingPlan: bounds must be finite");
+  }
+  bounds.w = std::clamp(bounds.w, kGeometryMinNormalizedSize, 1.0f);
+  bounds.h = std::clamp(bounds.h, kGeometryMinNormalizedSize, 1.0f);
+  bounds.x = std::clamp(bounds.x, 0.0f, 1.0f - bounds.w);
+  bounds.y = std::clamp(bounds.y, 0.0f, 1.0f - bounds.h);
+  return bounds;
+}
+
+auto ReferencePixelToUv(Extent2D full_reference, NormalizedRect bounds) -> Matrix3x3 {
+  const float full_w = static_cast<float>(full_reference.width);
+  const float full_h = static_cast<float>(full_reference.height);
+  Matrix3x3   matrix;
+  matrix.m[0] = 1.0f / (full_w * bounds.w);
+  matrix.m[1] = 0.0f;
+  matrix.m[2] = -bounds.x / bounds.w;
+  matrix.m[3] = 0.0f;
+  matrix.m[4] = 1.0f / (full_h * bounds.h);
+  matrix.m[5] = -bounds.y / bounds.h;
+  matrix.m[6] = 0.0f;
+  matrix.m[7] = 0.0f;
+  matrix.m[8] = 1.0f;
+  return matrix;
+}
+
+}  // namespace
+
+auto MakeRasterMaskSamplingPlan(const ResolvedRenderGeometry& geometry,
+                                NormalizedRect reference_bounds, Extent2D texture_extent)
+    -> TextureSamplingPlan {
+  if (texture_extent.Empty()) {
+    throw std::runtime_error("MakeRasterMaskSamplingPlan: texture_extent must be positive");
+  }
+  if (geometry.full_reference_extent.Empty() || geometry.render_extent.Empty()) {
+    throw std::runtime_error("MakeRasterMaskSamplingPlan: geometry extents must be positive");
+  }
+  const auto bounds = ClampBounds(reference_bounds);
+  TextureSamplingPlan plan;
+  plan.render_to_texture_uv =
+      ReferencePixelToUv(geometry.full_reference_extent, bounds) * geometry.render_to_reference;
+  plan.uv_dx  = Vector2{plan.render_to_texture_uv.m[0], plan.render_to_texture_uv.m[3]};
+  plan.uv_dy  = Vector2{plan.render_to_texture_uv.m[1], plan.render_to_texture_uv.m[4]};
+  plan.filter = geometry.filter;
+
+  const float tex_w = static_cast<float>(texture_extent.width);
+  const float tex_h = static_cast<float>(texture_extent.height);
+  const float rho_x = std::hypot(plan.uv_dx.x * tex_w, plan.uv_dx.y * tex_h);
+  const float rho_y = std::hypot(plan.uv_dy.x * tex_w, plan.uv_dy.y * tex_h);
+  plan.mip_level    = std::log2(std::max(std::max(rho_x, rho_y), 1.0e-6f));
+  return plan;
+}
+
+auto MakeLlfSamplingPlan(const ResolvedRenderGeometry& geometry, Extent2D reference_texture_extent)
+    -> TextureSamplingPlan {
+  return MakeRasterMaskSamplingPlan(geometry, NormalizedRect{}, reference_texture_extent);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -221,6 +221,46 @@ void CudaBackend::DownloadBufferRange(const Buffer& buffer, std::uint32_t offset
                   "CudaBackend::DownloadBufferRange sync");
 }
 
+void CudaBackend::UploadTexture2D(Texture2D& texture, std::span<const std::byte> bytes,
+                                  CommandContext& command_context) {
+  if (fail_next_upload_) {
+    fail_next_upload_ = false;
+    throw std::runtime_error("CudaBackend::UploadTexture2D: injected failure");
+  }
+  if (texture.DevicePointer() == nullptr) {
+    throw std::runtime_error("CudaBackend::UploadTexture2D: empty texture");
+  }
+  if (bytes.size() != texture.Bytes()) {
+    throw std::runtime_error("CudaBackend::UploadTexture2D: size does not match texture");
+  }
+  if (bytes.empty()) {
+    return;
+  }
+  cuda::CheckCuda(::cudaMemcpyAsync(texture.DevicePointer(), bytes.data(), bytes.size(),
+                                    cudaMemcpyHostToDevice, command_context.Stream()),
+                  "CudaBackend::UploadTexture2D");
+  ++h2d_copy_count_;
+  h2d_bytes_ += bytes.size();
+}
+
+void CudaBackend::DownloadTexture2D(const Texture2D& texture, std::span<std::byte> out,
+                                    CommandContext& command_context) const {
+  if (texture.DevicePointer() == nullptr) {
+    throw std::runtime_error("CudaBackend::DownloadTexture2D: empty texture");
+  }
+  if (out.size() != texture.Bytes()) {
+    throw std::runtime_error("CudaBackend::DownloadTexture2D: size does not match texture");
+  }
+  if (out.empty()) {
+    return;
+  }
+  cuda::CheckCuda(::cudaMemcpyAsync(out.data(), texture.DevicePointer(), out.size(),
+                                    cudaMemcpyDeviceToHost, command_context.Stream()),
+                  "CudaBackend::DownloadTexture2D");
+  cuda::CheckCuda(::cudaStreamSynchronize(command_context.Stream()),
+                  "CudaBackend::DownloadTexture2D sync");
+}
+
 void CudaBackend::GenerateMaskMipLevels(Texture2D&) {}
 
 void CudaBackend::Submit(CommandContext& command_context) {

--- a/alcedo_studio/src/edit/runtime/cuda/geometry_resample.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/geometry_resample.cu
@@ -1,0 +1,152 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/cuda/geometry_resample_pass.hpp"
+
+#include <stdexcept>
+#include <string>
+
+#include "cuda/cuda_check.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+namespace {
+
+__device__ auto ReadBorder(const float4* src, int width, int height, int x, int y, float4 border)
+    -> float4 {
+  if (x < 0 || y < 0 || x >= width || y >= height) {
+    return border;
+  }
+  return src[y * width + x];
+}
+
+__device__ auto BilinearSample(const float4* src, int width, int height, float sx, float sy,
+                               float4 border) -> float4 {
+  const float px = sx - 0.5f;
+  const float py = sy - 0.5f;
+  const int   x0 = static_cast<int>(floorf(px));
+  const int   y0 = static_cast<int>(floorf(py));
+  const float fx = px - static_cast<float>(x0);
+  const float fy = py - static_cast<float>(y0);
+  const float4 p00 = ReadBorder(src, width, height, x0, y0, border);
+  const float4 p10 = ReadBorder(src, width, height, x0 + 1, y0, border);
+  const float4 p01 = ReadBorder(src, width, height, x0, y0 + 1, border);
+  const float4 p11 = ReadBorder(src, width, height, x0 + 1, y0 + 1, border);
+  const float  w00 = (1.0f - fx) * (1.0f - fy);
+  const float  w10 = fx * (1.0f - fy);
+  const float  w01 = (1.0f - fx) * fy;
+  const float  w11 = fx * fy;
+  float4       out;
+  out.x = w00 * p00.x + w10 * p10.x + w01 * p01.x + w11 * p11.x;
+  out.y = w00 * p00.y + w10 * p10.y + w01 * p01.y + w11 * p11.y;
+  out.z = w00 * p00.z + w10 * p10.z + w01 * p01.z + w11 * p11.z;
+  out.w = w00 * p00.w + w10 * p10.w + w01 * p01.w + w11 * p11.w;
+  return out;
+}
+
+__device__ auto CubicWeight(float x) -> float {
+  x = fabsf(x);
+  if (x < 1.0f) {
+    return ((1.5f * x - 2.5f) * x) * x + 1.0f;
+  }
+  if (x < 2.0f) {
+    return (((-0.5f * x + 2.5f) * x) - 4.0f) * x + 2.0f;
+  }
+  return 0.0f;
+}
+
+__device__ auto BicubicSample(const float4* src, int width, int height, float sx, float sy,
+                              float4 border) -> float4 {
+  const float px = sx - 0.5f;
+  const float py = sy - 0.5f;
+  const int   x0 = static_cast<int>(floorf(px));
+  const int   y0 = static_cast<int>(floorf(py));
+  const float fx = px - static_cast<float>(x0);
+  const float fy = py - static_cast<float>(y0);
+  float4      acc = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+  float       wsum = 0.0f;
+  for (int j = -1; j <= 2; ++j) {
+    const float wy = CubicWeight(static_cast<float>(j) - fy);
+    for (int i = -1; i <= 2; ++i) {
+      const float  wx = CubicWeight(static_cast<float>(i) - fx);
+      const float  w  = wx * wy;
+      const float4 p  = ReadBorder(src, width, height, x0 + i, y0 + j, border);
+      acc.x += w * p.x;
+      acc.y += w * p.y;
+      acc.z += w * p.z;
+      acc.w += w * p.w;
+      wsum += w;
+    }
+  }
+  if (wsum <= 1.0e-8f) {
+    return border;
+  }
+  acc.x /= wsum;
+  acc.y /= wsum;
+  acc.z /= wsum;
+  acc.w /= wsum;
+  return acc;
+}
+
+__global__ void GeometryResampleKernel(const float4* src, float4* dst, int decoded_w, int decoded_h,
+                                       int render_w, int render_h, float m00, float m01, float m02,
+                                       float m10, float m11, float m12, float4 border,
+                                       int use_bicubic) {
+  const int x = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  const int y = static_cast<int>(blockIdx.y * blockDim.y + threadIdx.y);
+  if (x >= render_w || y >= render_h) {
+    return;
+  }
+  const float cx = static_cast<float>(x) + 0.5f;
+  const float cy = static_cast<float>(y) + 0.5f;
+  const float sx = m00 * cx + m01 * cy + m02;
+  const float sy = m10 * cx + m11 * cy + m12;
+  const float4 pixel = use_bicubic ? BicubicSample(src, decoded_w, decoded_h, sx, sy, border)
+                                   : BilinearSample(src, decoded_w, decoded_h, sx, sy, border);
+  dst[y * render_w + x] = pixel;
+}
+
+}  // namespace
+
+void GeometryResamplePass::Encode(const ResolvedRenderGeometry& geometry,
+                                  const CudaBackend::Texture2D& src, CudaBackend::Texture2D& dst,
+                                  CudaCommandContext& command_context) {
+  if (src.Format() != TextureFormat::Rgba32f || dst.Format() != TextureFormat::Rgba32f) {
+    throw std::runtime_error("GeometryResamplePass::Encode: textures must be RGBA32F");
+  }
+  if (src.Width() != geometry.decoded_extent.width ||
+      src.Height() != geometry.decoded_extent.height) {
+    throw std::runtime_error("GeometryResamplePass::Encode: src size must match decoded_extent");
+  }
+  if (dst.Width() != geometry.render_extent.width ||
+      dst.Height() != geometry.render_extent.height) {
+    throw std::runtime_error("GeometryResamplePass::Encode: dst size must match render_extent");
+  }
+  if (src.DevicePointer() == nullptr || dst.DevicePointer() == nullptr) {
+    throw std::runtime_error("GeometryResamplePass::Encode: empty texture");
+  }
+
+  const auto& gpu = geometry.gpu_data;
+  const dim3  block(16, 16);
+  const dim3  grid((gpu.render_width + block.x - 1) / block.x,
+                   (gpu.render_height + block.y - 1) / block.y);
+  if (grid.x == 0 || grid.y == 0) {
+    throw std::runtime_error("GeometryResamplePass::Encode: invalid launch grid");
+  }
+
+  const float4 border =
+      make_float4(gpu.border_rgba[0], gpu.border_rgba[1], gpu.border_rgba[2], gpu.border_rgba[3]);
+  const int use_bicubic = geometry.filter == TextureFilter::Bicubic ? 1 : 0;
+
+  GeometryResampleKernel<<<grid, block, 0, command_context.Stream()>>>(
+      static_cast<const float4*>(src.DevicePointer()), static_cast<float4*>(dst.DevicePointer()),
+      static_cast<int>(gpu.decoded_width), static_cast<int>(gpu.decoded_height),
+      static_cast<int>(gpu.render_width), static_cast<int>(gpu.render_height), gpu.render_to_decoded[0],
+      gpu.render_to_decoded[1], gpu.render_to_decoded[2], gpu.render_to_decoded[3],
+      gpu.render_to_decoded[4], gpu.render_to_decoded[5], border, use_bicubic);
+  cuda::CheckCuda(::cudaGetLastError(), "GeometryResamplePass::Encode launch");
+  ++launch_count_;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/geometry/render_geometry_resolver.hpp
+++ b/alcedo_studio/src/include/edit/geometry/render_geometry_resolver.hpp
@@ -1,0 +1,39 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/geometry/render_request.hpp"
+#include "edit/geometry/resolved_render_geometry.hpp"
+#include "edit/geometry/source_geometry.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Interprets crop, rotation, view ROI, and dynamic resolution into matrices and rects.
+ *
+ * Does not process pixels or allocate GPU memory. All integer rounding for image, mask,
+ * and LLF happens here.
+ *
+ * @param source Decoded and full-reference extents. @p decoded_to_reference is rebuilt
+ *        from those extents.
+ * @param image Document crop / rotation / expand_to_fit.
+ * @param view Visible EditSpace rect and optional viewport size.
+ * @param resolution Render scale, max edge, and filter quality.
+ * @param footprint Source-pixel neighborhood. @p requires_full_reference forces full decoded
+ *        and reference required rects (LLF).
+ *
+ * @throws std::runtime_error if extents are zero or non-finite, or @p render_scale is not
+ *         positive and finite.
+ *
+ * Not thread-safe only in the sense that it has no shared mutable state; the function is pure.
+ */
+[[nodiscard]] auto ResolveRenderGeometry(const SourceGeometry&     source,
+                                         const ImageGeometryParams& image,
+                                         const ViewRequest&         view,
+                                         const ResolutionRequest&   resolution,
+                                         const SamplingFootprint&   footprint)
+    -> ResolvedRenderGeometry;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/geometry/render_request.hpp
+++ b/alcedo_studio/src/include/edit/geometry/render_request.hpp
@@ -1,0 +1,59 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/geometry/types.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Document crop and rotation. Viewport and dynamic resolution are not stored here.
+ */
+struct ImageGeometryParams {
+  NormalizedRect crop_rect{};
+  float          rotation_degrees = 0.0f;
+  bool           expand_to_fit    = true;
+};
+
+/**
+ * @brief Per-frame view crop in EditSpace and optional widget pixel size.
+ *
+ * @p viewport_extent of (0, 0) means size comes from the visible edit-pixel rectangle.
+ */
+struct ViewRequest {
+  NormalizedRect visible_rect_in_edit_space{};
+  Extent2D       viewport_extent{};
+};
+
+/**
+ * @brief Per-frame output scale. Not persisted on PipelineDocument.
+ *
+ * @p max_edge of 0 disables the long-edge clamp. @p quality selects the resample filter.
+ */
+struct ResolutionRequest {
+  float           render_scale = 1.0f;
+  std::uint32_t   max_edge     = 0;
+  RenderQuality   quality      = RenderQuality::Preview;
+};
+
+/**
+ * @brief Neighborhood a runtime behavior needs in source pixels.
+ *
+ * Pointwise: zeros. Bilinear: radius 1. Bicubic: radius 2. LLF may set
+ * @p requires_full_reference.
+ */
+struct SamplingFootprint {
+  float radius_x                 = 0.0f;
+  float radius_y                 = 0.0f;
+  bool  requires_full_reference  = false;
+};
+
+struct RenderRequest {
+  ViewRequest        view{};
+  ResolutionRequest  resolution{};
+  SamplingFootprint  footprint{};
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/geometry/resolved_render_geometry.hpp
+++ b/alcedo_studio/src/include/edit/geometry/resolved_render_geometry.hpp
@@ -1,0 +1,61 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "edit/geometry/types.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief POD uniforms for GeometryResamplePass. No GPU resource types.
+ */
+struct GpuRenderGeometry {
+  float         render_to_decoded[9] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+  std::uint32_t decoded_width        = 0;
+  std::uint32_t decoded_height       = 0;
+  std::uint32_t render_width         = 0;
+  std::uint32_t render_height        = 0;
+  float         border_rgba[4]       = {0.0f, 0.0f, 0.0f, 1.0f};
+  std::uint32_t filter               = 0;
+};
+
+/**
+ * @brief Single rounding result for crop, rotation, view, and dynamic resolution.
+ *
+ * Image, raster-mask UV, and LLF must read this object. They must not re-round.
+ */
+struct ResolvedRenderGeometry {
+  Extent2D decoded_extent{};
+  Extent2D full_reference_extent{};
+  Extent2D edit_extent{};
+  Extent2D render_extent{};
+
+  Matrix3x3 decoded_to_reference = Matrix3x3::Identity();
+  Matrix3x3 reference_to_edit    = Matrix3x3::Identity();
+  Matrix3x3 edit_to_render       = Matrix3x3::Identity();
+  Matrix3x3 reference_to_render  = Matrix3x3::Identity();
+  Matrix3x3 render_to_reference  = Matrix3x3::Identity();
+  Matrix3x3 render_to_decoded    = Matrix3x3::Identity();
+
+  RectI required_decoded_region{};
+  RectI required_reference_region{};
+
+  TextureFilter     filter = TextureFilter::Bilinear;
+  GpuRenderGeometry gpu_data{};
+};
+
+/**
+ * @brief True when render_to_decoded is identity and decoded extent equals render extent.
+ *
+ * GraphCompiler (G4+) may skip GeometryResamplePass when this is true.
+ */
+[[nodiscard]] inline auto IsIdentityResample(const ResolvedRenderGeometry& geometry) -> bool {
+  return geometry.decoded_extent == geometry.render_extent &&
+         IsApproxIdentity(geometry.render_to_decoded);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/geometry/source_geometry.hpp
+++ b/alcedo_studio/src/include/edit/geometry/source_geometry.hpp
@@ -1,0 +1,57 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <stdexcept>
+
+#include "edit/geometry/types.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Decoded buffer size and the stable full-image reference it maps onto.
+ *
+ * @p sensor_active_area is recorded for Develop / CFA phase (G4). Image matrices
+ * do not bake a sensor offset: decoded space is already active-area pixels.
+ */
+struct SourceGeometry {
+  Extent2D      decoded_extent{};
+  Extent2D      full_reference_extent{};
+  RectI         sensor_active_area{};
+  std::uint8_t  downsample_passes = 0;
+  Matrix3x3     decoded_to_reference = Matrix3x3::Identity();
+};
+
+/**
+ * @brief Scale matrix from decoded pixel-center coords onto full reference coords.
+ *
+ * Uses extent ratio, not 2^passes, so odd full sizes still share normalized UVs.
+ */
+[[nodiscard]] inline auto MakeDecodedToReference(Extent2D decoded, Extent2D full_reference)
+    -> Matrix3x3 {
+  if (decoded.Empty() || full_reference.Empty()) {
+    throw std::runtime_error("MakeDecodedToReference: extents must be positive");
+  }
+  const float sx =
+      static_cast<float>(full_reference.width) / static_cast<float>(decoded.width);
+  const float sy =
+      static_cast<float>(full_reference.height) / static_cast<float>(decoded.height);
+  return Matrix3x3::Scale(sx, sy);
+}
+
+[[nodiscard]] inline auto MakeSourceGeometry(Extent2D decoded, Extent2D full_reference,
+                                             RectI sensor_active_area = {},
+                                             std::uint8_t downsample_passes = 0) -> SourceGeometry {
+  SourceGeometry source;
+  source.decoded_extent         = decoded;
+  source.full_reference_extent  = full_reference;
+  source.sensor_active_area     = sensor_active_area;
+  source.downsample_passes      = downsample_passes;
+  source.decoded_to_reference   = MakeDecodedToReference(decoded, full_reference);
+  return source;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/geometry/texture_sampling_plan.hpp
+++ b/alcedo_studio/src/include/edit/geometry/texture_sampling_plan.hpp
@@ -1,0 +1,44 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/geometry/resolved_render_geometry.hpp"
+#include "edit/geometry/types.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief How to sample a texture from RenderSpace. No GPU types.
+ *
+ * Raster masks: UV covers @p reference_bounds. Dynamic resolution updates this plan
+ * without recreating the R8 texture (G6).
+ */
+struct TextureSamplingPlan {
+  Matrix3x3     render_to_texture_uv = Matrix3x3::Identity();
+  Vector2       uv_dx{};
+  Vector2       uv_dy{};
+  float         mip_level = 0.0f;
+  TextureFilter filter    = TextureFilter::Bilinear;
+};
+
+/**
+ * @brief Maps render pixel centers to UV over a ReferenceSpace rectangle.
+ *
+ * @param geometry Shared resolver result. Must not be re-rounded by the caller.
+ * @param reference_bounds Normalized rect in ReferenceSpace covered by the texture.
+ * @param texture_extent Texel size of the R8 (or LLF) texture. Used only for mip.
+ */
+[[nodiscard]] auto MakeRasterMaskSamplingPlan(const ResolvedRenderGeometry& geometry,
+                                              NormalizedRect                reference_bounds,
+                                              Extent2D texture_extent) -> TextureSamplingPlan;
+
+/**
+ * @brief LLF reference sampling: full-frame bounds, same render_to_reference as the image.
+ */
+[[nodiscard]] auto MakeLlfSamplingPlan(const ResolvedRenderGeometry& geometry,
+                                       Extent2D                      reference_texture_extent)
+    -> TextureSamplingPlan;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/geometry/types.hpp
+++ b/alcedo_studio/src/include/edit/geometry/types.hpp
@@ -1,0 +1,178 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+
+namespace alcedo {
+
+inline constexpr float kGeometryMinNormalizedSize = 1e-4f;
+inline constexpr float kGeometryMatrixEpsilon     = 1e-4f;
+
+struct Extent2D {
+  std::uint32_t width  = 0;
+  std::uint32_t height = 0;
+
+  [[nodiscard]] auto Empty() const -> bool { return width == 0 || height == 0; }
+};
+
+inline auto operator==(const Extent2D& a, const Extent2D& b) -> bool {
+  return a.width == b.width && a.height == b.height;
+}
+
+inline auto operator!=(const Extent2D& a, const Extent2D& b) -> bool { return !(a == b); }
+
+/**
+ * @brief Integer rectangle in left-closed, right-open form [x, x+width) x [y, y+height).
+ */
+struct RectI {
+  std::int32_t x      = 0;
+  std::int32_t y      = 0;
+  std::int32_t width  = 0;
+  std::int32_t height = 0;
+
+  [[nodiscard]] auto X1() const -> std::int32_t { return x + width; }
+  [[nodiscard]] auto Y1() const -> std::int32_t { return y + height; }
+
+  [[nodiscard]] auto Contains(std::int32_t px, std::int32_t py) const -> bool {
+    return px >= x && px < X1() && py >= y && py < Y1();
+  }
+};
+
+inline auto operator==(const RectI& a, const RectI& b) -> bool {
+  return a.x == b.x && a.y == b.y && a.width == b.width && a.height == b.height;
+}
+
+struct Vector2 {
+  float x = 0.0f;
+  float y = 0.0f;
+};
+
+/**
+ * @brief Row-major 3x3 matrix mapping homogeneous 2D points (column vectors).
+ *
+ * Pixel-center coordinates use (x + 0.5, y + 0.5). Affine maps keep the last row [0, 0, 1].
+ */
+struct Matrix3x3 {
+  float m[9] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+
+  static auto Identity() -> Matrix3x3 { return {}; }
+
+  static auto Translate(float tx, float ty) -> Matrix3x3 {
+    Matrix3x3 r;
+    r.m[2] = tx;
+    r.m[5] = ty;
+    return r;
+  }
+
+  static auto Scale(float sx, float sy) -> Matrix3x3 {
+    Matrix3x3 r;
+    r.m[0] = sx;
+    r.m[4] = sy;
+    return r;
+  }
+
+  /// Counterclockwise rotation about the origin, @p radians.
+  static auto Rotate(float radians) -> Matrix3x3 {
+    const float c = std::cos(radians);
+    const float s = std::sin(radians);
+    Matrix3x3   r;
+    r.m[0] = c;
+    r.m[1] = -s;
+    r.m[3] = s;
+    r.m[4] = c;
+    return r;
+  }
+};
+
+inline auto operator*(const Matrix3x3& a, const Matrix3x3& b) -> Matrix3x3 {
+  Matrix3x3 c{};
+  for (int row = 0; row < 3; ++row) {
+    for (int col = 0; col < 3; ++col) {
+      c.m[row * 3 + col] = a.m[row * 3 + 0] * b.m[0 * 3 + col] + a.m[row * 3 + 1] * b.m[1 * 3 + col] +
+                           a.m[row * 3 + 2] * b.m[2 * 3 + col];
+    }
+  }
+  return c;
+}
+
+/**
+ * @brief Maps a 2D point with implicit w = 1. Does not divide by w (affine maps keep w = 1).
+ */
+inline auto TransformPoint(const Matrix3x3& matrix, Vector2 point) -> Vector2 {
+  return Vector2{matrix.m[0] * point.x + matrix.m[1] * point.y + matrix.m[2],
+                 matrix.m[3] * point.x + matrix.m[4] * point.y + matrix.m[5]};
+}
+
+/**
+ * @brief Analytic inverse of an affine 3x3 (last row [0, 0, 1]).
+ * @throws std::runtime_error if the upper 2x2 is singular.
+ */
+inline auto InvertAffine(const Matrix3x3& matrix) -> Matrix3x3 {
+  const float det = matrix.m[0] * matrix.m[4] - matrix.m[1] * matrix.m[3];
+  if (!std::isfinite(det) || std::fabs(det) < 1e-12f) {
+    throw std::runtime_error("InvertAffine: singular matrix");
+  }
+  const float inv_det = 1.0f / det;
+  Matrix3x3   inv;
+  inv.m[0] = matrix.m[4] * inv_det;
+  inv.m[1] = -matrix.m[1] * inv_det;
+  inv.m[2] = (matrix.m[1] * matrix.m[5] - matrix.m[4] * matrix.m[2]) * inv_det;
+  inv.m[3] = -matrix.m[3] * inv_det;
+  inv.m[4] = matrix.m[0] * inv_det;
+  inv.m[5] = (matrix.m[3] * matrix.m[2] - matrix.m[0] * matrix.m[5]) * inv_det;
+  inv.m[6] = 0.0f;
+  inv.m[7] = 0.0f;
+  inv.m[8] = 1.0f;
+  return inv;
+}
+
+[[nodiscard]] inline auto MatrixApproxEqual(const Matrix3x3& a, const Matrix3x3& b,
+                                            float epsilon = kGeometryMatrixEpsilon) -> bool {
+  for (int i = 0; i < 9; ++i) {
+    if (std::fabs(a.m[i] - b.m[i]) > epsilon) {
+      return false;
+    }
+  }
+  return true;
+}
+
+[[nodiscard]] inline auto IsApproxIdentity(const Matrix3x3& matrix,
+                                           float            epsilon = kGeometryMatrixEpsilon) -> bool {
+  return MatrixApproxEqual(matrix, Matrix3x3::Identity(), epsilon);
+}
+
+struct NormalizedRect {
+  float x = 0.0f;
+  float y = 0.0f;
+  float w = 1.0f;
+  float h = 1.0f;
+
+  [[nodiscard]] auto IsFullFrame() const -> bool {
+    return x == 0.0f && y == 0.0f && w == 1.0f && h == 1.0f;
+  }
+};
+
+enum class TextureFilter : std::uint8_t {
+  Bilinear = 0,
+  Bicubic  = 1,
+};
+
+enum class RenderQuality : std::uint8_t {
+  Preview = 0,
+  Export  = 1,
+};
+
+[[nodiscard]] inline auto PixelCenter(std::uint32_t x, std::uint32_t y) -> Vector2 {
+  return {static_cast<float>(x) + 0.5f, static_cast<float>(y) + 0.5f};
+}
+
+[[nodiscard]] inline auto NormalizedFromPixelCenter(Vector2 center, Extent2D extent) -> Vector2 {
+  return {center.x / static_cast<float>(extent.width), center.y / static_cast<float>(extent.height)};
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/image_geometry_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/image_geometry_model.hpp
@@ -4,20 +4,10 @@
 
 #pragma once
 
+#include "edit/geometry/types.hpp"
 #include "json.hpp"
 
 namespace alcedo {
-
-struct NormalizedRect {
-  float x = 0.0f;
-  float y = 0.0f;
-  float w = 1.0f;
-  float h = 1.0f;
-
-  [[nodiscard]] auto IsFullFrame() const -> bool {
-    return x == 0.0f && y == 0.0f && w == 1.0f && h == 1.0f;
-  }
-};
 
 /**
  * @brief Document-level crop and rotation. Not a user-visible graph node.

--- a/alcedo_studio/src/include/edit/graph/raster_mask_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/raster_mask_node_model.hpp
@@ -11,8 +11,8 @@
 
 #include <string_view>
 
+#include "edit/geometry/types.hpp"
 #include "edit/graph/i_node_model.hpp"
-#include "edit/graph/image_geometry_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 
 namespace alcedo {

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -127,6 +127,15 @@ class CudaBackend {
   void DownloadBufferRange(const Buffer& buffer, std::uint32_t offset, std::span<std::byte> out,
                            CommandContext& command_context) const;
 
+  /**
+   * @brief Copy tightly packed host rows into a linear Texture2D. @p bytes size must equal
+   *        texture.Bytes().
+   */
+  void UploadTexture2D(Texture2D& texture, std::span<const std::byte> bytes,
+                       CommandContext& command_context);
+  void DownloadTexture2D(const Texture2D& texture, std::span<std::byte> out,
+                         CommandContext& command_context) const;
+
   /// G6 will generate mips. G2 keeps the entry and does nothing.
   void GenerateMaskMipLevels(Texture2D& texture);
 

--- a/alcedo_studio/src/include/edit/runtime/cuda/geometry_resample_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/geometry_resample_pass.hpp
@@ -1,0 +1,35 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "edit/geometry/resolved_render_geometry.hpp"
+#include "edit/runtime/cuda/cuda_backend.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Internal GPU pass: crop, rotation, view crop, and dynamic scale in one kernel.
+ *
+ * Not a user node and not serialized. GraphCompiler (G4+) inserts this between Develop
+ * output and the first ColorGrade. One in-flight submission; does not allocate textures.
+ *
+ * @pre src is decoded RGBA32F, dst is render RGBA32F, sizes match @p geometry.
+ * @throws std::runtime_error on size or format mismatch, or CUDA launch failure.
+ */
+class GeometryResamplePass {
+ public:
+  void Encode(const ResolvedRenderGeometry& geometry, const CudaBackend::Texture2D& src,
+              CudaBackend::Texture2D& dst, CudaCommandContext& command_context);
+
+  [[nodiscard]] auto LaunchCount() const -> std::uint32_t { return launch_count_; }
+  void               ResetLaunchCount() { launch_count_ = 0; }
+
+ private:
+  std::uint32_t launch_count_ = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -241,7 +241,29 @@ gtest_discover_tests(GpuDagModelGraphTest TEST_PREFIX "GpuDagModelGraphTest."
   PROPERTIES LABELS "ci_core_flow;edit;graph")
 alcedo_register_test_target(GpuDagModelGraphTest edit)
 
-# GPU DAG Phase G2: CUDA workspace, ParameterArena, transient bump, texture lease.
+# GPU DAG Phase G3: RenderGeometryResolver (CPU).
+add_executable(GpuDagGeometryTest
+  ${ALCEDO_TEST_ROOT}/edit/geometry/render_geometry_resolver_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/geometry/sampling_and_document_test.cpp)
+target_include_directories(GpuDagGeometryTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(GpuDagGeometryTest PRIVATE GTest::gtest_main EditGeometry EditGraph)
+target_compile_definitions(GpuDagGeometryTest PRIVATE
+  ALCEDO_MODEL_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/operators/models"
+  ALCEDO_GEOMETRY_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/geometry")
+gtest_discover_tests(GpuDagGeometryTest TEST_PREFIX "GpuDagGeometryTest."
+  PROPERTIES LABELS "ci_core_flow;edit;geometry")
+alcedo_register_test_target(GpuDagGeometryTest edit)
+
+# GPU DAG Phase G3: CUDA GeometryResamplePass.
+if(ALCEDO_CUDA_ENABLED)
+  add_executable(GpuDagCudaGeometryTest
+    ${ALCEDO_TEST_ROOT}/edit/geometry/cuda_geometry_resample_test.cpp)
+  target_include_directories(GpuDagCudaGeometryTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagCudaGeometryTest PRIVATE GTest::gtest_main EditRuntimeCuda)
+  gtest_discover_tests(GpuDagCudaGeometryTest TEST_PREFIX "GpuDagCudaGeometryTest."
+    PROPERTIES LABELS "gpu;edit;geometry")
+  alcedo_register_test_target(GpuDagCudaGeometryTest gpu)
+endif()
 if(ALCEDO_CUDA_ENABLED)
   add_executable(GpuDagCudaWorkspaceTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/parameter_arena_test.cpp

--- a/alcedo_studio/tests/edit/geometry/cuda_geometry_resample_test.cpp
+++ b/alcedo_studio/tests/edit/geometry/cuda_geometry_resample_test.cpp
@@ -1,0 +1,164 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "edit/geometry/render_geometry_resolver.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/cuda/geometry_resample_pass.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+class CudaGeometryFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasCudaDevice()) {
+      GTEST_SKIP() << "No CUDA device available.";
+    }
+  }
+};
+
+struct Rgba {
+  float r = 0.0f;
+  float g = 0.0f;
+  float b = 0.0f;
+  float a = 1.0f;
+};
+
+auto ReadBorder(const std::vector<Rgba>& src, int width, int height, int x, int y, Rgba border)
+    -> Rgba {
+  if (x < 0 || y < 0 || x >= width || y >= height) {
+    return border;
+  }
+  return src[static_cast<std::size_t>(y) * static_cast<std::size_t>(width) +
+             static_cast<std::size_t>(x)];
+}
+
+auto BilinearSample(const std::vector<Rgba>& src, int width, int height, float sx, float sy,
+                    Rgba border) -> Rgba {
+  const float px = sx - 0.5f;
+  const float py = sy - 0.5f;
+  const int   x0 = static_cast<int>(std::floor(px));
+  const int   y0 = static_cast<int>(std::floor(py));
+  const float fx = px - static_cast<float>(x0);
+  const float fy = py - static_cast<float>(y0);
+  const auto  p00 = ReadBorder(src, width, height, x0, y0, border);
+  const auto  p10 = ReadBorder(src, width, height, x0 + 1, y0, border);
+  const auto  p01 = ReadBorder(src, width, height, x0, y0 + 1, border);
+  const auto  p11 = ReadBorder(src, width, height, x0 + 1, y0 + 1, border);
+  const float w00 = (1.0f - fx) * (1.0f - fy);
+  const float w10 = fx * (1.0f - fy);
+  const float w01 = (1.0f - fx) * fy;
+  const float w11 = fx * fy;
+  Rgba        out;
+  out.r = w00 * p00.r + w10 * p10.r + w01 * p01.r + w11 * p11.r;
+  out.g = w00 * p00.g + w10 * p10.g + w01 * p01.g + w11 * p11.g;
+  out.b = w00 * p00.b + w10 * p10.b + w01 * p01.b + w11 * p11.b;
+  out.a = w00 * p00.a + w10 * p10.a + w01 * p01.a + w11 * p11.a;
+  return out;
+}
+
+auto MakeSrcImage(std::uint32_t width, std::uint32_t height) -> std::vector<Rgba> {
+  std::vector<Rgba> pixels(static_cast<std::size_t>(width) * height);
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      auto& p = pixels[static_cast<std::size_t>(y) * width + x];
+      p.r     = (static_cast<float>(x) + 0.5f) / static_cast<float>(width);
+      p.g     = (static_cast<float>(y) + 0.5f) / static_cast<float>(height);
+      p.b     = 0.25f;
+      p.a     = 1.0f;
+    }
+  }
+  return pixels;
+}
+
+auto AsBytes(const std::vector<Rgba>& pixels) -> std::span<const std::byte> {
+  return std::span<const std::byte>(reinterpret_cast<const std::byte*>(pixels.data()),
+                                    pixels.size() * sizeof(Rgba));
+}
+
+}  // namespace
+
+TEST_F(CudaGeometryFixture, CropRotateViewportAndScaleExecuteAsOneCudaResample) {
+  ImageGeometryParams image;
+  image.crop_rect        = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
+  image.rotation_degrees = 15.0f;
+  image.expand_to_fit    = true;
+  ViewRequest view;
+  view.visible_rect_in_edit_space = NormalizedRect{0.10f, 0.10f, 0.80f, 0.80f};
+  view.viewport_extent            = Extent2D{40, 30};
+  const auto source               = MakeSourceGeometry({64, 48}, {64, 48});
+  const auto geometry = ResolveRenderGeometry(source, image, view, {}, {});
+  ASSERT_EQ(geometry.decoded_extent, (Extent2D{64, 48}));
+  ASSERT_EQ(geometry.render_extent, (Extent2D{40, 30}));
+
+  const auto host_src = MakeSrcImage(64, 48);
+  CudaRenderDevice device;
+  auto&            textures = device.Workspace().Textures();
+  textures.SetByteBudget(64ull * 48ull * 16ull * 4ull);
+
+  device.BeginRender();
+  auto src = textures.Acquire({64, 48, TextureFormat::Rgba32f});
+  auto dst = textures.Acquire(
+      {geometry.render_extent.width, geometry.render_extent.height, TextureFormat::Rgba32f});
+  device.Workspace().Device().UploadTexture2D(src.Texture(), AsBytes(host_src),
+                                              device.CommandContext());
+
+  GeometryResamplePass pass;
+  pass.Encode(geometry, src.Texture(), dst.Texture(), device.CommandContext());
+  EXPECT_EQ(pass.LaunchCount(), 1u);
+  device.EndRender();
+  device.WaitIdle();
+
+  std::vector<Rgba> host_dst(static_cast<std::size_t>(geometry.render_extent.width) *
+                             geometry.render_extent.height);
+  auto              out_bytes = std::span<std::byte>(reinterpret_cast<std::byte*>(host_dst.data()),
+                                                     host_dst.size() * sizeof(Rgba));
+  device.BeginRender();
+  device.Workspace().Device().DownloadTexture2D(dst.Texture(), out_bytes, device.CommandContext());
+  device.EndRender();
+  device.WaitIdle();
+
+  const Rgba border{0.0f, 0.0f, 0.0f, 1.0f};
+  float      max_err = 0.0f;
+  for (std::uint32_t y = 0; y < geometry.render_extent.height; ++y) {
+    for (std::uint32_t x = 0; x < geometry.render_extent.width; ++x) {
+      const auto center = PixelCenter(x, y);
+      const auto src_xy = TransformPoint(geometry.render_to_decoded, center);
+      const auto cpu    = BilinearSample(host_src, 64, 48, src_xy.x, src_xy.y, border);
+      const auto& gpu   = host_dst[static_cast<std::size_t>(y) * 40u + x];
+      max_err = std::max(max_err, std::fabs(cpu.r - gpu.r));
+      max_err = std::max(max_err, std::fabs(cpu.g - gpu.g));
+      max_err = std::max(max_err, std::fabs(cpu.b - gpu.b));
+      max_err = std::max(max_err, std::fabs(cpu.a - gpu.a));
+    }
+  }
+  EXPECT_LT(max_err, 1.0e-4f);
+
+  device.Workspace().Device().ResetCounters();
+  device.BeginRender();
+  pass.Encode(geometry, src.Texture(), dst.Texture(), device.CommandContext());
+  EXPECT_EQ(pass.LaunchCount(), 2u);
+  device.EndRender();
+  device.WaitIdle();
+  EXPECT_EQ(device.Workspace().Device().MallocCount(), 0u);
+  EXPECT_EQ(device.Workspace().Device().FreeCount(), 0u);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/geometry/render_geometry_resolver_test.cpp
+++ b/alcedo_studio/tests/edit/geometry/render_geometry_resolver_test.cpp
@@ -1,0 +1,160 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+#include "edit/geometry/render_geometry_resolver.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr float kPxEps = 1e-4f;
+
+auto ResolveSimple(const SourceGeometry& source, const ImageGeometryParams& image = {},
+                   const ViewRequest& view = {}, const ResolutionRequest& resolution = {},
+                   const SamplingFootprint& footprint = {}) -> ResolvedRenderGeometry {
+  return ResolveRenderGeometry(source, image, view, resolution, footprint);
+}
+
+}  // namespace
+
+TEST(GpuDagGeometry, RenderGeometryRoundTripsReferenceAndRenderPixelCenters) {
+  ImageGeometryParams image;
+  image.crop_rect         = NormalizedRect{0.10f, 0.15f, 0.70f, 0.60f};
+  image.rotation_degrees  = 23.0f;
+  image.expand_to_fit     = true;
+  ViewRequest view;
+  view.visible_rect_in_edit_space = NormalizedRect{0.20f, 0.10f, 0.50f, 0.60f};
+  view.viewport_extent            = Extent2D{320, 240};
+  const auto geometry =
+      ResolveSimple(MakeSourceGeometry({80, 60}, {80, 60}), image, view, {}, {});
+
+  float max_err = 0.0f;
+  for (std::uint32_t y = 0; y < geometry.render_extent.height; y += 7) {
+    for (std::uint32_t x = 0; x < geometry.render_extent.width; x += 11) {
+      const auto center = PixelCenter(x, y);
+      const auto ref    = TransformPoint(geometry.render_to_reference, center);
+      const auto back   = TransformPoint(geometry.reference_to_render, ref);
+      max_err           = std::max(max_err, std::fabs(back.x - center.x));
+      max_err           = std::max(max_err, std::fabs(back.y - center.y));
+    }
+  }
+  EXPECT_LT(max_err, kPxEps);
+}
+
+TEST(GpuDagGeometry, FullCropZeroRotationMapsReferenceCornersToRenderCorners) {
+  const auto geometry = ResolveSimple(MakeSourceGeometry({64, 48}, {64, 48}));
+  EXPECT_EQ(geometry.render_extent, (Extent2D{64, 48}));
+  EXPECT_EQ(geometry.edit_extent, (Extent2D{64, 48}));
+  EXPECT_TRUE(IsIdentityResample(geometry));
+
+  const auto top_left = TransformPoint(geometry.render_to_reference, PixelCenter(0, 0));
+  EXPECT_NEAR(top_left.x, 0.5f, kPxEps);
+  EXPECT_NEAR(top_left.y, 0.5f, kPxEps);
+
+  const auto bottom_right = TransformPoint(geometry.render_to_reference, PixelCenter(63, 47));
+  EXPECT_NEAR(bottom_right.x, 63.5f, kPxEps);
+  EXPECT_NEAR(bottom_right.y, 47.5f, kPxEps);
+}
+
+TEST(GpuDagGeometry, RotatedCropBoundsContainAllFourTransformedCorners) {
+  ImageGeometryParams image;
+  image.crop_rect        = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
+  image.rotation_degrees = 35.0f;
+  image.expand_to_fit    = true;
+  const auto geometry = ResolveSimple(MakeSourceGeometry({200, 100}, {200, 100}), image);
+
+  const Vector2 corners[] = {{50.0f, 25.0f}, {150.0f, 25.0f}, {150.0f, 75.0f}, {50.0f, 75.0f}};
+  const float   edit_w    = static_cast<float>(geometry.edit_extent.width);
+  const float   edit_h    = static_cast<float>(geometry.edit_extent.height);
+  for (const auto& corner : corners) {
+    const auto edit = TransformPoint(geometry.reference_to_edit, corner);
+    EXPECT_GE(edit.x, -1.0e-3f);
+    EXPECT_LE(edit.x, edit_w + 1.0e-3f);
+    EXPECT_GE(edit.y, -1.0e-3f);
+    EXPECT_LE(edit.y, edit_h + 1.0e-3f);
+  }
+  EXPECT_GT(geometry.edit_extent.width, 0u);
+  EXPECT_GT(geometry.edit_extent.height, 0u);
+}
+
+TEST(GpuDagGeometry, ViewportCropAndDynamicScaleProduceRequestedRenderExtent) {
+  ViewRequest view;
+  view.viewport_extent = Extent2D{1920, 1080};
+  ResolutionRequest half;
+  half.render_scale = 0.5f;
+  const auto scaled =
+      ResolveSimple(MakeSourceGeometry({100, 100}, {100, 100}), {}, view, half, {});
+  EXPECT_EQ(scaled.render_extent, (Extent2D{960, 540}));
+
+  ResolutionRequest clamped;
+  clamped.render_scale = 1.0f;
+  clamped.max_edge     = 800;
+  const auto capped =
+      ResolveSimple(MakeSourceGeometry({100, 100}, {100, 100}), {}, view, clamped, {});
+  EXPECT_EQ(capped.render_extent, (Extent2D{800, 450}));
+}
+
+TEST(GpuDagGeometry, DecodeScaleDoesNotChangeNormalizedReferenceCoordinates) {
+  ImageGeometryParams image;
+  image.crop_rect = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
+  const auto full =
+      ResolveSimple(MakeSourceGeometry({400, 300}, {400, 300}), image);
+  const auto quarter =
+      ResolveSimple(MakeSourceGeometry({100, 75}, {400, 300}, {}, 2), image);
+
+  EXPECT_EQ(full.edit_extent, quarter.edit_extent);
+  EXPECT_EQ(full.render_extent, quarter.render_extent);
+
+  const auto n_full = NormalizedFromPixelCenter(
+      TransformPoint(full.render_to_reference, PixelCenter(10, 8)), full.full_reference_extent);
+  const auto n_quarter = NormalizedFromPixelCenter(
+      TransformPoint(quarter.render_to_reference, PixelCenter(10, 8)),
+      quarter.full_reference_extent);
+  EXPECT_NEAR(n_full.x, n_quarter.x, 1.0e-5f);
+  EXPECT_NEAR(n_full.y, n_quarter.y, 1.0e-5f);
+
+  const auto n_decoded = NormalizedFromPixelCenter(PixelCenter(3, 5), Extent2D{100, 75});
+  const auto n_ref     = NormalizedFromPixelCenter(
+      TransformPoint(quarter.decoded_to_reference, PixelCenter(3, 5)), Extent2D{400, 300});
+  EXPECT_NEAR(n_decoded.x, n_ref.x, 1.0e-5f);
+  EXPECT_NEAR(n_decoded.y, n_ref.y, 1.0e-5f);
+}
+
+TEST(GpuDagGeometry, RequiredInputRegionExpandsForBicubicFootprintAndClampsToDecodedBounds) {
+  ViewRequest view;
+  view.visible_rect_in_edit_space = NormalizedRect{0.0f, 0.0f, 0.25f, 0.25f};
+  SamplingFootprint footprint;
+  footprint.radius_x = 2.0f;
+  footprint.radius_y = 2.0f;
+  const auto edge = ResolveSimple(MakeSourceGeometry({64, 64}, {64, 64}), {}, view, {}, footprint);
+  EXPECT_EQ(edge.required_decoded_region.x, 0);
+  EXPECT_EQ(edge.required_decoded_region.y, 0);
+  EXPECT_GE(edge.required_decoded_region.width, 16);
+  EXPECT_LE(edge.required_decoded_region.X1(), 64);
+  EXPECT_LE(edge.required_decoded_region.Y1(), 64);
+
+  view.visible_rect_in_edit_space = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
+  const auto interior =
+      ResolveSimple(MakeSourceGeometry({64, 64}, {64, 64}), {}, view, {}, footprint);
+  EXPECT_GE(interior.required_decoded_region.x, 0);
+  EXPECT_LT(interior.required_decoded_region.x, 16);
+  EXPECT_GT(interior.required_decoded_region.X1(), 48);
+  EXPECT_LE(interior.required_decoded_region.X1(), 64);
+}
+
+TEST(GpuDagGeometry, ResolveRenderGeometryRejectsZeroExtent) {
+  EXPECT_THROW(ResolveSimple(MakeSourceGeometry({0, 10}, {10, 10})), std::runtime_error);
+  EXPECT_THROW(ResolveSimple(MakeSourceGeometry({10, 10}, {0, 10})), std::runtime_error);
+  ResolutionRequest bad;
+  bad.render_scale = 0.0f;
+  EXPECT_THROW(ResolveSimple(MakeSourceGeometry({10, 10}, {10, 10}), {}, {}, bad, {}),
+               std::runtime_error);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/geometry/sampling_and_document_test.cpp
+++ b/alcedo_studio/tests/edit/geometry/sampling_and_document_test.cpp
@@ -1,0 +1,150 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "edit/geometry/render_geometry_resolver.hpp"
+#include "edit/geometry/texture_sampling_plan.hpp"
+#include "edit/graph/pipeline_document.hpp"
+
+namespace alcedo {
+namespace {
+
+auto FileContainsToken(const std::filesystem::path& path, const char* token) -> bool {
+  std::ifstream input(path);
+  std::string   line;
+  while (std::getline(input, line)) {
+    if (line.find(token) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ScanDirectoryForToken(const std::filesystem::path& root, const char* token,
+                           std::vector<std::string>* hits) {
+  if (!std::filesystem::exists(root)) {
+    hits->push_back("missing directory: " + root.string());
+    return;
+  }
+  for (const auto& entry : std::filesystem::directory_iterator(root)) {
+    if (!entry.is_regular_file() || entry.path().extension() != ".hpp") {
+      continue;
+    }
+    if (FileContainsToken(entry.path(), token)) {
+      hits->push_back(entry.path().filename().string() + " " + token);
+    }
+  }
+}
+
+}  // namespace
+
+TEST(GpuDagGeometry, RasterMaskSamplingMapsSameReferencePointAtQuarterAndFullPreview) {
+  const auto source = MakeSourceGeometry({200, 100}, {200, 100});
+  const NormalizedRect bounds{0.10f, 0.10f, 0.80f, 0.80f};
+  const Vector2        ref_center{0.40f * 200.0f, 0.30f * 100.0f};
+
+  ResolutionRequest full_res;
+  full_res.render_scale = 1.0f;
+  ResolutionRequest quarter_res;
+  quarter_res.render_scale = 0.25f;
+
+  const auto g_full    = ResolveRenderGeometry(source, {}, {}, full_res, {});
+  const auto g_quarter = ResolveRenderGeometry(source, {}, {}, quarter_res, {});
+  const auto plan_full =
+      MakeRasterMaskSamplingPlan(g_full, bounds, Extent2D{256, 256});
+  const auto plan_quarter =
+      MakeRasterMaskSamplingPlan(g_quarter, bounds, Extent2D{256, 256});
+
+  const auto uv_full = TransformPoint(
+      plan_full.render_to_texture_uv, TransformPoint(g_full.reference_to_render, ref_center));
+  const auto uv_quarter = TransformPoint(
+      plan_quarter.render_to_texture_uv, TransformPoint(g_quarter.reference_to_render, ref_center));
+
+  EXPECT_NEAR(uv_full.x, 0.375f, 1.0e-5f);
+  EXPECT_NEAR(uv_full.y, 0.25f, 1.0e-5f);
+  EXPECT_NEAR(uv_quarter.x, uv_full.x, 1.0e-5f);
+  EXPECT_NEAR(uv_quarter.y, uv_full.y, 1.0e-5f);
+}
+
+TEST(GpuDagGeometry, OddImageDimensionsUseOneRoundingResultAcrossImageMaskAndLlf) {
+  ImageGeometryParams image;
+  image.crop_rect = NormalizedRect{0.10f, 0.20f, 0.50f, 0.40f};
+  const auto source = MakeSourceGeometry({1001, 667}, {1001, 667});
+  const auto first  = ResolveRenderGeometry(source, image, {}, {}, {});
+  const auto second = ResolveRenderGeometry(source, image, {}, {}, {});
+  EXPECT_EQ(first.render_extent, second.render_extent);
+  EXPECT_EQ(first.edit_extent, second.edit_extent);
+  EXPECT_EQ(first.required_decoded_region, second.required_decoded_region);
+  EXPECT_EQ(first.required_reference_region, second.required_reference_region);
+  EXPECT_EQ(first.required_decoded_region, first.required_reference_region);
+
+  SamplingFootprint llf_footprint;
+  llf_footprint.requires_full_reference = true;
+  const auto with_llf = ResolveRenderGeometry(source, image, {}, {}, llf_footprint);
+  EXPECT_EQ(with_llf.render_extent, first.render_extent);
+  EXPECT_EQ(with_llf.required_decoded_region,
+            (RectI{0, 0, 1001, 667}));
+
+  const auto mask = MakeRasterMaskSamplingPlan(first, NormalizedRect{}, Extent2D{512, 512});
+  const auto llf  = MakeLlfSamplingPlan(first, Extent2D{128, 128});
+  const auto center = PixelCenter(3, 5);
+  const auto ref    = TransformPoint(first.render_to_reference, center);
+  const auto n      = NormalizedFromPixelCenter(ref, first.full_reference_extent);
+  const auto uv_m   = TransformPoint(mask.render_to_texture_uv, center);
+  const auto uv_l   = TransformPoint(llf.render_to_texture_uv, center);
+  EXPECT_NEAR(uv_m.x, n.x, 1.0e-5f);
+  EXPECT_NEAR(uv_m.y, n.y, 1.0e-5f);
+  EXPECT_NEAR(uv_l.x, n.x, 1.0e-5f);
+  EXPECT_NEAR(uv_l.y, n.y, 1.0e-5f);
+}
+
+TEST(GpuDagGeometry, DefaultPipelineDocumentHasNoGeometryNode) {
+  const auto document = CreateDefaultPipelineDocument();
+  ASSERT_EQ(document.Graph().NodeCount(), 3u);
+  ASSERT_NE(document.Develop(), nullptr);
+  ASSERT_NE(document.PrimaryGrade(), nullptr);
+  ASSERT_NE(document.Drt(), nullptr);
+  const auto json = document.ToJson();
+  const auto text = json.dump();
+  EXPECT_TRUE(json.contains("geometry"));
+  EXPECT_TRUE(json["geometry"].contains("crop_rect"));
+  EXPECT_TRUE(json["geometry"].contains("rotation_degrees"));
+  EXPECT_FALSE(text.find("viewport") != std::string::npos);
+  EXPECT_FALSE(text.find("render_scale") != std::string::npos);
+  EXPECT_FALSE(text.find("\"roi_") != std::string::npos);
+}
+
+TEST(GpuDagGeometry, OperatorParamPayloadsContainNoRoiFields) {
+  std::vector<std::string> hits;
+  ScanDirectoryForToken(std::filesystem::path{ALCEDO_MODEL_HEADER_ROOT}, "roi_", &hits);
+  EXPECT_TRUE(hits.empty()) << (hits.empty() ? "" : hits.front());
+}
+
+TEST(GpuDagGeometry, GeometryHeadersDoNotIncludeGpuOrImageBuffer) {
+  std::vector<std::string> hits;
+  const auto               root = std::filesystem::path{ALCEDO_GEOMETRY_HEADER_ROOT};
+  if (!std::filesystem::exists(root)) {
+    FAIL() << "missing geometry header root";
+  }
+  for (const auto& entry : std::filesystem::directory_iterator(root)) {
+    if (!entry.is_regular_file() || entry.path().extension() != ".hpp") {
+      continue;
+    }
+    const char* tokens[] = {"image_buffer.hpp", "cuda.h", "cuda_runtime", "OpenCL", "Metal/"};
+    for (const char* token : tokens) {
+      if (FileContainsToken(entry.path(), token)) {
+        hits.push_back(entry.path().filename().string() + " " + token);
+      }
+    }
+  }
+  EXPECT_TRUE(hits.empty()) << (hits.empty() ? "" : hits.front());
+}
+
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G2 complete (CUDA workspace, ParameterArena, lifted TransientBufferArena). G3 not started.
+Status: G3 complete (RenderGeometryResolver, TextureSamplingPlan, CUDA GeometryResamplePass). G4 not started.
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2154,6 +2154,79 @@ OddImageDimensionsUseOneRoundingResultAcrossImageMaskAndLlf
 - GeometryResamplePass 不成为用户节点；
 - 默认图仍然只有三个节点；
 - 图像、LLF 和 mask 使用相同的 render-to-reference 数据。
+
+##### Phase G3 completion record (2026-08-22)
+
+**Status:** complete — GPU-free RenderGeometryResolver (pixel-center matrices, one rounding owner), TextureSamplingPlan for mask/LLF, CUDA GeometryResamplePass as one kernel. Not a user node. No GraphCompiler.
+
+**Primary success call chain:**
+
+```text
+SourceGeometry + ImageGeometryParams + ViewRequest + ResolutionRequest + SamplingFootprint
+  -> ResolveRenderGeometry
+  -> ResolvedRenderGeometry (matrices, extents, required RectI, GpuRenderGeometry)
+  -> MakeRasterMaskSamplingPlan / MakeLlfSamplingPlan
+     or GeometryResamplePass::Encode
+  -> one CUDA kernel, RGBA32F at render_extent
+```
+
+**Primary failure call chain:**
+
+```text
+zero or non-finite extent, or render_scale <= 0
+  -> ResolveRenderGeometry throws
+  -> no matrices, no kernel
+```
+
+```text
+required AABB after footprint expansion
+  -> clamp to decoded / reference RectI
+  -> still inside source bounds
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `RenderGeometryRoundTripsReferenceAndRenderPixelCenters` | `GpuDagGeometryTest` | PASS |
+| `FullCropZeroRotationMapsReferenceCornersToRenderCorners` | `GpuDagGeometryTest` | PASS |
+| `RotatedCropBoundsContainAllFourTransformedCorners` | `GpuDagGeometryTest` | PASS |
+| `ViewportCropAndDynamicScaleProduceRequestedRenderExtent` | `GpuDagGeometryTest` | PASS |
+| `DecodeScaleDoesNotChangeNormalizedReferenceCoordinates` | `GpuDagGeometryTest` | PASS |
+| `RequiredInputRegionExpandsForBicubicFootprintAndClampsToDecodedBounds` | `GpuDagGeometryTest` | PASS |
+| `RasterMaskSamplingMapsSameReferencePointAtQuarterAndFullPreview` | `GpuDagGeometryTest` | PASS |
+| `OddImageDimensionsUseOneRoundingResultAcrossImageMaskAndLlf` | `GpuDagGeometryTest` | PASS |
+| `CropRotateViewportAndScaleExecuteAsOneCudaResample` | `GpuDagCudaGeometryTest` | PASS |
+| `ResolveRenderGeometryRejectsZeroExtent` | `GpuDagGeometryTest` | PASS |
+| Default document still three nodes; JSON has no viewport/scale | `GpuDagGeometryTest` | PASS |
+| Operator DTO headers contain no `roi_` | `GpuDagGeometryTest` | PASS |
+| Geometry headers have no GPU / ImageBuffer includes | `GpuDagGeometryTest` | PASS |
+| G1 `GpuDagModelGraphTest` regression | `GpuDagModelGraphTest` | PASS |
+| G2 `GpuDagCudaWorkspaceTest` regression | `GpuDagCudaWorkspaceTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagGeometryTest GpuDagCudaGeometryTest GpuDagModelGraphTest GpuDagCudaWorkspaceTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "GpuDagGeometryTest|GpuDagCudaGeometryTest|GpuDagModelGraphTest|GpuDagCudaWorkspaceTest"
+```
+
+Suite totals: `12/12` GpuDagGeometryTest PASS. `1/1` GpuDagCudaGeometryTest PASS. `17/17` GpuDagModelGraphTest PASS. `12/12` GpuDagCudaWorkspaceTest PASS. Combined `42/42` PASS.
+
+**Checklist / exit condition:** all G3 exit conditions met. GeometryResamplePass is a CUDA encode unit, not an `INodeModel`. Product `PipelineMgmtService` and old `CropRotateOp` are unchanged.
+
+**LOC note (grill-code-review):** largest new file is `render_geometry_resolver.cpp` (242 lines). `geometry_resample.cu` is 137 lines. No changed file exceeds 1000 LOC.
+
+**Remaining gaps:** GraphCompiler / ExecutionPlan insert the pass (G4+). Develop/grade/DRT kernels (G4–G7). MaskStore GPU textures and feather (G6). OpenCL and Metal GeometryResamplePass (G8/G9).
+
+**Files added:** `alcedo_studio/src/include/edit/geometry/*`, `alcedo_studio/src/edit/geometry/*`, `include/edit/runtime/cuda/geometry_resample_pass.hpp`, `src/edit/runtime/cuda/geometry_resample.cu`, `tests/edit/geometry/*`. CMake `EditGeometry` + `GpuDagGeometryTest` + `GpuDagCudaGeometryTest`.
+
+**Files removed:** none. `NormalizedRect` moved from `image_geometry_model.hpp` into `edit/geometry/types.hpp`.
+
+**Performance and allocation evidence:** `CropRotateViewportAndScaleExecuteAsOneCudaResample` asserts `LaunchCount() == 1` for the combined crop/rotate/view/scale kernel, GPU vs CPU pixel-center bilinear max error `< 1e-4`, and second encode malloc/free counts stay 0 after peak reserve.
+
+**Open work:** G4 CUDA Develop Endpoint.
 
 ## 37. Phase G4 — CUDA Develop Endpoint
 


### PR DESCRIPTION
## Summary

- Add the GPU-independent `RenderGeometryResolver` with one owner for pixel-center transforms, extents, and required input regions.
- Add sampling plans for raster masks and local tone resources.
- Add a single CUDA geometry resample pass that combines crop, rotation, viewport selection, and dynamic scale.

## Stack

Layer G3 of GitHub stack #99.

- Base: #95
- Next layer: #97

## Validation

- Geometry and CUDA geometry tests: 13/13 passed.
- Combined G1–G3 regression: 42/42 passed.
- The combined CUDA geometry operation launches one resample kernel and reuses peak allocations.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
