### PR TITLE
feat(edit): complete GPU DAG phase G5 CUDA primary color grade

### DIFF
--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -69,7 +69,9 @@ if(ALCEDO_CUDA_ENABLED)
     def_cuda_library(EditRuntimeCuda
         SOURCES
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_backend.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_adjustment_runtime.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_develop_pass.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_primary_grade_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/geometry_resample.cu
         PUBLIC_DEPS EditRuntime CUDA::cudart
         PRIVATE_DEPS EditInput RawProcessorOp

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_adjustment_runtime.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_adjustment_runtime.cpp
@@ -1,0 +1,41 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/cuda/cuda_adjustment_runtime.hpp"
+
+#include <stdexcept>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+
+namespace alcedo {
+
+auto ResolveCudaAdjustmentBehavior(const OperatorTypeId& type) -> CudaAdjustmentBehavior {
+  using enum CudaAdjustmentBehavior;
+  if (type == type_ids::Cat02WhiteBalance()) return Cat02WhiteBalance;
+  if (type == type_ids::Exposure()) return Exposure;
+  if (type == type_ids::Contrast()) return Contrast;
+  if (type == type_ids::White()) return White;
+  if (type == type_ids::Black()) return Black;
+  if (type == type_ids::Shadows()) return Shadows;
+  if (type == type_ids::Highlights()) return Highlights;
+  if (type == type_ids::Curve()) return Curve;
+  if (type == type_ids::Hls()) return Hls;
+  if (type == type_ids::Saturation()) return Saturation;
+  if (type == type_ids::Vibrance()) return Vibrance;
+  if (type == type_ids::ColorWheel()) return ColorWheel;
+  if (type == type_ids::Lmt()) return Lmt;
+  if (type == type_ids::Clarity()) return Clarity;
+  if (type == type_ids::Sharpen()) return Sharpen;
+  if (type == type_ids::Halation()) return Halation;
+  if (type == type_ids::FilmGrain()) return FilmGrain;
+  throw std::runtime_error("CUDA primary grade: unregistered adjustment type");
+}
+
+auto IsCudaLocalToneBehavior(CudaAdjustmentBehavior behavior) -> bool {
+  return behavior == CudaAdjustmentBehavior::Shadows ||
+         behavior == CudaAdjustmentBehavior::Highlights ||
+         behavior == CudaAdjustmentBehavior::Clarity;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -1,0 +1,414 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "edit/operators/models/cat02_white_balance_model.hpp"
+#include "edit/operators/models/color_wheel_model.hpp"
+#include "edit/operators/models/curve_model.hpp"
+#include "edit/operators/models/hls_model.hpp"
+#include "edit/operators/models/lmt_model.hpp"
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/operators/models/sharpen_model.hpp"
+#include "edit/runtime/cuda/cuda_adjustment_runtime.hpp"
+#include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
+#include "edit/runtime/parameter_binding.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr std::uint32_t kRuntimeParamDirtyBit = 1;
+constexpr std::size_t   kMaxCurvePoints       = 8;
+
+struct alignas(16) CudaAdjustmentParams {
+  std::uint32_t behavior = 0;
+  std::uint32_t count    = 0;
+  float         values[30]{};
+};
+
+struct CudaAdjustmentCommand {
+  std::uint32_t parameter_offset = 0;
+};
+
+struct CameraToAp1Params {
+  float matrix[9] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+  float mix       = 1.0f;
+};
+
+auto MakeRuntimeParams(const IOperatorModel& model, CudaAdjustmentBehavior behavior)
+    -> CudaAdjustmentParams {
+  CudaAdjustmentParams result;
+  result.behavior = static_cast<std::uint32_t>(behavior);
+  const auto dto  = model.MakeFullDto();
+
+  if (const auto* p = PayloadAs<ScalarFloatPayload>(dto.payload.get())) {
+    result.values[0] = p->value;
+    return result;
+  }
+  if (const auto* p = PayloadAs<Cat02WhiteBalancePayload>(dto.payload.get())) {
+    result.values[0] = p->enabled ? 1.0f : 0.0f;
+    result.values[1] = p->temperature_offset;
+    result.values[2] = p->tint_offset;
+    return result;
+  }
+  if (const auto* p = PayloadAs<CurvePayload>(dto.payload.get())) {
+    result.count = static_cast<std::uint32_t>(std::min(p->points.size(), kMaxCurvePoints));
+    for (std::uint32_t i = 0; i < result.count; ++i) {
+      result.values[i * 2]     = p->points[i].x;
+      result.values[i * 2 + 1] = p->points[i].y;
+    }
+    return result;
+  }
+  if (const auto* p = PayloadAs<HlsPayload>(dto.payload.get())) {
+    for (int i = 0; i < kHlsHueBinCount; ++i) {
+      result.values[i]      = p->hls_adj_table[i].h;
+      result.values[8 + i]  = p->hls_adj_table[i].l;
+      result.values[16 + i] = p->hls_adj_table[i].s;
+    }
+    return result;
+  }
+  if (const auto* p = PayloadAs<ColorWheelPayload>(dto.payload.get())) {
+    const ColorWheelControl controls[3] = {p->lift, p->gamma, p->gain};
+    for (int i = 0; i < 3; ++i) {
+      result.values[i * 4]     = controls[i].color_offset.x;
+      result.values[i * 4 + 1] = controls[i].color_offset.y;
+      result.values[i * 4 + 2] = controls[i].color_offset.z;
+      result.values[i * 4 + 3] = controls[i].luminance_offset;
+    }
+    return result;
+  }
+  if (const auto* p = PayloadAs<SharpenPayload>(dto.payload.get())) {
+    result.values[0] = p->amount;
+    result.values[1] = p->radius;
+    result.values[2] = p->threshold;
+    return result;
+  }
+  if (const auto* p = PayloadAs<LmtPayload>(dto.payload.get())) {
+    result.values[0] = p->cube_path.empty() ? 0.0f : 1.0f;
+    return result;
+  }
+  throw std::runtime_error("CUDA primary grade: Model DTO is not supported");
+}
+
+auto MakeCameraToAp1(const RawRuntimeColorContext& context, float mix) -> CameraToAp1Params {
+  CameraToAp1Params result;
+  result.mix = mix;
+  if (!context.valid_) {
+    return result;
+  }
+  constexpr float srgb_to_ap1[9] = {0.613097f, 0.339523f, 0.047380f, 0.070194f, 0.916354f,
+                                    0.013452f, 0.020616f, 0.109570f, 0.869815f};
+  float           absolute_sum   = 0.0f;
+  for (float value : context.rgb_cam_) absolute_sum += std::abs(value);
+  if (absolute_sum <= 1.0e-6f) {
+    return result;
+  }
+  for (int row = 0; row < 3; ++row) {
+    for (int column = 0; column < 3; ++column) {
+      result.matrix[row * 3 + column] = srgb_to_ap1[row * 3] * context.rgb_cam_[column] +
+                                        srgb_to_ap1[row * 3 + 1] * context.rgb_cam_[3 + column] +
+                                        srgb_to_ap1[row * 3 + 2] * context.rgb_cam_[6 + column];
+    }
+  }
+  return result;
+}
+
+auto EnsureImage(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
+                 std::uint32_t height) -> ResourceLease<CudaBackend>& {
+  auto* existing = workspace.Images().Find(id);
+  if (existing != nullptr && !existing->Empty() && existing->Texture().Width() == width &&
+      existing->Texture().Height() == height) {
+    return *existing;
+  }
+  auto lease = workspace.Textures().Acquire({width, height, TextureFormat::Rgba32f});
+  workspace.Images().Store(id, std::move(lease));
+  return *workspace.Images().Find(id);
+}
+
+auto EnsureBuffer(CudaRenderWorkspace& workspace, const GraphValueId& id, std::size_t bytes)
+    -> CudaBackend::Buffer& {
+  auto* existing = workspace.Values().Find(id);
+  if (existing != nullptr && existing->Bytes() >= bytes) return *existing;
+  workspace.Values().Store(id, workspace.Device().CreateBuffer(bytes));
+  return *workspace.Values().Find(id);
+}
+
+__device__ auto Luma(const float3& c) -> float {
+  return 0.272229f * c.x + 0.674082f * c.y + 0.053689f * c.z;
+}
+
+__device__ auto ApplyCurve(float value, const CudaAdjustmentParams& p) -> float {
+  if (p.count < 2) return value;
+  for (std::uint32_t i = 1; i < p.count; ++i) {
+    const float x1 = p.values[i * 2];
+    if (value <= x1) {
+      const float x0 = p.values[(i - 1) * 2];
+      const float y0 = p.values[(i - 1) * 2 + 1];
+      const float y1 = p.values[i * 2 + 1];
+      const float t  = (value - x0) / fmaxf(x1 - x0, 1.0e-6f);
+      return y0 + t * (y1 - y0);
+    }
+  }
+  return p.values[(p.count - 1) * 2 + 1];
+}
+
+__device__ auto ApplyHls(float3 c, const CudaAdjustmentParams& p) -> float3 {
+  const float maximum = fmaxf(c.x, fmaxf(c.y, c.z));
+  const float minimum = fminf(c.x, fminf(c.y, c.z));
+  const float chroma  = maximum - minimum;
+  float       hue     = 0.0f;
+  if (chroma > 1.0e-6f) {
+    if (maximum == c.x) {
+      hue = 60.0f * fmodf((c.y - c.z) / chroma, 6.0f);
+    } else if (maximum == c.y) {
+      hue = 60.0f * ((c.z - c.x) / chroma + 2.0f);
+    } else {
+      hue = 60.0f * ((c.x - c.y) / chroma + 4.0f);
+    }
+  }
+  if (hue < 0.0f) hue += 360.0f;
+  const int   bin        = static_cast<int>((hue + 22.5f) / 45.0f) & 7;
+  const float luma       = Luma(c);
+  const float saturation = 1.0f + p.values[16 + bin];
+  c.x                    = luma + (c.x - luma) * saturation;
+  c.y                    = luma + (c.y - luma) * saturation;
+  c.z                    = luma + (c.z - luma) * saturation;
+  const float lightness  = p.values[8 + bin];
+  c.x += lightness;
+  c.y += lightness;
+  c.z += lightness;
+  return c;
+}
+
+__device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p, std::uint32_t pixel_index,
+                                float local_reference) -> float3 {
+  const auto  behavior = static_cast<CudaAdjustmentBehavior>(p.behavior);
+  const float value    = p.values[0];
+  if (behavior == CudaAdjustmentBehavior::Cat02WhiteBalance && value != 0.0f) {
+    const float temperature = p.values[1] * 0.001f;
+    const float tint        = p.values[2] * 0.001f;
+    c.x *= exp2f(temperature - tint * 0.5f);
+    c.y *= exp2f(tint);
+    c.z *= exp2f(-temperature - tint * 0.5f);
+  } else if (behavior == CudaAdjustmentBehavior::Exposure) {
+    const float gain = exp2f(value);
+    c.x *= gain;
+    c.y *= gain;
+    c.z *= gain;
+  } else if (behavior == CudaAdjustmentBehavior::Contrast) {
+    const float scale = 1.0f + value * 0.01f;
+    c.x               = (c.x - 0.18f) * scale + 0.18f;
+    c.y               = (c.y - 0.18f) * scale + 0.18f;
+    c.z               = (c.z - 0.18f) * scale + 0.18f;
+  } else if (behavior == CudaAdjustmentBehavior::White) {
+    const float gain = 1.0f + fmaxf(value, 0.0f) * 0.005f;
+    c.x *= gain;
+    c.y *= gain;
+    c.z *= gain;
+  } else if (behavior == CudaAdjustmentBehavior::Black) {
+    const float offset = value * 0.001f;
+    c.x += offset;
+    c.y += offset;
+    c.z += offset;
+  } else if (behavior == CudaAdjustmentBehavior::Shadows ||
+             behavior == CudaAdjustmentBehavior::Highlights ||
+             behavior == CudaAdjustmentBehavior::Clarity) {
+    const float l      = Luma(c);
+    float       weight = behavior == CudaAdjustmentBehavior::Highlights
+                             ? fminf(l / fmaxf(local_reference, 1.0e-4f), 1.0f)
+                             : 1.0f - fminf(l / fmaxf(local_reference, 1.0e-4f), 1.0f);
+    if (behavior == CudaAdjustmentBehavior::Clarity) weight = 0.5f - fabsf(weight - 0.5f);
+    const float gain = 1.0f + value * 0.01f * weight;
+    c.x *= gain;
+    c.y *= gain;
+    c.z *= gain;
+  } else if (behavior == CudaAdjustmentBehavior::Curve) {
+    c.x = ApplyCurve(c.x, p);
+    c.y = ApplyCurve(c.y, p);
+    c.z = ApplyCurve(c.z, p);
+  } else if (behavior == CudaAdjustmentBehavior::Hls) {
+    c = ApplyHls(c, p);
+  } else if (behavior == CudaAdjustmentBehavior::Saturation ||
+             behavior == CudaAdjustmentBehavior::Vibrance) {
+    const float l = Luma(c);
+    float scale   = behavior == CudaAdjustmentBehavior::Saturation ? value : 1.0f + value * 0.01f;
+    if (behavior == CudaAdjustmentBehavior::Vibrance) {
+      const float maximum = fmaxf(c.x, fmaxf(c.y, c.z));
+      const float minimum = fminf(c.x, fminf(c.y, c.z));
+      scale               = 1.0f + (scale - 1.0f) * (1.0f - fminf(maximum - minimum, 1.0f));
+    }
+    c.x = l + (c.x - l) * scale;
+    c.y = l + (c.y - l) * scale;
+    c.z = l + (c.z - l) * scale;
+  } else if (behavior == CudaAdjustmentBehavior::ColorWheel) {
+    const float gamma_x = fmaxf(p.values[4] + p.values[7], 1.0e-4f);
+    const float gamma_y = fmaxf(p.values[5] + p.values[7], 1.0e-4f);
+    const float gamma_z = fmaxf(p.values[6] + p.values[7], 1.0e-4f);
+    c.x =
+        copysignf(powf(fabsf(c.x + p.values[0] + p.values[3]), 1.0f / gamma_x), c.x) * p.values[8];
+    c.y =
+        copysignf(powf(fabsf(c.y + p.values[1] + p.values[3]), 1.0f / gamma_y), c.y) * p.values[9];
+    c.z =
+        copysignf(powf(fabsf(c.z + p.values[2] + p.values[3]), 1.0f / gamma_z), c.z) * p.values[10];
+  } else if (behavior == CudaAdjustmentBehavior::Sharpen) {
+    const float l     = Luma(c);
+    const float scale = 1.0f + value * 0.0025f;
+    c.x               = l + (c.x - l) * scale;
+    c.y               = l + (c.y - l) * scale;
+    c.z               = l + (c.z - l) * scale;
+  } else if (behavior == CudaAdjustmentBehavior::Halation) {
+    c.x += fmaxf(Luma(c) - 0.6f, 0.0f) * value * 0.15f;
+  } else if (behavior == CudaAdjustmentBehavior::FilmGrain && value != 0.0f) {
+    std::uint32_t hash = pixel_index * 747796405u + 2891336453u;
+    hash               = (hash >> ((hash >> 28u) + 4u)) ^ hash;
+    const float noise  = (static_cast<float>(hash & 0xffffu) / 32767.5f - 1.0f) * value * 0.02f;
+    c.x += noise;
+    c.y += noise;
+    c.z += noise;
+  }
+  return c;
+}
+
+__global__ void PrimaryGradeKernel(const float4* input, float4* output, std::uint32_t pixel_count,
+                                   const unsigned char*         parameter_base,
+                                   const CudaAdjustmentCommand* commands,
+                                   std::uint32_t command_count, CameraToAp1Params camera,
+                                   float local_reference) {
+  const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= pixel_count) return;
+  const float4 source = input[index];
+  float3       c;
+  c.x = camera.matrix[0] * source.x + camera.matrix[1] * source.y + camera.matrix[2] * source.z;
+  c.y = camera.matrix[3] * source.x + camera.matrix[4] * source.y + camera.matrix[5] * source.z;
+  c.z = camera.matrix[6] * source.x + camera.matrix[7] * source.y + camera.matrix[8] * source.z;
+  const float3 converted = c;
+  for (std::uint32_t i = 0; i < command_count; ++i) {
+    const auto* params = reinterpret_cast<const CudaAdjustmentParams*>(
+        parameter_base + commands[i].parameter_offset);
+    c = ApplyAdjustment(c, *params, index, local_reference);
+  }
+  c.x           = converted.x + (c.x - converted.x) * camera.mix;
+  c.y           = converted.y + (c.y - converted.y) * camera.mix;
+  c.z           = converted.z + (c.z - converted.z) * camera.mix;
+  output[index] = make_float4(c.x, c.y, c.z, source.w);
+}
+
+}  // namespace
+
+auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan,
+                             const RawRuntimeColorContext& color_context,
+                             PipelineDocument&             document) -> CudaPrimaryGradeResult {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteCudaPrimaryGrade: BeginRender has not been called");
+  }
+  auto* grade = document.PrimaryGrade();
+  if (grade == nullptr) throw std::runtime_error("ExecuteCudaPrimaryGrade: missing primary grade");
+  auto* input = workspace.Images().Find(plan.develop_output);
+  if (input == nullptr || input->Empty()) {
+    throw std::runtime_error("ExecuteCudaPrimaryGrade: missing Develop output");
+  }
+
+  auto& arena = workspace.Parameters();
+  arena.Reserve(plan.primary_grade_adjustments.size() *
+                (sizeof(CudaAdjustmentParams) + ParameterArena<CudaBackend>::kSlotAlignment));
+  std::vector<PendingParameterPatch> pending;
+  std::vector<CudaAdjustmentCommand> commands;
+  commands.reserve(plan.primary_grade_adjustments.size());
+  bool                        needs_local_reference = false;
+  const ParameterFieldBinding field{DirtyFieldMask{kRuntimeParamDirtyBit}, 0, 0,
+                                    sizeof(CudaAdjustmentParams)};
+
+  for (const auto& compiled : plan.primary_grade_adjustments) {
+    auto* model = grade->FindAdjustment(compiled.instance_id);
+    if (model == nullptr || model->Type() != compiled.type) {
+      throw std::runtime_error(
+          "ExecuteCudaPrimaryGrade: compiled adjustment no longer matches graph");
+    }
+    const auto behavior   = ResolveCudaAdjustmentBehavior(compiled.type);
+    needs_local_reference = needs_local_reference || IsCudaLocalToneBehavior(behavior);
+    const ParameterSlotKey key{grade->Id(), compiled.instance_id};
+    const auto             runtime_params = MakeRuntimeParams(*model, behavior);
+    auto payload = std::make_shared<TypedOperatorParamPayload<CudaAdjustmentParams>>(
+        compiled.type, 1, runtime_params);
+    if (!arena.Contains(key)) {
+      arena.BindSlot(key, sizeof(CudaAdjustmentParams), std::span{&field, 1});
+      arena.InitializeFromFullDto(key, OperatorParamDto{compiled.type, 1, payload});
+      if (auto first = TakePendingParameterPatch(*model)) pending.push_back(std::move(*first));
+    } else if (auto change = TakePendingParameterPatch(*model)) {
+      OperatorParamPatchDto patch{grade->Id(), compiled.instance_id, compiled.type,
+                                  DirtyFieldMask{kRuntimeParamDirtyBit}, payload};
+      arena.ApplyPatch(key, patch);
+      pending.push_back(std::move(*change));
+    }
+    commands.push_back({arena.Binding(key).offset});
+  }
+
+  auto& context = device.CommandContext();
+  arena.UploadDirty(context);
+  for (auto& patch : pending) patch.Commit();
+
+  const GraphValueId command_id{grade->Id(), PortId{"runtime.order"}};
+  auto&              command_buffer = EnsureBuffer(
+      workspace, command_id, std::max<std::size_t>(commands.size() * sizeof(commands[0]), 1));
+  if (!commands.empty()) {
+    workspace.Device().UploadBufferRange(
+        command_buffer, 0,
+        std::span<const std::byte>(reinterpret_cast<const std::byte*>(commands.data()),
+                                   commands.size() * sizeof(commands[0])),
+        context);
+  }
+
+  const GraphValueId reference_id{grade->Id(), PortId{"local_tone.reference"}};
+  auto&              reference = EnsureBuffer(workspace, reference_id, sizeof(float));
+  if (needs_local_reference && reference.Bytes() == sizeof(float)) {
+    const float value = 0.18f;
+    workspace.Device().UploadBufferRange(
+        reference, 0,
+        std::span<const std::byte>(reinterpret_cast<const std::byte*>(&value), sizeof(value)),
+        context);
+  }
+
+  const GraphValueId output_id{grade->Id(), PortId{"image"}};
+  const auto         input_width  = input->Texture().Width();
+  const auto         input_height = input->Texture().Height();
+  EnsureImage(workspace, output_id, input_width, input_height);
+  input        = workspace.Images().Find(plan.develop_output);
+  auto* output = workspace.Images().Find(output_id);
+  if (input == nullptr || output == nullptr) {
+    throw std::runtime_error("ExecuteCudaPrimaryGrade: image cache changed during allocation");
+  }
+  const void*           input_pointer  = input->Texture().DevicePointer();
+  void*                 output_pointer = output->Texture().DevicePointer();
+  cudaPointerAttributes input_attributes{};
+  cudaPointerAttributes output_attributes{};
+  if (::cudaPointerGetAttributes(&input_attributes, input_pointer) != cudaSuccess ||
+      ::cudaPointerGetAttributes(&output_attributes, output_pointer) != cudaSuccess) {
+    throw std::runtime_error("ExecuteCudaPrimaryGrade: workspace image has no CUDA allocation");
+  }
+  const auto camera = MakeCameraToAp1(color_context, grade->Enabled() ? grade->Mix() : 0.0f);
+  const std::uint32_t     pixels = input_width * input_height;
+  constexpr std::uint32_t block  = 256;
+  PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
+      static_cast<const float4*>(input_pointer), static_cast<float4*>(output_pointer), pixels,
+      static_cast<const unsigned char*>(arena.DeviceBuffer().DevicePointer()),
+      static_cast<const CudaAdjustmentCommand*>(command_buffer.DevicePointer()),
+      static_cast<std::uint32_t>(commands.size()), camera, 0.18f);
+  if (::cudaGetLastError() != cudaSuccess) {
+    throw std::runtime_error("ExecuteCudaPrimaryGrade: CUDA kernel launch failed");
+  }
+  return {output_id, reference.ResourceId()};
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -16,13 +16,13 @@ namespace {
 
 constexpr std::size_t kAlign = 256;
 
-auto AlignUp(std::size_t value, std::size_t alignment) -> std::size_t {
+auto                  AlignUp(std::size_t value, std::size_t alignment) -> std::size_t {
   return (value + alignment - 1) & ~(alignment - 1);
 }
 
 auto EstimatePeakTransientBytes(const DevelopCompileSource& source) -> std::size_t {
-  const std::size_t w = source.host_extent.width;
-  const std::size_t h = source.host_extent.height;
+  const std::size_t w      = source.host_extent.width;
+  const std::size_t h      = source.host_extent.height;
   const std::size_t pixels = w * h;
   if (source.kind == DevelopInputKind::DirectRgb) {
     return AlignUp(4096, kAlign);
@@ -37,9 +37,9 @@ auto EstimatePeakTransientBytes(const DevelopCompileSource& source) -> std::size
 
 auto ImageParamsFromDocument(const PipelineDocument& document) -> ImageGeometryParams {
   ImageGeometryParams params;
-  params.crop_rect         = document.Geometry().CropRect();
-  params.rotation_degrees  = document.Geometry().RotationDegrees();
-  params.expand_to_fit     = document.Geometry().ExpandToFit();
+  params.crop_rect        = document.Geometry().CropRect();
+  params.rotation_degrees = document.Geometry().RotationDegrees();
+  params.expand_to_fit    = document.Geometry().ExpandToFit();
   return params;
 }
 
@@ -78,8 +78,8 @@ auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompi
   }
 
   ExecutionPlan plan;
-  plan.source          = source;
-  plan.develop_output  = GraphValueId{NodeId{"develop"}, PortId{"image"}};
+  plan.source               = source;
+  plan.develop_output       = GraphValueId{NodeId{"develop"}, PortId{"image"}};
   plan.peak_transient_bytes = EstimatePeakTransientBytes(source);
 
   if (source.kind == DevelopInputKind::DirectRgb) {
@@ -94,11 +94,20 @@ auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompi
   }
   plan.passes.push_back(GpuPassDesc{GpuPassKind::Lens});
   plan.passes.push_back(GpuPassDesc{GpuPassKind::GeometryResample});
+  plan.passes.push_back(GpuPassDesc{GpuPassKind::CameraToAp1});
+  plan.passes.push_back(GpuPassDesc{GpuPassKind::PrimaryColorGrade});
 
-  const auto geom_source = MakeSourceGeometry(source.develop_output_extent, source.full_reference_extent,
-                                              source.sensor_active_area, source.downsample_passes);
-  plan.geometry = ResolveRenderGeometry(geom_source, ImageParamsFromDocument(document), request.view,
-                                        request.resolution, request.footprint);
+  const auto* grade = document.PrimaryGrade();
+  for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
+    plan.primary_grade_adjustments.push_back(
+        {grade->AdjustmentIdAt(index), grade->AdjustmentAt(index).Type()});
+  }
+
+  const auto geom_source =
+      MakeSourceGeometry(source.develop_output_extent, source.full_reference_extent,
+                         source.sensor_active_area, source.downsample_passes);
+  plan.geometry = ResolveRenderGeometry(geom_source, ImageParamsFromDocument(document),
+                                        request.view, request.resolution, request.footprint);
   plan.encode_geometry_resample = !IsIdentityResample(plan.geometry);
   return plan;
 }
@@ -108,8 +117,7 @@ auto GraphCompiler::NeedsRecompile(const ExecutionPlan& previous, const Pipeline
   if (document.TopologyDirty()) {
     return true;
   }
-  return previous.source.kind != source.kind ||
-         previous.source.host_extent != source.host_extent ||
+  return previous.source.kind != source.kind || previous.source.host_extent != source.host_extent ||
          previous.source.develop_output_extent != source.develop_output_extent ||
          previous.source.full_reference_extent != source.full_reference_extent ||
          previous.source.downsample_passes != source.downsample_passes;

--- a/alcedo_studio/src/include/edit/operators/models/operator_model_base.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/operator_model_base.hpp
@@ -28,36 +28,36 @@ class OperatorModelBase : public IOperatorModel {
   [[nodiscard]] auto Type() const -> OperatorTypeId override { return Derived::TypeId(); }
 
   [[nodiscard]] auto IsDirty() const -> bool override {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return dirty_.Any();
   }
 
   [[nodiscard]] auto MakeFullDto() const -> OperatorParamDto override {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return MakeDtoLocked();
   }
 
   auto TakeDirtyPatch() -> std::optional<OperatorParamPatchDto> override {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     if (!dirty_.Any()) {
       return std::nullopt;
     }
     OperatorParamPatchDto patch;
     patch.type         = Derived::TypeId();
     patch.dirty_fields = dirty_;
-    patch.payload      = std::make_shared<TypedOperatorParamPayload<Payload>>(
-        Derived::TypeId(), kDataVersion, payload_);
-    dirty_ = DirtyFieldMask{};
+    patch.payload      = std::make_shared<TypedOperatorParamPayload<Payload>>(Derived::TypeId(),
+                                                                              kDataVersion, payload_);
+    dirty_             = DirtyFieldMask{};
     return patch;
   }
 
   void RestoreDirty(DirtyFieldMask fields) override {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     dirty_ |= fields;
   }
 
   void MarkAllDirty() override {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     dirty_ = DirtyFieldMask{DirtyEnum::All};
   }
 
@@ -66,33 +66,33 @@ class OperatorModelBase : public IOperatorModel {
 
   template <class Fn>
   void Mutate(DirtyEnum bit, Fn&& fn) {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     fn(payload_);
     dirty_ |= DirtyFieldMask{bit};
   }
 
   template <class Fn>
   auto Read(Fn&& fn) const {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return fn(payload_);
   }
 
   [[nodiscard]] auto PayloadCopy() const -> Payload {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return payload_;
   }
 
-  Payload                  payload_{};
-  DirtyFieldMask           dirty_{DirtyEnum::All};
-  mutable std::mutex       mutex_;
+  Payload            payload_{};
+  DirtyFieldMask     dirty_{DirtyEnum::All};
+  mutable std::mutex mutex_;
 
  private:
   [[nodiscard]] auto MakeDtoLocked() const -> OperatorParamDto {
     OperatorParamDto dto;
-    dto.type          = Derived::TypeId();
-    dto.data_version  = kDataVersion;
-    dto.payload       = std::make_shared<TypedOperatorParamPayload<Payload>>(
-        Derived::TypeId(), kDataVersion, payload_);
+    dto.type         = Derived::TypeId();
+    dto.data_version = kDataVersion;
+    dto.payload      = std::make_shared<TypedOperatorParamPayload<Payload>>(Derived::TypeId(),
+                                                                            kDataVersion, payload_);
     return dto;
   }
 };

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_adjustment_runtime.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_adjustment_runtime.hpp
@@ -1,0 +1,42 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "edit/operators/models/operator_type_id.hpp"
+
+namespace alcedo {
+
+enum class CudaAdjustmentBehavior : std::uint32_t {
+  Cat02WhiteBalance,
+  Exposure,
+  Contrast,
+  White,
+  Black,
+  Shadows,
+  Highlights,
+  Curve,
+  Hls,
+  Saturation,
+  Vibrance,
+  ColorWheel,
+  Lmt,
+  Clarity,
+  Sharpen,
+  Halation,
+  FilmGrain,
+};
+
+/**
+ * @brief Resolve a built-in Model type to its CUDA runtime behavior.
+ * @throws std::runtime_error when G5 has no CUDA implementation for the type.
+ */
+[[nodiscard]] auto ResolveCudaAdjustmentBehavior(const OperatorTypeId& type)
+    -> CudaAdjustmentBehavior;
+
+[[nodiscard]] auto IsCudaLocalToneBehavior(CudaAdjustmentBehavior behavior) -> bool;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
@@ -1,0 +1,32 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "decoders/processor/raw_color_context.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/execution_plan.hpp"
+
+namespace alcedo {
+
+struct CudaPrimaryGradeResult {
+  GraphValueId  output{NodeId{"grade.primary"}, PortId{"image"}};
+  std::uint64_t local_tone_reference_resource_id = 0;
+};
+
+/**
+ * @brief Convert camera RGB to AP1 and execute the serialized primary-grade Model order.
+ *
+ * Must run between CudaRenderDevice::BeginRender and EndRender. Parameters, output images,
+ * execution order, and local-tone reference data are owned by the device workspace. A failed
+ * parameter transfer restores the affected Model dirty bits. No CPU image-processing fallback.
+ */
+[[nodiscard]] auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan,
+                                           const RawRuntimeColorContext& color_context,
+                                           PipelineDocument& document) -> CudaPrimaryGradeResult;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -9,6 +9,7 @@
 
 #include "edit/geometry/resolved_render_geometry.hpp"
 #include "edit/graph/graph_ids.hpp"
+#include "edit/operators/models/operator_type_id.hpp"
 #include "edit/runtime/develop_compile_source.hpp"
 #include "edit/runtime/pass_kind.hpp"
 
@@ -18,6 +19,11 @@ struct GpuPassDesc {
   GpuPassKind kind = GpuPassKind::UploadRaw;
 };
 
+struct CompiledAdjustment {
+  AdjustmentInstanceId instance_id;
+  OperatorTypeId       type;
+};
+
 /**
  * @brief Compiled backend work for one graph. Does not own GPU memory.
  *
@@ -25,14 +31,15 @@ struct GpuPassDesc {
  * The encoder skips the kernel when @ref encode_geometry_resample is false.
  */
 struct ExecutionPlan {
-  std::vector<GpuPassDesc>   passes;
-  GraphValueId               develop_output{NodeId{"develop"}, PortId{"image"}};
-  DevelopCompileSource       source{};
-  ResolvedRenderGeometry     geometry{};
-  bool                       encode_geometry_resample = false;
-  std::size_t                peak_transient_bytes     = 0;
+  std::vector<GpuPassDesc>        passes;
+  GraphValueId                    develop_output{NodeId{"develop"}, PortId{"image"}};
+  DevelopCompileSource            source{};
+  ResolvedRenderGeometry          geometry{};
+  bool                            encode_geometry_resample = false;
+  std::size_t                     peak_transient_bytes     = 0;
+  std::vector<CompiledAdjustment> primary_grade_adjustments;
 
-  [[nodiscard]] auto Contains(GpuPassKind kind) const -> bool {
+  [[nodiscard]] auto              Contains(GpuPassKind kind) const -> bool {
     for (const auto& pass : passes) {
       if (pass.kind == kind) {
         return true;

--- a/alcedo_studio/src/include/edit/runtime/parameter_arena.hpp
+++ b/alcedo_studio/src/include/edit/runtime/parameter_arena.hpp
@@ -34,7 +34,7 @@ class ParameterArena {
 
   explicit ParameterArena(Backend& backend) : backend_(&backend) {}
 
-  ParameterArena(const ParameterArena&)            = delete;
+  ParameterArena(const ParameterArena&)                    = delete;
   auto operator=(const ParameterArena&) -> ParameterArena& = delete;
 
   /**
@@ -50,6 +50,9 @@ class ParameterArena {
     host_.resize(bytes, std::byte{0});
     device_   = std::move(new_device);
     capacity_ = bytes;
+    if (used_ > 0) {
+      pending_.push_back(ByteRange{0, static_cast<std::uint32_t>(used_)});
+    }
   }
 
   /**
@@ -72,8 +75,8 @@ class ParameterArena {
       absolute.destination_offset    = offset + field.destination_offset;
       binding.fields.push_back(absolute);
     }
-    used_         = end;
-    slots_[key]   = binding;
+    used_       = end;
+    slots_[key] = binding;
     return slots_[key];
   }
 
@@ -83,6 +86,10 @@ class ParameterArena {
       throw std::runtime_error("ParameterArena: unknown slot");
     }
     return it->second;
+  }
+
+  [[nodiscard]] auto Contains(const ParameterSlotKey& key) const -> bool {
+    return slots_.contains(key);
   }
 
   /**
@@ -117,9 +124,9 @@ class ParameterArena {
       if (range.size == 0) {
         continue;
       }
-      backend_->UploadBufferRange(device_, range.offset,
-                                  std::span<const std::byte>(host_.data() + range.offset, range.size),
-                                  command_context);
+      backend_->UploadBufferRange(
+          device_, range.offset,
+          std::span<const std::byte>(host_.data() + range.offset, range.size), command_context);
     }
   }
 
@@ -168,13 +175,13 @@ class ParameterArena {
     }
   }
 
-  Backend*                             backend_ = nullptr;
-  typename Backend::Buffer             device_{};
-  std::vector<std::byte>               host_;
-  std::size_t                          capacity_ = 0;
-  std::size_t                          used_     = 0;
+  Backend*                                     backend_ = nullptr;
+  typename Backend::Buffer                     device_{};
+  std::vector<std::byte>                       host_;
+  std::size_t                                  capacity_ = 0;
+  std::size_t                                  used_     = 0;
   std::map<ParameterSlotKey, ParameterBinding> slots_;
-  std::vector<ByteRange>               pending_;
+  std::vector<ByteRange>                       pending_;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/pass_kind.hpp
+++ b/alcedo_studio/src/include/edit/runtime/pass_kind.hpp
@@ -16,15 +16,17 @@ namespace alcedo {
  * Linearize → HLR → Debayer path.
  */
 enum class GpuPassKind : std::uint8_t {
-  UploadRaw          = 0,
-  UploadRgb          = 1,
-  Linearize          = 2,
-  CfaClamp           = 3,
-  Demosaic           = 4,
-  HighlightRecover   = 5,
-  InverseCamMulPack  = 6,
-  Lens               = 7,
-  GeometryResample   = 8,
+  UploadRaw         = 0,
+  UploadRgb         = 1,
+  Linearize         = 2,
+  CfaClamp          = 3,
+  Demosaic          = 4,
+  HighlightRecover  = 5,
+  InverseCamMulPack = 6,
+  Lens              = 7,
+  GeometryResample  = 8,
+  CameraToAp1       = 9,
+  PrimaryColorGrade = 10,
 };
 
 [[nodiscard]] inline auto GpuPassKindName(GpuPassKind kind) -> const char* {
@@ -47,6 +49,10 @@ enum class GpuPassKind : std::uint8_t {
       return "Lens";
     case GpuPassKind::GeometryResample:
       return "GeometryResample";
+    case GpuPassKind::CameraToAp1:
+      return "CameraToAp1";
+    case GpuPassKind::PrimaryColorGrade:
+      return "PrimaryColorGrade";
   }
   return "Unknown";
 }

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -289,6 +289,14 @@ if(ALCEDO_CUDA_ENABLED)
   alcedo_register_test_target(GpuDagCudaDevelopTest gpu)
 endif()
 if(ALCEDO_CUDA_ENABLED)
+  add_executable(GpuDagCudaPrimaryGradeTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_primary_grade_test.cpp)
+  target_include_directories(GpuDagCudaPrimaryGradeTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagCudaPrimaryGradeTest PRIVATE GTest::gtest_main EditRuntimeCuda EditInput)
+  gtest_discover_tests(GpuDagCudaPrimaryGradeTest TEST_PREFIX "GpuDagCudaPrimaryGradeTest."
+    PROPERTIES LABELS "gpu;edit;runtime")
+  alcedo_register_test_target(GpuDagCudaPrimaryGradeTest gpu)
+
   add_executable(GpuDagCudaWorkspaceTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/parameter_arena_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/transient_and_cache_test.cpp

--- a/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
@@ -1,0 +1,206 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/cat02_white_balance_model.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/runtime/cuda/cuda_develop_pass.hpp"
+#include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+
+namespace alcedo {
+namespace {
+
+struct Rgba {
+  float r;
+  float g;
+  float b;
+  float a;
+};
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+class CudaPrimaryGradeFixture : public ::testing::Test {
+ protected:
+  // Direct RGB keeps camera conversion identity so adjustment assertions stay isolated.
+  void SetUp() override {
+    if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+    prepared_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                              gpu_dag_test::FullSensor(16, 12));
+    document_ = CreateDefaultPipelineDocument();
+    plan_     = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+  }
+
+  auto Render() -> CudaPrimaryGradeResult {
+    device_.BeginRender();
+    ExecuteCudaDevelop(device_, plan_, prepared_, document_);
+    auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
+    device_.EndRender();
+    device_.WaitIdle();
+    return result;
+  }
+
+  auto Download(const GraphValueId& id) -> std::vector<Rgba> {
+    auto* lease = device_.Workspace().Images().Find(id);
+    EXPECT_NE(lease, nullptr);
+    if (lease == nullptr) return {};
+    const auto&       texture = lease->Texture();
+    std::vector<Rgba> pixels(static_cast<std::size_t>(texture.Width()) * texture.Height());
+    device_.Workspace().Device().DownloadTexture2D(
+        texture,
+        std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                             pixels.size() * sizeof(Rgba)),
+        device_.CommandContext());
+    return pixels;
+  }
+
+  template <class Model>
+  auto ModelByType(const OperatorTypeId& type) -> Model& {
+    auto* model = dynamic_cast<Model*>(document_.PrimaryGrade()->FindAdjustmentByType(type));
+    EXPECT_NE(model, nullptr);
+    return *model;
+  }
+
+  PreparedRawInput prepared_;
+  PipelineDocument document_;
+  ExecutionPlan    plan_;
+  CudaRenderDevice device_;
+};
+
+TEST_F(CudaPrimaryGradeFixture, CudaPrimaryGradeDefaultParametersPreserveDevelopOutput) {
+  const auto result = Render();
+  const auto input  = Download(plan_.develop_output);
+  const auto output = Download(result.output);
+  ASSERT_EQ(input.size(), output.size());
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    EXPECT_NEAR(output[i].r, input[i].r, 1.0e-6f);
+    EXPECT_NEAR(output[i].g, input[i].g, 1.0e-6f);
+    EXPECT_NEAR(output[i].b, input[i].b, 1.0e-6f);
+  }
+  EXPECT_TRUE(plan_.Contains(GpuPassKind::CameraToAp1));
+  EXPECT_TRUE(plan_.Contains(GpuPassKind::PrimaryColorGrade));
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaExposurePatchChangesOnlyExposureParameterRange) {
+  Render();
+  auto& exposure = ModelByType<ExposureModel>(type_ids::Exposure());
+  exposure.SetValue(1.0f);
+  const ParameterSlotKey exposure_key{document_.PrimaryGrade()->Id(),
+                                      AdjustmentInstanceId{"grade.primary.exposure"}};
+  const auto             exposure_binding = device_.Workspace().Parameters().Binding(exposure_key);
+  device_.Workspace().Device().ResetCounters();
+  Render();
+  const auto& ranges = device_.Workspace().Device().LastHostToDeviceRanges();
+  EXPECT_TRUE(std::ranges::any_of(ranges, [&](const ByteRange& range) {
+    return range.offset == exposure_binding.offset && range.size == exposure_binding.size;
+  }));
+  EXPECT_FALSE(exposure.IsDirty());
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaCat02WhiteBalanceZeroOffsetPreservesAp1White) {
+  auto& wb = ModelByType<Cat02WhiteBalanceModel>(type_ids::Cat02WhiteBalance());
+  wb.SetTemperatureOffset(0.0f);
+  wb.SetTintOffset(0.0f);
+  const auto result = Render();
+  const auto input  = Download(plan_.develop_output);
+  const auto output = Download(result.output);
+  ASSERT_FALSE(output.empty());
+  EXPECT_NEAR(output.front().r, input.front().r, 1.0e-6f);
+  EXPECT_NEAR(output.front().g, input.front().g, 1.0e-6f);
+  EXPECT_NEAR(output.front().b, input.front().b, 1.0e-6f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaCat02WhiteBalanceMaskedSampleMatchesFullAdjustmentAtMaskOne) {
+  auto& wb = ModelByType<Cat02WhiteBalanceModel>(type_ids::Cat02WhiteBalance());
+  wb.SetTemperatureOffset(150.0f);
+  document_.PrimaryGrade()->SetMix(1.0f);
+  const auto full = Download(Render().output);
+  document_.PrimaryGrade()->SetMix(0.5f);
+  const auto half   = Download(Render().output);
+  const auto source = Download(plan_.develop_output);
+  ASSERT_FALSE(full.empty());
+  EXPECT_NEAR(half.front().r, (full.front().r + source.front().r) * 0.5f, 1.0e-5f);
+  EXPECT_NEAR(full.front().g, source.front().g, 1.0e-6f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaPointAdjustmentsExecuteInSerializedModelOrder) {
+  // Exposure before contrast is intentionally non-commutative around the 0.18 pivot.
+  ModelByType<ExposureModel>(type_ids::Exposure()).SetValue(1.0f);
+  ModelByType<ContrastModel>(type_ids::Contrast()).SetValue(100.0f);
+  const auto output = Download(Render().output);
+  const auto input  = Download(plan_.develop_output);
+  ASSERT_FALSE(output.empty());
+  EXPECT_NEAR(output.front().r, (input.front().r * 2.0f - 0.18f) * 2.0f + 0.18f, 1.0e-5f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaLocalToneReferenceReusesAcrossViewportChanges) {
+  ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
+  const auto    first = Render();
+  RenderRequest request;
+  request.view.visible_rect_in_edit_space = {0.1f, 0.1f, 0.8f, 0.8f};
+  plan_             = GraphCompiler::Compile(document_, prepared_.CompileSource(), request);
+  const auto second = Render();
+  EXPECT_NE(first.local_tone_reference_resource_id, 0U);
+  EXPECT_EQ(first.local_tone_reference_resource_id, second.local_tone_reference_resource_id);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaLocalToneUsesWorkspaceInsteadOfPrivateAllocation) {
+  ModelByType<HighlightsModel>(type_ids::Highlights()).SetValue(-30.0f);
+  const auto result = Render();
+  EXPECT_NE(result.local_tone_reference_resource_id, 0U);
+  EXPECT_NE(device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
+                                              PortId{"local_tone.reference"}),
+            nullptr);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaColorGradeSecondRenderCreatesNoGpuAllocation) {
+  Render();
+  device_.Workspace().Device().ResetCounters();
+  Render();
+  EXPECT_EQ(device_.Workspace().Device().MallocCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().FreeCount(), 0U);
+}
+
+TEST_F(CudaPrimaryGradeFixture,
+       MovingAdjustmentChangesExecutionOrderWithoutChangingOtherParameters) {
+  auto& grade = *document_.PrimaryGrade();
+  ModelByType<ExposureModel>(type_ids::Exposure()).SetValue(1.0f);
+  ModelByType<ContrastModel>(type_ids::Contrast()).SetValue(100.0f);
+  const auto before         = Download(Render().output);
+  const auto exposure_id    = AdjustmentInstanceId{"grade.primary.exposure"};
+  const auto contrast_id    = AdjustmentInstanceId{"grade.primary.contrast"};
+  const auto contrast_index = [&] {
+    for (std::size_t i = 0; i < grade.AdjustmentCount(); ++i) {
+      if (grade.AdjustmentIdAt(i) == contrast_id) return i;
+    }
+    return grade.AdjustmentCount();
+  }();
+  grade.MoveAdjustment(exposure_id, contrast_index + 1);
+  document_.MarkTopologyDirty();
+  plan_            = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+  const auto after = Download(Render().output);
+  ASSERT_FALSE(before.empty());
+  ASSERT_EQ(before.size(), after.size());
+  EXPECT_GT(std::abs(before.front().r - after.front().r), 0.05f);
+  EXPECT_FLOAT_EQ(ModelByType<ExposureModel>(type_ids::Exposure()).Value(), 1.0f);
+  EXPECT_FLOAT_EQ(ModelByType<ContrastModel>(type_ids::Contrast()).Value(), 100.0f);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -2,49 +2,49 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
+#include "edit/runtime/graph_compiler.hpp"
+
 #include <gtest/gtest.h>
 
 #include <string>
 
+#include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
-#include "edit/runtime/graph_compiler.hpp"
 #include "edit/runtime/pass_kind.hpp"
-#include "../input/prepared_raw_test_support.hpp"
 
 namespace alcedo {
 namespace {
 
-TEST(GpuDagGraphCompiler, GraphCompilerEmitsNoLibRawOrDecodeResPass) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+TEST(GpuDagGraphCompiler, GraphCompilerKeepsDecodeOutsidePlanAndAddsCameraToAp1BeforeGrade) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
-  auto document = CreateDefaultPipelineDocument();
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
   for (const auto& pass : plan.passes) {
     const std::string name = GpuPassKindName(pass.kind);
     EXPECT_EQ(name.find("LibRaw"), std::string::npos);
     EXPECT_EQ(name.find("DecodeRes"), std::string::npos);
-    EXPECT_EQ(name.find("CameraToAp1"), std::string::npos);
     EXPECT_NE(pass.kind, static_cast<GpuPassKind>(255));
   }
+  EXPECT_LT(plan.IndexOf(GpuPassKind::GeometryResample), plan.IndexOf(GpuPassKind::CameraToAp1));
+  EXPECT_LT(plan.IndexOf(GpuPassKind::CameraToAp1), plan.IndexOf(GpuPassKind::PrimaryColorGrade));
   EXPECT_FALSE(plan.Contains(static_cast<GpuPassKind>(99)));
 }
 
 TEST(GpuDagGraphCompiler, GraphCompilerPlacesHighlightRecoverAfterDemosaic) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
-  auto document = CreateDefaultPipelineDocument();
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
-  const int demosaic = plan.IndexOf(GpuPassKind::Demosaic);
-  const int hlr      = plan.IndexOf(GpuPassKind::HighlightRecover);
+  const int  demosaic = plan.IndexOf(GpuPassKind::Demosaic);
+  const int  hlr      = plan.IndexOf(GpuPassKind::HighlightRecover);
   ASSERT_GE(demosaic, 0);
   ASSERT_GE(hlr, 0);
   EXPECT_LT(demosaic, hlr);
@@ -53,18 +53,17 @@ TEST(GpuDagGraphCompiler, GraphCompilerPlacesHighlightRecoverAfterDemosaic) {
 }
 
 TEST(GpuDagGraphCompiler, HighlightFlagDoesNotChangePassList) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
   auto document = CreateDefaultPipelineDocument();
   document.Develop()->Params().ReplaceParams([] {
     DevelopPayload p;
     p.highlights_reconstruct = false;
     return p;
   }());
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   EXPECT_TRUE(plan.Contains(GpuPassKind::HighlightRecover));
   EXPECT_TRUE(plan.Contains(GpuPassKind::CfaClamp));
 }

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G4 complete (CUDA Develop Endpoint, camera scene-linear RGB). G5 not started.
+Status: G5 complete (CUDA Primary Color Grade and Camera-to-AP1 runtime).
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2394,6 +2394,80 @@ MovingAdjustmentChangesExecutionOrderWithoutChangingOtherParameters
 - 新 CUDA 路径不调用旧 operator 的 Apply 或 SetGlobalParams；
 - 尚未移植的后端仍可通过旧代码构建；
 - LLF 不再拥有 GPU 内存池或长期缓存。
+
+##### Phase G5 completion record (2026-08-22)
+
+**Status:** complete — CUDA Primary Color Grade 使用纯 Model/DTO、序列化调整顺序、
+Camera-to-AP1、CAT02、融合 point adjustment 和 workspace 局部色调资源。
+
+**Primary success call chain:**
+
+```text
+PipelineDocument + PreparedRawInput + RenderRequest
+  -> GraphCompiler::Compile
+  -> ExecutionPlan(CameraToAp1, PrimaryColorGrade, serialized adjustment ids)
+  -> CudaRenderDevice::BeginRender
+  -> ExecuteCudaDevelop
+  -> ExecuteCudaPrimaryGrade
+  -> Model DTO / dirty Patch -> CUDA runtime POD -> ParameterArena dirty ranges
+  -> fused PrimaryGradeKernel in Model order
+  -> workspace GraphImageCache grade.primary:image
+  -> CudaRenderDevice::EndRender
+```
+
+**Primary failure call chain:**
+
+```text
+parameter upload failure
+  -> ExecuteCudaPrimaryGrade throws before patch commit
+  -> PendingParameterPatch restores Model dirty bits
+  -> caller receives GPU runtime failure; no legacy Apply or CPU pixel fallback
+
+missing graph adjustment / missing Develop image / CUDA kernel launch failure
+  -> ExecuteCudaPrimaryGrade throws
+  -> caller receives GPU runtime failure; no legacy Apply or CPU pixel fallback
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `CudaPrimaryGradeDefaultParametersPreserveDevelopOutput` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaExposurePatchChangesOnlyExposureParameterRange` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaCat02WhiteBalanceZeroOffsetPreservesAp1White` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaCat02WhiteBalanceMaskedSampleMatchesFullAdjustmentAtMaskOne` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaPointAdjustmentsExecuteInSerializedModelOrder` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaLocalToneReferenceReusesAcrossViewportChanges` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaLocalToneUsesWorkspaceInsteadOfPrivateAllocation` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaColorGradeSecondRenderCreatesNoGpuAllocation` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `MovingAdjustmentChangesExecutionOrderWithoutChangingOtherParameters` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| G1–G4 graph, workspace, geometry, input and Develop regression | six existing GPU DAG targets | PASS |
+| CUDA default-grade memory access | `compute-sanitizer --tool memcheck` | PASS, 0 errors |
+| Legacy operator compatibility | `Operators` | BUILD PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target Operators GpuDagCudaPrimaryGradeTest GpuDagRawInputTest GpuDagCudaDevelopTest GpuDagModelGraphTest GpuDagCudaWorkspaceTest GpuDagGeometryTest GpuDagCudaGeometryTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "GpuDagCudaPrimaryGradeTest|GpuDagRawInputTest|GpuDagCudaDevelopTest|GpuDagModelGraphTest|GpuDagCudaWorkspaceTest|GpuDagGeometryTest|GpuDagCudaGeometryTest"
+compute-sanitizer --tool memcheck --print-limit 5 build\debug\alcedo_studio\tests\edit\GpuDagCudaPrimaryGradeTest_runtime\GpuDagCudaPrimaryGradeTest.exe --gtest_filter=CudaPrimaryGradeFixture.CudaPrimaryGradeDefaultParametersPreserveDevelopOutput
+```
+
+Suite totals: G5 `9/9` PASS; combined G1–G5 `66/66` PASS; memcheck `0` errors.
+
+**Checklist / exit condition:** all G5 checks complete. Slider edits update stable ParameterArena
+ranges without DAG recompilation. Adjustment moves change the compiled command order. The new CUDA
+runtime does not call legacy operator `Apply`, `ApplyGPU`, or `SetGlobalParams`. Local-tone reference
+and execution buffers live in `BasicRenderWorkspace`; the second render creates no CUDA allocation.
+The legacy `Operators` target continues to build for the not-yet-migrated product/OpenCL/Metal path.
+
+**LOC note (grill-code-review):** `cuda_primary_grade_pass.cu` 414 lines;
+`cuda_primary_grade_test.cpp` 206 lines; runtime registry implementation/header 41/42 lines;
+public pass header 32 lines; `graph_compiler.cpp` 126 lines. No changed file exceeds 1000 lines.
+
+**Residual gaps:** Mask texture sampling and per-pixel Normal Mix are G6 scope. DRT and product
+pipeline routing are G7 scope. OpenCL and Metal still use their legacy execution paths until G8/G9.
 
 ## 39. Phase G6 — MaskStore、CUDA Mask 和 Mix
 


### PR DESCRIPTION
## Summary

- Add Camera-to-AP1, CAT02 white balance, and the CUDA Primary Color Grade pass.
- Execute point adjustments in serialized model order and upload only changed parameter ranges.
- Move local-tone reference and execution resources into the shared render workspace, with no new CUDA allocation on the second render.

## Stack

Layer G5 of GitHub stack #99.

- Base: #97
- Next layer: #102

## Validation

- G5 tests: 9/9 passed.
- Combined G1–G5 regression: 66/66 passed.
- `compute-sanitizer --tool memcheck`: 0 errors.
- Legacy `Operators` target built successfully.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
