### PR TITLE
feat(edit): complete GPU DAG CUDA product path

### DIFF
--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -273,7 +273,7 @@ def_library(ProjectService
 
 def_library(PipelineMgmtService
     SOURCES "${ALCEDO_APP_ROOT}/pipeline_service.cpp"
-    PUBLIC_DEPS ProjectService EditPipeline
+    PUBLIC_DEPS ProjectService EditPipeline EditGraph
 )
 
 def_library(AdjustmentTransferService

--- a/alcedo_studio/src/app/pipeline_service.cpp
+++ b/alcedo_studio/src/app/pipeline_service.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 
+#include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/history/commit_graph.hpp"
 #include "edit/history/edit_commit.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
@@ -24,6 +25,30 @@
 
 namespace alcedo {
 namespace {
+struct LoadedPipelineDocument {
+  std::shared_ptr<PipelineDocument> document;
+  bool                              mirror_legacy_stage_adapter = false;
+};
+
+auto LoadPipelineDocument(ElementStore& store, sl_element_id_t id,
+                          const std::shared_ptr<CPUPipelineExecutor>& legacy)
+    -> LoadedPipelineDocument {
+  const auto stored = store.GetPipelineJsonByElementId(id);
+  if (stored && stored->is_object() && stored->value("format_version", 0) == 2) {
+    return {std::make_shared<PipelineDocument>(PipelineDocument::FromJson(*stored)),
+            stored->contains("legacy_stage_adapter")};
+  }
+  if (legacy) {
+    auto imported = LegacyPipelineImporter::Import(legacy->ExportPipelineParams());
+    if (!imported.Ok()) {
+      throw std::runtime_error("PipelineMgmtService: legacy pipeline import failed: " +
+                               imported.error);
+    }
+    return {std::make_shared<PipelineDocument>(std::move(*imported.document)), true};
+  }
+  return {std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument()), true};
+}
+
 void ResetToDefaults(OperatorParams& params) {
   // OperatorParams has const members, so it is not assignable.
   // Reinitialize in-place to restore default values.
@@ -73,11 +98,8 @@ void EnsureDefaultColorTemp(CPUPipelineExecutor& exec) {
 
   nlohmann::json color_temp_params;
   color_temp_params["color_temp"] = {
-      {"mode", mode},
-      {"custom_cct", cct},
-      {"custom_tint", tint},
-      {"as_shot_cct", cct},
-      {"as_shot_tint", tint},
+      {"mode", mode},       {"custom_cct", cct},    {"custom_tint", tint},
+      {"as_shot_cct", cct}, {"as_shot_tint", tint},
   };
   to_ws_stage.SetOperator(OperatorType::COLOR_TEMP, color_temp_params, global_params);
 }
@@ -375,8 +397,7 @@ void PipelineMgmtService::HandleEviction(sl_element_id_t evicted_id) {
   if (pipeline_guard->pipeline_) {
     std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
     if (pipeline_guard->dirty_) {
-      storage_->GetElementStore().UpdatePipelineByElementId(
-          candidate, pipeline_guard->pipeline_);
+      storage_->GetElementStore().UpdatePipelineByElementId(candidate, pipeline_guard->pipeline_);
       pipeline_guard->dirty_ = false;
     }
     // Clear intermediate buffers before removing from cache to ensure timely memory release.
@@ -386,7 +407,7 @@ void PipelineMgmtService::HandleEviction(sl_element_id_t evicted_id) {
 
 auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<PipelineGuard> {
   std::shared_ptr<PipelineGuard> cached;
-  bool                          reinitialize = false;
+  bool                           reinitialize = false;
   {
     std::unique_lock<std::mutex> cache_lock(lock_);
     const auto                   it = loaded_pipelines_.find(id);
@@ -421,7 +442,7 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
   }
 
   std::shared_ptr<CPUPipelineExecutor> pipeline;
-  auto                                pipeline_guard = std::make_shared<PipelineGuard>();
+  auto                                 pipeline_guard = std::make_shared<PipelineGuard>();
   try {
     pipeline = storage_->GetLivePipeline(id);
     if (!pipeline) {
@@ -452,11 +473,16 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
   }
   storage_->RememberLivePipeline(id, pipeline);
 
-  pipeline_guard->pipeline_   = std::move(pipeline);
-  pipeline_guard->id_         = id;
-  pipeline_guard->pinned_     = true;
-  pipeline_guard->pin_count_  = 1;
-  pipeline_guard->dirty_      = false;
+  pipeline_guard->pipeline_ = std::move(pipeline);
+  auto loaded_document =
+      LoadPipelineDocument(storage_->GetElementStore(), id, pipeline_guard->pipeline_);
+  pipeline_guard->document_ = std::move(loaded_document.document);
+  pipeline_guard->pipeline_->SetPipelineDocument(pipeline_guard->document_,
+                                                 loaded_document.mirror_legacy_stage_adapter);
+  pipeline_guard->id_        = id;
+  pipeline_guard->pinned_    = true;
+  pipeline_guard->pin_count_ = 1;
+  pipeline_guard->dirty_     = false;
 
   std::shared_ptr<PipelineGuard> raced_cached;
   std::optional<sl_element_id_t> evicted;
@@ -469,7 +495,7 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
       raced_cached->pinned_ = true;
       pipeline_cache_.AccessElement(id);
     } else {
-      evicted = pipeline_cache_.RecordAccess_WithEvict(id, id);
+      evicted               = pipeline_cache_.RecordAccess_WithEvict(id, id);
       loaded_pipelines_[id] = pipeline_guard;
       if (!evicted.has_value() && loaded_pipelines_.size() + 1 > default_cache_capacity_) {
         pipeline_cache_.Resize(loaded_pipelines_.size() - 1);
@@ -485,22 +511,34 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
   return pipeline_guard;
 }
 
+void PipelineMgmtService::SyncPipelineDocument(const std::shared_ptr<PipelineGuard>& pipeline) {
+  if (!pipeline || !pipeline->document_) {
+    throw std::invalid_argument("PipelineMgmtService: cannot save a null PipelineDocument");
+  }
+  const auto json = pipeline->document_->ToJson();
+  if (json.value("format_version", 0) != 2) {
+    throw std::runtime_error("PipelineMgmtService: product save requires format version 2");
+  }
+  storage_->GetElementStore().UpdatePipelineJsonByElementId(pipeline->id_, json);
+  pipeline->dirty_ = false;
+}
+
 void PipelineMgmtService::InitializeImageRoot(const std::shared_ptr<PipelineGuard>& pipeline,
                                               const RawRuntimeColorContext* raw_color_context) {
   if (!pipeline || !pipeline->pipeline_) {
     throw std::runtime_error("PipelineMgmtService: cannot initialize a null pipeline root");
   }
 
-  nlohmann::json               root_params;
+  nlohmann::json root_params;
   {
     std::unique_lock<std::mutex> render_lock(pipeline->pipeline_->GetRenderLock());
     root_params = pipeline->pipeline_->ExportPipelineParams();
   }
 
-  auto               db_guard = storage_->GetDatabase().GetConnectionGuard();
-  auto               db_lock  = db_guard.Lock();
+  auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+  auto             db_lock  = db_guard.Lock();
   CommitGraphStore graph_service(db_guard.conn_);
-  auto               state = graph_service.GetImageEditState(pipeline->id_);
+  auto             state = graph_service.GetImageEditState(pipeline->id_);
   if (!state.has_value()) {
     auto graph = graph_service.CreateRootPipelinePersisted(
         pipeline->id_, root_params,
@@ -528,11 +566,11 @@ auto PipelineMgmtService::LoadEditorPipeline(sl_element_id_t id) -> std::shared_
   try {
     InitializeImageRoot(pipeline);
 
-    std::optional<CommitGraph>             graph;
+    std::optional<CommitGraph>              graph;
     std::optional<DecodedRootPipelineState> root_state;
     {
-      auto               db_guard = storage_->GetDatabase().GetConnectionGuard();
-      auto               db_lock  = db_guard.Lock();
+      auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+      auto             db_lock  = db_guard.Lock();
       CommitGraphStore graph_service(db_guard.conn_);
       graph = graph_service.LoadGraph(id);
       if (!graph.has_value()) {
@@ -551,8 +589,8 @@ auto PipelineMgmtService::LoadEditorPipeline(sl_element_id_t id) -> std::shared_
                                  std::to_string(id));
       }
 
-      const auto& state         = graph->GetImageEditState();
-      const auto  expected_head = graph->GetActiveVersionRef().head_commit_hash;
+      const auto& state          = graph->GetImageEditState();
+      const auto  expected_head  = graph->GetActiveVersionRef().head_commit_hash;
       const auto  expected_chain = graph->ChainHashForHead(expected_head);
       if (state.root_id != graph->GetRootId() ||
           state.materialized_head_commit_hash != expected_head ||
@@ -565,10 +603,10 @@ auto PipelineMgmtService::LoadEditorPipeline(sl_element_id_t id) -> std::shared_
     // History tip is sole authority. Checkpoint (params + head/chain label) is a fast path:
     // if the label matches the active Version tip, import params and skip first-parent replay.
     SetPipelineHistoryState(*pipeline, *graph);
-    const auto& state         = graph->GetImageEditState();
-    const auto  expected_head = graph->GetActiveVersionRef().head_commit_hash;
-    const auto  expected_chain = graph->ChainHashForHead(expected_head);
-    bool accepted_serialized_state = false;
+    const auto& state                     = graph->GetImageEditState();
+    const auto  expected_head             = graph->GetActiveVersionRef().head_commit_hash;
+    const auto  expected_chain            = graph->ChainHashForHead(expected_head);
+    bool        accepted_serialized_state = false;
     if (state.serialized_pipeline_state.has_value()) {
       const auto stored = DecodeSerializedPipelineState(*state.serialized_pipeline_state);
       if (stored.has_value() && stored->root_id == graph->GetRootId() &&
@@ -631,10 +669,10 @@ void PipelineMgmtService::SavePipeline(std::shared_ptr<PipelineGuard> pipeline) 
         pipeline_params = pipeline->pipeline_->ExportPipelineParams();
       }
 
-      auto               db_guard = storage_->GetDatabase().GetConnectionGuard();
-      auto               db_lock  = db_guard.Lock();
+      auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+      auto             db_lock  = db_guard.Lock();
       CommitGraphStore graph_service(db_guard.conn_);
-      auto stored_graph = graph_service.LoadGraph(pipeline->id_);
+      auto             stored_graph = graph_service.LoadGraph(pipeline->id_);
       if (!stored_graph.has_value()) {
         throw std::runtime_error(
             "PipelineMgmtService: cannot write serialized state without an edit graph");
@@ -681,13 +719,34 @@ void PipelineMgmtService::SavePipeline(std::shared_ptr<PipelineGuard> pipeline) 
     if (pipeline->pin_count_ > 0) {
       pipeline->pin_count_--;
     }
-    last_pin       = pipeline->pin_count_ == 0;
+    last_pin          = pipeline->pin_count_ == 0;
     pipeline->pinned_ = !last_pin;
   }
 
   // Shared by multiple callers (e.g. thumbnail + export): only the last owner may release/reset.
   if (!last_pin) {
     return;
+  }
+
+  // The editable pipeline table has one canonical representation from G7 onward. History keeps
+  // its serialized compatibility checkpoint separately, but a product save never writes the old
+  // stage array back over the format-version-2 graph.
+  if (pipeline->dirty_) {
+    nlohmann::json legacy_stage_adapter;
+    {
+      std::unique_lock<std::mutex> render_guard(pipeline->pipeline_->GetRenderLock());
+      legacy_stage_adapter = pipeline->pipeline_->ExportPipelineParams();
+    }
+    auto imported = LegacyPipelineImporter::Import(legacy_stage_adapter);
+    if (!imported.document.has_value()) {
+      throw std::runtime_error("PipelineMgmtService: cannot convert edited stages to format 2: " +
+                               imported.error);
+    }
+    *pipeline->document_                  = std::move(*imported.document);
+    auto document_json                    = pipeline->document_->ToJson();
+    document_json["legacy_stage_adapter"] = std::move(legacy_stage_adapter);
+    storage_->GetElementStore().UpdatePipelineJsonByElementId(pipeline->id_, document_json);
+    pipeline->dirty_ = false;
   }
 
   // Always clear intermediate buffers and GPU resources when returning a pipeline to cache.
@@ -704,14 +763,14 @@ void PipelineMgmtService::SavePipeline(std::shared_ptr<PipelineGuard> pipeline) 
   }
 
   // Save the pipeline back to the cache
-  sl_element_id_t                id      = pipeline->id_;
+  sl_element_id_t                id = pipeline->id_;
   // Store it back to the pipeline cache
   std::optional<sl_element_id_t> evicted;
   {
     std::unique_lock<std::mutex> cache_lock(lock_);
-    evicted = pipeline_cache_.RecordAccess_WithEvict(id, id);
-    pipeline->pinned_      = false;
-    loaded_pipelines_[id]  = pipeline;
+    evicted               = pipeline_cache_.RecordAccess_WithEvict(id, id);
+    pipeline->pinned_     = false;
+    loaded_pipelines_[id] = pipeline;
     if (!evicted.has_value() && loaded_pipelines_.size() + 1 > default_cache_capacity_) {
       pipeline_cache_.Resize(static_cast<uint32_t>(loaded_pipelines_.size() - 1));
     }
@@ -723,8 +782,7 @@ void PipelineMgmtService::SavePipeline(std::shared_ptr<PipelineGuard> pipeline) 
 
 auto PipelineMgmtService::PersistEditorHistoryState(
     const std::shared_ptr<PipelineGuard>& pipeline,
-    const ImageEditState&                 expected_materialized_state,
-    std::string*                          error) -> bool {
+    const ImageEditState& expected_materialized_state, std::string* error) -> bool {
   if (!pipeline || !pipeline->commit_graph_) {
     if (error != nullptr) {
       *error = "PipelineMgmtService: history persistence requires a loaded editor graph";
@@ -733,10 +791,10 @@ auto PipelineMgmtService::PersistEditorHistoryState(
   }
 
   try {
-    auto               db_guard = storage_->GetDatabase().GetConnectionGuard();
-    auto               db_lock  = db_guard.Lock();
+    auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    auto               stored_graph = graph_service.LoadGraph(pipeline->id_);
+    auto             stored_graph = graph_service.LoadGraph(pipeline->id_);
     if (!stored_graph.has_value()) {
       throw std::runtime_error("PipelineMgmtService: persisted editor graph is missing");
     }
@@ -778,12 +836,13 @@ auto PipelineMgmtService::CheckoutVersion(const std::shared_ptr<PipelineGuard>& 
     -> bool {
   if (!pipeline || !pipeline->pipeline_ || !pipeline->commit_graph_) {
     if (error != nullptr) {
-      *error = "PipelineMgmtService: checkout requires a loaded editor pipeline with a commit graph";
+      *error =
+          "PipelineMgmtService: checkout requires a loaded editor pipeline with a commit graph";
     }
     return false;
   }
 
-  auto& graph = *pipeline->commit_graph_;
+  auto&      graph            = *pipeline->commit_graph_;
   const auto prior_version_id = graph.GetActiveVersionId();
   if (prior_version_id == version_id) {
     // Already on the requested Version: logical head is the graph active head.
@@ -801,10 +860,10 @@ auto PipelineMgmtService::CheckoutVersion(const std::shared_ptr<PipelineGuard>& 
 
   DecodedRootPipelineState root_state;
   {
-    auto               db_guard = storage_->GetDatabase().GetConnectionGuard();
-    auto               db_lock  = db_guard.Lock();
+    auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    const auto root_encoded =
+    const auto       root_encoded =
         graph_service.GetRootSerializedPipelineState(pipeline->id_, graph.GetRootId());
     if (!root_encoded.has_value()) {
       if (error != nullptr) {
@@ -843,8 +902,8 @@ auto PipelineMgmtService::CheckoutVersion(const std::shared_ptr<PipelineGuard>& 
     try {
       graph.SetActiveVersionId(prior_version_id);
       std::unique_lock<std::mutex> render_lock(pipeline->pipeline_->GetRenderLock());
-      ImportSerializedPipelineState(*pipeline->pipeline_, prior_params, root_state.raw_color_context,
-                                    accelerator_preference_);
+      ImportSerializedPipelineState(*pipeline->pipeline_, prior_params,
+                                    root_state.raw_color_context, accelerator_preference_);
       pipeline->pipeline_->SetExecutionStages();
     } catch (...) {
       // Best-effort restore; still report the original checkout failure.
@@ -857,8 +916,8 @@ auto PipelineMgmtService::CheckoutVersion(const std::shared_ptr<PipelineGuard>& 
     try {
       graph.SetActiveVersionId(prior_version_id);
       std::unique_lock<std::mutex> render_lock(pipeline->pipeline_->GetRenderLock());
-      ImportSerializedPipelineState(*pipeline->pipeline_, prior_params, root_state.raw_color_context,
-                                    accelerator_preference_);
+      ImportSerializedPipelineState(*pipeline->pipeline_, prior_params,
+                                    root_state.raw_color_context, accelerator_preference_);
       pipeline->pipeline_->SetExecutionStages();
     } catch (...) {
     }
@@ -880,13 +939,13 @@ auto PipelineMgmtService::RebuildActiveEditorPipeline(
     return false;
   }
 
-  auto& graph = *pipeline->commit_graph_;
+  auto&                    graph = *pipeline->commit_graph_;
   DecodedRootPipelineState root_state;
   {
-    auto               db_guard = storage_->GetDatabase().GetConnectionGuard();
-    auto               db_lock  = db_guard.Lock();
+    auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    const auto root_encoded =
+    const auto       root_encoded =
         graph_service.GetRootSerializedPipelineState(pipeline->id_, graph.GetRootId());
     if (!root_encoded.has_value()) {
       if (error != nullptr) {
@@ -919,8 +978,8 @@ auto PipelineMgmtService::RebuildActiveEditorPipeline(
   } catch (const std::exception& ex) {
     try {
       std::unique_lock<std::mutex> render_lock(pipeline->pipeline_->GetRenderLock());
-      ImportSerializedPipelineState(*pipeline->pipeline_, prior_params, root_state.raw_color_context,
-                                    accelerator_preference_);
+      ImportSerializedPipelineState(*pipeline->pipeline_, prior_params,
+                                    root_state.raw_color_context, accelerator_preference_);
       pipeline->pipeline_->SetExecutionStages();
     } catch (...) {
     }
@@ -931,8 +990,8 @@ auto PipelineMgmtService::RebuildActiveEditorPipeline(
   } catch (...) {
     try {
       std::unique_lock<std::mutex> render_lock(pipeline->pipeline_->GetRenderLock());
-      ImportSerializedPipelineState(*pipeline->pipeline_, prior_params, root_state.raw_color_context,
-                                    accelerator_preference_);
+      ImportSerializedPipelineState(*pipeline->pipeline_, prior_params,
+                                    root_state.raw_color_context, accelerator_preference_);
       pipeline->pipeline_->SetExecutionStages();
     } catch (...) {
     }
@@ -944,8 +1003,8 @@ auto PipelineMgmtService::RebuildActiveEditorPipeline(
 }
 
 auto PipelineMgmtService::CollectUnreachableEditCommits() -> std::size_t {
-  auto               db_guard = storage_->GetDatabase().GetConnectionGuard();
-  auto               db_lock  = db_guard.Lock();
+  auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+  auto             db_lock  = db_guard.Lock();
   CommitGraphStore graph_service(db_guard.conn_);
   return graph_service.DeleteUnreachableCommitsForProject();
 }
@@ -980,8 +1039,8 @@ void PipelineMgmtService::DeletePipelines(std::span<const sl_element_id_t> ids) 
     }
   }
   try {
-    auto               db_guard = storage_->GetDatabase().GetConnectionGuard();
-    auto               db_lock  = db_guard.Lock();
+    auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
     for (const auto id : ids) {
       if (id != 0) {
@@ -1037,7 +1096,7 @@ void PipelineMgmtService::Sync() {
   for (const auto& pipeline_guard : dirty_pipelines) {
     std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
     storage_->GetElementStore().UpdatePipelineByElementId(pipeline_guard->id_,
-                                                                       pipeline_guard->pipeline_);
+                                                          pipeline_guard->pipeline_);
     {
       std::unique_lock<std::mutex> cache_lock(lock_);
       pipeline_guard->dirty_ = false;

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -78,11 +78,20 @@ if(ALCEDO_CUDA_ENABLED)
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_backend.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_adjustment_runtime.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_develop_pass.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_drt_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_mask_pass.cu
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_plan_executor.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_product_renderer.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_primary_grade_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/geometry_resample.cu
         PUBLIC_DEPS EditRuntime CUDA::cudart
-        PRIVATE_DEPS EditInput RawProcessorOp
+        PRIVATE_DEPS EditInput RawProcessorOp Operators
     )
     target_compile_definitions(EditRuntimeCuda PUBLIC HAVE_CUDA)
+endif()
+
+if(ALCEDO_CUDA_ENABLED)
+    # The existing scheduler owns CPUPipelineExecutor. Its CUDA branch is now a thin adapter into
+    # EditRuntimeCuda; OpenCL and Metal continue using the established stage adapters.
+    target_link_libraries(EditPipeline PRIVATE EditRuntimeCuda EditInput EditGraph)
 endif()

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -10,21 +10,24 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
+#include <opencv2/opencv.hpp>
 #include <sstream>
 #include <stdexcept>
 #include <vector>
-#include <opencv2/core.hpp>
-#include <opencv2/core/mat.hpp>
-
-#include "edit/pipeline/pipeline.hpp"
-
-#include <opencv2/opencv.hpp>
 
 #include "edit/operators/op_base.hpp"
 #include "edit/operators/raw/raw_decode_op.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
+#include "edit/pipeline/pipeline.hpp"
 #include "edit/pipeline/pipeline_stage.hpp"
 #include "image/image_buffer.hpp"
+#ifdef HAVE_CUDA
+#include "edit/graph/legacy_pipeline_importer.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#endif
 
 namespace alcedo {
 
@@ -43,10 +46,10 @@ auto FormatDurationMs(const double duration_ms) -> std::string {
 
 void SetCleanBaselineAdjustableOperators(
     std::array<PipelineStage, static_cast<int>(PipelineStageName::Stage_Count)>& stages,
-    OperatorParams& global_params) {
-  const nlohmann::json baseline = pipeline_defaults::MakeCleanBaselineAdjustableParams();
+    OperatorParams&                                                              global_params) {
+  const nlohmann::json baseline    = pipeline_defaults::MakeCleanBaselineAdjustableParams();
 
-  auto set_enabled = [&](PipelineStageName stage_name, OperatorType op_type,
+  auto                 set_enabled = [&](PipelineStageName stage_name, OperatorType op_type,
                          const nlohmann::json& params, bool enabled = true) {
     auto& stage = stages[static_cast<int>(stage_name)];
     stage.SetOperator(op_type, params, global_params);
@@ -81,11 +84,10 @@ void SetCleanBaselineAdjustableOperators(
   set_enabled(PipelineStageName::Output_Transform, OperatorType::ODT, baseline.at("odt"));
   set_enabled(PipelineStageName::Output_Transform, OperatorType::FILM_GRAIN,
               baseline.at("film_grain"));
-  set_enabled(PipelineStageName::Output_Transform, OperatorType::HALATION,
-              baseline.at("halation"));
+  set_enabled(PipelineStageName::Output_Transform, OperatorType::HALATION, baseline.at("halation"));
 }
 
-void PrintPipelineProfile(const ProfileClock::time_point apply_start,
+void PrintPipelineProfile(const ProfileClock::time_point  apply_start,
                           const std::vector<std::string>& executor_steps,
                           const std::vector<std::string>& stage_profiles) {
   std::ostringstream summary;
@@ -125,9 +127,9 @@ CPUPipelineExecutor::CPUPipelineExecutor()
                {PipelineStageName::Color_Adjustment, enable_cache_, true},
                {PipelineStageName::Detail_Adjustment, enable_cache_, true},
                {PipelineStageName::Output_Transform, enable_cache_, true}}) {
-  render_params_["resize"]                         = {};
-  render_params_["resize"]["downsample_algorithm"] = ToResizeAlgorithmParam(
-      ResizeDownsampleAlgorithm::Area);
+  render_params_["resize"] = {};
+  render_params_["resize"]["downsample_algorithm"] =
+      ToResizeAlgorithmParam(ResizeDownsampleAlgorithm::Area);
 
   // Initialize default pipeline
   InitDefaultPipeline();
@@ -151,9 +153,8 @@ void CPUPipelineExecutor::SetEnableCache(bool enable_cache) {
   // Reinitialize stages with the new cache setting
   ResetExecutionStagesCache();
   for (auto* stage : exec_stages_) {
-    const bool stage_cache_enabled = (stage->stage_ == PipelineStageName::Merged_Stage)
-                                         ? false
-                                         : enable_cache_;
+    const bool stage_cache_enabled =
+        (stage->stage_ == PipelineStageName::Merged_Stage) ? false : enable_cache_;
     stage->SetEnableCache(stage_cache_enabled);
   }
 }
@@ -167,9 +168,9 @@ CPUPipelineExecutor::CPUPipelineExecutor(bool enable_cache)
                {PipelineStageName::Color_Adjustment, enable_cache_, true},
                {PipelineStageName::Detail_Adjustment, enable_cache_, true},
                {PipelineStageName::Output_Transform, enable_cache_, true}}) {
-  render_params_["resize"]                         = {};
-  render_params_["resize"]["downsample_algorithm"] = ToResizeAlgorithmParam(
-      ResizeDownsampleAlgorithm::Area);
+  render_params_["resize"] = {};
+  render_params_["resize"]["downsample_algorithm"] =
+      ToResizeAlgorithmParam(ResizeDownsampleAlgorithm::Area);
   // Initialize default pipeline
   InitDefaultPipeline();
 }
@@ -183,6 +184,50 @@ auto CPUPipelineExecutor::GetStage(PipelineStageName stage) -> PipelineStage& {
 auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     -> std::shared_ptr<ImageBuffer> {
   const auto apply_start = ProfileClock::now();
+#ifdef HAVE_CUDA
+  if (resolved_accelerator_backend_ == GpuBackendKind::CUDA && pipeline_document_) {
+    // Existing editor controls still write the stage adapter during G7. Mirror it into the
+    // default three-node document only when it changed. Documents with additional graph nodes
+    // are edited as v2 data and must not be flattened by this transition path.
+    if (mirror_legacy_stage_adapter_ && pipeline_document_->Graph().Nodes().size() == 3U) {
+      const auto legacy = ExportPipelineParams();
+      if (legacy != cuda_product_legacy_snapshot_) {
+        auto imported = LegacyPipelineImporter::Import(legacy);
+        if (!imported.Ok()) {
+          throw std::runtime_error("CPUPipelineExecutor: legacy adapter import failed: " +
+                                   imported.error);
+        }
+        *pipeline_document_           = std::move(*imported.document);
+        cuda_product_legacy_snapshot_ = legacy;
+      }
+    }
+    if (!cuda_product_renderer_) {
+      cuda_product_renderer_ = std::make_shared<CudaProductRenderer>(pipeline_document_);
+    }
+    RenderRequest request;
+    if (const auto viewport = GetViewportRenderRegion();
+        viewport.has_value() && viewport->reference_width_ > 0 && viewport->reference_height_ > 0) {
+      request.view.visible_rect_in_edit_space = {
+          static_cast<float>(viewport->x_) / viewport->reference_width_,
+          static_cast<float>(viewport->y_) / viewport->reference_height_, viewport->scale_x_,
+          viewport->scale_y_};
+      if (viewport->target_width_ > 0 && viewport->target_height_ > 0) {
+        request.view.viewport_extent = {static_cast<std::uint32_t>(viewport->target_width_),
+                                        static_cast<std::uint32_t>(viewport->target_height_)};
+      }
+    }
+    if (render_params_.contains("resize") && render_params_["resize"].is_object()) {
+      const auto& resize = render_params_["resize"];
+      if (resize.value("enable_scale", false)) {
+        request.resolution.max_edge =
+            static_cast<std::uint32_t>(std::max(0, resize.value("maximum_edge", 0)));
+      }
+    }
+    request.resolution.quality = force_cpu_output_ ? RenderQuality::Export : RenderQuality::Preview;
+    return cuda_product_renderer_->Render(input, decode_res_, request, frame_sink_,
+                                          bound_frame_submission_, force_cpu_output_);
+  }
+#endif
   if (exec_stages_.empty()) {
     return input;
   }
@@ -203,10 +248,10 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
   // Before the merged GPU stream, re-trigger SetGlobalParams for operators
   // in stages that feed into it, so they pick up runtime data (e.g. raw decode
   // context) written by earlier non-merged stages.
-  auto refresh_before_merged = [&](PipelineStage* stage) {
+  auto                         refresh_before_merged = [&](PipelineStage* stage) {
     if (stage->stage_ == PipelineStageName::Merged_Stage) {
-      for (size_t i = static_cast<size_t>(PipelineStageName::To_WorkingSpace);
-           i < stages_.size(); ++i) {
+      for (size_t i = static_cast<size_t>(PipelineStageName::To_WorkingSpace); i < stages_.size();
+           ++i) {
         stages_[i].RefreshGlobalParams(global_params_);
       }
     }
@@ -217,10 +262,10 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     refresh_before_merged(stage);
     const auto refresh_elapsed = ProfileClock::now() - refresh_start;
 
-    const auto stage_start = ProfileClock::now();
+    const auto stage_start     = ProfileClock::now();
     stage->SetInputImage(output);
     stage->SetForceCPUOutput(force_cpu_output_);
-    output = stage->ApplyStage(global_params_);
+    output                    = stage->ApplyStage(global_params_);
 
     std::string stage_profile = stage->GetLastProfileSummary();
     if (stage_profile.empty()) {
@@ -234,8 +279,8 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     }
 
     if (stage->stage_ == PipelineStageName::Merged_Stage) {
-      stage_profile += " | refresh_global_params=" +
-                       FormatDurationMs(DurationToMs(refresh_elapsed));
+      stage_profile +=
+          " | refresh_global_params=" + FormatDurationMs(DurationToMs(refresh_elapsed));
     }
     stage_profiles.push_back(std::move(stage_profile));
   };
@@ -248,13 +293,15 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     const auto materialize_start = ProfileClock::now();
     if (input && input->buffer_valid_ && !input->cpu_data_valid_ && !input->gpu_data_valid_) {
       output = input->ShareEncodedBuffer();
-      executor_steps.push_back(std::string(step_name) + "_share_encoded=" +
-                               FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
+      executor_steps.push_back(
+          std::string(step_name) + "_share_encoded=" +
+          FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
       return;
     }
     output = std::make_shared<ImageBuffer>(input->Clone());
-    executor_steps.push_back(std::string(step_name) + "_clone=" +
-                             FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
+    executor_steps.push_back(
+        std::string(step_name) +
+        "_clone=" + FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
   };
 
   if (enable_cache_) {
@@ -265,16 +312,15 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
       }
     } else {
       // If cache is valid, use cached output
-      const auto cache_fetch_start = ProfileClock::now();
-      output = first_stage->GetOutputCache();
+      const auto cache_fetch_start   = ProfileClock::now();
+      output                         = first_stage->GetOutputCache();
       const auto cache_fetch_elapsed = ProfileClock::now() - cache_fetch_start;
       executor_steps.push_back("first_stage_cache_fetch=" +
                                FormatDurationMs(DurationToMs(cache_fetch_elapsed)));
-      stage_profiles.push_back("stage=" + first_stage->GetStageNameString() +
-                               " mode=executor_cache cache=hit total=" +
-                               FormatDurationMs(DurationToMs(cache_fetch_elapsed)) +
-                               " | get_output_cache=" +
-                               FormatDurationMs(DurationToMs(cache_fetch_elapsed)));
+      stage_profiles.push_back(
+          "stage=" + first_stage->GetStageNameString() + " mode=executor_cache cache=hit total=" +
+          FormatDurationMs(DurationToMs(cache_fetch_elapsed)) +
+          " | get_output_cache=" + FormatDurationMs(DurationToMs(cache_fetch_elapsed)));
       for (auto* stage : exec_stages_) {
         if (stage != first_stage) {
           apply_stage(stage);
@@ -291,6 +337,20 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
 
   PrintPipelineProfile(apply_start, executor_steps, stage_profiles);
   return output;
+}
+
+void CPUPipelineExecutor::SetPipelineDocument(std::shared_ptr<PipelineDocument> document,
+                                              bool mirror_legacy_stage_adapter) {
+#ifdef HAVE_CUDA
+  pipeline_document_            = std::move(document);
+  mirror_legacy_stage_adapter_  = mirror_legacy_stage_adapter;
+  cuda_product_legacy_snapshot_ = nullptr;
+  if (cuda_product_renderer_) {
+    cuda_product_renderer_->SetDocument(pipeline_document_);
+  }
+#else
+  (void)document;
+#endif
 }
 
 [[deprecated("SetPreviewMode is deprecated, set from pipeline scheduler instead")]] void
@@ -342,9 +402,8 @@ void CPUPipelineExecutor::SetExecutionStages() {
   }
 
   for (auto* stage : exec_stages_) {
-    const bool stage_cache_enabled = (stage->stage_ == PipelineStageName::Merged_Stage)
-                                         ? false
-                                         : enable_cache_;
+    const bool stage_cache_enabled =
+        (stage->stage_ == PipelineStageName::Merged_Stage) ? false : enable_cache_;
     stage->SetEnableCache(stage_cache_enabled);
   }
 }
@@ -403,8 +462,7 @@ void CPUPipelineExecutor::SetCancelRequested(std::function<bool()> cancel_reques
 void CPUPipelineExecutor::SetAcceleratorBackendPreference(
     const AcceleratorBackendPreference preference) {
   const auto resolved_backend = alcedo::ResolveAcceleratorBackend(preference);
-  if (accelerator_preference_ == preference &&
-      resolved_accelerator_backend_ == resolved_backend) {
+  if (accelerator_preference_ == preference && resolved_accelerator_backend_ == resolved_backend) {
     // A replaced RAW decode op (e.g. after direct stage writes) must still
     // follow the active runtime backend; re-apply even when nothing else
     // changed.
@@ -412,8 +470,8 @@ void CPUPipelineExecutor::SetAcceleratorBackendPreference(
     return;
   }
 
-  accelerator_preference_          = preference;
-  resolved_accelerator_backend_    = resolved_backend;
+  accelerator_preference_       = preference;
+  resolved_accelerator_backend_ = resolved_backend;
   ApplyRuntimeRawDecodeBackend();
 
   const auto previous_frame_sink = frame_sink_;
@@ -498,32 +556,31 @@ void CPUPipelineExecutor::ImportPipelineParams(const nlohmann::json& j) {
   SetExecutionStages();
 }
 
-void CPUPipelineExecutor::SetRenderRegion(int x, int y, float scale_factor_x,
-                                          float scale_factor_y, int reference_width,
-                                          int reference_height) {
+void CPUPipelineExecutor::SetRenderRegion(int x, int y, float scale_factor_x, float scale_factor_y,
+                                          int reference_width, int reference_height) {
   const nlohmann::json prev_resize_params =
       render_params_.contains("resize") ? render_params_["resize"] : nlohmann::json::object();
-  auto& resize_params = render_params_["resize"];
+  auto&       resize_params   = render_params_["resize"];
 
   const float clamped_scale_x = std::clamp(scale_factor_x, 1e-4f, 1.0f);
   const float clamped_scale_y =
       std::clamp((scale_factor_y > 0.0f) ? scale_factor_y : scale_factor_x, 1e-4f, 1.0f);
-  resize_params["enable_roi"] = (clamped_scale_x < (1.0f - 1e-4f)) ||
-                                (clamped_scale_y < (1.0f - 1e-4f));
-  resize_params["roi"]        = {{"x", std::max(0, x)},
-                                 {"y", std::max(0, y)},
-                                 {"resize_factor_x", clamped_scale_x},
-                                 {"resize_factor_y", clamped_scale_y},
-                                 {"resize_factor", std::max(clamped_scale_x, clamped_scale_y)},
-                                 {"reference_width", std::max(0, reference_width)},
-                                 {"reference_height", std::max(0, reference_height)}};
+  resize_params["enable_roi"] =
+      (clamped_scale_x < (1.0f - 1e-4f)) || (clamped_scale_y < (1.0f - 1e-4f));
+  resize_params["roi"]                        = {{"x", std::max(0, x)},
+                                                 {"y", std::max(0, y)},
+                                                 {"resize_factor_x", clamped_scale_x},
+                                                 {"resize_factor_y", clamped_scale_y},
+                                                 {"resize_factor", std::max(clamped_scale_x, clamped_scale_y)},
+                                                 {"reference_width", std::max(0, reference_width)},
+                                                 {"reference_height", std::max(0, reference_height)}};
 
-  global_params_.render_roi_enabled_ = resize_params["enable_roi"].get<bool>();
-  global_params_.render_roi_x_ = std::max(0, x);
-  global_params_.render_roi_y_ = std::max(0, y);
-  global_params_.render_roi_scale_x_ = clamped_scale_x;
-  global_params_.render_roi_scale_y_ = clamped_scale_y;
-  global_params_.render_roi_reference_width_ = std::max(0, reference_width);
+  global_params_.render_roi_enabled_          = resize_params["enable_roi"].get<bool>();
+  global_params_.render_roi_x_                = std::max(0, x);
+  global_params_.render_roi_y_                = std::max(0, y);
+  global_params_.render_roi_scale_x_          = clamped_scale_x;
+  global_params_.render_roi_scale_y_          = clamped_scale_y;
+  global_params_.render_roi_reference_width_  = std::max(0, reference_width);
   global_params_.render_roi_reference_height_ = std::max(0, reference_height);
 
   if (resize_params != prev_resize_params) {
@@ -552,7 +609,7 @@ void CPUPipelineExecutor::SetRenderRes(bool full_res, int max_side_length) {
 void CPUPipelineExecutor::SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm algorithm) {
   const nlohmann::json prev_resize_params =
       render_params_.contains("resize") ? render_params_["resize"] : nlohmann::json::object();
-  auto& resize_params = render_params_["resize"];
+  auto& resize_params                   = render_params_["resize"];
 
   resize_params["downsample_algorithm"] = ToResizeAlgorithmParam(algorithm);
 
@@ -563,7 +620,7 @@ void CPUPipelineExecutor::SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm
 }
 
 void CPUPipelineExecutor::SetDecodeRes(DecodeRes res) {
-  decode_res_ = res;
+  decode_res_     = res;
 
   // decode_res is a one-shot render parameter. Install it on the live op for this
   // Apply only; RawDecodeOp::GetParams deliberately omits it from durable export.
@@ -608,24 +665,22 @@ void CPUPipelineExecutor::RestoreOneShotRenderParams(const OneShotRenderParamsSn
       OperatorType::RESIZE, render_params_);
 
   if (render_params_.contains("resize") && render_params_["resize"].is_object()) {
-    const auto& resize_params              = render_params_["resize"];
-    global_params_.render_roi_enabled_     = resize_params.value("enable_roi", false);
+    const auto& resize_params          = render_params_["resize"];
+    global_params_.render_roi_enabled_ = resize_params.value("enable_roi", false);
     if (resize_params.contains("roi") && resize_params["roi"].is_object()) {
-      const auto& roi                          = resize_params["roi"];
-      global_params_.render_roi_x_             = roi.value("x", 0);
-      global_params_.render_roi_y_             = roi.value("y", 0);
-      global_params_.render_roi_scale_x_       = roi.value("resize_factor_x", 1.0f);
-      global_params_.render_roi_scale_y_       = roi.value("resize_factor_y", 1.0f);
-      global_params_.render_roi_reference_width_ =
-          roi.value("reference_width", 0);
-      global_params_.render_roi_reference_height_ =
-          roi.value("reference_height", 0);
+      const auto& roi                             = resize_params["roi"];
+      global_params_.render_roi_x_                = roi.value("x", 0);
+      global_params_.render_roi_y_                = roi.value("y", 0);
+      global_params_.render_roi_scale_x_          = roi.value("resize_factor_x", 1.0f);
+      global_params_.render_roi_scale_y_          = roi.value("resize_factor_y", 1.0f);
+      global_params_.render_roi_reference_width_  = roi.value("reference_width", 0);
+      global_params_.render_roi_reference_height_ = roi.value("reference_height", 0);
     } else {
-      global_params_.render_roi_x_               = 0;
-      global_params_.render_roi_y_               = 0;
-      global_params_.render_roi_scale_x_         = 1.0f;
-      global_params_.render_roi_scale_y_         = 1.0f;
-      global_params_.render_roi_reference_width_ = 0;
+      global_params_.render_roi_x_                = 0;
+      global_params_.render_roi_y_                = 0;
+      global_params_.render_roi_scale_x_          = 1.0f;
+      global_params_.render_roi_scale_y_          = 1.0f;
+      global_params_.render_roi_reference_width_  = 0;
       global_params_.render_roi_reference_height_ = 0;
     }
   }
@@ -697,7 +752,7 @@ void CPUPipelineExecutor::SetTemplateParams() {
                            lens_params["lens_calib"].value("enabled", true), global_params);
 
   nlohmann::json color_temp_params;
-  auto&          to_ws_stage = GetStage(PipelineStageName::To_WorkingSpace);
+  auto&          to_ws_stage      = GetStage(PipelineStageName::To_WorkingSpace);
   color_temp_params["color_temp"] = {{"mode", "as_shot"},
                                      {"custom_cct", 6500.0f},
                                      {"custom_tint", 0.0f},
@@ -709,8 +764,8 @@ void CPUPipelineExecutor::SetTemplateParams() {
   auto&          output_stage = GetStage(PipelineStageName::Output_Transform);
   output_params               = pipeline_defaults::MakeDefaultODTParams();
   output_stage.SetOperator(OperatorType::ODT, output_params, global_params);
-  output_stage.SetOperator(OperatorType::FILM_GRAIN, pipeline_defaults::MakeDefaultFilmGrainParams(),
-                           global_params);
+  output_stage.SetOperator(OperatorType::FILM_GRAIN,
+                           pipeline_defaults::MakeDefaultFilmGrainParams(), global_params);
   output_stage.SetOperator(OperatorType::HALATION, pipeline_defaults::MakeDefaultHalationParams(),
                            global_params);
 }
@@ -746,7 +801,8 @@ void CPUPipelineExecutor::ClearAllIntermediateBuffers() {
   }
 
   if (merged_stages_) {
-    merged_stages_->ResetRuntimeResources(PipelineStage::RuntimeResetMode::ClearIntermediateBuffers);
+    merged_stages_->ResetRuntimeResources(
+        PipelineStage::RuntimeResetMode::ClearIntermediateBuffers);
   }
 }
 

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
@@ -1,0 +1,139 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+
+#include "cuda/cuda_check.hpp"
+#include "cuda_drt_runtime_state.cuh"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/operators/GPU_kernels/color_mgmt/disp_enc_funcs.cuh"
+#include "edit/operators/GPU_kernels/color_mgmt/odt_funcs.cuh"
+#include "edit/operators/GPU_kernels/color_mgmt/open_drt_funcs.cuh"
+#include "edit/operators/cst/odt_op.hpp"
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/runtime/cuda/cuda_drt_pass.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr std::uint32_t kDrtDirtyBits = static_cast<std::uint32_t>(DrtDirty::All);
+
+auto EnsureDisplayImage(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
+                        std::uint32_t height) -> ResourceLease<CudaBackend>& {
+  auto* existing = workspace.Images().Find(id);
+  if (existing != nullptr && !existing->Empty() && existing->Texture().Width() == width &&
+      existing->Texture().Height() == height) {
+    return *existing;
+  }
+  auto lease = workspace.Textures().Acquire({width, height, TextureFormat::Rgba32f});
+  workspace.Images().Store(id, std::move(lease));
+  return *workspace.Images().Find(id);
+}
+
+void ResolveRuntime(CudaDrtRuntimeState& state, const DrtParamsModel& model) {
+  ODT_Op descriptor(nlohmann::json{{"odt", model.ToJson()}});
+  descriptor.SetGlobalParams(state.cpu_params);
+  state.gpu_params = GPUParamsConverter::ConvertFromCPU(state.cpu_params, state.gpu_params);
+}
+
+__global__ void DrtKernel(const float4* input, float4* output, std::uint32_t pixel_count,
+                          const GPU_TO_OUTPUT_Params* params) {
+  const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= pixel_count) return;
+  auto         runtime = *params;
+  const float4 source  = input[index];
+  const float3 scene   = make_float3(source.x, source.y, source.z);
+  float3       display_linear;
+  if (runtime.method_ == GPU_ODTMethod::ACES_2_0) {
+    auto aces      = runtime.aces_params_;
+    display_linear = CUDA::OutputTransform_fwd(scene, aces);
+  } else {
+    display_linear = CUDA::OpenDRTTransform_fwd(scene, runtime.open_drt_params_);
+  }
+  const float3 encoded = CUDA::DisplayEncoding(display_linear, runtime.limit_to_display_matx,
+                                               runtime.eotf, runtime.display_linear_scale_);
+  output[index]        = make_float4(encoded.x, encoded.y, encoded.z, source.w);
+}
+
+}  // namespace
+
+CudaRenderDevice::CudaRenderDevice() : drt_runtime_(std::make_unique<CudaDrtRuntimeState>()) {}
+
+CudaRenderDevice::~CudaRenderDevice() {
+  try {
+    WaitIdle();
+  } catch (...) {
+  }
+}
+
+void CudaRenderDevice::CancelRender() noexcept {
+  if (!workspace_.IsRendering()) return;
+  (void)::cudaStreamSynchronize(command_context_.Stream());
+  workspace_.CancelRender();
+}
+
+auto CudaRenderDevice::DrtRuntime() -> CudaDrtRuntimeState& { return *drt_runtime_; }
+
+auto ExecuteCudaDrt(CudaRenderDevice& device, const ExecutionPlan& plan, PipelineDocument& document)
+    -> CudaDrtResult {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteCudaDrt: BeginRender has not been called");
+  }
+  auto* drt = document.Drt();
+  if (drt == nullptr) throw std::runtime_error("ExecuteCudaDrt: missing DRT endpoint");
+  auto* input = workspace.Images().Find(plan.primary_grade_output);
+  if (input == nullptr || input->Empty()) {
+    throw std::runtime_error("ExecuteCudaDrt: missing primary-grade output");
+  }
+
+  auto&                       arena = workspace.Parameters();
+  const ParameterSlotKey      key{drt->Id(), AdjustmentInstanceId{"drt.output"}};
+  const ParameterFieldBinding field{DirtyFieldMask{kDrtDirtyBits}, 0, 0,
+                                    sizeof(GPU_TO_OUTPUT_Params)};
+  auto                        pending          = TakePendingParameterPatch(drt->Params());
+  const bool                  needs_initialize = !arena.Contains(key);
+  if (needs_initialize || pending.has_value()) {
+    ResolveRuntime(device.DrtRuntime(), drt->Params());
+    const auto runtime = device.DrtRuntime().gpu_params.to_output_params_;
+    auto       payload = std::make_shared<TypedOperatorParamPayload<GPU_TO_OUTPUT_Params>>(
+        drt->Params().Type(), 1, runtime);
+    if (needs_initialize) {
+      arena.BindSlot(key, sizeof(GPU_TO_OUTPUT_Params), std::span{&field, 1});
+      arena.InitializeFromFullDto(key, OperatorParamDto{drt->Params().Type(), 1, payload});
+    } else {
+      arena.ApplyPatch(
+          key, OperatorParamPatchDto{drt->Id(), AdjustmentInstanceId{"drt.output"},
+                                     drt->Params().Type(), DirtyFieldMask{kDrtDirtyBits}, payload});
+    }
+  }
+  arena.UploadDirty(device.CommandContext());
+  if (pending) pending->Commit();
+
+  const auto input_width  = input->Texture().Width();
+  const auto input_height = input->Texture().Height();
+  EnsureDisplayImage(workspace, plan.display_output, input_width, input_height);
+  input        = workspace.Images().Find(plan.primary_grade_output);
+  auto* output = workspace.Images().Find(plan.display_output);
+  if (input == nullptr || output == nullptr) {
+    throw std::runtime_error("ExecuteCudaDrt: image cache changed during allocation");
+  }
+  const auto& binding = arena.Binding(key);
+  const auto* params  = reinterpret_cast<const GPU_TO_OUTPUT_Params*>(
+      static_cast<const std::byte*>(arena.DeviceBuffer().DevicePointer()) + binding.offset);
+  const std::uint32_t     pixels = input_width * input_height;
+  constexpr std::uint32_t block  = 256;
+  DrtKernel<<<(pixels + block - 1) / block, block, 0, device.CommandContext().Stream()>>>(
+      static_cast<const float4*>(input->Texture().DevicePointer()),
+      static_cast<float4*>(output->Texture().DevicePointer()), pixels, params);
+  cuda::CheckCuda(::cudaGetLastError(), "ExecuteCudaDrt: kernel launch");
+  return {plan.display_output};
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_drt_runtime_state.cuh
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_drt_runtime_state.cuh
@@ -1,0 +1,21 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/operators/GPU_kernels/param.cuh"
+#include "edit/operators/op_base.hpp"
+
+namespace alcedo {
+
+/** CUDA-only resolved DRT data retained for the lifetime of one render device. */
+class CudaDrtRuntimeState {
+ public:
+  ~CudaDrtRuntimeState() { gpu_params.to_output_params_.Reset(); }
+
+  OperatorParams    cpu_params{};
+  GPUOperatorParams gpu_params{};
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
@@ -1,0 +1,42 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <exception>
+#include <stdexcept>
+
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/mask/mask_store.hpp"
+#include "edit/runtime/cuda/cuda_develop_pass.hpp"
+#include "edit/runtime/cuda/cuda_drt_pass.hpp"
+#include "edit/runtime/cuda/cuda_mask_pass.hpp"
+#include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/execution_plan.hpp"
+
+namespace alcedo {
+
+auto CudaRenderDevice::Execute(const ExecutionPlan& plan, const PreparedRawInput& input,
+                               PipelineDocument& document, MaskStore* mask_store) -> GraphValueId {
+  try {
+    BeginRender();
+    ExecuteCudaDevelop(*this, plan, input, document);
+    if (plan.primary_grade_mask) {
+      (void)ExecuteCudaMask(*this, plan, document, mask_store);
+    }
+    (void)ExecuteCudaPrimaryGrade(*this, plan, input.color_context, document);
+    const auto result = ExecuteCudaDrt(*this, plan, document);
+    EndRender();
+    return result.output;
+  } catch (const std::exception& ex) {
+    CancelRender();
+    ReportError(ex.what());
+    throw;
+  } catch (...) {
+    CancelRender();
+    ReportError("CUDA DAG execution failed with an unknown error");
+    throw;
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
@@ -1,0 +1,149 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <opencv2/core.hpp>
+#include <span>
+#include <stdexcept>
+#include <utility>
+
+#include "cuda/cuda_check.hpp"
+#include "edit/geometry/render_request.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "image/image_buffer.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo {
+namespace {
+
+void PresentCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id, IFrameSink& sink,
+                        const FrameCompletionSubmission& submission) {
+  auto* lease = device.Workspace().Images().Find(output_id);
+  if (lease == nullptr || lease->Empty()) {
+    throw std::runtime_error("CudaProductRenderer: DRT output is missing");
+  }
+  auto&      texture   = lease->Texture();
+  const auto width     = texture.Width();
+  const auto height    = texture.Height();
+  const auto row_bytes = static_cast<std::size_t>(width) * sizeof(float4);
+
+  sink.BindFrameSubmission(submission);
+  sink.EnsureSize(static_cast<int>(width), static_cast<int>(height));
+  const FrameWriteMapping mapping = sink.MapResourceForWrite(FrameMemoryDomain::CudaDevice);
+  if (!mapping) {
+    return;
+  }
+
+  try {
+    if (mapping.pixel_format != FramePixelFormat::RGBA32F) {
+      throw std::runtime_error("CudaProductRenderer: frame sink requires an RGBA32F target");
+    }
+    cudaError_t copy_result = cudaSuccess;
+    if (mapping.target_type == FrameWriteTargetType::LinearBuffer) {
+      const auto copy_kind = mapping.memory_domain == FrameMemoryDomain::CudaDevice
+                                 ? cudaMemcpyDeviceToDevice
+                                 : cudaMemcpyDeviceToHost;
+      copy_result =
+          ::cudaMemcpy2DAsync(mapping.data, mapping.row_bytes, texture.DevicePointer(), row_bytes,
+                              row_bytes, height, copy_kind, device.CommandContext().Stream());
+    } else if (mapping.target_type == FrameWriteTargetType::CudaArray &&
+               mapping.memory_domain == FrameMemoryDomain::CudaDevice) {
+      copy_result = ::cudaMemcpy2DToArrayAsync(
+          reinterpret_cast<cudaArray_t>(mapping.image_array), 0, 0, texture.DevicePointer(),
+          row_bytes, row_bytes, height, cudaMemcpyDeviceToDevice, device.CommandContext().Stream());
+    } else {
+      throw std::runtime_error("CudaProductRenderer: frame sink target is not CUDA-compatible");
+    }
+    cuda::CheckCuda(copy_result, "CudaProductRenderer: copy DRT output to frame sink");
+
+    if (mapping.cuda_signal_semaphore != nullptr && mapping.cuda_signal_value != 0) {
+      cudaExternalSemaphoreSignalParams signal_params{};
+      signal_params.params.fence.value = mapping.cuda_signal_value;
+      auto semaphore = reinterpret_cast<cudaExternalSemaphore_t>(mapping.cuda_signal_semaphore);
+      cuda::CheckCuda(::cudaSignalExternalSemaphoresAsync(&semaphore, &signal_params, 1,
+                                                          device.CommandContext().Stream()),
+                      "CudaProductRenderer: signal frame sink");
+    }
+    cuda::CheckCuda(::cudaStreamSynchronize(device.CommandContext().Stream()),
+                    "CudaProductRenderer: wait for frame sink copy");
+  } catch (...) {
+    sink.UnmapResource();
+    throw;
+  }
+  sink.UnmapResource();
+  sink.NotifyFrameReady(submission);
+}
+
+auto DownloadCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id)
+    -> std::shared_ptr<ImageBuffer> {
+  auto* lease = device.Workspace().Images().Find(output_id);
+  if (lease == nullptr || lease->Empty()) {
+    throw std::runtime_error("CudaProductRenderer: cannot download a missing DRT output");
+  }
+  auto&   texture = lease->Texture();
+  cv::Mat pixels(static_cast<int>(texture.Height()), static_cast<int>(texture.Width()), CV_32FC4);
+  auto    bytes = std::span<std::byte>{reinterpret_cast<std::byte*>(pixels.data),
+                                       pixels.total() * pixels.elemSize()};
+  device.Workspace().Device().DownloadTexture2D(texture, bytes, device.CommandContext());
+  return std::make_shared<ImageBuffer>(std::move(pixels));
+}
+
+}  // namespace
+
+CudaProductRenderer::CudaProductRenderer(std::shared_ptr<PipelineDocument> document)
+    : document_(std::move(document)), device_(std::make_unique<CudaRenderDevice>()) {
+  device_->SetErrorReporter([](std::string_view message) {
+    std::fprintf(stderr, "[ERROR] CUDA DAG product render failed: %.*s\n",
+                 static_cast<int>(message.size()), message.data());
+  });
+}
+
+CudaProductRenderer::~CudaProductRenderer() = default;
+
+void CudaProductRenderer::SetDocument(std::shared_ptr<PipelineDocument> document) {
+  if (!document) {
+    throw std::invalid_argument("CudaProductRenderer: PipelineDocument is null");
+  }
+  document_ = std::move(document);
+}
+
+auto CudaProductRenderer::Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
+                                 const RenderRequest& request, IFrameSink* sink,
+                                 const FrameCompletionSubmission& submission,
+                                 bool require_host_output) -> std::shared_ptr<ImageBuffer> {
+  if (!document_) {
+    throw std::runtime_error("CudaProductRenderer: PipelineDocument is not configured");
+  }
+  if (!input || !input->buffer_valid_) {
+    throw std::runtime_error("CudaProductRenderer: product path requires encoded image bytes");
+  }
+
+  auto&      encoded       = input->GetBuffer();
+  const auto encoded_bytes = std::span<const std::byte>{
+      reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
+  auto       prepared  = RawInputLoader::LoadEncoded(encoded_bytes, decode_res);
+  const auto plan      = GraphCompiler::Compile(*document_, prepared.CompileSource(), request);
+  const auto output_id = device_->Execute(plan, prepared, *document_);
+
+  try {
+    if (sink != nullptr) {
+      PresentCudaTexture(*device_, output_id, *sink, submission);
+    }
+    if (require_host_output) {
+      return DownloadCudaTexture(*device_, output_id);
+    }
+  } catch (const std::exception& ex) {
+    device_->ReportError(ex.what());
+    throw;
+  }
+  return std::make_shared<ImageBuffer>();
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -111,6 +111,9 @@ auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompi
     }
   }
   plan.passes.push_back(GpuPassDesc{GpuPassKind::PrimaryColorGrade});
+  plan.primary_grade_output = GraphValueId{grade->Id(), PortId{"image"}};
+  plan.display_output       = GraphValueId{document.Drt()->Id(), PortId{"display"}};
+  plan.passes.push_back(GpuPassDesc{GpuPassKind::Drt});
 
   for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
     plan.primary_grade_adjustments.push_back(

--- a/alcedo_studio/src/include/app/pipeline_service.hpp
+++ b/alcedo_studio/src/include/app/pipeline_service.hpp
@@ -14,6 +14,7 @@
 
 #include "app/image_pool_service.hpp"
 #include "decoders/processor/raw_color_context.hpp"
+#include "edit/graph/pipeline_document.hpp"
 #include "edit/history/commit_graph.hpp"
 #include "edit/history/commit_types.hpp"
 #include "edit/pipeline/pipeline.hpp"
@@ -43,6 +44,8 @@ namespace alcedo {
 ///   to the history tip; match skips first-parent replay.
 struct PipelineGuard {
   std::shared_ptr<CPUPipelineExecutor> pipeline_;
+  /// Authoritative format-version-2 graph used by the CUDA product renderer.
+  std::shared_ptr<PipelineDocument>    document_;
   sl_element_id_t                      id_;
   bool                                 dirty_     = false;
   /// Cache pin only: LoadPipeline / SavePipeline refcount so LRU eviction and
@@ -61,7 +64,7 @@ struct PipelineGuard {
   std::shared_ptr<CommitGraph>         commit_graph_;
 
   /// Active Version tip on commit_graph_ (history-owned). Empty graph → nullopt.
-  [[nodiscard]] auto working_head_commit_hash() const -> head_commit_hash_t {
+  [[nodiscard]] auto                   working_head_commit_hash() const -> head_commit_hash_t {
     if (!commit_graph_) {
       return std::nullopt;
     }
@@ -91,7 +94,7 @@ struct PipelineSnapshot {
 
 class PipelineMgmtService final {
  private:
-  std::shared_ptr<Storage>                                     storage_;
+  std::shared_ptr<Storage>                                            storage_;
 
   LRUCache<sl_element_id_t, sl_element_id_t>                          pipeline_cache_;
 
@@ -103,16 +106,14 @@ class PipelineMgmtService final {
 
   AcceleratorBackendPreference accelerator_preference_ = AcceleratorBackendPreference::Auto;
 
-  std::uint64_t editor_pipeline_history_rebuild_count_ = 0;
+  std::uint64_t                editor_pipeline_history_rebuild_count_ = 0;
 
   void                         HandleEviction(sl_element_id_t evicted_id);
 
  public:
   PipelineMgmtService() = delete;
   explicit PipelineMgmtService(std::shared_ptr<Storage> storage_service)
-      : storage_(storage_service),
-        pipeline_cache_(default_cache_capacity_),
-        loaded_pipelines_() {}
+      : storage_(storage_service), pipeline_cache_(default_cache_capacity_), loaded_pipelines_() {}
 
   void               SavePipeline(std::shared_ptr<PipelineGuard> pipeline);
 
@@ -120,11 +121,14 @@ class PipelineMgmtService final {
   /// caller keeps its editor guard pinned. `expected_materialized_state` is
   /// the state observed before the in-memory history mutation and prevents a
   /// concurrent writer from being overwritten.
-  auto PersistEditorHistoryState(const std::shared_ptr<PipelineGuard>& pipeline,
-                                 const ImageEditState&                 expected_materialized_state,
-                                 std::string* error = nullptr) -> bool;
+  auto               PersistEditorHistoryState(const std::shared_ptr<PipelineGuard>& pipeline,
+                                               const ImageEditState&                 expected_materialized_state,
+                                               std::string*                          error = nullptr) -> bool;
 
   auto               LoadPipeline(sl_element_id_t id) -> std::shared_ptr<PipelineGuard>;
+
+  /** @brief Save the guard's authoritative GPU DAG document as format version 2. */
+  void               SyncPipelineDocument(const std::shared_ptr<PipelineGuard>& pipeline);
 
   /// Load editor params for `id` using history tip as authority.
   /// If checkpoint (params + head/chain label) matches active Version tip, import params
@@ -159,19 +163,19 @@ class PipelineMgmtService final {
   /// pipeline. Does not invent a second head on the guard.
   ///
   /// @return true when the Version tip and pipeline params both match the checked-out head.
-  auto CheckoutVersion(const std::shared_ptr<PipelineGuard>& pipeline,
-                       const version_ref_id_t& version_id, std::string* error = nullptr) -> bool;
+  auto               CheckoutVersion(const std::shared_ptr<PipelineGuard>& pipeline,
+                                     const version_ref_id_t& version_id, std::string* error = nullptr) -> bool;
 
   /// Rebuild the executor params from the immutable root and the first-parent chain of the
   /// currently active Version tip. Used when the checkpoint label does not match history.
-  auto RebuildActiveEditorPipeline(const std::shared_ptr<PipelineGuard>& pipeline,
-                                   std::string* error = nullptr) -> bool;
+  auto               RebuildActiveEditorPipeline(const std::shared_ptr<PipelineGuard>& pipeline,
+                                                 std::string*                          error = nullptr) -> bool;
 
   /// Clean project-exit garbage collection: mark from every Version head through both parents and
   /// delete unreachable EditCommit rows. Must run only after the final successful save; abnormal
   /// shutdown must not call this.
   /// @return number of deleted commit rows.
-  auto CollectUnreachableEditCommits() -> std::size_t;
+  auto               CollectUnreachableEditCommits() -> std::size_t;
 
   void               DeletePipeline(sl_element_id_t id);
   void               DeletePipelines(std::span<const sl_element_id_t> ids);
@@ -204,14 +208,14 @@ class PipelineMgmtService final {
 /// Checkpoint label: which history tip the serialized params claim to match.
 /// Not a pipeline-owned head — only a tag stored next to the parameter table blob.
 struct PipelineCheckpointIdentity {
-  head_commit_hash_t       head  = std::nullopt;
+  head_commit_hash_t       head = std::nullopt;
   transaction_chain_hash_t chain{};
 };
 
 /// True when the checkpoint label on `state` matches the history tip after WAL attach.
 /// Match ⇒ safe to import params without first-parent SetOperator replay.
-[[nodiscard]] auto CheckpointMatchesLogicalHead(const ImageEditState& state,
-                                                head_commit_hash_t logical_head,
+[[nodiscard]] auto CheckpointMatchesLogicalHead(const ImageEditState&           state,
+                                                head_commit_hash_t              logical_head,
                                                 const transaction_chain_hash_t& logical_chain)
     -> bool;
 

--- a/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
@@ -20,6 +20,10 @@
 #include "ui/edit_viewer/frame_sink.hpp"
 
 namespace alcedo {
+class PipelineDocument;
+#ifdef HAVE_CUDA
+class CudaProductRenderer;
+#endif
 class CPUPipelineExecutor : public PipelineExecutor {
  private:
   sl_element_id_t                                                             bound_file_id_ = 0;
@@ -37,47 +41,51 @@ class CPUPipelineExecutor : public PipelineExecutor {
   bool                                                                        is_thumbnail_ = false;
 
   bool                             force_cpu_output_                                        = false;
-  DecodeRes                        decode_res_    = DecodeRes::FULL;
+  DecodeRes                        decode_res_ = DecodeRes::FULL;
   std::function<bool()>            cancel_requested_;
-  AcceleratorBackendPreference     accelerator_preference_ =
-      AcceleratorBackendPreference::Auto;
+  AcceleratorBackendPreference     accelerator_preference_ = AcceleratorBackendPreference::Auto;
   GpuBackendKind                   resolved_accelerator_backend_ = GpuBackendKind::None;
 
-  nlohmann::json                   render_params_ = {};
+  nlohmann::json                   render_params_                = {};
 
-  static constexpr PipelineBackend backend_       = PipelineBackend::CPU;
+  static constexpr PipelineBackend backend_                      = PipelineBackend::CPU;
 
   std::vector<PipelineStage*>      exec_stages_;
   std::unique_ptr<PipelineStage>   merged_stages_;
-  IFrameSink*                      frame_sink_      = nullptr;
+  IFrameSink*                      frame_sink_ = nullptr;
   FrameCompletionSubmission        bound_frame_submission_{};
+#ifdef HAVE_CUDA
+  std::shared_ptr<PipelineDocument>    pipeline_document_;
+  std::shared_ptr<CudaProductRenderer> cuda_product_renderer_;
+  nlohmann::json                       cuda_product_legacy_snapshot_;
+  bool                                 mirror_legacy_stage_adapter_ = false;
+#endif
 
-  void                             ResetStages();
+  void ResetStages();
 
-  void                             ResetExecutionStagesCache();
+  void ResetExecutionStagesCache();
 
-  void                             SetTemplateParams();
-  void                             ResolveAcceleratorBackend();
-  void                             ApplyAcceleratorBackendToStages();
-  void                             ApplyRuntimeRawDecodeBackend();
-  void                             SyncRawDecodeRuntimeControls();
+  void SetTemplateParams();
+  void ResolveAcceleratorBackend();
+  void ApplyAcceleratorBackendToStages();
+  void ApplyRuntimeRawDecodeBackend();
+  void SyncRawDecodeRuntimeControls();
 
  public:
   CPUPipelineExecutor();
   CPUPipelineExecutor(bool enable_cache);
 
-  void SetBoundFile(sl_element_id_t file_id) override { bound_file_id_ = file_id; }
-  auto GetBoundFile() const -> sl_element_id_t override { return bound_file_id_; }
+  void               SetBoundFile(sl_element_id_t file_id) override { bound_file_id_ = file_id; }
+  auto               GetBoundFile() const -> sl_element_id_t override { return bound_file_id_; }
 
-  void SetEnableCache(bool enable_cache);
-  auto GetBackend() -> PipelineBackend override;
+  void               SetEnableCache(bool enable_cache);
+  auto               GetBackend() -> PipelineBackend override;
 
-  void SetForceCPUOutput(bool force) override { force_cpu_output_ = force; }
-  void SetCancelRequested(std::function<bool()> cancel_requested);
+  void               SetForceCPUOutput(bool force) override { force_cpu_output_ = force; }
+  void               SetCancelRequested(std::function<bool()> cancel_requested);
 
-  void SetAcceleratorBackendPreference(AcceleratorBackendPreference preference);
-  [[nodiscard]] auto GetAcceleratorBackendPreference() const
-      -> AcceleratorBackendPreference {
+  void               SetAcceleratorBackendPreference(AcceleratorBackendPreference preference);
+  [[nodiscard]] auto GetAcceleratorBackendPreference() const -> AcceleratorBackendPreference {
     return accelerator_preference_;
   }
   [[nodiscard]] auto GetResolvedAcceleratorBackend() const -> GpuBackendKind {
@@ -88,6 +96,10 @@ class CPUPipelineExecutor : public PipelineExecutor {
 
   auto GetStage(PipelineStageName stage) -> PipelineStage& override;
   auto Apply(std::shared_ptr<ImageBuffer> input) -> std::shared_ptr<ImageBuffer> override;
+
+  /** @brief Select the format-version-2 document used by the CUDA product path. */
+  void SetPipelineDocument(std::shared_ptr<PipelineDocument> document,
+                           bool                              mirror_legacy_stage_adapter = false);
 
   void SetPreviewMode(bool is_preview);
 
@@ -108,14 +120,14 @@ class CPUPipelineExecutor : public PipelineExecutor {
   void BindFrameSubmission(const FramePreviewMetadata& metadata, FramePresentationMode mode);
   [[nodiscard]] auto BoundFrameSubmission() const -> FrameCompletionSubmission;
 
-  auto GetGlobalParams() -> OperatorParams& override { return global_params_; }
+  auto               GetGlobalParams() -> OperatorParams& override { return global_params_; }
 
   /**
    * @brief Serialize the pipeline parameters to JSON
    *
    * @return nlohmann::json
    */
-  auto ExportPipelineParams() const -> nlohmann::json override;
+  auto               ExportPipelineParams() const -> nlohmann::json override;
   /**
    * @brief Set the pipeline parameters from JSON. It will reset all stages and operators, as well
    * as cache. After importing, you need to call SetExecutionStages() to rebuild the execution
@@ -123,20 +135,18 @@ class CPUPipelineExecutor : public PipelineExecutor {
    *
    * @param j
    */
-  void ImportPipelineParams(const nlohmann::json& j) override;
+  void               ImportPipelineParams(const nlohmann::json& j) override;
 
-  void SetRenderRegion(int x, int y, float scale_factor_x,
-                       float scale_factor_y = -1.0f,
-                       int reference_width = 0,
-                       int reference_height = 0) override;
+  void SetRenderRegion(int x, int y, float scale_factor_x, float scale_factor_y = -1.0f,
+                       int reference_width = 0, int reference_height = 0) override;
   void SetRenderRes(bool full_res, int max_side_length = 2048) override;
   void SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm algorithm) override;
   void SetDecodeRes(DecodeRes res);
 
   /// Snapshot of one-shot render parameters that must not leak across Apply calls.
   struct OneShotRenderParamsSnapshot {
-    DecodeRes      decode_res_      = DecodeRes::FULL;
-    nlohmann::json render_params_   = {};
+    DecodeRes      decode_res_       = DecodeRes::FULL;
+    nlohmann::json render_params_    = {};
     bool           force_cpu_output_ = false;
     bool           enable_cache_     = true;
   };
@@ -144,24 +154,24 @@ class CPUPipelineExecutor : public PipelineExecutor {
   [[nodiscard]] auto CaptureOneShotRenderParams() const -> OneShotRenderParamsSnapshot;
   void               RestoreOneShotRenderParams(const OneShotRenderParamsSnapshot& snapshot);
 
-  void RegisterAllOperators();
-  void ResetToCleanBaselineAdjustments();
+  void               RegisterAllOperators();
+  void               ResetToCleanBaselineAdjustments();
 
-  void InitDefaultPipeline();
+  void               InitDefaultPipeline();
 
   /**
    * @brief Install image-local raw metadata into the pipeline (transition path).
    *        Prefer writing inherent RAW params into RawDecodeOp at import so that
    *        reload and render no longer require a per-frame inject.
    */
-  void InjectRawMetadata(const RawRuntimeColorContext& ctx);
+  void               InjectRawMetadata(const RawRuntimeColorContext& ctx);
 
   /**
    * @brief Clear all intermediate image buffers from all stages.
    *        Call this after pipeline execution when you want to release memory
    *        while keeping the pipeline configuration intact.
    */
-  void ClearAllIntermediateBuffers();
+  void               ClearAllIntermediateBuffers();
 
   /**
    * @brief Release transient merged-stage preview scratch buffers while keeping
@@ -170,14 +180,14 @@ class CPUPipelineExecutor : public PipelineExecutor {
    *        FAST_PREVIEW baseline and the large scratch high-water mark should
    *        not stay pinned in VRAM.
    */
-  void ReleasePreviewGpuScratch();
+  void               ReleasePreviewGpuScratch();
 
   /**
    * @brief Release persistent GPU allocations held by execution stages.
    *        Useful for batch export to avoid holding large VRAM allocations
    *        across many cached pipelines.
    */
-  void ReleaseAllGPUResources();
+  void               ReleaseAllGPUResources();
 
   [[nodiscard]] auto DebugGetMergedStageScratchBytes() const -> size_t;
 

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -81,6 +81,9 @@ class BasicRenderWorkspace {
 
   [[nodiscard]] auto IsRendering() const -> bool { return rendering_; }
 
+  /** @brief Leave a failed encode without submitting its incomplete command stream. */
+  void               CancelRender() { rendering_ = false; }
+
  private:
   Backend                       backend_{};
   ParameterArena<Backend>       parameters_;

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_drt_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_drt_pass.hpp
@@ -1,0 +1,29 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/execution_plan.hpp"
+
+namespace alcedo {
+
+class PipelineDocument;
+
+struct CudaDrtResult {
+  GraphValueId output{NodeId{"drt"}, PortId{"display"}};
+};
+
+/**
+ * @brief Encode the selected ACES 2.0 or OpenDRT display transform on CUDA.
+ *
+ * The input must be the compiled primary-grade AP1 image. The device owns resolved ACES tables
+ * and reuses them until DRT parameters change. A failed parameter upload retains Model dirty bits.
+ * No CPU image-processing fallback is attempted.
+ */
+[[nodiscard]] auto ExecuteCudaDrt(CudaRenderDevice& device, const ExecutionPlan& plan,
+                                  PipelineDocument& document) -> CudaDrtResult;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
@@ -1,0 +1,46 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <memory>
+
+#include "edit/geometry/render_request.hpp"
+#include "type/type.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo {
+
+class CudaRenderDevice;
+class ImageBuffer;
+class PipelineDocument;
+
+/**
+ * @brief Product adapter from the existing scheduler inputs to the CUDA DAG renderer.
+ *
+ * Owns one device workspace per loaded pipeline so node results and allocations survive
+ * consecutive scheduler frames. Failures are reported and propagated; this adapter never calls
+ * the old CPU image-processing stages.
+ */
+class CudaProductRenderer {
+ public:
+  explicit CudaProductRenderer(std::shared_ptr<PipelineDocument> document);
+  ~CudaProductRenderer();
+
+  CudaProductRenderer(const CudaProductRenderer&)                                  = delete;
+  auto               operator=(const CudaProductRenderer&) -> CudaProductRenderer& = delete;
+
+  void               SetDocument(std::shared_ptr<PipelineDocument> document);
+
+  [[nodiscard]] auto Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
+                            const RenderRequest& request, IFrameSink* sink,
+                            const FrameCompletionSubmission& submission, bool require_host_output)
+      -> std::shared_ptr<ImageBuffer>;
+
+ private:
+  std::shared_ptr<PipelineDocument> document_;
+  std::unique_ptr<CudaRenderDevice> device_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
@@ -4,12 +4,22 @@
 
 #pragma once
 
+#include <functional>
+#include <memory>
+#include <string_view>
+
 #include "edit/runtime/basic_render_workspace.hpp"
 #include "edit/runtime/cuda/cuda_backend.hpp"
 
 namespace alcedo {
 
 using CudaRenderWorkspace = BasicRenderWorkspace<CudaBackend>;
+
+class CudaDrtRuntimeState;
+class MaskStore;
+class PipelineDocument;
+struct ExecutionPlan;
+struct PreparedRawInput;
 
 /**
  * @brief Owns a CUDA workspace and one command context. Does not own a graph or plan.
@@ -18,24 +28,46 @@ using CudaRenderWorkspace = BasicRenderWorkspace<CudaBackend>;
  */
 class CudaRenderDevice {
  public:
+  CudaRenderDevice();
+  ~CudaRenderDevice();
+
+  CudaRenderDevice(const CudaRenderDevice&)                                  = delete;
+  auto               operator=(const CudaRenderDevice&) -> CudaRenderDevice& = delete;
+
   [[nodiscard]] auto Workspace() -> CudaRenderWorkspace& { return workspace_; }
   [[nodiscard]] auto Workspace() const -> const CudaRenderWorkspace& { return workspace_; }
   [[nodiscard]] auto CommandContext() -> CudaCommandContext& { return command_context_; }
 
-  void BeginRender() { workspace_.BeginRender(command_context_); }
-  void EndRender() { workspace_.EndRender(command_context_); }
-  void WaitIdle() { workspace_.Device().Wait(command_context_); }
+  void               BeginRender() { workspace_.BeginRender(command_context_); }
+  void               EndRender() { workspace_.EndRender(command_context_); }
+  void               WaitIdle() { workspace_.Device().Wait(command_context_); }
+  void               CancelRender() noexcept;
 
-  ~CudaRenderDevice() {
-    try {
-      WaitIdle();
-    } catch (...) {
-    }
+  /** @brief Install the app-layer error receiver. Called synchronously on the render thread. */
+  void               SetErrorReporter(std::function<void(std::string_view)> reporter) {
+    error_reporter_ = std::move(reporter);
+  }
+  void ReportError(std::string_view message) const {
+    if (error_reporter_) error_reporter_(message);
   }
 
+  [[nodiscard]] auto DrtRuntime() -> CudaDrtRuntimeState&;
+
+  /**
+   * @brief Execute the complete compiled CUDA DAG and return its display texture identity.
+   *
+   * Reports and rethrows failures after cancelling the incomplete submission. There is no CPU
+   * image-processing fallback.
+   */
+  [[nodiscard]] auto Execute(const ExecutionPlan& plan, const PreparedRawInput& input,
+                             PipelineDocument& document, MaskStore* mask_store = nullptr)
+      -> GraphValueId;
+
  private:
-  CudaRenderWorkspace workspace_;
-  CudaCommandContext  command_context_;
+  CudaRenderWorkspace                   workspace_;
+  CudaCommandContext                    command_context_;
+  std::unique_ptr<CudaDrtRuntimeState>  drt_runtime_;
+  std::function<void(std::string_view)> error_reporter_;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -48,6 +48,8 @@ struct ExecutionPlan {
   std::vector<CompiledAdjustment> primary_grade_adjustments;
   std::optional<CompiledMask>     primary_grade_mask;
   GraphValueId                    mask_output{NodeId{""}, PortId{"mask"}};
+  GraphValueId                    primary_grade_output{NodeId{"grade.primary"}, PortId{"image"}};
+  GraphValueId                    display_output{NodeId{"drt"}, PortId{"display"}};
 
   [[nodiscard]] auto              Contains(GpuPassKind kind) const -> bool {
     for (const auto& pass : passes) {

--- a/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
@@ -12,10 +12,11 @@
 namespace alcedo {
 
 /**
- * @brief Builds a Develop-only ExecutionPlan. Does not allocate GPU memory.
+ * @brief Builds the complete Develop -> PrimaryColorGrade -> DRT plan. Does not allocate GPU
+ * memory.
  *
- * Validates the three-node document. ColorGrade and DRT are accepted as graph
- * nodes but are not emitted as GPU passes in G4. Camera-to-AP1 is not a pass.
+ * Validates the three-node document. Camera-to-AP1 remains part of Develop rather than a
+ * separately allocated pass.
  *
  * Recompile when topology is dirty, input kind changes, or decoded extent
  * changes. Highlight / demosaic / lens flags are encoder branches, not new

--- a/alcedo_studio/src/include/edit/runtime/pass_kind.hpp
+++ b/alcedo_studio/src/include/edit/runtime/pass_kind.hpp
@@ -29,6 +29,7 @@ enum class GpuPassKind : std::uint8_t {
   MaskEvaluate      = 10,
   MaskFeather       = 11,
   PrimaryColorGrade = 12,
+  Drt               = 13,
 };
 
 [[nodiscard]] inline auto GpuPassKindName(GpuPassKind kind) -> const char* {
@@ -59,6 +60,8 @@ enum class GpuPassKind : std::uint8_t {
       return "MaskFeather";
     case GpuPassKind::PrimaryColorGrade:
       return "PrimaryColorGrade";
+    case GpuPassKind::Drt:
+      return "Drt";
   }
   return "Unknown";
 }

--- a/alcedo_studio/src/include/storage/mapper/pipeline/pipeline_mapper.hpp
+++ b/alcedo_studio/src/include/storage/mapper/pipeline/pipeline_mapper.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "edit/pipeline/pipeline_cpu.hpp"
+#include "json.hpp"
 #include "storage/mapper/duckorm/duckdb_types.hpp"
 #include "storage/mapper/mapper.hpp"
 #include "type/type.hpp"
@@ -23,10 +24,9 @@ struct PipelineMapperParams {
 /**
  * @brief Single-table mapper for PipelineParam rows and CPUPipelineExecutor snapshots.
  */
-class PipelineMapper
-    : public Mapper<PipelineMapper, std::shared_ptr<CPUPipelineExecutor>, PipelineMapperParams,
-                    sl_element_id_t>,
-      public FieldReflectable<PipelineMapper> {
+class PipelineMapper : public Mapper<PipelineMapper, std::shared_ptr<CPUPipelineExecutor>,
+                                     PipelineMapperParams, sl_element_id_t>,
+                       public FieldReflectable<PipelineMapper> {
  private:
   static constexpr uint32_t    field_count_                                      = 2;
   static constexpr const char* table_name_                                       = "PipelineParam";
@@ -40,10 +40,16 @@ class PipelineMapper
   static auto ToParams(const std::shared_ptr<CPUPipelineExecutor> source) -> PipelineMapperParams;
   static auto FromParams(PipelineMapperParams&& param) -> std::shared_ptr<CPUPipelineExecutor>;
 
-  auto GetPipelineParamByFileId(const sl_element_id_t file_id)
+  auto        GetPipelineParamByFileId(const sl_element_id_t file_id)
       -> std::shared_ptr<CPUPipelineExecutor>;
-  void UpdatePipelineParamByFileId(const sl_element_id_t                      file_id,
-                                   const std::shared_ptr<CPUPipelineExecutor> pipeline);
+  void               UpdatePipelineParamByFileId(const sl_element_id_t                      file_id,
+                                                 const std::shared_ptr<CPUPipelineExecutor> pipeline);
+
+  /** @brief Read the stored pipeline JSON without constructing a legacy executor. */
+  [[nodiscard]] auto GetPipelineJsonByFileId(sl_element_id_t file_id)
+      -> std::optional<nlohmann::json>;
+  /** @brief Persist the authoritative format-version-2 pipeline document JSON. */
+  void UpdatePipelineJsonByFileId(sl_element_id_t file_id, const nlohmann::json& document);
 
   friend struct FieldReflectable<PipelineMapper>;
   using Mapper::Mapper;

--- a/alcedo_studio/src/include/storage/store/sleeve/element_store.hpp
+++ b/alcedo_studio/src/include/storage/store/sleeve/element_store.hpp
@@ -18,14 +18,14 @@
 #include "sleeve/sleeve_element/sleeve_element.hpp"
 #include "sleeve/sleeve_filter/filter_combo.hpp"
 #include "storage/mapper/duckorm/duckdb_expr.hpp"
-#include "storage/store/store_types.hpp"
-#include "storage/mapper/sleeve/edit_history/recovery_metadata_mapper.hpp"
 #include "storage/mapper/pipeline/pipeline_mapper.hpp"
 #include "storage/mapper/sleeve/edit_history/history_mapper.hpp"
+#include "storage/mapper/sleeve/edit_history/recovery_metadata_mapper.hpp"
 #include "storage/mapper/sleeve/element/element_id_mapper.hpp"
 #include "storage/mapper/sleeve/element/element_mapper.hpp"
 #include "storage/mapper/sleeve/element/file_mapper.hpp"
 #include "storage/mapper/sleeve/element/folder_mapper.hpp"
+#include "storage/store/store_types.hpp"
 #include "type/type.hpp"
 
 namespace alcedo {
@@ -51,16 +51,16 @@ struct FolderStatsView {
  * (extra filter predicates only; folder scope ids stay embedded as trusted integers).
  */
 struct ScopedFileQuery {
-  std::string                 from_where_;
-  duckorm::SqlFragment        binds_{};
+  std::string          from_where_;
+  duckorm::SqlFragment binds_{};
 };
 
 /// Build the shared scope query fragment (FROM ... JOIN ... WHERE) for file-in-folder queries.
 /// All folder-scoped file lookups (search, stats, listing, pagination) must use this builder so
 /// the scope definition stays consistent across the application.
-auto BuildScopedFileQuery(
-    sl_element_id_t                           folder_id,
-    const std::optional<duckorm::SqlFragment>& extra_filter = std::nullopt) -> ScopedFileQuery;
+auto BuildScopedFileQuery(sl_element_id_t                            folder_id,
+                          const std::optional<duckorm::SqlFragment>& extra_filter = std::nullopt)
+    -> ScopedFileQuery;
 
 struct FileListEntry {
   sl_element_id_t file_id_  = 0;
@@ -70,26 +70,26 @@ struct FileListEntry {
 
 class ElementStore {
  private:
-  ConnectionGuard    guard_;
+  ConnectionGuard       guard_;
 
-  ElementMapper     element_mapper_;
-  ElementIdMapper   element_id_mapper_;
+  ElementMapper         element_mapper_;
+  ElementIdMapper       element_id_mapper_;
 
-  FileMapper        file_mapper_;
-  FolderMapper      folder_mapper_;
-  EditHistoryMapper history_mapper_;
-  PipelineMapper    pipeline_mapper_;
-  EditHistoryMapper edit_history_mapper_;
+  FileMapper            file_mapper_;
+  FolderMapper          folder_mapper_;
+  EditHistoryMapper     history_mapper_;
+  PipelineMapper        pipeline_mapper_;
+  EditHistoryMapper     edit_history_mapper_;
   std::function<void()> materialize_pre_commit_hook_{};
 
   // Insert the element row plus its child rows (file binding / folder content /
   // edit history). Does not touch sync_flag_ and does not manage a transaction, so
   // it can run either autocommit (AddElement) or inside a shared transaction
   // (AddElements).
-  void InsertElementRows(const std::shared_ptr<SleeveElement>& element);
+  void                  InsertElementRows(const std::shared_ptr<SleeveElement>& element);
   // Update the element row plus its child rows. Same transaction-neutrality contract
   // as InsertElementRows.
-  void UpdateElementRows(const std::shared_ptr<SleeveElement>& element);
+  void                  UpdateElementRows(const std::shared_ptr<SleeveElement>& element);
 
  public:
   ElementStore(ConnectionGuard&& guard);
@@ -120,35 +120,35 @@ class ElementStore {
   auto GetElementIdsInFolderByFilter(const std::shared_ptr<FilterCombo> filter,
                                      const sl_element_id_t              folder_id)
       -> std::vector<sl_element_id_t>;
-  auto BuildFolderStats(
-      sl_element_id_t                            folder_id,
-      const std::optional<duckorm::SqlFragment>& extra_filter = std::nullopt,
-      const std::string&                         active_semantic_model_key = {}) -> FolderStatsView;
+  auto BuildFolderStats(sl_element_id_t                            folder_id,
+                        const std::optional<duckorm::SqlFragment>& extra_filter = std::nullopt,
+                        const std::string& active_semantic_model_key = {}) -> FolderStatsView;
 
   /// Return lightweight file metadata for every live File in a folder, queried directly from DB
   /// without materializing full SleeveElement objects.
   auto ListFilesInFolder(sl_element_id_t folder_id) const -> std::vector<FileListEntry>;
-  auto ListFilesInFolderPage(
-      sl_element_id_t folder_id, size_t offset, size_t limit,
-      const std::optional<duckorm::SqlFragment>& extra_filter = std::nullopt) const
-      -> std::vector<FileListEntry>;
+  auto ListFilesInFolderPage(sl_element_id_t folder_id, size_t offset, size_t limit,
+                             const std::optional<duckorm::SqlFragment>& extra_filter =
+                                 std::nullopt) const -> std::vector<FileListEntry>;
   auto CountFilesInFolder(
       sl_element_id_t                            folder_id,
       const std::optional<duckorm::SqlFragment>& extra_filter = std::nullopt) const -> size_t;
 
   /// Return element IDs for files in a folder matching an extra SqlFragment predicate.
   /// Uses the same BuildScopedFileQuery infrastructure for consistency with stats queries.
-  auto ListFilteredFileIds(
-      sl_element_id_t                            folder_id,
-      const std::optional<duckorm::SqlFragment>& extra_filter = std::nullopt) const
-      -> std::vector<sl_element_id_t>;
+  auto ListFilteredFileIds(sl_element_id_t                            folder_id,
+                           const std::optional<duckorm::SqlFragment>& extra_filter =
+                               std::nullopt) const -> std::vector<sl_element_id_t>;
 
   void EnsureChildrenLoaded(sl_element_id_t folder_id);
 
   auto GetPipelineByElementId(const sl_element_id_t element_id)
       -> std::shared_ptr<CPUPipelineExecutor>;
-  auto UpdatePipelineByElementId(const sl_element_id_t                      element_id,
-                                 const std::shared_ptr<CPUPipelineExecutor> pipeline) -> void;
+  auto               UpdatePipelineByElementId(const sl_element_id_t                      element_id,
+                                               const std::shared_ptr<CPUPipelineExecutor> pipeline) -> void;
+  [[nodiscard]] auto GetPipelineJsonByElementId(sl_element_id_t element_id)
+      -> std::optional<nlohmann::json>;
+  void UpdatePipelineJsonByElementId(sl_element_id_t element_id, const nlohmann::json& document);
   auto RemovePipelineByElementId(const sl_element_id_t element_id) -> void;
   auto RemovePipelinesByElementIds(std::span<const sl_element_id_t> element_ids) -> void;
 
@@ -162,10 +162,10 @@ class ElementStore {
   /// recovery metadata on this controller's connection. Editor materialization
   /// and Version publication must use this path instead of separate
   /// SaveHistory()/SavePipeline() calls.
-  auto MaterializeEditorState(const std::shared_ptr<EditHistory>& history,
+  auto MaterializeEditorState(const std::shared_ptr<EditHistory>&         history,
                               const std::shared_ptr<CPUPipelineExecutor>& pipeline,
-                              const EditorRecoveryMetadata& recovery_metadata,
-                              std::string* error = nullptr) -> bool;
+                              const EditorRecoveryMetadata&               recovery_metadata,
+                              std::string*                                error = nullptr) -> bool;
 
   auto GetEditorRecoveryMetadata(sl_element_id_t file_id) -> std::optional<EditorRecoveryMetadata>;
 

--- a/alcedo_studio/src/storage/mapper/pipeline/pipeline_mapper.cpp
+++ b/alcedo_studio/src/storage/mapper/pipeline/pipeline_mapper.cpp
@@ -38,10 +38,34 @@ auto PipelineMapper::FromParams(PipelineMapperParams&& param)
   auto pipeline = std::make_shared<CPUPipelineExecutor>();
   pipeline->SetBoundFile(param.file_id);
   if (param.param_json) {
-    pipeline->ImportPipelineParams(nlohmann::json::parse(std::move(*param.param_json)));
+    const auto json = nlohmann::json::parse(std::move(*param.param_json));
+    // Format 2 is executed by the GPU DAG. The nested stage adapter keeps the unchanged
+    // OpenCL/Metal and editor-control paths buildable until G8/G9; it is not the persisted graph.
+    if (json.value("format_version", 0) == 2 && json.contains("legacy_stage_adapter")) {
+      pipeline->ImportPipelineParams(json.at("legacy_stage_adapter"));
+    } else if (json.value("format_version", 0) != 2) {
+      pipeline->ImportPipelineParams(json);
+    }
     pipeline->SetExecutionStages();
   }
   return pipeline;
+}
+
+auto PipelineMapper::GetPipelineJsonByFileId(sl_element_id_t file_id)
+    -> std::optional<nlohmann::json> {
+  auto rows = GetParams(std::format(PipelineMapper::PrimeKeyClause(), file_id).c_str());
+  if (rows.size() > 1) {
+    throw std::runtime_error("PipelineMapper: multiple pipeline JSON rows for file_id " +
+                             std::to_string(file_id));
+  }
+  if (rows.empty() || !rows.front().param_json) return std::nullopt;
+  return nlohmann::json::parse(*rows.front().param_json);
+}
+
+void PipelineMapper::UpdatePipelineJsonByFileId(sl_element_id_t       file_id,
+                                                const nlohmann::json& document) {
+  PipelineMapperParams params{file_id, std::make_unique<std::string>(document.dump())};
+  UpdateParams(file_id, params);
 }
 
 auto PipelineMapper::GetPipelineParamByFileId(const sl_element_id_t file_id)

--- a/alcedo_studio/src/storage/store/sleeve/element_store.cpp
+++ b/alcedo_studio/src/storage/store/sleeve/element_store.cpp
@@ -17,8 +17,8 @@
 #include "sleeve/sleeve_element/sleeve_element.hpp"
 #include "sleeve/sleeve_element/sleeve_file.hpp"
 #include "sleeve/sleeve_element/sleeve_folder.hpp"
-#include "storage/store/ai/ai_store.hpp"
 #include "storage/mapper/duckorm/duckdb_orm.hpp"
+#include "storage/store/ai/ai_store.hpp"
 #include "type/hash_type.hpp"
 #include "type/type.hpp"
 #include "utils/string/convert.hpp"
@@ -31,8 +31,8 @@ auto BuildScopedFileQuery(sl_element_id_t                            folder_id,
   ScopedFileQuery scope;
   std::string     extra_where;
   if (extra_filter.has_value() && !extra_filter->empty()) {
-    extra_where = " AND (" + extra_filter->sql_ + ")";
-    scope.binds_.sql_ = extra_filter->sql_;
+    extra_where         = " AND (" + extra_filter->sql_ + ")";
+    scope.binds_.sql_   = extra_filter->sql_;
     scope.binds_.binds_ = extra_filter->binds_;
   }
 
@@ -278,7 +278,7 @@ void ElementStore::RemoveElement(const std::shared_ptr<SleeveElement> element) {
   if (element->type_ == ElementType::FILE) {
     auto file = std::static_pointer_cast<SleeveFile>(element);
     DeleteSemanticAndAiRowsForFiles(guard_.conn_,
-                               std::span<const sl_element_id_t>(&file->element_id_, 1));
+                                    std::span<const sl_element_id_t>(&file->element_id_, 1));
     history_mapper_.RemoveById(file->element_id_);
     pipeline_mapper_.RemoveById(file->element_id_);
     file_mapper_.RemoveById(file->element_id_);
@@ -386,11 +386,10 @@ auto ElementStore::GetElementsInFolderByFilter(const std::shared_ptr<FilterCombo
     -> std::vector<std::shared_ptr<SleeveElement>> {
   auto       db_lock    = guard_.Lock();
   const auto where_frag = FilterSQLCompiler::Compile(filter->GetRoot());
-  const auto where =
-      where_frag.empty() ? std::optional<duckorm::SqlFragment>{} : where_frag;
+  const auto where      = where_frag.empty() ? std::optional<duckorm::SqlFragment>{} : where_frag;
   // Always resolve ids through the prepared-bind list path so SqlFragment
   // binds stay valid. Then load full elements by primary key.
-  const auto ids = ListFilteredFileIds(folder_id, where);
+  const auto ids        = ListFilteredFileIds(folder_id, where);
   std::vector<std::shared_ptr<SleeveElement>> out;
   out.reserve(ids.size());
   for (const auto id : ids) {
@@ -406,8 +405,7 @@ auto ElementStore::GetElementIdsInFolderByFilter(const std::shared_ptr<FilterCom
     -> std::vector<sl_element_id_t> {
   auto       db_lock    = guard_.Lock();
   const auto where_frag = FilterSQLCompiler::Compile(filter->GetRoot());
-  const auto where =
-      where_frag.empty() ? std::optional<duckorm::SqlFragment>{} : where_frag;
+  const auto where      = where_frag.empty() ? std::optional<duckorm::SqlFragment>{} : where_frag;
   return ListFilteredFileIds(folder_id, where);
 }
 
@@ -418,11 +416,11 @@ auto ElementStore::BuildFolderStats(sl_element_id_t                            f
   auto            db_lock = guard_.Lock();
   FolderStatsView out;
 
-  const auto  base_query = BuildScopedFileQuery(folder_id, extra_filter);
-  const auto& base_join  = base_query.from_where_;
-  const auto& binds      = base_query.binds_;
+  const auto      base_query = BuildScopedFileQuery(folder_id, extra_filter);
+  const auto&     base_join  = base_query.from_where_;
+  const auto&     binds      = base_query.binds_;
 
-  out.total_photo_count_ = static_cast<int>(
+  out.total_photo_count_     = static_cast<int>(
       RunScalarInt64(guard_.conn_, std::format("SELECT COUNT(*) {}", base_join), binds));
 
   out.date_stats_ = RunGroupByQuery(
@@ -520,8 +518,8 @@ auto ElementStore::ListFilesInFolderPage(
   return out;
 }
 
-auto ElementStore::CountFilesInFolder(
-    sl_element_id_t folder_id, const std::optional<duckorm::SqlFragment>& extra_filter) const
+auto ElementStore::CountFilesInFolder(sl_element_id_t                            folder_id,
+                                      const std::optional<duckorm::SqlFragment>& extra_filter) const
     -> size_t {
   auto              db_lock = guard_.Lock();
   const auto        scope   = BuildScopedFileQuery(folder_id, extra_filter);
@@ -538,8 +536,8 @@ auto ElementStore::ListFilteredFileIds(
   const auto                   scope = BuildScopedFileQuery(folder_id, extra_filter);
   const auto                   sql = std::format("SELECT e.id {} ORDER BY e.id", scope.from_where_);
 
-  duckdb_result     result;
-  duckdb_connection conn = guard_.conn_;
+  duckdb_result                result;
+  duckdb_connection            conn = guard_.conn_;
   if (duckorm::execute_query(conn, sql, scope.binds_, &result) != DuckDBSuccess) {
     duckdb_destroy_result(&result);
     return out;
@@ -561,10 +559,23 @@ auto ElementStore::GetPipelineByElementId(const sl_element_id_t element_id)
   return pipeline_mapper_.GetPipelineParamByFileId(element_id);
 }
 
-auto ElementStore::UpdatePipelineByElementId(
-    const sl_element_id_t element_id, const std::shared_ptr<CPUPipelineExecutor> pipeline) -> void {
+auto ElementStore::UpdatePipelineByElementId(const sl_element_id_t                      element_id,
+                                             const std::shared_ptr<CPUPipelineExecutor> pipeline)
+    -> void {
   auto db_lock = guard_.Lock();
   pipeline_mapper_.UpdatePipelineParamByFileId(element_id, pipeline);
+}
+
+auto ElementStore::GetPipelineJsonByElementId(sl_element_id_t element_id)
+    -> std::optional<nlohmann::json> {
+  auto db_lock = guard_.Lock();
+  return pipeline_mapper_.GetPipelineJsonByFileId(element_id);
+}
+
+void ElementStore::UpdatePipelineJsonByElementId(sl_element_id_t       element_id,
+                                                 const nlohmann::json& document) {
+  auto db_lock = guard_.Lock();
+  pipeline_mapper_.UpdatePipelineJsonByFileId(element_id, document);
 }
 
 auto ElementStore::RemovePipelineByElementId(const sl_element_id_t element_id) -> void {
@@ -585,8 +596,7 @@ auto ElementStore::GetEditHistoryByFileId(const sl_element_id_t file_id)
 }
 
 auto ElementStore::UpdateEditHistoryByFileId(const sl_element_id_t              file_id,
-                                                  const std::shared_ptr<EditHistory> history)
-    -> void {
+                                             const std::shared_ptr<EditHistory> history) -> void {
   auto db_lock = guard_.Lock();
   history_mapper_.Update(history, file_id);
 }
@@ -596,8 +606,7 @@ auto ElementStore::RemoveEditHistoryByFileId(const sl_element_id_t file_id) -> v
   history_mapper_.RemoveById(file_id);
 }
 
-auto ElementStore::RemoveEditHistoriesByFileIds(std::span<const sl_element_id_t> file_ids)
-    -> void {
+auto ElementStore::RemoveEditHistoriesByFileIds(std::span<const sl_element_id_t> file_ids) -> void {
   auto db_lock = guard_.Lock();
   history_mapper_.RemoveByIds(file_ids);
 }
@@ -606,9 +615,9 @@ namespace {
 auto ToRecoveryMapperParams(const EditorRecoveryMetadata& metadata)
     -> EditorRecoveryMetadataMapperParams {
   EditorRecoveryMetadataMapperParams params;
-  params.file_id                         = metadata.element_id;
-  params.version_id                      = std::make_unique<std::string>(metadata.version_id.ToString());
-  params.journal_generation              = metadata.journal_generation;
+  params.file_id            = metadata.element_id;
+  params.version_id         = std::make_unique<std::string>(metadata.version_id.ToString());
+  params.journal_generation = metadata.journal_generation;
   params.materialized_operation_sequence = metadata.materialized_operation_sequence;
   params.transaction_chain_hash =
       std::make_unique<std::string>(metadata.transaction_chain_hash.ToString());
@@ -637,9 +646,9 @@ auto FromRecoveryMapperParams(EditorRecoveryMetadataMapperParams&& params)
 }  // namespace
 
 auto ElementStore::MaterializeEditorState(const std::shared_ptr<EditHistory>&         history,
-    const std::shared_ptr<CPUPipelineExecutor>& pipeline,
-                                               const EditorRecoveryMetadata& recovery_metadata,
-                                               std::string*                  error) -> bool {
+                                          const std::shared_ptr<CPUPipelineExecutor>& pipeline,
+                                          const EditorRecoveryMetadata& recovery_metadata,
+                                          std::string*                  error) -> bool {
   if (!history || !pipeline) {
     if (error) {
       *error = "MaterializeEditorState requires history and pipeline";
@@ -696,9 +705,9 @@ auto ElementStore::MaterializeEditorState(const std::shared_ptr<EditHistory>&   
 
 auto ElementStore::GetEditorRecoveryMetadata(sl_element_id_t file_id)
     -> std::optional<EditorRecoveryMetadata> {
-  auto db_lock = guard_.Lock();
+  auto                         db_lock = guard_.Lock();
   EditorRecoveryMetadataMapper mapper(guard_.conn_);
-  auto rows = mapper.Get(std::format("file_id={}", file_id).c_str());
+  auto                         rows = mapper.Get(std::format("file_id={}", file_id).c_str());
   if (rows.empty()) {
     return std::nullopt;
   }

--- a/alcedo_studio/tests/app/pipeline_service_test.cpp
+++ b/alcedo_studio/tests/app/pipeline_service_test.cpp
@@ -6,10 +6,11 @@
 
 #include <duckdb.h>
 #include <gtest/gtest.h>
+
+#include <atomic>
 #include <filesystem>
 #include <format>
 #include <memory>
-#include <atomic>
 #include <random>
 #include <thread>
 #include <unordered_map>
@@ -58,6 +59,25 @@ class PipelineMapperTests : public ::testing::Test {
 TEST_F(PipelineMapperTests, InitTest) {
   ProjectService project(db_path_, meta_path_);
   EXPECT_NO_THROW(PipelineMgmtService pipeline_service(project.GetStorage()));
+}
+
+TEST_F(PipelineMapperTests, PipelineMgmtServiceBuildsDefaultGpuDagForNewImage) {
+  ProjectService      project(db_path_, meta_path_);
+  PipelineMgmtService pipeline_service(project.GetStorage());
+  auto                guard = pipeline_service.LoadPipeline(9001);
+  ASSERT_NE(guard, nullptr);
+  ASSERT_NE(guard->document_, nullptr);
+  EXPECT_EQ(guard->document_->Graph().Nodes().size(), 3U);
+  EXPECT_EQ(guard->document_->Graph().Edges().size(), 2U);
+  EXPECT_EQ(guard->document_->ToJson().at("format_version"), 2);
+
+  guard->dirty_ = true;
+  pipeline_service.SavePipeline(guard);
+  const auto stored = project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(9001);
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->at("format_version"), 2);
+  EXPECT_EQ(stored->at("nodes").size(), 3U);
+  EXPECT_FALSE(stored->contains("stages"));
 }
 
 TEST_F(PipelineMapperTests, BasicPipelineRWTest) {
@@ -126,8 +146,7 @@ TEST_F(PipelineMapperTests, DefaultOutputTransformUsesOpenDRT) {
   ASSERT_TRUE(exported["Output Transform"]["Output Transform"].contains("odt"));
   ASSERT_TRUE(exported["Output Transform"]["Output Transform"]["odt"].contains("params"));
   ASSERT_TRUE(exported["Output Transform"]["Output Transform"]["odt"]["params"].contains("odt"));
-  const auto& odt =
-      exported["Output Transform"]["Output Transform"]["odt"]["params"]["odt"];
+  const auto& odt = exported["Output Transform"]["Output Transform"]["odt"]["params"]["odt"];
   EXPECT_EQ(odt["method"], "open_drt");
   EXPECT_EQ(odt["encoding_eotf"], "gamma_2_2");
   EXPECT_EQ(odt["limiting_space"], "rec709");
@@ -145,17 +164,16 @@ TEST_F(PipelineMapperTests, DefaultOutputTransformUsesOpenDRT) {
 TEST_F(PipelineMapperTests, DefaultPipelineAdjustmentsUseCleanBaseline) {
   CPUPipelineExecutor exec;
 
-  const auto exported = exec.ExportPipelineParams();
+  const auto          exported = exec.ExportPipelineParams();
   EXPECT_EQ(exported["Basic Adjustment"]["Basic Adjustment"]["exposure"]["params"]["exposure"],
             1.5);
   EXPECT_EQ(exported["Basic Adjustment"]["Basic Adjustment"]["contrast"]["params"]["contrast"],
             0.0);
   EXPECT_EQ(exported["Color Adjustment"]["Color Adjustment"]["saturation"]["params"]["saturation"],
             30.0);
-  EXPECT_EQ(exported["Color Adjustment"]["Color Adjustment"]["ocio_lmt"]["params"]["ocio_lmt"],
-            "");
-  EXPECT_FALSE(exported["Geometry Adjustment"]["Geometry Adjustment"]["crop_rotate"]["enable"]
-                   .get<bool>());
+  EXPECT_EQ(exported["Color Adjustment"]["Color Adjustment"]["ocio_lmt"]["params"]["ocio_lmt"], "");
+  EXPECT_FALSE(
+      exported["Geometry Adjustment"]["Geometry Adjustment"]["crop_rotate"]["enable"].get<bool>());
   EXPECT_EQ(exported["Geometry Adjustment"]["Geometry Adjustment"]["crop_rotate"]["params"]
                     ["crop_rotate"]["enabled"],
             false);
@@ -172,10 +190,10 @@ TEST_F(PipelineMapperTests, DefaultPipelineAdjustmentsUseCleanBaseline) {
 
 TEST_F(PipelineMapperTests, ResetToCleanBaselineAdjustmentsPreservesLoadingAndColorTemp) {
   CPUPipelineExecutor exec;
-  auto&               loading = exec.GetStage(PipelineStageName::Image_Loading);
-  auto&               to_ws   = exec.GetStage(PipelineStageName::To_WorkingSpace);
+  auto&               loading                 = exec.GetStage(PipelineStageName::Image_Loading);
+  auto&               to_ws                   = exec.GetStage(PipelineStageName::To_WorkingSpace);
 
-  nlohmann::json raw_params = pipeline_defaults::MakeDefaultRawDecodeParams();
+  nlohmann::json      raw_params              = pipeline_defaults::MakeDefaultRawDecodeParams();
   raw_params["raw"]["highlights_reconstruct"] = false;
   loading.SetOperator(OperatorType::RAW_DECODE, raw_params);
 
@@ -194,8 +212,8 @@ TEST_F(PipelineMapperTests, ResetToCleanBaselineAdjustmentsPreservesLoadingAndCo
   EXPECT_EQ(exported["Image Loading"]["Image Loading"]["raw_decode"]["params"]["raw"]
                     ["highlights_reconstruct"],
             false);
-  EXPECT_EQ(exported["To Working Space"]["To Working Space"]["color_temp"]["params"]
-                    ["color_temp"]["mode"],
+  EXPECT_EQ(exported["To Working Space"]["To Working Space"]["color_temp"]["params"]["color_temp"]
+                    ["mode"],
             "custom");
   EXPECT_EQ(exported["Basic Adjustment"]["Basic Adjustment"]["exposure"]["params"]["exposure"],
             1.5);
@@ -217,8 +235,8 @@ TEST_F(PipelineMapperTests, LoadPipelineRepairsLensCalibEnableMismatchFromParams
     ASSERT_TRUE(lens_entry.contains("params"));
     ASSERT_TRUE(lens_entry["params"].contains("lens_calib"));
 
-    lens_entry["enable"]                                  = true;
-    lens_entry["params"]["lens_calib"]["enabled"]         = false;
+    lens_entry["enable"]                          = true;
+    lens_entry["params"]["lens_calib"]["enabled"] = false;
     pipeline_guard->pipeline_->ImportPipelineParams(serialized);
 
     auto op = pipeline_guard->pipeline_->GetStage(PipelineStageName::Image_Loading)
@@ -239,9 +257,8 @@ TEST_F(PipelineMapperTests, LoadPipelineRepairsLensCalibEnableMismatchFromParams
 
     auto                reloaded = pipeline_service.LoadPipeline(44);
     ASSERT_NE(reloaded, nullptr);
-    auto                op =
-        reloaded->pipeline_->GetStage(PipelineStageName::Image_Loading)
-            .GetOperator(OperatorType::LENS_CALIBRATION);
+    auto op = reloaded->pipeline_->GetStage(PipelineStageName::Image_Loading)
+                  .GetOperator(OperatorType::LENS_CALIBRATION);
     ASSERT_TRUE(op.has_value());
     ASSERT_NE(op.value(), nullptr);
     EXPECT_FALSE(op.value()->enable_);
@@ -256,15 +273,15 @@ TEST_F(PipelineMapperTests, OutputTransformPersistencePreservesSharedAndMethodSp
   auto                pipeline_guard = pipeline_service.LoadPipeline(43);
   ASSERT_NE(pipeline_guard, nullptr);
 
-  nlohmann::json odt_params = pipeline_defaults::MakeDefaultODTParams();
-  odt_params["odt"]["method"] = "aces_2_0";
-  odt_params["odt"]["encoding_space"] = "rec2020";
-  odt_params["odt"]["encoding_eotf"] = "st2084";
-  odt_params["odt"]["peak_luminance"] = 600.0f;
-  odt_params["odt"]["limiting_space"] = "p3_d65";
-  odt_params["odt"]["open_drt"]["look_preset"] = "umbra";
-  odt_params["odt"]["open_drt"]["tonescale_preset"] = "aces_2_0";
-  odt_params["odt"]["open_drt"]["creative_white"] = "d60";
+  nlohmann::json odt_params                             = pipeline_defaults::MakeDefaultODTParams();
+  odt_params["odt"]["method"]                           = "aces_2_0";
+  odt_params["odt"]["encoding_space"]                   = "rec2020";
+  odt_params["odt"]["encoding_eotf"]                    = "st2084";
+  odt_params["odt"]["peak_luminance"]                   = 600.0f;
+  odt_params["odt"]["limiting_space"]                   = "p3_d65";
+  odt_params["odt"]["open_drt"]["look_preset"]          = "umbra";
+  odt_params["odt"]["open_drt"]["tonescale_preset"]     = "aces_2_0";
+  odt_params["odt"]["open_drt"]["creative_white"]       = "d60";
   odt_params["odt"]["open_drt"]["creative_white_limit"] = 23.5f;
   odt_params["odt"]["open_drt"]["display_grey_luminance"] = 12.5f;
 
@@ -279,8 +296,7 @@ TEST_F(PipelineMapperTests, OutputTransformPersistencePreservesSharedAndMethodSp
   ASSERT_NE(reloaded, nullptr);
 
   const nlohmann::json exported = reloaded->pipeline_->ExportPipelineParams();
-  const auto& odt =
-      exported["Output Transform"]["Output Transform"]["odt"]["params"]["odt"];
+  const auto& odt = exported["Output Transform"]["Output Transform"]["odt"]["params"]["odt"];
   EXPECT_EQ(odt["method"], "aces_2_0");
   EXPECT_EQ(odt["encoding_space"], "rec2020");
   EXPECT_EQ(odt["encoding_eotf"], "st2084");
@@ -431,15 +447,15 @@ TEST_F(PipelineMapperTests, CacheTest2) {
 
 TEST_F(PipelineMapperTests, DISABLED_FuzzTest) {
   {
-    ProjectService      project(db_path_, meta_path_);
-    PipelineMgmtService pipeline_service(project.GetStorage());
+    ProjectService                                   project(db_path_, meta_path_);
+    PipelineMgmtService                              pipeline_service(project.GetStorage());
 
-    constexpr int                 kOpsCount        = 500;
-    constexpr int                 kIdRange         = 96;
-    std::mt19937                  rng{12345};
-    std::uniform_int_distribution<int> id_dist(1, kIdRange);
-    std::uniform_int_distribution<int> op_dist(0, 5);
-    std::uniform_real_distribution<float> value_dist(-2.0f, 2.0f);
+    constexpr int                                    kOpsCount = 500;
+    constexpr int                                    kIdRange  = 96;
+    std::mt19937                                     rng{12345};
+    std::uniform_int_distribution<int>               id_dist(1, kIdRange);
+    std::uniform_int_distribution<int>               op_dist(0, 5);
+    std::uniform_real_distribution<float>            value_dist(-2.0f, 2.0f);
     std::unordered_map<sl_element_id_t, std::string> expected_dump;
     const auto empty_dump = CPUPipelineExecutor().ExportPipelineParams().dump();
 
@@ -463,7 +479,7 @@ TEST_F(PipelineMapperTests, DISABLED_FuzzTest) {
         // Load + modify + save (dirty path)
         auto guard = pipeline_service.LoadPipeline(id);
         ASSERT_NE(guard, nullptr);
-        auto& stage = guard->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
+        auto&          stage = guard->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
         nlohmann::json params;
         params["exposure"] = static_cast<float>(id) + value_dist(rng);
         stage.SetOperator(OperatorType::EXPOSURE, params);
@@ -474,11 +490,11 @@ TEST_F(PipelineMapperTests, DISABLED_FuzzTest) {
         // Load + modify without save (pinned & dirty in cache)
         auto guard = pipeline_service.LoadPipeline(id);
         ASSERT_NE(guard, nullptr);
-        auto& stage = guard->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
+        auto&          stage = guard->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
         nlohmann::json params;
         params["contrast"] = static_cast<float>(id) + value_dist(rng);
         stage.SetOperator(OperatorType::CONTRAST, params);
-        guard->dirty_ = true;
+        guard->dirty_     = true;
         expected_dump[id] = guard->pipeline_->ExportPipelineParams().dump();
       } else if (op == 3) {
         // Sync all dirty pipelines
@@ -488,7 +504,7 @@ TEST_F(PipelineMapperTests, DISABLED_FuzzTest) {
         auto guard = pipeline_service.LoadPipeline(static_cast<sl_element_id_t>(kIdRange + id));
         ASSERT_NE(guard, nullptr);
         EXPECT_EQ(guard->id_, static_cast<sl_element_id_t>(kIdRange + id));
-        auto dump = guard->pipeline_->ExportPipelineParams().dump();
+        auto       dump   = guard->pipeline_->ExportPipelineParams().dump();
         const auto far_id = static_cast<sl_element_id_t>(kIdRange + id);
         if (expected_dump.contains(far_id)) {
           EXPECT_EQ(dump, expected_dump.at(far_id));
@@ -527,24 +543,24 @@ TEST_F(PipelineMapperTests, DISABLED_FuzzTest) {
 }
 
 TEST_F(PipelineMapperTests, DISABLED_ThreadSafeTest) {
-  ProjectService      project(db_path_, meta_path_);
-  PipelineMgmtService pipeline_service(project.GetStorage());
+  ProjectService           project(db_path_, meta_path_);
+  PipelineMgmtService      pipeline_service(project.GetStorage());
 
-  constexpr int kThreads   = 8;
-  constexpr int kOpsPerThr = 200;
-  constexpr int kIdRange   = 64;
+  constexpr int            kThreads   = 8;
+  constexpr int            kOpsPerThr = 200;
+  constexpr int            kIdRange   = 64;
 
-  std::atomic<int> ops_count{0};
+  std::atomic<int>         ops_count{0};
   std::vector<std::thread> workers;
   workers.reserve(kThreads);
 
   for (int t = 0; t < kThreads; ++t) {
     workers.emplace_back([t, &pipeline_service, &ops_count]() {
       for (int i = 0; i < kOpsPerThr; ++i) {
-        const auto id = static_cast<sl_element_id_t>((t * kOpsPerThr + i) % kIdRange + 1);
+        const auto id    = static_cast<sl_element_id_t>((t * kOpsPerThr + i) % kIdRange + 1);
         auto       guard = pipeline_service.LoadPipeline(id);
         ASSERT_NE(guard, nullptr);
-        auto& stage = guard->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
+        auto&          stage = guard->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
         nlohmann::json params;
         params["exposure"] = static_cast<float>(id) + static_cast<float>(t) * 0.01f;
         stage.SetOperator(OperatorType::EXPOSURE, params);
@@ -585,7 +601,7 @@ TEST_F(PipelineMapperTests, LoadPipelineSnapshotClonesParamsAndDoesNotTouchLiveG
     ProjectService      project(db_path_, meta_path_);
     PipelineMgmtService ps(project.GetStorage());
 
-    auto g1 = ps.LoadPipeline(1);
+    auto                g1 = ps.LoadPipeline(1);
     ASSERT_NE(g1, nullptr);
     ASSERT_NE(g1->pipeline_, nullptr);
 
@@ -595,24 +611,24 @@ TEST_F(PipelineMapperTests, LoadPipelineSnapshotClonesParamsAndDoesNotTouchLiveG
     exp1["exposure"] = 1.5f;
     stage.SetOperator(OperatorType::EXPOSURE, exp1);
     g1->dirty_ = true;
-    params_v1   = g1->pipeline_->ExportPipelineParams();
+    params_v1  = g1->pipeline_->ExportPipelineParams();
 
     // Capture a snapshot of the current (dirty, pinned) live state.
     std::string err;
     auto        snap = ps.LoadPipelineSnapshot(1, 0, &err);
     ASSERT_NE(snap, nullptr);
     ASSERT_NE(snap->executor_, nullptr);
-    EXPECT_NE(snap->executor_, g1->pipeline_);                       // independent instance
-    EXPECT_EQ(snap->pipeline_params_, params_v1);                    // captured current params
-    EXPECT_EQ(snap->executor_->ExportPipelineParams(), params_v1);    // snapshot holds them
+    EXPECT_NE(snap->executor_, g1->pipeline_);                      // independent instance
+    EXPECT_EQ(snap->pipeline_params_, params_v1);                   // captured current params
+    EXPECT_EQ(snap->executor_->ExportPipelineParams(), params_v1);  // snapshot holds them
 
     // Acceptance: the live guard is untouched by the capture.
-    EXPECT_EQ(g1->dirty_, true);                                      // dirty NOT cleared
-    EXPECT_EQ(g1->pin_count_, size_t{1});                             // pin NOT changed
-    EXPECT_EQ(g1->pipeline_->ExportPipelineParams(), params_v1);      // live exec unchanged
+    EXPECT_EQ(g1->dirty_, true);                                  // dirty NOT cleared
+    EXPECT_EQ(g1->pin_count_, size_t{1});                         // pin NOT changed
+    EXPECT_EQ(g1->pipeline_->ExportPipelineParams(), params_v1);  // live exec unchanged
 
     ps.ReleasePipelineSnapshot(snap);
-    EXPECT_EQ(g1->dirty_, true);                                      // release didn't touch live
+    EXPECT_EQ(g1->dirty_, true);  // release didn't touch live
     EXPECT_EQ(g1->pin_count_, size_t{1});
 
     // Later user edit after the snapshot. Must persist, not be overwritten.
@@ -620,8 +636,8 @@ TEST_F(PipelineMapperTests, LoadPipelineSnapshotClonesParamsAndDoesNotTouchLiveG
     exp2["exposure"] = 2.5f;
     stage.SetOperator(OperatorType::EXPOSURE, exp2);
     g1->dirty_ = true;
-    params_v2   = g1->pipeline_->ExportPipelineParams();
-    EXPECT_NE(params_v2, params_v1);                                  // the later edit took effect
+    params_v2  = g1->pipeline_->ExportPipelineParams();
+    EXPECT_NE(params_v2, params_v1);  // the later edit took effect
 
     ps.SavePipeline(g1);  // return to cache (last pin)
     ps.Sync();            // write the later edit to storage
@@ -646,8 +662,8 @@ TEST_F(PipelineMapperTests, LoadPipelineSnapshotFallbackRepairsAndReleasesPin) {
   PipelineMgmtService ps(project.GetStorage());
 
   // 999 was never loaded → cache-miss fallback inside LoadPipelineSnapshot.
-  std::string err;
-  auto        snap = ps.LoadPipelineSnapshot(999, 0, &err);
+  std::string         err;
+  auto                snap = ps.LoadPipelineSnapshot(999, 0, &err);
   ASSERT_NE(snap, nullptr);
   ASSERT_NE(snap->executor_, nullptr);
 
@@ -666,7 +682,7 @@ TEST_F(PipelineMapperTests, EditorLoadUsesMatchingSerializedStateWithoutReconstr
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService first(project.GetStorage());
 
-  auto initial = first.LoadEditorPipeline(701);
+  auto                initial = first.LoadEditorPipeline(701);
   ASSERT_NE(initial, nullptr);
   ASSERT_NE(initial->pipeline_, nullptr);
   EXPECT_NE(initial->root_id_, Hash128{});
@@ -693,7 +709,7 @@ TEST_F(PipelineMapperTests, LoadWithMatchingCheckpointSkipsFullReplay) {
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService first(project.GetStorage());
 
-  auto initial = first.LoadEditorPipeline(731);
+  auto                initial = first.LoadEditorPipeline(731);
   ASSERT_NE(initial, nullptr);
   first.SavePipeline(initial);
 
@@ -707,12 +723,11 @@ TEST_F(PipelineMapperTests, LoadWithMatchingCheckpointSkipsFullReplay) {
   reopened.SavePipeline(loaded);
 }
 
-TEST_F(PipelineMapperTests,
-       PersistEditorHistoryStateWritesNewActiveVersionBeforeEditorReopen) {
+TEST_F(PipelineMapperTests, PersistEditorHistoryStateWritesNewActiveVersionBeforeEditorReopen) {
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService pipeline_service(project.GetStorage());
 
-  auto guard = pipeline_service.LoadEditorPipeline(715);
+  auto                guard = pipeline_service.LoadEditorPipeline(715);
   ASSERT_NE(guard, nullptr);
   ASSERT_NE(guard->commit_graph_, nullptr);
   const auto expected_materialized_state = guard->commit_graph_->GetImageEditState();
@@ -722,17 +737,16 @@ TEST_F(PipelineMapperTests,
   guard->serialized_state_needs_writeback_ = true;
 
   std::string error;
-  ASSERT_TRUE(pipeline_service.PersistEditorHistoryState(guard, expected_materialized_state,
-                                                         &error))
+  ASSERT_TRUE(
+      pipeline_service.PersistEditorHistoryState(guard, expected_materialized_state, &error))
       << error;
   EXPECT_FALSE(guard->serialized_state_needs_writeback_);
 
   {
-    auto               db_guard =
-        project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto               db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    const auto         persisted = graph_service.LoadGraph(715);
+    const auto       persisted = graph_service.LoadGraph(715);
     ASSERT_TRUE(persisted.has_value());
     EXPECT_EQ(persisted->GetActiveVersionId(), new_version);
     EXPECT_EQ(persisted->GetActiveVersionRef().head_commit_hash, std::nullopt);
@@ -753,11 +767,11 @@ TEST_F(PipelineMapperTests, DeletePipelinesRemovesTheDeletedImagesMiniGitGraphOn
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService pipelines(project.GetStorage());
 
-  auto deleted = pipelines.LoadEditorPipeline(711);
-  auto retained = pipelines.LoadEditorPipeline(712);
+  auto                deleted  = pipelines.LoadEditorPipeline(711);
+  auto                retained = pipelines.LoadEditorPipeline(712);
   ASSERT_NE(deleted, nullptr);
   ASSERT_NE(retained, nullptr);
-  const auto deleted_root = deleted->root_id_;
+  const auto deleted_root  = deleted->root_id_;
   const auto retained_root = retained->root_id_;
   pipelines.SavePipeline(deleted);
   pipelines.SavePipeline(retained);
@@ -765,8 +779,8 @@ TEST_F(PipelineMapperTests, DeletePipelinesRemovesTheDeletedImagesMiniGitGraphOn
   const std::vector<sl_element_id_t> deleted_ids = {711};
   pipelines.DeletePipelines(deleted_ids);
 
-  auto               db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-  auto               db_lock  = db_guard.Lock();
+  auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+  auto             db_lock  = db_guard.Lock();
   CommitGraphStore graph_service(db_guard.conn_);
   EXPECT_FALSE(graph_service.GetImageEditState(711).has_value());
   EXPECT_FALSE(graph_service.GetRootSerializedPipelineState(711, deleted_root).has_value());
@@ -778,7 +792,7 @@ TEST_F(PipelineMapperTests, StaleSerializedStateRebuildsAndIsWrittenBack) {
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService first(project.GetStorage());
 
-  auto initial = first.LoadEditorPipeline(702);
+  auto                initial = first.LoadEditorPipeline(702);
   ASSERT_NE(initial, nullptr);
   const auto root_id = initial->root_id_;
   first.SavePipeline(initial);
@@ -786,21 +800,21 @@ TEST_F(PipelineMapperTests, StaleSerializedStateRebuildsAndIsWrittenBack) {
   commit_hash_t            expected_head{};
   transaction_chain_hash_t expected_chain{};
   {
-    auto db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    auto graph = graph_service.LoadGraph(702);
+    auto             graph = graph_service.LoadGraph(702);
     ASSERT_TRUE(graph.has_value());
 
     OrdinaryEditPayload payload;
-    payload.operator_type   = OperatorType::EXPOSURE;
-    payload.stage_name      = PipelineStageName::Basic_Adjustment;
-    payload.field_name      = "exposure";
-    payload.before_value    = 1.5f;
-    payload.after_value     = 2.0f;
-    payload.before_enabled  = true;
-    payload.after_enabled   = true;
-    auto commit = EditCommit::MakeEdit(graph->GetRootId(), std::nullopt, std::move(payload));
+    payload.operator_type  = OperatorType::EXPOSURE;
+    payload.stage_name     = PipelineStageName::Basic_Adjustment;
+    payload.field_name     = "exposure";
+    payload.before_value   = 1.5f;
+    payload.after_value    = 2.0f;
+    payload.before_enabled = true;
+    payload.after_enabled  = true;
+    auto commit   = EditCommit::MakeEdit(graph->GetRootId(), std::nullopt, std::move(payload));
     expected_head = commit.GetCommitHash();
     ASSERT_TRUE(graph->InsertCommit(std::move(commit)));
     graph->MoveWorkingHead(graph->GetActiveVersionId(), expected_head);
@@ -808,8 +822,8 @@ TEST_F(PipelineMapperTests, StaleSerializedStateRebuildsAndIsWrittenBack) {
 
     // This is an untagged serialized state. Its graph state remains valid, but the editor must
     // reject it and replay the new first-parent commit from the immutable root.
-    graph_service.Materialize(graph->CaptureMaterializationWithSerializedPipelineState(
-        nlohmann::json{{"legacy", true}}));
+    graph_service.Materialize(
+        graph->CaptureMaterializationWithSerializedPipelineState(nlohmann::json{{"legacy", true}}));
   }
 
   PipelineMgmtService reopened(project.GetStorage());
@@ -820,7 +834,7 @@ TEST_F(PipelineMapperTests, StaleSerializedStateRebuildsAndIsWrittenBack) {
   EXPECT_EQ(rebuilt->transaction_chain_hash(), expected_chain);
   EXPECT_TRUE(rebuilt->serialized_state_needs_writeback_);
   EXPECT_EQ(rebuilt->pipeline_->ExportPipelineParams()["Basic Adjustment"]["Basic Adjustment"]
-                                          ["exposure"]["params"]["exposure"],
+                                                      ["exposure"]["params"]["exposure"],
             2.0f);
   reopened.SavePipeline(rebuilt);
 
@@ -831,7 +845,7 @@ TEST_F(PipelineMapperTests, StaleSerializedStateRebuildsAndIsWrittenBack) {
   EXPECT_EQ(matched->working_head_commit_hash(), expected_head);
   EXPECT_EQ(matched->transaction_chain_hash(), expected_chain);
   EXPECT_EQ(matched->pipeline_->ExportPipelineParams()["Basic Adjustment"]["Basic Adjustment"]
-                                               ["exposure"]["params"]["exposure"],
+                                                      ["exposure"]["params"]["exposure"],
             2.0f);
   after_writeback.SavePipeline(matched);
 }
@@ -841,35 +855,34 @@ TEST_F(PipelineMapperTests,
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService first(project.GetStorage());
 
-  auto initial = first.LoadEditorPipeline(732);
+  auto                initial = first.LoadEditorPipeline(732);
   ASSERT_NE(initial, nullptr);
   first.SavePipeline(initial);
 
   commit_hash_t expected_head{};
   {
-    auto db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    auto graph = graph_service.LoadGraph(732);
+    auto             graph = graph_service.LoadGraph(732);
     ASSERT_TRUE(graph.has_value());
 
     OrdinaryEditPayload payload;
-    payload.operator_type   = OperatorType::EXPOSURE;
-    payload.stage_name      = PipelineStageName::Basic_Adjustment;
-    payload.field_name      = "exposure";
-    payload.before_value    = 0.0f;
-    payload.after_value     = 3.25f;
-    payload.before_enabled  = true;
-    payload.after_enabled   = true;
-    auto commit = EditCommit::MakeEdit(graph->GetRootId(), std::nullopt, std::move(payload));
+    payload.operator_type  = OperatorType::EXPOSURE;
+    payload.stage_name     = PipelineStageName::Basic_Adjustment;
+    payload.field_name     = "exposure";
+    payload.before_value   = 0.0f;
+    payload.after_value    = 3.25f;
+    payload.before_enabled = true;
+    payload.after_enabled  = true;
+    auto commit   = EditCommit::MakeEdit(graph->GetRootId(), std::nullopt, std::move(payload));
     expected_head = commit.GetCommitHash();
     ASSERT_TRUE(graph->InsertCommit(std::move(commit)));
     graph->MoveWorkingHead(graph->GetActiveVersionId(), expected_head);
 
     // Deliberately wrong params under a non-matching checkpoint identity.
     graph_service.Materialize(graph->CaptureMaterializationWithSerializedPipelineState(
-        nlohmann::json{{"legacy", true},
-                       {"stale_exposure", 0.0f}}));
+        nlohmann::json{{"legacy", true}, {"stale_exposure", 0.0f}}));
   }
 
   PipelineMgmtService reopened(project.GetStorage());
@@ -879,33 +892,32 @@ TEST_F(PipelineMapperTests,
   EXPECT_EQ(reopened.EditorPipelineHistoryRebuildCount(), 1u);
   EXPECT_EQ(rebuilt->working_head_commit_hash(), expected_head);
   EXPECT_EQ(rebuilt->pipeline_->ExportPipelineParams()["Basic Adjustment"]["Basic Adjustment"]
-                                          ["exposure"]["params"]["exposure"],
+                                                      ["exposure"]["params"]["exposure"],
             3.25f)
       << "rebuild must follow history, not stale checkpoint JSON values";
   reopened.SavePipeline(rebuilt);
 }
 
-TEST_F(PipelineMapperTests,
-       SerializedStateWritebackRejectsAConcurrentMaterializedHistoryChange) {
+TEST_F(PipelineMapperTests, SerializedStateWritebackRejectsAConcurrentMaterializedHistoryChange) {
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService pipelines(project.GetStorage());
 
-  auto local = pipelines.LoadEditorPipeline(703);
+  auto                local = pipelines.LoadEditorPipeline(703);
   ASSERT_NE(local, nullptr);
   ASSERT_NE(local->commit_graph_, nullptr);
-  const auto root_id = local->root_id_;
+  const auto          root_id = local->root_id_;
 
   OrdinaryEditPayload local_payload;
-  local_payload.operator_type   = OperatorType::EXPOSURE;
-  local_payload.stage_name      = PipelineStageName::Basic_Adjustment;
-  local_payload.field_name      = "$operator_params";
-  local_payload.before_value    = nlohmann::json{{"exposure", 0.0f}};
-  local_payload.after_value     = nlohmann::json{{"exposure", 1.0f}};
-  local_payload.before_enabled  = true;
-  local_payload.after_enabled   = true;
-  const auto local_version = local->commit_graph_->CreateVersionRefAtRoot("Local Writeback");
-  auto local_commit = EditCommit::MakeEdit(root_id, std::nullopt, std::move(local_payload));
-  const auto local_head = local_commit.GetCommitHash();
+  local_payload.operator_type  = OperatorType::EXPOSURE;
+  local_payload.stage_name     = PipelineStageName::Basic_Adjustment;
+  local_payload.field_name     = "$operator_params";
+  local_payload.before_value   = nlohmann::json{{"exposure", 0.0f}};
+  local_payload.after_value    = nlohmann::json{{"exposure", 1.0f}};
+  local_payload.before_enabled = true;
+  local_payload.after_enabled  = true;
+  const auto local_version     = local->commit_graph_->CreateVersionRefAtRoot("Local Writeback");
+  auto       local_commit = EditCommit::MakeEdit(root_id, std::nullopt, std::move(local_payload));
+  const auto local_head   = local_commit.GetCommitHash();
   ASSERT_TRUE(local->commit_graph_->InsertCommit(std::move(local_commit)));
   local->commit_graph_->MoveWorkingHead(local_version, local_head);
   local->commit_graph_->SetActiveVersionId(local_version);
@@ -913,22 +925,22 @@ TEST_F(PipelineMapperTests,
 
   commit_hash_t remote_head{};
   {
-    auto db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    auto remote_graph = graph_service.LoadGraph(703);
+    auto             remote_graph = graph_service.LoadGraph(703);
     ASSERT_TRUE(remote_graph.has_value());
 
     OrdinaryEditPayload remote_payload;
-    remote_payload.operator_type   = OperatorType::EXPOSURE;
-    remote_payload.stage_name      = PipelineStageName::Basic_Adjustment;
-    remote_payload.field_name      = "$operator_params";
-    remote_payload.before_value    = nlohmann::json{{"exposure", 0.0f}};
-    remote_payload.after_value     = nlohmann::json{{"exposure", 2.0f}};
-    remote_payload.before_enabled  = true;
-    remote_payload.after_enabled   = true;
+    remote_payload.operator_type  = OperatorType::EXPOSURE;
+    remote_payload.stage_name     = PipelineStageName::Basic_Adjustment;
+    remote_payload.field_name     = "$operator_params";
+    remote_payload.before_value   = nlohmann::json{{"exposure", 0.0f}};
+    remote_payload.after_value    = nlohmann::json{{"exposure", 2.0f}};
+    remote_payload.before_enabled = true;
+    remote_payload.after_enabled  = true;
     auto remote_commit = EditCommit::MakeEdit(root_id, std::nullopt, std::move(remote_payload));
-    remote_head = remote_commit.GetCommitHash();
+    remote_head        = remote_commit.GetCommitHash();
     ASSERT_TRUE(remote_graph->InsertCommit(std::move(remote_commit)));
     remote_graph->MoveWorkingHead(remote_graph->GetActiveVersionId(), remote_head);
     graph_service.Materialize(remote_graph->CaptureMaterialization());
@@ -938,10 +950,10 @@ TEST_F(PipelineMapperTests,
   EXPECT_TRUE(local->serialized_state_needs_writeback_);
 
   {
-    auto db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    const auto persisted = graph_service.LoadGraph(703);
+    const auto       persisted = graph_service.LoadGraph(703);
     ASSERT_TRUE(persisted.has_value());
     EXPECT_EQ(persisted->GetActiveVersionRef().head_commit_hash, remote_head);
     EXPECT_NE(persisted->GetActiveVersionRef().head_commit_hash, local_head);
@@ -956,10 +968,10 @@ TEST_F(PipelineMapperTests,
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService pipeline_service(project.GetStorage());
 
-  auto guard = pipeline_service.LoadEditorPipeline(720);
+  auto                guard = pipeline_service.LoadEditorPipeline(720);
   ASSERT_NE(guard, nullptr);
   ASSERT_NE(guard->commit_graph_, nullptr);
-  const auto root_id = guard->root_id_;
+  const auto          root_id = guard->root_id_;
 
   // Commit an adjustment: the working head advances, but ImageEditState.materialized_*
   // stays at root (MoveWorkingHead never advances materialized state by design).
@@ -971,8 +983,8 @@ TEST_F(PipelineMapperTests,
   payload.after_value    = 1.0f;
   payload.before_enabled = true;
   payload.after_enabled  = true;
-  auto edit = EditCommit::MakeEdit(root_id, std::nullopt, std::move(payload));
-  const auto new_head = edit.GetCommitHash();
+  auto       edit        = EditCommit::MakeEdit(root_id, std::nullopt, std::move(payload));
+  const auto new_head    = edit.GetCommitHash();
   ASSERT_TRUE(guard->commit_graph_->InsertCommit(std::move(edit)));
   guard->commit_graph_->MoveWorkingHead(guard->commit_graph_->GetActiveVersionId(), new_head);
 
@@ -980,8 +992,8 @@ TEST_F(PipelineMapperTests,
   // production checkpoint path, does NOT call ApplyMaterializedState, so the in-memory
   // materialized_* stays at root while DuckDB advances to the working head.
   {
-    auto db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
     graph_service.Materialize(
         guard->commit_graph_->CaptureMaterializationWithSerializedPipelineState(
@@ -991,22 +1003,20 @@ TEST_F(PipelineMapperTests,
   // DuckDB now holds the working head; the in-memory graph still reports root.
   commit_hash_t durable_head{};
   {
-    auto db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
     auto             persisted = graph_service.LoadGraph(720);
     ASSERT_TRUE(persisted.has_value());
     durable_head = persisted->GetImageEditState().materialized_head_commit_hash.value();
     ASSERT_EQ(durable_head, new_head);
   }
-  EXPECT_EQ(guard->commit_graph_->GetImageEditState().materialized_head_commit_hash,
-            std::nullopt)
+  EXPECT_EQ(guard->commit_graph_->GetImageEditState().materialized_head_commit_hash, std::nullopt)
       << "in-memory materialized head must stay stale until the post-checkpoint sync";
 
   // Fix B: mirror the durable materialization into the in-memory state.
   guard->commit_graph_->MaterializeActiveHeadInMemory();
-  EXPECT_EQ(guard->commit_graph_->GetImageEditState().materialized_head_commit_hash,
-            new_head);
+  EXPECT_EQ(guard->commit_graph_->GetImageEditState().materialized_head_commit_hash, new_head);
   EXPECT_EQ(guard->commit_graph_->GetImageEditState().materialized_transaction_chain_hash,
             guard->transaction_chain_hash());
 
@@ -1022,24 +1032,24 @@ TEST_F(PipelineMapperTests,
 }
 
 TEST_F(PipelineMapperTests, ImmutableRootRestoresImportedRawColorAndLensState) {
-  ProjectService      project(db_path_, meta_path_);
-  PipelineMgmtService first(project.GetStorage());
+  ProjectService         project(db_path_, meta_path_);
+  PipelineMgmtService    first(project.GetStorage());
 
   RawRuntimeColorContext raw_context;
   raw_context.valid_                        = true;
   raw_context.output_in_camera_space_       = true;
   raw_context.camera_make_                  = "Alcedo Camera Co";
   raw_context.camera_model_                 = "Root State Test";
-  raw_context.lens_metadata_valid_           = true;
-  raw_context.lens_make_                     = "Alcedo Optics";
-  raw_context.lens_model_                    = "Fixed 35";
-  raw_context.focal_length_mm_               = 35.0f;
-  raw_context.color_matrices_valid_          = true;
-  raw_context.color_matrix_1_[0]             = 0.625;
-  raw_context.dng_warp_rectilinear_present_  = true;
-  raw_context.dng_warp_rectilinear_applied_  = true;
+  raw_context.lens_metadata_valid_          = true;
+  raw_context.lens_make_                    = "Alcedo Optics";
+  raw_context.lens_model_                   = "Fixed 35";
+  raw_context.focal_length_mm_              = 35.0f;
+  raw_context.color_matrices_valid_         = true;
+  raw_context.color_matrix_1_[0]            = 0.625;
+  raw_context.dng_warp_rectilinear_present_ = true;
+  raw_context.dng_warp_rectilinear_applied_ = true;
 
-  auto initial = first.LoadPipeline(704);
+  auto initial                              = first.LoadPipeline(704);
   ASSERT_NE(initial, nullptr);
   initial->pipeline_->InjectRawMetadata(raw_context);
   first.InitializeImageRoot(initial, &raw_context);
@@ -1047,10 +1057,10 @@ TEST_F(PipelineMapperTests, ImmutableRootRestoresImportedRawColorAndLensState) {
   first.SavePipeline(initial);
 
   {
-    auto db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    const auto encoded = graph_service.GetRootSerializedPipelineState(704, root_id);
+    const auto       encoded = graph_service.GetRootSerializedPipelineState(704, root_id);
     ASSERT_TRUE(encoded.has_value());
     ASSERT_TRUE(encoded->contains("raw_color_context"));
     EXPECT_EQ((*encoded)["raw_color_context"]["CameraModel"], "Root State Test");
@@ -1074,13 +1084,13 @@ TEST_F(PipelineMapperTests, RootStateRejectsDifferentImageOwner) {
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService pipelines(project.GetStorage());
 
-  auto first = pipelines.LoadEditorPipeline(705);
-  auto second = pipelines.LoadEditorPipeline(706);
+  auto                first  = pipelines.LoadEditorPipeline(705);
+  auto                second = pipelines.LoadEditorPipeline(706);
   ASSERT_NE(first, nullptr);
   ASSERT_NE(second, nullptr);
 
-  auto db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-  auto db_lock  = db_guard.Lock();
+  auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+  auto             db_lock  = db_guard.Lock();
   CommitGraphStore graph_service(db_guard.conn_);
   EXPECT_THROW(graph_service.GetRootSerializedPipelineState(706, first->root_id_),
                std::runtime_error);
@@ -1093,8 +1103,8 @@ TEST_F(PipelineMapperTests, SyncPipelineDoesNotPersistUnrelatedDirtyGuards) {
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService pipelines(project.GetStorage());
 
-  auto requested = pipelines.LoadPipeline(707);
-  auto unrelated = pipelines.LoadPipeline(708);
+  auto                requested = pipelines.LoadPipeline(707);
+  auto                unrelated = pipelines.LoadPipeline(708);
   ASSERT_NE(requested, nullptr);
   ASSERT_NE(unrelated, nullptr);
   requested->dirty_ = true;
@@ -1118,33 +1128,32 @@ TEST_F(PipelineMapperTests, EditorLoadReportsMissingReachableCommit) {
 
   commit_hash_t missing_hash{};
   {
-    auto db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
-    auto db_lock  = db_guard.Lock();
+    auto             db_guard = project.GetStorage()->GetDatabase().GetConnectionGuard();
+    auto             db_lock  = db_guard.Lock();
     CommitGraphStore graph_service(db_guard.conn_);
-    auto graph = graph_service.LoadGraph(703);
+    auto             graph = graph_service.LoadGraph(703);
     ASSERT_TRUE(graph.has_value());
 
     OrdinaryEditPayload payload;
-    payload.operator_type   = OperatorType::EXPOSURE;
-    payload.stage_name      = PipelineStageName::Basic_Adjustment;
-    payload.field_name      = "exposure";
-    payload.before_value    = 1.5f;
-    payload.after_value     = 2.0f;
-    payload.before_enabled  = true;
-    payload.after_enabled   = true;
-    auto commit = EditCommit::MakeEdit(graph->GetRootId(), std::nullopt, std::move(payload));
+    payload.operator_type  = OperatorType::EXPOSURE;
+    payload.stage_name     = PipelineStageName::Basic_Adjustment;
+    payload.field_name     = "exposure";
+    payload.before_value   = 1.5f;
+    payload.after_value    = 2.0f;
+    payload.before_enabled = true;
+    payload.after_enabled  = true;
+    auto commit  = EditCommit::MakeEdit(graph->GetRootId(), std::nullopt, std::move(payload));
     missing_hash = commit.GetCommitHash();
     ASSERT_TRUE(graph->InsertCommit(std::move(commit)));
     graph->MoveWorkingHead(graph->GetActiveVersionId(), missing_hash);
     graph_service.Materialize(graph->CaptureMaterialization());
 
     duckdb_result result;
-    ASSERT_EQ(duckdb_query(
-                  db_guard.conn_,
-                  std::format("DELETE FROM EditCommit WHERE commit_hash='{}';",
-                              missing_hash.ToString())
-                      .c_str(),
-                  &result),
+    ASSERT_EQ(duckdb_query(db_guard.conn_,
+                           std::format("DELETE FROM EditCommit WHERE commit_hash='{}';",
+                                       missing_hash.ToString())
+                               .c_str(),
+                           &result),
               DuckDBSuccess);
     duckdb_destroy_result(&result);
   }

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -306,6 +306,15 @@ if(ALCEDO_CUDA_ENABLED)
     PROPERTIES LABELS "gpu;edit;runtime")
   alcedo_register_test_target(GpuDagCudaPrimaryGradeTest gpu)
 
+  add_executable(GpuDagCudaDrtProductTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_drt_product_test.cpp)
+  target_include_directories(GpuDagCudaDrtProductTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagCudaDrtProductTest PRIVATE
+    GTest::gtest_main EditRuntimeCuda EditInput)
+  gtest_discover_tests(GpuDagCudaDrtProductTest TEST_PREFIX "GpuDagCudaDrtProductTest."
+    PROPERTIES LABELS "gpu;edit;runtime;product")
+  alcedo_register_test_target(GpuDagCudaDrtProductTest gpu)
+
   add_executable(GpuDagCudaMaskTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_mask_test.cpp)
   target_include_directories(GpuDagCudaMaskTest PUBLIC ${ALCEDO_INCLUDE_DIR})

--- a/alcedo_studio/tests/edit/runtime/cuda_drt_product_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_drt_product_test.cpp
@@ -1,0 +1,191 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/legacy_pipeline_importer.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+
+namespace alcedo {
+namespace {
+
+struct Rgba {
+  float r;
+  float g;
+  float b;
+  float a;
+};
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+auto Download(CudaRenderDevice& device, const GraphValueId& id) -> std::vector<Rgba> {
+  device.WaitIdle();
+  auto* image = device.Workspace().Images().Find(id);
+  EXPECT_NE(image, nullptr);
+  if (image == nullptr) return {};
+  const auto&       texture = image->Texture();
+  std::vector<Rgba> pixels(static_cast<std::size_t>(texture.Width()) * texture.Height());
+  device.Workspace().Device().DownloadTexture2D(
+      texture,
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                           pixels.size() * sizeof(Rgba)),
+      device.CommandContext());
+  return pixels;
+}
+
+auto AllFiniteDisplayValues(const std::vector<Rgba>& pixels) -> bool {
+  if (pixels.empty()) return false;
+  for (const auto& pixel : pixels) {
+    if (!std::isfinite(pixel.r) || !std::isfinite(pixel.g) || !std::isfinite(pixel.b) ||
+        !std::isfinite(pixel.a)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+class CudaDrtProductFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+    input_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                           gpu_dag_test::FullSensor(16, 12));
+  }
+
+  auto Render(PipelineDocument& document) -> std::vector<Rgba> {
+    const auto plan   = GraphCompiler::Compile(document, input_.CompileSource(), RenderRequest{});
+    const auto output = device_.Execute(plan, input_, document);
+    EXPECT_TRUE(plan.Contains(GpuPassKind::Drt));
+    return Download(device_, output);
+  }
+
+  PreparedRawInput input_;
+  CudaRenderDevice device_;
+};
+
+TEST(GpuDagCudaDrtProduct, DefaultCudaPipelineBuildsThreeVisibleNodes) {
+  const auto document = CreateDefaultPipelineDocument();
+  EXPECT_EQ(document.Graph().Nodes().size(), 3U);
+  EXPECT_EQ(document.Graph().Edges().size(), 2U);
+  ASSERT_NE(document.Develop(), nullptr);
+  ASSERT_NE(document.PrimaryGrade(), nullptr);
+  ASSERT_NE(document.Drt(), nullptr);
+  EXPECT_EQ(document.ToJson().at("format_version"), 2);
+}
+
+TEST_F(CudaDrtProductFixture, CudaDrtOpenDrtProducesFiniteDisplayReferredOutput) {
+  auto       document = CreateDefaultPipelineDocument();
+  const auto pixels   = Render(document);
+  EXPECT_TRUE(AllFiniteDisplayValues(pixels));
+  EXPECT_NEAR(pixels.front().a, 1.0f, 1.0e-6f);
+}
+
+TEST_F(CudaDrtProductFixture, CudaDrtAces20ProducesFiniteDisplayReferredOutput) {
+  auto document = CreateDefaultPipelineDocument();
+  auto params   = document.Drt()->Params().Params();
+  params.method = DrtMethod::Aces20;
+  document.Drt()->Params().ReplaceParams(params);
+  EXPECT_TRUE(AllFiniteDisplayValues(Render(document)));
+}
+
+TEST_F(CudaDrtProductFixture, ChangingDrtPeakLuminanceKeepsDevelopAndGradeCacheValid) {
+  auto document = CreateDefaultPipelineDocument();
+  Render(document);
+  auto* develop =
+      device_.Workspace().Images().Find(GraphValueId{NodeId{"develop"}, PortId{"image"}});
+  auto* grade =
+      device_.Workspace().Images().Find(GraphValueId{NodeId{"grade.primary"}, PortId{"image"}});
+  ASSERT_NE(develop, nullptr);
+  ASSERT_NE(grade, nullptr);
+  const auto develop_id = develop->Texture().ResourceId();
+  const auto grade_id   = grade->Texture().ResourceId();
+
+  auto       params     = document.Drt()->Params().Params();
+  params.peak_luminance = 200.0f;
+  document.Drt()->Params().ReplaceParams(params);
+  EXPECT_TRUE(AllFiniteDisplayValues(Render(document)));
+  EXPECT_EQ(device_.Workspace()
+                .Images()
+                .Find(GraphValueId{NodeId{"develop"}, PortId{"image"}})
+                ->Texture()
+                .ResourceId(),
+            develop_id);
+  EXPECT_EQ(device_.Workspace()
+                .Images()
+                .Find(GraphValueId{NodeId{"grade.primary"}, PortId{"image"}})
+                ->Texture()
+                .ResourceId(),
+            grade_id);
+}
+
+TEST_F(CudaDrtProductFixture, LegacyPipelineImportRendersSameCudaReferenceWithinTolerance) {
+  nlohmann::json legacy;
+  legacy["Basic Adjustment"]["Basic Adjustment"]["exposure"] = {
+      {"type", 2}, {"enable", true}, {"params", {{"exposure", 0.75f}}}};
+  legacy["Output Transform"]["Output Transform"]["odt"] = {
+      {"type", 17},
+      {"enable", true},
+      {"params", {{"odt", {{"method", "open_drt"}, {"peak_luminance", 100.0f}}}}}};
+  auto imported = LegacyPipelineImporter::Import(legacy);
+  ASSERT_TRUE(imported.Ok()) << imported.error;
+  auto  reference = CreateDefaultPipelineDocument();
+  auto* exposure  = dynamic_cast<ExposureModel*>(
+      reference.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(0.75f);
+
+  const auto       imported_pixels = Render(*imported.document);
+  CudaRenderDevice reference_device;
+  const auto plan = GraphCompiler::Compile(reference, input_.CompileSource(), RenderRequest{});
+  const auto reference_pixels =
+      Download(reference_device, reference_device.Execute(plan, input_, reference));
+  ASSERT_EQ(imported_pixels.size(), reference_pixels.size());
+  for (std::size_t i = 0; i < imported_pixels.size(); ++i) {
+    EXPECT_NEAR(imported_pixels[i].r, reference_pixels[i].r, 1.0e-5f);
+    EXPECT_NEAR(imported_pixels[i].g, reference_pixels[i].g, 1.0e-5f);
+    EXPECT_NEAR(imported_pixels[i].b, reference_pixels[i].b, 1.0e-5f);
+  }
+}
+
+TEST_F(CudaDrtProductFixture, CudaBackendFailureDoesNotEnterCpuImageProcessing) {
+  auto        document = CreateDefaultPipelineDocument();
+  std::string reported;
+  device_.SetErrorReporter([&reported](std::string_view message) { reported = message; });
+  device_.Workspace().Device().FailNextUpload();
+  EXPECT_THROW(
+      {
+        const auto plan = GraphCompiler::Compile(document, input_.CompileSource(), RenderRequest{});
+        (void)device_.Execute(plan, input_, document);
+      },
+      std::runtime_error);
+  EXPECT_FALSE(reported.empty());
+  EXPECT_FALSE(device_.Workspace().IsRendering());
+}
+
+TEST_F(CudaDrtProductFixture, CudaDefaultPipelineSecondRenderCreatesNoGpuAllocation) {
+  auto document = CreateDefaultPipelineDocument();
+  Render(document);
+  device_.Workspace().Device().ResetCounters();
+  Render(document);
+  EXPECT_EQ(device_.Workspace().Device().MallocCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().FreeCount(), 0U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G6 complete (persistent R8 MaskStore, CUDA masks, exact feather, and Normal Mix).
+Status: G7 complete (CUDA ACES 2.0/OpenDRT DRT and Windows/CUDA product DAG routing).
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2684,6 +2684,151 @@ CudaDefaultPipelineSecondRenderCreatesNoGpuAllocation
 - 默认图保存为三个节点；
 - CUDA 从输入到 DRT 完整运行；
 - UI 文件没有修改。
+
+##### Phase G7 completion record (2026-08-22)
+
+**Status:** complete — CUDA ACES 2.0/OpenDRT、显示色域/EOTF、DRT dirty Patch、完整
+`CudaRenderDevice::Execute`、PipelineMgmtService v2 文档持有/保存，以及现有 scheduler 到
+CUDA DAG 和 frame sink 的产品路径均已接入。OpenCL/Metal 继续使用原有 stage 适配器。
+
+**Primary product call chain:**
+
+```text
+PipelineScheduler -> CPUPipelineExecutor::Apply
+  -> changed legacy editor controls -> LegacyPipelineImporter (default three-node transition only)
+  -> CudaProductRenderer::Render
+  -> RawInputLoader::LoadEncoded (CPU unpack boundary)
+  -> GraphCompiler::Compile(RenderRequest with viewport ROI / target extent / max edge)
+  -> CudaRenderDevice::Execute
+  -> ExecuteCudaDevelop
+  -> optional ExecuteCudaMask
+  -> ExecuteCudaPrimaryGrade
+  -> ExecuteCudaDrt
+  -> persistent RGBA32F display texture
+  -> CUDA device copy to IFrameSink mapping
+  -> external semaphore signal -> NotifyFrameReady
+```
+
+Pure v2 documents do not mirror the legacy stage adapter. The transition import runs only for a
+legacy/default document whose graph still has exactly the three visible nodes, so a document with
+additional v2 nodes such as masks is not flattened by the old editor-control path.
+
+**DRT parameter and execution call chain:**
+
+```text
+DrtParamsModel dirty fields
+  -> TakePendingParameterPatch
+  -> ODT_Op runtime resolution (ACES 2.0 tables or OpenDRT settings)
+  -> GPUParamsConverter
+  -> stable ParameterArena slot keyed by (drt, drt.output)
+  -> dirty-range upload
+  -> DrtKernel(scene-linear AP1 -> DRT -> display gamut -> EOTF)
+  -> GraphImageCache[(drt, display)]
+```
+
+The pending DRT patch commits only after the GPU upload succeeds. A DRT-only change reuses the
+Develop and Primary Color Grade image resources. The second identical render performs no CUDA
+allocation or free.
+
+**Persistence and legacy-load call chain:**
+
+```text
+PipelineMgmtService::LoadPipeline
+  -> ElementStore::GetPipelineJsonByElementId
+  -> format v2 -> PipelineDocument::FromJson
+     old stage JSON -> LegacyPipelineImporter::Import
+  -> PipelineGuard::document_
+  -> CPUPipelineExecutor::SetPipelineDocument
+
+PipelineMgmtService::SavePipeline / SyncPipelineDocument
+  -> PipelineDocument::ToJson(format_version = 2, three visible nodes)
+  -> optional nested legacy_stage_adapter for unchanged OpenCL/Metal/editor controls
+  -> ElementStore::UpdatePipelineJsonByElementId
+  -> PipelineMapper raw JSON update
+```
+
+The top-level stored representation is always format version 2. New saves do not write the old
+stage object as the pipeline root.
+
+**Primary failure call chain:**
+
+```text
+CUDA allocation / upload / kernel failure
+  -> CudaRenderDevice::Execute catches
+  -> BasicRenderWorkspace::CancelRender
+  -> synchronous runtime error reporter
+  -> exception propagated through CudaProductRenderer and PipelineScheduler
+  -> no legacy CPU image-processing Apply path
+
+frame-sink map / copy / semaphore / host-download failure
+  -> CudaProductRenderer reports synchronously
+  -> exception propagated through PipelineScheduler
+  -> no legacy CPU image-processing Apply path
+```
+
+**Files added:**
+
+- `alcedo_studio/src/include/edit/runtime/cuda/cuda_drt_pass.hpp`
+- `alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp`
+- `alcedo_studio/src/edit/runtime/cuda/cuda_drt_runtime_state.cuh`
+- `alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu`
+- `alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp`
+- `alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu`
+- `alcedo_studio/tests/edit/runtime/cuda_drt_product_test.cpp`
+
+**Files removed:** none.
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `DefaultCudaPipelineBuildsThreeVisibleNodes` | `GpuDagCudaDrtProductTest` | PASS |
+| `CudaDrtOpenDrtProducesFiniteDisplayReferredOutput` | `GpuDagCudaDrtProductTest` | PASS |
+| `CudaDrtAces20ProducesFiniteDisplayReferredOutput` | `GpuDagCudaDrtProductTest` | PASS |
+| `ChangingDrtPeakLuminanceKeepsDevelopAndGradeCacheValid` | `GpuDagCudaDrtProductTest` | PASS |
+| `PipelineMgmtServiceBuildsDefaultGpuDagForNewImage` | `PipelineMapperTest` | PASS |
+| `LegacyPipelineImportRendersSameCudaReferenceWithinTolerance` | `GpuDagCudaDrtProductTest` | PASS |
+| `CudaBackendFailureDoesNotEnterCpuImageProcessing` | `GpuDagCudaDrtProductTest` | PASS |
+| `CudaDefaultPipelineSecondRenderCreatesNoGpuAllocation` | `GpuDagCudaDrtProductTest` | PASS |
+| Pipeline/storage/history compatibility regression | `PipelineMapperTest` | PASS, `26/26` |
+| G1–G7 graph, geometry, input, workspace, Develop, mask, grade, and DRT regression | ten GPU DAG targets | PASS, `90/90` |
+| Windows/CUDA product executable | `alcedo_main` | BUILD PASS |
+| UI source unchanged | `git diff --name-only -- alcedo_studio/src/ui` | PASS, empty |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target alcedo_main PipelineMapperTest GpuDagCudaDrtProductTest --parallel 4
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target GpuDagModelGraphTest GpuDagGeometryTest GpuDagMaskStoreTest GpuDagRawInputTest GpuDagCudaGeometryTest GpuDagCudaDevelopTest GpuDagCudaPrimaryGradeTest GpuDagCudaMaskTest GpuDagCudaWorkspaceTest GpuDagCudaDrtProductTest --parallel 4
+GpuDagCudaDrtProductTest.exe --gtest_color=no --gtest_brief=1
+PipelineMapperTest.exe --gtest_color=no --gtest_brief=1
+```
+
+Suite totals: G7 required tests `8/8` PASS; affected GPU DAG tests `90/90` PASS;
+PipelineMgmtService/storage/history tests `26/26` PASS. The two disabled pre-existing
+`PipelineMapperTest` cases were not executed.
+
+**Checklist / exit condition:** all G7 checks complete. Windows/CUDA defaults to the v2 three-node
+DAG, scheduler requests preserve viewport ROI and output-resolution intent, display output is
+written directly to the existing frame sink, and host output is downloaded only for callers that
+explicitly require it. CUDA errors cancel the incomplete workspace submission and propagate
+without CPU image processing. The stored root is format version 2 with three visible nodes. No UI
+source file changed.
+
+**Performance and allocation evidence:** a DRT peak-luminance-only edit retained both upstream
+texture resource ids. A second identical default render recorded `0` CUDA allocations and `0`
+CUDA frees. The DRT output texture and resolved method resources remain owned by the per-pipeline
+`CudaRenderDevice` workspace/runtime state.
+
+**LOC note (grill-code-review):** new implementation files remain focused:
+`cuda_product_renderer.cu` 149 lines, `cuda_drt_pass.cu` 139 lines,
+`cuda_plan_executor.cpp` 42 lines, and `cuda_drt_product_test.cpp` 191 lines. Existing large
+`pipeline_service.cpp` and `pipeline_cpu.cpp` received localized routing/persistence changes; no
+new file exceeds 500 lines.
+
+**Residual gaps:** OpenCL and Metal still execute through their existing stage adapters and consume
+the nested compatibility data; their full DAG runtime migrations remain G8 and G9 scope.
 
 ## 41. Phase G8 — OpenCL 移植
 

--- a/scripts/cmake/copy_linked_runtime_dlls.cmake
+++ b/scripts/cmake/copy_linked_runtime_dlls.cmake
@@ -22,11 +22,26 @@ endif()
 
 if(DEFINED ALCEDO_RUNTIME_EXECUTABLE AND EXISTS "${ALCEDO_RUNTIME_EXECUTABLE}")
   string(REPLACE "," ";" _alcedo_runtime_search_dirs "${ALCEDO_RUNTIME_SEARCH_DIRS}")
+  # The executable directory already contains files copied by applocal. Passing it back to
+  # GET_RUNTIME_DEPENDENCIES together with the package bin directory makes identical DLL names
+  # appear as conflicting candidates on CMake 4.x.
+  cmake_path(NORMAL_PATH ALCEDO_RUNTIME_DEST OUTPUT_VARIABLE _alcedo_runtime_dest_normalized)
+  set(_alcedo_filtered_runtime_search_dirs "")
+  foreach(_alcedo_runtime_search_dir IN LISTS _alcedo_runtime_search_dirs)
+    cmake_path(NORMAL_PATH _alcedo_runtime_search_dir OUTPUT_VARIABLE _alcedo_runtime_search_dir_normalized)
+    if(NOT _alcedo_runtime_search_dir_normalized STREQUAL _alcedo_runtime_dest_normalized)
+      list(APPEND _alcedo_filtered_runtime_search_dirs "${_alcedo_runtime_search_dir}")
+    endif()
+  endforeach()
+  set(_alcedo_runtime_search_dirs "${_alcedo_filtered_runtime_search_dirs}")
   file(GET_RUNTIME_DEPENDENCIES
     EXECUTABLES "${ALCEDO_RUNTIME_EXECUTABLE}"
     DIRECTORIES ${_alcedo_runtime_search_dirs}
     RESOLVED_DEPENDENCIES_VAR _alcedo_resolved_runtime_dlls
     UNRESOLVED_DEPENDENCIES_VAR _alcedo_unresolved_runtime_dlls
+    # Applocal can place a dependency beside the executable before this validation pass. CMake
+    # 4.x otherwise treats that valid local copy plus the package-bin source as a fatal conflict.
+    CONFLICTING_DEPENDENCIES_PREFIX _alcedo_runtime_conflicts
     PRE_EXCLUDE_REGEXES
       "api-ms-win-.*"
       "ext-ms-.*"


### PR DESCRIPTION
## Summary

- Add the CUDA DRT pass and `CudaProductRenderer` as the CUDA product session.
- Switch `PipelineService` / `CPUPipelineExecutor` onto the live `PipelineDocument` path.
- Complete the CUDA product path from Develop through Primary Color Grade to DRT.

## Stack

Layer G7 of GitHub stack #99.

- Base: #102
- Next layer: #100

## Validation

- Adds CUDA DRT product tests and pipeline service coverage for the document-backed path.
- No CPU pixel-processing fallback on the CUDA product path.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
