### PR TITLE
feat(edit): add CUDA Develop endpoint after CPU RAW unpack

### DIFF
--- a/alcedo_studio/src/decoders/processor/operators/gpu/cuda_highlight_reconstruct.cu
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/cuda_highlight_reconstruct.cu
@@ -629,24 +629,51 @@ HighlightWorkspace::HighlightWorkspace(HighlightWorkspace&& other) noexcept
       sums_(std::exchange(other.sums_, nullptr)),
       cnts_(std::exchange(other.cnts_, nullptr)),
       mask_capacity_(std::exchange(other.mask_capacity_, 0)),
-      result_(std::move(other.result_)) {}
+      result_(std::move(other.result_)),
+      owns_device_(std::exchange(other.owns_device_, true)) {}
 
 auto HighlightWorkspace::operator=(HighlightWorkspace&& other) noexcept -> HighlightWorkspace& {
   if (this != &other) {
     Release();
-    anyclipped_ = std::exchange(other.anyclipped_, nullptr);
-    sums_       = std::exchange(other.sums_, nullptr);
-    cnts_       = std::exchange(other.cnts_, nullptr);
+    anyclipped_    = std::exchange(other.anyclipped_, nullptr);
+    sums_          = std::exchange(other.sums_, nullptr);
+    cnts_          = std::exchange(other.cnts_, nullptr);
     mask_capacity_ = std::exchange(other.mask_capacity_, 0);
-    result_      = std::move(other.result_);
+    result_        = std::move(other.result_);
+    owns_device_   = std::exchange(other.owns_device_, true);
   }
   return *this;
+}
+
+void HighlightWorkspace::BindExternal(int* anyclipped, float* sums, float* cnts, void* result_rgb,
+                                      int width, int height) {
+  Release();
+  owns_device_    = false;
+  anyclipped_     = anyclipped;
+  sums_           = sums;
+  cnts_           = cnts;
+  const int w     = std::max(width, 0);
+  const int h     = std::max(height, 0);
+  mask_capacity_  = static_cast<size_t>(w) * static_cast<size_t>(h);
+  if (result_rgb != nullptr && w > 0 && h > 0) {
+    const std::size_t step = static_cast<std::size_t>(w) * sizeof(float) * 3;
+    result_                = cv::cuda::GpuMat(h, w, CV_32FC3, result_rgb, step);
+  }
 }
 
 void HighlightWorkspace::Reserve(int width, int height) {
   const size_t pixels = static_cast<size_t>(std::max(width, 0)) * static_cast<size_t>(std::max(height, 0));
   if (pixels == 0) {
-    result_.release();
+    if (owns_device_) {
+      result_.release();
+    }
+    return;
+  }
+
+  if (!owns_device_) {
+    if (mask_capacity_ < pixels || anyclipped_ == nullptr || sums_ == nullptr || cnts_ == nullptr) {
+      throw std::runtime_error("HighlightWorkspace::Reserve: external buffers are too small");
+    }
     return;
   }
 
@@ -656,26 +683,30 @@ void HighlightWorkspace::Reserve(int width, int height) {
     CUDA_CHECK(cudaMalloc(&sums_, sizeof(float) * 4));
     CUDA_CHECK(cudaMalloc(&cnts_, sizeof(float) * 4));
     mask_capacity_ = pixels;
+    owns_device_   = true;
   }
 
   result_.create(height, width, CV_32FC3);
 }
 
 void HighlightWorkspace::Release() {
-  if (cnts_ != nullptr) {
-    CUDA_CHECK(cudaFree(cnts_));
-    cnts_ = nullptr;
+  if (owns_device_) {
+    if (cnts_ != nullptr) {
+      CUDA_CHECK(cudaFree(cnts_));
+    }
+    if (sums_ != nullptr) {
+      CUDA_CHECK(cudaFree(sums_));
+    }
+    if (anyclipped_ != nullptr) {
+      CUDA_CHECK(cudaFree(anyclipped_));
+    }
   }
-  if (sums_ != nullptr) {
-    CUDA_CHECK(cudaFree(sums_));
-    sums_ = nullptr;
-  }
-  if (anyclipped_ != nullptr) {
-    CUDA_CHECK(cudaFree(anyclipped_));
-    anyclipped_ = nullptr;
-  }
+  cnts_          = nullptr;
+  sums_          = nullptr;
+  anyclipped_    = nullptr;
   mask_capacity_ = 0;
   result_.release();
+  owns_device_ = true;
 }
 
 // WB multipliers come from file metadata or the camera's as-shot estimate and can be zero,
@@ -689,9 +720,8 @@ auto ChannelRatio(const float value, const float green) -> float {
   return std::clamp(value / green, 0.25f, 4.0f);
 }
 
-auto BuildHighlightCorrection(LibRaw& raw_processor) -> HighlightCorrection {
-  const float* cam_mul = raw_processor.imgdata.color.cam_mul;
-  const float  green   = std::isfinite(cam_mul[1]) && cam_mul[1] > 0.0f ? cam_mul[1] : 1.0f;
+auto BuildHighlightCorrection(const float* cam_mul) -> HighlightCorrection {
+  const float green = std::isfinite(cam_mul[1]) && cam_mul[1] > 0.0f ? cam_mul[1] : 1.0f;
 
   HighlightCorrection correction;
   correction.clips[0]    = kHilightMagic * ChannelRatio(cam_mul[0], green);
@@ -701,6 +731,10 @@ auto BuildHighlightCorrection(LibRaw& raw_processor) -> HighlightCorrection {
   correction.clipdark[1] = kChromaRingLo * correction.clips[1];
   correction.clipdark[2] = kChromaRingLo * correction.clips[2];
   return correction;
+}
+
+auto BuildHighlightCorrection(LibRaw& raw_processor) -> HighlightCorrection {
+  return BuildHighlightCorrection(raw_processor.imgdata.color.cam_mul);
 }
 
 void FinalizeHighlightCorrection(const HighlightAccumulation& accumulation,

--- a/alcedo_studio/src/decoders/processor/operators/gpu/cuda_white_balance.cu
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/cuda_white_balance.cu
@@ -5,6 +5,8 @@
 #include <opencv2/core/cuda_types.hpp>
 #include <opencv2/core/cuda_stream_accessor.hpp>
 
+#include <stdexcept>
+
 #include "decoders/processor/raw_normalization.hpp"
 #include "decoders/processor/operators/gpu/cuda_raw_proc_utils.hpp"
 #include "decoders/processor/operators/gpu/cuda_white_balance.hpp"
@@ -81,6 +83,48 @@ __global__ void ToLinearRefKernel(cv::cuda::PtrStep<float> image, int width, int
   image(row, col) = pixel_val;
 }
 
+__global__ void ToLinearRefFromU16Kernel(cv::cuda::PtrStep<ushort> src, cv::cuda::PtrStep<float> dst,
+                                         int width, int height, WBParams wb_params,
+                                         RawCfaPattern pattern) {
+  const int col = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row = blockIdx.y * blockDim.y + threadIdx.y;
+  if (col >= width || row >= height) {
+    return;
+  }
+
+  const int   color_idx = RawColorAt(pattern, row, col);
+  const float sample    = static_cast<float>(src(row, col));
+
+  float pattern_black = 0.0f;
+  if (wb_params.black_tile_width > 0 && wb_params.black_tile_height > 0) {
+    const int tile_y = row % wb_params.black_tile_height;
+    const int tile_x = col % wb_params.black_tile_width;
+    pattern_black    = wb_params.pattern_black[tile_y * wb_params.black_tile_width + tile_x];
+  }
+  const float black = wb_params.black_level[color_idx] + pattern_black;
+  float       pixel_val =
+      raw_norm::NormalizeSample(sample, black, wb_params.white_level[color_idx]);
+  pixel_val *= raw_norm::RelativeWhiteBalanceMultiplier(
+      wb_params.wb_multipliers, color_idx, wb_params.apply_white_balance != 0);
+  dst(row, col) = pixel_val;
+}
+
+auto MakeWbParams(const RawLinearizationParams& params) -> WBParams {
+  WBParams wb_params = {};
+  for (int c = 0; c < 4; ++c) {
+    wb_params.black_level[c]    = params.black_level[c];
+    wb_params.white_level[c]    = params.white_level[c];
+    wb_params.wb_multipliers[c] = params.cam_mul[c];
+  }
+  wb_params.apply_white_balance = params.apply_as_shot_wb;
+  wb_params.black_tile_width    = params.black_tile_width;
+  wb_params.black_tile_height   = params.black_tile_height;
+  for (int i = 0; i < 36; ++i) {
+    wb_params.pattern_black[i] = params.pattern_black[i];
+  }
+  return wb_params;
+}
+
 static auto GetWBCoeff(const libraw_rawdata_t& raw_data) -> const float* {
   return raw_data.color.cam_mul;
 }
@@ -124,6 +168,27 @@ void ToLinearRef(cv::cuda::GpuMat& image, LibRaw& raw_processor, const RawCfaPat
   ToLinearRefKernel<<<num_blocks, threads_per_block, 0, cuda_stream>>>(
       image, image.cols, image.rows, wb_params, pattern);
 
+  CUDA_CHECK(cudaGetLastError());
+  MaybeWait(stream);
+}
+
+void ToLinearRef(const cv::cuda::GpuMat& src_u16, cv::cuda::GpuMat& dst_f32,
+                 const RawLinearizationParams& params, const RawCfaPattern& pattern,
+                 cv::cuda::Stream* stream) {
+  if (src_u16.type() != CV_16UC1) {
+    throw std::runtime_error("CUDA::ToLinearRef: src must be CV_16UC1");
+  }
+  if (dst_f32.type() != CV_32FC1 || dst_f32.size() != src_u16.size() || dst_f32.empty()) {
+    throw std::runtime_error("CUDA::ToLinearRef: dst must be a preallocated CV_32FC1 of src size");
+  }
+
+  const WBParams wb_params         = MakeWbParams(params);
+  const dim3     threads_per_block(32, 32);
+  const dim3     num_blocks((src_u16.cols + threads_per_block.x - 1) / threads_per_block.x,
+                            (src_u16.rows + threads_per_block.y - 1) / threads_per_block.y);
+  const cudaStream_t cuda_stream = GetCudaStream(stream);
+  ToLinearRefFromU16Kernel<<<num_blocks, threads_per_block, 0, cuda_stream>>>(
+      src_u16, dst_f32, src_u16.cols, src_u16.rows, wb_params, pattern);
   CUDA_CHECK(cudaGetLastError());
   MaybeWait(stream);
 }

--- a/alcedo_studio/src/decoders/processor/operators/gpu/cuda_xtrans_interpolate.cu
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/cuda_xtrans_interpolate.cu
@@ -180,6 +180,47 @@ __global__ void XTransRgbKernel(const cv::cuda::PtrStep<float> raw,
 
 }  // namespace
 
+void XTransToRGB_Ref(const cv::cuda::GpuMat& raw, cv::cuda::GpuMat& green, cv::cuda::GpuMat& output,
+                     const XTransPattern6x6& pattern, int passes, cv::cuda::Stream* stream) {
+  if (raw.empty()) {
+    throw std::runtime_error("CUDA::XTransToRGB_Ref: input image is empty");
+  }
+  if (raw.type() != CV_32FC1) {
+    throw std::runtime_error("CUDA::XTransToRGB_Ref: expected CV_32FC1 raw input");
+  }
+  if (green.type() != CV_32FC1 || green.size() != raw.size() || green.empty()) {
+    throw std::runtime_error("CUDA::XTransToRGB_Ref: green must be a preallocated CV_32FC1 of raw size");
+  }
+  if (output.type() != CV_32FC3 || output.size() != raw.size() || output.empty()) {
+    throw std::runtime_error("CUDA::XTransToRGB_Ref: output must be a preallocated CV_32FC3 of raw size");
+  }
+
+  const int width  = raw.cols;
+  const int height = raw.rows;
+  if (width <= 0 || height <= 0) {
+    return;
+  }
+
+  cv::cuda::Stream  local_stream;
+  cv::cuda::Stream& active_stream = stream == nullptr ? local_stream : *stream;
+  cudaStream_t      cuda_stream   = cv::cuda::StreamAccessor::getStream(active_stream);
+
+  const dim3 threads(32, 8);
+  const dim3 blocks((width + threads.x - 1) / threads.x, (height + threads.y - 1) / threads.y);
+  const int  green_radius = 3;
+  const int  rb_radius    = std::max(passes, 1) > 1 ? 4 : 3;
+
+  XTransGreenKernel<<<blocks, threads, 0, cuda_stream>>>(raw, green, width, height, pattern,
+                                                         green_radius);
+  CUDA_CHECK(cudaGetLastError());
+  XTransRgbKernel<<<blocks, threads, 0, cuda_stream>>>(raw, green, output, width, height, pattern,
+                                                       rb_radius);
+  CUDA_CHECK(cudaGetLastError());
+  if (stream == nullptr) {
+    active_stream.waitForCompletion();
+  }
+}
+
 void XTransToRGB_Ref(cv::cuda::GpuMat& image, const XTransPattern6x6& pattern, int passes) {
   if (image.empty()) {
     throw std::runtime_error("CUDA::XTransToRGB_Ref: input image is empty");
@@ -196,25 +237,7 @@ void XTransToRGB_Ref(cv::cuda::GpuMat& image, const XTransPattern6x6& pattern, i
 
   cv::cuda::GpuMat green(height, width, CV_32FC1);
   cv::cuda::GpuMat output(height, width, CV_32FC3);
-
-  cv::cuda::Stream stream;
-  cudaStream_t     cuda_stream = cv::cuda::StreamAccessor::getStream(stream);
-
-  const dim3       threads(32, 8);
-  const dim3 blocks((width + threads.x - 1) / threads.x, (height + threads.y - 1) / threads.y);
-
-  const int  green_radius = 3;
-  const int  rb_radius    = std::max(passes, 1) > 1 ? 4 : 3;
-
-  XTransGreenKernel<<<blocks, threads, 0, cuda_stream>>>(image, green, width, height, pattern,
-                                                         green_radius);
-  CUDA_CHECK(cudaGetLastError());
-
-  XTransRgbKernel<<<blocks, threads, 0, cuda_stream>>>(image, green, output, width, height, pattern,
-                                                       rb_radius);
-  CUDA_CHECK(cudaGetLastError());
-
-  stream.waitForCompletion();
+  XTransToRGB_Ref(image, green, output, pattern, passes, nullptr);
   image = output;
 }
 

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -51,9 +51,17 @@ def_library(EditGraph
     PUBLIC_DEPS JSON EditGeometry
 )
 
+# CPU RAW unpack / downsample. No CUDA, no ImageBuffer.
+def_library(EditInput
+    SOURCES ${ALCEDO_SRC_ROOT}/edit/input/raw_input_loader.cpp
+    PUBLIC_DEPS EditGeometry JSON libraw::raw_r opencv_core
+)
+
 # GPU-agnostic DAG runtime (parameter arena, texture LRU, KV cache). No CUDA headers.
 def_library(EditRuntime
-    SOURCES ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
+    SOURCES
+        ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
+        ${ALCEDO_SRC_ROOT}/edit/runtime/graph_compiler.cpp
     PUBLIC_DEPS EditGraph EditGeometry
 )
 
@@ -61,8 +69,10 @@ if(ALCEDO_CUDA_ENABLED)
     def_cuda_library(EditRuntimeCuda
         SOURCES
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_backend.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_develop_pass.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/geometry_resample.cu
         PUBLIC_DEPS EditRuntime CUDA::cudart
+        PRIVATE_DEPS EditInput RawProcessorOp
     )
     target_compile_definitions(EditRuntimeCuda PUBLIC HAVE_CUDA)
 endif()

--- a/alcedo_studio/src/edit/input/raw_input_loader.cpp
+++ b/alcedo_studio/src/edit/input/raw_input_loader.cpp
@@ -1,0 +1,436 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/input/raw_input_loader.hpp"
+
+#include "decoders/libraw_unpack_guard.hpp"
+#include "decoders/processor/raw_normalization.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+#include <utility>
+
+#include <libraw/libraw.h>
+#include <opencv2/core.hpp>
+
+namespace alcedo {
+namespace {
+
+constexpr int kRcdOutputCropRadius = 4;
+
+auto HashBytes(std::span<const std::byte> bytes) -> std::uint64_t {
+  std::uint64_t hash = 14695981039346656037ull;
+  for (const auto byte : bytes) {
+    hash ^= static_cast<std::uint8_t>(byte);
+    hash *= 1099511628211ull;
+  }
+  return hash;
+}
+
+auto ScaleCoordFloor(int value, int divisor) -> int { return value / divisor; }
+
+auto ScaleCoordCeil(int value, int divisor) -> int { return (value + divisor - 1) / divisor; }
+
+auto ScaleDivisor(std::uint8_t downsample_passes) -> int {
+  return 1 << static_cast<int>(downsample_passes);
+}
+
+auto BuildActiveAreaRect(const RawSensorGeometry& sensor, Extent2D image_size, int scale_divisor)
+    -> RectI {
+  const int raw_width  = std::max(sensor.raw_width, 0);
+  const int raw_height = std::max(sensor.raw_height, 0);
+  const int raw_left   = std::clamp(sensor.left_margin, 0, raw_width);
+  const int raw_top    = std::clamp(sensor.top_margin, 0, raw_height);
+  const int raw_right  = std::clamp(raw_left + sensor.width, raw_left, raw_width);
+  const int raw_bottom = std::clamp(raw_top + sensor.height, raw_top, raw_height);
+
+  const int img_w = static_cast<int>(image_size.width);
+  const int img_h = static_cast<int>(image_size.height);
+  const int left  = std::clamp(ScaleCoordFloor(raw_left, scale_divisor), 0, img_w);
+  const int top   = std::clamp(ScaleCoordFloor(raw_top, scale_divisor), 0, img_h);
+  const int right = std::clamp(ScaleCoordCeil(raw_right, scale_divisor), left, img_w);
+  const int bottom = std::clamp(ScaleCoordCeil(raw_bottom, scale_divisor), top, img_h);
+  if (right - left <= 0 || bottom - top <= 0) {
+    return RectI{0, 0, img_w, img_h};
+  }
+  return RectI{left, top, right - left, bottom - top};
+}
+
+auto HasValidDefaultCrop(const RawSensorGeometry& sensor) -> bool {
+  const int raw_width  = std::max(sensor.raw_width, 0);
+  const int raw_height = std::max(sensor.raw_height, 0);
+  const int raw_left   = std::clamp(sensor.left_margin, 0, raw_width);
+  const int raw_top    = std::clamp(sensor.top_margin, 0, raw_height);
+  const int raw_right  = std::clamp(raw_left + sensor.width, raw_left, raw_width);
+  const int raw_bottom = std::clamp(raw_top + sensor.height, raw_top, raw_height);
+  const int crop_w     = static_cast<int>(sensor.default_crop[2]);
+  const int crop_h     = static_cast<int>(sensor.default_crop[3]);
+  if (crop_w <= 0 || crop_h <= 0) {
+    return false;
+  }
+  const int crop_l = static_cast<int>(sensor.default_crop[0]);
+  const int crop_t = static_cast<int>(sensor.default_crop[1]);
+  return crop_l >= raw_left && crop_t >= raw_top && crop_l + crop_w <= raw_right &&
+         crop_t + crop_h <= raw_bottom;
+}
+
+auto BuildDecodeCropRect(const RawSensorGeometry& sensor, Extent2D image_size, int scale_divisor)
+    -> RectI {
+  const RectI active = BuildActiveAreaRect(sensor, image_size, scale_divisor);
+  if (!HasValidDefaultCrop(sensor)) {
+    return active;
+  }
+  const int img_w = static_cast<int>(image_size.width);
+  const int img_h = static_cast<int>(image_size.height);
+  const int left =
+      std::clamp(ScaleCoordFloor(static_cast<int>(sensor.default_crop[0]), scale_divisor), 0, img_w);
+  const int top =
+      std::clamp(ScaleCoordFloor(static_cast<int>(sensor.default_crop[1]), scale_divisor), 0, img_h);
+  const int right = std::clamp(
+      ScaleCoordCeil(static_cast<int>(sensor.default_crop[0] + sensor.default_crop[2]), scale_divisor),
+      left, img_w);
+  const int bottom = std::clamp(
+      ScaleCoordCeil(static_cast<int>(sensor.default_crop[1] + sensor.default_crop[3]), scale_divisor),
+      top, img_h);
+  if (right - left <= 0 || bottom - top <= 0) {
+    return active;
+  }
+  return RectI{left, top, right - left, bottom - top};
+}
+
+auto BuildBorderLossCrop(const RawSensorGeometry& sensor, Extent2D output_size, int scale_divisor,
+                         int source_border) -> RectI {
+  if (source_border <= 0) {
+    return BuildDecodeCropRect(sensor, output_size, scale_divisor);
+  }
+  const Extent2D source_size{output_size.width + static_cast<std::uint32_t>(2 * source_border),
+                             output_size.height + static_cast<std::uint32_t>(2 * source_border)};
+  const RectI    source_crop = BuildDecodeCropRect(sensor, source_size, scale_divisor);
+  const int      out_w       = static_cast<int>(output_size.width);
+  const int      out_h       = static_cast<int>(output_size.height);
+  const int      left        = std::clamp(source_crop.x, 0, out_w);
+  const int      top         = std::clamp(source_crop.y, 0, out_h);
+  const int      right =
+      std::clamp(source_crop.x + source_crop.width - 2 * source_border, left, out_w);
+  const int bottom =
+      std::clamp(source_crop.y + source_crop.height - 2 * source_border, top, out_h);
+  if (right <= left || bottom <= top) {
+    throw std::runtime_error("RawInputLoader: decode crop is too small for demosaic border");
+  }
+  return RectI{left, top, right - left, bottom - top};
+}
+
+auto OrientedExtent(Extent2D extent, int flip) -> Extent2D {
+  if (flip == 5 || flip == 6) {
+    return Extent2D{extent.height, extent.width};
+  }
+  return extent;
+}
+
+void FillOutputGeometry(PreparedRawInput& input, DecodeRes decode_res_for_full_reference) {
+  (void)decode_res_for_full_reference;
+  const std::uint8_t passes = input.downsample_passes;
+  const int          divisor = ScaleDivisor(passes);
+  const Extent2D     host    = input.host_extent;
+
+  if (input.input_kind == RawInputKind::DebayeredRgb) {
+    const RectI crop               = BuildDecodeCropRect(input.sensor, host, divisor);
+    input.demosaic_output_crop     = crop;
+    input.develop_output_extent    = OrientedExtent(
+        Extent2D{static_cast<std::uint32_t>(crop.width), static_cast<std::uint32_t>(crop.height)},
+        input.sensor.orientation_flip);
+    const int full_div = 1;
+    const Extent2D full_host{static_cast<std::uint32_t>(std::max(input.sensor.raw_width, 0)),
+                             static_cast<std::uint32_t>(std::max(input.sensor.raw_height, 0))};
+    const RectI full_crop = BuildDecodeCropRect(input.sensor, full_host, full_div);
+    input.full_reference_extent = OrientedExtent(
+        Extent2D{static_cast<std::uint32_t>(full_crop.width),
+                 static_cast<std::uint32_t>(full_crop.height)},
+        input.sensor.orientation_flip);
+    input.sensor_active_area = BuildActiveAreaRect(input.sensor, host, divisor);
+    return;
+  }
+
+  const bool bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
+  const int  border = bayer ? kRcdOutputCropRadius : 0;
+  const Extent2D demosaic_extent{
+      static_cast<std::uint32_t>(std::max(0, static_cast<int>(host.width) - 2 * border)),
+      static_cast<std::uint32_t>(std::max(0, static_cast<int>(host.height) - 2 * border))};
+  const RectI crop =
+      bayer ? BuildBorderLossCrop(input.sensor, demosaic_extent, divisor, border)
+            : BuildDecodeCropRect(input.sensor, host, divisor);
+  input.demosaic_output_crop  = crop;
+  input.develop_output_extent = OrientedExtent(
+      Extent2D{static_cast<std::uint32_t>(crop.width), static_cast<std::uint32_t>(crop.height)},
+      input.sensor.orientation_flip);
+
+  const Extent2D full_host{static_cast<std::uint32_t>(std::max(input.sensor.raw_width, 0)),
+                           static_cast<std::uint32_t>(std::max(input.sensor.raw_height, 0))};
+  const Extent2D full_demosaic{
+      static_cast<std::uint32_t>(std::max(0, static_cast<int>(full_host.width) - 2 * border)),
+      static_cast<std::uint32_t>(std::max(0, static_cast<int>(full_host.height) - 2 * border))};
+  const RectI full_crop =
+      bayer ? BuildBorderLossCrop(input.sensor, full_demosaic, 1, border)
+            : BuildDecodeCropRect(input.sensor, full_host, 1);
+  input.full_reference_extent = OrientedExtent(
+      Extent2D{static_cast<std::uint32_t>(full_crop.width),
+               static_cast<std::uint32_t>(full_crop.height)},
+      input.sensor.orientation_flip);
+  input.sensor_active_area = BuildActiveAreaRect(input.sensor, host, divisor);
+}
+
+auto CopyPlane(const cv::Mat& src, HostPixelFormat format) -> HostImagePlane {
+  HostImagePlane plane;
+  plane.extent       = Extent2D{static_cast<std::uint32_t>(src.cols),
+                                static_cast<std::uint32_t>(src.rows)};
+  plane.stride_bytes = static_cast<std::uint32_t>(src.cols * src.elemSize());
+  plane.format       = format;
+  const std::size_t bytes = plane.ByteCount();
+  auto              storage = std::shared_ptr<std::byte>(new std::byte[bytes], std::default_delete<std::byte[]>());
+  if (src.isContinuous() && static_cast<std::size_t>(src.step) == plane.stride_bytes) {
+    std::memcpy(storage.get(), src.data, bytes);
+  } else {
+    for (int y = 0; y < src.rows; ++y) {
+      std::memcpy(storage.get() + static_cast<std::size_t>(y) * plane.stride_bytes, src.ptr(y),
+                  plane.stride_bytes);
+    }
+  }
+  plane.bytes = std::const_pointer_cast<const std::byte>(storage);
+  return plane;
+}
+
+auto WrapU16Cfa(const HostImagePlane& plane) -> cv::Mat {
+  if (plane.format != HostPixelFormat::U16Cfa || !plane.bytes) {
+    throw std::runtime_error("RawInputLoader: expected U16 CFA plane");
+  }
+  return cv::Mat(static_cast<int>(plane.extent.height), static_cast<int>(plane.extent.width),
+                 CV_16UC1, const_cast<std::byte*>(plane.bytes.get()), plane.stride_bytes);
+}
+
+void DownsampleInPlace(PreparedRawInput& input, std::uint8_t passes) {
+  if (passes == 0 || input.input_kind == RawInputKind::DebayeredRgb) {
+    return;
+  }
+  cv::Mat current = WrapU16Cfa(input.pixels).clone();
+  for (std::uint8_t i = 0; i < passes; ++i) {
+    if (current.cols < 2 || current.rows < 2) {
+      throw std::runtime_error("RawInputLoader: CFA too small to downsample");
+    }
+    current = DownsampleRaw2x(current, input.cfa_pattern);
+  }
+  input.pixels      = CopyPlane(current, HostPixelFormat::U16Cfa);
+  input.host_extent = input.pixels.extent;
+  input.downsample_passes = passes;
+}
+
+auto LinearizationFromLibRaw(LibRaw& raw) -> RawLinearizationParams {
+  RawLinearizationParams params;
+  const auto             curve = raw_norm::BuildLinearizationCurve(raw.imgdata.rawdata);
+  for (int c = 0; c < 4; ++c) {
+    params.black_level[c] = curve.black_level[c];
+    params.white_level[c] = curve.white_level[c];
+    params.cam_mul[c]     = raw.imgdata.color.cam_mul[c];
+  }
+  params.apply_as_shot_wb  = raw.imgdata.color.as_shot_wb_applied != 1 ? 1 : 0;
+  const int tile_width     = raw.imgdata.rawdata.color.cblack[4];
+  const int tile_height    = raw.imgdata.rawdata.color.cblack[5];
+  const int entries        = tile_width * tile_height;
+  if (entries > 0 && entries <= 36) {
+    params.black_tile_width  = tile_width;
+    params.black_tile_height = tile_height;
+    for (int i = 0; i < entries; ++i) {
+      params.pattern_black[i] = static_cast<float>(raw.imgdata.rawdata.color.cblack[6 + i]);
+    }
+  }
+  return params;
+}
+
+auto SensorFromLibRaw(const LibRaw& raw) -> RawSensorGeometry {
+  RawSensorGeometry sensor;
+  const auto&       sizes = raw.imgdata.sizes;
+  sensor.raw_width        = sizes.raw_width;
+  sensor.raw_height       = sizes.raw_height;
+  sensor.width            = sizes.width;
+  sensor.height           = sizes.height;
+  sensor.left_margin      = sizes.left_margin;
+  sensor.top_margin       = sizes.top_margin;
+  sensor.orientation_flip = sizes.flip;
+  const auto& crop        = raw.imgdata.color.dng_levels.default_crop;
+  for (int i = 0; i < 4; ++i) {
+    sensor.default_crop[i] = crop[i];
+  }
+  return sensor;
+}
+
+void FillColorContext(LibRaw& raw, RawRuntimeColorContext& ctx) {
+  ctx.valid_                  = true;
+  ctx.output_in_camera_space_ = true;
+  for (int i = 0; i < 3; ++i) {
+    ctx.cam_mul_[i] = raw.imgdata.color.cam_mul[i];
+    ctx.pre_mul_[i] = raw.imgdata.color.pre_mul[i];
+  }
+  ctx.camera_make_  = raw.imgdata.idata.make;
+  ctx.camera_model_ = raw.imgdata.idata.model;
+}
+
+auto FinishPrepared(PreparedRawInput input, DecodeRes decode_res) -> PreparedRawInput {
+  const auto passes = DecodeResToDownsamplePasses(decode_res);
+  DownsampleInPlace(input, passes);
+  FillOutputGeometry(input, DecodeRes::FULL);
+  input.content_key.content_hash = HashBytes(input.pixels.Span());
+  input.working_space            = SceneWorkingSpace::CameraRgb;
+  return input;
+}
+
+void ThrowIfUnsupported(LibRaw& raw, RawInputKind kind, const RawCfaPattern& pattern) {
+  if (raw.imgdata.idata.is_foveon != 0U || raw.is_fuji_rotated() != 0) {
+    throw std::runtime_error("RawInputLoader: unsupported CFA layout");
+  }
+  if (kind == RawInputKind::Unsupported) {
+    throw std::runtime_error("RawInputLoader: unsupported raw input");
+  }
+  if (kind == RawInputKind::BayerRaw) {
+    if (raw.imgdata.idata.filters == 0U || raw.imgdata.idata.filters == 1U) {
+      throw std::runtime_error("RawInputLoader: unsupported CFA layout");
+    }
+    if (pattern.kind == RawCfaKind::Bayer2x2 && !IsClassic2x2Bayer(pattern.bayer_pattern)) {
+      throw std::runtime_error("RawInputLoader: unsupported 2x2 CFA pattern");
+    }
+  }
+}
+
+}  // namespace
+
+auto PreparedRawInput::CompileSource() const -> DevelopCompileSource {
+  DevelopCompileSource source;
+  if (input_kind == RawInputKind::DebayeredRgb) {
+    source.kind = DevelopInputKind::DirectRgb;
+  } else if (cfa_pattern.kind == RawCfaKind::XTrans6x6) {
+    source.kind = DevelopInputKind::XTransCfa;
+  } else {
+    source.kind = DevelopInputKind::BayerCfa;
+  }
+  source.host_extent            = host_extent;
+  source.develop_output_extent  = develop_output_extent;
+  source.full_reference_extent  = full_reference_extent;
+  source.sensor_active_area     = sensor_active_area;
+  source.downsample_passes      = downsample_passes;
+  return source;
+}
+
+auto RawInputLoader::FromUnpackedCfa(HostImagePlane plane, RawCfaPattern pattern,
+                                     RawLinearizationParams linearization, RawSensorGeometry sensor,
+                                     DecodeRes decode_res) -> PreparedRawInput {
+  if (plane.format != HostPixelFormat::U16Cfa || plane.extent.Empty() || !plane.bytes) {
+    throw std::runtime_error("RawInputLoader::FromUnpackedCfa: U16 CFA plane required");
+  }
+  if (pattern.kind != RawCfaKind::Bayer2x2 && pattern.kind != RawCfaKind::XTrans6x6) {
+    throw std::runtime_error("RawInputLoader::FromUnpackedCfa: unsupported CFA");
+  }
+  if (pattern.kind == RawCfaKind::Bayer2x2 && !IsClassic2x2Bayer(pattern.bayer_pattern)) {
+    throw std::runtime_error("RawInputLoader::FromUnpackedCfa: unsupported 2x2 CFA pattern");
+  }
+  if (sensor.raw_width == 0) {
+    sensor.raw_width  = static_cast<std::int32_t>(plane.extent.width);
+    sensor.raw_height = static_cast<std::int32_t>(plane.extent.height);
+    sensor.width      = sensor.raw_width;
+    sensor.height     = sensor.raw_height;
+  }
+
+  PreparedRawInput input;
+  input.pixels        = std::move(plane);
+  input.host_extent   = input.pixels.extent;
+  input.input_kind    = RawInputKind::BayerRaw;
+  input.cfa_pattern   = pattern;
+  input.linearization = linearization;
+  input.sensor        = sensor;
+  input.color_context.valid_                  = true;
+  input.color_context.output_in_camera_space_ = true;
+  for (int i = 0; i < 3; ++i) {
+    input.color_context.cam_mul_[i] = linearization.cam_mul[i];
+  }
+  return FinishPrepared(std::move(input), decode_res);
+}
+
+auto RawInputLoader::FromDirectRgb(HostImagePlane plane, RawSensorGeometry sensor)
+    -> PreparedRawInput {
+  if (plane.format != HostPixelFormat::F32Rgba || plane.extent.Empty() || !plane.bytes) {
+    throw std::runtime_error("RawInputLoader::FromDirectRgb: F32 RGBA plane required");
+  }
+  if (sensor.raw_width == 0) {
+    sensor.raw_width  = static_cast<std::int32_t>(plane.extent.width);
+    sensor.raw_height = static_cast<std::int32_t>(plane.extent.height);
+    sensor.width      = sensor.raw_width;
+    sensor.height     = sensor.raw_height;
+  }
+  PreparedRawInput input;
+  input.pixels      = std::move(plane);
+  input.host_extent = input.pixels.extent;
+  input.input_kind  = RawInputKind::DebayeredRgb;
+  input.sensor      = sensor;
+  input.linearization.apply_as_shot_wb = 0;
+  input.color_context.valid_                  = true;
+  input.color_context.output_in_camera_space_ = true;
+  return FinishPrepared(std::move(input), DecodeRes::FULL);
+}
+
+auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes decode_res)
+    -> PreparedRawInput {
+  if (encoded.empty()) {
+    throw std::runtime_error("RawInputLoader::LoadEncoded: empty buffer");
+  }
+  LibRaw raw;
+  if (raw.open_buffer(const_cast<void*>(static_cast<const void*>(encoded.data())), encoded.size()) !=
+      LIBRAW_SUCCESS) {
+    throw std::runtime_error("RawInputLoader::LoadEncoded: LibRaw open_buffer failed");
+  }
+  if (libraw_guard::Unpack(raw) != LIBRAW_SUCCESS) {
+    raw.recycle();
+    throw std::runtime_error("RawInputLoader::LoadEncoded: LibRaw unpack failed");
+  }
+
+  const auto kind    = ClassifyRawInput(raw.imgdata.rawdata, raw.imgdata.idata);
+  const auto pattern = kind == RawInputKind::BayerRaw ? ReadLibRawCfaPattern(raw) : RawCfaPattern{};
+  try {
+    ThrowIfUnsupported(raw, kind, pattern);
+  } catch (...) {
+    raw.recycle();
+    throw;
+  }
+
+  PreparedRawInput input;
+  input.sensor        = SensorFromLibRaw(raw);
+  input.linearization = LinearizationFromLibRaw(raw);
+  FillColorContext(raw, input.color_context);
+
+  if (kind == RawInputKind::DebayeredRgb) {
+    raw.recycle();
+    throw std::runtime_error(
+        "RawInputLoader::LoadEncoded: encoded direct RGB is not used in G4 tests; "
+        "call FromDirectRgb");
+  }
+
+  const auto& sizes = raw.imgdata.sizes;
+  cv::Mat view(sizes.raw_height, sizes.raw_width, CV_16UC1, raw.imgdata.rawdata.raw_image,
+               sizes.raw_pitch != 0 ? static_cast<std::size_t>(sizes.raw_pitch)
+                                    : static_cast<std::size_t>(sizes.raw_width) * sizeof(std::uint16_t));
+  input.pixels      = CopyPlane(view, HostPixelFormat::U16Cfa);
+  input.host_extent = input.pixels.extent;
+  input.input_kind  = RawInputKind::BayerRaw;
+  input.cfa_pattern = pattern;
+  raw.recycle();
+  return FinishPrepared(std::move(input), decode_res);
+}
+
+auto RawInputLoader::TryLoadEncoded(std::span<const std::byte> encoded, DecodeRes decode_res)
+    -> std::optional<PreparedRawInput> {
+  try {
+    return LoadEncoded(encoded, decode_res);
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -243,6 +243,25 @@ void CudaBackend::UploadTexture2D(Texture2D& texture, std::span<const std::byte>
   h2d_bytes_ += bytes.size();
 }
 
+void CudaBackend::UploadDeviceMemory(void* dst, std::span<const std::byte> bytes,
+                                     CommandContext& command_context) {
+  if (fail_next_upload_) {
+    fail_next_upload_ = false;
+    throw std::runtime_error("CudaBackend::UploadDeviceMemory: injected failure");
+  }
+  if (bytes.empty()) {
+    return;
+  }
+  if (dst == nullptr) {
+    throw std::runtime_error("CudaBackend::UploadDeviceMemory: null destination");
+  }
+  cuda::CheckCuda(::cudaMemcpyAsync(dst, bytes.data(), bytes.size(), cudaMemcpyHostToDevice,
+                                    command_context.Stream()),
+                  "CudaBackend::UploadDeviceMemory");
+  ++h2d_copy_count_;
+  h2d_bytes_ += bytes.size();
+}
+
 void CudaBackend::DownloadTexture2D(const Texture2D& texture, std::span<std::byte> out,
                                     CommandContext& command_context) const {
   if (texture.DevicePointer() == nullptr) {

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
@@ -1,0 +1,228 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/cuda/cuda_develop_pass.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+
+#include <opencv2/core/cuda.hpp>
+#include <opencv2/core/cuda_stream_accessor.hpp>
+
+#include "decoders/processor/operators/gpu/cuda_color_space_conv.hpp"
+#include "decoders/processor/operators/gpu/cuda_debayer_rcd.hpp"
+#include "decoders/processor/operators/gpu/cuda_highlight_reconstruct.hpp"
+#include "decoders/processor/operators/gpu/cuda_image_ops.hpp"
+#include "decoders/processor/operators/gpu/cuda_white_balance.hpp"
+#include "decoders/processor/operators/gpu/cuda_xtrans_interpolate.hpp"
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/runtime/cuda/geometry_resample_pass.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+namespace {
+
+auto WrapStream(cudaStream_t native) -> cv::cuda::Stream {
+  return cv::cuda::StreamAccessor::wrapStream(native);
+}
+
+auto WrapU16(void* ptr, int width, int height) -> cv::cuda::GpuMat {
+  return cv::cuda::GpuMat(height, width, CV_16UC1, ptr,
+                          static_cast<std::size_t>(width) * sizeof(std::uint16_t));
+}
+
+auto WrapF32C1(void* ptr, int width, int height) -> cv::cuda::GpuMat {
+  return cv::cuda::GpuMat(height, width, CV_32FC1, ptr,
+                          static_cast<std::size_t>(width) * sizeof(float));
+}
+
+auto WrapF32C3(void* ptr, int width, int height) -> cv::cuda::GpuMat {
+  return cv::cuda::GpuMat(height, width, CV_32FC3, ptr,
+                          static_cast<std::size_t>(width) * sizeof(float) * 3);
+}
+
+auto WrapF32C4(void* ptr, int width, int height) -> cv::cuda::GpuMat {
+  return cv::cuda::GpuMat(height, width, CV_32FC4, ptr,
+                          static_cast<std::size_t>(width) * sizeof(float) * 4);
+}
+
+auto AllocateTransient(CudaRenderWorkspace& workspace, std::size_t bytes) -> void* {
+  return workspace.TransientBuffers().Allocate(bytes);
+}
+
+auto EnsureImage(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
+                 std::uint32_t height) -> ResourceLease<CudaBackend>& {
+  auto* existing = workspace.Images().Find(id);
+  if (existing != nullptr && !existing->Empty()) {
+    const auto& tex = existing->Texture();
+    if (tex.Width() == width && tex.Height() == height && tex.Format() == TextureFormat::Rgba32f) {
+      return *existing;
+    }
+  }
+  auto lease = workspace.Textures().Acquire({width, height, TextureFormat::Rgba32f});
+  workspace.Images().Store(id, std::move(lease));
+  auto* stored = workspace.Images().Find(id);
+  if (stored == nullptr) {
+    throw std::runtime_error("ExecuteCudaDevelop: failed to store develop image");
+  }
+  return *stored;
+}
+
+auto CropIfNeeded(cv::cuda::GpuMat plane, const RectI& crop) -> cv::cuda::GpuMat {
+  if (crop.width <= 0 || crop.height <= 0) {
+    return plane;
+  }
+  if (crop.x == 0 && crop.y == 0 && crop.width == plane.cols && crop.height == plane.rows) {
+    return plane;
+  }
+  return plane(cv::Rect(crop.x, crop.y, crop.width, crop.height));
+}
+
+}  // namespace
+
+void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
+                        const PreparedRawInput& input, PipelineDocument& document) {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteCudaDevelop: BeginRender has not been called");
+  }
+  auto* develop = document.Develop();
+  if (develop == nullptr) {
+    throw std::runtime_error("ExecuteCudaDevelop: missing develop node");
+  }
+
+  auto pending = TakePendingParameterPatch(develop->Params());
+
+  if (workspace.Textures().ByteBudget() == 0) {
+    workspace.Textures().SetByteBudget(64ull << 20);
+  }
+  if (plan.peak_transient_bytes > 0) {
+    workspace.TransientBuffers().Reserve(plan.peak_transient_bytes);
+  }
+
+  auto&        ctx    = device.CommandContext();
+  auto         stream = WrapStream(ctx.Stream());
+  const auto   flags  = develop->Params().Params();
+  const bool   hlr    = flags.highlights_reconstruct;
+  const GraphValueId develop_id = plan.develop_output;
+  const auto   out_w  = plan.source.develop_output_extent.width;
+  const auto   out_h  = plan.source.develop_output_extent.height;
+  auto&        out_lease = EnsureImage(workspace, develop_id, out_w, out_h);
+  auto&        out_tex   = out_lease.Texture();
+
+  if (input.input_kind == RawInputKind::DebayeredRgb ||
+      plan.source.kind == DevelopInputKind::DirectRgb) {
+    if (input.pixels.format != HostPixelFormat::F32Rgba ||
+        input.pixels.ByteCount() != out_tex.Bytes()) {
+      throw std::runtime_error("ExecuteCudaDevelop: direct RGB size does not match output");
+    }
+    workspace.Device().UploadTexture2D(out_tex, input.pixels.Span(), ctx);
+    if (pending.has_value()) {
+      pending->Commit();
+    }
+    return;
+  }
+
+  const int w = static_cast<int>(input.host_extent.width);
+  const int h = static_cast<int>(input.host_extent.height);
+  if (w <= 0 || h <= 0) {
+    throw std::runtime_error("ExecuteCudaDevelop: empty CFA");
+  }
+  const std::uint32_t packed_stride = static_cast<std::uint32_t>(w) * sizeof(std::uint16_t);
+  if (input.pixels.stride_bytes != packed_stride) {
+    throw std::runtime_error("ExecuteCudaDevelop: CFA plane must be tightly packed");
+  }
+
+  void* u16_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(std::uint16_t));
+  void* f32_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+  workspace.Device().UploadDeviceMemory(u16_ptr, input.pixels.Span(), ctx);
+
+  auto src_u16 = WrapU16(u16_ptr, w, h);
+  auto linear  = WrapF32C1(f32_ptr, w, h);
+  CUDA::ToLinearRef(src_u16, linear, input.linearization, input.cfa_pattern, &stream);
+
+  const bool xtrans = input.cfa_pattern.kind == RawCfaKind::XTrans6x6;
+  if (!hlr || xtrans) {
+    CUDA::Clamp01(linear, &stream);
+  }
+
+  cv::cuda::GpuMat packed = WrapF32C4(out_tex.DevicePointer(), static_cast<int>(out_w),
+                                      static_cast<int>(out_h));
+
+  if (xtrans) {
+    void* green_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+    void* rgb_ptr =
+        AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float) * 3);
+    auto green  = WrapF32C1(green_ptr, w, h);
+    auto rgb    = WrapF32C3(rgb_ptr, w, h);
+    const int passes = input.downsample_passes == 0 ? 3 : 1;
+    CUDA::XTransToRGB_Ref(linear, green, rgb, input.cfa_pattern.xtrans_pattern, passes, &stream);
+    auto cropped = CropIfNeeded(rgb, input.demosaic_output_crop);
+    if (input.sensor.orientation_flip == 0 &&
+        (packed.cols != cropped.cols || packed.rows != cropped.rows)) {
+      throw std::runtime_error("ExecuteCudaDevelop: X-Trans output extent does not match plan");
+    }
+    CUDA::ApplyInverseCamMulAndPackRGBAOriented(cropped, packed, input.linearization.cam_mul,
+                                                input.sensor.orientation_flip, &stream);
+  } else {
+    void* r_ptr  = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+    void* g_ptr  = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+    void* b_ptr  = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+    void* vh_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+    void* pq_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+
+    CUDA::RcdWorkspace rcd;
+    rcd.BindExternal(r_ptr, g_ptr, b_ptr, vh_ptr, pq_ptr, cv::Size(w, h));
+    CUDA::Bayer2x2ToPlanarRGB_RCD(linear, input.cfa_pattern.bayer_pattern, &rcd, &stream);
+
+    auto r = CropIfNeeded(rcd.r, input.demosaic_output_crop);
+    auto g = CropIfNeeded(rcd.g, input.demosaic_output_crop);
+    auto b = CropIfNeeded(rcd.b, input.demosaic_output_crop);
+    if (input.sensor.orientation_flip == 0 && (packed.cols != r.cols || packed.rows != r.rows)) {
+      throw std::runtime_error("ExecuteCudaDevelop: Bayer output extent does not match plan");
+    }
+
+    if (hlr) {
+      const int cw = r.cols;
+      const int ch = r.rows;
+      int*   anyclipped = static_cast<int*>(AllocateTransient(workspace, sizeof(int)));
+      float* sums       = static_cast<float*>(AllocateTransient(workspace, sizeof(float) * 4));
+      float* cnts       = static_cast<float*>(AllocateTransient(workspace, sizeof(float) * 4));
+      void*  hlr_rgb    = AllocateTransient(workspace, static_cast<std::size_t>(cw) * ch * sizeof(float) * 3);
+      CUDA::HighlightWorkspace highlight;
+      highlight.BindExternal(anyclipped, sums, cnts, hlr_rgb, cw, ch);
+      CUDA::HighlightCorrection   correction = CUDA::BuildHighlightCorrection(input.linearization.cam_mul);
+      CUDA::HighlightAccumulation accumulation;
+      CUDA::AccumulateHighlightStats(r, g, b, correction, cv::Rect{}, highlight, accumulation,
+                                     &stream);
+      CUDA::FinalizeHighlightCorrection(accumulation, correction);
+      CUDA::ApplyHighlightCorrectionAndPackRGBAOriented(r, g, b, packed, correction,
+                                                        input.linearization.cam_mul,
+                                                        input.sensor.orientation_flip, &highlight,
+                                                        &stream);
+    } else {
+      void* merge_ptr =
+          AllocateTransient(workspace, static_cast<std::size_t>(r.cols) * r.rows * sizeof(float) * 3);
+      auto merged = WrapF32C3(merge_ptr, r.cols, r.rows);
+      CUDA::MergeRGB(r, g, b, merged, &stream);
+      CUDA::ApplyInverseCamMulAndPackRGBAOriented(merged, packed, input.linearization.cam_mul,
+                                                  input.sensor.orientation_flip, &stream);
+    }
+  }
+
+  if (plan.encode_geometry_resample) {
+    const auto rw = plan.geometry.render_extent.width;
+    const auto rh = plan.geometry.render_extent.height;
+    auto       dest = workspace.Textures().Acquire({rw, rh, TextureFormat::Rgba32f});
+    GeometryResamplePass pass;
+    pass.Encode(plan.geometry, out_tex, dest.Texture(), ctx);
+    workspace.Images().Store(develop_id, std::move(dest));
+  }
+
+  if (pending.has_value()) {
+    pending->Commit();
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -1,0 +1,118 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/graph_compiler.hpp"
+
+#include <stdexcept>
+#include <string>
+
+#include "edit/geometry/render_geometry_resolver.hpp"
+#include "edit/geometry/source_geometry.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr std::size_t kAlign = 256;
+
+auto AlignUp(std::size_t value, std::size_t alignment) -> std::size_t {
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+auto EstimatePeakTransientBytes(const DevelopCompileSource& source) -> std::size_t {
+  const std::size_t w = source.host_extent.width;
+  const std::size_t h = source.host_extent.height;
+  const std::size_t pixels = w * h;
+  if (source.kind == DevelopInputKind::DirectRgb) {
+    return AlignUp(4096, kAlign);
+  }
+  // U16 CFA + F32 CFA + 5 RCD planes + merge RGB + HLR result + HLR stats + XTrans green/rgb.
+  const std::size_t bytes = AlignUp(pixels * 2, kAlign) + AlignUp(pixels * 4, kAlign) +
+                            5 * AlignUp(pixels * 4, kAlign) + AlignUp(pixels * 12, kAlign) +
+                            AlignUp(pixels * 12, kAlign) + AlignUp(4 + 16 + 16, kAlign) +
+                            AlignUp(pixels * 4, kAlign) + AlignUp(pixels * 12, kAlign);
+  return bytes + 64 * kAlign;
+}
+
+auto ImageParamsFromDocument(const PipelineDocument& document) -> ImageGeometryParams {
+  ImageGeometryParams params;
+  params.crop_rect         = document.Geometry().CropRect();
+  params.rotation_degrees  = document.Geometry().RotationDegrees();
+  params.expand_to_fit     = document.Geometry().ExpandToFit();
+  return params;
+}
+
+void RequireDefaultEndpoints(const PipelineDocument& document) {
+  const auto errors = document.Graph().Validate();
+  if (!errors.empty()) {
+    throw std::runtime_error("GraphCompiler: graph is invalid: " + errors.front().message);
+  }
+  if (document.Develop() == nullptr) {
+    throw std::runtime_error("GraphCompiler: missing develop endpoint");
+  }
+  if (document.PrimaryGrade() == nullptr) {
+    throw std::runtime_error("GraphCompiler: missing primary color grade");
+  }
+  if (document.Drt() == nullptr) {
+    throw std::runtime_error("GraphCompiler: missing DRT endpoint");
+  }
+  for (const auto& node : document.Graph().Nodes()) {
+    const auto& type = node->Type();
+    if (type == type_ids::DevelopNode() || type == type_ids::ColorGradeNode() ||
+        type == type_ids::DrtNode()) {
+      continue;
+    }
+    throw std::runtime_error("GraphCompiler: G4 compiles only the default three-node document");
+  }
+}
+
+}  // namespace
+
+auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompileSource& source,
+                            const RenderRequest& request) -> ExecutionPlan {
+  RequireDefaultEndpoints(document);
+  if (source.host_extent.Empty() || source.develop_output_extent.Empty() ||
+      source.full_reference_extent.Empty()) {
+    throw std::runtime_error("GraphCompiler: source extents must be positive");
+  }
+
+  ExecutionPlan plan;
+  plan.source          = source;
+  plan.develop_output  = GraphValueId{NodeId{"develop"}, PortId{"image"}};
+  plan.peak_transient_bytes = EstimatePeakTransientBytes(source);
+
+  if (source.kind == DevelopInputKind::DirectRgb) {
+    plan.passes.push_back(GpuPassDesc{GpuPassKind::UploadRgb});
+  } else {
+    plan.passes.push_back(GpuPassDesc{GpuPassKind::UploadRaw});
+    plan.passes.push_back(GpuPassDesc{GpuPassKind::Linearize});
+    plan.passes.push_back(GpuPassDesc{GpuPassKind::CfaClamp});
+    plan.passes.push_back(GpuPassDesc{GpuPassKind::Demosaic});
+    plan.passes.push_back(GpuPassDesc{GpuPassKind::HighlightRecover});
+    plan.passes.push_back(GpuPassDesc{GpuPassKind::InverseCamMulPack});
+  }
+  plan.passes.push_back(GpuPassDesc{GpuPassKind::Lens});
+  plan.passes.push_back(GpuPassDesc{GpuPassKind::GeometryResample});
+
+  const auto geom_source = MakeSourceGeometry(source.develop_output_extent, source.full_reference_extent,
+                                              source.sensor_active_area, source.downsample_passes);
+  plan.geometry = ResolveRenderGeometry(geom_source, ImageParamsFromDocument(document), request.view,
+                                        request.resolution, request.footprint);
+  plan.encode_geometry_resample = !IsIdentityResample(plan.geometry);
+  return plan;
+}
+
+auto GraphCompiler::NeedsRecompile(const ExecutionPlan& previous, const PipelineDocument& document,
+                                   const DevelopCompileSource& source) -> bool {
+  if (document.TopologyDirty()) {
+    return true;
+  }
+  return previous.source.kind != source.kind ||
+         previous.source.host_extent != source.host_extent ||
+         previous.source.develop_output_extent != source.develop_output_extent ||
+         previous.source.full_reference_extent != source.full_reference_extent ||
+         previous.source.downsample_passes != source.downsample_passes;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_debayer_rcd.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_debayer_rcd.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdexcept>
+
 #include <opencv2/core/cuda.hpp>
 
 #include "decoders/processor/raw_processor_pattern.hpp"
@@ -17,8 +19,30 @@ struct RcdWorkspace {
   cv::cuda::GpuMat vh_dir;
   cv::cuda::GpuMat pq_dir;
 
+  /**
+   * @brief Wrap five preallocated F32C1 planes. @ref Reserve then only re-wraps; it does
+   *        not call GpuMat::create. Pointers must stay valid for the current submission.
+   */
+  void BindExternal(void* red, void* green, void* blue, void* vh, void* pq, const cv::Size& size) {
+    bound_external_ = true;
+    bound_size_     = size;
+    r_ptr_          = red;
+    g_ptr_          = green;
+    b_ptr_          = blue;
+    vh_ptr_         = vh;
+    pq_ptr_         = pq;
+    WrapBoundPlanes();
+  }
+
   void Reserve(const cv::Size& size) {
     if (size.width <= 0 || size.height <= 0) {
+      return;
+    }
+    if (bound_external_) {
+      if (size != bound_size_) {
+        throw std::runtime_error("RcdWorkspace::Reserve: bound size does not match");
+      }
+      WrapBoundPlanes();
       return;
     }
     r.create(size, CV_32FC1);
@@ -27,6 +51,24 @@ struct RcdWorkspace {
     vh_dir.create(size, CV_32FC1);
     pq_dir.create(size, CV_32FC1);
   }
+
+ private:
+  void WrapBoundPlanes() {
+    const std::size_t step = static_cast<std::size_t>(bound_size_.width) * sizeof(float);
+    r                      = cv::cuda::GpuMat(bound_size_.height, bound_size_.width, CV_32FC1, r_ptr_, step);
+    g                      = cv::cuda::GpuMat(bound_size_.height, bound_size_.width, CV_32FC1, g_ptr_, step);
+    b                      = cv::cuda::GpuMat(bound_size_.height, bound_size_.width, CV_32FC1, b_ptr_, step);
+    vh_dir                 = cv::cuda::GpuMat(bound_size_.height, bound_size_.width, CV_32FC1, vh_ptr_, step);
+    pq_dir                 = cv::cuda::GpuMat(bound_size_.height, bound_size_.width, CV_32FC1, pq_ptr_, step);
+  }
+
+  bool      bound_external_ = false;
+  cv::Size  bound_size_{};
+  void*     r_ptr_  = nullptr;
+  void*     g_ptr_  = nullptr;
+  void*     b_ptr_  = nullptr;
+  void*     vh_ptr_ = nullptr;
+  void*     pq_ptr_ = nullptr;
 };
 
 void Bayer2x2ToRGB_RCD(cv::cuda::GpuMat& image, const BayerPattern2x2& pattern,

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_highlight_reconstruct.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_highlight_reconstruct.hpp
@@ -38,6 +38,13 @@ class HighlightWorkspace {
   HighlightWorkspace(HighlightWorkspace&& other) noexcept;
   auto operator=(HighlightWorkspace&& other) noexcept -> HighlightWorkspace&;
 
+  /**
+   * @brief Use caller-owned device pointers. Subsequent @ref Reserve calls will not cudaMalloc.
+   * @p result_rgb may be null when only stats buffers are required.
+   */
+  void BindExternal(int* anyclipped, float* sums, float* cnts, void* result_rgb, int width,
+                    int height);
+
  private:
   friend auto BuildHighlightCorrection(LibRaw& raw_processor) -> HighlightCorrection;
   friend void Clamp01(cv::cuda::GpuMat& img, cv::cuda::Stream* stream);
@@ -95,9 +102,11 @@ class HighlightWorkspace {
   float*           cnts_          = nullptr;
   size_t           mask_capacity_ = 0;
   cv::cuda::GpuMat result_;
+  bool             owns_device_   = true;
 };
 
 auto BuildHighlightCorrection(LibRaw& raw_processor) -> HighlightCorrection;
+auto BuildHighlightCorrection(const float* cam_mul) -> HighlightCorrection;
 void FinalizeHighlightCorrection(const HighlightAccumulation& accumulation,
                                  HighlightCorrection& correction);
 void AccumulateHighlightStats(const cv::cuda::GpuMat& img, const HighlightCorrection& correction,

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_white_balance.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_white_balance.hpp
@@ -9,12 +9,21 @@
 #include <opencv2/core.hpp>
 #include <opencv2/core/cuda.hpp>
 
+#include "decoders/processor/raw_linearization_params.hpp"
 #include "decoders/processor/raw_processor_pattern.hpp"
 #include "image/image_buffer.hpp"
 
 namespace alcedo {
 namespace CUDA {
 void ToLinearRef(cv::cuda::GpuMat& img, LibRaw& raw_processor, const RawCfaPattern& pattern,
+                 cv::cuda::Stream* stream = nullptr);
+
+/**
+ * @brief Linearize U16 CFA into a preallocated F32 plane. Does not allocate @p dst.
+ * @pre src is CV_16UC1, dst is CV_32FC1 with the same size, and dst already owns its storage.
+ */
+void ToLinearRef(const cv::cuda::GpuMat& src_u16, cv::cuda::GpuMat& dst_f32,
+                 const RawLinearizationParams& params, const RawCfaPattern& pattern,
                  cv::cuda::Stream* stream = nullptr);
 };
 };  // namespace alcedo

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_xtrans_interpolate.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_xtrans_interpolate.hpp
@@ -13,5 +13,12 @@ namespace CUDA {
 
 void XTransToRGB_Ref(cv::cuda::GpuMat& image, const XTransPattern6x6& pattern, int passes);
 
+/**
+ * @brief X-Trans interpolate into preallocated green (F32C1) and RGB (F32C3) planes.
+ * @pre green and output match @p raw size; neither is allocated by this function.
+ */
+void XTransToRGB_Ref(const cv::cuda::GpuMat& raw, cv::cuda::GpuMat& green, cv::cuda::GpuMat& output,
+                     const XTransPattern6x6& pattern, int passes, cv::cuda::Stream* stream);
+
 }  // namespace CUDA
 }  // namespace alcedo

--- a/alcedo_studio/src/include/decoders/processor/raw_linearization_params.hpp
+++ b/alcedo_studio/src/include/decoders/processor/raw_linearization_params.hpp
@@ -1,0 +1,27 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+namespace alcedo {
+
+/**
+ * @brief Black/white and as-shot cam_mul used by GPU linearization. No LibRaw types.
+ *
+ * @p apply_as_shot_wb is true when the file has not already applied camera white
+ * balance, matching LibRaw `as_shot_wb_applied != 1`.
+ */
+struct RawLinearizationParams {
+  float         black_level[4]     = {0.0f, 0.0f, 0.0f, 0.0f};
+  float         white_level[4]     = {1.0f, 1.0f, 1.0f, 1.0f};
+  float         cam_mul[4]         = {1.0f, 1.0f, 1.0f, 1.0f};
+  std::int32_t  apply_as_shot_wb   = 1;
+  std::int32_t  black_tile_width   = 0;
+  std::int32_t  black_tile_height  = 0;
+  float         pattern_black[36]  = {};
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/input/prepared_raw_input.hpp
+++ b/alcedo_studio/src/include/edit/input/prepared_raw_input.hpp
@@ -1,0 +1,87 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <span>
+
+#include "decoders/processor/raw_color_context.hpp"
+#include "decoders/processor/raw_linearization_params.hpp"
+#include "decoders/processor/raw_processor_pattern.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/runtime/develop_compile_source.hpp"
+
+namespace alcedo {
+
+enum class HostPixelFormat : std::uint8_t {
+  U16Cfa  = 0,
+  F32Rgba = 1,
+};
+
+enum class SceneWorkingSpace : std::uint8_t {
+  CameraRgb = 0,
+};
+
+/**
+ * @brief Host pixel plane for a prepared develop input. Shared bytes, tightly packed rows.
+ */
+struct HostImagePlane {
+  std::shared_ptr<const std::byte> bytes;
+  Extent2D                         extent{};
+  std::uint32_t                    stride_bytes = 0;
+  HostPixelFormat                  format       = HostPixelFormat::U16Cfa;
+
+  [[nodiscard]] auto ByteCount() const -> std::size_t {
+    return static_cast<std::size_t>(stride_bytes) * extent.height;
+  }
+
+  [[nodiscard]] auto Span() const -> std::span<const std::byte> {
+    if (!bytes || ByteCount() == 0) {
+      return {};
+    }
+    return {bytes.get(), ByteCount()};
+  }
+};
+
+/**
+ * @brief LibRaw size fields needed to crop after demosaic. No LibRaw type.
+ */
+struct RawSensorGeometry {
+  std::int32_t  raw_width      = 0;
+  std::int32_t  raw_height     = 0;
+  std::int32_t  width          = 0;
+  std::int32_t  height         = 0;
+  std::int32_t  left_margin    = 0;
+  std::int32_t  top_margin     = 0;
+  std::uint16_t default_crop[4] = {};
+  std::int32_t  orientation_flip = 0;
+};
+
+/**
+ * @brief CPU-side develop input. GPU work starts at upload.
+ *
+ * Output of Develop is camera scene-linear RGB. Camera-to-AP1 is a later node.
+ */
+struct PreparedRawInput {
+  HostImagePlane           pixels;
+  Extent2D                 host_extent{};
+  Extent2D                 develop_output_extent{};
+  Extent2D                 full_reference_extent{};
+  RectI                    sensor_active_area{};
+  RectI                    demosaic_output_crop{};
+  std::uint8_t             downsample_passes = 0;
+  RawInputKind             input_kind        = RawInputKind::BayerRaw;
+  RawCfaPattern            cfa_pattern{};
+  RawLinearizationParams   linearization{};
+  RawSensorGeometry        sensor{};
+  RawRuntimeColorContext   color_context{};
+  SourceContentKey         content_key{};
+  SceneWorkingSpace        working_space = SceneWorkingSpace::CameraRgb;
+
+  [[nodiscard]] auto CompileSource() const -> DevelopCompileSource;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/input/raw_input_loader.hpp
+++ b/alcedo_studio/src/include/edit/input/raw_input_loader.hpp
@@ -1,0 +1,62 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "edit/input/prepared_raw_input.hpp"
+#include "type/type.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief CPU LibRaw unpack, active-area metadata, and DecodeRes downsample.
+ *
+ * These steps are not GPU passes and do not belong in ExecutionPlan.
+ */
+class RawInputLoader {
+ public:
+  /**
+   * @brief Open encoded bytes, unpack, downsample, then recycle LibRaw.
+   * @throws std::runtime_error on LibRaw failure or unsupported CFA.
+   */
+  [[nodiscard]] static auto LoadEncoded(std::span<const std::byte> encoded, DecodeRes decode_res)
+      -> PreparedRawInput;
+
+  /**
+   * @brief Build a prepared CFA input without LibRaw. Used by tests and synthetic paths.
+   */
+  [[nodiscard]] static auto FromUnpackedCfa(HostImagePlane plane, RawCfaPattern pattern,
+                                            RawLinearizationParams linearization,
+                                            RawSensorGeometry sensor, DecodeRes decode_res)
+      -> PreparedRawInput;
+
+  /**
+   * @brief Direct RGB (already demosaiced) host plane. No LibRaw.
+   */
+  [[nodiscard]] static auto FromDirectRgb(HostImagePlane plane, RawSensorGeometry sensor)
+      -> PreparedRawInput;
+
+  [[nodiscard]] static auto TryLoadEncoded(std::span<const std::byte> encoded, DecodeRes decode_res)
+      -> std::optional<PreparedRawInput>;
+};
+
+[[nodiscard]] inline auto DecodeResToDownsamplePasses(DecodeRes decode_res) -> std::uint8_t {
+  switch (decode_res) {
+    case DecodeRes::FULL:
+      return 0;
+    case DecodeRes::HALF:
+      return 1;
+    case DecodeRes::QUARTER:
+      return 2;
+    case DecodeRes::EIGHTH:
+      return 3;
+  }
+  return 0;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -6,6 +6,7 @@
 
 #include <stdexcept>
 
+#include "edit/runtime/graph_image_cache.hpp"
 #include "edit/runtime/node_result_cache.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/texture_pool.hpp"
@@ -45,6 +46,8 @@ class BasicRenderWorkspace {
   [[nodiscard]] auto Textures() -> TexturePool<Backend>& { return textures_; }
   [[nodiscard]] auto MaskTextures() -> TexturePool<Backend>& { return mask_textures_; }
   [[nodiscard]] auto Values() -> NodeResultCache<Backend>& { return values_; }
+  [[nodiscard]] auto Images() -> GraphImageCache<Backend>& { return images_; }
+  [[nodiscard]] auto Images() const -> const GraphImageCache<Backend>& { return images_; }
 
   /**
    * @brief Wait the previous submission, rewind transients, start a new submission id.
@@ -84,6 +87,7 @@ class BasicRenderWorkspace {
   TexturePool<Backend>           textures_;
   TexturePool<Backend>           mask_textures_;
   NodeResultCache<Backend>       values_{};
+  GraphImageCache<Backend>       images_{};
   bool                           rendering_ = false;
 };
 

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -136,6 +136,12 @@ class CudaBackend {
   void DownloadTexture2D(const Texture2D& texture, std::span<std::byte> out,
                          CommandContext& command_context) const;
 
+  /**
+   * @brief Host-to-device copy into an arbitrary device pointer (transient CFA, etc.).
+   */
+  void UploadDeviceMemory(void* dst, std::span<const std::byte> bytes,
+                          CommandContext& command_context);
+
   /// G6 will generate mips. G2 keeps the entry and does nothing.
   void GenerateMaskMipLevels(Texture2D& texture);
 

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
@@ -1,0 +1,26 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/execution_plan.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Encode CUDA Develop for the current in-flight submission.
+ *
+ * Must be called between BeginRender and EndRender. Failures throw; there is
+ * no CPU Apply fallback. Develop output is camera scene-linear RGBA32F.
+ *
+ * CUDA order: Linearize → (optional CFA Clamp01) → Demosaic → HighlightRecover
+ * on RGB when enabled. Camera-to-AP1 is not applied.
+ */
+void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
+                        const PreparedRawInput& input, PipelineDocument& document);
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/develop_compile_source.hpp
+++ b/alcedo_studio/src/include/edit/runtime/develop_compile_source.hpp
@@ -1,0 +1,38 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "edit/geometry/types.hpp"
+
+namespace alcedo {
+
+enum class DevelopInputKind : std::uint8_t {
+  BayerCfa  = 0,
+  XTransCfa = 1,
+  DirectRgb = 2,
+};
+
+/**
+ * @brief GPU-free develop compile inputs. No LibRaw, no pixel buffers.
+ */
+struct DevelopCompileSource {
+  DevelopInputKind kind                   = DevelopInputKind::BayerCfa;
+  Extent2D         host_extent{};
+  Extent2D         develop_output_extent{};
+  Extent2D         full_reference_extent{};
+  RectI            sensor_active_area{};
+  std::uint8_t     downsample_passes      = 0;
+};
+
+/**
+ * @brief Identity of a prepared source. No write counters.
+ */
+struct SourceContentKey {
+  std::uint64_t content_hash = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -1,0 +1,54 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "edit/geometry/resolved_render_geometry.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/runtime/develop_compile_source.hpp"
+#include "edit/runtime/pass_kind.hpp"
+
+namespace alcedo {
+
+struct GpuPassDesc {
+  GpuPassKind kind = GpuPassKind::UploadRaw;
+};
+
+/**
+ * @brief Compiled backend work for one graph. Does not own GPU memory.
+ *
+ * Always includes GeometryResample so a viewport change does not recompile.
+ * The encoder skips the kernel when @ref encode_geometry_resample is false.
+ */
+struct ExecutionPlan {
+  std::vector<GpuPassDesc>   passes;
+  GraphValueId               develop_output{NodeId{"develop"}, PortId{"image"}};
+  DevelopCompileSource       source{};
+  ResolvedRenderGeometry     geometry{};
+  bool                       encode_geometry_resample = false;
+  std::size_t                peak_transient_bytes     = 0;
+
+  [[nodiscard]] auto Contains(GpuPassKind kind) const -> bool {
+    for (const auto& pass : passes) {
+      if (pass.kind == kind) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] auto IndexOf(GpuPassKind kind) const -> int {
+    for (int i = 0; i < static_cast<int>(passes.size()); ++i) {
+      if (passes[static_cast<std::size_t>(i)].kind == kind) {
+        return i;
+      }
+    }
+    return -1;
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
@@ -1,0 +1,35 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/geometry/render_request.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/runtime/develop_compile_source.hpp"
+#include "edit/runtime/execution_plan.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Builds a Develop-only ExecutionPlan. Does not allocate GPU memory.
+ *
+ * Validates the three-node document. ColorGrade and DRT are accepted as graph
+ * nodes but are not emitted as GPU passes in G4. Camera-to-AP1 is not a pass.
+ *
+ * Recompile when topology is dirty, input kind changes, or decoded extent
+ * changes. Highlight / demosaic / lens flags are encoder branches, not new
+ * pass lists.
+ */
+class GraphCompiler {
+ public:
+  [[nodiscard]] static auto Compile(const PipelineDocument&     document,
+                                    const DevelopCompileSource& source,
+                                    const RenderRequest&        request) -> ExecutionPlan;
+
+  [[nodiscard]] static auto NeedsRecompile(const ExecutionPlan&        previous,
+                                           const PipelineDocument&     document,
+                                           const DevelopCompileSource& source) -> bool;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
@@ -1,0 +1,53 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <utility>
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/runtime/texture_pool.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief KV cache of node image outputs keyed by producer node and output port.
+ *
+ * Values are Texture2D leases held across frames so a matching size is reused
+ * without a second Acquire. Not thread-safe.
+ */
+template <class Backend>
+class GraphImageCache {
+ public:
+  void Store(GraphValueId id, ResourceLease<Backend> lease) {
+    images_.insert_or_assign(std::move(id), std::move(lease));
+  }
+
+  [[nodiscard]] auto Find(const GraphValueId& id) -> ResourceLease<Backend>* {
+    const auto it = images_.find(id);
+    return it == images_.end() ? nullptr : &it->second;
+  }
+
+  [[nodiscard]] auto Find(const GraphValueId& id) const -> const ResourceLease<Backend>* {
+    const auto it = images_.find(id);
+    return it == images_.end() ? nullptr : &it->second;
+  }
+
+  [[nodiscard]] auto Find(const NodeId& producer, const PortId& output_port)
+      -> ResourceLease<Backend>* {
+    return Find(GraphValueId{producer, output_port});
+  }
+
+  void Erase(const GraphValueId& id) { images_.erase(id); }
+  void Clear() { images_.clear(); }
+  [[nodiscard]] auto Size() const -> std::size_t { return images_.size(); }
+
+ private:
+  std::map<GraphValueId, ResourceLease<Backend>> images_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/pass_kind.hpp
+++ b/alcedo_studio/src/include/edit/runtime/pass_kind.hpp
@@ -1,0 +1,54 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+namespace alcedo {
+
+/**
+ * @brief Backend work items produced by GraphCompiler. Not serialized.
+ *
+ * CUDA full-frame Develop order is Linearize, optional CFA clamp, Demosaic,
+ * then HighlightRecover on RGB. That matches ProcessCudaFullFrame, not the CPU
+ * Linearize → HLR → Debayer path.
+ */
+enum class GpuPassKind : std::uint8_t {
+  UploadRaw          = 0,
+  UploadRgb          = 1,
+  Linearize          = 2,
+  CfaClamp           = 3,
+  Demosaic           = 4,
+  HighlightRecover   = 5,
+  InverseCamMulPack  = 6,
+  Lens               = 7,
+  GeometryResample   = 8,
+};
+
+[[nodiscard]] inline auto GpuPassKindName(GpuPassKind kind) -> const char* {
+  switch (kind) {
+    case GpuPassKind::UploadRaw:
+      return "UploadRaw";
+    case GpuPassKind::UploadRgb:
+      return "UploadRgb";
+    case GpuPassKind::Linearize:
+      return "Linearize";
+    case GpuPassKind::CfaClamp:
+      return "CfaClamp";
+    case GpuPassKind::Demosaic:
+      return "Demosaic";
+    case GpuPassKind::HighlightRecover:
+      return "HighlightRecover";
+    case GpuPassKind::InverseCamMulPack:
+      return "InverseCamMulPack";
+    case GpuPassKind::Lens:
+      return "Lens";
+    case GpuPassKind::GeometryResample:
+      return "GeometryResample";
+  }
+  return "Unknown";
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/render_context.hpp
+++ b/alcedo_studio/src/include/edit/runtime/render_context.hpp
@@ -1,0 +1,22 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/geometry/resolved_render_geometry.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/runtime/develop_compile_source.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Per-frame read-only render inputs. Does not own GPU memory.
+ */
+struct RenderContext {
+  SourceContentKey              source_key{};
+  RenderQuality                 quality = RenderQuality::Preview;
+  const ResolvedRenderGeometry* geometry = nullptr;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -264,6 +264,30 @@ if(ALCEDO_CUDA_ENABLED)
     PROPERTIES LABELS "gpu;edit;geometry")
   alcedo_register_test_target(GpuDagCudaGeometryTest gpu)
 endif()
+
+# GPU DAG Phase G4: CPU RawInputLoader / GraphCompiler (no CUDA required).
+add_executable(GpuDagRawInputTest
+  ${ALCEDO_TEST_ROOT}/edit/input/raw_input_loader_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/runtime/graph_compiler_test.cpp)
+target_include_directories(GpuDagRawInputTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(GpuDagRawInputTest PRIVATE GTest::gtest_main EditInput EditRuntime)
+target_compile_definitions(GpuDagRawInputTest PRIVATE
+  ALCEDO_RUNTIME_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/runtime"
+  ALCEDO_INPUT_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/input")
+gtest_discover_tests(GpuDagRawInputTest TEST_PREFIX "GpuDagRawInputTest."
+  PROPERTIES LABELS "ci_core_flow;edit;input")
+alcedo_register_test_target(GpuDagRawInputTest edit)
+
+# GPU DAG Phase G4: CUDA Develop Endpoint.
+if(ALCEDO_CUDA_ENABLED)
+  add_executable(GpuDagCudaDevelopTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_develop_test.cpp)
+  target_include_directories(GpuDagCudaDevelopTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagCudaDevelopTest PRIVATE GTest::gtest_main EditRuntimeCuda EditInput)
+  gtest_discover_tests(GpuDagCudaDevelopTest TEST_PREFIX "GpuDagCudaDevelopTest."
+    PROPERTIES LABELS "gpu;edit;runtime")
+  alcedo_register_test_target(GpuDagCudaDevelopTest gpu)
+endif()
 if(ALCEDO_CUDA_ENABLED)
   add_executable(GpuDagCudaWorkspaceTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/parameter_arena_test.cpp

--- a/alcedo_studio/tests/edit/input/prepared_raw_test_support.hpp
+++ b/alcedo_studio/tests/edit/input/prepared_raw_test_support.hpp
@@ -1,0 +1,104 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "decoders/processor/raw_processor_pattern.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+
+namespace alcedo {
+namespace gpu_dag_test {
+
+inline auto MakeRggbPattern() -> RawCfaPattern {
+  RawCfaPattern pattern;
+  pattern.kind = RawCfaKind::Bayer2x2;
+  return pattern;
+}
+
+inline auto MakeXTransPattern() -> RawCfaPattern {
+  static constexpr int kRawFc[36] = {
+      1, 2, 1, 1, 0, 1, 1, 0, 1, 2, 1, 2, 0, 1, 0, 1, 2, 1,
+      1, 2, 1, 1, 0, 1, 1, 0, 1, 2, 1, 2, 2, 1, 2, 0, 1, 0,
+  };
+  RawCfaPattern pattern;
+  pattern.kind = RawCfaKind::XTrans6x6;
+  for (int i = 0; i < 36; ++i) {
+    pattern.xtrans_pattern.raw_fc[i] = kRawFc[i];
+    pattern.xtrans_pattern.rgb_fc[i] = FoldRawColorToRgb(kRawFc[i]);
+  }
+  return pattern;
+}
+
+inline auto DefaultLinearization() -> RawLinearizationParams {
+  RawLinearizationParams params;
+  for (int c = 0; c < 4; ++c) {
+    params.black_level[c] = 0.0f;
+    params.white_level[c] = 16383.0f;
+  }
+  params.cam_mul[0]        = 2.0f;
+  params.cam_mul[1]        = 1.0f;
+  params.cam_mul[2]        = 1.5f;
+  params.cam_mul[3]        = 1.0f;
+  params.apply_as_shot_wb  = 1;
+  return params;
+}
+
+inline auto MakeU16CfaPlane(std::uint32_t width, std::uint32_t height, const RawCfaPattern& pattern)
+    -> HostImagePlane {
+  HostImagePlane plane;
+  plane.extent       = Extent2D{width, height};
+  plane.stride_bytes = width * static_cast<std::uint32_t>(sizeof(std::uint16_t));
+  plane.format       = HostPixelFormat::U16Cfa;
+  const std::size_t bytes = plane.ByteCount();
+  auto storage = std::shared_ptr<std::byte>(new std::byte[bytes], [](std::byte* p) { delete[] p; });
+  auto* samples = reinterpret_cast<std::uint16_t*>(storage.get());
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      const int color = RgbColorAt(pattern, static_cast<int>(y), static_cast<int>(x));
+      const std::uint16_t base[3] = {4000, 5000, 3000};
+      samples[y * width + x] =
+          static_cast<std::uint16_t>(base[color] + ((7 * y + 3 * x) % 17) * 10);
+    }
+  }
+  plane.bytes = std::const_pointer_cast<const std::byte>(storage);
+  return plane;
+}
+
+inline auto MakeF32RgbaPlane(std::uint32_t width, std::uint32_t height) -> HostImagePlane {
+  HostImagePlane plane;
+  plane.extent       = Extent2D{width, height};
+  plane.stride_bytes = width * 16U;
+  plane.format       = HostPixelFormat::F32Rgba;
+  const std::size_t bytes = plane.ByteCount();
+  auto storage = std::shared_ptr<std::byte>(new std::byte[bytes], [](std::byte* p) { delete[] p; });
+  auto* px = reinterpret_cast<float*>(storage.get());
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      const std::size_t i = (static_cast<std::size_t>(y) * width + x) * 4;
+      px[i + 0] = (static_cast<float>(x) + 0.5f) / static_cast<float>(width);
+      px[i + 1] = (static_cast<float>(y) + 0.5f) / static_cast<float>(height);
+      px[i + 2] = 0.25f;
+      px[i + 3] = 1.0f;
+    }
+  }
+  plane.bytes = std::const_pointer_cast<const std::byte>(storage);
+  return plane;
+}
+
+inline auto FullSensor(std::uint32_t width, std::uint32_t height) -> RawSensorGeometry {
+  RawSensorGeometry sensor;
+  sensor.raw_width  = static_cast<std::int32_t>(width);
+  sensor.raw_height = static_cast<std::int32_t>(height);
+  sensor.width      = sensor.raw_width;
+  sensor.height     = sensor.raw_height;
+  return sensor;
+}
+
+}  // namespace gpu_dag_test
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/input/raw_input_loader_test.cpp
+++ b/alcedo_studio/tests/edit/input/raw_input_loader_test.cpp
@@ -1,0 +1,138 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "prepared_raw_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+TEST(GpuDagRawInput, RawInputLoaderUnpacksBeforePipelineBuild) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  EXPECT_FALSE(prepared.host_extent.Empty());
+  EXPECT_FALSE(plan.Contains(GpuPassKind::UploadRgb));
+  EXPECT_TRUE(plan.Contains(GpuPassKind::UploadRaw));
+  for (const auto& pass : plan.passes) {
+    const char* name = GpuPassKindName(pass.kind);
+    EXPECT_EQ(std::string(name).find("LibRaw"), std::string::npos);
+    EXPECT_EQ(std::string(name).find("DecodeRes"), std::string::npos);
+  }
+}
+
+TEST(GpuDagRawInput, RawInputLoaderDownsampleUpdatesCfaPatternAndPhase) {
+  const auto xtrans = gpu_dag_test::MakeXTransPattern();
+  const auto full = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, xtrans), xtrans, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  const auto half = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, xtrans), xtrans, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::HALF);
+
+  EXPECT_EQ(full.host_extent, (Extent2D{64, 64}));
+  EXPECT_EQ(half.host_extent, (Extent2D{32, 32}));
+  EXPECT_EQ(half.downsample_passes, 1);
+  EXPECT_NE(std::memcmp(full.cfa_pattern.xtrans_pattern.raw_fc, half.cfa_pattern.xtrans_pattern.raw_fc,
+                        sizeof(full.cfa_pattern.xtrans_pattern.raw_fc)),
+            0);
+
+  const auto bayer = gpu_dag_test::MakeRggbPattern();
+  const auto bayer_full = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, bayer), bayer, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  const auto bayer_half = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, bayer), bayer, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::HALF);
+  EXPECT_EQ(bayer_half.host_extent, (Extent2D{32, 32}));
+  EXPECT_EQ(std::memcmp(bayer_full.cfa_pattern.bayer_pattern.raw_fc,
+                        bayer_half.cfa_pattern.bayer_pattern.raw_fc,
+                        sizeof(bayer_full.cfa_pattern.bayer_pattern.raw_fc)),
+            0);
+}
+
+TEST(GpuDagRawInput, PreparedRawInputKeepsFullReferenceExtentAcrossDecodeRes) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto full = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  const auto half = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::HALF);
+
+  EXPECT_EQ(full.full_reference_extent, half.full_reference_extent);
+  EXPECT_NE(full.develop_output_extent, half.develop_output_extent);
+  EXPECT_EQ(full.full_reference_extent, full.develop_output_extent);
+}
+
+TEST(GpuDagRawInput, DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint) {
+  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(48, 32),
+                                                gpu_dag_test::FullSensor(48, 32));
+  EXPECT_EQ(prepared.input_kind, RawInputKind::DebayeredRgb);
+  EXPECT_EQ(prepared.CompileSource().kind, DevelopInputKind::DirectRgb);
+
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  EXPECT_TRUE(plan.Contains(GpuPassKind::UploadRgb));
+  EXPECT_FALSE(plan.Contains(GpuPassKind::UploadRaw));
+  EXPECT_FALSE(plan.Contains(GpuPassKind::Linearize));
+  EXPECT_FALSE(plan.Contains(GpuPassKind::Demosaic));
+}
+
+TEST(GpuDagRawInput, UnsupportedCfaDoesNotProducePreparedRawInput) {
+  RawCfaPattern bad;
+  bad.kind = RawCfaKind::Bayer2x2;
+  bad.bayer_pattern.raw_fc[0] = 0;
+  bad.bayer_pattern.raw_fc[1] = 0;
+  bad.bayer_pattern.raw_fc[2] = 0;
+  bad.bayer_pattern.raw_fc[3] = 0;
+  EXPECT_THROW(
+      {
+        auto prepared = RawInputLoader::FromUnpackedCfa(
+            gpu_dag_test::MakeU16CfaPlane(16, 16, bad), bad, gpu_dag_test::DefaultLinearization(),
+            gpu_dag_test::FullSensor(16, 16), DecodeRes::FULL);
+        (void)prepared;
+      },
+      std::runtime_error);
+
+  std::byte empty{};
+  EXPECT_FALSE(RawInputLoader::TryLoadEncoded(std::span<const std::byte>(&empty, 0), DecodeRes::FULL)
+                   .has_value());
+}
+
+TEST(GpuDagRawInput, InputHeadersDoNotIncludeGpuOrImageBuffer) {
+  const auto root = std::filesystem::path{ALCEDO_INPUT_HEADER_ROOT};
+  ASSERT_TRUE(std::filesystem::exists(root));
+  for (const auto& entry : std::filesystem::directory_iterator(root)) {
+    if (!entry.is_regular_file() || entry.path().extension() != ".hpp") {
+      continue;
+    }
+    std::ifstream input(entry.path());
+    std::string   line;
+    while (std::getline(input, line)) {
+      EXPECT_EQ(line.find("image_buffer.hpp"), std::string::npos) << entry.path();
+      EXPECT_EQ(line.find("cuda_runtime"), std::string::npos) << entry.path();
+    }
+  }
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
@@ -1,0 +1,200 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cmath>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/runtime/cuda/cuda_develop_pass.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/texture_format.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+class CudaDevelopFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasCudaDevice()) {
+      GTEST_SKIP() << "No CUDA device available.";
+    }
+  }
+};
+
+struct Rgba {
+  float r = 0.0f;
+  float g = 0.0f;
+  float b = 0.0f;
+  float a = 1.0f;
+};
+
+auto DownloadDevelop(CudaRenderDevice& device, const ExecutionPlan& plan) -> std::vector<Rgba> {
+  auto* lease = device.Workspace().Images().Find(plan.develop_output);
+  EXPECT_NE(lease, nullptr);
+  if (lease == nullptr) {
+    return {};
+  }
+  const auto& tex = lease->Texture();
+  std::vector<Rgba> pixels(static_cast<std::size_t>(tex.Width()) * tex.Height());
+  device.Workspace().Device().DownloadTexture2D(
+      tex,
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()), pixels.size() * sizeof(Rgba)),
+      device.CommandContext());
+  return pixels;
+}
+
+auto AllFiniteNonZero(const std::vector<Rgba>& pixels) -> bool {
+  bool any = false;
+  for (const auto& p : pixels) {
+    if (!std::isfinite(p.r) || !std::isfinite(p.g) || !std::isfinite(p.b) || !std::isfinite(p.a)) {
+      return false;
+    }
+    any = any || p.r != 0.0f || p.g != 0.0f || p.b != 0.0f;
+  }
+  return any;
+}
+
+}  // namespace
+
+TEST_F(CudaDevelopFixture, CudaDevelopProducesFiniteCameraSceneLinearRgbFromBayerInput) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  EXPECT_EQ(plan.source.kind, DevelopInputKind::BayerCfa);
+  EXPECT_LT(plan.IndexOf(GpuPassKind::Demosaic), plan.IndexOf(GpuPassKind::HighlightRecover));
+
+  CudaRenderDevice device;
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+
+  const auto pixels = DownloadDevelop(device, plan);
+  ASSERT_FALSE(pixels.empty());
+  EXPECT_TRUE(AllFiniteNonZero(pixels));
+  EXPECT_EQ(prepared.working_space, SceneWorkingSpace::CameraRgb);
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopProducesFiniteCameraSceneLinearRgbFromXTransInput) {
+  const auto pattern = gpu_dag_test::MakeXTransPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  EXPECT_EQ(plan.source.kind, DevelopInputKind::XTransCfa);
+
+  CudaRenderDevice device;
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+
+  const auto pixels = DownloadDevelop(device, plan);
+  ASSERT_FALSE(pixels.empty());
+  EXPECT_TRUE(AllFiniteNonZero(pixels));
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopUsesWorkspaceForAllTemporaryBuffers) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  CudaRenderDevice device;
+  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  EXPECT_GT(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
+  device.EndRender();
+  device.WaitIdle();
+  EXPECT_NE(device.Workspace().Images().Find(plan.develop_output), nullptr);
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopSecondRenderCreatesNoGpuAllocation) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  CudaRenderDevice device;
+  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+  device.Workspace().Device().ResetCounters();
+
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+
+  EXPECT_EQ(device.Workspace().Device().MallocCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().FreeCount(), 0U);
+}
+
+TEST_F(CudaDevelopFixture, DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint) {
+  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(32, 24),
+                                                gpu_dag_test::FullSensor(32, 24));
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  ASSERT_TRUE(plan.Contains(GpuPassKind::UploadRgb));
+
+  CudaRenderDevice device;
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+
+  const auto pixels = DownloadDevelop(device, plan);
+  ASSERT_EQ(pixels.size(), 32U * 24U);
+  EXPECT_NEAR(pixels.front().a, 1.0f, 1e-5f);
+  EXPECT_TRUE(std::isfinite(pixels.front().r));
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopUploadFailureRestoresDirtyAndDoesNotFallback) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  CudaRenderDevice device;
+  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+  device.Workspace().Device().FailNextUpload();
+  device.BeginRender();
+  EXPECT_THROW(ExecuteCudaDevelop(device, plan, prepared, document), std::runtime_error);
+  device.EndRender();
+  EXPECT_TRUE(document.Develop()->Params().IsDirty());
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -1,0 +1,73 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/pass_kind.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+TEST(GpuDagGraphCompiler, GraphCompilerEmitsNoLibRawOrDecodeResPass) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  for (const auto& pass : plan.passes) {
+    const std::string name = GpuPassKindName(pass.kind);
+    EXPECT_EQ(name.find("LibRaw"), std::string::npos);
+    EXPECT_EQ(name.find("DecodeRes"), std::string::npos);
+    EXPECT_EQ(name.find("CameraToAp1"), std::string::npos);
+    EXPECT_NE(pass.kind, static_cast<GpuPassKind>(255));
+  }
+  EXPECT_FALSE(plan.Contains(static_cast<GpuPassKind>(99)));
+}
+
+TEST(GpuDagGraphCompiler, GraphCompilerPlacesHighlightRecoverAfterDemosaic) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  const int demosaic = plan.IndexOf(GpuPassKind::Demosaic);
+  const int hlr      = plan.IndexOf(GpuPassKind::HighlightRecover);
+  ASSERT_GE(demosaic, 0);
+  ASSERT_GE(hlr, 0);
+  EXPECT_LT(demosaic, hlr);
+  EXPECT_LT(plan.IndexOf(GpuPassKind::Linearize), demosaic);
+  EXPECT_TRUE(plan.Contains(GpuPassKind::GeometryResample));
+}
+
+TEST(GpuDagGraphCompiler, HighlightFlagDoesNotChangePassList) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  document.Develop()->Params().ReplaceParams([] {
+    DevelopPayload p;
+    p.highlights_reconstruct = false;
+    return p;
+  }());
+  const auto plan =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  EXPECT_TRUE(plan.Contains(GpuPassKind::HighlightRecover));
+  EXPECT_TRUE(plan.Contains(GpuPassKind::CfaClamp));
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G3 complete (RenderGeometryResolver, TextureSamplingPlan, CUDA GeometryResamplePass). G4 not started.
+Status: G4 complete (CUDA Develop Endpoint, camera scene-linear RGB). G5 not started.
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2273,6 +2273,73 @@ DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint
 - GPU 不执行 RAW DecodeRes 降采样；
 - Develop 不调用 CPU 图像算子；
 - Develop 输出格式和色彩空间明确。
+
+##### Phase G4 completion record (2026-08-22)
+
+**Status:** complete — CUDA Develop Endpoint on `feature/gpu-dag-cuda-develop`. Output is **camera scene-linear RGBA32F**, not AP1. Camera-to-AP1 is deferred to G5 as a dedicated unmaskable CameraColor node so CCT changes do not dirty Develop / re-run demosaic.
+
+**Highlight recovery order:** CUDA full-frame (`ProcessCudaFullFrame`) is Linearize → (optional CFA Clamp01 when HLR is off) → Demosaic → HighlightRecover on RGB. The CPU path (`ApplyLinearization` → `ApplyHighlightReconstruct` → `ApplyDebayer`) is not the G4 reference. `GraphCompiler` emits `Demosaic` before `HighlightRecover`. Encoder matches CUDA: Bayer + HLR uses planar RCD then `ApplyHighlightCorrectionAndPackRGBAOriented`; Bayer without HLR clamps CFA then packs with inverse cam_mul; non-neural X-Trans always clamps CFA then `XTransToRGB_Ref`.
+
+**Primary success call chain:**
+
+```text
+RawInputLoader::FromUnpackedCfa | LoadEncoded | FromDirectRgb
+  -> PreparedRawInput (CPU unpack + DecodeRes downsample, LibRaw recycled)
+  -> GraphCompiler::Compile (Develop passes + GeometryResample; no LibRaw / DecodeRes / CameraToAp1)
+  -> CudaRenderDevice.BeginRender
+  -> ExecuteCudaDevelop (workspace transients + Images() RGBA32F)
+  -> Linearize -> Demosaic -> HighlightRecover (RGB) | InverseCamMulPack
+  -> GraphImageCache[develop/image] camera scene-linear RGBA32F
+  -> EndRender / WaitIdle
+```
+
+**Primary failure call chain:**
+
+```text
+CudaBackend::FailNextUpload
+  -> ExecuteCudaDevelop throws
+  -> PendingParameterPatch destructor RestoreDirty
+  -> Develop params remain dirty; no CPU Apply fallback
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `RawInputLoaderUnpacksBeforePipelineBuild` | `GpuDagRawInputTest` | PASS |
+| `RawInputLoaderDownsampleUpdatesCfaPatternAndPhase` | `GpuDagRawInputTest` | PASS |
+| `PreparedRawInputKeepsFullReferenceExtentAcrossDecodeRes` | `GpuDagRawInputTest` | PASS |
+| `DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint` | `GpuDagRawInputTest` + `GpuDagCudaDevelopTest` | PASS |
+| `GraphCompilerEmitsNoLibRawOrDecodeResPass` (also no CameraToAp1) | `GpuDagRawInputTest` | PASS |
+| `GraphCompilerPlacesHighlightRecoverAfterDemosaic` | `GpuDagRawInputTest` | PASS |
+| `CudaDevelopProducesFiniteAp1SceneLinearRgbFromBayerInput` mapped to `CudaDevelopProducesFiniteCameraSceneLinearRgbFromBayerInput` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopProducesFiniteAp1SceneLinearRgbFromXTransInput` mapped to `CudaDevelopProducesFiniteCameraSceneLinearRgbFromXTransInput` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopUsesWorkspaceForAllTemporaryBuffers` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopSecondRenderCreatesNoGpuAllocation` | `GpuDagCudaDevelopTest` | PASS |
+| Upload failure restores dirty; no CPU Apply | `GpuDagCudaDevelopTest` | PASS |
+| G1 `GpuDagModelGraphTest` regression | `GpuDagModelGraphTest` | PASS |
+| G2 `GpuDagCudaWorkspaceTest` regression | `GpuDagCudaWorkspaceTest` | PASS |
+| G3 `GpuDagGeometryTest` / `GpuDagCudaGeometryTest` regression | those binaries | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagRawInputTest GpuDagCudaDevelopTest GpuDagModelGraphTest GpuDagCudaWorkspaceTest GpuDagGeometryTest GpuDagCudaGeometryTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "GpuDagRawInputTest|GpuDagCudaDevelopTest|GpuDagModelGraphTest|GpuDagCudaWorkspaceTest|GpuDagGeometryTest|GpuDagCudaGeometryTest"
+```
+
+Suite totals: `9/9` GpuDagRawInputTest PASS. `6/6` GpuDagCudaDevelopTest PASS. `17/17` GpuDagModelGraphTest PASS. `12/12` GpuDagCudaWorkspaceTest PASS. `12/12` GpuDagGeometryTest PASS. `1/1` GpuDagCudaGeometryTest PASS. Combined `57/57` PASS.
+
+**Checklist / exit condition:** ExecutionPlan has no LibRaw or DecodeRes pass. GPU does not downsample RAW. Develop does not call CPU image operators. Output format is RGBA32F camera scene-linear (`SceneWorkingSpace::CameraRgb`). Product `PipelineMgmtService` and old `RawDecodeOp` / `RawProcessor` are unchanged.
+
+**LOC note (grill-code-review):** `raw_input_loader.cpp` 396 lines. `cuda_develop_pass.cpp` 197 lines. `graph_compiler.cpp` 102 lines. No changed file exceeds 1000 LOC.
+
+**Remaining gaps:** Camera-to-AP1 and CAT02 stay in G5 (four-node graph: Develop → CameraColor → ColorGrade → DRT). NeuralEngine demosaic is not executed in G4 (Legacy RCD / `XTransToRGB_Ref` only). Lensfun is a no-op unless DNG warp is present; G4 tests do not cover DNG warp. Full-frame only (no 9000px tiled path). DemosaicNet arena is not unified with workspace.
+
+**Files added:** `include/edit/input/*`, `edit/input/raw_input_loader.cpp`, `include/edit/runtime/{pass_kind,execution_plan,graph_compiler,render_context,develop_compile_source,graph_image_cache}.hpp`, `edit/runtime/graph_compiler.cpp`, `include/edit/runtime/cuda/cuda_develop_pass.hpp`, `edit/runtime/cuda/cuda_develop_pass.cpp`, `include/decoders/processor/raw_linearization_params.hpp`, G4 tests under `tests/edit/input` and `tests/edit/runtime`.
+
+**Open work:** G5 CUDA Primary Color Grade plus CameraColor node.
 
 ## 38. Phase G5 — CUDA Primary Color Grade
 


### PR DESCRIPTION
## Summary

- Add `RawInputLoader` and `PreparedRawInput` so LibRaw unpack and RAW downsampling finish before the edit plan is built.
- Add `GraphCompiler`, the initial execution plan, graph image cache, and the CUDA Develop endpoint.
- Produce camera scene-linear RGBA32F on CUDA with no CPU pixel-processing fallback.

## Stack

Layer G4 of GitHub stack #99.

- Base: #96
- Next layer: #98

## Validation

- RAW input tests: 9/9 passed.
- CUDA Develop tests: 6/6 passed.
- Combined G1–G4 regression: 57/57 passed.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
