### PR TITLE
fix(edit): check and restore CUDA DAG default product path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,20 @@ Agents working in this repository must be decisive and implementation-driven. Do
 
 When the user names a concrete integration or capability, treat it as the target and work out the implementation path, constraints, tests, and risks directly. If there are real blockers, state them as concrete engineering facts and propose the closest viable implementation, not a soft retreat to a weaker product.
 
+## No fallback unless the user explicitly allows it
+
+Do **not** add, restore, or "temporarily" use any fallback, degraded path, silent substitute, or weaker stand-in unless the user has **explicitly** allowed that specific fallback in this conversation (or in an existing, already-landed product rule they pointed at).
+
+This includes, and is not limited to:
+
+- Lowering decode / render / quality settings to hide slowness (for example changing Interactive `DecodeRes::FULL` to `HALF` so Neural Engine or a slow GPU path does not run)
+- Falling back from Neural Engine / GPU / CUDA to Legacy, CPU, another backend, or a cheaper operator when the requested path fails or looks expensive
+- Catch-and-continue that swallows the real error and proceeds on a substitute implementation
+- Preview-only, downsample-only, or "good enough for now" substitutes for a requested full-quality path
+- Retrying a different algorithm, resolution, or backend after a failure without being told to
+
+If the requested path cannot be implemented, **fail with the real error** and state the engineering blocker. Do not ship a weaker product and call it a fix. Performance of a CUDA **debug** build is not a reason to change product decode or quality policy.
+
 ## Temporary files and local workspace
 
 Do **not** create temporary directories or ad-hoc dump files at the repository root

--- a/alcedo_studio/src/app/export_service.cpp
+++ b/alcedo_studio/src/app/export_service.cpp
@@ -105,9 +105,17 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
   auto         final_path = recipe.codec_.export_path_;
   std::filesystem::path temporary_path;
   result.output_path_ = final_path;
-  std::error_code cleanup_error;
+  std::error_code                   cleanup_error;
+  std::shared_ptr<PipelineSnapshot> pipeline_snapshot;
+  auto                              release_pipeline_snapshot = [&]() {
+    if (!pipeline_snapshot) {
+      return;
+    }
+    pipeline_service_->ReleasePipelineSnapshot(pipeline_snapshot);
+    pipeline_snapshot.reset();
+  };
 
-  std::string     stage = "prepare-name";
+  std::string stage = "prepare-name";
   try {
     if (final_path.empty() || final_path.filename().empty()) {
       throw std::runtime_error("ExportService: output path must contain a file name");
@@ -128,12 +136,16 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
     temporary_path = TemporaryExportPath(final_path, task.image_id_);
     std::filesystem::remove(temporary_path, cleanup_error);
 
-    stage               = "load-pipeline";
-    // Get the pipeline executor from sleeve service
-    auto pipeline_guard = pipeline_service_->LoadPipeline(task.sleeve_id_);
-    if (!pipeline_guard || !pipeline_guard->pipeline_) {
-      throw std::runtime_error("[ERROR] ExportService: Failed to load pipeline for sleeve id " +
-                               std::to_string(task.sleeve_id_));
+    stage = "load-pipeline";
+    std::string snapshot_error;
+    pipeline_snapshot =
+        pipeline_service_->LoadPipelineSnapshot(task.sleeve_id_, task.image_id_, &snapshot_error);
+    if (!pipeline_snapshot || !pipeline_snapshot->executor_) {
+      throw std::runtime_error(
+          snapshot_error.empty()
+              ? "[ERROR] ExportService: Failed to snapshot pipeline for sleeve id " +
+                    std::to_string(task.sleeve_id_)
+              : snapshot_error);
     }
     stage           = "load-source";
     // Get the image from image pool service
@@ -152,18 +164,14 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
     // To avoid reading too many images into memory at once, we let the pipeline load the image
     // So we create a dummy Image object with only the path set
     render_task.input_desc_           = std::make_shared<Image>(img_src_path, ImageType::DEFAULT);
-    render_task.pipeline_executor_    = pipeline_guard->pipeline_;
+    render_task.pipeline_executor_    = pipeline_snapshot->executor_;
     render_task.options_.is_blocking_ = true;
     render_task.options_.is_callback_ = false;
 
     // Inject pre-extracted raw metadata from the real Image into the pipeline
     // so downstream operators resolve eagerly.
-    try {
-      if (source_img->HasRawColorContext()) {
-        pipeline_guard->pipeline_->InjectRawMetadata(source_img->GetRawColorContext());
-      }
-    } catch (...) {
-      // Non-fatal: metadata injection is best-effort.
+    if (source_img->HasRawColorContext()) {
+      pipeline_snapshot->executor_->InjectRawMetadata(source_img->GetRawColorContext());
     }
 
     // Use full res export, even though the task requires resizing,
@@ -181,19 +189,18 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
       // Wait for the render to complete
       rendered_image = render_future.get();
     } catch (...) {
-      pipeline_service_->SavePipeline(pipeline_guard);
       throw;
     }
 
     stage = "prepare-output";
     // Save pipeline back to storage
     const auto export_profile =
-        ResolveExportColorProfileConfig(pipeline_guard->pipeline_->GetGlobalParams());
+        ResolveExportColorProfileConfig(pipeline_snapshot->executor_->GetGlobalParams());
     const auto effective_profile = recipe.icc_ == ExportIccPolicy::OMIT
                                        ? std::optional<ExportColorProfileConfig>{}
                                        : export_profile;
     const bool wrote_ultra_hdr   = ImageWriter::ShouldWriteUltraHdr(recipe.codec_, export_profile);
-    pipeline_service_->SavePipeline(pipeline_guard);
+    release_pipeline_snapshot();
     stage                      = "encode";
     recipe.codec_.export_path_ = temporary_path;
     ImageWriter::WriteImageToPath(img_src_path, rendered_image, recipe, export_profile,
@@ -218,12 +225,14 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
     result.resolution_tags_written_ = recipe.resize_.dpi_ > 0.0;
     return result;
   } catch (const std::exception& error) {
+    release_pipeline_snapshot();
     if (!temporary_path.empty()) std::filesystem::remove(temporary_path, cleanup_error);
     result.success_      = false;
     result.failed_stage_ = std::move(stage);
     result.message_      = error.what();
     return result;
   } catch (...) {
+    release_pipeline_snapshot();
     if (!temporary_path.empty()) std::filesystem::remove(temporary_path, cleanup_error);
     result.success_      = false;
     result.failed_stage_ = std::move(stage);

--- a/alcedo_studio/src/app/pipeline_service.cpp
+++ b/alcedo_studio/src/app/pipeline_service.cpp
@@ -32,9 +32,6 @@ struct LoadedPipelineDocument {
 
 auto FinishLoadedDocument(std::shared_ptr<PipelineDocument> document, bool mirror)
     -> LoadedPipelineDocument {
-  if (kTemporaryPrimaryGradeOvalMask && document) {
-    AttachTemporaryPrimaryGradeOvalMask(*document);
-  }
   return {std::move(document), mirror};
 }
 

--- a/alcedo_studio/src/app/pipeline_service.cpp
+++ b/alcedo_studio/src/app/pipeline_service.cpp
@@ -30,13 +30,22 @@ struct LoadedPipelineDocument {
   bool                              mirror_legacy_stage_adapter = false;
 };
 
+auto FinishLoadedDocument(std::shared_ptr<PipelineDocument> document, bool mirror)
+    -> LoadedPipelineDocument {
+  if (kTemporaryPrimaryGradeOvalMask && document) {
+    AttachTemporaryPrimaryGradeOvalMask(*document);
+  }
+  return {std::move(document), mirror};
+}
+
 auto LoadPipelineDocument(ElementStore& store, sl_element_id_t id,
                           const std::shared_ptr<CPUPipelineExecutor>& legacy)
     -> LoadedPipelineDocument {
   const auto stored = store.GetPipelineJsonByElementId(id);
   if (stored && stored->is_object() && stored->value("format_version", 0) == 2) {
-    return {std::make_shared<PipelineDocument>(PipelineDocument::FromJson(*stored)),
-            stored->contains("legacy_stage_adapter")};
+    return FinishLoadedDocument(
+        std::make_shared<PipelineDocument>(PipelineDocument::FromJson(*stored)),
+        stored->contains("legacy_stage_adapter"));
   }
   if (legacy) {
     auto imported = LegacyPipelineImporter::Import(legacy->ExportPipelineParams());
@@ -44,9 +53,11 @@ auto LoadPipelineDocument(ElementStore& store, sl_element_id_t id,
       throw std::runtime_error("PipelineMgmtService: legacy pipeline import failed: " +
                                imported.error);
     }
-    return {std::make_shared<PipelineDocument>(std::move(*imported.document)), true};
+    return FinishLoadedDocument(
+        std::make_shared<PipelineDocument>(std::move(*imported.document)), true);
   }
-  return {std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument()), true};
+  return FinishLoadedDocument(
+      std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument()), true);
 }
 
 void ResetToDefaults(OperatorParams& params) {

--- a/alcedo_studio/src/app/thumbnail_service.cpp
+++ b/alcedo_studio/src/app/thumbnail_service.cpp
@@ -21,10 +21,9 @@
 #include "app/pipeline_service.hpp"
 #include "app/render_service.hpp"
 #include "app/thumbnail_disk_cache_service.hpp"
-#include "storage/store/edit_history/commit_graph_store.hpp"
 #include "concurrency/thread_pool.hpp"
-#include "json.hpp"
 #include "renderer/pipeline_task.hpp"
+#include "storage/store/edit_history/commit_graph_store.hpp"
 
 namespace alcedo {
 namespace {
@@ -123,22 +122,6 @@ auto MakeDisplayCacheThumbnailBuffer(ImageBuffer& source) -> std::unique_ptr<Ima
   return std::make_unique<ImageBuffer>(std::move(rgba8));
 }
 
-auto ReadColorTempOperatorParams(const std::shared_ptr<PipelineGuard>& pipeline)
-    -> std::optional<nlohmann::json> {
-  if (!pipeline || !pipeline->pipeline_) {
-    return std::nullopt;
-  }
-
-  auto& to_ws_stage      = pipeline->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
-  auto  color_temp_entry = to_ws_stage.GetOperator(OperatorType::COLOR_TEMP);
-  if (!color_temp_entry.has_value() || !color_temp_entry.value() ||
-      !color_temp_entry.value()->op_) {
-    return std::nullopt;
-  }
-
-  return color_temp_entry.value()->op_->GetParams();
-}
-
 constexpr ThumbnailResolution kAllThumbnailResolutions[] = {
     ThumbnailResolution::k256,
     ThumbnailResolution::k512,
@@ -159,7 +142,7 @@ struct ThumbnailService::State {
   std::shared_ptr<SleeveServiceImpl>             sleeve_service_     = nullptr;
   std::shared_ptr<ImagePoolService>              image_pool_service_ = nullptr;
   std::shared_ptr<PipelineMgmtService>           pipeline_service_   = nullptr;
-  std::shared_ptr<Storage>                 storage_    = nullptr;
+  std::shared_ptr<Storage>                       storage_            = nullptr;
   std::string                                    project_uuid_;
   std::unique_ptr<ThumbnailDiskCacheService>     disk_cache_service_;
   ThreadPool                                     disk_read_thread_pool_;
@@ -185,10 +168,10 @@ struct ThumbnailService::State {
   // Pipeline scheduler (global/shared), must outlive tasks.
   std::shared_ptr<PipelineScheduler> pipeline_scheduler_ = nullptr;
 
-  State(std::shared_ptr<SleeveServiceImpl>      sleeve_service,
-        std::shared_ptr<ImagePoolService>       image_pool_service,
-        std::shared_ptr<PipelineMgmtService>    pipeline_service,
-        std::shared_ptr<Storage>          storage_service, std::string project_uuid,
+  State(std::shared_ptr<SleeveServiceImpl>   sleeve_service,
+        std::shared_ptr<ImagePoolService>    image_pool_service,
+        std::shared_ptr<PipelineMgmtService> pipeline_service,
+        std::shared_ptr<Storage> storage_service, std::string project_uuid,
         std::filesystem::path thumbnail_cache_root)
       : sleeve_service_(std::move(sleeve_service)),
         image_pool_service_(std::move(image_pool_service)),
@@ -248,10 +231,10 @@ struct ThumbnailService::State {
   auto ReadCurrentVersionHash(sl_element_id_t id) -> std::string {
     if (storage_) {
       try {
-        auto               db_guard = storage_->GetDatabase().GetConnectionGuard();
-        auto               db_lock  = db_guard.Lock();
+        auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+        auto             db_lock  = db_guard.Lock();
         CommitGraphStore graph_service(db_guard.conn_);
-        const auto         graph = graph_service.LoadGraph(id);
+        const auto       graph = graph_service.LoadGraph(id);
         if (graph.has_value()) {
           const auto head = graph->GetActiveVersionRef().head_commit_hash;
           return head.has_value() ? head->ToString() : graph->GetRootId().ToString();
@@ -292,12 +275,12 @@ struct ThumbnailService::State {
   ~State() { disk_read_thread_pool_.Shutdown(); }
 };
 
-ThumbnailService::ThumbnailService(std::shared_ptr<SleeveServiceImpl>      sleeve_service,
-                                   std::shared_ptr<ImagePoolService>       image_pool_service,
-                                   std::shared_ptr<PipelineMgmtService>    pipeline_service,
-                                   std::shared_ptr<Storage>          storage_service,
-                                   const std::string&                      project_uuid,
-                                   const std::filesystem::path&            thumbnail_cache_root)
+ThumbnailService::ThumbnailService(std::shared_ptr<SleeveServiceImpl>   sleeve_service,
+                                   std::shared_ptr<ImagePoolService>    image_pool_service,
+                                   std::shared_ptr<PipelineMgmtService> pipeline_service,
+                                   std::shared_ptr<Storage>             storage_service,
+                                   const std::string&                   project_uuid,
+                                   const std::filesystem::path&         thumbnail_cache_root)
     : state_(std::make_shared<State>(std::move(sleeve_service), std::move(image_pool_service),
                                      std::move(pipeline_service), std::move(storage_service),
                                      project_uuid, thumbnail_cache_root)) {}
@@ -382,28 +365,25 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
   auto schedule_pipeline_render = [st, id, image_id, cache_key, resolution, gen_token,
                                    expected_gen]() {
     struct ThumbnailTaskContext {
-      std::shared_ptr<PipelineGuard> pipeline{};
-      std::optional<nlohmann::json>  pre_render_color_temp_params{};
-      std::atomic<bool>              pipeline_released{false};
+      std::shared_ptr<PipelineSnapshot> snapshot{};
+      std::atomic<bool>                 snapshot_released{false};
     };
 
     auto task_context          = std::make_shared<ThumbnailTaskContext>();
 
-    auto release_task_pipeline = [st, task_context]() {
-      auto pipeline = task_context->pipeline;
-      if (!pipeline || task_context->pipeline_released.exchange(true)) {
+    auto release_task_snapshot = [st, task_context]() {
+      auto snapshot = task_context->snapshot;
+      if (!snapshot || task_context->snapshot_released.exchange(true)) {
         return;
       }
       try {
-        st->pipeline_service_->SavePipeline(pipeline);
+        st->pipeline_service_->ReleasePipelineSnapshot(snapshot);
       } catch (...) {
       }
     };
 
-    auto fail_pending_request = [st, cache_key, task_context, release_task_pipeline](
-                                    const std::string&                    message,
-                                    const std::shared_ptr<PipelineGuard>& pipeline,
-                                    bool                                  throw_after) -> bool {
+    auto fail_pending_request = [st, cache_key, release_task_snapshot](const std::string& message,
+                                                                       bool throw_after) -> bool {
       std::vector<State::PendingCallback> callbacks;
       {
         std::unique_lock lock(st->cache_lock_);
@@ -416,16 +396,7 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
         st->thumbnail_cache_data_.erase(cache_key);
       }
 
-      if (pipeline) {
-        if (task_context->pipeline == pipeline) {
-          release_task_pipeline();
-        } else {
-          try {
-            st->pipeline_service_->SavePipeline(pipeline);
-          } catch (...) {
-          }
-        }
-      }
+      release_task_snapshot();
 
       for (const auto& pending_cb : callbacks) {
         DispatchThumbnailResultCallback(
@@ -458,30 +429,19 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
 
     thumb_task.prepare_ = [st, id, image_id, task_context,
                            fail_pending_request](PipelineTask& task) mutable -> bool {
-      std::shared_ptr<PipelineGuard> pipeline;
-      try {
-        pipeline = st->pipeline_service_->LoadPipeline(id);
-      } catch (const std::exception& e) {
+      std::string error;
+      task_context->snapshot = st->pipeline_service_->LoadPipelineSnapshot(id, image_id, &error);
+      if (!task_context->snapshot || !task_context->snapshot->executor_) {
         return fail_pending_request(
-            std::format("[ERROR] ThumbnailService: Failed to load pipeline for file ID {}: {}", id,
-                        e.what()),
-            nullptr, false);
-      } catch (...) {
-        return fail_pending_request(
-            std::format(
-                "[ERROR] ThumbnailService: Failed to load pipeline for file ID {}: unknown error.",
-                id),
-            nullptr, false);
+            error.empty()
+                ? std::format("[ERROR] ThumbnailService: Pipeline for file ID {} not available.",
+                              id)
+                : error,
+            false);
       }
 
-      task_context->pipeline = pipeline;
-      if (!pipeline || !pipeline->pipeline_) {
-        return fail_pending_request(
-            std::format("[ERROR] ThumbnailService: Pipeline for file ID {} not available.", id),
-            pipeline, false);
-      }
-
-      pipeline->pipeline_->SetForceCPUOutput(true);
+      auto executor = task_context->snapshot->executor_;
+      executor->SetForceCPUOutput(true);
 
       std::shared_ptr<Image> img_result;
       try {
@@ -491,32 +451,31 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
         return fail_pending_request(
             std::format("[ERROR] ThumbnailService: Failed to load image ID {} for element {}: {}",
                         image_id, id, e.what()),
-            pipeline, false);
+            false);
       } catch (...) {
         return fail_pending_request(std::format("[ERROR] ThumbnailService: Failed to load image ID "
                                                 "{} for element {}: unknown error.",
                                                 image_id, id),
-                                    pipeline, false);
+                                    false);
       }
 
       if (!img_result) {
         return fail_pending_request(
             std::format("[ERROR] ThumbnailService: Image with ID {} not found in pool.", image_id),
-            pipeline, false);
+            false);
       }
 
-      task_context->pre_render_color_temp_params = ReadColorTempOperatorParams(pipeline);
-      task.pipeline_executor_                    = pipeline->pipeline_;
-      task.input_desc_                           = std::move(img_result);
+      task.pipeline_executor_ = std::move(executor);
+      task.input_desc_        = std::move(img_result);
       return true;
     };
 
-    thumb_task.callback_ = [st, id, cache_key, task_context, release_task_pipeline, gen_token,
+    thumb_task.callback_ = [st, id, cache_key, release_task_snapshot, gen_token,
                             expected_gen](ImageBuffer& result_buffer) {
       // Strategy A: stale tasks must not touch pending_ because a newer request
       // for the same element/resolution may already have claimed that slot.
       if (gen_token && gen_token->load() != expected_gen) {
-        release_task_pipeline();
+        release_task_snapshot();
         return;
       }
 
@@ -535,7 +494,7 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
         std::unique_lock lock(st->cache_lock_);
 
         if (gen_token && gen_token->load() != expected_gen) {
-          release_task_pipeline();
+          release_task_snapshot();
           return;
         }
 
@@ -586,7 +545,7 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
             st->thumbnail_cache_data_.erase(guard_it);
           }
         }
-        release_task_pipeline();
+        release_task_snapshot();
         for (const auto& pending_cb : callbacks) {
           DispatchThumbnailResultCallback(
               pending_cb.callback_, pending_cb.dispatcher_,
@@ -598,15 +557,7 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
         return;
       }
 
-      const auto pipeline = task_context->pipeline;
-      if (pipeline) {
-        const auto post_render_color_temp_params = ReadColorTempOperatorParams(pipeline);
-        if (post_render_color_temp_params != task_context->pre_render_color_temp_params) {
-          pipeline->dirty_ = true;
-        }
-      }
-
-      release_task_pipeline();
+      release_task_snapshot();
 
       const auto status = guard ? ThumbnailRequestStatus::kReady : ThumbnailRequestStatus::kError;
       const std::string message =
@@ -629,12 +580,12 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
       fail_pending_request(
           std::format("[ERROR] ThumbnailService: Failed to schedule thumbnail for element {}: {}",
                       id, e.what()),
-          task_context->pipeline, true);
+          true);
     } catch (...) {
       fail_pending_request(std::format("[ERROR] ThumbnailService: Failed to schedule thumbnail for "
                                        "element {}: unknown error.",
                                        id),
-                           task_context->pipeline, true);
+                           true);
     }
   };
 

--- a/alcedo_studio/src/decoders/CMakeLists.txt
+++ b/alcedo_studio/src/decoders/CMakeLists.txt
@@ -131,7 +131,7 @@ def_cuda_library(Operators
     SOURCES ${OPERATORS_SRCS}
     PUBLIC_DEPS ImageBuffer JSON OpenColorIO::OpenColorIO hwy::hwy lensfun::lensfun
     # Image provides RawColorContextToJson/FromJson used by RawDecodeOp durable params.
-    PRIVATE_DEPS ${ALCEDO_OPENCV_IMAGE_DEPS} RawProcessor Image
+    PRIVATE_DEPS ${ALCEDO_OPENCV_IMAGE_DEPS} RawProcessor Image EditGraph
 )
 if(ALCEDO_CUDA_ENABLED)
     set_target_properties(Operators PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)

--- a/alcedo_studio/src/decoders/processor/operators/gpu/cuda_dng_warp.cu
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/cuda_dng_warp.cu
@@ -2,17 +2,16 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
-#include "decoders/processor/operators/gpu/cuda_dng_warp.hpp"
-
 #include <cuda_runtime.h>
-#include <opencv2/core/cuda_stream_accessor.hpp>
-#include <opencv2/core/cuda_types.hpp>
 
 #include <algorithm>
 #include <cmath>
+#include <opencv2/core/cuda_stream_accessor.hpp>
+#include <opencv2/core/cuda_types.hpp>
 #include <stdexcept>
 #include <type_traits>
 
+#include "decoders/processor/operators/gpu/cuda_dng_warp.hpp"
 #include "decoders/processor/operators/gpu/cuda_raw_proc_utils.hpp"
 
 namespace alcedo {
@@ -20,10 +19,10 @@ namespace CUDA {
 namespace {
 
 struct WarpRectilinearParams {
-  int   coefficient_set_count = 0;
+  int   coefficient_set_count  = 0;
   float coefficient_sets[3][6] = {};
-  float center_x = 0.5f;
-  float center_y = 0.5f;
+  float center_x               = 0.5f;
+  float center_y               = 0.5f;
 };
 
 auto GetCudaStream(cv::cuda::Stream* stream) -> cudaStream_t {
@@ -58,23 +57,23 @@ __device__ auto ReadWithBorder(const cv::cuda::PtrStepSz<float4>& src, const int
 template <typename PixelT>
 __device__ auto BilinearSample(const cv::cuda::PtrStepSz<PixelT>& src, const float sx,
                                const float sy) -> PixelT {
-  const int   x0  = static_cast<int>(floorf(sx));
-  const int   y0  = static_cast<int>(floorf(sy));
-  const int   x1  = x0 + 1;
-  const int   y1  = y0 + 1;
-  const float fx  = sx - static_cast<float>(x0);
-  const float fy  = sy - static_cast<float>(y0);
-  const float w00 = (1.0f - fx) * (1.0f - fy);
-  const float w10 = fx * (1.0f - fy);
-  const float w01 = (1.0f - fx) * fy;
-  const float w11 = fx * fy;
+  const int    x0  = static_cast<int>(floorf(sx));
+  const int    y0  = static_cast<int>(floorf(sy));
+  const int    x1  = x0 + 1;
+  const int    y1  = y0 + 1;
+  const float  fx  = sx - static_cast<float>(x0);
+  const float  fy  = sy - static_cast<float>(y0);
+  const float  w00 = (1.0f - fx) * (1.0f - fy);
+  const float  w10 = fx * (1.0f - fy);
+  const float  w01 = (1.0f - fx) * fy;
+  const float  w11 = fx * fy;
 
   const PixelT p00 = ReadWithBorder(src, x0, y0);
   const PixelT p10 = ReadWithBorder(src, x1, y0);
   const PixelT p01 = ReadWithBorder(src, x0, y1);
   const PixelT p11 = ReadWithBorder(src, x1, y1);
 
-  PixelT out{};
+  PixelT       out{};
   if constexpr (std::is_same_v<PixelT, float3>) {
     out.x = p00.x * w00 + p10.x * w10 + p01.x * w01 + p11.x * w11;
     out.y = p00.y * w00 + p10.y * w10 + p01.y * w01 + p11.y * w11;
@@ -103,17 +102,16 @@ __device__ auto WarpSourceCoord(const int x, const int y, const int plane, const
     return make_float2(static_cast<float>(x), static_cast<float>(y));
   }
 
-  const int   set_index = (p.coefficient_set_count <= 1) ? 0 : min(max(plane, 0), 2);
-  const float* coeffs   = p.coefficient_sets[set_index];
-  const float dx        = (static_cast<float>(x) - cx) / m;
-  const float dy        = (static_cast<float>(y) - cy) / m;
-  const float r2        = dx * dx + dy * dy;
-  const float f         = coeffs[0] + coeffs[1] * r2 + coeffs[2] * r2 * r2 +
-                  coeffs[3] * r2 * r2 * r2;
-  const float dxr = f * dx;
-  const float dyr = f * dy;
-  const float dxt = coeffs[4] * (2.0f * dx * dy) + coeffs[5] * (r2 + 2.0f * dx * dx);
-  const float dyt = coeffs[5] * (2.0f * dx * dy) + coeffs[4] * (r2 + 2.0f * dy * dy);
+  const int    set_index = (p.coefficient_set_count <= 1) ? 0 : min(max(plane, 0), 2);
+  const float* coeffs    = p.coefficient_sets[set_index];
+  const float  dx        = (static_cast<float>(x) - cx) / m;
+  const float  dy        = (static_cast<float>(y) - cy) / m;
+  const float  r2        = dx * dx + dy * dy;
+  const float  f   = coeffs[0] + coeffs[1] * r2 + coeffs[2] * r2 * r2 + coeffs[3] * r2 * r2 * r2;
+  const float  dxr = f * dx;
+  const float  dyr = f * dy;
+  const float  dxt = coeffs[4] * (2.0f * dx * dy) + coeffs[5] * (r2 + 2.0f * dx * dx);
+  const float  dyt = coeffs[5] * (2.0f * dx * dy) + coeffs[4] * (r2 + 2.0f * dy * dy);
   return make_float2(cx + m * (dxr + dxt), cy + m * (dyr + dyt));
 }
 
@@ -136,8 +134,8 @@ __device__ auto BilinearSampleChannel(const cv::cuda::PtrStepSz<float4>& src, co
 
 template <typename PixelT>
 __global__ void WarpRectilinearKernel(const cv::cuda::PtrStepSz<PixelT> src,
-                                      cv::cuda::PtrStepSz<PixelT> dst,
-                                      const WarpRectilinearParams p) {
+                                      cv::cuda::PtrStepSz<PixelT>       dst,
+                                      const WarpRectilinearParams       p) {
   const int x = blockIdx.x * blockDim.x + threadIdx.x;
   const int y = blockIdx.y * blockDim.y + threadIdx.y;
   if (x >= dst.cols || y >= dst.rows) {
@@ -176,17 +174,36 @@ auto BuildParams(const dng::WarpRectilinear& warp) -> WarpRectilinearParams {
 }
 
 template <typename PixelT>
-void LaunchWarp(cv::cuda::GpuMat& img, const dng::WarpRectilinear& warp, cudaStream_t stream) {
-  cv::cuda::GpuMat out(img.rows, img.cols, img.type());
-  const dim3       block(32, 8);
-  const dim3       grid((img.cols + block.x - 1) / block.x, (img.rows + block.y - 1) / block.y);
-  WarpRectilinearKernel<PixelT><<<grid, block, 0, stream>>>(img, out, BuildParams(warp));
+void LaunchWarp(const cv::cuda::GpuMat& src, cv::cuda::GpuMat& dst,
+                const dng::WarpRectilinear& warp, cudaStream_t stream) {
+  const dim3 block(32, 8);
+  const dim3 grid((dst.cols + block.x - 1) / block.x, (dst.rows + block.y - 1) / block.y);
+  WarpRectilinearKernel<PixelT><<<grid, block, 0, stream>>>(src, dst, BuildParams(warp));
   CUDA_CHECK(cudaGetLastError());
   MaybeSync(stream);
-  img = std::move(out);
 }
 
 }  // namespace
+
+void WarpDngRectilinear(const cv::cuda::GpuMat& src, cv::cuda::GpuMat& dst,
+                        const dng::WarpRectilinear& warp, cv::cuda::Stream* stream) {
+  if (src.empty() || dst.empty()) {
+    throw std::runtime_error("CUDA::WarpDngRectilinear requires non-empty images");
+  }
+  if (src.size() != dst.size() || src.type() != dst.type()) {
+    throw std::runtime_error("CUDA::WarpDngRectilinear requires matching source and destination");
+  }
+  const cudaStream_t cuda_stream = GetCudaStream(stream);
+  if (src.type() == CV_32FC3) {
+    LaunchWarp<float3>(src, dst, warp, cuda_stream);
+    return;
+  }
+  if (src.type() == CV_32FC4) {
+    LaunchWarp<float4>(src, dst, warp, cuda_stream);
+    return;
+  }
+  throw std::runtime_error("CUDA::WarpDngRectilinear expects CV_32FC3/CV_32FC4 input");
+}
 
 void ApplyDngWarpRectilinear(cv::cuda::GpuMat& img, const dng::WarpRectilinear& warp,
                              cv::cuda::Stream* stream) {
@@ -194,12 +211,15 @@ void ApplyDngWarpRectilinear(cv::cuda::GpuMat& img, const dng::WarpRectilinear& 
     return;
   }
   const cudaStream_t cuda_stream = GetCudaStream(stream);
+  cv::cuda::GpuMat   out(img.rows, img.cols, img.type());
   if (img.type() == CV_32FC3) {
-    LaunchWarp<float3>(img, warp, cuda_stream);
+    LaunchWarp<float3>(img, out, warp, cuda_stream);
+    img = std::move(out);
     return;
   }
   if (img.type() == CV_32FC4) {
-    LaunchWarp<float4>(img, warp, cuda_stream);
+    LaunchWarp<float4>(img, out, warp, cuda_stream);
+    img = std::move(out);
     return;
   }
   throw std::runtime_error("CUDA::ApplyDngWarpRectilinear expects CV_32FC3/CV_32FC4 input");

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -71,8 +71,9 @@ def_library(EditRuntime
     SOURCES
         ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
         ${ALCEDO_SRC_ROOT}/edit/runtime/graph_compiler.cpp
+        ${ALCEDO_SRC_ROOT}/edit/runtime/result_content_key.cpp
         ${ALCEDO_SRC_ROOT}/edit/runtime/static_execution_plan_cache.cpp
-    PUBLIC_DEPS EditGraph EditGeometry
+    PUBLIC_DEPS EditGraph EditGeometry EditInput
 )
 
 if(ALCEDO_CUDA_ENABLED)
@@ -80,6 +81,7 @@ if(ALCEDO_CUDA_ENABLED)
         SOURCES
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_backend.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_adjustment_runtime.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_camera_color_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_develop_pass.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_drt_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_mask_pass.cu

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -60,7 +60,9 @@ def_library(EditGraph
 
 # CPU RAW unpack / downsample. No CUDA, no ImageBuffer.
 def_library(EditInput
-    SOURCES ${ALCEDO_SRC_ROOT}/edit/input/raw_input_loader.cpp
+    SOURCES
+        ${ALCEDO_SRC_ROOT}/edit/input/raw_input_loader.cpp
+        ${ALCEDO_SRC_ROOT}/edit/input/prepared_source_cache.cpp
     PUBLIC_DEPS EditGeometry JSON libraw::raw_r opencv_core
 )
 
@@ -69,6 +71,7 @@ def_library(EditRuntime
     SOURCES
         ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
         ${ALCEDO_SRC_ROOT}/edit/runtime/graph_compiler.cpp
+        ${ALCEDO_SRC_ROOT}/edit/runtime/static_execution_plan_cache.cpp
     PUBLIC_DEPS EditGraph EditGeometry
 )
 

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -45,6 +45,7 @@ set(EDIT_GRAPH_SRCS
     ${ALCEDO_SRC_ROOT}/edit/operators/models/sharpen_model.cpp
     ${ALCEDO_SRC_ROOT}/edit/graph/analytic_mask_node_model.cpp
     ${ALCEDO_SRC_ROOT}/edit/graph/color_grade_node_model.cpp
+    ${ALCEDO_SRC_ROOT}/edit/graph/develop_color_transform.cpp
     ${ALCEDO_SRC_ROOT}/edit/graph/develop_node_model.cpp
     ${ALCEDO_SRC_ROOT}/edit/graph/drt_node_model.cpp
     ${ALCEDO_SRC_ROOT}/edit/graph/legacy_pipeline_importer.cpp
@@ -56,6 +57,7 @@ set(EDIT_GRAPH_SRCS
 def_library(EditGraph
     SOURCES ${EDIT_GRAPH_SRCS}
     PUBLIC_DEPS JSON EditGeometry EditMaskStore
+    PRIVATE_DEPS ${ALCEDO_OPENCV_CORE_DEPS}
 )
 
 # CPU RAW unpack / downsample. No CUDA, no ImageBuffer.

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -88,6 +88,7 @@ if(ALCEDO_CUDA_ENABLED)
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_render_device.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_sensor_demosaic.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_drt_pass.cu
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_local_tone_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_mask_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_plan_executor.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_product_renderer.cu

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -2,8 +2,8 @@
 # 5. Business Logic & State
 # ==============================================================================
 
-set(HISTORY_SRCS 
-    ${ALCEDO_SRC_ROOT}/edit/history/edit_history.cpp 
+set(HISTORY_SRCS
+    ${ALCEDO_SRC_ROOT}/edit/history/edit_history.cpp
     ${ALCEDO_SRC_ROOT}/edit/history/version.cpp
     ${ALCEDO_SRC_ROOT}/edit/history/edit_transaction.cpp
     ${ALCEDO_SRC_ROOT}/edit/history/editor_transaction_journal.cpp
@@ -85,6 +85,8 @@ if(ALCEDO_CUDA_ENABLED)
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_adjustment_runtime.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_camera_color_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_develop_pass.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_render_device.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_sensor_demosaic.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_drt_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_mask_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_plan_executor.cpp
@@ -92,7 +94,7 @@ if(ALCEDO_CUDA_ENABLED)
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_primary_grade_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/geometry_resample.cu
         PUBLIC_DEPS EditRuntime CUDA::cudart
-        PRIVATE_DEPS EditInput RawProcessorOp Operators
+        PRIVATE_DEPS EditInput RawProcessorOp Operators CudaDemosaicNetEntry
     )
     target_compile_definitions(EditRuntimeCuda PUBLIC HAVE_CUDA)
 endif()

--- a/alcedo_studio/src/edit/graph/develop_color_transform.cpp
+++ b/alcedo_studio/src/edit/graph/develop_color_transform.cpp
@@ -1,0 +1,719 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/develop_color_transform.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+
+#include <opencv2/core.hpp>
+
+#include "edit/operators/basic/planckian_locus_table.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr double kCalibrationLowCCT  = 2856.0;
+constexpr double kCalibrationHighCCT = 6504.0;
+constexpr double kCustomCCTMin       = 2000.0;
+constexpr double kCustomCCTMax       = 15000.0;
+constexpr double kCustomTintMin      = -150.0;
+constexpr double kCustomTintMax      = 150.0;
+constexpr double kTintScale          = 3000.0;
+constexpr double kDeterminantEpsilon = 1e-10;
+constexpr double kValueEpsilon       = 1e-10;
+constexpr double kAsShotSolveEpsilon = 1e-8;
+constexpr int    kAsShotSolveMaxIter = 16;
+constexpr double kOhnoNearLocusDuv   = 0.002;
+constexpr double kD50X               = 0.34567;
+constexpr double kD50Y               = 0.35850;
+constexpr double kD60X               = 0.32168;
+constexpr double kD60Y               = 0.33767;
+const cv::Matx33d kXyzD60ToAp1(1.6410233797, -0.3248032942, -0.2364246952, -0.6636628587,
+                               1.6153315917, 0.0167563477, 0.0117218943, -0.0082844420,
+                               0.9883948585);
+
+auto ClampFinite(double value, double min_value, double max_value) -> double {
+  if (!std::isfinite(value)) {
+    return min_value;
+  }
+  return std::clamp(value, min_value, max_value);
+}
+
+auto IsFiniteMatrix(const cv::Matx33d& m) -> bool {
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      if (!std::isfinite(m(r, c))) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+auto MatrixFromArray9(const std::array<double, 9>& m) -> cv::Matx33d {
+  return cv::Matx33d(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8]);
+}
+
+auto IsFiniteInvertible(const cv::Matx33d& m) -> bool {
+  if (!IsFiniteMatrix(m)) {
+    return false;
+  }
+  const double det = cv::determinant(m);
+  return std::isfinite(det) && std::abs(det) >= kDeterminantEpsilon;
+}
+
+auto SanitizeEndpointCct(double cct, double fallback) -> double {
+  return (std::isfinite(cct) && cct > kValueEpsilon) ? cct : fallback;
+}
+
+auto HasDualIlluminantCalibration(const DevelopCameraProfile& profile) -> bool {
+  if (!profile.calibration_illuminants_valid) {
+    return false;
+  }
+  const double cct1 = profile.color_matrix_1_cct;
+  const double cct2 = profile.color_matrix_2_cct;
+  return std::isfinite(cct1) && std::isfinite(cct2) && cct1 > kValueEpsilon &&
+         cct2 > kValueEpsilon && std::abs(cct1 - cct2) > kValueEpsilon;
+}
+
+auto InterpolateColorMatrix(const cv::Matx33d& cm1, const cv::Matx33d& cm2, double cct,
+                            double endpoint_cct_1, double endpoint_cct_2) -> cv::Matx33d {
+  const double cct1       = SanitizeEndpointCct(endpoint_cct_1, kCalibrationLowCCT);
+  const double cct2       = SanitizeEndpointCct(endpoint_cct_2, kCalibrationHighCCT);
+  const double low_cct    = std::min(cct1, cct2);
+  const double high_cct   = std::max(cct1, cct2);
+  const bool   cm1_is_low = cct1 <= cct2;
+  const cv::Matx33d& low_matrix  = cm1_is_low ? cm1 : cm2;
+  const cv::Matx33d& high_matrix = cm1_is_low ? cm2 : cm1;
+
+  if (!std::isfinite(cct)) {
+    return high_matrix;
+  }
+  if (cct <= low_cct) {
+    return low_matrix;
+  }
+  if (cct >= high_cct) {
+    return high_matrix;
+  }
+
+  const double inv_t  = 1.0 / cct;
+  const double inv_t1 = 1.0 / low_cct;
+  const double inv_t2 = 1.0 / high_cct;
+  const double denom  = inv_t2 - inv_t1;
+  if (std::abs(denom) <= kValueEpsilon) {
+    return high_matrix;
+  }
+  const double w = std::clamp((inv_t - inv_t1) / denom, 0.0, 1.0);
+  return low_matrix * (1.0 - w) + high_matrix * w;
+}
+
+auto Invert3x3(const cv::Matx33d& m, cv::Matx33d& out) -> bool {
+  const double det = cv::determinant(m);
+  if (!std::isfinite(det) || std::abs(det) < kDeterminantEpsilon) {
+    return false;
+  }
+  out = m.inv();
+  return IsFiniteMatrix(out);
+}
+
+auto XYZToXY(const cv::Vec3d& xyz, cv::Vec2d& out_xy) -> bool {
+  const double sum = xyz[0] + xyz[1] + xyz[2];
+  if (!std::isfinite(sum) || std::abs(sum) <= kValueEpsilon) {
+    return false;
+  }
+  const double x = xyz[0] / sum;
+  const double y = xyz[1] / sum;
+  if (!std::isfinite(x) || !std::isfinite(y) || y <= 0.0 || x <= 0.0 || (x + y) >= 1.0) {
+    return false;
+  }
+  out_xy = cv::Vec2d(x, y);
+  return true;
+}
+
+auto XYToXYZ(const cv::Vec2d& xy) -> cv::Vec3d {
+  const double y = std::max(xy[1], kValueEpsilon);
+  return cv::Vec3d(xy[0] / y, 1.0, (1.0 - xy[0] - xy[1]) / y);
+}
+
+auto XYToUV(const cv::Vec2d& xy) -> cv::Vec2d {
+  const double den = (-xy[0] + 6.0 * xy[1] + 1.5);
+  if (std::abs(den) <= kValueEpsilon) {
+    return cv::Vec2d(0.0, 0.0);
+  }
+  return cv::Vec2d(2.0 * xy[0] / den, 3.0 * xy[1] / den);
+}
+
+auto UVToXY(const cv::Vec2d& uv) -> cv::Vec2d {
+  const double den = (uv[0] - 4.0 * uv[1] + 2.0);
+  if (std::abs(den) <= kValueEpsilon) {
+    return cv::Vec2d(kD50X, kD50Y);
+  }
+  return cv::Vec2d(1.5 * uv[0] / den, uv[1] / den);
+}
+
+struct PlanckianLocusPoint {
+  cv::Vec2d uv_;
+  cv::Vec2d perp_;
+  bool      valid_ = false;
+};
+
+struct OhnoSolution {
+  bool   valid_ = false;
+  double cct_   = 0.0;
+  double duv_   = 0.0;
+};
+
+using PlanckianTable = std::span<const planckian_locus::PlanckianLocusEntry>;
+
+auto OhnoPlanckianTable() -> PlanckianTable {
+  return PlanckianTable(planckian_locus::kUvTable.data(), planckian_locus::kUvTable.size());
+}
+
+auto EntryUV(const planckian_locus::PlanckianLocusEntry& entry) -> cv::Vec2d {
+  return cv::Vec2d(entry.u_, entry.v_);
+}
+
+auto PlanckianUVAtCCT(double cct) -> cv::Vec2d {
+  const auto   table    = OhnoPlanckianTable();
+  const double safe_cct = ClampFinite(cct, planckian_locus::kMinCct, planckian_locus::kMaxCct);
+  if (safe_cct <= table.front().cct_) {
+    return EntryUV(table.front());
+  }
+  if (safe_cct >= table.back().cct_) {
+    return EntryUV(table.back());
+  }
+  const auto upper = std::lower_bound(table.begin(), table.end(), safe_cct,
+                                      [](const planckian_locus::PlanckianLocusEntry& entry,
+                                         double value) { return entry.cct_ < value; });
+  const auto   lower = upper - 1;
+  const double denom = upper->cct_ - lower->cct_;
+  if (std::abs(denom) <= kValueEpsilon) {
+    return EntryUV(*upper);
+  }
+  const double t = std::clamp((safe_cct - lower->cct_) / denom, 0.0, 1.0);
+  return EntryUV(*lower) * (1.0 - t) + EntryUV(*upper) * t;
+}
+
+auto PlanckianLocusAtCCT(double cct) -> PlanckianLocusPoint {
+  const double safe_cct = ClampFinite(cct, kCustomCCTMin, kCustomCCTMax);
+  const double delta_k =
+      std::clamp(safe_cct * 0.001, 0.5, std::max(0.5, 0.25 * (kCustomCCTMax - kCustomCCTMin)));
+  const double low_cct  = std::max(kCustomCCTMin, safe_cct - delta_k);
+  const double high_cct = std::min(kCustomCCTMax, safe_cct + delta_k);
+
+  PlanckianLocusPoint pt;
+  pt.uv_ = PlanckianUVAtCCT(safe_cct);
+  if ((high_cct - low_cct) <= kValueEpsilon) {
+    pt.perp_  = cv::Vec2d(0.0, 0.0);
+    pt.valid_ = false;
+    return pt;
+  }
+  const cv::Vec2d tangent =
+      (PlanckianUVAtCCT(high_cct) - PlanckianUVAtCCT(low_cct)) / (high_cct - low_cct);
+  const double tangent_len = std::sqrt(tangent[0] * tangent[0] + tangent[1] * tangent[1]);
+  if (tangent_len <= kValueEpsilon) {
+    pt.perp_  = cv::Vec2d(0.0, 0.0);
+    pt.valid_ = false;
+  } else {
+    pt.perp_  = cv::Vec2d(-tangent[1] / tangent_len, tangent[0] / tangent_len);
+    pt.valid_ = true;
+  }
+  return pt;
+}
+
+auto Distance(const cv::Vec2d& a, const cv::Vec2d& b) -> double {
+  const double du = a[0] - b[0];
+  const double dv = a[1] - b[1];
+  return std::sqrt(du * du + dv * dv);
+}
+
+auto SignFromDeltaV(double delta_v) -> double { return (delta_v < 0.0) ? -1.0 : 1.0; }
+
+auto FindClosestOhnoSample(const cv::Vec2d& uv, PlanckianTable table) -> size_t {
+  size_t best_index       = 0;
+  double best_distance_sq = std::numeric_limits<double>::max();
+  for (size_t i = 0; i < table.size(); ++i) {
+    const double du          = uv[0] - table[i].u_;
+    const double dv          = uv[1] - table[i].v_;
+    const double distance_sq = du * du + dv * dv;
+    if (distance_sq < best_distance_sq) {
+      best_distance_sq = distance_sq;
+      best_index       = i;
+    }
+  }
+  if (best_index == 0) {
+    return 1;
+  }
+  if (best_index + 1 >= table.size()) {
+    return table.size() - 2;
+  }
+  return best_index;
+}
+
+auto SolveOhnoTriangular(const cv::Vec2d& uv, PlanckianTable table, size_t m) -> OhnoSolution {
+  const auto& p0    = table[m - 1];
+  const auto& p2    = table[m + 1];
+  const cv::Vec2d p0_uv = EntryUV(p0);
+  const cv::Vec2d p2_uv = EntryUV(p2);
+  const double    d0    = Distance(uv, p0_uv);
+  const double    d2    = Distance(uv, p2_uv);
+  const cv::Vec2d chord = p2_uv - p0_uv;
+  const double    l     = std::sqrt(chord[0] * chord[0] + chord[1] * chord[1]);
+  if (l <= kValueEpsilon) {
+    return {};
+  }
+  const double x     = std::clamp((d0 * d0 - d2 * d2 + l * l) / (2.0 * l), 0.0, l);
+  const double alpha = x / l;
+  const double cct   = p0.cct_ + (p2.cct_ - p0.cct_) * alpha;
+  const double v_tx  = p0.v_ + (p2.v_ - p0.v_) * alpha;
+  const double duv   = std::sqrt(std::max(0.0, d0 * d0 - x * x)) * SignFromDeltaV(uv[1] - v_tx);
+  return OhnoSolution{std::isfinite(cct) && std::isfinite(duv), cct, duv};
+}
+
+auto SolveOhnoParabolic(const cv::Vec2d& uv, PlanckianTable table, size_t m) -> OhnoSolution {
+  const auto& p0 = table[m - 1];
+  const auto& p1 = table[m];
+  const auto& p2 = table[m + 1];
+  const double t0 = p0.cct_ * 0.001;
+  const double t1 = p1.cct_ * 0.001;
+  const double t2 = p2.cct_ * 0.001;
+  const double d0 = Distance(uv, EntryUV(p0));
+  const double d1 = Distance(uv, EntryUV(p1));
+  const double d2 = Distance(uv, EntryUV(p2));
+  const double denom0 = (t0 - t1) * (t0 - t2);
+  const double denom1 = (t1 - t0) * (t1 - t2);
+  const double denom2 = (t2 - t0) * (t2 - t1);
+  if (std::abs(denom0) <= kValueEpsilon || std::abs(denom1) <= kValueEpsilon ||
+      std::abs(denom2) <= kValueEpsilon) {
+    return {};
+  }
+  const double a = d0 / denom0 + d1 / denom1 + d2 / denom2;
+  const double b = -d0 * (t1 + t2) / denom0 - d1 * (t0 + t2) / denom1 - d2 * (t0 + t1) / denom2;
+  const double c = d0 * t1 * t2 / denom0 + d1 * t0 * t2 / denom1 + d2 * t0 * t1 / denom2;
+  if (!std::isfinite(a) || std::abs(a) <= kValueEpsilon) {
+    return {};
+  }
+  const double tx       = std::clamp(-b / (2.0 * a), t0, t2);
+  const double cct      = tx * 1000.0;
+  const double distance = std::max(0.0, a * tx * tx + b * tx + c);
+  const double v_tx     = PlanckianUVAtCCT(cct)[1];
+  const double duv      = distance * SignFromDeltaV(uv[1] - v_tx);
+  return OhnoSolution{std::isfinite(cct) && std::isfinite(duv), cct, duv};
+}
+
+auto OhnoTemperatureDuv(const cv::Vec2d& uv, double& out_cct, double& out_duv) -> bool {
+  if (!std::isfinite(uv[0]) || !std::isfinite(uv[1])) {
+    return false;
+  }
+  const auto table = OhnoPlanckianTable();
+  if (table.size() < 3) {
+    return false;
+  }
+  const size_t       m          = FindClosestOhnoSample(uv, table);
+  const OhnoSolution triangular = SolveOhnoTriangular(uv, table, m);
+  const OhnoSolution parabolic  = SolveOhnoParabolic(uv, table, m);
+  const OhnoSolution& selected =
+      (triangular.valid_ && (std::abs(triangular.duv_) < kOhnoNearLocusDuv || !parabolic.valid_))
+          ? triangular
+          : parabolic;
+  if (!selected.valid_) {
+    return false;
+  }
+  out_cct = ClampFinite(selected.cct_, kCustomCCTMin, kCustomCCTMax);
+  out_duv = selected.duv_;
+  return std::isfinite(out_cct) && std::isfinite(out_duv);
+}
+
+auto UVToTemperatureTint(const cv::Vec2d& uv, double& out_cct, double& out_tint) -> bool {
+  double duv = 0.0;
+  if (!OhnoTemperatureDuv(uv, out_cct, duv)) {
+    return false;
+  }
+  const auto locus = PlanckianLocusAtCCT(out_cct);
+  if (!locus.valid_) {
+    return false;
+  }
+  const double delta_u = uv[0] - locus.uv_[0];
+  const double delta_v = uv[1] - locus.uv_[1];
+  out_tint             = -kTintScale * (delta_u * locus.perp_[0] + delta_v * locus.perp_[1]);
+  return std::isfinite(out_cct) && std::isfinite(out_tint);
+}
+
+auto TemperatureTintToUV(double cct, double tint) -> cv::Vec2d {
+  const auto locus = PlanckianLocusAtCCT(cct);
+  if (!locus.valid_) {
+    return locus.uv_;
+  }
+  const double duv = ClampFinite(tint, kCustomTintMin, kCustomTintMax) / kTintScale;
+  return cv::Vec2d(locus.uv_[0] - locus.perp_[0] * duv, locus.uv_[1] - locus.perp_[1] * duv);
+}
+
+auto BuildBradfordCAT(const cv::Vec2d& src_xy, const cv::Vec2d& dst_xy) -> cv::Matx33d {
+  static const cv::Matx33d kBradford(0.8951, 0.2664, -0.1614, -0.7502, 1.7135, 0.0367, 0.0389,
+                                     -0.0685, 1.0296);
+  static const cv::Matx33d kBradfordInv(0.9869929, -0.1470543, 0.1599627, 0.4323053, 0.5183603,
+                                        0.0492912, -0.0085287, 0.0400428, 0.9684867);
+  const cv::Vec3d src_xyz = XYToXYZ(src_xy);
+  const cv::Vec3d dst_xyz = XYToXYZ(dst_xy);
+  const cv::Vec3d src_lms = kBradford * src_xyz;
+  const cv::Vec3d dst_lms = kBradford * dst_xyz;
+  const cv::Matx33d diag  = cv::Matx33d::diag(cv::Vec3d(
+      dst_lms[0] / std::max(src_lms[0], kValueEpsilon),
+      dst_lms[1] / std::max(src_lms[1], kValueEpsilon),
+      dst_lms[2] / std::max(src_lms[2], kValueEpsilon)));
+  return kBradfordInv * diag * kBradford;
+}
+
+void StoreMatrix(const cv::Matx33d& src, std::array<float, 9>& dst) {
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      dst[static_cast<std::size_t>(r * 3 + c)] = static_cast<float>(src(r, c));
+    }
+  }
+}
+
+auto ResolveColorMatrixEndpoints(const DevelopCameraProfile& profile, cv::Matx33d& cm1,
+                                 cv::Matx33d& cm2, double& endpoint_cct_1, double& endpoint_cct_2)
+    -> ColorTransformError {
+  if (!profile.color_matrices_valid) {
+    return ColorTransformError::MissingCameraMatrices;
+  }
+  cm1 = MatrixFromArray9(profile.color_matrix_1);
+  cm2 = MatrixFromArray9(profile.color_matrix_2);
+  if (!IsFiniteInvertible(cm1)) {
+    return ColorTransformError::SingularCameraMatrix;
+  }
+  if (HasDualIlluminantCalibration(profile)) {
+    if (!IsFiniteInvertible(cm2)) {
+      return ColorTransformError::SingularCameraMatrix;
+    }
+    endpoint_cct_1 = profile.color_matrix_1_cct;
+    endpoint_cct_2 = profile.color_matrix_2_cct;
+  } else {
+    cm2            = cm1;
+    endpoint_cct_1 = 5000.0;
+    endpoint_cct_2 = 5000.0;
+  }
+  return ColorTransformError::Ok;
+}
+
+auto ResolveForwardMatrixEndpoints(const DevelopCameraProfile& profile, cv::Matx33d& fm1,
+                                   cv::Matx33d& fm2) -> bool {
+  if (!profile.forward_matrices_valid) {
+    return false;
+  }
+  fm1 = MatrixFromArray9(profile.forward_matrix_1);
+  fm2 = MatrixFromArray9(profile.forward_matrix_2);
+  if (!HasDualIlluminantCalibration(profile)) {
+    fm2 = fm1;
+  }
+  return IsFiniteMatrix(fm1) && IsFiniteMatrix(fm2);
+}
+
+auto ResolveAsShotCameraNeutral(const DevelopCameraProfile& profile, cv::Vec3d& out_neutral)
+    -> bool {
+  if (profile.as_shot_neutral_valid) {
+    const cv::Vec3d neutral(profile.as_shot_neutral[0], profile.as_shot_neutral[1],
+                            profile.as_shot_neutral[2]);
+    if (std::all_of(std::begin(neutral.val), std::end(neutral.val), [](double value) {
+          return std::isfinite(value) && value > kValueEpsilon;
+        })) {
+      out_neutral = neutral;
+      return true;
+    }
+  }
+  const double r = std::max(static_cast<double>(profile.cam_mul[0]), kValueEpsilon);
+  const double g = std::max(static_cast<double>(profile.cam_mul[1]), kValueEpsilon);
+  const double b = std::max(static_cast<double>(profile.cam_mul[2]), kValueEpsilon);
+  if (!std::isfinite(r) || !std::isfinite(g) || !std::isfinite(b)) {
+    return false;
+  }
+  out_neutral = cv::Vec3d(g / r, 1.0, g / b);
+  return std::all_of(std::begin(out_neutral.val), std::end(out_neutral.val), [](double value) {
+    return std::isfinite(value) && value > kValueEpsilon;
+  });
+}
+
+auto TintAtCctForXY(double cct, const cv::Vec2d& xy, double& out_tint) -> bool {
+  const auto locus = PlanckianLocusAtCCT(cct);
+  if (!locus.valid_) {
+    return false;
+  }
+  const cv::Vec2d uv     = XYToUV(xy);
+  const double    delta_u = uv[0] - locus.uv_[0];
+  const double    delta_v = uv[1] - locus.uv_[1];
+  out_tint                = -kTintScale * (delta_u * locus.perp_[0] + delta_v * locus.perp_[1]);
+  return std::isfinite(out_tint);
+}
+
+struct AsShotCctEvaluation {
+  bool      valid_         = false;
+  double    candidate_cct_ = 0.0;
+  double    derived_cct_   = 0.0;
+  double    residual_      = 0.0;
+  double    tint_          = 0.0;
+  cv::Vec2d xy_            = cv::Vec2d(kD50X, kD50Y);
+};
+
+auto EvaluateAsShotAtCct(const cv::Vec3d& camera_neutral, const cv::Matx33d& cm1,
+                         const cv::Matx33d& cm2, double endpoint_cct_1, double endpoint_cct_2,
+                         double candidate_cct) -> AsShotCctEvaluation {
+  AsShotCctEvaluation eval;
+  eval.candidate_cct_ = ClampFinite(candidate_cct, kCustomCCTMin, kCustomCCTMax);
+  const cv::Matx33d xyz_to_camera =
+      InterpolateColorMatrix(cm1, cm2, eval.candidate_cct_, endpoint_cct_1, endpoint_cct_2);
+  cv::Matx33d camera_to_xyz;
+  if (!Invert3x3(xyz_to_camera, camera_to_xyz)) {
+    return eval;
+  }
+  const cv::Vec3d white_xyz = camera_to_xyz * camera_neutral;
+  if (!XYZToXY(white_xyz, eval.xy_)) {
+    return eval;
+  }
+  double derived_tint = 0.0;
+  if (!UVToTemperatureTint(XYToUV(eval.xy_), eval.derived_cct_, derived_tint)) {
+    return eval;
+  }
+  if (!TintAtCctForXY(eval.candidate_cct_, eval.xy_, eval.tint_)) {
+    return eval;
+  }
+  eval.residual_ = eval.derived_cct_ - eval.candidate_cct_;
+  eval.valid_    = std::isfinite(eval.residual_) && std::isfinite(eval.tint_);
+  return eval;
+}
+
+auto IsBetterAsShotEvaluation(const AsShotCctEvaluation& candidate,
+                              const AsShotCctEvaluation& incumbent) -> bool {
+  if (!candidate.valid_) {
+    return false;
+  }
+  if (!incumbent.valid_) {
+    return true;
+  }
+  return std::abs(candidate.residual_) < std::abs(incumbent.residual_);
+}
+
+auto HasOppositeSigns(double a, double b) -> bool {
+  return (a <= 0.0 && b >= 0.0) || (a >= 0.0 && b <= 0.0);
+}
+
+auto RefineAsShotCctRoot(const cv::Vec3d& camera_neutral, const cv::Matx33d& cm1,
+                         const cv::Matx33d& cm2, double endpoint_cct_1, double endpoint_cct_2,
+                         AsShotCctEvaluation low, AsShotCctEvaluation high)
+    -> AsShotCctEvaluation {
+  AsShotCctEvaluation best = IsBetterAsShotEvaluation(low, high) ? low : high;
+  for (int i = 0; i < kAsShotSolveMaxIter; ++i) {
+    const double mid_cct = 0.5 * (low.candidate_cct_ + high.candidate_cct_);
+    auto         mid =
+        EvaluateAsShotAtCct(camera_neutral, cm1, cm2, endpoint_cct_1, endpoint_cct_2, mid_cct);
+    if (!mid.valid_) {
+      break;
+    }
+    if (IsBetterAsShotEvaluation(mid, best)) {
+      best = mid;
+    }
+    if (std::abs(mid.residual_) <= kAsShotSolveEpsilon) {
+      return mid;
+    }
+    if (HasOppositeSigns(low.residual_, mid.residual_)) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+  return best;
+}
+
+auto SolveAsShotWhiteXY(const DevelopCameraProfile& profile, const cv::Matx33d& cm1,
+                        const cv::Matx33d& cm2, double endpoint_cct_1, double endpoint_cct_2,
+                        cv::Vec2d& out_xy, double& out_cct, double& out_tint) -> bool {
+  cv::Vec3d camera_neutral;
+  if (!ResolveAsShotCameraNeutral(profile, camera_neutral)) {
+    return false;
+  }
+  AsShotCctEvaluation best;
+  AsShotCctEvaluation previous;
+  constexpr int       kScanCount = 96;
+  const double        min_mired  = 1.0e6 / kCustomCCTMax;
+  const double        max_mired  = 1.0e6 / kCustomCCTMin;
+  for (int i = 0; i <= kScanCount; ++i) {
+    const double t     = static_cast<double>(i) / static_cast<double>(kScanCount);
+    const double mired = max_mired + (min_mired - max_mired) * t;
+    const double cct   = 1.0e6 / std::max(mired, kValueEpsilon);
+    auto eval =
+        EvaluateAsShotAtCct(camera_neutral, cm1, cm2, endpoint_cct_1, endpoint_cct_2, cct);
+    if (!eval.valid_) {
+      continue;
+    }
+    if (IsBetterAsShotEvaluation(eval, best)) {
+      best = eval;
+    }
+    if (previous.valid_ && HasOppositeSigns(previous.residual_, eval.residual_)) {
+      auto refined = RefineAsShotCctRoot(camera_neutral, cm1, cm2, endpoint_cct_1, endpoint_cct_2,
+                                         previous, eval);
+      if (IsBetterAsShotEvaluation(refined, best)) {
+        best = refined;
+      }
+    }
+    previous = eval;
+  }
+  if (!best.valid_) {
+    return false;
+  }
+  out_xy   = best.xy_;
+  out_cct  = best.candidate_cct_;
+  out_tint = best.tint_;
+  return true;
+}
+
+auto BuildCameraToXyzD50FromForwardMatrix(const cv::Matx33d& cm1, const cv::Matx33d& cm2,
+                                          const cv::Matx33d& fm1, const cv::Matx33d& fm2,
+                                          double cct, double endpoint_cct_1, double endpoint_cct_2,
+                                          const cv::Vec2d& white_xy,
+                                          cv::Matx33d&     out_camera_to_xyz_d50) -> bool {
+  const cv::Matx33d xyz_to_camera =
+      InterpolateColorMatrix(cm1, cm2, cct, endpoint_cct_1, endpoint_cct_2);
+  const cv::Matx33d forward_matrix =
+      InterpolateColorMatrix(fm1, fm2, cct, endpoint_cct_1, endpoint_cct_2);
+  const cv::Vec3d reference_neutral = xyz_to_camera * XYToXYZ(white_xy);
+  if (!std::all_of(std::begin(reference_neutral.val), std::end(reference_neutral.val),
+                   [](double value) { return std::isfinite(value) && value > kValueEpsilon; })) {
+    return false;
+  }
+  const cv::Matx33d reference_scale = cv::Matx33d::diag(
+      cv::Vec3d(1.0 / reference_neutral[0], 1.0 / reference_neutral[1], 1.0 / reference_neutral[2]));
+  out_camera_to_xyz_d50 = forward_matrix * reference_scale;
+  return IsFiniteMatrix(out_camera_to_xyz_d50);
+}
+
+auto IsCustomWbMode(const std::string& mode) -> bool {
+  return mode == "custom";
+}
+
+auto Fail(ColorTransformError error) -> ColorTransformResult {
+  return ColorTransformResult{false, error, {}};
+}
+
+}  // namespace
+
+void BindDevelopCameraProfile(DevelopPayload& payload, const RawRuntimeColorContext& imported) {
+  auto& profile                     = payload.camera_profile;
+  profile.color_matrices_valid      = imported.color_matrices_valid_;
+  profile.forward_matrices_valid    = imported.forward_matrices_valid_;
+  profile.as_shot_neutral_valid     = imported.as_shot_neutral_valid_;
+  profile.calibration_illuminants_valid = imported.calibration_illuminants_valid_;
+  profile.color_matrix_1_cct        = imported.color_matrix_1_cct_;
+  profile.color_matrix_2_cct        = imported.color_matrix_2_cct_;
+  for (int i = 0; i < 9; ++i) {
+    profile.color_matrix_1[static_cast<std::size_t>(i)]   = imported.color_matrix_1_[i];
+    profile.color_matrix_2[static_cast<std::size_t>(i)]   = imported.color_matrix_2_[i];
+    profile.forward_matrix_1[static_cast<std::size_t>(i)] = imported.forward_matrix_1_[i];
+    profile.forward_matrix_2[static_cast<std::size_t>(i)] = imported.forward_matrix_2_[i];
+  }
+  for (int i = 0; i < 3; ++i) {
+    profile.as_shot_neutral[static_cast<std::size_t>(i)] = imported.as_shot_neutral_[i];
+    profile.cam_mul[static_cast<std::size_t>(i)]        = imported.cam_mul_[i];
+  }
+
+  DevelopPayload as_shot = payload;
+  as_shot.wb_mode        = "as_shot";
+  const auto solved      = ResolveDevelopColorTransform(as_shot);
+  if (solved.ok) {
+    payload.as_shot_cct  = solved.transform.resolved_cct;
+    payload.as_shot_tint = solved.transform.resolved_tint;
+  }
+}
+
+auto ResolveDevelopColorTransform(const DevelopPayload& develop) -> ColorTransformResult {
+  cv::Matx33d cm1;
+  cv::Matx33d cm2;
+  double      endpoint_cct_1 = kCalibrationLowCCT;
+  double      endpoint_cct_2 = kCalibrationHighCCT;
+  const auto  endpoint_error =
+      ResolveColorMatrixEndpoints(develop.camera_profile, cm1, cm2, endpoint_cct_1, endpoint_cct_2);
+  if (endpoint_error != ColorTransformError::Ok) {
+    return Fail(endpoint_error);
+  }
+
+  cv::Matx33d fm1;
+  cv::Matx33d fm2;
+  const bool  has_forward_matrices =
+      ResolveForwardMatrixEndpoints(develop.camera_profile, fm1, fm2);
+
+  cv::Vec2d selected_xy(kD50X, kD50Y);
+  double    selected_cct  = develop.custom_cct;
+  double    selected_tint = develop.custom_tint;
+  if (!IsCustomWbMode(develop.wb_mode)) {
+    if (!SolveAsShotWhiteXY(develop.camera_profile, cm1, cm2, endpoint_cct_1, endpoint_cct_2,
+                            selected_xy, selected_cct, selected_tint)) {
+      return Fail(ColorTransformError::InvalidAsShotNeutral);
+    }
+  } else {
+    selected_cct  = ClampFinite(develop.custom_cct, kCustomCCTMin, kCustomCCTMax);
+    selected_tint = ClampFinite(develop.custom_tint, kCustomTintMin, kCustomTintMax);
+    selected_xy   = UVToXY(TemperatureTintToUV(selected_cct, selected_tint));
+  }
+
+  const cv::Matx33d xyz_to_camera =
+      InterpolateColorMatrix(cm1, cm2, selected_cct, endpoint_cct_1, endpoint_cct_2);
+  cv::Matx33d camera_to_xyz;
+  if (!Invert3x3(xyz_to_camera, camera_to_xyz)) {
+    return Fail(ColorTransformError::SingularCameraMatrix);
+  }
+
+  cv::Matx33d camera_to_xyz_d50;
+  if (has_forward_matrices) {
+    if (!BuildCameraToXyzD50FromForwardMatrix(cm1, cm2, fm1, fm2, selected_cct, endpoint_cct_1,
+                                              endpoint_cct_2, selected_xy, camera_to_xyz_d50)) {
+      return Fail(ColorTransformError::NonFiniteMatrix);
+    }
+  } else {
+    const cv::Matx33d cat_src_to_d50 = BuildBradfordCAT(selected_xy, cv::Vec2d(kD50X, kD50Y));
+    camera_to_xyz_d50                = cat_src_to_d50 * camera_to_xyz;
+    if (!IsFiniteMatrix(camera_to_xyz_d50)) {
+      return Fail(ColorTransformError::NonFiniteMatrix);
+    }
+  }
+
+  const cv::Matx33d cat_d50_to_d60 =
+      BuildBradfordCAT(cv::Vec2d(kD50X, kD50Y), cv::Vec2d(kD60X, kD60Y));
+  const cv::Matx33d xyz_d50_to_ap1 = kXyzD60ToAp1 * cat_d50_to_d60;
+  const cv::Matx33d camera_to_ap1  = xyz_d50_to_ap1 * camera_to_xyz_d50;
+  if (!IsFiniteMatrix(camera_to_ap1) || !IsFiniteMatrix(xyz_d50_to_ap1)) {
+    return Fail(ColorTransformError::NonFiniteMatrix);
+  }
+
+  DevelopColorTransform transform;
+  StoreMatrix(camera_to_xyz, transform.camera_to_xyz);
+  StoreMatrix(camera_to_xyz_d50, transform.camera_to_xyz_d50);
+  StoreMatrix(xyz_d50_to_ap1, transform.xyz_d50_to_ap1);
+  StoreMatrix(camera_to_ap1, transform.camera_to_ap1);
+  transform.resolved_cct  = static_cast<float>(ClampFinite(selected_cct, kCustomCCTMin, kCustomCCTMax));
+  transform.resolved_tint = static_cast<float>(ClampFinite(selected_tint, kCustomTintMin, kCustomTintMax));
+  return ColorTransformResult{true, ColorTransformError::Ok, transform};
+}
+
+auto ColorTransformErrorMessage(ColorTransformError error) -> std::string_view {
+  switch (error) {
+    case ColorTransformError::Ok:
+      return "ok";
+    case ColorTransformError::MissingCameraMatrices:
+      return "missing camera matrices";
+    case ColorTransformError::SingularCameraMatrix:
+      return "singular camera matrix";
+    case ColorTransformError::NonFiniteMatrix:
+      return "non-finite color matrix";
+    case ColorTransformError::InvalidAsShotNeutral:
+      return "invalid as-shot neutral";
+    case ColorTransformError::InvalidWhitePoint:
+      return "invalid white point";
+  }
+  return "color transform error";
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/develop_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/develop_node_model.cpp
@@ -17,6 +17,7 @@ auto DevelopParamsModel::IsDefault() const -> bool {
 
 auto DevelopParamsModel::ToJson() const -> nlohmann::json {
   const auto payload = PayloadCopy();
+  const auto& profile = payload.camera_profile;
   return {{"demosaic_method", payload.demosaic_method},
           {"highlights_reconstruct", payload.highlights_reconstruct},
           {"use_camera_wb", payload.use_camera_wb},
@@ -26,6 +27,19 @@ auto DevelopParamsModel::ToJson() const -> nlohmann::json {
           {"custom_tint", payload.custom_tint},
           {"as_shot_cct", payload.as_shot_cct},
           {"as_shot_tint", payload.as_shot_tint},
+          {"camera_profile",
+           {{"color_matrices_valid", profile.color_matrices_valid},
+            {"color_matrix_1", json_util::MakeJsonArray(profile.color_matrix_1.data(), 9)},
+            {"color_matrix_2", json_util::MakeJsonArray(profile.color_matrix_2.data(), 9)},
+            {"forward_matrices_valid", profile.forward_matrices_valid},
+            {"forward_matrix_1", json_util::MakeJsonArray(profile.forward_matrix_1.data(), 9)},
+            {"forward_matrix_2", json_util::MakeJsonArray(profile.forward_matrix_2.data(), 9)},
+            {"as_shot_neutral_valid", profile.as_shot_neutral_valid},
+            {"as_shot_neutral", json_util::MakeJsonArray(profile.as_shot_neutral.data(), 3)},
+            {"calibration_illuminants_valid", profile.calibration_illuminants_valid},
+            {"color_matrix_1_cct", profile.color_matrix_1_cct},
+            {"color_matrix_2_cct", profile.color_matrix_2_cct},
+            {"cam_mul", json_util::MakeJsonArray(profile.cam_mul.data(), 3)}}},
           {"lens_enabled", payload.lens_enabled},
           {"apply_vignetting", payload.apply_vignetting},
           {"apply_distortion", payload.apply_distortion},
@@ -50,6 +64,30 @@ void DevelopParamsModel::LoadJson(const nlohmann::json& json) {
     payload.custom_tint            = json_util::ReadFloat(json, "custom_tint", payload.custom_tint);
     payload.as_shot_cct            = json_util::ReadFloat(json, "as_shot_cct", payload.as_shot_cct);
     payload.as_shot_tint           = json_util::ReadFloat(json, "as_shot_tint", payload.as_shot_tint);
+    if (json.contains("camera_profile") && json["camera_profile"].is_object()) {
+      const auto& profile_json = json["camera_profile"];
+      auto&       profile      = payload.camera_profile;
+      profile.color_matrices_valid =
+          json_util::ReadBool(profile_json, "color_matrices_valid", profile.color_matrices_valid);
+      json_util::ReadNumberArray(profile_json, "color_matrix_1", profile.color_matrix_1.data(), 9);
+      json_util::ReadNumberArray(profile_json, "color_matrix_2", profile.color_matrix_2.data(), 9);
+      profile.forward_matrices_valid = json_util::ReadBool(
+          profile_json, "forward_matrices_valid", profile.forward_matrices_valid);
+      json_util::ReadNumberArray(profile_json, "forward_matrix_1", profile.forward_matrix_1.data(),
+                                 9);
+      json_util::ReadNumberArray(profile_json, "forward_matrix_2", profile.forward_matrix_2.data(),
+                                 9);
+      profile.as_shot_neutral_valid =
+          json_util::ReadBool(profile_json, "as_shot_neutral_valid", profile.as_shot_neutral_valid);
+      json_util::ReadNumberArray(profile_json, "as_shot_neutral", profile.as_shot_neutral.data(), 3);
+      profile.calibration_illuminants_valid = json_util::ReadBool(
+          profile_json, "calibration_illuminants_valid", profile.calibration_illuminants_valid);
+      profile.color_matrix_1_cct =
+          json_util::ReadDouble(profile_json, "color_matrix_1_cct", profile.color_matrix_1_cct);
+      profile.color_matrix_2_cct =
+          json_util::ReadDouble(profile_json, "color_matrix_2_cct", profile.color_matrix_2_cct);
+      json_util::ReadNumberArray(profile_json, "cam_mul", profile.cam_mul.data(), 3);
+    }
     payload.lens_enabled           = json_util::ReadBool(json, "lens_enabled", payload.lens_enabled);
     payload.apply_vignetting       = json_util::ReadBool(json, "apply_vignetting", payload.apply_vignetting);
     payload.apply_distortion       = json_util::ReadBool(json, "apply_distortion", payload.apply_distortion);

--- a/alcedo_studio/src/edit/graph/develop_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/develop_node_model.cpp
@@ -104,6 +104,9 @@ void DevelopParamsModel::LoadJson(const nlohmann::json& json) {
 }
 
 void DevelopParamsModel::ReplaceParams(DevelopPayload payload) {
+  if (payload == PayloadCopy()) {
+    return;
+  }
   Mutate(DevelopDirty::All, [payload = std::move(payload)](DevelopPayload& dest) mutable {
     dest = std::move(payload);
   });

--- a/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
+++ b/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 
 #include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/cat02_white_balance_model.hpp"
 #include "edit/operators/models/json_read.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 
@@ -312,11 +313,19 @@ auto LegacyPipelineImporter::Import(const nlohmann::json& stage_json) -> LegacyI
     }
   }
   if (const auto* tint = FindOp(operators, kLegacyTint)) {
-    auto model = std::make_unique<TintModel>();
-    const auto nested = NestedOrSelf(tint->params, "tint");
-    ApplyScalar(model.get(), nested, "tint");
-    document.InsertAdjustment(NodeId{"grade.primary"}, grade->AdjustmentCount(),
-                              AdjustmentInstanceId{"grade.primary.tint"}, std::move(model));
+    // Legacy Tint is not a CUDA grade kernel. Fold it into CAT02 tint_offset so reopen of
+    // stored pipelines does not insert an unregistered adjustment type.
+    if (auto* cat02 = dynamic_cast<Cat02WhiteBalanceModel*>(
+            grade->FindAdjustmentByType(type_ids::Cat02WhiteBalance()))) {
+      const auto nested = NestedOrSelf(tint->params, "tint");
+      float      value  = 0.0f;
+      if (nested.is_number()) {
+        value = nested.get<float>();
+      } else {
+        value = json_util::ReadFloat(nested, "tint", 0.0f);
+      }
+      cat02->SetTintOffset(value);
+    }
   }
   if (const auto* odt = FindOp(operators, kLegacyOdt)) {
     drt->Params().LoadJson(NestedOrSelf(odt->params, "odt"));

--- a/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
+++ b/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
@@ -9,6 +9,7 @@
 
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/models/cat02_white_balance_model.hpp"
+#include "edit/operators/models/i_operator_model.hpp"
 #include "edit/operators/models/json_read.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 
@@ -104,6 +105,18 @@ auto FindOp(const std::vector<LegacyOperator>& operators, int type) -> const Leg
   return nullptr;
 }
 
+void LoadJsonIfChanged(IOperatorModel* model, const nlohmann::json& json) {
+  if (model == nullptr || json.empty()) {
+    return;
+  }
+  const auto before    = model->ToJson();
+  const bool was_dirty = model->IsDirty();
+  model->LoadJson(json);
+  if (!was_dirty && model->ToJson() == before) {
+    (void)model->TakeDirtyPatch();
+  }
+}
+
 void ApplyScalar(IOperatorModel* model, const nlohmann::json& value, const char* new_key) {
   if (model == nullptr) {
     return;
@@ -116,9 +129,7 @@ void ApplyScalar(IOperatorModel* model, const nlohmann::json& value, const char*
   } else if (value.is_object()) {
     json = value;
   }
-  if (!json.empty()) {
-    model->LoadJson(json);
-  }
+  LoadJsonIfChanged(model, json);
 }
 
 void ApplyCrop(ImageGeometryModel& geometry, const LegacyOperator& op) {
@@ -203,21 +214,16 @@ void ApplyGradeScalar(ColorGradeNodeModel& grade, const OperatorTypeId& type,
     const float multiplier = std::max(0.0f, 1.0f + offset / 100.0f);
     nlohmann::json json;
     json[new_key] = multiplier;
-    model->LoadJson(json);
+    LoadJsonIfChanged(model, json);
     return;
   }
   ApplyScalar(model, value, new_key);
 }
 
-}  // namespace
-
-auto LegacyPipelineImporter::Import(const nlohmann::json& stage_json) -> LegacyImportResult {
-  LegacyImportResult result;
-  const auto         operators = CollectOperators(stage_json);
+auto ValidateOperators(const std::vector<LegacyOperator>& operators) -> std::string {
   for (const auto& op : operators) {
     if (IsFatalUnknown(op.type)) {
-      result.error = "Unknown legacy operator type: " + std::to_string(op.type);
-      return result;
+      return "Unknown legacy operator type: " + std::to_string(op.type);
     }
     if (!IsSkippedType(op.type) && op.type != kLegacyRawDecode && op.type != kLegacyExposure &&
         op.type != kLegacyContrast && op.type != kLegacyWhite && op.type != kLegacyBlack &&
@@ -227,56 +233,60 @@ auto LegacyPipelineImporter::Import(const nlohmann::json& stage_json) -> LegacyI
         op.type != kLegacyClarity && op.type != kLegacySharpen && op.type != kLegacyColorWheel &&
         op.type != kLegacyCropRotate && op.type != kLegacyLensCalibration &&
         op.type != kLegacyColorTemp && op.type != kLegacyFilmGrain && op.type != kLegacyHalation) {
-      result.error = "Unknown legacy operator type: " + std::to_string(op.type);
-      return result;
+      return "Unknown legacy operator type: " + std::to_string(op.type);
     }
   }
+  return {};
+}
 
-  auto document = CreateDefaultPipelineDocument();
+auto ApplyOperators(PipelineDocument& document, const std::vector<LegacyOperator>& operators)
+    -> std::string {
+  auto* grade = document.PrimaryGrade();
+  auto* drt   = document.Drt();
+  if (grade == nullptr || drt == nullptr) {
+    return "Document is missing grade or DRT";
+  }
+
   if (const auto* crop = FindOp(operators, kLegacyCropRotate)) {
     ApplyCrop(document.Geometry(), *crop);
   }
   if (auto* develop = document.Develop()) {
     ApplyDevelop(develop->Params(), operators);
   }
-  auto* grade = document.PrimaryGrade();
-  auto* drt   = document.Drt();
-  if (grade == nullptr || drt == nullptr) {
-    result.error = "Default document is missing grade or DRT";
-    return result;
-  }
 
   ApplyGradeScalar(*grade, type_ids::Exposure(), FindOp(operators, kLegacyExposure), "exposure",
                    "exposure_ev", false);
   ApplyGradeScalar(*grade, type_ids::Contrast(), FindOp(operators, kLegacyContrast), "contrast",
                    "contrast", false);
-  ApplyGradeScalar(*grade, type_ids::White(), FindOp(operators, kLegacyWhite), "white", "white", false);
-  ApplyGradeScalar(*grade, type_ids::Black(), FindOp(operators, kLegacyBlack), "black", "black", false);
-  ApplyGradeScalar(*grade, type_ids::Shadows(), FindOp(operators, kLegacyShadows), "shadows", "shadows",
+  ApplyGradeScalar(*grade, type_ids::White(), FindOp(operators, kLegacyWhite), "white", "white",
                    false);
-  ApplyGradeScalar(*grade, type_ids::Highlights(), FindOp(operators, kLegacyHighlights), "highlights",
-                   "highlights", false);
-  ApplyGradeScalar(*grade, type_ids::Saturation(), FindOp(operators, kLegacySaturation), "saturation",
-                   "saturation", true);
+  ApplyGradeScalar(*grade, type_ids::Black(), FindOp(operators, kLegacyBlack), "black", "black",
+                   false);
+  ApplyGradeScalar(*grade, type_ids::Shadows(), FindOp(operators, kLegacyShadows), "shadows",
+                   "shadows", false);
+  ApplyGradeScalar(*grade, type_ids::Highlights(), FindOp(operators, kLegacyHighlights),
+                   "highlights", "highlights", false);
+  ApplyGradeScalar(*grade, type_ids::Saturation(), FindOp(operators, kLegacySaturation),
+                   "saturation", "saturation", true);
   ApplyGradeScalar(*grade, type_ids::Vibrance(), FindOp(operators, kLegacyVibrance), "vibrance",
                    "vibrance", false);
-  ApplyGradeScalar(*grade, type_ids::Clarity(), FindOp(operators, kLegacyClarity), "clarity", "clarity",
-                   false);
+  ApplyGradeScalar(*grade, type_ids::Clarity(), FindOp(operators, kLegacyClarity), "clarity",
+                   "clarity", false);
 
   if (const auto* curve = FindOp(operators, kLegacyCurve)) {
     if (auto* model = grade->FindAdjustmentByType(type_ids::Curve())) {
       const auto nested = NestedOrSelf(curve->params, "curve");
-      model->LoadJson(nested.is_object() ? nested : curve->params);
+      LoadJsonIfChanged(model, nested.is_object() ? nested : curve->params);
     }
   }
   if (const auto* hls = FindOp(operators, kLegacyHls)) {
     if (auto* model = grade->FindAdjustmentByType(type_ids::Hls())) {
-      model->LoadJson(NestedOrSelf(hls->params, "HLS"));
+      LoadJsonIfChanged(model, NestedOrSelf(hls->params, "HLS"));
     }
   }
   if (const auto* wheel = FindOp(operators, kLegacyColorWheel)) {
     if (auto* model = grade->FindAdjustmentByType(type_ids::ColorWheel())) {
-      model->LoadJson(NestedOrSelf(wheel->params, "color_wheel"));
+      LoadJsonIfChanged(model, NestedOrSelf(wheel->params, "color_wheel"));
     }
   }
   if (const auto* lmt = FindOp(operators, kLegacyLmt)) {
@@ -287,17 +297,18 @@ auto LegacyPipelineImporter::Import(const nlohmann::json& stage_json) -> LegacyI
       } else {
         json["cube_path"] = json_util::ReadString(lmt->params, "cube_path", {});
       }
-      model->LoadJson(json);
+      LoadJsonIfChanged(model, json);
     }
   }
   if (const auto* sharpen = FindOp(operators, kLegacySharpen)) {
     if (auto* model = grade->FindAdjustmentByType(type_ids::Sharpen())) {
       const auto nested = NestedOrSelf(sharpen->params, "sharpen");
       nlohmann::json json;
-      json["amount"]    = json_util::ReadFloat(nested, "offset", json_util::ReadFloat(nested, "amount", 0.0f));
+      json["amount"] =
+          json_util::ReadFloat(nested, "offset", json_util::ReadFloat(nested, "amount", 0.0f));
       json["radius"]    = json_util::ReadFloat(nested, "radius", 3.0f);
       json["threshold"] = json_util::ReadFloat(nested, "threshold", 0.0f);
-      model->LoadJson(json);
+      LoadJsonIfChanged(model, json);
     }
   }
   if (const auto* grain = FindOp(operators, kLegacyFilmGrain)) {
@@ -328,11 +339,30 @@ auto LegacyPipelineImporter::Import(const nlohmann::json& stage_json) -> LegacyI
     }
   }
   if (const auto* odt = FindOp(operators, kLegacyOdt)) {
-    drt->Params().LoadJson(NestedOrSelf(odt->params, "odt"));
+    LoadJsonIfChanged(&drt->Params(), NestedOrSelf(odt->params, "odt"));
   }
+  return {};
+}
 
-  result.document = std::move(document);
+}  // namespace
+
+auto LegacyPipelineImporter::Import(const nlohmann::json& stage_json) -> LegacyImportResult {
+  LegacyImportResult result;
+  auto               document = CreateDefaultPipelineDocument();
+  result.error                = ApplyOnto(document, stage_json);
+  if (result.error.empty()) {
+    result.document = std::move(document);
+  }
   return result;
+}
+
+auto LegacyPipelineImporter::ApplyOnto(PipelineDocument&     document,
+                                       const nlohmann::json& stage_json) -> std::string {
+  const auto operators = CollectOperators(stage_json);
+  if (const auto error = ValidateOperators(operators); !error.empty()) {
+    return error;
+  }
+  return ApplyOperators(document, operators);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/pipeline_document.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_document.cpp
@@ -10,6 +10,7 @@
 #include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/raster_mask_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
 
 namespace alcedo {
 
@@ -138,6 +139,50 @@ auto CreateDefaultPipelineDocument() -> PipelineDocument {
   document.Graph().Connect(NodeId{"grade.primary"}, PortId{"image"}, NodeId{"drt"}, PortId{"image"});
   document.MarkTopologyDirty();
   return document;
+}
+
+void AttachTemporaryPrimaryGradeOvalMask(PipelineDocument& document) {
+  auto* grade = document.PrimaryGrade();
+  if (grade == nullptr) {
+    throw std::invalid_argument(
+        "AttachTemporaryPrimaryGradeOvalMask: missing primary color grade");
+  }
+
+  const NodeId mask_id{"mask.ui_test.radial"};
+  if (document.Graph().FindNode(mask_id) == nullptr) {
+    auto node = std::make_unique<AnalyticMaskNodeModel>(mask_id, AnalyticMaskKind::Radial);
+    RadialMaskParams radial;
+    radial.center_x      = 0.5f;
+    radial.center_y      = 0.5f;
+    radial.major_radius  = 0.32f;
+    radial.minor_radius  = 0.20f;
+    radial.rotation      = 0.0f;
+    radial.inner_feather = 0.0f;
+    radial.outer_feather = 0.12f;
+    radial.invert        = false;
+    node->SetRadial(radial);
+    document.Graph().AddNode(std::move(node));
+    document.Graph().Connect(mask_id, PortId{"mask"}, NodeId{"grade.primary"}, PortId{"mask"});
+    document.MarkTopologyDirty();
+  }
+
+  auto* exposure =
+      dynamic_cast<ExposureModel*>(grade->FindAdjustmentByType(type_ids::Exposure()));
+  if (exposure == nullptr) {
+    throw std::invalid_argument("AttachTemporaryPrimaryGradeOvalMask: missing exposure adjustment");
+  }
+  if (exposure->Value() == ExposureTraits::kDefault) {
+    exposure->SetValue(1.0f);
+  }
+}
+
+auto AllowsLegacyStageAdapterRemirror(const PipelineDocument& document) -> bool {
+  const auto count = document.Graph().NodeCount();
+  if (count == 3U) {
+    return true;
+  }
+  return kTemporaryPrimaryGradeOvalMask && count == 4U &&
+         document.Graph().FindNode(NodeId{"mask.ui_test.radial"}) != nullptr;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/pipeline_document.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_document.cpp
@@ -10,7 +10,6 @@
 #include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/raster_mask_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
-#include "edit/operators/models/scalar_operator_model.hpp"
 
 namespace alcedo {
 
@@ -141,48 +140,9 @@ auto CreateDefaultPipelineDocument() -> PipelineDocument {
   return document;
 }
 
-void AttachTemporaryPrimaryGradeOvalMask(PipelineDocument& document) {
-  auto* grade = document.PrimaryGrade();
-  if (grade == nullptr) {
-    throw std::invalid_argument(
-        "AttachTemporaryPrimaryGradeOvalMask: missing primary color grade");
-  }
-
-  const NodeId mask_id{"mask.ui_test.radial"};
-  if (document.Graph().FindNode(mask_id) == nullptr) {
-    auto node = std::make_unique<AnalyticMaskNodeModel>(mask_id, AnalyticMaskKind::Radial);
-    RadialMaskParams radial;
-    radial.center_x      = 0.5f;
-    radial.center_y      = 0.5f;
-    radial.major_radius  = 0.32f;
-    radial.minor_radius  = 0.20f;
-    radial.rotation      = 0.0f;
-    radial.inner_feather = 0.0f;
-    radial.outer_feather = 0.12f;
-    radial.invert        = false;
-    node->SetRadial(radial);
-    document.Graph().AddNode(std::move(node));
-    document.Graph().Connect(mask_id, PortId{"mask"}, NodeId{"grade.primary"}, PortId{"mask"});
-    document.MarkTopologyDirty();
-  }
-
-  auto* exposure =
-      dynamic_cast<ExposureModel*>(grade->FindAdjustmentByType(type_ids::Exposure()));
-  if (exposure == nullptr) {
-    throw std::invalid_argument("AttachTemporaryPrimaryGradeOvalMask: missing exposure adjustment");
-  }
-  if (exposure->Value() == ExposureTraits::kDefault) {
-    exposure->SetValue(1.0f);
-  }
-}
-
 auto AllowsLegacyStageAdapterRemirror(const PipelineDocument& document) -> bool {
-  const auto count = document.Graph().NodeCount();
-  if (count == 3U) {
-    return true;
-  }
-  return kTemporaryPrimaryGradeOvalMask && count == 4U &&
-         document.Graph().FindNode(NodeId{"mask.ui_test.radial"}) != nullptr;
+  return document.Develop() != nullptr && document.PrimaryGrade() != nullptr &&
+         document.Drt() != nullptr;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/input/prepared_source_cache.cpp
+++ b/alcedo_studio/src/edit/input/prepared_source_cache.cpp
@@ -138,4 +138,12 @@ auto PreparedSourceCache::AcquireEncoded(std::span<const std::byte> encoded, Dec
   return MakeLease(it->second);
 }
 
+void PreparedSourceCache::Clear() {
+  entries_.clear();
+  bytes_used_ = 0;
+  memo_ptr_   = nullptr;
+  memo_size_  = 0;
+  memo_hash_  = 0;
+}
+
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/input/prepared_source_cache.cpp
+++ b/alcedo_studio/src/edit/input/prepared_source_cache.cpp
@@ -1,0 +1,141 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/input/prepared_source_cache.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace alcedo {
+namespace {
+
+auto DefaultUnpack(std::span<const std::byte> encoded, DecodeRes decode_res) -> PreparedRawInput {
+  return RawInputLoader::LoadEncoded(encoded, decode_res);
+}
+
+auto HostBytes(const PreparedRawInput& input) -> std::size_t { return input.pixels.ByteCount(); }
+
+}  // namespace
+
+PreparedSourceCache::Lease::Lease(const Lease& other) : entry_(other.entry_) {}
+
+auto PreparedSourceCache::Lease::operator=(const Lease& other) -> Lease& {
+  entry_ = other.entry_;
+  return *this;
+}
+
+PreparedSourceCache::Lease::Lease(Lease&& other) noexcept : entry_(std::move(other.entry_)) {}
+
+auto PreparedSourceCache::Lease::operator=(Lease&& other) noexcept -> Lease& {
+  entry_ = std::move(other.entry_);
+  return *this;
+}
+
+PreparedSourceCache::Lease::~Lease() = default;
+
+auto PreparedSourceCache::Lease::Get() const -> const PreparedRawInput& {
+  if (!entry_ || !entry_->input) {
+    throw std::runtime_error("PreparedSourceCache::Lease: empty lease");
+  }
+  return *entry_->input;
+}
+
+auto PreparedSourceCache::Lease::Key() const -> const PreparedSourceKey& {
+  if (!entry_) {
+    throw std::runtime_error("PreparedSourceCache::Lease: empty lease");
+  }
+  return entry_->key;
+}
+
+auto PreparedSourceCache::Lease::Shared() const -> std::shared_ptr<const PreparedRawInput> {
+  if (!entry_) {
+    return nullptr;
+  }
+  return entry_->input;
+}
+
+PreparedSourceCache::PreparedSourceCache() : unpack_(DefaultUnpack) {}
+
+PreparedSourceCache::PreparedSourceCache(UnpackFn unpack)
+    : unpack_(unpack ? std::move(unpack) : UnpackFn{DefaultUnpack}) {}
+
+auto PreparedSourceCache::HashEncoded(std::span<const std::byte> encoded) -> std::uint64_t {
+  if (encoded.data() == memo_ptr_ && encoded.size() == memo_size_) {
+    return memo_hash_;
+  }
+  const auto hash = HashContentBytes(encoded);
+  memo_ptr_       = encoded.data();
+  memo_size_      = encoded.size();
+  memo_hash_      = hash;
+  return hash;
+}
+
+void PreparedSourceCache::SetHostByteBudget(std::size_t bytes) {
+  byte_budget_ = bytes;
+  EvictUnleasedToFit(0);
+}
+
+void PreparedSourceCache::EvictUnleasedToFit(std::size_t extra_bytes) {
+  if (byte_budget_ == 0) {
+    return;
+  }
+  while (bytes_used_ + extra_bytes > byte_budget_) {
+    std::shared_ptr<Entry> victim;
+    PreparedSourceLookup   victim_key{};
+    for (auto& [key, entry] : entries_) {
+      if (!entry || entry.use_count() != 1) {
+        continue;
+      }
+      if (!victim || entry->last_used < victim->last_used) {
+        victim     = entry;
+        victim_key = key;
+      }
+    }
+    if (!victim) {
+      return;
+    }
+    bytes_used_ -= victim->bytes;
+    entries_.erase(victim_key);
+  }
+}
+
+auto PreparedSourceCache::MakeLease(std::shared_ptr<Entry> entry) -> Lease {
+  entry->last_used = use_clock_++;
+  Lease lease;
+  lease.entry_ = std::move(entry);
+  return lease;
+}
+
+auto PreparedSourceCache::AcquireEncoded(std::span<const std::byte> encoded, DecodeRes decode_res)
+    -> Lease {
+  const auto lookup = PreparedSourceLookup{
+      HashEncoded(encoded), encoded.size(), DecodeResToDownsamplePasses(decode_res),
+      kRawInputPreparationVersion};
+  if (auto it = entries_.find(lookup); it != entries_.end()) {
+    ++stats_.hits;
+    return MakeLease(it->second);
+  }
+
+  ++stats_.misses;
+  ++stats_.libraw_open_unpack_count;
+  auto prepared                        = unpack_(encoded, decode_res);
+  prepared.content_key.content_hash    = lookup.encoded_content_hash;
+  prepared.source_key.encoded_content_hash = lookup.encoded_content_hash;
+  prepared.source_key.encoded_byte_count   = lookup.encoded_byte_count;
+  prepared.source_key.downsample_passes    = lookup.downsample_passes;
+  prepared.source_key.preparation_version  = lookup.preparation_version;
+
+  auto entry          = std::make_shared<Entry>();
+  entry->key          = prepared.source_key;
+  entry->lookup       = lookup;
+  entry->bytes        = HostBytes(prepared);
+  entry->input        = std::make_shared<const PreparedRawInput>(std::move(prepared));
+  EvictUnleasedToFit(entry->bytes);
+  bytes_used_ += entry->bytes;
+  auto [it, inserted] = entries_.emplace(lookup, entry);
+  (void)inserted;
+  return MakeLease(it->second);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/input/raw_input_loader.cpp
+++ b/alcedo_studio/src/edit/input/raw_input_loader.cpp
@@ -8,6 +8,7 @@
 #include "decoders/processor/raw_normalization.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <stdexcept>
 #include <utility>
@@ -20,13 +21,37 @@ namespace {
 
 constexpr int kRcdOutputCropRadius = 4;
 
-auto HashBytes(std::span<const std::byte> bytes) -> std::uint64_t {
-  std::uint64_t hash = 14695981039346656037ull;
-  for (const auto byte : bytes) {
-    hash ^= static_cast<std::uint8_t>(byte);
-    hash *= 1099511628211ull;
+auto MixU64(std::uint64_t hash, std::uint64_t value) -> std::uint64_t {
+  hash ^= value;
+  hash *= 1099511628211ull;
+  return hash;
+}
+
+auto HashCfaPattern(const RawCfaPattern& pattern) -> std::uint64_t {
+  std::uint64_t hash = MixU64(14695981039346656037ull, static_cast<std::uint64_t>(pattern.kind));
+  if (pattern.kind == RawCfaKind::XTrans6x6) {
+    for (int i = 0; i < 36; ++i) {
+      hash = MixU64(hash, static_cast<std::uint64_t>(pattern.xtrans_pattern.raw_fc[i] + 1));
+    }
+  } else {
+    for (int i = 0; i < 4; ++i) {
+      hash = MixU64(hash, static_cast<std::uint64_t>(pattern.bayer_pattern.raw_fc[i] + 1));
+    }
   }
   return hash;
+}
+
+auto FillSourceKey(PreparedRawInput& input, std::uint64_t encoded_hash,
+                   std::uint64_t encoded_byte_count) -> void {
+  input.content_key.content_hash       = encoded_hash;
+  input.source_key.encoded_content_hash = encoded_hash;
+  input.source_key.encoded_byte_count  = encoded_byte_count;
+  input.source_key.input_kind          = input.input_kind;
+  input.source_key.cfa_hash            = HashCfaPattern(input.cfa_pattern);
+  input.source_key.downsample_passes   = input.downsample_passes;
+  input.source_key.sensor_active_area  = input.sensor_active_area;
+  input.source_key.orientation_flip    = input.sensor.orientation_flip;
+  input.source_key.preparation_version = kRawInputPreparationVersion;
 }
 
 auto ScaleCoordFloor(int value, int divisor) -> int { return value / divisor; }
@@ -275,12 +300,13 @@ void FillColorContext(LibRaw& raw, RawRuntimeColorContext& ctx) {
   ctx.camera_model_ = raw.imgdata.idata.model;
 }
 
-auto FinishPrepared(PreparedRawInput input, DecodeRes decode_res) -> PreparedRawInput {
+auto FinishPrepared(PreparedRawInput input, DecodeRes decode_res, std::uint64_t encoded_hash,
+                    std::uint64_t encoded_byte_count) -> PreparedRawInput {
   const auto passes = DecodeResToDownsamplePasses(decode_res);
   DownsampleInPlace(input, passes);
   FillOutputGeometry(input, DecodeRes::FULL);
-  input.content_key.content_hash = HashBytes(input.pixels.Span());
-  input.working_space            = SceneWorkingSpace::CameraRgb;
+  FillSourceKey(input, encoded_hash, encoded_byte_count);
+  input.working_space = SceneWorkingSpace::CameraRgb;
   return input;
 }
 
@@ -351,7 +377,9 @@ auto RawInputLoader::FromUnpackedCfa(HostImagePlane plane, RawCfaPattern pattern
   for (int i = 0; i < 3; ++i) {
     input.color_context.cam_mul_[i] = linearization.cam_mul[i];
   }
-  return FinishPrepared(std::move(input), decode_res);
+  const auto encoded_hash  = HashContentBytes(input.pixels.Span());
+  const auto encoded_bytes = input.pixels.ByteCount();
+  return FinishPrepared(std::move(input), decode_res, encoded_hash, encoded_bytes);
 }
 
 auto RawInputLoader::FromDirectRgb(HostImagePlane plane, RawSensorGeometry sensor)
@@ -373,7 +401,9 @@ auto RawInputLoader::FromDirectRgb(HostImagePlane plane, RawSensorGeometry senso
   input.linearization.apply_as_shot_wb = 0;
   input.color_context.valid_                  = true;
   input.color_context.output_in_camera_space_ = true;
-  return FinishPrepared(std::move(input), DecodeRes::FULL);
+  const auto encoded_hash  = HashContentBytes(input.pixels.Span());
+  const auto encoded_bytes = input.pixels.ByteCount();
+  return FinishPrepared(std::move(input), DecodeRes::FULL, encoded_hash, encoded_bytes);
 }
 
 auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes decode_res)
@@ -421,7 +451,7 @@ auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes d
   input.input_kind  = RawInputKind::BayerRaw;
   input.cfa_pattern = pattern;
   raw.recycle();
-  return FinishPrepared(std::move(input), decode_res);
+  return FinishPrepared(std::move(input), decode_res, HashContentBytes(encoded), encoded.size());
 }
 
 auto RawInputLoader::TryLoadEncoded(std::span<const std::byte> encoded, DecodeRes decode_res)

--- a/alcedo_studio/src/edit/input/raw_input_loader.cpp
+++ b/alcedo_studio/src/edit/input/raw_input_loader.cpp
@@ -4,24 +4,24 @@
 
 #include "edit/input/raw_input_loader.hpp"
 
-#include "decoders/libraw_unpack_guard.hpp"
-#include "decoders/processor/raw_normalization.hpp"
+#include <libraw/libraw.h>
 
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <opencv2/core.hpp>
 #include <stdexcept>
 #include <utility>
 
-#include <libraw/libraw.h>
-#include <opencv2/core.hpp>
+#include "decoders/libraw_unpack_guard.hpp"
+#include "decoders/processor/raw_normalization.hpp"
 
 namespace alcedo {
 namespace {
 
 constexpr int kRcdOutputCropRadius = 4;
 
-auto MixU64(std::uint64_t hash, std::uint64_t value) -> std::uint64_t {
+auto          MixU64(std::uint64_t hash, std::uint64_t value) -> std::uint64_t {
   hash ^= value;
   hash *= 1099511628211ull;
   return hash;
@@ -41,17 +41,36 @@ auto HashCfaPattern(const RawCfaPattern& pattern) -> std::uint64_t {
   return hash;
 }
 
+auto HashDngWarp(const std::optional<dng::WarpRectilinear>& warp) -> std::uint64_t {
+  if (!warp.has_value()) return 0;
+  std::uint64_t hash = MixU64(14695981039346656037ull, warp->coefficient_set_count);
+  for (const auto& set : warp->coefficient_sets) {
+    for (double value : set) {
+      std::uint64_t bits = 0;
+      static_assert(sizeof(bits) == sizeof(value));
+      std::memcpy(&bits, &value, sizeof(bits));
+      hash = MixU64(hash, bits);
+    }
+  }
+  std::uint64_t center_x = 0;
+  std::uint64_t center_y = 0;
+  std::memcpy(&center_x, &warp->center_x, sizeof(center_x));
+  std::memcpy(&center_y, &warp->center_y, sizeof(center_y));
+  return MixU64(MixU64(hash, center_x), center_y);
+}
+
 auto FillSourceKey(PreparedRawInput& input, std::uint64_t encoded_hash,
                    std::uint64_t encoded_byte_count) -> void {
-  input.content_key.content_hash       = encoded_hash;
+  input.content_key.content_hash        = encoded_hash;
   input.source_key.encoded_content_hash = encoded_hash;
-  input.source_key.encoded_byte_count  = encoded_byte_count;
-  input.source_key.input_kind          = input.input_kind;
-  input.source_key.cfa_hash            = HashCfaPattern(input.cfa_pattern);
-  input.source_key.downsample_passes   = input.downsample_passes;
-  input.source_key.sensor_active_area  = input.sensor_active_area;
-  input.source_key.orientation_flip    = input.sensor.orientation_flip;
-  input.source_key.preparation_version = kRawInputPreparationVersion;
+  input.source_key.encoded_byte_count   = encoded_byte_count;
+  input.source_key.input_kind           = input.input_kind;
+  input.source_key.cfa_hash             = HashCfaPattern(input.cfa_pattern);
+  input.source_key.dng_warp_hash        = HashDngWarp(input.dng_warp_rectilinear);
+  input.source_key.downsample_passes    = input.downsample_passes;
+  input.source_key.sensor_active_area   = input.sensor_active_area;
+  input.source_key.orientation_flip     = input.sensor.orientation_flip;
+  input.source_key.preparation_version  = kRawInputPreparationVersion;
 }
 
 auto ScaleCoordFloor(int value, int divisor) -> int { return value / divisor; }
@@ -71,12 +90,12 @@ auto BuildActiveAreaRect(const RawSensorGeometry& sensor, Extent2D image_size, i
   const int raw_right  = std::clamp(raw_left + sensor.width, raw_left, raw_width);
   const int raw_bottom = std::clamp(raw_top + sensor.height, raw_top, raw_height);
 
-  const int img_w = static_cast<int>(image_size.width);
-  const int img_h = static_cast<int>(image_size.height);
-  const int left  = std::clamp(ScaleCoordFloor(raw_left, scale_divisor), 0, img_w);
-  const int top   = std::clamp(ScaleCoordFloor(raw_top, scale_divisor), 0, img_h);
-  const int right = std::clamp(ScaleCoordCeil(raw_right, scale_divisor), left, img_w);
-  const int bottom = std::clamp(ScaleCoordCeil(raw_bottom, scale_divisor), top, img_h);
+  const int img_w      = static_cast<int>(image_size.width);
+  const int img_h      = static_cast<int>(image_size.height);
+  const int left       = std::clamp(ScaleCoordFloor(raw_left, scale_divisor), 0, img_w);
+  const int top        = std::clamp(ScaleCoordFloor(raw_top, scale_divisor), 0, img_h);
+  const int right      = std::clamp(ScaleCoordCeil(raw_right, scale_divisor), left, img_w);
+  const int bottom     = std::clamp(ScaleCoordCeil(raw_bottom, scale_divisor), top, img_h);
   if (right - left <= 0 || bottom - top <= 0) {
     return RectI{0, 0, img_w, img_h};
   }
@@ -109,16 +128,18 @@ auto BuildDecodeCropRect(const RawSensorGeometry& sensor, Extent2D image_size, i
   }
   const int img_w = static_cast<int>(image_size.width);
   const int img_h = static_cast<int>(image_size.height);
-  const int left =
-      std::clamp(ScaleCoordFloor(static_cast<int>(sensor.default_crop[0]), scale_divisor), 0, img_w);
-  const int top =
-      std::clamp(ScaleCoordFloor(static_cast<int>(sensor.default_crop[1]), scale_divisor), 0, img_h);
-  const int right = std::clamp(
-      ScaleCoordCeil(static_cast<int>(sensor.default_crop[0] + sensor.default_crop[2]), scale_divisor),
-      left, img_w);
-  const int bottom = std::clamp(
-      ScaleCoordCeil(static_cast<int>(sensor.default_crop[1] + sensor.default_crop[3]), scale_divisor),
-      top, img_h);
+  const int left  = std::clamp(
+      ScaleCoordFloor(static_cast<int>(sensor.default_crop[0]), scale_divisor), 0, img_w);
+  const int top = std::clamp(
+      ScaleCoordFloor(static_cast<int>(sensor.default_crop[1]), scale_divisor), 0, img_h);
+  const int right =
+      std::clamp(ScaleCoordCeil(static_cast<int>(sensor.default_crop[0] + sensor.default_crop[2]),
+                                scale_divisor),
+                 left, img_w);
+  const int bottom =
+      std::clamp(ScaleCoordCeil(static_cast<int>(sensor.default_crop[1] + sensor.default_crop[3]),
+                                scale_divisor),
+                 top, img_h);
   if (right - left <= 0 || bottom - top <= 0) {
     return active;
   }
@@ -137,10 +158,8 @@ auto BuildBorderLossCrop(const RawSensorGeometry& sensor, Extent2D output_size, 
   const int      out_h       = static_cast<int>(output_size.height);
   const int      left        = std::clamp(source_crop.x, 0, out_w);
   const int      top         = std::clamp(source_crop.y, 0, out_h);
-  const int      right =
-      std::clamp(source_crop.x + source_crop.width - 2 * source_border, left, out_w);
-  const int bottom =
-      std::clamp(source_crop.y + source_crop.height - 2 * source_border, top, out_h);
+  const int right  = std::clamp(source_crop.x + source_crop.width - 2 * source_border, left, out_w);
+  const int bottom = std::clamp(source_crop.y + source_crop.height - 2 * source_border, top, out_h);
   if (right <= left || bottom <= top) {
     throw std::runtime_error("RawInputLoader: decode crop is too small for demosaic border");
   }
@@ -156,36 +175,35 @@ auto OrientedExtent(Extent2D extent, int flip) -> Extent2D {
 
 void FillOutputGeometry(PreparedRawInput& input, DecodeRes decode_res_for_full_reference) {
   (void)decode_res_for_full_reference;
-  const std::uint8_t passes = input.downsample_passes;
+  const std::uint8_t passes  = input.downsample_passes;
   const int          divisor = ScaleDivisor(passes);
   const Extent2D     host    = input.host_extent;
 
   if (input.input_kind == RawInputKind::DebayeredRgb) {
-    const RectI crop               = BuildDecodeCropRect(input.sensor, host, divisor);
-    input.demosaic_output_crop     = crop;
-    input.develop_output_extent    = OrientedExtent(
+    const RectI crop            = BuildDecodeCropRect(input.sensor, host, divisor);
+    input.demosaic_output_crop  = crop;
+    input.develop_output_extent = OrientedExtent(
         Extent2D{static_cast<std::uint32_t>(crop.width), static_cast<std::uint32_t>(crop.height)},
         input.sensor.orientation_flip);
-    const int full_div = 1;
+    const int      full_div = 1;
     const Extent2D full_host{static_cast<std::uint32_t>(std::max(input.sensor.raw_width, 0)),
                              static_cast<std::uint32_t>(std::max(input.sensor.raw_height, 0))};
-    const RectI full_crop = BuildDecodeCropRect(input.sensor, full_host, full_div);
-    input.full_reference_extent = OrientedExtent(
-        Extent2D{static_cast<std::uint32_t>(full_crop.width),
-                 static_cast<std::uint32_t>(full_crop.height)},
-        input.sensor.orientation_flip);
+    const RectI    full_crop = BuildDecodeCropRect(input.sensor, full_host, full_div);
+    input.full_reference_extent =
+        OrientedExtent(Extent2D{static_cast<std::uint32_t>(full_crop.width),
+                                static_cast<std::uint32_t>(full_crop.height)},
+                       input.sensor.orientation_flip);
     input.sensor_active_area = BuildActiveAreaRect(input.sensor, host, divisor);
     return;
   }
 
-  const bool bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
-  const int  border = bayer ? kRcdOutputCropRadius : 0;
+  const bool     bayer  = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
+  const int      border = bayer ? kRcdOutputCropRadius : 0;
   const Extent2D demosaic_extent{
       static_cast<std::uint32_t>(std::max(0, static_cast<int>(host.width) - 2 * border)),
       static_cast<std::uint32_t>(std::max(0, static_cast<int>(host.height) - 2 * border))};
-  const RectI crop =
-      bayer ? BuildBorderLossCrop(input.sensor, demosaic_extent, divisor, border)
-            : BuildDecodeCropRect(input.sensor, host, divisor);
+  const RectI crop = bayer ? BuildBorderLossCrop(input.sensor, demosaic_extent, divisor, border)
+                           : BuildDecodeCropRect(input.sensor, host, divisor);
   input.demosaic_output_crop  = crop;
   input.develop_output_extent = OrientedExtent(
       Extent2D{static_cast<std::uint32_t>(crop.width), static_cast<std::uint32_t>(crop.height)},
@@ -196,24 +214,24 @@ void FillOutputGeometry(PreparedRawInput& input, DecodeRes decode_res_for_full_r
   const Extent2D full_demosaic{
       static_cast<std::uint32_t>(std::max(0, static_cast<int>(full_host.width) - 2 * border)),
       static_cast<std::uint32_t>(std::max(0, static_cast<int>(full_host.height) - 2 * border))};
-  const RectI full_crop =
-      bayer ? BuildBorderLossCrop(input.sensor, full_demosaic, 1, border)
-            : BuildDecodeCropRect(input.sensor, full_host, 1);
-  input.full_reference_extent = OrientedExtent(
-      Extent2D{static_cast<std::uint32_t>(full_crop.width),
-               static_cast<std::uint32_t>(full_crop.height)},
-      input.sensor.orientation_flip);
+  const RectI full_crop = bayer ? BuildBorderLossCrop(input.sensor, full_demosaic, 1, border)
+                                : BuildDecodeCropRect(input.sensor, full_host, 1);
+  input.full_reference_extent =
+      OrientedExtent(Extent2D{static_cast<std::uint32_t>(full_crop.width),
+                              static_cast<std::uint32_t>(full_crop.height)},
+                     input.sensor.orientation_flip);
   input.sensor_active_area = BuildActiveAreaRect(input.sensor, host, divisor);
 }
 
 auto CopyPlane(const cv::Mat& src, HostPixelFormat format) -> HostImagePlane {
   HostImagePlane plane;
-  plane.extent       = Extent2D{static_cast<std::uint32_t>(src.cols),
-                                static_cast<std::uint32_t>(src.rows)};
-  plane.stride_bytes = static_cast<std::uint32_t>(src.cols * src.elemSize());
-  plane.format       = format;
+  plane.extent =
+      Extent2D{static_cast<std::uint32_t>(src.cols), static_cast<std::uint32_t>(src.rows)};
+  plane.stride_bytes      = static_cast<std::uint32_t>(src.cols * src.elemSize());
+  plane.format            = format;
   const std::size_t bytes = plane.ByteCount();
-  auto              storage = std::shared_ptr<std::byte>(new std::byte[bytes], std::default_delete<std::byte[]>());
+  auto              storage =
+      std::shared_ptr<std::byte>(new std::byte[bytes], std::default_delete<std::byte[]>());
   if (src.isContinuous() && static_cast<std::size_t>(src.step) == plane.stride_bytes) {
     std::memcpy(storage.get(), src.data, bytes);
   } else {
@@ -245,8 +263,8 @@ void DownsampleInPlace(PreparedRawInput& input, std::uint8_t passes) {
     }
     current = DownsampleRaw2x(current, input.cfa_pattern);
   }
-  input.pixels      = CopyPlane(current, HostPixelFormat::U16Cfa);
-  input.host_extent = input.pixels.extent;
+  input.pixels            = CopyPlane(current, HostPixelFormat::U16Cfa);
+  input.host_extent       = input.pixels.extent;
   input.downsample_passes = passes;
 }
 
@@ -258,10 +276,10 @@ auto LinearizationFromLibRaw(LibRaw& raw) -> RawLinearizationParams {
     params.white_level[c] = curve.white_level[c];
     params.cam_mul[c]     = raw.imgdata.color.cam_mul[c];
   }
-  params.apply_as_shot_wb  = raw.imgdata.color.as_shot_wb_applied != 1 ? 1 : 0;
-  const int tile_width     = raw.imgdata.rawdata.color.cblack[4];
-  const int tile_height    = raw.imgdata.rawdata.color.cblack[5];
-  const int entries        = tile_width * tile_height;
+  params.apply_as_shot_wb = raw.imgdata.color.as_shot_wb_applied != 1 ? 1 : 0;
+  const int tile_width    = raw.imgdata.rawdata.color.cblack[4];
+  const int tile_height   = raw.imgdata.rawdata.color.cblack[5];
+  const int entries       = tile_width * tile_height;
   if (entries > 0 && entries <= 36) {
     params.black_tile_width  = tile_width;
     params.black_tile_height = tile_height;
@@ -338,11 +356,11 @@ auto PreparedRawInput::CompileSource() const -> DevelopCompileSource {
   } else {
     source.kind = DevelopInputKind::BayerCfa;
   }
-  source.host_extent            = host_extent;
-  source.develop_output_extent  = develop_output_extent;
-  source.full_reference_extent  = full_reference_extent;
-  source.sensor_active_area     = sensor_active_area;
-  source.downsample_passes      = downsample_passes;
+  source.host_extent           = host_extent;
+  source.develop_output_extent = develop_output_extent;
+  source.full_reference_extent = full_reference_extent;
+  source.sensor_active_area    = sensor_active_area;
+  source.downsample_passes     = downsample_passes;
   return source;
 }
 
@@ -366,12 +384,12 @@ auto RawInputLoader::FromUnpackedCfa(HostImagePlane plane, RawCfaPattern pattern
   }
 
   PreparedRawInput input;
-  input.pixels        = std::move(plane);
-  input.host_extent   = input.pixels.extent;
-  input.input_kind    = RawInputKind::BayerRaw;
-  input.cfa_pattern   = pattern;
-  input.linearization = linearization;
-  input.sensor        = sensor;
+  input.pixels                                = std::move(plane);
+  input.host_extent                           = input.pixels.extent;
+  input.input_kind                            = RawInputKind::BayerRaw;
+  input.cfa_pattern                           = pattern;
+  input.linearization                         = linearization;
+  input.sensor                                = sensor;
   input.color_context.valid_                  = true;
   input.color_context.output_in_camera_space_ = true;
   for (int i = 0; i < 3; ++i) {
@@ -394,15 +412,15 @@ auto RawInputLoader::FromDirectRgb(HostImagePlane plane, RawSensorGeometry senso
     sensor.height     = sensor.raw_height;
   }
   PreparedRawInput input;
-  input.pixels      = std::move(plane);
-  input.host_extent = input.pixels.extent;
-  input.input_kind  = RawInputKind::DebayeredRgb;
-  input.sensor      = sensor;
-  input.linearization.apply_as_shot_wb = 0;
+  input.pixels                                = std::move(plane);
+  input.host_extent                           = input.pixels.extent;
+  input.input_kind                            = RawInputKind::DebayeredRgb;
+  input.sensor                                = sensor;
+  input.linearization.apply_as_shot_wb        = 0;
   input.color_context.valid_                  = true;
   input.color_context.output_in_camera_space_ = true;
-  const auto encoded_hash  = HashContentBytes(input.pixels.Span());
-  const auto encoded_bytes = input.pixels.ByteCount();
+  const auto encoded_hash                     = HashContentBytes(input.pixels.Span());
+  const auto encoded_bytes                    = input.pixels.ByteCount();
   return FinishPrepared(std::move(input), DecodeRes::FULL, encoded_hash, encoded_bytes);
 }
 
@@ -411,9 +429,11 @@ auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes d
   if (encoded.empty()) {
     throw std::runtime_error("RawInputLoader::LoadEncoded: empty buffer");
   }
-  LibRaw raw;
-  if (raw.open_buffer(const_cast<void*>(static_cast<const void*>(encoded.data())), encoded.size()) !=
-      LIBRAW_SUCCESS) {
+  const auto dng_metadata = dng::ExtractMetadata(std::span<const std::uint8_t>(
+      reinterpret_cast<const std::uint8_t*>(encoded.data()), encoded.size()));
+  LibRaw     raw;
+  if (raw.open_buffer(const_cast<void*>(static_cast<const void*>(encoded.data())),
+                      encoded.size()) != LIBRAW_SUCCESS) {
     throw std::runtime_error("RawInputLoader::LoadEncoded: LibRaw open_buffer failed");
   }
   if (libraw_guard::Unpack(raw) != LIBRAW_SUCCESS) {
@@ -434,6 +454,14 @@ auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes d
   input.sensor        = SensorFromLibRaw(raw);
   input.linearization = LinearizationFromLibRaw(raw);
   FillColorContext(raw, input.color_context);
+  if (dng_metadata.warp_rectilinear.has_value()) {
+    input.dng_warp_rectilinear                        = dng_metadata.warp_rectilinear;
+    input.color_context.dng_warp_rectilinear_present_ = true;
+  }
+  if (dng_metadata.default_crop[2] > 0 && dng_metadata.default_crop[3] > 0) {
+    std::copy(dng_metadata.default_crop.begin(), dng_metadata.default_crop.end(),
+              input.sensor.default_crop);
+  }
 
   if (kind == RawInputKind::DebayeredRgb) {
     raw.recycle();
@@ -443,9 +471,10 @@ auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes d
   }
 
   const auto& sizes = raw.imgdata.sizes;
-  cv::Mat view(sizes.raw_height, sizes.raw_width, CV_16UC1, raw.imgdata.rawdata.raw_image,
-               sizes.raw_pitch != 0 ? static_cast<std::size_t>(sizes.raw_pitch)
-                                    : static_cast<std::size_t>(sizes.raw_width) * sizeof(std::uint16_t));
+  cv::Mat     view(sizes.raw_height, sizes.raw_width, CV_16UC1, raw.imgdata.rawdata.raw_image,
+               sizes.raw_pitch != 0
+                       ? static_cast<std::size_t>(sizes.raw_pitch)
+                       : static_cast<std::size_t>(sizes.raw_width) * sizeof(std::uint16_t));
   input.pixels      = CopyPlane(view, HostPixelFormat::U16Cfa);
   input.host_extent = input.pixels.extent;
   input.input_kind  = RawInputKind::BayerRaw;

--- a/alcedo_studio/src/edit/operators/basic/color_temp_op.cpp
+++ b/alcedo_studio/src/edit/operators/basic/color_temp_op.cpp
@@ -3,43 +3,28 @@
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
 #include "edit/operators/basic/color_temp_op.hpp"
-#include "edit/operators/basic/planckian_locus_table.hpp"
 
-#include <iostream>
 #include <opencv2/core.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <functional>
-#include <limits>
-#include <span>
 #include <stdexcept>
 #include <string>
 
+#include "edit/graph/develop_color_transform.hpp"
+
 namespace alcedo {
 namespace {
-constexpr double kCalibrationLowCCT   = 2856.0;
-constexpr double kCalibrationHighCCT  = 6504.0;
-constexpr double kCustomCCTMin        = 2000.0;
-constexpr double kCustomCCTMax        = 15000.0;
-constexpr double kCustomTintMin       = -150.0;
-constexpr double kCustomTintMax       = 150.0;
-constexpr double kTintScale           = 3000.0;  // Adobe DNG SDK temperature/tint model.
-constexpr double kDeterminantEpsilon  = 1e-10;
-constexpr double kValueEpsilon        = 1e-10;
-constexpr double kAsShotSolveEpsilon  = 1e-8;
-constexpr int    kAsShotSolveMaxIter  = 16;
-constexpr double kOhnoNearLocusDuv    = 0.002;
-constexpr double kD50X                = 0.34567;
-constexpr double kD50Y                = 0.35850;
-constexpr double kD60X                = 0.32168;
-constexpr double kD60Y                = 0.33767;
-// ACEScg (AP1) white is D60. This is XYZ(D60) -> AP1 in column-vector form.
-const cv::Matx33d kXyzD60ToAp1(1.6410233797, -0.3248032942, -0.2364246952, -0.6636628587,
-                               1.6153315917, 0.0167563477, 0.0117218943, -0.0082844420,
-                               0.9883948585);
+constexpr double kCustomCCTMin      = 2000.0;
+constexpr double kCustomCCTMax      = 15000.0;
+constexpr double kCustomTintMin     = -150.0;
+constexpr double kCustomTintMax     = 150.0;
+constexpr double kValueEpsilon      = 1e-10;
 
 auto ClampFinite(double value, double min_value, double max_value) -> double {
   if (!std::isfinite(value)) {
@@ -121,10 +106,6 @@ auto BuildRuntimeCacheKey(const OperatorParams& params, ColorTempMode mode, floa
   return key;
 }
 
-auto MatrixFromArray9(const double m[9]) -> cv::Matx33d {
-  return cv::Matx33d(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8]);
-}
-
 auto HasValidCamXyz(const float m[9]) -> bool {
   double sum = 0.0;
   for (int i = 0; i < 9; ++i) {
@@ -140,7 +121,6 @@ auto BuildFallbackXyzToCamera(const OperatorParams& params, cv::Matx33d& out) ->
   if (!HasValidCamXyz(params.raw_cam_xyz_)) {
     return false;
   }
-
   const double g = std::max(static_cast<double>(params.raw_pre_mul_[1]), kValueEpsilon);
   const cv::Matx33d pre =
       cv::Matx33d::diag(cv::Vec3d(params.raw_pre_mul_[0] / g, 1.0, params.raw_pre_mul_[2] / g));
@@ -151,589 +131,55 @@ auto BuildFallbackXyzToCamera(const OperatorParams& params, cv::Matx33d& out) ->
   return IsFiniteMatrix(out);
 }
 
-auto SanitizeEndpointCct(double cct, double fallback) -> double {
-  return (std::isfinite(cct) && cct > kValueEpsilon) ? cct : fallback;
+auto DevelopPayloadFromColorTemp(const OperatorParams& params, ColorTempMode mode, float custom_cct,
+                                 float custom_tint) -> DevelopPayload {
+  DevelopPayload develop;
+  develop.wb_mode     = (mode == ColorTempMode::CUSTOM) ? "custom" : "as_shot";
+  develop.custom_cct  = custom_cct;
+  develop.custom_tint = custom_tint;
+  auto& profile       = develop.camera_profile;
+  profile.color_matrices_valid          = params.raw_color_matrices_valid_;
+  profile.forward_matrices_valid        = params.raw_forward_matrices_valid_;
+  profile.as_shot_neutral_valid         = params.raw_as_shot_neutral_valid_;
+  profile.calibration_illuminants_valid = params.raw_calibration_illuminants_valid_;
+  profile.color_matrix_1_cct            = params.raw_color_matrix_1_cct_;
+  profile.color_matrix_2_cct            = params.raw_color_matrix_2_cct_;
+  for (int i = 0; i < 9; ++i) {
+    profile.color_matrix_1[static_cast<std::size_t>(i)]   = params.raw_color_matrix_1_[i];
+    profile.color_matrix_2[static_cast<std::size_t>(i)]   = params.raw_color_matrix_2_[i];
+    profile.forward_matrix_1[static_cast<std::size_t>(i)] = params.raw_forward_matrix_1_[i];
+    profile.forward_matrix_2[static_cast<std::size_t>(i)] = params.raw_forward_matrix_2_[i];
+  }
+  for (int i = 0; i < 3; ++i) {
+    profile.as_shot_neutral[static_cast<std::size_t>(i)] = params.raw_as_shot_neutral_[i];
+    profile.cam_mul[static_cast<std::size_t>(i)]        = params.raw_cam_mul_[i];
+  }
+  return develop;
 }
 
-auto HasDualIlluminantCalibration(const OperatorParams& params) -> bool {
-  if (!params.raw_calibration_illuminants_valid_) {
-    return false;
-  }
-
-  const double cct1 = params.raw_color_matrix_1_cct_;
-  const double cct2 = params.raw_color_matrix_2_cct_;
-  return std::isfinite(cct1) && std::isfinite(cct2) && cct1 > kValueEpsilon &&
-         cct2 > kValueEpsilon && std::abs(cct1 - cct2) > kValueEpsilon;
-}
-
-auto InterpolateColorMatrix(const cv::Matx33d& cm1, const cv::Matx33d& cm2, double cct,
-                            double endpoint_cct_1, double endpoint_cct_2)
-    -> cv::Matx33d {
-  const double cct1 = SanitizeEndpointCct(endpoint_cct_1, kCalibrationLowCCT);
-  const double cct2 = SanitizeEndpointCct(endpoint_cct_2, kCalibrationHighCCT);
-  const double low_cct  = std::min(cct1, cct2);
-  const double high_cct = std::max(cct1, cct2);
-  const bool   cm1_is_low = cct1 <= cct2;
-  const cv::Matx33d& low_matrix  = cm1_is_low ? cm1 : cm2;
-  const cv::Matx33d& high_matrix = cm1_is_low ? cm2 : cm1;
-
-  if (!std::isfinite(cct)) {
-    return high_matrix;
-  }
-
-  if (cct <= low_cct) {
-    return low_matrix;
-  }
-  if (cct >= high_cct) {
-    return high_matrix;
-  }
-
-  const double inv_t  = 1.0 / cct;
-  const double inv_t1 = 1.0 / low_cct;
-  const double inv_t2 = 1.0 / high_cct;
-  const double denom  = inv_t2 - inv_t1;
-  if (std::abs(denom) <= kValueEpsilon) {
-    return high_matrix;
-  }
-
-  const double w = std::clamp((inv_t - inv_t1) / denom, 0.0, 1.0);
-  return low_matrix * (1.0 - w) + high_matrix * w;
-}
-
-auto Invert3x3(const cv::Matx33d& m, cv::Matx33d& out) -> bool {
-  const double det = cv::determinant(m);
-  if (!std::isfinite(det) || std::abs(det) < kDeterminantEpsilon) {
-    return false;
-  }
-  out = m.inv();
-  return IsFiniteMatrix(out);
-}
-
-auto XYZToXY(const cv::Vec3d& xyz, cv::Vec2d& out_xy) -> bool {
-  const double sum = xyz[0] + xyz[1] + xyz[2];
-  if (!std::isfinite(sum) || std::abs(sum) <= kValueEpsilon) {
-    return false;
-  }
-  const double x = xyz[0] / sum;
-  const double y = xyz[1] / sum;
-  if (!std::isfinite(x) || !std::isfinite(y) || y <= 0.0 || x <= 0.0 || (x + y) >= 1.0) {
-    return false;
-  }
-  out_xy = cv::Vec2d(x, y);
-  return true;
-}
-
-auto XYToXYZ(const cv::Vec2d& xy) -> cv::Vec3d {
-  const double y = std::max(xy[1], kValueEpsilon);
-  const double X = xy[0] / y;
-  const double Y = 1.0;
-  const double Z = (1.0 - xy[0] - xy[1]) / y;
-  return cv::Vec3d(X, Y, Z);
-}
-
-auto XYToUV(const cv::Vec2d& xy) -> cv::Vec2d {
-  const double den = (-xy[0] + 6.0 * xy[1] + 1.5);
-  if (std::abs(den) <= kValueEpsilon) {
-    return cv::Vec2d(0.0, 0.0);
-  }
-  return cv::Vec2d(2.0 * xy[0] / den, 3.0 * xy[1] / den);
-}
-
-auto UVToXY(const cv::Vec2d& uv) -> cv::Vec2d {
-  const double den = (uv[0] - 4.0 * uv[1] + 2.0);
-  if (std::abs(den) <= kValueEpsilon) {
-    return cv::Vec2d(kD50X, kD50Y);
-  }
-  return cv::Vec2d(1.5 * uv[0] / den, uv[1] / den);
-}
-
-struct PlanckianLocusPoint {
-  cv::Vec2d uv_;     // point on the Planckian locus
-  cv::Vec2d perp_;   // normalized isotherm direction at this CCT
-  bool      valid_;  // false when the perpendicular direction degenerates
-};
-
-struct OhnoSolution {
-  bool   valid_ = false;
-  double cct_   = 0.0;
-  double duv_   = 0.0;
-};
-
-using PlanckianTable = std::span<const planckian_locus::PlanckianLocusEntry>;
-
-auto OhnoPlanckianTable() -> PlanckianTable {
-  return PlanckianTable(planckian_locus::kUvTable.data(), planckian_locus::kUvTable.size());
-}
-
-auto EntryUV(const planckian_locus::PlanckianLocusEntry& entry) -> cv::Vec2d {
-  return cv::Vec2d(entry.u_, entry.v_);
-}
-
-auto PlanckianUVAtCCT(double cct) -> cv::Vec2d {
-  const auto table = OhnoPlanckianTable();
-  const double safe_cct =
-      ClampFinite(cct, planckian_locus::kMinCct, planckian_locus::kMaxCct);
-
-  if (safe_cct <= table.front().cct_) {
-    return EntryUV(table.front());
-  }
-  if (safe_cct >= table.back().cct_) {
-    return EntryUV(table.back());
-  }
-
-  const auto upper = std::lower_bound(table.begin(), table.end(), safe_cct,
-                                      [](const planckian_locus::PlanckianLocusEntry& entry,
-                                         double value) { return entry.cct_ < value; });
-  const auto lower = upper - 1;
-  const double denom = upper->cct_ - lower->cct_;
-  if (std::abs(denom) <= kValueEpsilon) {
-    return EntryUV(*upper);
-  }
-
-  const double t = std::clamp((safe_cct - lower->cct_) / denom, 0.0, 1.0);
-  return EntryUV(*lower) * (1.0 - t) + EntryUV(*upper) * t;
-}
-
-auto PlanckianLocusAtCCT(double cct) -> PlanckianLocusPoint {
-  const double safe_cct = ClampFinite(cct, kCustomCCTMin, kCustomCCTMax);
-  const double delta_k =
-      std::clamp(safe_cct * 0.001, 0.5, std::max(0.5, 0.25 * (kCustomCCTMax - kCustomCCTMin)));
-  const double low_cct  = std::max(kCustomCCTMin, safe_cct - delta_k);
-  const double high_cct = std::min(kCustomCCTMax, safe_cct + delta_k);
-
-  PlanckianLocusPoint pt;
-  pt.uv_ = PlanckianUVAtCCT(safe_cct);
-  if ((high_cct - low_cct) <= kValueEpsilon) {
-    pt.perp_  = cv::Vec2d(0.0, 0.0);
-    pt.valid_ = false;
-    return pt;
-  }
-
-  const cv::Vec2d tangent = (PlanckianUVAtCCT(high_cct) - PlanckianUVAtCCT(low_cct)) /
-                            (high_cct - low_cct);
-  const double tangent_len = std::sqrt(tangent[0] * tangent[0] + tangent[1] * tangent[1]);
-
-  if (tangent_len <= kValueEpsilon) {
-    pt.perp_  = cv::Vec2d(0.0, 0.0);
-    pt.valid_ = false;
-  } else {
-    pt.perp_  = cv::Vec2d(-tangent[1] / tangent_len, tangent[0] / tangent_len);
-    pt.valid_ = true;
-  }
-  return pt;
-}
-
-auto Distance(const cv::Vec2d& a, const cv::Vec2d& b) -> double {
-  const double du = a[0] - b[0];
-  const double dv = a[1] - b[1];
-  return std::sqrt(du * du + dv * dv);
-}
-
-auto SignFromDeltaV(double delta_v) -> double { return (delta_v < 0.0) ? -1.0 : 1.0; }
-
-auto FindClosestOhnoSample(const cv::Vec2d& uv, PlanckianTable table) -> size_t {
-  size_t best_index       = 0;
-  double best_distance_sq = std::numeric_limits<double>::max();
-
-  for (size_t i = 0; i < table.size(); ++i) {
-    const double du          = uv[0] - table[i].u_;
-    const double dv          = uv[1] - table[i].v_;
-    const double distance_sq = du * du + dv * dv;
-    if (distance_sq < best_distance_sq) {
-      best_distance_sq = distance_sq;
-      best_index       = i;
-    }
-  }
-
-  if (best_index == 0) {
-    return 1;
-  }
-  if (best_index + 1 >= table.size()) {
-    return table.size() - 2;
-  }
-  return best_index;
-}
-
-auto SolveOhnoTriangular(const cv::Vec2d& uv, PlanckianTable table, size_t m) -> OhnoSolution {
-  const auto& p0 = table[m - 1];
-  const auto& p2 = table[m + 1];
-  const cv::Vec2d p0_uv = EntryUV(p0);
-  const cv::Vec2d p2_uv = EntryUV(p2);
-
-  const double d0 = Distance(uv, p0_uv);
-  const double d2 = Distance(uv, p2_uv);
-
-  const cv::Vec2d chord = p2_uv - p0_uv;
-  const double    l     = std::sqrt(chord[0] * chord[0] + chord[1] * chord[1]);
-  if (l <= kValueEpsilon) {
-    return {};
-  }
-
-  const double x     = std::clamp((d0 * d0 - d2 * d2 + l * l) / (2.0 * l), 0.0, l);
-  const double alpha = x / l;
-  const double cct   = p0.cct_ + (p2.cct_ - p0.cct_) * alpha;
-  const double v_tx  = p0.v_ + (p2.v_ - p0.v_) * alpha;
-  const double duv   = std::sqrt(std::max(0.0, d0 * d0 - x * x)) * SignFromDeltaV(uv[1] - v_tx);
-
-  return OhnoSolution{std::isfinite(cct) && std::isfinite(duv), cct, duv};
-}
-
-auto SolveOhnoParabolic(const cv::Vec2d& uv, PlanckianTable table, size_t m) -> OhnoSolution {
-  const auto& p0 = table[m - 1];
-  const auto& p1 = table[m];
-  const auto& p2 = table[m + 1];
-
-  const double t0 = p0.cct_ * 0.001;
-  const double t1 = p1.cct_ * 0.001;
-  const double t2 = p2.cct_ * 0.001;
-  const double d0 = Distance(uv, EntryUV(p0));
-  const double d1 = Distance(uv, EntryUV(p1));
-  const double d2 = Distance(uv, EntryUV(p2));
-
-  const double denom0 = (t0 - t1) * (t0 - t2);
-  const double denom1 = (t1 - t0) * (t1 - t2);
-  const double denom2 = (t2 - t0) * (t2 - t1);
-  if (std::abs(denom0) <= kValueEpsilon || std::abs(denom1) <= kValueEpsilon ||
-      std::abs(denom2) <= kValueEpsilon) {
-    return {};
-  }
-
-  const double a = d0 / denom0 + d1 / denom1 + d2 / denom2;
-  const double b = -d0 * (t1 + t2) / denom0 - d1 * (t0 + t2) / denom1 -
-                   d2 * (t0 + t1) / denom2;
-  const double c = d0 * t1 * t2 / denom0 + d1 * t0 * t2 / denom1 +
-                   d2 * t0 * t1 / denom2;
-  if (!std::isfinite(a) || std::abs(a) <= kValueEpsilon) {
-    return {};
-  }
-
-  const double tx       = std::clamp(-b / (2.0 * a), t0, t2);
-  const double cct      = tx * 1000.0;
-  const double distance = std::max(0.0, a * tx * tx + b * tx + c);
-  const double v_tx     = PlanckianUVAtCCT(cct)[1];
-  const double duv      = distance * SignFromDeltaV(uv[1] - v_tx);
-
-  return OhnoSolution{std::isfinite(cct) && std::isfinite(duv), cct, duv};
-}
-
-auto OhnoTemperatureDuv(const cv::Vec2d& uv, double& out_cct, double& out_duv) -> bool {
-  if (!std::isfinite(uv[0]) || !std::isfinite(uv[1])) {
-    return false;
-  }
-
-  const auto table = OhnoPlanckianTable();
-  if (table.size() < 3) {
-    return false;
-  }
-
-  const size_t       m           = FindClosestOhnoSample(uv, table);
-  const OhnoSolution triangular  = SolveOhnoTriangular(uv, table, m);
-  const OhnoSolution parabolic   = SolveOhnoParabolic(uv, table, m);
-  const OhnoSolution& selected =
-      (triangular.valid_ && (std::abs(triangular.duv_) < kOhnoNearLocusDuv || !parabolic.valid_))
-          ? triangular
-          : parabolic;
-
-  if (!selected.valid_) {
-    return false;
-  }
-
-  out_cct = ClampFinite(selected.cct_, kCustomCCTMin, kCustomCCTMax);
-  out_duv = selected.duv_;
-  return std::isfinite(out_cct) && std::isfinite(out_duv);
-}
-
-auto UVToTemperatureTint(const cv::Vec2d& uv, double& out_cct, double& out_tint) -> bool {
-  double duv = 0.0;
-  if (!OhnoTemperatureDuv(uv, out_cct, duv)) {
-    return false;
-  }
-
-  const auto locus = PlanckianLocusAtCCT(out_cct);
-  if (!locus.valid_) {
-    return false;
-  }
-
-  const double delta_u = uv[0] - locus.uv_[0];
-  const double delta_v = uv[1] - locus.uv_[1];
-  out_tint = -kTintScale * (delta_u * locus.perp_[0] + delta_v * locus.perp_[1]);
-  return std::isfinite(out_cct) && std::isfinite(out_tint);
-}
-
-auto TemperatureTintToUV(double cct, double tint) -> cv::Vec2d {
-  const auto locus = PlanckianLocusAtCCT(cct);
-  if (!locus.valid_) {
-    return locus.uv_;
-  }
-  const double duv = ClampFinite(tint, kCustomTintMin, kCustomTintMax) / kTintScale;
-  return cv::Vec2d(locus.uv_[0] - locus.perp_[0] * duv,
-                   locus.uv_[1] - locus.perp_[1] * duv);
-}
-
-auto BuildBradfordCAT(const cv::Vec2d& src_xy, const cv::Vec2d& dst_xy) -> cv::Matx33d {
-  static const cv::Matx33d kBradford(0.8951, 0.2664, -0.1614, -0.7502, 1.7135, 0.0367, 0.0389,
-                                     -0.0685, 1.0296);
-  static const cv::Matx33d kBradfordInv(0.9869929, -0.1470543, 0.1599627, 0.4323053, 0.5183603,
-                                        0.0492912, -0.0085287, 0.0400428, 0.9684867);
-
-  const cv::Vec3d src_xyz = XYToXYZ(src_xy);
-  const cv::Vec3d dst_xyz = XYToXYZ(dst_xy);
-
-  const cv::Vec3d src_lms = kBradford * src_xyz;
-  const cv::Vec3d dst_lms = kBradford * dst_xyz;
-
-  const cv::Matx33d diag = cv::Matx33d::diag(cv::Vec3d(
-      dst_lms[0] / std::max(src_lms[0], kValueEpsilon), dst_lms[1] / std::max(src_lms[1], kValueEpsilon),
-      dst_lms[2] / std::max(src_lms[2], kValueEpsilon)));
-  return kBradfordInv * diag * kBradford;
-}
-
-void StoreMatrix(const cv::Matx33d& src, float dst[9]) {
-  for (int r = 0; r < 3; ++r) {
-    for (int c = 0; c < 3; ++c) {
-      dst[r * 3 + c] = static_cast<float>(src(r, c));
-    }
-  }
-}
-
-auto ResolveColorMatrixEndpoints(const OperatorParams& params, cv::Matx33d& cm1, cv::Matx33d& cm2,
-                                 double& endpoint_cct_1, double& endpoint_cct_2) -> bool {
-  endpoint_cct_1 = kCalibrationLowCCT;
-  endpoint_cct_2 = kCalibrationHighCCT;
-
-  // Use pre-resolved Adobe DNG colour matrices stored in OperatorParams.
-  // These are looked up once at import time by MetadataExtractor.
-  if (params.raw_color_matrices_valid_) {
-    cm1 = MatrixFromArray9(params.raw_color_matrix_1_);
-    cm2 = MatrixFromArray9(params.raw_color_matrix_2_);
-    if (HasDualIlluminantCalibration(params)) {
-      endpoint_cct_1 = params.raw_color_matrix_1_cct_;
-      endpoint_cct_2 = params.raw_color_matrix_2_cct_;
-    } else {
-      // Match Adobe DNG SDK behavior: if either calibration illuminant is
-      // missing/invalid, treat the profile as a single calibration instead of
-      // interpolating Matrix1/2 across a fabricated 2856K/6504K range.
-      cm2            = cm1;
-      endpoint_cct_1 = 5000.0;
-      endpoint_cct_2 = 5000.0;
-    }
-    return IsFiniteMatrix(cm1) && IsFiniteMatrix(cm2);
-  }
-
-  // Fallback: derive a single matrix from libraw cam_xyz / pre_mul.
+auto ApplyCamXyzFallback(const OperatorParams& params, DevelopPayload& develop) -> bool {
   cv::Matx33d fallback;
   if (!BuildFallbackXyzToCamera(params, fallback)) {
     return false;
   }
-  cm1 = fallback;
-  cm2 = fallback;
+  auto& profile                         = develop.camera_profile;
+  profile.color_matrices_valid          = true;
+  profile.forward_matrices_valid        = false;
+  profile.calibration_illuminants_valid = false;
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      const double value = fallback(r, c);
+      profile.color_matrix_1[static_cast<std::size_t>(r * 3 + c)] = value;
+      profile.color_matrix_2[static_cast<std::size_t>(r * 3 + c)] = value;
+    }
+  }
   return true;
 }
 
-auto ResolveForwardMatrixEndpoints(const OperatorParams& params, cv::Matx33d& fm1,
-                                   cv::Matx33d& fm2) -> bool {
-  if (!params.raw_forward_matrices_valid_) {
-    return false;
-  }
-
-  fm1 = MatrixFromArray9(params.raw_forward_matrix_1_);
-  fm2 = MatrixFromArray9(params.raw_forward_matrix_2_);
-  if (!HasDualIlluminantCalibration(params)) {
-    fm2 = fm1;
-  }
-  return IsFiniteMatrix(fm1) && IsFiniteMatrix(fm2);
+void CopyMatrix(const std::array<float, 9>& src, float dst[9]) {
+  std::memcpy(dst, src.data(), 9 * sizeof(float));
 }
 
-auto ResolveAsShotCameraNeutral(const OperatorParams& params, cv::Vec3d& out_neutral) -> bool {
-  if (params.raw_as_shot_neutral_valid_) {
-    const cv::Vec3d neutral(params.raw_as_shot_neutral_[0], params.raw_as_shot_neutral_[1],
-                            params.raw_as_shot_neutral_[2]);
-    if (std::all_of(std::begin(neutral.val), std::end(neutral.val), [](double value) {
-          return std::isfinite(value) && value > kValueEpsilon;
-        })) {
-      out_neutral = neutral;
-      return true;
-    }
-  }
-
-  const double r = std::max(static_cast<double>(params.raw_cam_mul_[0]), kValueEpsilon);
-  const double g = std::max(static_cast<double>(params.raw_cam_mul_[1]), kValueEpsilon);
-  const double b = std::max(static_cast<double>(params.raw_cam_mul_[2]), kValueEpsilon);
-  if (!std::isfinite(r) || !std::isfinite(g) || !std::isfinite(b)) {
-    return false;
-  }
-
-  out_neutral = cv::Vec3d(g / r, 1.0, g / b);
-  return std::all_of(std::begin(out_neutral.val), std::end(out_neutral.val), [](double value) {
-    return std::isfinite(value) && value > kValueEpsilon;
-  });
-}
-
-auto TintAtCctForXY(double cct, const cv::Vec2d& xy, double& out_tint) -> bool {
-  const auto locus = PlanckianLocusAtCCT(cct);
-  if (!locus.valid_) {
-    return false;
-  }
-
-  const cv::Vec2d uv = XYToUV(xy);
-  const double delta_u = uv[0] - locus.uv_[0];
-  const double delta_v = uv[1] - locus.uv_[1];
-  out_tint = -kTintScale * (delta_u * locus.perp_[0] + delta_v * locus.perp_[1]);
-  return std::isfinite(out_tint);
-}
-
-struct AsShotCctEvaluation {
-  bool      valid_         = false;
-  double    candidate_cct_ = 0.0;
-  double    derived_cct_   = 0.0;
-  double    residual_      = 0.0;
-  double    tint_          = 0.0;
-  cv::Vec2d xy_            = cv::Vec2d(kD50X, kD50Y);
-};
-
-auto EvaluateAsShotAtCct(const cv::Vec3d& camera_neutral, const cv::Matx33d& cm1,
-                         const cv::Matx33d& cm2, double endpoint_cct_1,
-                         double endpoint_cct_2, double candidate_cct)
-    -> AsShotCctEvaluation {
-  AsShotCctEvaluation eval;
-  eval.candidate_cct_ = ClampFinite(candidate_cct, kCustomCCTMin, kCustomCCTMax);
-
-  const cv::Matx33d xyz_to_camera =
-      InterpolateColorMatrix(cm1, cm2, eval.candidate_cct_, endpoint_cct_1, endpoint_cct_2);
-  cv::Matx33d camera_to_xyz;
-  if (!Invert3x3(xyz_to_camera, camera_to_xyz)) {
-    return eval;
-  }
-
-  const cv::Vec3d white_xyz = camera_to_xyz * camera_neutral;
-  if (!XYZToXY(white_xyz, eval.xy_)) {
-    return eval;
-  }
-
-  double derived_tint = 0.0;
-  if (!UVToTemperatureTint(XYToUV(eval.xy_), eval.derived_cct_, derived_tint)) {
-    return eval;
-  }
-  if (!TintAtCctForXY(eval.candidate_cct_, eval.xy_, eval.tint_)) {
-    return eval;
-  }
-
-  eval.residual_ = eval.derived_cct_ - eval.candidate_cct_;
-  eval.valid_    = std::isfinite(eval.residual_) && std::isfinite(eval.tint_);
-  return eval;
-}
-
-auto IsBetterAsShotEvaluation(const AsShotCctEvaluation& candidate,
-                              const AsShotCctEvaluation& incumbent) -> bool {
-  if (!candidate.valid_) {
-    return false;
-  }
-  if (!incumbent.valid_) {
-    return true;
-  }
-  return std::abs(candidate.residual_) < std::abs(incumbent.residual_);
-}
-
-auto HasOppositeSigns(double a, double b) -> bool {
-  return (a <= 0.0 && b >= 0.0) || (a >= 0.0 && b <= 0.0);
-}
-
-auto RefineAsShotCctRoot(const cv::Vec3d& camera_neutral, const cv::Matx33d& cm1,
-                         const cv::Matx33d& cm2, double endpoint_cct_1,
-                         double endpoint_cct_2, AsShotCctEvaluation low,
-                         AsShotCctEvaluation high) -> AsShotCctEvaluation {
-  AsShotCctEvaluation best = IsBetterAsShotEvaluation(low, high) ? low : high;
-
-  for (int i = 0; i < kAsShotSolveMaxIter; ++i) {
-    const double mid_cct = 0.5 * (low.candidate_cct_ + high.candidate_cct_);
-    auto mid = EvaluateAsShotAtCct(camera_neutral, cm1, cm2, endpoint_cct_1, endpoint_cct_2,
-                                   mid_cct);
-    if (!mid.valid_) {
-      break;
-    }
-    if (IsBetterAsShotEvaluation(mid, best)) {
-      best = mid;
-    }
-    if (std::abs(mid.residual_) <= kAsShotSolveEpsilon) {
-      return mid;
-    }
-    if (HasOppositeSigns(low.residual_, mid.residual_)) {
-      high = mid;
-    } else {
-      low = mid;
-    }
-  }
-
-  return best;
-}
-
-auto SolveAsShotWhiteXY(const OperatorParams& params, const cv::Matx33d& cm1, const cv::Matx33d& cm2,
-                        double endpoint_cct_1, double endpoint_cct_2, cv::Vec2d& out_xy,
-                        double& out_cct, double& out_tint) -> bool {
-  cv::Vec3d camera_neutral;
-  if (!ResolveAsShotCameraNeutral(params, camera_neutral)) {
-    return false;
-  }
-
-  AsShotCctEvaluation best;
-  AsShotCctEvaluation previous;
-  constexpr int       kScanCount = 96;
-  const double        min_mired  = 1.0e6 / kCustomCCTMax;
-  const double        max_mired  = 1.0e6 / kCustomCCTMin;
-
-  for (int i = 0; i <= kScanCount; ++i) {
-    const double t     = static_cast<double>(i) / static_cast<double>(kScanCount);
-    const double mired = max_mired + (min_mired - max_mired) * t;
-    const double cct   = 1.0e6 / std::max(mired, kValueEpsilon);
-    auto eval = EvaluateAsShotAtCct(camera_neutral, cm1, cm2, endpoint_cct_1, endpoint_cct_2,
-                                    cct);
-    if (!eval.valid_) {
-      continue;
-    }
-    if (IsBetterAsShotEvaluation(eval, best)) {
-      best = eval;
-    }
-    if (previous.valid_ && HasOppositeSigns(previous.residual_, eval.residual_)) {
-      auto refined = RefineAsShotCctRoot(camera_neutral, cm1, cm2, endpoint_cct_1,
-                                         endpoint_cct_2, previous, eval);
-      if (IsBetterAsShotEvaluation(refined, best)) {
-        best = refined;
-      }
-    }
-    previous = eval;
-  }
-
-  if (!best.valid_) {
-    return false;
-  }
-
-  out_xy   = best.xy_;
-  out_cct  = best.candidate_cct_;
-  out_tint = best.tint_;
-  return true;
-}
-
-auto BuildCameraToXyzD50FromForwardMatrix(const cv::Matx33d& cm1, const cv::Matx33d& cm2,
-                                          const cv::Matx33d& fm1, const cv::Matx33d& fm2,
-                                          double cct, double endpoint_cct_1,
-                                          double endpoint_cct_2, const cv::Vec2d& white_xy,
-                                          cv::Matx33d& out_camera_to_xyz_d50) -> bool {
-  const cv::Matx33d xyz_to_camera =
-      InterpolateColorMatrix(cm1, cm2, cct, endpoint_cct_1, endpoint_cct_2);
-  const cv::Matx33d forward_matrix =
-      InterpolateColorMatrix(fm1, fm2, cct, endpoint_cct_1, endpoint_cct_2);
-
-  const cv::Vec3d reference_neutral = xyz_to_camera * XYToXYZ(white_xy);
-  if (!std::all_of(std::begin(reference_neutral.val), std::end(reference_neutral.val),
-                   [](double value) { return std::isfinite(value) && value > kValueEpsilon; })) {
-    return false;
-  }
-
-  const cv::Matx33d reference_scale = cv::Matx33d::diag(
-      cv::Vec3d(1.0 / reference_neutral[0], 1.0 / reference_neutral[1], 1.0 / reference_neutral[2]));
-  out_camera_to_xyz_d50 = forward_matrix * reference_scale;
-  return IsFiniteMatrix(out_camera_to_xyz_d50);
-}
 }  // namespace
 
 ColorTempOp::ColorTempOp(const nlohmann::json& params) { SetParams(params); }
@@ -788,8 +234,6 @@ void ColorTempOp::SetParams(const nlohmann::json& params) {
     mode_ = ParseMode(j["mode"].get<std::string>());
   }
 
-  // Durable custom keys; accept legacy cct/tint as custom when mode is custom
-  // (or when custom_* is absent and mode is custom after parse).
   if (j.contains("custom_cct")) {
     custom_cct_ = static_cast<float>(
         ClampFinite(j["custom_cct"].get<double>(), kCustomCCTMin, kCustomCCTMax));
@@ -806,9 +250,6 @@ void ColorTempOp::SetParams(const nlohmann::json& params) {
         static_cast<float>(ClampFinite(j["tint"].get<double>(), kCustomTintMin, kCustomTintMax));
   }
 
-  // Image-local as-shot baseline. Prefer as_shot_*; accept resolved_* as legacy
-  // alias. Missing keys must not fall back to custom_* — transfer packages
-  // intentionally strip as-shot CCT/Tint.
   if (j.contains("as_shot_cct")) {
     resolved_cct_ = static_cast<float>(
         ClampFinite(j["as_shot_cct"].get<double>(), kCustomCCTMin, kCustomCCTMax));
@@ -816,7 +257,6 @@ void ColorTempOp::SetParams(const nlohmann::json& params) {
     resolved_cct_ = static_cast<float>(
         ClampFinite(j["resolved_cct"].get<double>(), kCustomCCTMin, kCustomCCTMax));
   } else if (j.contains("cct") && mode_ == ColorTempMode::AS_SHOT) {
-    // Legacy GetParams mirrored as-shot into cct when mode was as_shot.
     resolved_cct_ =
         static_cast<float>(ClampFinite(j["cct"].get<double>(), kCustomCCTMin, kCustomCCTMax));
   }
@@ -857,7 +297,6 @@ auto ColorTempModeFromParams(const nlohmann::json& params) -> ColorTempMode {
 auto ColorTempAsShotBaseline(const nlohmann::json& params, double& out_cct, double& out_tint)
     -> void {
   const auto inner = ColorTempInner(params);
-  // Prefer as_shot_*; accept resolved_* and legacy as_shot-mirrored cct/tint.
   if (inner.contains("as_shot_cct") && inner["as_shot_cct"].is_number()) {
     out_cct = inner["as_shot_cct"].get<double>();
   } else if (inner.contains("resolved_cct") && inner["resolved_cct"].is_number()) {
@@ -906,14 +345,12 @@ auto ColorTempOp::DetectMergeConflict(const nlohmann::json& current,
                                       const nlohmann::json& incoming) const -> bool {
   const auto current_mode  = ColorTempModeFromParams(current);
   const auto incoming_mode = ColorTempModeFromParams(incoming);
-  // as_shot is portable intent only; image-local CCT/Tint must not force a conflict.
   if (current_mode == ColorTempMode::AS_SHOT && incoming_mode == ColorTempMode::AS_SHOT) {
     return false;
   }
   if (current_mode != incoming_mode) {
     return true;
   }
-  // Both custom: compare user-authored CCT/Tint only.
   const auto cur = ColorTempInner(current);
   const auto inc = ColorTempInner(incoming);
   const double cur_cct  = ColorTempCustomCct(cur);
@@ -952,7 +389,6 @@ auto ColorTempOp::MergeParams(const nlohmann::json& current, const nlohmann::jso
     return result;
   }
 
-  // Take custom values from incoming; keep current's as-shot baseline.
   const auto inc = ColorTempInner(incoming);
   double baseline_cct  = 6500.0;
   double baseline_tint = 0.0;
@@ -966,19 +402,17 @@ auto ColorTempOp::MergeParams(const nlohmann::json& current, const nlohmann::jso
 }
 
 void ColorTempOp::SetGlobalParams(OperatorParams& params) const {
-  params.color_temp_mode_         = mode_;
-  params.color_temp_custom_cct_   = custom_cct_;
-  params.color_temp_custom_tint_  = custom_tint_;
-  params.color_temp_resolved_cct_ = resolved_cct_;
+  params.color_temp_mode_          = mode_;
+  params.color_temp_custom_cct_    = custom_cct_;
+  params.color_temp_custom_tint_   = custom_tint_;
+  params.color_temp_resolved_cct_  = resolved_cct_;
   params.color_temp_resolved_tint_ = resolved_tint_;
   params.color_temp_runtime_dirty_ = true;
-
-  // Eagerly resolve camera→XYZ/AP1 matrices now instead of deferring to pipeline Apply.
   ResolveRuntime(params);
 }
 
 void ColorTempOp::EnableGlobalParams(OperatorParams& params, bool enable) {
-  params.color_temp_enabled_      = enable;
+  params.color_temp_enabled_       = enable;
   params.color_temp_runtime_dirty_ = true;
 }
 
@@ -990,98 +424,44 @@ void ColorTempOp::ResolveRuntime(OperatorParams& params) const {
   const std::uint64_t runtime_cache_key =
       BuildRuntimeCacheKey(params, mode_, custom_cct_, custom_tint_);
   if (params.color_temp_cache_key_valid_ && params.color_temp_cache_key_ == runtime_cache_key) {
-    resolved_cct_                 = params.color_temp_resolved_cct_;
-    resolved_tint_                = params.color_temp_resolved_tint_;
+    resolved_cct_                    = params.color_temp_resolved_cct_;
+    resolved_tint_                   = params.color_temp_resolved_tint_;
     params.color_temp_runtime_dirty_ = false;
     return;
   }
   params.color_temp_cache_key_       = runtime_cache_key;
   params.color_temp_cache_key_valid_ = true;
 
-  if (!params.color_temp_enabled_) {
-    params.color_temp_matrices_valid_ = false;
-    params.color_temp_runtime_dirty_  = false;
-    return;
-  }
-  if (!params.raw_runtime_valid_) {
+  if (!params.color_temp_enabled_ || !params.raw_runtime_valid_) {
     params.color_temp_matrices_valid_ = false;
     params.color_temp_runtime_dirty_  = false;
     return;
   }
 
-  cv::Matx33d cm1;
-  cv::Matx33d cm2;
-  cv::Matx33d fm1;
-  cv::Matx33d fm2;
-  double     endpoint_cct_1 = kCalibrationLowCCT;
-  double     endpoint_cct_2 = kCalibrationHighCCT;
-  if (!ResolveColorMatrixEndpoints(params, cm1, cm2, endpoint_cct_1, endpoint_cct_2)) {
-    params.color_temp_matrices_valid_ = false;
-    params.color_temp_runtime_dirty_  = false;
-    return;
+  auto payload = DevelopPayloadFromColorTemp(params, mode_, custom_cct_, custom_tint_);
+  auto result  = ResolveDevelopColorTransform(payload);
+  if (!result.ok && result.error == ColorTransformError::MissingCameraMatrices &&
+      ApplyCamXyzFallback(params, payload)) {
+    result = ResolveDevelopColorTransform(payload);
   }
-  const bool has_forward_matrices = ResolveForwardMatrixEndpoints(params, fm1, fm2);
-
-  cv::Vec2d selected_xy(kD50X, kD50Y);
-  double    selected_cct  = custom_cct_;
-  double    selected_tint = custom_tint_;
-
-  if (mode_ == ColorTempMode::AS_SHOT) {
-    if (!SolveAsShotWhiteXY(params, cm1, cm2, endpoint_cct_1, endpoint_cct_2, selected_xy,
-                            selected_cct, selected_tint)) {
-      params.color_temp_matrices_valid_ = false;
-      params.color_temp_runtime_dirty_  = false;
-      return;
-    }
-  } else {
-    selected_cct  = ClampFinite(custom_cct_, kCustomCCTMin, kCustomCCTMax);
-    selected_tint = ClampFinite(custom_tint_, kCustomTintMin, kCustomTintMax);
-    selected_xy   = UVToXY(TemperatureTintToUV(selected_cct, selected_tint));
-  }
-
-  const cv::Matx33d xyz_to_camera =
-      InterpolateColorMatrix(cm1, cm2, selected_cct, endpoint_cct_1, endpoint_cct_2);
-  cv::Matx33d       camera_to_xyz;
-  if (!Invert3x3(xyz_to_camera, camera_to_xyz)) {
-    std::cout << "ColorTempOp: Failed to invert XYZ to camera matrix.\n";
+  if (!result.ok) {
     params.color_temp_matrices_valid_ = false;
     params.color_temp_runtime_dirty_  = false;
     return;
   }
 
-  cv::Matx33d camera_to_xyz_d50;
-  if (has_forward_matrices) {
-    if (!BuildCameraToXyzD50FromForwardMatrix(cm1, cm2, fm1, fm2, selected_cct, endpoint_cct_1,
-                                              endpoint_cct_2, selected_xy, camera_to_xyz_d50)) {
-      params.color_temp_matrices_valid_ = false;
-      params.color_temp_runtime_dirty_  = false;
-      return;
-    }
-  } else {
-    const cv::Matx33d cat_src_to_d50 = BuildBradfordCAT(selected_xy, cv::Vec2d(kD50X, kD50Y));
-    camera_to_xyz_d50                = cat_src_to_d50 * camera_to_xyz;
-  }
+  CopyMatrix(result.transform.camera_to_xyz, params.color_temp_cam_to_xyz_);
+  CopyMatrix(result.transform.camera_to_xyz_d50, params.color_temp_cam_to_xyz_d50_);
+  CopyMatrix(result.transform.xyz_d50_to_ap1, params.color_temp_xyz_d50_to_ap1_);
+  CopyMatrix(result.transform.camera_to_ap1, params.color_temp_cam_to_ap1_);
 
-  const cv::Matx33d cat_d50_to_d60 = BuildBradfordCAT(cv::Vec2d(kD50X, kD50Y), cv::Vec2d(kD60X, kD60Y));
-  const cv::Matx33d xyz_d50_to_ap1 = kXyzD60ToAp1 * cat_d50_to_d60;
-  const cv::Matx33d camera_to_ap1  = xyz_d50_to_ap1 * camera_to_xyz_d50;
-
-  StoreMatrix(camera_to_xyz, params.color_temp_cam_to_xyz_);
-  StoreMatrix(camera_to_xyz_d50, params.color_temp_cam_to_xyz_d50_);
-  StoreMatrix(xyz_d50_to_ap1, params.color_temp_xyz_d50_to_ap1_);
-  StoreMatrix(camera_to_ap1, params.color_temp_cam_to_ap1_);
-
-  resolved_cct_ = static_cast<float>(ClampFinite(selected_cct, kCustomCCTMin, kCustomCCTMax));
-  resolved_tint_ = static_cast<float>(ClampFinite(selected_tint, kCustomTintMin, kCustomTintMax));
-
-  // Reflect runtime-selected values back into effective exported params.
-  params.color_temp_custom_cct_         = resolved_cct_;
-  params.color_temp_custom_tint_        = resolved_tint_;
-  params.color_temp_resolved_cct_       = resolved_cct_;
-  params.color_temp_resolved_tint_      = resolved_tint_;
-  params.color_temp_resolved_xy_[0]     = static_cast<float>(selected_xy[0]);
-  params.color_temp_resolved_xy_[1]     = static_cast<float>(selected_xy[1]);
-  params.color_temp_runtime_dirty_      = false;
-  params.color_temp_matrices_valid_     = true;
+  resolved_cct_  = result.transform.resolved_cct;
+  resolved_tint_ = result.transform.resolved_tint;
+  params.color_temp_custom_cct_      = resolved_cct_;
+  params.color_temp_custom_tint_     = resolved_tint_;
+  params.color_temp_resolved_cct_    = resolved_cct_;
+  params.color_temp_resolved_tint_   = resolved_tint_;
+  params.color_temp_runtime_dirty_   = false;
+  params.color_temp_matrices_valid_  = true;
 }
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/operators/models/cat02_white_balance_model.cpp
+++ b/alcedo_studio/src/edit/operators/models/cat02_white_balance_model.cpp
@@ -17,12 +17,18 @@ auto Cat02WhiteBalanceModel::IsDefault() const -> bool {
 }
 
 void Cat02WhiteBalanceModel::SetEnabled(bool enabled) {
+  if (Enabled() == enabled) {
+    return;
+  }
   Mutate(Cat02WhiteBalanceDirty::Enabled,
          [enabled](Cat02WhiteBalancePayload& payload) { payload.enabled = enabled; });
 }
 
 void Cat02WhiteBalanceModel::SetTemperatureOffset(float offset) {
   const float clamped = std::clamp(offset, -100.0f, 100.0f);
+  if (TemperatureOffset() == clamped) {
+    return;
+  }
   Mutate(Cat02WhiteBalanceDirty::Temperature, [clamped](Cat02WhiteBalancePayload& payload) {
     payload.temperature_offset = clamped;
   });
@@ -30,6 +36,9 @@ void Cat02WhiteBalanceModel::SetTemperatureOffset(float offset) {
 
 void Cat02WhiteBalanceModel::SetTintOffset(float offset) {
   const float clamped = std::clamp(offset, -100.0f, 100.0f);
+  if (TintOffset() == clamped) {
+    return;
+  }
   Mutate(Cat02WhiteBalanceDirty::Tint,
          [clamped](Cat02WhiteBalancePayload& payload) { payload.tint_offset = clamped; });
 }

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -43,8 +43,11 @@ void ApplyImportedCameraProfile(PipelineDocument&             document,
     return;
   }
   auto payload = develop->Params().Params();
-  BindDevelopCameraProfile(payload, imported);
-  develop->Params().ReplaceParams(std::move(payload));
+  auto next    = payload;
+  BindDevelopCameraProfile(next, imported);
+  if (next != payload) {
+    develop->Params().ReplaceParams(std::move(next));
+  }
 }
 #endif
 
@@ -201,20 +204,22 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
 #ifdef HAVE_CUDA
   if (resolved_accelerator_backend_ == GpuBackendKind::CUDA && pipeline_document_) {
     // Existing editor controls still write the stage adapter during G7. Mirror it into the
-    // default three-node document only when it changed. Documents with additional graph nodes
-    // are edited as v2 data and must not be flattened by this transition path.
-    if (mirror_legacy_stage_adapter_ && pipeline_document_->Graph().Nodes().size() == 3U) {
+    // live document only when it changed. ApplyOnto keeps extra graph nodes (the oval-mask
+    // probe) and import-time camera matrices; replacing the document would rebuild every
+    // Model, mark them dirty, and miss GPU result cache on slider frames.
+    if (mirror_legacy_stage_adapter_ && AllowsLegacyStageAdapterRemirror(*pipeline_document_)) {
       const auto legacy = ExportPipelineParams();
       if (legacy != cuda_product_legacy_snapshot_) {
-        auto imported = LegacyPipelineImporter::Import(legacy);
-        if (!imported.Ok()) {
-          throw std::runtime_error("CPUPipelineExecutor: legacy adapter import failed: " +
-                                   imported.error);
+        const auto error = LegacyPipelineImporter::ApplyOnto(*pipeline_document_, legacy);
+        if (!error.empty()) {
+          throw std::runtime_error("CPUPipelineExecutor: legacy adapter import failed: " + error);
         }
-        *pipeline_document_           = std::move(*imported.document);
         cuda_product_legacy_snapshot_ = legacy;
         if (injected_raw_color_context_.has_value()) {
           ApplyImportedCameraProfile(*pipeline_document_, *injected_raw_color_context_);
+        }
+        if (kTemporaryPrimaryGradeOvalMask) {
+          AttachTemporaryPrimaryGradeOvalMask(*pipeline_document_);
         }
       }
     }
@@ -364,6 +369,9 @@ void CPUPipelineExecutor::SetPipelineDocument(std::shared_ptr<PipelineDocument> 
   pipeline_document_            = std::move(document);
   mirror_legacy_stage_adapter_  = mirror_legacy_stage_adapter;
   cuda_product_legacy_snapshot_ = nullptr;
+  if (kTemporaryPrimaryGradeOvalMask && pipeline_document_) {
+    AttachTemporaryPrimaryGradeOvalMask(*pipeline_document_);
+  }
   if (pipeline_document_ && injected_raw_color_context_.has_value()) {
     ApplyImportedCameraProfile(*pipeline_document_, *injected_raw_color_context_);
   }

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -204,9 +204,12 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
 #ifdef HAVE_CUDA
   if (resolved_accelerator_backend_ == GpuBackendKind::CUDA && pipeline_document_) {
     // Existing editor controls still write the stage adapter during G7. Mirror it into the
-    // live document only when it changed. ApplyOnto keeps extra graph nodes (the oval-mask
-    // probe) and import-time camera matrices; replacing the document would rebuild every
-    // Model, mark them dirty, and miss GPU result cache on slider frames.
+    // live document only when it changed. ApplyOnto keeps extra graph nodes and import-time
+    // camera matrices; replacing the document would rebuild every Model, mark them dirty,
+    // and miss GPU result cache on slider frames.
+    if (!cuda_product_renderer_) {
+      cuda_product_renderer_ = std::make_shared<CudaProductRenderer>(pipeline_document_);
+    }
     if (mirror_legacy_stage_adapter_ && AllowsLegacyStageAdapterRemirror(*pipeline_document_)) {
       const auto legacy = ExportPipelineParams();
       if (legacy != cuda_product_legacy_snapshot_) {
@@ -218,13 +221,7 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
         if (injected_raw_color_context_.has_value()) {
           ApplyImportedCameraProfile(*pipeline_document_, *injected_raw_color_context_);
         }
-        if (kTemporaryPrimaryGradeOvalMask) {
-          AttachTemporaryPrimaryGradeOvalMask(*pipeline_document_);
-        }
       }
-    }
-    if (!cuda_product_renderer_) {
-      cuda_product_renderer_ = std::make_shared<CudaProductRenderer>(pipeline_document_);
     }
     RenderRequest request;
     if (const auto& viewport = render_request_viewport_;
@@ -369,9 +366,6 @@ void CPUPipelineExecutor::SetPipelineDocument(std::shared_ptr<PipelineDocument> 
   pipeline_document_            = std::move(document);
   mirror_legacy_stage_adapter_  = mirror_legacy_stage_adapter;
   cuda_product_legacy_snapshot_ = nullptr;
-  if (kTemporaryPrimaryGradeOvalMask && pipeline_document_) {
-    AttachTemporaryPrimaryGradeOvalMask(*pipeline_document_);
-  }
   if (pipeline_document_ && injected_raw_color_context_.has_value()) {
     ApplyImportedCameraProfile(*pipeline_document_, *injected_raw_color_context_);
   }

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -24,6 +24,7 @@
 #include "edit/pipeline/pipeline_stage.hpp"
 #include "image/image_buffer.hpp"
 #ifdef HAVE_CUDA
+#include "edit/graph/develop_color_transform.hpp"
 #include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
@@ -33,6 +34,18 @@ namespace alcedo {
 
 namespace {
 using ProfileClock = std::chrono::steady_clock;
+
+#ifdef HAVE_CUDA
+void ApplyImportedCameraProfile(PipelineDocument& document, const RawRuntimeColorContext& imported) {
+  auto* develop = document.Develop();
+  if (develop == nullptr) {
+    return;
+  }
+  auto payload = develop->Params().Params();
+  BindDevelopCameraProfile(payload, imported);
+  develop->Params().ReplaceParams(std::move(payload));
+}
+#endif
 
 auto DurationToMs(const ProfileClock::duration duration) -> double {
   return std::chrono::duration<double, std::milli>(duration).count();
@@ -199,6 +212,9 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
         }
         *pipeline_document_           = std::move(*imported.document);
         cuda_product_legacy_snapshot_ = legacy;
+        if (injected_raw_color_context_.has_value()) {
+          ApplyImportedCameraProfile(*pipeline_document_, *injected_raw_color_context_);
+        }
       }
     }
     if (!cuda_product_renderer_) {
@@ -345,11 +361,15 @@ void CPUPipelineExecutor::SetPipelineDocument(std::shared_ptr<PipelineDocument> 
   pipeline_document_            = std::move(document);
   mirror_legacy_stage_adapter_  = mirror_legacy_stage_adapter;
   cuda_product_legacy_snapshot_ = nullptr;
+  if (pipeline_document_ && injected_raw_color_context_.has_value()) {
+    ApplyImportedCameraProfile(*pipeline_document_, *injected_raw_color_context_);
+  }
   if (cuda_product_renderer_) {
     cuda_product_renderer_->SetDocument(pipeline_document_);
   }
 #else
   (void)document;
+  (void)mirror_legacy_stage_adapter;
 #endif
 }
 
@@ -778,6 +798,32 @@ void CPUPipelineExecutor::InitDefaultPipeline() {
 
 void CPUPipelineExecutor::InjectRawMetadata(const RawRuntimeColorContext& ctx) {
   global_params_.PopulateRawMetadata(ctx);
+  injected_raw_color_context_ = ctx;
+#ifdef HAVE_CUDA
+  if (pipeline_document_) {
+    ApplyImportedCameraProfile(*pipeline_document_, ctx);
+  }
+#endif
+
+  // EditorColorTempModel loads as_shot_cct from ColorTempOp JSON. Persist the
+  // import-time solve so the panel does not re-parse RAW.
+  auto& to_ws_stage = GetStage(PipelineStageName::To_WorkingSpace);
+  if (const auto color_temp_entry = to_ws_stage.GetOperator(OperatorType::COLOR_TEMP);
+      color_temp_entry.has_value() && color_temp_entry.value() && color_temp_entry.value()->op_) {
+    color_temp_entry.value()->op_->SetGlobalParams(global_params_);
+    auto color_temp_params = color_temp_entry.value()->op_->GetParams();
+#ifdef HAVE_CUDA
+    if (pipeline_document_ != nullptr && pipeline_document_->Develop() != nullptr) {
+      const auto& develop = pipeline_document_->Develop()->Params().Params();
+      if (!color_temp_params.contains("color_temp") || !color_temp_params["color_temp"].is_object()) {
+        color_temp_params["color_temp"] = nlohmann::json::object();
+      }
+      color_temp_params["color_temp"]["as_shot_cct"]  = develop.as_shot_cct;
+      color_temp_params["color_temp"]["as_shot_tint"] = develop.as_shot_tint;
+    }
+#endif
+    to_ws_stage.SetOperator(OperatorType::COLOR_TEMP, color_temp_params, global_params_);
+  }
 
   // Install image-local inherent RAW context on the decode operator so later
   // GetParams/SetGlobalParams/Apply use the same durable state without a

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -36,7 +36,8 @@ namespace {
 using ProfileClock = std::chrono::steady_clock;
 
 #ifdef HAVE_CUDA
-void ApplyImportedCameraProfile(PipelineDocument& document, const RawRuntimeColorContext& imported) {
+void ApplyImportedCameraProfile(PipelineDocument&             document,
+                                const RawRuntimeColorContext& imported) {
   auto* develop = document.Develop();
   if (develop == nullptr) {
     return;
@@ -221,7 +222,7 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
       cuda_product_renderer_ = std::make_shared<CudaProductRenderer>(pipeline_document_);
     }
     RenderRequest request;
-    if (const auto viewport = GetViewportRenderRegion();
+    if (const auto& viewport = render_request_viewport_;
         viewport.has_value() && viewport->reference_width_ > 0 && viewport->reference_height_ > 0) {
       request.view.visible_rect_in_edit_space = {
           static_cast<float>(viewport->x_) / viewport->reference_width_,
@@ -240,8 +241,10 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
       }
     }
     request.resolution.quality = force_cpu_output_ ? RenderQuality::Export : RenderQuality::Preview;
+    const auto cache_policy    = enable_cache_ ? CudaProductCachePolicy::UseSessionCache
+                                               : CudaProductCachePolicy::BypassSessionCache;
     return cuda_product_renderer_->Render(input, decode_res_, request, frame_sink_,
-                                          bound_frame_submission_, force_cpu_output_);
+                                          bound_frame_submission_, force_cpu_output_, cache_policy);
   }
 #endif
   if (exec_stages_.empty()) {
@@ -667,10 +670,11 @@ void CPUPipelineExecutor::SetDecodeRes(DecodeRes res) {
 
 auto CPUPipelineExecutor::CaptureOneShotRenderParams() const -> OneShotRenderParamsSnapshot {
   OneShotRenderParamsSnapshot snapshot;
-  snapshot.decode_res_       = decode_res_;
-  snapshot.render_params_    = render_params_;
-  snapshot.force_cpu_output_ = force_cpu_output_;
-  snapshot.enable_cache_     = enable_cache_;
+  snapshot.decode_res_              = decode_res_;
+  snapshot.render_params_           = render_params_;
+  snapshot.force_cpu_output_        = force_cpu_output_;
+  snapshot.enable_cache_            = enable_cache_;
+  snapshot.render_request_viewport_ = render_request_viewport_;
   return snapshot;
 }
 
@@ -680,7 +684,8 @@ void CPUPipelineExecutor::RestoreOneShotRenderParams(const OneShotRenderParamsSn
     // SetEnableCache rebuilds stage cache flags; only call when the value changes.
     SetEnableCache(snapshot.enable_cache_);
   }
-  render_params_ = snapshot.render_params_;
+  render_params_           = snapshot.render_params_;
+  render_request_viewport_ = snapshot.render_request_viewport_;
   stages_[static_cast<int>(PipelineStageName::Geometry_Adjustment)].SetOperator(
       OperatorType::RESIZE, render_params_);
 
@@ -815,7 +820,8 @@ void CPUPipelineExecutor::InjectRawMetadata(const RawRuntimeColorContext& ctx) {
 #ifdef HAVE_CUDA
     if (pipeline_document_ != nullptr && pipeline_document_->Develop() != nullptr) {
       const auto& develop = pipeline_document_->Develop()->Params().Params();
-      if (!color_temp_params.contains("color_temp") || !color_temp_params["color_temp"].is_object()) {
+      if (!color_temp_params.contains("color_temp") ||
+          !color_temp_params["color_temp"].is_object()) {
         color_temp_params["color_temp"] = nlohmann::json::object();
       }
       color_temp_params["color_temp"]["as_shot_cct"]  = develop.as_shot_cct;
@@ -850,6 +856,11 @@ void CPUPipelineExecutor::ClearAllIntermediateBuffers() {
     merged_stages_->ResetRuntimeResources(
         PipelineStage::RuntimeResetMode::ClearIntermediateBuffers);
   }
+#ifdef HAVE_CUDA
+  if (cuda_product_renderer_) {
+    cuda_product_renderer_->ReleaseSessionCaches();
+  }
+#endif
 }
 
 void CPUPipelineExecutor::ReleasePreviewGpuScratch() {
@@ -866,6 +877,11 @@ void CPUPipelineExecutor::ReleaseAllGPUResources() {
   if (merged_stages_) {
     merged_stages_->ResetRuntimeResources(PipelineStage::RuntimeResetMode::ReleaseGpuResources);
   }
+#ifdef HAVE_CUDA
+  if (cuda_product_renderer_) {
+    cuda_product_renderer_->ReleaseSessionCaches();
+  }
+#endif
 }
 
 auto CPUPipelineExecutor::DebugGetMergedStageScratchBytes() const -> size_t {

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_acescc.cuh
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_acescc.cuh
@@ -1,0 +1,33 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace alcedo::cuda_acescc {
+
+__device__ __forceinline__ auto Encode(float value) -> float {
+  constexpr float kA          = 9.72f;
+  constexpr float kB          = 17.52f;
+  constexpr float kOffset     = 0.0000152587890625f;
+  constexpr float kTransition = 0.000030517578125f;
+  constexpr float kFloor      = (-16.0f + kA) / kB;
+  if (value < 0.0f) return kFloor + value;
+  if (value < kTransition) return (log2f(kOffset + value * 0.5f) + kA) / kB;
+  return (log2f(value) + kA) / kB;
+}
+
+__device__ __forceinline__ auto Decode(float value) -> float {
+  constexpr float kA         = 9.72f;
+  constexpr float kB         = 17.52f;
+  constexpr float kOffset    = 0.0000152587890625f;
+  constexpr float kFloor     = (-16.0f + kA) / kB;
+  constexpr float kThreshold = (-15.0f + kA) / kB;
+  if (value < kFloor) return value - kFloor;
+  if (value <= kThreshold) return (exp2f(value * kB - kA) - kOffset) * 2.0f;
+  return exp2f(value * kB - kA);
+}
+
+}  // namespace alcedo::cuda_acescc

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_adjustment_runtime.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_adjustment_runtime.cpp
@@ -42,8 +42,7 @@ auto ResolveCudaAdjustmentBehavior(const OperatorTypeId& type) -> CudaAdjustment
 
 auto IsCudaLocalToneBehavior(CudaAdjustmentBehavior behavior) -> bool {
   return behavior == CudaAdjustmentBehavior::Shadows ||
-         behavior == CudaAdjustmentBehavior::Highlights ||
-         behavior == CudaAdjustmentBehavior::Clarity;
+         behavior == CudaAdjustmentBehavior::Highlights;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_adjustment_runtime.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_adjustment_runtime.cpp
@@ -10,7 +10,8 @@
 
 namespace alcedo {
 
-auto ResolveCudaAdjustmentBehavior(const OperatorTypeId& type) -> CudaAdjustmentBehavior {
+auto TryResolveCudaAdjustmentBehavior(const OperatorTypeId& type)
+    -> std::optional<CudaAdjustmentBehavior> {
   using enum CudaAdjustmentBehavior;
   if (type == type_ids::Cat02WhiteBalance()) return Cat02WhiteBalance;
   if (type == type_ids::Exposure()) return Exposure;
@@ -29,6 +30,13 @@ auto ResolveCudaAdjustmentBehavior(const OperatorTypeId& type) -> CudaAdjustment
   if (type == type_ids::Sharpen()) return Sharpen;
   if (type == type_ids::Halation()) return Halation;
   if (type == type_ids::FilmGrain()) return FilmGrain;
+  return std::nullopt;
+}
+
+auto ResolveCudaAdjustmentBehavior(const OperatorTypeId& type) -> CudaAdjustmentBehavior {
+  if (auto behavior = TryResolveCudaAdjustmentBehavior(type)) {
+    return *behavior;
+  }
   throw std::runtime_error("CUDA primary grade: unregistered adjustment type");
 }
 

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -341,4 +341,15 @@ void CudaBackend::ResetCounters() {
 
 void CudaBackend::FailNextUpload() { fail_next_upload_ = true; }
 
+auto DefaultProductTextureBudgetBytes() -> std::size_t {
+  constexpr std::size_t kFloorBytes = 256ull << 20;
+  std::size_t           free_bytes  = 0;
+  std::size_t           total_bytes = 0;
+  if (::cudaMemGetInfo(&free_bytes, &total_bytes) != cudaSuccess || total_bytes == 0) {
+    return kFloorBytes;
+  }
+  const auto quarter = total_bytes / 4;
+  return quarter > kFloorBytes ? quarter : kFloorBytes;
+}
+
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -241,6 +241,22 @@ void CudaBackend::UploadTexture2D(Texture2D& texture, std::span<const std::byte>
   h2d_bytes_ += bytes.size();
 }
 
+void CudaBackend::CopyTexture2D(const Texture2D& src, Texture2D& dst,
+                                CommandContext& command_context) {
+  if (src.DevicePointer() == nullptr || dst.DevicePointer() == nullptr) {
+    throw std::runtime_error("CudaBackend::CopyTexture2D: empty texture");
+  }
+  if (src.Width() != dst.Width() || src.Height() != dst.Height() || src.Format() != dst.Format()) {
+    throw std::runtime_error("CudaBackend::CopyTexture2D: size or format mismatch");
+  }
+  if (src.Bytes() == 0) {
+    return;
+  }
+  cuda::CheckCuda(::cudaMemcpyAsync(dst.DevicePointer(), src.DevicePointer(), src.Bytes(),
+                                    cudaMemcpyDeviceToDevice, command_context.Stream()),
+                  "CudaBackend::CopyTexture2D");
+}
+
 void CudaBackend::UploadR8TextureRect(Texture2D& texture, RectI rectangle,
                                       std::span<const std::byte> bytes,
                                       CommandContext&            command_context) {

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_camera_color_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_camera_color_pass.cu
@@ -4,66 +4,67 @@
 
 #include <cuda_runtime.h>
 
-#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
 #include <stdexcept>
+#include <string>
 
+#include "edit/graph/develop_color_transform.hpp"
+#include "edit/graph/develop_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_param_dto.hpp"
+#include "edit/runtime/camera_color_gpu_params.hpp"
 #include "edit/runtime/cuda/cuda_develop_pass.hpp"
+#include "edit/runtime/parameter_arena.hpp"
+#include "edit/runtime/parameter_binding.hpp"
 #include "edit/runtime/texture_format.hpp"
 
 namespace alcedo {
 namespace {
 
-struct CameraToAp1Params {
-  float matrix[9] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
-};
-
-auto MakeCameraToAp1(const RawRuntimeColorContext& context) -> CameraToAp1Params {
-  CameraToAp1Params result;
-  if (!context.valid_) {
-    return result;
+auto MakeGpuParams(const DevelopColorTransform& transform) -> CameraColorGpuParams {
+  CameraColorGpuParams params;
+  for (int i = 0; i < 9; ++i) {
+    params.camera_to_ap1[i] = transform.camera_to_ap1[static_cast<std::size_t>(i)];
   }
-  constexpr float srgb_to_ap1[9] = {0.613097f, 0.339523f, 0.047380f, 0.070194f, 0.916354f,
-                                    0.013452f, 0.020616f, 0.109570f, 0.869815f};
-  float           absolute_sum   = 0.0f;
-  for (float value : context.rgb_cam_) {
-    absolute_sum += std::abs(value);
-  }
-  if (absolute_sum <= 1.0e-6f) {
-    return result;
-  }
-  for (int row = 0; row < 3; ++row) {
-    for (int column = 0; column < 3; ++column) {
-      result.matrix[row * 3 + column] = srgb_to_ap1[row * 3] * context.rgb_cam_[column] +
-                                        srgb_to_ap1[row * 3 + 1] * context.rgb_cam_[3 + column] +
-                                        srgb_to_ap1[row * 3 + 2] * context.rgb_cam_[6 + column];
-    }
-  }
-  return result;
+  return params;
 }
 
 __global__ void CameraColorKernel(const float4* input, float4* output, std::uint32_t pixel_count,
-                                  CameraToAp1Params camera) {
+                                  const CameraColorGpuParams* camera) {
   const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= pixel_count) {
     return;
   }
   const float4 source = input[index];
+  const float* m      = camera->camera_to_ap1;
   float3       c;
-  c.x = camera.matrix[0] * source.x + camera.matrix[1] * source.y + camera.matrix[2] * source.z;
-  c.y = camera.matrix[3] * source.x + camera.matrix[4] * source.y + camera.matrix[5] * source.z;
-  c.z = camera.matrix[6] * source.x + camera.matrix[7] * source.y + camera.matrix[8] * source.z;
-  output[index] = make_float4(c.x, c.y, c.z, source.w);
+  c.x               = m[0] * source.x + m[1] * source.y + m[2] * source.z;
+  c.y               = m[3] * source.x + m[4] * source.y + m[5] * source.z;
+  c.z               = m[6] * source.x + m[7] * source.y + m[8] * source.z;
+  output[index]     = make_float4(c.x, c.y, c.z, source.w);
 }
 
 }  // namespace
 
 void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
-                            const RawRuntimeColorContext& color_context,
-                            const PipelineDocument& /*document*/) {
+                            const PipelineDocument& document) {
   auto& workspace = device.Workspace();
   if (!workspace.IsRendering()) {
     throw std::runtime_error("ExecuteCudaCameraColor: BeginRender has not been called");
   }
+  const auto* develop = document.Develop();
+  if (develop == nullptr) {
+    throw std::runtime_error("ExecuteCudaCameraColor: missing develop node");
+  }
+  const auto resolved = ResolveDevelopColorTransform(develop->Params().Params());
+  if (!resolved.ok) {
+    throw std::runtime_error(std::string("ExecuteCudaCameraColor: ") +
+                             std::string(ColorTransformErrorMessage(resolved.error)));
+  }
+
   auto* input = workspace.Images().Find(plan.geometry_output);
   if (input == nullptr || input->Empty()) {
     throw std::runtime_error("ExecuteCudaCameraColor: missing geometry.scene_source");
@@ -76,12 +77,33 @@ void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
   if (input == nullptr) {
     throw std::runtime_error("ExecuteCudaCameraColor: geometry texture lost during acquire");
   }
-  const auto camera = MakeCameraToAp1(color_context);
-  const std::uint32_t     pixels = width * height;
-  constexpr std::uint32_t block  = 256;
-  CameraColorKernel<<<(pixels + block - 1) / block, block, 0, device.CommandContext().Stream()>>>(
+
+  const auto             gpu_params = MakeGpuParams(resolved.transform);
+  auto&                  arena      = workspace.Parameters();
+  const ParameterSlotKey key{develop->Id(), kDevelopCameraColorSlot};
+  const ParameterFieldBinding field{DirtyFieldMask{DevelopDirty::WhiteBalance}, 0, 0,
+                                    sizeof(CameraColorGpuParams)};
+  auto payload = std::make_shared<TypedOperatorParamPayload<CameraColorGpuParams>>(
+      type_ids::DevelopNode(), 1, gpu_params);
+  if (!arena.Contains(key)) {
+    arena.BindSlot(key, sizeof(CameraColorGpuParams), std::span{&field, 1});
+    arena.InitializeFromFullDto(key, OperatorParamDto{type_ids::DevelopNode(), 1, payload});
+  } else {
+    OperatorParamPatchDto patch{develop->Id(), kDevelopCameraColorSlot, type_ids::DevelopNode(),
+                                DirtyFieldMask{DevelopDirty::WhiteBalance}, payload};
+    arena.ApplyPatch(key, patch);
+  }
+  auto& context = device.CommandContext();
+  arena.UploadDirty(context);
+
+  const auto          binding = arena.Binding(key);
+  const std::uint32_t pixels  = width * height;
+  constexpr std::uint32_t block = 256;
+  const auto* params = reinterpret_cast<const CameraColorGpuParams*>(
+      static_cast<const std::byte*>(arena.DeviceBuffer().DevicePointer()) + binding.offset);
+  CameraColorKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
       static_cast<const float4*>(input->Texture().DevicePointer()),
-      static_cast<float4*>(output.Texture().DevicePointer()), pixels, camera);
+      static_cast<float4*>(output.Texture().DevicePointer()), pixels, params);
   if (::cudaGetLastError() != cudaSuccess) {
     throw std::runtime_error("ExecuteCudaCameraColor: CUDA kernel launch failed");
   }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_camera_color_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_camera_color_pass.cu
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <string>
 
+#include "cuda_acescc.cuh"
 #include "edit/graph/develop_color_transform.hpp"
 #include "edit/graph/develop_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
@@ -41,10 +42,11 @@ __global__ void CameraColorKernel(const float4* input, float4* output, std::uint
   const float4 source = input[index];
   const float* m      = camera->camera_to_ap1;
   float3       c;
-  c.x               = m[0] * source.x + m[1] * source.y + m[2] * source.z;
-  c.y               = m[3] * source.x + m[4] * source.y + m[5] * source.z;
-  c.z               = m[6] * source.x + m[7] * source.y + m[8] * source.z;
-  output[index]     = make_float4(c.x, c.y, c.z, source.w);
+  c.x           = m[0] * source.x + m[1] * source.y + m[2] * source.z;
+  c.y           = m[3] * source.x + m[4] * source.y + m[5] * source.z;
+  c.z           = m[6] * source.x + m[7] * source.y + m[8] * source.z;
+  output[index] = make_float4(cuda_acescc::Encode(c.x), cuda_acescc::Encode(c.y),
+                              cuda_acescc::Encode(c.z), source.w);
 }
 
 }  // namespace
@@ -71,16 +73,16 @@ void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
   }
   const auto width  = input->Texture().Width();
   const auto height = input->Texture().Height();
-  auto& output = workspace.AcquireImageForWrite(plan.develop_output,
-                                                {width, height, TextureFormat::Rgba32f});
-  input        = workspace.Images().Find(plan.geometry_output);
+  auto&      output =
+      workspace.AcquireImageForWrite(plan.develop_output, {width, height, TextureFormat::Rgba32f});
+  input = workspace.Images().Find(plan.geometry_output);
   if (input == nullptr) {
     throw std::runtime_error("ExecuteCudaCameraColor: geometry texture lost during acquire");
   }
 
-  const auto             gpu_params = MakeGpuParams(resolved.transform);
-  auto&                  arena      = workspace.Parameters();
-  const ParameterSlotKey key{develop->Id(), kDevelopCameraColorSlot};
+  const auto                  gpu_params = MakeGpuParams(resolved.transform);
+  auto&                       arena      = workspace.Parameters();
+  const ParameterSlotKey      key{develop->Id(), kDevelopCameraColorSlot};
   const ParameterFieldBinding field{DirtyFieldMask{DevelopDirty::WhiteBalance}, 0, 0,
                                     sizeof(CameraColorGpuParams)};
   auto payload = std::make_shared<TypedOperatorParamPayload<CameraColorGpuParams>>(
@@ -96,10 +98,10 @@ void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
   auto& context = device.CommandContext();
   arena.UploadDirty(context);
 
-  const auto          binding = arena.Binding(key);
-  const std::uint32_t pixels  = width * height;
-  constexpr std::uint32_t block = 256;
-  const auto* params = reinterpret_cast<const CameraColorGpuParams*>(
+  const auto              binding = arena.Binding(key);
+  const std::uint32_t     pixels  = width * height;
+  constexpr std::uint32_t block   = 256;
+  const auto*             params  = reinterpret_cast<const CameraColorGpuParams*>(
       static_cast<const std::byte*>(arena.DeviceBuffer().DevicePointer()) + binding.offset);
   CameraColorKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
       static_cast<const float4*>(input->Texture().DevicePointer()),

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_camera_color_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_camera_color_pass.cu
@@ -1,0 +1,90 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <stdexcept>
+
+#include "edit/runtime/cuda/cuda_develop_pass.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+namespace {
+
+struct CameraToAp1Params {
+  float matrix[9] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+};
+
+auto MakeCameraToAp1(const RawRuntimeColorContext& context) -> CameraToAp1Params {
+  CameraToAp1Params result;
+  if (!context.valid_) {
+    return result;
+  }
+  constexpr float srgb_to_ap1[9] = {0.613097f, 0.339523f, 0.047380f, 0.070194f, 0.916354f,
+                                    0.013452f, 0.020616f, 0.109570f, 0.869815f};
+  float           absolute_sum   = 0.0f;
+  for (float value : context.rgb_cam_) {
+    absolute_sum += std::abs(value);
+  }
+  if (absolute_sum <= 1.0e-6f) {
+    return result;
+  }
+  for (int row = 0; row < 3; ++row) {
+    for (int column = 0; column < 3; ++column) {
+      result.matrix[row * 3 + column] = srgb_to_ap1[row * 3] * context.rgb_cam_[column] +
+                                        srgb_to_ap1[row * 3 + 1] * context.rgb_cam_[3 + column] +
+                                        srgb_to_ap1[row * 3 + 2] * context.rgb_cam_[6 + column];
+    }
+  }
+  return result;
+}
+
+__global__ void CameraColorKernel(const float4* input, float4* output, std::uint32_t pixel_count,
+                                  CameraToAp1Params camera) {
+  const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= pixel_count) {
+    return;
+  }
+  const float4 source = input[index];
+  float3       c;
+  c.x = camera.matrix[0] * source.x + camera.matrix[1] * source.y + camera.matrix[2] * source.z;
+  c.y = camera.matrix[3] * source.x + camera.matrix[4] * source.y + camera.matrix[5] * source.z;
+  c.z = camera.matrix[6] * source.x + camera.matrix[7] * source.y + camera.matrix[8] * source.z;
+  output[index] = make_float4(c.x, c.y, c.z, source.w);
+}
+
+}  // namespace
+
+void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
+                            const RawRuntimeColorContext& color_context,
+                            const PipelineDocument& /*document*/) {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteCudaCameraColor: BeginRender has not been called");
+  }
+  auto* input = workspace.Images().Find(plan.geometry_output);
+  if (input == nullptr || input->Empty()) {
+    throw std::runtime_error("ExecuteCudaCameraColor: missing geometry.scene_source");
+  }
+  const auto width  = input->Texture().Width();
+  const auto height = input->Texture().Height();
+  auto& output = workspace.AcquireImageForWrite(plan.develop_output,
+                                                {width, height, TextureFormat::Rgba32f});
+  input        = workspace.Images().Find(plan.geometry_output);
+  if (input == nullptr) {
+    throw std::runtime_error("ExecuteCudaCameraColor: geometry texture lost during acquire");
+  }
+  const auto camera = MakeCameraToAp1(color_context);
+  const std::uint32_t     pixels = width * height;
+  constexpr std::uint32_t block  = 256;
+  CameraColorKernel<<<(pixels + block - 1) / block, block, 0, device.CommandContext().Stream()>>>(
+      static_cast<const float4*>(input->Texture().DevicePointer()),
+      static_cast<float4*>(output.Texture().DevicePointer()), pixels, camera);
+  if (::cudaGetLastError() != cudaSuccess) {
+    throw std::runtime_error("ExecuteCudaCameraColor: CUDA kernel launch failed");
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
@@ -108,8 +108,8 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
   const GraphValueId develop_id = plan.develop_output;
   const auto   out_w  = plan.source.develop_output_extent.width;
   const auto   out_h  = plan.source.develop_output_extent.height;
-  auto&        out_lease = EnsureImage(workspace, develop_id, out_w, out_h);
-  auto&        out_tex   = out_lease.Texture();
+  auto&        decoded_lease = EnsureImage(workspace, develop_id, out_w, out_h);
+  auto&        out_tex       = decoded_lease.Texture();
 
   if (input.input_kind == RawInputKind::DebayeredRgb ||
       plan.source.kind == DevelopInputKind::DirectRgb) {
@@ -212,11 +212,14 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
   }
 
   if (plan.encode_geometry_resample) {
-    const auto rw = plan.geometry.render_extent.width;
-    const auto rh = plan.geometry.render_extent.height;
+    // Viewport ROI and max-edge (dynamic resolution) live on RenderRequest, not on the
+    // document. They only change render_extent. Re-query the decoded texture after
+    // Acquire: TexturePool::entries_ may reallocate and invalidate Texture2D&.
+    const auto rw   = plan.geometry.render_extent.width;
+    const auto rh   = plan.geometry.render_extent.height;
     auto       dest = workspace.Textures().Acquire({rw, rh, TextureFormat::Rgba32f});
     GeometryResamplePass pass;
-    pass.Encode(plan.geometry, out_tex, dest.Texture(), ctx);
+    pass.Encode(plan.geometry, decoded_lease.Texture(), dest.Texture(), ctx);
     workspace.Images().Store(develop_id, std::move(dest));
   }
 

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
@@ -5,12 +5,12 @@
 #include "edit/runtime/cuda/cuda_develop_pass.hpp"
 
 #include <cstdint>
-#include <stdexcept>
-
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/core/cuda_stream_accessor.hpp>
+#include <stdexcept>
 
 #include "decoders/processor/operators/gpu/cuda_color_space_conv.hpp"
+#include "decoders/processor/operators/gpu/cuda_dng_warp.hpp"
 #include "decoders/processor/operators/gpu/cuda_highlight_reconstruct.hpp"
 #include "decoders/processor/operators/gpu/cuda_white_balance.hpp"
 #include "edit/operators/models/pending_parameter_patch.hpp"
@@ -71,15 +71,18 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
     workspace.TransientBuffers().Reserve(plan.peak_transient_bytes);
   }
 
-  auto&        ctx    = device.CommandContext();
-  auto         stream = WrapStream(ctx.Stream());
-  const auto   flags  = develop->Params().Params();
-  const bool   hlr    = flags.highlights_reconstruct;
-  const GraphValueId sensor_id = plan.sensor_linear_output;
-  const auto   out_w  = plan.source.develop_output_extent.width;
-  const auto   out_h  = plan.source.develop_output_extent.height;
-  auto&        decoded_lease = AcquireRgba(workspace, sensor_id, out_w, out_h);
-  auto&        out_tex       = decoded_lease.Texture();
+  auto&              ctx           = device.CommandContext();
+  auto               stream        = WrapStream(ctx.Stream());
+  const auto         flags         = develop->Params().Params();
+  const bool         hlr           = flags.highlights_reconstruct;
+  const GraphValueId sensor_id     = plan.sensor_linear_output;
+  const GraphValueId demosaic_id   = input.dng_warp_rectilinear.has_value()
+                                         ? GraphValueId{NodeId{"develop"}, PortId{"sensor_unwarped"}}
+                                         : sensor_id;
+  const auto         out_w         = plan.source.develop_output_extent.width;
+  const auto         out_h         = plan.source.develop_output_extent.height;
+  auto&              decoded_lease = AcquireRgba(workspace, demosaic_id, out_w, out_h);
+  auto&              out_tex       = decoded_lease.Texture();
 
   if (input.input_kind == RawInputKind::DebayeredRgb ||
       plan.source.kind == DevelopInputKind::DirectRgb) {
@@ -104,7 +107,8 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
     throw std::runtime_error("ExecuteCudaDevelop: CFA plane must be tightly packed");
   }
 
-  void* u16_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(std::uint16_t));
+  void* u16_ptr =
+      AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(std::uint16_t));
   void* f32_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
   workspace.Device().UploadDeviceMemory(u16_ptr, input.pixels.Span(), ctx);
 
@@ -116,9 +120,22 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
     CUDA::Clamp01(linear, &stream);
   }
 
-  cv::cuda::GpuMat packed = WrapF32C4(out_tex.DevicePointer(), static_cast<int>(out_w),
-                                      static_cast<int>(out_h));
+  cv::cuda::GpuMat packed =
+      WrapF32C4(out_tex.DevicePointer(), static_cast<int>(out_w), static_cast<int>(out_h));
   ExecuteCudaSensorDemosaicAndPack(device, input, flags, linear, packed, stream);
+
+  if (input.dng_warp_rectilinear.has_value()) {
+    auto& warped_lease = AcquireRgba(workspace, sensor_id, out_w, out_h);
+    auto* unwarped     = workspace.Images().Find(demosaic_id);
+    if (unwarped == nullptr) {
+      throw std::runtime_error("ExecuteCudaDevelop: DNG warp source was lost");
+    }
+    auto source = WrapF32C4(unwarped->Texture().DevicePointer(), static_cast<int>(out_w),
+                            static_cast<int>(out_h));
+    auto warped = WrapF32C4(warped_lease.Texture().DevicePointer(), static_cast<int>(out_w),
+                            static_cast<int>(out_h));
+    CUDA::WarpDngRectilinear(source, warped, *input.dng_warp_rectilinear, &stream);
+  }
 
   if (pending.has_value()) {
     pending->Commit();
@@ -136,8 +153,8 @@ void ExecuteCudaGeometryResample(CudaRenderDevice& device, const ExecutionPlan& 
   }
   const auto width  = plan.geometry.render_extent.width;
   const auto height = plan.geometry.render_extent.height;
-  auto& dest = AcquireRgba(workspace, plan.geometry_output, width, height);
-  sensor     = workspace.Images().Find(plan.sensor_linear_output);
+  auto&      dest   = AcquireRgba(workspace, plan.geometry_output, width, height);
+  sensor            = workspace.Images().Find(plan.sensor_linear_output);
   if (sensor == nullptr) {
     throw std::runtime_error("ExecuteCudaGeometryResample: sensor texture lost during acquire");
   }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
@@ -11,12 +11,10 @@
 #include <opencv2/core/cuda_stream_accessor.hpp>
 
 #include "decoders/processor/operators/gpu/cuda_color_space_conv.hpp"
-#include "decoders/processor/operators/gpu/cuda_debayer_rcd.hpp"
 #include "decoders/processor/operators/gpu/cuda_highlight_reconstruct.hpp"
-#include "decoders/processor/operators/gpu/cuda_image_ops.hpp"
 #include "decoders/processor/operators/gpu/cuda_white_balance.hpp"
-#include "decoders/processor/operators/gpu/cuda_xtrans_interpolate.hpp"
 #include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/runtime/cuda/cuda_sensor_demosaic.hpp"
 #include "edit/runtime/cuda/geometry_resample_pass.hpp"
 #include "edit/runtime/texture_format.hpp"
 
@@ -37,11 +35,6 @@ auto WrapF32C1(void* ptr, int width, int height) -> cv::cuda::GpuMat {
                           static_cast<std::size_t>(width) * sizeof(float));
 }
 
-auto WrapF32C3(void* ptr, int width, int height) -> cv::cuda::GpuMat {
-  return cv::cuda::GpuMat(height, width, CV_32FC3, ptr,
-                          static_cast<std::size_t>(width) * sizeof(float) * 3);
-}
-
 auto WrapF32C4(void* ptr, int width, int height) -> cv::cuda::GpuMat {
   return cv::cuda::GpuMat(height, width, CV_32FC4, ptr,
                           static_cast<std::size_t>(width) * sizeof(float) * 4);
@@ -54,16 +47,6 @@ auto AllocateTransient(CudaRenderWorkspace& workspace, std::size_t bytes) -> voi
 auto AcquireRgba(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
                  std::uint32_t height) -> ResourceLease<CudaBackend>& {
   return workspace.AcquireImageForWrite(id, {width, height, TextureFormat::Rgba32f});
-}
-
-auto CropIfNeeded(cv::cuda::GpuMat plane, const RectI& crop) -> cv::cuda::GpuMat {
-  if (crop.width <= 0 || crop.height <= 0) {
-    return plane;
-  }
-  if (crop.x == 0 && crop.y == 0 && crop.width == plane.cols && crop.height == plane.rows) {
-    return plane;
-  }
-  return plane(cv::Rect(crop.x, crop.y, crop.width, crop.height));
 }
 
 }  // namespace
@@ -82,7 +65,7 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
   auto pending = TakePendingParameterPatch(develop->Params());
 
   if (workspace.Textures().ByteBudget() == 0) {
-    workspace.Textures().SetByteBudget(64ull << 20);
+    workspace.Textures().SetByteBudget(DefaultProductTextureBudgetBytes());
   }
   if (plan.peak_transient_bytes > 0) {
     workspace.TransientBuffers().Reserve(plan.peak_transient_bytes);
@@ -129,74 +112,13 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
   auto linear  = WrapF32C1(f32_ptr, w, h);
   CUDA::ToLinearRef(src_u16, linear, input.linearization, input.cfa_pattern, &stream);
 
-  const bool xtrans = input.cfa_pattern.kind == RawCfaKind::XTrans6x6;
-  if (!hlr || xtrans) {
+  if (!hlr) {
     CUDA::Clamp01(linear, &stream);
   }
 
   cv::cuda::GpuMat packed = WrapF32C4(out_tex.DevicePointer(), static_cast<int>(out_w),
                                       static_cast<int>(out_h));
-
-  if (xtrans) {
-    void* green_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
-    void* rgb_ptr =
-        AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float) * 3);
-    auto green  = WrapF32C1(green_ptr, w, h);
-    auto rgb    = WrapF32C3(rgb_ptr, w, h);
-    const int passes = input.downsample_passes == 0 ? 3 : 1;
-    CUDA::XTransToRGB_Ref(linear, green, rgb, input.cfa_pattern.xtrans_pattern, passes, &stream);
-    auto cropped = CropIfNeeded(rgb, input.demosaic_output_crop);
-    if (input.sensor.orientation_flip == 0 &&
-        (packed.cols != cropped.cols || packed.rows != cropped.rows)) {
-      throw std::runtime_error("ExecuteCudaDevelop: X-Trans output extent does not match plan");
-    }
-    CUDA::ApplyInverseCamMulAndPackRGBAOriented(cropped, packed, input.linearization.cam_mul,
-                                                input.sensor.orientation_flip, &stream);
-  } else {
-    void* r_ptr  = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
-    void* g_ptr  = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
-    void* b_ptr  = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
-    void* vh_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
-    void* pq_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
-
-    CUDA::RcdWorkspace rcd;
-    rcd.BindExternal(r_ptr, g_ptr, b_ptr, vh_ptr, pq_ptr, cv::Size(w, h));
-    CUDA::Bayer2x2ToPlanarRGB_RCD(linear, input.cfa_pattern.bayer_pattern, &rcd, &stream);
-
-    auto r = CropIfNeeded(rcd.r, input.demosaic_output_crop);
-    auto g = CropIfNeeded(rcd.g, input.demosaic_output_crop);
-    auto b = CropIfNeeded(rcd.b, input.demosaic_output_crop);
-    if (input.sensor.orientation_flip == 0 && (packed.cols != r.cols || packed.rows != r.rows)) {
-      throw std::runtime_error("ExecuteCudaDevelop: Bayer output extent does not match plan");
-    }
-
-    if (hlr) {
-      const int cw = r.cols;
-      const int ch = r.rows;
-      int*   anyclipped = static_cast<int*>(AllocateTransient(workspace, sizeof(int)));
-      float* sums       = static_cast<float*>(AllocateTransient(workspace, sizeof(float) * 4));
-      float* cnts       = static_cast<float*>(AllocateTransient(workspace, sizeof(float) * 4));
-      void*  hlr_rgb    = AllocateTransient(workspace, static_cast<std::size_t>(cw) * ch * sizeof(float) * 3);
-      CUDA::HighlightWorkspace highlight;
-      highlight.BindExternal(anyclipped, sums, cnts, hlr_rgb, cw, ch);
-      CUDA::HighlightCorrection   correction = CUDA::BuildHighlightCorrection(input.linearization.cam_mul);
-      CUDA::HighlightAccumulation accumulation;
-      CUDA::AccumulateHighlightStats(r, g, b, correction, cv::Rect{}, highlight, accumulation,
-                                     &stream);
-      CUDA::FinalizeHighlightCorrection(accumulation, correction);
-      CUDA::ApplyHighlightCorrectionAndPackRGBAOriented(r, g, b, packed, correction,
-                                                        input.linearization.cam_mul,
-                                                        input.sensor.orientation_flip, &highlight,
-                                                        &stream);
-    } else {
-      void* merge_ptr =
-          AllocateTransient(workspace, static_cast<std::size_t>(r.cols) * r.rows * sizeof(float) * 3);
-      auto merged = WrapF32C3(merge_ptr, r.cols, r.rows);
-      CUDA::MergeRGB(r, g, b, merged, &stream);
-      CUDA::ApplyInverseCamMulAndPackRGBAOriented(merged, packed, input.linearization.cam_mul,
-                                                  input.sensor.orientation_flip, &stream);
-    }
-  }
+  ExecuteCudaSensorDemosaicAndPack(device, input, flags, linear, packed, stream);
 
   if (pending.has_value()) {
     pending->Commit();

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
@@ -51,22 +51,9 @@ auto AllocateTransient(CudaRenderWorkspace& workspace, std::size_t bytes) -> voi
   return workspace.TransientBuffers().Allocate(bytes);
 }
 
-auto EnsureImage(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
+auto AcquireRgba(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
                  std::uint32_t height) -> ResourceLease<CudaBackend>& {
-  auto* existing = workspace.Images().Find(id);
-  if (existing != nullptr && !existing->Empty()) {
-    const auto& tex = existing->Texture();
-    if (tex.Width() == width && tex.Height() == height && tex.Format() == TextureFormat::Rgba32f) {
-      return *existing;
-    }
-  }
-  auto lease = workspace.Textures().Acquire({width, height, TextureFormat::Rgba32f});
-  workspace.Images().Store(id, std::move(lease));
-  auto* stored = workspace.Images().Find(id);
-  if (stored == nullptr) {
-    throw std::runtime_error("ExecuteCudaDevelop: failed to store develop image");
-  }
-  return *stored;
+  return workspace.AcquireImageForWrite(id, {width, height, TextureFormat::Rgba32f});
 }
 
 auto CropIfNeeded(cv::cuda::GpuMat plane, const RectI& crop) -> cv::cuda::GpuMat {
@@ -105,10 +92,10 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
   auto         stream = WrapStream(ctx.Stream());
   const auto   flags  = develop->Params().Params();
   const bool   hlr    = flags.highlights_reconstruct;
-  const GraphValueId develop_id = plan.develop_output;
+  const GraphValueId sensor_id = plan.sensor_linear_output;
   const auto   out_w  = plan.source.develop_output_extent.width;
   const auto   out_h  = plan.source.develop_output_extent.height;
-  auto&        decoded_lease = EnsureImage(workspace, develop_id, out_w, out_h);
+  auto&        decoded_lease = AcquireRgba(workspace, sensor_id, out_w, out_h);
   auto&        out_tex       = decoded_lease.Texture();
 
   if (input.input_kind == RawInputKind::DebayeredRgb ||
@@ -211,21 +198,33 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
     }
   }
 
-  if (plan.encode_geometry_resample) {
-    // Viewport ROI and max-edge (dynamic resolution) live on RenderRequest, not on the
-    // document. They only change render_extent. Re-query the decoded texture after
-    // Acquire: TexturePool::entries_ may reallocate and invalidate Texture2D&.
-    const auto rw   = plan.geometry.render_extent.width;
-    const auto rh   = plan.geometry.render_extent.height;
-    auto       dest = workspace.Textures().Acquire({rw, rh, TextureFormat::Rgba32f});
-    GeometryResamplePass pass;
-    pass.Encode(plan.geometry, decoded_lease.Texture(), dest.Texture(), ctx);
-    workspace.Images().Store(develop_id, std::move(dest));
-  }
-
   if (pending.has_value()) {
     pending->Commit();
   }
+}
+
+void ExecuteCudaGeometryResample(CudaRenderDevice& device, const ExecutionPlan& plan) {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteCudaGeometryResample: BeginRender has not been called");
+  }
+  auto* sensor = workspace.Images().Find(plan.sensor_linear_output);
+  if (sensor == nullptr || sensor->Empty()) {
+    throw std::runtime_error("ExecuteCudaGeometryResample: missing develop.sensor_linear");
+  }
+  const auto width  = plan.geometry.render_extent.width;
+  const auto height = plan.geometry.render_extent.height;
+  auto& dest = AcquireRgba(workspace, plan.geometry_output, width, height);
+  sensor     = workspace.Images().Find(plan.sensor_linear_output);
+  if (sensor == nullptr) {
+    throw std::runtime_error("ExecuteCudaGeometryResample: sensor texture lost during acquire");
+  }
+  if (!plan.encode_geometry_resample) {
+    workspace.Device().CopyTexture2D(sensor->Texture(), dest.Texture(), device.CommandContext());
+    return;
+  }
+  GeometryResamplePass pass;
+  pass.Encode(plan.geometry, sensor->Texture(), dest.Texture(), device.CommandContext());
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
@@ -56,23 +56,6 @@ __global__ void DrtKernel(const float4* input, float4* output, std::uint32_t pix
 
 }  // namespace
 
-CudaRenderDevice::CudaRenderDevice() : drt_runtime_(std::make_unique<CudaDrtRuntimeState>()) {}
-
-CudaRenderDevice::~CudaRenderDevice() {
-  try {
-    WaitIdle();
-  } catch (...) {
-  }
-}
-
-void CudaRenderDevice::CancelRender() noexcept {
-  if (!workspace_.IsRendering()) return;
-  (void)::cudaStreamSynchronize(command_context_.Stream());
-  workspace_.CancelRender();
-}
-
-auto CudaRenderDevice::DrtRuntime() -> CudaDrtRuntimeState& { return *drt_runtime_; }
-
 auto ExecuteCudaDrt(CudaRenderDevice& device, const ExecutionPlan& plan, PipelineDocument& document)
     -> CudaDrtResult {
   auto& workspace = device.Workspace();

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
@@ -10,6 +10,7 @@
 #include <stdexcept>
 
 #include "cuda/cuda_check.hpp"
+#include "cuda_acescc.cuh"
 #include "cuda_drt_runtime_state.cuh"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/operators/GPU_kernels/color_mgmt/disp_enc_funcs.cuh"
@@ -41,7 +42,8 @@ __global__ void DrtKernel(const float4* input, float4* output, std::uint32_t pix
   if (index >= pixel_count) return;
   auto         runtime = *params;
   const float4 source  = input[index];
-  const float3 scene   = make_float3(source.x, source.y, source.z);
+  const float3 scene   = make_float3(cuda_acescc::Decode(source.x), cuda_acescc::Decode(source.y),
+                                     cuda_acescc::Decode(source.z));
   float3       display_linear;
   if (runtime.method_ == GPU_ODTMethod::ACES_2_0) {
     auto aces      = runtime.aces_params_;

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
@@ -26,14 +26,7 @@ constexpr std::uint32_t kDrtDirtyBits = static_cast<std::uint32_t>(DrtDirty::All
 
 auto EnsureDisplayImage(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
                         std::uint32_t height) -> ResourceLease<CudaBackend>& {
-  auto* existing = workspace.Images().Find(id);
-  if (existing != nullptr && !existing->Empty() && existing->Texture().Width() == width &&
-      existing->Texture().Height() == height) {
-    return *existing;
-  }
-  auto lease = workspace.Textures().Acquire({width, height, TextureFormat::Rgba32f});
-  workspace.Images().Store(id, std::move(lease));
-  return *workspace.Images().Find(id);
+  return workspace.AcquireImageForWrite(id, {width, height, TextureFormat::Rgba32f});
 }
 
 void ResolveRuntime(CudaDrtRuntimeState& state, const DrtParamsModel& model) {

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_local_tone_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_local_tone_pass.cu
@@ -9,11 +9,14 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "cuda_acescc.cuh"
+#include "edit/geometry/texture_sampling_plan.hpp"
 #include "edit/pipeline/local_tone_mapping.hpp"
 #include "edit/runtime/cuda/cuda_local_tone_pass.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
@@ -128,6 +131,11 @@ __device__ auto RemapDelta(float delta, float sigma, float alpha, float beta) ->
   return sign * (sigma + beta * (magnitude - sigma));
 }
 
+__device__ auto Transform(const float* matrix, float x, float y) -> float2 {
+  return make_float2(matrix[0] * x + matrix[1] * y + matrix[2],
+                     matrix[3] * x + matrix[4] * y + matrix[5]);
+}
+
 __global__ void ExtractKernel(const float4* input, float* output, int input_width, int input_height,
                               int output_width, int output_height) {
   const int x = blockIdx.x * blockDim.x + threadIdx.x;
@@ -137,6 +145,20 @@ __global__ void ExtractKernel(const float4* input, float* output, int input_widt
   const float sy = (y + 0.5f) * input_height / static_cast<float>(output_height) - 0.5f;
   output[y * output_width + x] =
       LogIntensity(ReadRgbaBilinear(input, input_width, input_height, sx, sy));
+}
+
+__global__ void ExtractReferenceKernel(const float4* input, float* output, int input_width,
+                                       int input_height, int output_width, int output_height,
+                                       Matrix3x3 reference_to_render, float full_ref_w,
+                                       float full_ref_h) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= output_width || y >= output_height) return;
+  const float  u   = (x + 0.5f) / static_cast<float>(output_width);
+  const float  v   = (y + 0.5f) / static_cast<float>(output_height);
+  const float2 src = Transform(reference_to_render.m, u * full_ref_w, v * full_ref_h);
+  output[y * output_width + x] =
+      LogIntensity(ReadRgbaBilinear(input, input_width, input_height, src.x - 0.5f, src.y - 0.5f));
 }
 
 __global__ void DownKernel(const float* input, float* output, int input_width, int input_height,
@@ -212,13 +234,14 @@ __device__ auto Bilinear(const float* plane, int width, int height, float x, flo
 
 __global__ void ApplyKernel(const float4* input, const float* reference, const float* adjusted,
                             float4* output, int width, int height, int adjusted_width,
-                            int adjusted_height) {
+                            int adjusted_height, Matrix3x3 render_to_uv) {
   const int x = blockIdx.x * blockDim.x + threadIdx.x;
   const int y = blockIdx.y * blockDim.y + threadIdx.y;
   if (x >= width || y >= height) return;
   const int       index       = y * width + x;
-  const float     ax          = (x + 0.5f) * adjusted_width / static_cast<float>(width) - 0.5f;
-  const float     ay          = (y + 0.5f) * adjusted_height / static_cast<float>(height) - 0.5f;
+  const float2    uv          = Transform(render_to_uv.m, x + 0.5f, y + 0.5f);
+  const float     ax          = uv.x * adjusted_width - 0.5f;
+  const float     ay          = uv.y * adjusted_height - 0.5f;
   const float     reference_l = Bilinear(reference, adjusted_width, adjusted_height, ax, ay);
   const float     adjusted_l  = Bilinear(adjusted, adjusted_width, adjusted_height, ax, ay);
   const float4    pixel       = input[index];
@@ -259,24 +282,91 @@ void CheckLaunch(const char* operation) {
   }
 }
 
+struct CanonicalLlfCache {
+  ContentKey key{};
+  int        mask_width        = 0;
+  int        mask_height       = 0;
+  int        source_long_edge  = 0;
+  bool       canonical         = false;
+};
+
+auto CacheSlot(const CudaRenderWorkspace& workspace, const NodeId& grade_id) -> CanonicalLlfCache& {
+  static std::map<std::pair<const void*, std::string>, CanonicalLlfCache> slots;
+  return slots[std::make_pair(&workspace, std::string{grade_id.Value()})];
+}
+
+auto LocalUvPlan(std::uint32_t width, std::uint32_t height) -> Matrix3x3 {
+  Matrix3x3 matrix;
+  matrix.m[0] = 1.0f / static_cast<float>(width);
+  matrix.m[4] = 1.0f / static_cast<float>(height);
+  return matrix;
+}
+
 }  // namespace
 
 auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id,
                           const GraphValueId& output_id, const NodeId& grade_id,
                           std::uint32_t width, std::uint32_t height, float shadows_slider,
-                          float highlights_slider) -> std::uint64_t {
+                          float highlights_slider, const ResolvedRenderGeometry& geometry,
+                          ContentKey reference_key) -> CudaLocalToneResult {
   auto& workspace = device.Workspace();
   auto* input     = workspace.Images().Find(input_id);
   if (!workspace.IsRendering() || input == nullptr || input->Empty()) {
     throw std::runtime_error("ExecuteCudaLocalTone: missing active input");
   }
+  if (geometry.full_reference_extent.Empty() || geometry.render_extent.Empty()) {
+    throw std::runtime_error("ExecuteCudaLocalTone: geometry extents must be positive");
+  }
   auto& output = workspace.AcquireImageForWrite(output_id, {width, height, TextureFormat::Rgba32f});
   input        = workspace.Images().Find(input_id);
 
-  const auto reference_dims =
-      local_tone_mapping::ComputeMaskDimensions(static_cast<int>(width), static_cast<int>(height),
-                                                local_tone_mapping::kReferenceMaskMaxLongEdge);
-  const auto                     layout = MakeLayout(reference_dims.width, reference_dims.height);
+  const auto canonical_dims = local_tone_mapping::ComputeMaskDimensions(
+      static_cast<int>(geometry.full_reference_extent.width),
+      static_cast<int>(geometry.full_reference_extent.height),
+      local_tone_mapping::kReferenceMaskMaxLongEdge);
+  const bool full_edit = CoversFullEditSpace(geometry);
+  const int  current_long_edge =
+      std::max(static_cast<int>(width), static_cast<int>(height));
+  auto&      slot            = CacheSlot(workspace, grade_id);
+  const auto canonical_bytes = static_cast<std::size_t>(canonical_dims.width) *
+                               static_cast<std::size_t>(canonical_dims.height) * sizeof(float);
+  auto* cached_source = workspace.Values().Find(LevelId(grade_id, "source", 0));
+  auto* cached_result = workspace.Values().Find(LevelId(grade_id, "result", 0));
+  const bool cache_valid =
+      slot.canonical && slot.key == reference_key && slot.mask_width == canonical_dims.width &&
+      slot.mask_height == canonical_dims.height && cached_source != nullptr &&
+      cached_source->Bytes() >= canonical_bytes && cached_result != nullptr &&
+      cached_result->Bytes() >= canonical_bytes;
+  const bool sample_canonical = cache_valid && !(full_edit && current_long_edge > slot.source_long_edge);
+
+  const dim3          block{16, 16, 1};
+  auto                stream = device.CommandContext().Stream();
+  CudaLocalToneResult tone;
+
+  if (sample_canonical) {
+    const auto sampling = MakeLlfSamplingPlan(
+        geometry, Extent2D{static_cast<std::uint32_t>(slot.mask_width),
+                           static_cast<std::uint32_t>(slot.mask_height)});
+    ApplyKernel<<<Grid(static_cast<int>(width), static_cast<int>(height), block), block, 0,
+                  stream>>>(
+        static_cast<const float4*>(input->Texture().DevicePointer()),
+        static_cast<const float*>(cached_source->DevicePointer()),
+        static_cast<const float*>(cached_result->DevicePointer()),
+        static_cast<float4*>(output.Texture().DevicePointer()), static_cast<int>(width),
+        static_cast<int>(height), slot.mask_width, slot.mask_height, sampling.render_to_texture_uv);
+    CheckLaunch("canonical sample");
+    tone.reference_resource_id       = cached_source->ResourceId();
+    tone.sampled_canonical_reference = true;
+    return tone;
+  }
+
+  const bool seed_canonical = full_edit;
+  const auto mask_dims =
+      seed_canonical ? canonical_dims
+                     : local_tone_mapping::ComputeMaskDimensions(
+                           static_cast<int>(width), static_cast<int>(height),
+                           local_tone_mapping::kReferenceMaskMaxLongEdge);
+  const auto                     layout = MakeLayout(mask_dims.width, mask_dims.height);
   std::array<float*, kMaxLevels> source{};
   std::array<float*, kMaxLevels> remap_a{};
   std::array<float*, kMaxLevels> remap_b{};
@@ -296,11 +386,17 @@ auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id
     if (level == 0) reference_id = source_buffer.ResourceId();
   }
 
-  const dim3 block{16, 16, 1};
-  auto       stream = device.CommandContext().Stream();
-  ExtractKernel<<<Grid(layout.widths[0], layout.heights[0], block), block, 0, stream>>>(
-      static_cast<const float4*>(input->Texture().DevicePointer()), source[0],
-      static_cast<int>(width), static_cast<int>(height), layout.widths[0], layout.heights[0]);
+  if (seed_canonical) {
+    ExtractReferenceKernel<<<Grid(layout.widths[0], layout.heights[0], block), block, 0, stream>>>(
+        static_cast<const float4*>(input->Texture().DevicePointer()), source[0],
+        static_cast<int>(width), static_cast<int>(height), layout.widths[0], layout.heights[0],
+        geometry.reference_to_render, static_cast<float>(geometry.full_reference_extent.width),
+        static_cast<float>(geometry.full_reference_extent.height));
+  } else {
+    ExtractKernel<<<Grid(layout.widths[0], layout.heights[0], block), block, 0, stream>>>(
+        static_cast<const float4*>(input->Texture().DevicePointer()), source[0],
+        static_cast<int>(width), static_cast<int>(height), layout.widths[0], layout.heights[0]);
+  }
   for (int level = 1; level < layout.count; ++level) {
     DownKernel<<<Grid(layout.widths[level], layout.heights[level], block), block, 0, stream>>>(
         source[level - 1], source[level], layout.widths[level - 1], layout.heights[level - 1],
@@ -349,12 +445,44 @@ auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id
         layout.heights[level], layout.widths[level + 1], layout.heights[level + 1]);
     std::swap(result[level], remap_a[level]);
   }
+  auto* named_result = workspace.Values().Find(LevelId(grade_id, "result", 0));
+  if (named_result == nullptr) {
+    throw std::runtime_error("ExecuteCudaLocalTone: missing result.0 after pyramid collapse");
+  }
+  if (result[0] != named_result->DevicePointer()) {
+    if (::cudaMemcpyAsync(named_result->DevicePointer(), result[0],
+                          static_cast<std::size_t>(layout.widths[0]) * layout.heights[0] *
+                              sizeof(float),
+                          cudaMemcpyDeviceToDevice, stream) != cudaSuccess) {
+      throw std::runtime_error("ExecuteCudaLocalTone: cannot store collapsed reference");
+    }
+    result[0] = static_cast<float*>(named_result->DevicePointer());
+  }
+
+  const Matrix3x3 apply_uv =
+      seed_canonical
+          ? MakeLlfSamplingPlan(geometry, Extent2D{static_cast<std::uint32_t>(layout.widths[0]),
+                                                   static_cast<std::uint32_t>(layout.heights[0])})
+                .render_to_texture_uv
+          : LocalUvPlan(width, height);
   ApplyKernel<<<Grid(static_cast<int>(width), static_cast<int>(height), block), block, 0, stream>>>(
       static_cast<const float4*>(input->Texture().DevicePointer()), source[0], result[0],
       static_cast<float4*>(output.Texture().DevicePointer()), static_cast<int>(width),
-      static_cast<int>(height), layout.widths[0], layout.heights[0]);
+      static_cast<int>(height), layout.widths[0], layout.heights[0], apply_uv);
   CheckLaunch("kernel launch");
-  return reference_id;
+
+  if (seed_canonical) {
+    slot.key              = reference_key;
+    slot.mask_width       = layout.widths[0];
+    slot.mask_height      = layout.heights[0];
+    slot.source_long_edge = current_long_edge;
+    slot.canonical        = true;
+  } else {
+    slot = {};
+  }
+  tone.reference_resource_id = reference_id;
+  tone.rebuilt_reference     = true;
+  return tone;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_local_tone_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_local_tone_pass.cu
@@ -1,0 +1,360 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "cuda_acescc.cuh"
+#include "edit/pipeline/local_tone_mapping.hpp"
+#include "edit/runtime/cuda/cuda_local_tone_pass.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+namespace {
+
+using local_tone_mapping::LlfSample;
+
+constexpr int   kMaxLevels = local_tone_mapping::kMaxLevels;
+constexpr float kRadius    = 18.0f;
+
+struct PyramidLayout {
+  int                         count = 0;
+  std::array<int, kMaxLevels> widths{};
+  std::array<int, kMaxLevels> heights{};
+};
+
+auto MakeLayout(int width, int height) -> PyramidLayout {
+  PyramidLayout layout;
+  layout.count      = local_tone_mapping::ComputeLevelCount(width, height, kRadius);
+  layout.widths[0]  = width;
+  layout.heights[0] = height;
+  for (int level = 1; level < layout.count; ++level) {
+    layout.widths[level]  = std::max(1, (layout.widths[level - 1] + 1) / 2);
+    layout.heights[level] = std::max(1, (layout.heights[level - 1] + 1) / 2);
+  }
+  return layout;
+}
+
+auto EnsureBuffer(CudaRenderWorkspace& workspace, const GraphValueId& id, std::size_t bytes)
+    -> CudaBackend::Buffer& {
+  auto* buffer = workspace.Values().Find(id);
+  if (buffer != nullptr && buffer->Bytes() >= bytes) return *buffer;
+  workspace.Values().Store(id, workspace.Device().CreateBuffer(bytes));
+  return *workspace.Values().Find(id);
+}
+
+auto LevelId(const NodeId& grade_id, const char* family, int level) -> GraphValueId {
+  return {grade_id, PortId{std::string{"local_tone."} + family + "." + std::to_string(level)}};
+}
+
+__device__ auto Ap1Intensity(const float4& pixel) -> float {
+  return 0.272229f * pixel.x + 0.674082f * pixel.y + 0.053689f * pixel.z;
+}
+
+__device__ auto LogIntensity(const float4& acescc) -> float {
+  const float4 linear = make_float4(cuda_acescc::Decode(acescc.x), cuda_acescc::Decode(acescc.y),
+                                    cuda_acescc::Decode(acescc.z), acescc.w);
+  return cuda_acescc::Encode(fmaxf(Ap1Intensity(linear), 1.0e-6f));
+}
+
+__device__ auto ReadRgbaBilinear(const float4* input, int width, int height, float x, float y)
+    -> float4 {
+  x               = fminf(fmaxf(x, 0.0f), width - 1.0f);
+  y               = fminf(fmaxf(y, 0.0f), height - 1.0f);
+  const int    x0 = static_cast<int>(floorf(x));
+  const int    y0 = static_cast<int>(floorf(y));
+  const int    x1 = min(x0 + 1, width - 1);
+  const int    y1 = min(y0 + 1, height - 1);
+  const float  tx = x - x0;
+  const float  ty = y - y0;
+  const float4 a  = input[y0 * width + x0];
+  const float4 b  = input[y0 * width + x1];
+  const float4 c  = input[y1 * width + x0];
+  const float4 d  = input[y1 * width + x1];
+  const float4 ab = make_float4(a.x + (b.x - a.x) * tx, a.y + (b.y - a.y) * tx,
+                                a.z + (b.z - a.z) * tx, a.w + (b.w - a.w) * tx);
+  const float4 cd = make_float4(c.x + (d.x - c.x) * tx, c.y + (d.y - c.y) * tx,
+                                c.z + (d.z - c.z) * tx, c.w + (d.w - c.w) * tx);
+  return make_float4(ab.x + (cd.x - ab.x) * ty, ab.y + (cd.y - ab.y) * ty,
+                     ab.z + (cd.z - ab.z) * ty, ab.w + (cd.w - ab.w) * ty);
+}
+
+__device__ auto PlaneRead(const float* src, int x, int y, int width, int height) -> float {
+  x = min(max(x, 0), width - 1);
+  y = min(max(y, 0), height - 1);
+  return src[static_cast<std::size_t>(y) * width + x];
+}
+
+__device__ auto Weight(int tap) -> float {
+  return (tap == -2 || tap == 2)   ? 1.0f / 16.0f
+         : (tap == -1 || tap == 1) ? 4.0f / 16.0f
+                                   : 6.0f / 16.0f;
+}
+
+__device__ auto Expand(const float* coarse, int coarse_width, int coarse_height, int x, int y)
+    -> float {
+  float sum = 0.0f;
+  for (int ky = -2; ky <= 2; ++ky) {
+    const int sample_y = y - ky;
+    if ((sample_y & 1) != 0) continue;
+    const int cy = min(max(sample_y / 2, 0), coarse_height - 1);
+    for (int kx = -2; kx <= 2; ++kx) {
+      const int sample_x = x - kx;
+      if ((sample_x & 1) != 0) continue;
+      const int cx = min(max(sample_x / 2, 0), coarse_width - 1);
+      sum += 4.0f * Weight(kx) * Weight(ky) * coarse[cy * coarse_width + cx];
+    }
+  }
+  return sum;
+}
+
+__device__ auto RemapDelta(float delta, float sigma, float alpha, float beta) -> float {
+  const float magnitude = fabsf(delta);
+  if (magnitude <= 1.0e-6f) return 0.0f;
+  const float sign = copysignf(1.0f, delta);
+  if (magnitude <= sigma) {
+    return sign * sigma * powf(fminf(magnitude / fmaxf(sigma, 1.0e-6f), 1.0f), alpha);
+  }
+  return sign * (sigma + beta * (magnitude - sigma));
+}
+
+__global__ void ExtractKernel(const float4* input, float* output, int input_width, int input_height,
+                              int output_width, int output_height) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= output_width || y >= output_height) return;
+  const float sx = (x + 0.5f) * input_width / static_cast<float>(output_width) - 0.5f;
+  const float sy = (y + 0.5f) * input_height / static_cast<float>(output_height) - 0.5f;
+  output[y * output_width + x] =
+      LogIntensity(ReadRgbaBilinear(input, input_width, input_height, sx, sy));
+}
+
+__global__ void DownKernel(const float* input, float* output, int input_width, int input_height,
+                           int output_width, int output_height) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= output_width || y >= output_height) return;
+  float sum = 0.0f;
+  for (int ky = -2; ky <= 2; ++ky) {
+    for (int kx = -2; kx <= 2; ++kx) {
+      sum += Weight(kx) * Weight(ky) *
+             PlaneRead(input, x * 2 + kx, y * 2 + ky, input_width, input_height);
+    }
+  }
+  output[y * output_width + x] = sum;
+}
+
+__global__ void RemapKernel(const float* input, float* output, int width, int height,
+                            LlfSample sample, float sigma) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+  const int index = y * width + x;
+  output[index] =
+      sample.target + RemapDelta(input[index] - sample.gamma, sigma, sample.alpha, sample.beta);
+}
+
+__global__ void SelectKernel(const float* source, const float* lo, const float* lo_coarse,
+                             const float* hi, const float* hi_coarse, float* output, int width,
+                             int height, int coarse_width, int coarse_height, float gamma_lo,
+                             float gamma_hi, bool first, bool last, bool top) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+  const int   index = y * width + x;
+  const float value = source[index];
+  if (!((first && value <= gamma_hi) || (last && value >= gamma_lo) ||
+        (value >= gamma_lo && value < gamma_hi)))
+    return;
+  const float t =
+      fminf(fmaxf((value - gamma_lo) / fmaxf(gamma_hi - gamma_lo, 1.0e-6f), 0.0f), 1.0f);
+  if (top) {
+    output[index] = lo[index] + (hi[index] - lo[index]) * t;
+    return;
+  }
+  const float lap_lo = lo[index] - Expand(lo_coarse, coarse_width, coarse_height, x, y);
+  const float lap_hi = hi[index] - Expand(hi_coarse, coarse_width, coarse_height, x, y);
+  output[index]      = lap_lo + (lap_hi - lap_lo) * t;
+}
+
+__global__ void CollapseKernel(const float* lap, const float* coarse, float* output, int width,
+                               int height, int coarse_width, int coarse_height) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+  const int index = y * width + x;
+  output[index]   = lap[index] + Expand(coarse, coarse_width, coarse_height, x, y);
+}
+
+__device__ auto Bilinear(const float* plane, int width, int height, float x, float y) -> float {
+  x              = fminf(fmaxf(x, 0.0f), width - 1.0f);
+  y              = fminf(fmaxf(y, 0.0f), height - 1.0f);
+  const int   x0 = static_cast<int>(floorf(x));
+  const int   y0 = static_cast<int>(floorf(y));
+  const int   x1 = min(x0 + 1, width - 1);
+  const int   y1 = min(y0 + 1, height - 1);
+  const float tx = x - x0;
+  const float ty = y - y0;
+  const float a  = plane[y0 * width + x0] + (plane[y0 * width + x1] - plane[y0 * width + x0]) * tx;
+  const float b  = plane[y1 * width + x0] + (plane[y1 * width + x1] - plane[y1 * width + x0]) * tx;
+  return a + (b - a) * ty;
+}
+
+__global__ void ApplyKernel(const float4* input, const float* reference, const float* adjusted,
+                            float4* output, int width, int height, int adjusted_width,
+                            int adjusted_height) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+  const int       index       = y * width + x;
+  const float     ax          = (x + 0.5f) * adjusted_width / static_cast<float>(width) - 0.5f;
+  const float     ay          = (y + 0.5f) * adjusted_height / static_cast<float>(height) - 0.5f;
+  const float     reference_l = Bilinear(reference, adjusted_width, adjusted_height, ax, ay);
+  const float     adjusted_l  = Bilinear(adjusted, adjusted_width, adjusted_height, ax, ay);
+  const float4    pixel       = input[index];
+  const float     source_l    = LogIntensity(pixel);
+  const float     source_intensity = fmaxf(cuda_acescc::Decode(source_l), 1.0e-5f);
+  const float     target_intensity = cuda_acescc::Decode(source_l + adjusted_l - reference_l);
+  const float     ratio            = fminf(fmaxf(target_intensity / source_intensity, 0.0f), 32.0f);
+  float           r                = cuda_acescc::Decode(pixel.x) * ratio;
+  float           g                = cuda_acescc::Decode(pixel.y) * ratio;
+  float           b                = cuda_acescc::Decode(pixel.z) * ratio;
+  constexpr float kLower           = -1.0e-5f;
+  float           gamut_scale      = 1.0f;
+  if (r < kLower && target_intensity > r) {
+    gamut_scale = fminf(gamut_scale, (target_intensity - kLower) / (target_intensity - r));
+  }
+  if (g < kLower && target_intensity > g) {
+    gamut_scale = fminf(gamut_scale, (target_intensity - kLower) / (target_intensity - g));
+  }
+  if (b < kLower && target_intensity > b) {
+    gamut_scale = fminf(gamut_scale, (target_intensity - kLower) / (target_intensity - b));
+  }
+  gamut_scale = fminf(fmaxf(gamut_scale, 0.0f), 1.0f);
+  r           = target_intensity + (r - target_intensity) * gamut_scale;
+  g           = target_intensity + (g - target_intensity) * gamut_scale;
+  b           = target_intensity + (b - target_intensity) * gamut_scale;
+  output[index] =
+      make_float4(cuda_acescc::Encode(r), cuda_acescc::Encode(g), cuda_acescc::Encode(b), pixel.w);
+}
+
+auto Grid(int width, int height, dim3 block) -> dim3 {
+  return {static_cast<unsigned>((width + block.x - 1) / block.x),
+          static_cast<unsigned>((height + block.y - 1) / block.y), 1};
+}
+
+void CheckLaunch(const char* operation) {
+  if (::cudaGetLastError() != cudaSuccess) {
+    throw std::runtime_error(std::string{"CUDA local tone: "} + operation + " failed");
+  }
+}
+
+}  // namespace
+
+auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id,
+                          const GraphValueId& output_id, const NodeId& grade_id,
+                          std::uint32_t width, std::uint32_t height, float shadows_slider,
+                          float highlights_slider) -> std::uint64_t {
+  auto& workspace = device.Workspace();
+  auto* input     = workspace.Images().Find(input_id);
+  if (!workspace.IsRendering() || input == nullptr || input->Empty()) {
+    throw std::runtime_error("ExecuteCudaLocalTone: missing active input");
+  }
+  auto& output = workspace.AcquireImageForWrite(output_id, {width, height, TextureFormat::Rgba32f});
+  input        = workspace.Images().Find(input_id);
+
+  const auto reference_dims =
+      local_tone_mapping::ComputeMaskDimensions(static_cast<int>(width), static_cast<int>(height),
+                                                local_tone_mapping::kReferenceMaskMaxLongEdge);
+  const auto                     layout = MakeLayout(reference_dims.width, reference_dims.height);
+  std::array<float*, kMaxLevels> source{};
+  std::array<float*, kMaxLevels> remap_a{};
+  std::array<float*, kMaxLevels> remap_b{};
+  std::array<float*, kMaxLevels> result{};
+  std::uint64_t                  reference_id = 0;
+  for (int level = 0; level < layout.count; ++level) {
+    const auto bytes =
+        static_cast<std::size_t>(layout.widths[level]) * layout.heights[level] * sizeof(float);
+    auto& source_buffer = EnsureBuffer(workspace, LevelId(grade_id, "source", level), bytes);
+    auto& a_buffer      = EnsureBuffer(workspace, LevelId(grade_id, "remap_a", level), bytes);
+    auto& b_buffer      = EnsureBuffer(workspace, LevelId(grade_id, "remap_b", level), bytes);
+    auto& result_buffer = EnsureBuffer(workspace, LevelId(grade_id, "result", level), bytes);
+    source[level]       = static_cast<float*>(source_buffer.DevicePointer());
+    remap_a[level]      = static_cast<float*>(a_buffer.DevicePointer());
+    remap_b[level]      = static_cast<float*>(b_buffer.DevicePointer());
+    result[level]       = static_cast<float*>(result_buffer.DevicePointer());
+    if (level == 0) reference_id = source_buffer.ResourceId();
+  }
+
+  const dim3 block{16, 16, 1};
+  auto       stream = device.CommandContext().Stream();
+  ExtractKernel<<<Grid(layout.widths[0], layout.heights[0], block), block, 0, stream>>>(
+      static_cast<const float4*>(input->Texture().DevicePointer()), source[0],
+      static_cast<int>(width), static_cast<int>(height), layout.widths[0], layout.heights[0]);
+  for (int level = 1; level < layout.count; ++level) {
+    DownKernel<<<Grid(layout.widths[level], layout.heights[level], block), block, 0, stream>>>(
+        source[level - 1], source[level], layout.widths[level - 1], layout.heights[level - 1],
+        layout.widths[level], layout.heights[level]);
+  }
+
+  const float shadow_amount    = std::clamp(shadows_slider * 1.5f / 80.0f, -1.5f, 1.5f);
+  const float highlight_amount = std::clamp(-highlights_slider * 1.5f / 100.0f, -1.5f, 1.5f);
+  const float sigma            = local_tone_mapping::SigmaR(shadow_amount, highlight_amount);
+  const auto  samples          = local_tone_mapping::BuildSamples(shadow_amount, highlight_amount);
+  for (int level = 0; level < layout.count; ++level) {
+    ::cudaMemsetAsync(
+        result[level], 0,
+        static_cast<std::size_t>(layout.widths[level]) * layout.heights[level] * sizeof(float),
+        stream);
+  }
+  const auto build_remap = [&](const LlfSample& sample, std::array<float*, kMaxLevels>& levels) {
+    RemapKernel<<<Grid(layout.widths[0], layout.heights[0], block), block, 0, stream>>>(
+        source[0], levels[0], layout.widths[0], layout.heights[0], sample, sigma);
+    for (int level = 1; level < layout.count; ++level) {
+      DownKernel<<<Grid(layout.widths[level], layout.heights[level], block), block, 0, stream>>>(
+          levels[level - 1], levels[level], layout.widths[level - 1], layout.heights[level - 1],
+          layout.widths[level], layout.heights[level]);
+    }
+  };
+  build_remap(samples[0], remap_a);
+  build_remap(samples[1], remap_b);
+  for (std::size_t pair = 0; pair + 1 < samples.size(); ++pair) {
+    for (int level = 0; level < layout.count; ++level) {
+      const bool top = level + 1 == layout.count;
+      SelectKernel<<<Grid(layout.widths[level], layout.heights[level], block), block, 0, stream>>>(
+          source[level], remap_a[level], top ? nullptr : remap_a[level + 1], remap_b[level],
+          top ? nullptr : remap_b[level + 1], result[level], layout.widths[level],
+          layout.heights[level], top ? 1 : layout.widths[level + 1],
+          top ? 1 : layout.heights[level + 1], samples[pair].gamma, samples[pair + 1].gamma,
+          pair == 0, pair + 2 == samples.size(), top);
+    }
+    if (pair + 2 < samples.size()) {
+      std::swap(remap_a, remap_b);
+      build_remap(samples[pair + 2], remap_b);
+    }
+  }
+  for (int level = layout.count - 2; level >= 0; --level) {
+    CollapseKernel<<<Grid(layout.widths[level], layout.heights[level], block), block, 0, stream>>>(
+        result[level], result[level + 1], remap_a[level], layout.widths[level],
+        layout.heights[level], layout.widths[level + 1], layout.heights[level + 1]);
+    std::swap(result[level], remap_a[level]);
+  }
+  ApplyKernel<<<Grid(static_cast<int>(width), static_cast<int>(height), block), block, 0, stream>>>(
+      static_cast<const float4*>(input->Texture().DevicePointer()), source[0], result[0],
+      static_cast<float4*>(output.Texture().DevicePointer()), static_cast<int>(width),
+      static_cast<int>(height), layout.widths[0], layout.heights[0]);
+  CheckLaunch("kernel launch");
+  return reference_id;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
@@ -49,14 +49,7 @@ auto CopyRectangle(const MaskAsset& asset, RectI rectangle) -> std::vector<std::
 
 auto EnsureOutput(CudaRenderWorkspace& workspace, const GraphValueId& id, Extent2D extent)
     -> ResourceLease<CudaBackend>& {
-  auto* existing = workspace.Images().Find(id);
-  if (existing != nullptr && existing->Texture().Width() == extent.width &&
-      existing->Texture().Height() == extent.height &&
-      existing->Texture().Format() == TextureFormat::R8)
-    return *existing;
-  workspace.Images().Store(
-      id, workspace.Textures().Acquire({extent.width, extent.height, TextureFormat::R8}));
-  return *workspace.Images().Find(id);
+  return workspace.AcquireImageForWrite(id, {extent.width, extent.height, TextureFormat::R8});
 }
 
 __device__ auto Transform(const float* matrix, float x, float y) -> float2 {

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
@@ -41,7 +41,7 @@ auto CudaRenderDevice::Execute(const ExecutionPlan& plan, const PreparedRawInput
   try {
     auto& workspace = Workspace();
     if (workspace.Textures().ByteBudget() == 0) {
-      workspace.Textures().SetByteBudget(64ull << 20);
+      workspace.Textures().SetByteBudget(DefaultProductTextureBudgetBytes());
     }
     BeginRender();
     const auto keys       = BuildFrameResultContentKeys(plan, input, document);

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
@@ -95,7 +95,7 @@ auto CudaRenderDevice::Execute(const ExecutionPlan& plan, const PreparedRawInput
                    completed)) {
       ++stats.primary_grade_skip;
     } else {
-      (void)ExecuteCudaPrimaryGrade(*this, plan, input.color_context, document);
+      (void)ExecuteCudaPrimaryGrade(*this, plan, input, document);
       Record(*this, plan.primary_grade_output, keys.primary_grade, keys.geometry_extent);
       ++stats.primary_grade_execute;
     }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
@@ -75,7 +75,7 @@ auto CudaRenderDevice::Execute(const ExecutionPlan& plan, const PreparedRawInput
                    completed)) {
       ++stats.camera_color_skip;
     } else {
-      ExecuteCudaCameraColor(*this, plan, input.color_context, document);
+      ExecuteCudaCameraColor(*this, plan, document);
       Record(*this, plan.develop_output, keys.develop_image, keys.geometry_extent);
       ++stats.camera_color_execute;
     }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
@@ -13,21 +13,109 @@
 #include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
 #include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/result_content_key.hpp"
+#include "edit/runtime/texture_format.hpp"
 
 namespace alcedo {
+namespace {
+
+constexpr TextureFormat kResultFormat = TextureFormat::Rgba32f;
+
+auto BindOrMiss(CudaRenderWorkspace& images_owner, const GraphValueId& id, ContentKey key,
+                ImageExtent extent, std::uint64_t completed,
+                TextureFormat format = kResultFormat) -> bool {
+  return images_owner.Images().BindValidResult(id, key, extent, format, completed) != nullptr;
+}
+
+void Record(CudaRenderDevice& device, const GraphValueId& id, ContentKey key, ImageExtent extent,
+            TextureFormat format = kResultFormat) {
+  device.Workspace().Images().RecordUnpublished(id, key, extent, format,
+                                                device.CommandContext().SubmissionId());
+}
+
+}  // namespace
 
 auto CudaRenderDevice::Execute(const ExecutionPlan& plan, const PreparedRawInput& input,
-                               PipelineDocument& document, MaskStore* mask_store) -> GraphValueId {
+                               PipelineDocument& document, MaskStore* mask_store,
+                               bool publish_on_success) -> GraphValueId {
   try {
-    BeginRender();
-    ExecuteCudaDevelop(*this, plan, input, document);
-    if (plan.primary_grade_mask) {
-      (void)ExecuteCudaMask(*this, plan, document, mask_store);
+    auto& workspace = Workspace();
+    if (workspace.Textures().ByteBudget() == 0) {
+      workspace.Textures().SetByteBudget(64ull << 20);
     }
-    (void)ExecuteCudaPrimaryGrade(*this, plan, input.color_context, document);
-    const auto result = ExecuteCudaDrt(*this, plan, document);
+    BeginRender();
+    const auto keys       = BuildFrameResultContentKeys(plan, input, document);
+    const auto completed  = workspace.Device().CompletedSubmission();
+    auto&      stats      = pass_stats_;
+    const auto hits_before  = workspace.Images().ContentHitCount();
+    const auto misses_before = workspace.Images().ContentMissCount();
+
+    if (BindOrMiss(workspace, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent,
+                   completed)) {
+      ++stats.sensor_develop_skip;
+    } else {
+      const auto h2d_before = workspace.Device().HostToDeviceBytes();
+      ExecuteCudaDevelop(*this, plan, input, document);
+      stats.source_h2d_bytes += workspace.Device().HostToDeviceBytes() - h2d_before;
+      ++stats.source_h2d_count;
+      Record(*this, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent);
+      ++stats.sensor_develop_execute;
+    }
+
+    if (BindOrMiss(workspace, plan.geometry_output, keys.geometry_scene_source,
+                   keys.geometry_extent, completed)) {
+      ++stats.geometry_skip;
+    } else {
+      ExecuteCudaGeometryResample(*this, plan);
+      Record(*this, plan.geometry_output, keys.geometry_scene_source, keys.geometry_extent);
+      ++stats.geometry_execute;
+    }
+
+    if (BindOrMiss(workspace, plan.develop_output, keys.develop_image, keys.geometry_extent,
+                   completed)) {
+      ++stats.camera_color_skip;
+    } else {
+      ExecuteCudaCameraColor(*this, plan, input.color_context, document);
+      Record(*this, plan.develop_output, keys.develop_image, keys.geometry_extent);
+      ++stats.camera_color_execute;
+    }
+
+    if (plan.primary_grade_mask) {
+      if (BindOrMiss(workspace, plan.mask_output, keys.mask, keys.geometry_extent, completed,
+                     TextureFormat::R8)) {
+        ++stats.mask_skip;
+      } else {
+        (void)ExecuteCudaMask(*this, plan, document, mask_store);
+        Record(*this, plan.mask_output, keys.mask, keys.geometry_extent, TextureFormat::R8);
+        ++stats.mask_execute;
+      }
+    }
+
+    if (BindOrMiss(workspace, plan.primary_grade_output, keys.primary_grade, keys.geometry_extent,
+                   completed)) {
+      ++stats.primary_grade_skip;
+    } else {
+      (void)ExecuteCudaPrimaryGrade(*this, plan, input.color_context, document);
+      Record(*this, plan.primary_grade_output, keys.primary_grade, keys.geometry_extent);
+      ++stats.primary_grade_execute;
+    }
+
+    if (BindOrMiss(workspace, plan.display_output, keys.drt_display, keys.geometry_extent,
+                   completed)) {
+      ++stats.drt_skip;
+    } else {
+      (void)ExecuteCudaDrt(*this, plan, document);
+      Record(*this, plan.display_output, keys.drt_display, keys.geometry_extent);
+      ++stats.drt_execute;
+    }
+
+    stats.result_content_hits += workspace.Images().ContentHitCount() - hits_before;
+    stats.result_content_misses += workspace.Images().ContentMissCount() - misses_before;
     EndRender();
-    return result.output;
+    if (publish_on_success) {
+      PublishResults();
+    }
+    return plan.display_output;
   } catch (const std::exception& ex) {
     CancelRender();
     ReportError(ex.what());

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -119,8 +119,18 @@ __device__ auto Luma(const float3& c) -> float {
   return 0.272229f * c.x + 0.674082f * c.y + 0.053689f * c.z;
 }
 
+__device__ auto ExtrapolateCurve(float value, const CudaAdjustmentParams& p, std::uint32_t a,
+                                 std::uint32_t b) -> float {
+  const float x0 = p.values[a * 2];
+  const float y0 = p.values[a * 2 + 1];
+  const float x1 = p.values[b * 2];
+  const float y1 = p.values[b * 2 + 1];
+  return y0 + (value - x0) * (y1 - y0) / fmaxf(x1 - x0, 1.0e-6f);
+}
+
 __device__ auto ApplyCurve(float value, const CudaAdjustmentParams& p) -> float {
   if (p.count < 2) return value;
+  if (value <= p.values[0]) return ExtrapolateCurve(value, p, 0, 1);
   for (std::uint32_t i = 1; i < p.count; ++i) {
     const float x1 = p.values[i * 2];
     if (value <= x1) {
@@ -131,7 +141,7 @@ __device__ auto ApplyCurve(float value, const CudaAdjustmentParams& p) -> float 
       return y0 + t * (y1 - y0);
     }
   }
-  return p.values[(p.count - 1) * 2 + 1];
+  return ExtrapolateCurve(value, p, p.count - 2, p.count - 1);
 }
 
 __device__ auto ApplyHls(float3 c, const CudaAdjustmentParams& p) -> float3 {
@@ -374,7 +384,7 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
     throw std::runtime_error("ExecuteCudaPrimaryGrade: workspace image has no CUDA allocation");
   }
   CameraToAp1Params camera;
-  camera.mix = grade->Enabled() ? grade->Mix() : 0.0f;
+  camera.mix                       = grade->Enabled() ? grade->Mix() : 0.0f;
   const std::uint8_t* mask_pointer = nullptr;
   if (plan.primary_grade_mask) {
     auto* mask = workspace.Images().Find(plan.mask_output);

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -26,6 +26,7 @@
 #include "edit/runtime/cuda/cuda_local_tone_pass.hpp"
 #include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
 #include "edit/runtime/parameter_binding.hpp"
+#include "edit/runtime/result_content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
 
 namespace alcedo {
@@ -284,9 +285,8 @@ __global__ void FinalMixKernel(const float4* source, float4* adjusted, std::uint
 }  // namespace
 
 auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan,
-                             const RawRuntimeColorContext& color_context,
-                             PipelineDocument&             document) -> CudaPrimaryGradeResult {
-  (void)color_context;
+                             const PreparedRawInput& prepared, PipelineDocument& document)
+    -> CudaPrimaryGradeResult {
   auto& workspace = device.Workspace();
   if (!workspace.IsRendering()) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: BeginRender has not been called");
@@ -409,7 +409,7 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       static_cast<const unsigned char*>(arena.DeviceBuffer().DevicePointer());
   const bool    local_tone_active     = local_tone_mapping::ShouldRun(shadows_slider * 1.5f / 80.0f,
                                                                       -highlights_slider * 1.5f / 100.0f);
-  std::uint64_t reference_resource_id = 0;
+  CudaLocalToneResult local_tone;
   if (local_tone_active) {
     const GraphValueId local_input_id{grade->Id(), PortId{"local_tone.input"}};
     const GraphValueId local_output_id{grade->Id(), PortId{"local_tone.output"}};
@@ -420,9 +420,10 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
         static_cast<float4*>(local_input.Texture().DevicePointer()), pixels, parameter_base,
         device_commands, static_cast<std::uint32_t>(commands_before_local_tone.size()),
         local_tone_mapping::kAcesccMiddleGray);
-    reference_resource_id =
+    local_tone =
         ExecuteCudaLocalTone(device, local_input_id, local_output_id, grade->Id(), input_width,
-                             input_height, shadows_slider, highlights_slider);
+                             input_height, shadows_slider, highlights_slider, plan.geometry,
+                             HashLlfReferenceKey(plan, prepared, document));
     auto* local_output = workspace.Images().Find(local_output_id);
     output             = workspace.Images().Find(output_id);
     PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
@@ -446,7 +447,8 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
   if (::cudaGetLastError() != cudaSuccess) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: CUDA kernel launch failed");
   }
-  return {output_id, reference_resource_id};
+  return {output_id, local_tone.reference_resource_id, local_tone.rebuilt_reference,
+          local_tone.sampled_canonical_reference};
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -337,10 +337,13 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       throw std::runtime_error(
           "ExecuteCudaPrimaryGrade: compiled adjustment no longer matches graph");
     }
-    const auto behavior   = ResolveCudaAdjustmentBehavior(compiled.type);
-    needs_local_reference = needs_local_reference || IsCudaLocalToneBehavior(behavior);
+    const auto behavior = TryResolveCudaAdjustmentBehavior(compiled.type);
+    if (!behavior.has_value()) {
+      continue;
+    }
+    needs_local_reference = needs_local_reference || IsCudaLocalToneBehavior(*behavior);
     const ParameterSlotKey key{grade->Id(), compiled.instance_id};
-    const auto             runtime_params = MakeRuntimeParams(*model, behavior);
+    const auto             runtime_params = MakeRuntimeParams(*model, *behavior);
     auto payload = std::make_shared<TypedOperatorParamPayload<CudaAdjustmentParams>>(
         compiled.type, 1, runtime_params);
     if (!arena.Contains(key)) {

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -21,7 +21,9 @@
 #include "edit/operators/models/pending_parameter_patch.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 #include "edit/operators/models/sharpen_model.hpp"
+#include "edit/pipeline/local_tone_mapping.hpp"
 #include "edit/runtime/cuda/cuda_adjustment_runtime.hpp"
+#include "edit/runtime/cuda/cuda_local_tone_pass.hpp"
 #include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
 #include "edit/runtime/parameter_binding.hpp"
 #include "edit/runtime/texture_format.hpp"
@@ -40,11 +42,6 @@ struct alignas(16) CudaAdjustmentParams {
 
 struct CudaAdjustmentCommand {
   std::uint32_t parameter_offset = 0;
-};
-
-struct CameraToAp1Params {
-  float matrix[9] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
-  float mix       = 1.0f;
 };
 
 auto MakeRuntimeParams(const IOperatorModel& model, CudaAdjustmentBehavior behavior)
@@ -183,10 +180,10 @@ __device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p, std::ui
     c.y *= exp2f(tint);
     c.z *= exp2f(-temperature - tint * 0.5f);
   } else if (behavior == CudaAdjustmentBehavior::Exposure) {
-    const float gain = exp2f(value);
-    c.x *= gain;
-    c.y *= gain;
-    c.z *= gain;
+    const float offset = value / 17.52f;
+    c.x += offset;
+    c.y += offset;
+    c.z += offset;
   } else if (behavior == CudaAdjustmentBehavior::Contrast) {
     const float scale = 1.0f + value * 0.01f;
     c.x               = (c.x - 0.18f) * scale + 0.18f;
@@ -202,15 +199,11 @@ __device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p, std::ui
     c.x += offset;
     c.y += offset;
     c.z += offset;
-  } else if (behavior == CudaAdjustmentBehavior::Shadows ||
-             behavior == CudaAdjustmentBehavior::Highlights ||
-             behavior == CudaAdjustmentBehavior::Clarity) {
+  } else if (behavior == CudaAdjustmentBehavior::Clarity) {
     const float l      = Luma(c);
-    float       weight = behavior == CudaAdjustmentBehavior::Highlights
-                             ? fminf(l / fmaxf(local_reference, 1.0e-4f), 1.0f)
-                             : 1.0f - fminf(l / fmaxf(local_reference, 1.0e-4f), 1.0f);
-    if (behavior == CudaAdjustmentBehavior::Clarity) weight = 0.5f - fabsf(weight - 0.5f);
-    const float gain = 1.0f + value * 0.01f * weight;
+    float       weight = 1.0f - fminf(l / fmaxf(local_reference, 1.0e-4f), 1.0f);
+    weight             = 0.5f - fabsf(weight - 0.5f);
+    const float gain   = 1.0f + value * 0.01f * weight;
     c.x *= gain;
     c.y *= gain;
     c.z *= gain;
@@ -264,26 +257,28 @@ __device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p, std::ui
 __global__ void PrimaryGradeKernel(const float4* input, float4* output, std::uint32_t pixel_count,
                                    const unsigned char*         parameter_base,
                                    const CudaAdjustmentCommand* commands,
-                                   std::uint32_t command_count, CameraToAp1Params camera,
-                                   float local_reference, const std::uint8_t* mask) {
+                                   std::uint32_t command_count, float local_reference) {
   const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= pixel_count) return;
   const float4 source = input[index];
-  float3       c;
-  c.x = camera.matrix[0] * source.x + camera.matrix[1] * source.y + camera.matrix[2] * source.z;
-  c.y = camera.matrix[3] * source.x + camera.matrix[4] * source.y + camera.matrix[5] * source.z;
-  c.z = camera.matrix[6] * source.x + camera.matrix[7] * source.y + camera.matrix[8] * source.z;
-  const float3 converted = c;
+  float3       c      = make_float3(source.x, source.y, source.z);
   for (std::uint32_t i = 0; i < command_count; ++i) {
     const auto* params = reinterpret_cast<const CudaAdjustmentParams*>(
         parameter_base + commands[i].parameter_offset);
     c = ApplyAdjustment(c, *params, index, local_reference);
   }
-  const float mix = camera.mix * (mask == nullptr ? 1.0f : mask[index] / 255.0f);
-  c.x             = converted.x + (c.x - converted.x) * mix;
-  c.y             = converted.y + (c.y - converted.y) * mix;
-  c.z             = converted.z + (c.z - converted.z) * mix;
-  output[index]   = make_float4(c.x, c.y, c.z, source.w);
+  output[index] = make_float4(c.x, c.y, c.z, source.w);
+}
+
+__global__ void FinalMixKernel(const float4* source, float4* adjusted, std::uint32_t pixel_count,
+                               float grade_mix, const std::uint8_t* mask) {
+  const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= pixel_count) return;
+  const float  mix = grade_mix * (mask == nullptr ? 1.0f : mask[index] / 255.0f);
+  const float4 a   = adjusted[index];
+  const float4 s   = source[index];
+  adjusted[index] =
+      make_float4(s.x + (a.x - s.x) * mix, s.y + (a.y - s.y) * mix, s.z + (a.z - s.z) * mix, s.w);
 }
 
 }  // namespace
@@ -307,9 +302,13 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
   arena.Reserve(plan.primary_grade_adjustments.size() *
                 (sizeof(CudaAdjustmentParams) + ParameterArena<CudaBackend>::kSlotAlignment));
   std::vector<PendingParameterPatch> pending;
-  std::vector<CudaAdjustmentCommand> commands;
-  commands.reserve(plan.primary_grade_adjustments.size());
-  bool                        needs_local_reference = false;
+  std::vector<CudaAdjustmentCommand> commands_before_local_tone;
+  std::vector<CudaAdjustmentCommand> commands_after_local_tone;
+  commands_before_local_tone.reserve(plan.primary_grade_adjustments.size());
+  commands_after_local_tone.reserve(plan.primary_grade_adjustments.size());
+  bool                        reached_local_tone = false;
+  float                       shadows_slider     = 0.0f;
+  float                       highlights_slider  = 0.0f;
   const ParameterFieldBinding field{DirtyFieldMask{kRuntimeParamDirtyBit}, 0, 0,
                                     sizeof(CudaAdjustmentParams)};
 
@@ -323,7 +322,11 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
     if (!behavior.has_value()) {
       continue;
     }
-    needs_local_reference = needs_local_reference || IsCudaLocalToneBehavior(*behavior);
+    if (IsCudaLocalToneBehavior(*behavior) &&
+        compiled.algorithm != CompiledAdjustmentAlgorithm::LocalLaplacian) {
+      throw std::runtime_error(
+          "ExecuteCudaPrimaryGrade: Shadows/Highlights were not compiled for LLF");
+    }
     const ParameterSlotKey key{grade->Id(), compiled.instance_id};
     const auto             runtime_params = MakeRuntimeParams(*model, *behavior);
     auto payload = std::make_shared<TypedOperatorParamPayload<CudaAdjustmentParams>>(
@@ -338,13 +341,29 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       arena.ApplyPatch(key, patch);
       pending.push_back(std::move(*change));
     }
-    commands.push_back({arena.Binding(key).offset});
+    if (compiled.algorithm == CompiledAdjustmentAlgorithm::LocalLaplacian &&
+        *behavior == CudaAdjustmentBehavior::Shadows) {
+      shadows_slider     = runtime_params.values[0];
+      reached_local_tone = true;
+      continue;
+    }
+    if (compiled.algorithm == CompiledAdjustmentAlgorithm::LocalLaplacian &&
+        *behavior == CudaAdjustmentBehavior::Highlights) {
+      highlights_slider  = runtime_params.values[0];
+      reached_local_tone = true;
+      continue;
+    }
+    auto& destination = reached_local_tone ? commands_after_local_tone : commands_before_local_tone;
+    destination.push_back({arena.Binding(key).offset});
   }
 
   auto& context = device.CommandContext();
   arena.UploadDirty(context);
   for (auto& patch : pending) patch.Commit();
 
+  std::vector<CudaAdjustmentCommand> commands = commands_before_local_tone;
+  commands.insert(commands.end(), commands_after_local_tone.begin(),
+                  commands_after_local_tone.end());
   const GraphValueId command_id{grade->Id(), PortId{"runtime.order"}};
   auto&              command_buffer = EnsureBuffer(
       workspace, command_id, std::max<std::size_t>(commands.size() * sizeof(commands[0]), 1));
@@ -353,16 +372,6 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
         command_buffer, 0,
         std::span<const std::byte>(reinterpret_cast<const std::byte*>(commands.data()),
                                    commands.size() * sizeof(commands[0])),
-        context);
-  }
-
-  const GraphValueId reference_id{grade->Id(), PortId{"local_tone.reference"}};
-  auto&              reference = EnsureBuffer(workspace, reference_id, sizeof(float));
-  if (needs_local_reference && reference.Bytes() == sizeof(float)) {
-    const float value = 0.18f;
-    workspace.Device().UploadBufferRange(
-        reference, 0,
-        std::span<const std::byte>(reinterpret_cast<const std::byte*>(&value), sizeof(value)),
         context);
   }
 
@@ -383,8 +392,6 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       ::cudaPointerGetAttributes(&output_attributes, output_pointer) != cudaSuccess) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: workspace image has no CUDA allocation");
   }
-  CameraToAp1Params camera;
-  camera.mix                       = grade->Enabled() ? grade->Mix() : 0.0f;
   const std::uint8_t* mask_pointer = nullptr;
   if (plan.primary_grade_mask) {
     auto* mask = workspace.Images().Find(plan.mask_output);
@@ -396,15 +403,50 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
   }
   const std::uint32_t     pixels = input_width * input_height;
   constexpr std::uint32_t block  = 256;
-  PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
-      static_cast<const float4*>(input_pointer), static_cast<float4*>(output_pointer), pixels,
-      static_cast<const unsigned char*>(arena.DeviceBuffer().DevicePointer()),
-      static_cast<const CudaAdjustmentCommand*>(command_buffer.DevicePointer()),
-      static_cast<std::uint32_t>(commands.size()), camera, 0.18f, mask_pointer);
+  const auto*             device_commands =
+      static_cast<const CudaAdjustmentCommand*>(command_buffer.DevicePointer());
+  const auto* parameter_base =
+      static_cast<const unsigned char*>(arena.DeviceBuffer().DevicePointer());
+  const bool    local_tone_active     = local_tone_mapping::ShouldRun(shadows_slider * 1.5f / 80.0f,
+                                                                      -highlights_slider * 1.5f / 100.0f);
+  std::uint64_t reference_resource_id = 0;
+  if (local_tone_active) {
+    const GraphValueId local_input_id{grade->Id(), PortId{"local_tone.input"}};
+    const GraphValueId local_output_id{grade->Id(), PortId{"local_tone.output"}};
+    auto& local_input = EnsureImage(workspace, local_input_id, input_width, input_height);
+    input             = workspace.Images().Find(plan.develop_output);
+    PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
+        static_cast<const float4*>(input->Texture().DevicePointer()),
+        static_cast<float4*>(local_input.Texture().DevicePointer()), pixels, parameter_base,
+        device_commands, static_cast<std::uint32_t>(commands_before_local_tone.size()),
+        local_tone_mapping::kAcesccMiddleGray);
+    reference_resource_id =
+        ExecuteCudaLocalTone(device, local_input_id, local_output_id, grade->Id(), input_width,
+                             input_height, shadows_slider, highlights_slider);
+    auto* local_output = workspace.Images().Find(local_output_id);
+    output             = workspace.Images().Find(output_id);
+    PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
+        static_cast<const float4*>(local_output->Texture().DevicePointer()),
+        static_cast<float4*>(output->Texture().DevicePointer()), pixels, parameter_base,
+        device_commands + commands_before_local_tone.size(),
+        static_cast<std::uint32_t>(commands_after_local_tone.size()),
+        local_tone_mapping::kAcesccMiddleGray);
+  } else {
+    PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
+        static_cast<const float4*>(input_pointer), static_cast<float4*>(output_pointer), pixels,
+        parameter_base, device_commands, static_cast<std::uint32_t>(commands.size()),
+        local_tone_mapping::kAcesccMiddleGray);
+  }
+  input  = workspace.Images().Find(plan.develop_output);
+  output = workspace.Images().Find(output_id);
+  FinalMixKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
+      static_cast<const float4*>(input->Texture().DevicePointer()),
+      static_cast<float4*>(output->Texture().DevicePointer()), pixels,
+      grade->Enabled() ? grade->Mix() : 0.0f, mask_pointer);
   if (::cudaGetLastError() != cudaSuccess) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: CUDA kernel launch failed");
   }
-  return {output_id, reference.ResourceId()};
+  return {output_id, reference_resource_id};
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -24,6 +24,7 @@
 #include "edit/runtime/cuda/cuda_adjustment_runtime.hpp"
 #include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
 #include "edit/runtime/parameter_binding.hpp"
+#include "edit/runtime/texture_format.hpp"
 
 namespace alcedo {
 namespace {
@@ -101,39 +102,9 @@ auto MakeRuntimeParams(const IOperatorModel& model, CudaAdjustmentBehavior behav
   throw std::runtime_error("CUDA primary grade: Model DTO is not supported");
 }
 
-auto MakeCameraToAp1(const RawRuntimeColorContext& context, float mix) -> CameraToAp1Params {
-  CameraToAp1Params result;
-  result.mix = mix;
-  if (!context.valid_) {
-    return result;
-  }
-  constexpr float srgb_to_ap1[9] = {0.613097f, 0.339523f, 0.047380f, 0.070194f, 0.916354f,
-                                    0.013452f, 0.020616f, 0.109570f, 0.869815f};
-  float           absolute_sum   = 0.0f;
-  for (float value : context.rgb_cam_) absolute_sum += std::abs(value);
-  if (absolute_sum <= 1.0e-6f) {
-    return result;
-  }
-  for (int row = 0; row < 3; ++row) {
-    for (int column = 0; column < 3; ++column) {
-      result.matrix[row * 3 + column] = srgb_to_ap1[row * 3] * context.rgb_cam_[column] +
-                                        srgb_to_ap1[row * 3 + 1] * context.rgb_cam_[3 + column] +
-                                        srgb_to_ap1[row * 3 + 2] * context.rgb_cam_[6 + column];
-    }
-  }
-  return result;
-}
-
 auto EnsureImage(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
                  std::uint32_t height) -> ResourceLease<CudaBackend>& {
-  auto* existing = workspace.Images().Find(id);
-  if (existing != nullptr && !existing->Empty() && existing->Texture().Width() == width &&
-      existing->Texture().Height() == height) {
-    return *existing;
-  }
-  auto lease = workspace.Textures().Acquire({width, height, TextureFormat::Rgba32f});
-  workspace.Images().Store(id, std::move(lease));
-  return *workspace.Images().Find(id);
+  return workspace.AcquireImageForWrite(id, {width, height, TextureFormat::Rgba32f});
 }
 
 auto EnsureBuffer(CudaRenderWorkspace& workspace, const GraphValueId& id, std::size_t bytes)
@@ -310,6 +281,7 @@ __global__ void PrimaryGradeKernel(const float4* input, float4* output, std::uin
 auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan,
                              const RawRuntimeColorContext& color_context,
                              PipelineDocument&             document) -> CudaPrimaryGradeResult {
+  (void)color_context;
   auto& workspace = device.Workspace();
   if (!workspace.IsRendering()) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: BeginRender has not been called");
@@ -401,7 +373,8 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       ::cudaPointerGetAttributes(&output_attributes, output_pointer) != cudaSuccess) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: workspace image has no CUDA allocation");
   }
-  const auto camera = MakeCameraToAp1(color_context, grade->Enabled() ? grade->Mix() : 0.0f);
+  CameraToAp1Params camera;
+  camera.mix = grade->Enabled() ? grade->Mix() : 0.0f;
   const std::uint8_t* mask_pointer = nullptr;
   if (plan.primary_grade_mask) {
     auto* mask = workspace.Images().Find(plan.mask_output);

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
@@ -13,7 +13,6 @@
 #include "cuda/cuda_check.hpp"
 #include "edit/geometry/render_request.hpp"
 #include "edit/graph/pipeline_document.hpp"
-#include "edit/input/raw_input_loader.hpp"
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
 #include "edit/runtime/graph_compiler.hpp"
@@ -98,7 +97,14 @@ auto DownloadCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id
 }  // namespace
 
 CudaProductRenderer::CudaProductRenderer(std::shared_ptr<PipelineDocument> document)
-    : document_(std::move(document)), device_(std::make_unique<CudaRenderDevice>()) {
+    : CudaProductRenderer(std::move(document), PreparedSourceCache::UnpackFn{}) {}
+
+CudaProductRenderer::CudaProductRenderer(std::shared_ptr<PipelineDocument> document,
+                                         PreparedSourceCache::UnpackFn     unpack)
+    : document_(std::move(document)),
+      device_(std::make_unique<CudaRenderDevice>()),
+      source_cache_(std::move(unpack)),
+      plan_cache_(kCudaDagBackendCapabilityVersion) {
   device_->SetErrorReporter([](std::string_view message) {
     std::fprintf(stderr, "[ERROR] CUDA DAG product render failed: %.*s\n",
                  static_cast<int>(message.size()), message.data());
@@ -128,9 +134,13 @@ auto CudaProductRenderer::Render(const std::shared_ptr<ImageBuffer>& input, Deco
   auto&      encoded       = input->GetBuffer();
   const auto encoded_bytes = std::span<const std::byte>{
       reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
-  auto       prepared  = RawInputLoader::LoadEncoded(encoded_bytes, decode_res);
-  const auto plan      = GraphCompiler::Compile(*document_, prepared.CompileSource(), request);
-  const auto output_id = device_->Execute(plan, prepared, *document_);
+  const auto prepared_lease = source_cache_.AcquireEncoded(encoded_bytes, decode_res);
+  auto       plan           = plan_cache_.GetOrCompile(*document_, prepared_lease.Get().CompileSource());
+  GraphCompiler::BindFrameGeometry(plan, *document_, request);
+  if (document_->TopologyDirty()) {
+    document_->ClearTopologyDirty();
+  }
+  const auto output_id = device_->Execute(plan, prepared_lease.Get(), *document_);
 
   try {
     if (sink != nullptr) {
@@ -144,6 +154,24 @@ auto CudaProductRenderer::Render(const std::shared_ptr<ImageBuffer>& input, Deco
     throw;
   }
   return std::make_shared<ImageBuffer>();
+}
+
+auto CudaProductRenderer::Stats() const -> CudaProductSessionStats {
+  const auto source = source_cache_.GetStats();
+  const auto plan   = plan_cache_.GetStats();
+  CudaProductSessionStats stats;
+  stats.prepared_source_hits     = source.hits;
+  stats.prepared_source_misses   = source.misses;
+  stats.libraw_open_unpack_count = source.libraw_open_unpack_count;
+  stats.plan_cache_hits          = plan.hits;
+  stats.plan_cache_misses        = plan.misses;
+  stats.plan_compile_count       = plan.compiles;
+  return stats;
+}
+
+void CudaProductRenderer::ResetStats() {
+  source_cache_.ResetStats();
+  plan_cache_.ResetStats();
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
@@ -6,6 +6,7 @@
 
 #include <cstdio>
 #include <opencv2/core.hpp>
+#include <optional>
 #include <span>
 #include <stdexcept>
 #include <utility>
@@ -13,6 +14,7 @@
 #include "cuda/cuda_check.hpp"
 #include "edit/geometry/render_request.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
 #include "edit/runtime/graph_compiler.hpp"
@@ -103,8 +105,14 @@ CudaProductRenderer::CudaProductRenderer(std::shared_ptr<PipelineDocument> docum
                                          PreparedSourceCache::UnpackFn     unpack)
     : document_(std::move(document)),
       device_(std::make_unique<CudaRenderDevice>()),
-      source_cache_(std::move(unpack)),
+      unpack_(unpack ? std::move(unpack)
+                     : PreparedSourceCache::UnpackFn{[](std::span<const std::byte> encoded,
+                                                        DecodeRes                  decode_res) {
+                         return RawInputLoader::LoadEncoded(encoded, decode_res);
+                       }}),
+      source_cache_(unpack_),
       plan_cache_(kCudaDagBackendCapabilityVersion) {
+  device_->Workspace().Textures().SetByteBudget(DefaultProductTextureBudgetBytes());
   device_->SetErrorReporter([](std::string_view message) {
     std::fprintf(stderr, "[ERROR] CUDA DAG product render failed: %.*s\n",
                  static_cast<int>(message.size()), message.data());
@@ -123,7 +131,8 @@ void CudaProductRenderer::SetDocument(std::shared_ptr<PipelineDocument> document
 auto CudaProductRenderer::Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
                                  const RenderRequest& request, IFrameSink* sink,
                                  const FrameCompletionSubmission& submission,
-                                 bool require_host_output) -> std::shared_ptr<ImageBuffer> {
+                                 bool require_host_output, CudaProductCachePolicy cache_policy)
+    -> std::shared_ptr<ImageBuffer> {
   if (!document_) {
     throw std::runtime_error("CudaProductRenderer: PipelineDocument is not configured");
   }
@@ -134,36 +143,73 @@ auto CudaProductRenderer::Render(const std::shared_ptr<ImageBuffer>& input, Deco
   auto&      encoded       = input->GetBuffer();
   const auto encoded_bytes = std::span<const std::byte>{
       reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
-  const auto prepared_lease = source_cache_.AcquireEncoded(encoded_bytes, decode_res);
-  auto       plan           = plan_cache_.GetOrCompile(*document_, prepared_lease.Get().CompileSource());
+  const bool use_session_cache = cache_policy == CudaProductCachePolicy::UseSessionCache;
+  if (!use_session_cache && !one_shot_device_) {
+    one_shot_device_ = std::make_unique<CudaRenderDevice>();
+    one_shot_device_->Workspace().Textures().SetByteBudget(DefaultProductTextureBudgetBytes());
+    one_shot_device_->SetErrorReporter([](std::string_view message) {
+      std::fprintf(stderr, "[ERROR] CUDA DAG one-shot render failed: %.*s\n",
+                   static_cast<int>(message.size()), message.data());
+    });
+  }
+
+  std::optional<PreparedSourceCache::Lease> prepared_lease;
+  std::optional<PreparedRawInput>           one_shot_prepared;
+  ExecutionPlan                             plan;
+  CudaRenderDevice*                         render_device = device_.get();
+  if (use_session_cache) {
+    prepared_lease.emplace(source_cache_.AcquireEncoded(encoded_bytes, decode_res));
+    plan = plan_cache_.GetOrCompile(*document_, prepared_lease->Get().CompileSource());
+  } else {
+    one_shot_prepared.emplace(unpack_(encoded_bytes, decode_res));
+    plan          = GraphCompiler::CompileStatic(*document_, one_shot_prepared->CompileSource(),
+                                                 kCudaDagBackendCapabilityVersion);
+    render_device = one_shot_device_.get();
+  }
   GraphCompiler::BindFrameGeometry(plan, *document_, request);
   if (document_->TopologyDirty()) {
     document_->ClearTopologyDirty();
   }
-  const auto output_id =
-      device_->Execute(plan, prepared_lease.Get(), *document_, nullptr, false);
+  const auto& prepared  = use_session_cache ? prepared_lease->Get() : *one_shot_prepared;
+  const auto  output_id = render_device->Execute(plan, prepared, *document_, nullptr, false);
+  const auto  release_one_shot_resources = [&]() {
+    if (use_session_cache) {
+      return;
+    }
+    render_device->Workspace().Images().DiscardUnpublished();
+    render_device->WaitIdle();
+    render_device->Workspace().ReleaseSessionResources();
+  };
 
   try {
     if (sink != nullptr) {
-      PresentCudaTexture(*device_, output_id, *sink, submission);
+      PresentCudaTexture(*render_device, output_id, *sink, submission);
     }
     if (require_host_output) {
-      auto host = DownloadCudaTexture(*device_, output_id);
-      device_->PublishResults();
+      auto host = DownloadCudaTexture(*render_device, output_id);
+      if (use_session_cache) {
+        render_device->PublishResults();
+      } else {
+        release_one_shot_resources();
+      }
       return host;
     }
-    device_->PublishResults();
+    if (use_session_cache) {
+      render_device->PublishResults();
+    } else {
+      release_one_shot_resources();
+    }
   } catch (const std::exception& ex) {
-    device_->Workspace().Images().DiscardUnpublished();
-    device_->ReportError(ex.what());
+    render_device->Workspace().Images().DiscardUnpublished();
+    render_device->ReportError(ex.what());
     throw;
   }
   return std::make_shared<ImageBuffer>();
 }
 
 auto CudaProductRenderer::Stats() const -> CudaProductSessionStats {
-  const auto source = source_cache_.GetStats();
-  const auto plan   = plan_cache_.GetStats();
+  const auto              source = source_cache_.GetStats();
+  const auto              plan   = plan_cache_.GetStats();
   CudaProductSessionStats stats;
   stats.prepared_source_hits     = source.hits;
   stats.prepared_source_misses   = source.misses;
@@ -179,6 +225,34 @@ void CudaProductRenderer::ResetStats() {
   source_cache_.ResetStats();
   plan_cache_.ResetStats();
   device_->ResetPassStats();
+}
+
+void CudaProductRenderer::ReleaseSessionCaches() {
+  if (!device_) {
+    return;
+  }
+  device_->WaitIdle();
+  device_->Workspace().ReleaseSessionResources();
+  device_->ReleaseNeuralDemosaicWorkspace();
+  one_shot_device_.reset();
+  source_cache_.Clear();
+  plan_cache_.Clear();
+  device_->ResetPassStats();
+}
+
+auto CudaProductRenderer::SessionResources() const -> CudaProductSessionResources {
+  CudaProductSessionResources resources;
+  if (!device_) {
+    return resources;
+  }
+  const auto& workspace                 = device_->Workspace();
+  resources.published_result_count      = workspace.Images().PublishedCount();
+  resources.texture_pool_used_bytes     = workspace.Textures().UsedBytes();
+  resources.texture_pool_entry_count    = workspace.Textures().EntryCount();
+  resources.prepared_source_host_bytes  = source_cache_.HostBytesUsed();
+  resources.prepared_source_entry_count = source_cache_.EntryCount();
+  resources.session_value_ids           = workspace.Images().CurrentValueIds();
+  return resources;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
@@ -5,6 +5,7 @@
 #include <cuda_runtime.h>
 
 #include <cstdio>
+#include <filesystem>
 #include <opencv2/core.hpp>
 #include <optional>
 #include <span>
@@ -15,6 +16,7 @@
 #include "edit/geometry/render_request.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
+#include "edit/mask/mask_store.hpp"
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
 #include "edit/runtime/graph_compiler.hpp"
@@ -180,6 +182,9 @@ CudaProductRenderer::CudaProductRenderer(std::shared_ptr<PipelineDocument> docum
                                          PreparedSourceCache::UnpackFn     unpack)
     : document_(std::move(document)),
       device_(std::make_unique<CudaRenderDevice>()),
+      one_shot_device_(),
+      mask_store_(std::make_unique<MaskStore>(std::filesystem::temp_directory_path() /
+                                              "alcedo_studio" / "product_mask_store")),
       unpack_(unpack ? std::move(unpack)
                      : PreparedSourceCache::UnpackFn{[](std::span<const std::byte> encoded,
                                                         DecodeRes                  decode_res) {
@@ -195,6 +200,8 @@ CudaProductRenderer::CudaProductRenderer(std::shared_ptr<PipelineDocument> docum
 }
 
 CudaProductRenderer::~CudaProductRenderer() = default;
+
+auto CudaProductRenderer::MaskAssets() -> MaskStore& { return *mask_store_; }
 
 void CudaProductRenderer::SetDocument(std::shared_ptr<PipelineDocument> document) {
   if (!document) {
@@ -246,7 +253,8 @@ auto CudaProductRenderer::Render(const std::shared_ptr<ImageBuffer>& input, Deco
     document_->ClearTopologyDirty();
   }
   const auto& prepared  = use_session_cache ? prepared_lease->Get() : *one_shot_prepared;
-  const auto  output_id = render_device->Execute(plan, prepared, *document_, nullptr, false);
+  const auto  output_id =
+      render_device->Execute(plan, prepared, *document_, mask_store_.get(), false);
   const auto  release_one_shot_resources = [&]() {
     if (use_session_cache) {
       return;

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
@@ -37,7 +37,7 @@ void PresentCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id,
   sink.EnsureSize(static_cast<int>(width), static_cast<int>(height));
   const FrameWriteMapping mapping = sink.MapResourceForWrite(FrameMemoryDomain::CudaDevice);
   if (!mapping) {
-    return;
+    throw std::runtime_error("CudaProductRenderer: frame sink rejected the write mapping");
   }
 
   try {
@@ -140,16 +140,21 @@ auto CudaProductRenderer::Render(const std::shared_ptr<ImageBuffer>& input, Deco
   if (document_->TopologyDirty()) {
     document_->ClearTopologyDirty();
   }
-  const auto output_id = device_->Execute(plan, prepared_lease.Get(), *document_);
+  const auto output_id =
+      device_->Execute(plan, prepared_lease.Get(), *document_, nullptr, false);
 
   try {
     if (sink != nullptr) {
       PresentCudaTexture(*device_, output_id, *sink, submission);
     }
     if (require_host_output) {
-      return DownloadCudaTexture(*device_, output_id);
+      auto host = DownloadCudaTexture(*device_, output_id);
+      device_->PublishResults();
+      return host;
     }
+    device_->PublishResults();
   } catch (const std::exception& ex) {
+    device_->Workspace().Images().DiscardUnpublished();
     device_->ReportError(ex.what());
     throw;
   }
@@ -166,12 +171,14 @@ auto CudaProductRenderer::Stats() const -> CudaProductSessionStats {
   stats.plan_cache_hits          = plan.hits;
   stats.plan_cache_misses        = plan.misses;
   stats.plan_compile_count       = plan.compiles;
+  stats.pass                     = device_->PassStats();
   return stats;
 }
 
 void CudaProductRenderer::ResetStats() {
   source_cache_.ResetStats();
   plan_cache_.ResetStats();
+  device_->ResetPassStats();
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
@@ -18,14 +18,85 @@
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
 #include "edit/runtime/graph_compiler.hpp"
+#include "edit/scope/detail/scope_cuda_shared.cuh"
+#include "edit/scope/scope_analyzer.hpp"
 #include "image/image_buffer.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 
 namespace alcedo {
 namespace {
 
+auto ViewerDisplayConfigFromDrt(const DrtPayload& payload) -> ViewerDisplayConfig {
+  ViewerDisplayConfig config;
+  switch (payload.encoding_space) {
+    case DrtColorSpace::Rec2020:
+      config.encoding_space = ColorUtils::ColorSpace::REC2020;
+      break;
+    case DrtColorSpace::P3D65:
+      config.encoding_space = ColorUtils::ColorSpace::P3_D65;
+      break;
+    case DrtColorSpace::Rec709:
+    default:
+      config.encoding_space = ColorUtils::ColorSpace::REC709;
+      break;
+  }
+  switch (payload.encoding_eotf) {
+    case DrtEotf::Linear:
+      config.encoding_eotf = ColorUtils::EOTF::LINEAR;
+      break;
+    case DrtEotf::St2084:
+      config.encoding_eotf = ColorUtils::EOTF::ST2084;
+      break;
+    case DrtEotf::Hlg:
+      config.encoding_eotf = ColorUtils::EOTF::HLG;
+      break;
+    case DrtEotf::Gamma26:
+      config.encoding_eotf = ColorUtils::EOTF::GAMMA_2_6;
+      break;
+    case DrtEotf::Bt1886:
+      config.encoding_eotf = ColorUtils::EOTF::BT1886;
+      break;
+    case DrtEotf::Gamma18:
+      config.encoding_eotf = ColorUtils::EOTF::GAMMA_1_8;
+      break;
+    case DrtEotf::Gamma22:
+    default:
+      config.encoding_eotf = ColorUtils::EOTF::GAMMA_2_2;
+      break;
+  }
+  config.peak_luminance = payload.peak_luminance;
+  return config;
+}
+
+void SubmitCudaDisplayFrame(IFrameSink& sink, const CudaBackend::Texture2D& texture,
+                            cudaStream_t stream, const FrameWriteMapping& mapping,
+                            const ViewerDisplayConfig& display_config) {
+  const auto width     = static_cast<int>(texture.Width());
+  const auto height    = static_cast<int>(texture.Height());
+  const auto row_bytes = static_cast<std::size_t>(width) * sizeof(float4);
+
+  auto final_image           = std::make_shared<scope::cuda_detail::CudaLinearImageResource>();
+  final_image->device_ptr    = texture.DevicePointer();
+  final_image->row_bytes     = row_bytes;
+  final_image->width         = width;
+  final_image->height        = height;
+  final_image->format        = FramePixelFormat::RGBA32F;
+  final_image->owns_memory   = false;
+  final_image->native_object = mapping.native_object;
+
+  auto ready_signal    = std::make_shared<scope::cuda_detail::CudaStreamSignalResource>();
+  ready_signal->stream = stream;
+
+  sink.SubmitFinalDisplayFrame(FinalDisplayFrameView{
+      SharedGpuImageHandle{GpuBackend::Cuda, std::move(final_image), width, height, row_bytes,
+                           FramePixelFormat::RGBA32F},
+      width, height, FramePixelFormat::RGBA32F, display_config, AnalysisDomain::DisplayEncoded,
+      GpuSignalHandle{GpuBackend::Cuda, std::move(ready_signal)}, 0});
+}
+
 void PresentCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id, IFrameSink& sink,
-                        const FrameCompletionSubmission& submission) {
+                        const FrameCompletionSubmission& submission,
+                        const ViewerDisplayConfig& display_config) {
   auto* lease = device.Workspace().Images().Find(output_id);
   if (lease == nullptr || lease->Empty()) {
     throw std::runtime_error("CudaProductRenderer: DRT output is missing");
@@ -72,6 +143,10 @@ void PresentCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id,
                                                           device.CommandContext().Stream()),
                       "CudaProductRenderer: signal frame sink");
     }
+    // Histogram/waveform StageFrame copies this DRT texture on the same stream.
+    // Submit before synchronize so that copy is enqueued while the pointer is valid.
+    SubmitCudaDisplayFrame(sink, texture, device.CommandContext().Stream(), mapping,
+                           display_config);
     cuda::CheckCuda(::cudaStreamSynchronize(device.CommandContext().Stream()),
                     "CudaProductRenderer: wait for frame sink copy");
   } catch (...) {
@@ -181,9 +256,14 @@ auto CudaProductRenderer::Render(const std::shared_ptr<ImageBuffer>& input, Deco
     render_device->Workspace().ReleaseSessionResources();
   };
 
+  ViewerDisplayConfig display_config{};
+  if (const auto* drt = document_->Drt()) {
+    display_config = ViewerDisplayConfigFromDrt(drt->Params().Params());
+  }
+
   try {
     if (sink != nullptr) {
-      PresentCudaTexture(*render_device, output_id, *sink, submission);
+      PresentCudaTexture(*render_device, output_id, *sink, submission, display_config);
     }
     if (require_host_output) {
       auto host = DownloadCudaTexture(*render_device, output_id);

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_render_device.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_render_device.cpp
@@ -1,0 +1,40 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+
+#include <cuda_runtime.h>
+
+#include "cuda_drt_runtime_state.cuh"
+#include "decoders/processor/operators/gpu/cuda_demosaicnet.hpp"
+
+namespace alcedo {
+
+CudaRenderDevice::CudaRenderDevice() : drt_runtime_(std::make_unique<CudaDrtRuntimeState>()) {}
+
+CudaRenderDevice::~CudaRenderDevice() {
+  try {
+    WaitIdle();
+  } catch (...) {
+  }
+}
+
+void CudaRenderDevice::CancelRender() noexcept {
+  if (!workspace_.IsRendering()) return;
+  (void)::cudaStreamSynchronize(command_context_.Stream());
+  workspace_.CancelRender();
+}
+
+auto CudaRenderDevice::DrtRuntime() -> CudaDrtRuntimeState& { return *drt_runtime_; }
+
+auto CudaRenderDevice::NeuralDemosaicWorkspace() -> CUDA::NeuralDemosaicWorkspace& {
+  if (!neural_workspace_) {
+    neural_workspace_ = std::make_unique<CUDA::NeuralDemosaicWorkspace>();
+  }
+  return *neural_workspace_;
+}
+
+void CudaRenderDevice::ReleaseNeuralDemosaicWorkspace() { neural_workspace_.reset(); }
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_sensor_demosaic.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_sensor_demosaic.cpp
@@ -1,0 +1,252 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/cuda/cuda_sensor_demosaic.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+#include <opencv2/core/cuda_stream_accessor.hpp>
+
+#include "decoders/processor/nn/demosaicnet_cache.hpp"
+#include "decoders/processor/nn/demosaicnet_preprocess.hpp"
+#include "decoders/processor/neural_tile_jobs.hpp"
+#include "decoders/processor/operators/gpu/cuda_color_space_conv.hpp"
+#include "decoders/processor/operators/gpu/cuda_debayer_rcd.hpp"
+#include "decoders/processor/operators/gpu/cuda_demosaicnet.hpp"
+#include "decoders/processor/operators/gpu/cuda_highlight_reconstruct.hpp"
+#include "decoders/processor/operators/gpu/cuda_image_ops.hpp"
+#include "decoders/processor/operators/gpu/cuda_xtrans_interpolate.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+
+namespace alcedo {
+namespace {
+
+DemosaicNetModelCache* g_neural_model_cache_for_test = nullptr;
+
+auto AllocateTransient(CudaRenderWorkspace& workspace, std::size_t bytes) -> void* {
+  return workspace.TransientBuffers().Allocate(bytes);
+}
+
+auto WrapF32C1(void* ptr, int width, int height) -> cv::cuda::GpuMat {
+  return cv::cuda::GpuMat(height, width, CV_32FC1, ptr,
+                          static_cast<std::size_t>(width) * sizeof(float));
+}
+
+auto WrapF32C3(void* ptr, int width, int height) -> cv::cuda::GpuMat {
+  return cv::cuda::GpuMat(height, width, CV_32FC3, ptr,
+                          static_cast<std::size_t>(width) * sizeof(float) * 3);
+}
+
+auto CropIfNeeded(cv::cuda::GpuMat plane, const RectI& crop) -> cv::cuda::GpuMat {
+  if (crop.width <= 0 || crop.height <= 0) {
+    return plane;
+  }
+  const int x = std::max(0, crop.x);
+  const int y = std::max(0, crop.y);
+  const int w = std::min(crop.width, plane.cols - x);
+  const int h = std::min(crop.height, plane.rows - y);
+  if (w <= 0 || h <= 0) {
+    return plane;
+  }
+  if (x == 0 && y == 0 && w == plane.cols && h == plane.rows) {
+    return plane;
+  }
+  return plane(cv::Rect(x, y, w, h));
+}
+
+void ThrowIfPackedExtentMismatch(const cv::cuda::GpuMat& packed, const cv::cuda::GpuMat& rgb,
+                                 int orientation_flip, const char* label) {
+  if (orientation_flip == 0 && (packed.cols != rgb.cols || packed.rows != rgb.rows)) {
+    throw std::runtime_error(std::string("ExecuteCudaDevelop: ") + label +
+                             " output extent does not match plan");
+  }
+}
+
+void PackRgbWithOptionalHighlight(CudaRenderWorkspace& workspace, cv::cuda::GpuMat rgb,
+                                  cv::cuda::GpuMat packed, const float* cam_mul, int orientation_flip,
+                                  bool hlr, cv::cuda::Stream& stream) {
+  if (!hlr) {
+    CUDA::ApplyInverseCamMulAndPackRGBAOriented(rgb, packed, cam_mul, orientation_flip, &stream);
+    return;
+  }
+  const int cw = rgb.cols;
+  const int ch = rgb.rows;
+  int*   anyclipped = static_cast<int*>(AllocateTransient(workspace, sizeof(int)));
+  float* sums       = static_cast<float*>(AllocateTransient(workspace, sizeof(float) * 4));
+  float* cnts       = static_cast<float*>(AllocateTransient(workspace, sizeof(float) * 4));
+  void*  hlr_rgb    = AllocateTransient(workspace, static_cast<std::size_t>(cw) * ch * sizeof(float) * 3);
+  CUDA::HighlightWorkspace highlight;
+  highlight.BindExternal(anyclipped, sums, cnts, hlr_rgb, cw, ch);
+  CUDA::HighlightCorrection   correction = CUDA::BuildHighlightCorrection(cam_mul);
+  CUDA::HighlightAccumulation accumulation;
+  CUDA::AccumulateHighlightStats(rgb, correction, cv::Rect{}, highlight, accumulation, &stream);
+  CUDA::FinalizeHighlightCorrection(accumulation, correction);
+  CUDA::ApplyHighlightCorrectionAndPackRGBAOriented(rgb, packed, correction, cam_mul,
+                                                    orientation_flip, &highlight, &stream);
+}
+
+void DemosaicBayerRcd(CudaRenderWorkspace& workspace, const PreparedRawInput& input,
+                      cv::cuda::GpuMat linear, cv::cuda::GpuMat packed, bool hlr,
+                      cv::cuda::Stream& stream) {
+  const int w = linear.cols;
+  const int h = linear.rows;
+  void* r_ptr  = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+  void* g_ptr  = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+  void* b_ptr  = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+  void* vh_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+  void* pq_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+
+  CUDA::RcdWorkspace rcd;
+  rcd.BindExternal(r_ptr, g_ptr, b_ptr, vh_ptr, pq_ptr, cv::Size(w, h));
+  CUDA::Bayer2x2ToPlanarRGB_RCD(linear, input.cfa_pattern.bayer_pattern, &rcd, &stream);
+
+  auto r = CropIfNeeded(rcd.r, input.demosaic_output_crop);
+  auto g = CropIfNeeded(rcd.g, input.demosaic_output_crop);
+  auto b = CropIfNeeded(rcd.b, input.demosaic_output_crop);
+  if (input.sensor.orientation_flip == 0 && (packed.cols != r.cols || packed.rows != r.rows)) {
+    throw std::runtime_error("ExecuteCudaDevelop: Bayer output extent does not match plan");
+  }
+
+  if (hlr) {
+    const int cw = r.cols;
+    const int ch = r.rows;
+    int*   anyclipped = static_cast<int*>(AllocateTransient(workspace, sizeof(int)));
+    float* sums       = static_cast<float*>(AllocateTransient(workspace, sizeof(float) * 4));
+    float* cnts       = static_cast<float*>(AllocateTransient(workspace, sizeof(float) * 4));
+    void*  hlr_rgb    = AllocateTransient(workspace, static_cast<std::size_t>(cw) * ch * sizeof(float) * 3);
+    CUDA::HighlightWorkspace highlight;
+    highlight.BindExternal(anyclipped, sums, cnts, hlr_rgb, cw, ch);
+    CUDA::HighlightCorrection   correction = CUDA::BuildHighlightCorrection(input.linearization.cam_mul);
+    CUDA::HighlightAccumulation accumulation;
+    CUDA::AccumulateHighlightStats(r, g, b, correction, cv::Rect{}, highlight, accumulation, &stream);
+    CUDA::FinalizeHighlightCorrection(accumulation, correction);
+    CUDA::ApplyHighlightCorrectionAndPackRGBAOriented(r, g, b, packed, correction,
+                                                      input.linearization.cam_mul,
+                                                      input.sensor.orientation_flip, &highlight,
+                                                      &stream);
+    return;
+  }
+
+  void* merge_ptr =
+      AllocateTransient(workspace, static_cast<std::size_t>(r.cols) * r.rows * sizeof(float) * 3);
+  auto merged = WrapF32C3(merge_ptr, r.cols, r.rows);
+  CUDA::MergeRGB(r, g, b, merged, &stream);
+  CUDA::ApplyInverseCamMulAndPackRGBAOriented(merged, packed, input.linearization.cam_mul,
+                                              input.sensor.orientation_flip, &stream);
+}
+
+void DemosaicXTransInterpolator(CudaRenderWorkspace& workspace, const PreparedRawInput& input,
+                                cv::cuda::GpuMat linear, cv::cuda::GpuMat packed, bool hlr,
+                                cv::cuda::Stream& stream) {
+  const int w = linear.cols;
+  const int h = linear.rows;
+  void* green_ptr = AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float));
+  void* rgb_ptr =
+      AllocateTransient(workspace, static_cast<std::size_t>(w) * h * sizeof(float) * 3);
+  auto green  = WrapF32C1(green_ptr, w, h);
+  auto rgb    = WrapF32C3(rgb_ptr, w, h);
+  const int passes = input.downsample_passes == 0 ? 3 : 1;
+  CUDA::XTransToRGB_Ref(linear, green, rgb, input.cfa_pattern.xtrans_pattern, passes, &stream);
+  auto cropped = CropIfNeeded(rgb, input.demosaic_output_crop);
+  ThrowIfPackedExtentMismatch(packed, cropped, input.sensor.orientation_flip, "X-Trans");
+  PackRgbWithOptionalHighlight(workspace, cropped, packed, input.linearization.cam_mul,
+                               input.sensor.orientation_flip, hlr, stream);
+}
+
+void DemosaicNeuralEngine(CudaRenderDevice& device, const PreparedRawInput& input,
+                          cv::cuda::GpuMat linear, cv::cuda::GpuMat packed, bool hlr,
+                          cv::cuda::Stream& stream) {
+  cv::cuda::GpuMat neural_cfa;
+  const auto       prep = PrepareNeuralEngineCfa(linear, input.cfa_pattern, neural_cfa, &stream);
+  if (!prep.succeeded) {
+    throw std::runtime_error("ExecuteCudaDevelop: Neural Engine preprocess failed: " + prep.error);
+  }
+
+  const bool is_bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
+  const auto policy =
+      is_bayer ? detail::MakeBayerStudentTilePolicy() : detail::MakeXTransStudentTilePolicy();
+  cv::cuda::GpuMat output_rgb(neural_cfa.size(), CV_32FC3);
+
+  auto&                         neural_workspace = device.NeuralDemosaicWorkspace();
+  CUDA::NeuralDemosaicOptions   neural_options;
+  neural_options.workspace = &neural_workspace;
+  if (g_neural_model_cache_for_test != nullptr) {
+    neural_options.model_cache = g_neural_model_cache_for_test;
+    neural_options.load_options.model_dir = "alcedo-missing-demosaicnet-models";
+  }
+
+  const auto variant = is_bayer ? DemosaicNetVariant::Bayer : DemosaicNetVariant::XTrans;
+  auto&      cache   = neural_options.model_cache != nullptr ? *neural_options.model_cache
+                                                             : DemosaicNetModelCache::Instance();
+  DemosaicNetLoadOptions load_options = neural_options.load_options;
+  load_options.stream = cv::cuda::StreamAccessor::getStream(stream);
+  if (!cache.EnsureLoaded(variant, load_options)) {
+    throw std::runtime_error("ExecuteCudaDevelop: Neural Engine unavailable: " + cache.LastError());
+  }
+
+  const int tile_h = policy.input_tile.height;
+  const int tile_w = policy.input_tile.width;
+  neural_workspace.EnsureCapacity(variant, tile_h, tile_w,
+                                  static_cast<std::size_t>(3) * static_cast<std::size_t>(tile_h) *
+                                      static_cast<std::size_t>(tile_w));
+
+  const auto jobs =
+      detail::BuildTileJobs(cv::Rect(0, 0, neural_cfa.cols, neural_cfa.rows), neural_cfa.size(),
+                            policy);
+  cv::cuda::GpuMat tile_rgb;
+  for (const auto& job : jobs) {
+    const auto result = CUDA::EnqueueDemosaicStudentTileWithNeuralEngine(
+        neural_cfa, job.input_origin, prep.aligned_pattern, tile_rgb, &stream, neural_options);
+    if (!result.succeeded) {
+      throw std::runtime_error("ExecuteCudaDevelop: Neural Engine tile failed: " + result.error);
+    }
+    tile_rgb(job.model_output_roi).copyTo(output_rgb(job.destination_roi), stream);
+  }
+
+  auto cropped = CropIfNeeded(output_rgb, input.demosaic_output_crop);
+  ThrowIfPackedExtentMismatch(packed, cropped, input.sensor.orientation_flip, "Neural Engine");
+  PackRgbWithOptionalHighlight(device.Workspace(), cropped, packed, input.linearization.cam_mul,
+                               input.sensor.orientation_flip, hlr, stream);
+}
+
+}  // namespace
+
+auto ResolveDevelopDemosaicMethod(const DevelopPayload& params, RawCfaKind cfa_kind,
+                                  std::uint32_t downsample_passes) -> RawDemosaicMethod {
+  if (downsample_passes != 0) {
+    return RawDemosaicMethod::Legacy;
+  }
+  const auto parsed = RawDemosaicMethodFromString(params.demosaic_method);
+  if (parsed != RawDemosaicMethod::Default) {
+    return parsed;
+  }
+  return cfa_kind == RawCfaKind::XTrans6x6 ? RawDemosaicMethod::NeuralEngine
+                                           : RawDemosaicMethod::Legacy;
+}
+
+void SetDevelopNeuralModelCacheForTesting(DemosaicNetModelCache* cache) {
+  g_neural_model_cache_for_test = cache;
+}
+
+void ExecuteCudaSensorDemosaicAndPack(CudaRenderDevice& device, const PreparedRawInput& input,
+                                      const DevelopPayload& params, cv::cuda::GpuMat linear,
+                                      cv::cuda::GpuMat packed, cv::cuda::Stream& stream) {
+  const bool hlr = params.highlights_reconstruct;
+  const auto method =
+      ResolveDevelopDemosaicMethod(params, input.cfa_pattern.kind, input.downsample_passes);
+  if (method == RawDemosaicMethod::NeuralEngine) {
+    DemosaicNeuralEngine(device, input, linear, packed, hlr, stream);
+    return;
+  }
+  if (input.cfa_pattern.kind == RawCfaKind::XTrans6x6) {
+    DemosaicXTransInterpolator(device.Workspace(), input, linear, packed, hlr, stream);
+    return;
+  }
+  DemosaicBayerRcd(device.Workspace(), input, linear, packed, hlr, stream);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/geometry_resample.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/geometry_resample.cu
@@ -117,11 +117,19 @@ void GeometryResamplePass::Encode(const ResolvedRenderGeometry& geometry,
   }
   if (src.Width() != geometry.decoded_extent.width ||
       src.Height() != geometry.decoded_extent.height) {
-    throw std::runtime_error("GeometryResamplePass::Encode: src size must match decoded_extent");
+    throw std::runtime_error(
+        "GeometryResamplePass::Encode: src size " + std::to_string(src.Width()) + "x" +
+        std::to_string(src.Height()) + " must match decoded_extent " +
+        std::to_string(geometry.decoded_extent.width) + "x" +
+        std::to_string(geometry.decoded_extent.height));
   }
   if (dst.Width() != geometry.render_extent.width ||
       dst.Height() != geometry.render_extent.height) {
-    throw std::runtime_error("GeometryResamplePass::Encode: dst size must match render_extent");
+    throw std::runtime_error(
+        "GeometryResamplePass::Encode: dst size " + std::to_string(dst.Width()) + "x" +
+        std::to_string(dst.Height()) + " must match render_extent " +
+        std::to_string(geometry.render_extent.width) + "x" +
+        std::to_string(geometry.render_extent.height));
   }
   if (src.DevicePointer() == nullptr || dst.DevicePointer() == nullptr) {
     throw std::runtime_error("GeometryResamplePass::Encode: empty texture");

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -4,12 +4,20 @@
 
 #include "edit/runtime/graph_compiler.hpp"
 
+#include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include "edit/geometry/render_geometry_resolver.hpp"
 #include "edit/geometry/source_geometry.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/i_node_model.hpp"
+#include "edit/graph/pipeline_graph.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_type_id.hpp"
 
 namespace alcedo {
 namespace {
@@ -43,6 +51,64 @@ auto ImageParamsFromDocument(const PipelineDocument& document) -> ImageGeometryP
   return params;
 }
 
+auto MixU64(std::uint64_t hash, std::uint64_t value) -> std::uint64_t {
+  hash ^= value;
+  hash *= 1099511628211ull;
+  return hash;
+}
+
+auto MixText(std::uint64_t hash, std::string_view text) -> std::uint64_t {
+  hash = MixU64(hash, Fnv1a64(text));
+  return MixU64(hash, 0xFFull);
+}
+
+auto HashGraphTopology(const PipelineDocument& document) -> std::uint64_t {
+  std::uint64_t hash = MixU64(14695981039346656037ull, 1);
+
+  std::vector<const INodeModel*> nodes;
+  nodes.reserve(document.Graph().Nodes().size());
+  for (const auto& node : document.Graph().Nodes()) {
+    nodes.push_back(node.get());
+  }
+  std::sort(nodes.begin(), nodes.end(), [](const INodeModel* a, const INodeModel* b) {
+    return a->Id() < b->Id();
+  });
+  for (const auto* node : nodes) {
+    hash = MixText(hash, node->Id().Value());
+    hash = MixText(hash, node->Type().Text());
+    const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(node);
+    if (grade == nullptr) {
+      continue;
+    }
+    hash = MixU64(hash, grade->AdjustmentCount());
+    for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
+      hash = MixText(hash, grade->AdjustmentIdAt(index).Value());
+      hash = MixText(hash, grade->AdjustmentAt(index).Type().Text());
+    }
+  }
+
+  std::vector<GraphEdge> edges = document.Graph().Edges();
+  std::sort(edges.begin(), edges.end(), [](const GraphEdge& a, const GraphEdge& b) {
+    if (a.from_node != b.from_node) {
+      return a.from_node < b.from_node;
+    }
+    if (a.from_port != b.from_port) {
+      return a.from_port < b.from_port;
+    }
+    if (a.to_node != b.to_node) {
+      return a.to_node < b.to_node;
+    }
+    return a.to_port < b.to_port;
+  });
+  for (const auto& edge : edges) {
+    hash = MixText(hash, edge.from_node.Value());
+    hash = MixText(hash, edge.from_port.Value());
+    hash = MixText(hash, edge.to_node.Value());
+    hash = MixText(hash, edge.to_port.Value());
+  }
+  return hash;
+}
+
 void RequireDefaultEndpoints(const PipelineDocument& document) {
   const auto errors = document.Graph().Validate();
   if (!errors.empty()) {
@@ -70,8 +136,19 @@ void RequireDefaultEndpoints(const PipelineDocument& document) {
 
 }  // namespace
 
-auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompileSource& source,
-                            const RenderRequest& request) -> ExecutionPlan {
+auto GraphCompiler::MakeStaticPlanKey(const PipelineDocument& document,
+                                      const DevelopCompileSource& source,
+                                      std::uint32_t backend_capability_version) -> StaticPlanKey {
+  StaticPlanKey key;
+  key.topology_hash              = HashGraphTopology(document);
+  key.source_layout              = source;
+  key.backend_capability_version = backend_capability_version;
+  return key;
+}
+
+auto GraphCompiler::CompileStatic(const PipelineDocument& document,
+                                  const DevelopCompileSource& source,
+                                  std::uint32_t backend_capability_version) -> ExecutionPlan {
   RequireDefaultEndpoints(document);
   if (source.host_extent.Empty() || source.develop_output_extent.Empty() ||
       source.full_reference_extent.Empty()) {
@@ -79,6 +156,7 @@ auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompi
   }
 
   ExecutionPlan plan;
+  plan.static_key           = MakeStaticPlanKey(document, source, backend_capability_version);
   plan.source               = source;
   plan.develop_output       = GraphValueId{NodeId{"develop"}, PortId{"image"}};
   plan.peak_transient_bytes = EstimatePeakTransientBytes(source);
@@ -119,25 +197,30 @@ auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompi
     plan.primary_grade_adjustments.push_back(
         {grade->AdjustmentIdAt(index), grade->AdjustmentAt(index).Type()});
   }
+  return plan;
+}
 
+void GraphCompiler::BindFrameGeometry(ExecutionPlan& plan, const PipelineDocument& document,
+                                      const RenderRequest& request) {
   const auto geom_source =
-      MakeSourceGeometry(source.develop_output_extent, source.full_reference_extent,
-                         source.sensor_active_area, source.downsample_passes);
+      MakeSourceGeometry(plan.source.develop_output_extent, plan.source.full_reference_extent,
+                         plan.source.sensor_active_area, plan.source.downsample_passes);
   plan.geometry = ResolveRenderGeometry(geom_source, ImageParamsFromDocument(document),
                                         request.view, request.resolution, request.footprint);
   plan.encode_geometry_resample = !IsIdentityResample(plan.geometry);
+}
+
+auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompileSource& source,
+                            const RenderRequest& request) -> ExecutionPlan {
+  auto plan = CompileStatic(document, source);
+  BindFrameGeometry(plan, document, request);
   return plan;
 }
 
 auto GraphCompiler::NeedsRecompile(const ExecutionPlan& previous, const PipelineDocument& document,
                                    const DevelopCompileSource& source) -> bool {
-  if (document.TopologyDirty()) {
-    return true;
-  }
-  return previous.source.kind != source.kind || previous.source.host_extent != source.host_extent ||
-         previous.source.develop_output_extent != source.develop_output_extent ||
-         previous.source.full_reference_extent != source.full_reference_extent ||
-         previous.source.downsample_passes != source.downsample_passes;
+  return previous.static_key !=
+         MakeStaticPlanKey(document, source, previous.static_key.backend_capability_version);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -156,10 +156,12 @@ auto GraphCompiler::CompileStatic(const PipelineDocument& document,
   }
 
   ExecutionPlan plan;
-  plan.static_key           = MakeStaticPlanKey(document, source, backend_capability_version);
-  plan.source               = source;
-  plan.develop_output       = GraphValueId{NodeId{"develop"}, PortId{"image"}};
-  plan.peak_transient_bytes = EstimatePeakTransientBytes(source);
+  plan.static_key            = MakeStaticPlanKey(document, source, backend_capability_version);
+  plan.source                = source;
+  plan.sensor_linear_output  = GraphValueId{NodeId{"develop"}, PortId{"sensor_linear"}};
+  plan.geometry_output       = GraphValueId{NodeId{"geometry"}, PortId{"scene_source"}};
+  plan.develop_output        = GraphValueId{NodeId{"develop"}, PortId{"image"}};
+  plan.peak_transient_bytes  = EstimatePeakTransientBytes(source);
   const auto* grade         = document.PrimaryGrade();
 
   if (source.kind == DevelopInputKind::DirectRgb) {

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -62,20 +62,26 @@ auto MixText(std::uint64_t hash, std::string_view text) -> std::uint64_t {
   return MixU64(hash, 0xFFull);
 }
 
+auto CompileAdjustmentAlgorithm(const OperatorTypeId& type) -> CompiledAdjustmentAlgorithm {
+  if (type == type_ids::Shadows() || type == type_ids::Highlights()) {
+    return CompiledAdjustmentAlgorithm::LocalLaplacian;
+  }
+  return CompiledAdjustmentAlgorithm::Pointwise;
+}
+
 auto HashGraphTopology(const PipelineDocument& document) -> std::uint64_t {
-  std::uint64_t hash = MixU64(14695981039346656037ull, 1);
+  std::uint64_t                  hash = MixU64(14695981039346656037ull, 1);
 
   std::vector<const INodeModel*> nodes;
   nodes.reserve(document.Graph().Nodes().size());
   for (const auto& node : document.Graph().Nodes()) {
     nodes.push_back(node.get());
   }
-  std::sort(nodes.begin(), nodes.end(), [](const INodeModel* a, const INodeModel* b) {
-    return a->Id() < b->Id();
-  });
+  std::sort(nodes.begin(), nodes.end(),
+            [](const INodeModel* a, const INodeModel* b) { return a->Id() < b->Id(); });
   for (const auto* node : nodes) {
-    hash = MixText(hash, node->Id().Value());
-    hash = MixText(hash, node->Type().Text());
+    hash              = MixText(hash, node->Id().Value());
+    hash              = MixText(hash, node->Type().Text());
     const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(node);
     if (grade == nullptr) {
       continue;
@@ -136,7 +142,7 @@ void RequireDefaultEndpoints(const PipelineDocument& document) {
 
 }  // namespace
 
-auto GraphCompiler::MakeStaticPlanKey(const PipelineDocument& document,
+auto GraphCompiler::MakeStaticPlanKey(const PipelineDocument&     document,
                                       const DevelopCompileSource& source,
                                       std::uint32_t backend_capability_version) -> StaticPlanKey {
   StaticPlanKey key;
@@ -146,7 +152,7 @@ auto GraphCompiler::MakeStaticPlanKey(const PipelineDocument& document,
   return key;
 }
 
-auto GraphCompiler::CompileStatic(const PipelineDocument& document,
+auto GraphCompiler::CompileStatic(const PipelineDocument&     document,
                                   const DevelopCompileSource& source,
                                   std::uint32_t backend_capability_version) -> ExecutionPlan {
   RequireDefaultEndpoints(document);
@@ -156,13 +162,13 @@ auto GraphCompiler::CompileStatic(const PipelineDocument& document,
   }
 
   ExecutionPlan plan;
-  plan.static_key            = MakeStaticPlanKey(document, source, backend_capability_version);
-  plan.source                = source;
-  plan.sensor_linear_output  = GraphValueId{NodeId{"develop"}, PortId{"sensor_linear"}};
-  plan.geometry_output       = GraphValueId{NodeId{"geometry"}, PortId{"scene_source"}};
-  plan.develop_output        = GraphValueId{NodeId{"develop"}, PortId{"image"}};
-  plan.peak_transient_bytes  = EstimatePeakTransientBytes(source);
+  plan.static_key           = MakeStaticPlanKey(document, source, backend_capability_version);
+  plan.source               = source;
+  plan.sensor_linear_output = GraphValueId{NodeId{"develop"}, PortId{"sensor_linear"}};
+  plan.geometry_output      = GraphValueId{NodeId{"geometry"}, PortId{"scene_source"}};
+  plan.develop_output       = GraphValueId{NodeId{"develop"}, PortId{"image"}};
   const auto* grade         = document.PrimaryGrade();
+  plan.peak_transient_bytes = EstimatePeakTransientBytes(source);
 
   if (source.kind == DevelopInputKind::DirectRgb) {
     plan.passes.push_back(GpuPassDesc{GpuPassKind::UploadRgb});
@@ -196,8 +202,9 @@ auto GraphCompiler::CompileStatic(const PipelineDocument& document,
   plan.passes.push_back(GpuPassDesc{GpuPassKind::Drt});
 
   for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
+    const auto& type = grade->AdjustmentAt(index).Type();
     plan.primary_grade_adjustments.push_back(
-        {grade->AdjustmentIdAt(index), grade->AdjustmentAt(index).Type()});
+        {grade->AdjustmentIdAt(index), type, CompileAdjustmentAlgorithm(type)});
   }
   return plan;
 }

--- a/alcedo_studio/src/edit/runtime/result_content_key.cpp
+++ b/alcedo_studio/src/edit/runtime/result_content_key.cpp
@@ -74,8 +74,7 @@ auto MixSensorDevelopParams(ContentHash& hash, const DevelopPayload& params) -> 
   hash.MixText(params.lens_profile_db_path);
 }
 
-auto MixCameraColorParams(ContentHash& hash, const DevelopPayload& params,
-                          const RawRuntimeColorContext& color) -> void {
+auto MixCameraColorParams(ContentHash& hash, const DevelopPayload& params) -> void {
   hash.MixBool(params.use_camera_wb);
   hash.MixF32(params.user_wb);
   hash.MixText(params.wb_mode);
@@ -83,39 +82,31 @@ auto MixCameraColorParams(ContentHash& hash, const DevelopPayload& params,
   hash.MixF32(params.custom_tint);
   hash.MixF32(params.as_shot_cct);
   hash.MixF32(params.as_shot_tint);
-  hash.MixBool(color.valid_);
-  hash.MixBool(color.color_matrices_valid_);
-  hash.MixBool(color.forward_matrices_valid_);
-  hash.MixBool(color.as_shot_neutral_valid_);
-  hash.MixBool(color.calibration_illuminants_valid_);
-  for (float value : color.cam_mul_) {
+  const auto& profile = params.camera_profile;
+  hash.MixBool(profile.color_matrices_valid);
+  hash.MixBool(profile.forward_matrices_valid);
+  hash.MixBool(profile.as_shot_neutral_valid);
+  hash.MixBool(profile.calibration_illuminants_valid);
+  for (double value : profile.color_matrix_1) {
+    hash.MixF64(value);
+  }
+  for (double value : profile.color_matrix_2) {
+    hash.MixF64(value);
+  }
+  for (double value : profile.forward_matrix_1) {
+    hash.MixF64(value);
+  }
+  for (double value : profile.forward_matrix_2) {
+    hash.MixF64(value);
+  }
+  for (double value : profile.as_shot_neutral) {
+    hash.MixF64(value);
+  }
+  for (float value : profile.cam_mul) {
     hash.MixF32(value);
   }
-  for (float value : color.pre_mul_) {
-    hash.MixF32(value);
-  }
-  for (float value : color.rgb_cam_) {
-    hash.MixF32(value);
-  }
-  for (double value : color.color_matrix_1_) {
-    hash.MixF64(value);
-  }
-  for (double value : color.color_matrix_2_) {
-    hash.MixF64(value);
-  }
-  for (double value : color.forward_matrix_1_) {
-    hash.MixF64(value);
-  }
-  for (double value : color.forward_matrix_2_) {
-    hash.MixF64(value);
-  }
-  for (double value : color.as_shot_neutral_) {
-    hash.MixF64(value);
-  }
-  hash.MixF64(color.color_matrix_1_cct_);
-  hash.MixF64(color.color_matrix_2_cct_);
-  hash.MixText(color.camera_make_);
-  hash.MixText(color.camera_model_);
+  hash.MixF64(profile.color_matrix_1_cct);
+  hash.MixF64(profile.color_matrix_2_cct);
 }
 
 auto MixGrade(ContentHash& hash, const ColorGradeNodeModel& grade) -> void {
@@ -193,7 +184,7 @@ auto BuildFrameResultContentKeys(const ExecutionPlan& plan, const PreparedRawInp
 
   ContentHash camera;
   camera.MixKey(keys.geometry_scene_source);
-  MixCameraColorParams(camera, params, input.color_context);
+  MixCameraColorParams(camera, params);
   camera.MixU32(kCameraColorImplementationVersion);
   keys.develop_image = camera.Key();
 

--- a/alcedo_studio/src/edit/runtime/result_content_key.cpp
+++ b/alcedo_studio/src/edit/runtime/result_content_key.cpp
@@ -1,0 +1,228 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/result_content_key.hpp"
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/develop_node_model.hpp"
+#include "edit/graph/drt_node_model.hpp"
+
+namespace alcedo {
+namespace {
+
+auto MixExtent(ContentHash& hash, Extent2D extent) -> void {
+  hash.MixU32(extent.width);
+  hash.MixU32(extent.height);
+}
+
+auto MixRect(ContentHash& hash, RectI rect) -> void {
+  hash.MixI32(rect.x);
+  hash.MixI32(rect.y);
+  hash.MixI32(rect.width);
+  hash.MixI32(rect.height);
+}
+
+auto MixMatrix(ContentHash& hash, const Matrix3x3& matrix) -> void {
+  for (float value : matrix.m) {
+    hash.MixF32(value);
+  }
+}
+
+auto MixPreparedSource(ContentHash& hash, const PreparedSourceKey& key) -> void {
+  hash.MixU64(key.encoded_content_hash);
+  hash.MixU64(key.encoded_byte_count);
+  hash.MixU32(static_cast<std::uint32_t>(key.input_kind));
+  hash.MixU64(key.cfa_hash);
+  hash.MixU32(key.downsample_passes);
+  MixRect(hash, key.sensor_active_area);
+  hash.MixI32(key.orientation_flip);
+  hash.MixU32(key.preparation_version);
+}
+
+auto MixLinearization(ContentHash& hash, const RawLinearizationParams& linearization) -> void {
+  for (float value : linearization.black_level) {
+    hash.MixF32(value);
+  }
+  for (float value : linearization.white_level) {
+    hash.MixF32(value);
+  }
+  for (float value : linearization.cam_mul) {
+    hash.MixF32(value);
+  }
+  hash.MixI32(linearization.apply_as_shot_wb);
+  hash.MixI32(linearization.black_tile_width);
+  hash.MixI32(linearization.black_tile_height);
+  for (float value : linearization.pattern_black) {
+    hash.MixF32(value);
+  }
+}
+
+auto MixSensorDevelopParams(ContentHash& hash, const DevelopPayload& params) -> void {
+  hash.MixText(params.demosaic_method);
+  hash.MixBool(params.highlights_reconstruct);
+  hash.MixBool(params.lens_enabled);
+  hash.MixBool(params.apply_vignetting);
+  hash.MixBool(params.apply_distortion);
+  hash.MixBool(params.apply_tca);
+  hash.MixBool(params.apply_crop);
+  hash.MixBool(params.auto_scale);
+  hash.MixBool(params.use_user_scale);
+  hash.MixF32(params.user_scale);
+  hash.MixBool(params.projection_enabled);
+  hash.MixText(params.target_projection);
+  hash.MixText(params.lens_profile_db_path);
+}
+
+auto MixCameraColorParams(ContentHash& hash, const DevelopPayload& params,
+                          const RawRuntimeColorContext& color) -> void {
+  hash.MixBool(params.use_camera_wb);
+  hash.MixF32(params.user_wb);
+  hash.MixText(params.wb_mode);
+  hash.MixF32(params.custom_cct);
+  hash.MixF32(params.custom_tint);
+  hash.MixF32(params.as_shot_cct);
+  hash.MixF32(params.as_shot_tint);
+  hash.MixBool(color.valid_);
+  hash.MixBool(color.color_matrices_valid_);
+  hash.MixBool(color.forward_matrices_valid_);
+  hash.MixBool(color.as_shot_neutral_valid_);
+  hash.MixBool(color.calibration_illuminants_valid_);
+  for (float value : color.cam_mul_) {
+    hash.MixF32(value);
+  }
+  for (float value : color.pre_mul_) {
+    hash.MixF32(value);
+  }
+  for (float value : color.rgb_cam_) {
+    hash.MixF32(value);
+  }
+  for (double value : color.color_matrix_1_) {
+    hash.MixF64(value);
+  }
+  for (double value : color.color_matrix_2_) {
+    hash.MixF64(value);
+  }
+  for (double value : color.forward_matrix_1_) {
+    hash.MixF64(value);
+  }
+  for (double value : color.forward_matrix_2_) {
+    hash.MixF64(value);
+  }
+  for (double value : color.as_shot_neutral_) {
+    hash.MixF64(value);
+  }
+  hash.MixF64(color.color_matrix_1_cct_);
+  hash.MixF64(color.color_matrix_2_cct_);
+  hash.MixText(color.camera_make_);
+  hash.MixText(color.camera_model_);
+}
+
+auto MixGrade(ContentHash& hash, const ColorGradeNodeModel& grade) -> void {
+  hash.MixBool(grade.Enabled());
+  hash.MixF32(grade.Mix());
+  hash.MixU64(grade.AdjustmentCount());
+  for (std::size_t index = 0; index < grade.AdjustmentCount(); ++index) {
+    hash.MixText(grade.AdjustmentIdAt(index).Value());
+    hash.MixText(grade.AdjustmentAt(index).Type().Text());
+    hash.MixText(grade.AdjustmentAt(index).ToJson().dump());
+  }
+}
+
+}  // namespace
+
+auto HashPreparedSourceKey(const PreparedSourceKey& key) -> ContentKey {
+  ContentHash hash;
+  MixPreparedSource(hash, key);
+  return hash.Key();
+}
+
+auto HashResolvedRenderGeometry(const ResolvedRenderGeometry& geometry) -> ContentKey {
+  ContentHash hash;
+  MixExtent(hash, geometry.decoded_extent);
+  MixExtent(hash, geometry.full_reference_extent);
+  MixExtent(hash, geometry.edit_extent);
+  MixExtent(hash, geometry.render_extent);
+  MixMatrix(hash, geometry.decoded_to_reference);
+  MixMatrix(hash, geometry.reference_to_edit);
+  MixMatrix(hash, geometry.edit_to_render);
+  MixMatrix(hash, geometry.reference_to_render);
+  MixMatrix(hash, geometry.render_to_reference);
+  MixMatrix(hash, geometry.render_to_decoded);
+  MixRect(hash, geometry.required_decoded_region);
+  MixRect(hash, geometry.required_reference_region);
+  hash.MixU32(static_cast<std::uint32_t>(geometry.filter));
+  hash.MixU32(geometry.gpu_data.decoded_width);
+  hash.MixU32(geometry.gpu_data.decoded_height);
+  hash.MixU32(geometry.gpu_data.render_width);
+  hash.MixU32(geometry.gpu_data.render_height);
+  hash.MixU32(geometry.gpu_data.filter);
+  for (float value : geometry.gpu_data.render_to_decoded) {
+    hash.MixF32(value);
+  }
+  for (float value : geometry.gpu_data.border_rgba) {
+    hash.MixF32(value);
+  }
+  hash.MixU32(kGeometryImplementationVersion);
+  return hash.Key();
+}
+
+auto BuildFrameResultContentKeys(const ExecutionPlan& plan, const PreparedRawInput& input,
+                                 const PipelineDocument& document) -> FrameResultContentKeys {
+  FrameResultContentKeys keys;
+  keys.sensor_extent = ImageExtent{plan.source.develop_output_extent.width,
+                                   plan.source.develop_output_extent.height};
+  keys.geometry_extent =
+      ImageExtent{plan.geometry.render_extent.width, plan.geometry.render_extent.height};
+
+  const auto* develop = document.Develop();
+  const auto  params  = develop == nullptr ? DevelopPayload{} : develop->Params().Params();
+
+  ContentHash sensor;
+  MixPreparedSource(sensor, input.source_key);
+  MixLinearization(sensor, input.linearization);
+  MixSensorDevelopParams(sensor, params);
+  sensor.MixU32(static_cast<std::uint32_t>(input.input_kind));
+  sensor.MixU32(kSensorDevelopImplementationVersion);
+  keys.sensor_linear = sensor.Key();
+
+  ContentHash geometry;
+  geometry.MixKey(keys.sensor_linear);
+  geometry.MixKey(HashResolvedRenderGeometry(plan.geometry));
+  keys.geometry_scene_source = geometry.Key();
+
+  ContentHash camera;
+  camera.MixKey(keys.geometry_scene_source);
+  MixCameraColorParams(camera, params, input.color_context);
+  camera.MixU32(kCameraColorImplementationVersion);
+  keys.develop_image = camera.Key();
+
+  if (plan.primary_grade_mask) {
+    ContentHash mask;
+    mask.MixKey(keys.geometry_scene_source);
+    mask.MixText(plan.primary_grade_mask->node_id.Value());
+    mask.MixU32(static_cast<std::uint32_t>(plan.primary_grade_mask->kind));
+    mask.MixU32(kMaskImplementationVersion);
+    keys.mask = mask.Key();
+  }
+
+  ContentHash grade;
+  grade.MixKey(keys.develop_image);
+  if (document.PrimaryGrade() != nullptr) {
+    MixGrade(grade, *document.PrimaryGrade());
+  }
+  grade.MixKey(keys.mask);
+  grade.MixU32(kPrimaryGradeImplementationVersion);
+  keys.primary_grade = grade.Key();
+
+  ContentHash drt;
+  drt.MixKey(keys.primary_grade);
+  if (document.Drt() != nullptr) {
+    drt.MixText(document.Drt()->Params().ToJson().dump());
+  }
+  drt.MixU32(kDrtImplementationVersion);
+  keys.drt_display = drt.Key();
+  return keys;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/result_content_key.cpp
+++ b/alcedo_studio/src/edit/runtime/result_content_key.cpp
@@ -34,6 +34,7 @@ auto MixPreparedSource(ContentHash& hash, const PreparedSourceKey& key) -> void 
   hash.MixU64(key.encoded_byte_count);
   hash.MixU32(static_cast<std::uint32_t>(key.input_kind));
   hash.MixU64(key.cfa_hash);
+  hash.MixU64(key.dng_warp_hash);
   hash.MixU32(key.downsample_passes);
   MixRect(hash, key.sensor_active_area);
   hash.MixI32(key.orientation_flip);

--- a/alcedo_studio/src/edit/runtime/result_content_key.cpp
+++ b/alcedo_studio/src/edit/runtime/result_content_key.cpp
@@ -4,9 +4,11 @@
 
 #include "edit/runtime/result_content_key.hpp"
 
+#include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/develop_node_model.hpp"
 #include "edit/graph/drt_node_model.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
 
 namespace alcedo {
 namespace {
@@ -121,6 +123,48 @@ auto MixGrade(ContentHash& hash, const ColorGradeNodeModel& grade) -> void {
   }
 }
 
+auto MixNormalizedRect(ContentHash& hash, NormalizedRect rect) -> void {
+  hash.MixF32(rect.x);
+  hash.MixF32(rect.y);
+  hash.MixF32(rect.w);
+  hash.MixF32(rect.h);
+}
+
+auto MixCompiledMask(ContentHash& hash, const PipelineDocument& document, const CompiledMask& mask)
+    -> void {
+  hash.MixText(mask.node_id.Value());
+  hash.MixU32(static_cast<std::uint32_t>(mask.kind));
+  const auto* node = document.Graph().FindNode(mask.node_id);
+  if (const auto* analytic = dynamic_cast<const AnalyticMaskNodeModel*>(node)) {
+    hash.MixU32(static_cast<std::uint32_t>(analytic->Kind()));
+    const auto& radial = analytic->Radial();
+    hash.MixF32(radial.center_x);
+    hash.MixF32(radial.center_y);
+    hash.MixF32(radial.major_radius);
+    hash.MixF32(radial.minor_radius);
+    hash.MixF32(radial.rotation);
+    hash.MixF32(radial.inner_feather);
+    hash.MixF32(radial.outer_feather);
+    hash.MixBool(radial.invert);
+    const auto& graduated = analytic->GraduatedNd();
+    hash.MixF32(graduated.origin_x);
+    hash.MixF32(graduated.origin_y);
+    hash.MixF32(graduated.normal_x);
+    hash.MixF32(graduated.normal_y);
+    hash.MixF32(graduated.transition_distance);
+    hash.MixF32(graduated.start_value);
+    hash.MixF32(graduated.end_value);
+    hash.MixBool(graduated.invert);
+    return;
+  }
+  if (const auto* raster = dynamic_cast<const RasterMaskNodeModel*>(node)) {
+    hash.MixText(raster->AssetKey().Value());
+    MixNormalizedRect(hash, raster->ReferenceBounds());
+    hash.MixF32(raster->FeatherRadius());
+    hash.MixBool(raster->Invert());
+  }
+}
+
 }  // namespace
 
 auto HashPreparedSourceKey(const PreparedSourceKey& key) -> ContentKey {
@@ -214,8 +258,7 @@ auto BuildFrameResultContentKeys(const ExecutionPlan& plan, const PreparedRawInp
   if (plan.primary_grade_mask) {
     ContentHash mask;
     mask.MixKey(keys.geometry_scene_source);
-    mask.MixText(plan.primary_grade_mask->node_id.Value());
-    mask.MixU32(static_cast<std::uint32_t>(plan.primary_grade_mask->kind));
+    MixCompiledMask(mask, document, *plan.primary_grade_mask);
     mask.MixU32(kMaskImplementationVersion);
     keys.mask = mask.Key();
   }

--- a/alcedo_studio/src/edit/runtime/result_content_key.cpp
+++ b/alcedo_studio/src/edit/runtime/result_content_key.cpp
@@ -129,6 +129,28 @@ auto HashPreparedSourceKey(const PreparedSourceKey& key) -> ContentKey {
   return hash.Key();
 }
 
+auto HashLlfReferenceKey(const ExecutionPlan& plan, const PreparedRawInput& input,
+                         const PipelineDocument& document) -> ContentKey {
+  ContentHash hash;
+  MixPreparedSource(hash, input.source_key);
+  MixExtent(hash, plan.geometry.full_reference_extent);
+  MixExtent(hash, plan.geometry.edit_extent);
+  MixMatrix(hash, plan.geometry.reference_to_edit);
+  MixExtent(hash, plan.source.host_extent);
+  MixExtent(hash, plan.source.develop_output_extent);
+  MixExtent(hash, plan.source.full_reference_extent);
+  hash.MixU32(static_cast<std::uint32_t>(plan.source.kind));
+  hash.MixU32(plan.source.downsample_passes);
+  MixRect(hash, plan.source.sensor_active_area);
+  const auto* develop = document.Develop();
+  MixCameraColorParams(hash, develop == nullptr ? DevelopPayload{} : develop->Params().Params());
+  if (document.PrimaryGrade() != nullptr) {
+    MixGrade(hash, *document.PrimaryGrade());
+  }
+  hash.MixU32(kLlfReferenceImplementationVersion);
+  return hash.Key();
+}
+
 auto HashResolvedRenderGeometry(const ResolvedRenderGeometry& geometry) -> ContentKey {
   ContentHash hash;
   MixExtent(hash, geometry.decoded_extent);

--- a/alcedo_studio/src/edit/runtime/static_execution_plan_cache.cpp
+++ b/alcedo_studio/src/edit/runtime/static_execution_plan_cache.cpp
@@ -1,0 +1,26 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/static_execution_plan_cache.hpp"
+
+namespace alcedo {
+
+StaticExecutionPlanCache::StaticExecutionPlanCache(std::uint32_t backend_capability_version)
+    : backend_capability_version_(backend_capability_version) {}
+
+auto StaticExecutionPlanCache::GetOrCompile(const PipelineDocument&     document,
+                                            const DevelopCompileSource& source) -> ExecutionPlan {
+  const auto key = GraphCompiler::MakeStaticPlanKey(document, source, backend_capability_version_);
+  if (auto it = plans_.find(key); it != plans_.end()) {
+    ++stats_.hits;
+    return it->second;
+  }
+  ++stats_.misses;
+  ++stats_.compiles;
+  auto plan = GraphCompiler::CompileStatic(document, source, backend_capability_version_);
+  plans_.emplace(key, plan);
+  return plan;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/scope/cuda_scope_analyzer.cu
+++ b/alcedo_studio/src/edit/scope/cuda_scope_analyzer.cu
@@ -6,12 +6,16 @@
 
 #include "edit/scope/scope_analyzer.hpp"
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <string>
+
+#include "utils/diagnostics/scope_diag.hpp"
 
 #include "edit/scope/detail/scope_cuda_shared.cuh"
 
@@ -192,6 +196,7 @@ class CudaScopeAnalyzerImpl final : public IScopeAnalyzer {
         frame.ready_signal.resource.get());
     if (!image_resource || !signal_resource || !image_resource->device_ptr ||
         !signal_resource->stream) {
+      diag::NoteScope("stage_skip missing_cuda_buffer_or_stream");
       return {};
     }
 
@@ -216,6 +221,7 @@ class CudaScopeAnalyzerImpl final : public IScopeAnalyzer {
     ReclaimCompletedSlots();
     ScopeSlot* slot = AcquireIdleSlot();
     if (!slot) {
+      diag::NoteScope("stage_skip no_idle_slot");
       return {};
     }
 
@@ -230,6 +236,7 @@ class CudaScopeAnalyzerImpl final : public IScopeAnalyzer {
         cudaMemcpyDeviceToDevice, signal_resource->stream);
     if (copy_status != cudaSuccess) {
       slot->phase = ScopeSlot::Phase::Idle;
+      diag::NoteScope(std::string("stage_skip memcpy=") + cudaGetErrorString(copy_status));
       return {};
     }
     cudaEventRecord(slot->input_ready->event, signal_resource->stream);
@@ -263,6 +270,7 @@ class CudaScopeAnalyzerImpl final : public IScopeAnalyzer {
         static_cast<scope::cuda_detail::CudaLinearImageResource*>(frame.image.resource.get());
     if (!event_resource || event_resource->slot_index < 0 || !image_resource ||
         !image_resource->device_ptr) {
+      diag::NoteScope("submit_skip missing_staged_event");
       return;
     }
 
@@ -320,6 +328,7 @@ class CudaScopeAnalyzerImpl final : public IScopeAnalyzer {
 
   auto GetLatestOutput() -> ScopeOutputSet override {
     std::lock_guard<std::mutex> lock(mutex_);
+    ReclaimCompletedSlots();
 
     ScopeSlot* latest_slot = nullptr;
     for (auto& slot : slots_) {
@@ -337,6 +346,7 @@ class CudaScopeAnalyzerImpl final : public IScopeAnalyzer {
     if (!latest_slot) {
       return {};
     }
+    consumed_generation_ = std::max(consumed_generation_, latest_slot->generation);
 
     ScopeOutputSet output;
     output.generation      = latest_slot->generation;
@@ -394,11 +404,19 @@ class CudaScopeAnalyzerImpl final : public IScopeAnalyzer {
 
  private:
   void ReclaimCompletedSlots() {
-    // Caller holds mutex_.
+    // Caller holds mutex_. Keep the newest completed Dispatched slot until
+    // GetLatestOutput has returned it. Reclaiming on complete used to idle the
+    // only live histogram buffer before the deferred poll could copy it, which
+    // left the editor stuck on "Reading display scope" during continuous presents.
     for (auto& slot : slots_) {
       slot.EnsureAnalysisDoneEvent();
-      if (slot.phase == ScopeSlot::Phase::Dispatched && slot.analysis_done &&
-          cudaEventQuery(slot.analysis_done) == cudaSuccess) {
+      if (slot.phase != ScopeSlot::Phase::Dispatched || !slot.analysis_done) {
+        continue;
+      }
+      if (cudaEventQuery(slot.analysis_done) != cudaSuccess) {
+        continue;
+      }
+      if (slot.generation < consumed_generation_) {
         slot.phase = ScopeSlot::Phase::Idle;
       }
     }
@@ -474,7 +492,8 @@ class CudaScopeAnalyzerImpl final : public IScopeAnalyzer {
   cudaStream_t                                  analysis_stream_ = nullptr;
   ScopeRequest                                  current_request_{};
   std::chrono::steady_clock::time_point         last_stage_time_{};
-  uint64_t                                      next_generation_ = 1;
+  uint64_t                                      next_generation_      = 1;
+  uint64_t                                      consumed_generation_  = 0;
   std::mutex                                    mutex_{};
 };
 

--- a/alcedo_studio/src/edit/scope/final_display_frame_tap.cpp
+++ b/alcedo_studio/src/edit/scope/final_display_frame_tap.cpp
@@ -4,7 +4,10 @@
 
 #include "edit/scope/final_display_frame_tap.hpp"
 
+#include <sstream>
 #include <utility>
+
+#include "utils/diagnostics/scope_diag.hpp"
 
 namespace alcedo {
 namespace {
@@ -229,7 +232,13 @@ void FinalDisplayFrameTapSink::SubmitFinalDisplayFrame(const FinalDisplayFrameVi
   // pipeline source (result_ptr / stream) is still valid. The deferred poll
   // later analyzes this staged frame instead of the pipeline's reused scratch.
   FinalDisplayFrameView staged_frame;
-  if (scope_analyzer_ && scope_update_allowed && stamped_frame) {
+  if (!scope_analyzer_) {
+    diag::NoteScope("present analyzer_missing");
+  } else if (!scope_update_allowed) {
+    diag::NoteScope("present skip scope_update_disallowed");
+  } else if (!stamped_frame) {
+    diag::NoteScope("present skip empty_display_frame");
+  } else {
     staged_frame = scope_analyzer_->StageFrame(stamped_frame, request);
   }
 
@@ -240,6 +249,17 @@ void FinalDisplayFrameTapSink::SubmitFinalDisplayFrame(const FinalDisplayFrameVi
     }
     // Staging only failed (no idle slot / throttle / non-owning backend): keep
     // the previous staged frame rather than the pipeline's reused source.
+  }
+
+  {
+    std::ostringstream line;
+    line << "present allowed=" << (scope_update_allowed ? 1 : 0) << " active=" << (active ? 1 : 0)
+         << " deferred=" << (deferred ? 1 : 0) << " staged=" << (staged_frame ? 1 : 0)
+         << " backend=" << static_cast<unsigned>(stamped_frame.image.backend)
+         << " size=" << stamped_frame.width << "x" << stamped_frame.height
+         << " identity=" << stamped_frame.image_identity << " epoch=" << stamped_frame.session_epoch
+         << " gen=" << stamped_frame.display_generation;
+    diag::NoteScope(line.str());
   }
 
   if (scope_analyzer_ && active && !deferred && scope_update_allowed) {

--- a/alcedo_studio/src/include/app/thumbnail_service.hpp
+++ b/alcedo_studio/src/include/app/thumbnail_service.hpp
@@ -79,9 +79,10 @@ class ThumbnailService {
                     bool pin_if_found = true, CallbackDispatcher dispatcher = nullptr,
                     ThumbnailResolution resolution = ThumbnailResolution::k1024);
 
-  // Request a thumbnail and receive a detailed result. This distinguishes
-  // cancellation from render/load failures, while GetThumbnail preserves the
-  // legacy guard/null callback contract.
+  // Request a thumbnail and receive a detailed result. Rendering uses an independent pipeline
+  // snapshot, so background filmstrip work never occupies the live editor executor. This
+  // distinguishes cancellation from render/load failures, while GetThumbnail preserves the
+  // legacy guard/null callback behavior.
   void GetThumbnailDetailed(sl_element_id_t id, image_id_t image_id,
                             ThumbnailResultCallback callback, bool pin_if_found = true,
                             CallbackDispatcher  dispatcher = nullptr,

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_dng_warp.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_dng_warp.hpp
@@ -11,6 +11,15 @@
 namespace alcedo {
 namespace CUDA {
 
+/**
+ * @brief Apply DNG OpcodeList3 WarpRectilinear from @p src into caller-owned @p dst.
+ *
+ * Images must have identical extent and CV_32FC3 or CV_32FC4 type. The function enqueues work on
+ * @p stream and does not allocate GPU storage. Throws for incompatible images or CUDA failure.
+ */
+void WarpDngRectilinear(const cv::cuda::GpuMat& src, cv::cuda::GpuMat& dst,
+                        const dng::WarpRectilinear& warp, cv::cuda::Stream* stream = nullptr);
+
 void ApplyDngWarpRectilinear(cv::cuda::GpuMat& img, const dng::WarpRectilinear& warp,
                              cv::cuda::Stream* stream = nullptr);
 

--- a/alcedo_studio/src/include/edit/geometry/resolved_render_geometry.hpp
+++ b/alcedo_studio/src/include/edit/geometry/resolved_render_geometry.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 
 #include "edit/geometry/types.hpp"
@@ -56,6 +57,32 @@ struct ResolvedRenderGeometry {
 [[nodiscard]] inline auto IsIdentityResample(const ResolvedRenderGeometry& geometry) -> bool {
   return geometry.decoded_extent == geometry.render_extent &&
          IsApproxIdentity(geometry.render_to_decoded);
+}
+
+/**
+ * @brief True when this render covers the whole EditSpace, not a viewport ROI.
+ *
+ * A full-view dynamic-resolution frame still returns true. A visible subrect returns
+ * false. LLF uses this to decide whether the frame can seed the canonical reference.
+ */
+[[nodiscard]] inline auto CoversFullEditSpace(const ResolvedRenderGeometry& geometry) -> bool {
+  if (geometry.edit_extent.Empty() || geometry.render_extent.Empty()) {
+    return false;
+  }
+  const float det = geometry.edit_to_render.m[0] * geometry.edit_to_render.m[4] -
+                    geometry.edit_to_render.m[1] * geometry.edit_to_render.m[3];
+  if (!std::isfinite(det) || std::fabs(det) < 1e-12f) {
+    return false;
+  }
+  const auto render_to_edit = InvertAffine(geometry.edit_to_render);
+  const auto top_left       = TransformPoint(render_to_edit, {0.0f, 0.0f});
+  const auto bottom_right   = TransformPoint(
+      render_to_edit, {static_cast<float>(geometry.render_extent.width),
+                       static_cast<float>(geometry.render_extent.height)});
+  constexpr float kPixel = 1.5f;
+  return top_left.x <= kPixel && top_left.y <= kPixel &&
+         bottom_right.x >= static_cast<float>(geometry.edit_extent.width) - kPixel &&
+         bottom_right.y >= static_cast<float>(geometry.edit_extent.height) - kPixel;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/develop_color_transform.hpp
+++ b/alcedo_studio/src/include/edit/graph/develop_color_transform.hpp
@@ -1,0 +1,80 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <array>
+#include <string_view>
+
+#include "decoders/processor/raw_color_context.hpp"
+#include "edit/graph/develop_node_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Camera→XYZ/AP1 matrices produced from stored Develop camera-profile params.
+ *
+ * Row-major 3×3, column vectors. CCT/tint interpolation uses ColorMatrix/ForwardMatrix
+ * fields bound at import. The interpolated camera→AP1 matrix is written into the GPU
+ * parameter body; this struct is not serialized.
+ */
+struct DevelopColorTransform {
+  std::array<float, 9> camera_to_xyz{};
+  std::array<float, 9> camera_to_xyz_d50{};
+  std::array<float, 9> xyz_d50_to_ap1{};
+  std::array<float, 9> camera_to_ap1{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+  float                resolved_cct  = 6500.0f;
+  float                resolved_tint = 0.0f;
+};
+
+enum class ColorTransformError {
+  Ok = 0,
+  MissingCameraMatrices,
+  SingularCameraMatrix,
+  NonFiniteMatrix,
+  InvalidAsShotNeutral,
+  InvalidWhitePoint,
+};
+
+/**
+ * @brief Result of @ref ResolveDevelopColorTransform.
+ *
+ * @c ok is true only when every matrix is finite and invertible. Failure never
+ * yields an identity camera→AP1 stand-in.
+ */
+struct ColorTransformResult {
+  bool                  ok     = false;
+  ColorTransformError   error  = ColorTransformError::MissingCameraMatrices;
+  DevelopColorTransform transform{};
+};
+
+/**
+ * @brief Copy import-time RAW camera matrices into Develop payload fields.
+ *
+ * Also solves as-shot CCT/tint from AsShotNeutral (or cam_mul fallback).
+ * `InjectRawMetadata` copies those values into ColorTempOp JSON so
+ * EditorColorTempModel can display them without parsing RAW again.
+ *
+ * @pre @p imported was populated at import by MetadataExtractor.
+ * Side effects: overwrites camera-profile fields and, on success, as-shot CCT/tint.
+ */
+void BindDevelopCameraProfile(DevelopPayload& payload, const RawRuntimeColorContext& imported);
+
+/**
+ * @brief Interpolate stored ColorMatrix/ForwardMatrix fields for the current CCT/tint.
+ *
+ * @pre @p develop.camera_profile.color_matrices_valid is true and both colour
+ *      matrices are finite and invertible. Does not read LibRaw, rgb_cam, cam_xyz,
+ *      or the CameraMatrices database.
+ * @return Success with camera→AP1, or a typed error. Missing or singular matrices
+ *         are errors, never identity.
+ * Thread: CPU, no shared mutable state. Call when the user changes CCT/tint or
+ *         when first filling the GPU parameter body.
+ */
+[[nodiscard]] auto ResolveDevelopColorTransform(const DevelopPayload& develop)
+    -> ColorTransformResult;
+
+[[nodiscard]] auto ColorTransformErrorMessage(ColorTransformError error) -> std::string_view;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/develop_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/develop_node_model.hpp
@@ -80,6 +80,25 @@ struct DevelopPayload {
   std::string lens_profile_db_path     = "src/config/lens_calib";
 };
 
+inline auto operator==(const DevelopPayload& a, const DevelopPayload& b) -> bool {
+  return a.demosaic_method == b.demosaic_method &&
+         a.highlights_reconstruct == b.highlights_reconstruct &&
+         a.use_camera_wb == b.use_camera_wb && a.user_wb == b.user_wb && a.wb_mode == b.wb_mode &&
+         a.custom_cct == b.custom_cct && a.custom_tint == b.custom_tint &&
+         a.as_shot_cct == b.as_shot_cct && a.as_shot_tint == b.as_shot_tint &&
+         a.camera_profile == b.camera_profile && a.lens_enabled == b.lens_enabled &&
+         a.apply_vignetting == b.apply_vignetting && a.apply_distortion == b.apply_distortion &&
+         a.apply_tca == b.apply_tca && a.apply_crop == b.apply_crop &&
+         a.auto_scale == b.auto_scale && a.use_user_scale == b.use_user_scale &&
+         a.user_scale == b.user_scale && a.projection_enabled == b.projection_enabled &&
+         a.target_projection == b.target_projection &&
+         a.lens_profile_db_path == b.lens_profile_db_path;
+}
+
+inline auto operator!=(const DevelopPayload& a, const DevelopPayload& b) -> bool {
+  return !(a == b);
+}
+
 enum class DevelopDirty : std::uint32_t {
   None        = 0,
   Demosaic    = 1U << 0,

--- a/alcedo_studio/src/include/edit/graph/develop_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/develop_node_model.hpp
@@ -17,6 +17,45 @@
 
 namespace alcedo {
 
+/**
+ * @brief Import-time camera colour matrices stored on the Develop node.
+ *
+ * ColorMatrix/ForwardMatrix/AsShotNeutral/illuminant CCT are copied from the
+ * image at import. CameraColor interpolates these fields; it does not parse RAW
+ * or look up the CameraMatrices database at render time. cam_mul is only used
+ * to derive as-shot neutral when AsShotNeutral is absent.
+ */
+struct DevelopCameraProfile {
+  bool                  color_matrices_valid = false;
+  std::array<double, 9> color_matrix_1{};
+  std::array<double, 9> color_matrix_2{};
+  bool                  forward_matrices_valid = false;
+  std::array<double, 9> forward_matrix_1{};
+  std::array<double, 9> forward_matrix_2{};
+  bool                  as_shot_neutral_valid = false;
+  std::array<double, 3> as_shot_neutral{};
+  bool                  calibration_illuminants_valid = false;
+  double                color_matrix_1_cct            = 2856.0;
+  double                color_matrix_2_cct            = 6504.0;
+  std::array<float, 3>  cam_mul{1.0f, 1.0f, 1.0f};
+};
+
+inline auto operator==(const DevelopCameraProfile& a, const DevelopCameraProfile& b) -> bool {
+  return a.color_matrices_valid == b.color_matrices_valid && a.color_matrix_1 == b.color_matrix_1 &&
+         a.color_matrix_2 == b.color_matrix_2 &&
+         a.forward_matrices_valid == b.forward_matrices_valid &&
+         a.forward_matrix_1 == b.forward_matrix_1 && a.forward_matrix_2 == b.forward_matrix_2 &&
+         a.as_shot_neutral_valid == b.as_shot_neutral_valid &&
+         a.as_shot_neutral == b.as_shot_neutral &&
+         a.calibration_illuminants_valid == b.calibration_illuminants_valid &&
+         a.color_matrix_1_cct == b.color_matrix_1_cct &&
+         a.color_matrix_2_cct == b.color_matrix_2_cct && a.cam_mul == b.cam_mul;
+}
+
+inline auto operator!=(const DevelopCameraProfile& a, const DevelopCameraProfile& b) -> bool {
+  return !(a == b);
+}
+
 struct DevelopPayload {
   std::string demosaic_method          = "default";
   bool        highlights_reconstruct   = true;
@@ -27,6 +66,7 @@ struct DevelopPayload {
   float       custom_tint              = 0.0f;
   float       as_shot_cct              = 6500.0f;
   float       as_shot_tint             = 0.0f;
+  DevelopCameraProfile camera_profile{};
   bool        lens_enabled             = false;
   bool        apply_vignetting         = true;
   bool        apply_distortion         = true;

--- a/alcedo_studio/src/include/edit/graph/legacy_pipeline_importer.hpp
+++ b/alcedo_studio/src/include/edit/graph/legacy_pipeline_importer.hpp
@@ -30,6 +30,17 @@ class LegacyPipelineImporter {
    * @return Document on success; error string and empty document on failure.
    */
   [[nodiscard]] static auto Import(const nlohmann::json& stage_json) -> LegacyImportResult;
+
+  /**
+   * @brief Write imported operator values onto an existing document without replacing the graph.
+   *
+   * Keeps extra nodes (masks), camera-profile fields the JSON does not own, and topology.
+   * Missing operators in @p stage_json are left unchanged. Unknown types fail before mutation.
+   *
+   * @return Empty string on success; error text and an unmodified graph on failure.
+   */
+  [[nodiscard]] static auto ApplyOnto(PipelineDocument&     document,
+                                      const nlohmann::json& stage_json) -> std::string;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
@@ -65,33 +65,10 @@ class PipelineDocument {
 [[nodiscard]] auto CreateDefaultPipelineDocument() -> PipelineDocument;
 
 /**
- * @brief Temporary product probe. Set false to stop attaching the oval mask on load.
- *
- * Does not change CreateDefaultPipelineDocument. Product load remirrors the legacy
- * stage adapter onto the live graph in place, then re-attaches this oval so editor
- * sliders reach Primary Color Grade while the mask stays connected.
- */
-inline constexpr bool kTemporaryPrimaryGradeOvalMask = true;
-
-/**
- * @brief Attach a centered radial oval to Primary Color Grade.
- *
- * Idempotent. Adds node id `mask.ui_test.radial` when missing and connects its mask output
- * to `grade.primary.mask`. Sets Exposure to +1 EV only when it is still at the default 0
- * so a later legacy remirror can keep slider values. Does not replace
- * @ref CreateDefaultPipelineDocument.
- *
- * @param document Graph that already contains `grade.primary`.
- * @pre `document.PrimaryGrade()` is non-null and contains an Exposure adjustment.
- * @throws std::invalid_argument if the primary grade or Exposure model is missing.
- */
-void AttachTemporaryPrimaryGradeOvalMask(PipelineDocument& document);
-
-/**
  * @brief True when Apply may remirror the legacy stage adapter into this document.
  *
- * The default three-node graph qualifies. The temporary oval-mask probe (exactly one extra
- * `mask.ui_test.radial` node) also qualifies so UI sliders keep reaching Primary Color Grade.
+ * Requires the canonical Develop, Primary Color Grade, and DRT nodes. Extra nodes such as
+ * a mask stay in place because remirror writes operator values onto the existing graph.
  */
 [[nodiscard]] auto AllowsLegacyStageAdapterRemirror(const PipelineDocument& document) -> bool;
 

--- a/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
@@ -64,4 +64,35 @@ class PipelineDocument {
  */
 [[nodiscard]] auto CreateDefaultPipelineDocument() -> PipelineDocument;
 
+/**
+ * @brief Temporary product probe. Set false to stop attaching the oval mask on load.
+ *
+ * Does not change CreateDefaultPipelineDocument. Product load remirrors the legacy
+ * stage adapter onto the live graph in place, then re-attaches this oval so editor
+ * sliders reach Primary Color Grade while the mask stays connected.
+ */
+inline constexpr bool kTemporaryPrimaryGradeOvalMask = true;
+
+/**
+ * @brief Attach a centered radial oval to Primary Color Grade.
+ *
+ * Idempotent. Adds node id `mask.ui_test.radial` when missing and connects its mask output
+ * to `grade.primary.mask`. Sets Exposure to +1 EV only when it is still at the default 0
+ * so a later legacy remirror can keep slider values. Does not replace
+ * @ref CreateDefaultPipelineDocument.
+ *
+ * @param document Graph that already contains `grade.primary`.
+ * @pre `document.PrimaryGrade()` is non-null and contains an Exposure adjustment.
+ * @throws std::invalid_argument if the primary grade or Exposure model is missing.
+ */
+void AttachTemporaryPrimaryGradeOvalMask(PipelineDocument& document);
+
+/**
+ * @brief True when Apply may remirror the legacy stage adapter into this document.
+ *
+ * The default three-node graph qualifies. The temporary oval-mask probe (exactly one extra
+ * `mask.ui_test.radial` node) also qualifies so UI sliders keep reaching Primary Color Grade.
+ */
+[[nodiscard]] auto AllowsLegacyStageAdapterRemirror(const PipelineDocument& document) -> bool;
+
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/input/prepared_raw_input.hpp
+++ b/alcedo_studio/src/include/edit/input/prepared_raw_input.hpp
@@ -6,8 +6,10 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <span>
 
+#include "decoders/dng_default_crop.hpp"
 #include "decoders/processor/raw_color_context.hpp"
 #include "decoders/processor/raw_linearization_params.hpp"
 #include "decoders/processor/raw_processor_pattern.hpp"
@@ -17,12 +19,12 @@
 namespace alcedo {
 
 /// Bumped when LibRaw unpack, CFA downsample, or active-area mapping rules change.
-inline constexpr std::uint32_t kRawInputPreparationVersion = 1;
+inline constexpr std::uint32_t kRawInputPreparationVersion = 2;
 
 /**
  * @brief FNV-1a 64-bit hash of opaque bytes. Used for encoded-source identity, not pixels.
  */
-[[nodiscard]] inline auto HashContentBytes(std::span<const std::byte> bytes) -> std::uint64_t {
+[[nodiscard]] inline auto      HashContentBytes(std::span<const std::byte> bytes) -> std::uint64_t {
   std::uint64_t hash = 14695981039346656037ull;
   for (const auto byte : bytes) {
     hash ^= static_cast<std::uint8_t>(byte);
@@ -49,7 +51,7 @@ struct HostImagePlane {
   std::uint32_t                    stride_bytes = 0;
   HostPixelFormat                  format       = HostPixelFormat::U16Cfa;
 
-  [[nodiscard]] auto ByteCount() const -> std::size_t {
+  [[nodiscard]] auto               ByteCount() const -> std::size_t {
     return static_cast<std::size_t>(stride_bytes) * extent.height;
   }
 
@@ -65,13 +67,13 @@ struct HostImagePlane {
  * @brief LibRaw size fields needed to crop after demosaic. No LibRaw type.
  */
 struct RawSensorGeometry {
-  std::int32_t  raw_width      = 0;
-  std::int32_t  raw_height     = 0;
-  std::int32_t  width          = 0;
-  std::int32_t  height         = 0;
-  std::int32_t  left_margin    = 0;
-  std::int32_t  top_margin     = 0;
-  std::uint16_t default_crop[4] = {};
+  std::int32_t  raw_width        = 0;
+  std::int32_t  raw_height       = 0;
+  std::int32_t  width            = 0;
+  std::int32_t  height           = 0;
+  std::int32_t  left_margin      = 0;
+  std::int32_t  top_margin       = 0;
+  std::uint16_t default_crop[4]  = {};
   std::int32_t  orientation_flip = 0;
 };
 
@@ -82,10 +84,10 @@ struct RawSensorGeometry {
  * downsample policy reuse one host result.
  */
 struct PreparedSourceLookup {
-  std::uint64_t encoded_content_hash  = 0;
-  std::uint64_t encoded_byte_count    = 0;
-  std::uint8_t  downsample_passes     = 0;
-  std::uint32_t preparation_version   = kRawInputPreparationVersion;
+  std::uint64_t encoded_content_hash = 0;
+  std::uint64_t encoded_byte_count   = 0;
+  std::uint8_t  downsample_passes    = 0;
+  std::uint32_t preparation_version  = kRawInputPreparationVersion;
 };
 
 inline auto operator==(const PreparedSourceLookup& a, const PreparedSourceLookup& b) -> bool {
@@ -112,14 +114,15 @@ inline auto operator<(const PreparedSourceLookup& a, const PreparedSourceLookup&
  * @brief Content identity of a prepared host source. Viewport ROI is not included.
  */
 struct PreparedSourceKey {
-  std::uint64_t encoded_content_hash = 0;
-  std::uint64_t encoded_byte_count   = 0;
-  RawInputKind  input_kind           = RawInputKind::BayerRaw;
-  std::uint64_t cfa_hash             = 0;
-  std::uint8_t  downsample_passes    = 0;
-  RectI         sensor_active_area{};
-  std::int32_t  orientation_flip     = 0;
-  std::uint32_t preparation_version  = kRawInputPreparationVersion;
+  std::uint64_t      encoded_content_hash = 0;
+  std::uint64_t      encoded_byte_count   = 0;
+  RawInputKind       input_kind           = RawInputKind::BayerRaw;
+  std::uint64_t      cfa_hash             = 0;
+  std::uint64_t      dng_warp_hash        = 0;
+  std::uint8_t       downsample_passes    = 0;
+  RectI              sensor_active_area{};
+  std::int32_t       orientation_flip    = 0;
+  std::uint32_t      preparation_version = kRawInputPreparationVersion;
 
   [[nodiscard]] auto Lookup() const -> PreparedSourceLookup {
     return PreparedSourceLookup{encoded_content_hash, encoded_byte_count, downsample_passes,
@@ -130,9 +133,9 @@ struct PreparedSourceKey {
 inline auto operator==(const PreparedSourceKey& a, const PreparedSourceKey& b) -> bool {
   return a.encoded_content_hash == b.encoded_content_hash &&
          a.encoded_byte_count == b.encoded_byte_count && a.input_kind == b.input_kind &&
-         a.cfa_hash == b.cfa_hash && a.downsample_passes == b.downsample_passes &&
-         a.sensor_active_area == b.sensor_active_area &&
-         a.orientation_flip == b.orientation_flip &&
+         a.cfa_hash == b.cfa_hash && a.dng_warp_hash == b.dng_warp_hash &&
+         a.downsample_passes == b.downsample_passes &&
+         a.sensor_active_area == b.sensor_active_area && a.orientation_flip == b.orientation_flip &&
          a.preparation_version == b.preparation_version;
 }
 
@@ -142,23 +145,24 @@ inline auto operator==(const PreparedSourceKey& a, const PreparedSourceKey& b) -
  * Output of Develop is camera scene-linear RGB. Camera-to-AP1 is a later node.
  */
 struct PreparedRawInput {
-  HostImagePlane           pixels;
-  Extent2D                 host_extent{};
-  Extent2D                 develop_output_extent{};
-  Extent2D                 full_reference_extent{};
-  RectI                    sensor_active_area{};
-  RectI                    demosaic_output_crop{};
-  std::uint8_t             downsample_passes = 0;
-  RawInputKind             input_kind        = RawInputKind::BayerRaw;
-  RawCfaPattern            cfa_pattern{};
-  RawLinearizationParams   linearization{};
-  RawSensorGeometry        sensor{};
-  RawRuntimeColorContext   color_context{};
-  SourceContentKey         content_key{};
-  PreparedSourceKey        source_key{};
-  SceneWorkingSpace        working_space = SceneWorkingSpace::CameraRgb;
+  HostImagePlane                      pixels;
+  Extent2D                            host_extent{};
+  Extent2D                            develop_output_extent{};
+  Extent2D                            full_reference_extent{};
+  RectI                               sensor_active_area{};
+  RectI                               demosaic_output_crop{};
+  std::uint8_t                        downsample_passes = 0;
+  RawInputKind                        input_kind        = RawInputKind::BayerRaw;
+  RawCfaPattern                       cfa_pattern{};
+  RawLinearizationParams              linearization{};
+  RawSensorGeometry                   sensor{};
+  RawRuntimeColorContext              color_context{};
+  std::optional<dng::WarpRectilinear> dng_warp_rectilinear;
+  SourceContentKey                    content_key{};
+  PreparedSourceKey                   source_key{};
+  SceneWorkingSpace                   working_space = SceneWorkingSpace::CameraRgb;
 
-  [[nodiscard]] auto CompileSource() const -> DevelopCompileSource;
+  [[nodiscard]] auto                  CompileSource() const -> DevelopCompileSource;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/input/prepared_raw_input.hpp
+++ b/alcedo_studio/src/include/edit/input/prepared_raw_input.hpp
@@ -16,6 +16,21 @@
 
 namespace alcedo {
 
+/// Bumped when LibRaw unpack, CFA downsample, or active-area mapping rules change.
+inline constexpr std::uint32_t kRawInputPreparationVersion = 1;
+
+/**
+ * @brief FNV-1a 64-bit hash of opaque bytes. Used for encoded-source identity, not pixels.
+ */
+[[nodiscard]] inline auto HashContentBytes(std::span<const std::byte> bytes) -> std::uint64_t {
+  std::uint64_t hash = 14695981039346656037ull;
+  for (const auto byte : bytes) {
+    hash ^= static_cast<std::uint8_t>(byte);
+    hash *= 1099511628211ull;
+  }
+  return hash;
+}
+
 enum class HostPixelFormat : std::uint8_t {
   U16Cfa  = 0,
   F32Rgba = 1,
@@ -61,6 +76,67 @@ struct RawSensorGeometry {
 };
 
 /**
+ * @brief Pre-unpack lookup for PreparedSourceCache. Quality is not part of this identity.
+ *
+ * DecodeRes is stored as downsample pass count so preview/export frames that share the same
+ * downsample policy reuse one host result.
+ */
+struct PreparedSourceLookup {
+  std::uint64_t encoded_content_hash  = 0;
+  std::uint64_t encoded_byte_count    = 0;
+  std::uint8_t  downsample_passes     = 0;
+  std::uint32_t preparation_version   = kRawInputPreparationVersion;
+};
+
+inline auto operator==(const PreparedSourceLookup& a, const PreparedSourceLookup& b) -> bool {
+  return a.encoded_content_hash == b.encoded_content_hash &&
+         a.encoded_byte_count == b.encoded_byte_count &&
+         a.downsample_passes == b.downsample_passes &&
+         a.preparation_version == b.preparation_version;
+}
+
+inline auto operator<(const PreparedSourceLookup& a, const PreparedSourceLookup& b) -> bool {
+  if (a.encoded_content_hash != b.encoded_content_hash) {
+    return a.encoded_content_hash < b.encoded_content_hash;
+  }
+  if (a.encoded_byte_count != b.encoded_byte_count) {
+    return a.encoded_byte_count < b.encoded_byte_count;
+  }
+  if (a.downsample_passes != b.downsample_passes) {
+    return a.downsample_passes < b.downsample_passes;
+  }
+  return a.preparation_version < b.preparation_version;
+}
+
+/**
+ * @brief Content identity of a prepared host source. Viewport ROI is not included.
+ */
+struct PreparedSourceKey {
+  std::uint64_t encoded_content_hash = 0;
+  std::uint64_t encoded_byte_count   = 0;
+  RawInputKind  input_kind           = RawInputKind::BayerRaw;
+  std::uint64_t cfa_hash             = 0;
+  std::uint8_t  downsample_passes    = 0;
+  RectI         sensor_active_area{};
+  std::int32_t  orientation_flip     = 0;
+  std::uint32_t preparation_version  = kRawInputPreparationVersion;
+
+  [[nodiscard]] auto Lookup() const -> PreparedSourceLookup {
+    return PreparedSourceLookup{encoded_content_hash, encoded_byte_count, downsample_passes,
+                                preparation_version};
+  }
+};
+
+inline auto operator==(const PreparedSourceKey& a, const PreparedSourceKey& b) -> bool {
+  return a.encoded_content_hash == b.encoded_content_hash &&
+         a.encoded_byte_count == b.encoded_byte_count && a.input_kind == b.input_kind &&
+         a.cfa_hash == b.cfa_hash && a.downsample_passes == b.downsample_passes &&
+         a.sensor_active_area == b.sensor_active_area &&
+         a.orientation_flip == b.orientation_flip &&
+         a.preparation_version == b.preparation_version;
+}
+
+/**
  * @brief CPU-side develop input. GPU work starts at upload.
  *
  * Output of Develop is camera scene-linear RGB. Camera-to-AP1 is a later node.
@@ -79,6 +155,7 @@ struct PreparedRawInput {
   RawSensorGeometry        sensor{};
   RawRuntimeColorContext   color_context{};
   SourceContentKey         content_key{};
+  PreparedSourceKey        source_key{};
   SceneWorkingSpace        working_space = SceneWorkingSpace::CameraRgb;
 
   [[nodiscard]] auto CompileSource() const -> DevelopCompileSource;

--- a/alcedo_studio/src/include/edit/input/prepared_source_cache.hpp
+++ b/alcedo_studio/src/include/edit/input/prepared_source_cache.hpp
@@ -89,6 +89,14 @@ class PreparedSourceCache {
   [[nodiscard]] auto GetStats() const -> Stats { return stats_; }
   void               ResetStats() { stats_ = {}; }
 
+  /**
+   * @brief Drop every host prepared-source entry, including leased ones.
+   *
+   * Call after WaitIdle when returning a pipeline session. Live Lease objects
+   * then see an empty cache on next use.
+   */
+  void Clear();
+
  private:
   struct Entry {
     PreparedSourceKey                       key{};

--- a/alcedo_studio/src/include/edit/input/prepared_source_cache.hpp
+++ b/alcedo_studio/src/include/edit/input/prepared_source_cache.hpp
@@ -1,0 +1,116 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <span>
+
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "type/type.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Host cache of unpacked RAW (or synthetic) develop inputs keyed by content.
+ *
+ * Preview and export quality share an entry when encoded bytes, DecodeRes, and the
+ * preparation version match. A leased entry is never replaced when DecodeRes changes;
+ * the new policy is inserted under a new key. Not thread-safe.
+ */
+class PreparedSourceCache {
+  struct Entry;
+
+ public:
+  /**
+   * @brief CPU unpack replacement used on a cache miss.
+   *
+   * Production uses LibRaw open/unpack. Tests may inject a counting function.
+   * The cache overwrites encoded-hash identity on the returned input.
+   */
+  using UnpackFn = std::function<PreparedRawInput(std::span<const std::byte>, DecodeRes)>;
+
+  struct Stats {
+    std::uint64_t hits                   = 0;
+    std::uint64_t misses                 = 0;
+    std::uint64_t libraw_open_unpack_count = 0;
+  };
+
+  class Lease {
+   public:
+    Lease() = default;
+    Lease(const Lease& other);
+    auto operator=(const Lease& other) -> Lease&;
+    Lease(Lease&& other) noexcept;
+    auto operator=(Lease&& other) noexcept -> Lease&;
+    ~Lease();
+
+    [[nodiscard]] explicit operator bool() const { return static_cast<bool>(entry_); }
+    [[nodiscard]] auto     Get() const -> const PreparedRawInput&;
+    [[nodiscard]] auto     Key() const -> const PreparedSourceKey&;
+    [[nodiscard]] auto     Shared() const -> std::shared_ptr<const PreparedRawInput>;
+
+   private:
+    friend class PreparedSourceCache;
+    std::shared_ptr<Entry> entry_;
+  };
+
+  PreparedSourceCache();
+  explicit PreparedSourceCache(UnpackFn unpack);
+
+  /**
+   * @brief Return a leased host result for @p encoded and @p decode_res.
+   *
+   * Hashes encoded bytes, looks up by that hash plus downsample policy, and unpacks only
+   * on a miss. Quality is not an argument; callers share this result across preview/export.
+   *
+   * @pre @p encoded may be empty only for a miss that the unpacker accepts.
+   * @throws whatever the unpacker throws on a miss.
+   */
+  [[nodiscard]] auto AcquireEncoded(std::span<const std::byte> encoded, DecodeRes decode_res)
+      -> Lease;
+
+  /**
+   * @brief Host byte budget for unleased entries. Zero means unlimited.
+   *
+   * Insertion of a leased miss never fails because the budget is full. Unleased entries
+   * are evicted first, in least-recently-used order.
+   */
+  void               SetHostByteBudget(std::size_t bytes);
+  [[nodiscard]] auto HostByteBudget() const -> std::size_t { return byte_budget_; }
+  [[nodiscard]] auto HostBytesUsed() const -> std::size_t { return bytes_used_; }
+  [[nodiscard]] auto EntryCount() const -> std::size_t { return entries_.size(); }
+  [[nodiscard]] auto GetStats() const -> Stats { return stats_; }
+  void               ResetStats() { stats_ = {}; }
+
+ private:
+  struct Entry {
+    PreparedSourceKey                       key{};
+    PreparedSourceLookup                    lookup{};
+    std::shared_ptr<const PreparedRawInput> input;
+    std::size_t                             bytes     = 0;
+    std::uint64_t                           last_used = 0;
+  };
+
+  auto HashEncoded(std::span<const std::byte> encoded) -> std::uint64_t;
+  void EvictUnleasedToFit(std::size_t extra_bytes);
+  auto MakeLease(std::shared_ptr<Entry> entry) -> Lease;
+
+  UnpackFn                                        unpack_;
+  std::map<PreparedSourceLookup, std::shared_ptr<Entry>> entries_;
+  std::size_t                                     byte_budget_ = 512ull * 1024ull * 1024ull;
+  std::size_t                                     bytes_used_  = 0;
+  std::uint64_t                                   use_clock_   = 1;
+  Stats                                           stats_{};
+  const std::byte*                                memo_ptr_    = nullptr;
+  std::size_t                                     memo_size_   = 0;
+  std::uint64_t                                   memo_hash_   = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/operators/GPU_kernels/color_mgmt/odt_funcs.cuh
+++ b/alcedo_studio/src/include/edit/operators/GPU_kernels/color_mgmt/odt_funcs.cuh
@@ -618,12 +618,9 @@ GPU_FUNC float3 OutputTransform_fwd(const float3& in_color, GPU_ODTParams& p) {
   if (!isfinite_f(in_color.x) || !isfinite_f(in_color.y) || !isfinite_f(in_color.z)) {
     return make_float3(0.f, 0.f, 0.f);
   }
-  // float3 color          = make_float3(in_color.x, in_color.y, in_color.z);
-  // float3 color          = mult_f3_f33(in_color, AP1_TO_AP0);
-  // float3 in_AP1 = clamp_f3(in_color, 0.f, 1.f);
-  float3 AP0_clamped    = clamp_AP1(in_color, 0.0f, p.ts_.forward_limit_);
+  float3 AP0 = mult_f3_f33(in_color, AP1_TO_AP0);
 
-  float3 JMh            = RGB_to_JMh(AP0_clamped, p.input_params_);
+  float3 JMh            = RGB_to_JMh(AP0, p.input_params_);
   float3 tonemapped_JMh = tonemap_and_compress_fwd(JMh, p);
   float3 compressed_JMh = gamut_compress_fwd(tonemapped_JMh, p);
   float3 out_rgb = JMh_to_RGB(compressed_JMh, p.limit_params_);

--- a/alcedo_studio/src/include/edit/operators/models/json_read.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/json_read.hpp
@@ -17,6 +17,53 @@ inline auto ReadFloat(const nlohmann::json& json, const char* key, float fallbac
   return json[key].get<float>();
 }
 
+inline auto ReadDouble(const nlohmann::json& json, const char* key, double fallback) -> double {
+  if (!json.contains(key) || !json[key].is_number()) {
+    return fallback;
+  }
+  return json[key].get<double>();
+}
+
+inline void ReadNumberArray(const nlohmann::json& json, const char* key, double* dest, int count) {
+  if (dest == nullptr || count <= 0 || !json.contains(key) || !json[key].is_array()) {
+    return;
+  }
+  const auto& values = json[key];
+  for (int i = 0; i < count && i < static_cast<int>(values.size()); ++i) {
+    if (values[i].is_number()) {
+      dest[i] = values[i].get<double>();
+    }
+  }
+}
+
+inline void ReadNumberArray(const nlohmann::json& json, const char* key, float* dest, int count) {
+  if (dest == nullptr || count <= 0 || !json.contains(key) || !json[key].is_array()) {
+    return;
+  }
+  const auto& values = json[key];
+  for (int i = 0; i < count && i < static_cast<int>(values.size()); ++i) {
+    if (values[i].is_number()) {
+      dest[i] = values[i].get<float>();
+    }
+  }
+}
+
+inline auto MakeJsonArray(const double* values, int count) -> nlohmann::json {
+  nlohmann::json array = nlohmann::json::array();
+  for (int i = 0; i < count; ++i) {
+    array.push_back(values[i]);
+  }
+  return array;
+}
+
+inline auto MakeJsonArray(const float* values, int count) -> nlohmann::json {
+  nlohmann::json array = nlohmann::json::array();
+  for (int i = 0; i < count; ++i) {
+    array.push_back(values[i]);
+  }
+  return array;
+}
+
 inline auto ReadBool(const nlohmann::json& json, const char* key, bool fallback) -> bool {
   if (!json.contains(key) || !json[key].is_boolean()) {
     return fallback;

--- a/alcedo_studio/src/include/edit/operators/models/scalar_operator_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/scalar_operator_model.hpp
@@ -43,6 +43,9 @@ class ScalarOperatorModel final
    */
   void SetValue(float value) {
     const float clamped = std::clamp(value, Traits::kMin, Traits::kMax);
+    if (Value() == clamped) {
+      return;
+    }
     this->Mutate(Dirty::Value, [clamped](Payload& payload) { payload.value = clamped; });
   }
 

--- a/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
@@ -19,8 +19,11 @@
 #include "type/type.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 
+#ifdef HAVE_CUDA
+#include "edit/graph/pipeline_document.hpp"
+#endif
+
 namespace alcedo {
-class PipelineDocument;
 #ifdef HAVE_CUDA
 class CudaProductRenderer;
 #endif
@@ -37,6 +40,7 @@ class CPUPipelineExecutor : public PipelineExecutor {
   std::mutex                                                                  render_lock_;
 
   OperatorParams                                                              global_params_;
+  std::optional<RawRuntimeColorContext>                                       injected_raw_color_context_;
 
   bool                                                                        is_thumbnail_ = false;
 

--- a/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
@@ -40,24 +40,25 @@ class CPUPipelineExecutor : public PipelineExecutor {
   std::mutex                                                                  render_lock_;
 
   OperatorParams                                                              global_params_;
-  std::optional<RawRuntimeColorContext>                                       injected_raw_color_context_;
+  std::optional<RawRuntimeColorContext> injected_raw_color_context_;
 
-  bool                                                                        is_thumbnail_ = false;
+  bool                                  is_thumbnail_     = false;
 
-  bool                             force_cpu_output_                                        = false;
-  DecodeRes                        decode_res_ = DecodeRes::FULL;
-  std::function<bool()>            cancel_requested_;
-  AcceleratorBackendPreference     accelerator_preference_ = AcceleratorBackendPreference::Auto;
-  GpuBackendKind                   resolved_accelerator_backend_ = GpuBackendKind::None;
+  bool                                  force_cpu_output_ = false;
+  DecodeRes                             decode_res_       = DecodeRes::FULL;
+  std::function<bool()>                 cancel_requested_;
+  AcceleratorBackendPreference        accelerator_preference_ = AcceleratorBackendPreference::Auto;
+  GpuBackendKind                      resolved_accelerator_backend_ = GpuBackendKind::None;
 
-  nlohmann::json                   render_params_                = {};
+  nlohmann::json                      render_params_                = {};
+  std::optional<ViewportRenderRegion> render_request_viewport_      = std::nullopt;
 
-  static constexpr PipelineBackend backend_                      = PipelineBackend::CPU;
+  static constexpr PipelineBackend    backend_                      = PipelineBackend::CPU;
 
-  std::vector<PipelineStage*>      exec_stages_;
-  std::unique_ptr<PipelineStage>   merged_stages_;
-  IFrameSink*                      frame_sink_ = nullptr;
-  FrameCompletionSubmission        bound_frame_submission_{};
+  std::vector<PipelineStage*>         exec_stages_;
+  std::unique_ptr<PipelineStage>      merged_stages_;
+  IFrameSink*                         frame_sink_ = nullptr;
+  FrameCompletionSubmission           bound_frame_submission_{};
 #ifdef HAVE_CUDA
   std::shared_ptr<PipelineDocument>    pipeline_document_;
   std::shared_ptr<CudaProductRenderer> cuda_product_renderer_;
@@ -121,6 +122,11 @@ class CPUPipelineExecutor : public PipelineExecutor {
   auto GetFrameSink() const -> IFrameSink* { return frame_sink_; }
 
   auto GetViewportRenderRegion() const -> std::optional<ViewportRenderRegion>;
+  /// Freeze the viewport geometry carried by the current render request.
+  /// A null value explicitly means full-frame rendering; Apply never re-reads live UI state.
+  void SetRenderRequestViewport(std::optional<ViewportRenderRegion> viewport) {
+    render_request_viewport_ = std::move(viewport);
+  }
   void BindFrameSubmission(const FramePreviewMetadata& metadata, FramePresentationMode mode);
   [[nodiscard]] auto BoundFrameSubmission() const -> FrameCompletionSubmission;
 
@@ -149,10 +155,11 @@ class CPUPipelineExecutor : public PipelineExecutor {
 
   /// Snapshot of one-shot render parameters that must not leak across Apply calls.
   struct OneShotRenderParamsSnapshot {
-    DecodeRes      decode_res_       = DecodeRes::FULL;
-    nlohmann::json render_params_    = {};
-    bool           force_cpu_output_ = false;
-    bool           enable_cache_     = true;
+    DecodeRes                           decode_res_              = DecodeRes::FULL;
+    nlohmann::json                      render_params_           = {};
+    bool                                force_cpu_output_        = false;
+    bool                                enable_cache_            = true;
+    std::optional<ViewportRenderRegion> render_request_viewport_ = std::nullopt;
   };
 
   [[nodiscard]] auto CaptureOneShotRenderParams() const -> OneShotRenderParamsSnapshot;
@@ -200,5 +207,11 @@ class CPUPipelineExecutor : public PipelineExecutor {
   /// cache. Used by tests to assert re-attaching a frame sink does not wipe
   /// the cross-frame LLF mask cache (the 42ed19b CanReuseReferenceForRoi path).
   [[nodiscard]] auto DebugGetMergedStageIdentity() const -> std::uintptr_t;
+
+#ifdef HAVE_CUDA
+  [[nodiscard]] auto DebugCudaProductRenderer() -> CudaProductRenderer* {
+    return cuda_product_renderer_.get();
+  }
+#endif
 };
 };  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -51,14 +51,23 @@ class BasicRenderWorkspace {
   [[nodiscard]] auto Images() const -> const GraphImageCache<Backend>& { return images_; }
 
   /**
-   * @brief Wait the previous submission, rewind transients, start a new submission id.
+   * @brief Allocate an unpublished write texture for @p id. See GraphImageCache.
+   */
+  auto AcquireImageForWrite(const GraphValueId& id, const TextureRequest& request)
+      -> ResourceLease<Backend>& {
+    return images_.AcquireTextureForWrite(textures_, backend_, id, request);
+  }
+
+  /**
+   * @brief Wait the previous submission, drop leftover unpublished writes, start a new id.
    * @throws std::runtime_error if called re-entrantly.
    */
-  void               BeginRender(CommandContext& command_context) {
+  void BeginRender(CommandContext& command_context) {
     if (rendering_) {
       throw std::runtime_error("BasicRenderWorkspace::BeginRender: already rendering");
     }
     backend_.Wait(command_context);
+    images_.DiscardUnpublished();
     transients_.Reset();
     textures_.BeginFrame();
     mask_textures_.BeginFrame();
@@ -81,8 +90,13 @@ class BasicRenderWorkspace {
 
   [[nodiscard]] auto IsRendering() const -> bool { return rendering_; }
 
-  /** @brief Leave a failed encode without submitting its incomplete command stream. */
-  void               CancelRender() { rendering_ = false; }
+  /**
+   * @brief Leave a failed encode without submitting. Unpublished writes are discarded.
+   */
+  void CancelRender() {
+    images_.DiscardUnpublished();
+    rendering_ = false;
+  }
 
  private:
   Backend                       backend_{};

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -45,6 +45,7 @@ class BasicRenderWorkspace {
   [[nodiscard]] auto Parameters() -> ParameterArena<Backend>& { return parameters_; }
   [[nodiscard]] auto TransientBuffers() -> TransientBufferArena<Backend>& { return transients_; }
   [[nodiscard]] auto Textures() -> TexturePool<Backend>& { return textures_; }
+  [[nodiscard]] auto Textures() const -> const TexturePool<Backend>& { return textures_; }
   [[nodiscard]] auto MaskTextures() -> MaskTextureCache<Backend>& { return mask_textures_; }
   [[nodiscard]] auto Values() -> NodeResultCache<Backend>& { return values_; }
   [[nodiscard]] auto Images() -> GraphImageCache<Backend>& { return images_; }
@@ -96,6 +97,24 @@ class BasicRenderWorkspace {
   void CancelRender() {
     images_.DiscardUnpublished();
     rendering_ = false;
+  }
+
+  /**
+   * @brief Drop published GPU results, textures, transients, and parameter slots.
+   *
+   * @pre Not rendering. Caller WaitIdle first so no texture is still busy.
+   */
+  void ReleaseSessionResources() {
+    if (rendering_) {
+      throw std::runtime_error(
+          "BasicRenderWorkspace::ReleaseSessionResources: cannot release while rendering");
+    }
+    images_.Clear();
+    values_.Clear();
+    mask_textures_.Clear();
+    textures_.ReleaseUnleased();
+    transients_.ReleaseDeviceMemory();
+    parameters_.Clear();
   }
 
  private:

--- a/alcedo_studio/src/include/edit/runtime/camera_color_gpu_params.hpp
+++ b/alcedo_studio/src/include/edit/runtime/camera_color_gpu_params.hpp
@@ -1,0 +1,24 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/graph/graph_ids.hpp"
+
+namespace alcedo {
+
+inline const AdjustmentInstanceId kDevelopCameraColorSlot{"camera_color"};
+
+/**
+ * @brief GPU parameter body for CameraColorPass.
+ *
+ * CPU interpolation writes @ref camera_to_ap1 here. The kernel only multiplies
+ * camera RGB by this matrix. Not serialized in pipeline JSON.
+ */
+struct alignas(16) CameraColorGpuParams {
+  float camera_to_ap1[9] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+  float pad[3]           = {};
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/content_key.hpp
@@ -18,8 +18,8 @@ inline constexpr std::uint64_t kContentHashPrime  = 1099511628211ull;
 inline constexpr std::uint32_t kSensorDevelopImplementationVersion = 1;
 /// Bumped when GeometryResample sampling rules change.
 inline constexpr std::uint32_t kGeometryImplementationVersion = 1;
-/// Bumped when CameraColorPass math changes. G7R.3 replaces the current matrix path.
-inline constexpr std::uint32_t kCameraColorImplementationVersion = 1;
+/// Bumped when CameraColorPass math changes. Version 2 hashes Develop camera-profile params.
+inline constexpr std::uint32_t kCameraColorImplementationVersion = 2;
 /// Bumped when Primary Grade pixel rules change.
 inline constexpr std::uint32_t kPrimaryGradeImplementationVersion = 1;
 /// Bumped when DRT pixel rules change.

--- a/alcedo_studio/src/include/edit/runtime/content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/content_key.hpp
@@ -11,21 +11,21 @@
 
 namespace alcedo {
 
-inline constexpr std::uint64_t kContentHashOffset = 14695981039346656037ull;
-inline constexpr std::uint64_t kContentHashPrime  = 1099511628211ull;
+inline constexpr std::uint64_t kContentHashOffset                  = 14695981039346656037ull;
+inline constexpr std::uint64_t kContentHashPrime                   = 1099511628211ull;
 
 /// Bumped when SensorDevelop pixel rules change. 2: method-aware demosaic + HLR-gated Clamp01.
 inline constexpr std::uint32_t kSensorDevelopImplementationVersion = 2;
 /// Bumped when GeometryResample sampling rules change.
-inline constexpr std::uint32_t kGeometryImplementationVersion = 1;
-/// Bumped when CameraColorPass math changes. Version 2 hashes Develop camera-profile params.
-inline constexpr std::uint32_t kCameraColorImplementationVersion = 2;
+inline constexpr std::uint32_t kGeometryImplementationVersion      = 1;
+/// Bumped when CameraColorPass math changes. Version 3 encodes its AP1 result as ACEScc.
+inline constexpr std::uint32_t kCameraColorImplementationVersion   = 3;
 /// Bumped when Primary Grade pixel rules change.
-inline constexpr std::uint32_t kPrimaryGradeImplementationVersion = 1;
-/// Bumped when DRT pixel rules change. 2: no hard AP1 clamp before tonescale.
-inline constexpr std::uint32_t kDrtImplementationVersion = 2;
+inline constexpr std::uint32_t kPrimaryGradeImplementationVersion  = 2;
+/// Bumped when DRT pixel rules change. Version 3 decodes AP1/ACEScc before the DRT.
+inline constexpr std::uint32_t kDrtImplementationVersion           = 3;
 /// Bumped when mask raster sampling rules change.
-inline constexpr std::uint32_t kMaskImplementationVersion = 1;
+inline constexpr std::uint32_t kMaskImplementationVersion          = 1;
 
 /**
  * @brief Content identity of a cached GPU image result.
@@ -34,7 +34,7 @@ inline constexpr std::uint32_t kMaskImplementationVersion = 1;
  * address, or ResourceId.
  */
 struct ContentKey {
-  std::uint64_t hash = 0;
+  std::uint64_t      hash = 0;
 
   [[nodiscard]] auto Empty() const -> bool { return hash == 0; }
 };

--- a/alcedo_studio/src/include/edit/runtime/content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/content_key.hpp
@@ -26,8 +26,8 @@ inline constexpr std::uint32_t kPrimaryGradeImplementationVersion  = 3;
 inline constexpr std::uint32_t kLlfReferenceImplementationVersion  = 1;
 /// Bumped when DRT pixel rules change. Version 3 decodes AP1/ACEScc before the DRT.
 inline constexpr std::uint32_t kDrtImplementationVersion           = 3;
-/// Bumped when mask raster sampling rules change.
-inline constexpr std::uint32_t kMaskImplementationVersion          = 1;
+/// Bumped when mask raster sampling rules change. Version 2 mixes analytic/raster params.
+inline constexpr std::uint32_t kMaskImplementationVersion          = 2;
 
 /**
  * @brief Content identity of a cached GPU image result.

--- a/alcedo_studio/src/include/edit/runtime/content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/content_key.hpp
@@ -1,0 +1,107 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <bit>
+#include <cstdint>
+#include <span>
+#include <string_view>
+
+namespace alcedo {
+
+inline constexpr std::uint64_t kContentHashOffset = 14695981039346656037ull;
+inline constexpr std::uint64_t kContentHashPrime  = 1099511628211ull;
+
+/// Bumped when SensorDevelop pixel rules change.
+inline constexpr std::uint32_t kSensorDevelopImplementationVersion = 1;
+/// Bumped when GeometryResample sampling rules change.
+inline constexpr std::uint32_t kGeometryImplementationVersion = 1;
+/// Bumped when CameraColorPass math changes. G7R.3 replaces the current matrix path.
+inline constexpr std::uint32_t kCameraColorImplementationVersion = 1;
+/// Bumped when Primary Grade pixel rules change.
+inline constexpr std::uint32_t kPrimaryGradeImplementationVersion = 1;
+/// Bumped when DRT pixel rules change.
+inline constexpr std::uint32_t kDrtImplementationVersion = 1;
+/// Bumped when mask raster sampling rules change.
+inline constexpr std::uint32_t kMaskImplementationVersion = 1;
+
+/**
+ * @brief Content identity of a cached GPU image result.
+ *
+ * Built from input values and implementation versions. Not a write counter, texture
+ * address, or ResourceId.
+ */
+struct ContentKey {
+  std::uint64_t hash = 0;
+
+  [[nodiscard]] auto Empty() const -> bool { return hash == 0; }
+};
+
+struct ImageExtent {
+  std::uint32_t width  = 0;
+  std::uint32_t height = 0;
+};
+
+inline auto operator==(ImageExtent a, ImageExtent b) -> bool {
+  return a.width == b.width && a.height == b.height;
+}
+
+inline auto operator!=(ImageExtent a, ImageExtent b) -> bool { return !(a == b); }
+
+inline auto operator==(ContentKey a, ContentKey b) -> bool { return a.hash == b.hash; }
+inline auto operator!=(ContentKey a, ContentKey b) -> bool { return a.hash != b.hash; }
+inline auto operator<(ContentKey a, ContentKey b) -> bool { return a.hash < b.hash; }
+
+/**
+ * @brief Incremental FNV-1a mixer for ContentKey construction.
+ *
+ * Not thread-safe. One builder per key.
+ */
+class ContentHash {
+ public:
+  ContentHash() = default;
+
+  auto MixU64(std::uint64_t value) -> ContentHash& {
+    hash_ ^= value;
+    hash_ *= kContentHashPrime;
+    return *this;
+  }
+
+  auto MixU32(std::uint32_t value) -> ContentHash& { return MixU64(value); }
+
+  auto MixI32(std::int32_t value) -> ContentHash& {
+    return MixU32(static_cast<std::uint32_t>(value));
+  }
+
+  auto MixBool(bool value) -> ContentHash& { return MixU64(value ? 1ull : 0ull); }
+
+  auto MixF32(float value) -> ContentHash& { return MixU32(std::bit_cast<std::uint32_t>(value)); }
+
+  auto MixF64(double value) -> ContentHash& { return MixU64(std::bit_cast<std::uint64_t>(value)); }
+
+  auto MixKey(ContentKey key) -> ContentHash& { return MixU64(key.hash); }
+
+  auto MixBytes(std::span<const std::byte> bytes) -> ContentHash& {
+    for (const auto byte : bytes) {
+      MixU64(static_cast<std::uint8_t>(byte));
+    }
+    return *this;
+  }
+
+  auto MixText(std::string_view text) -> ContentHash& {
+    MixU64(text.size());
+    for (const unsigned char byte : text) {
+      MixU64(byte);
+    }
+    return MixU64(0xFFull);
+  }
+
+  [[nodiscard]] auto Key() const -> ContentKey { return ContentKey{hash_}; }
+
+ private:
+  std::uint64_t hash_ = kContentHashOffset;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/content_key.hpp
@@ -20,8 +20,10 @@ inline constexpr std::uint32_t kSensorDevelopImplementationVersion = 2;
 inline constexpr std::uint32_t kGeometryImplementationVersion      = 1;
 /// Bumped when CameraColorPass math changes. Version 3 encodes its AP1 result as ACEScc.
 inline constexpr std::uint32_t kCameraColorImplementationVersion   = 3;
-/// Bumped when Primary Grade pixel rules change.
-inline constexpr std::uint32_t kPrimaryGradeImplementationVersion  = 2;
+/// Bumped when Primary Grade pixel rules change. Version 3 samples canonical LLF on ROI.
+inline constexpr std::uint32_t kPrimaryGradeImplementationVersion  = 3;
+/// Bumped when the canonical LLF reference identity or sampling rules change.
+inline constexpr std::uint32_t kLlfReferenceImplementationVersion  = 1;
 /// Bumped when DRT pixel rules change. Version 3 decodes AP1/ACEScc before the DRT.
 inline constexpr std::uint32_t kDrtImplementationVersion           = 3;
 /// Bumped when mask raster sampling rules change.

--- a/alcedo_studio/src/include/edit/runtime/content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/content_key.hpp
@@ -14,16 +14,16 @@ namespace alcedo {
 inline constexpr std::uint64_t kContentHashOffset = 14695981039346656037ull;
 inline constexpr std::uint64_t kContentHashPrime  = 1099511628211ull;
 
-/// Bumped when SensorDevelop pixel rules change.
-inline constexpr std::uint32_t kSensorDevelopImplementationVersion = 1;
+/// Bumped when SensorDevelop pixel rules change. 2: method-aware demosaic + HLR-gated Clamp01.
+inline constexpr std::uint32_t kSensorDevelopImplementationVersion = 2;
 /// Bumped when GeometryResample sampling rules change.
 inline constexpr std::uint32_t kGeometryImplementationVersion = 1;
 /// Bumped when CameraColorPass math changes. Version 2 hashes Develop camera-profile params.
 inline constexpr std::uint32_t kCameraColorImplementationVersion = 2;
 /// Bumped when Primary Grade pixel rules change.
 inline constexpr std::uint32_t kPrimaryGradeImplementationVersion = 1;
-/// Bumped when DRT pixel rules change.
-inline constexpr std::uint32_t kDrtImplementationVersion = 1;
+/// Bumped when DRT pixel rules change. 2: no hard AP1 clamp before tonescale.
+inline constexpr std::uint32_t kDrtImplementationVersion = 2;
 /// Bumped when mask raster sampling rules change.
 inline constexpr std::uint32_t kMaskImplementationVersion = 1;
 

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_adjustment_runtime.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_adjustment_runtime.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include "edit/operators/models/operator_type_id.hpp"
 
@@ -29,6 +30,13 @@ enum class CudaAdjustmentBehavior : std::uint32_t {
   Halation,
   FilmGrain,
 };
+
+/**
+ * @brief Resolve a built-in Model type to its CUDA runtime behavior.
+ * @return nullopt when the type has no CUDA grade implementation (legacy Tint, etc.).
+ */
+[[nodiscard]] auto TryResolveCudaAdjustmentBehavior(const OperatorTypeId& type)
+    -> std::optional<CudaAdjustmentBehavior>;
 
 /**
  * @brief Resolve a built-in Model type to its CUDA runtime behavior.

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -134,6 +134,10 @@ class CudaBackend {
    */
   void UploadTexture2D(Texture2D& texture, std::span<const std::byte> bytes,
                        CommandContext& command_context);
+  /**
+   * @brief Device-to-device copy of matching RGBA32F textures for identity geometry/camera.
+   */
+  void CopyTexture2D(const Texture2D& src, Texture2D& dst, CommandContext& command_context);
   /** @brief Upload a tightly packed R8 rectangle into an R8 texture. */
   void UploadR8TextureRect(Texture2D& texture, RectI rectangle, std::span<const std::byte> bytes,
                            CommandContext& command_context);
@@ -150,6 +154,7 @@ class CudaBackend {
   void Wait(CommandContext& command_context);
 
   [[nodiscard]] auto HasInFlightSubmission() const -> bool { return in_flight_submission_ != 0; }
+  [[nodiscard]] auto CompletedSubmission() const -> std::uint64_t { return completed_submission_; }
   [[nodiscard]] auto IsResourceBusy(std::uint64_t submitted_on) const -> bool {
     return submitted_on != 0 && submitted_on > completed_submission_;
   }

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -196,4 +196,12 @@ class CudaBackend {
   std::vector<RectI>     last_texture_rectangles_;
 };
 
+/**
+ * @brief Per-session TexturePool budget from device memory.
+ *
+ * Uses a quarter of total device memory, floored at 256 MiB so a preview ROI
+ * still fits when the card reports a small total. Not the 64 MiB test leftover.
+ */
+[[nodiscard]] auto DefaultProductTextureBudgetBytes() -> std::size_t;
+
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
@@ -12,15 +12,32 @@
 namespace alcedo {
 
 /**
- * @brief Encode CUDA Develop for the current in-flight submission.
+ * @brief Encode SensorDevelop into `develop.sensor_linear` for the current submission.
  *
  * Must be called between BeginRender and EndRender. Failures throw; there is
- * no CPU Apply fallback. Develop output is camera scene-linear RGBA32F.
+ * no CPU Apply fallback. Output is camera scene-linear RGBA32F before geometry.
+ * Source host bytes are uploaded only from this pass.
  *
  * CUDA order: Linearize → (optional CFA Clamp01) → Demosaic → HighlightRecover
- * on RGB when enabled. Camera-to-AP1 is not applied.
+ * on RGB when enabled. Geometry and CameraColor are separate passes.
  */
 void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
                         const PreparedRawInput& input, PipelineDocument& document);
+
+/**
+ * @brief Write `geometry.scene_source` from `develop.sensor_linear`.
+ *
+ * Identity geometry copies the sensor texture. Non-identity runs GeometryResamplePass.
+ */
+void ExecuteCudaGeometryResample(CudaRenderDevice& device, const ExecutionPlan& plan);
+
+/**
+ * @brief Write `develop.image` from `geometry.scene_source` using the current camera matrix.
+ *
+ * G7R.3 replaces the matrix construction. This pass is independently skippable.
+ */
+void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
+                            const RawRuntimeColorContext& color_context,
+                            const PipelineDocument&       document);
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
@@ -32,12 +32,11 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
 void ExecuteCudaGeometryResample(CudaRenderDevice& device, const ExecutionPlan& plan);
 
 /**
- * @brief Write `develop.image` from `geometry.scene_source` using the CPU-resolved
- *        camera→AP1 matrix stored in the GPU parameter body.
+ * @brief Write AP1/ACEScc `develop.image` from camera-linear `geometry.scene_source`.
  *
- * Interpolates Develop camera-profile matrices on the CPU when this pass runs
- * (CCT/tint dirty or first bind). Missing or singular matrices throw; identity
- * is never substituted. Independently skippable from SensorDevelop and Geometry.
+ * Interpolates the Develop camera-profile matrices on the CPU, applies camera→AP1 in scene-linear,
+ * then encodes AP1 as the graph working space. Missing or singular matrices throw; identity is
+ * never substituted. Independently skippable from SensorDevelop and Geometry.
  */
 void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
                             const PipelineDocument& document);

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
@@ -32,12 +32,14 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
 void ExecuteCudaGeometryResample(CudaRenderDevice& device, const ExecutionPlan& plan);
 
 /**
- * @brief Write `develop.image` from `geometry.scene_source` using the current camera matrix.
+ * @brief Write `develop.image` from `geometry.scene_source` using the CPU-resolved
+ *        camera→AP1 matrix stored in the GPU parameter body.
  *
- * G7R.3 replaces the matrix construction. This pass is independently skippable.
+ * Interpolates Develop camera-profile matrices on the CPU when this pass runs
+ * (CCT/tint dirty or first bind). Missing or singular matrices throw; identity
+ * is never substituted. Independently skippable from SensorDevelop and Geometry.
  */
 void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
-                            const RawRuntimeColorContext& color_context,
-                            const PipelineDocument&       document);
+                            const PipelineDocument& document);
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_drt_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_drt_pass.hpp
@@ -18,9 +18,10 @@ struct CudaDrtResult {
 /**
  * @brief Encode the selected ACES 2.0 or OpenDRT display transform on CUDA.
  *
- * The input must be the compiled primary-grade AP1 image. The device owns resolved ACES tables
- * and reuses them until DRT parameters change. A failed parameter upload retains Model dirty bits.
- * No CPU image-processing fallback is attempted.
+ * The input must be the compiled primary-grade AP1/ACEScc working-space image. The pass decodes
+ * ACEScc to AP1 scene-linear before the selected display rendering transform. The device owns
+ * resolved ACES tables and reuses them until DRT parameters change. A failed parameter upload
+ * retains Model dirty bits. No CPU image-processing fallback is attempted.
  */
 [[nodiscard]] auto ExecuteCudaDrt(CudaRenderDevice& device, const ExecutionPlan& plan,
                                   PipelineDocument& document) -> CudaDrtResult;

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_drt_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_drt_pass.hpp
@@ -5,12 +5,11 @@
 #pragma once
 
 #include "edit/graph/graph_ids.hpp"
+#include "edit/graph/pipeline_document.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
 #include "edit/runtime/execution_plan.hpp"
 
 namespace alcedo {
-
-class PipelineDocument;
 
 struct CudaDrtResult {
   GraphValueId output{NodeId{"drt"}, PortId{"display"}};

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_local_tone_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_local_tone_pass.hpp
@@ -6,25 +6,37 @@
 
 #include <cstdint>
 
+#include "edit/geometry/resolved_render_geometry.hpp"
 #include "edit/graph/graph_ids.hpp"
+#include "edit/runtime/content_key.hpp"
 
 namespace alcedo {
 
 class CudaRenderDevice;
 
+struct CudaLocalToneResult {
+  std::uint64_t reference_resource_id          = 0;
+  bool          rebuilt_reference              = false;
+  bool          sampled_canonical_reference    = false;
+};
+
 /**
  * @brief Apply the Shadows/Highlights local-Laplacian stage to AP1/ACEScc pixels.
  *
- * Pyramid storage is owned by the render workspace and is reused by later submissions.
- * Both input and output must be RGBA32F images of @p width by @p height. The slider
- * values use the persisted [-100, 100] UI scale. Throws on missing resources or CUDA failure.
+ * The canonical LLF reference covers full ReferenceSpace and does not include the
+ * viewport ROI. A full-EditSpace frame seeds or upgrades that reference. A viewport
+ * ROI samples it through MakeLlfSamplingPlan instead of rebuilding the pyramids.
  *
- * @return Resource id of the workspace-owned level-zero LLF reference buffer.
+ * Pyramid storage is owned by the render workspace. Both input and output must be
+ * RGBA32F images of @p width by @p height. Slider values use the persisted [-100, 100]
+ * UI scale. Throws on missing resources, invalid geometry, or CUDA failure.
  */
 [[nodiscard]] auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input,
                                         const GraphValueId& output, const NodeId& grade_id,
                                         std::uint32_t width, std::uint32_t height,
-                                        float shadows_slider, float highlights_slider)
-    -> std::uint64_t;
+                                        float shadows_slider, float highlights_slider,
+                                        const ResolvedRenderGeometry& geometry,
+                                        ContentKey                    reference_key)
+    -> CudaLocalToneResult;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_local_tone_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_local_tone_pass.hpp
@@ -1,0 +1,30 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "edit/graph/graph_ids.hpp"
+
+namespace alcedo {
+
+class CudaRenderDevice;
+
+/**
+ * @brief Apply the Shadows/Highlights local-Laplacian stage to AP1/ACEScc pixels.
+ *
+ * Pyramid storage is owned by the render workspace and is reused by later submissions.
+ * Both input and output must be RGBA32F images of @p width by @p height. The slider
+ * values use the persisted [-100, 100] UI scale. Throws on missing resources or CUDA failure.
+ *
+ * @return Resource id of the workspace-owned level-zero LLF reference buffer.
+ */
+[[nodiscard]] auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input,
+                                        const GraphValueId& output, const NodeId& grade_id,
+                                        std::uint32_t width, std::uint32_t height,
+                                        float shadows_slider, float highlights_slider)
+    -> std::uint64_t;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
@@ -19,7 +19,7 @@ struct CudaPrimaryGradeResult {
 };
 
 /**
- * @brief Convert camera RGB to AP1 and execute the serialized primary-grade Model order.
+ * @brief Execute the serialized primary-grade Model order on AP1 scene-linear input.
  *
  * Must run between CudaRenderDevice::BeginRender and EndRender. Parameters, output images,
  * execution order, and local-tone reference data are owned by the device workspace. A failed

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
@@ -19,7 +19,10 @@ struct CudaPrimaryGradeResult {
 };
 
 /**
- * @brief Execute the serialized primary-grade Model order on AP1 scene-linear input.
+ * @brief Execute the serialized primary-grade Model order in the AP1/ACEScc working space.
+ *
+ * CameraColor produces the encoded graph input. This pass keeps every intermediate and its graph
+ * output in AP1/ACEScc, including mix, mask application, and the local-Laplacian tone stage.
  *
  * Must run between CudaRenderDevice::BeginRender and EndRender. Parameters, output images,
  * execution order, and local-tone reference data are owned by the device workspace. A failed

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
@@ -6,8 +6,8 @@
 
 #include <cstdint>
 
-#include "decoders/processor/raw_color_context.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
 #include "edit/runtime/execution_plan.hpp"
 
@@ -15,7 +15,9 @@ namespace alcedo {
 
 struct CudaPrimaryGradeResult {
   GraphValueId  output{NodeId{"grade.primary"}, PortId{"image"}};
-  std::uint64_t local_tone_reference_resource_id = 0;
+  std::uint64_t local_tone_reference_resource_id       = 0;
+  bool          local_tone_rebuilt_reference           = false;
+  bool          local_tone_sampled_canonical_reference = false;
 };
 
 /**
@@ -29,7 +31,8 @@ struct CudaPrimaryGradeResult {
  * parameter transfer restores the affected Model dirty bits. No CPU image-processing fallback.
  */
 [[nodiscard]] auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan,
-                                           const RawRuntimeColorContext& color_context,
-                                           PipelineDocument& document) -> CudaPrimaryGradeResult;
+                                           const PreparedRawInput& prepared,
+                                           PipelineDocument&       document)
+    -> CudaPrimaryGradeResult;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "edit/geometry/render_request.hpp"
+#include "edit/input/prepared_source_cache.hpp"
+#include "edit/runtime/static_execution_plan_cache.hpp"
 #include "type/type.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 
@@ -16,16 +19,37 @@ class CudaRenderDevice;
 class ImageBuffer;
 class PipelineDocument;
 
+/// CUDA DAG backend capability mixed into the static plan key. Bump when pass
+/// lists or backend traits that affect compilation change.
+inline constexpr std::uint32_t kCudaDagBackendCapabilityVersion = 1;
+
 /**
- * @brief Product adapter from the existing scheduler inputs to the CUDA DAG renderer.
+ * @brief Queryable prepare/compile counters for one product pipeline session.
  *
- * Owns one device workspace per loaded pipeline so node results and allocations survive
- * consecutive scheduler frames. Failures are reported and propagated; this adapter never calls
- * the old CPU image-processing stages.
+ * Hit/miss/compile counts are the cache identity for G7R.1. GPU pass skip and
+ * result-content hits belong to later G7R work.
+ */
+struct CudaProductSessionStats {
+  std::uint64_t prepared_source_hits       = 0;
+  std::uint64_t prepared_source_misses     = 0;
+  std::uint64_t libraw_open_unpack_count   = 0;
+  std::uint64_t plan_cache_hits            = 0;
+  std::uint64_t plan_cache_misses          = 0;
+  std::uint64_t plan_compile_count         = 0;
+};
+
+/**
+ * @brief Reusable CUDA product session for one opened PipelineDocument.
+ *
+ * Owns PreparedSourceCache, the static ExecutionPlan cache, and one
+ * CudaRenderDevice/workspace. Not created per Apply. Preview and export frames
+ * that share encoded bytes and DecodeRes reuse the same PreparedRawInput.
  */
 class CudaProductRenderer {
  public:
   explicit CudaProductRenderer(std::shared_ptr<PipelineDocument> document);
+  CudaProductRenderer(std::shared_ptr<PipelineDocument> document,
+                      PreparedSourceCache::UnpackFn     unpack);
   ~CudaProductRenderer();
 
   CudaProductRenderer(const CudaProductRenderer&)                                  = delete;
@@ -38,9 +62,22 @@ class CudaProductRenderer {
                             const FrameCompletionSubmission& submission, bool require_host_output)
       -> std::shared_ptr<ImageBuffer>;
 
+  /**
+   * @brief Snapshot of source and static-plan cache counters since construction or ResetStats.
+   */
+  [[nodiscard]] auto Stats() const -> CudaProductSessionStats;
+  void               ResetStats();
+
+  [[nodiscard]] auto SourceCache() -> PreparedSourceCache& { return source_cache_; }
+  [[nodiscard]] auto SourceCache() const -> const PreparedSourceCache& { return source_cache_; }
+  [[nodiscard]] auto PlanCache() -> StaticExecutionPlanCache& { return plan_cache_; }
+  [[nodiscard]] auto PlanCache() const -> const StaticExecutionPlanCache& { return plan_cache_; }
+
  private:
   std::shared_ptr<PipelineDocument> document_;
   std::unique_ptr<CudaRenderDevice> device_;
+  PreparedSourceCache               source_cache_;
+  StaticExecutionPlanCache          plan_cache_{kCudaDagBackendCapabilityVersion};
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
@@ -21,6 +21,7 @@ namespace alcedo {
 
 class CudaRenderDevice;
 class ImageBuffer;
+class MaskStore;
 
 /** @brief Select whether a render may read or publish the editor session caches. */
 enum class CudaProductCachePolicy {
@@ -113,11 +114,13 @@ class CudaProductRenderer {
   [[nodiscard]] auto SourceCache() const -> const PreparedSourceCache& { return source_cache_; }
   [[nodiscard]] auto PlanCache() -> StaticExecutionPlanCache& { return plan_cache_; }
   [[nodiscard]] auto PlanCache() const -> const StaticExecutionPlanCache& { return plan_cache_; }
+  [[nodiscard]] auto MaskAssets() -> MaskStore&;
 
  private:
   std::shared_ptr<PipelineDocument> document_;
   std::unique_ptr<CudaRenderDevice> device_;
   std::unique_ptr<CudaRenderDevice> one_shot_device_;
+  std::unique_ptr<MaskStore>        mask_store_;
   PreparedSourceCache::UnpackFn     unpack_;
   PreparedSourceCache               source_cache_;
   StaticExecutionPlanCache          plan_cache_{kCudaDagBackendCapabilityVersion};

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
@@ -9,6 +9,7 @@
 
 #include "edit/geometry/render_request.hpp"
 #include "edit/input/prepared_source_cache.hpp"
+#include "edit/runtime/gpu_node_pass_stats.hpp"
 #include "edit/runtime/static_execution_plan_cache.hpp"
 #include "type/type.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
@@ -24,10 +25,7 @@ class PipelineDocument;
 inline constexpr std::uint32_t kCudaDagBackendCapabilityVersion = 1;
 
 /**
- * @brief Queryable prepare/compile counters for one product pipeline session.
- *
- * Hit/miss/compile counts are the cache identity for G7R.1. GPU pass skip and
- * result-content hits belong to later G7R work.
+ * @brief Queryable prepare/compile and result-cache counters for one product session.
  */
 struct CudaProductSessionStats {
   std::uint64_t prepared_source_hits       = 0;
@@ -36,6 +34,7 @@ struct CudaProductSessionStats {
   std::uint64_t plan_cache_hits            = 0;
   std::uint64_t plan_cache_misses          = 0;
   std::uint64_t plan_compile_count         = 0;
+  GpuNodePassStats pass{};
 };
 
 /**

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "edit/geometry/render_request.hpp"
+#include "edit/graph/pipeline_document.hpp"
 #include "edit/input/prepared_source_cache.hpp"
 #include "edit/runtime/gpu_node_pass_stats.hpp"
 #include "edit/runtime/static_execution_plan_cache.hpp"
@@ -18,7 +19,6 @@ namespace alcedo {
 
 class CudaRenderDevice;
 class ImageBuffer;
-class PipelineDocument;
 
 /// CUDA DAG backend capability mixed into the static plan key. Bump when pass
 /// lists or backend traits that affect compilation change.

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
@@ -6,8 +6,10 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "edit/geometry/render_request.hpp"
+#include "edit/graph/graph_ids.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/prepared_source_cache.hpp"
 #include "edit/runtime/gpu_node_pass_stats.hpp"
@@ -20,6 +22,12 @@ namespace alcedo {
 class CudaRenderDevice;
 class ImageBuffer;
 
+/** @brief Select whether a render may read or publish the editor session caches. */
+enum class CudaProductCachePolicy {
+  UseSessionCache,
+  BypassSessionCache,
+};
+
 /// CUDA DAG backend capability mixed into the static plan key. Bump when pass
 /// lists or backend traits that affect compilation change.
 inline constexpr std::uint32_t kCudaDagBackendCapabilityVersion = 1;
@@ -28,21 +36,33 @@ inline constexpr std::uint32_t kCudaDagBackendCapabilityVersion = 1;
  * @brief Queryable prepare/compile and result-cache counters for one product session.
  */
 struct CudaProductSessionStats {
-  std::uint64_t prepared_source_hits       = 0;
-  std::uint64_t prepared_source_misses     = 0;
-  std::uint64_t libraw_open_unpack_count   = 0;
-  std::uint64_t plan_cache_hits            = 0;
-  std::uint64_t plan_cache_misses          = 0;
-  std::uint64_t plan_compile_count         = 0;
+  std::uint64_t    prepared_source_hits     = 0;
+  std::uint64_t    prepared_source_misses   = 0;
+  std::uint64_t    libraw_open_unpack_count = 0;
+  std::uint64_t    plan_cache_hits          = 0;
+  std::uint64_t    plan_cache_misses        = 0;
+  std::uint64_t    plan_compile_count       = 0;
   GpuNodePassStats pass{};
+};
+
+/**
+ * @brief Live GPU/host allocations owned by one product session.
+ */
+struct CudaProductSessionResources {
+  std::size_t               published_result_count      = 0;
+  std::size_t               texture_pool_used_bytes     = 0;
+  std::size_t               texture_pool_entry_count    = 0;
+  std::size_t               prepared_source_host_bytes  = 0;
+  std::size_t               prepared_source_entry_count = 0;
+  std::vector<GraphValueId> session_value_ids;
 };
 
 /**
  * @brief Reusable CUDA product session for one opened PipelineDocument.
  *
- * Owns PreparedSourceCache, the static ExecutionPlan cache, and one
- * CudaRenderDevice/workspace. Not created per Apply. Preview and export frames
- * that share encoded bytes and DecodeRes reuse the same PreparedRawInput.
+ * Owns the editor session caches/device plus a lazily created one-shot device for
+ * thumbnail and export work. Not created per Apply. Only session renders reuse
+ * prepared sources, static plans, and published GPU results.
  */
 class CudaProductRenderer {
  public:
@@ -56,9 +76,17 @@ class CudaProductRenderer {
 
   void               SetDocument(std::shared_ptr<PipelineDocument> document);
 
-  [[nodiscard]] auto Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
-                            const RenderRequest& request, IFrameSink* sink,
-                            const FrameCompletionSubmission& submission, bool require_host_output)
+  /**
+   * @brief Render one frame on the owning thread.
+   *
+   * @param cache_policy Session mode reads and publishes reusable editor results. Bypass mode
+   *        uses an isolated one-shot workspace and releases its result resources after delivery.
+   * @throws std::runtime_error for invalid input, CUDA execution, or presentation failure.
+   */
+  [[nodiscard]] auto Render(
+      const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res, const RenderRequest& request,
+      IFrameSink* sink, const FrameCompletionSubmission& submission, bool require_host_output,
+      CudaProductCachePolicy cache_policy = CudaProductCachePolicy::UseSessionCache)
       -> std::shared_ptr<ImageBuffer>;
 
   /**
@@ -66,6 +94,20 @@ class CudaProductRenderer {
    */
   [[nodiscard]] auto Stats() const -> CudaProductSessionStats;
   void               ResetStats();
+
+  /**
+   * @brief Drop GPU result textures, host prepared sources, the plan cache, and
+   *        the session Neural workspace. Keeps the CudaRenderDevice.
+   *
+   * Call when the pipeline is returned to PipelineMgmtService. The next Render
+   * rebuilds caches from the still-owned PipelineDocument.
+   */
+  void               ReleaseSessionCaches();
+
+  [[nodiscard]] auto SessionResources() const -> CudaProductSessionResources;
+
+  [[nodiscard]] auto Device() -> CudaRenderDevice& { return *device_; }
+  [[nodiscard]] auto Device() const -> const CudaRenderDevice& { return *device_; }
 
   [[nodiscard]] auto SourceCache() -> PreparedSourceCache& { return source_cache_; }
   [[nodiscard]] auto SourceCache() const -> const PreparedSourceCache& { return source_cache_; }
@@ -75,6 +117,8 @@ class CudaProductRenderer {
  private:
   std::shared_ptr<PipelineDocument> document_;
   std::unique_ptr<CudaRenderDevice> device_;
+  std::unique_ptr<CudaRenderDevice> one_shot_device_;
+  PreparedSourceCache::UnpackFn     unpack_;
   PreparedSourceCache               source_cache_;
   StaticExecutionPlanCache          plan_cache_{kCudaDagBackendCapabilityVersion};
 };

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
@@ -22,6 +22,10 @@ using CudaRenderWorkspace = BasicRenderWorkspace<CudaBackend>;
 class CudaDrtRuntimeState;
 class MaskStore;
 
+namespace CUDA {
+class NeuralDemosaicWorkspace;
+}
+
 /**
  * @brief Owns a CUDA workspace and one command context. Does not own a graph or plan.
  *
@@ -69,6 +73,14 @@ class CudaRenderDevice {
   [[nodiscard]] auto DrtRuntime() -> CudaDrtRuntimeState&;
 
   /**
+   * @brief Session-owned Neural Engine activation workspace. Created on first use.
+   */
+  [[nodiscard]] auto NeuralDemosaicWorkspace() -> CUDA::NeuralDemosaicWorkspace&;
+
+  /** @brief Drop the session Neural Engine workspace. Weights stay in the process cache. */
+  void ReleaseNeuralDemosaicWorkspace();
+
+  /**
    * @brief Execute the complete compiled CUDA DAG and return its display texture identity.
    *
    * Skips GPU node passes whose content keys are already published. When
@@ -82,11 +94,12 @@ class CudaRenderDevice {
                              bool publish_on_success = true) -> GraphValueId;
 
  private:
-  CudaRenderWorkspace                   workspace_;
-  CudaCommandContext                    command_context_;
-  std::unique_ptr<CudaDrtRuntimeState>  drt_runtime_;
-  std::function<void(std::string_view)> error_reporter_;
-  GpuNodePassStats                      pass_stats_{};
+  CudaRenderWorkspace                              workspace_;
+  CudaCommandContext                               command_context_;
+  std::unique_ptr<CudaDrtRuntimeState>             drt_runtime_;
+  std::unique_ptr<CUDA::NeuralDemosaicWorkspace>   neural_workspace_;
+  std::function<void(std::string_view)>            error_reporter_;
+  GpuNodePassStats                                 pass_stats_{};
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
@@ -8,8 +8,11 @@
 #include <memory>
 #include <string_view>
 
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
 #include "edit/runtime/basic_render_workspace.hpp"
 #include "edit/runtime/cuda/cuda_backend.hpp"
+#include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/gpu_node_pass_stats.hpp"
 
 namespace alcedo {
@@ -18,9 +21,6 @@ using CudaRenderWorkspace = BasicRenderWorkspace<CudaBackend>;
 
 class CudaDrtRuntimeState;
 class MaskStore;
-class PipelineDocument;
-struct ExecutionPlan;
-struct PreparedRawInput;
 
 /**
  * @brief Owns a CUDA workspace and one command context. Does not own a graph or plan.

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
@@ -10,6 +10,7 @@
 
 #include "edit/runtime/basic_render_workspace.hpp"
 #include "edit/runtime/cuda/cuda_backend.hpp"
+#include "edit/runtime/gpu_node_pass_stats.hpp"
 
 namespace alcedo {
 
@@ -43,6 +44,20 @@ class CudaRenderDevice {
   void               WaitIdle() { workspace_.Device().Wait(command_context_); }
   void               CancelRender() noexcept;
 
+  /**
+   * @brief Publish unpublished GPU image results for the submission ended by EndRender.
+   *
+   * Call after a successful present or host download. Kernel or frame-sink failure must
+   * leave results unpublished via CancelRender / DiscardUnpublished.
+   */
+  void PublishResults() {
+    workspace_.Images().PublishSuccessfulSubmission(command_context_.SubmissionId());
+  }
+
+  [[nodiscard]] auto PassStats() -> GpuNodePassStats& { return pass_stats_; }
+  [[nodiscard]] auto PassStats() const -> const GpuNodePassStats& { return pass_stats_; }
+  void               ResetPassStats() { pass_stats_.Reset(); }
+
   /** @brief Install the app-layer error receiver. Called synchronously on the render thread. */
   void               SetErrorReporter(std::function<void(std::string_view)> reporter) {
     error_reporter_ = std::move(reporter);
@@ -56,18 +71,22 @@ class CudaRenderDevice {
   /**
    * @brief Execute the complete compiled CUDA DAG and return its display texture identity.
    *
-   * Reports and rethrows failures after cancelling the incomplete submission. There is no CPU
-   * image-processing fallback.
+   * Skips GPU node passes whose content keys are already published. When
+   * @p publish_on_success is true, unpublished writes are published after a successful
+   * submit. Product present paths pass false and call @ref PublishResults after the sink
+   * succeeds. Reports and rethrows failures after cancelling the incomplete submission.
+   * There is no CPU image-processing fallback.
    */
   [[nodiscard]] auto Execute(const ExecutionPlan& plan, const PreparedRawInput& input,
-                             PipelineDocument& document, MaskStore* mask_store = nullptr)
-      -> GraphValueId;
+                             PipelineDocument& document, MaskStore* mask_store = nullptr,
+                             bool publish_on_success = true) -> GraphValueId;
 
  private:
   CudaRenderWorkspace                   workspace_;
   CudaCommandContext                    command_context_;
   std::unique_ptr<CudaDrtRuntimeState>  drt_runtime_;
   std::function<void(std::string_view)> error_reporter_;
+  GpuNodePassStats                      pass_stats_{};
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_sensor_demosaic.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_sensor_demosaic.hpp
@@ -1,0 +1,48 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include <opencv2/core/cuda.hpp>
+
+#include "decoders/processor/nn/demosaicnet_cache.hpp"
+#include "decoders/processor/raw_demosaic_method.hpp"
+#include "decoders/processor/raw_processor_pattern.hpp"
+#include "edit/graph/develop_node_model.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+
+namespace alcedo {
+
+class CudaRenderDevice;
+
+/**
+ * @brief Resolve the product demosaic method from Develop params and CFA.
+ *
+ * Reduced-resolution inputs (downsample_passes != 0) always use Legacy.
+ * Default is Legacy on Bayer and Neural Engine on X-Trans.
+ */
+[[nodiscard]] auto ResolveDevelopDemosaicMethod(const DevelopPayload& params, RawCfaKind cfa_kind,
+                                                std::uint32_t downsample_passes)
+    -> RawDemosaicMethod;
+
+/**
+ * @brief Test hook: inject a model cache so Neural load failure can be asserted.
+ *
+ * Null restores the process-wide cache. Not thread-safe.
+ */
+void SetDevelopNeuralModelCacheForTesting(DemosaicNetModelCache* cache);
+
+/**
+ * @brief Demosaic linearized CFA and pack camera RGB into @p packed_rgba.
+ *
+ * Highlight reconstruction runs on RGB when enabled. Neural Engine failures throw
+ * with the engine error string; there is no Legacy fallback.
+ */
+void ExecuteCudaSensorDemosaicAndPack(CudaRenderDevice& device, const PreparedRawInput& input,
+                                      const DevelopPayload& params, cv::cuda::GpuMat linear,
+                                      cv::cuda::GpuMat packed, cv::cuda::Stream& stream);
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/develop_compile_source.hpp
+++ b/alcedo_studio/src/include/edit/runtime/develop_compile_source.hpp
@@ -28,6 +28,18 @@ struct DevelopCompileSource {
   std::uint8_t     downsample_passes      = 0;
 };
 
+inline auto operator==(const DevelopCompileSource& a, const DevelopCompileSource& b) -> bool {
+  return a.kind == b.kind && a.host_extent == b.host_extent &&
+         a.develop_output_extent == b.develop_output_extent &&
+         a.full_reference_extent == b.full_reference_extent &&
+         a.sensor_active_area == b.sensor_active_area &&
+         a.downsample_passes == b.downsample_passes;
+}
+
+inline auto operator!=(const DevelopCompileSource& a, const DevelopCompileSource& b) -> bool {
+  return !(a == b);
+}
+
 /**
  * @brief Identity of a prepared source. No write counters.
  */

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -108,6 +108,8 @@ inline auto operator<(const StaticPlanKey& a, const StaticPlanKey& b) -> bool {
 struct ExecutionPlan {
   StaticPlanKey                   static_key{};
   std::vector<GpuPassDesc>        passes;
+  GraphValueId                    sensor_linear_output{NodeId{"develop"}, PortId{"sensor_linear"}};
+  GraphValueId                    geometry_output{NodeId{"geometry"}, PortId{"scene_source"}};
   GraphValueId                    develop_output{NodeId{"develop"}, PortId{"image"}};
   DevelopCompileSource            source{};
   ResolvedRenderGeometry          geometry{};

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -20,9 +20,16 @@ struct GpuPassDesc {
   GpuPassKind kind = GpuPassKind::UploadRaw;
 };
 
+/** @brief Backend algorithm selected at graph compile time for one grade adjustment. */
+enum class CompiledAdjustmentAlgorithm : std::uint8_t {
+  Pointwise,
+  LocalLaplacian,
+};
+
 struct CompiledAdjustment {
-  AdjustmentInstanceId instance_id;
-  OperatorTypeId       type;
+  AdjustmentInstanceId        instance_id;
+  OperatorTypeId              type;
+  CompiledAdjustmentAlgorithm algorithm = CompiledAdjustmentAlgorithm::Pointwise;
 };
 
 enum class CompiledMaskKind : std::uint8_t { Analytic, Raster };
@@ -38,9 +45,9 @@ struct CompiledMask {
  * Source layout is the decoded host/develop extents, not ResolvedRenderGeometry.
  */
 struct StaticPlanKey {
-  std::uint64_t        topology_hash               = 0;
+  std::uint64_t        topology_hash = 0;
   DevelopCompileSource source_layout{};
-  std::uint32_t        backend_capability_version  = 0;
+  std::uint32_t        backend_capability_version = 0;
 };
 
 inline auto operator==(const StaticPlanKey& a, const StaticPlanKey& b) -> bool {
@@ -67,7 +74,8 @@ inline auto operator<(const StaticPlanKey& a, const StaticPlanKey& b) -> bool {
     return a.source_layout.host_extent.height < b.source_layout.host_extent.height;
   }
   if (a.source_layout.develop_output_extent.width != b.source_layout.develop_output_extent.width) {
-    return a.source_layout.develop_output_extent.width < b.source_layout.develop_output_extent.width;
+    return a.source_layout.develop_output_extent.width <
+           b.source_layout.develop_output_extent.width;
   }
   if (a.source_layout.develop_output_extent.height !=
       b.source_layout.develop_output_extent.height) {
@@ -75,7 +83,8 @@ inline auto operator<(const StaticPlanKey& a, const StaticPlanKey& b) -> bool {
            b.source_layout.develop_output_extent.height;
   }
   if (a.source_layout.full_reference_extent.width != b.source_layout.full_reference_extent.width) {
-    return a.source_layout.full_reference_extent.width < b.source_layout.full_reference_extent.width;
+    return a.source_layout.full_reference_extent.width <
+           b.source_layout.full_reference_extent.width;
   }
   if (a.source_layout.full_reference_extent.height !=
       b.source_layout.full_reference_extent.height) {

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -33,12 +33,80 @@ struct CompiledMask {
 };
 
 /**
+ * @brief Identity of a static compiled plan. Parameter values and viewport are omitted.
+ *
+ * Source layout is the decoded host/develop extents, not ResolvedRenderGeometry.
+ */
+struct StaticPlanKey {
+  std::uint64_t        topology_hash               = 0;
+  DevelopCompileSource source_layout{};
+  std::uint32_t        backend_capability_version  = 0;
+};
+
+inline auto operator==(const StaticPlanKey& a, const StaticPlanKey& b) -> bool {
+  return a.topology_hash == b.topology_hash && a.source_layout == b.source_layout &&
+         a.backend_capability_version == b.backend_capability_version;
+}
+
+inline auto operator!=(const StaticPlanKey& a, const StaticPlanKey& b) -> bool { return !(a == b); }
+
+inline auto operator<(const StaticPlanKey& a, const StaticPlanKey& b) -> bool {
+  if (a.topology_hash != b.topology_hash) {
+    return a.topology_hash < b.topology_hash;
+  }
+  if (a.backend_capability_version != b.backend_capability_version) {
+    return a.backend_capability_version < b.backend_capability_version;
+  }
+  if (a.source_layout.kind != b.source_layout.kind) {
+    return a.source_layout.kind < b.source_layout.kind;
+  }
+  if (a.source_layout.host_extent.width != b.source_layout.host_extent.width) {
+    return a.source_layout.host_extent.width < b.source_layout.host_extent.width;
+  }
+  if (a.source_layout.host_extent.height != b.source_layout.host_extent.height) {
+    return a.source_layout.host_extent.height < b.source_layout.host_extent.height;
+  }
+  if (a.source_layout.develop_output_extent.width != b.source_layout.develop_output_extent.width) {
+    return a.source_layout.develop_output_extent.width < b.source_layout.develop_output_extent.width;
+  }
+  if (a.source_layout.develop_output_extent.height !=
+      b.source_layout.develop_output_extent.height) {
+    return a.source_layout.develop_output_extent.height <
+           b.source_layout.develop_output_extent.height;
+  }
+  if (a.source_layout.full_reference_extent.width != b.source_layout.full_reference_extent.width) {
+    return a.source_layout.full_reference_extent.width < b.source_layout.full_reference_extent.width;
+  }
+  if (a.source_layout.full_reference_extent.height !=
+      b.source_layout.full_reference_extent.height) {
+    return a.source_layout.full_reference_extent.height <
+           b.source_layout.full_reference_extent.height;
+  }
+  if (a.source_layout.downsample_passes != b.source_layout.downsample_passes) {
+    return a.source_layout.downsample_passes < b.source_layout.downsample_passes;
+  }
+  if (a.source_layout.sensor_active_area.x != b.source_layout.sensor_active_area.x) {
+    return a.source_layout.sensor_active_area.x < b.source_layout.sensor_active_area.x;
+  }
+  if (a.source_layout.sensor_active_area.y != b.source_layout.sensor_active_area.y) {
+    return a.source_layout.sensor_active_area.y < b.source_layout.sensor_active_area.y;
+  }
+  if (a.source_layout.sensor_active_area.width != b.source_layout.sensor_active_area.width) {
+    return a.source_layout.sensor_active_area.width < b.source_layout.sensor_active_area.width;
+  }
+  return a.source_layout.sensor_active_area.height < b.source_layout.sensor_active_area.height;
+}
+
+/**
  * @brief Compiled backend work for one graph. Does not own GPU memory.
  *
  * Always includes GeometryResample so a viewport change does not recompile.
- * The encoder skips the kernel when @ref encode_geometry_resample is false.
+ * @ref geometry and @ref encode_geometry_resample are per-frame and are filled by
+ * GraphCompiler::BindFrameGeometry. The encoder skips the kernel when
+ * @ref encode_geometry_resample is false.
  */
 struct ExecutionPlan {
+  StaticPlanKey                   static_key{};
   std::vector<GpuPassDesc>        passes;
   GraphValueId                    develop_output{NodeId{"develop"}, PortId{"image"}};
   DevelopCompileSource            source{};

--- a/alcedo_studio/src/include/edit/runtime/gpu_node_pass_stats.hpp
+++ b/alcedo_studio/src/include/edit/runtime/gpu_node_pass_stats.hpp
@@ -1,0 +1,37 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+namespace alcedo {
+
+/**
+ * @brief Per-session execute/skip and source-upload counters for content-aware result cache.
+ *
+ * G7R.5 adds timing and allocation fields. Tests must assert these counters, not ResourceId.
+ */
+struct GpuNodePassStats {
+  std::uint64_t sensor_develop_execute = 0;
+  std::uint64_t sensor_develop_skip    = 0;
+  std::uint64_t geometry_execute       = 0;
+  std::uint64_t geometry_skip          = 0;
+  std::uint64_t camera_color_execute   = 0;
+  std::uint64_t camera_color_skip      = 0;
+  std::uint64_t mask_execute           = 0;
+  std::uint64_t mask_skip              = 0;
+  std::uint64_t primary_grade_execute  = 0;
+  std::uint64_t primary_grade_skip     = 0;
+  std::uint64_t drt_execute            = 0;
+  std::uint64_t drt_skip               = 0;
+  std::uint64_t source_h2d_count       = 0;
+  std::uint64_t source_h2d_bytes       = 0;
+  std::uint64_t result_content_hits    = 0;
+  std::uint64_t result_content_misses  = 0;
+
+  void Reset() { *this = GpuNodePassStats{}; }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
@@ -17,8 +17,8 @@ namespace alcedo {
  * @brief Builds the complete Develop -> PrimaryColorGrade -> DRT plan. Does not allocate GPU
  * memory.
  *
- * Validates the three-node document. Camera-to-AP1 remains part of Develop rather than a
- * separately allocated pass.
+ * Validates the three-node document. SensorDevelop, GeometryResample, and CameraToAp1 are
+ * separate compiled passes with distinct GraphValueIds.
  *
  * The static plan key covers graph topology, adjustment types and order, source layout,
  * and backend capability version. Viewport, crop, CCT, Grade values, and DRT values are

--- a/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "edit/geometry/render_request.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/runtime/develop_compile_source.hpp"
@@ -18,19 +20,50 @@ namespace alcedo {
  * Validates the three-node document. Camera-to-AP1 remains part of Develop rather than a
  * separately allocated pass.
  *
- * Recompile when topology is dirty, input kind changes, or decoded extent
- * changes. Highlight / demosaic / lens flags are encoder branches, not new
- * pass lists.
+ * The static plan key covers graph topology, adjustment types and order, source layout,
+ * and backend capability version. Viewport, crop, CCT, Grade values, and DRT values are
+ * bound per frame and do not recompile the static pass list.
  */
 class GraphCompiler {
  public:
+  /**
+   * @brief Compile pass list and parameter bindings. Does not resolve viewport geometry.
+   *
+   * @param backend_capability_version Backend trait revision mixed into @ref StaticPlanKey.
+   */
+  [[nodiscard]] static auto CompileStatic(const PipelineDocument&     document,
+                                          const DevelopCompileSource& source,
+                                          std::uint32_t backend_capability_version = 0)
+      -> ExecutionPlan;
+
+  /**
+   * @brief Fill @p plan.geometry from the document crop/rotation and the per-frame request.
+   *
+   * Does not change @p plan.static_key or the pass list. Must run before execute.
+   */
+  static void BindFrameGeometry(ExecutionPlan& plan, const PipelineDocument& document,
+                                const RenderRequest& request);
+
+  /**
+   * @brief CompileStatic plus BindFrameGeometry. Existing tests and one-shot callers use this.
+   */
   [[nodiscard]] static auto Compile(const PipelineDocument&     document,
                                     const DevelopCompileSource& source,
                                     const RenderRequest&        request) -> ExecutionPlan;
 
+  /**
+   * @brief True when topology, source layout, or backend capability differs from @p previous.
+   *
+   * Parameter values and viewport are not inputs and never force a recompile.
+   */
   [[nodiscard]] static auto NeedsRecompile(const ExecutionPlan&        previous,
                                            const PipelineDocument&     document,
                                            const DevelopCompileSource& source) -> bool;
+
+  [[nodiscard]] static auto MakeStaticPlanKey(const PipelineDocument&     document,
+                                              const DevelopCompileSource& source,
+                                              std::uint32_t backend_capability_version = 0)
+      -> StaticPlanKey;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
@@ -6,35 +6,184 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <map>
+#include <stdexcept>
 #include <utility>
 
 #include "edit/graph/graph_ids.hpp"
+#include "edit/runtime/content_key.hpp"
 #include "edit/runtime/texture_pool.hpp"
 
 namespace alcedo {
 
+struct ResultIdentity {
+  GraphValueId value_id;
+  ContentKey   content_key;
+
+  friend auto operator<(const ResultIdentity& a, const ResultIdentity& b) -> bool {
+    if (a.value_id != b.value_id) {
+      return a.value_id < b.value_id;
+    }
+    return a.content_key < b.content_key;
+  }
+};
+
 /**
- * @brief KV cache of node image outputs keyed by producer node and output port.
+ * @brief GPU image results keyed by GraphValueId and content, separate from allocation reuse.
  *
- * Values are Texture2D leases held across frames so a matching size is reused
- * without a second Acquire. Not thread-safe.
+ * Callers must use @ref AcquireTextureForWrite, @ref FindValidResult / @ref BindValidResult,
+ * and @ref PublishSuccessfulSubmission. A matching ResourceId is allocation reuse, not a
+ * content hit. Not thread-safe. One in-flight submission.
+ *
+ * @tparam Backend Texture factory used by TexturePool.
  */
 template <class Backend>
 class GraphImageCache {
  public:
-  void Store(GraphValueId id, ResourceLease<Backend> lease) {
-    images_.insert_or_assign(std::move(id), std::move(lease));
+  /**
+   * @brief True when a published result matches value, key, extent, and format, and
+   *        @p last_writer has completed.
+   *
+   * Does not bind the value as current and does not update LRU.
+   */
+  [[nodiscard]] auto FindValidResult(const GraphValueId& id, ContentKey key, ImageExtent extent,
+                                     TextureFormat format, std::uint64_t completed_submission) const
+      -> bool {
+    const auto* published = FindPublished(id, key);
+    return published != nullptr && Matches(*published, extent, format) &&
+           !WriterBusy(*published, completed_submission);
   }
 
+  /**
+   * @brief Bind a completed published result as the current texture for @p id.
+   *
+   * @return The bound lease, or nullptr on miss. Misses include size/format mismatch and
+   *         an in-flight last_writer. Counts a content hit or miss.
+   */
+  auto BindValidResult(const GraphValueId& id, ContentKey key, ImageExtent extent,
+                       TextureFormat format, std::uint64_t completed_submission)
+      -> ResourceLease<Backend>* {
+    auto* published = FindPublished(id, key);
+    if (published == nullptr || !Matches(*published, extent, format) ||
+        WriterBusy(*published, completed_submission)) {
+      ++content_misses_;
+      return nullptr;
+    }
+    ++content_hits_;
+    published->lru_tick = ++lru_clock_;
+    current_[id]        = key;
+    return &published->texture;
+  }
+
+  /**
+   * @brief Allocate or reuse a texture for an unpublished write of @p id.
+   *
+   * Reuses an in-flight write slot of the same size. Does not steal a published result of
+   * another content key. Overwriting a same-size unpublished slot drops its unrecorded
+   * identity. Evicts completed, non-current published results to fit the pool budget.
+   *
+   * @pre @p pool and @p backend outlive this cache.
+   */
+  auto AcquireTextureForWrite(TexturePool<Backend>& pool, Backend& backend, const GraphValueId& id,
+                              const TextureRequest& request) -> ResourceLease<Backend>& {
+    if (request.width == 0 || request.height == 0) {
+      throw std::runtime_error("GraphImageCache::AcquireTextureForWrite: invalid size");
+    }
+    if (auto* slot = FindWrite(id)) {
+      if (!slot->texture.Empty()) {
+        const auto& tex = slot->texture.Texture();
+        if (tex.Width() == request.width && tex.Height() == request.height &&
+            tex.Format() == request.format) {
+          slot->has_key = false;
+          slot->key     = {};
+          return slot->texture;
+        }
+      }
+      write_slots_.erase(id);
+    }
+
+    current_.erase(id);
+    EvictCompletedUnleased(pool, backend, request);
+
+    WriteSlot slot;
+    slot.texture = pool.Acquire(request);
+    slot.extent  = ImageExtent{request.width, request.height};
+    slot.format  = request.format;
+    auto [it, inserted] = write_slots_.emplace(id, std::move(slot));
+    (void)inserted;
+    return it->second.texture;
+  }
+
+  /**
+   * @brief Attach a content key to the unpublished write of @p id.
+   *
+   * The result is not valid until @ref PublishSuccessfulSubmission. If this texture was
+   * previously published under another key, that identity must already have been removed;
+   * this method only annotates the write slot.
+   *
+   * @throws std::runtime_error when @p id has no write slot.
+   */
+  void RecordUnpublished(const GraphValueId& id, ContentKey key, ImageExtent extent,
+                         TextureFormat format, std::uint64_t submission_id) {
+    auto* slot = FindWrite(id);
+    if (slot == nullptr) {
+      throw std::runtime_error("GraphImageCache::RecordUnpublished: no write slot");
+    }
+    if (slot->extent != extent || slot->format != format) {
+      throw std::runtime_error("GraphImageCache::RecordUnpublished: extent or format mismatch");
+    }
+    slot->key         = key;
+    slot->has_key     = true;
+    slot->last_writer = submission_id;
+  }
+
+  /**
+   * @brief Atomically publish unpublished writes recorded for @p submission_id.
+   *
+   * Write slots without a content key are dropped. Replacing a published (id, key) pair
+   * releases the previous lease. Failed or cancelled submissions must call
+   * @ref DiscardUnpublished instead.
+   */
+  void PublishSuccessfulSubmission(std::uint64_t submission_id) {
+    for (auto& [id, slot] : write_slots_) {
+      if (!slot.has_key || slot.last_writer != submission_id) {
+        continue;
+      }
+      PublishedResult published;
+      published.texture     = std::move(slot.texture);
+      published.extent      = slot.extent;
+      published.format      = slot.format;
+      published.last_writer = slot.last_writer;
+      published.lru_tick    = ++lru_clock_;
+      published_.insert_or_assign(ResultIdentity{id, slot.key}, std::move(published));
+      current_[id] = slot.key;
+    }
+    write_slots_.clear();
+  }
+
+  /**
+   * @brief Drop unpublished writes without publishing. Previously published results stay.
+   */
+  void DiscardUnpublished() { write_slots_.clear(); }
+
+  /**
+   * @brief Current texture for @p id: this-frame write slot, else last bound/published result.
+   */
   [[nodiscard]] auto Find(const GraphValueId& id) -> ResourceLease<Backend>* {
-    const auto it = images_.find(id);
-    return it == images_.end() ? nullptr : &it->second;
+    if (auto* slot = FindWrite(id)) {
+      return &slot->texture;
+    }
+    auto* published = FindCurrentPublished(id);
+    return published == nullptr ? nullptr : &published->texture;
   }
 
   [[nodiscard]] auto Find(const GraphValueId& id) const -> const ResourceLease<Backend>* {
-    const auto it = images_.find(id);
-    return it == images_.end() ? nullptr : &it->second;
+    if (const auto* slot = FindWrite(id)) {
+      return &slot->texture;
+    }
+    const auto* published = FindCurrentPublished(id);
+    return published == nullptr ? nullptr : &published->texture;
   }
 
   [[nodiscard]] auto Find(const NodeId& producer, const PortId& output_port)
@@ -42,12 +191,139 @@ class GraphImageCache {
     return Find(GraphValueId{producer, output_port});
   }
 
-  void Erase(const GraphValueId& id) { images_.erase(id); }
-  void Clear() { images_.clear(); }
-  [[nodiscard]] auto Size() const -> std::size_t { return images_.size(); }
+  /**
+   * @brief Drop completed published results that are not the current binding, oldest first.
+   *
+   * Releasing a lease makes the texture reusable by TexturePool without treating that reuse
+   * as a content hit. Stops once a matching-size texture is unleased or no victim remains.
+   * Does not evict in-flight write slots or results whose last_writer is still busy.
+   */
+  void EvictCompletedUnleased(TexturePool<Backend>& pool, Backend& backend,
+                              const TextureRequest& needed) {
+    if (pool.ByteBudget() == 0) {
+      return;
+    }
+    const auto needed_bytes = static_cast<std::size_t>(needed.width) * needed.height *
+                              TextureFormatBytesPerPixel(needed.format);
+    bool released_matching = false;
+    while (!released_matching && pool.UsedBytes() + needed_bytes > pool.ByteBudget()) {
+      ResultIdentity   victim_id;
+      PublishedResult* victim  = nullptr;
+      std::uint64_t    oldest  = (std::numeric_limits<std::uint64_t>::max)();
+      for (auto& [identity, entry] : published_) {
+        if (backend.IsResourceBusy(entry.last_writer)) {
+          continue;
+        }
+        const auto current = current_.find(identity.value_id);
+        if (current != current_.end() && current->second == identity.content_key) {
+          continue;
+        }
+        if (entry.lru_tick < oldest) {
+          oldest    = entry.lru_tick;
+          victim    = &entry;
+          victim_id = identity;
+        }
+      }
+      if (victim == nullptr) {
+        break;
+      }
+      released_matching = victim->extent.width == needed.width &&
+                          victim->extent.height == needed.height && victim->format == needed.format;
+      published_.erase(victim_id);
+    }
+  }
+
+  [[nodiscard]] auto PublishedCount() const -> std::size_t { return published_.size(); }
+  [[nodiscard]] auto UnpublishedCount() const -> std::size_t { return write_slots_.size(); }
+  [[nodiscard]] auto ContentHitCount() const -> std::uint64_t { return content_hits_; }
+  [[nodiscard]] auto ContentMissCount() const -> std::uint64_t { return content_misses_; }
+
+  [[nodiscard]] auto PublishedContentKey(const GraphValueId& id) const -> ContentKey {
+    const auto it = current_.find(id);
+    return it == current_.end() ? ContentKey{} : it->second;
+  }
+
+  [[nodiscard]] auto PublishedLastWriter(const GraphValueId& id, ContentKey key) const
+      -> std::uint64_t {
+    const auto* published = FindPublished(id, key);
+    return published == nullptr ? 0 : published->last_writer;
+  }
+
+  void Clear() {
+    write_slots_.clear();
+    published_.clear();
+    current_.clear();
+  }
 
  private:
-  std::map<GraphValueId, ResourceLease<Backend>> images_;
+  struct WriteSlot {
+    ResourceLease<Backend> texture;
+    ContentKey             key{};
+    ImageExtent            extent{};
+    TextureFormat          format = TextureFormat::R8;
+    std::uint64_t          last_writer = 0;
+    bool                   has_key     = false;
+  };
+
+  struct PublishedResult {
+    ResourceLease<Backend> texture;
+    ImageExtent            extent{};
+    TextureFormat          format      = TextureFormat::R8;
+    std::uint64_t          last_writer = 0;
+    std::uint64_t          lru_tick    = 0;
+  };
+
+  static auto Matches(const PublishedResult& entry, ImageExtent extent, TextureFormat format)
+      -> bool {
+    return entry.extent == extent && entry.format == format && !entry.texture.Empty();
+  }
+
+  static auto WriterBusy(const PublishedResult& entry, std::uint64_t completed_submission) -> bool {
+    return entry.last_writer != 0 && entry.last_writer > completed_submission;
+  }
+
+  auto FindWrite(const GraphValueId& id) -> WriteSlot* {
+    const auto it = write_slots_.find(id);
+    return it == write_slots_.end() ? nullptr : &it->second;
+  }
+
+  auto FindWrite(const GraphValueId& id) const -> const WriteSlot* {
+    const auto it = write_slots_.find(id);
+    return it == write_slots_.end() ? nullptr : &it->second;
+  }
+
+  auto FindPublished(const GraphValueId& id, ContentKey key) -> PublishedResult* {
+    const auto it = published_.find(ResultIdentity{id, key});
+    return it == published_.end() ? nullptr : &it->second;
+  }
+
+  auto FindPublished(const GraphValueId& id, ContentKey key) const -> const PublishedResult* {
+    const auto it = published_.find(ResultIdentity{id, key});
+    return it == published_.end() ? nullptr : &it->second;
+  }
+
+  auto FindCurrentPublished(const GraphValueId& id) -> PublishedResult* {
+    const auto it = current_.find(id);
+    if (it == current_.end()) {
+      return nullptr;
+    }
+    return FindPublished(id, it->second);
+  }
+
+  auto FindCurrentPublished(const GraphValueId& id) const -> const PublishedResult* {
+    const auto it = current_.find(id);
+    if (it == current_.end()) {
+      return nullptr;
+    }
+    return FindPublished(id, it->second);
+  }
+
+  std::map<GraphValueId, WriteSlot>           write_slots_;
+  std::map<ResultIdentity, PublishedResult>   published_;
+  std::map<GraphValueId, ContentKey>          current_;
+  std::uint64_t                               lru_clock_      = 0;
+  std::uint64_t                               content_hits_   = 0;
+  std::uint64_t                               content_misses_ = 0;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 #include "edit/graph/graph_ids.hpp"
 #include "edit/runtime/content_key.hpp"
@@ -253,6 +254,15 @@ class GraphImageCache {
     write_slots_.clear();
     published_.clear();
     current_.clear();
+  }
+
+  [[nodiscard]] auto CurrentValueIds() const -> std::vector<GraphValueId> {
+    std::vector<GraphValueId> ids;
+    ids.reserve(current_.size());
+    for (const auto& [id, key] : current_) {
+      ids.push_back(id);
+    }
+    return ids;
   }
 
  private:

--- a/alcedo_studio/src/include/edit/runtime/mask_texture_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/mask_texture_cache.hpp
@@ -73,6 +73,14 @@ class MaskTextureCache {
   [[nodiscard]] auto UsedBytes() const -> std::size_t { return used_bytes_; }
   [[nodiscard]] auto EntryCount() const -> std::size_t { return entries_.size(); }
 
+  /**
+   * @brief Drop every mask texture. Caller must not hold MaskTextureLease objects.
+   */
+  void Clear() {
+    entries_.clear();
+    used_bytes_ = 0;
+  }
+
   void               BeginFrame() {
     for (auto& [key, entry] : entries_) entry.used_this_frame = false;
   }

--- a/alcedo_studio/src/include/edit/runtime/node_result_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/node_result_cache.hpp
@@ -14,9 +14,10 @@
 namespace alcedo {
 
 /**
- * @brief KV cache of node outputs keyed by producer node and output port.
+ * @brief KV cache of non-image node buffers keyed by producer node and output port.
  *
- * Values are owning backend buffers. Not thread-safe.
+ * GPU image results live in GraphImageCache with content keys. This cache holds
+ * runtime buffers such as adjustment command lists. Not thread-safe.
  */
 template <class Backend>
 class NodeResultCache {

--- a/alcedo_studio/src/include/edit/runtime/parameter_arena.hpp
+++ b/alcedo_studio/src/include/edit/runtime/parameter_arena.hpp
@@ -140,6 +140,18 @@ class ParameterArena {
   [[nodiscard]] auto used_bytes() const -> std::size_t { return used_; }
   [[nodiscard]] auto DeviceBuffer() const -> const typename Backend::Buffer& { return device_; }
 
+  /**
+   * @brief Drop host and device parameter storage. Caller must WaitIdle first.
+   */
+  void Clear() {
+    slots_.clear();
+    pending_.clear();
+    host_.clear();
+    device_   = {};
+    used_     = 0;
+    capacity_ = 0;
+  }
+
  private:
   static auto AlignUp(std::size_t value, std::uint32_t alignment) -> std::size_t {
     return (value + alignment - 1) & ~(static_cast<std::size_t>(alignment) - 1);

--- a/alcedo_studio/src/include/edit/runtime/result_content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/result_content_key.hpp
@@ -39,6 +39,15 @@ struct FrameResultContentKeys {
 [[nodiscard]] auto HashResolvedRenderGeometry(const ResolvedRenderGeometry& geometry) -> ContentKey;
 
 /**
+ * @brief Identity of the canonical LLF reference. Viewport ROI is omitted.
+ *
+ * Includes prepared source, user crop/rotation, CameraColor params, and Primary Grade
+ * adjustments. Viewport, render extent, and dynamic scale are not mixed.
+ */
+[[nodiscard]] auto HashLlfReferenceKey(const ExecutionPlan& plan, const PreparedRawInput& input,
+                                       const PipelineDocument& document) -> ContentKey;
+
+/**
  * @brief Build layer keys for the current document, prepared source, and bound geometry.
  *
  * @pre @p plan.geometry is the per-frame ResolvedRenderGeometry.

--- a/alcedo_studio/src/include/edit/runtime/result_content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/result_content_key.hpp
@@ -1,0 +1,51 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/geometry/resolved_render_geometry.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/execution_plan.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Content keys and extents for one product frame's GPU result cache lookups.
+ *
+ * Viewport is in @ref geometry_scene_source only. CCT/tint is in @ref develop_image only.
+ */
+struct FrameResultContentKeys {
+  ContentKey  sensor_linear{};
+  ContentKey  geometry_scene_source{};
+  ContentKey  develop_image{};
+  ContentKey  primary_grade{};
+  ContentKey  drt_display{};
+  ContentKey  mask{};
+  ImageExtent sensor_extent{};
+  ImageExtent geometry_extent{};
+};
+
+/**
+ * @brief Hash PreparedSourceKey fields. Viewport is omitted.
+ */
+[[nodiscard]] auto HashPreparedSourceKey(const PreparedSourceKey& key) -> ContentKey;
+
+/**
+ * @brief Hash the full ResolvedRenderGeometry, including crop, rotation, ROI, and sampling.
+ */
+[[nodiscard]] auto HashResolvedRenderGeometry(const ResolvedRenderGeometry& geometry) -> ContentKey;
+
+/**
+ * @brief Build layer keys for the current document, prepared source, and bound geometry.
+ *
+ * @pre @p plan.geometry is the per-frame ResolvedRenderGeometry.
+ */
+[[nodiscard]] auto BuildFrameResultContentKeys(const ExecutionPlan&    plan,
+                                               const PreparedRawInput& input,
+                                               const PipelineDocument& document)
+    -> FrameResultContentKeys;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/static_execution_plan_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/static_execution_plan_cache.hpp
@@ -1,0 +1,59 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Cache of static ExecutionPlan values keyed by topology and source layout.
+ *
+ * Viewport, crop, CCT, Grade, and DRT parameter values are not part of the key.
+ * Returned plans are copies; callers bind per-frame geometry without mutating the cache.
+ * Not thread-safe.
+ */
+class StaticExecutionPlanCache {
+ public:
+  struct Stats {
+    std::uint64_t hits     = 0;
+    std::uint64_t misses   = 0;
+    std::uint64_t compiles = 0;
+  };
+
+  /**
+   * @param backend_capability_version Mixed into every lookup key so a backend
+   *        capability change cannot reuse another backend's pass list.
+   */
+  explicit StaticExecutionPlanCache(std::uint32_t backend_capability_version = 0);
+
+  /**
+   * @brief Return a copy of the cached static plan, compiling on miss.
+   *
+   * @post Returned plan has empty/default geometry until BindFrameGeometry.
+   */
+  [[nodiscard]] auto GetOrCompile(const PipelineDocument&     document,
+                                  const DevelopCompileSource& source) -> ExecutionPlan;
+
+  [[nodiscard]] auto GetStats() const -> Stats { return stats_; }
+  void               ResetStats() { stats_ = {}; }
+  [[nodiscard]] auto EntryCount() const -> std::size_t { return plans_.size(); }
+  [[nodiscard]] auto BackendCapabilityVersion() const -> std::uint32_t {
+    return backend_capability_version_;
+  }
+
+ private:
+  std::uint32_t                     backend_capability_version_ = 0;
+  std::map<StaticPlanKey, ExecutionPlan> plans_;
+  Stats                             stats_{};
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/static_execution_plan_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/static_execution_plan_cache.hpp
@@ -49,6 +49,7 @@ class StaticExecutionPlanCache {
   [[nodiscard]] auto BackendCapabilityVersion() const -> std::uint32_t {
     return backend_capability_version_;
   }
+  void Clear() { plans_.clear(); }
 
  private:
   std::uint32_t                     backend_capability_version_ = 0;

--- a/alcedo_studio/src/include/edit/runtime/texture_pool.hpp
+++ b/alcedo_studio/src/include/edit/runtime/texture_pool.hpp
@@ -166,6 +166,25 @@ class TexturePool {
   }
 
   /**
+   * @brief Destroy every unleased, idle texture. Does not wait; caller must WaitIdle first.
+   *
+   * GraphImageCache::Clear drops leases. This call then frees the device memory.
+   */
+  void ReleaseUnleased() {
+    for (auto& entry : entries_) {
+      if (!entry.alive || entry.lease_count > 0) {
+        continue;
+      }
+      if (backend_->IsResourceBusy(entry.submitted_on)) {
+        continue;
+      }
+      used_bytes_ -= entry.bytes;
+      entry.texture = {};
+      entry.alive   = false;
+    }
+  }
+
+  /**
    * @brief Drop unleased, idle textures until used + needed fits the budget, if possible.
    */
   void EvictUntil(std::size_t needed_bytes) {

--- a/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
@@ -122,6 +122,9 @@ class TransientBufferArena {
   /// Rewind bump pointer to zero. Does not free device memory.
   void Reset() noexcept { offset_ = 0; }
 
+  /// Free the device slab. Requires no live bump allocations (`used_bytes() == 0`).
+  void ReleaseDeviceMemory() noexcept { ResetSlab(); }
+
   void Rewind(std::size_t mark_bytes) {
     if (mark_bytes > offset_) {
       throw std::runtime_error("TransientBufferArena::Rewind: mark is past current offset");

--- a/alcedo_studio/src/include/io/image/image_loader.hpp
+++ b/alcedo_studio/src/include/io/image/image_loader.hpp
@@ -14,6 +14,11 @@
 #include "image/image.hpp"
 #include "type/type.hpp"
 #include "utils/queue/queue.hpp"
+
+#ifdef LoadImage
+#undef LoadImage
+#endif
+
 namespace alcedo {
 
 class ImageLoader {

--- a/alcedo_studio/src/include/renderer/pipeline_task.hpp
+++ b/alcedo_studio/src/include/renderer/pipeline_task.hpp
@@ -9,6 +9,7 @@
 #include <future>
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "edit/operators/op_kernel.hpp"
 #include "edit/pipeline/pipeline.hpp"
@@ -69,7 +70,7 @@ struct PipelineTask {
   std::function<bool()>                             cancel_requested_;
   // Optional control-plane completion (preview + export). Invoked once on every
   // terminal path so callers do not need a dedicated blocking worker thread.
-  std::function<void(bool success)>                 on_complete_;
+  std::function<void(bool success, std::string message)> on_complete_;
 
   TaskOptions                                       options_;
 

--- a/alcedo_studio/src/include/utils/diagnostics/scope_diag.hpp
+++ b/alcedo_studio/src/include/utils/diagnostics/scope_diag.hpp
@@ -1,0 +1,31 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <string_view>
+
+namespace alcedo::diag {
+
+/// Stdout scope-path gates. Distinct from [RENDER_E2E] so a flooded present
+/// log still shows whether histogram/waveform staging and polling ran.
+/// Repeats of the same line after the first 16 prints are suppressed.
+inline void NoteScope(std::string_view event) {
+  static std::mutex  mutex;
+  static int         count = 0;
+  static std::string last;
+  const std::string  line(event);
+  std::lock_guard    lock(mutex);
+  if (line == last && count >= 16) {
+    return;
+  }
+  last = line;
+  ++count;
+  std::cout << "[SCOPE] " << line << std::endl;
+}
+
+}  // namespace alcedo::diag

--- a/alcedo_studio/src/renderer/pipeline_scheduler.cpp
+++ b/alcedo_studio/src/renderer/pipeline_scheduler.cpp
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+
 #include "image/image_buffer.hpp"
 #include "io/image/image_loader.hpp"
 #include "renderer/pipeline_task.hpp"
@@ -189,8 +190,8 @@ void ApplyRenderFrameRole(const std::shared_ptr<CPUPipelineExecutor>& pipeline_e
 }
 
 auto LoadViewportRegion(const std::shared_ptr<CPUPipelineExecutor>& pipeline_executor,
-                        bool should_use_viewport_region,
-                        const std::optional<ViewportRenderRegion>& requested_region)
+                        bool                                        should_use_viewport_region,
+                        const std::optional<ViewportRenderRegion>&  requested_region)
     -> std::optional<ViewportRenderRegion> {
   if (!pipeline_executor || !should_use_viewport_region) {
     return std::nullopt;
@@ -230,9 +231,12 @@ void PipelineTask::SetExecutorRenderParams() {
   const bool viewport_region_render  = (requested_render_type == RenderType::FAST_PREVIEW ||
                                        requested_render_type == RenderType::DETAIL_ROI_PREVIEW) &&
                                       desc.use_viewport_region_;
-  const auto viewport_region =
-      LoadViewportRegion(pipeline_executor_, viewport_region_render && !rotation_active_fast_preview,
-                         desc.viewport_region_);
+  const auto viewport_region = LoadViewportRegion(
+      pipeline_executor_, viewport_region_render && !rotation_active_fast_preview,
+      desc.viewport_region_);
+  // Freeze request geometry before any branch returns. In particular, Quality Base must carry
+  // null (full frame) instead of re-reading a live ROI later inside Apply.
+  pipeline_executor_->SetRenderRequestViewport(viewport_region);
   if (viewport_region.has_value()) {
     region_x                = viewport_region->x_;
     region_y                = viewport_region->y_;
@@ -242,7 +246,7 @@ void PipelineTask::SetExecutorRenderParams() {
     region_reference_height = viewport_region->reference_height_;
   }
 
-  FramePreviewMetadata frame_metadata = desc.frame_metadata_;
+  FramePreviewMetadata  frame_metadata    = desc.frame_metadata_;
   FramePresentationMode presentation_mode = FramePresentationMode::FullFrame;
 
   if (requested_render_type == RenderType::FAST_PREVIEW) {
@@ -266,8 +270,8 @@ void PipelineTask::SetExecutorRenderParams() {
     }
 
     presentation_mode = FramePresentationMode::RoiFrame;
-    frame_metadata = MetadataFromRegion(frame_metadata, viewport_region, region_x, region_y,
-                                        region_scale_x, region_scale_y);
+    frame_metadata    = MetadataFromRegion(frame_metadata, viewport_region, region_x, region_y,
+                                           region_scale_x, region_scale_y);
     frame_metadata.scope_update_allowed = frame_metadata.scope_refresh_requested;
     ApplyRenderFrameRole(pipeline_executor_, frame_metadata);
     pipeline_executor_->BindFrameSubmission(frame_metadata, presentation_mode);
@@ -300,8 +304,8 @@ void PipelineTask::SetExecutorRenderParams() {
     frame_metadata.frame_role = (region_scale_x < (1.0f - 1e-4f) || region_scale_y < (1.0f - 1e-4f))
                                     ? FrameRole::DetailPatch
                                     : FrameRole::QualityBase;
-    frame_metadata = MetadataFromRegion(frame_metadata, viewport_region, region_x, region_y,
-                                        region_scale_x, region_scale_y);
+    frame_metadata    = MetadataFromRegion(frame_metadata, viewport_region, region_x, region_y,
+                                           region_scale_x, region_scale_y);
     presentation_mode = FramePresentationMode::ViewportTransformed;
     ApplyRenderFrameRole(pipeline_executor_, frame_metadata);
     pipeline_executor_->BindFrameSubmission(frame_metadata, presentation_mode);
@@ -387,7 +391,6 @@ void PipelineTask::ResetThumbnailRenderParams() {
   pipeline_executor_->SetEnableCache(true);
   pipeline_executor_->SetDecodeRes(DecodeRes::FULL);
   pipeline_executor_->SetCancelRequested(nullptr);
-  pipeline_executor_->ClearAllIntermediateBuffers();
 }
 
 PipelineScheduler::PipelineScheduler() : thread_pool_(1) {}
@@ -432,24 +435,27 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
   }
   thread_pool_.Submit([this, task = std::move(task)]() mutable {
     std::optional<bool> completion_result;
+    std::string         completion_message;
     // Some render paths return from inside the render_lock scope. Record the
     // result there, but invoke the external completion only when this outer
     // guard is destroyed, after every inner lock and render parameter guard.
-    auto completion_guard = std::unique_ptr<void, std::function<void(void*)>>(
-        reinterpret_cast<void*>(1), [&task, &completion_result](void*) {
+    auto                completion_guard = std::unique_ptr<void, std::function<void(void*)>>(
+        reinterpret_cast<void*>(1), [&task, &completion_result, &completion_message](void*) {
           if (!completion_result.has_value() || !task.on_complete_) {
             return;
           }
           try {
-            task.on_complete_(*completion_result);
+            task.on_complete_(*completion_result, std::move(completion_message));
           } catch (...) {
           }
         });
-    const auto finish = [&completion_result](bool success) {
+    const auto finish = [&completion_result, &completion_message](bool        success,
+                                                                  std::string message = {}) {
       if (completion_result.has_value()) {
         return;
       }
-      completion_result = success;
+      completion_result  = success;
+      completion_message = std::move(message);
     };
 
     const auto set_blocking_value = [&task](std::shared_ptr<ImageBuffer> value) {
@@ -532,10 +538,15 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
           bool prepared = false;
           try {
             prepared = (*task.prepare_)(task);
+          } catch (const std::exception& ex) {
+            notify_thumbnail_failure_callbacks();
+            set_blocking_exception();
+            finish(false, ex.what());
+            return;
           } catch (...) {
             notify_thumbnail_failure_callbacks();
             set_blocking_exception();
-            finish(false);
+            finish(false, "Pipeline render failed");
             return;
           }
           if (!prepared) {
@@ -578,10 +589,15 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
               bool prepared = false;
               try {
                 prepared = (*task.configure_under_render_lock_)(task);
+              } catch (const std::exception& ex) {
+                notify_thumbnail_failure_callbacks();
+                set_blocking_exception();
+                finish(false, ex.what());
+                return;
               } catch (...) {
                 notify_thumbnail_failure_callbacks();
                 set_blocking_exception();
-                finish(false);
+                finish(false, "Pipeline render failed");
                 return;
               }
               if (!prepared) {
@@ -630,8 +646,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
           // their explicit post-render baseline so geometry caches survive
           // consecutive interactive requests.
           auto render_params_guard = std::unique_ptr<void, std::function<void(void*)>>(
-              reinterpret_cast<void*>(1),
-              [&task, &prior_one_shot, &restore_frame_sink](void*) {
+              reinterpret_cast<void*>(1), [&task, &prior_one_shot, &restore_frame_sink](void*) {
                 if (prior_one_shot.has_value() && task.pipeline_executor_) {
                   task.pipeline_executor_->RestoreOneShotRenderParams(*prior_one_shot);
                 }
@@ -717,6 +732,14 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
         set_blocking_value(nullptr);
         finish(false);
       }
+    } catch (const std::exception& ex) {
+      try {
+        apply_state_transition_after_render();
+      } catch (...) {
+      }
+      notify_thumbnail_failure_callbacks();
+      set_blocking_exception();
+      finish(false, ex.what());
     } catch (...) {
       try {
         apply_state_transition_after_render();
@@ -724,7 +747,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
       }
       notify_thumbnail_failure_callbacks();
       set_blocking_exception();
-      finish(false);
+      finish(false, "Pipeline render failed");
     }
   });
 }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_scope_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_scope_controller.cpp
@@ -7,7 +7,10 @@
 #include <QMetaObject>
 #include <QThreadPool>
 #include <algorithm>
+#include <sstream>
 #include <utility>
+
+#include "utils/diagnostics/scope_diag.hpp"
 
 namespace alcedo::ui {
 namespace {
@@ -60,6 +63,12 @@ void EditorScopeController::set_visual_active(bool active) {
   frame_tap_->SetScopeActive(active);
   last_scheduled_display_generation_ = 0;
   last_scheduled_frame_id_           = 0;
+  {
+    std::ostringstream line;
+    line << "visual_active=" << (active ? 1 : 0) << " identity=" << image_identity_
+         << " epoch=" << session_epoch_;
+    alcedo::diag::NoteScope(line.str());
+  }
   if (active) {
     poll_timer_.start();
   } else {
@@ -151,6 +160,7 @@ void EditorScopeController::scheduleSnapshotRefresh() {
 
   const auto scope_frame = frame_tap_->GetCurrentScopeFrameView();
   if (!scope_frame) {
+    alcedo::diag::NoteScope("poll no_staged_frame");
     refresh_in_flight_->store(false);
     return;
   }
@@ -179,6 +189,15 @@ void EditorScopeController::scheduleSnapshotRefresh() {
       const auto output = analyzer->GetLatestOutput();
       if (output.generation != 0) {
         next_snapshot = alcedo::ReadScopeRenderSnapshot(output);
+      }
+      {
+        std::ostringstream line;
+        line << "poll output_gen=" << output.generation
+             << " hist=" << (next_snapshot.histogram.valid ? 1 : 0)
+             << " wave=" << (next_snapshot.waveform.valid ? 1 : 0)
+             << " submit_new=" << (submit_new_frame ? 1 : 0)
+             << " frame_gen=" << scope_frame.display_generation;
+        alcedo::diag::NoteScope(line.str());
       }
       if (submit_new_frame) {
         analyzer->SubmitFrame(scope_frame, request);
@@ -216,15 +235,21 @@ auto EditorScopeController::publishSnapshot(alcedo::ScopeRenderSnapshot next_sna
   if (!visual_active_ || expected_request_revision != request_revision_ ||
       expected_image_identity != image_identity_ ||
       expected_session_epoch != session_epoch_) {
+    alcedo::diag::NoteScope("snapshot_reject stale_controller_identity");
     return false;
   }
   if (next_snapshot.generation == 0 ||
       (next_snapshot.image_identity != 0 && next_snapshot.image_identity != image_identity_) ||
       (next_snapshot.session_epoch != 0 &&
        next_snapshot.session_epoch != session_epoch_)) {
+    std::ostringstream line;
+    line << "snapshot_reject identity have=" << next_snapshot.image_identity << "/"
+         << next_snapshot.session_epoch << " want=" << image_identity_ << "/" << session_epoch_;
+    alcedo::diag::NoteScope(line.str());
     return false;
   }
   if (!next_snapshot.histogram.valid && !next_snapshot.waveform.valid) {
+    alcedo::diag::NoteScope("snapshot_reject empty_plot");
     return false;
   }
   // Publish the latest completed analysis of the current image. During
@@ -239,6 +264,14 @@ auto EditorScopeController::publishSnapshot(alcedo::ScopeRenderSnapshot next_sna
   }
 
   snapshot_ = std::move(next_snapshot);
+  {
+    std::ostringstream line;
+    line << "snapshot_published gen=" << snapshot_.generation
+         << " hist=" << (snapshot_.histogram.valid ? 1 : 0)
+         << " wave=" << (snapshot_.waveform.valid ? 1 : 0)
+         << " display=" << snapshot_.display_generation;
+    alcedo::diag::NoteScope(line.str());
+  }
   emit SnapshotChanged();
   return true;
 }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
@@ -10,6 +10,7 @@
 #include <QThread>
 #include <chrono>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 #include "app/editor_adjustment_pipeline.hpp"
@@ -479,13 +480,18 @@ void EditorSessionRenderSchedulerPort::DispatchPipelineFrame(Job job, alcedo::IF
       };
     }
     const auto request_for_trace = job.request;
-    task.on_complete_            = [this, job, request_for_trace](bool success) mutable {
+    task.on_complete_            = [this, job, request_for_trace](bool success,
+                                                       std::string message) mutable {
       TraceDetailRequest("pipeline-return", request_for_trace, success ? "success" : "failed");
       if (JobIsCancelled(job)) {
         FinishJob(job, false, "Cancelled during execution");
         return;
       }
-      FinishJob(job, success, success ? "Frame ready" : "Pipeline returned an empty result");
+      if (success) {
+        FinishJob(job, true, "Frame ready");
+        return;
+      }
+      FinishJob(job, false, message.empty() ? "Pipeline returned an empty result" : std::move(message));
     };
     scheduler->ScheduleTask(std::move(task));
   } catch (const std::exception& ex) {

--- a/alcedo_studio/src/utils/diagnostics/render_e2e_timing.cpp
+++ b/alcedo_studio/src/utils/diagnostics/render_e2e_timing.cpp
@@ -6,6 +6,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <mutex>
@@ -85,6 +86,14 @@ void EnsurePresentChainPrefix(Sample* sample, const Clock::time_point now) {
   if (!sample->present_wake_at.has_value()) {
     sample->present_wake_at = sample->producer_ready_at;
   }
+}
+
+auto RenderE2ePrintEnabled() -> bool {
+  const char* value = std::getenv("ALCEDO_RENDER_E2E");
+  if (value == nullptr || value[0] == '\0') {
+    return true;
+  }
+  return value[0] != '0';
 }
 
 }  // namespace
@@ -249,6 +258,11 @@ void NoteRenderE2eDisplayed(const std::uint64_t request_id) {
   // Render-thread work after the frame starts: target fulfill + createFrom.
   // consume_begin is retained for diagnostics if fulfill ever grows.
   const double import_ms = MsBetween(render_enter, now);
+
+  if (!RenderE2ePrintEnabled()) {
+    (void)consume_begin;
+    return;
+  }
 
   std::cout << std::fixed << std::setprecision(2) << "[RENDER_E2E] request=" << request_id
             << " reason=" << (sample.reason.empty() ? "?" : sample.reason)

--- a/alcedo_studio/tests/app/pipeline_service_test.cpp
+++ b/alcedo_studio/tests/app/pipeline_service_test.cpp
@@ -618,7 +618,8 @@ TEST_F(PipelineMapperTests, LoadPipelineSnapshotClonesParamsAndDoesNotTouchLiveG
     auto        snap = ps.LoadPipelineSnapshot(1, 0, &err);
     ASSERT_NE(snap, nullptr);
     ASSERT_NE(snap->executor_, nullptr);
-    EXPECT_NE(snap->executor_, g1->pipeline_);                      // independent instance
+    EXPECT_NE(snap->executor_, g1->pipeline_);  // independent instance
+    EXPECT_NE(&snap->executor_->GetRenderLock(), &g1->pipeline_->GetRenderLock());
     EXPECT_EQ(snap->pipeline_params_, params_v1);                   // captured current params
     EXPECT_EQ(snap->executor_->ExportPipelineParams(), params_v1);  // snapshot holds them
 

--- a/alcedo_studio/tests/app/thumbnail_service_test.cpp
+++ b/alcedo_studio/tests/app/thumbnail_service_test.cpp
@@ -11,9 +11,8 @@
 #include <cstdint>
 #include <deque>
 #include <exception>
-#include <fstream>
-#include <thread>
 #include <filesystem>
+#include <fstream>
 #include <functional>
 #include <future>
 #include <iostream>
@@ -21,11 +20,12 @@
 #include <opencv2/highgui.hpp>
 #include <opencv2/opencv.hpp>
 #include <random>
+#include <thread>
 #include <unordered_set>
 #include <vector>
 
-#include "app/import_service.hpp"
 #include "app/history_mgmt_service.hpp"
+#include "app/import_service.hpp"
 #include "app/pipeline_service.hpp"
 #include "app/project_service.hpp"
 #include "app/sleeve_service.hpp"
@@ -104,11 +104,9 @@ static uint64_t HashImageBufferCpuBytes(ImageBuffer& buffer) {
   return HashMatBytes(mat);
 }
 
-static std::shared_ptr<ThumbnailGuard> GetThumbnailBlocking(ThumbnailService& service,
-                                                            sl_element_id_t id, image_id_t image_id,
-                                                            bool pin_if_found = true,
-                                                            ThumbnailResolution resolution =
-                                                                ThumbnailResolution::k1024) {
+static std::shared_ptr<ThumbnailGuard> GetThumbnailBlocking(
+    ThumbnailService& service, sl_element_id_t id, image_id_t image_id, bool pin_if_found = true,
+    ThumbnailResolution resolution = ThumbnailResolution::k1024) {
   std::promise<std::shared_ptr<ThumbnailGuard>> done;
   auto                                          fut = done.get_future();
   service.GetThumbnail(
@@ -621,7 +619,8 @@ class ThumbnailServiceTests : public ::testing::Test {
     static int db_seq = 0;
     const auto suffix = "_" + std::to_string(db_seq++);
     db_path_ = std::filesystem::temp_directory_path() / ("thumbnail_service_test" + suffix + ".db");
-    meta_path_ = std::filesystem::temp_directory_path() / ("thumbnail_service_test" + suffix + ".json");
+    meta_path_ =
+        std::filesystem::temp_directory_path() / ("thumbnail_service_test" + suffix + ".json");
     try {
       if (std::filesystem::exists(db_path_)) {
         std::filesystem::remove(db_path_);
@@ -682,18 +681,18 @@ TEST(ThumbnailCacheUtilityTest, ResizeWithEvictDropsLruRecordsImmediately) {
 }
 
 TEST_F(ThumbnailServiceTests, ThumbnailTaskPropagatesDecodeResolutionToRawOperator) {
-  auto exec = std::make_shared<CPUPipelineExecutor>(false);
+  auto         exec = std::make_shared<CPUPipelineExecutor>(false);
 
   PipelineTask task;
-  task.pipeline_executor_ = exec;
+  task.pipeline_executor_                 = exec;
   task.options_.render_desc_.render_type_ = RenderType::THUMBNAIL;
-  task.options_.render_desc_.max_edge_ = 256;
-  task.options_.render_desc_.decode_res_ = DecodeRes::EIGHTH;
+  task.options_.render_desc_.max_edge_    = 256;
+  task.options_.render_desc_.decode_res_  = DecodeRes::EIGHTH;
 
   task.SetExecutorRenderParams();
 
   auto& raw_stage = exec->GetStage(PipelineStageName::Image_Loading);
-  auto raw_entry = raw_stage.GetOperator(OperatorType::RAW_DECODE);
+  auto  raw_entry = raw_stage.GetOperator(OperatorType::RAW_DECODE);
   ASSERT_TRUE(raw_entry.has_value());
   ASSERT_NE(raw_entry.value(), nullptr);
   ASSERT_NE(raw_entry.value()->op_, nullptr);
@@ -701,7 +700,7 @@ TEST_F(ThumbnailServiceTests, ThumbnailTaskPropagatesDecodeResolutionToRawOperat
   ASSERT_TRUE(params.contains("raw"));
   EXPECT_EQ(params["raw"].value("decode_res", -1), static_cast<int>(DecodeRes::EIGHTH));
 
-  task.options_.render_desc_.max_edge_ = 512;
+  task.options_.render_desc_.max_edge_   = 512;
   task.options_.render_desc_.decode_res_ = DecodeRes::QUARTER;
   task.SetExecutorRenderParams();
   raw_entry = raw_stage.GetOperator(OperatorType::RAW_DECODE);
@@ -709,8 +708,7 @@ TEST_F(ThumbnailServiceTests, ThumbnailTaskPropagatesDecodeResolutionToRawOperat
   ASSERT_NE(raw_entry.value(), nullptr);
   ASSERT_NE(raw_entry.value()->op_, nullptr);
   const auto updated_params = raw_entry.value()->op_->GetParams();
-  EXPECT_EQ(updated_params["raw"].value("decode_res", -1),
-            static_cast<int>(DecodeRes::QUARTER));
+  EXPECT_EQ(updated_params["raw"].value("decode_res", -1), static_cast<int>(DecodeRes::QUARTER));
 
   task.ResetThumbnailRenderParams();
 }
@@ -753,10 +751,10 @@ TEST_F(ThumbnailServiceTests, DISABLED_GenerateThumbnailAndCallbacks) {
   ASSERT_EQ(snapshot.metadata_ok_.size(), paths.size());
 
   // Get the first file's thumbnail
-  const auto file_id          = snapshot.created_.front().element_id_;
-  const auto image_id         = snapshot.created_.front().image_id_;
+  const auto       file_id          = snapshot.created_.front().element_id_;
+  const auto       image_id         = snapshot.created_.front().image_id_;
 
-  auto       pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
   ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
 
@@ -861,15 +859,15 @@ TEST_F(ThumbnailServiceTests, MetalGeometryPipelineThumbnailStillRenders) {
     GTEST_SKIP() << "Sample RAW file is missing: " << raw_path.string();
   }
 
-  ProjectService    project(db_path_, meta_path_);
-  auto              fs_service = project.GetSleeveService();
-  auto              img_pool   = project.GetImagePoolService();
-  ImportServiceImpl import_service(fs_service, img_pool);
+  ProjectService             project(db_path_, meta_path_);
+  auto                       fs_service = project.GetSleeveService();
+  auto                       img_pool   = project.GetImagePoolService();
+  ImportServiceImpl          import_service(fs_service, img_pool);
 
   std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
   std::promise<ImportResult> final_result;
   auto                       final_result_future = final_result.get_future();
-  import_job->on_finished_ = [&final_result](const ImportResult& result) {
+  import_job->on_finished_                       = [&final_result](const ImportResult& result) {
     final_result.set_value(result);
   };
 
@@ -890,26 +888,26 @@ TEST_F(ThumbnailServiceTests, MetalGeometryPipelineThumbnailStillRenders) {
   project.GetImagePoolService()->SyncWithStorage();
   project.SaveProject(meta_path_);
 
-  const auto element_id = snapshot.created_.front().element_id_;
-  const auto image_id   = snapshot.created_.front().image_id_;
+  const auto element_id       = snapshot.created_.front().element_id_;
+  const auto image_id         = snapshot.created_.front().image_id_;
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
-  auto pipeline_guard   = pipeline_service->LoadPipeline(element_id);
+  auto       pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto       pipeline_guard   = pipeline_service->LoadPipeline(element_id);
   ASSERT_NE(pipeline_guard, nullptr);
   ASSERT_NE(pipeline_guard->pipeline_, nullptr);
 
-  auto exec = pipeline_guard->pipeline_;
-  auto& global_params  = exec->GetGlobalParams();
-  auto& loading_stage  = exec->GetStage(PipelineStageName::Image_Loading);
-  auto& geometry_stage = exec->GetStage(PipelineStageName::Geometry_Adjustment);
+  auto           exec           = pipeline_guard->pipeline_;
+  auto&          global_params  = exec->GetGlobalParams();
+  auto&          loading_stage  = exec->GetStage(PipelineStageName::Image_Loading);
+  auto&          geometry_stage = exec->GetStage(PipelineStageName::Geometry_Adjustment);
 
   // The decode backend is a runtime property of the pipeline (resolved from
   // the accelerator preference); the params must not carry it.
-  nlohmann::json raw_params = pipeline_defaults::MakeDefaultRawDecodeParams();
-  raw_params["raw"]["backend"] = "alcedo";
+  nlohmann::json raw_params     = pipeline_defaults::MakeDefaultRawDecodeParams();
+  raw_params["raw"]["backend"]  = "alcedo";
   loading_stage.SetOperator(OperatorType::RAW_DECODE, raw_params);
 
-  nlohmann::json crop_params = pipeline_defaults::MakeDefaultCropRotateParams();
+  nlohmann::json crop_params                  = pipeline_defaults::MakeDefaultCropRotateParams();
   crop_params["crop_rotate"]["enabled"]       = true;
   crop_params["crop_rotate"]["enable_crop"]   = true;
   crop_params["crop_rotate"]["angle_degrees"] = 0.0f;
@@ -944,21 +942,20 @@ TEST_F(ThumbnailServiceTests, MetalGeometryPipelineThumbnailStillRenders) {
 }
 
 TEST_F(ThumbnailServiceTests, ThumbnailRenderUsesInjectedRawMetadataForDng) {
-  const auto raw_path =
-      std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
+  const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
   if (!std::filesystem::exists(raw_path)) {
     GTEST_SKIP() << "Sample DNG file is missing: " << raw_path.string();
   }
 
-  ProjectService    project(db_path_, meta_path_);
-  auto              fs_service = project.GetSleeveService();
-  auto              img_pool   = project.GetImagePoolService();
-  ImportServiceImpl import_service(fs_service, img_pool);
+  ProjectService             project(db_path_, meta_path_);
+  auto                       fs_service = project.GetSleeveService();
+  auto                       img_pool   = project.GetImagePoolService();
+  ImportServiceImpl          import_service(fs_service, img_pool);
 
   std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
   std::promise<ImportResult> final_result;
   auto                       final_result_future = final_result.get_future();
-  import_job->on_finished_ = [&final_result](const ImportResult& result) {
+  import_job->on_finished_                       = [&final_result](const ImportResult& result) {
     final_result.set_value(result);
   };
 
@@ -979,10 +976,10 @@ TEST_F(ThumbnailServiceTests, ThumbnailRenderUsesInjectedRawMetadataForDng) {
   project.GetImagePoolService()->SyncWithStorage();
   project.SaveProject(meta_path_);
 
-  const auto element_id = snapshot.created_.front().element_id_;
-  const auto image_id   = snapshot.created_.front().image_id_;
+  const auto       element_id       = snapshot.created_.front().element_id_;
+  const auto       image_id         = snapshot.created_.front().image_id_;
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
   ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
 
   const uint64_t thumbnail_hash = GetThumbnailHashBlocking(thumbnail_service, element_id, image_id);
@@ -1031,21 +1028,20 @@ TEST_F(ThumbnailServiceTests, ThumbnailRenderUsesInjectedRawMetadataForDng) {
 // state. Verified by pinning + dirtying the live guard across the render and
 // asserting pin_count_/dirty_ are unchanged afterward.
 TEST_F(ThumbnailServiceTests, AnalysisRenditionRendersWithoutSavePipelineOnLiveGuard) {
-  const auto raw_path =
-      std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
+  const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
   if (!std::filesystem::exists(raw_path)) {
     GTEST_SKIP() << "Sample DNG file is missing: " << raw_path.string();
   }
 
-  ProjectService    project(db_path_, meta_path_);
-  auto              fs_service = project.GetSleeveService();
-  auto              img_pool   = project.GetImagePoolService();
-  ImportServiceImpl import_service(fs_service, img_pool);
+  ProjectService             project(db_path_, meta_path_);
+  auto                       fs_service = project.GetSleeveService();
+  auto                       img_pool   = project.GetImagePoolService();
+  ImportServiceImpl          import_service(fs_service, img_pool);
 
   std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
   std::promise<ImportResult> final_result;
   auto                       final_result_future = final_result.get_future();
-  import_job->on_finished_                        = [&final_result](const ImportResult& result) {
+  import_job->on_finished_                       = [&final_result](const ImportResult& result) {
     final_result.set_value(result);
   };
 
@@ -1066,16 +1062,16 @@ TEST_F(ThumbnailServiceTests, AnalysisRenditionRendersWithoutSavePipelineOnLiveG
   project.GetImagePoolService()->SyncWithStorage();
   project.SaveProject(meta_path_);
 
-  const auto element_id = snapshot.created_.front().element_id_;
-  const auto image_id   = snapshot.created_.front().image_id_;
+  const auto       element_id       = snapshot.created_.front().element_id_;
+  const auto       image_id         = snapshot.created_.front().image_id_;
 
-  auto            pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
   ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
 
   // Pin the live guard and mark it dirty. A correct snapshot render must leave
   // both untouched: it never calls SavePipeline on this guard, so the pin is not
   // decremented and dirty state is not cleared.
-  auto live_guard = pipeline_service->LoadPipeline(element_id);
+  auto             live_guard = pipeline_service->LoadPipeline(element_id);
   ASSERT_NE(live_guard, nullptr);
   ASSERT_NE(live_guard->pipeline_, nullptr);
   live_guard->dirty_ = true;
@@ -1095,39 +1091,83 @@ TEST_F(ThumbnailServiceTests, AnalysisRenditionRendersWithoutSavePipelineOnLiveG
 
   // Acceptance: the live guard was not released or reset by the analysis render.
   EXPECT_EQ(live_guard->pin_count_, size_t{1});  // no SavePipeline on the live guard
-  EXPECT_EQ(live_guard->dirty_, true);          // dirty not cleared
-  ASSERT_NE(live_guard->pipeline_, nullptr);   // executor still valid
+  EXPECT_EQ(live_guard->dirty_, true);           // dirty not cleared
+  ASSERT_NE(live_guard->pipeline_, nullptr);     // executor still valid
 
   thumbnail_service.ReleaseAnalysisRendition(result.key);
   pipeline_service->SavePipeline(live_guard);  // release the test's pin
 }
 
-TEST_F(ThumbnailServiceTests,
-       DiskCacheTracksRootAndActiveHeadAndServesAfterPipelineIsRemoved) {
-  const auto raw_path =
-      std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
+TEST_F(ThumbnailServiceTests, OrdinaryThumbnailRendersWithoutUsingLiveEditorExecutor) {
+  const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
+  if (!std::filesystem::exists(raw_path)) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << raw_path.string();
+  }
+
+  ProjectService             project(db_path_, meta_path_);
+  auto                       fs_service = project.GetSleeveService();
+  auto                       img_pool   = project.GetImagePoolService();
+  ImportServiceImpl          import_service(fs_service, img_pool);
+  auto                       import_job = std::make_shared<ImportJob>();
+  std::promise<ImportResult> imported;
+  auto                       imported_future = imported.get_future();
+  import_job->on_finished_                   = [&imported](const ImportResult& result) {
+    imported.set_value(result);
+  };
+  import_job = import_service.ImportToFolder({raw_path}, L"", {}, import_job);
+  ASSERT_NE(import_job, nullptr);
+  ASSERT_EQ(imported_future.wait_for(60s), std::future_status::ready);
+  ASSERT_EQ(imported_future.get().imported_, 1u);
+  ASSERT_NE(import_job->import_log_, nullptr);
+  const auto import_snapshot = import_job->import_log_->Snapshot();
+  ASSERT_EQ(import_snapshot.created_.size(), 1u);
+  import_service.SyncImports(import_snapshot, L"");
+  project.GetSleeveService()->Sync();
+  project.GetImagePoolService()->SyncWithStorage();
+
+  const auto       element_id       = import_snapshot.created_.front().element_id_;
+  const auto       image_id         = import_snapshot.created_.front().image_id_;
+  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
+  auto             live_guard = pipeline_service->LoadPipeline(element_id);
+  ASSERT_NE(live_guard, nullptr);
+  ASSERT_NE(live_guard->pipeline_, nullptr);
+  live_guard->dirty_ = true;
+  ASSERT_EQ(live_guard->pin_count_, size_t{1});
+
+  auto thumbnail = GetThumbnailBlocking(thumbnail_service, element_id, image_id, true,
+                                        ThumbnailResolution::k256);
+  ASSERT_NE(thumbnail, nullptr);
+  ASSERT_NE(thumbnail->thumbnail_buffer_, nullptr);
+  EXPECT_EQ(live_guard->pin_count_, size_t{1});
+  EXPECT_TRUE(live_guard->dirty_);
+
+  thumbnail_service.ReleaseThumbnail(ThumbnailCacheKey{element_id, ThumbnailResolution::k256});
+  pipeline_service->SavePipeline(live_guard);
+}
+
+TEST_F(ThumbnailServiceTests, DiskCacheTracksRootAndActiveHeadAndServesAfterPipelineIsRemoved) {
+  const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
   if (!std::filesystem::exists(raw_path)) {
     GTEST_SKIP() << "Sample RAW file is missing: " << raw_path.string();
   }
 
   const auto cache_root =
       std::filesystem::temp_directory_path() /
-      ("thumbnail_disk_cache_e2e_" + std::to_string(
-                                      std::chrono::steady_clock::now()
-                                          .time_since_epoch()
-                                          .count()));
+      ("thumbnail_disk_cache_e2e_" +
+       std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
   std::error_code cleanup_ec;
   std::filesystem::remove_all(cache_root, cleanup_ec);
 
-  ProjectService    project(db_path_, meta_path_);
-  auto              fs_service = project.GetSleeveService();
-  auto              img_pool   = project.GetImagePoolService();
-  ImportServiceImpl import_service(fs_service, img_pool);
+  ProjectService             project(db_path_, meta_path_);
+  auto                       fs_service = project.GetSleeveService();
+  auto                       img_pool   = project.GetImagePoolService();
+  ImportServiceImpl          import_service(fs_service, img_pool);
 
   std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
   std::promise<ImportResult> final_result;
   auto                       final_result_future = final_result.get_future();
-  import_job->on_finished_ = [&final_result](const ImportResult& result) {
+  import_job->on_finished_                       = [&final_result](const ImportResult& result) {
     final_result.set_value(result);
   };
 
@@ -1148,32 +1188,32 @@ TEST_F(ThumbnailServiceTests,
   project.GetImagePoolService()->SyncWithStorage();
   project.SaveProject(meta_path_);
 
-  const auto element_id = snapshot.created_.front().element_id_;
-  const auto image_id   = snapshot.created_.front().image_id_;
+  const auto element_id            = snapshot.created_.front().element_id_;
+  const auto image_id              = snapshot.created_.front().image_id_;
 
-  auto root_pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
-  auto root_guard = root_pipeline_service->LoadEditorPipeline(element_id);
+  auto       root_pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto       root_guard            = root_pipeline_service->LoadEditorPipeline(element_id);
   ASSERT_NE(root_guard, nullptr);
   root_pipeline_service->SavePipeline(root_guard);
 
   root_id_t root_id{};
   {
-    auto               db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto               db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    auto               graph = graph_service.LoadGraph(element_id);
+    auto             graph = graph_service.LoadGraph(element_id);
     ASSERT_TRUE(graph.has_value());
     root_id = graph->GetRootId();
   }
 
   uint64_t first_hash = 0;
   {
-    auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
     ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service,
                                        project.GetStorage(), project.GetProjectUUID(), cache_root);
 
-    auto guard = GetThumbnailBlocking(thumbnail_service, element_id, image_id, true,
-                                      ThumbnailResolution::k256);
+    auto             guard = GetThumbnailBlocking(thumbnail_service, element_id, image_id, true,
+                                                  ThumbnailResolution::k256);
     ASSERT_NE(guard, nullptr);
     ASSERT_NE(guard->thumbnail_buffer_, nullptr);
     first_hash = HashImageBufferCpuBytes(*guard->thumbnail_buffer_);
@@ -1188,16 +1228,15 @@ TEST_F(ThumbnailServiceTests,
     nlohmann::json metadata;
     metadata_file >> metadata;
     ASSERT_EQ(metadata["entries"].size(), 1u);
-    EXPECT_EQ(metadata["entries"][0]["edit_version_hash"].get<std::string>(),
-              root_id.ToString());
+    EXPECT_EQ(metadata["entries"][0]["edit_version_hash"].get<std::string>(), root_id.ToString());
   }
 
   commit_hash_t active_head{};
   {
-    auto               db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto               db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    auto               graph = graph_service.LoadGraph(element_id);
+    auto             graph = graph_service.LoadGraph(element_id);
     ASSERT_TRUE(graph.has_value());
 
     OrdinaryEditPayload payload;
@@ -1217,11 +1256,11 @@ TEST_F(ThumbnailServiceTests,
   }
 
   {
-    auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
     ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service,
                                        project.GetStorage(), project.GetProjectUUID(), cache_root);
-    auto guard = GetThumbnailBlocking(thumbnail_service, element_id, image_id, true,
-                                      ThumbnailResolution::k256);
+    auto             guard = GetThumbnailBlocking(thumbnail_service, element_id, image_id, true,
+                                                  ThumbnailResolution::k256);
     ASSERT_NE(guard, nullptr);
     ASSERT_NE(guard->thumbnail_buffer_, nullptr);
     thumbnail_service.ReleaseThumbnail(ThumbnailCacheKey{element_id, ThumbnailResolution::k256});
@@ -1246,12 +1285,12 @@ TEST_F(ThumbnailServiceTests,
   deleting_pipeline_service->Sync();
 
   {
-    auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
     ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service,
                                        project.GetStorage(), project.GetProjectUUID(), cache_root);
 
-    auto guard = GetThumbnailBlocking(thumbnail_service, element_id, image_id, true,
-                                      ThumbnailResolution::k256);
+    auto             guard = GetThumbnailBlocking(thumbnail_service, element_id, image_id, true,
+                                                  ThumbnailResolution::k256);
     ASSERT_NE(guard, nullptr);
     ASSERT_NE(guard->thumbnail_buffer_, nullptr);
     auto* buffer = guard->thumbnail_buffer_.get();
@@ -1325,10 +1364,10 @@ TEST_F(ThumbnailServiceTests, DISABLED_PipelineRestoredFromDBGeneratesCorrectThu
   // changes.
   {
     ProjectService project(db_path_, meta_path_);
-    auto           img_pool = project.GetImagePoolService();
-    auto pipeline_service   = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    auto           img_pool         = project.GetImagePoolService();
+    auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
-    std::string pipline_before;
+    std::string    pipline_before;
     {
       ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
       default_hash = GetThumbnailHashBlocking(thumbnail_service, file_id, image_id);
@@ -1376,9 +1415,9 @@ TEST_F(ThumbnailServiceTests, DISABLED_PipelineRestoredFromDBGeneratesCorrectThu
   // Phase 3: reopen project (pipeline restored from DB) and ensure thumbnail matches the modified
   // one.
   {
-    ProjectService project(db_path_, meta_path_);
-    auto           img_pool = project.GetImagePoolService();
-    auto pipeline_service   = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    ProjectService   project(db_path_, meta_path_);
+    auto             img_pool         = project.GetImagePoolService();
+    auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
     ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
     const auto       restored_hash = GetThumbnailHashBlocking(thumbnail_service, file_id, image_id);
@@ -1446,8 +1485,8 @@ TEST_F(ThumbnailServiceTests, DISABLED_FuzzScrollBrowsingNoThrowReloadService) {
   // Phase 1: browse/fuzz.
   {
     ProjectService project(db_path_, meta_path_);
-    auto           img_pool = project.GetImagePoolService();
-    auto pipeline_service   = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    auto           img_pool         = project.GetImagePoolService();
+    auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
     {
       ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
@@ -1463,8 +1502,8 @@ TEST_F(ThumbnailServiceTests, DISABLED_FuzzScrollBrowsingNoThrowReloadService) {
   // Phase 2: simulate reloading the service and browsing again.
   {
     ProjectService project(db_path_, meta_path_);
-    auto           img_pool = project.GetImagePoolService();
-    auto pipeline_service   = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    auto           img_pool         = project.GetImagePoolService();
+    auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
     {
       ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
@@ -1547,8 +1586,8 @@ TEST_F(ThumbnailServiceTests, FuzzScrollBrowsingSharedPtrLifetimeStress) {
   std::cout << "[ThumbnailFuzz] Starting phase 1 browsing fuzz..." << std::endl;
   {
     ProjectService project(db_path_, meta_path_);
-    auto           img_pool = project.GetImagePoolService();
-    auto pipeline_service   = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    auto           img_pool         = project.GetImagePoolService();
+    auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
     {
       ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
@@ -1589,8 +1628,8 @@ TEST_F(ThumbnailServiceTests, FuzzScrollBrowsingSharedPtrLifetimeStress) {
   // Phase 2: reload service and stress again.
   {
     ProjectService project(db_path_, meta_path_);
-    auto           img_pool = project.GetImagePoolService();
-    auto pipeline_service   = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    auto           img_pool         = project.GetImagePoolService();
+    auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
     {
       ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
@@ -1654,8 +1693,8 @@ TEST_F(ThumbnailServiceTests, DISABLED_Generate16ThumbnailsAndValidateAll) {
   ASSERT_GE(snapshot.created_.size(), paths.size());
   ASSERT_GE(snapshot.metadata_ok_.size(), paths.size());
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
-  auto scheduler        = std::make_shared<PipelineScheduler>(8);
+  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto             scheduler        = std::make_shared<PipelineScheduler>(8);
   ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
 
   std::vector<std::pair<sl_element_id_t, image_id_t>> ids;
@@ -1724,13 +1763,13 @@ TEST_F(ThumbnailServiceTests, DISABLED_Generate16ThumbnailsAndValidateAll) {
 }
 
 TEST_F(ThumbnailServiceTests, MissingPipelineThrows) {
-  ProjectService project(db_path_, meta_path_);
-  auto           img_pool        = project.GetImagePoolService();
+  ProjectService   project(db_path_, meta_path_);
+  auto             img_pool         = project.GetImagePoolService();
 
-  auto           storage_service = project.GetStorage();
-  auto           conn_guard      = storage_service->GetDatabase().GetConnectionGuard();
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
-  auto scheduler        = std::make_shared<PipelineScheduler>();
+  auto             storage_service  = project.GetStorage();
+  auto             conn_guard       = storage_service->GetDatabase().GetConnectionGuard();
+  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto             scheduler        = std::make_shared<PipelineScheduler>();
 
   ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
 
@@ -1740,12 +1779,12 @@ TEST_F(ThumbnailServiceTests, MissingPipelineThrows) {
 
 TEST_F(ThumbnailServiceTests, MissingImageThrows) {
   ProjectService project(db_path_, meta_path_);
-  auto           img_pool        = project.GetImagePoolService();
+  auto           img_pool         = project.GetImagePoolService();
 
-  auto           storage_service = project.GetStorage();
-  auto           conn_guard      = storage_service->GetDatabase().GetConnectionGuard();
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
-  auto scheduler        = std::make_shared<PipelineScheduler>();
+  auto           storage_service  = project.GetStorage();
+  auto           conn_guard       = storage_service->GetDatabase().GetConnectionGuard();
+  auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto           scheduler        = std::make_shared<PipelineScheduler>();
 
   constexpr sl_element_id_t kMissingImageId = 7777;
 
@@ -1800,18 +1839,16 @@ TEST_F(ThumbnailServiceTests, CacheKeySeparatesResolutions) {
     img_pool->SyncWithStorage();
     project.SaveProject(meta_path_);
 
-    const auto eid = snapshot.created_[0].element_id_;
-    const auto iid = snapshot.created_[0].image_id_;
+    const auto       eid = snapshot.created_[0].element_id_;
+    const auto       iid = snapshot.created_[0].image_id_;
 
     ThumbnailService svc(fs_service, img_pool, pipeline_service);
 
-    auto guard_256 = GetThumbnailBlocking(svc, eid, iid, true,
-                                          ThumbnailResolution::k256);
+    auto guard_256 = GetThumbnailBlocking(svc, eid, iid, true, ThumbnailResolution::k256);
     ASSERT_NE(guard_256, nullptr);
     ASSERT_NE(guard_256->thumbnail_buffer_, nullptr);
 
-    auto guard_1024 = GetThumbnailBlocking(svc, eid, iid, true,
-                                           ThumbnailResolution::k1024);
+    auto guard_1024 = GetThumbnailBlocking(svc, eid, iid, true, ThumbnailResolution::k1024);
     ASSERT_NE(guard_1024, nullptr);
     ASSERT_NE(guard_1024->thumbnail_buffer_, nullptr);
 
@@ -1820,8 +1857,8 @@ TEST_F(ThumbnailServiceTests, CacheKeySeparatesResolutions) {
 
     // Releasing one request key must not release the other tier for the same element.
     svc.ReleaseThumbnail(ThumbnailCacheKey{eid, ThumbnailResolution::k256});
-    auto guard_1024_still_cached = GetThumbnailBlocking(svc, eid, iid, true,
-                                                        ThumbnailResolution::k1024);
+    auto guard_1024_still_cached =
+        GetThumbnailBlocking(svc, eid, iid, true, ThumbnailResolution::k1024);
     ASSERT_NE(guard_1024_still_cached, nullptr);
     EXPECT_EQ(guard_1024_still_cached.get(), guard_1024.get());
     svc.ReleaseThumbnail(ThumbnailCacheKey{eid, ThumbnailResolution::k1024});
@@ -1848,13 +1885,11 @@ TEST_F(ThumbnailServiceTests, CacheKeySeparatesResolutions) {
     // Release via ReleaseThumbnail (clears all tiers), then re-request.
     // Both tiers should be independently recoverable.
     svc.ReleaseThumbnail(eid);
-    auto guard_256_after = GetThumbnailBlocking(svc, eid, iid, false,
-                                                ThumbnailResolution::k256);
+    auto guard_256_after = GetThumbnailBlocking(svc, eid, iid, false, ThumbnailResolution::k256);
     ASSERT_NE(guard_256_after, nullptr);
     ASSERT_NE(guard_256_after->thumbnail_buffer_, nullptr);
 
-    auto guard_1024_after = GetThumbnailBlocking(svc, eid, iid, false,
-                                                 ThumbnailResolution::k1024);
+    auto guard_1024_after = GetThumbnailBlocking(svc, eid, iid, false, ThumbnailResolution::k1024);
     ASSERT_NE(guard_1024_after, nullptr);
     ASSERT_NE(guard_1024_after->thumbnail_buffer_, nullptr);
 
@@ -1898,8 +1933,8 @@ TEST_F(ThumbnailServiceTests, MultiResolutionPinIndependence) {
     img_pool->SyncWithStorage();
     project.SaveProject(meta_path_);
 
-    const auto eid = snapshot.created_[0].element_id_;
-    const auto iid = snapshot.created_[0].image_id_;
+    const auto       eid = snapshot.created_[0].element_id_;
+    const auto       iid = snapshot.created_[0].image_id_;
 
     ThumbnailService svc(fs_service, img_pool, pipeline_service);
 
@@ -1917,8 +1952,7 @@ TEST_F(ThumbnailServiceTests, MultiResolutionPinIndependence) {
     }
 
     // After all releases, unpinned request should succeed and get a fresh entry.
-    auto fresh = GetThumbnailBlocking(svc, eid, iid, false,
-                                      ThumbnailResolution::k1024);
+    auto fresh = GetThumbnailBlocking(svc, eid, iid, false, ThumbnailResolution::k1024);
     ASSERT_NE(fresh, nullptr);
     ASSERT_NE(fresh->thumbnail_buffer_, nullptr);
     // Newly-created guard always starts at pin_count_=1 (the request itself
@@ -1965,17 +1999,17 @@ TEST_F(ThumbnailServiceTests, DISABLED_CancelPendingDoesNotCrash) {
     img_pool->SyncWithStorage();
     project.SaveProject(meta_path_);
 
-    const auto eid = snapshot.created_[0].element_id_;
-    const auto iid = snapshot.created_[0].image_id_;
+    const auto                                    eid = snapshot.created_[0].element_id_;
+    const auto                                    iid = snapshot.created_[0].image_id_;
 
-    ThumbnailService svc(fs_service, img_pool, pipeline_service);
+    ThumbnailService                              svc(fs_service, img_pool, pipeline_service);
 
     // Issue non-pinned request at slowest resolution.
     std::promise<std::shared_ptr<ThumbnailGuard>> promise;
-    auto fut2 = promise.get_future();
-    svc.GetThumbnail(eid, iid,
-                     [&promise](std::shared_ptr<ThumbnailGuard> g) { promise.set_value(g); },
-                     false, nullptr, ThumbnailResolution::k2048);
+    auto                                          fut2 = promise.get_future();
+    svc.GetThumbnail(
+        eid, iid, [&promise](std::shared_ptr<ThumbnailGuard> g) { promise.set_value(g); }, false,
+        nullptr, ThumbnailResolution::k2048);
 
     // Cancel immediately.
     EXPECT_NO_THROW(svc.CancelPending(eid));
@@ -2027,29 +2061,26 @@ TEST_F(ThumbnailServiceTests, DISABLED_CancelPendingStressMultiple) {
     img_pool->SyncWithStorage();
     project.SaveProject(meta_path_);
 
-    const auto eid = snapshot.created_[0].element_id_;
-    const auto iid = snapshot.created_[0].image_id_;
+    const auto                eid = snapshot.created_[0].element_id_;
+    const auto                iid = snapshot.created_[0].image_id_;
 
-    ThumbnailService svc(fs_service, img_pool, pipeline_service);
+    ThumbnailService          svc(fs_service, img_pool, pipeline_service);
 
     // 50 rapid cancel+request cycles at various resolutions.
-    const ThumbnailResolution tiers[] = {
-        ThumbnailResolution::k256, ThumbnailResolution::k512,
-        ThumbnailResolution::k1024, ThumbnailResolution::k2048};
+    const ThumbnailResolution tiers[] = {ThumbnailResolution::k256, ThumbnailResolution::k512,
+                                         ThumbnailResolution::k1024, ThumbnailResolution::k2048};
 
     for (int cycle = 0; cycle < 50; ++cycle) {
-      auto res = tiers[cycle % 4];
+      auto                                                      res = tiers[cycle % 4];
       std::vector<std::future<std::shared_ptr<ThumbnailGuard>>> futures;
 
       // Fire several requests.
       for (int r = 0; r < 4; ++r) {
         auto promise = std::make_shared<std::promise<std::shared_ptr<ThumbnailGuard>>>();
         futures.push_back(promise->get_future());
-        svc.GetThumbnail(eid, iid,
-                         [promise](std::shared_ptr<ThumbnailGuard> g) {
-                           promise->set_value(g);
-                         },
-                         false, nullptr, res);
+        svc.GetThumbnail(
+            eid, iid, [promise](std::shared_ptr<ThumbnailGuard> g) { promise->set_value(g); },
+            false, nullptr, res);
       }
 
       // Cancel immediately.
@@ -2063,8 +2094,7 @@ TEST_F(ThumbnailServiceTests, DISABLED_CancelPendingStressMultiple) {
     }
 
     // Final request should still succeed.
-    auto final_guard = GetThumbnailBlocking(svc, eid, iid, false,
-                                            ThumbnailResolution::k1024);
+    auto final_guard = GetThumbnailBlocking(svc, eid, iid, false, ThumbnailResolution::k1024);
     ASSERT_NE(final_guard, nullptr);
     ASSERT_NE(final_guard->thumbnail_buffer_, nullptr);
   }
@@ -2105,22 +2135,20 @@ TEST_F(ThumbnailServiceTests, ResizeCachePreservesPinnedEntries) {
     img_pool->SyncWithStorage();
     project.SaveProject(meta_path_);
 
-    const auto eid = snapshot.created_[0].element_id_;
-    const auto iid = snapshot.created_[0].image_id_;
+    const auto       eid = snapshot.created_[0].element_id_;
+    const auto       iid = snapshot.created_[0].image_id_;
 
     ThumbnailService svc(fs_service, img_pool, pipeline_service);
 
     // Pin k1024.
-    auto guard = GetThumbnailBlocking(svc, eid, iid, true,
-                                      ThumbnailResolution::k1024);
+    auto             guard = GetThumbnailBlocking(svc, eid, iid, true, ThumbnailResolution::k1024);
     ASSERT_NE(guard, nullptr);
     ASSERT_GT(guard->pin_count_, 0);
 
     // Resize to 1 — pinned entry survives.
     EXPECT_NO_THROW(svc.ResizeCache(1));
 
-    auto still_there = GetThumbnailBlocking(svc, eid, iid, false,
-                                            ThumbnailResolution::k1024);
+    auto still_there = GetThumbnailBlocking(svc, eid, iid, false, ThumbnailResolution::k1024);
     ASSERT_NE(still_there, nullptr);
     EXPECT_EQ(still_there.get(), guard.get());
 
@@ -2165,8 +2193,8 @@ TEST_F(ThumbnailServiceTests, ResizeCacheClampsToBounds) {
     img_pool->SyncWithStorage();
     project.SaveProject(meta_path_);
 
-    const auto eid = snapshot.created_[0].element_id_;
-    const auto iid = snapshot.created_[0].image_id_;
+    const auto       eid = snapshot.created_[0].element_id_;
+    const auto       iid = snapshot.created_[0].image_id_;
 
     ThumbnailService svc(fs_service, img_pool, pipeline_service);
 
@@ -2175,8 +2203,7 @@ TEST_F(ThumbnailServiceTests, ResizeCacheClampsToBounds) {
     EXPECT_NO_THROW(svc.ResizeCache(1000000));
 
     // Normal operation after extreme resizes should work.
-    auto guard = GetThumbnailBlocking(svc, eid, iid, false,
-                                      ThumbnailResolution::k1024);
+    auto guard = GetThumbnailBlocking(svc, eid, iid, false, ThumbnailResolution::k1024);
     ASSERT_NE(guard, nullptr);
     ASSERT_NE(guard->thumbnail_buffer_, nullptr);
   }
@@ -2217,10 +2244,10 @@ TEST_F(ThumbnailServiceTests, InvalidateClearsAllResolutionTiers) {
     img_pool->SyncWithStorage();
     project.SaveProject(meta_path_);
 
-    const auto eid = snapshot.created_[0].element_id_;
-    const auto iid = snapshot.created_[0].image_id_;
+    const auto                                   eid = snapshot.created_[0].element_id_;
+    const auto                                   iid = snapshot.created_[0].image_id_;
 
-    ThumbnailService svc(fs_service, img_pool, pipeline_service);
+    ThumbnailService                             svc(fs_service, img_pool, pipeline_service);
 
     // Build cache for all 4 tiers (unpinned).
     std::vector<std::shared_ptr<ThumbnailGuard>> guards;
@@ -2280,14 +2307,14 @@ TEST_F(ThumbnailServiceTests, BackwardCompatibleDefaultResolution) {
     img_pool->SyncWithStorage();
     project.SaveProject(meta_path_);
 
-    const auto eid = snapshot.created_[0].element_id_;
-    const auto iid = snapshot.created_[0].image_id_;
+    const auto                                    eid = snapshot.created_[0].element_id_;
+    const auto                                    iid = snapshot.created_[0].image_id_;
 
-    ThumbnailService svc(fs_service, img_pool, pipeline_service);
+    ThumbnailService                              svc(fs_service, img_pool, pipeline_service);
 
     // Old-style call (no resolution param) defaults to k1024.
     std::promise<std::shared_ptr<ThumbnailGuard>> done;
-    auto fut2 = done.get_future();
+    auto                                          fut2 = done.get_future();
     svc.GetThumbnail(eid, iid,
                      [&done](std::shared_ptr<ThumbnailGuard> guard) { done.set_value(guard); });
     ASSERT_EQ(fut2.wait_for(120s), std::future_status::ready);
@@ -2335,8 +2362,8 @@ TEST_F(ThumbnailServiceTests, DISABLED_FuzzCompositeKeyMultiResNoCrash) {
     ASSERT_EQ(fut.wait_for(120s), std::future_status::ready);
     ASSERT_EQ(fut.get().failed_, 0u);
 
-    auto snapshot = import_job->import_log_->Snapshot();
-    const size_t count = std::min<size_t>(8, snapshot.created_.size());
+    auto         snapshot = import_job->import_log_->Snapshot();
+    const size_t count    = std::min<size_t>(8, snapshot.created_.size());
     for (size_t i = 0; i < count; ++i) {
       ids.push_back({snapshot.created_[i].element_id_, snapshot.created_[i].image_id_});
     }
@@ -2351,17 +2378,17 @@ TEST_F(ThumbnailServiceTests, DISABLED_FuzzCompositeKeyMultiResNoCrash) {
   // Phase 1: fuzz with zoom-like resolution switching.
   {
     ProjectService project(db_path_, meta_path_);
-    auto           img_pool = project.GetImagePoolService();
-    auto pipeline_service   = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    auto           img_pool         = project.GetImagePoolService();
+    auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
     {
-      ThumbnailService svc(project.GetSleeveService(), img_pool, pipeline_service);
+      ThumbnailService          svc(project.GetSleeveService(), img_pool, pipeline_service);
 
-      const ThumbnailResolution all_res[] = {
-          ThumbnailResolution::k256, ThumbnailResolution::k512,
-          ThumbnailResolution::k1024, ThumbnailResolution::k2048};
+      const ThumbnailResolution all_res[] = {ThumbnailResolution::k256, ThumbnailResolution::k512,
+                                             ThumbnailResolution::k1024,
+                                             ThumbnailResolution::k2048};
 
-      std::mt19937                    rng(0xDECAFBADu);
+      std::mt19937              rng(0xDECAFBADu);
       std::uniform_int_distribution<size_t> idx_dist(0, ids.size() - 1);
       std::uniform_int_distribution<int>    res_dist(0, 3);
 
@@ -2373,7 +2400,7 @@ TEST_F(ThumbnailServiceTests, DISABLED_FuzzCompositeKeyMultiResNoCrash) {
         const auto res        = all_res[res_dist(rng)];
 
         // Request with pin.
-        auto guard = GetThumbnailBlocking(svc, element_id, image_id, true, res);
+        auto       guard      = GetThumbnailBlocking(svc, element_id, image_id, true, res);
         ASSERT_NE(guard, nullptr);
         ASSERT_NE(guard->thumbnail_buffer_, nullptr);
         ASSERT_GT(guard->pin_count_, 0) << "iter=" << iter;
@@ -2398,8 +2425,7 @@ TEST_F(ThumbnailServiceTests, DISABLED_FuzzCompositeKeyMultiResNoCrash) {
 
       // Verify every element still renderable.
       for (const auto& [eid, iid] : ids) {
-        auto guard = GetThumbnailBlocking(svc, eid, iid, false,
-                                          ThumbnailResolution::k1024);
+        auto guard = GetThumbnailBlocking(svc, eid, iid, false, ThumbnailResolution::k1024);
         ASSERT_NE(guard, nullptr);
         ASSERT_NE(guard->thumbnail_buffer_, nullptr);
       }
@@ -2437,11 +2463,11 @@ TEST_F(ThumbnailServiceTests, CancelPendingReturnsNull) {
   }
   ASSERT_GE(paths.size(), 1u);
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto            pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
   // Import.
-  sl_element_id_t eid = 0;
-  image_id_t      iid = 0;
+  sl_element_id_t eid              = 0;
+  image_id_t      iid              = 0;
   {
     std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
     std::promise<ImportResult> final_result;
@@ -2467,13 +2493,13 @@ TEST_F(ThumbnailServiceTests, CancelPendingReturnsNull) {
 
   // Issue requests at 3 resolutions, then cancel.
   std::vector<std::future<std::shared_ptr<ThumbnailGuard>>> futures;
-  for (auto res : {ThumbnailResolution::k256, ThumbnailResolution::k512,
-                   ThumbnailResolution::k1024}) {
+  for (auto res :
+       {ThumbnailResolution::k256, ThumbnailResolution::k512, ThumbnailResolution::k1024}) {
     auto promise = std::make_shared<std::promise<std::shared_ptr<ThumbnailGuard>>>();
     futures.push_back(promise->get_future());
-    svc.GetThumbnail(eid, iid,
-                     [promise](std::shared_ptr<ThumbnailGuard> g) { promise->set_value(g); },
-                     false, nullptr, res);
+    svc.GetThumbnail(
+        eid, iid, [promise](std::shared_ptr<ThumbnailGuard> g) { promise->set_value(g); }, false,
+        nullptr, res);
   }
 
   // Cancel — pending callbacks fire with nullptr (Strategy C).
@@ -2510,10 +2536,10 @@ TEST_F(ThumbnailServiceTests, CancelPendingDrainsAllResolutions) {
   }
   ASSERT_GE(paths.size(), 1u);
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto            pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
-  sl_element_id_t eid = 0;
-  image_id_t      iid = 0;
+  sl_element_id_t eid              = 0;
+  image_id_t      iid              = 0;
   {
     std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
     std::promise<ImportResult> final_result;
@@ -2535,28 +2561,27 @@ TEST_F(ThumbnailServiceTests, CancelPendingDrainsAllResolutions) {
     iid = snapshot.created_[0].image_id_;
   }
 
-  ThumbnailService svc(fs_service, img_pool, pipeline_service);
+  ThumbnailService          svc(fs_service, img_pool, pipeline_service);
 
   // Fire one request per resolution tier — all land in pending_.
-  std::atomic<int> callback_count{0};
-  std::atomic<int> null_count{0};
-  std::promise<void> all_done;
-  auto               all_fut = all_done.get_future();
+  std::atomic<int>          callback_count{0};
+  std::atomic<int>          null_count{0};
+  std::promise<void>        all_done;
+  auto                      all_fut = all_done.get_future();
 
-  const ThumbnailResolution tiers[] = {
-      ThumbnailResolution::k256, ThumbnailResolution::k512,
-      ThumbnailResolution::k1024, ThumbnailResolution::k2048};
+  const ThumbnailResolution tiers[] = {ThumbnailResolution::k256, ThumbnailResolution::k512,
+                                       ThumbnailResolution::k1024, ThumbnailResolution::k2048};
 
   for (auto res : tiers) {
-    svc.GetThumbnail(eid, iid,
-                     [&callback_count, &null_count, &all_done,
-                      expected = 4](std::shared_ptr<ThumbnailGuard> g) {
-                       if (g == nullptr) null_count++;
-                       if (callback_count.fetch_add(1) + 1 == expected) {
-                         all_done.set_value();
-                       }
-                     },
-                     false, nullptr, res);
+    svc.GetThumbnail(
+        eid, iid,
+        [&callback_count, &null_count, &all_done, expected = 4](std::shared_ptr<ThumbnailGuard> g) {
+          if (g == nullptr) null_count++;
+          if (callback_count.fetch_add(1) + 1 == expected) {
+            all_done.set_value();
+          }
+        },
+        false, nullptr, res);
   }
 
   // Cancel — all 4 pending callbacks fire with nullptr.
@@ -2586,10 +2611,10 @@ TEST_F(ThumbnailServiceTests, ReleaseThumbnailTriggersCancel) {
   }
   ASSERT_GE(paths.size(), 1u);
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto            pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
-  sl_element_id_t eid = 0;
-  image_id_t      iid = 0;
+  sl_element_id_t eid              = 0;
+  image_id_t      iid              = 0;
   {
     std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
     std::promise<ImportResult> final_result;
@@ -2614,16 +2639,16 @@ TEST_F(ThumbnailServiceTests, ReleaseThumbnailTriggersCancel) {
   ThumbnailService svc(fs_service, img_pool, pipeline_service);
 
   // Pin a thumbnail at k256 (fast) so it's in cache.
-  auto guard = GetThumbnailBlocking(svc, eid, iid, true, ThumbnailResolution::k256);
+  auto             guard = GetThumbnailBlocking(svc, eid, iid, true, ThumbnailResolution::k256);
   ASSERT_NE(guard, nullptr);
   ASSERT_GT(guard->pin_count_, 0);
 
   // Queue a second request at a different resolution → lands in pending_.
   std::promise<std::shared_ptr<ThumbnailGuard>> promise;
-  auto fut2 = promise.get_future();
-  svc.GetThumbnail(eid, iid,
-                   [&promise](std::shared_ptr<ThumbnailGuard> g) { promise.set_value(g); },
-                   false, nullptr, ThumbnailResolution::k512);
+  auto                                          fut2 = promise.get_future();
+  svc.GetThumbnail(
+      eid, iid, [&promise](std::shared_ptr<ThumbnailGuard> g) { promise.set_value(g); }, false,
+      nullptr, ThumbnailResolution::k512);
 
   // ReleaseThumbnail → CancelPending → pending callback drained.
   EXPECT_NO_THROW(svc.ReleaseThumbnail(eid));
@@ -2651,10 +2676,10 @@ TEST_F(ThumbnailServiceTests, RapidCancelRequestCycle) {
   }
   ASSERT_GE(paths.size(), 1u);
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto            pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
-  sl_element_id_t eid = 0;
-  image_id_t      iid = 0;
+  sl_element_id_t eid              = 0;
+  image_id_t      iid              = 0;
   {
     std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
     std::promise<ImportResult> final_result;
@@ -2676,27 +2701,26 @@ TEST_F(ThumbnailServiceTests, RapidCancelRequestCycle) {
     iid = snapshot.created_[0].image_id_;
   }
 
-  ThumbnailService svc(fs_service, img_pool, pipeline_service);
+  ThumbnailService          svc(fs_service, img_pool, pipeline_service);
 
-  const ThumbnailResolution tiers[] = {
-      ThumbnailResolution::k256, ThumbnailResolution::k512,
-      ThumbnailResolution::k1024, ThumbnailResolution::k2048};
+  const ThumbnailResolution tiers[] = {ThumbnailResolution::k256, ThumbnailResolution::k512,
+                                       ThumbnailResolution::k1024, ThumbnailResolution::k2048};
 
-  std::mt19937                    rng(0xBEEFCAFEu);
+  std::mt19937              rng(0xBEEFCAFEu);
   std::uniform_int_distribution<int> res_dist(0, 3);
   std::uniform_int_distribution<int> count_dist(1, 4);
 
   for (int cycle = 0; cycle < 30; ++cycle) {
-    const auto res   = tiers[res_dist(rng)];
-    const int  n_req = count_dist(rng);
+    const auto                                                res   = tiers[res_dist(rng)];
+    const int                                                 n_req = count_dist(rng);
 
     std::vector<std::future<std::shared_ptr<ThumbnailGuard>>> futures;
     for (int r = 0; r < n_req; ++r) {
       auto promise = std::make_shared<std::promise<std::shared_ptr<ThumbnailGuard>>>();
       futures.push_back(promise->get_future());
-      EXPECT_NO_THROW(svc.GetThumbnail(eid, iid,
-                        [promise](std::shared_ptr<ThumbnailGuard> g) { promise->set_value(g); },
-                        false, nullptr, res));
+      EXPECT_NO_THROW(svc.GetThumbnail(
+          eid, iid, [promise](std::shared_ptr<ThumbnailGuard> g) { promise->set_value(g); }, false,
+          nullptr, res));
     }
 
     EXPECT_NO_THROW(svc.CancelPending(eid));
@@ -2759,14 +2783,15 @@ TEST_F(ThumbnailServiceTests, CancelIsolationMultipleElements) {
   ThumbnailService svc(fs_service, img_pool, pipeline_service);
 
   // Request thumbnails for all elements concurrently.
-  const size_t n = ids.size();
+  const size_t     n = ids.size();
   std::vector<std::future<std::shared_ptr<ThumbnailGuard>>> futures(n);
   for (size_t i = 0; i < n; ++i) {
     auto promise = std::make_shared<std::promise<std::shared_ptr<ThumbnailGuard>>>();
     futures[i]   = promise->get_future();
-    svc.GetThumbnail(ids[i].first, ids[i].second,
-                     [promise](std::shared_ptr<ThumbnailGuard> g) { promise->set_value(g); },
-                     false, nullptr, ThumbnailResolution::k256);
+    svc.GetThumbnail(
+        ids[i].first, ids[i].second,
+        [promise](std::shared_ptr<ThumbnailGuard> g) { promise->set_value(g); }, false, nullptr,
+        ThumbnailResolution::k256);
   }
 
   // Cancel only element 0.
@@ -2806,10 +2831,10 @@ TEST_F(ThumbnailServiceTests, GenerationTokenSurvivesConcurrentCancel) {
   }
   ASSERT_GE(paths.size(), 1u);
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto            pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
-  sl_element_id_t eid = 0;
-  image_id_t      iid = 0;
+  sl_element_id_t eid              = 0;
+  image_id_t      iid              = 0;
   {
     std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
     std::promise<ImportResult> final_result;
@@ -2831,14 +2856,14 @@ TEST_F(ThumbnailServiceTests, GenerationTokenSurvivesConcurrentCancel) {
     iid = snapshot.created_[0].image_id_;
   }
 
-  ThumbnailService svc(fs_service, img_pool, pipeline_service);
+  ThumbnailService  svc(fs_service, img_pool, pipeline_service);
 
   std::atomic<bool> stop{false};
   std::atomic<int>  cancel_count{0};
   std::atomic<int>  request_count{0};
   std::atomic<int>  error_count{0};
 
-  auto cancel_thread = [&]() {
+  auto              cancel_thread = [&]() {
     while (!stop.load()) {
       try {
         svc.CancelPending(eid);
@@ -2855,11 +2880,15 @@ TEST_F(ThumbnailServiceTests, GenerationTokenSurvivesConcurrentCancel) {
       try {
         auto p = std::make_shared<std::promise<std::shared_ptr<ThumbnailGuard>>>();
         auto f = p->get_future();
-        svc.GetThumbnail(eid, iid,
-                         [p](std::shared_ptr<ThumbnailGuard> g) {
-                           try { p->set_value(g); } catch (...) {}
-                         },
-                         false, nullptr, ThumbnailResolution::k256);
+        svc.GetThumbnail(
+            eid, iid,
+            [p](std::shared_ptr<ThumbnailGuard> g) {
+              try {
+                p->set_value(g);
+              } catch (...) {
+              }
+            },
+            false, nullptr, ThumbnailResolution::k256);
         f.wait_for(5s);
         request_count++;
       } catch (...) {
@@ -2905,10 +2934,10 @@ TEST_F(ThumbnailServiceTests, CancelWhileRenderInProgress) {
   }
   ASSERT_GE(paths.size(), 1u);
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto            pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
-  sl_element_id_t eid = 0;
-  image_id_t      iid = 0;
+  sl_element_id_t eid              = 0;
+  image_id_t      iid              = 0;
   {
     std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
     std::promise<ImportResult> final_result;
@@ -2930,14 +2959,14 @@ TEST_F(ThumbnailServiceTests, CancelWhileRenderInProgress) {
     iid = snapshot.created_[0].image_id_;
   }
 
-  ThumbnailService svc(fs_service, img_pool, pipeline_service);
+  ThumbnailService                              svc(fs_service, img_pool, pipeline_service);
 
   // k2048 = highest decode resolution, slowest render.
   std::promise<std::shared_ptr<ThumbnailGuard>> promise;
-  auto thumb_fut = promise.get_future();
-  svc.GetThumbnail(eid, iid,
-                   [&promise](std::shared_ptr<ThumbnailGuard> g) { promise.set_value(g); },
-                   false, nullptr, ThumbnailResolution::k2048);
+  auto                                          thumb_fut = promise.get_future();
+  svc.GetThumbnail(
+      eid, iid, [&promise](std::shared_ptr<ThumbnailGuard> g) { promise.set_value(g); }, false,
+      nullptr, ThumbnailResolution::k2048);
 
   // Let the render start, then cancel.
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -2969,10 +2998,10 @@ TEST_F(ThumbnailServiceTests, CancelThenImmediateRerequestSameTierCompletes) {
   }
   ASSERT_GE(paths.size(), 1u);
 
-  auto pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto            pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
-  sl_element_id_t eid = 0;
-  image_id_t      iid = 0;
+  sl_element_id_t eid              = 0;
+  image_id_t      iid              = 0;
   {
     std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
     std::promise<ImportResult> final_result;
@@ -2996,23 +3025,31 @@ TEST_F(ThumbnailServiceTests, CancelThenImmediateRerequestSameTierCompletes) {
 
   ThumbnailService svc(fs_service, img_pool, pipeline_service);
 
-  auto old_promise = std::make_shared<std::promise<std::shared_ptr<ThumbnailGuard>>>();
-  auto old_fut = old_promise->get_future();
-  svc.GetThumbnail(eid, iid,
-                   [old_promise](std::shared_ptr<ThumbnailGuard> g) {
-                     try { old_promise->set_value(g); } catch (...) {}
-                   },
-                   false, nullptr, ThumbnailResolution::k2048);
+  auto             old_promise = std::make_shared<std::promise<std::shared_ptr<ThumbnailGuard>>>();
+  auto             old_fut     = old_promise->get_future();
+  svc.GetThumbnail(
+      eid, iid,
+      [old_promise](std::shared_ptr<ThumbnailGuard> g) {
+        try {
+          old_promise->set_value(g);
+        } catch (...) {
+        }
+      },
+      false, nullptr, ThumbnailResolution::k2048);
 
   svc.CancelPending(eid);
 
   auto new_promise = std::make_shared<std::promise<std::shared_ptr<ThumbnailGuard>>>();
-  auto new_fut = new_promise->get_future();
-  svc.GetThumbnail(eid, iid,
-                   [new_promise](std::shared_ptr<ThumbnailGuard> g) {
-                     try { new_promise->set_value(g); } catch (...) {}
-                   },
-                   false, nullptr, ThumbnailResolution::k2048);
+  auto new_fut     = new_promise->get_future();
+  svc.GetThumbnail(
+      eid, iid,
+      [new_promise](std::shared_ptr<ThumbnailGuard> g) {
+        try {
+          new_promise->set_value(g);
+        } catch (...) {
+        }
+      },
+      false, nullptr, ThumbnailResolution::k2048);
 
   ASSERT_EQ(old_fut.wait_for(120s), std::future_status::ready);
   (void)old_fut.get();
@@ -3058,8 +3095,8 @@ TEST_F(ThumbnailServiceTests, FuzzCancelRequestRace) {
     ASSERT_EQ(fut.wait_for(120s), std::future_status::ready);
     ASSERT_EQ(fut.get().failed_, 0u);
 
-    auto snapshot = import_job->import_log_->Snapshot();
-    const size_t count = std::min<size_t>(16, snapshot.created_.size());
+    auto         snapshot = import_job->import_log_->Snapshot();
+    const size_t count    = std::min<size_t>(16, snapshot.created_.size());
     ids.reserve(count);
     for (size_t i = 0; i < count; ++i) {
       ids.push_back({snapshot.created_[i].element_id_, snapshot.created_[i].image_id_});
@@ -3074,22 +3111,21 @@ TEST_F(ThumbnailServiceTests, FuzzCancelRequestRace) {
 
   // Phase 1: fuzz.
   {
-    ProjectService project(db_path_, meta_path_);
-    auto           img_pool = project.GetImagePoolService();
-    auto pipeline_service   = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    ProjectService   project(db_path_, meta_path_);
+    auto             img_pool         = project.GetImagePoolService();
+    auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
     ThumbnailService svc(project.GetSleeveService(), img_pool, pipeline_service);
 
-    const ThumbnailResolution all_res[] = {
-        ThumbnailResolution::k256, ThumbnailResolution::k512,
-        ThumbnailResolution::k1024, ThumbnailResolution::k2048};
+    const ThumbnailResolution all_res[] = {ThumbnailResolution::k256, ThumbnailResolution::k512,
+                                           ThumbnailResolution::k1024, ThumbnailResolution::k2048};
 
-    std::atomic<bool> stop{false};
-    std::atomic<int>  ops_completed{0};
-    std::atomic<int>  errors{0};
+    std::atomic<bool>         stop{false};
+    std::atomic<int>          ops_completed{0};
+    std::atomic<int>          errors{0};
 
-    auto worker = [&](uint32_t seed) {
-      std::mt19937                    rng(seed);
+    auto                      worker = [&](uint32_t seed) {
+      std::mt19937                          rng(seed);
       std::uniform_int_distribution<size_t> idx_dist(0, ids.size() - 1);
       std::uniform_int_distribution<int>    res_dist(0, 3);
       std::uniform_int_distribution<int>    op_dist(0, 99);
@@ -3107,11 +3143,15 @@ TEST_F(ThumbnailServiceTests, FuzzCancelRequestRace) {
           } else if (op < 55) {
             auto p = std::make_shared<std::promise<std::shared_ptr<ThumbnailGuard>>>();
             auto f = p->get_future();
-            svc.GetThumbnail(element_id, image_id,
-                             [p](std::shared_ptr<ThumbnailGuard> g) {
-                               try { p->set_value(g); } catch (...) {}
-                             },
-                             false, nullptr, res);
+            svc.GetThumbnail(
+                element_id, image_id,
+                [p](std::shared_ptr<ThumbnailGuard> g) {
+                  try {
+                    p->set_value(g);
+                  } catch (...) {
+                  }
+                },
+                false, nullptr, res);
             svc.CancelPending(element_id);
             f.wait_for(10s);
           } else if (op < 70) {

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -277,7 +277,9 @@ endif()
 # GPU DAG Phase G4: CPU RawInputLoader / GraphCompiler (no CUDA required).
 add_executable(GpuDagRawInputTest
   ${ALCEDO_TEST_ROOT}/edit/input/raw_input_loader_test.cpp
-  ${ALCEDO_TEST_ROOT}/edit/runtime/graph_compiler_test.cpp)
+  ${ALCEDO_TEST_ROOT}/edit/input/prepared_source_cache_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/runtime/graph_compiler_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/runtime/static_execution_plan_cache_test.cpp)
 target_include_directories(GpuDagRawInputTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(GpuDagRawInputTest PRIVATE GTest::gtest_main EditInput EditRuntime)
 target_compile_definitions(GpuDagRawInputTest PRIVATE
@@ -307,10 +309,11 @@ if(ALCEDO_CUDA_ENABLED)
   alcedo_register_test_target(GpuDagCudaPrimaryGradeTest gpu)
 
   add_executable(GpuDagCudaDrtProductTest
-    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_drt_product_test.cpp)
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_drt_product_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_product_plan_cache_test.cpp)
   target_include_directories(GpuDagCudaDrtProductTest PUBLIC ${ALCEDO_INCLUDE_DIR})
   target_link_libraries(GpuDagCudaDrtProductTest PRIVATE
-    GTest::gtest_main EditRuntimeCuda EditInput)
+    GTest::gtest_main EditRuntimeCuda EditInput Image)
   gtest_discover_tests(GpuDagCudaDrtProductTest TEST_PREFIX "GpuDagCudaDrtProductTest."
     PROPERTIES LABELS "gpu;edit;runtime;product")
   alcedo_register_test_target(GpuDagCudaDrtProductTest gpu)

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -279,6 +279,7 @@ add_executable(GpuDagRawInputTest
   ${ALCEDO_TEST_ROOT}/edit/input/raw_input_loader_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/input/prepared_source_cache_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/graph_compiler_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/runtime/result_content_key_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/static_execution_plan_cache_test.cpp)
 target_include_directories(GpuDagRawInputTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(GpuDagRawInputTest PRIVATE GTest::gtest_main EditInput EditRuntime)
@@ -310,7 +311,8 @@ if(ALCEDO_CUDA_ENABLED)
 
   add_executable(GpuDagCudaDrtProductTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_drt_product_test.cpp
-    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_product_plan_cache_test.cpp)
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_product_plan_cache_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_result_cache_test.cpp)
   target_include_directories(GpuDagCudaDrtProductTest PUBLIC ${ALCEDO_INCLUDE_DIR})
   target_link_libraries(GpuDagCudaDrtProductTest PRIVATE
     GTest::gtest_main EditRuntimeCuda EditInput Image)
@@ -330,6 +332,7 @@ if(ALCEDO_CUDA_ENABLED)
     ${ALCEDO_TEST_ROOT}/edit/runtime/parameter_arena_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/transient_and_cache_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/texture_lease_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/graph_image_cache_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/header_hygiene_test.cpp)
   target_include_directories(GpuDagCudaWorkspaceTest PUBLIC ${ALCEDO_INCLUDE_DIR})
   target_link_libraries(GpuDagCudaWorkspaceTest PRIVATE GTest::gtest_main EditRuntimeCuda)

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -231,7 +231,8 @@ add_executable(GpuDagModelGraphTest
   ${ALCEDO_TEST_ROOT}/edit/graph/dirty_patch_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/graph/json_roundtrip_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/graph/legacy_import_test.cpp
-  ${ALCEDO_TEST_ROOT}/edit/graph/header_hygiene_test.cpp)
+  ${ALCEDO_TEST_ROOT}/edit/graph/header_hygiene_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/graph/develop_color_transform_test.cpp)
 target_include_directories(GpuDagModelGraphTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(GpuDagModelGraphTest PRIVATE GTest::gtest_main EditGraph)
 target_compile_definitions(GpuDagModelGraphTest PRIVATE
@@ -312,7 +313,8 @@ if(ALCEDO_CUDA_ENABLED)
   add_executable(GpuDagCudaDrtProductTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_drt_product_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_product_plan_cache_test.cpp
-    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_result_cache_test.cpp)
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_result_cache_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/develop_camera_profile_import_test.cpp)
   target_include_directories(GpuDagCudaDrtProductTest PUBLIC ${ALCEDO_INCLUDE_DIR})
   target_link_libraries(GpuDagCudaDrtProductTest PRIVATE
     GTest::gtest_main EditRuntimeCuda EditInput Image)

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -316,10 +316,11 @@ if(ALCEDO_CUDA_ENABLED)
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_drt_product_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_product_plan_cache_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_result_cache_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_product_scope_present_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/develop_camera_profile_import_test.cpp)
   target_include_directories(GpuDagCudaDrtProductTest PUBLIC ${ALCEDO_INCLUDE_DIR})
   target_link_libraries(GpuDagCudaDrtProductTest PRIVATE
-    GTest::gtest_main EditRuntimeCuda EditInput Image)
+    GTest::gtest_main EditRuntimeCuda EditInput Image EditPipeline)
   gtest_discover_tests(GpuDagCudaDrtProductTest TEST_PREFIX "GpuDagCudaDrtProductTest."
     PROPERTIES LABELS "gpu;edit;runtime;product")
   alcedo_register_test_target(GpuDagCudaDrtProductTest gpu)

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -296,7 +296,8 @@ if(ALCEDO_CUDA_ENABLED)
   add_executable(GpuDagCudaDevelopTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_develop_test.cpp)
   target_include_directories(GpuDagCudaDevelopTest PUBLIC ${ALCEDO_INCLUDE_DIR})
-  target_link_libraries(GpuDagCudaDevelopTest PRIVATE GTest::gtest_main EditRuntimeCuda EditInput)
+  target_link_libraries(GpuDagCudaDevelopTest PRIVATE GTest::gtest_main EditRuntimeCuda EditInput
+    DemosaicNet)
   gtest_discover_tests(GpuDagCudaDevelopTest TEST_PREFIX "GpuDagCudaDevelopTest."
     PROPERTIES LABELS "gpu;edit;runtime")
   alcedo_register_test_target(GpuDagCudaDevelopTest gpu)

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -286,7 +286,8 @@ target_include_directories(GpuDagRawInputTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(GpuDagRawInputTest PRIVATE GTest::gtest_main EditInput EditRuntime)
 target_compile_definitions(GpuDagRawInputTest PRIVATE
   ALCEDO_RUNTIME_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/runtime"
-  ALCEDO_INPUT_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/input")
+  ALCEDO_INPUT_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/input"
+  ALCEDO_CI_RAW_FIXTURE_ROOT="${ALCEDO_TEST_ROOT}/resources/sample_images/ci_rawfiles")
 gtest_discover_tests(GpuDagRawInputTest TEST_PREFIX "GpuDagRawInputTest."
   PROPERTIES LABELS "ci_core_flow;edit;input")
 alcedo_register_test_target(GpuDagRawInputTest edit)

--- a/alcedo_studio/tests/edit/geometry/sampling_and_document_test.cpp
+++ b/alcedo_studio/tests/edit/geometry/sampling_and_document_test.cpp
@@ -105,6 +105,32 @@ TEST(GpuDagGeometry, OddImageDimensionsUseOneRoundingResultAcrossImageMaskAndLlf
   EXPECT_NEAR(uv_l.y, n.y, 1.0e-5f);
 }
 
+TEST(GpuDagGeometry, FullViewCoversEditSpaceAndViewportRoiDoesNot) {
+  const auto source = MakeSourceGeometry({200, 100}, {200, 100});
+  const auto full   = ResolveRenderGeometry(source, {}, {}, {}, {});
+  EXPECT_TRUE(CoversFullEditSpace(full));
+
+  ResolutionRequest scaled;
+  scaled.max_edge = 50;
+  const auto downscaled = ResolveRenderGeometry(source, {}, {}, scaled, {});
+  EXPECT_TRUE(CoversFullEditSpace(downscaled));
+  EXPECT_LT(downscaled.render_extent.width, full.render_extent.width);
+
+  ViewRequest roi;
+  roi.visible_rect_in_edit_space = {0.25f, 0.10f, 0.40f, 0.50f};
+  const auto cropped = ResolveRenderGeometry(source, {}, roi, {}, {});
+  EXPECT_FALSE(CoversFullEditSpace(cropped));
+
+  const auto llf = MakeLlfSamplingPlan(cropped, Extent2D{128, 64});
+  const auto full_uv =
+      TransformPoint(MakeLlfSamplingPlan(full, Extent2D{128, 64}).render_to_texture_uv,
+                     TransformPoint(full.reference_to_render, Vector2{120.0f, 40.0f}));
+  const auto roi_uv = TransformPoint(llf.render_to_texture_uv,
+                                     TransformPoint(cropped.reference_to_render, Vector2{120.0f, 40.0f}));
+  EXPECT_NEAR(full_uv.x, roi_uv.x, 1.0e-5f);
+  EXPECT_NEAR(full_uv.y, roi_uv.y, 1.0e-5f);
+}
+
 TEST(GpuDagGeometry, DefaultPipelineDocumentHasNoGeometryNode) {
   const auto document = CreateDefaultPipelineDocument();
   ASSERT_EQ(document.Graph().NodeCount(), 3u);

--- a/alcedo_studio/tests/edit/graph/default_pipeline_test.cpp
+++ b/alcedo_studio/tests/edit/graph/default_pipeline_test.cpp
@@ -7,11 +7,9 @@
 #include <cstddef>
 #include <string>
 
-#include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/operators/models/adjustment_catalog.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
-#include "edit/operators/models/scalar_operator_model.hpp"
 
 namespace alcedo {
 
@@ -25,6 +23,7 @@ TEST(GpuDagModelGraph, DefaultPipelineHasDevelopGradeAndDrtNodes) {
   EXPECT_EQ(document.PrimaryGrade()->Type(), type_ids::ColorGradeNode());
   EXPECT_EQ(document.Drt()->Type(), type_ids::DrtNode());
   EXPECT_TRUE(document.Graph().Validate().empty());
+  EXPECT_TRUE(AllowsLegacyStageAdapterRemirror(document));
 }
 
 TEST(GpuDagModelGraph, DefaultPipelineConnectsDevelopThroughPrimaryGradeToDrt) {
@@ -77,59 +76,6 @@ TEST(GpuDagModelGraph, DefaultPrimaryGradeUsesFullMixAndNoMask) {
   for (const auto& edge : document.Graph().Edges()) {
     EXPECT_NE(edge.to_port, PortId{"mask"});
   }
-}
-
-TEST(GpuDagModelGraph, TemporaryOvalMaskConnectsToPrimaryGradeMaskPort) {
-  auto document = CreateDefaultPipelineDocument();
-  ASSERT_EQ(document.Graph().NodeCount(), 3u);
-  AttachTemporaryPrimaryGradeOvalMask(document);
-  AttachTemporaryPrimaryGradeOvalMask(document);
-
-  ASSERT_EQ(document.Graph().NodeCount(), 4u);
-  EXPECT_TRUE(document.Graph().Validate().empty());
-  const auto* mask = dynamic_cast<const AnalyticMaskNodeModel*>(
-      document.Graph().FindNode(NodeId{"mask.ui_test.radial"}));
-  ASSERT_NE(mask, nullptr);
-  EXPECT_EQ(mask->Kind(), AnalyticMaskKind::Radial);
-  EXPECT_FLOAT_EQ(mask->Radial().center_x, 0.5f);
-  EXPECT_FLOAT_EQ(mask->Radial().center_y, 0.5f);
-  EXPECT_FLOAT_EQ(mask->Radial().major_radius, 0.32f);
-  EXPECT_FLOAT_EQ(mask->Radial().minor_radius, 0.20f);
-  EXPECT_FLOAT_EQ(mask->Radial().outer_feather, 0.12f);
-
-  int mask_edges = 0;
-  for (const auto& edge : document.Graph().Edges()) {
-    if (edge.to_node == NodeId{"grade.primary"} && edge.to_port == PortId{"mask"}) {
-      EXPECT_EQ(edge.from_node, NodeId{"mask.ui_test.radial"});
-      EXPECT_EQ(edge.from_port, PortId{"mask"});
-      ++mask_edges;
-    }
-  }
-  EXPECT_EQ(mask_edges, 1);
-
-  const auto* grade = document.PrimaryGrade();
-  ASSERT_NE(grade, nullptr);
-  EXPECT_FLOAT_EQ(grade->Mix(), 1.0f);
-  const auto* exposure =
-      dynamic_cast<const ExposureModel*>(grade->FindAdjustmentByType(type_ids::Exposure()));
-  ASSERT_NE(exposure, nullptr);
-  EXPECT_FLOAT_EQ(exposure->Value(), 1.0f);
-}
-
-TEST(GpuDagModelGraph, TemporaryOvalMaskKeepsNonDefaultExposureAndAllowsLegacyRemirror) {
-  auto document = CreateDefaultPipelineDocument();
-  EXPECT_TRUE(AllowsLegacyStageAdapterRemirror(document));
-  AttachTemporaryPrimaryGradeOvalMask(document);
-  EXPECT_TRUE(AllowsLegacyStageAdapterRemirror(document));
-
-  auto* exposure =
-      dynamic_cast<ExposureModel*>(document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
-  ASSERT_NE(exposure, nullptr);
-  exposure->SetValue(2.25f);
-  AttachTemporaryPrimaryGradeOvalMask(document);
-  EXPECT_FLOAT_EQ(exposure->Value(), 2.25f);
-  EXPECT_EQ(document.Graph().NodeCount(), 4u);
-  EXPECT_TRUE(document.Graph().Validate().empty());
 }
 
 TEST(GpuDagModelGraph, BuiltinCatalogTypeIdsAreUnique) {

--- a/alcedo_studio/tests/edit/graph/default_pipeline_test.cpp
+++ b/alcedo_studio/tests/edit/graph/default_pipeline_test.cpp
@@ -7,9 +7,11 @@
 #include <cstddef>
 #include <string>
 
+#include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/operators/models/adjustment_catalog.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
 
 namespace alcedo {
 
@@ -75,6 +77,59 @@ TEST(GpuDagModelGraph, DefaultPrimaryGradeUsesFullMixAndNoMask) {
   for (const auto& edge : document.Graph().Edges()) {
     EXPECT_NE(edge.to_port, PortId{"mask"});
   }
+}
+
+TEST(GpuDagModelGraph, TemporaryOvalMaskConnectsToPrimaryGradeMaskPort) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_EQ(document.Graph().NodeCount(), 3u);
+  AttachTemporaryPrimaryGradeOvalMask(document);
+  AttachTemporaryPrimaryGradeOvalMask(document);
+
+  ASSERT_EQ(document.Graph().NodeCount(), 4u);
+  EXPECT_TRUE(document.Graph().Validate().empty());
+  const auto* mask = dynamic_cast<const AnalyticMaskNodeModel*>(
+      document.Graph().FindNode(NodeId{"mask.ui_test.radial"}));
+  ASSERT_NE(mask, nullptr);
+  EXPECT_EQ(mask->Kind(), AnalyticMaskKind::Radial);
+  EXPECT_FLOAT_EQ(mask->Radial().center_x, 0.5f);
+  EXPECT_FLOAT_EQ(mask->Radial().center_y, 0.5f);
+  EXPECT_FLOAT_EQ(mask->Radial().major_radius, 0.32f);
+  EXPECT_FLOAT_EQ(mask->Radial().minor_radius, 0.20f);
+  EXPECT_FLOAT_EQ(mask->Radial().outer_feather, 0.12f);
+
+  int mask_edges = 0;
+  for (const auto& edge : document.Graph().Edges()) {
+    if (edge.to_node == NodeId{"grade.primary"} && edge.to_port == PortId{"mask"}) {
+      EXPECT_EQ(edge.from_node, NodeId{"mask.ui_test.radial"});
+      EXPECT_EQ(edge.from_port, PortId{"mask"});
+      ++mask_edges;
+    }
+  }
+  EXPECT_EQ(mask_edges, 1);
+
+  const auto* grade = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  EXPECT_FLOAT_EQ(grade->Mix(), 1.0f);
+  const auto* exposure =
+      dynamic_cast<const ExposureModel*>(grade->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_FLOAT_EQ(exposure->Value(), 1.0f);
+}
+
+TEST(GpuDagModelGraph, TemporaryOvalMaskKeepsNonDefaultExposureAndAllowsLegacyRemirror) {
+  auto document = CreateDefaultPipelineDocument();
+  EXPECT_TRUE(AllowsLegacyStageAdapterRemirror(document));
+  AttachTemporaryPrimaryGradeOvalMask(document);
+  EXPECT_TRUE(AllowsLegacyStageAdapterRemirror(document));
+
+  auto* exposure =
+      dynamic_cast<ExposureModel*>(document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(2.25f);
+  AttachTemporaryPrimaryGradeOvalMask(document);
+  EXPECT_FLOAT_EQ(exposure->Value(), 2.25f);
+  EXPECT_EQ(document.Graph().NodeCount(), 4u);
+  EXPECT_TRUE(document.Graph().Validate().empty());
 }
 
 TEST(GpuDagModelGraph, BuiltinCatalogTypeIdsAreUnique) {

--- a/alcedo_studio/tests/edit/graph/develop_color_transform_test.cpp
+++ b/alcedo_studio/tests/edit/graph/develop_color_transform_test.cpp
@@ -1,0 +1,283 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+#include "edit/graph/develop_color_transform.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "test_camera_profile.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr double kLowCct  = 2856.0;
+constexpr double kHighCct = 6504.0;
+
+auto DualIlluminantPayload() -> DevelopPayload {
+  DevelopPayload payload;
+  payload.wb_mode     = "custom";
+  payload.custom_cct  = 6504.0f;
+  payload.custom_tint = 0.0f;
+  gpu_dag_test::FillTestCameraProfile(payload.camera_profile);
+  return payload;
+}
+
+auto Invert3x3(const std::array<double, 9>& m) -> std::array<double, 9> {
+  const double a = m[0];
+  const double b = m[1];
+  const double c = m[2];
+  const double d = m[3];
+  const double e = m[4];
+  const double f = m[5];
+  const double g = m[6];
+  const double h = m[7];
+  const double i = m[8];
+  const double det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+  const double inv = 1.0 / det;
+  return {(e * i - f * h) * inv, (c * h - b * i) * inv, (b * f - c * e) * inv,
+          (f * g - d * i) * inv, (a * i - c * g) * inv, (c * d - a * f) * inv,
+          (d * h - e * g) * inv, (b * g - a * h) * inv, (a * e - b * d) * inv};
+}
+
+auto MeanMatrix(const std::array<double, 9>& a, const std::array<double, 9>& b)
+    -> std::array<double, 9> {
+  std::array<double, 9> mean{};
+  for (int i = 0; i < 9; ++i) {
+    mean[static_cast<std::size_t>(i)] = 0.5 * (a[static_cast<std::size_t>(i)] + b[static_cast<std::size_t>(i)]);
+  }
+  return mean;
+}
+
+void ExpectMatrixNear(const std::array<float, 9>& actual, const std::array<double, 9>& expected,
+                      double epsilon) {
+  for (int i = 0; i < 9; ++i) {
+    EXPECT_NEAR(actual[static_cast<std::size_t>(i)], expected[static_cast<std::size_t>(i)], epsilon)
+        << "index " << i;
+  }
+}
+
+auto CameraToXyzAt(DevelopPayload payload, float cct) -> ColorTransformResult {
+  payload.wb_mode     = "custom";
+  payload.custom_cct  = cct;
+  payload.custom_tint = 0.0f;
+  return ResolveDevelopColorTransform(payload);
+}
+
+TEST(GpuDagModelGraph, DevelopColorTransformInterpolatesDualIlluminantMatricesInMiredSpace) {
+  auto payload = DualIlluminantPayload();
+  const double mired_mid = 2.0 / (1.0 / kLowCct + 1.0 / kHighCct);
+  const double kelvin_mid = 0.5 * (kLowCct + kHighCct);
+
+  const auto low    = CameraToXyzAt(payload, static_cast<float>(kLowCct));
+  const auto high   = CameraToXyzAt(payload, static_cast<float>(kHighCct));
+  const auto mired  = CameraToXyzAt(payload, static_cast<float>(mired_mid));
+  const auto kelvin = CameraToXyzAt(payload, static_cast<float>(kelvin_mid));
+  ASSERT_TRUE(low.ok);
+  ASSERT_TRUE(high.ok);
+  ASSERT_TRUE(mired.ok);
+  ASSERT_TRUE(kelvin.ok);
+
+  ExpectMatrixNear(low.transform.camera_to_xyz, Invert3x3(payload.camera_profile.color_matrix_1),
+                   1.0e-5);
+  ExpectMatrixNear(high.transform.camera_to_xyz, Invert3x3(payload.camera_profile.color_matrix_2),
+                   1.0e-5);
+  ExpectMatrixNear(mired.transform.camera_to_xyz,
+                   Invert3x3(MeanMatrix(payload.camera_profile.color_matrix_1,
+                                        payload.camera_profile.color_matrix_2)),
+                   1.0e-5);
+
+  double kelvin_delta = 0.0;
+  for (int i = 0; i < 9; ++i) {
+    kelvin_delta += std::abs(mired.transform.camera_to_xyz[static_cast<std::size_t>(i)] -
+                             kelvin.transform.camera_to_xyz[static_cast<std::size_t>(i)]);
+  }
+  EXPECT_GT(kelvin_delta, 1.0e-4);
+}
+
+TEST(GpuDagModelGraph, DevelopColorTransformInterpolatesForwardMatricesWithTheSameWeight) {
+  auto payload = DualIlluminantPayload();
+  payload.camera_profile.forward_matrices_valid = true;
+  payload.camera_profile.forward_matrix_1 = {0.80, 0.10, 0.05, 0.12, 0.78, -0.04, 0.02, -0.11, 0.95};
+  payload.camera_profile.forward_matrix_2 = {0.70, 0.16, 0.09, 0.08, 0.72, -0.08, 0.04, -0.18, 1.05};
+
+  const double mired_mid = 2.0 / (1.0 / kLowCct + 1.0 / kHighCct);
+  const auto without_fm = CameraToXyzAt(DualIlluminantPayload(), static_cast<float>(mired_mid));
+  const auto with_fm    = CameraToXyzAt(payload, static_cast<float>(mired_mid));
+  ASSERT_TRUE(without_fm.ok);
+  ASSERT_TRUE(with_fm.ok);
+
+  double d50_delta = 0.0;
+  for (int i = 0; i < 9; ++i) {
+    d50_delta += std::abs(with_fm.transform.camera_to_xyz_d50[static_cast<std::size_t>(i)] -
+                          without_fm.transform.camera_to_xyz_d50[static_cast<std::size_t>(i)]);
+  }
+  EXPECT_GT(d50_delta, 1.0e-3);
+
+  auto swapped = payload;
+  swapped.camera_profile.color_matrix_1   = payload.camera_profile.color_matrix_2;
+  swapped.camera_profile.color_matrix_2   = payload.camera_profile.color_matrix_1;
+  swapped.camera_profile.forward_matrix_1 = payload.camera_profile.forward_matrix_2;
+  swapped.camera_profile.forward_matrix_2 = payload.camera_profile.forward_matrix_1;
+  swapped.camera_profile.color_matrix_1_cct = kHighCct;
+  swapped.camera_profile.color_matrix_2_cct = kLowCct;
+  const auto swapped_mid = CameraToXyzAt(swapped, static_cast<float>(mired_mid));
+  ASSERT_TRUE(swapped_mid.ok);
+  for (int i = 0; i < 9; ++i) {
+    EXPECT_NEAR(with_fm.transform.camera_to_ap1[static_cast<std::size_t>(i)],
+                swapped_mid.transform.camera_to_ap1[static_cast<std::size_t>(i)], 1.0e-5f);
+  }
+}
+
+TEST(GpuDagModelGraph, DevelopColorTransformUsesSingleProfileWhenCalibrationIlluminantsAreIncomplete) {
+  auto payload = DualIlluminantPayload();
+  payload.camera_profile.calibration_illuminants_valid = false;
+  const auto low  = CameraToXyzAt(payload, static_cast<float>(kLowCct));
+  const auto high = CameraToXyzAt(payload, static_cast<float>(kHighCct));
+  ASSERT_TRUE(low.ok);
+  ASSERT_TRUE(high.ok);
+  for (int i = 0; i < 9; ++i) {
+    EXPECT_FLOAT_EQ(low.transform.camera_to_xyz[static_cast<std::size_t>(i)],
+                    high.transform.camera_to_xyz[static_cast<std::size_t>(i)]);
+  }
+  ExpectMatrixNear(low.transform.camera_to_xyz, Invert3x3(payload.camera_profile.color_matrix_1),
+                   1.0e-5);
+}
+
+TEST(GpuDagModelGraph, DevelopColorTransformSolvesAsShotNeutralWithoutUsingCamMulAsColorMatrix) {
+  auto payload = DualIlluminantPayload();
+  payload.wb_mode = "as_shot";
+  payload.camera_profile.cam_mul = {4.0f, 1.0f, 0.25f};
+  const auto first = ResolveDevelopColorTransform(payload);
+  ASSERT_TRUE(first.ok);
+
+  payload.camera_profile.cam_mul = {0.2f, 1.0f, 5.0f};
+  const auto second = ResolveDevelopColorTransform(payload);
+  ASSERT_TRUE(second.ok);
+  for (int i = 0; i < 9; ++i) {
+    EXPECT_FLOAT_EQ(first.transform.camera_to_ap1[static_cast<std::size_t>(i)],
+                    second.transform.camera_to_ap1[static_cast<std::size_t>(i)]);
+  }
+
+  bool diagonal = true;
+  for (int i = 0; i < 9; ++i) {
+    const float value = first.transform.camera_to_ap1[static_cast<std::size_t>(i)];
+    if (i % 4 != 0 && std::abs(value) > 1.0e-4f) {
+      diagonal = false;
+    }
+  }
+  EXPECT_FALSE(diagonal);
+}
+
+TEST(GpuDagModelGraph, DevelopColorTransformDoesNotUseLibRawRgbCamOrPreMulAsCameraMatrix) {
+  RawRuntimeColorContext imported;
+  imported.valid_                           = true;
+  imported.color_matrices_valid_            = true;
+  imported.calibration_illuminants_valid_   = true;
+  imported.as_shot_neutral_valid_           = true;
+  imported.color_matrix_1_cct_              = kLowCct;
+  imported.color_matrix_2_cct_              = kHighCct;
+  imported.as_shot_neutral_[0]              = 0.45;
+  imported.as_shot_neutral_[1]              = 1.0;
+  imported.as_shot_neutral_[2]              = 0.62;
+  imported.cam_mul_[0]                      = 2.0f;
+  imported.cam_mul_[1]                      = 1.0f;
+  imported.cam_mul_[2]                      = 1.5f;
+  const auto profile = DualIlluminantPayload().camera_profile;
+  for (int i = 0; i < 9; ++i) {
+    imported.color_matrix_1_[i] = profile.color_matrix_1[static_cast<std::size_t>(i)];
+    imported.color_matrix_2_[i] = profile.color_matrix_2[static_cast<std::size_t>(i)];
+    imported.rgb_cam_[i]        = 9.0f;
+    imported.pre_mul_[i % 3]    = 8.0f;
+  }
+
+  DevelopPayload first;
+  first.wb_mode     = "custom";
+  first.custom_cct  = 5000.0f;
+  BindDevelopCameraProfile(first, imported);
+  const auto a = ResolveDevelopColorTransform(first);
+  ASSERT_TRUE(a.ok);
+
+  for (int i = 0; i < 9; ++i) {
+    imported.rgb_cam_[i] = -3.0f;
+  }
+  imported.pre_mul_[0] = 0.1f;
+  imported.pre_mul_[1] = 4.0f;
+  imported.pre_mul_[2] = 0.2f;
+  DevelopPayload second;
+  second.wb_mode    = "custom";
+  second.custom_cct = 5000.0f;
+  BindDevelopCameraProfile(second, imported);
+  const auto b = ResolveDevelopColorTransform(second);
+  ASSERT_TRUE(b.ok);
+  for (int i = 0; i < 9; ++i) {
+    EXPECT_FLOAT_EQ(a.transform.camera_to_ap1[static_cast<std::size_t>(i)],
+                    b.transform.camera_to_ap1[static_cast<std::size_t>(i)]);
+  }
+  EXPECT_NE(a.transform.camera_to_ap1[0], 1.0f);
+  EXPECT_NE(a.transform.camera_to_ap1[1], 0.0f);
+}
+
+TEST(GpuDagModelGraph, DevelopColorTransformRejectsMissingOrSingularCameraMatrices) {
+  DevelopPayload missing;
+  const auto missing_result = ResolveDevelopColorTransform(missing);
+  EXPECT_FALSE(missing_result.ok);
+  EXPECT_EQ(missing_result.error, ColorTransformError::MissingCameraMatrices);
+
+  auto singular = DualIlluminantPayload();
+  singular.camera_profile.color_matrix_1 = {};
+  singular.camera_profile.color_matrix_2 = {};
+  const auto singular_result = ResolveDevelopColorTransform(singular);
+  EXPECT_FALSE(singular_result.ok);
+  EXPECT_EQ(singular_result.error, ColorTransformError::SingularCameraMatrix);
+}
+
+TEST(GpuDagModelGraph, DevelopCameraProfileJsonRoundTripPreservesMatricesAndAsShotNeutral) {
+  auto document = CreateDefaultPipelineDocument();
+  auto payload  = DualIlluminantPayload();
+  payload.as_shot_cct  = 5123.0f;
+  payload.as_shot_tint = -12.5f;
+  document.Develop()->Params().ReplaceParams(payload);
+
+  const auto restored = PipelineDocument::FromJson(document.ToJson());
+  ASSERT_NE(restored.Develop(), nullptr);
+  const auto roundtrip = restored.Develop()->Params().Params();
+  EXPECT_EQ(roundtrip.camera_profile, payload.camera_profile);
+  EXPECT_FLOAT_EQ(roundtrip.as_shot_cct, payload.as_shot_cct);
+  EXPECT_FLOAT_EQ(roundtrip.as_shot_tint, payload.as_shot_tint);
+  EXPECT_EQ(roundtrip.wb_mode, payload.wb_mode);
+}
+
+TEST(GpuDagModelGraph, BindDevelopCameraProfileWritesAsShotCctFromStoredNeutral) {
+  RawRuntimeColorContext imported;
+  imported.valid_                         = true;
+  imported.color_matrices_valid_          = true;
+  imported.calibration_illuminants_valid_ = true;
+  imported.as_shot_neutral_valid_         = true;
+  imported.color_matrix_1_cct_            = kLowCct;
+  imported.color_matrix_2_cct_            = kHighCct;
+  imported.as_shot_neutral_[0]            = 0.45;
+  imported.as_shot_neutral_[1]            = 1.0;
+  imported.as_shot_neutral_[2]            = 0.62;
+  const auto profile = DualIlluminantPayload().camera_profile;
+  for (int i = 0; i < 9; ++i) {
+    imported.color_matrix_1_[i] = profile.color_matrix_1[static_cast<std::size_t>(i)];
+    imported.color_matrix_2_[i] = profile.color_matrix_2[static_cast<std::size_t>(i)];
+  }
+
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::ApplyImportedCameraProfile(document, imported);
+  const auto bound = document.Develop()->Params().Params();
+  EXPECT_TRUE(bound.camera_profile.color_matrices_valid);
+  EXPECT_GE(bound.as_shot_cct, 2000.0f);
+  EXPECT_LE(bound.as_shot_cct, 15000.0f);
+  EXPECT_GE(bound.as_shot_tint, -150.0f);
+  EXPECT_LE(bound.as_shot_tint, 150.0f);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
+++ b/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
@@ -4,10 +4,12 @@
 
 #include <gtest/gtest.h>
 
+#include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/models/cat02_white_balance_model.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
+#include "test_camera_profile.hpp"
 
 namespace alcedo {
 
@@ -107,6 +109,49 @@ TEST(GpuDagModelGraph, LegacyImportFailsOnUnknownOperatorType) {
   EXPECT_FALSE(result.Ok());
   EXPECT_FALSE(result.error.empty());
   EXPECT_FALSE(result.document.has_value());
+}
+
+TEST(GpuDagModelGraph, ApplyOntoKeepsOvalMaskCameraProfileAndUpdatesExposure) {
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  AttachTemporaryPrimaryGradeOvalMask(document);
+  document.ClearTopologyDirty();
+  const auto profile_before = document.Develop()->Params().Params().camera_profile;
+  const auto method_before  = document.Develop()->Params().Params().demosaic_method;
+
+  nlohmann::json json;
+  json["Basic Adjustment"]["Basic Adjustment"]["exposure"] = {
+      {"type", 2}, {"enable", true}, {"params", {{"exposure", 2.25}}}};
+  EXPECT_TRUE(LegacyPipelineImporter::ApplyOnto(document, json).empty());
+
+  EXPECT_EQ(document.Graph().NodeCount(), 4u);
+  EXPECT_FALSE(document.TopologyDirty());
+  EXPECT_NE(document.Graph().FindNode(NodeId{"mask.ui_test.radial"}), nullptr);
+  EXPECT_EQ(document.Develop()->Params().Params().camera_profile, profile_before);
+  EXPECT_EQ(document.Develop()->Params().Params().demosaic_method, method_before);
+  const auto* exposure = dynamic_cast<const ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_FLOAT_EQ(exposure->Value(), 2.25f);
+  const auto* contrast = dynamic_cast<const ContrastModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Contrast()));
+  ASSERT_NE(contrast, nullptr);
+  EXPECT_FLOAT_EQ(contrast->Value(), 0.0f);
+}
+
+TEST(GpuDagModelGraph, ApplyOntoRejectsUnknownTypeWithoutMutatingDocument) {
+  auto document = CreateDefaultPipelineDocument();
+  AttachTemporaryPrimaryGradeOvalMask(document);
+  document.ClearTopologyDirty();
+  auto json = MakeLegacyStageJson();
+  json["Basic Adjustment"]["Basic Adjustment"]["mystery"] = {
+      {"type", 21}, {"enable", true}, {"params", nlohmann::json::object()}};
+  EXPECT_FALSE(LegacyPipelineImporter::ApplyOnto(document, json).empty());
+  EXPECT_EQ(document.Graph().NodeCount(), 4u);
+  const auto* exposure = dynamic_cast<const ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_FLOAT_EQ(exposure->Value(), 1.0f);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
+++ b/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
@@ -4,8 +4,11 @@
 
 #include <gtest/gtest.h>
 
-#include "edit/graph/analytic_mask_node_model.hpp"
+#include <memory>
+
 #include "edit/graph/legacy_pipeline_importer.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/models/cat02_white_balance_model.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
@@ -53,6 +56,15 @@ auto MakeLegacyStageJson() -> nlohmann::json {
       {"enable", true},
       {"params", {{"odt", {{"method", "aces_2_0"}, {"peak_luminance", 200.0}}}}}};
   return json;
+}
+
+void ConnectRasterMask(PipelineDocument& document, std::string asset_key = "test.raster") {
+  auto node = std::make_unique<RasterMaskNodeModel>(NodeId{"mask.raster"});
+  node->SetAssetKey(std::move(asset_key));
+  document.Graph().AddNode(std::move(node));
+  document.Graph().Connect(NodeId{"mask.raster"}, PortId{"mask"}, NodeId{"grade.primary"},
+                           PortId{"mask"});
+  document.MarkTopologyDirty();
 }
 
 }  // namespace
@@ -111,10 +123,10 @@ TEST(GpuDagModelGraph, LegacyImportFailsOnUnknownOperatorType) {
   EXPECT_FALSE(result.document.has_value());
 }
 
-TEST(GpuDagModelGraph, ApplyOntoKeepsOvalMaskCameraProfileAndUpdatesExposure) {
+TEST(GpuDagModelGraph, ApplyOntoKeepsRasterMaskCameraProfileAndUpdatesExposure) {
   auto document = CreateDefaultPipelineDocument();
   gpu_dag_test::EnsureTestCameraProfile(document);
-  AttachTemporaryPrimaryGradeOvalMask(document);
+  ConnectRasterMask(document);
   document.ClearTopologyDirty();
   const auto profile_before = document.Develop()->Params().Params().camera_profile;
   const auto method_before  = document.Develop()->Params().Params().demosaic_method;
@@ -126,7 +138,8 @@ TEST(GpuDagModelGraph, ApplyOntoKeepsOvalMaskCameraProfileAndUpdatesExposure) {
 
   EXPECT_EQ(document.Graph().NodeCount(), 4u);
   EXPECT_FALSE(document.TopologyDirty());
-  EXPECT_NE(document.Graph().FindNode(NodeId{"mask.ui_test.radial"}), nullptr);
+  EXPECT_NE(document.Graph().FindNode(NodeId{"mask.raster"}), nullptr);
+  EXPECT_TRUE(AllowsLegacyStageAdapterRemirror(document));
   EXPECT_EQ(document.Develop()->Params().Params().camera_profile, profile_before);
   EXPECT_EQ(document.Develop()->Params().Params().demosaic_method, method_before);
   const auto* exposure = dynamic_cast<const ExposureModel*>(
@@ -141,17 +154,16 @@ TEST(GpuDagModelGraph, ApplyOntoKeepsOvalMaskCameraProfileAndUpdatesExposure) {
 
 TEST(GpuDagModelGraph, ApplyOntoRejectsUnknownTypeWithoutMutatingDocument) {
   auto document = CreateDefaultPipelineDocument();
-  AttachTemporaryPrimaryGradeOvalMask(document);
   document.ClearTopologyDirty();
   auto json = MakeLegacyStageJson();
   json["Basic Adjustment"]["Basic Adjustment"]["mystery"] = {
       {"type", 21}, {"enable", true}, {"params", nlohmann::json::object()}};
   EXPECT_FALSE(LegacyPipelineImporter::ApplyOnto(document, json).empty());
-  EXPECT_EQ(document.Graph().NodeCount(), 4u);
+  EXPECT_EQ(document.Graph().NodeCount(), 3u);
   const auto* exposure = dynamic_cast<const ExposureModel*>(
       document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
   ASSERT_NE(exposure, nullptr);
-  EXPECT_FLOAT_EQ(exposure->Value(), 1.0f);
+  EXPECT_FLOAT_EQ(exposure->Value(), 0.0f);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
+++ b/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
@@ -6,6 +6,7 @@
 
 #include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/cat02_white_balance_model.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 
 namespace alcedo {
@@ -43,6 +44,8 @@ auto MakeLegacyStageJson() -> nlohmann::json {
       {"type", 2}, {"enable", true}, {"params", {{"exposure", 1.5}}}};
   json["Color Adjustment"]["Color Adjustment"]["saturation"] = {
       {"type", 10}, {"enable", true}, {"params", {{"saturation", 30.0}}}};
+  json["Color Adjustment"]["Color Adjustment"]["tint"] = {
+      {"type", 11}, {"enable", true}, {"params", {{"tint", 12.0}}}};
   json["Output Transform"]["Output Transform"]["odt"] = {
       {"type", 17},
       {"enable", true},
@@ -88,6 +91,12 @@ TEST(GpuDagModelGraph, LegacyStageJsonMapsRawGradeGeometryAndDrtToNewDocument) {
 
   EXPECT_EQ(document.Drt()->Params().Params().method, DrtMethod::Aces20);
   EXPECT_FLOAT_EQ(document.Drt()->Params().Params().peak_luminance, 200.0f);
+
+  EXPECT_EQ(document.PrimaryGrade()->FindAdjustmentByType(type_ids::Tint()), nullptr);
+  const auto* cat02 = dynamic_cast<const Cat02WhiteBalanceModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Cat02WhiteBalance()));
+  ASSERT_NE(cat02, nullptr);
+  EXPECT_FLOAT_EQ(cat02->TintOffset(), 12.0f);
 }
 
 TEST(GpuDagModelGraph, LegacyImportFailsOnUnknownOperatorType) {

--- a/alcedo_studio/tests/edit/graph/test_camera_profile.hpp
+++ b/alcedo_studio/tests/edit/graph/test_camera_profile.hpp
@@ -1,0 +1,57 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/graph/develop_color_transform.hpp"
+#include "edit/graph/pipeline_document.hpp"
+
+namespace alcedo {
+namespace gpu_dag_test {
+
+/**
+ * @brief Non-diagonal dual-illuminant XYZ→camera matrices for CameraColor tests.
+ *
+ * Invertible and off-diagonal so a cam_mul diagonal, rgb_cam identity, or linear
+ * Kelvin interpolator cannot match the mired dual-illuminant result by accident.
+ * No-op when @p profile.color_matrices_valid is already true.
+ */
+inline void FillTestCameraProfile(DevelopCameraProfile& profile) {
+  if (profile.color_matrices_valid) {
+    return;
+  }
+  profile.color_matrices_valid          = true;
+  profile.calibration_illuminants_valid = true;
+  profile.color_matrix_1_cct            = 2856.0;
+  profile.color_matrix_2_cct            = 6504.0;
+  profile.color_matrix_1                = {1.85, 0.22, 0.08, 0.36, 1.62, 0.14, 0.06, 0.28, 1.76};
+  profile.color_matrix_2                = {1.42, 0.42, 0.24, 0.32, 1.48, 0.26, 0.16, 0.38, 1.66};
+  profile.as_shot_neutral_valid         = true;
+  profile.as_shot_neutral               = {0.45, 1.0, 0.62};
+  profile.cam_mul                       = {2.0f, 1.0f, 1.5f};
+}
+
+inline void EnsureTestCameraProfile(PipelineDocument& document) {
+  auto* develop = document.Develop();
+  if (develop == nullptr) {
+    return;
+  }
+  auto payload = develop->Params().Params();
+  FillTestCameraProfile(payload.camera_profile);
+  develop->Params().ReplaceParams(std::move(payload));
+}
+
+inline void ApplyImportedCameraProfile(PipelineDocument& document,
+                                       const RawRuntimeColorContext& imported) {
+  auto* develop = document.Develop();
+  if (develop == nullptr) {
+    return;
+  }
+  auto payload = develop->Params().Params();
+  BindDevelopCameraProfile(payload, imported);
+  develop->Params().ReplaceParams(std::move(payload));
+}
+
+}  // namespace gpu_dag_test
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/input/prepared_source_cache_test.cpp
+++ b/alcedo_studio/tests/edit/input/prepared_source_cache_test.cpp
@@ -1,0 +1,137 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "edit/input/prepared_source_cache.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "prepared_raw_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+auto MakeEncoded(std::uint8_t tag) -> std::vector<std::byte> {
+  std::vector<std::byte> bytes(32);
+  bytes[0] = std::byte{tag};
+  bytes[1] = std::byte{0xA5};
+  return bytes;
+}
+
+auto MakeUnpacker(int* calls) -> PreparedSourceCache::UnpackFn {
+  return [calls](std::span<const std::byte>, DecodeRes decode_res) {
+    ++*calls;
+    const auto pattern = gpu_dag_test::MakeRggbPattern();
+    return RawInputLoader::FromUnpackedCfa(
+        gpu_dag_test::MakeU16CfaPlane(32, 32, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+        gpu_dag_test::FullSensor(32, 32), decode_res);
+  };
+}
+
+TEST(GpuDagRawInput, PreparedSourceKeyIncludesEncodedHashKindDecodeResAndPreparationVersion) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto full    = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(32, 32, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(32, 32), DecodeRes::FULL);
+  const auto half = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(32, 32, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(32, 32), DecodeRes::HALF);
+
+  EXPECT_EQ(full.source_key.encoded_content_hash, half.source_key.encoded_content_hash);
+  EXPECT_EQ(full.source_key.preparation_version, kRawInputPreparationVersion);
+  EXPECT_EQ(full.source_key.downsample_passes, 0);
+  EXPECT_EQ(half.source_key.downsample_passes, 1);
+  EXPECT_EQ(full.source_key.input_kind, RawInputKind::BayerRaw);
+  EXPECT_NE(full.source_key.Lookup(), half.source_key.Lookup());
+  EXPECT_EQ(full.content_key.content_hash, full.source_key.encoded_content_hash);
+}
+
+TEST(GpuDagRawInput, PreparedSourceCacheReusesHostResultForSameEncodedKeyWithoutCallingUnpack) {
+  int                  unpack_calls = 0;
+  PreparedSourceCache  cache(MakeUnpacker(&unpack_calls));
+  const auto           encoded = MakeEncoded(1);
+
+  const auto first  = cache.AcquireEncoded(encoded, DecodeRes::FULL);
+  const auto second = cache.AcquireEncoded(encoded, DecodeRes::FULL);
+
+  EXPECT_EQ(unpack_calls, 1);
+  EXPECT_EQ(cache.GetStats().libraw_open_unpack_count, 1U);
+  EXPECT_EQ(cache.GetStats().hits, 1U);
+  EXPECT_EQ(cache.GetStats().misses, 1U);
+  EXPECT_EQ(first.Shared().get(), second.Shared().get());
+  EXPECT_EQ(first.Key(), second.Key());
+  EXPECT_EQ(first.Key().downsample_passes, 0);
+}
+
+TEST(GpuDagRawInput, PreparedSourceCacheSharesHostResultAcrossPreviewAndExportQuality) {
+  int                 unpack_calls = 0;
+  PreparedSourceCache cache(MakeUnpacker(&unpack_calls));
+  const auto          encoded = MakeEncoded(2);
+
+  const auto preview = cache.AcquireEncoded(encoded, DecodeRes::FULL);
+  const auto export_frame = cache.AcquireEncoded(encoded, DecodeRes::FULL);
+
+  EXPECT_EQ(unpack_calls, 1);
+  EXPECT_EQ(preview.Shared().get(), export_frame.Shared().get());
+  EXPECT_EQ(preview.Get().pixels.bytes.get(), export_frame.Get().pixels.bytes.get());
+}
+
+TEST(GpuDagRawInput, PreparedSourceCacheUsesNewKeyForDecodeResChangeWithoutReplacingLeasedEntry) {
+  int                 unpack_calls = 0;
+  PreparedSourceCache cache(MakeUnpacker(&unpack_calls));
+  const auto          encoded = MakeEncoded(3);
+
+  const auto full = cache.AcquireEncoded(encoded, DecodeRes::FULL);
+  const auto full_ptr = full.Shared();
+  const auto half = cache.AcquireEncoded(encoded, DecodeRes::HALF);
+
+  EXPECT_EQ(unpack_calls, 2);
+  EXPECT_EQ(cache.EntryCount(), 2U);
+  EXPECT_EQ(full.Shared().get(), full_ptr.get());
+  EXPECT_NE(full.Shared().get(), half.Shared().get());
+  EXPECT_NE(full.Key().Lookup(), half.Key().Lookup());
+  EXPECT_EQ(full.Get().host_extent, (Extent2D{32, 32}));
+  EXPECT_EQ(half.Get().host_extent, (Extent2D{16, 16}));
+}
+
+TEST(GpuDagRawInput, PreparedSourceCacheReusesMatchingSourceAfterSwitchingEncodedBuffers) {
+  int                 unpack_calls = 0;
+  PreparedSourceCache cache(MakeUnpacker(&unpack_calls));
+  const auto          first_bytes  = MakeEncoded(4);
+  const auto          second_bytes = MakeEncoded(5);
+
+  const auto a1 = cache.AcquireEncoded(first_bytes, DecodeRes::FULL);
+  const auto b  = cache.AcquireEncoded(second_bytes, DecodeRes::FULL);
+  const auto a2 = cache.AcquireEncoded(first_bytes, DecodeRes::FULL);
+
+  EXPECT_EQ(unpack_calls, 2);
+  EXPECT_EQ(cache.GetStats().hits, 1U);
+  EXPECT_EQ(cache.GetStats().misses, 2U);
+  EXPECT_EQ(a1.Shared().get(), a2.Shared().get());
+  EXPECT_NE(a1.Shared().get(), b.Shared().get());
+}
+
+TEST(GpuDagRawInput, PreparedSourceCacheDoesNotEvictLeasedEntryWhenHostBudgetIsExceeded) {
+  int                 unpack_calls = 0;
+  PreparedSourceCache cache(MakeUnpacker(&unpack_calls));
+  cache.SetHostByteBudget(1);
+  const auto first_bytes  = MakeEncoded(6);
+  const auto second_bytes = MakeEncoded(7);
+
+  const auto leased = cache.AcquireEncoded(first_bytes, DecodeRes::FULL);
+  const auto other  = cache.AcquireEncoded(second_bytes, DecodeRes::FULL);
+
+  EXPECT_EQ(unpack_calls, 2);
+  EXPECT_TRUE(static_cast<bool>(leased));
+  EXPECT_EQ(leased.Get().host_extent, (Extent2D{32, 32}));
+  EXPECT_EQ(other.Get().host_extent, (Extent2D{32, 32}));
+  EXPECT_NE(leased.Shared().get(), other.Shared().get());
+  EXPECT_GE(cache.EntryCount(), 1U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/input/raw_input_loader_test.cpp
+++ b/alcedo_studio/tests/edit/input/raw_input_loader_test.cpp
@@ -2,31 +2,42 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
+#include "edit/input/raw_input_loader.hpp"
+
 #include <gtest/gtest.h>
 
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <string>
 #include <vector>
 
 #include "edit/graph/pipeline_document.hpp"
-#include "edit/input/raw_input_loader.hpp"
 #include "edit/runtime/graph_compiler.hpp"
 #include "prepared_raw_test_support.hpp"
 
 namespace alcedo {
 namespace {
 
-TEST(GpuDagRawInput, RawInputLoaderUnpacksBeforePipelineBuild) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
-  const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+auto ReadBytes(const std::filesystem::path& path) -> std::vector<std::byte> {
+  std::ifstream input(path, std::ios::binary);
+  if (!input) return {};
+  const std::vector<char> chars((std::istreambuf_iterator<char>(input)),
+                                std::istreambuf_iterator<char>());
+  std::vector<std::byte>  bytes(chars.size());
+  std::memcpy(bytes.data(), chars.data(), chars.size());
+  return bytes;
+}
 
-  auto document = CreateDefaultPipelineDocument();
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+TEST(GpuDagRawInput, RawInputLoaderUnpacksBeforePipelineBuild) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
   EXPECT_FALSE(prepared.host_extent.Empty());
   EXPECT_FALSE(plan.Contains(GpuPassKind::UploadRgb));
@@ -40,7 +51,7 @@ TEST(GpuDagRawInput, RawInputLoaderUnpacksBeforePipelineBuild) {
 
 TEST(GpuDagRawInput, RawInputLoaderDownsampleUpdatesCfaPatternAndPhase) {
   const auto xtrans = gpu_dag_test::MakeXTransPattern();
-  const auto full = RawInputLoader::FromUnpackedCfa(
+  const auto full   = RawInputLoader::FromUnpackedCfa(
       gpu_dag_test::MakeU16CfaPlane(64, 64, xtrans), xtrans, gpu_dag_test::DefaultLinearization(),
       gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
   const auto half = RawInputLoader::FromUnpackedCfa(
@@ -50,11 +61,12 @@ TEST(GpuDagRawInput, RawInputLoaderDownsampleUpdatesCfaPatternAndPhase) {
   EXPECT_EQ(full.host_extent, (Extent2D{64, 64}));
   EXPECT_EQ(half.host_extent, (Extent2D{32, 32}));
   EXPECT_EQ(half.downsample_passes, 1);
-  EXPECT_NE(std::memcmp(full.cfa_pattern.xtrans_pattern.raw_fc, half.cfa_pattern.xtrans_pattern.raw_fc,
-                        sizeof(full.cfa_pattern.xtrans_pattern.raw_fc)),
-            0);
+  EXPECT_NE(
+      std::memcmp(full.cfa_pattern.xtrans_pattern.raw_fc, half.cfa_pattern.xtrans_pattern.raw_fc,
+                  sizeof(full.cfa_pattern.xtrans_pattern.raw_fc)),
+      0);
 
-  const auto bayer = gpu_dag_test::MakeRggbPattern();
+  const auto bayer      = gpu_dag_test::MakeRggbPattern();
   const auto bayer_full = RawInputLoader::FromUnpackedCfa(
       gpu_dag_test::MakeU16CfaPlane(64, 64, bayer), bayer, gpu_dag_test::DefaultLinearization(),
       gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
@@ -70,12 +82,12 @@ TEST(GpuDagRawInput, RawInputLoaderDownsampleUpdatesCfaPatternAndPhase) {
 
 TEST(GpuDagRawInput, PreparedRawInputKeepsFullReferenceExtentAcrossDecodeRes) {
   const auto pattern = gpu_dag_test::MakeRggbPattern();
-  const auto full = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  const auto full    = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
   const auto half = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::HALF);
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::HALF);
 
   EXPECT_EQ(full.full_reference_extent, half.full_reference_extent);
   EXPECT_NE(full.develop_output_extent, half.develop_output_extent);
@@ -88,9 +100,8 @@ TEST(GpuDagRawInput, DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint) {
   EXPECT_EQ(prepared.input_kind, RawInputKind::DebayeredRgb);
   EXPECT_EQ(prepared.CompileSource().kind, DevelopInputKind::DirectRgb);
 
-  auto document = CreateDefaultPipelineDocument();
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   EXPECT_TRUE(plan.Contains(GpuPassKind::UploadRgb));
   EXPECT_FALSE(plan.Contains(GpuPassKind::UploadRaw));
   EXPECT_FALSE(plan.Contains(GpuPassKind::Linearize));
@@ -99,7 +110,7 @@ TEST(GpuDagRawInput, DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint) {
 
 TEST(GpuDagRawInput, UnsupportedCfaDoesNotProducePreparedRawInput) {
   RawCfaPattern bad;
-  bad.kind = RawCfaKind::Bayer2x2;
+  bad.kind                    = RawCfaKind::Bayer2x2;
   bad.bayer_pattern.raw_fc[0] = 0;
   bad.bayer_pattern.raw_fc[1] = 0;
   bad.bayer_pattern.raw_fc[2] = 0;
@@ -114,8 +125,9 @@ TEST(GpuDagRawInput, UnsupportedCfaDoesNotProducePreparedRawInput) {
       std::runtime_error);
 
   std::byte empty{};
-  EXPECT_FALSE(RawInputLoader::TryLoadEncoded(std::span<const std::byte>(&empty, 0), DecodeRes::FULL)
-                   .has_value());
+  EXPECT_FALSE(
+      RawInputLoader::TryLoadEncoded(std::span<const std::byte>(&empty, 0), DecodeRes::FULL)
+          .has_value());
 }
 
 TEST(GpuDagRawInput, InputHeadersDoNotIncludeGpuOrImageBuffer) {
@@ -132,6 +144,19 @@ TEST(GpuDagRawInput, InputHeadersDoNotIncludeGpuOrImageBuffer) {
       EXPECT_EQ(line.find("cuda_runtime"), std::string::npos) << entry.path();
     }
   }
+}
+
+TEST(GpuDagRawInput, EncodedDngCarriesOpcodeList3WarpIntoPreparedInput) {
+  const auto root = std::filesystem::path{ALCEDO_CI_RAW_FIXTURE_ROOT};
+  const auto path = root / "tag @ryanbreitkreutz - free raws from @signatureeditsco - DSC06683.dng";
+  const auto encoded = ReadBytes(path);
+  ASSERT_FALSE(encoded.empty()) << path;
+
+  const auto prepared = RawInputLoader::LoadEncoded(encoded, DecodeRes::FULL);
+  ASSERT_TRUE(prepared.dng_warp_rectilinear.has_value());
+  EXPECT_GT(prepared.dng_warp_rectilinear->coefficient_set_count, 0U);
+  EXPECT_TRUE(prepared.color_context.dng_warp_rectilinear_present_);
+  EXPECT_NE(prepared.source_key.dng_warp_hash, 0U);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/pipeline/pipeline_frame_sink_test.cpp
+++ b/alcedo_studio/tests/edit/pipeline/pipeline_frame_sink_test.cpp
@@ -156,7 +156,7 @@ TEST_F(PipelineFrameSinkTest, BindFrameSubmissionIsNoOpWhenSinkIsDetached) {
 }
 
 TEST_F(PipelineFrameSinkTest, BindFrameSubmissionForwardsToAttachedSink) {
-  auto exec = std::make_shared<CPUPipelineExecutor>();
+  auto          exec = std::make_shared<CPUPipelineExecutor>();
   MockFrameSink sink;
   exec->SetExecutionStages(&sink);
 
@@ -333,10 +333,8 @@ TEST_F(PipelineFrameSinkTest, DetailRoiPreviewUsesFrozenRequestRegionInsteadOfCh
 
   EXPECT_EQ(sink.viewport_render_region_calls_, 0);
   EXPECT_EQ(sink.last_bound_submission_.metadata.frame_role, FrameRole::DetailPatch);
-  EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.x, 316.0f / 903.0f,
-              1.0e-5f);
-  EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.y, 428.0f / 1351.0f,
-              1.0e-5f);
+  EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.x, 316.0f / 903.0f, 1.0e-5f);
+  EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.y, 428.0f / 1351.0f, 1.0e-5f);
   EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.width, 0.491694f, 1.0e-5f);
   EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.height, 0.170244f, 1.0e-5f);
 
@@ -348,6 +346,43 @@ TEST_F(PipelineFrameSinkTest, DetailRoiPreviewUsesFrozenRequestRegionInsteadOfCh
   const auto params = resize_entry.value()->op_->GetParams();
   ASSERT_TRUE(params.contains("resize"));
   EXPECT_EQ(params["resize"].value("maximum_edge", 0), 3008);
+  const auto frozen = exec->CaptureOneShotRenderParams().render_request_viewport_;
+  ASSERT_TRUE(frozen.has_value());
+  EXPECT_EQ(frozen->x_, requested_region.x_);
+  EXPECT_EQ(frozen->y_, requested_region.y_);
+}
+
+TEST_F(PipelineFrameSinkTest, QualityBaseAfterRoiClearsFrozenViewportGeometry) {
+  auto          exec = std::make_shared<CPUPipelineExecutor>();
+  MockFrameSink sink;
+  exec->SetExecutionStages(&sink);
+  sink.viewport_render_region_ = ViewportRenderRegion{.x_                = 700,
+                                                      .y_                = 300,
+                                                      .scale_x_          = 0.2f,
+                                                      .scale_y_          = 0.3f,
+                                                      .reference_width_  = 5000,
+                                                      .reference_height_ = 3000,
+                                                      .target_width_     = 1800,
+                                                      .target_height_    = 1200};
+
+  PipelineTask roi;
+  roi.pipeline_executor_                         = exec;
+  roi.options_.render_desc_.render_type_         = RenderType::DETAIL_ROI_PREVIEW;
+  roi.options_.render_desc_.use_viewport_region_ = true;
+  roi.SetExecutorRenderParams();
+  ASSERT_TRUE(exec->CaptureOneShotRenderParams().render_request_viewport_.has_value());
+
+  PipelineTask quality_base;
+  quality_base.pipeline_executor_                 = exec;
+  quality_base.options_.render_desc_.render_type_ = RenderType::QUALITY_BASE_PREVIEW;
+  quality_base.SetExecutorRenderParams();
+
+  EXPECT_FALSE(exec->CaptureOneShotRenderParams().render_request_viewport_.has_value());
+  EXPECT_EQ(sink.last_bound_submission_.mode, FramePresentationMode::ViewportTransformed);
+  EXPECT_FLOAT_EQ(sink.last_bound_submission_.metadata.source_roi_norm.x, 0.0f);
+  EXPECT_FLOAT_EQ(sink.last_bound_submission_.metadata.source_roi_norm.y, 0.0f);
+  EXPECT_FLOAT_EQ(sink.last_bound_submission_.metadata.source_roi_norm.width, 1.0f);
+  EXPECT_FLOAT_EQ(sink.last_bound_submission_.metadata.source_roi_norm.height, 1.0f);
 }
 
 TEST_F(PipelineFrameSinkTest, ActiveCudaHighlightShadowKeepsDetailRoiPreviewAsPatch) {
@@ -750,7 +785,7 @@ TEST_F(PipelineFrameSinkTest, SetAcceleratorBackendPreservesFrameSink) {
 TEST_F(PipelineFrameSinkTest, HistoryQueuesBehindRenderOwnershipOfLivePipeline) {
   // render_lock_ is sole live-pipeline ownership for the full frame. History
   // must wait until render releases it — not race under a second occupancy bit.
-  auto                     exec = std::make_shared<CPUPipelineExecutor>();
+  auto                         exec = std::make_shared<CPUPipelineExecutor>();
   std::unique_lock<std::mutex> worker_lock(exec->GetRenderLock());
   EXPECT_TRUE(worker_lock.owns_lock());
 
@@ -796,7 +831,8 @@ TEST_F(PipelineFrameSinkTest, ConcurrentDetachAndRenderLockIsDeadlockFree) {
       {
         std::unique_lock<std::mutex> lock(exec->GetRenderLock());
         // Simulate the render path's use of frame sink methods.
-        exec->BindFrameSubmission(FramePreviewMetadata{}, FramePresentationMode::ViewportTransformed);
+        exec->BindFrameSubmission(FramePreviewMetadata{},
+                                  FramePresentationMode::ViewportTransformed);
         (void)exec->GetViewportRenderRegion();
       }
       ops.fetch_add(1);
@@ -1011,19 +1047,17 @@ TEST_F(PipelineFrameSinkTest, ImportedRawBackendCannotOverrideRuntimePreference)
 
   // Params never carry the backend: exported state has no backend key.
   // Exported stage state is nested as stage name -> {script_name -> {…}}.
-  const nlohmann::json exported = exec->ExportPipelineParams();
-  const nlohmann::json raw_params =
-      exported.value("Image_Loading", nlohmann::json::object())
-          .value("Image_Loading", nlohmann::json::object())
-          .value("raw_decode", nlohmann::json::object())
-          .value("params", nlohmann::json::object())
-          .value("raw", nlohmann::json::object());
+  const nlohmann::json exported   = exec->ExportPipelineParams();
+  const nlohmann::json raw_params = exported.value("Image_Loading", nlohmann::json::object())
+                                        .value("Image_Loading", nlohmann::json::object())
+                                        .value("raw_decode", nlohmann::json::object())
+                                        .value("params", nlohmann::json::object())
+                                        .value("raw", nlohmann::json::object());
   EXPECT_FALSE(raw_params.contains("gpu_backend"));
 
   // A state saved under a different backend (CUDA) must not change the decode.
-  nlohmann::json stored = exported;
-  stored["Image_Loading"]["Image_Loading"]["raw_decode"]["params"]["raw"]["gpu_backend"] =
-      "cuda";
+  nlohmann::json stored                                                                  = exported;
+  stored["Image_Loading"]["Image_Loading"]["raw_decode"]["params"]["raw"]["gpu_backend"] = "cuda";
   exec->ImportPipelineParams(stored);
 
   EXPECT_EQ(RawDecodeBackendOf(*exec), RawGpuBackend::CPU);

--- a/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
@@ -2,18 +2,24 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <span>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
+#include "decoders/processor/nn/demosaicnet_cache.hpp"
+#include "decoders/processor/nn/demosaicnet_preprocess_common.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/runtime/cuda/cuda_develop_pass.hpp"
+#include "edit/runtime/cuda/cuda_sensor_demosaic.hpp"
 #include "edit/runtime/graph_compiler.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "../input/prepared_raw_test_support.hpp"
@@ -55,6 +61,64 @@ auto DownloadDevelop(CudaRenderDevice& device, const ExecutionPlan& plan) -> std
       std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()), pixels.size() * sizeof(Rgba)),
       device.CommandContext());
   return pixels;
+}
+
+auto SetDevelopMethod(PipelineDocument& document, std::string method, bool highlights) -> void {
+  auto payload                 = document.Develop()->Params().Params();
+  payload.demosaic_method      = std::move(method);
+  payload.highlights_reconstruct = highlights;
+  document.Develop()->Params().ReplaceParams(std::move(payload));
+}
+
+auto MakeOverRangeCfa(const RawCfaPattern& pattern, std::uint32_t width, std::uint32_t height)
+    -> HostImagePlane {
+  auto plane = gpu_dag_test::MakeU16CfaPlane(width, height, pattern);
+  auto* samples = const_cast<std::uint16_t*>(
+      reinterpret_cast<const std::uint16_t*>(plane.bytes.get()));
+  for (std::uint32_t i = 0; i < width * height; i += 7) {
+    samples[i] = 30000;
+  }
+  return plane;
+}
+
+auto MaxChannel(const std::vector<Rgba>& pixels) -> float {
+  float max_value = 0.0f;
+  for (const auto& p : pixels) {
+    max_value = std::max(max_value, std::max(p.r, std::max(p.g, p.b)));
+  }
+  return max_value;
+}
+
+auto PixelsDiffer(const std::vector<Rgba>& a, const std::vector<Rgba>& b) -> bool {
+  if (a.size() != b.size() || a.empty()) {
+    return false;
+  }
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    if (std::abs(a[i].r - b[i].r) > 1.0e-4f || std::abs(a[i].g - b[i].g) > 1.0e-4f ||
+        std::abs(a[i].b - b[i].b) > 1.0e-4f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto NeuralEngineAvailable(DemosaicNetVariant variant) -> bool {
+  DemosaicNetLoadOptions options;
+  return DemosaicNetModelCache::Instance().EnsureLoaded(variant, options);
+}
+
+auto RenderDevelop(PipelineDocument& document, const PreparedRawInput& prepared)
+    -> std::vector<Rgba> {
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  CudaRenderDevice device;
+  if (plan.peak_transient_bytes > 0) {
+    device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+  }
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+  return DownloadDevelop(device, plan);
 }
 
 auto AllFiniteNonZero(const std::vector<Rgba>& pixels) -> bool {
@@ -99,6 +163,7 @@ TEST_F(CudaDevelopFixture, CudaDevelopProducesFiniteCameraSceneLinearRgbFromXTra
       gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
       gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
   auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "legacy", true);
   const auto plan =
       GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   EXPECT_EQ(plan.source.kind, DevelopInputKind::XTransCfa);
@@ -177,6 +242,141 @@ TEST_F(CudaDevelopFixture, DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint)
   ASSERT_EQ(pixels.size(), 32U * 24U);
   EXPECT_NEAR(pixels.front().a, 1.0f, 1e-5f);
   EXPECT_TRUE(std::isfinite(pixels.front().r));
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopDefaultBayerUsesLegacyRcdNotNeural) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto def_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(def_doc, "default", true);
+  auto legacy_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(legacy_doc, "legacy", true);
+  const auto default_pixels = RenderDevelop(def_doc, prepared);
+  const auto legacy_pixels  = RenderDevelop(legacy_doc, prepared);
+  ASSERT_EQ(default_pixels.size(), legacy_pixels.size());
+  EXPECT_FALSE(PixelsDiffer(default_pixels, legacy_pixels));
+  if (NeuralEngineAvailable(DemosaicNetVariant::Bayer)) {
+    auto neural_doc = CreateDefaultPipelineDocument();
+    SetDevelopMethod(neural_doc, "neural_engine", true);
+    const auto neural_pixels = RenderDevelop(neural_doc, prepared);
+    EXPECT_TRUE(PixelsDiffer(default_pixels, neural_pixels));
+  }
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopDefaultXTransUsesNeuralEngine) {
+  if (!NeuralEngineAvailable(DemosaicNetVariant::XTrans)) {
+    GTEST_SKIP() << "X-Trans Neural Engine weights are not available.";
+  }
+  RawCfaPattern pattern;
+  pattern.kind = RawCfaKind::XTrans6x6;
+  for (int i = 0; i < 36; ++i) {
+    pattern.xtrans_pattern.rgb_fc[i] = kDemosaicNetXTransTargetRgb[i];
+    pattern.xtrans_pattern.raw_fc[i] = kDemosaicNetXTransTargetRgb[i];
+  }
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(72, 72, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(72, 72), DecodeRes::FULL);
+  auto def_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(def_doc, "default", true);
+  auto neural_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(neural_doc, "neural_engine", true);
+  auto legacy_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(legacy_doc, "legacy", true);
+  const auto default_pixels = RenderDevelop(def_doc, prepared);
+  const auto neural_pixels  = RenderDevelop(neural_doc, prepared);
+  const auto legacy_pixels  = RenderDevelop(legacy_doc, prepared);
+  EXPECT_FALSE(PixelsDiffer(default_pixels, neural_pixels));
+  EXPECT_TRUE(PixelsDiffer(default_pixels, legacy_pixels));
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopExplicitNeuralEngineChangesBayerPixelsVersusLegacy) {
+  if (!NeuralEngineAvailable(DemosaicNetVariant::Bayer)) {
+    GTEST_SKIP() << "Bayer Neural Engine weights are not available.";
+  }
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto legacy_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(legacy_doc, "legacy", true);
+  auto neural_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(neural_doc, "neural_engine", true);
+  EXPECT_TRUE(PixelsDiffer(RenderDevelop(legacy_doc, prepared), RenderDevelop(neural_doc, prepared)));
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructOnSkipsCfaClamp01ForBayerAndXTrans) {
+  const auto bayer = gpu_dag_test::MakeRggbPattern();
+  const auto bayer_prepared = RawInputLoader::FromUnpackedCfa(
+      MakeOverRangeCfa(bayer, 64, 64), bayer, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto bayer_on = CreateDefaultPipelineDocument();
+  SetDevelopMethod(bayer_on, "legacy", true);
+  auto bayer_off = CreateDefaultPipelineDocument();
+  SetDevelopMethod(bayer_off, "legacy", false);
+  const auto bayer_on_px  = RenderDevelop(bayer_on, bayer_prepared);
+  const auto bayer_off_px = RenderDevelop(bayer_off, bayer_prepared);
+  EXPECT_GT(MaxChannel(bayer_on_px), 1.0f);
+  EXPECT_TRUE(PixelsDiffer(bayer_on_px, bayer_off_px));
+
+  const auto xtrans = gpu_dag_test::MakeXTransPattern();
+  const auto xtrans_prepared = RawInputLoader::FromUnpackedCfa(
+      MakeOverRangeCfa(xtrans, 64, 64), xtrans, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto xtrans_on = CreateDefaultPipelineDocument();
+  SetDevelopMethod(xtrans_on, "legacy", true);
+  auto xtrans_off = CreateDefaultPipelineDocument();
+  SetDevelopMethod(xtrans_off, "legacy", false);
+  const auto xtrans_on_px  = RenderDevelop(xtrans_on, xtrans_prepared);
+  const auto xtrans_off_px = RenderDevelop(xtrans_off, xtrans_prepared);
+  EXPECT_TRUE(PixelsDiffer(xtrans_on_px, xtrans_off_px));
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructOffAppliesCfaClamp01) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      MakeOverRangeCfa(pattern, 64, 64), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "legacy", false);
+  const auto pixels = RenderDevelop(document, prepared);
+  EXPECT_TRUE(AllFiniteNonZero(pixels));
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructChangesXTransRgb) {
+  const auto pattern = gpu_dag_test::MakeXTransPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      MakeOverRangeCfa(pattern, 64, 64), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto on_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(on_doc, "legacy", true);
+  auto off_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(off_doc, "legacy", false);
+  EXPECT_TRUE(PixelsDiffer(RenderDevelop(on_doc, prepared), RenderDevelop(off_doc, prepared)));
+}
+
+TEST_F(CudaDevelopFixture, CudaDevelopNeuralEngineFailureThrowsErrorStringAndDoesNotFallBackToLegacy) {
+  DemosaicNetModelCache failing;
+  SetDevelopNeuralModelCacheForTesting(&failing);
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "neural_engine", true);
+  try {
+    (void)RenderDevelop(document, prepared);
+    SetDevelopNeuralModelCacheForTesting(nullptr);
+    FAIL() << "Neural Engine failure must throw";
+  } catch (const std::runtime_error& ex) {
+    SetDevelopNeuralModelCacheForTesting(nullptr);
+    const std::string message = ex.what();
+    EXPECT_NE(message.find("Neural Engine"), std::string::npos);
+  } catch (...) {
+    SetDevelopNeuralModelCacheForTesting(nullptr);
+    throw;
+  }
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopUploadFailureRestoresDirtyAndDoesNotFallback) {

--- a/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
@@ -2,6 +2,9 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -10,9 +13,7 @@
 #include <string>
 #include <vector>
 
-#include <cuda_runtime.h>
-#include <gtest/gtest.h>
-
+#include "../input/prepared_raw_test_support.hpp"
 #include "decoders/processor/nn/demosaicnet_cache.hpp"
 #include "decoders/processor/nn/demosaicnet_preprocess_common.hpp"
 #include "edit/graph/pipeline_document.hpp"
@@ -22,7 +23,6 @@
 #include "edit/runtime/cuda/cuda_sensor_demosaic.hpp"
 #include "edit/runtime/graph_compiler.hpp"
 #include "edit/runtime/texture_format.hpp"
-#include "../input/prepared_raw_test_support.hpp"
 
 namespace alcedo {
 namespace {
@@ -54,27 +54,28 @@ auto DownloadDevelop(CudaRenderDevice& device, const ExecutionPlan& plan) -> std
   if (lease == nullptr) {
     return {};
   }
-  const auto& tex = lease->Texture();
+  const auto&       tex = lease->Texture();
   std::vector<Rgba> pixels(static_cast<std::size_t>(tex.Width()) * tex.Height());
   device.Workspace().Device().DownloadTexture2D(
       tex,
-      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()), pixels.size() * sizeof(Rgba)),
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                           pixels.size() * sizeof(Rgba)),
       device.CommandContext());
   return pixels;
 }
 
 auto SetDevelopMethod(PipelineDocument& document, std::string method, bool highlights) -> void {
-  auto payload                 = document.Develop()->Params().Params();
-  payload.demosaic_method      = std::move(method);
+  auto payload                   = document.Develop()->Params().Params();
+  payload.demosaic_method        = std::move(method);
   payload.highlights_reconstruct = highlights;
   document.Develop()->Params().ReplaceParams(std::move(payload));
 }
 
 auto MakeOverRangeCfa(const RawCfaPattern& pattern, std::uint32_t width, std::uint32_t height)
     -> HostImagePlane {
-  auto plane = gpu_dag_test::MakeU16CfaPlane(width, height, pattern);
-  auto* samples = const_cast<std::uint16_t*>(
-      reinterpret_cast<const std::uint16_t*>(plane.bytes.get()));
+  auto  plane = gpu_dag_test::MakeU16CfaPlane(width, height, pattern);
+  auto* samples =
+      const_cast<std::uint16_t*>(reinterpret_cast<const std::uint16_t*>(plane.bytes.get()));
   for (std::uint32_t i = 0; i < width * height; i += 7) {
     samples[i] = 30000;
   }
@@ -135,13 +136,12 @@ auto AllFiniteNonZero(const std::vector<Rgba>& pixels) -> bool {
 }  // namespace
 
 TEST_F(CudaDevelopFixture, CudaDevelopProducesFiniteCameraSceneLinearRgbFromBayerInput) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
-  auto document = CreateDefaultPipelineDocument();
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   EXPECT_EQ(plan.source.kind, DevelopInputKind::BayerCfa);
   EXPECT_LT(plan.IndexOf(GpuPassKind::Demosaic), plan.IndexOf(GpuPassKind::HighlightRecover));
 
@@ -158,14 +158,13 @@ TEST_F(CudaDevelopFixture, CudaDevelopProducesFiniteCameraSceneLinearRgbFromBaye
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopProducesFiniteCameraSceneLinearRgbFromXTransInput) {
-  const auto pattern = gpu_dag_test::MakeXTransPattern();
+  const auto pattern  = gpu_dag_test::MakeXTransPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
   auto document = CreateDefaultPipelineDocument();
   SetDevelopMethod(document, "legacy", true);
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   EXPECT_EQ(plan.source.kind, DevelopInputKind::XTransCfa);
 
   CudaRenderDevice device;
@@ -180,13 +179,12 @@ TEST_F(CudaDevelopFixture, CudaDevelopProducesFiniteCameraSceneLinearRgbFromXTra
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopUsesWorkspaceForAllTemporaryBuffers) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
-  auto document = CreateDefaultPipelineDocument();
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
   CudaRenderDevice device;
   device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
@@ -199,13 +197,12 @@ TEST_F(CudaDevelopFixture, CudaDevelopUsesWorkspaceForAllTemporaryBuffers) {
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopSecondRenderCreatesNoGpuAllocation) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
-  auto document = CreateDefaultPipelineDocument();
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
   CudaRenderDevice device;
   device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
@@ -225,11 +222,10 @@ TEST_F(CudaDevelopFixture, CudaDevelopSecondRenderCreatesNoGpuAllocation) {
 }
 
 TEST_F(CudaDevelopFixture, DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint) {
-  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(32, 24),
-                                                gpu_dag_test::FullSensor(32, 24));
-  auto document = CreateDefaultPipelineDocument();
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  auto       prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(32, 24),
+                                                      gpu_dag_test::FullSensor(32, 24));
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   ASSERT_TRUE(plan.Contains(GpuPassKind::UploadRgb));
 
   CudaRenderDevice device;
@@ -245,10 +241,10 @@ TEST_F(CudaDevelopFixture, DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint)
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopDefaultBayerUsesLegacyRcdNotNeural) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
   auto def_doc = CreateDefaultPipelineDocument();
   SetDevelopMethod(def_doc, "default", true);
   auto legacy_doc = CreateDefaultPipelineDocument();
@@ -276,8 +272,8 @@ TEST_F(CudaDevelopFixture, CudaDevelopDefaultXTransUsesNeuralEngine) {
     pattern.xtrans_pattern.raw_fc[i] = kDemosaicNetXTransTargetRgb[i];
   }
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(72, 72, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(72, 72), DecodeRes::FULL);
+      gpu_dag_test::MakeU16CfaPlane(72, 72, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(72, 72), DecodeRes::FULL);
   auto def_doc = CreateDefaultPipelineDocument();
   SetDevelopMethod(def_doc, "default", true);
   auto neural_doc = CreateDefaultPipelineDocument();
@@ -295,19 +291,20 @@ TEST_F(CudaDevelopFixture, CudaDevelopExplicitNeuralEngineChangesBayerPixelsVers
   if (!NeuralEngineAvailable(DemosaicNetVariant::Bayer)) {
     GTEST_SKIP() << "Bayer Neural Engine weights are not available.";
   }
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
   auto legacy_doc = CreateDefaultPipelineDocument();
   SetDevelopMethod(legacy_doc, "legacy", true);
   auto neural_doc = CreateDefaultPipelineDocument();
   SetDevelopMethod(neural_doc, "neural_engine", true);
-  EXPECT_TRUE(PixelsDiffer(RenderDevelop(legacy_doc, prepared), RenderDevelop(neural_doc, prepared)));
+  EXPECT_TRUE(
+      PixelsDiffer(RenderDevelop(legacy_doc, prepared), RenderDevelop(neural_doc, prepared)));
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructOnSkipsCfaClamp01ForBayerAndXTrans) {
-  const auto bayer = gpu_dag_test::MakeRggbPattern();
+  const auto bayer          = gpu_dag_test::MakeRggbPattern();
   const auto bayer_prepared = RawInputLoader::FromUnpackedCfa(
       MakeOverRangeCfa(bayer, 64, 64), bayer, gpu_dag_test::DefaultLinearization(),
       gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
@@ -320,7 +317,7 @@ TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructOnSkipsCfaClamp01ForBa
   EXPECT_GT(MaxChannel(bayer_on_px), 1.0f);
   EXPECT_TRUE(PixelsDiffer(bayer_on_px, bayer_off_px));
 
-  const auto xtrans = gpu_dag_test::MakeXTransPattern();
+  const auto xtrans          = gpu_dag_test::MakeXTransPattern();
   const auto xtrans_prepared = RawInputLoader::FromUnpackedCfa(
       MakeOverRangeCfa(xtrans, 64, 64), xtrans, gpu_dag_test::DefaultLinearization(),
       gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
@@ -334,7 +331,7 @@ TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructOnSkipsCfaClamp01ForBa
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructOffAppliesCfaClamp01) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
       MakeOverRangeCfa(pattern, 64, 64), pattern, gpu_dag_test::DefaultLinearization(),
       gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
@@ -345,7 +342,7 @@ TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructOffAppliesCfaClamp01) 
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructChangesXTransRgb) {
-  const auto pattern = gpu_dag_test::MakeXTransPattern();
+  const auto pattern  = gpu_dag_test::MakeXTransPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
       MakeOverRangeCfa(pattern, 64, 64), pattern, gpu_dag_test::DefaultLinearization(),
       gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
@@ -356,13 +353,33 @@ TEST_F(CudaDevelopFixture, CudaDevelopHighlightReconstructChangesXTransRgb) {
   EXPECT_TRUE(PixelsDiffer(RenderDevelop(on_doc, prepared), RenderDevelop(off_doc, prepared)));
 }
 
-TEST_F(CudaDevelopFixture, CudaDevelopNeuralEngineFailureThrowsErrorStringAndDoesNotFallBackToLegacy) {
+TEST_F(CudaDevelopFixture, CudaDevelopAppliesPreparedDngRectilinearWarpAfterDemosaic) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  auto       prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(96, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(96, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "legacy", false);
+  const auto           unwarped = RenderDevelop(document, prepared);
+
+  dng::WarpRectilinear warp;
+  warp.coefficient_set_count    = 1;
+  warp.coefficient_sets[0]      = {1.0, 0.28, 0.0, 0.0, 0.0, 0.0};
+  prepared.dng_warp_rectilinear = warp;
+  const auto warped             = RenderDevelop(document, prepared);
+
+  ASSERT_EQ(unwarped.size(), warped.size());
+  EXPECT_TRUE(PixelsDiffer(unwarped, warped));
+}
+
+TEST_F(CudaDevelopFixture,
+       CudaDevelopNeuralEngineFailureThrowsErrorStringAndDoesNotFallBackToLegacy) {
   DemosaicNetModelCache failing;
   SetDevelopNeuralModelCacheForTesting(&failing);
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
   auto document = CreateDefaultPipelineDocument();
   SetDevelopMethod(document, "neural_engine", true);
   try {
@@ -380,13 +397,12 @@ TEST_F(CudaDevelopFixture, CudaDevelopNeuralEngineFailureThrowsErrorStringAndDoe
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopUploadFailureRestoresDirtyAndDoesNotFallback) {
-  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
-      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern,
-      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
-  auto document = CreateDefaultPipelineDocument();
-  const auto plan =
-      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
   CudaRenderDevice device;
   device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);

--- a/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
@@ -43,7 +43,7 @@ struct Rgba {
 };
 
 auto DownloadDevelop(CudaRenderDevice& device, const ExecutionPlan& plan) -> std::vector<Rgba> {
-  auto* lease = device.Workspace().Images().Find(plan.develop_output);
+  auto* lease = device.Workspace().Images().Find(plan.sensor_linear_output);
   EXPECT_NE(lease, nullptr);
   if (lease == nullptr) {
     return {};
@@ -130,7 +130,7 @@ TEST_F(CudaDevelopFixture, CudaDevelopUsesWorkspaceForAllTemporaryBuffers) {
   EXPECT_GT(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
   device.EndRender();
   device.WaitIdle();
-  EXPECT_NE(device.Workspace().Images().Find(plan.develop_output), nullptr);
+  EXPECT_NE(device.Workspace().Images().Find(plan.sensor_linear_output), nullptr);
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopSecondRenderCreatesNoGpuAllocation) {

--- a/alcedo_studio/tests/edit/runtime/cuda_drt_product_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_drt_product_test.cpp
@@ -5,6 +5,7 @@
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <span>
@@ -182,6 +183,122 @@ TEST_F(CudaDrtProductFixture, CudaBackendFailureDoesNotEnterCpuImageProcessing) 
       std::runtime_error);
   EXPECT_FALSE(reported.empty());
   EXPECT_FALSE(device_.Workspace().IsRendering());
+}
+
+auto MakeConstantRgb(std::uint32_t width, std::uint32_t height, float value) -> HostImagePlane {
+  auto plane = gpu_dag_test::MakeF32RgbaPlane(width, height);
+  auto* px   = const_cast<float*>(reinterpret_cast<const float*>(plane.bytes.get()));
+  for (std::uint32_t i = 0; i < width * height; ++i) {
+    px[i * 4 + 0] = value;
+    px[i * 4 + 1] = value;
+    px[i * 4 + 2] = value;
+    px[i * 4 + 3] = 1.0f;
+  }
+  return plane;
+}
+
+auto MaxRgb(const std::vector<Rgba>& pixels) -> float {
+  float max_value = 0.0f;
+  for (const auto& pixel : pixels) {
+    max_value = std::max(max_value, std::max(pixel.r, std::max(pixel.g, pixel.b)));
+  }
+  return max_value;
+}
+
+TEST_F(CudaDrtProductFixture, DrtInputIsNotHardClampedToForwardLimitBeforeTonescale) {
+  auto low_doc  = CreateDefaultPipelineDocument();
+  auto high_doc = CreateDefaultPipelineDocument();
+  auto params   = low_doc.Drt()->Params().Params();
+  params.method = DrtMethod::Aces20;
+  low_doc.Drt()->Params().ReplaceParams(params);
+  high_doc.Drt()->Params().ReplaceParams(params);
+  PreparedRawInput low_input =
+      RawInputLoader::FromDirectRgb(MakeConstantRgb(16, 12, 1.0f), gpu_dag_test::FullSensor(16, 12));
+  PreparedRawInput high_input =
+      RawInputLoader::FromDirectRgb(MakeConstantRgb(16, 12, 4.0f), gpu_dag_test::FullSensor(16, 12));
+  gpu_dag_test::EnsureTestCameraProfile(low_doc);
+  gpu_dag_test::EnsureTestCameraProfile(high_doc);
+  const auto low_pixels  = Download(device_, device_.Execute(
+      GraphCompiler::Compile(low_doc, low_input.CompileSource(), RenderRequest{}), low_input,
+      low_doc));
+  CudaRenderDevice high_device;
+  const auto high_pixels = Download(high_device, high_device.Execute(
+      GraphCompiler::Compile(high_doc, high_input.CompileSource(), RenderRequest{}), high_input,
+      high_doc));
+  ASSERT_EQ(low_pixels.size(), high_pixels.size());
+  bool differ = false;
+  for (std::size_t i = 0; i < low_pixels.size(); ++i) {
+    if (std::abs(low_pixels[i].r - high_pixels[i].r) > 1.0e-4f ||
+        std::abs(low_pixels[i].g - high_pixels[i].g) > 1.0e-4f ||
+        std::abs(low_pixels[i].b - high_pixels[i].b) > 1.0e-4f) {
+      differ = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(differ);
+  EXPECT_TRUE(AllFiniteDisplayValues(low_pixels));
+  EXPECT_TRUE(AllFiniteDisplayValues(high_pixels));
+}
+
+TEST_F(CudaDrtProductFixture, HighlightReconstructOnSurvivesIntoDrtInsteadOfBeingClippedToUnitCube) {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  auto plane         = gpu_dag_test::MakeU16CfaPlane(64, 64, pattern);
+  auto* samples      = const_cast<std::uint16_t*>(
+      reinterpret_cast<const std::uint16_t*>(plane.bytes.get()));
+  for (std::uint32_t i = 0; i < 64 * 64; i += 5) {
+    samples[i] = 30000;
+  }
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      plane, pattern, gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(64, 64),
+      DecodeRes::FULL);
+  auto on_doc = CreateDefaultPipelineDocument();
+  auto payload = on_doc.Develop()->Params().Params();
+  payload.demosaic_method        = "legacy";
+  payload.highlights_reconstruct = true;
+  on_doc.Develop()->Params().ReplaceParams(payload);
+  auto off_doc = CreateDefaultPipelineDocument();
+  payload.highlights_reconstruct = false;
+  off_doc.Develop()->Params().ReplaceParams(payload);
+  gpu_dag_test::EnsureTestCameraProfile(on_doc);
+  gpu_dag_test::EnsureTestCameraProfile(off_doc);
+  const auto on_pixels = Download(device_, device_.Execute(
+      GraphCompiler::Compile(on_doc, prepared.CompileSource(), RenderRequest{}), prepared, on_doc));
+  CudaRenderDevice off_device;
+  const auto off_pixels = Download(off_device, off_device.Execute(
+      GraphCompiler::Compile(off_doc, prepared.CompileSource(), RenderRequest{}), prepared, off_doc));
+  EXPECT_TRUE(AllFiniteDisplayValues(on_pixels));
+  EXPECT_TRUE(AllFiniteDisplayValues(off_pixels));
+  bool differ = false;
+  for (std::size_t i = 0; i < on_pixels.size() && i < off_pixels.size(); ++i) {
+    if (std::abs(on_pixels[i].r - off_pixels[i].r) > 1.0e-4f ||
+        std::abs(on_pixels[i].g - off_pixels[i].g) > 1.0e-4f ||
+        std::abs(on_pixels[i].b - off_pixels[i].b) > 1.0e-4f) {
+      differ = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(differ);
+}
+
+TEST_F(CudaDrtProductFixture, OpenDrtAndAcesStillLimitDisplayReferredOutput) {
+  auto open_doc = CreateDefaultPipelineDocument();
+  auto aces_doc = CreateDefaultPipelineDocument();
+  auto aces     = aces_doc.Drt()->Params().Params();
+  aces.method   = DrtMethod::Aces20;
+  aces_doc.Drt()->Params().ReplaceParams(aces);
+  auto input = RawInputLoader::FromDirectRgb(MakeConstantRgb(16, 12, 1000.0f),
+                                             gpu_dag_test::FullSensor(16, 12));
+  gpu_dag_test::EnsureTestCameraProfile(open_doc);
+  gpu_dag_test::EnsureTestCameraProfile(aces_doc);
+  const auto open_pixels = Download(device_, device_.Execute(
+      GraphCompiler::Compile(open_doc, input.CompileSource(), RenderRequest{}), input, open_doc));
+  CudaRenderDevice aces_device;
+  const auto aces_pixels = Download(aces_device, aces_device.Execute(
+      GraphCompiler::Compile(aces_doc, input.CompileSource(), RenderRequest{}), input, aces_doc));
+  EXPECT_TRUE(AllFiniteDisplayValues(open_pixels));
+  EXPECT_TRUE(AllFiniteDisplayValues(aces_pixels));
+  EXPECT_LT(MaxRgb(open_pixels), 4.0f);
+  EXPECT_LT(MaxRgb(aces_pixels), 4.0f);
 }
 
 TEST_F(CudaDrtProductFixture, CudaDefaultPipelineSecondRenderCreatesNoGpuAllocation) {

--- a/alcedo_studio/tests/edit/runtime/cuda_drt_product_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_drt_product_test.cpp
@@ -8,9 +8,11 @@
 #include <cmath>
 #include <cstddef>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
+#include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/graph/pipeline_document.hpp"
@@ -69,6 +71,7 @@ class CudaDrtProductFixture : public ::testing::Test {
   }
 
   auto Render(PipelineDocument& document) -> std::vector<Rgba> {
+    gpu_dag_test::EnsureTestCameraProfile(document);
     const auto plan   = GraphCompiler::Compile(document, input_.CompileSource(), RenderRequest{});
     const auto output = device_.Execute(plan, input_, document);
     EXPECT_TRUE(plan.Contains(GpuPassKind::Drt));
@@ -145,6 +148,8 @@ TEST_F(CudaDrtProductFixture, LegacyPipelineImportRendersSameCudaReferenceWithin
   auto imported = LegacyPipelineImporter::Import(legacy);
   ASSERT_TRUE(imported.Ok()) << imported.error;
   auto  reference = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(reference);
+  gpu_dag_test::EnsureTestCameraProfile(*imported.document);
   auto* exposure  = dynamic_cast<ExposureModel*>(
       reference.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
   ASSERT_NE(exposure, nullptr);
@@ -165,6 +170,7 @@ TEST_F(CudaDrtProductFixture, LegacyPipelineImportRendersSameCudaReferenceWithin
 
 TEST_F(CudaDrtProductFixture, CudaBackendFailureDoesNotEnterCpuImageProcessing) {
   auto        document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
   std::string reported;
   device_.SetErrorReporter([&reported](std::string_view message) { reported = message; });
   device_.Workspace().Device().FailNextUpload();

--- a/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
@@ -13,6 +13,7 @@
 #include <span>
 #include <vector>
 
+#include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/raster_mask_node_model.hpp"
@@ -49,6 +50,7 @@ class CudaMaskFixture : public ::testing::Test {
     prepared_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(width, height),
                                               gpu_dag_test::FullSensor(width, height));
     document_ = CreateDefaultPipelineDocument();
+    gpu_dag_test::EnsureTestCameraProfile(document_);
   }
 
   auto MakeRaster(std::string key, std::uint8_t fill = 0) -> MaskAsset {
@@ -100,7 +102,7 @@ class CudaMaskFixture : public ::testing::Test {
     device_.BeginRender();
     (void)ExecuteCudaDevelop(device_, plan_, prepared_, document_);
     ExecuteCudaGeometryResample(device_, plan_);
-    ExecuteCudaCameraColor(device_, plan_, prepared_.color_context, document_);
+    ExecuteCudaCameraColor(device_, plan_, document_);
     (void)ExecuteCudaMask(device_, plan_, document_, store_.get());
     auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
     device_.EndRender();
@@ -308,7 +310,7 @@ TEST_F(CudaMaskFixture, CudaColorGradeMixUsesInputAtMaskZeroAndAdjustedAtMaskOne
   device_.BeginRender();
   (void)ExecuteCudaDevelop(device_, plan_, prepared_, document_);
   ExecuteCudaGeometryResample(device_, plan_);
-  ExecuteCudaCameraColor(device_, plan_, prepared_.color_context, document_);
+  ExecuteCudaCameraColor(device_, plan_, document_);
   const RectI dirty{0, 0, static_cast<std::int32_t>(width_ / 2),
                     static_cast<std::int32_t>(height_)};
   (void)ExecuteCudaMask(device_, plan_, document_, store_.get(), std::span{&dirty, 1});

--- a/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
@@ -104,7 +104,7 @@ class CudaMaskFixture : public ::testing::Test {
     ExecuteCudaGeometryResample(device_, plan_);
     ExecuteCudaCameraColor(device_, plan_, document_);
     (void)ExecuteCudaMask(device_, plan_, document_, store_.get());
-    auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
+    auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_, document_);
     device_.EndRender();
     device_.WaitIdle();
     return result;
@@ -314,7 +314,7 @@ TEST_F(CudaMaskFixture, CudaColorGradeMixUsesInputAtMaskZeroAndAdjustedAtMaskOne
   const RectI dirty{0, 0, static_cast<std::int32_t>(width_ / 2),
                     static_cast<std::int32_t>(height_)};
   (void)ExecuteCudaMask(device_, plan_, document_, store_.get(), std::span{&dirty, 1});
-  const auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
+  const auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_, document_);
   device_.EndRender();
   device_.WaitIdle();
   const auto source = DownloadImage(plan_.develop_output);

--- a/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
@@ -99,6 +99,8 @@ class CudaMaskFixture : public ::testing::Test {
   auto RenderGrade() -> CudaPrimaryGradeResult {
     device_.BeginRender();
     (void)ExecuteCudaDevelop(device_, plan_, prepared_, document_);
+    ExecuteCudaGeometryResample(device_, plan_);
+    ExecuteCudaCameraColor(device_, plan_, prepared_.color_context, document_);
     (void)ExecuteCudaMask(device_, plan_, document_, store_.get());
     auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
     device_.EndRender();
@@ -305,6 +307,8 @@ TEST_F(CudaMaskFixture, CudaColorGradeMixUsesInputAtMaskZeroAndAdjustedAtMaskOne
   store_->Save(asset);
   device_.BeginRender();
   (void)ExecuteCudaDevelop(device_, plan_, prepared_, document_);
+  ExecuteCudaGeometryResample(device_, plan_);
+  ExecuteCudaCameraColor(device_, plan_, prepared_.color_context, document_);
   const RectI dirty{0, 0, static_cast<std::int32_t>(width_ / 2),
                     static_cast<std::int32_t>(height_)};
   (void)ExecuteCudaMask(device_, plan_, document_, store_.get(), std::span{&dirty, 1});

--- a/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
@@ -11,7 +11,10 @@
 #include <cstdint>
 #include <span>
 #include <stdexcept>
+#include <string>
 #include <vector>
+
+#include "edit/geometry/types.hpp"
 
 #include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
@@ -96,7 +99,7 @@ auto RenderLocalToneCenter(float surroundings, float center, float shadows_value
   ExecuteCudaDevelop(device, plan, prepared, document);
   ExecuteCudaGeometryResample(device, plan);
   ExecuteCudaCameraColor(device, plan, document);
-  const auto result = ExecuteCudaPrimaryGrade(device, plan, prepared.color_context, document);
+  const auto result = ExecuteCudaPrimaryGrade(device, plan, prepared, document);
   device.EndRender();
   device.WaitIdle();
   auto* lease = device.Workspace().Images().Find(result.output);
@@ -128,7 +131,7 @@ class CudaPrimaryGradeFixture : public ::testing::Test {
     ExecuteCudaDevelop(device_, plan_, prepared_, document_);
     ExecuteCudaGeometryResample(device_, plan_);
     ExecuteCudaCameraColor(device_, plan_, document_);
-    auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
+    auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_, document_);
     device_.EndRender();
     device_.WaitIdle();
     return result;
@@ -257,6 +260,10 @@ TEST_F(CudaPrimaryGradeFixture, CudaLocalTonePyramidBuffersReuseAcrossViewportCh
   const auto second = Render();
   EXPECT_NE(first.local_tone_reference_resource_id, 0U);
   EXPECT_EQ(first.local_tone_reference_resource_id, second.local_tone_reference_resource_id);
+  EXPECT_TRUE(first.local_tone_rebuilt_reference);
+  EXPECT_FALSE(first.local_tone_sampled_canonical_reference);
+  EXPECT_FALSE(second.local_tone_rebuilt_reference);
+  EXPECT_TRUE(second.local_tone_sampled_canonical_reference);
 }
 
 TEST_F(CudaPrimaryGradeFixture, CudaLocalToneUsesWorkspaceInsteadOfPrivateAllocation) {
@@ -338,6 +345,129 @@ TEST(GpuDagCudaPrimaryGrade, HighlightsLlfRespondsToNeighborhoodWithIdenticalCen
   const float dark_neighborhood   = RenderLocalToneCenter(0.10f, 0.80f, 0.0f, -80.0f);
   const float bright_neighborhood = RenderLocalToneCenter(1.50f, 0.80f, 0.0f, -80.0f);
   EXPECT_GT(std::abs(dark_neighborhood - bright_neighborhood), 1.0e-4f);
+}
+
+auto MakeSplitPlane(std::uint32_t width, std::uint32_t height, float left, float right)
+    -> HostImagePlane {
+  HostImagePlane plane;
+  plane.extent       = {width, height};
+  plane.stride_bytes = width * 16U;
+  plane.format       = HostPixelFormat::F32Rgba;
+  auto  storage      = std::shared_ptr<std::byte>(new std::byte[plane.ByteCount()],
+                                                  [](std::byte* p) { delete[] p; });
+  auto* pixels       = reinterpret_cast<float*>(storage.get());
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      const float value = x < width / 2 ? left : right;
+      const auto  index = (static_cast<std::size_t>(y) * width + x) * 4;
+      pixels[index + 0] = value;
+      pixels[index + 1] = value;
+      pixels[index + 2] = value;
+      pixels[index + 3] = 1.0f;
+    }
+  }
+  plane.bytes = std::const_pointer_cast<const std::byte>(storage);
+  return plane;
+}
+
+auto DownloadLocalTonePlane(CudaRenderDevice& device, const NodeId& grade_id) -> std::vector<float> {
+  auto* buffer = device.Workspace().Values().Find(grade_id, PortId{"local_tone.source.0"});
+  EXPECT_NE(buffer, nullptr);
+  if (buffer == nullptr) return {};
+  std::vector<float> plane(buffer->Bytes() / sizeof(float));
+  device.Workspace().Device().DownloadBufferRange(
+      *buffer, 0,
+      std::span<std::byte>(reinterpret_cast<std::byte*>(plane.data()), buffer->Bytes()),
+      device.CommandContext());
+  return plane;
+}
+
+auto RenderPreparedGrade(CudaRenderDevice& device, PipelineDocument& document,
+                         const PreparedRawInput& prepared, const ExecutionPlan& plan)
+    -> CudaPrimaryGradeResult {
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  ExecuteCudaGeometryResample(device, plan);
+  ExecuteCudaCameraColor(device, plan, document);
+  auto result = ExecuteCudaPrimaryGrade(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+  return result;
+}
+
+auto DownloadGrade(CudaRenderDevice& device, const GraphValueId& id) -> std::vector<Rgba> {
+  auto* lease = device.Workspace().Images().Find(id);
+  EXPECT_NE(lease, nullptr);
+  if (lease == nullptr) return {};
+  const auto&       texture = lease->Texture();
+  std::vector<Rgba> pixels(static_cast<std::size_t>(texture.Width()) * texture.Height());
+  device.Workspace().Device().DownloadTexture2D(
+      texture,
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                           pixels.size() * sizeof(Rgba)),
+      device.CommandContext());
+  return pixels;
+}
+
+TEST(GpuDagCudaPrimaryGrade, RoiFrameSamplesCanonicalLlfReferenceInsteadOfRebuilding) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+  constexpr std::uint32_t kWidth  = 64;
+  constexpr std::uint32_t kHeight = 64;
+  auto                    prepared =
+      RawInputLoader::FromDirectRgb(MakeSplitPlane(kWidth, kHeight, 1.0f, 0.05f),
+                                    gpu_dag_test::FullSensor(kWidth, kHeight));
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  auto* shadows = dynamic_cast<ShadowsModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Shadows()));
+  ASSERT_NE(shadows, nullptr);
+  shadows->SetValue(80.0f);
+
+  auto             full_plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  CudaRenderDevice device;
+  const auto       full_grade = RenderPreparedGrade(device, document, prepared, full_plan);
+  EXPECT_TRUE(full_grade.local_tone_rebuilt_reference);
+  EXPECT_FALSE(full_grade.local_tone_sampled_canonical_reference);
+  const auto full_pixels = DownloadGrade(device, full_grade.output);
+  const auto full_mask   = DownloadLocalTonePlane(device, document.PrimaryGrade()->Id());
+  ASSERT_FALSE(full_pixels.empty());
+  ASSERT_FALSE(full_mask.empty());
+
+  RenderRequest roi_request;
+  roi_request.view.visible_rect_in_edit_space = {0.5f, 0.0f, 0.5f, 1.0f};
+  auto roi_plan = GraphCompiler::Compile(document, prepared.CompileSource(), roi_request);
+  const auto roi_grade = RenderPreparedGrade(device, document, prepared, roi_plan);
+  EXPECT_FALSE(roi_grade.local_tone_rebuilt_reference);
+  EXPECT_TRUE(roi_grade.local_tone_sampled_canonical_reference);
+  EXPECT_EQ(full_grade.local_tone_reference_resource_id, roi_grade.local_tone_reference_resource_id);
+  const auto roi_pixels = DownloadGrade(device, roi_grade.output);
+  const auto roi_mask   = DownloadLocalTonePlane(device, document.PrimaryGrade()->Id());
+  ASSERT_FALSE(roi_pixels.empty());
+  ASSERT_EQ(full_mask, roi_mask);
+
+  const auto full_probe =
+      TransformPoint(full_plan.geometry.render_to_reference, PixelCenter(48, 32));
+  const auto roi_probe = TransformPoint(roi_plan.geometry.reference_to_render, full_probe);
+  const auto roi_x     = static_cast<int>(std::floor(roi_probe.x));
+  const auto roi_y     = static_cast<int>(std::floor(roi_probe.y));
+  const auto roi_w     = static_cast<int>(roi_plan.geometry.render_extent.width);
+  const auto roi_h     = static_cast<int>(roi_plan.geometry.render_extent.height);
+  ASSERT_GE(roi_x, 0);
+  ASSERT_GE(roi_y, 0);
+  ASSERT_LT(roi_x, roi_w);
+  ASSERT_LT(roi_y, roi_h);
+  const float sampled = roi_pixels[static_cast<std::size_t>(roi_y) * roi_w + roi_x].r;
+  const float full    = full_pixels[static_cast<std::size_t>(32) * kWidth + 48].r;
+  EXPECT_NEAR(sampled, full, 2.0e-3f);
+
+  CudaRenderDevice isolated;
+  const auto       isolated_grade = RenderPreparedGrade(isolated, document, prepared, roi_plan);
+  EXPECT_TRUE(isolated_grade.local_tone_rebuilt_reference);
+  EXPECT_FALSE(isolated_grade.local_tone_sampled_canonical_reference);
+  const auto isolated_pixels = DownloadGrade(isolated, isolated_grade.output);
+  ASSERT_FALSE(isolated_pixels.empty());
+  const float rebuilt = isolated_pixels[static_cast<std::size_t>(roi_y) * roi_w + roi_x].r;
+  EXPECT_GT(std::abs(rebuilt - sampled), 1.0e-4f);
 }
 
 TEST(GpuDagCudaPrimaryGrade, ExecuteCudaCameraColorRejectsMissingCameraMatrices) {

--- a/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
@@ -50,6 +50,8 @@ class CudaPrimaryGradeFixture : public ::testing::Test {
   auto Render() -> CudaPrimaryGradeResult {
     device_.BeginRender();
     ExecuteCudaDevelop(device_, plan_, prepared_, document_);
+    ExecuteCudaGeometryResample(device_, plan_);
+    ExecuteCudaCameraColor(device_, plan_, prepared_.color_context, document_);
     auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
     device_.EndRender();
     device_.WaitIdle();

--- a/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
@@ -49,7 +49,7 @@ class CudaPrimaryGradeFixture : public ::testing::Test {
                                               gpu_dag_test::FullSensor(16, 12));
     document_ = CreateDefaultPipelineDocument();
     gpu_dag_test::EnsureTestCameraProfile(document_);
-    plan_     = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
   }
 
   auto Render() -> CudaPrimaryGradeResult {
@@ -111,6 +111,24 @@ TEST_F(CudaPrimaryGradeFixture, CudaPrimaryGradeDefaultParametersPreserveDevelop
   EXPECT_GT(compared, 0U);
   EXPECT_TRUE(plan_.Contains(GpuPassKind::CameraToAp1));
   EXPECT_TRUE(plan_.Contains(GpuPassKind::PrimaryColorGrade));
+}
+
+TEST_F(CudaPrimaryGradeFixture, DefaultCurvePreservesSceneLinearHighlightsAboveOne) {
+  const auto result = Render();
+  const auto input  = Download(plan_.develop_output);
+  const auto output = Download(result.output);
+  ASSERT_EQ(input.size(), output.size());
+  bool compared_highlight = false;
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    if (std::max({input[i].r, input[i].g, input[i].b}) <= 1.0f) {
+      continue;
+    }
+    EXPECT_NEAR(output[i].r, input[i].r, 1.0e-6f);
+    EXPECT_NEAR(output[i].g, input[i].g, 1.0e-6f);
+    EXPECT_NEAR(output[i].b, input[i].b, 1.0e-6f);
+    compared_highlight = true;
+  }
+  EXPECT_TRUE(compared_highlight);
 }
 
 TEST_F(CudaPrimaryGradeFixture, CudaExposurePatchChangesOnlyExposureParameterRange) {

--- a/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
@@ -34,9 +34,80 @@ struct Rgba {
   float a;
 };
 
+auto AcesccEncode(float value) -> float {
+  constexpr float kA          = 9.72f;
+  constexpr float kB          = 17.52f;
+  constexpr float kOffset     = 0.0000152587890625f;
+  constexpr float kTransition = 0.000030517578125f;
+  constexpr float kFloor      = (-16.0f + kA) / kB;
+  if (value < 0.0f) return kFloor + value;
+  if (value < kTransition) return (std::log2(kOffset + value * 0.5f) + kA) / kB;
+  return (std::log2(value) + kA) / kB;
+}
+
+auto MakeNeighborhoodPlane(std::uint32_t width, std::uint32_t height, float surroundings,
+                           float center) -> HostImagePlane {
+  HostImagePlane plane;
+  plane.extent       = {width, height};
+  plane.stride_bytes = width * 16U;
+  plane.format       = HostPixelFormat::F32Rgba;
+  auto  storage      = std::shared_ptr<std::byte>(new std::byte[plane.ByteCount()],
+                                                  [](std::byte* p) { delete[] p; });
+  auto* pixels       = reinterpret_cast<float*>(storage.get());
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      const float value = x == width / 2 && y == height / 2 ? center : surroundings;
+      const auto  index = (static_cast<std::size_t>(y) * width + x) * 4;
+      pixels[index + 0] = value;
+      pixels[index + 1] = value;
+      pixels[index + 2] = value;
+      pixels[index + 3] = 1.0f;
+    }
+  }
+  plane.bytes = std::const_pointer_cast<const std::byte>(storage);
+  return plane;
+}
+
 auto HasCudaDevice() -> bool {
   int count = 0;
   return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+auto RenderLocalToneCenter(float surroundings, float center, float shadows_value,
+                           float highlights_value) -> float {
+  constexpr std::uint32_t width  = 64;
+  constexpr std::uint32_t height = 64;
+  auto                    prepared =
+      RawInputLoader::FromDirectRgb(MakeNeighborhoodPlane(width, height, surroundings, center),
+                                    gpu_dag_test::FullSensor(width, height));
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  auto* shadows = dynamic_cast<ShadowsModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Shadows()));
+  auto* highlights = dynamic_cast<HighlightsModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Highlights()));
+  EXPECT_NE(shadows, nullptr);
+  EXPECT_NE(highlights, nullptr);
+  shadows->SetValue(shadows_value);
+  highlights->SetValue(highlights_value);
+  auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  CudaRenderDevice device;
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  ExecuteCudaGeometryResample(device, plan);
+  ExecuteCudaCameraColor(device, plan, document);
+  const auto result = ExecuteCudaPrimaryGrade(device, plan, prepared.color_context, document);
+  device.EndRender();
+  device.WaitIdle();
+  auto* lease = device.Workspace().Images().Find(result.output);
+  EXPECT_NE(lease, nullptr);
+  std::vector<Rgba> pixels(static_cast<std::size_t>(width) * height);
+  device.Workspace().Device().DownloadTexture2D(
+      lease->Texture(),
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                           pixels.size() * sizeof(Rgba)),
+      device.CommandContext());
+  return pixels[static_cast<std::size_t>(height / 2) * width + width / 2].r;
 }
 
 class CudaPrimaryGradeFixture : public ::testing::Test {
@@ -113,22 +184,16 @@ TEST_F(CudaPrimaryGradeFixture, CudaPrimaryGradeDefaultParametersPreserveDevelop
   EXPECT_TRUE(plan_.Contains(GpuPassKind::PrimaryColorGrade));
 }
 
-TEST_F(CudaPrimaryGradeFixture, DefaultCurvePreservesSceneLinearHighlightsAboveOne) {
+TEST_F(CudaPrimaryGradeFixture, DefaultCurvePreservesAcesccWorkingValuesWithoutClipping) {
   const auto result = Render();
   const auto input  = Download(plan_.develop_output);
   const auto output = Download(result.output);
   ASSERT_EQ(input.size(), output.size());
-  bool compared_highlight = false;
   for (std::size_t i = 0; i < input.size(); ++i) {
-    if (std::max({input[i].r, input[i].g, input[i].b}) <= 1.0f) {
-      continue;
-    }
     EXPECT_NEAR(output[i].r, input[i].r, 1.0e-6f);
     EXPECT_NEAR(output[i].g, input[i].g, 1.0e-6f);
     EXPECT_NEAR(output[i].b, input[i].b, 1.0e-6f);
-    compared_highlight = true;
   }
-  EXPECT_TRUE(compared_highlight);
 }
 
 TEST_F(CudaPrimaryGradeFixture, CudaExposurePatchChangesOnlyExposureParameterRange) {
@@ -180,10 +245,10 @@ TEST_F(CudaPrimaryGradeFixture, CudaPointAdjustmentsExecuteInSerializedModelOrde
   const auto output = Download(Render().output);
   const auto input  = Download(plan_.develop_output);
   ASSERT_FALSE(output.empty());
-  EXPECT_NEAR(output.front().r, (input.front().r * 2.0f - 0.18f) * 2.0f + 0.18f, 1.0e-5f);
+  EXPECT_NEAR(output.front().r, (input.front().r + 1.0f / 17.52f - 0.18f) * 2.0f + 0.18f, 1.0e-5f);
 }
 
-TEST_F(CudaPrimaryGradeFixture, CudaLocalToneReferenceReusesAcrossViewportChanges) {
+TEST_F(CudaPrimaryGradeFixture, CudaLocalTonePyramidBuffersReuseAcrossViewportChanges) {
   ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
   const auto    first = Render();
   RenderRequest request;
@@ -198,9 +263,18 @@ TEST_F(CudaPrimaryGradeFixture, CudaLocalToneUsesWorkspaceInsteadOfPrivateAlloca
   ModelByType<HighlightsModel>(type_ids::Highlights()).SetValue(-30.0f);
   const auto result = Render();
   EXPECT_NE(result.local_tone_reference_resource_id, 0U);
-  EXPECT_NE(device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
-                                              PortId{"local_tone.reference"}),
-            nullptr);
+  const auto* source        = device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
+                                                                PortId{"local_tone.source.0"});
+  const auto* result_buffer = device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
+                                                                PortId{"local_tone.result.0"});
+  ASSERT_NE(source, nullptr);
+  ASSERT_NE(result_buffer, nullptr);
+  EXPECT_GT(source->Bytes(), sizeof(float));
+  EXPECT_EQ(source->Bytes(), result_buffer->Bytes());
+  device_.Workspace().Device().ResetCounters();
+  (void)Render();
+  EXPECT_EQ(device_.Workspace().Device().MallocCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().FreeCount(), 0U);
 }
 
 TEST_F(CudaPrimaryGradeFixture, CudaColorGradeSecondRenderCreatesNoGpuAllocation) {
@@ -236,7 +310,7 @@ TEST_F(CudaPrimaryGradeFixture,
   EXPECT_FLOAT_EQ(ModelByType<ContrastModel>(type_ids::Contrast()).Value(), 100.0f);
 }
 
-TEST_F(CudaPrimaryGradeFixture, DevelopImageGraphValueIsAp1SceneLinear) {
+TEST_F(CudaPrimaryGradeFixture, CameraColorEncodesAp1AsAcesccGraphWorkingSpace) {
   (void)Render();
   const auto pixels = Download(plan_.develop_output);
   ASSERT_FALSE(pixels.empty());
@@ -246,10 +320,24 @@ TEST_F(CudaPrimaryGradeFixture, DevelopImageGraphValueIsAp1SceneLinear) {
   const float  src_g = 0.5f / 12.0f;
   const float  src_b = 0.25f;
   const float* m     = resolved.transform.camera_to_ap1.data();
-  EXPECT_NEAR(pixels.front().r, m[0] * src_r + m[1] * src_g + m[2] * src_b, 1.0e-5f);
-  EXPECT_NEAR(pixels.front().g, m[3] * src_r + m[4] * src_g + m[5] * src_b, 1.0e-5f);
-  EXPECT_NEAR(pixels.front().b, m[6] * src_r + m[7] * src_g + m[8] * src_b, 1.0e-5f);
+  EXPECT_NEAR(pixels.front().r, AcesccEncode(m[0] * src_r + m[1] * src_g + m[2] * src_b), 1.0e-5f);
+  EXPECT_NEAR(pixels.front().g, AcesccEncode(m[3] * src_r + m[4] * src_g + m[5] * src_b), 1.0e-5f);
+  EXPECT_NEAR(pixels.front().b, AcesccEncode(m[6] * src_r + m[7] * src_g + m[8] * src_b), 1.0e-5f);
   EXPECT_NEAR(pixels.front().a, 1.0f, 1.0e-6f);
+}
+
+TEST(GpuDagCudaPrimaryGrade, ShadowsLlfRespondsToNeighborhoodWithIdenticalCenterPixel) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+  const float dark_neighborhood   = RenderLocalToneCenter(0.02f, 0.08f, 80.0f, 0.0f);
+  const float bright_neighborhood = RenderLocalToneCenter(0.45f, 0.08f, 80.0f, 0.0f);
+  EXPECT_GT(std::abs(dark_neighborhood - bright_neighborhood), 1.0e-4f);
+}
+
+TEST(GpuDagCudaPrimaryGrade, HighlightsLlfRespondsToNeighborhoodWithIdenticalCenterPixel) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+  const float dark_neighborhood   = RenderLocalToneCenter(0.10f, 0.80f, 0.0f, -80.0f);
+  const float bright_neighborhood = RenderLocalToneCenter(1.50f, 0.80f, 0.0f, -80.0f);
+  EXPECT_GT(std::abs(dark_neighborhood - bright_neighborhood), 1.0e-4f);
 }
 
 TEST(GpuDagCudaPrimaryGrade, ExecuteCudaCameraColorRejectsMissingCameraMatrices) {

--- a/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
@@ -10,9 +10,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
+#include <stdexcept>
 #include <vector>
 
+#include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/develop_color_transform.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/operators/models/cat02_white_balance_model.hpp"
@@ -38,12 +41,14 @@ auto HasCudaDevice() -> bool {
 
 class CudaPrimaryGradeFixture : public ::testing::Test {
  protected:
-  // Direct RGB keeps camera conversion identity so adjustment assertions stay isolated.
+  // Direct RGB plus a stored dual-illuminant camera profile. Grade assertions
+  // compare against develop.image after CameraColor, not camera RGB.
   void SetUp() override {
     if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
     prepared_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
                                               gpu_dag_test::FullSensor(16, 12));
     document_ = CreateDefaultPipelineDocument();
+    gpu_dag_test::EnsureTestCameraProfile(document_);
     plan_     = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
   }
 
@@ -51,7 +56,7 @@ class CudaPrimaryGradeFixture : public ::testing::Test {
     device_.BeginRender();
     ExecuteCudaDevelop(device_, plan_, prepared_, document_);
     ExecuteCudaGeometryResample(device_, plan_);
-    ExecuteCudaCameraColor(device_, plan_, prepared_.color_context, document_);
+    ExecuteCudaCameraColor(device_, plan_, document_);
     auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
     device_.EndRender();
     device_.WaitIdle();
@@ -90,11 +95,20 @@ TEST_F(CudaPrimaryGradeFixture, CudaPrimaryGradeDefaultParametersPreserveDevelop
   const auto input  = Download(plan_.develop_output);
   const auto output = Download(result.output);
   ASSERT_EQ(input.size(), output.size());
+  std::size_t compared = 0;
   for (std::size_t i = 0; i < input.size(); ++i) {
+    // Default grade is identity inside the unclamped AP1 unit cube. CameraColor
+    // of Direct RGB can produce values > 1; those are outside this assertion.
+    if (input[i].r < 0.0f || input[i].r > 1.0f || input[i].g < 0.0f || input[i].g > 1.0f ||
+        input[i].b < 0.0f || input[i].b > 1.0f) {
+      continue;
+    }
     EXPECT_NEAR(output[i].r, input[i].r, 1.0e-6f);
     EXPECT_NEAR(output[i].g, input[i].g, 1.0e-6f);
     EXPECT_NEAR(output[i].b, input[i].b, 1.0e-6f);
+    ++compared;
   }
+  EXPECT_GT(compared, 0U);
   EXPECT_TRUE(plan_.Contains(GpuPassKind::CameraToAp1));
   EXPECT_TRUE(plan_.Contains(GpuPassKind::PrimaryColorGrade));
 }
@@ -202,6 +216,38 @@ TEST_F(CudaPrimaryGradeFixture,
   EXPECT_GT(std::abs(before.front().r - after.front().r), 0.05f);
   EXPECT_FLOAT_EQ(ModelByType<ExposureModel>(type_ids::Exposure()).Value(), 1.0f);
   EXPECT_FLOAT_EQ(ModelByType<ContrastModel>(type_ids::Contrast()).Value(), 100.0f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, DevelopImageGraphValueIsAp1SceneLinear) {
+  (void)Render();
+  const auto pixels = Download(plan_.develop_output);
+  ASSERT_FALSE(pixels.empty());
+  const auto resolved = ResolveDevelopColorTransform(document_.Develop()->Params().Params());
+  ASSERT_TRUE(resolved.ok);
+  const float  src_r = 0.5f / 16.0f;
+  const float  src_g = 0.5f / 12.0f;
+  const float  src_b = 0.25f;
+  const float* m     = resolved.transform.camera_to_ap1.data();
+  EXPECT_NEAR(pixels.front().r, m[0] * src_r + m[1] * src_g + m[2] * src_b, 1.0e-5f);
+  EXPECT_NEAR(pixels.front().g, m[3] * src_r + m[4] * src_g + m[5] * src_b, 1.0e-5f);
+  EXPECT_NEAR(pixels.front().b, m[6] * src_r + m[7] * src_g + m[8] * src_b, 1.0e-5f);
+  EXPECT_NEAR(pixels.front().a, 1.0f, 1.0e-6f);
+}
+
+TEST(GpuDagCudaPrimaryGrade, ExecuteCudaCameraColorRejectsMissingCameraMatrices) {
+  if (!HasCudaDevice()) {
+    GTEST_SKIP() << "No CUDA device available.";
+  }
+  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                                gpu_dag_test::FullSensor(16, 12));
+  auto document = CreateDefaultPipelineDocument();
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  CudaRenderDevice device;
+  device.BeginRender();
+  ExecuteCudaDevelop(device, plan, prepared, document);
+  ExecuteCudaGeometryResample(device, plan);
+  EXPECT_THROW(ExecuteCudaCameraColor(device, plan, document), std::runtime_error);
+  device.EndRender();
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
@@ -10,6 +10,7 @@
 #include <span>
 #include <vector>
 
+#include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/legacy_pipeline_importer.hpp"
@@ -54,6 +55,7 @@ TEST(GpuDagCudaDrtProduct, ProductRendererCompilesStaticPlanOnlyForTopologyOrSou
   if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
 
   auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  gpu_dag_test::EnsureTestCameraProfile(*document);
   CudaProductRenderer renderer(document, MakeUnpacker());
   const auto          image = MakeEncodedImage(11);
   RenderRequest       request;
@@ -129,6 +131,7 @@ TEST(GpuDagCudaDrtProduct, ProductRendererReusesPreparedSourceAfterSwitchingEnco
   if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
 
   auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  gpu_dag_test::EnsureTestCameraProfile(*document);
   CudaProductRenderer renderer(document, MakeUnpacker());
   const auto          image_a = MakeEncodedImage(21);
   const auto          image_b = MakeEncodedImage(22);
@@ -148,6 +151,7 @@ TEST(GpuDagCudaDrtProduct, ProductRendererViewportAndMaxEdgeResampleDecodedSourc
   if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
 
   auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  gpu_dag_test::EnsureTestCameraProfile(*document);
   CudaProductRenderer renderer(document, MakeUnpacker());
   const auto          image = MakeEncodedImage(31);
   RenderRequest       request;
@@ -179,6 +183,7 @@ TEST(GpuDagCudaDrtProduct, ProductRendererRendersLegacyImportWithTintWithoutUnre
   ASSERT_EQ(imported.document->PrimaryGrade()->FindAdjustmentByType(type_ids::Tint()), nullptr);
 
   auto document = std::make_shared<PipelineDocument>(std::move(*imported.document));
+  gpu_dag_test::EnsureTestCameraProfile(*document);
   document->InsertAdjustment(NodeId{"grade.primary"}, document->PrimaryGrade()->AdjustmentCount(),
                              AdjustmentInstanceId{"grade.primary.tint"},
                              std::make_unique<TintModel>());

--- a/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
@@ -18,6 +18,7 @@
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
 #include "edit/runtime/graph_compiler.hpp"
 #include "image/image_buffer.hpp"
 
@@ -39,9 +40,9 @@ auto MakeEncodedImage(std::uint8_t tag) -> std::shared_ptr<ImageBuffer> {
 auto MakeUnpacker() -> PreparedSourceCache::UnpackFn {
   return [](std::span<const std::byte>, DecodeRes decode_res) {
     const auto pattern = gpu_dag_test::MakeRggbPattern();
-    return RawInputLoader::FromUnpackedCfa(
-        gpu_dag_test::MakeU16CfaPlane(32, 32, pattern), pattern, gpu_dag_test::DefaultLinearization(),
-        gpu_dag_test::FullSensor(32, 32), decode_res);
+    return RawInputLoader::FromUnpackedCfa(gpu_dag_test::MakeU16CfaPlane(32, 32, pattern), pattern,
+                                           gpu_dag_test::DefaultLinearization(),
+                                           gpu_dag_test::FullSensor(32, 32), decode_res);
   };
 }
 
@@ -70,13 +71,13 @@ TEST(GpuDagCudaDrtProduct, ProductRendererCompilesStaticPlanOnlyForTopologyOrSou
   exposure->SetValue(0.8f);
   ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
 
-  auto develop = document->Develop()->Params().Params();
+  auto develop       = document->Develop()->Params().Params();
   develop.wb_mode    = "custom";
   develop.custom_cct = 4800.0f;
   document->Develop()->Params().ReplaceParams(develop);
   ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
 
-  auto drt = document->Drt()->Params().Params();
+  auto drt           = document->Drt()->Params().Params();
   drt.peak_luminance = 180.0f;
   document->Drt()->Params().ReplaceParams(drt);
   ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
@@ -86,13 +87,13 @@ TEST(GpuDagCudaDrtProduct, ProductRendererCompilesStaticPlanOnlyForTopologyOrSou
 
   document->Geometry().SetCropRect({0.05f, 0.05f, 0.9f, 0.9f});
 
-  auto& encoded = image->GetBuffer();
+  auto&      encoded       = image->GetBuffer();
   const auto encoded_bytes = std::span<const std::byte>{
       reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
-  const auto source = renderer.SourceCache().AcquireEncoded(encoded_bytes, DecodeRes::FULL);
-  auto       plan   = renderer.PlanCache().GetOrCompile(*document, source.Get().CompileSource());
-  const auto key    = plan.static_key;
-  RenderRequest viewport = request;
+  const auto    source = renderer.SourceCache().AcquireEncoded(encoded_bytes, DecodeRes::FULL);
+  auto          plan   = renderer.PlanCache().GetOrCompile(*document, source.Get().CompileSource());
+  const auto    key    = plan.static_key;
+  RenderRequest viewport                   = request;
   viewport.view.visible_rect_in_edit_space = {0.1f, 0.1f, 0.8f, 0.8f};
   viewport.view.viewport_extent            = {24, 24};
   GraphCompiler::BindFrameGeometry(plan, *document, viewport);
@@ -147,7 +148,8 @@ TEST(GpuDagCudaDrtProduct, ProductRendererReusesPreparedSourceAfterSwitchingEnco
   EXPECT_EQ(renderer.Stats().plan_compile_count, 1U);
 }
 
-TEST(GpuDagCudaDrtProduct, ProductRendererViewportAndMaxEdgeResampleDecodedSourceWithoutSizeMismatch) {
+TEST(GpuDagCudaDrtProduct,
+     ProductRendererViewportAndMaxEdgeResampleDecodedSourceWithoutSizeMismatch) {
   if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
 
   auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
@@ -158,7 +160,7 @@ TEST(GpuDagCudaDrtProduct, ProductRendererViewportAndMaxEdgeResampleDecodedSourc
   request.view.viewport_extent = {48, 32};
   request.resolution.max_edge  = 48;
 
-  const auto output = RenderHost(renderer, image, DecodeRes::FULL, request);
+  const auto output            = RenderHost(renderer, image, DecodeRes::FULL, request);
   ASSERT_NE(output, nullptr);
   const auto& cpu = output->GetCPUData();
   EXPECT_EQ(cpu.cols, 48);
@@ -166,7 +168,7 @@ TEST(GpuDagCudaDrtProduct, ProductRendererViewportAndMaxEdgeResampleDecodedSourc
 
   request.view.visible_rect_in_edit_space = {0.1f, 0.1f, 0.8f, 0.8f};
   request.view.viewport_extent            = {40, 24};
-  const auto cropped = RenderHost(renderer, image, DecodeRes::FULL, request);
+  const auto cropped                      = RenderHost(renderer, image, DecodeRes::FULL, request);
   ASSERT_NE(cropped, nullptr);
   EXPECT_EQ(cropped->GetCPUData().cols, 40);
   EXPECT_EQ(cropped->GetCPUData().rows, 24);
@@ -190,6 +192,25 @@ TEST(GpuDagCudaDrtProduct, ProductRendererRendersLegacyImportWithTintWithoutUnre
   CudaProductRenderer renderer(document, MakeUnpacker());
   const auto          image = MakeEncodedImage(41);
   ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, RenderRequest{}), nullptr);
+}
+
+TEST(GpuDagCudaDrtProduct, LegacyShadowControlExecutesLocalLaplacianWorkspacePath) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+
+  nlohmann::json legacy;
+  legacy["Basic Adjustment"]["Basic Adjustment"]["shadows"] = {
+      {"type", 6}, {"enable", true}, {"params", {{"shadows", 60.0f}}}};
+  auto imported = LegacyPipelineImporter::Import(legacy);
+  ASSERT_TRUE(imported.Ok()) << imported.error;
+  auto document = std::make_shared<PipelineDocument>(std::move(*imported.document));
+  gpu_dag_test::EnsureTestCameraProfile(*document);
+
+  CudaProductRenderer renderer(document, MakeUnpacker());
+  ASSERT_NE(RenderHost(renderer, MakeEncodedImage(42), DecodeRes::FULL, RenderRequest{}), nullptr);
+  const auto* reference = renderer.Device().Workspace().Values().Find(
+      document->PrimaryGrade()->Id(), PortId{"local_tone.source.0"});
+  ASSERT_NE(reference, nullptr);
+  EXPECT_GT(reference->Bytes(), sizeof(float));
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
@@ -12,6 +12,7 @@
 
 #include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
@@ -141,6 +142,49 @@ TEST(GpuDagCudaDrtProduct, ProductRendererReusesPreparedSourceAfterSwitchingEnco
   EXPECT_EQ(renderer.Stats().prepared_source_misses, 2U);
   EXPECT_EQ(renderer.Stats().prepared_source_hits, 1U);
   EXPECT_EQ(renderer.Stats().plan_compile_count, 1U);
+}
+
+TEST(GpuDagCudaDrtProduct, ProductRendererViewportAndMaxEdgeResampleDecodedSourceWithoutSizeMismatch) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+
+  auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  CudaProductRenderer renderer(document, MakeUnpacker());
+  const auto          image = MakeEncodedImage(31);
+  RenderRequest       request;
+  request.view.viewport_extent = {48, 32};
+  request.resolution.max_edge  = 48;
+
+  const auto output = RenderHost(renderer, image, DecodeRes::FULL, request);
+  ASSERT_NE(output, nullptr);
+  const auto& cpu = output->GetCPUData();
+  EXPECT_EQ(cpu.cols, 48);
+  EXPECT_EQ(cpu.rows, 32);
+
+  request.view.visible_rect_in_edit_space = {0.1f, 0.1f, 0.8f, 0.8f};
+  request.view.viewport_extent            = {40, 24};
+  const auto cropped = RenderHost(renderer, image, DecodeRes::FULL, request);
+  ASSERT_NE(cropped, nullptr);
+  EXPECT_EQ(cropped->GetCPUData().cols, 40);
+  EXPECT_EQ(cropped->GetCPUData().rows, 24);
+}
+
+TEST(GpuDagCudaDrtProduct, ProductRendererRendersLegacyImportWithTintWithoutUnregisteredType) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+
+  nlohmann::json legacy;
+  legacy["Color Adjustment"]["Color Adjustment"]["tint"] = {
+      {"type", 11}, {"enable", true}, {"params", {{"tint", 18.0f}}}};
+  auto imported = LegacyPipelineImporter::Import(legacy);
+  ASSERT_TRUE(imported.Ok()) << imported.error;
+  ASSERT_EQ(imported.document->PrimaryGrade()->FindAdjustmentByType(type_ids::Tint()), nullptr);
+
+  auto document = std::make_shared<PipelineDocument>(std::move(*imported.document));
+  document->InsertAdjustment(NodeId{"grade.primary"}, document->PrimaryGrade()->AdjustmentCount(),
+                             AdjustmentInstanceId{"grade.primary.tint"},
+                             std::make_unique<TintModel>());
+  CudaProductRenderer renderer(document, MakeUnpacker());
+  const auto          image = MakeEncodedImage(41);
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, RenderRequest{}), nullptr);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
@@ -1,0 +1,147 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "image/image_buffer.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+auto MakeEncodedImage(std::uint8_t tag) -> std::shared_ptr<ImageBuffer> {
+  std::vector<std::uint8_t> bytes(64, tag);
+  bytes[0] = tag;
+  bytes[1] = 0x5A;
+  return std::make_shared<ImageBuffer>(std::move(bytes));
+}
+
+auto MakeUnpacker() -> PreparedSourceCache::UnpackFn {
+  return [](std::span<const std::byte>, DecodeRes decode_res) {
+    const auto pattern = gpu_dag_test::MakeRggbPattern();
+    return RawInputLoader::FromUnpackedCfa(
+        gpu_dag_test::MakeU16CfaPlane(32, 32, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+        gpu_dag_test::FullSensor(32, 32), decode_res);
+  };
+}
+
+auto RenderHost(CudaProductRenderer& renderer, const std::shared_ptr<ImageBuffer>& input,
+                DecodeRes decode_res, const RenderRequest& request)
+    -> std::shared_ptr<ImageBuffer> {
+  return renderer.Render(input, decode_res, request, nullptr, FrameCompletionSubmission{}, true);
+}
+
+TEST(GpuDagCudaDrtProduct, ProductRendererCompilesStaticPlanOnlyForTopologyOrSourceLayoutChange) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+
+  auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  CudaProductRenderer renderer(document, MakeUnpacker());
+  const auto          image = MakeEncodedImage(11);
+  RenderRequest       request;
+
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
+  EXPECT_EQ(renderer.Stats().libraw_open_unpack_count, 1U);
+  EXPECT_EQ(renderer.Stats().plan_compile_count, 1U);
+
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document->PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(0.8f);
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
+
+  auto develop = document->Develop()->Params().Params();
+  develop.wb_mode    = "custom";
+  develop.custom_cct = 4800.0f;
+  document->Develop()->Params().ReplaceParams(develop);
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
+
+  auto drt = document->Drt()->Params().Params();
+  drt.peak_luminance = 180.0f;
+  document->Drt()->Params().ReplaceParams(drt);
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
+
+  request.resolution.quality = RenderQuality::Export;
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
+
+  document->Geometry().SetCropRect({0.05f, 0.05f, 0.9f, 0.9f});
+
+  auto& encoded = image->GetBuffer();
+  const auto encoded_bytes = std::span<const std::byte>{
+      reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
+  const auto source = renderer.SourceCache().AcquireEncoded(encoded_bytes, DecodeRes::FULL);
+  auto       plan   = renderer.PlanCache().GetOrCompile(*document, source.Get().CompileSource());
+  const auto key    = plan.static_key;
+  RenderRequest viewport = request;
+  viewport.view.visible_rect_in_edit_space = {0.1f, 0.1f, 0.8f, 0.8f};
+  viewport.view.viewport_extent            = {24, 24};
+  GraphCompiler::BindFrameGeometry(plan, *document, viewport);
+  EXPECT_EQ(plan.static_key, key);
+  EXPECT_NE(plan.geometry.render_extent.width, 0U);
+  document->Geometry().SetCropRect({});
+
+  EXPECT_EQ(renderer.Stats().libraw_open_unpack_count, 1U);
+  EXPECT_EQ(renderer.Stats().plan_compile_count, 1U);
+  EXPECT_EQ(renderer.Stats().prepared_source_misses, 1U);
+  EXPECT_GE(renderer.Stats().prepared_source_hits, 4U);
+  EXPECT_GE(renderer.Stats().plan_cache_hits, 4U);
+
+  auto* grade = document->PrimaryGrade();
+  grade->MoveAdjustment(grade->AdjustmentIdAt(0), grade->AdjustmentCount() - 1);
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
+  EXPECT_EQ(renderer.Stats().plan_compile_count, 2U);
+  EXPECT_EQ(renderer.Stats().libraw_open_unpack_count, 1U);
+
+  document->Graph().AddNode(std::make_unique<AnalyticMaskNodeModel>(NodeId{"mask.radial"}));
+  document->Graph().Connect(NodeId{"mask.radial"}, PortId{"mask"}, NodeId{"grade.primary"},
+                            PortId{"mask"});
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
+  EXPECT_EQ(renderer.Stats().plan_compile_count, 3U);
+
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::HALF, request), nullptr);
+  EXPECT_EQ(renderer.Stats().libraw_open_unpack_count, 2U);
+  EXPECT_EQ(renderer.Stats().plan_compile_count, 4U);
+
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
+  EXPECT_EQ(renderer.Stats().libraw_open_unpack_count, 2U);
+  EXPECT_EQ(renderer.Stats().plan_compile_count, 4U);
+}
+
+TEST(GpuDagCudaDrtProduct, ProductRendererReusesPreparedSourceAfterSwitchingEncodedBuffers) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+
+  auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  CudaProductRenderer renderer(document, MakeUnpacker());
+  const auto          image_a = MakeEncodedImage(21);
+  const auto          image_b = MakeEncodedImage(22);
+  RenderRequest       request;
+
+  ASSERT_NE(RenderHost(renderer, image_a, DecodeRes::FULL, request), nullptr);
+  ASSERT_NE(RenderHost(renderer, image_b, DecodeRes::FULL, request), nullptr);
+  ASSERT_NE(RenderHost(renderer, image_a, DecodeRes::FULL, request), nullptr);
+
+  EXPECT_EQ(renderer.Stats().libraw_open_unpack_count, 2U);
+  EXPECT_EQ(renderer.Stats().prepared_source_misses, 2U);
+  EXPECT_EQ(renderer.Stats().prepared_source_hits, 1U);
+  EXPECT_EQ(renderer.Stats().plan_compile_count, 1U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/cuda_product_scope_present_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_product_scope_present_test.cpp
@@ -1,0 +1,313 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#include "edit/scope/detail/scope_cuda_shared.cuh"
+#include "edit/scope/final_display_frame_tap.hpp"
+#include "edit/scope/scope_analyzer.hpp"
+#include "image/image_buffer.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+auto MakeEncodedImage(std::uint8_t tag) -> std::shared_ptr<ImageBuffer> {
+  std::vector<std::uint8_t> bytes(64, tag);
+  bytes[0] = tag;
+  bytes[1] = 0x5A;
+  return std::make_shared<ImageBuffer>(std::move(bytes));
+}
+
+auto MakeUnpacker() -> PreparedSourceCache::UnpackFn {
+  return [](std::span<const std::byte>, DecodeRes decode_res) {
+    const auto pattern = gpu_dag_test::MakeRggbPattern();
+    return RawInputLoader::FromUnpackedCfa(gpu_dag_test::MakeU16CfaPlane(32, 32, pattern), pattern,
+                                           gpu_dag_test::DefaultLinearization(),
+                                           gpu_dag_test::FullSensor(32, 32), decode_res);
+  };
+}
+
+enum class PresentEvent {
+  Bind,
+  Ensure,
+  Map,
+  Submit,
+  Unmap,
+  Notify,
+};
+
+class RecordingCudaPresentSink final : public IFrameSink {
+ public:
+  ~RecordingCudaPresentSink() override { ReleaseDeviceBuffer(); }
+
+  void EnsureSize(int width, int height) override {
+    events_.push_back(PresentEvent::Ensure);
+    width_  = width;
+    height_ = height;
+    const auto bytes = static_cast<std::size_t>(width) * static_cast<std::size_t>(height) *
+                       sizeof(float) * 4U;
+    if (device_bytes_ != bytes) {
+      ReleaseDeviceBuffer();
+      if (bytes > 0) {
+        if (::cudaMalloc(&device_, bytes) != cudaSuccess) {
+          throw std::runtime_error("RecordingCudaPresentSink: cudaMalloc failed");
+        }
+        device_bytes_ = bytes;
+      }
+    }
+  }
+
+  auto MapResourceForWrite(FrameMemoryDomain /*domain*/) -> FrameWriteMapping override {
+    events_.push_back(PresentEvent::Map);
+    mapped_ = true;
+    FrameWriteMapping mapping;
+    mapping.data           = device_;
+    mapping.row_bytes      = static_cast<std::size_t>(width_) * sizeof(float) * 4U;
+    mapping.pixel_format   = FramePixelFormat::RGBA32F;
+    mapping.memory_domain  = FrameMemoryDomain::CudaDevice;
+    mapping.target_type    = FrameWriteTargetType::LinearBuffer;
+    mapping.native_object  = reinterpret_cast<std::uintptr_t>(device_);
+    return mapping;
+  }
+
+  void UnmapResource() override {
+    events_.push_back(PresentEvent::Unmap);
+    mapped_ = false;
+  }
+
+  void BindFrameSubmission(const FrameCompletionSubmission& submission) override {
+    events_.push_back(PresentEvent::Bind);
+    last_bound_ = submission;
+  }
+
+  void SubmitFinalDisplayFrame(const FinalDisplayFrameView& frame) override {
+    events_.push_back(PresentEvent::Submit);
+    submitted_while_mapped_ = mapped_;
+    last_frame_             = frame;
+    ++submit_count_;
+  }
+
+  void NotifyFrameReady(const FrameCompletionSubmission& submission) override {
+    events_.push_back(PresentEvent::Notify);
+    last_notified_ = submission;
+  }
+
+  auto GetWidth() const -> int override { return width_; }
+  auto GetHeight() const -> int override { return height_; }
+
+  std::vector<PresentEvent>   events_;
+  FinalDisplayFrameView       last_frame_{};
+  FrameCompletionSubmission   last_bound_{};
+  FrameCompletionSubmission   last_notified_{};
+  int                         submit_count_           = 0;
+  bool                        submitted_while_mapped_ = false;
+
+ private:
+  void ReleaseDeviceBuffer() {
+    if (device_ != nullptr) {
+      ::cudaFree(device_);
+      device_       = nullptr;
+      device_bytes_ = 0;
+    }
+  }
+
+  void*       device_       = nullptr;
+  std::size_t device_bytes_ = 0;
+  int         width_        = 0;
+  int         height_       = 0;
+  bool        mapped_       = false;
+};
+
+auto LinearImage(const FinalDisplayFrameView& frame)
+    -> const scope::cuda_detail::CudaLinearImageResource* {
+  if (frame.image.backend != GpuBackend::Cuda || !frame.image.resource) {
+    return nullptr;
+  }
+  return static_cast<const scope::cuda_detail::CudaLinearImageResource*>(
+      frame.image.resource.get());
+}
+
+auto StreamSignal(const FinalDisplayFrameView& frame)
+    -> const scope::cuda_detail::CudaStreamSignalResource* {
+  if (frame.ready_signal.backend != GpuBackend::Cuda || !frame.ready_signal.resource) {
+    return nullptr;
+  }
+  return static_cast<const scope::cuda_detail::CudaStreamSignalResource*>(
+      frame.ready_signal.resource.get());
+}
+
+class CudaProductScopePresentFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasCudaDevice()) {
+      GTEST_SKIP() << "No CUDA device available.";
+    }
+    document_ = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+    gpu_dag_test::EnsureTestCameraProfile(*document_);
+    renderer_ = std::make_unique<CudaProductRenderer>(document_, MakeUnpacker());
+    image_    = MakeEncodedImage(91);
+  }
+
+  auto RenderTo(IFrameSink& sink, const FrameCompletionSubmission& submission = {})
+      -> std::shared_ptr<ImageBuffer> {
+    return renderer_->Render(image_, DecodeRes::FULL, RenderRequest{}, &sink, submission, false);
+  }
+
+  std::shared_ptr<PipelineDocument>    document_;
+  std::unique_ptr<CudaProductRenderer> renderer_;
+  std::shared_ptr<ImageBuffer>         image_;
+};
+
+TEST_F(CudaProductScopePresentFixture,
+       ProductPresentSubmitsReadableCudaDisplayFrameBeforeUnmapAndNotify) {
+  RecordingCudaPresentSink sink;
+  FrameCompletionSubmission submission;
+  submission.metadata.image_identity          = 18;
+  submission.metadata.session_epoch           = 4;
+  submission.metadata.presentation_request_id = 249;
+  submission.metadata.scope_update_allowed    = true;
+
+  ASSERT_NE(RenderTo(sink, submission), nullptr);
+
+  const std::vector<PresentEvent> expected = {PresentEvent::Bind,   PresentEvent::Ensure,
+                                              PresentEvent::Map,    PresentEvent::Submit,
+                                              PresentEvent::Unmap,  PresentEvent::Notify};
+  EXPECT_EQ(sink.events_, expected);
+  EXPECT_EQ(sink.submit_count_, 1);
+  EXPECT_TRUE(sink.submitted_while_mapped_);
+  EXPECT_EQ(sink.last_bound_.metadata.presentation_request_id, 249U);
+  EXPECT_EQ(sink.last_notified_.metadata.presentation_request_id, 249U);
+
+  const auto& frame = sink.last_frame_;
+  ASSERT_TRUE(static_cast<bool>(frame));
+  EXPECT_EQ(frame.image.backend, GpuBackend::Cuda);
+  EXPECT_EQ(frame.format, FramePixelFormat::RGBA32F);
+  EXPECT_EQ(frame.domain, AnalysisDomain::DisplayEncoded);
+  EXPECT_GT(frame.width, 0);
+  EXPECT_GT(frame.height, 0);
+  EXPECT_EQ(frame.width, sink.GetWidth());
+  EXPECT_EQ(frame.height, sink.GetHeight());
+  EXPECT_EQ(frame.display_config.encoding_space, ColorUtils::ColorSpace::REC709);
+  EXPECT_EQ(frame.display_config.encoding_eotf, ColorUtils::EOTF::GAMMA_2_2);
+
+  const auto* image = LinearImage(frame);
+  ASSERT_NE(image, nullptr);
+  EXPECT_NE(image->device_ptr, nullptr);
+  EXPECT_FALSE(image->owns_memory);
+  EXPECT_EQ(image->width, frame.width);
+  EXPECT_EQ(image->height, frame.height);
+  EXPECT_EQ(image->row_bytes, static_cast<std::size_t>(frame.width) * sizeof(float) * 4U);
+
+  const auto* signal = StreamSignal(frame);
+  ASSERT_NE(signal, nullptr);
+  EXPECT_NE(signal->stream, nullptr);
+
+  std::vector<float> host(static_cast<std::size_t>(frame.width) * frame.height * 4U, 0.0f);
+  ASSERT_EQ(::cudaMemcpy2D(host.data(), image->row_bytes, image->device_ptr, image->row_bytes,
+                           image->row_bytes, static_cast<std::size_t>(frame.height),
+                           cudaMemcpyDeviceToHost),
+            cudaSuccess);
+  bool any_finite_rgb = false;
+  for (std::size_t i = 0; i + 3 < host.size(); i += 4) {
+    ASSERT_TRUE(std::isfinite(host[i]));
+    ASSERT_TRUE(std::isfinite(host[i + 1]));
+    ASSERT_TRUE(std::isfinite(host[i + 2]));
+    if (host[i] != 0.0f || host[i + 1] != 0.0f || host[i + 2] != 0.0f) {
+      any_finite_rgb = true;
+    }
+  }
+  EXPECT_TRUE(any_finite_rgb);
+}
+
+TEST_F(CudaProductScopePresentFixture, ProductPresentDisplayConfigMatchesDrtEncoding) {
+  auto payload               = document_->Drt()->Params().Params();
+  payload.encoding_space     = DrtColorSpace::Rec2020;
+  payload.encoding_eotf      = DrtEotf::St2084;
+  payload.peak_luminance     = 1000.0f;
+  document_->Drt()->Params().ReplaceParams(payload);
+
+  RecordingCudaPresentSink sink;
+  ASSERT_NE(RenderTo(sink), nullptr);
+  EXPECT_EQ(sink.submit_count_, 1);
+  EXPECT_EQ(sink.last_frame_.display_config.encoding_space, ColorUtils::ColorSpace::REC2020);
+  EXPECT_EQ(sink.last_frame_.display_config.encoding_eotf, ColorUtils::EOTF::ST2084);
+  EXPECT_FLOAT_EQ(sink.last_frame_.display_config.peak_luminance, 1000.0f);
+}
+
+auto WaitForHistogramSnapshot(IScopeAnalyzer& analyzer, std::uint64_t image_identity,
+                              std::uint64_t session_epoch) -> ScopeRenderSnapshot {
+  ScopeRenderSnapshot snapshot;
+  for (int attempt = 0; attempt < 200; ++attempt) {
+    const auto output = analyzer.GetLatestOutput();
+    if (output.generation != 0 && output.histogram_valid) {
+      snapshot = ReadScopeRenderSnapshot(output);
+      if (snapshot.histogram.valid && snapshot.image_identity == image_identity &&
+          snapshot.session_epoch == session_epoch) {
+        return snapshot;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  return snapshot;
+}
+
+TEST_F(CudaProductScopePresentFixture,
+       DeferredTapKeepsCompletedHistogramAfterLaterPresentWouldHaveReclaimedTheSlot) {
+  auto                     analyzer = CreateCudaScopeAnalyzer();
+  ASSERT_NE(analyzer, nullptr);
+  RecordingCudaPresentSink downstream;
+  FinalDisplayFrameTapSink tap(&downstream, analyzer);
+  tap.SetScopeAnalysisDeferred(true);
+  tap.SetScopeActive(true);
+  ScopeRequest request;
+  request.enabled_mask = static_cast<uint32_t>(ScopeType::Histogram);
+  request.target_fps   = 0;
+  tap.SetScopeRequest(request);
+
+  FrameCompletionSubmission first;
+  first.metadata.image_identity          = 18;
+  first.metadata.session_epoch           = 4;
+  first.metadata.presentation_request_id = 31;
+  first.metadata.scope_update_allowed    = true;
+  ASSERT_NE(RenderTo(tap, first), nullptr);
+  ASSERT_TRUE(static_cast<bool>(tap.GetCurrentScopeFrameView()));
+
+  analyzer->SubmitFrame(tap.GetCurrentScopeFrameView(), request);
+  // Give the analysis stream time to finish without consuming the slot.
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  FrameCompletionSubmission second = first;
+  second.metadata.presentation_request_id = 32;
+  ASSERT_NE(RenderTo(tap, second), nullptr);
+
+  const auto snapshot = WaitForHistogramSnapshot(*analyzer, 18, 4);
+  EXPECT_TRUE(snapshot.histogram.valid);
+  EXPECT_EQ(snapshot.image_identity, 18U);
+  EXPECT_EQ(snapshot.session_epoch, 4U);
+  EXPECT_GT(snapshot.generation, 0U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
@@ -4,11 +4,11 @@
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
-#include <opencv2/core.hpp>
 
 #include <cmath>
 #include <cstdint>
 #include <memory>
+#include <opencv2/core.hpp>
 #include <span>
 #include <stdexcept>
 #include <vector>
@@ -55,6 +55,13 @@ auto RenderHost(CudaProductRenderer& renderer, const std::shared_ptr<ImageBuffer
   return renderer.Render(input, decode_res, request, nullptr, FrameCompletionSubmission{}, true);
 }
 
+auto RenderHostWithoutSessionCache(CudaProductRenderer&                renderer,
+                                   const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
+                                   const RenderRequest& request) -> std::shared_ptr<ImageBuffer> {
+  return renderer.Render(input, decode_res, request, nullptr, FrameCompletionSubmission{}, true,
+                         CudaProductCachePolicy::BypassSessionCache);
+}
+
 auto OutputIsFinite(const std::shared_ptr<ImageBuffer>& image) -> bool {
   if (!image || !image->cpu_data_valid_) {
     return false;
@@ -97,7 +104,7 @@ class CudaResultCacheProductFixture : public ::testing::Test {
         document_->PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
   }
 
-  std::shared_ptr<PipelineDocument> document_;
+  std::shared_ptr<PipelineDocument>    document_;
   std::unique_ptr<CudaProductRenderer> renderer_;
   std::shared_ptr<ImageBuffer>         image_;
 };
@@ -144,10 +151,11 @@ TEST_F(CudaResultCacheProductFixture, ExposureEditRunsOnlyPrimaryGradeAndDrtPass
   EXPECT_EQ(stats.pass.camera_color_skip, 1U);
 }
 
-TEST_F(CudaResultCacheProductFixture, DevelopCctEditReusesSensorAndGeometryAndRunsCameraColorGradeDrt) {
+TEST_F(CudaResultCacheProductFixture,
+       DevelopCctEditReusesSensorAndGeometryAndRunsCameraColorGradeDrt) {
   ASSERT_TRUE(OutputIsFinite(Render()));
   renderer_->ResetStats();
-  auto develop = document_->Develop()->Params().Params();
+  auto develop       = document_->Develop()->Params().Params();
   develop.wb_mode    = "custom";
   develop.custom_cct = 4800.0f;
   document_->Develop()->Params().ReplaceParams(develop);
@@ -167,7 +175,7 @@ TEST_F(CudaResultCacheProductFixture, DevelopCctEditReusesSensorAndGeometryAndRu
 TEST_F(CudaResultCacheProductFixture, DrtEditRunsOnlyDrtPass) {
   ASSERT_TRUE(OutputIsFinite(Render()));
   renderer_->ResetStats();
-  auto drt = document_->Drt()->Params().Params();
+  auto drt           = document_->Drt()->Params().Params();
   drt.peak_luminance = 180.0f;
   document_->Drt()->Params().ReplaceParams(drt);
   ASSERT_TRUE(OutputIsFinite(Render()));
@@ -182,7 +190,8 @@ TEST_F(CudaResultCacheProductFixture, DrtEditRunsOnlyDrtPass) {
   EXPECT_EQ(stats.pass.primary_grade_skip, 1U);
 }
 
-TEST_F(CudaResultCacheProductFixture, ViewportChangeReusesSensorDevelopAndRunsGeometryAndDownstream) {
+TEST_F(CudaResultCacheProductFixture,
+       ViewportChangeReusesSensorDevelopAndRunsGeometryAndDownstream) {
   ASSERT_TRUE(OutputIsFinite(Render()));
   renderer_->ResetStats();
   RenderRequest request;
@@ -199,7 +208,8 @@ TEST_F(CudaResultCacheProductFixture, ViewportChangeReusesSensorDevelopAndRunsGe
   EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
 }
 
-TEST_F(CudaResultCacheProductFixture, GeometryEditReusesSensorDevelopAndInvalidatesPostGeometryResult) {
+TEST_F(CudaResultCacheProductFixture,
+       GeometryEditReusesSensorDevelopAndInvalidatesPostGeometryResult) {
   ASSERT_TRUE(OutputIsFinite(Render()));
   renderer_->ResetStats();
   document_->Geometry().SetCropRect({0.05f, 0.05f, 0.9f, 0.9f});
@@ -215,10 +225,11 @@ TEST_F(CudaResultCacheProductFixture, GeometryEditReusesSensorDevelopAndInvalida
   EXPECT_EQ(stats.pass.geometry_skip, 0U);
 }
 
-TEST_F(CudaResultCacheProductFixture, RawDevelopEditInvalidatesSensorDevelopAndAllDownstreamResults) {
+TEST_F(CudaResultCacheProductFixture,
+       RawDevelopEditInvalidatesSensorDevelopAndAllDownstreamResults) {
   ASSERT_TRUE(OutputIsFinite(Render()));
   renderer_->ResetStats();
-  auto develop = document_->Develop()->Params().Params();
+  auto develop                   = document_->Develop()->Params().Params();
   develop.highlights_reconstruct = !develop.highlights_reconstruct;
   document_->Develop()->Params().ReplaceParams(develop);
   ASSERT_TRUE(OutputIsFinite(Render()));
@@ -231,6 +242,79 @@ TEST_F(CudaResultCacheProductFixture, RawDevelopEditInvalidatesSensorDevelopAndA
   EXPECT_EQ(stats.pass.primary_grade_execute, 1U);
   EXPECT_EQ(stats.pass.drt_execute, 1U);
   EXPECT_EQ(stats.pass.sensor_develop_skip, 0U);
+}
+
+TEST_F(CudaResultCacheProductFixture, ImageSwitchBackAfterReleaseSessionCachesMissesAndReexecutes) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ReleaseSessionCaches();
+  const auto released = renderer_->SessionResources();
+  EXPECT_EQ(released.published_result_count, 0U);
+  EXPECT_EQ(released.texture_pool_entry_count, 0U);
+  EXPECT_EQ(released.prepared_source_entry_count, 0U);
+  renderer_->ResetStats();
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.prepared_source_misses, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 1U);
+  EXPECT_EQ(stats.pass.drt_execute, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 0U);
+}
+
+TEST_F(CudaResultCacheProductFixture,
+       ClearAllIntermediateBuffersReleasesCudaProductSessionGpuAndHostCaches) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  EXPECT_GT(renderer_->SessionResources().texture_pool_used_bytes, 0U);
+  EXPECT_GT(renderer_->SessionResources().published_result_count, 0U);
+  EXPECT_GT(renderer_->SessionResources().prepared_source_host_bytes, 0U);
+  renderer_->ReleaseSessionCaches();
+  const auto resources = renderer_->SessionResources();
+  EXPECT_EQ(resources.texture_pool_used_bytes, 0U);
+  EXPECT_EQ(resources.texture_pool_entry_count, 0U);
+  EXPECT_EQ(resources.published_result_count, 0U);
+  EXPECT_EQ(resources.prepared_source_host_bytes, 0U);
+  EXPECT_EQ(resources.prepared_source_entry_count, 0U);
+  EXPECT_TRUE(resources.session_value_ids.empty());
+}
+
+TEST_F(CudaResultCacheProductFixture, TexturePoolBudgetNoLongerHardCodedTo64MiBOnProductPath) {
+  EXPECT_GT(renderer_->Device().Workspace().Textures().ByteBudget(), 64ull << 20);
+}
+
+TEST_F(CudaResultCacheProductFixture,
+       ViewportChangeAfterSessionReleaseStillReusesSensorLinearOnTheLivePipeline) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  RenderRequest request;
+  request.view.visible_rect_in_edit_space = {0.1f, 0.1f, 0.8f, 0.8f};
+  request.view.viewport_extent            = {24, 16};
+  ASSERT_TRUE(OutputIsFinite(Render(request)));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.pass.geometry_execute, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture, ThreeSequentialImagePinsDoNotRetainPreviousImageGpuTextures) {
+  auto document_a = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  auto document_b = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  auto document_c = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  gpu_dag_test::EnsureTestCameraProfile(*document_a);
+  gpu_dag_test::EnsureTestCameraProfile(*document_b);
+  gpu_dag_test::EnsureTestCameraProfile(*document_c);
+  CudaProductRenderer session_a(document_a, MakeUnpacker());
+  CudaProductRenderer session_b(document_b, MakeUnpacker());
+  CudaProductRenderer session_c(document_c, MakeUnpacker());
+  ASSERT_TRUE(OutputIsFinite(RenderHost(session_a, MakeEncodedImage(11), DecodeRes::FULL, {})));
+  EXPECT_GT(session_a.SessionResources().texture_pool_used_bytes, 0U);
+  session_a.ReleaseSessionCaches();
+  ASSERT_TRUE(OutputIsFinite(RenderHost(session_b, MakeEncodedImage(12), DecodeRes::FULL, {})));
+  EXPECT_EQ(session_a.SessionResources().texture_pool_used_bytes, 0U);
+  EXPECT_GT(session_b.SessionResources().texture_pool_used_bytes, 0U);
+  session_b.ReleaseSessionCaches();
+  ASSERT_TRUE(OutputIsFinite(RenderHost(session_c, MakeEncodedImage(13), DecodeRes::FULL, {})));
+  EXPECT_EQ(session_a.SessionResources().texture_pool_used_bytes, 0U);
+  EXPECT_EQ(session_b.SessionResources().texture_pool_used_bytes, 0U);
+  EXPECT_GT(session_c.SessionResources().texture_pool_used_bytes, 0U);
 }
 
 TEST_F(CudaResultCacheProductFixture, ImageSwitchBackReusesMatchingPreparedSourceAndGpuResults) {
@@ -253,6 +337,35 @@ TEST_F(CudaResultCacheProductFixture, ImageSwitchBackReusesMatchingPreparedSourc
   EXPECT_EQ(stats.pass.drt_skip, 1U);
 }
 
+TEST_F(CudaResultCacheProductFixture, OneShotRenderDoesNotReadWriteOrClearEditorSessionCaches) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto resources_before = renderer_->SessionResources();
+  renderer_->ResetStats();
+
+  ASSERT_TRUE(
+      OutputIsFinite(RenderHostWithoutSessionCache(*renderer_, image_, DecodeRes::FULL, {})));
+
+  const auto after_one_shot = renderer_->Stats();
+  EXPECT_EQ(after_one_shot.prepared_source_hits, 0U);
+  EXPECT_EQ(after_one_shot.prepared_source_misses, 0U);
+  EXPECT_EQ(after_one_shot.plan_cache_hits, 0U);
+  EXPECT_EQ(after_one_shot.plan_cache_misses, 0U);
+  EXPECT_EQ(after_one_shot.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(renderer_->SessionResources().published_result_count,
+            resources_before.published_result_count);
+  EXPECT_EQ(renderer_->SessionResources().prepared_source_entry_count,
+            resources_before.prepared_source_entry_count);
+
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto after_preview = renderer_->Stats();
+  EXPECT_EQ(after_preview.prepared_source_hits, 1U);
+  EXPECT_EQ(after_preview.libraw_open_unpack_count, 0U);
+  EXPECT_EQ(after_preview.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(after_preview.pass.drt_execute, 0U);
+  EXPECT_EQ(after_preview.pass.sensor_develop_skip, 1U);
+  EXPECT_EQ(after_preview.pass.drt_skip, 1U);
+}
+
 class CudaResultCacheDeviceFixture : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -269,16 +382,16 @@ class CudaResultCacheDeviceFixture : public ::testing::Test {
     return GraphCompiler::Compile(document_, input_.CompileSource(), request);
   }
 
-  PreparedRawInput   input_;
-  PipelineDocument   document_;
-  CudaRenderDevice   device_;
+  PreparedRawInput input_;
+  PipelineDocument document_;
+  CudaRenderDevice device_;
 };
 
 TEST_F(CudaResultCacheDeviceFixture, FailedSubmissionDoesNotPublishResultContentKey) {
-  auto plan = Compile();
+  auto       plan       = Compile();
   const auto first_keys = BuildFrameResultContentKeys(plan, input_, document_);
   ASSERT_EQ(device_.Execute(plan, input_, document_), plan.display_output);
-  auto develop = document_.Develop()->Params().Params();
+  auto develop                   = document_.Develop()->Params().Params();
   develop.highlights_reconstruct = !develop.highlights_reconstruct;
   document_.Develop()->Params().ReplaceParams(develop);
   const auto second_keys = BuildFrameResultContentKeys(plan, input_, document_);
@@ -286,12 +399,13 @@ TEST_F(CudaResultCacheDeviceFixture, FailedSubmissionDoesNotPublishResultContent
   device_.Workspace().Device().FailNextUpload();
   EXPECT_THROW((void)device_.Execute(plan, input_, document_), std::runtime_error);
   device_.WaitIdle();
-  auto& images = device_.Workspace().Images();
+  auto&      images    = device_.Workspace().Images();
   const auto completed = device_.Workspace().Device().CompletedSubmission();
   EXPECT_TRUE(images.FindValidResult(plan.sensor_linear_output, first_keys.sensor_linear,
                                      first_keys.sensor_extent, TextureFormat::Rgba32f, completed));
   EXPECT_TRUE(images.FindValidResult(plan.display_output, first_keys.drt_display,
-                                     first_keys.geometry_extent, TextureFormat::Rgba32f, completed));
+                                     first_keys.geometry_extent, TextureFormat::Rgba32f,
+                                     completed));
   EXPECT_FALSE(images.FindValidResult(plan.sensor_linear_output, second_keys.sensor_linear,
                                       second_keys.sensor_extent, TextureFormat::Rgba32f,
                                       completed));
@@ -300,21 +414,21 @@ TEST_F(CudaResultCacheDeviceFixture, FailedSubmissionDoesNotPublishResultContent
                                       completed));
 }
 
-TEST_F(CudaResultCacheDeviceFixture, CancelledSubmissionKeepsPreviouslyCompletedCacheEntriesUsable) {
-  auto plan = Compile();
+TEST_F(CudaResultCacheDeviceFixture,
+       CancelledSubmissionKeepsPreviouslyCompletedCacheEntriesUsable) {
+  auto       plan = Compile();
   const auto keys = BuildFrameResultContentKeys(plan, input_, document_);
   ASSERT_EQ(device_.Execute(plan, input_, document_), plan.display_output);
   device_.BeginRender();
-  (void)device_.Workspace().AcquireImageForWrite(plan.display_output,
-                                                 {keys.geometry_extent.width,
-                                                  keys.geometry_extent.height,
-                                                  TextureFormat::Rgba32f});
+  (void)device_.Workspace().AcquireImageForWrite(
+      plan.display_output,
+      {keys.geometry_extent.width, keys.geometry_extent.height, TextureFormat::Rgba32f});
   device_.CancelRender();
   device_.WaitIdle();
   const auto completed = device_.Workspace().Device().CompletedSubmission();
-  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(
-      plan.display_output, keys.drt_display, keys.geometry_extent, TextureFormat::Rgba32f,
-      completed));
+  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(plan.display_output, keys.drt_display,
+                                                           keys.geometry_extent,
+                                                           TextureFormat::Rgba32f, completed));
   ASSERT_EQ(device_.Execute(plan, input_, document_), plan.display_output);
   EXPECT_EQ(device_.PassStats().drt_skip, 1U);
 }

--- a/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
@@ -15,6 +15,8 @@
 
 #include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
@@ -24,6 +26,7 @@
 #include "edit/runtime/result_content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "image/image_buffer.hpp"
+#include "json.hpp"
 
 namespace alcedo {
 namespace {
@@ -149,6 +152,51 @@ TEST_F(CudaResultCacheProductFixture, ExposureEditRunsOnlyPrimaryGradeAndDrtPass
   EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
   EXPECT_EQ(stats.pass.geometry_skip, 1U);
   EXPECT_EQ(stats.pass.camera_color_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture,
+       TemporaryOvalSecondUnchangedRenderSkipsSensorGeometryCameraMaskGradeAndDrt) {
+  AttachTemporaryPrimaryGradeOvalMask(*document_);
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.geometry_execute, 0U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 0U);
+  EXPECT_EQ(stats.pass.mask_execute, 0U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 0U);
+  EXPECT_EQ(stats.pass.drt_execute, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.pass.geometry_skip, 1U);
+  EXPECT_EQ(stats.pass.camera_color_skip, 1U);
+  EXPECT_EQ(stats.pass.mask_skip, 1U);
+  EXPECT_EQ(stats.pass.primary_grade_skip, 1U);
+  EXPECT_EQ(stats.pass.drt_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture,
+       ApplyOntoExposureWithTemporaryOvalReusesSensorGeometryCameraAndMask) {
+  AttachTemporaryPrimaryGradeOvalMask(*document_);
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  nlohmann::json json;
+  json["Basic Adjustment"]["Basic Adjustment"]["exposure"] = {
+      {"type", 2}, {"enable", true}, {"params", {{"exposure", 0.75}}}};
+  ASSERT_TRUE(LegacyPipelineImporter::ApplyOnto(*document_, json).empty());
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.pass.source_h2d_count, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.geometry_execute, 0U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 0U);
+  EXPECT_EQ(stats.pass.mask_execute, 0U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 1U);
+  EXPECT_EQ(stats.pass.drt_execute, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.pass.geometry_skip, 1U);
+  EXPECT_EQ(stats.pass.camera_color_skip, 1U);
+  EXPECT_EQ(stats.pass.mask_skip, 1U);
 }
 
 TEST_F(CudaResultCacheProductFixture,

--- a/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
@@ -82,6 +83,7 @@ class CudaResultCacheProductFixture : public ::testing::Test {
       GTEST_SKIP() << "No CUDA device available.";
     }
     document_ = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+    gpu_dag_test::EnsureTestCameraProfile(*document_);
     renderer_ = std::make_unique<CudaProductRenderer>(document_, MakeUnpacker());
     image_    = MakeEncodedImage(71);
   }
@@ -260,6 +262,7 @@ class CudaResultCacheDeviceFixture : public ::testing::Test {
     input_    = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
                                               gpu_dag_test::FullSensor(16, 12));
     document_ = CreateDefaultPipelineDocument();
+    gpu_dag_test::EnsureTestCameraProfile(document_);
   }
 
   auto Compile(const RenderRequest& request = {}) -> ExecutionPlan {

--- a/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
@@ -1,0 +1,320 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <opencv2/core.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/result_content_key.hpp"
+#include "edit/runtime/texture_format.hpp"
+#include "image/image_buffer.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+auto MakeEncodedImage(std::uint8_t tag) -> std::shared_ptr<ImageBuffer> {
+  std::vector<std::uint8_t> bytes(64, tag);
+  bytes[0] = tag;
+  bytes[1] = 0x5A;
+  return std::make_shared<ImageBuffer>(std::move(bytes));
+}
+
+auto MakeUnpacker() -> PreparedSourceCache::UnpackFn {
+  return [](std::span<const std::byte>, DecodeRes decode_res) {
+    const auto pattern = gpu_dag_test::MakeRggbPattern();
+    return RawInputLoader::FromUnpackedCfa(gpu_dag_test::MakeU16CfaPlane(32, 32, pattern), pattern,
+                                           gpu_dag_test::DefaultLinearization(),
+                                           gpu_dag_test::FullSensor(32, 32), decode_res);
+  };
+}
+
+auto RenderHost(CudaProductRenderer& renderer, const std::shared_ptr<ImageBuffer>& input,
+                DecodeRes decode_res, const RenderRequest& request)
+    -> std::shared_ptr<ImageBuffer> {
+  return renderer.Render(input, decode_res, request, nullptr, FrameCompletionSubmission{}, true);
+}
+
+auto OutputIsFinite(const std::shared_ptr<ImageBuffer>& image) -> bool {
+  if (!image || !image->cpu_data_valid_) {
+    return false;
+  }
+  const auto& mat = image->GetCPUData();
+  if (mat.empty() || mat.type() != CV_32FC4) {
+    return false;
+  }
+  for (int row = 0; row < mat.rows; ++row) {
+    const auto* pixels = mat.ptr<cv::Vec4f>(row);
+    for (int col = 0; col < mat.cols; ++col) {
+      for (int channel = 0; channel < 4; ++channel) {
+        if (!std::isfinite(pixels[col][channel])) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+class CudaResultCacheProductFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasCudaDevice()) {
+      GTEST_SKIP() << "No CUDA device available.";
+    }
+    document_ = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+    renderer_ = std::make_unique<CudaProductRenderer>(document_, MakeUnpacker());
+    image_    = MakeEncodedImage(71);
+  }
+
+  auto Render(const RenderRequest& request = {}) -> std::shared_ptr<ImageBuffer> {
+    return RenderHost(*renderer_, image_, DecodeRes::FULL, request);
+  }
+
+  auto Exposure() -> ExposureModel* {
+    return dynamic_cast<ExposureModel*>(
+        document_->PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  }
+
+  std::shared_ptr<PipelineDocument> document_;
+  std::unique_ptr<CudaProductRenderer> renderer_;
+  std::shared_ptr<ImageBuffer>         image_;
+};
+
+TEST_F(CudaResultCacheProductFixture,
+       SecondUnchangedProductRenderRunsNoLibRawNoSourceUploadAndNoGpuNodePass) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.libraw_open_unpack_count, 0U);
+  EXPECT_EQ(stats.plan_compile_count, 0U);
+  EXPECT_EQ(stats.pass.source_h2d_count, 0U);
+  EXPECT_EQ(stats.pass.source_h2d_bytes, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.geometry_execute, 0U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 0U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 0U);
+  EXPECT_EQ(stats.pass.drt_execute, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.pass.geometry_skip, 1U);
+  EXPECT_EQ(stats.pass.camera_color_skip, 1U);
+  EXPECT_EQ(stats.pass.primary_grade_skip, 1U);
+  EXPECT_EQ(stats.pass.drt_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture, ExposureEditRunsOnlyPrimaryGradeAndDrtPasses) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  auto* exposure = Exposure();
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(0.75f);
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.libraw_open_unpack_count, 0U);
+  EXPECT_EQ(stats.pass.source_h2d_count, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.geometry_execute, 0U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 0U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 1U);
+  EXPECT_EQ(stats.pass.drt_execute, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.pass.geometry_skip, 1U);
+  EXPECT_EQ(stats.pass.camera_color_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture, DevelopCctEditReusesSensorAndGeometryAndRunsCameraColorGradeDrt) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  auto develop = document_->Develop()->Params().Params();
+  develop.wb_mode    = "custom";
+  develop.custom_cct = 4800.0f;
+  document_->Develop()->Params().ReplaceParams(develop);
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.libraw_open_unpack_count, 0U);
+  EXPECT_EQ(stats.pass.source_h2d_count, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.geometry_execute, 0U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 1U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 1U);
+  EXPECT_EQ(stats.pass.drt_execute, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.pass.geometry_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture, DrtEditRunsOnlyDrtPass) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  auto drt = document_->Drt()->Params().Params();
+  drt.peak_luminance = 180.0f;
+  document_->Drt()->Params().ReplaceParams(drt);
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.pass.source_h2d_count, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.geometry_execute, 0U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 0U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 0U);
+  EXPECT_EQ(stats.pass.drt_execute, 1U);
+  EXPECT_EQ(stats.pass.drt_skip, 0U);
+  EXPECT_EQ(stats.pass.primary_grade_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture, ViewportChangeReusesSensorDevelopAndRunsGeometryAndDownstream) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  RenderRequest request;
+  request.view.visible_rect_in_edit_space = {0.1f, 0.1f, 0.8f, 0.8f};
+  request.view.viewport_extent            = {24, 16};
+  ASSERT_TRUE(OutputIsFinite(Render(request)));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.pass.source_h2d_count, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.geometry_execute, 1U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 1U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 1U);
+  EXPECT_EQ(stats.pass.drt_execute, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture, GeometryEditReusesSensorDevelopAndInvalidatesPostGeometryResult) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  document_->Geometry().SetCropRect({0.05f, 0.05f, 0.9f, 0.9f});
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.pass.source_h2d_count, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.geometry_execute, 1U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 1U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 1U);
+  EXPECT_EQ(stats.pass.drt_execute, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.pass.geometry_skip, 0U);
+}
+
+TEST_F(CudaResultCacheProductFixture, RawDevelopEditInvalidatesSensorDevelopAndAllDownstreamResults) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  renderer_->ResetStats();
+  auto develop = document_->Develop()->Params().Params();
+  develop.highlights_reconstruct = !develop.highlights_reconstruct;
+  document_->Develop()->Params().ReplaceParams(develop);
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.pass.source_h2d_count, 1U);
+  EXPECT_GT(stats.pass.source_h2d_bytes, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 1U);
+  EXPECT_EQ(stats.pass.geometry_execute, 1U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 1U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 1U);
+  EXPECT_EQ(stats.pass.drt_execute, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 0U);
+}
+
+TEST_F(CudaResultCacheProductFixture, ImageSwitchBackReusesMatchingPreparedSourceAndGpuResults) {
+  const auto image_a = MakeEncodedImage(81);
+  const auto image_b = MakeEncodedImage(82);
+  ASSERT_TRUE(OutputIsFinite(RenderHost(*renderer_, image_a, DecodeRes::FULL, {})));
+  ASSERT_TRUE(OutputIsFinite(RenderHost(*renderer_, image_b, DecodeRes::FULL, {})));
+  renderer_->ResetStats();
+  ASSERT_TRUE(OutputIsFinite(RenderHost(*renderer_, image_a, DecodeRes::FULL, {})));
+  const auto stats = renderer_->Stats();
+  EXPECT_EQ(stats.libraw_open_unpack_count, 0U);
+  EXPECT_EQ(stats.prepared_source_hits, 1U);
+  EXPECT_EQ(stats.pass.source_h2d_count, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.pass.geometry_execute, 0U);
+  EXPECT_EQ(stats.pass.camera_color_execute, 0U);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 0U);
+  EXPECT_EQ(stats.pass.drt_execute, 0U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.pass.drt_skip, 1U);
+}
+
+class CudaResultCacheDeviceFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasCudaDevice()) {
+      GTEST_SKIP() << "No CUDA device available.";
+    }
+    input_    = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                              gpu_dag_test::FullSensor(16, 12));
+    document_ = CreateDefaultPipelineDocument();
+  }
+
+  auto Compile(const RenderRequest& request = {}) -> ExecutionPlan {
+    return GraphCompiler::Compile(document_, input_.CompileSource(), request);
+  }
+
+  PreparedRawInput   input_;
+  PipelineDocument   document_;
+  CudaRenderDevice   device_;
+};
+
+TEST_F(CudaResultCacheDeviceFixture, FailedSubmissionDoesNotPublishResultContentKey) {
+  auto plan = Compile();
+  const auto first_keys = BuildFrameResultContentKeys(plan, input_, document_);
+  ASSERT_EQ(device_.Execute(plan, input_, document_), plan.display_output);
+  auto develop = document_.Develop()->Params().Params();
+  develop.highlights_reconstruct = !develop.highlights_reconstruct;
+  document_.Develop()->Params().ReplaceParams(develop);
+  const auto second_keys = BuildFrameResultContentKeys(plan, input_, document_);
+  ASSERT_NE(second_keys.sensor_linear, first_keys.sensor_linear);
+  device_.Workspace().Device().FailNextUpload();
+  EXPECT_THROW((void)device_.Execute(plan, input_, document_), std::runtime_error);
+  device_.WaitIdle();
+  auto& images = device_.Workspace().Images();
+  const auto completed = device_.Workspace().Device().CompletedSubmission();
+  EXPECT_TRUE(images.FindValidResult(plan.sensor_linear_output, first_keys.sensor_linear,
+                                     first_keys.sensor_extent, TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(images.FindValidResult(plan.display_output, first_keys.drt_display,
+                                     first_keys.geometry_extent, TextureFormat::Rgba32f, completed));
+  EXPECT_FALSE(images.FindValidResult(plan.sensor_linear_output, second_keys.sensor_linear,
+                                      second_keys.sensor_extent, TextureFormat::Rgba32f,
+                                      completed));
+  EXPECT_FALSE(images.FindValidResult(plan.display_output, second_keys.drt_display,
+                                      second_keys.geometry_extent, TextureFormat::Rgba32f,
+                                      completed));
+}
+
+TEST_F(CudaResultCacheDeviceFixture, CancelledSubmissionKeepsPreviouslyCompletedCacheEntriesUsable) {
+  auto plan = Compile();
+  const auto keys = BuildFrameResultContentKeys(plan, input_, document_);
+  ASSERT_EQ(device_.Execute(plan, input_, document_), plan.display_output);
+  device_.BeginRender();
+  (void)device_.Workspace().AcquireImageForWrite(plan.display_output,
+                                                 {keys.geometry_extent.width,
+                                                  keys.geometry_extent.height,
+                                                  TextureFormat::Rgba32f});
+  device_.CancelRender();
+  device_.WaitIdle();
+  const auto completed = device_.Workspace().Device().CompletedSubmission();
+  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(
+      plan.display_output, keys.drt_display, keys.geometry_extent, TextureFormat::Rgba32f,
+      completed));
+  ASSERT_EQ(device_.Execute(plan, input_, document_), plan.display_output);
+  EXPECT_EQ(device_.PassStats().drt_skip, 1U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
@@ -15,10 +15,11 @@
 
 #include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
-#include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
 #include "edit/input/raw_input_loader.hpp"
+#include "edit/mask/mask_store.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
@@ -50,6 +51,20 @@ auto MakeUnpacker() -> PreparedSourceCache::UnpackFn {
                                            gpu_dag_test::DefaultLinearization(),
                                            gpu_dag_test::FullSensor(32, 32), decode_res);
   };
+}
+
+void ConnectFilledRasterMask(PipelineDocument& document, MaskStore& store) {
+  MaskAsset asset;
+  asset.key               = MaskAssetKey{"test.raster"};
+  asset.descriptor.extent = {32, 32};
+  asset.pixels.assign(32U * 32U, 255);
+  store.Save(asset);
+  auto node = std::make_unique<RasterMaskNodeModel>(NodeId{"mask.raster"});
+  node->SetAssetKey(asset.key);
+  document.Graph().AddNode(std::move(node));
+  document.Graph().Connect(NodeId{"mask.raster"}, PortId{"mask"}, NodeId{"grade.primary"},
+                           PortId{"mask"});
+  document.MarkTopologyDirty();
 }
 
 auto RenderHost(CudaProductRenderer& renderer, const std::shared_ptr<ImageBuffer>& input,
@@ -155,8 +170,8 @@ TEST_F(CudaResultCacheProductFixture, ExposureEditRunsOnlyPrimaryGradeAndDrtPass
 }
 
 TEST_F(CudaResultCacheProductFixture,
-       TemporaryOvalSecondUnchangedRenderSkipsSensorGeometryCameraMaskGradeAndDrt) {
-  AttachTemporaryPrimaryGradeOvalMask(*document_);
+       RasterMaskSecondUnchangedRenderSkipsSensorGeometryCameraMaskGradeAndDrt) {
+  ConnectFilledRasterMask(*document_, renderer_->MaskAssets());
   ASSERT_TRUE(OutputIsFinite(Render()));
   renderer_->ResetStats();
   ASSERT_TRUE(OutputIsFinite(Render()));
@@ -176,8 +191,8 @@ TEST_F(CudaResultCacheProductFixture,
 }
 
 TEST_F(CudaResultCacheProductFixture,
-       ApplyOntoExposureWithTemporaryOvalReusesSensorGeometryCameraAndMask) {
-  AttachTemporaryPrimaryGradeOvalMask(*document_);
+       ApplyOntoExposureWithRasterMaskReusesSensorGeometryCameraAndMask) {
+  ConnectFilledRasterMask(*document_, renderer_->MaskAssets());
   ASSERT_TRUE(OutputIsFinite(Render()));
   renderer_->ResetStats();
   nlohmann::json json;

--- a/alcedo_studio/tests/edit/runtime/develop_camera_profile_import_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/develop_camera_profile_import_test.cpp
@@ -1,0 +1,94 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <filesystem>
+#include <utility>
+
+#include "edit/graph/develop_color_transform.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "../graph/test_camera_profile.hpp"
+#include "image/image.hpp"
+#include "image/metadata_extractor.hpp"
+
+namespace alcedo {
+namespace {
+
+auto BindFromSample(const std::filesystem::path& path, ImageType type)
+    -> std::pair<RawRuntimeColorContext, DevelopPayload> {
+  Image image(1, path, type);
+  MetadataExtractor::ExtractEXIF_ToImage(path, image);
+  EXPECT_TRUE(image.HasRawColorContext());
+  const auto ctx = image.GetRawColorContext();
+  auto       document = CreateDefaultPipelineDocument();
+  gpu_dag_test::ApplyImportedCameraProfile(document, ctx);
+  return {ctx, document.Develop()->Params().Params()};
+}
+
+TEST(GpuDagCudaDrtProduct, BindDevelopCameraProfileCopiesDngColorMatricesFromMetadataExtractor) {
+  const auto sample =
+      std::filesystem::path(TEST_IMG_PATH) / "raw" / "bad_dng" / "bad_color_dng.dng";
+  if (!std::filesystem::exists(sample)) {
+    GTEST_SKIP() << "Sample DNG not found: " << sample.string();
+  }
+  const auto [ctx, payload] = BindFromSample(sample, ImageType::DNG);
+  EXPECT_TRUE(ctx.color_matrices_valid_);
+  EXPECT_TRUE(payload.camera_profile.color_matrices_valid);
+  EXPECT_EQ(payload.camera_profile.color_matrices_valid, ctx.color_matrices_valid_);
+  EXPECT_EQ(payload.camera_profile.forward_matrices_valid, ctx.forward_matrices_valid_);
+  EXPECT_EQ(payload.camera_profile.as_shot_neutral_valid, ctx.as_shot_neutral_valid_);
+  EXPECT_EQ(payload.camera_profile.calibration_illuminants_valid,
+            ctx.calibration_illuminants_valid_);
+  EXPECT_DOUBLE_EQ(payload.camera_profile.color_matrix_1_cct, ctx.color_matrix_1_cct_);
+  EXPECT_DOUBLE_EQ(payload.camera_profile.color_matrix_2_cct, ctx.color_matrix_2_cct_);
+  for (int i = 0; i < 9; ++i) {
+    EXPECT_DOUBLE_EQ(payload.camera_profile.color_matrix_1[static_cast<std::size_t>(i)],
+                     ctx.color_matrix_1_[i]);
+    EXPECT_DOUBLE_EQ(payload.camera_profile.color_matrix_2[static_cast<std::size_t>(i)],
+                     ctx.color_matrix_2_[i]);
+  }
+  EXPECT_NEAR(ctx.as_shot_neutral_[0], 0.30864197, 1e-6);
+  EXPECT_NEAR(payload.camera_profile.as_shot_neutral[0], ctx.as_shot_neutral_[0], 1e-6);
+  EXPECT_GE(payload.as_shot_cct, 2000.0f);
+  EXPECT_LE(payload.as_shot_cct, 15000.0f);
+
+  const auto resolved = ResolveDevelopColorTransform(payload);
+  ASSERT_TRUE(resolved.ok);
+  EXPECT_NE(resolved.transform.camera_to_ap1[0], 1.0f);
+}
+
+TEST(GpuDagCudaDrtProduct, BindDevelopCameraProfileCopiesNonDngCameraMatricesFromMetadataExtractor) {
+  const auto sample =
+      std::filesystem::path(TEST_IMG_PATH) / "raw" / "cct_test" / "_DSC8085.ARW";
+  if (!std::filesystem::exists(sample)) {
+    GTEST_SKIP() << "Sample ARW not found: " << sample.string();
+  }
+  const auto [ctx, payload] = BindFromSample(sample, ImageType::ARW);
+  EXPECT_TRUE(ctx.color_matrices_valid_);
+  EXPECT_TRUE(payload.camera_profile.color_matrices_valid);
+  EXPECT_DOUBLE_EQ(payload.camera_profile.color_matrix_1_cct, ctx.color_matrix_1_cct_);
+  EXPECT_DOUBLE_EQ(payload.camera_profile.color_matrix_2_cct, ctx.color_matrix_2_cct_);
+  EXPECT_GE(payload.as_shot_cct, 2000.0f);
+  EXPECT_LE(payload.as_shot_cct, 15000.0f);
+
+  auto custom = payload;
+  custom.wb_mode    = "custom";
+  custom.custom_cct = 4000.0f;
+  const auto as_shot = ResolveDevelopColorTransform(payload);
+  const auto edited  = ResolveDevelopColorTransform(custom);
+  ASSERT_TRUE(as_shot.ok);
+  ASSERT_TRUE(edited.ok);
+  double delta = 0.0;
+  for (int i = 0; i < 9; ++i) {
+    delta += std::abs(as_shot.transform.camera_to_ap1[static_cast<std::size_t>(i)] -
+                      edited.transform.camera_to_ap1[static_cast<std::size_t>(i)]);
+  }
+  EXPECT_GT(delta, 1.0e-4);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -6,10 +6,12 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <string>
 
 #include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/runtime/pass_kind.hpp"
 
@@ -96,20 +98,24 @@ TEST(GpuDagGraphCompiler, DefaultPipelineCompilesShadowsAndHighlightsToLocalLapl
   EXPECT_TRUE(saw_curve);
 }
 
-TEST(GpuDagGraphCompiler, GraphCompilerEmitsMaskEvaluateWhenTemporaryOvalMaskAttached) {
+TEST(GpuDagGraphCompiler, GraphCompilerEmitsMaskEvaluateWhenRasterMaskConnected) {
   const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
       gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
       gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
   auto document = CreateDefaultPipelineDocument();
-  AttachTemporaryPrimaryGradeOvalMask(document);
+  auto node     = std::make_unique<RasterMaskNodeModel>(NodeId{"mask.raster"});
+  node->SetAssetKey(MaskAssetKey{"test.raster"});
+  document.Graph().AddNode(std::move(node));
+  document.Graph().Connect(NodeId{"mask.raster"}, PortId{"mask"}, NodeId{"grade.primary"},
+                           PortId{"mask"});
   const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
   EXPECT_TRUE(plan.Contains(GpuPassKind::MaskEvaluate));
   EXPECT_TRUE(plan.Contains(GpuPassKind::MaskFeather));
   ASSERT_TRUE(plan.primary_grade_mask.has_value());
-  EXPECT_EQ(plan.primary_grade_mask->node_id, NodeId{"mask.ui_test.radial"});
-  EXPECT_EQ(plan.primary_grade_mask->kind, CompiledMaskKind::Analytic);
+  EXPECT_EQ(plan.primary_grade_mask->node_id, NodeId{"mask.raster"});
+  EXPECT_EQ(plan.primary_grade_mask->kind, CompiledMaskKind::Raster);
   EXPECT_LT(plan.IndexOf(GpuPassKind::CameraToAp1), plan.IndexOf(GpuPassKind::MaskEvaluate));
   EXPECT_LT(plan.IndexOf(GpuPassKind::MaskEvaluate), plan.IndexOf(GpuPassKind::MaskFeather));
   EXPECT_LT(plan.IndexOf(GpuPassKind::MaskFeather), plan.IndexOf(GpuPassKind::PrimaryColorGrade));

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -96,5 +96,24 @@ TEST(GpuDagGraphCompiler, DefaultPipelineCompilesShadowsAndHighlightsToLocalLapl
   EXPECT_TRUE(saw_curve);
 }
 
+TEST(GpuDagGraphCompiler, GraphCompilerEmitsMaskEvaluateWhenTemporaryOvalMaskAttached) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  AttachTemporaryPrimaryGradeOvalMask(document);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  EXPECT_TRUE(plan.Contains(GpuPassKind::MaskEvaluate));
+  EXPECT_TRUE(plan.Contains(GpuPassKind::MaskFeather));
+  ASSERT_TRUE(plan.primary_grade_mask.has_value());
+  EXPECT_EQ(plan.primary_grade_mask->node_id, NodeId{"mask.ui_test.radial"});
+  EXPECT_EQ(plan.primary_grade_mask->kind, CompiledMaskKind::Analytic);
+  EXPECT_LT(plan.IndexOf(GpuPassKind::CameraToAp1), plan.IndexOf(GpuPassKind::MaskEvaluate));
+  EXPECT_LT(plan.IndexOf(GpuPassKind::MaskEvaluate), plan.IndexOf(GpuPassKind::MaskFeather));
+  EXPECT_LT(plan.IndexOf(GpuPassKind::MaskFeather), plan.IndexOf(GpuPassKind::PrimaryColorGrade));
+}
+
 }  // namespace
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -68,5 +68,33 @@ TEST(GpuDagGraphCompiler, HighlightFlagDoesNotChangePassList) {
   EXPECT_TRUE(plan.Contains(GpuPassKind::CfaClamp));
 }
 
+TEST(GpuDagGraphCompiler, DefaultPipelineCompilesShadowsAndHighlightsToLocalLaplacianOnly) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  const auto document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  bool       saw_shadows    = false;
+  bool       saw_highlights = false;
+  bool       saw_curve      = false;
+  for (const auto& adjustment : plan.primary_grade_adjustments) {
+    if (adjustment.type == type_ids::Shadows()) {
+      saw_shadows = true;
+      EXPECT_EQ(adjustment.algorithm, CompiledAdjustmentAlgorithm::LocalLaplacian);
+    } else if (adjustment.type == type_ids::Highlights()) {
+      saw_highlights = true;
+      EXPECT_EQ(adjustment.algorithm, CompiledAdjustmentAlgorithm::LocalLaplacian);
+    } else if (adjustment.type == type_ids::Curve()) {
+      saw_curve = true;
+      EXPECT_EQ(adjustment.algorithm, CompiledAdjustmentAlgorithm::Pointwise);
+    }
+  }
+  EXPECT_TRUE(saw_shadows);
+  EXPECT_TRUE(saw_highlights);
+  EXPECT_TRUE(saw_curve);
+}
+
 }  // namespace
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
@@ -1,0 +1,122 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "cuda_workspace_test_support.hpp"
+
+#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+namespace {
+
+using cuda_workspace_test::CudaWorkspaceFixture;
+
+constexpr std::uint32_t kWidth  = 8;
+constexpr std::uint32_t kHeight = 8;
+
+auto Value() -> GraphValueId { return {NodeId{"develop"}, PortId{"sensor_linear"}}; }
+
+auto PublishWrite(CudaRenderDevice& device, const GraphValueId& id, ContentKey key) {
+  auto& workspace = device.Workspace();
+  device.BeginRender();
+  (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
+  workspace.Images().RecordUnpublished(id, key, ImageExtent{kWidth, kHeight}, TextureFormat::Rgba32f,
+                                       device.CommandContext().SubmissionId());
+  device.EndRender();
+  device.PublishResults();
+  device.WaitIdle();
+}
+
+TEST_F(CudaWorkspaceFixture, ResultCacheDoesNotTreatReusedTextureAllocationAsContentHit) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  workspace.Textures().SetByteBudget(static_cast<std::size_t>(kWidth) * kHeight * 16);
+  const GraphValueId id    = Value();
+  const ContentKey   key_a{11};
+  const ContentKey   key_b{22};
+  PublishWrite(device, id, key_a);
+  const auto completed = workspace.Device().CompletedSubmission();
+  ASSERT_TRUE(workspace.Images().FindValidResult(id, key_a, {kWidth, kHeight},
+                                                 TextureFormat::Rgba32f, completed));
+  const auto resource_a = workspace.Images().Find(id)->Texture().ResourceId();
+
+  device.BeginRender();
+  auto& write = workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
+  EXPECT_EQ(write.Texture().ResourceId(), resource_a);
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, key_a, {kWidth, kHeight},
+                                                  TextureFormat::Rgba32f, completed));
+  workspace.Images().RecordUnpublished(id, key_b, {kWidth, kHeight}, TextureFormat::Rgba32f,
+                                       device.CommandContext().SubmissionId());
+  device.EndRender();
+  device.PublishResults();
+  device.WaitIdle();
+  const auto done = workspace.Device().CompletedSubmission();
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, key_a, {kWidth, kHeight},
+                                                  TextureFormat::Rgba32f, done));
+  EXPECT_TRUE(workspace.Images().FindValidResult(id, key_b, {kWidth, kHeight},
+                                                 TextureFormat::Rgba32f, done));
+}
+
+TEST_F(CudaWorkspaceFixture, FailedSubmissionDoesNotPublishResultContentKey) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  const GraphValueId id  = Value();
+  const ContentKey   key{31};
+  device.BeginRender();
+  (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
+  workspace.Images().RecordUnpublished(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+                                       device.CommandContext().SubmissionId());
+  device.CancelRender();
+  device.WaitIdle();
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+                                                  workspace.Device().CompletedSubmission()));
+  EXPECT_EQ(workspace.Images().PublishedCount(), 0U);
+}
+
+TEST_F(CudaWorkspaceFixture, CancelledSubmissionKeepsPreviouslyCompletedCacheEntriesUsable) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  const GraphValueId id     = Value();
+  const ContentKey   first{41};
+  const ContentKey   second{42};
+  PublishWrite(device, id, first);
+  const auto completed = workspace.Device().CompletedSubmission();
+  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight},
+                                                 TextureFormat::Rgba32f, completed));
+
+  device.BeginRender();
+  (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
+  workspace.Images().RecordUnpublished(id, second, {kWidth, kHeight}, TextureFormat::Rgba32f,
+                                       device.CommandContext().SubmissionId());
+  device.CancelRender();
+  device.WaitIdle();
+  EXPECT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight},
+                                                 TextureFormat::Rgba32f,
+                                                 workspace.Device().CompletedSubmission()));
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, second, {kWidth, kHeight},
+                                                  TextureFormat::Rgba32f,
+                                                  workspace.Device().CompletedSubmission()));
+}
+
+TEST_F(CudaWorkspaceFixture, UnpublishedWriteIsNotAContentHitUntilPublish) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  const GraphValueId id  = Value();
+  const ContentKey   key{51};
+  device.BeginRender();
+  (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
+  workspace.Images().RecordUnpublished(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+                                       device.CommandContext().SubmissionId());
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+                                                  workspace.Device().CompletedSubmission()));
+  ASSERT_NE(workspace.Images().Find(id), nullptr);
+  device.EndRender();
+  device.PublishResults();
+  device.WaitIdle();
+  EXPECT_TRUE(workspace.Images().FindValidResult(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+                                                 workspace.Device().CompletedSubmission()));
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
@@ -125,5 +125,21 @@ TEST(GpuDagResultContentKey, IdenticalInputsProduceIdenticalKeys) {
   EXPECT_EQ(a.drt_display, b.drt_display);
 }
 
+TEST(GpuDagResultContentKey, CameraProfileChangeInvalidatesDevelopImageNotSensorLinear) {
+  auto prepared = MakePrepared();
+  auto document = CreateDefaultPipelineDocument();
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+
+  auto develop = document.Develop()->Params().Params();
+  develop.camera_profile.color_matrices_valid = true;
+  develop.camera_profile.color_matrix_1[0]    = 0.91;
+  document.Develop()->Params().ReplaceParams(develop);
+  const auto edited = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(edited.sensor_linear, base.sensor_linear);
+  EXPECT_EQ(edited.geometry_scene_source, base.geometry_scene_source);
+  EXPECT_NE(edited.develop_image, base.develop_image);
+}
+
 }  // namespace
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
@@ -95,6 +95,34 @@ TEST(GpuDagResultContentKey, GeometryKeyIncludesViewportAndCropAndIgnoresGrade) 
   EXPECT_NE(after_grade.primary_grade, base.primary_grade);
 }
 
+TEST(GpuDagResultContentKey, LlfReferenceKeyIgnoresViewportAndFollowsCropAndGrade) {
+  auto prepared = MakePrepared();
+  auto document = CreateDefaultPipelineDocument();
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base      = HashLlfReferenceKey(plan, prepared, document);
+  const auto base_keys = BuildFrameResultContentKeys(plan, prepared, document);
+
+  RenderRequest viewport;
+  viewport.view.visible_rect_in_edit_space = {0.25f, 0.25f, 0.5f, 0.5f};
+  viewport.view.viewport_extent            = {8, 6};
+  GraphCompiler::BindFrameGeometry(plan, document, viewport);
+  EXPECT_EQ(HashLlfReferenceKey(plan, prepared, document), base);
+  EXPECT_NE(BuildFrameResultContentKeys(plan, prepared, document).geometry_scene_source,
+            base_keys.geometry_scene_source);
+
+  document.Geometry().SetCropRect({0.1f, 0.1f, 0.8f, 0.8f});
+  GraphCompiler::BindFrameGeometry(plan, document, viewport);
+  EXPECT_NE(HashLlfReferenceKey(plan, prepared, document), base);
+
+  document.Geometry().SetCropRect({});
+  GraphCompiler::BindFrameGeometry(plan, document, RenderRequest{});
+  auto* shadows = dynamic_cast<ShadowsModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Shadows()));
+  ASSERT_NE(shadows, nullptr);
+  shadows->SetValue(40.0f);
+  EXPECT_NE(HashLlfReferenceKey(plan, prepared, document), base);
+}
+
 TEST(GpuDagResultContentKey, HighlightRecoverChangesSensorLinearAndAllDownstreamKeys) {
   auto prepared = MakePrepared();
   auto document = CreateDefaultPipelineDocument();

--- a/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
@@ -1,0 +1,129 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/result_content_key.hpp"
+
+namespace alcedo {
+namespace {
+
+auto MakePrepared() -> PreparedRawInput {
+  return RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                       gpu_dag_test::FullSensor(16, 12));
+}
+
+TEST(GpuDagResultContentKey, GraphCompilerAssignsDistinctSensorGeometryAndDevelopValueIds) {
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan = GraphCompiler::Compile(document, MakePrepared().CompileSource(), RenderRequest{});
+  EXPECT_EQ(plan.sensor_linear_output.producer.Value(), "develop");
+  EXPECT_EQ(plan.sensor_linear_output.output_port.Value(), "sensor_linear");
+  EXPECT_EQ(plan.geometry_output.producer.Value(), "geometry");
+  EXPECT_EQ(plan.geometry_output.output_port.Value(), "scene_source");
+  EXPECT_EQ(plan.develop_output.producer.Value(), "develop");
+  EXPECT_EQ(plan.develop_output.output_port.Value(), "image");
+  EXPECT_TRUE(plan.sensor_linear_output < plan.geometry_output ||
+              plan.geometry_output < plan.sensor_linear_output);
+  EXPECT_TRUE(plan.geometry_output < plan.develop_output ||
+              plan.develop_output < plan.geometry_output);
+  EXPECT_TRUE(plan.sensor_linear_output < plan.develop_output ||
+              plan.develop_output < plan.sensor_linear_output);
+}
+
+TEST(GpuDagResultContentKey, SensorLinearKeyIgnoresCctTintGradeAndDrt) {
+  auto prepared = MakePrepared();
+  auto document = CreateDefaultPipelineDocument();
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+
+  auto develop = document.Develop()->Params().Params();
+  develop.wb_mode    = "custom";
+  develop.custom_cct = 4200.0f;
+  develop.custom_tint = 8.0f;
+  document.Develop()->Params().ReplaceParams(develop);
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(1.25f);
+  auto drt = document.Drt()->Params().Params();
+  drt.peak_luminance = 200.0f;
+  document.Drt()->Params().ReplaceParams(drt);
+
+  const auto edited = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(edited.sensor_linear, base.sensor_linear);
+  EXPECT_EQ(edited.geometry_scene_source, base.geometry_scene_source);
+  EXPECT_NE(edited.develop_image, base.develop_image);
+  EXPECT_NE(edited.primary_grade, base.primary_grade);
+  EXPECT_NE(edited.drt_display, base.drt_display);
+}
+
+TEST(GpuDagResultContentKey, GeometryKeyIncludesViewportAndCropAndIgnoresGrade) {
+  auto prepared = MakePrepared();
+  auto document = CreateDefaultPipelineDocument();
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+
+  RenderRequest viewport;
+  viewport.view.visible_rect_in_edit_space = {0.1f, 0.1f, 0.8f, 0.8f};
+  viewport.view.viewport_extent            = {12, 8};
+  GraphCompiler::BindFrameGeometry(plan, document, viewport);
+  const auto after_view = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(after_view.sensor_linear, base.sensor_linear);
+  EXPECT_NE(after_view.geometry_scene_source, base.geometry_scene_source);
+
+  document.Geometry().SetCropRect({0.05f, 0.05f, 0.9f, 0.9f});
+  GraphCompiler::BindFrameGeometry(plan, document, RenderRequest{});
+  const auto after_crop = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(after_crop.sensor_linear, base.sensor_linear);
+  EXPECT_NE(after_crop.geometry_scene_source, base.geometry_scene_source);
+
+  document.Geometry().SetCropRect({});
+  GraphCompiler::BindFrameGeometry(plan, document, RenderRequest{});
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(-0.5f);
+  const auto after_grade = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(after_grade.geometry_scene_source, base.geometry_scene_source);
+  EXPECT_EQ(after_grade.develop_image, base.develop_image);
+  EXPECT_NE(after_grade.primary_grade, base.primary_grade);
+}
+
+TEST(GpuDagResultContentKey, HighlightRecoverChangesSensorLinearAndAllDownstreamKeys) {
+  auto prepared = MakePrepared();
+  auto document = CreateDefaultPipelineDocument();
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+
+  auto develop = document.Develop()->Params().Params();
+  develop.highlights_reconstruct = !develop.highlights_reconstruct;
+  document.Develop()->Params().ReplaceParams(develop);
+  const auto edited = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_NE(edited.sensor_linear, base.sensor_linear);
+  EXPECT_NE(edited.geometry_scene_source, base.geometry_scene_source);
+  EXPECT_NE(edited.develop_image, base.develop_image);
+  EXPECT_NE(edited.primary_grade, base.primary_grade);
+  EXPECT_NE(edited.drt_display, base.drt_display);
+}
+
+TEST(GpuDagResultContentKey, IdenticalInputsProduceIdenticalKeys) {
+  auto prepared = MakePrepared();
+  auto document = CreateDefaultPipelineDocument();
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto a  = BuildFrameResultContentKeys(plan, prepared, document);
+  const auto b  = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(a.sensor_linear, b.sensor_linear);
+  EXPECT_EQ(a.geometry_scene_source, b.geometry_scene_source);
+  EXPECT_EQ(a.develop_image, b.develop_image);
+  EXPECT_EQ(a.primary_grade, b.primary_grade);
+  EXPECT_EQ(a.drt_display, b.drt_display);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
@@ -4,11 +4,13 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
-#include "edit/graph/analytic_mask_node_model.hpp"
 #include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 #include "edit/runtime/graph_compiler.hpp"
@@ -20,6 +22,15 @@ namespace {
 auto MakePrepared() -> PreparedRawInput {
   return RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
                                        gpu_dag_test::FullSensor(16, 12));
+}
+
+void ConnectRasterMask(PipelineDocument& document, std::string asset_key = "test.raster") {
+  auto node = std::make_unique<RasterMaskNodeModel>(NodeId{"mask.raster"});
+  node->SetAssetKey(std::move(asset_key));
+  document.Graph().AddNode(std::move(node));
+  document.Graph().Connect(NodeId{"mask.raster"}, PortId{"mask"}, NodeId{"grade.primary"},
+                           PortId{"mask"});
+  document.MarkTopologyDirty();
 }
 
 TEST(GpuDagResultContentKey, GraphCompilerAssignsDistinctSensorGeometryAndDevelopValueIds) {
@@ -143,10 +154,10 @@ TEST(GpuDagResultContentKey, HighlightRecoverChangesSensorLinearAndAllDownstream
   EXPECT_NE(edited.drt_display, base.drt_display);
 }
 
-TEST(GpuDagResultContentKey, ExposureEditWithTemporaryOvalKeepsSensorGeometryDevelopAndMask) {
+TEST(GpuDagResultContentKey, ExposureEditWithRasterMaskKeepsSensorGeometryDevelopAndMask) {
   auto prepared = MakePrepared();
   auto document = CreateDefaultPipelineDocument();
-  AttachTemporaryPrimaryGradeOvalMask(document);
+  ConnectRasterMask(document);
   auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   const auto base = BuildFrameResultContentKeys(plan, prepared, document);
   ASSERT_FALSE(base.mask.Empty());
@@ -164,19 +175,16 @@ TEST(GpuDagResultContentKey, ExposureEditWithTemporaryOvalKeepsSensorGeometryDev
   EXPECT_NE(edited.drt_display, base.drt_display);
 }
 
-TEST(GpuDagResultContentKey, AnalyticMaskParamChangeInvalidatesMaskAndGradeNotSensor) {
+TEST(GpuDagResultContentKey, RasterMaskParamChangeInvalidatesMaskAndGradeNotSensor) {
   auto prepared = MakePrepared();
   auto document = CreateDefaultPipelineDocument();
-  AttachTemporaryPrimaryGradeOvalMask(document);
+  ConnectRasterMask(document);
   auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   const auto base = BuildFrameResultContentKeys(plan, prepared, document);
 
-  auto* mask = dynamic_cast<AnalyticMaskNodeModel*>(
-      document.Graph().FindNode(NodeId{"mask.ui_test.radial"}));
+  auto* mask = dynamic_cast<RasterMaskNodeModel*>(document.Graph().FindNode(NodeId{"mask.raster"}));
   ASSERT_NE(mask, nullptr);
-  auto radial            = mask->Radial();
-  radial.major_radius    = 0.41f;
-  mask->SetRadial(radial);
+  mask->SetFeatherRadius(1.25f);
   const auto edited = BuildFrameResultContentKeys(plan, prepared, document);
   EXPECT_EQ(edited.sensor_linear, base.sensor_linear);
   EXPECT_EQ(edited.geometry_scene_source, base.geometry_scene_source);
@@ -214,11 +222,11 @@ TEST(GpuDagResultContentKey, CameraProfileChangeInvalidatesDevelopImageNotSensor
   EXPECT_NE(edited.develop_image, base.develop_image);
 }
 
-TEST(GpuDagResultContentKey, ApplyOntoExposureKeepsSensorGeometryCameraAndMaskWithOval) {
+TEST(GpuDagResultContentKey, ApplyOntoExposureKeepsSensorGeometryCameraAndMaskWithRaster) {
   auto prepared = MakePrepared();
   auto document = CreateDefaultPipelineDocument();
   gpu_dag_test::EnsureTestCameraProfile(document);
-  AttachTemporaryPrimaryGradeOvalMask(document);
+  ConnectRasterMask(document);
   auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   const auto base = BuildFrameResultContentKeys(plan, prepared, document);
   ASSERT_FALSE(base.mask.Empty());

--- a/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
@@ -4,7 +4,10 @@
 
 #include <gtest/gtest.h>
 
+#include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
@@ -140,6 +143,48 @@ TEST(GpuDagResultContentKey, HighlightRecoverChangesSensorLinearAndAllDownstream
   EXPECT_NE(edited.drt_display, base.drt_display);
 }
 
+TEST(GpuDagResultContentKey, ExposureEditWithTemporaryOvalKeepsSensorGeometryDevelopAndMask) {
+  auto prepared = MakePrepared();
+  auto document = CreateDefaultPipelineDocument();
+  AttachTemporaryPrimaryGradeOvalMask(document);
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+  ASSERT_FALSE(base.mask.Empty());
+
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(2.0f);
+  const auto edited = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(edited.sensor_linear, base.sensor_linear);
+  EXPECT_EQ(edited.geometry_scene_source, base.geometry_scene_source);
+  EXPECT_EQ(edited.develop_image, base.develop_image);
+  EXPECT_EQ(edited.mask, base.mask);
+  EXPECT_NE(edited.primary_grade, base.primary_grade);
+  EXPECT_NE(edited.drt_display, base.drt_display);
+}
+
+TEST(GpuDagResultContentKey, AnalyticMaskParamChangeInvalidatesMaskAndGradeNotSensor) {
+  auto prepared = MakePrepared();
+  auto document = CreateDefaultPipelineDocument();
+  AttachTemporaryPrimaryGradeOvalMask(document);
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+
+  auto* mask = dynamic_cast<AnalyticMaskNodeModel*>(
+      document.Graph().FindNode(NodeId{"mask.ui_test.radial"}));
+  ASSERT_NE(mask, nullptr);
+  auto radial            = mask->Radial();
+  radial.major_radius    = 0.41f;
+  mask->SetRadial(radial);
+  const auto edited = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(edited.sensor_linear, base.sensor_linear);
+  EXPECT_EQ(edited.geometry_scene_source, base.geometry_scene_source);
+  EXPECT_EQ(edited.develop_image, base.develop_image);
+  EXPECT_NE(edited.mask, base.mask);
+  EXPECT_NE(edited.primary_grade, base.primary_grade);
+}
+
 TEST(GpuDagResultContentKey, IdenticalInputsProduceIdenticalKeys) {
   auto prepared = MakePrepared();
   auto document = CreateDefaultPipelineDocument();
@@ -167,6 +212,29 @@ TEST(GpuDagResultContentKey, CameraProfileChangeInvalidatesDevelopImageNotSensor
   EXPECT_EQ(edited.sensor_linear, base.sensor_linear);
   EXPECT_EQ(edited.geometry_scene_source, base.geometry_scene_source);
   EXPECT_NE(edited.develop_image, base.develop_image);
+}
+
+TEST(GpuDagResultContentKey, ApplyOntoExposureKeepsSensorGeometryCameraAndMaskWithOval) {
+  auto prepared = MakePrepared();
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  AttachTemporaryPrimaryGradeOvalMask(document);
+  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+  ASSERT_FALSE(base.mask.Empty());
+
+  nlohmann::json json;
+  json["Basic Adjustment"]["Basic Adjustment"]["exposure"] = {
+      {"type", 2}, {"enable", true}, {"params", {{"exposure", 2.0}}}};
+  ASSERT_TRUE(LegacyPipelineImporter::ApplyOnto(document, json).empty());
+  GraphCompiler::BindFrameGeometry(plan, document, RenderRequest{});
+  const auto edited = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(edited.sensor_linear, base.sensor_linear);
+  EXPECT_EQ(edited.geometry_scene_source, base.geometry_scene_source);
+  EXPECT_EQ(edited.develop_image, base.develop_image);
+  EXPECT_EQ(edited.mask, base.mask);
+  EXPECT_NE(edited.primary_grade, base.primary_grade);
+  EXPECT_NE(edited.drt_display, base.drt_display);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/runtime/static_execution_plan_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/static_execution_plan_cache_test.cpp
@@ -1,0 +1,170 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/static_execution_plan_cache.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+auto MakePrepared(DecodeRes decode_res = DecodeRes::FULL) -> PreparedRawInput {
+  const auto pattern = gpu_dag_test::MakeRggbPattern();
+  return RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), decode_res);
+}
+
+TEST(GpuDagGraphCompiler, GraphCompilerNeedsRecompileIsFalseForUnchangedTopologyAndSourceLayout) {
+  auto       document = CreateDefaultPipelineDocument();
+  const auto prepared = MakePrepared();
+  const auto plan     = GraphCompiler::CompileStatic(document, prepared.CompileSource());
+
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(0.75f);
+
+  auto develop = document.Develop()->Params().Params();
+  develop.wb_mode    = "custom";
+  develop.custom_cct = 4200.0f;
+  document.Develop()->Params().ReplaceParams(develop);
+
+  auto drt = document.Drt()->Params().Params();
+  drt.peak_luminance = 200.0f;
+  document.Drt()->Params().ReplaceParams(drt);
+  document.Geometry().SetCropRect({0.1f, 0.1f, 0.8f, 0.8f});
+  document.Geometry().SetRotationDegrees(15.0f);
+
+  EXPECT_FALSE(GraphCompiler::NeedsRecompile(plan, document, prepared.CompileSource()));
+  EXPECT_EQ(plan.static_key, GraphCompiler::MakeStaticPlanKey(document, prepared.CompileSource()));
+}
+
+TEST(GpuDagGraphCompiler, GraphCompilerNeedsRecompileIsTrueWhenAdjustmentOrderChanges) {
+  auto       document = CreateDefaultPipelineDocument();
+  const auto prepared = MakePrepared();
+  const auto plan     = GraphCompiler::CompileStatic(document, prepared.CompileSource());
+  auto*      grade    = document.PrimaryGrade();
+  grade->MoveAdjustment(grade->AdjustmentIdAt(0), grade->AdjustmentCount() - 1);
+
+  EXPECT_TRUE(GraphCompiler::NeedsRecompile(plan, document, prepared.CompileSource()));
+}
+
+TEST(GpuDagGraphCompiler, GraphCompilerNeedsRecompileIsTrueWhenSourceExtentChanges) {
+  auto       document = CreateDefaultPipelineDocument();
+  const auto full     = MakePrepared(DecodeRes::FULL);
+  const auto half     = MakePrepared(DecodeRes::HALF);
+  const auto plan     = GraphCompiler::CompileStatic(document, full.CompileSource());
+
+  EXPECT_TRUE(GraphCompiler::NeedsRecompile(plan, document, half.CompileSource()));
+}
+
+TEST(GpuDagGraphCompiler, GraphCompilerCompileDoesNotBakeViewportIntoStaticPlanKey) {
+  auto           document = CreateDefaultPipelineDocument();
+  const auto     prepared = MakePrepared();
+  RenderRequest  preview;
+  RenderRequest  viewport;
+  viewport.view.visible_rect_in_edit_space = {0.25f, 0.25f, 0.5f, 0.5f};
+  viewport.view.viewport_extent            = {48, 32};
+  viewport.resolution.quality              = RenderQuality::Export;
+
+  const auto preview_plan  = GraphCompiler::Compile(document, prepared.CompileSource(), preview);
+  auto       viewport_plan = GraphCompiler::CompileStatic(document, prepared.CompileSource());
+  const auto static_key    = viewport_plan.static_key;
+  GraphCompiler::BindFrameGeometry(viewport_plan, document, viewport);
+
+  EXPECT_EQ(preview_plan.static_key, viewport_plan.static_key);
+  EXPECT_EQ(viewport_plan.static_key, static_key);
+  EXPECT_NE(preview_plan.geometry.render_extent.width, viewport_plan.geometry.render_extent.width);
+  EXPECT_FALSE(GraphCompiler::NeedsRecompile(preview_plan, document, prepared.CompileSource()));
+}
+
+TEST(GpuDagGraphCompiler, GraphCompilerBindsFrameGeometryWithoutChangingStaticPlanKey) {
+  auto       document = CreateDefaultPipelineDocument();
+  const auto prepared = MakePrepared();
+  auto       plan     = GraphCompiler::CompileStatic(document, prepared.CompileSource());
+  EXPECT_EQ(plan.geometry.render_extent.width, 0U);
+
+  RenderRequest request;
+  request.view.viewport_extent = {40, 30};
+  const auto key_before        = plan.static_key;
+  GraphCompiler::BindFrameGeometry(plan, document, request);
+  EXPECT_EQ(plan.static_key, key_before);
+  EXPECT_GT(plan.geometry.render_extent.width, 0U);
+}
+
+TEST(GpuDagGraphCompiler, StaticExecutionPlanCacheCompilesOnceForRepeatedParameterAndViewportEdits) {
+  auto                      document = CreateDefaultPipelineDocument();
+  const auto                prepared = MakePrepared();
+  StaticExecutionPlanCache  cache;
+  (void)cache.GetOrCompile(document, prepared.CompileSource());
+
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(-0.5f);
+  auto drt = document.Drt()->Params().Params();
+  drt.peak_luminance = 160.0f;
+  document.Drt()->Params().ReplaceParams(drt);
+
+  auto plan = cache.GetOrCompile(document, prepared.CompileSource());
+  RenderRequest request;
+  request.view.viewport_extent = {64, 48};
+  GraphCompiler::BindFrameGeometry(plan, document, request);
+
+  EXPECT_EQ(cache.GetStats().compiles, 1U);
+  EXPECT_EQ(cache.GetStats().hits, 1U);
+  EXPECT_EQ(cache.GetStats().misses, 1U);
+  EXPECT_FALSE(GraphCompiler::NeedsRecompile(plan, document, prepared.CompileSource()));
+}
+
+TEST(GpuDagGraphCompiler, StaticExecutionPlanCacheRecompilesWhenMaskTopologyChanges) {
+  auto                     document = CreateDefaultPipelineDocument();
+  const auto               prepared = MakePrepared();
+  StaticExecutionPlanCache cache;
+  const auto               first = cache.GetOrCompile(document, prepared.CompileSource());
+  EXPECT_FALSE(first.primary_grade_mask.has_value());
+
+  document.Graph().AddNode(std::make_unique<AnalyticMaskNodeModel>(NodeId{"mask.radial"}));
+  document.Graph().Connect(NodeId{"mask.radial"}, PortId{"mask"}, NodeId{"grade.primary"},
+                           PortId{"mask"});
+  const auto second = cache.GetOrCompile(document, prepared.CompileSource());
+
+  EXPECT_EQ(cache.GetStats().compiles, 2U);
+  EXPECT_EQ(cache.GetStats().misses, 2U);
+  EXPECT_TRUE(second.primary_grade_mask.has_value());
+  EXPECT_TRUE(GraphCompiler::NeedsRecompile(first, document, prepared.CompileSource()));
+}
+
+TEST(GpuDagGraphCompiler, StaticExecutionPlanCacheRecompilesWhenSourceLayoutChanges) {
+  auto                     document = CreateDefaultPipelineDocument();
+  StaticExecutionPlanCache cache;
+  (void)cache.GetOrCompile(document, MakePrepared(DecodeRes::FULL).CompileSource());
+  (void)cache.GetOrCompile(document, MakePrepared(DecodeRes::HALF).CompileSource());
+  EXPECT_EQ(cache.GetStats().compiles, 2U);
+  EXPECT_EQ(cache.EntryCount(), 2U);
+}
+
+TEST(GpuDagGraphCompiler, StaticExecutionPlanCacheExposesHitMissAndCompileCounts) {
+  auto                     document = CreateDefaultPipelineDocument();
+  const auto               prepared = MakePrepared();
+  StaticExecutionPlanCache cache(3);
+  (void)cache.GetOrCompile(document, prepared.CompileSource());
+  (void)cache.GetOrCompile(document, prepared.CompileSource());
+  (void)cache.GetOrCompile(document, prepared.CompileSource());
+
+  EXPECT_EQ(cache.GetStats().misses, 1U);
+  EXPECT_EQ(cache.GetStats().hits, 2U);
+  EXPECT_EQ(cache.GetStats().compiles, 1U);
+  EXPECT_EQ(cache.BackendCapabilityVersion(), 3U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/renderer/pipeline_scheduler_request_id_test.cpp
+++ b/alcedo_studio/tests/renderer/pipeline_scheduler_request_id_test.cpp
@@ -11,7 +11,9 @@
 #include <memory>
 #include <mutex>
 #include <opencv2/core.hpp>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "edit/operators/operator_registeration.hpp"
@@ -194,7 +196,7 @@ TEST(PipelineSchedulerRequestIdTest, CompletionRunsAfterLivePipelineRenderLockIs
   task.options_.render_desc_.render_type_ = RenderType::FAST_PREVIEW;
   auto lock_released = std::make_shared<std::promise<bool>>();
   auto completed     = lock_released->get_future();
-  task.on_complete_  = [exec, lock_released](bool) {
+  task.on_complete_  = [exec, lock_released](bool, std::string) {
     const bool acquired = exec->GetRenderLock().try_lock();
     if (acquired) {
       exec->GetRenderLock().unlock();
@@ -283,6 +285,33 @@ TEST(DirectPresentQueueRequestIdTest, ConsumeNewestReadyPrefersHigherRequestId) 
   const auto frame = queue.ConsumeNewestReady(FrameRole::InteractivePrimary, 1, 10);
   ASSERT_TRUE(frame.has_value());
   EXPECT_EQ(frame->slot.preview_metadata.presentation_request_id, 2u);
+}
+
+TEST(PipelineSchedulerRequestIdTest, EditorRenderFailureForwardsExceptionMessageInsteadOfEmptyResult) {
+  RegisterAllOperators();
+  auto exec = std::make_shared<CPUPipelineExecutor>();
+  exec->SetAcceleratorBackendPreference(AcceleratorBackendPreference::CPU);
+  exec->SetExecutionStages();
+
+  PipelineScheduler scheduler(1);
+  PipelineTask      task;
+  task.input_                             = MakeSolidImage(8, 8);
+  task.pipeline_executor_                 = exec;
+  task.options_.render_desc_.render_type_ = RenderType::FAST_PREVIEW;
+  auto done                               = std::make_shared<std::promise<std::pair<bool, std::string>>>();
+  auto future                             = done->get_future();
+  task.configure_under_render_lock_       = [](PipelineTask&) -> bool {
+    throw std::runtime_error("Neural Engine unavailable: missing weights");
+  };
+  task.on_complete_ = [done](bool success, std::string message) {
+    done->set_value({success, std::move(message)});
+  };
+
+  scheduler.ScheduleTask(std::move(task));
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(30)), std::future_status::ready);
+  const auto result = future.get();
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(result.second, "Neural Engine unavailable: missing weights");
 }
 
 }  // namespace

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -1892,7 +1892,7 @@ Stack:
 | G5 | `feature/gpu-dag-cuda-grade` | G4 | CUDA 调色、CAT02、LLF workspace 化 |
 | G6 | `feature/gpu-dag-cuda-mask-mix` | G5 | MaskStore、R8 mask、feather、Mix |
 | G7 | `feature/gpu-dag-cuda-drt-product` | G6 | CUDA DRT 和 app 管线路径切换 |
-| G7R | `feature/gpu-dag-cuda-default-recovery` | G7 | CameraMatrices 色彩、内容缓存和默认管线性能恢复 |
+| G7R | `feature/gpu-dag-cuda-check-and-fix` | G7 | CameraMatrices 色彩、内容缓存和默认管线性能恢复 |
 | G8 | `feature/gpu-dag-opencl` | G7R | OpenCL 完整移植 |
 | G9 | `feature/gpu-dag-metal` | G8 | Metal 完整移植 |
 | G10 | `feature/gpu-dag-final-removal` | G9 | 删除旧 stage、CPU 图像路径和过渡代码；全平台验证 |
@@ -2944,7 +2944,7 @@ DAG runtime 移植必须在 G7R 达标后进入 G8/G9。
 
 ## 41. Phase G7R — CUDA 默认管线行为、颜色与性能恢复
 
-Branch: `feature/gpu-dag-cuda-default-recovery`
+Branch: `feature/gpu-dag-cuda-check-and-fix`
 
 Base: `feature/gpu-dag-cuda-drt-product`
 
@@ -3461,7 +3461,7 @@ timing remains G7R.5.
 
 ### 41.5b G7R.H — CUDA 默认管线产品回归修复
 
-Branch: `feature/gpu-dag-cuda-default-recovery`
+Branch: `feature/gpu-dag-cuda-check-and-fix`
 
 在 G7R.4 CAT02 之前修复三件产品回归：RAW demosaic/HLR 未接入 CUDA Develop、归还 pipeline 时 GPU 会话缓存不释放、DRT 入口硬裁 scene-linear。
 
@@ -4198,7 +4198,7 @@ deadlock teardown 问题需要拆成单独回归并修复，不能用跳过整�
 
 Branch: `feature/gpu-dag-opencl`
 
-Base: `feature/gpu-dag-cuda-default-recovery`
+Base: `feature/gpu-dag-cuda-check-and-fix`
 
 目标：
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -1890,7 +1890,7 @@ Stack:
 | G5 | `feature/gpu-dag-cuda-grade` | G4 | CUDA 调色、CAT02、LLF workspace 化 |
 | G6 | `feature/gpu-dag-cuda-mask-mix` | G5 | MaskStore、R8 mask、feather、Mix |
 | G7 | `feature/gpu-dag-cuda-drt-product` | G6 | CUDA DRT 和 app 管线路径切换 |
-| G7R | `feature/gpu-dag-cuda-default-recovery` | G7 | scheduler、CameraMatrices 色彩、内容缓存和默认管线性能恢复 |
+| G7R | `feature/gpu-dag-cuda-default-recovery` | G7 | CameraMatrices 色彩、内容缓存和默认管线性能恢复 |
 | G8 | `feature/gpu-dag-opencl` | G7R | OpenCL 完整移植 |
 | G9 | `feature/gpu-dag-metal` | G8 | Metal 完整移植 |
 | G10 | `feature/gpu-dag-final-removal` | G9 | 删除旧 stage、CPU 图像路径和过渡代码；全平台验证 |
@@ -2933,7 +2933,7 @@ CUDA frees. The DRT output texture and resolved method resources remain owned by
 `pipeline_service.cpp` and `pipeline_cpu.cpp` received localized routing/persistence changes; no
 new file exceeds 500 lines.
 
-**Residual gaps:** G7R 审计确认当前 CUDA 产品路径仍缺少完整 scheduler 意图传递、
+**Residual gaps:** G7R 审计确认当前 CUDA 产品路径仍缺少
 PreparedRawInput/ExecutionPlan/节点结果的内容感知缓存、geometry 后缓存，以及正确的
 CameraMatrices 双光源 Camera→AP1。G7 的资源 ID 与零 allocation 证据不能证明结果 cache hit
 或没有重复计算。G7 接入的 legacy 参数镜像、importer 和 nested adapter 也不是目标架构，
@@ -2949,14 +2949,12 @@ Base: `feature/gpu-dag-cuda-drt-product`
 Status: required；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
 
 Requirement source: `codex://threads/01a0273a-48bd-7702-9503-127bb5e2ec1e`。本阶段恢复该
-任务中已经明确的 Develop endpoint、GPU workspace KV cache、动态分辨率和 scheduler 集成
-要求，不重新定义产品范围。
+任务中已经明确的 Develop endpoint、GPU workspace KV cache 和动态分辨率要求，不重新定义
+产品范围。
 
 目标：
 
 - 保留 G4/G5 把传感器开发与 CameraColorPass 分开的正确设计，使 Develop 的昂贵结果可缓存；
-- 让 scheduler 独占交互帧、质量帧、细节补帧、取消、过期帧抑制、busy 和 frame sink；
-- 让 Preview 与 Export 使用完全独立的 PipelineSession/workspace，不保留状态恢复路径；
 - 从 CUDA 产品路径删除 legacy 参数、importer、snapshot 和 stage adapter；
 - 使用 CameraMatrices/DNG 双光源矩阵插值恢复正确的 RAW CCT/tint 和 Camera→AP1；
 - 增加 geometry 后 camera scene-linear 结果缓存，并让所有结果缓存使用内容 key；
@@ -2978,7 +2976,6 @@ Requirement source: `codex://threads/01a0273a-48bd-7702-9503-127bb5e2ec1e`。本
 | P0 | Structural evidence | `CudaProductRenderer::Render` 每次都 `LoadEncoded` 和 `Compile`，executor 每次无条件运行 Develop、Grade、DRT | `cuda_product_renderer.cu`、`cuda_plan_executor.cpp` | 无变化帧不重复输入准备、编译和 GPU 节点执行 |
 | P0 | Structural evidence | `GraphImageCache`/`NodeResultCache` 只按 `GraphValueId` 保存资源，没有内容 key 和有效性；当前所谓 cache valid 只比较纹理 `ResourceId` | cache headers 与 G7 测试断言 | 分配复用与结果命中成为两个独立概念，缓存命中由内容 key 证明 |
 | P0 | Structural evidence | 当前没有 geometry 后结果缓存，CCT、Grade 或 DRT 编辑无法明确复用重采样结果 | Develop pass 与 workspace image map | `geometry.scene_source` 是内容感知的一级结果缓存 |
-| P0 | Structural evidence | scheduler 在 `Apply` 前后判断 stale，但 CUDA renderer 在 `Apply` 内部直接写 frame sink；渲染后的 stale 判断可能晚于旧帧呈现 | `pipeline_scheduler.cpp`、`pipeline_cpu.cpp`、`cuda_product_renderer.cu` | scheduler 独占 present 权限；DAG 返回未呈现结果，不接收完整 scheduler 状态机 |
 | P1 | Structural evidence | 当前 creative white balance 只做每通道指数缩放，不是计划要求的 AP1/CAT02 色适配 | CUDA adjustment runtime | 局部色温使用实际 CAT02；不与 RAW CameraColorPass 混用 |
 | P1 | Coverage gap | `ChangingDrtPeakLuminanceKeepsDevelopAndGradeCacheValid` 只比较资源 ID；第二帧测试只检查 malloc/free | `cuda_drt_product_test.cpp` | 测试断言 LibRaw、H2D、compile、每类 pass execute/skip 和内容 key |
 | P1 | Coverage gap | Primary Grade 色彩测试使用 direct RGB，并明确让 camera conversion 保持 identity | `cuda_primary_grade_test.cpp` | 加入真实 RAW、CameraMatrices、双光源插值和 AP1 reference 测试 |
@@ -2993,21 +2990,18 @@ ctest --test-dir build/debug --output-on-failure \
 结果为 `26/26` PASS，耗时 `5.53 s`。该结果只证明现有窄测试仍通过，不否定上表问题。
 直接执行真实 RAW 编辑器用例时结果是 `0` PASS、`1` SKIPPED；它受
 `ALCEDO_RUN_DEADLOCKING_RAW_GPU_E2E` 控制。因此目前没有一个默认执行的测试同时覆盖真实
-RAW、CameraMatrices 色彩、scheduler 状态和重复渲染性能。
+RAW、CameraMatrices 色彩和重复渲染性能。
 
 ### 41.2 恢复后的产品调用链
 
 默认三节点图不增加用户节点。产品执行链固定为：
 
 ```text
-PipelineScheduler
-  -> ScheduledTask
-       request id / frame role / stale state / busy state / display sink
-       这些字段只由 scheduler 持有
-  -> resolve immutable RenderRequest
+CPUPipelineExecutor::Apply
+  -> translate existing executor inputs into immutable RenderRequest
        source content key / document snapshot
        viewport / target extent / max edge / DecodeRes / quality
-  -> CudaProductPipelineSession::Render(RenderRequest, optional cancel query)
+  -> CudaProductPipelineSession::Render
   -> PreparedSourceCache lookup
        miss -> RawInputLoader open + unpack + downsample + complete color metadata
   -> Static ExecutionPlan lookup
@@ -3022,61 +3016,15 @@ PipelineScheduler
        DrtPass
   -> completion fence
   -> publish successful cache entries
-  -> return RenderedFrame(texture/value id/fence or host image)
-  -> PipelineScheduler checks cancel/stale/revision
-  -> latest eligible preview frame only -> IFrameSink
-  -> scheduler records completion exactly once
-
-ExportService
-  -> independent ExportPipelineSession + ExportRenderWorkspace
-  -> host/file output
-  -> never reads, changes, restores, or presents through the editor preview session
+  -> existing bound FrameSubmission / IFrameSink path
+  -> return through the existing CPUPipelineExecutor result path
 ```
 
 `CudaProductPipelineSession` 表示一个打开图像和 PipelineDocument 的可复用运行实例。它拥有
 PreparedSourceCache、静态 ExecutionPlan、CudaRenderDevice/workspace 和结果 cache metadata。
-它不能在每个 `Apply` 调用中临时创建，也不能借助旧 merged stage 保存结果。它不拥有
-`IFrameSink`，也不判断 InteractivePrimary、QualityBase 或 DetailPatch 的呈现顺序。
+它不能在每个 `Apply` 调用中临时创建，也不能借助旧 merged stage 保存结果。
 
-### 41.3 G7R.1 — 收回 present 权限并精简 DAG request
-
-工作：
-
-- `RenderRequest` 只携带会改变像素、输出尺寸或 cache key 的不可变输入；不得复制 scheduler
-  状态机；
-- `InteractivePrimary`、`QualityBase` 和 `DetailPatch` 只由 scheduler 解释，并在调用 DAG 前解析
-  为具体 viewport、ROI、输出尺寸、采样策略和质量参数；DAG 不读取这些 frame-role 标签；
-- source content key 和不可变 document snapshot/revision 可以进入 `RenderRequest`，因为它们参与
-  cache 身份；UI busy、stale、最新 request id 和合成顺序不能进入 GraphCompiler 或 pass 参数；
-- 允许传入一个简单的 `cancel_requested()` 查询，使 renderer 可以少做已经没人需要的工作；
-  取消查询是性能优化，不能决定哪个结果最终呈现；
-- `CudaProductPipelineSession::Render` 返回 `RenderedFrame` 或等价结果，其中包含 GPU value/
-  texture、完成 fence、extent/format 和可选 host image；renderer 不调用 `IFrameSink`；
-- scheduler 在收到 `RenderedFrame` 后、调用 frame sink 前执行最终 cancel/stale/revision 检查；
-- 一个 scheduler task 只能完成一次：成功、取消或失败三者互斥；busy、quality 和 detail 状态只在
-  scheduler 中清理；
-- QualityBase 和 DetailPatch 的 revision 匹配、合成和呈现顺序只由 scheduler 处理；编辑变化后
-  旧 detail patch 不得合成到新 primary；
-- 保留现有 single in-flight preview 限制；已经提交的旧 GPU 工作可以安全完成和回收，但返回
-  scheduler 后可以被丢弃；
-- Preview 和 full-resolution Export 使用不同 PipelineSession、RenderDevice、workspace、cache
-  和输出目标。Export 不连接 editor frame sink，不保存或恢复 preview 参数；
-- scheduler 的旧 scratch/reset 动作在 DAG 路径只 rewind 每帧 transient，不能清空已发布的
-  Prepared RAW、sensor develop、geometry、AP1、Grade 或 DRT 结果缓存；
-- DAG 路径不再依赖旧 executor 的全局 cancel 标记、merged-stage reset 或 stage cache 状态；
-- 从 CUDA 产品路径删除 legacy stage adapter、legacy parameter snapshot、
-  `ExportPipelineParams` 镜像和 `LegacyPipelineImporter`；UI/app service 直接修改新 Model。
-
-主要文件：
-
-- `alcedo_studio/src/renderer/pipeline_scheduler.cpp`
-- `alcedo_studio/src/include/renderer/pipeline_task.hpp`
-- `alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp`
-- `alcedo_studio/src/include/edit/geometry/render_request.hpp`
-- `alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu`
-- `alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp`
-
-### 41.4 G7R.2 — 缓存 Prepared RAW 和静态 ExecutionPlan
+### 41.3 G7R.1 — 缓存 Prepared RAW 和静态 ExecutionPlan
 
 Prepared source key 至少包含：
 
@@ -3100,7 +3048,7 @@ LibRaw/input-preparation implementation version
 - 接入并测试 `GraphCompiler::NeedsRecompile`，或删除该未使用 API 并用单一 plan key 机制替代；
 - plan cache miss、hit 和 compile count 必须可查询。
 
-### 41.5 G7R.3 — 内容感知结果缓存和 geometry 后缓存
+### 41.4 G7R.2 — 内容感知结果缓存和 geometry 后缓存
 
 实现第 27 节定义的五层缓存，并保持以下值语义：
 
@@ -3136,7 +3084,7 @@ drt.display             = display-referred output
 - `alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp`
 - `alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp`
 
-### 41.6 G7R.4 — 恢复 CameraMatrices 双光源插值和 Develop AP1 输出
+### 41.5 G7R.3 — 恢复 CameraMatrices 双光源插值和 Develop AP1 输出
 
 颜色实现必须从旧 `ColorTempOp::ResolveRuntime` 提取一个不依赖 `OperatorParams` 的纯解析器，
 例如：
@@ -3187,7 +3135,7 @@ DNG 解析能力，或提取共享 `RawColorMetadataResolver`。不得继续维�
 `FillColorContext` 副本。若 `LoadEncoded` 只有字节而没有路径，DNG tag 读取必须支持内存输入，
 或由调用方把已经解析的不可变 metadata snapshot 一起传入；不能因此退回 LibRaw 对角缩放。
 
-### 41.7 G7R.5 — 正确实现独立的 creative CAT02
+### 41.6 G7R.4 — 正确实现独立的 creative CAT02
 
 Primary Grade 的第一个 adjustment 是 scene-linear AP1 creative white balance，与 RAW
 CameraColorPass 是两个不同功能：
@@ -3199,7 +3147,7 @@ CameraColorPass 是两个不同功能：
 - zero offset 必须是严格 identity；
 - 参数 dirty 只让当前 Grade 和 DRT 失效，不让 CameraColor、Geometry 或 SensorDevelop 失效。
 
-### 41.8 G7R.6 — 可观测性与性能恢复
+### 41.7 G7R.5 — 可观测性与性能恢复
 
 为测试和 profiling 增加每个 pipeline session 的只读统计快照：
 
@@ -3215,14 +3163,13 @@ GPU allocation/free count and bytes
 CPU prepare/compile/submit/present duration
 GPU pass and total submission duration
 renderer completed/aborted/failed count
-scheduler presented/discarded-stale/cancelled task count
 ```
 
 统计默认关闭或使用低成本原子计数；测试构建可开启细粒度计时。性能验收不能依赖日志文本。
 
-### 41.9 必须新增或加强的测试
+### 41.8 必须新增或加强的测试
 
-#### 41.9.1 RAW metadata 与颜色单元测试
+#### 41.8.1 RAW metadata 与颜色单元测试
 
 ```text
 RawInputLoaderPopulatesCompleteColorContextFromRealRaw
@@ -3241,7 +3188,7 @@ CudaCat02MapsSourceWhiteToRequestedWhiteInAp1
 输出。双光源测试使用非对角矩阵，使 `cam_mul` 对角实现、`rgb_cam` 固定矩阵实现和错误的
 线性 Kelvin 插值都必然失败。
 
-#### 41.9.2 真实 RAW reference 测试
+#### 41.8.2 真实 RAW reference 测试
 
 使用 `alcedo_studio/tests/resources/sample_images/ci_rawfiles` 中至少一个 DNG 和一个非 DNG RAW。
 reference 来自重构前提交 `bf6686fb` 的旧 CameraMatrices/ColorTemp 路径，在固定输入、
@@ -3258,7 +3205,7 @@ CudaRealRawColorTransformProducesFiniteAp1WithoutChannelCollapse
 误差范围必须在 fixture 中按阶段说明。至少断言每通道有限值、非零动态范围、参考白点、色卡或
 固定 patch 的 RGB/xy 误差；不能只断言“图像存在”。
 
-#### 41.9.3 缓存和最小执行集测试
+#### 41.8.3 缓存和最小执行集测试
 
 ```text
 SecondUnchangedProductRenderRunsNoLibRawNoSourceUploadAndNoGpuNodePass
@@ -3272,40 +3219,23 @@ ProductRendererCompilesStaticPlanOnlyForTopologyOrSourceLayoutChange
 ResultCacheDoesNotTreatReusedTextureAllocationAsContentHit
 FailedSubmissionDoesNotPublishResultContentKey
 CancelledSubmissionKeepsPreviouslyCompletedCacheEntriesUsable
+ImageSwitchBackReusesMatchingPreparedSourceAndGpuResults
 ```
 
 每个测试断言内容 key、execute/skip counter、LibRaw count、H2D bytes 和输出像素；禁止只比较
 `ResourceId` 或 malloc/free。
 
-#### 41.9.4 Scheduler 状态回归测试
-
-```text
-RenderRequestContainsNoSchedulerRoleOrPresentationTarget
-ProductRendererReturnsFrameWithoutCallingDisplaySink
-PipelineSchedulerIsTheOnlyPreviewPresentationOwner
-InteractiveReplacementDoesNotPresentStaleFrame
-InteractiveQualityDetailSequencePresentsInOrderAndClearsBusy
-EditRevisionChangeRejectsOlderQualityAndDetailFrames
-CancelledScheduledRenderCompletesExactlyOnceAndKeepsSessionReusable
-ScheduledRenderFailureClearsBusyAndReportsTheOriginalError
-ImageSwitchBackReusesMatchingPreparedSourceWithoutPresentingOldFrame
-FullResolutionExportUsesIndependentPipelineSession
-FullResolutionExportDoesNotMutatePreviewWorkspace
-FullResolutionExportNeverWritesEditorFrameSink
-```
-
-#### 41.9.5 编辑器真实 RAW E2E
+#### 41.8.4 编辑器真实 RAW E2E
 
 ```text
 RealRawEditorColorTempEditChangesPixelsWithoutRerunningDemosaic
 RealRawEditorExposureEditKeepsPreparedSensorAndGeometryResults
-RealRawEditorRapidEditsPresentOnlyLatestRevisionAndReturnToIdle
 ```
 
 这些测试必须进入默认 CUDA CI，不得依赖 `ALCEDO_RUN_DEADLOCKING_RAW_GPU_E2E` 才执行。现有
 deadlock teardown 问题需要拆成单独回归并修复，不能用跳过整个真实 RAW 行为测试来规避。
 
-### 41.10 重构前性能 A/B 验收
+### 41.9 重构前性能 A/B 验收
 
 基线固定为重构前提交 `bf6686fb`。在同一台机器、同一 CUDA driver/GPU、同一 MSVC/CMake
 配置、同一输入 RAW、同一 DecodeRes、同一 viewport/输出尺寸和同一编辑序列下比较。Debug
@@ -3317,13 +3247,13 @@ deadlock teardown 问题需要拆成单独回归并修复，不能用跳过整�
 
 | 场景 | G7R 的强制执行集 | 强制为零的工作 |
 | --- | --- | --- |
-| 无变化重复渲染 | DAG 只查找并返回已完成结果；scheduler 可在 DAG 外呈现 | LibRaw、source H2D、plan compile、所有图像节点 pass、GPU alloc/free |
+| 无变化重复渲染 | 查找并复用已完成结果，沿现有输出路径提交 | LibRaw、source H2D、plan compile、所有图像节点 pass、GPU alloc/free |
 | Exposure 连续调整 | PrimaryGrade、DRT | LibRaw、source H2D、SensorDevelop、Geometry、CameraColor、GPU alloc/free |
 | RAW CCT/tint 连续调整 | CameraColor、PrimaryGrade、DRT | LibRaw、source H2D、SensorDevelop、Geometry、GPU alloc/free |
 | DRT 连续调整 | DRT | LibRaw、source H2D、SensorDevelop、Geometry、CameraColor、PrimaryGrade、GPU alloc/free |
 | viewport/geometry 改变 | Geometry、CameraColor、PrimaryGrade、DRT | LibRaw、source H2D、SensorDevelop、GPU alloc/free |
 | RAW Develop 参数改变 | SensorDevelop 及下游 | 重复 LibRaw open/unpack、无关 source preparation、GPU alloc/free |
-| 切换图像后切回 | DAG 命中仍在预算内的 source/GPU 结果；scheduler 决定是否呈现 | 对命中项的 LibRaw、source H2D 和图像节点 pass |
+| 切换图像后切回 | 命中仍在预算内的 source/GPU 结果，沿现有输出路径提交 | 对命中项的 LibRaw、source H2D 和图像节点 pass |
 
 量化完成条件：
 
@@ -3331,11 +3261,10 @@ deadlock teardown 问题需要拆成单独回归并修复，不能用跳过整�
 - warm interactive median 不高于 `bf6686fb` 基线的 `1.05x`，p95 不高于 `1.10x`；
 - QualityBase、DetailPatch 和切图返回场景的 median/p95 不比基线差 10%；
 - 无变化、Exposure、CCT 和 DRT 连续编辑从第二帧开始 GPU allocation/free 均为 0；
-- DAG 计算时间与 scheduler/frame-sink 呈现时间分别报告，不能用显示同步掩盖节点重算；
 - 若新路径优于基线，记录绝对时间与提升比例；若未达到阈值，G7R 不得标记 complete；
 - 性能报告写入本 Phase completion record，包含 GPU、driver、CPU、构建类型、fixture 和命令。
 
-### 41.11 完成条件
+### 41.10 完成条件
 
 - 用户可见图仍然只有 Develop、Primary Color Grade 和 DRT；
 - G4/G5 的缓存拆分保留，并存在独立 `develop.sensor_linear`、`geometry.scene_source`、
@@ -3343,15 +3272,12 @@ deadlock teardown 问题需要拆成单独回归并修复，不能用跳过整�
 - `develop.image` 被 reference 测试证明是 AP1 scene-linear；
 - Camera→AP1 使用 CameraMatrices/DNG 双光源插值，`cam_mul/pre_mul` 不作为颜色矩阵；
 - as-shot/custom CCT/tint 和 creative CAT02 分别通过数学单元测试和真实 RAW reference 测试；
-- DAG request 只包含像素计算和 cache 身份输入；renderer 返回未呈现的 `RenderedFrame`；
-- scheduler 独占 frame sink，并让取消、过期帧抑制、quality/detail 和 busy 清理通过默认测试；
-- Preview 与 Export 使用独立 PipelineSession/workspace；Export 不保存、修改或恢复 preview 状态；
 - CUDA 产品路径不再包含 legacy 参数镜像、stage adapter 或 `LegacyPipelineImporter`；
 - 缓存命中由内容 key 和 pass counter 证明，不由资源 ID 推断；
-- 第 41.9 节测试全部默认执行并通过；
-- 第 41.10 节 A/B 达标，并把完整测量写回 completion record；
-- G7 completion record 中“upstream cache valid”和“scheduler 已完整接入”的结论，在 G7R
-  完成前只视为历史记录，不作为 G8 的验收依据；
+- 第 41.8 节测试全部默认执行并通过；
+- 第 41.9 节 A/B 达标，并把完整测量写回 completion record；
+- G7 completion record 中“upstream cache valid”的结论，在 G7R 完成前只视为历史记录，
+  不作为 G8 的验收依据；
 - G8 必须以 G7R 分支为 base，不得从当前 G7 直接开始 OpenCL 移植。
 
 ## 42. Phase G8 — OpenCL 移植
@@ -3580,7 +3506,7 @@ Metal output
 - 首帧创建成本单独报告；
 - 第二帧开始不得分配 GPU buffer 或 texture；
 - 无变化重复渲染不得重新 open/unpack RAW、上传 source、编译静态 plan 或执行图像节点 pass；
-- Exposure、RAW CCT/tint、DRT、viewport/geometry 编辑分别断言第 41.10 节的最小执行集；
+- Exposure、RAW CCT/tint、DRT、viewport/geometry 编辑分别断言第 41.9 节的最小执行集；
 - cache hit 必须由内容 key 和 pass skip counter 证明，不能由相同 `ResourceId` 推断；
 - 无参数变化时参数上传字节数必须为 0；
 - 单字段变化时只上传对应字段范围；
@@ -3588,7 +3514,7 @@ Metal output
 - dynamic resolution 变化不得重新生成不变的 feather resource；
 - LLF reference 可以跨 viewport 变化复用；
 - GPU 内存预算和 LRU 清理字节数可查询；
-- CUDA 产品路径必须与重构前提交 `bf6686fb` 做同机 Release A/B，并满足第 41.10 节阈值。
+- CUDA 产品路径必须与重构前提交 `bf6686fb` 做同机 Release A/B，并满足第 41.9 节阈值。
 
 ## 46. 构建与运行
 
@@ -3684,18 +3610,11 @@ ctest --test-dir build/macos-debug --output-on-failure
 - [ ] 不存在 `LegacyPipelineImporter`、legacy parameter snapshot 或 nested stage adapter。
 - [ ] 新保存只写 format version 2，不写旧 stage JSON。
 
-### 47.8 Scheduler 和性能
+### 47.8 性能
 
-- [ ] DAG request 只包含像素计算和 cache 身份输入，不包含 scheduler 状态机。
-- [ ] DAG renderer 返回未呈现的结果；scheduler 是 editor frame sink 的唯一调用者。
-- [ ] InteractivePrimary、QualityBase 和 DetailPatch 只在 scheduler 中解析和排序。
-- [ ] 取消、失败和成功都恰好完成一次，并清理 busy/quality/detail 状态。
-- [ ] 过期帧不会覆盖最新 frame sink 输出。
-- [ ] Preview 与 Export 使用独立 PipelineSession、workspace、cache 和输出目标。
-- [ ] Export 不保存、修改或恢复 Preview 状态，也不连接 editor frame sink。
 - [ ] 切图返回只命中相同 source/document revision 的缓存。
-- [ ] 真实 RAW 编辑器颜色与状态测试默认进入 CUDA CI，不依赖环境变量才执行。
-- [ ] G7R 与重构前提交 `bf6686fb` 的同机 A/B 满足第 41.10 节阈值。
+- [ ] 真实 RAW 编辑器颜色和缓存测试默认进入 CUDA CI，不依赖环境变量才执行。
+- [ ] G7R 与重构前提交 `bf6686fb` 的同机 A/B 满足第 41.9 节阈值。
 - [ ] G7R 完成后才允许以其为 base 开始 G8。
 
 ## 48. 风险与处理

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1–G7R.2 complete；G7R.3–G7R.5 remaining；G7R 仍阻塞 G8。
+Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1–G7R.3 complete；G7R.4–G7R.5 remaining；G7R 仍阻塞 G8。
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2946,7 +2946,7 @@ Branch: `feature/gpu-dag-cuda-default-recovery`
 
 Base: `feature/gpu-dag-cuda-drt-product`
 
-Status: G7R.1–G7R.2 complete；G7R.3–G7R.5 remaining；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
+Status: G7R.1–G7R.3 complete；G7R.4–G7R.5 remaining；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
 
 Requirement source: `codex://threads/01a0273a-48bd-7702-9503-127bb5e2ec1e`。本阶段恢复该
 任务中已经明确的 Develop endpoint、GPU workspace KV cache 和动态分辨率要求，不重新定义
@@ -3326,6 +3326,135 @@ ResolveDevelopColorTransform(const DevelopPayload& develop,
 DNG 解析能力，或提取共享 `RawColorMetadataResolver`。不得继续维护只有六个字段的
 `FillColorContext` 副本。若 `LoadEncoded` 只有字节而没有路径，DNG tag 读取必须支持内存输入，
 或由调用方把已经解析的不可变 metadata snapshot 一起传入；不能因此退回 LibRaw 对角缩放。
+
+实施时 ColorMatrix/ForwardMatrix/AsShotNeutral 作为 Develop JSON 的可序列化参数存在，在导入时
+由 MetadataExtractor 写入 `DevelopPayload::camera_profile`。`ResolveDevelopColorTransform`
+只读该 payload，不接收 `RawRuntimeColorContext`，也不在 GPU execute 时打开 RAW 或查询
+CameraMatrices 数据库。用户 CCT/tint 由 CPU 做 mired 双光源插值，把解析后的 3×3 写入
+`CameraColorGpuParams`；kernel 只做 camera RGB × 该矩阵。`develop_color_transform.hpp`
+包含 `develop_node_model.hpp`，`BindDevelopCameraProfile` 只接受 `DevelopPayload&`。
+`PipelineDocument` 绑定发生在 `CPUPipelineExecutor` 内部。CUDA/executor 头文件包含
+`pipeline_document.hpp`，不使用 `PipelineDocument` 前向声明。解析结果用
+`ColorTransformResult`，不用 `std::expected`。
+
+工作：
+
+- [x] `DevelopCameraProfile` 进入 `DevelopPayload`，JSON `camera_profile` 可往返；
+- [x] `ResolveDevelopColorTransform(const DevelopPayload&)` 执行第 1–9 步，不依赖
+  `OperatorParams`、LibRaw、`rgb_cam`、`cam_xyz`、`pre_mul` 或 CameraMatrices 数据库；
+- [x] `BindDevelopCameraProfile` 在 `InjectRawMetadata` 时从 MetadataExtractor 上下文复制矩阵，
+  并求解 as-shot CCT/tint；`SetPipelineDocument` 与 CUDA legacy JSON mirror 之后重新绑定，
+  避免 profile 被擦掉；
+- [x] CameraColorPass 在 CPU 插值后 `BindSlot`/`ApplyPatch` 到 ParameterArena slot
+  `{develop, "camera_color"}`，kernel 只乘 `camera_to_ap1`；
+- [x] 缺失或奇异矩阵抛错，CUDA 路径不静默 identity；
+- [x] `develop.image` 内容 key 哈希 camera_profile 与 WB/CCT；
+  `kCameraColorImplementationVersion = 2`；
+- [x] OpenCL/Metal 仍走的 `ColorTempOp` 改为调用同一解析器。
+
+##### Phase G7R.3 completion record (2026-08-23)
+
+**Status:** complete — serializable Develop camera profile, CPU mired dual-illuminant
+interpolation, CUDA CameraColor multiplies the uploaded 3×3, import bind from
+MetadataExtractor. Creative CAT02 remains G7R.4. 41.8.2 `bf6686fb` pixel goldens
+and 41.8.4 editor E2E remain residual.
+
+**Primary success call chain:**
+
+```text
+ImportService / PipelineController / ExportService
+  -> MetadataExtractor::ExtractEXIF_ToImage
+       PopulateRuntimeContextFromOpenLibRaw (ColorMatrix/ForwardMatrix/AsShotNeutral)
+  -> CPUPipelineExecutor::InjectRawMetadata
+  -> BindDevelopCameraProfile(DevelopPayload, RawRuntimeColorContext)
+       copy matrices onto DevelopPayload.camera_profile
+       as-shot resolve -> as_shot_cct / as_shot_tint
+  -> ColorTempOp JSON {as_shot_cct, as_shot_tint, mode, custom_cct, custom_tint}
+       EditorColorTempModel::loadFromOperatorParams
+  -> user CCT/tint edit submits ColorTemp JSON
+  -> CUDA legacy import copies mode/CCT/tint onto DevelopPayload
+  -> ExecuteCudaCameraColor
+       ResolveDevelopColorTransform(DevelopPayload)   // CPU, stored matrices only
+       ParameterArena BindSlot/ApplyPatch {develop, "camera_color"}
+       UploadDirty
+       CameraColorKernel: ap1 = camera_to_ap1 * camera_rgb
+  -> publish develop.image (ACES AP1 scene-linear)
+```
+
+**Primary failure call chain:**
+
+```text
+missing / singular / non-finite ColorMatrix on DevelopPayload
+  -> ResolveDevelopColorTransform returns ColorTransformResult.ok = false
+  -> ExecuteCudaCameraColor throws (no identity camera_to_ap1)
+  -> CudaRenderDevice::CancelRender + DiscardUnpublished
+  -> previously published geometry.scene_source remains valid
+  -> exception returns through CPUPipelineExecutor (no CPU image processing)
+
+legacy JSON mirror would drop camera_profile
+  -> InjectRawMetadata stashes RawRuntimeColorContext
+  -> ApplyImportedCameraProfile after SetPipelineDocument and after each mirror
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `DevelopColorTransformInterpolatesDualIlluminantMatricesInMiredSpace` | `GpuDagModelGraphTest` | PASS |
+| `DevelopColorTransformInterpolatesForwardMatricesWithTheSameWeight` | `GpuDagModelGraphTest` | PASS |
+| `DevelopColorTransformUsesSingleProfileWhenCalibrationIlluminantsAreIncomplete` | `GpuDagModelGraphTest` | PASS |
+| `DevelopColorTransformSolvesAsShotNeutralWithoutUsingCamMulAsColorMatrix` | `GpuDagModelGraphTest` | PASS |
+| `DevelopColorTransformDoesNotUseLibRawRgbCamOrPreMulAsCameraMatrix` | `GpuDagModelGraphTest` | PASS |
+| `DevelopColorTransformRejectsMissingOrSingularCameraMatrices` | `GpuDagModelGraphTest` | PASS |
+| `DevelopCameraProfileJsonRoundTripPreservesMatricesAndAsShotNeutral` | `GpuDagModelGraphTest` | PASS |
+| `BindDevelopCameraProfileWritesAsShotCctFromStoredNeutral` | `GpuDagModelGraphTest` | PASS |
+| `DevelopImageGraphValueIsAp1SceneLinear` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `ExecuteCudaCameraColorRejectsMissingCameraMatrices` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `BindDevelopCameraProfileCopiesDngColorMatricesFromMetadataExtractor` | `GpuDagCudaDrtProductTest` | PASS |
+| `BindDevelopCameraProfileCopiesNonDngCameraMatricesFromMetadataExtractor` | `GpuDagCudaDrtProductTest` | PASS |
+| `CameraProfileChangeInvalidatesDevelopImageNotSensorLinear` | `GpuDagRawInputTest` | PASS |
+| `DevelopCctEditReusesSensorAndGeometryAndRunsCameraColorGradeDrt` | `GpuDagCudaDrtProductTest` | PASS |
+| `CudaCat02WhiteBalanceZeroOffsetPreservesAp1White` | `GpuDagCudaPrimaryGradeTest` | PASS (channel-scale CAT02; G7R.4 replaces) |
+
+`RawInputLoaderPopulatesCompleteColorContextFromRealRaw` is not added. EditInput stays
+Image-free; CameraColor no longer reads `PreparedRawInput.color_context`. Import-time
+MetadataExtractor bind is the source of the serializable profile. The two
+`BindDevelopCameraProfileCopies*` tests cover DNG and ARW.
+
+`CudaCat02ZeroOffsetIsExactIdentity` and `CudaCat02MapsSourceWhiteToRequestedWhiteInAp1`
+belong to G7R.4.
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagCudaPrimaryGradeTest GpuDagCudaDrtProductTest GpuDagCudaMaskTest GpuDagModelGraphTest GpuDagRawInputTest GpuDagCudaWorkspaceTest GpuDagCudaDevelopTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "GpuDagModelGraphTest|GpuDagRawInputTest|GpuDagCudaDevelopTest|GpuDagCudaPrimaryGradeTest|GpuDagCudaDrtProductTest|GpuDagCudaMaskTest|GpuDagCudaWorkspaceTest"
+```
+
+Suite totals: `123/123` PASS (`GpuDagModelGraphTest` 26, `GpuDagRawInputTest` 30,
+CUDA Develop 6, CUDA Primary Grade 11, CUDA DRT product 23, CUDA Mask 11,
+CUDA workspace 16).
+
+**Checklist / exit condition:** seven of seven G7R.3 work items checked. Algorithm
+steps 1–10 run from stored Develop params (step 1 at import bind, steps 2–9 in
+`ResolveDevelopColorTransform`, step 10 in CameraColorPass).
+
+**LOC note (grill-code-review):** new files: `develop_color_transform.cpp` 665,
+`develop_color_transform.hpp` 74, `camera_color_gpu_params.hpp` 18,
+`develop_color_transform_test.cpp` 251, `test_camera_profile.hpp` 39,
+`develop_camera_profile_import_test.cpp` 83. `color_temp_op.cpp` 418 (was ~1087).
+`cuda_camera_color_pass.cu` 100. `develop_node_model.hpp` 114,
+`develop_node_model.cpp` 121. No new file exceeds 1000 lines.
+`pipeline_cpu.cpp` remains 742; this phase only binds the camera profile on inject,
+document set, and legacy mirror.
+
+**Remaining gaps:** 41.8.2 `bf6686fb` CameraToAp1 pixel goldens are not generated.
+41.8.4 editor real-RAW E2E still sits behind `ALCEDO_RUN_DEADLOCKING_RAW_GPU_E2E`.
+`RawInputLoader::FillColorContext` still writes only cam_mul/pre_mul/make/model;
+the CUDA product path does not use that context for CameraColor. OpenCL/Metal
+`ColorTempOp` still has a `cam_xyz` fallback when ColorMatrix is missing; CUDA
+does not. Creative CAT02 remains per-channel scaling until G7R.4. 41.9 A/B
+timing remains G7R.5.
 
 ### 41.6 G7R.4 — 正确实现独立的 creative CAT02
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1–G7R.3 complete；G7R.H complete（含 one-shot 缓存隔离修复与 canonical LLF ROI 采样）；G7R.4–G7R.5 remaining；G7R 仍阻塞 G8。
+Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1–G7R.3 complete；G7R.H complete（含 one-shot 缓存隔离、canonical LLF ROI 采样，以及 CUDA 产品 present 示波器 tap）；G7R.4–G7R.5 remaining；G7R 仍阻塞 G8。
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -3936,6 +3936,117 @@ Suite total: `119/119` PASS。
 **LOC note (grill-code-review):** `cuda_local_tone_pass.cu` 488 lines，`cuda_primary_grade_pass.cu` 454 lines，`cuda_primary_grade_test.cpp` 490 lines。没有本次修改的文件超过 1000 行。
 
 **Residual gaps:** 没有先行全图帧时，孤立 ROI 仍走局部 extract，不会伪造 canonical 缓存。canonical 身份的主机侧槽以 workspace 指针为键，GPU 平面仍由 workspace `Values()` 持有；`ReleaseSessionResources` 清掉平面后下一次全图帧会重新播种。G7R.4 CAT02 与 G7R.5 统计仍未做。
+
+##### Phase G7R.H CUDA 产品 present 恢复 histogram/waveform tap（2026-08-23）
+
+**Status:** complete — CUDA DAG 产品路径在拷贝 DRT 输出到 viewport 之后，把同一张 display-encoded 纹理提交给 `FinalDisplayFrameTapSink`，histogram 和 waveform 可以再次读取。
+
+**Root cause:** 旧 CUDA `GPU_KernelLauncher` 在 present 时调用 `SubmitFinalDisplayFrame`。`CudaProductRenderer::PresentCudaTexture` 只做了 `BindFrameSubmission` / `MapResourceForWrite` / copy / `UnmapResource` / `NotifyFrameReady`。示波器 tap 因此永远拿不到 staged frame，QML 停在 `Reading display scope`。
+
+**Primary success call chain:**
+
+```text
+editor session render (CUDA DAG)
+  -> CPUPipelineExecutor::Apply
+  -> CudaProductRenderer::Render
+       PresentCudaTexture
+         BindFrameSubmission
+         copy DRT texture -> frame sink
+         SubmitFinalDisplayFrame (CUDA linear buffer + render stream)
+           FinalDisplayFrameTapSink::SubmitFinalDisplayFrame
+             IScopeAnalyzer::StageFrame
+         cudaStreamSynchronize
+         UnmapResource / NotifyFrameReady
+  -> EditorScopeController poll
+       SubmitFrame + ReadScopeRenderSnapshot
+       hasSnapshot true
+```
+
+**Primary failure call chain:**
+
+```text
+frame sink rejects CUDA RGBA32F mapping
+  -> throw runtime_error
+  -> UnmapResource
+  -> no NotifyFrameReady
+  -> scheduler on_complete_(false, what())
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `ProductPresentSubmitsReadableCudaDisplayFrameBeforeUnmapAndNotify` | `GpuDagCudaDrtProductTest` | PASS |
+| `ProductPresentDisplayConfigMatchesDrtEncoding` | `GpuDagCudaDrtProductTest` | PASS |
+| existing CUDA product suite | `GpuDagCudaDrtProductTest` | PASS, `35/35` |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagCudaDrtProductTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R GpuDagCudaDrtProductTest
+```
+
+Suite totals: `35/35` PASS.
+
+**Checklist / exit condition:** CUDA 产品 present 在 Unmap/Notify 之前提交可读的 CUDA display frame；显示配置跟随 DRT encoding。
+
+**LOC note (grill-code-review):** `cuda_product_renderer.cu` 339 lines，`cuda_product_scope_present_test.cpp` 258 lines。没有文件超过 1000 行。
+
+**Residual gaps:** 本二进制没有驱动 QML `EditorScopeController` 或真实 analyzer kernel；tap 与 analyzer 的既有测试仍在 `EditorScopeControllerTest`。编辑器里真实 RAW 的 histogram/waveform 仍需产品侧确认。G7R.4 CAT02 与 G7R.5 统计仍未做。
+
+##### Phase G7R.H CUDA scope slot reclaim and [SCOPE] diagnostics（2026-08-23）
+
+**Status:** complete — CUDA analyzer 不再在 deferred poll 读走结果之前把唯一完成槽标成 Idle；控制台增加 `[SCOPE]` 门闩日志，`ALCEDO_RENDER_E2E=0` 可关掉 `[RENDER_E2E]`。
+
+**Root cause:** DAG 产品 present 已经 `SubmitFinalDisplayFrame`。示波器仍空白，是因为 `CudaScopeAnalyzer` 在 `StageFrame` 里把 `Dispatched` 且 `analysis_done` 的槽立刻标成 `Idle`。生产路径是 deferred poll：先 `GetLatestOutput` 再 `SubmitFrame`。连续 present 时，下一次 `StageFrame` 会复用那个刚算完的 histogram 槽，poll 永远读到空输出，QML 停在 Reading display scope。`[RENDER_E2E]` 走 stdout 且每帧一行，盖住了示波器是否 staging/polling。
+
+**Primary success call chain:**
+
+```text
+CudaProductRenderer::PresentCudaTexture
+  -> FinalDisplayFrameTapSink::SubmitFinalDisplayFrame
+       StageFrame (slot Staged)
+  -> EditorScopeController poll
+       SubmitFrame (slot Dispatched)
+       GetLatestOutput keeps newest completed Dispatched slot until consumed
+       ReadScopeRenderSnapshot
+       hasSnapshot true
+```
+
+**Primary failure call chain:**
+
+```text
+StageFrame while newer generation is not yet consumed
+  -> completed slot stays Dispatched
+  -> later StageFrame uses a different idle slot
+  -> GetLatestOutput still returns the completed histogram
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `DeferredTapKeepsCompletedHistogramAfterLaterPresentWouldHaveReclaimedTheSlot` | `GpuDagCudaDrtProductTest` | PASS |
+| `ProductPresentSubmitsReadableCudaDisplayFrameBeforeUnmapAndNotify` | `GpuDagCudaDrtProductTest` | PASS |
+| existing CUDA product suite | `GpuDagCudaDrtProductTest` | PASS, `36/36` |
+| existing scope controller suite | `EditorScopeControllerTest` | PASS, `15/15` |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagCudaDrtProductTest EditorScopeControllerTest alcedo_main --parallel 4
+ctest --test-dir build/debug --output-on-failure -R GpuDagCudaDrtProductTest
+ctest --test-dir build/debug --output-on-failure -R EditorScopeControllerTest
+```
+
+Suite totals: `36/36` and `15/15` PASS.
+
+**Checklist / exit condition:** completed histogram survives a later present; `[SCOPE]` lines identify staging/poll/publish; `alcedo_main` relinked.
+
+**LOC note (grill-code-review):** `cuda_scope_analyzer.cu` 512 lines，`final_display_frame_tap.cpp` 307 lines，`editor_scope_controller.cpp` 280 lines。没有文件超过 1000 行。
+
+**Residual gaps:** `[SCOPE]` 同类行超过 16 次后抑制。未在本二进制里驱动真实 QML 面板。G7R.4 / G7R.5 仍未做。
 
 ### 41.6 G7R.4 — 正确实现独立的 creative CAT02
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1–G7R.3 complete；G7R.H complete（含 one-shot 缓存隔离修复）；G7R.4–G7R.5 remaining；G7R 仍阻塞 G8。
+Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1–G7R.3 complete；G7R.H complete（含 one-shot 缓存隔离修复与 canonical LLF ROI 采样）；G7R.4–G7R.5 remaining；G7R 仍阻塞 G8。
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -3878,6 +3878,65 @@ Suite total: related discovered set `159/159` PASS；LLF memcheck `2/2` PASS；D
 进入 prepared input，并以合成非恒等参数证明 CUDA 像素结果实际改变；没有保存新的大型 golden
 图像。
 
+##### 41.5.1 Canonical LLF reference 与 ROI 坐标采样（2026-08-23）
+
+**Status:** complete — CUDA Shadows/Highlights 不再从当前 viewport ROI 重建内部蒙版。
+全 EditSpace 帧按 `full_reference_extent` 把 log-intensity 提取到 ReferenceSpace 的
+canonical LLF 平面（长边不超过 `kReferenceMaskMaxLongEdge`），并写入 workspace pyramid。
+后续 ROI 帧用 G3 `MakeLlfSamplingPlan` 把 render 像素中心映射到该平面，只应用已有
+reference/adjusted 亮度，不重跑 Gaussian/Laplacian。`HashLlfReferenceKey` 含 source、
+crop/rotation、CameraColor 和 Grade，不含 viewport。没有 canonical 缓存的 ROI 仍从
+当前帧局部构建，且不会把局部结果标成 canonical。
+
+**Primary success call chain:**
+
+```text
+full-EditSpace PrimaryGrade
+  -> ExecuteCudaLocalTone
+  -> ExtractReferenceKernel (reference_to_render)
+  -> workspace local_tone.source/result pyramids
+  -> ApplyKernel + MakeLlfSamplingPlan
+viewport ROI PrimaryGrade (same HashLlfReferenceKey)
+  -> ExecuteCudaLocalTone
+  -> skip extract/remap/select/collapse
+  -> ApplyKernel samples canonical planes by render_to_texture_uv
+```
+
+**Primary failure call chain:**
+
+```text
+missing input / zero geometry extent / CUDA launch failure
+  -> ExecuteCudaLocalTone throws
+  -> CudaRenderDevice cancels unpublished submission
+  -> no CPU, curve, or other-backend substitute
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `RoiFrameSamplesCanonicalLlfReferenceInsteadOfRebuilding` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaLocalTonePyramidBuffersReuseAcrossViewportChanges` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `FullViewCoversEditSpaceAndViewportRoiDoesNot` | `GpuDagGeometryTest` | PASS |
+| `LlfReferenceKeyIgnoresViewportAndFollowsCropAndGrade` | `GpuDagRawInputTest` | PASS |
+| `ShadowsLlfRespondsToNeighborhoodWithIdenticalCenterPixel` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `HighlightsLlfRespondsToNeighborhoodWithIdenticalCenterPixel` | `GpuDagCudaPrimaryGradeTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagCudaPrimaryGradeTest GpuDagGeometryTest GpuDagRawInputTest GpuDagCudaMaskTest GpuDagCudaDrtProductTest GpuDagCudaDevelopTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "^(GpuDagCudaPrimaryGradeTest|GpuDagGeometryTest|GpuDagRawInputTest|GpuDagCudaMaskTest|GpuDagCudaDrtProductTest|GpuDagCudaDevelopTest)\."
+```
+
+Suite total: `119/119` PASS。
+
+**Checklist / exit condition:** G3 “图像、LLF 和 mask 使用相同的 render-to-reference 数据” 已接到 CUDA LLF apply。ROI 放大不再重算 canonical 蒙版。
+
+**LOC note (grill-code-review):** `cuda_local_tone_pass.cu` 488 lines，`cuda_primary_grade_pass.cu` 454 lines，`cuda_primary_grade_test.cpp` 490 lines。没有本次修改的文件超过 1000 行。
+
+**Residual gaps:** 没有先行全图帧时，孤立 ROI 仍走局部 extract，不会伪造 canonical 缓存。canonical 身份的主机侧槽以 workspace 指针为键，GPU 平面仍由 workspace `Values()` 持有；`ReleaseSessionResources` 清掉平面后下一次全图帧会重新播种。G7R.4 CAT02 与 G7R.5 统计仍未做。
+
 ### 41.6 G7R.4 — 正确实现独立的 creative CAT02
 
 Primary Grade 的第一个 adjustment 是 creative white balance，与 RAW
@@ -4329,7 +4388,7 @@ ctest --test-dir build/macos-debug --output-on-failure
 ### 47.5 Geometry 和 Mask
 
 - [ ] crop、rotation、view ROI 和 dynamic resolution 只执行一次图像重采样。
-- [ ] LLF 和 mask 使用相同的 RenderGeometry 数据。
+- [x] LLF 和 mask 使用相同的 RenderGeometry 数据。
 - [x] Rasterized Mask 使用 R8。
 - [x] Rasterized Mask 任意一条边不大于 4096。
 - [x] Rasterized Mask 作为 GPU texture 采样。

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -94,10 +94,10 @@ UI scope:
 | Rasterized Mask | R8 UNORM；任意一条边不大于 4096 |
 | Feather | GPU exact signed Euclidean distance field；持久数据仍为 R8 |
 | RAW 输入 | LibRaw open、unpack、active area 和降采样在管线外 |
-| Develop 逻辑输出 | `develop.image`，scene-linear ACES AP1；CameraColorPass 完成后才可写入 |
+| Develop 逻辑输出 | `develop.image`，AP1 primaries / ACEScc encoded；CameraColorPass 完成后才可写入 |
 | Develop 内部缓存 | `develop.sensor_linear` 保存传感器开发结果；不是用户可见端口 |
 | Geometry 后缓存 | `geometry.scene_source` 保存重采样后的 camera scene-linear RGB；不是用户可见节点 |
-| 中间调色 | scene-linear ACES AP1 |
+| 中间调色 | AP1 primaries / ACEScc encoded 工作空间 |
 | 局部色温 | 基于 CAT02，以 AP1 白点为参考 |
 | DRT | ACES 2.0 或 OpenDRT |
 | Geometry | 管线文档的全局 ImageGeometryModel，不是第四个用户节点 |
@@ -426,7 +426,8 @@ PreparedRawInput
        - 解析 as-shot 或 custom CCT/tint
        - 按标定光源在 CameraMatrices 的双光源矩阵间插值
        - camera RGB -> XYZ D50 -> XYZ D60 -> ACES AP1
-  -> develop.image               # Develop 的唯一用户可见输出
+       - AP1 scene-linear -> ACEScc encode
+  -> develop.image               # AP1/ACEScc；Develop 的唯一用户可见输出
 ```
 
 G4 只生成 camera scene-linear，G5 再执行 CameraColorPass 的拆分是正确的缓存边界，
@@ -455,8 +456,8 @@ Develop 输出固定为：
 
 ```text
 float RGB
-scene-linear
 ACES AP1 primaries
+ACEScc encoded
 ACES white point
 ```
 
@@ -519,7 +520,8 @@ DRT 参数包括：
 - peak luminance；
 - OpenDRT look 和 tonescale 参数。
 
-DRT 接收 AP1 scene-linear 图像，输出 display-referred GPU texture。
+DRT 接收 AP1 primaries / ACEScc encoded 工作空间图像，在端点内部解码为 AP1
+scene-linear 后执行所选 DRT，并输出 display-referred GPU texture。
 
 ### 7.4 端点规则
 
@@ -1276,7 +1278,7 @@ Develop Endpoint 从上传 PreparedRawInput 开始。之后的图像计算只使
 | 项目 | RAW white balance | CAT02 scene white balance |
 | --- | --- | --- |
 | 所属位置 | Develop Endpoint | ColorGradeNode |
-| 输入 | camera/CFA 数据 | AP1 scene-linear RGB |
+| 输入 | camera/CFA 数据 | AP1 primaries / ACEScc encoded RGB |
 | 参考 | 相机 metadata 或用户 RAW CCT | AP1 白点 |
 | 蒙版 | 不支持局部 mask | 支持 ColorGradeNode mask |
 | 主要用途 | 胶片 develop | scene-referred 局部或全局调色 |
@@ -2324,8 +2326,8 @@ Base: `feature/gpu-dag-render-geometry`
 
 - 把 LibRaw unpack 和 RAW 降采样移到管线输入之前；
 - 实现 CUDA Develop Endpoint 的传感器开发子阶段；
-- 输出可缓存的 camera scene-linear GPU 图像；G5 的 CameraColorPass 再完成 Develop 的
-  AP1 scene-linear 逻辑输出。
+- 输出可缓存的 camera scene-linear GPU 图像；G5 的 CameraColorPass 再完成 Camera→AP1，
+  并把 Develop 的图输出编码为 AP1 primaries / ACEScc 工作空间。
 
 工作：
 
@@ -2447,7 +2449,7 @@ Base: `feature/gpu-dag-cuda-develop`
 
 - 实现默认 ColorGradeNode 的 CUDA 执行；
 - 从可缓存的 G4 camera scene-linear 结果出发，在 Grade 前执行独立 CameraColorPass，并让
-  `develop.image` 成为 AP1 scene-linear；
+  `develop.image` 成为 AP1 primaries / ACEScc encoded 工作空间图像；
 - 增加纯 Model，并让新 CUDA 路径只使用这些 Model；
 - 旧 operator 类只供尚未移植的 OpenCL 和 Metal 路径临时使用；
 - 把 LLF 内存和缓存迁入 workspace。
@@ -2659,7 +2661,7 @@ PipelineDocument mask edge + serialized MaskAssetKey + RenderRequest
   -> parallel-band exact signed Euclidean distance -> cached distance buffer -> feather sample
   -> RenderSpace R8 mask
   -> ExecuteCudaPrimaryGrade -> per-pixel Normal Mix
-  -> scene-linear output
+  -> AP1/ACEScc working-space output
 ```
 
 **Primary failure call chain:**
@@ -2828,7 +2830,7 @@ DrtParamsModel dirty fields
   -> GPUParamsConverter
   -> stable ParameterArena slot keyed by (drt, drt.output)
   -> dirty-range upload
-  -> DrtKernel(scene-linear AP1 -> DRT -> display gamut -> EOTF)
+  -> DrtKernel(AP1/ACEScc -> decode scene-linear AP1 -> DRT -> display gamut -> EOTF)
   -> GraphImageCache[(drt, display)]
 ```
 
@@ -3144,8 +3146,8 @@ failure visible until the result cache owns geometry.
 ```text
 develop.sensor_linear   = camera scene-linear，geometry 前
 geometry.scene_source   = camera scene-linear，geometry 后
-develop.image           = ACES AP1 scene-linear，CameraColorPass 后
-grade.<id>.image        = ACES AP1 scene-linear
+develop.image           = AP1 primaries / ACEScc encoded，CameraColorPass 后
+grade.<id>.image        = AP1 primaries / ACEScc encoded
 drt.display             = display-referred output
 ```
 
@@ -3377,8 +3379,9 @@ ImportService / PipelineController / ExportService
        ResolveDevelopColorTransform(DevelopPayload)   // CPU, stored matrices only
        ParameterArena BindSlot/ApplyPatch {develop, "camera_color"}
        UploadDirty
-       CameraColorKernel: ap1 = camera_to_ap1 * camera_rgb
-  -> publish develop.image (ACES AP1 scene-linear)
+        CameraColorKernel: ap1_linear = camera_to_ap1 * camera_rgb
+                           working = ACESccEncode(ap1_linear)
+   -> publish develop.image (AP1 primaries / ACEScc encoded)
 ```
 
 **Primary failure call chain:**
@@ -3408,7 +3411,7 @@ legacy JSON mirror would drop camera_profile
 | `DevelopColorTransformRejectsMissingOrSingularCameraMatrices` | `GpuDagModelGraphTest` | PASS |
 | `DevelopCameraProfileJsonRoundTripPreservesMatricesAndAsShotNeutral` | `GpuDagModelGraphTest` | PASS |
 | `BindDevelopCameraProfileWritesAsShotCctFromStoredNeutral` | `GpuDagModelGraphTest` | PASS |
-| `DevelopImageGraphValueIsAp1SceneLinear` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CameraColorEncodesAp1AsAcesccGraphWorkingSpace` | `GpuDagCudaPrimaryGradeTest` | PASS |
 | `ExecuteCudaCameraColorRejectsMissingCameraMatrices` | `GpuDagCudaPrimaryGradeTest` | PASS |
 | `BindDevelopCameraProfileCopiesDngColorMatricesFromMetadataExtractor` | `GpuDagCudaDrtProductTest` | PASS |
 | `BindDevelopCameraProfileCopiesNonDngCameraMatricesFromMetadataExtractor` | `GpuDagCudaDrtProductTest` | PASS |
@@ -3628,10 +3631,10 @@ zero CUDA node execution。
 而不是 `queue`；`queue≈50 ms, pipeline≈12.5 s` 与锁等待完全一致，不是冷启动结论。
 
 同时修复两个独立产品回归：Quality Base 在 ROI 放大期间重新读取 live viewport，导致 ROI
-结果按 full-frame 展示而拉伸；默认 Curve 把 AP1 scene-linear 中所有大于 1 的值返回为末端
-控制点 1，造成 ACES 和 OpenDRT 共同输入在 DRT 前硬裁。旧管线的 RGC 曲线没有执行该硬裁；
-新管线明确保持 Primary Grade 为 AP1 scene-linear，因此默认 Curve 改为沿首尾线段外推，
-不引入 ACEScc 往返或第二套色彩域。
+结果按 full-frame 展示而拉伸；默认 Curve 对工作空间中超过控制点范围的数值返回末端控制点，
+造成 ACES 和 OpenDRT 共同输入在 DRT 前硬裁。旧管线的 RGC 曲线没有执行该硬裁，因此默认
+Curve 改为沿首尾线段外推。这里此前把 Primary Grade 记为 AP1 scene-linear 是错误的；
+第 41.5.1 节记录工作空间边界和 LLF 修正。
 
 **Primary success call chains:**
 
@@ -3653,10 +3656,10 @@ ROI zoom -> panel/demosaic change -> Quality Base
   -> full-frame result keeps source aspect ratio
 
 scene-linear highlight > 1
-  -> CameraColorPass produces AP1 scene-linear
-  -> PrimaryGrade default Curve extrapolates the identity end segment
-  -> highlight remains > 1 at grade output
-  -> selected DRT owns highlight mapping
+  -> CameraColorPass converts camera RGB to AP1 and encodes ACEScc
+  -> PrimaryGrade reads and writes AP1/ACEScc; default Curve extrapolates its identity end segment
+  -> encoded highlight remains available at grade output
+  -> selected DRT decodes ACEScc and owns highlight mapping
 ```
 
 **Primary failure call chain:**
@@ -3700,7 +3703,7 @@ snapshot set `39/39` PASS（2 disabled）；direct real-DNG thumbnail set `2/2` 
 
 **Checklist / exit condition:** ordinary thumbnail and export no longer render on the live editor
 executor；one-shot tasks still bypass session caches；Quality Base cannot inherit a live ROI；default
-Primary Grade cannot clip AP1 highlights above 1；RAW demosaic/HLR selection and failures remain
+Primary Grade cannot clip AP1/ACEScc working values；RAW demosaic/HLR selection and failures remain
 observable。
 
 **LOC note (grill-code-review):** no new production module or dependency. The fix reuses
@@ -3713,12 +3716,175 @@ range, but do not replay the user's exact multi-photo filmstrip timing trace. Pr
 should confirm that any remaining long thumbnail duration is visible only on the thumbnail worker，
 not inside an InteractivePrimary request's `pipeline` duration。
 
+##### 41.5.1 Phase G7R.H AP1/ACEScc 工作空间与 Shadows/Highlights LLF 修正（2026-08-23）
+
+**Status:** complete — 此项修正撤销了上一条 completion record 中“Primary Grade 为 AP1
+scene-linear”的错误语义。图级工作空间现在由 CameraColorPass 建立：CameraColorPass 在 Geometry
+之后把 camera scene-linear 转换到 AP1 primaries，再编码为 ACEScc；所有 Grade 输入和输出继续
+保持 AP1/ACEScc；DRT 端点负责解码 ACEScc，然后执行 ACES 2.0 或 OpenDRT，并转换到用户选择的
+输出 encoding space、EOTF 和 limiting space。Primary Grade 不再自行执行 Camera→AP1，也不在
+节点边界做 ACEScc 往返。
+
+Shadows 和 Highlights 已从 pointwise adjustment kernel 移除，改为真正的 CUDA multi-level
+Gaussian/Laplacian local Laplacian filter。LLF 从 AP1/ACEScc 解码亮度，构建 reference/remap
+pyramids，按相邻 gamma samples 选择 Laplacian 层并 collapse，最后把局部亮度差重新应用到
+AP1，做 lower-gamut fit 后编码回 ACEScc。所有 pyramid buffer 都由 `CudaRenderWorkspace`
+持有；LLF 不调用私有 `cudaMalloc/cudaFree`，warm render 不产生 GPU allocation/free。
+
+**Primary success call chains:**
+
+```text
+Develop sensor pass -> camera scene-linear
+  -> GeometryResamplePass -> geometry.scene_source (camera scene-linear)
+  -> CameraColorKernel -> camera_to_ap1 -> ACESccEncode
+  -> publish develop.image (AP1 primaries / ACEScc encoded)
+  -> PrimaryGrade commands before Shadows/Highlights (AP1/ACEScc)
+  -> ExecuteCudaLocalTone
+       -> Extract ACEScc log intensity
+       -> Gaussian source pyramid
+       -> sampled remap pyramids
+       -> Laplacian select + collapse
+       -> apply AP1 intensity delta + ACESccEncode
+  -> PrimaryGrade commands after Shadows/Highlights (AP1/ACEScc)
+  -> grade mix/mask in AP1/ACEScc
+  -> publish grade.<id>.image (AP1 primaries / ACEScc encoded)
+  -> DrtKernel -> ACESccDecode -> selected DRT -> selected display encoding
+```
+
+**Primary failure call chain:**
+
+```text
+missing workspace image / invalid CUDA allocation / kernel launch failure
+  -> explicit exception from CameraColor, PrimaryGrade, LLF or DRT pass
+  -> CudaRenderDevice cancels submission and discards unpublished results
+  -> no CPU, legacy curve, alternate backend or lower-quality substitute
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `CameraColorEncodesAp1AsAcesccGraphWorkingSpace` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `DefaultCurvePreservesAcesccWorkingValuesWithoutClipping` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `ShadowsLlfRespondsToNeighborhoodWithIdenticalCenterPixel` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `HighlightsLlfRespondsToNeighborhoodWithIdenticalCenterPixel` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaLocalToneUsesWorkspaceInsteadOfPrivateAllocation` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `CudaColorGradeSecondRenderCreatesNoGpuAllocation` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| Shadows/Highlights CUDA memcheck | `compute-sanitizer` | PASS, 0 errors |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagCudaPrimaryGradeTest GpuDagCudaDrtProductTest GpuDagCudaDevelopTest GpuDagRawInputTest GpuDagModelGraphTest GpuDagCudaMaskTest GpuDagCudaWorkspaceTest GpuDagGeometryTest GpuDagCudaGeometryTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "^(GpuDagCudaPrimaryGradeTest|GpuDagCudaDrtProductTest|GpuDagCudaDevelopTest|GpuDagRawInputTest|GpuDagModelGraphTest|GpuDagCudaMaskTest|GpuDagCudaWorkspaceTest|GpuDagGeometryTest|GpuDagCudaGeometryTest)\."
+compute-sanitizer --tool memcheck --print-limit 5 build\debug\alcedo_studio\tests\edit\GpuDagCudaPrimaryGradeTest_runtime\GpuDagCudaPrimaryGradeTest.exe --gtest_filter=GpuDagCudaPrimaryGrade.ShadowsLlfRespondsToNeighborhoodWithIdenticalCenterPixel:GpuDagCudaPrimaryGrade.HighlightsLlfRespondsToNeighborhoodWithIdenticalCenterPixel
+```
+
+Suite total: combined related set `155/155` PASS；post-format Primary Grade + DRT product set
+`46/46` PASS；compute-sanitizer targeted set `2/2` PASS with `ERROR SUMMARY: 0 errors`。
+
+**LOC note (grill-code-review):** `cuda_local_tone_pass.cu` 361 lines，
+`cuda_primary_grade_pass.cu` 444 lines，`cuda_primary_grade_test.cpp` 364 lines。没有本次修改的
+文件超过 1000 行；没有新增第三方依赖。
+
+**Residual gap:** 本次修复使用当前 post-Geometry render extent 构建 LLF reference，并复用
+workspace pyramid allocations；full-frame、跨 ROI 的 reference content cache 仍需沿
+`MakeLlfSamplingPlan` 接入独立的 canonical reference 输入。该项不能用 pointwise curve 或固定
+标量代替，且不影响本次已证明的 LLF 空间行为和 AP1/ACEScc 工作空间边界。
+
+##### 41.5.1 默认 DAG 算法分派与 DNG WarpRectilinear 修正（2026-08-23）
+
+**Status:** complete — 修正范围是默认文档经过 `GraphCompiler` 和 legacy/UI stage adapter 后的
+实际算法选择，以及 encoded DNG 的 OpcodeList3 `WarpRectilinear` 进入 CUDA Develop 的路径。
+
+默认文档虽然一直包含独立的 Shadows、Highlights 和 Curve type id，但旧的 compiled
+adjustment 没有记录执行算法，CUDA Primary Grade 因而曾把 Shadows/Highlights 当作 pointwise
+亮度曲线执行。`CompiledAdjustment` 现在显式记录 `Pointwise` 或 `LocalLaplacian`；compiler 只把
+Shadows/Highlights 标记为 `LocalLaplacian`，Curve 继续保持 `Pointwise`。Primary Grade 对任何没有
+被编译为 LLF 的 Shadows/Highlights 直接报错，不会静默执行 curve、CPU 或其他替代路径。
+
+`RawInputLoader` 现在从 encoded DNG 解析 OpcodeList3 warp，保存到 `PreparedRawInput`，并把完整
+系数与中心点 hash 纳入 prepared source identity。CUDA Develop 在 demosaic、HLR 和 RGBA pack
+之后、GeometryResample 和 CameraColor/ACEScc 之前，把 warp 写入 workspace-owned 目标图像；
+caller-owned warp API 不分配私有 GPU 图像。缺少图像、类型/尺寸不匹配或 CUDA kernel 失败均直接
+抛错。
+
+**Primary success call chains:**
+
+```text
+CreateDefaultPipelineDocument / LegacyPipelineImporter
+  -> GraphCompiler::CompileStatic
+  -> Shadows + Highlights => CompiledAdjustmentAlgorithm::LocalLaplacian
+  -> Curve => CompiledAdjustmentAlgorithm::Pointwise
+  -> ExecuteCudaPrimaryGrade
+  -> ExecuteCudaLocalTone -> workspace Gaussian/Laplacian pyramids
+  -> AP1/ACEScc grade output -> DRT
+```
+
+```text
+encoded DNG bytes
+  -> RawInputLoader::LoadEncoded -> ExtractMetadata(OpcodeList3 WarpRectilinear)
+  -> PreparedRawInput + dng_warp_hash
+  -> ExecuteCudaDevelop -> demosaic/HLR/pack
+  -> CUDA::WarpDngRectilinear(unwarped, sensor_linear, coefficients)
+  -> GeometryResample -> CameraColor -> AP1/ACEScc working space
+```
+
+**Primary failure call chains:**
+
+```text
+Shadows/Highlights compiled without LocalLaplacian
+  -> ExecuteCudaPrimaryGrade throws
+  -> CudaRenderDevice cancels the unpublished submission
+  -> no curve or backend substitute
+
+invalid/missing DNG warp image or CUDA launch failure
+  -> WarpDngRectilinear throws
+  -> Develop submission is cancelled
+  -> no unwarped result is published as success
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `DefaultPipelineCompilesShadowsAndHighlightsToLocalLaplacianOnly` | `GpuDagRawInputTest` | PASS |
+| `LegacyShadowControlExecutesLocalLaplacianWorkspacePath` | `GpuDagCudaDrtProductTest` | PASS |
+| `ShadowsLlfRespondsToNeighborhoodWithIdenticalCenterPixel` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `HighlightsLlfRespondsToNeighborhoodWithIdenticalCenterPixel` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `EncodedDngCarriesOpcodeList3WarpIntoPreparedInput` | `GpuDagRawInputTest` | PASS with real DNG |
+| `CudaDevelopAppliesPreparedDngRectilinearWarpAfterDemosaic` | `GpuDagCudaDevelopTest` | PASS |
+| LLF CUDA memcheck | `compute-sanitizer` | PASS, 0 errors |
+| DNG warp CUDA memcheck | `compute-sanitizer` | PASS, 0 errors |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build build\debug --target GpuDagCudaPrimaryGradeTest GpuDagCudaDrtProductTest GpuDagCudaDevelopTest GpuDagRawInputTest GpuDagModelGraphTest GpuDagCudaMaskTest GpuDagCudaWorkspaceTest GpuDagGeometryTest GpuDagCudaGeometryTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "^(GpuDagCudaPrimaryGradeTest|GpuDagCudaDrtProductTest|GpuDagCudaDevelopTest|GpuDagRawInputTest|GpuDagModelGraphTest|GpuDagCudaMaskTest|GpuDagCudaWorkspaceTest|GpuDagGeometryTest|GpuDagCudaGeometryTest)\."
+compute-sanitizer --tool memcheck --print-limit 5 build\debug\alcedo_studio\tests\edit\GpuDagCudaPrimaryGradeTest_runtime\GpuDagCudaPrimaryGradeTest.exe --gtest_filter=GpuDagCudaPrimaryGrade.ShadowsLlfRespondsToNeighborhoodWithIdenticalCenterPixel:GpuDagCudaPrimaryGrade.HighlightsLlfRespondsToNeighborhoodWithIdenticalCenterPixel
+compute-sanitizer --tool memcheck --print-limit 5 build\debug\alcedo_studio\tests\edit\GpuDagCudaDevelopTest_runtime\GpuDagCudaDevelopTest.exe --gtest_filter=CudaDevelopFixture.CudaDevelopAppliesPreparedDngRectilinearWarpAfterDemosaic
+```
+
+Suite total: related discovered set `159/159` PASS；LLF memcheck `2/2` PASS；DNG warp memcheck
+`1/1` PASS；两次 sanitizer 均为 `ERROR SUMMARY: 0 errors`。
+
+**LOC note (grill-code-review):** `cuda_local_tone_pass.cu` 360 lines，
+`cuda_primary_grade_pass.cu` 452 lines，`raw_input_loader.cpp` 495 lines，
+`cuda_develop_pass.cpp` 169 lines，`cuda_dng_warp.cu` 229 lines。没有本次修改的文件超过 1000 行。
+
+**Residual gaps:** full-frame、跨 ROI 的 canonical LLF reference 仍是上一条记录明确列出的独立
+剩余项；本次没有用当前 ROI 缓存冒充 canonical reference。DNG 测试证明真实文件的 warp 元数据
+进入 prepared input，并以合成非恒等参数证明 CUDA 像素结果实际改变；没有保存新的大型 golden
+图像。
+
 ### 41.6 G7R.4 — 正确实现独立的 creative CAT02
 
-Primary Grade 的第一个 adjustment 是 scene-linear AP1 creative white balance，与 RAW
+Primary Grade 的第一个 adjustment 是 creative white balance，与 RAW
 CameraColorPass 是两个不同功能：
 
-- 输入和输出都保持 AP1/D60；
+- 节点输入和输出都保持 AP1 primaries / ACEScc encoded；需要 scene-linear 运算时只在该
+  adjustment 内部解码并重新编码，不能改变图的工作空间；
 - temperature/tint offset 先解析成源/目标白点，不直接变成 RGB 通道指数倍率；
 - 使用 CAT02 cone response 矩阵、白点 LMS 比例和逆 CAT02 完成色适配；
 - mix 在适配后以原 AP1 像素和适配像素插值；
@@ -3757,7 +3923,7 @@ DevelopColorTransformUsesSingleProfileWhenCalibrationIlluminantsAreIncomplete
 DevelopColorTransformSolvesAsShotNeutralWithoutUsingCamMulAsColorMatrix
 DevelopColorTransformDoesNotUseLibRawRgbCamOrPreMulAsCameraMatrix
 DevelopColorTransformRejectsMissingOrSingularCameraMatrices
-DevelopImageGraphValueIsAp1SceneLinear
+CameraColorEncodesAp1AsAcesccGraphWorkingSpace
 CudaCat02ZeroOffsetIsExactIdentity
 CudaCat02MapsSourceWhiteToRequestedWhiteInAp1
 ```
@@ -3847,7 +4013,7 @@ deadlock teardown 问题需要拆成单独回归并修复，不能用跳过整�
 - 用户可见图仍然只有 Develop、Primary Color Grade 和 DRT；
 - G4/G5 的缓存拆分保留，并存在独立 `develop.sensor_linear`、`geometry.scene_source`、
   `develop.image`；
-- `develop.image` 被 reference 测试证明是 AP1 scene-linear；
+- `develop.image` 被 reference 测试证明是 AP1 primaries / ACEScc encoded；
 - Camera→AP1 使用 CameraMatrices/DNG 双光源插值，`cam_mul/pre_mul` 不作为颜色矩阵；
 - as-shot/custom CCT/tint 和 creative CAT02 分别通过数学单元测试和真实 RAW reference 测试；
 - CUDA 产品路径不再包含 legacy 参数镜像、stage adapter 或 `LegacyPipelineImporter`；
@@ -4144,20 +4310,21 @@ ctest --test-dir build/macos-debug --output-on-failure
 - [x] Prepared RAW、静态 ExecutionPlan 和节点结果都有可查询的内容感知 cache hit/miss。
 - [x] `develop.sensor_linear` 和 `geometry.scene_source` 是独立、可淘汰、submission-safe 的结果缓存。
 - [x] 无变化渲染不执行 LibRaw、source H2D、plan compile 或 GPU 图像节点 pass。
-- [ ] LLF 不管理自己的内存池。
+- [x] LLF 不管理自己的内存池。
 - [x] Mask GPU LRU 只存在于 workspace。
 
 ### 47.4 RAW 和颜色
 
 - [ ] LibRaw unpack 在编辑管线之前完成。
 - [ ] RAW DecodeRes 降采样在 CPU 输入准备中完成。
-- [ ] Develop 输出 AP1 scene-linear RGB。
+- [ ] Geometry 和 CameraColor 后的 Develop 图输出 AP1 primaries / ACEScc encoded RGB。
 - [ ] Camera→AP1 使用 CameraMatrices/DNG 双光源矩阵和标定光源 CCT 在 mired 空间插值。
 - [ ] `cam_mul/pre_mul` 只用于 RAW 归一化和 neutral 推导，不作为 Camera→AP1 矩阵。
 - [ ] metadata 缺失或矩阵无效时返回明确错误，不静默使用 identity。
 - [ ] RAW CameraColorPass 与 Primary Grade creative CAT02 分别拥有 dirty key 和测试。
 - [ ] CAT02 调整以 AP1 白点为参考。
-- [ ] DRT 支持 ACES 2.0 和 OpenDRT。
+- [ ] DRT 从 AP1/ACEScc 工作空间解码后支持 ACES 2.0 和 OpenDRT，并转换到用户选择的
+  encoding space / EOTF / limiting space。
 
 ### 47.5 Geometry 和 Mask
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G7 complete (CUDA ACES 2.0/OpenDRT DRT and Windows/CUDA product DAG routing).
+Status: G1–G7 implementation landed；G7 产品验收撤回；G7R（CUDA 默认管线行为、颜色与性能恢复）为必做阶段并阻塞 G8。
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -87,21 +87,23 @@ UI scope:
 | GPU 内存 | `BasicRenderWorkspace<Backend>` 统一管理 |
 | 后端复用 | C++ 模板和 Backend Traits |
 | GPU 运行入口 | 最外层使用类型隐藏；模板内部使用静态类型 |
-| GPU 缓存 | workspace 内的通用 KV cache 和 texture LRU |
+| GPU 缓存 | workspace 内的内容感知结果缓存和 texture LRU；分配复用不等于结果命中 |
 | 持久蒙版 | app 之下的 MaskStore 模块 |
 | 主存蒙版缓存 | MaskStore 可以按字节预算保存 R8 副本 |
 | GPU 蒙版缓存 | workspace 按 GPU 字节预算管理 |
 | Rasterized Mask | R8 UNORM；任意一条边不大于 4096 |
 | Feather | GPU exact signed Euclidean distance field；持久数据仍为 R8 |
 | RAW 输入 | LibRaw open、unpack、active area 和降采样在管线外 |
-| Develop 输出 | scene-linear ACES AP1 |
+| Develop 逻辑输出 | `develop.image`，scene-linear ACES AP1；CameraColorPass 完成后才可写入 |
+| Develop 内部缓存 | `develop.sensor_linear` 保存传感器开发结果；不是用户可见端口 |
+| Geometry 后缓存 | `geometry.scene_source` 保存重采样后的 camera scene-linear RGB；不是用户可见节点 |
 | 中间调色 | scene-linear ACES AP1 |
 | 局部色温 | 基于 CAT02，以 AP1 白点为参考 |
 | DRT | ACES 2.0 或 OpenDRT |
 | Geometry | 管线文档的全局 ImageGeometryModel，不是第四个用户节点 |
 | ROI | RenderGeometryResolver 统一计算 |
 | 动态分辨率 | RenderRequest 输入；不保存进持久参数 |
-| 图像重采样 | GraphCompiler 插入一个内部 GeometryResamplePass |
+| 图像重采样 | GraphCompiler 在传感器开发缓存和 CameraColorPass 之间插入一个内部 GeometryResamplePass |
 | 后端顺序 | CUDA，然后 OpenCL，然后 Metal |
 | 稳定运行 | 每帧不得创建和销毁 GPU 缓冲区或纹理 |
 
@@ -411,6 +413,43 @@ Develop 不执行：
 - LibRaw open；
 - LibRaw unpack；
 - RAW DecodeRes 降采样。
+
+Develop 是用户可见的逻辑端点，但编译后必须保留以下内部值边界：
+
+```text
+PreparedRawInput
+  -> SensorDevelopPass
+  -> develop.sensor_linear       # camera scene-linear；可跨 CCT、调色和 DRT 编辑复用
+  -> GeometryResamplePass
+  -> geometry.scene_source       # geometry 后 camera scene-linear；可跨 CCT、调色和 DRT 编辑复用
+  -> CameraColorPass
+       - 解析 as-shot 或 custom CCT/tint
+       - 按标定光源在 CameraMatrices 的双光源矩阵间插值
+       - camera RGB -> XYZ D50 -> XYZ D60 -> ACES AP1
+  -> develop.image               # Develop 的唯一用户可见输出
+```
+
+G4 只生成 camera scene-linear，G5 再执行 CameraColorPass 的拆分是正确的缓存边界，
+不得把两者重新合并。`develop.sensor_linear`、`geometry.scene_source` 和 `develop.image`
+必须使用不同 `GraphValueId` 和不同内容 key。CCT 或 tint 改变时只让 CameraColorPass 及其
+下游失效，不得重新 open/unpack RAW，不得重新上传 CFA，不得重新执行线性化、解拜尔、
+高光恢复、镜头校正或 GeometryResamplePass。
+
+CameraColorPass 的矩阵来源必须与旧管线 `ColorTempOp::ResolveRuntime` 一致：
+
+- 优先使用 RAW/DNG metadata 或项目 CameraMatrices 数据库中的 `ColorMatrix1/2`；
+- 使用 `CalibrationIlluminant1/2` 对应的 CCT，在 mired 空间对双光源矩阵插值；
+- 有 `ForwardMatrix1/2` 时，同样插值 forward matrix，并按 DNG reference neutral 构造
+  camera RGB 到 XYZ D50；
+- 没有 forward matrix 时，反转插值后的 XYZ 到 camera matrix，再从所选白点 Bradford
+  适配到 D50；
+- 最后执行 D50 到 D60 的 Bradford 适配和 XYZ D60 到 AP1；
+- `cam_mul`、`pre_mul` 只用于传感器白平衡、as-shot neutral 推导和 RAW 归一化，不能用作
+  CameraColorPass 的对角 Camera→AP1 矩阵；
+- LibRaw `rgb_cam`/`cam_xyz` 可以保留在 metadata snapshot 中用于诊断，但 G7R 的
+  CameraColorPass 不使用它们替代 CameraMatrices/DNG profile；
+- 需要 CameraColorPass 但找不到可用矩阵时返回明确错误，禁止静默使用 identity；直接 RGB
+  输入只有在输入描述明确声明其源色域时，才允许通过已知色域矩阵进入 AP1。
 
 Develop 输出固定为：
 
@@ -1536,32 +1575,62 @@ LLF reference cache 不包含当前 viewport ROI。用户平移或缩放视图�
 
 ## 27. Cache 和 dirty 传播
 
-参数 dirty 后，GraphDirtyTracker 标记当前节点和所有下游节点：
+GraphDirtyTracker 需要同时追踪用户节点和 Develop 内部 pass 值。`ResourceId` 相同只说明
+GPU 分配被复用，不能说明图像结果仍有效。结果缓存项至少包含：
 
-```text
-Develop dirty:
-  Develop dirty
-  all ColorGrade nodes dirty
-  DRT dirty
-
-Grade B dirty:
-  upstream nodes stay valid
-  Grade B dirty
-  downstream nodes dirty
-
-DRT dirty:
-  upstream nodes stay valid
-  DRT dirty
+```cpp
+struct CachedImageResult {
+  GraphValueId value_id;
+  ContentKey content_key;
+  ImageExtent extent;
+  TextureFormat format;
+  ResourceLease texture;
+  SubmissionId last_writer;
+};
 ```
 
-MaskNode dirty 时，只标记读取该 mask 的 ColorGradeNode 及其下游。
+只有 `value_id`、`content_key`、尺寸、格式都匹配，并且 `last_writer` 已完成时才是结果命中。
+仅在相同 `GraphValueId` 下找到同尺寸纹理属于 allocation reuse，仍必须执行 pass，不能记为
+cache hit。
+
+默认 CUDA 图的内部 dirty 传播必须是：
+
+```text
+RAW 文件或输入准备参数改变:
+  PreparedRawInput -> SensorDevelop -> Geometry -> CameraColor -> Grade -> DRT
+
+线性化、解拜尔、高光恢复、AI 降噪或镜头参数改变:
+  SensorDevelop -> Geometry -> CameraColor -> Grade -> DRT
+
+crop、rotation、viewport ROI、输出尺寸或 DecodeRes 几何映射改变:
+  Geometry -> CameraColor -> Grade -> DRT
+
+RAW as-shot/custom CCT、tint 或 CameraMatrices 内容改变:
+  CameraColor -> Grade -> DRT
+
+Primary Grade 参数或其 mask 改变:
+  affected Grade -> downstream Grade -> DRT
+
+DRT 参数改变:
+  DRT only
+```
+
+MaskNode dirty 时，只标记读取该 mask 的 ColorGradeNode 及其下游。取消或失败的 submission
+不能发布任何新 cache key；它在开始前已经命中的上游结果仍保持可用。
 
 ### 27.1 缓存身份
 
-缓存使用实际输入值或内容 hash，不使用递增数字。
+缓存使用实际输入值或内容 hash，不使用递增数字，也不使用纹理地址或 `ResourceId` 代替内容
+身份。
 
 | 资源 | 是否包含 viewport ROI | key 来源 |
 | --- | ---: | --- |
+| PreparedRawInput | 否 | 原始字节内容、输入种类、DecodeRes、LibRaw 输入准备版本 |
+| `develop.sensor_linear` | 否 | PreparedRawInput key、线性化、解拜尔、高光恢复、AI 降噪、镜头参数和实现版本 |
+| `geometry.scene_source` | 是 | sensor-linear key 和完整 ResolvedRenderGeometry |
+| `develop.image` | 间接包含 | geometry key、WB mode、resolved CCT/tint、CameraMatrices 内容和颜色算法版本 |
+| Primary Grade 输出 | 间接包含 | develop AP1 key、调整顺序、每个调整参数、mask sampling key 和 mix |
+| DRT 输出 | 间接包含 | grade key、DRT method、显示色域、EOTF 和 DRT 参数 |
 | 磁盘 R8 数据 | 否 | R8 descriptor 和 pixels |
 | 主存 R8 数据 | 否 | MaskAssetKey |
 | GPU base R8 texture | 否 | MaskAssetKey |
@@ -1570,9 +1639,28 @@ MaskNode dirty 时，只标记读取该 mask 的 ColorGradeNode 及其下游。
 | mask sampling plan | 是 | descriptor 和 ResolvedRenderGeometry |
 | LLF reference | 否 | input content 和 LLF 参数 |
 | LLF 当前输出 | 是 | reference resource 和当前 geometry |
-| 普通节点输出 | 视行为而定 | input content、params 和 geometry |
+
+`develop.image` 的 CameraMatrices 内容必须包含最终选中的 `ColorMatrix1/2`、
+`ForwardMatrix1/2`、标定光源 CCT、as-shot neutral、矩阵来源和版本。`cam_mul` 与 `pre_mul`
+可以进入 sensor-linear/as-shot neutral 的 key，但不能作为 Camera→AP1 的矩阵身份。
 
 同一组实际输入产生相同 key。视图回到原位置时可以再次使用相同数据。
+
+### 27.2 必须存在的缓存层级
+
+每个打开的图像/版本至少持有以下可淘汰结果：
+
+```text
+PreparedSourceCache[source_key]
+SensorDevelopCache[sensor_develop_key]        -> develop.sensor_linear
+GeometryResultCache[geometry_key]             -> geometry.scene_source
+DevelopAp1Cache[develop_ap1_key]              -> develop.image
+NodeResultCache[grade_or_drt_key]              -> node output
+```
+
+这些缓存共享 workspace 的 GPU 字节预算和 submission 安全淘汰规则。PreparedSourceCache 使用
+主存字节预算。切换到另一张图再切回时，只要条目未被淘汰且内容 key 匹配，就可以复用已准备
+RAW 和相应 GPU 结果。任何缓存都不得依赖“这次仍使用同一纹理对象”来判定有效性。
 
 ## 28. 序列化
 
@@ -1660,26 +1748,22 @@ PipelineDocument 不保存：
 }
 ```
 
-### 28.1 旧数据读取
+### 28.1 旧数据处理
 
-迁移只提供一个方向：
+新产品路径完全废弃 legacy 参数和旧 stage JSON：
 
 ```text
-旧 stage JSON
-  -> LegacyPipelineImporter
-  -> 新 PipelineDocument
+format version 2 PipelineDocument -> load
+旧 stage JSON                     -> explicit unsupported-format error
 ```
 
-新 PipelineDocument 不再写回旧 stage JSON。
-
-导入规则：
-
-- RAW 和镜头参数进入 DevelopModel；
-- crop 和 rotation 进入 ImageGeometryModel；
-- scene-referred 调整进入 Primary Color Grade；
-- ODT 或 OpenDRT 参数进入 DrtModel；
-- 缺失字段使用新默认值；
-- 未知旧 operator 记录错误并停止导入，不静默丢弃用户参数。
+- 不在加载、编辑或每帧渲染时调用 `LegacyPipelineImporter`；
+- 不把 legacy operator 参数镜像到新 Model；
+- 不在新 JSON 中保存 nested legacy adapter；
+- 不用新默认值静默替换旧参数；旧格式必须返回清楚的版本错误；
+- `LegacyPipelineImporter`、legacy snapshot 和 CUDA 产品 legacy stage adapter 在 G7R 删除，
+  不延后到 OpenCL/Metal 移植；
+- UI 和 app service 直接读取、修改 `PipelineDocument` 中的 Model。
 
 ## 29. CPU 路径删除
 
@@ -1781,13 +1865,14 @@ OpenCL、Metal 和旧代码删除都保持可读。
 ```text
 Stack:
 [x] GPU DAG design
-[ ] Model and graph foundation        <- current
-[ ] CUDA workspace
-[ ] Render geometry
-[ ] CUDA Develop
-[ ] CUDA Color Grade
-[ ] CUDA Mask and Mix
-[ ] CUDA DRT and product path
+[x] Model and graph foundation
+[x] CUDA workspace
+[x] Render geometry
+[x] CUDA Develop
+[x] CUDA Color Grade
+[x] CUDA Mask and Mix
+[x] CUDA DRT and product path
+[ ] CUDA default pipeline recovery    <- current
 [ ] OpenCL
 [ ] Metal
 [ ] Final removal and qualification
@@ -1805,7 +1890,8 @@ Stack:
 | G5 | `feature/gpu-dag-cuda-grade` | G4 | CUDA 调色、CAT02、LLF workspace 化 |
 | G6 | `feature/gpu-dag-cuda-mask-mix` | G5 | MaskStore、R8 mask、feather、Mix |
 | G7 | `feature/gpu-dag-cuda-drt-product` | G6 | CUDA DRT 和 app 管线路径切换 |
-| G8 | `feature/gpu-dag-opencl` | G7 | OpenCL 完整移植 |
+| G7R | `feature/gpu-dag-cuda-default-recovery` | G7 | scheduler、CameraMatrices 色彩、内容缓存和默认管线性能恢复 |
+| G8 | `feature/gpu-dag-opencl` | G7R | OpenCL 完整移植 |
 | G9 | `feature/gpu-dag-metal` | G8 | Metal 完整移植 |
 | G10 | `feature/gpu-dag-final-removal` | G9 | 删除旧 stage、CPU 图像路径和过渡代码；全平台验证 |
 
@@ -2237,8 +2323,9 @@ Base: `feature/gpu-dag-render-geometry`
 目标：
 
 - 把 LibRaw unpack 和 RAW 降采样移到管线输入之前；
-- 实现 CUDA Develop Endpoint；
-- 输出 AP1 scene-linear GPU 图像。
+- 实现 CUDA Develop Endpoint 的传感器开发子阶段；
+- 输出可缓存的 camera scene-linear GPU 图像；G5 的 CameraColorPass 再完成 Develop 的
+  AP1 scene-linear 逻辑输出。
 
 工作：
 
@@ -2248,11 +2335,11 @@ Base: `feature/gpu-dag-render-geometry`
 - 保留 CPU LibRaw unpack；
 - 保留 CPU RAW 降采样；
 - 从旧 RawDecodeOp 移出 GPU Develop 行为；
-- 把高光恢复、解拜尔、AI 降噪、RAW white balance、镜头校正和 camera-to-AP1
-  编译为 Develop Pass；
+- 把高光恢复、解拜尔、AI 降噪、RAW white balance 和镜头校正编译为 SensorDevelop Pass；
+- camera-to-AP1 延后到 G5，使 CCT/tint 修改复用本阶段输出；
 - 使用 workspace 管理所有 Develop 临时内存；
 - 建立直接 RGB 输入；
-- 建立 Develop output GraphValue。
+- 建立内部 `develop.sensor_linear` GraphValue。
 
 测试：
 
@@ -2260,8 +2347,8 @@ Base: `feature/gpu-dag-render-geometry`
 RawInputLoaderUnpacksBeforePipelineBuild
 RawInputLoaderDownsampleUpdatesCfaPatternAndPhase
 PreparedRawInputKeepsFullReferenceExtentAcrossDecodeRes
-CudaDevelopProducesFiniteAp1SceneLinearRgbFromBayerInput
-CudaDevelopProducesFiniteAp1SceneLinearRgbFromXTransInput
+CudaDevelopProducesFiniteCameraSceneLinearRgbFromBayerInput
+CudaDevelopProducesFiniteCameraSceneLinearRgbFromXTransInput
 CudaDevelopUsesWorkspaceForAllTemporaryBuffers
 CudaDevelopSecondRenderCreatesNoGpuAllocation
 DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint
@@ -2272,11 +2359,15 @@ DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint
 - ExecutionPlan 中没有 LibRaw Pass；
 - GPU 不执行 RAW DecodeRes 降采样；
 - Develop 不调用 CPU 图像算子；
-- Develop 输出格式和色彩空间明确。
+- `develop.sensor_linear` 的格式和 camera scene-linear 色彩空间明确。
 
 ##### Phase G4 completion record (2026-08-22)
 
-**Status:** complete — CUDA Develop Endpoint on `feature/gpu-dag-cuda-develop`. Output is **camera scene-linear RGBA32F**, not AP1. Camera-to-AP1 is deferred to G5 as a dedicated unmaskable CameraColor node so CCT changes do not dirty Develop / re-run demosaic.
+**Status:** complete — CUDA Develop 的传感器开发部分位于
+`feature/gpu-dag-cuda-develop`。输出是 **camera scene-linear RGBA32F**，Camera-to-AP1
+延后到 G5 的独立、不可挂 mask 的内部 CameraColorPass，使 CCT 变化不让传感器开发结果失效，
+也不重新执行解拜尔。这一拆分是保留项；完整 Develop 逻辑端点仍必须在 CameraColorPass 后输出
+AP1。
 
 **Highlight recovery order:** CUDA full-frame (`ProcessCudaFullFrame`) is Linearize → (optional CFA Clamp01 when HLR is off) → Demosaic → HighlightRecover on RGB. The CPU path (`ApplyLinearization` → `ApplyHighlightReconstruct` → `ApplyDebayer`) is not the G4 reference. `GraphCompiler` emits `Demosaic` before `HighlightRecover`. Encoder matches CUDA: Bayer + HLR uses planar RCD then `ApplyHighlightCorrectionAndPackRGBAOriented`; Bayer without HLR clamps CFA then packs with inverse cam_mul; non-neural X-Trans always clamps CFA then `XTransToRGB_Ref`.
 
@@ -2289,7 +2380,8 @@ RawInputLoader::FromUnpackedCfa | LoadEncoded | FromDirectRgb
   -> CudaRenderDevice.BeginRender
   -> ExecuteCudaDevelop (workspace transients + Images() RGBA32F)
   -> Linearize -> Demosaic -> HighlightRecover (RGB) | InverseCamMulPack
-  -> GraphImageCache[develop/image] camera scene-linear RGBA32F
+  -> current GraphImageCache[develop/image] camera scene-linear RGBA32F
+     G7R migration: GraphImageCache[develop/sensor_linear]
   -> EndRender / WaitIdle
 ```
 
@@ -2312,8 +2404,8 @@ CudaBackend::FailNextUpload
 | `DirectRgbInputBypassesLibRawAndEntersDevelopEndpoint` | `GpuDagRawInputTest` + `GpuDagCudaDevelopTest` | PASS |
 | `GraphCompilerEmitsNoLibRawOrDecodeResPass` (also no CameraToAp1) | `GpuDagRawInputTest` | PASS |
 | `GraphCompilerPlacesHighlightRecoverAfterDemosaic` | `GpuDagRawInputTest` | PASS |
-| `CudaDevelopProducesFiniteAp1SceneLinearRgbFromBayerInput` mapped to `CudaDevelopProducesFiniteCameraSceneLinearRgbFromBayerInput` | `GpuDagCudaDevelopTest` | PASS |
-| `CudaDevelopProducesFiniteAp1SceneLinearRgbFromXTransInput` mapped to `CudaDevelopProducesFiniteCameraSceneLinearRgbFromXTransInput` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopProducesFiniteCameraSceneLinearRgbFromBayerInput` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopProducesFiniteCameraSceneLinearRgbFromXTransInput` | `GpuDagCudaDevelopTest` | PASS |
 | `CudaDevelopUsesWorkspaceForAllTemporaryBuffers` | `GpuDagCudaDevelopTest` | PASS |
 | `CudaDevelopSecondRenderCreatesNoGpuAllocation` | `GpuDagCudaDevelopTest` | PASS |
 | Upload failure restores dirty; no CPU Apply | `GpuDagCudaDevelopTest` | PASS |
@@ -2335,7 +2427,11 @@ Suite totals: `9/9` GpuDagRawInputTest PASS. `6/6` GpuDagCudaDevelopTest PASS. `
 
 **LOC note (grill-code-review):** `raw_input_loader.cpp` 396 lines. `cuda_develop_pass.cpp` 197 lines. `graph_compiler.cpp` 102 lines. No changed file exceeds 1000 LOC.
 
-**Remaining gaps:** Camera-to-AP1 and CAT02 stay in G5 (four-node graph: Develop → CameraColor → ColorGrade → DRT). NeuralEngine demosaic is not executed in G4 (Legacy RCD / `XTransToRGB_Ref` only). Lensfun is a no-op unless DNG warp is present; G4 tests do not cover DNG warp. Full-frame only (no 9000px tiled path). DemosaicNet arena is not unified with workspace.
+**Remaining gaps:** Camera-to-AP1 and CAT02 stay in G5。CameraColor 是 Develop 内部 pass，
+不是第四个用户节点；用户图仍为 Develop → ColorGrade → DRT。NeuralEngine demosaic is not
+executed in G4 (Legacy RCD / `XTransToRGB_Ref` only). Lensfun is a no-op unless DNG warp is
+present; G4 tests do not cover DNG warp. Full-frame only (no 9000px tiled path). DemosaicNet
+arena is not unified with workspace.
 
 **Files added:** `include/edit/input/*`, `edit/input/raw_input_loader.cpp`, `include/edit/runtime/{pass_kind,execution_plan,graph_compiler,render_context,develop_compile_source,graph_image_cache}.hpp`, `edit/runtime/graph_compiler.cpp`, `include/edit/runtime/cuda/cuda_develop_pass.hpp`, `edit/runtime/cuda/cuda_develop_pass.cpp`, `include/decoders/processor/raw_linearization_params.hpp`, G4 tests under `tests/edit/input` and `tests/edit/runtime`.
 
@@ -2350,12 +2446,17 @@ Base: `feature/gpu-dag-cuda-develop`
 目标：
 
 - 实现默认 ColorGradeNode 的 CUDA 执行；
+- 从可缓存的 G4 camera scene-linear 结果出发，在 Grade 前执行独立 CameraColorPass，并让
+  `develop.image` 成为 AP1 scene-linear；
 - 增加纯 Model，并让新 CUDA 路径只使用这些 Model；
 - 旧 operator 类只供尚未移植的 OpenCL 和 Metal 路径临时使用；
 - 把 LLF 内存和缓存迁入 workspace。
 
 工作：
 
+- 缓存 `develop.sensor_linear` 和 `geometry.scene_source`，CCT/tint 改变时只重跑
+  CameraColorPass 及其下游；
+- 按 CameraMatrices/DNG 双光源矩阵插值解析 Camera→AP1；
 - 实现 CUDA adjustment runtime registry；
 - 实现 pointwise fusion；
 - 实现 CAT02 scene white balance；
@@ -2468,6 +2569,11 @@ public pass header 32 lines; `graph_compiler.cpp` 126 lines. No changed file exc
 
 **Residual gaps:** Mask texture sampling and per-pixel Normal Mix are G6 scope. DRT and product
 pipeline routing are G7 scope. OpenCL and Metal still use their legacy execution paths until G8/G9.
+
+**G7R audit note:** G5 的缓存边界要求正确，但当前实现没有完成该要求：Camera→AP1 被融合进
+`PrimaryGradeKernel`，读取的是不完整 `RawRuntimeColorContext`，且 `develop.image` 仍指向
+camera RGB。现有 CAT02 测试使用 direct RGB identity 路径，只证明零 offset/mix 行为，未证明
+CameraMatrices 双光源插值或实际 CAT02。第 41 节负责按原意修复，不回退 G4/G5 的拆分。
 
 ## 39. Phase G6 — MaskStore、CUDA Mask 和 Mix
 
@@ -2827,14 +2933,432 @@ CUDA frees. The DRT output texture and resolved method resources remain owned by
 `pipeline_service.cpp` and `pipeline_cpu.cpp` received localized routing/persistence changes; no
 new file exceeds 500 lines.
 
-**Residual gaps:** OpenCL and Metal still execute through their existing stage adapters and consume
-the nested compatibility data; their full DAG runtime migrations remain G8 and G9 scope.
+**Residual gaps:** G7R 审计确认当前 CUDA 产品路径仍缺少完整 scheduler 意图传递、
+PreparedRawInput/ExecutionPlan/节点结果的内容感知缓存、geometry 后缓存，以及正确的
+CameraMatrices 双光源 Camera→AP1。G7 的资源 ID 与零 allocation 证据不能证明结果 cache hit
+或没有重复计算。G7 接入的 legacy 参数镜像、importer 和 nested adapter 也不是目标架构，
+G7R 必须从 CUDA 产品路径删除。OpenCL 和 Metal 仍通过旧 stage adapter 执行；它们的完整
+DAG runtime 移植必须在 G7R 达标后进入 G8/G9。
 
-## 41. Phase G8 — OpenCL 移植
+## 41. Phase G7R — CUDA 默认管线行为、颜色与性能恢复
+
+Branch: `feature/gpu-dag-cuda-default-recovery`
+
+Base: `feature/gpu-dag-cuda-drt-product`
+
+Status: required；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
+
+Requirement source: `codex://threads/01a0273a-48bd-7702-9503-127bb5e2ec1e`。本阶段恢复该
+任务中已经明确的 Develop endpoint、GPU workspace KV cache、动态分辨率和 scheduler 集成
+要求，不重新定义产品范围。
+
+目标：
+
+- 保留 G4/G5 把传感器开发与 CameraColorPass 分开的正确设计，使 Develop 的昂贵结果可缓存；
+- 让 scheduler 独占交互帧、质量帧、细节补帧、取消、过期帧抑制、busy 和 frame sink；
+- 让 Preview 与 Export 使用完全独立的 PipelineSession/workspace，不保留状态恢复路径；
+- 从 CUDA 产品路径删除 legacy 参数、importer、snapshot 和 stage adapter；
+- 使用 CameraMatrices/DNG 双光源矩阵插值恢复正确的 RAW CCT/tint 和 Camera→AP1；
+- 增加 geometry 后 camera scene-linear 结果缓存，并让所有结果缓存使用内容 key；
+- 消除无变化渲染中的 LibRaw open/unpack、源图上传、GraphCompiler 编译和 GPU pass 重算；
+- 用同机 A/B 数据证明默认 CUDA 管线达到重构前基线，不以“没有新 GPU 分配”代替性能证据。
+
+### 41.1 审计结论与现有证据
+
+本节区分用户观察到的运行时失败、已执行测试、结构检查和覆盖缺口。代码检查可以证明调用
+发生或测试没有断言某项行为，但不能代替像素正确性测试。
+
+| 优先级 | 证据类别 | 问题 | 当前证据 | 必须恢复的行为 |
+| --- | --- | --- | --- | --- |
+| P0 | Observed failure | 真实 RAW 输出明显偏绿，色温行为不正确 | 编辑器实际使用反馈；当前本地真实 RAW E2E 被环境开关跳过，尚无自动化像素复现 | 真实 RAW 在 as-shot 与 custom CCT 下匹配旧管线参考，不出现通道异常 |
+| P0 | Structural evidence | `RawInputLoader::FillColorContext` 只写 `cam_mul`、`pre_mul`、make/model，未写 CameraMatrices、forward matrices、标定光源和 as-shot neutral | `raw_input_loader.cpp` 与 `metadata_extractor.cpp::PopulateMetadataRuntimeContext` 对比 | 输入准备使用完整、共享的 RAW 色彩 metadata 解析结果 |
+| P0 | Structural evidence | 当前 `MakeCameraToAp1` 计算 `sRGB_to_AP1 * rgb_cam`；`rgb_cam` 全零时静默返回 identity | `cuda_primary_grade_pass.cu` | CameraColorPass 使用旧管线双光源矩阵插值；缺失矩阵不能静默 identity |
+| P0 | Structural evidence | Develop 的 WB mode、as-shot/custom CCT 和 tint 已进入 Model/JSON，但 CUDA pass 未消费；Develop 只读取高光恢复开关 | `cuda_develop_pass.cpp` 与 Develop DTO/Model 对比 | CCT/tint 进入独立 CameraColorPass 内容 key 并真实改变像素 |
+| P0 | Structural evidence | `develop.image` 在当前执行路径中实际保存 geometry 后 camera RGB，而 GraphCompiler 把该端口声明为 AP1 | Develop pass、ExecutionPlan 与 Primary Grade 输入对比 | `develop.image` 只能保存 CameraColorPass 后 AP1；内部缓存使用不同值 ID |
+| P0 | Structural evidence | `CudaProductRenderer::Render` 每次都 `LoadEncoded` 和 `Compile`，executor 每次无条件运行 Develop、Grade、DRT | `cuda_product_renderer.cu`、`cuda_plan_executor.cpp` | 无变化帧不重复输入准备、编译和 GPU 节点执行 |
+| P0 | Structural evidence | `GraphImageCache`/`NodeResultCache` 只按 `GraphValueId` 保存资源，没有内容 key 和有效性；当前所谓 cache valid 只比较纹理 `ResourceId` | cache headers 与 G7 测试断言 | 分配复用与结果命中成为两个独立概念，缓存命中由内容 key 证明 |
+| P0 | Structural evidence | 当前没有 geometry 后结果缓存，CCT、Grade 或 DRT 编辑无法明确复用重采样结果 | Develop pass 与 workspace image map | `geometry.scene_source` 是内容感知的一级结果缓存 |
+| P0 | Structural evidence | scheduler 在 `Apply` 前后判断 stale，但 CUDA renderer 在 `Apply` 内部直接写 frame sink；渲染后的 stale 判断可能晚于旧帧呈现 | `pipeline_scheduler.cpp`、`pipeline_cpu.cpp`、`cuda_product_renderer.cu` | scheduler 独占 present 权限；DAG 返回未呈现结果，不接收完整 scheduler 状态机 |
+| P1 | Structural evidence | 当前 creative white balance 只做每通道指数缩放，不是计划要求的 AP1/CAT02 色适配 | CUDA adjustment runtime | 局部色温使用实际 CAT02；不与 RAW CameraColorPass 混用 |
+| P1 | Coverage gap | `ChangingDrtPeakLuminanceKeepsDevelopAndGradeCacheValid` 只比较资源 ID；第二帧测试只检查 malloc/free | `cuda_drt_product_test.cpp` | 测试断言 LibRaw、H2D、compile、每类 pass execute/skip 和内容 key |
+| P1 | Coverage gap | Primary Grade 色彩测试使用 direct RGB，并明确让 camera conversion 保持 identity | `cuda_primary_grade_test.cpp` | 加入真实 RAW、CameraMatrices、双光源插值和 AP1 reference 测试 |
+
+审计时执行的集中测试：
+
+```text
+ctest --test-dir build/debug --output-on-failure \
+  -R "GpuDagRawInputTest|GpuDagCudaPrimaryGradeTest|GpuDagCudaDrtProductTest|EditorRealRawGpuE2eTest.CudaSustainedImageSwitches"
+```
+
+结果为 `26/26` PASS，耗时 `5.53 s`。该结果只证明现有窄测试仍通过，不否定上表问题。
+直接执行真实 RAW 编辑器用例时结果是 `0` PASS、`1` SKIPPED；它受
+`ALCEDO_RUN_DEADLOCKING_RAW_GPU_E2E` 控制。因此目前没有一个默认执行的测试同时覆盖真实
+RAW、CameraMatrices 色彩、scheduler 状态和重复渲染性能。
+
+### 41.2 恢复后的产品调用链
+
+默认三节点图不增加用户节点。产品执行链固定为：
+
+```text
+PipelineScheduler
+  -> ScheduledTask
+       request id / frame role / stale state / busy state / display sink
+       这些字段只由 scheduler 持有
+  -> resolve immutable RenderRequest
+       source content key / document snapshot
+       viewport / target extent / max edge / DecodeRes / quality
+  -> CudaProductPipelineSession::Render(RenderRequest, optional cancel query)
+  -> PreparedSourceCache lookup
+       miss -> RawInputLoader open + unpack + downsample + complete color metadata
+  -> Static ExecutionPlan lookup
+       miss -> GraphCompiler::Compile
+  -> ResolvedRenderGeometry
+  -> ResultCache lookup and minimal pass schedule
+       SensorDevelopPass -> develop.sensor_linear
+       GeometryResamplePass -> geometry.scene_source
+       CameraColorPass -> develop.image
+       optional MaskPass
+       PrimaryGradePass
+       DrtPass
+  -> completion fence
+  -> publish successful cache entries
+  -> return RenderedFrame(texture/value id/fence or host image)
+  -> PipelineScheduler checks cancel/stale/revision
+  -> latest eligible preview frame only -> IFrameSink
+  -> scheduler records completion exactly once
+
+ExportService
+  -> independent ExportPipelineSession + ExportRenderWorkspace
+  -> host/file output
+  -> never reads, changes, restores, or presents through the editor preview session
+```
+
+`CudaProductPipelineSession` 表示一个打开图像和 PipelineDocument 的可复用运行实例。它拥有
+PreparedSourceCache、静态 ExecutionPlan、CudaRenderDevice/workspace 和结果 cache metadata。
+它不能在每个 `Apply` 调用中临时创建，也不能借助旧 merged stage 保存结果。它不拥有
+`IFrameSink`，也不判断 InteractivePrimary、QualityBase 或 DetailPatch 的呈现顺序。
+
+### 41.3 G7R.1 — 收回 present 权限并精简 DAG request
+
+工作：
+
+- `RenderRequest` 只携带会改变像素、输出尺寸或 cache key 的不可变输入；不得复制 scheduler
+  状态机；
+- `InteractivePrimary`、`QualityBase` 和 `DetailPatch` 只由 scheduler 解释，并在调用 DAG 前解析
+  为具体 viewport、ROI、输出尺寸、采样策略和质量参数；DAG 不读取这些 frame-role 标签；
+- source content key 和不可变 document snapshot/revision 可以进入 `RenderRequest`，因为它们参与
+  cache 身份；UI busy、stale、最新 request id 和合成顺序不能进入 GraphCompiler 或 pass 参数；
+- 允许传入一个简单的 `cancel_requested()` 查询，使 renderer 可以少做已经没人需要的工作；
+  取消查询是性能优化，不能决定哪个结果最终呈现；
+- `CudaProductPipelineSession::Render` 返回 `RenderedFrame` 或等价结果，其中包含 GPU value/
+  texture、完成 fence、extent/format 和可选 host image；renderer 不调用 `IFrameSink`；
+- scheduler 在收到 `RenderedFrame` 后、调用 frame sink 前执行最终 cancel/stale/revision 检查；
+- 一个 scheduler task 只能完成一次：成功、取消或失败三者互斥；busy、quality 和 detail 状态只在
+  scheduler 中清理；
+- QualityBase 和 DetailPatch 的 revision 匹配、合成和呈现顺序只由 scheduler 处理；编辑变化后
+  旧 detail patch 不得合成到新 primary；
+- 保留现有 single in-flight preview 限制；已经提交的旧 GPU 工作可以安全完成和回收，但返回
+  scheduler 后可以被丢弃；
+- Preview 和 full-resolution Export 使用不同 PipelineSession、RenderDevice、workspace、cache
+  和输出目标。Export 不连接 editor frame sink，不保存或恢复 preview 参数；
+- scheduler 的旧 scratch/reset 动作在 DAG 路径只 rewind 每帧 transient，不能清空已发布的
+  Prepared RAW、sensor develop、geometry、AP1、Grade 或 DRT 结果缓存；
+- DAG 路径不再依赖旧 executor 的全局 cancel 标记、merged-stage reset 或 stage cache 状态；
+- 从 CUDA 产品路径删除 legacy stage adapter、legacy parameter snapshot、
+  `ExportPipelineParams` 镜像和 `LegacyPipelineImporter`；UI/app service 直接修改新 Model。
+
+主要文件：
+
+- `alcedo_studio/src/renderer/pipeline_scheduler.cpp`
+- `alcedo_studio/src/include/renderer/pipeline_task.hpp`
+- `alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp`
+- `alcedo_studio/src/include/edit/geometry/render_request.hpp`
+- `alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu`
+- `alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp`
+
+### 41.4 G7R.2 — 缓存 Prepared RAW 和静态 ExecutionPlan
+
+Prepared source key 至少包含：
+
+```text
+encoded content hash
+input kind and CFA description
+DecodeRes/downsample policy
+active area and orientation inputs
+LibRaw/input-preparation implementation version
+```
+
+工作：
+
+- 同一 source key 的 preview/quality/detail 渲染共享 PreparedRawInput；
+- 未淘汰的 source 再次打开时复用主存结果，不重新执行 LibRaw open/unpack；
+- DecodeRes 或输入准备规则改变时生成新 key，不覆盖仍被 submission 使用的旧条目；
+- source host bytes 只在 `develop.sensor_linear` miss 时上传；
+- 静态 ExecutionPlan key 只包含 graph topology、节点/调整类型与顺序、source layout 和后端能力；
+- 参数值、viewport、CCT、Grade 和 DRT 编辑不触发静态 plan 重编译；
+- ResolvedRenderGeometry 和 pass dirty schedule 属于每帧只读数据，不通过重编译静态图表达；
+- 接入并测试 `GraphCompiler::NeedsRecompile`，或删除该未使用 API 并用单一 plan key 机制替代；
+- plan cache miss、hit 和 compile count 必须可查询。
+
+### 41.5 G7R.3 — 内容感知结果缓存和 geometry 后缓存
+
+实现第 27 节定义的五层缓存，并保持以下值语义：
+
+```text
+develop.sensor_linear   = camera scene-linear，geometry 前
+geometry.scene_source   = camera scene-linear，geometry 后
+develop.image           = ACES AP1 scene-linear，CameraColorPass 后
+grade.<id>.image        = ACES AP1 scene-linear
+drt.display             = display-referred output
+```
+
+工作：
+
+- 从 `GraphImageCache` 中拆出 allocation slots 与 valid results，或让 API 强制调用者明确选择
+  `AcquireTextureForWrite`、`FindValidResult`、`PublishResult`；
+- 缓存查找比较 value ID、内容 key、extent、format 和完成 submission；
+- pass 写入临时 unpublished 状态，只在 submission 成功后原子发布内容 key；
+- 取消、kernel 失败、frame-sink 失败不能把部分写入标成有效；
+- 同 key 已命中时跳过 pass，保留原 `last_writer` 和内容身份；
+- 同一物理纹理被新 key 覆写前，先移除旧结果身份；
+- geometry cache key 使用完整 ResolvedRenderGeometry，包括 crop、rotation、ROI、目标尺寸、
+  DecodeRes 映射和采样规则；
+- CCT/tint、Grade、mask 或 DRT 改变不得使 `geometry.scene_source` 失效；
+- viewport/geometry 改变复用 `develop.sensor_linear`，只重跑 Geometry 和下游；
+- workspace LRU 按 GPU 字节预算淘汰已完成且没有 lease 的结果；
+- 结果缓存支持 source/document revision 隔离，防止切图后错误命中。
+
+主要文件：
+
+- `alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp`
+- `alcedo_studio/src/include/edit/runtime/node_result_cache.hpp`
+- `alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp`
+- `alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp`
+- `alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp`
+
+### 41.6 G7R.4 — 恢复 CameraMatrices 双光源插值和 Develop AP1 输出
+
+颜色实现必须从旧 `ColorTempOp::ResolveRuntime` 提取一个不依赖 `OperatorParams` 的纯解析器，
+例如：
+
+```cpp
+struct DevelopColorTransform {
+  Matrix3x3 camera_to_xyz;
+  Matrix3x3 camera_to_xyz_d50;
+  Matrix3x3 xyz_d50_to_ap1;
+  Matrix3x3 camera_to_ap1;
+  float resolved_cct;
+  float resolved_tint;
+  ContentKey content_key;
+};
+
+Expected<DevelopColorTransform, ColorTransformError>
+ResolveDevelopColorTransform(const DevelopPayload& develop,
+                             const RawRuntimeColorContext& raw);
+```
+
+算法顺序固定为：
+
+1. 从 DNG metadata 或 CameraMatrices 数据库选择 `ColorMatrix1/2`，并读取对应标定光源 CCT；
+2. 缺少任一有效标定光源时按单光源 profile 处理，不虚构 2856K/6504K 双光源区间；
+3. as-shot 模式从 `AsShotNeutral` 求解相机白点；只有 metadata 未提供 neutral 时才由
+   `cam_mul` 推导 neutral；
+4. custom 模式把 CCT/tint 转为目标 xy；
+5. 在 mired 空间按目标 CCT 插值 `ColorMatrix1/2`；
+6. 存在 `ForwardMatrix1/2` 时以相同权重插值 forward matrix，并用 reference neutral 缩放
+   得到 camera→XYZ D50；
+7. 不存在 forward matrix 时反转插值后的 XYZ→camera 矩阵，再从目标白点 Bradford 到 D50；
+8. 执行 Bradford D50→D60 和 XYZ D60→ACES AP1；
+9. 校验每个矩阵有限、可逆且输出有限，再生成 content key；
+10. CameraColorPass 只消费解析后的 3×3 矩阵，并把结果写入 `develop.image`。
+
+明确禁止：
+
+- 用 `cam_mul` 或 `pre_mul` 构造 Camera→AP1 对角矩阵；
+- 使用 LibRaw `rgb_cam`、`cam_xyz` 或 `pre_mul` 路径替代 CameraMatrices/DNG profile；
+- 先假定 camera RGB 是 sRGB，再乘 `sRGB_to_AP1`；
+- metadata 缺失、矩阵全零或不可逆时静默使用 identity；
+- 在 Primary Grade kernel 内隐式完成 Camera→AP1；CameraColorPass 必须是可单独失效和计数的
+  Develop 内部 pass；
+- 把 RAW CCT/tint 与 Primary Grade 的 creative CAT02 参数合并成一个 dirty 区域。
+
+输入准备必须复用 `MetadataExtractor::PopulateRuntimeContextFromOpenLibRaw` 及其 CameraMatrices/
+DNG 解析能力，或提取共享 `RawColorMetadataResolver`。不得继续维护只有六个字段的
+`FillColorContext` 副本。若 `LoadEncoded` 只有字节而没有路径，DNG tag 读取必须支持内存输入，
+或由调用方把已经解析的不可变 metadata snapshot 一起传入；不能因此退回 LibRaw 对角缩放。
+
+### 41.7 G7R.5 — 正确实现独立的 creative CAT02
+
+Primary Grade 的第一个 adjustment 是 scene-linear AP1 creative white balance，与 RAW
+CameraColorPass 是两个不同功能：
+
+- 输入和输出都保持 AP1/D60；
+- temperature/tint offset 先解析成源/目标白点，不直接变成 RGB 通道指数倍率；
+- 使用 CAT02 cone response 矩阵、白点 LMS 比例和逆 CAT02 完成色适配；
+- mix 在适配后以原 AP1 像素和适配像素插值；
+- zero offset 必须是严格 identity；
+- 参数 dirty 只让当前 Grade 和 DRT 失效，不让 CameraColor、Geometry 或 SensorDevelop 失效。
+
+### 41.8 G7R.6 — 可观测性与性能恢复
+
+为测试和 profiling 增加每个 pipeline session 的只读统计快照：
+
+```text
+prepared source cache hit/miss
+LibRaw open/unpack count
+static plan cache hit/miss/compile count
+source H2D copy count and bytes
+parameter H2D ranges and bytes
+per-pass execute/skip count
+result cache hit/miss by GraphValueId
+GPU allocation/free count and bytes
+CPU prepare/compile/submit/present duration
+GPU pass and total submission duration
+renderer completed/aborted/failed count
+scheduler presented/discarded-stale/cancelled task count
+```
+
+统计默认关闭或使用低成本原子计数；测试构建可开启细粒度计时。性能验收不能依赖日志文本。
+
+### 41.9 必须新增或加强的测试
+
+#### 41.9.1 RAW metadata 与颜色单元测试
+
+```text
+RawInputLoaderPopulatesCompleteColorContextFromRealRaw
+DevelopColorTransformInterpolatesDualIlluminantMatricesInMiredSpace
+DevelopColorTransformInterpolatesForwardMatricesWithTheSameWeight
+DevelopColorTransformUsesSingleProfileWhenCalibrationIlluminantsAreIncomplete
+DevelopColorTransformSolvesAsShotNeutralWithoutUsingCamMulAsColorMatrix
+DevelopColorTransformDoesNotUseLibRawRgbCamOrPreMulAsCameraMatrix
+DevelopColorTransformRejectsMissingOrSingularCameraMatrices
+DevelopImageGraphValueIsAp1SceneLinear
+CudaCat02ZeroOffsetIsExactIdentity
+CudaCat02MapsSourceWhiteToRequestedWhiteInAp1
+```
+
+`DevelopColorTransformRejectsMissingOrSingularCameraMatrices` 必须断言明确错误，不能接受 identity
+输出。双光源测试使用非对角矩阵，使 `cam_mul` 对角实现、`rgb_cam` 固定矩阵实现和错误的
+线性 Kelvin 插值都必然失败。
+
+#### 41.9.2 真实 RAW reference 测试
+
+使用 `alcedo_studio/tests/resources/sample_images/ci_rawfiles` 中至少一个 DNG 和一个非 DNG RAW。
+reference 来自重构前提交 `bf6686fb` 的旧 CameraMatrices/ColorTemp 路径，在固定输入、
+DecodeRes、geometry 和 CCT/tint 下生成。保存可审查的浮点 reference 或确定性统计，不以肉眼
+截图作为唯一断言。
+
+```text
+CudaRealRawAsShotCameraToAp1MatchesPreRebuildReference
+CudaRealRawCustomCctCameraToAp1MatchesPreRebuildReference
+CudaRealRawCctEndpointsMatchCameraProfileMatrices
+CudaRealRawColorTransformProducesFiniteAp1WithoutChannelCollapse
+```
+
+误差范围必须在 fixture 中按阶段说明。至少断言每通道有限值、非零动态范围、参考白点、色卡或
+固定 patch 的 RGB/xy 误差；不能只断言“图像存在”。
+
+#### 41.9.3 缓存和最小执行集测试
+
+```text
+SecondUnchangedProductRenderRunsNoLibRawNoSourceUploadAndNoGpuNodePass
+ExposureEditRunsOnlyPrimaryGradeAndDrtPasses
+DevelopCctEditReusesSensorAndGeometryAndRunsCameraColorGradeDrt
+DrtEditRunsOnlyDrtPass
+ViewportChangeReusesSensorDevelopAndRunsGeometryAndDownstream
+GeometryEditReusesSensorDevelopAndInvalidatesPostGeometryResult
+RawDevelopEditInvalidatesSensorDevelopAndAllDownstreamResults
+ProductRendererCompilesStaticPlanOnlyForTopologyOrSourceLayoutChange
+ResultCacheDoesNotTreatReusedTextureAllocationAsContentHit
+FailedSubmissionDoesNotPublishResultContentKey
+CancelledSubmissionKeepsPreviouslyCompletedCacheEntriesUsable
+```
+
+每个测试断言内容 key、execute/skip counter、LibRaw count、H2D bytes 和输出像素；禁止只比较
+`ResourceId` 或 malloc/free。
+
+#### 41.9.4 Scheduler 状态回归测试
+
+```text
+RenderRequestContainsNoSchedulerRoleOrPresentationTarget
+ProductRendererReturnsFrameWithoutCallingDisplaySink
+PipelineSchedulerIsTheOnlyPreviewPresentationOwner
+InteractiveReplacementDoesNotPresentStaleFrame
+InteractiveQualityDetailSequencePresentsInOrderAndClearsBusy
+EditRevisionChangeRejectsOlderQualityAndDetailFrames
+CancelledScheduledRenderCompletesExactlyOnceAndKeepsSessionReusable
+ScheduledRenderFailureClearsBusyAndReportsTheOriginalError
+ImageSwitchBackReusesMatchingPreparedSourceWithoutPresentingOldFrame
+FullResolutionExportUsesIndependentPipelineSession
+FullResolutionExportDoesNotMutatePreviewWorkspace
+FullResolutionExportNeverWritesEditorFrameSink
+```
+
+#### 41.9.5 编辑器真实 RAW E2E
+
+```text
+RealRawEditorColorTempEditChangesPixelsWithoutRerunningDemosaic
+RealRawEditorExposureEditKeepsPreparedSensorAndGeometryResults
+RealRawEditorRapidEditsPresentOnlyLatestRevisionAndReturnToIdle
+```
+
+这些测试必须进入默认 CUDA CI，不得依赖 `ALCEDO_RUN_DEADLOCKING_RAW_GPU_E2E` 才执行。现有
+deadlock teardown 问题需要拆成单独回归并修复，不能用跳过整个真实 RAW 行为测试来规避。
+
+### 41.10 重构前性能 A/B 验收
+
+基线固定为重构前提交 `bf6686fb`。在同一台机器、同一 CUDA driver/GPU、同一 MSVC/CMake
+配置、同一输入 RAW、同一 DecodeRes、同一 viewport/输出尺寸和同一编辑序列下比较。Debug
+用于行为测试；性能结论使用同一份 Release 构建配置。
+
+每个场景执行一次冷启动和至少 30 次 warm render，报告 median、p95、CPU 准备时间、GPU
+时间、LibRaw 次数、H2D 字节和各 pass 次数。首帧单独报告，不能用首帧或缓存预热隐藏 warm
+回归。
+
+| 场景 | G7R 的强制执行集 | 强制为零的工作 |
+| --- | --- | --- |
+| 无变化重复渲染 | DAG 只查找并返回已完成结果；scheduler 可在 DAG 外呈现 | LibRaw、source H2D、plan compile、所有图像节点 pass、GPU alloc/free |
+| Exposure 连续调整 | PrimaryGrade、DRT | LibRaw、source H2D、SensorDevelop、Geometry、CameraColor、GPU alloc/free |
+| RAW CCT/tint 连续调整 | CameraColor、PrimaryGrade、DRT | LibRaw、source H2D、SensorDevelop、Geometry、GPU alloc/free |
+| DRT 连续调整 | DRT | LibRaw、source H2D、SensorDevelop、Geometry、CameraColor、PrimaryGrade、GPU alloc/free |
+| viewport/geometry 改变 | Geometry、CameraColor、PrimaryGrade、DRT | LibRaw、source H2D、SensorDevelop、GPU alloc/free |
+| RAW Develop 参数改变 | SensorDevelop 及下游 | 重复 LibRaw open/unpack、无关 source preparation、GPU alloc/free |
+| 切换图像后切回 | DAG 命中仍在预算内的 source/GPU 结果；scheduler 决定是否呈现 | 对命中项的 LibRaw、source H2D 和图像节点 pass |
+
+量化完成条件：
+
+- 每个场景都满足上表的 pass/H2D/LibRaw 硬限制；任何一次多余重算都算失败；
+- warm interactive median 不高于 `bf6686fb` 基线的 `1.05x`，p95 不高于 `1.10x`；
+- QualityBase、DetailPatch 和切图返回场景的 median/p95 不比基线差 10%；
+- 无变化、Exposure、CCT 和 DRT 连续编辑从第二帧开始 GPU allocation/free 均为 0；
+- DAG 计算时间与 scheduler/frame-sink 呈现时间分别报告，不能用显示同步掩盖节点重算；
+- 若新路径优于基线，记录绝对时间与提升比例；若未达到阈值，G7R 不得标记 complete；
+- 性能报告写入本 Phase completion record，包含 GPU、driver、CPU、构建类型、fixture 和命令。
+
+### 41.11 完成条件
+
+- 用户可见图仍然只有 Develop、Primary Color Grade 和 DRT；
+- G4/G5 的缓存拆分保留，并存在独立 `develop.sensor_linear`、`geometry.scene_source`、
+  `develop.image`；
+- `develop.image` 被 reference 测试证明是 AP1 scene-linear；
+- Camera→AP1 使用 CameraMatrices/DNG 双光源插值，`cam_mul/pre_mul` 不作为颜色矩阵；
+- as-shot/custom CCT/tint 和 creative CAT02 分别通过数学单元测试和真实 RAW reference 测试；
+- DAG request 只包含像素计算和 cache 身份输入；renderer 返回未呈现的 `RenderedFrame`；
+- scheduler 独占 frame sink，并让取消、过期帧抑制、quality/detail 和 busy 清理通过默认测试；
+- Preview 与 Export 使用独立 PipelineSession/workspace；Export 不保存、修改或恢复 preview 状态；
+- CUDA 产品路径不再包含 legacy 参数镜像、stage adapter 或 `LegacyPipelineImporter`；
+- 缓存命中由内容 key 和 pass counter 证明，不由资源 ID 推断；
+- 第 41.9 节测试全部默认执行并通过；
+- 第 41.10 节 A/B 达标，并把完整测量写回 completion record；
+- G7 completion record 中“upstream cache valid”和“scheduler 已完整接入”的结论，在 G7R
+  完成前只视为历史记录，不作为 G8 的验收依据；
+- G8 必须以 G7R 分支为 base，不得从当前 G7 直接开始 OpenCL 移植。
+
+## 42. Phase G8 — OpenCL 移植
 
 Branch: `feature/gpu-dag-opencl`
 
-Base: `feature/gpu-dag-cuda-drt-product`
+Base: `feature/gpu-dag-cuda-default-recovery`
 
 目标：
 
@@ -2874,7 +3398,7 @@ OpenClBackendFailureDoesNotEnterCpuImageProcessing
 - OpenCL 稳定渲染不创建 GPU buffer 或 image；
 - OpenCL 产品路径不再使用 PipelineStage。
 
-## 42. Phase G9 — Metal 移植
+## 43. Phase G9 — Metal 移植
 
 Branch: `feature/gpu-dag-metal`
 
@@ -2918,7 +3442,7 @@ MetalBackendFailureDoesNotEnterCpuImageProcessing
 - Metal 稳定渲染不创建 buffer、texture 或 compute pipeline state；
 - Metal 产品路径不再使用 PipelineStage。
 
-## 43. Phase G10 — 最终删除与全平台验证
+## 44. Phase G10 — 最终删除与全平台验证
 
 Branch: `feature/gpu-dag-final-removal`
 
@@ -2947,6 +3471,7 @@ Base: `feature/gpu-dag-metal`
 - LLF 私有 allocator 和 cache；
 - 每个算子的 GPU 内存管理；
 - 旧 OpenCL 和 Metal adapter；
+- LegacyPipelineImporter、legacy parameter snapshot 和 nested stage adapter；
 - 已迁移后的重复 kernel 入口；
 - 旧 stage JSON writer。
 
@@ -2960,7 +3485,7 @@ NoPipelineStageTypeRemainsInFirstPartySource
 NoOperatorParamsAggregateRemainsInFirstPartySource
 NoCpuImageOperatorEntryPointRemainsInProductPipeline
 DefaultPipelineRoundTripPreservesThreeNodeGraph
-LegacyPipelineImporterPreservesSupportedUserAdjustments
+NoLegacyParameterImporterOrStageAdapterRemainsInProductPath
 RasterMaskRoundTripPreservesR8DataAndSamplingBounds
 CropRotateViewportAndDynamicResolutionMatchAcrossBackends
 SteadyStateRenderAllocatesNoGpuBufferOrTextureAcrossBackends
@@ -2978,9 +3503,9 @@ OnlyDirtyParameterRangesTransferAcrossBackends
 - 所有持久蒙版通过 MaskStore；
 - 三个后端通过共同参考测试。
 
-## 44. 测试分层
+## 45. 测试分层
 
-### 44.1 Model 单元测试
+### 45.1 Model 单元测试
 
 - 默认值；
 - 参数限制；
@@ -2991,7 +3516,7 @@ OnlyDirtyParameterRangesTransferAcrossBackends
 - RestoreDirty；
 - MakeFullDto。
 
-### 44.2 Graph 单元测试
+### 45.2 Graph 单元测试
 
 - 端口类型；
 - cycle 检查；
@@ -3001,7 +3526,7 @@ OnlyDirtyParameterRangesTransferAcrossBackends
 - topology dirty；
 - 调整实例顺序。
 
-### 44.3 Geometry property 测试
+### 45.3 Geometry property 测试
 
 - forward/inverse round trip；
 - pixel center；
@@ -3011,7 +3536,7 @@ OnlyDirtyParameterRangesTransferAcrossBackends
 - DecodeRes 不改变 ReferenceSpace；
 - mask、LLF 和 image 映射一致。
 
-### 44.4 Workspace 单元测试
+### 45.4 Workspace 单元测试
 
 - grow-only；
 - live allocation 时不增长；
@@ -3023,7 +3548,7 @@ OnlyDirtyParameterRangesTransferAcrossBackends
 - KV lookup；
 - no allocation after reserve。
 
-### 44.5 后端集成测试
+### 45.5 后端集成测试
 
 - Develop；
 - Geometry；
@@ -3036,9 +3561,9 @@ OnlyDirtyParameterRangesTransferAcrossBackends
 - DRT；
 - dynamic resolution；
 - serialization；
-- legacy import。
+- unsupported old-format error。
 
-### 44.6 后端一致性测试
+### 45.6 后端一致性测试
 
 使用同一输入、PipelineDocument、RenderRequest 和 MaskAsset：
 
@@ -3050,18 +3575,22 @@ Metal output
 
 测试需要为每类行为定义清楚的误差范围。离散 mask 边缘和随机 grain 需要固定 seed。
 
-### 44.7 性能和分配测试
+### 45.7 性能和分配测试
 
 - 首帧创建成本单独报告；
 - 第二帧开始不得分配 GPU buffer 或 texture；
+- 无变化重复渲染不得重新 open/unpack RAW、上传 source、编译静态 plan 或执行图像节点 pass；
+- Exposure、RAW CCT/tint、DRT、viewport/geometry 编辑分别断言第 41.10 节的最小执行集；
+- cache hit 必须由内容 key 和 pass skip counter 证明，不能由相同 `ResourceId` 推断；
 - 无参数变化时参数上传字节数必须为 0；
 - 单字段变化时只上传对应字段范围；
 - viewport 变化不得重新上传不变的 R8 mask；
 - dynamic resolution 变化不得重新生成不变的 feather resource；
 - LLF reference 可以跨 viewport 变化复用；
-- GPU 内存预算和 LRU 清理字节数可查询。
+- GPU 内存预算和 LRU 清理字节数可查询；
+- CUDA 产品路径必须与重构前提交 `bf6686fb` 做同机 Release A/B，并满足第 41.10 节阈值。
 
-## 45. 构建与运行
+## 46. 构建与运行
 
 Windows 配置和构建使用项目包装脚本：
 
@@ -3081,9 +3610,9 @@ ctest --test-dir build/macos-debug --output-on-failure
 
 每个 Stacked PR 只运行它影响的集中测试和必要回归测试。G10 运行完整测试集。
 
-## 46. 全局完成条件
+## 47. 全局完成条件
 
-### 46.1 架构
+### 47.1 架构
 
 - [ ] 默认 PipelineDocument 有且只有 Develop、Primary Color Grade 和 DRT 三个节点。
 - [ ] Geometry 是全局 Model 和内部 Pass，不是第四个用户节点。
@@ -3094,7 +3623,7 @@ ctest --test-dir build/macos-debug --output-on-failure
 - [ ] operators 只保存参数 Model、DTO 和序列化逻辑。
 - [ ] GPU 执行代码不在 operators 参数目录。
 
-### 46.2 参数
+### 47.2 参数
 
 - [ ] 不使用参数计数器。
 - [ ] 连续修改合并为一个 dirty Patch。
@@ -3102,24 +3631,31 @@ ctest --test-dir build/macos-debug --output-on-failure
 - [ ] 单字段变化不上传完整参数区。
 - [ ] GPU workspace 重建时使用完整 DTO。
 
-### 46.3 GPU 资源
+### 47.3 GPU 资源
 
 - [ ] BasicRenderWorkspace 通过模板支持 CUDA、OpenCL 和 Metal。
 - [ ] 每个 RenderDevice 只有一个 workspace。
 - [ ] 每个 RenderDevice 只有一份 ParameterArena。
 - [ ] 稳定渲染不创建或销毁 GPU buffer 和 texture。
+- [ ] Prepared RAW、静态 ExecutionPlan 和节点结果都有可查询的内容感知 cache hit/miss。
+- [ ] `develop.sensor_linear` 和 `geometry.scene_source` 是独立、可淘汰、submission-safe 的结果缓存。
+- [ ] 无变化渲染不执行 LibRaw、source H2D、plan compile 或 GPU 图像节点 pass。
 - [ ] LLF 不管理自己的内存池。
 - [x] Mask GPU LRU 只存在于 workspace。
 
-### 46.4 RAW 和颜色
+### 47.4 RAW 和颜色
 
 - [ ] LibRaw unpack 在编辑管线之前完成。
 - [ ] RAW DecodeRes 降采样在 CPU 输入准备中完成。
 - [ ] Develop 输出 AP1 scene-linear RGB。
+- [ ] Camera→AP1 使用 CameraMatrices/DNG 双光源矩阵和标定光源 CCT 在 mired 空间插值。
+- [ ] `cam_mul/pre_mul` 只用于 RAW 归一化和 neutral 推导，不作为 Camera→AP1 矩阵。
+- [ ] metadata 缺失或矩阵无效时返回明确错误，不静默使用 identity。
+- [ ] RAW CameraColorPass 与 Primary Grade creative CAT02 分别拥有 dirty key 和测试。
 - [ ] CAT02 调整以 AP1 白点为参考。
 - [ ] DRT 支持 ACES 2.0 和 OpenDRT。
 
-### 46.5 Geometry 和 Mask
+### 47.5 Geometry 和 Mask
 
 - [ ] crop、rotation、view ROI 和 dynamic resolution 只执行一次图像重采样。
 - [ ] LLF 和 mask 使用相同的 RenderGeometry 数据。
@@ -3131,7 +3667,7 @@ ctest --test-dir build/macos-debug --output-on-failure
 - [x] view 或 render scale 变化不重新创建不变的 mask texture。
 - [x] MaskStore root 可以由用户配置。
 
-### 46.6 后端
+### 47.6 后端
 
 - [ ] CUDA 完整通过。
 - [ ] OpenCL 完整通过。
@@ -3140,16 +3676,31 @@ ctest --test-dir build/macos-debug --output-on-failure
       workspace 模板。
 - [ ] GPU 后端失败时不进入 CPU 图像处理。
 
-### 46.7 数据
+### 47.7 数据
 
 - [ ] 新 JSON 只保存节点、边、Model 和 MaskAssetKey。
 - [ ] 新 JSON 不保存 GPU 或 viewport 短期状态。
-- [ ] 旧 stage JSON 可以单向导入。
-- [ ] 新保存不再写旧 stage JSON。
+- [ ] 旧 stage JSON 返回明确 unsupported-format error，不进入新产品路径。
+- [ ] 不存在 `LegacyPipelineImporter`、legacy parameter snapshot 或 nested stage adapter。
+- [ ] 新保存只写 format version 2，不写旧 stage JSON。
 
-## 47. 风险与处理
+### 47.8 Scheduler 和性能
 
-### 47.1 旧管线删除范围大
+- [ ] DAG request 只包含像素计算和 cache 身份输入，不包含 scheduler 状态机。
+- [ ] DAG renderer 返回未呈现的结果；scheduler 是 editor frame sink 的唯一调用者。
+- [ ] InteractivePrimary、QualityBase 和 DetailPatch 只在 scheduler 中解析和排序。
+- [ ] 取消、失败和成功都恰好完成一次，并清理 busy/quality/detail 状态。
+- [ ] 过期帧不会覆盖最新 frame sink 输出。
+- [ ] Preview 与 Export 使用独立 PipelineSession、workspace、cache 和输出目标。
+- [ ] Export 不保存、修改或恢复 Preview 状态，也不连接 editor frame sink。
+- [ ] 切图返回只命中相同 source/document revision 的缓存。
+- [ ] 真实 RAW 编辑器颜色与状态测试默认进入 CUDA CI，不依赖环境变量才执行。
+- [ ] G7R 与重构前提交 `bf6686fb` 的同机 A/B 满足第 41.10 节阈值。
+- [ ] G7R 完成后才允许以其为 base 开始 G8。
+
+## 48. 风险与处理
+
+### 48.1 旧管线删除范围大
 
 处理：
 
@@ -3157,18 +3708,19 @@ ctest --test-dir build/macos-debug --output-on-failure
 - 每个 PR 保持可构建；
 - CUDA 先完成端到端；
 - OpenCL 和 Metal 各自独立移植；
-- 最后一个 PR 才删除全部过渡代码。
+- G7R 删除 legacy 参数 importer、snapshot 和 CUDA 产品 adapter；
+- G8/G9 分别删除尚未移植后端的执行 adapter；G10 只做最终验证和剩余清理。
 
-### 47.2 默认调色顺序变化
+### 48.2 默认调色顺序变化
 
 处理：
 
 - 默认顺序写入明确列表；
-- legacy importer 使用固定映射；
+- format version 2 直接保存和读取明确 Model 顺序；旧 stage JSON 返回版本错误；
 - 使用 golden 图像和参数 round-trip 测试；
 - GraphCompiler 不自动改变 Model 顺序。
 
-### 47.3 ROI 与 mask 错位
+### 48.3 ROI 与 mask 错位
 
 处理：
 
@@ -3177,7 +3729,7 @@ ctest --test-dir build/macos-debug --output-on-failure
 - 使用 pixel-center property 测试；
 - 使用 crop、rotation、odd size 和 dynamic resolution 组合测试。
 
-### 47.4 GPU 内存增长
+### 48.4 GPU 内存增长
 
 处理：
 
@@ -3187,7 +3739,7 @@ ctest --test-dir build/macos-debug --output-on-failure
 - transient memory 在每帧完成后 rewind；
 - 测试记录稳定状态分配次数和峰值。
 
-### 47.5 Stacked PR 评审困难
+### 48.5 Stacked PR 评审困难
 
 处理：
 
@@ -3197,7 +3749,7 @@ ctest --test-dir build/macos-debug --output-on-failure
 - 每个 Phase 完成后在本文件记录主要调用路径、测试和未完成项；
 - 父 PR 变化后立即更新子分支，避免长时间分离。
 
-## 48. Phase 完成记录格式
+## 49. Phase 完成记录格式
 
 每个 Phase 完成后，在对应章节末尾增加：
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1–G7R.3 complete；G7R.4–G7R.5 remaining；G7R 仍阻塞 G8。
+Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1–G7R.3 complete；G7R.H complete（含 one-shot 缓存隔离修复）；G7R.4–G7R.5 remaining；G7R 仍阻塞 G8。
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2946,7 +2946,7 @@ Branch: `feature/gpu-dag-cuda-default-recovery`
 
 Base: `feature/gpu-dag-cuda-drt-product`
 
-Status: G7R.1–G7R.3 complete；G7R.4–G7R.5 remaining；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
+Status: G7R.1–G7R.3 complete；G7R.H complete；G7R.4–G7R.5 remaining；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
 
 Requirement source: `codex://threads/01a0273a-48bd-7702-9503-127bb5e2ec1e`。本阶段恢复该
 任务中已经明确的 Develop endpoint、GPU workspace KV cache 和动态分辨率要求，不重新定义
@@ -3455,6 +3455,263 @@ the CUDA product path does not use that context for CameraColor. OpenCL/Metal
 `ColorTempOp` still has a `cam_xyz` fallback when ColorMatrix is missing; CUDA
 does not. Creative CAT02 remains per-channel scaling until G7R.4. 41.9 A/B
 timing remains G7R.5.
+
+### 41.5b G7R.H — CUDA 默认管线产品回归修复
+
+Branch: `feature/gpu-dag-cuda-default-recovery`
+
+在 G7R.4 CAT02 之前修复三件产品回归：RAW demosaic/HLR 未接入 CUDA Develop、归还 pipeline 时 GPU 会话缓存不释放、DRT 入口硬裁 scene-linear。
+
+工作：
+
+- [x] SensorDevelop 读取 `demosaic_method`；default Bayer=Legacy RCD，default X-Trans=Neural Engine
+- [x] Neural 失败抛错误字符串，不静默落到 Legacy
+- [x] HLR on 时 CFA 不 Clamp01；HLR 在 Bayer 和 X-Trans demosaic 之后的 RGB 上运行
+- [x] `CudaProductRenderer::ReleaseSessionCaches` 在 `ClearAllIntermediateBuffers` / `ReleaseAllGPUResources` 中调用
+- [x] 产品 TexturePool 预算来自设备显存（下限 256 MiB），不再写死 64 MiB
+- [x] 删除 `OutputTransform_fwd` 入口 `clamp_AP1`；`kDrtImplementationVersion = 2`；`kSensorDevelopImplementationVersion = 2`
+- [x] `PipelineScheduler` 把异常 `what()` 传给 `on_complete_(success, message)`
+
+##### Phase G7R.H completion record (2026-08-23)
+
+**Status:** complete — CUDA Develop honors demosaic/HLR, session caches drop on pipeline return, DRT no longer hard-clips AP1 before tonescale.
+
+**Primary success call chain:**
+
+```text
+EditorRawDecodePanel submit method / highlights_reconstruct
+  -> CPUPipelineExecutor::Apply mirrors legacy JSON
+  -> ExecuteCudaDevelop
+       ToLinearRef
+       Clamp01(CFA) only if HLR off
+       ResolveDevelopDemosaicMethod
+       RCD | XTrans interpolator | Neural student tiles
+       optional HighlightCorrection on RGB
+       pack develop.sensor_linear
+
+editor switch image -> SavePipeline last pin
+  -> ClearAllIntermediateBuffers
+       -> CudaProductRenderer::ReleaseSessionCaches
+            WaitIdle
+            GraphImageCache::Clear + TexturePool::ReleaseUnleased
+            PreparedSourceCache::Clear
+            NeuralDemosaicWorkspace reset
+```
+
+**Primary failure call chain:**
+
+```text
+Neural preprocess / tile / EnsureLoaded failed
+  -> throw runtime_error("Neural Engine ...")
+  -> CudaRenderDevice::CancelRender + ReportError
+  -> PipelineScheduler catch exception -> on_complete_(false, what())
+  -> FinishJob(false, message) -> editor last_error_
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `CudaDevelopDefaultBayerUsesLegacyRcdNotNeural` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopDefaultXTransUsesNeuralEngine` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopExplicitNeuralEngineChangesBayerPixelsVersusLegacy` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopHighlightReconstructOnSkipsCfaClamp01ForBayerAndXTrans` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopHighlightReconstructOffAppliesCfaClamp01` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopHighlightReconstructChangesXTransRgb` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopNeuralEngineFailureThrowsErrorStringAndDoesNotFallBackToLegacy` | `GpuDagCudaDevelopTest` | PASS |
+| `EditorRenderFailureForwardsExceptionMessageInsteadOfEmptyResult` | `PipelineSchedulerRequestIdTest` | PASS |
+| `ClearAllIntermediateBuffersReleasesCudaProductSessionGpuAndHostCaches` | `GpuDagCudaDrtProductTest` | PASS |
+| `ThreeSequentialImagePinsDoNotRetainPreviousImageGpuTextures` | `GpuDagCudaDrtProductTest` | PASS |
+| `TexturePoolBudgetNoLongerHardCodedTo64MiBOnProductPath` | `GpuDagCudaDrtProductTest` | PASS |
+| `ImageSwitchBackAfterReleaseSessionCachesMissesAndReexecutes` | `GpuDagCudaDrtProductTest` | PASS |
+| `ViewportChangeAfterSessionReleaseStillReusesSensorLinearOnTheLivePipeline` | `GpuDagCudaDrtProductTest` | PASS |
+| `DrtInputIsNotHardClampedToForwardLimitBeforeTonescale` | `GpuDagCudaDrtProductTest` | PASS |
+| `HighlightReconstructOnSurvivesIntoDrtInsteadOfBeingClippedToUnitCube` | `GpuDagCudaDrtProductTest` | PASS |
+| `OpenDrtAndAcesStillLimitDisplayReferredOutput` | `GpuDagCudaDrtProductTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagCudaDevelopTest GpuDagCudaDrtProductTest GpuDagCudaWorkspaceTest PipelineSchedulerRequestIdTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "GpuDagCudaDevelopTest|GpuDagCudaDrtProductTest|GpuDagCudaWorkspaceTest|PipelineSchedulerRequestIdTest"
+```
+
+Suite totals: `67/67` PASS.
+
+**Checklist / exit condition:** all G7R.H work items checked.
+
+**LOC note (grill-code-review):** `cuda_sensor_demosaic.cpp` 252, `cuda_sensor_demosaic.hpp` 48, `cuda_develop_pass.cpp` 152, `cuda_render_device.cpp` 40, `cuda_product_renderer.cu` 212. No new file exceeds 1000 lines.
+
+**Residual gaps:** `SavePipeline` / `HandleEviction` themselves were not driven through `PipelineMgmtService` in this binary (DuckDB + LibRaw winsock clash). They call `ClearAllIntermediateBuffers`, which calls `ReleaseSessionCaches` (proven). Real Fuji/Sony files in the editor still need a product pass. CAT02 remains G7R.4. 41.9 A/B remains G7R.5.
+
+##### Phase G7R.H one-shot cache isolation correction (2026-08-23)
+
+**Status:** complete — thumbnail/export 继续复用同一个 `CPUPipelineExecutor` 和
+`PipelineDocument`，但不读取、发布或清空 editor session cache。
+
+**Root cause:** CUDA DAG product path 没有读取 `CPUPipelineExecutor::enable_cache_`。
+`THUMBNAIL` / `FULL_RES_EXPORT` 虽然调用 `SetEnableCache(false)`，仍写入
+`CudaProductRenderer` 的 PreparedSource、static plan 和 GPU result cache。thumbnail 完成后
+`ResetThumbnailRenderParams` 又调用 `ClearAllIntermediateBuffers`，进而执行
+`ReleaseSessionCaches`。filmstrip 的后台 thumbnail 因此会清空同一 pipeline 的 editor cache，
+下一次 ImageSwitch 偶发承担 LibRaw、H2D 和所有 CUDA pass 的冷启动成本。export 不执行这次
+清理，反而会把 one-shot full-resolution 结果留在 editor cache。
+
+**Primary success call chain:**
+
+```text
+filmstrip ImageSwitch editor preview
+  -> PipelineTask::SetExecutorRenderParams -> SetEnableCache(true)
+  -> CPUPipelineExecutor::Apply
+  -> CudaProductRenderer::Render(UseSessionCache)
+  -> PreparedSourceCache / StaticExecutionPlanCache / GraphImageCache hit
+  -> no LibRaw, no H2D, no CUDA node pass on unchanged matching content
+
+thumbnail or export
+  -> PipelineTask::SetExecutorRenderParams -> SetEnableCache(false)
+  -> CPUPipelineExecutor::Apply
+  -> CudaProductRenderer::Render(BypassSessionCache)
+  -> direct prepare + static compile + isolated one-shot CudaRenderDevice/workspace
+  -> present or host download
+  -> discard unpublished results + wait idle + release one-shot GPU result resources
+  -> restore one-shot render params; editor session cache remains unchanged
+```
+
+**Primary failure call chain:**
+
+```text
+one-shot unpack / compile / CUDA execute / present fails
+  -> CudaRenderDevice::CancelRender or renderer discards unpublished results
+  -> exception reaches PipelineScheduler
+  -> on_complete_(false, what()) / blocking promise exception
+  -> editor session cache remains owned only by the session render lane
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `OneShotRenderDoesNotReadWriteOrClearEditorSessionCaches` | `GpuDagCudaDrtProductTest` | PASS, repeated 3/3 |
+| `ImageSwitchBackReusesMatchingPreparedSourceAndGpuResults` | `GpuDagCudaDrtProductTest` | PASS |
+| CUDA product cache/develop/DRT regression suite | `GpuDagCudaDrtProductTest` | 32/32 PASS |
+| scheduler request identity, cache reuse and error propagation suite | `PipelineSchedulerRequestIdTest` | 7/7 PASS |
+| one-shot pipeline/sink state suite | `PipelineFrameSinkTest` | 31/32 initial; isolated allocator-address assertion 3/3 PASS on rerun |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build build\debug --target GpuDagCudaDrtProductTest PipelineSchedulerRequestIdTest PipelineFrameSinkTest --parallel 4
+build\debug\alcedo_studio\tests\edit\GpuDagCudaDrtProductTest_runtime\GpuDagCudaDrtProductTest.exe
+build\debug\alcedo_studio\tests\edit\PipelineSchedulerRequestIdTest_runtime\PipelineSchedulerRequestIdTest.exe
+build\debug\alcedo_studio\tests\edit\PipelineFrameSinkTest_runtime\PipelineFrameSinkTest.exe
+build\debug\alcedo_studio\tests\edit\PipelineFrameSinkTest_runtime\PipelineFrameSinkTest.exe --gtest_filter=PipelineFrameSinkTest.ReattachingFrameSinkPreservesMergedStage --gtest_repeat=3
+```
+
+**Checklist / exit condition:** one-shot work cannot observe or mutate editor session result caches；
+thumbnail completion no longer clears those caches；matching ImageSwitch still proves zero LibRaw and
+zero CUDA node execution。
+
+**LOC note (grill-code-review):** `cuda_product_renderer.hpp` 126，
+`cuda_product_renderer.cu` 258，`pipeline_cpu.cpp` 893，`pipeline_scheduler.cpp` 751，
+`cuda_result_cache_test.cpp` 437。没有文件超过 1000 行；本修复没有增加新模块或新依赖。
+
+**Residual gaps:** 尚未在当前自动化测试中重放用户的真实 filmstrip trace，因此 12.6 s 尖峰的
+产品侧消失仍需真实 RAW 手动验证。首次完整 `PipelineFrameSinkTest` 中
+`ReattachingFrameSinkPreservesMergedStage` 因 allocator 复用同一地址失败一次；单测连续复跑
+3/3 通过。该断言用对象地址判断重建，属于独立的测试稳定性问题，本修复未修改它。
+
+##### Phase G7R.H filmstrip 争用、请求几何与 scene-linear 高光修正（2026-08-23）
+
+**Status:** complete — 更正上一条记录对 12.6 s 尖峰的解释；one-shot cache 隔离是必要的，
+但不是全部根因。普通 thumbnail 和 export 仍曾复用 live editor executor，因此后台完整渲染
+会占用同一把 `render_lock_`。该等待发生在 scheduler worker 内，计入 `[RENDER_E2E] pipeline`
+而不是 `queue`；`queue≈50 ms, pipeline≈12.5 s` 与锁等待完全一致，不是冷启动结论。
+
+同时修复两个独立产品回归：Quality Base 在 ROI 放大期间重新读取 live viewport，导致 ROI
+结果按 full-frame 展示而拉伸；默认 Curve 把 AP1 scene-linear 中所有大于 1 的值返回为末端
+控制点 1，造成 ACES 和 OpenDRT 共同输入在 DRT 前硬裁。旧管线的 RGC 曲线没有执行该硬裁；
+新管线明确保持 Primary Grade 为 AP1 scene-linear，因此默认 Curve 改为沿首尾线段外推，
+不引入 ACEScc 往返或第二套色彩域。
+
+**Primary success call chains:**
+
+```text
+filmstrip thumbnail / export
+  -> PipelineMgmtService::LoadPipelineSnapshot
+       -> briefly copy current params under live render_lock_
+       -> build independent CPUPipelineExecutor + independent render_lock_
+  -> PipelineScheduler renders on snapshot executor with BypassSessionCache
+  -> ReleasePipelineSnapshot clears only snapshot resources
+  -> live editor pin, dirty state, executor and session caches remain untouched
+
+ROI zoom -> panel/demosaic change -> Quality Base
+  -> request captures optional ViewportRenderRegion
+  -> PipelineTask::SetExecutorRenderParams
+       -> FAST/DETAIL stores the frozen ROI
+       -> Quality Base stores explicit null/full-frame geometry
+  -> CPUPipelineExecutor::Apply builds RenderRequest only from frozen task geometry
+  -> full-frame result keeps source aspect ratio
+
+scene-linear highlight > 1
+  -> CameraColorPass produces AP1 scene-linear
+  -> PrimaryGrade default Curve extrapolates the identity end segment
+  -> highlight remains > 1 at grade output
+  -> selected DRT owns highlight mapping
+```
+
+**Primary failure call chain:**
+
+```text
+snapshot capture / RAW metadata inject / thumbnail or export render fails
+  -> explicit error or blocking promise exception
+  -> ReleasePipelineSnapshot clears isolated resources
+  -> live editor executor and caches remain valid
+  -> no Legacy/backend/quality substitute
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `OrdinaryThumbnailRendersWithoutUsingLiveEditorExecutor` | `ThumbnailServiceTest` | PASS, real DNG |
+| `AnalysisRenditionRendersWithoutSavePipelineOnLiveGuard` | `ThumbnailServiceTest` | PASS, real DNG |
+| `LoadPipelineSnapshotClonesParamsAndDoesNotTouchLiveGuard` | `PipelineMapperTest` | PASS, independent executor and mutex |
+| `QualityBaseAfterRoiClearsFrozenViewportGeometry` | `PipelineFrameSinkTest` | PASS |
+| `DetailRoiPreviewUsesFrozenRequestRegionInsteadOfChangedSinkRegion` | `PipelineFrameSinkTest` | PASS |
+| `DefaultCurvePreservesSceneLinearHighlightsAboveOne` | `GpuDagCudaPrimaryGradeTest` | PASS |
+| `DrtInputIsNotHardClampedToForwardLimitBeforeTonescale` | `GpuDagCudaDrtProductTest` | PASS |
+| `CudaDevelopDefaultXTransUsesNeuralEngine` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopExplicitNeuralEngineChangesBayerPixelsVersusLegacy` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopHighlightReconstructOnSkipsCfaClamp01ForBayerAndXTrans` | `GpuDagCudaDevelopTest` | PASS |
+| `CudaDevelopNeuralEngineFailureThrowsErrorStringAndDoesNotFallBackToLegacy` | `GpuDagCudaDevelopTest` | PASS |
+| export snapshot path writes readable SDR and Ultra HDR files | `ExportServiceTest` | 2/2 PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build build\debug --target PipelineFrameSinkTest ThumbnailServiceTest ExportServiceTest PipelineMapperTest GpuDagCudaDevelopTest GpuDagCudaPrimaryGradeTest GpuDagCudaDrtProductTest EditorRawDecodePanelQmlTest EditorSessionRenderSchedulerPortTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "^(PipelineFrameSinkTest|GpuDagCudaPrimaryGradeTest|GpuDagCudaDrtProductTest|PipelineMapperTest|ExportServiceTest|EditorRawDecodePanelQmlTest|EditorSessionRenderSchedulerPortTest)\."
+build\debug\alcedo_studio\tests\app\ThumbnailServiceTest_runtime\ThumbnailServiceTest.exe --gtest_filter=ThumbnailServiceTests.OrdinaryThumbnailRendersWithoutUsingLiveEditorExecutor:ThumbnailServiceTests.AnalysisRenditionRendersWithoutSavePipelineOnLiveGuard
+ctest --test-dir build/debug --output-on-failure -R "^(GpuDagCudaDevelopTest|PipelineMapperTest)\."
+```
+
+Suite totals: combined discovered set `123/123` PASS（4 disabled）；RAW Develop + latest pipeline
+snapshot set `39/39` PASS（2 disabled）；direct real-DNG thumbnail set `2/2` PASS。
+
+**Checklist / exit condition:** ordinary thumbnail and export no longer render on the live editor
+executor；one-shot tasks still bypass session caches；Quality Base cannot inherit a live ROI；default
+Primary Grade cannot clip AP1 highlights above 1；RAW demosaic/HLR selection and failures remain
+observable。
+
+**LOC note (grill-code-review):** no new production module or dependency. The fix reuses
+`PipelineSnapshot` and adds one request-scoped optional viewport value. Existing large files remain
+`thumbnail_service.cpp` 1190 lines and `thumbnail_service_test.cpp` 3215 lines；this change does not
+split them because the snapshot lifecycle already belongs to the existing service path。
+
+**Residual gaps:** automated tests prove ownership, cache isolation, request geometry and pixel
+range, but do not replay the user's exact multi-photo filmstrip timing trace. Product validation
+should confirm that any remaining long thumbnail duration is visible only on the thumbnail worker，
+not inside an InteractivePrimary request's `pipeline` duration。
 
 ### 41.6 G7R.4 — 正确实现独立的 creative CAT02
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1 complete；G7R.2–G7R.5 remaining；G7R 仍阻塞 G8。
+Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1–G7R.2 complete；G7R.3–G7R.5 remaining；G7R 仍阻塞 G8。
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2946,7 +2946,7 @@ Branch: `feature/gpu-dag-cuda-default-recovery`
 
 Base: `feature/gpu-dag-cuda-drt-product`
 
-Status: G7R.1 complete；G7R.2–G7R.5 remaining；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
+Status: G7R.1–G7R.2 complete；G7R.3–G7R.5 remaining；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
 
 Requirement source: `codex://threads/01a0273a-48bd-7702-9503-127bb5e2ec1e`。本阶段恢复该
 任务中已经明确的 Develop endpoint、GPU workspace KV cache 和动态分辨率要求，不重新定义
@@ -3041,7 +3041,7 @@ LibRaw/input-preparation implementation version
 - [x] 同一 source key 的 preview/quality/detail 渲染共享 PreparedRawInput；
 - [x] 未淘汰的 source 再次打开时复用主存结果，不重新执行 LibRaw open/unpack；
 - [x] DecodeRes 或输入准备规则改变时生成新 key，不覆盖仍被 submission 使用的旧条目；
-- [ ] source host bytes 只在 `develop.sensor_linear` miss 时上传；
+- [x] source host bytes 只在 `develop.sensor_linear` miss 时上传；
 - [x] 静态 ExecutionPlan key 只包含 graph topology、节点/调整类型与顺序、source layout 和后端能力；
 - [x] 参数值、viewport、CCT、Grade 和 DRT 编辑不触发静态 plan 重编译；
 - [x] ResolvedRenderGeometry 和 pass dirty schedule 属于每帧只读数据，不通过重编译静态图表达；
@@ -3151,19 +3151,19 @@ drt.display             = display-referred output
 
 工作：
 
-- 从 `GraphImageCache` 中拆出 allocation slots 与 valid results，或让 API 强制调用者明确选择
+- [x] 从 `GraphImageCache` 中拆出 allocation slots 与 valid results，或让 API 强制调用者明确选择
   `AcquireTextureForWrite`、`FindValidResult`、`PublishResult`；
-- 缓存查找比较 value ID、内容 key、extent、format 和完成 submission；
-- pass 写入临时 unpublished 状态，只在 submission 成功后原子发布内容 key；
-- 取消、kernel 失败、frame-sink 失败不能把部分写入标成有效；
-- 同 key 已命中时跳过 pass，保留原 `last_writer` 和内容身份；
-- 同一物理纹理被新 key 覆写前，先移除旧结果身份；
-- geometry cache key 使用完整 ResolvedRenderGeometry，包括 crop、rotation、ROI、目标尺寸、
+- [x] 缓存查找比较 value ID、内容 key、extent、format 和完成 submission；
+- [x] pass 写入临时 unpublished 状态，只在 submission 成功后原子发布内容 key；
+- [x] 取消、kernel 失败、frame-sink 失败不能把部分写入标成有效；
+- [x] 同 key 已命中时跳过 pass，保留原 `last_writer` 和内容身份；
+- [x] 同一物理纹理被新 key 覆写前，先移除旧结果身份；
+- [x] geometry cache key 使用完整 ResolvedRenderGeometry，包括 crop、rotation、ROI、目标尺寸、
   DecodeRes 映射和采样规则；
-- CCT/tint、Grade、mask 或 DRT 改变不得使 `geometry.scene_source` 失效；
-- viewport/geometry 改变复用 `develop.sensor_linear`，只重跑 Geometry 和下游；
-- workspace LRU 按 GPU 字节预算淘汰已完成且没有 lease 的结果；
-- 结果缓存支持 source/document revision 隔离，防止切图后错误命中。
+- [x] CCT/tint、Grade、mask 或 DRT 改变不得使 `geometry.scene_source` 失效；
+- [x] viewport/geometry 改变复用 `develop.sensor_linear`，只重跑 Geometry 和下游；
+- [x] workspace LRU 按 GPU 字节预算淘汰已完成且没有 lease 的结果；
+- [x] 结果缓存支持 source/document revision 隔离，防止切图后错误命中。
 
 主要文件：
 
@@ -3172,6 +3172,109 @@ drt.display             = display-referred output
 - `alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp`
 - `alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp`
 - `alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp`
+
+##### Phase G7R.2 completion record (2026-08-22)
+
+**Status:** complete — content-keyed GPU result cache with independent
+`develop.sensor_linear`, `geometry.scene_source`, and `develop.image` values.
+Unchanged, Exposure, CCT, DRT, viewport, geometry, Develop, and image-switch
+frames skip or execute the required pass set. Source H2D runs only on a
+`develop.sensor_linear` miss.
+
+`GraphImageCache` is now a content-keyed result cache. Allocation reuse is
+`AcquireTextureForWrite` / TexturePool. A content hit is `BindValidResult` /
+`FindValidResult` with matching value ID, content key, extent, format, and a
+completed `last_writer`. Passes write unpublished slots; `PublishResults` runs
+only after a successful submit and, on the product path, after present/download.
+
+**Primary success call chain:**
+
+```text
+CPUPipelineExecutor::Apply
+  -> CudaProductRenderer::Render
+  -> PreparedSourceCache::AcquireEncoded
+  -> StaticExecutionPlanCache::GetOrCompile
+  -> GraphCompiler::BindFrameGeometry
+  -> BuildFrameResultContentKeys
+  -> CudaRenderDevice::Execute(publish_on_success=false)
+       BeginRender waits previous submission and drops leftover unpublished writes
+       BindValidResult(develop.sensor_linear)
+         hit  -> skip SensorDevelop, no source H2D
+         miss -> ExecuteCudaDevelop + RecordUnpublished
+       BindValidResult(geometry.scene_source)
+         hit  -> skip Geometry
+         miss -> ExecuteCudaGeometryResample + RecordUnpublished
+       BindValidResult(develop.image)
+         hit  -> skip CameraColor
+         miss -> ExecuteCudaCameraColor + RecordUnpublished
+       BindValidResult(grade.primary.image) / (drt, display)
+         hit  -> skip
+         miss -> ExecuteCudaPrimaryGrade / ExecuteCudaDrt + RecordUnpublished
+  -> present or host download
+  -> CudaRenderDevice::PublishResults
+```
+
+**Primary failure call chain:**
+
+```text
+kernel / source H2D / frame-sink mapping failure
+  -> CudaRenderDevice::CancelRender
+  -> GraphImageCache::DiscardUnpublished
+  -> previously published content keys remain FindValidResult hits
+  -> new unpublished keys are not published
+  -> exception returns through CPUPipelineExecutor (no CPU image processing)
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `SecondUnchangedProductRenderRunsNoLibRawNoSourceUploadAndNoGpuNodePass` | `GpuDagCudaDrtProductTest` | PASS |
+| `ExposureEditRunsOnlyPrimaryGradeAndDrtPasses` | `GpuDagCudaDrtProductTest` | PASS |
+| `DevelopCctEditReusesSensorAndGeometryAndRunsCameraColorGradeDrt` | `GpuDagCudaDrtProductTest` | PASS |
+| `DrtEditRunsOnlyDrtPass` | `GpuDagCudaDrtProductTest` | PASS |
+| `ViewportChangeReusesSensorDevelopAndRunsGeometryAndDownstream` | `GpuDagCudaDrtProductTest` | PASS |
+| `GeometryEditReusesSensorDevelopAndInvalidatesPostGeometryResult` | `GpuDagCudaDrtProductTest` | PASS |
+| `RawDevelopEditInvalidatesSensorDevelopAndAllDownstreamResults` | `GpuDagCudaDrtProductTest` | PASS |
+| `ImageSwitchBackReusesMatchingPreparedSourceAndGpuResults` | `GpuDagCudaDrtProductTest` | PASS |
+| `ResultCacheDoesNotTreatReusedTextureAllocationAsContentHit` | `GpuDagCudaWorkspaceTest` | PASS |
+| `FailedSubmissionDoesNotPublishResultContentKey` | `GpuDagCudaWorkspaceTest` and `GpuDagCudaDrtProductTest` | PASS |
+| `CancelledSubmissionKeepsPreviouslyCompletedCacheEntriesUsable` | `GpuDagCudaWorkspaceTest` and `GpuDagCudaDrtProductTest` | PASS |
+| `SensorLinearKeyIgnoresCctTintGradeAndDrt` | `GpuDagRawInputTest` | PASS |
+| `GeometryKeyIncludesViewportAndCropAndIgnoresGrade` | `GpuDagRawInputTest` | PASS |
+| `HighlightRecoverChangesSensorLinearAndAllDownstreamKeys` | `GpuDagRawInputTest` | PASS |
+| `ProductRendererCompilesStaticPlanOnlyForTopologyOrSourceLayoutChange` | `GpuDagCudaDrtProductTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagRawInputTest GpuDagCudaDrtProductTest GpuDagCudaDevelopTest GpuDagCudaPrimaryGradeTest GpuDagCudaWorkspaceTest GpuDagCudaMaskTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "GpuDagRawInputTest|GpuDagCudaDrtProductTest|GpuDagCudaDevelopTest|GpuDagCudaPrimaryGradeTest|GpuDagCudaWorkspaceTest|GpuDagCudaMaskTest"
+```
+
+Suite totals: `92/92` PASS (`GpuDagRawInputTest` 29, CUDA Develop 6, CUDA Primary Grade 9,
+CUDA DRT product 21, CUDA Mask 11, CUDA workspace 16). One mask mix test was updated
+to run Geometry and CameraColor before Primary Grade after the value-ID split.
+
+**Checklist / exit condition:** all 11 G7R.2 work items checked. G7R.1 remaining
+source-H2D-on-sensor-miss item is also checked.
+
+**LOC note (grill-code-review):** new files stay small: `content_key.hpp` 107,
+`graph_image_cache.hpp` 329, `gpu_node_pass_stats.hpp` 37,
+`result_content_key.hpp` 51, `result_content_key.cpp` 228,
+`cuda_camera_color_pass.cu` 90, `cuda_plan_executor.cpp` 130,
+`result_content_key_test.cpp` 129, `graph_image_cache_test.cpp` 122,
+`cuda_result_cache_test.cpp` 320. `cuda_develop_pass.cpp` 230,
+`cuda_product_renderer.cu` 184, `cuda_primary_grade_pass.cu` 400.
+No changed file exceeds 500 lines.
+
+**Residual gaps:** CameraColor still uses the current `rgb_cam` × sRGB→AP1 matrix
+and may still fall back to identity; G7R.3 replaces that with CameraMatrices/DNG
+dual-illuminant interpolation and rejects missing/singular matrices. Creative
+CAT02 remains channel scaling until G7R.4. Full 41.9 A/B timing, GPU
+allocation/free, and duration snapshots remain G7R.5. `develop.image` is a
+separate AP1-bound GraphValue after CameraColor, but AP1 correctness is not
+claimed until G7R.3 reference tests.
 
 ### 41.5 G7R.3 — 恢复 CameraMatrices 双光源插值和 Develop AP1 输出
 
@@ -3652,9 +3755,9 @@ ctest --test-dir build/macos-debug --output-on-failure
 - [ ] 每个 RenderDevice 只有一个 workspace。
 - [ ] 每个 RenderDevice 只有一份 ParameterArena。
 - [ ] 稳定渲染不创建或销毁 GPU buffer 和 texture。
-- [ ] Prepared RAW、静态 ExecutionPlan 和节点结果都有可查询的内容感知 cache hit/miss。
-- [ ] `develop.sensor_linear` 和 `geometry.scene_source` 是独立、可淘汰、submission-safe 的结果缓存。
-- [ ] 无变化渲染不执行 LibRaw、source H2D、plan compile 或 GPU 图像节点 pass。
+- [x] Prepared RAW、静态 ExecutionPlan 和节点结果都有可查询的内容感知 cache hit/miss。
+- [x] `develop.sensor_linear` 和 `geometry.scene_source` 是独立、可淘汰、submission-safe 的结果缓存。
+- [x] 无变化渲染不执行 LibRaw、source H2D、plan compile 或 GPU 图像节点 pass。
 - [ ] LLF 不管理自己的内存池。
 - [x] Mask GPU LRU 只存在于 workspace。
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G1–G7 implementation landed；G7 产品验收撤回；G7R（CUDA 默认管线行为、颜色与性能恢复）为必做阶段并阻塞 G8。
+Status: G1–G7 implementation landed；G7 产品验收撤回；G7R.1 complete；G7R.2–G7R.5 remaining；G7R 仍阻塞 G8。
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2946,7 +2946,7 @@ Branch: `feature/gpu-dag-cuda-default-recovery`
 
 Base: `feature/gpu-dag-cuda-drt-product`
 
-Status: required；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
+Status: G7R.1 complete；G7R.2–G7R.5 remaining；G7R 完成前禁止开始 G8 的 OpenCL 像素路径移植。
 
 Requirement source: `codex://threads/01a0273a-48bd-7702-9503-127bb5e2ec1e`。本阶段恢复该
 任务中已经明确的 Develop endpoint、GPU workspace KV cache 和动态分辨率要求，不重新定义
@@ -3038,15 +3038,104 @@ LibRaw/input-preparation implementation version
 
 工作：
 
-- 同一 source key 的 preview/quality/detail 渲染共享 PreparedRawInput；
-- 未淘汰的 source 再次打开时复用主存结果，不重新执行 LibRaw open/unpack；
-- DecodeRes 或输入准备规则改变时生成新 key，不覆盖仍被 submission 使用的旧条目；
-- source host bytes 只在 `develop.sensor_linear` miss 时上传；
-- 静态 ExecutionPlan key 只包含 graph topology、节点/调整类型与顺序、source layout 和后端能力；
-- 参数值、viewport、CCT、Grade 和 DRT 编辑不触发静态 plan 重编译；
-- ResolvedRenderGeometry 和 pass dirty schedule 属于每帧只读数据，不通过重编译静态图表达；
-- 接入并测试 `GraphCompiler::NeedsRecompile`，或删除该未使用 API 并用单一 plan key 机制替代；
-- plan cache miss、hit 和 compile count 必须可查询。
+- [x] 同一 source key 的 preview/quality/detail 渲染共享 PreparedRawInput；
+- [x] 未淘汰的 source 再次打开时复用主存结果，不重新执行 LibRaw open/unpack；
+- [x] DecodeRes 或输入准备规则改变时生成新 key，不覆盖仍被 submission 使用的旧条目；
+- [ ] source host bytes 只在 `develop.sensor_linear` miss 时上传；
+- [x] 静态 ExecutionPlan key 只包含 graph topology、节点/调整类型与顺序、source layout 和后端能力；
+- [x] 参数值、viewport、CCT、Grade 和 DRT 编辑不触发静态 plan 重编译；
+- [x] ResolvedRenderGeometry 和 pass dirty schedule 属于每帧只读数据，不通过重编译静态图表达；
+- [x] 接入并测试 `GraphCompiler::NeedsRecompile`，或删除该未使用 API 并用单一 plan key 机制替代；
+- [x] plan cache miss、hit 和 compile count 必须可查询。
+
+##### Phase G7R.1 completion record (2026-08-22)
+
+**Status:** complete — reusable CUDA product session caches PreparedRawInput and the static
+ExecutionPlan by content key. Parameter, viewport, CCT, Grade, and DRT edits no longer
+recompile. Source H2D skip on `develop.sensor_linear` miss is owned by G7R.2.
+
+`CudaProductRenderer` is the session named in 41.2 (`CudaProductPipelineSession`). It is
+created once per `CPUPipelineExecutor` and owns PreparedSourceCache, StaticExecutionPlanCache,
+and one `CudaRenderDevice`.
+
+**Primary success call chain:**
+
+```text
+CPUPipelineExecutor::Apply
+  -> CudaProductRenderer::Render
+  -> PreparedSourceCache::AcquireEncoded(encoded hash + DecodeRes + prep version)
+       hit  -> lease existing PreparedRawInput
+       miss -> unpack (LibRaw in production) + insert under a new key
+  -> StaticExecutionPlanCache::GetOrCompile(StaticPlanKey)
+       hit  -> copy cached pass list
+       miss -> GraphCompiler::CompileStatic
+  -> GraphCompiler::BindFrameGeometry (per-frame ResolvedRenderGeometry)
+  -> CudaRenderDevice::Execute
+  -> existing IFrameSink present or host download
+```
+
+**Primary failure call chain:**
+
+```text
+unpack / CompileStatic / Execute throw
+  -> PreparedSourceCache lease released; prior host and plan entries stay
+  -> CudaRenderDevice::CancelRender + ReportError
+  -> exception returns through CPUPipelineExecutor (no CPU image processing)
+```
+
+DecodeRes change inserts a second prepared-source key and does not replace a leased FULL
+entry. Adjustment-order or mask-topology change compiles a new static plan and leaves the
+previous plan in the cache.
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `PreparedSourceKeyIncludesEncodedHashKindDecodeResAndPreparationVersion` | `GpuDagRawInputTest` | PASS |
+| `PreparedSourceCacheReusesHostResultForSameEncodedKeyWithoutCallingUnpack` | `GpuDagRawInputTest` | PASS |
+| `PreparedSourceCacheSharesHostResultAcrossPreviewAndExportQuality` | `GpuDagRawInputTest` | PASS |
+| `PreparedSourceCacheUsesNewKeyForDecodeResChangeWithoutReplacingLeasedEntry` | `GpuDagRawInputTest` | PASS |
+| `PreparedSourceCacheReusesMatchingSourceAfterSwitchingEncodedBuffers` | `GpuDagRawInputTest` | PASS |
+| `PreparedSourceCacheDoesNotEvictLeasedEntryWhenHostBudgetIsExceeded` | `GpuDagRawInputTest` | PASS |
+| `GraphCompilerNeedsRecompileIsFalseForUnchangedTopologyAndSourceLayout` | `GpuDagRawInputTest` | PASS |
+| `GraphCompilerNeedsRecompileIsTrueWhenAdjustmentOrderChanges` | `GpuDagRawInputTest` | PASS |
+| `GraphCompilerNeedsRecompileIsTrueWhenSourceExtentChanges` | `GpuDagRawInputTest` | PASS |
+| `GraphCompilerCompileDoesNotBakeViewportIntoStaticPlanKey` | `GpuDagRawInputTest` | PASS |
+| `GraphCompilerBindsFrameGeometryWithoutChangingStaticPlanKey` | `GpuDagRawInputTest` | PASS |
+| `StaticExecutionPlanCacheCompilesOnceForRepeatedParameterAndViewportEdits` | `GpuDagRawInputTest` | PASS |
+| `StaticExecutionPlanCacheRecompilesWhenMaskTopologyChanges` | `GpuDagRawInputTest` | PASS |
+| `StaticExecutionPlanCacheRecompilesWhenSourceLayoutChanges` | `GpuDagRawInputTest` | PASS |
+| `StaticExecutionPlanCacheExposesHitMissAndCompileCounts` | `GpuDagRawInputTest` | PASS |
+| `ProductRendererCompilesStaticPlanOnlyForTopologyOrSourceLayoutChange` | `GpuDagCudaDrtProductTest` | PASS |
+| `ProductRendererReusesPreparedSourceAfterSwitchingEncodedBuffers` | `GpuDagCudaDrtProductTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagRawInputTest GpuDagCudaDrtProductTest GpuDagCudaDevelopTest GpuDagCudaPrimaryGradeTest --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "GpuDagRawInputTest|GpuDagCudaDrtProductTest|GpuDagCudaDevelopTest|GpuDagCudaPrimaryGradeTest|GpuDagCudaWorkspaceTest.GpuDagCudaWorkspace.GpuAndRuntimeHeadersDoNotIncludeCudaOrImageBuffer"
+```
+
+Suite totals: `49/49` PASS (`GpuDagRawInputTest` 24, CUDA Develop 6, CUDA Primary Grade 9,
+CUDA DRT product 9, runtime header hygiene 1).
+
+**Checklist / exit condition:** eight of nine G7R.1 work items checked. The remaining item is
+source H2D only on `develop.sensor_linear` miss.
+
+**LOC note (grill-code-review):** new files stay small: `prepared_source_cache.hpp` 99,
+`prepared_source_cache.cpp` 117, `static_execution_plan_cache.hpp` 49,
+`static_execution_plan_cache.cpp` 21, `cuda_product_plan_cache_test.cpp` 120,
+`prepared_source_cache_test.cpp` 113, `static_execution_plan_cache_test.cpp` 141.
+`cuda_product_renderer.cu` 157, `graph_compiler.cpp` 202, `raw_input_loader.cpp` 424.
+No changed file exceeds 500 lines.
+
+**Residual gaps:** source host-byte upload still runs on every `ExecuteCudaDevelop` of a Bayer
+input. Skipping H2D requires the G7R.2 `develop.sensor_linear` result cache. GPU node pass
+skip, geometry-after cache, CameraMatrices AP1, CAT02, and 41.9 A/B remain G7R.2–G7R.5.
+Crop/viewport still force GeometryResample; the product Bayer path currently throws
+`GeometryResamplePass::Encode: textures must be RGBA32F` for those frames, so the product
+test binds viewport/crop geometry without executing that resample. G7R.2 should keep that
+failure visible until the result cache owns geometry.
 
 ### 41.4 G7R.2 — 内容感知结果缓存和 geometry 后缓存
 


### PR DESCRIPTION
## Summary

- Restore prepared RAW and static `ExecutionPlan` caches, then content-key GPU result reuse.
- Restore CameraColor from stored camera matrices and the CUDA product render lifecycle.
- Run CUDA LLF in AP1/ACEScc, sample canonical LLF on ROI frames, and restore histogram/waveform scopes.
- Remirror editor sliders onto the live graph. Drop the temporary oval-mask probe and wire raster `MaskStore` into `CudaProductRenderer`.

## Stack

Layer G7R of GitHub stack #99.

- Base: #101
- Trunk: `main`

## Validation

- Adds product plan-cache, result-cache, camera-profile, scope-present, and remirror coverage.
- Default remirror is allowed whenever Develop, Primary Color Grade, and DRT exist; extra mask nodes stay in place.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
