### PR TITLE
feat(edit): complete GPU DAG phase G6 CUDA masks

### DIFF
--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -27,6 +27,13 @@ def_library(EditGeometry
         ${ALCEDO_SRC_ROOT}/edit/geometry/texture_sampling_plan.cpp
 )
 
+# GPU-free persistent R8 mask repository and host byte-budget cache.
+def_library(EditMaskStore
+    SOURCES
+        ${ALCEDO_SRC_ROOT}/edit/mask/mask_store.cpp
+    PUBLIC_DEPS EditGeometry
+)
+
 # GPU DAG document/graph/models. No ImageBuffer, Operators, or GPU backends.
 set(EDIT_GRAPH_SRCS
     ${ALCEDO_SRC_ROOT}/edit/operators/models/adjustment_catalog.cpp
@@ -48,7 +55,7 @@ set(EDIT_GRAPH_SRCS
 
 def_library(EditGraph
     SOURCES ${EDIT_GRAPH_SRCS}
-    PUBLIC_DEPS JSON EditGeometry
+    PUBLIC_DEPS JSON EditGeometry EditMaskStore
 )
 
 # CPU RAW unpack / downsample. No CUDA, no ImageBuffer.
@@ -71,6 +78,7 @@ if(ALCEDO_CUDA_ENABLED)
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_backend.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_adjustment_runtime.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_develop_pass.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_mask_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_primary_grade_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/geometry_resample.cu
         PUBLIC_DEPS EditRuntime CUDA::cudart

--- a/alcedo_studio/src/edit/graph/raster_mask_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/raster_mask_node_model.cpp
@@ -14,21 +14,23 @@ RasterMaskNodeModel::RasterMaskNodeModel(NodeId id) : id_(std::move(id)) {
 
 auto RasterMaskNodeModel::InputPorts() const -> std::span<const PortDescriptor> { return {}; }
 
-auto RasterMaskNodeModel::OutputPorts() const -> std::span<const PortDescriptor> { return outputs_; }
+auto RasterMaskNodeModel::OutputPorts() const -> std::span<const PortDescriptor> {
+  return outputs_;
+}
 
 auto RasterMaskNodeModel::ToJson() const -> nlohmann::json {
   return {{"id", std::string{id_.Value()}},
           {"type", std::string{Type().Text()}},
           {"params",
-           {{"asset_key", asset_key_},
-            {"reference_bounds",
-             nlohmann::json::array({reference_bounds_.x, reference_bounds_.y, reference_bounds_.w,
-                                    reference_bounds_.h})},
+           {{"asset_key", std::string{asset_key_.Value()}},
+            {"reference_bounds", nlohmann::json::array({reference_bounds_.x, reference_bounds_.y,
+                                                        reference_bounds_.w, reference_bounds_.h})},
             {"feather_radius", feather_radius_},
             {"invert", invert_}}}};
 }
 
-auto RasterMaskNodeModel::FromJson(const nlohmann::json& json) -> std::unique_ptr<RasterMaskNodeModel> {
+auto RasterMaskNodeModel::FromJson(const nlohmann::json& json)
+    -> std::unique_ptr<RasterMaskNodeModel> {
   auto node = std::make_unique<RasterMaskNodeModel>(NodeId{json.at("id").get<std::string>()});
   if (!json.contains("params") || !json["params"].is_object()) {
     return node;

--- a/alcedo_studio/src/edit/mask/mask_store.cpp
+++ b/alcedo_studio/src/edit/mask/mask_store.cpp
@@ -1,0 +1,179 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/mask_store.hpp"
+
+#include <array>
+#include <atomic>
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+#include <system_error>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace alcedo {
+namespace {
+
+constexpr std::array<char, 8> kMagic   = {'A', 'L', 'C', 'R', '8', 'M', 'S', 'K'};
+constexpr std::uint32_t       kVersion = 1;
+std::atomic<std::uint64_t>    g_temp_sequence{0};
+
+struct FileHeader {
+  char          magic[8];
+  std::uint32_t version;
+  std::uint32_t width;
+  std::uint32_t height;
+  float         bounds[4];
+  std::uint32_t key_bytes;
+  std::uint32_t pixel_bytes;
+};
+static_assert(sizeof(FileHeader) == 44);
+
+auto SafeFileName(const MaskAssetKey& key) -> std::string {
+  if (key.Empty()) throw std::invalid_argument("MaskAssetKey must not be empty");
+  constexpr char digits[] = "0123456789abcdef";
+  std::string    result;
+  result.reserve(key.Value().size() * 2 + 7);
+  for (const unsigned char c : key.Value()) {
+    result.push_back(digits[c >> 4]);
+    result.push_back(digits[c & 0x0f]);
+  }
+  return result + ".r8mask";
+}
+
+void ReplaceCompleteFile(const std::filesystem::path& source,
+                         const std::filesystem::path& destination) {
+#ifdef _WIN32
+  if (!::MoveFileExW(source.c_str(), destination.c_str(),
+                     MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+    throw std::system_error(static_cast<int>(::GetLastError()), std::system_category(),
+                            "MaskStore atomic replacement failed");
+  }
+#else
+  std::filesystem::rename(source, destination);
+#endif
+}
+
+}  // namespace
+
+void ValidateMaskAsset(const MaskAsset& asset) {
+  if (asset.key.Empty()) throw std::invalid_argument("MaskAsset key must not be empty");
+  const auto extent = asset.descriptor.extent;
+  if (extent.Empty() || extent.width > kMaximumRasterMaskAxis ||
+      extent.height > kMaximumRasterMaskAxis) {
+    throw std::invalid_argument("Raster mask axes must be in [1, 4096]");
+  }
+  const auto required = static_cast<std::size_t>(extent.width) * extent.height;
+  if (asset.pixels.size() != required) {
+    throw std::invalid_argument("Raster mask must contain tightly packed R8 pixels");
+  }
+}
+
+MaskStore::MaskStore(std::filesystem::path root, std::size_t host_cache_budget_bytes)
+    : root_(std::move(root)), host_cache_budget_bytes_(host_cache_budget_bytes) {
+  if (root_.empty()) throw std::invalid_argument("MaskStore root must not be empty");
+}
+
+auto MaskStore::PathFor(const MaskAssetKey& key) const -> std::filesystem::path {
+  return root_ / SafeFileName(key);
+}
+
+void MaskStore::SetHostCacheBudget(std::size_t bytes) {
+  host_cache_budget_bytes_ = bytes;
+  EvictHostCache();
+}
+
+void MaskStore::Save(const MaskAsset& asset) {
+  ValidateMaskAsset(asset);
+  std::filesystem::create_directories(root_);
+  const auto destination = PathFor(asset.key);
+  auto       temporary   = destination;
+  temporary += ".tmp." + std::to_string(++g_temp_sequence);
+  try {
+    std::ofstream stream(temporary, std::ios::binary | std::ios::trunc);
+    if (!stream) throw std::runtime_error("MaskStore could not open temporary file");
+    FileHeader header{};
+    std::memcpy(header.magic, kMagic.data(), kMagic.size());
+    header.version     = kVersion;
+    header.width       = asset.descriptor.extent.width;
+    header.height      = asset.descriptor.extent.height;
+    header.bounds[0]   = asset.descriptor.reference_bounds.x;
+    header.bounds[1]   = asset.descriptor.reference_bounds.y;
+    header.bounds[2]   = asset.descriptor.reference_bounds.w;
+    header.bounds[3]   = asset.descriptor.reference_bounds.h;
+    header.key_bytes   = static_cast<std::uint32_t>(asset.key.Value().size());
+    header.pixel_bytes = static_cast<std::uint32_t>(asset.pixels.size());
+    stream.write(reinterpret_cast<const char*>(&header), sizeof(header));
+    stream.write(asset.key.Value().data(), static_cast<std::streamsize>(header.key_bytes));
+    stream.write(reinterpret_cast<const char*>(asset.pixels.data()),
+                 static_cast<std::streamsize>(asset.pixels.size()));
+    stream.flush();
+    if (!stream) throw std::runtime_error("MaskStore temporary write did not complete");
+    stream.close();
+    ReplaceCompleteFile(temporary, destination);
+  } catch (...) {
+    std::error_code ignored;
+    std::filesystem::remove(temporary, ignored);
+    throw;
+  }
+  StoreInCache(std::make_shared<const MaskAsset>(asset));
+}
+
+auto MaskStore::Load(const MaskAssetKey& key) -> std::shared_ptr<const MaskAsset> {
+  if (const auto found = cache_.find(key); found != cache_.end()) {
+    lru_.splice(lru_.begin(), lru_, found->second.lru);
+    return found->second.asset;
+  }
+  std::ifstream stream(PathFor(key), std::ios::binary);
+  if (!stream) throw std::runtime_error("MaskStore asset does not exist");
+  FileHeader header{};
+  stream.read(reinterpret_cast<char*>(&header), sizeof(header));
+  if (!stream || std::memcmp(header.magic, kMagic.data(), kMagic.size()) != 0 ||
+      header.version != kVersion || header.key_bytes == 0 || header.key_bytes > 4096) {
+    throw std::runtime_error("MaskStore file header is invalid");
+  }
+  auto        asset = std::make_shared<MaskAsset>();
+  std::string stored_key(header.key_bytes, '\0');
+  stream.read(stored_key.data(), static_cast<std::streamsize>(stored_key.size()));
+  asset->key                         = MaskAssetKey{std::move(stored_key)};
+  asset->descriptor.extent           = {header.width, header.height};
+  asset->descriptor.reference_bounds = {header.bounds[0], header.bounds[1], header.bounds[2],
+                                        header.bounds[3]};
+  asset->pixels.resize(static_cast<std::size_t>(header.pixel_bytes));
+  stream.read(reinterpret_cast<char*>(asset->pixels.data()),
+              static_cast<std::streamsize>(asset->pixels.size()));
+  if (!stream || asset->key != key) throw std::runtime_error("MaskStore file is incomplete");
+  ValidateMaskAsset(*asset);
+  StoreInCache(asset);
+  return asset;
+}
+
+void MaskStore::StoreInCache(std::shared_ptr<const MaskAsset> asset) {
+  const auto key = asset->key;
+  if (const auto found = cache_.find(key); found != cache_.end()) {
+    cache_bytes_ -= found->second.asset->ByteSize();
+    lru_.erase(found->second.lru);
+    cache_.erase(found);
+  }
+  lru_.push_front(key);
+  cache_bytes_ += asset->ByteSize();
+  cache_.emplace(key, CacheEntry{std::move(asset), lru_.begin()});
+  EvictHostCache();
+}
+
+void MaskStore::EvictHostCache() {
+  if (host_cache_budget_bytes_ == 0) return;
+  while (cache_bytes_ > host_cache_budget_bytes_ && !lru_.empty()) {
+    const auto key = lru_.back();
+    const auto it  = cache_.find(key);
+    cache_bytes_ -= it->second.asset->ByteSize();
+    cache_.erase(it);
+    lru_.pop_back();
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -29,11 +29,11 @@ CudaCommandContext::CudaCommandContext(CudaCommandContext&& other) noexcept
 auto CudaCommandContext::operator=(CudaCommandContext&& other) noexcept -> CudaCommandContext& {
   if (this != &other) {
     Destroy();
-    stream_            = other.stream_;
-    event_             = other.event_;
-    submission_id_     = other.submission_id_;
-    other.stream_      = nullptr;
-    other.event_       = nullptr;
+    stream_              = other.stream_;
+    event_               = other.event_;
+    submission_id_       = other.submission_id_;
+    other.stream_        = nullptr;
+    other.event_         = nullptr;
     other.submission_id_ = 0;
   }
   return *this;
@@ -170,8 +170,7 @@ auto CudaBackend::CreateBuffer(std::size_t bytes) -> Buffer {
 
 auto CudaBackend::CreateTexture2D(std::uint32_t width, std::uint32_t height, TextureFormat format)
     -> Texture2D {
-  const auto bytes =
-      static_cast<std::size_t>(width) * height * TextureFormatBytesPerPixel(format);
+  const auto bytes = static_cast<std::size_t>(width) * height * TextureFormatBytesPerPixel(format);
   if (bytes == 0) {
     return {};
   }
@@ -183,7 +182,7 @@ auto CudaBackend::CreateTexture2D(std::uint32_t width, std::uint32_t height, Tex
 
 void CudaBackend::UploadBufferRange(Buffer& buffer, std::uint32_t offset,
                                     std::span<const std::byte> bytes,
-                                    CommandContext& command_context) {
+                                    CommandContext&            command_context) {
   if (fail_next_upload_) {
     fail_next_upload_ = false;
     throw std::runtime_error("CudaBackend::UploadBufferRange: injected failure");
@@ -200,13 +199,12 @@ void CudaBackend::UploadBufferRange(Buffer& buffer, std::uint32_t offset,
                   "CudaBackend::UploadBufferRange");
   ++h2d_copy_count_;
   h2d_bytes_ += bytes.size();
-  last_h2d_ranges_.push_back(
-      ByteRange{offset, static_cast<std::uint32_t>(bytes.size())});
+  last_h2d_ranges_.push_back(ByteRange{offset, static_cast<std::uint32_t>(bytes.size())});
 }
 
 void CudaBackend::DownloadBufferRange(const Buffer& buffer, std::uint32_t offset,
                                       std::span<std::byte> out,
-                                      CommandContext& command_context) const {
+                                      CommandContext&      command_context) const {
   if (out.empty()) {
     return;
   }
@@ -241,6 +239,27 @@ void CudaBackend::UploadTexture2D(Texture2D& texture, std::span<const std::byte>
                   "CudaBackend::UploadTexture2D");
   ++h2d_copy_count_;
   h2d_bytes_ += bytes.size();
+}
+
+void CudaBackend::UploadR8TextureRect(Texture2D& texture, RectI rectangle,
+                                      std::span<const std::byte> bytes,
+                                      CommandContext&            command_context) {
+  if (texture.Format() != TextureFormat::R8 || rectangle.x < 0 || rectangle.y < 0 ||
+      rectangle.width <= 0 || rectangle.height <= 0 ||
+      rectangle.X1() > static_cast<std::int32_t>(texture.Width()) ||
+      rectangle.Y1() > static_cast<std::int32_t>(texture.Height()) ||
+      bytes.size() != static_cast<std::size_t>(rectangle.width) * rectangle.height) {
+    throw std::runtime_error("CudaBackend::UploadR8TextureRect: invalid rectangle");
+  }
+  auto* destination = static_cast<std::byte*>(texture.DevicePointer()) +
+                      static_cast<std::size_t>(rectangle.y) * texture.Width() + rectangle.x;
+  cuda::CheckCuda(::cudaMemcpy2DAsync(destination, texture.Width(), bytes.data(), rectangle.width,
+                                      rectangle.width, rectangle.height, cudaMemcpyHostToDevice,
+                                      command_context.Stream()),
+                  "CudaBackend::UploadR8TextureRect");
+  ++h2d_copy_count_;
+  h2d_bytes_ += bytes.size();
+  last_texture_rectangles_.push_back(rectangle);
 }
 
 void CudaBackend::UploadDeviceMemory(void* dst, std::span<const std::byte> bytes,
@@ -280,8 +299,6 @@ void CudaBackend::DownloadTexture2D(const Texture2D& texture, std::span<std::byt
                   "CudaBackend::DownloadTexture2D sync");
 }
 
-void CudaBackend::GenerateMaskMipLevels(Texture2D&) {}
-
 void CudaBackend::Submit(CommandContext& command_context) {
   cuda::CheckCuda(::cudaEventRecord(command_context.Event(), command_context.Stream()),
                   "CudaBackend::Submit");
@@ -303,6 +320,7 @@ void CudaBackend::ResetCounters() {
   h2d_copy_count_ = 0;
   h2d_bytes_      = 0;
   last_h2d_ranges_.clear();
+  last_texture_rectangles_.clear();
 }
 
 void CudaBackend::FailNextUpload() { fail_next_upload_ = true; }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
@@ -1,0 +1,423 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "edit/geometry/texture_sampling_plan.hpp"
+#include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
+#include "edit/runtime/cuda/cuda_mask_pass.hpp"
+
+namespace alcedo {
+namespace {
+
+auto UnionDirtyRectangles(std::span<const RectI> rectangles, Extent2D extent) -> RectI {
+  if (rectangles.empty()) return {};
+  std::int32_t x0 = static_cast<std::int32_t>(extent.width);
+  std::int32_t y0 = static_cast<std::int32_t>(extent.height);
+  std::int32_t x1 = 0;
+  std::int32_t y1 = 0;
+  for (const auto& rect : rectangles) {
+    if (rect.width <= 0 || rect.height <= 0) continue;
+    x0 = std::min(x0, std::max(rect.x, 0));
+    y0 = std::min(y0, std::max(rect.y, 0));
+    x1 = std::max(x1, std::min(rect.X1(), static_cast<std::int32_t>(extent.width)));
+    y1 = std::max(y1, std::min(rect.Y1(), static_cast<std::int32_t>(extent.height)));
+  }
+  return x1 > x0 && y1 > y0 ? RectI{x0, y0, x1 - x0, y1 - y0} : RectI{};
+}
+
+auto CopyRectangle(const MaskAsset& asset, RectI rectangle) -> std::vector<std::byte> {
+  std::vector<std::byte> bytes(static_cast<std::size_t>(rectangle.width) * rectangle.height);
+  for (std::int32_t row = 0; row < rectangle.height; ++row) {
+    const auto source =
+        static_cast<std::size_t>(rectangle.y + row) * asset.descriptor.extent.width + rectangle.x;
+    std::copy_n(reinterpret_cast<const std::byte*>(asset.pixels.data() + source), rectangle.width,
+                bytes.data() + static_cast<std::size_t>(row) * rectangle.width);
+  }
+  return bytes;
+}
+
+auto EnsureOutput(CudaRenderWorkspace& workspace, const GraphValueId& id, Extent2D extent)
+    -> ResourceLease<CudaBackend>& {
+  auto* existing = workspace.Images().Find(id);
+  if (existing != nullptr && existing->Texture().Width() == extent.width &&
+      existing->Texture().Height() == extent.height &&
+      existing->Texture().Format() == TextureFormat::R8)
+    return *existing;
+  workspace.Images().Store(
+      id, workspace.Textures().Acquire({extent.width, extent.height, TextureFormat::R8}));
+  return *workspace.Images().Find(id);
+}
+
+__device__ auto Transform(const float* matrix, float x, float y) -> float2 {
+  return make_float2(matrix[0] * x + matrix[1] * y + matrix[2],
+                     matrix[3] * x + matrix[4] * y + matrix[5]);
+}
+
+__device__ auto SampleR8(const std::uint8_t* pixels, std::uint32_t width, std::uint32_t height,
+                         float u, float v) -> float {
+  if (u < 0.0f || v < 0.0f || u > 1.0f || v > 1.0f) return 0.0f;
+  const float x  = u * width - 0.5f;
+  const float y  = v * height - 0.5f;
+  const int   x0 = max(0, min(static_cast<int>(width) - 1, static_cast<int>(floorf(x))));
+  const int   y0 = max(0, min(static_cast<int>(height) - 1, static_cast<int>(floorf(y))));
+  const int   x1 = min(x0 + 1, static_cast<int>(width) - 1);
+  const int   y1 = min(y0 + 1, static_cast<int>(height) - 1);
+  const float tx = fminf(fmaxf(x - floorf(x), 0.0f), 1.0f);
+  const float ty = fminf(fmaxf(y - floorf(y), 0.0f), 1.0f);
+  const float a  = pixels[y0 * width + x0] * (1.0f - tx) + pixels[y0 * width + x1] * tx;
+  const float b  = pixels[y1 * width + x0] * (1.0f - tx) + pixels[y1 * width + x1] * tx;
+  return (a * (1.0f - ty) + b * ty) / 255.0f;
+}
+
+__device__ auto SampleF32(const float* pixels, std::uint32_t width, std::uint32_t height, float u,
+                          float v) -> float {
+  if (u < 0.0f || v < 0.0f || u > 1.0f || v > 1.0f) return -1.0e6f;
+  const float x  = u * width - 0.5f;
+  const float y  = v * height - 0.5f;
+  const int   x0 = max(0, min(static_cast<int>(width) - 1, static_cast<int>(floorf(x))));
+  const int   y0 = max(0, min(static_cast<int>(height) - 1, static_cast<int>(floorf(y))));
+  const int   x1 = min(x0 + 1, static_cast<int>(width) - 1);
+  const int   y1 = min(y0 + 1, static_cast<int>(height) - 1);
+  const float tx = fminf(fmaxf(x - floorf(x), 0.0f), 1.0f);
+  const float ty = fminf(fmaxf(y - floorf(y), 0.0f), 1.0f);
+  const float a  = pixels[y0 * width + x0] * (1.0f - tx) + pixels[y0 * width + x1] * tx;
+  const float b  = pixels[y1 * width + x0] * (1.0f - tx) + pixels[y1 * width + x1] * tx;
+  return a * (1.0f - ty) + b * ty;
+}
+
+__global__ void RasterSampleKernel(const std::uint8_t* source, std::uint32_t source_width,
+                                   std::uint32_t source_height, std::uint8_t* output,
+                                   std::uint32_t output_width, std::uint32_t output_height,
+                                   Matrix3x3 render_to_uv, bool invert) {
+  const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= output_width * output_height) return;
+  const auto x     = index % output_width;
+  const auto y     = index / output_width;
+  const auto uv    = Transform(render_to_uv.m, x + 0.5f, y + 0.5f);
+  float      value = SampleR8(source, source_width, source_height, uv.x, uv.y);
+  if (invert) value = 1.0f - value;
+  output[index] = static_cast<std::uint8_t>(fminf(fmaxf(value * 255.0f + 0.5f, 0.0f), 255.0f));
+}
+
+__global__ void GenerateR8MipKernel(const std::uint8_t* source, std::uint32_t source_width,
+                                    std::uint32_t source_height, std::uint8_t* destination,
+                                    std::uint32_t destination_width,
+                                    std::uint32_t destination_height) {
+  const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= destination_width * destination_height) return;
+  const auto    x        = index % destination_width;
+  const auto    y        = index / destination_width;
+  const auto    source_x = x * 2;
+  const auto    source_y = y * 2;
+  std::uint32_t sum      = 0;
+  std::uint32_t count    = 0;
+  for (std::uint32_t dy = 0; dy < 2; ++dy) {
+    for (std::uint32_t dx = 0; dx < 2; ++dx) {
+      const auto sx = source_x + dx;
+      const auto sy = source_y + dy;
+      if (sx < source_width && sy < source_height) {
+        sum += source[sy * source_width + sx];
+        ++count;
+      }
+    }
+  }
+  destination[index] = static_cast<std::uint8_t>((sum + count / 2) / count);
+}
+
+void GenerateMipChain(MaskTextureLease<CudaBackend>& source, CudaCommandContext& context) {
+  constexpr std::uint32_t block = 256;
+  for (std::size_t level = 1; level < source.MipLevelCount(); ++level) {
+    auto&      previous = source.Texture(level - 1);
+    auto&      next     = source.Texture(level);
+    const auto pixels   = next.Width() * next.Height();
+    GenerateR8MipKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
+        static_cast<const std::uint8_t*>(previous.DevicePointer()), previous.Width(),
+        previous.Height(), static_cast<std::uint8_t*>(next.DevicePointer()), next.Width(),
+        next.Height());
+  }
+}
+
+__global__ void ParallelBandHorizontalKernel(const std::uint8_t* source, float* squared_distance,
+                                             std::uint32_t width, std::uint32_t height,
+                                             bool target_inside) {
+  const auto y = blockIdx.x;
+  if (y >= height || threadIdx.x != 0) return;
+  constexpr int missing = -100000;
+  int           nearest = missing;
+  for (std::uint32_t x = 0; x < width; ++x) {
+    const bool inside = source[y * width + x] >= 128;
+    if (inside == target_inside) nearest = static_cast<int>(x);
+    const float dx                  = static_cast<float>(static_cast<int>(x) - nearest);
+    squared_distance[y * width + x] = nearest == missing ? 1.0e20f : dx * dx;
+  }
+  nearest = -missing;
+  for (int x = static_cast<int>(width) - 1; x >= 0; --x) {
+    const bool inside = source[y * width + x] >= 128;
+    if (inside == target_inside) nearest = x;
+    if (nearest != -missing) {
+      const float dx                  = static_cast<float>(x - nearest);
+      squared_distance[y * width + x] = fminf(squared_distance[y * width + x], dx * dx);
+    }
+  }
+}
+
+__global__ void ParallelBandVerticalKernel(const float* horizontal, float* squared_distance,
+                                           std::uint32_t width, std::uint32_t height) {
+  const auto x = blockIdx.x;
+  if (x >= width || threadIdx.x != 0) return;
+  extern __shared__ unsigned char shared[];
+  auto*                           sites      = reinterpret_cast<int*>(shared);
+  auto*                           boundaries = reinterpret_cast<float*>(sites + height);
+  int                             count      = 0;
+  for (std::uint32_t y = 0; y < height; ++y) {
+    const float f = horizontal[y * width + x];
+    if (f >= 1.0e19f) continue;
+    float boundary = -1.0e20f;
+    while (count > 0) {
+      const int   previous   = sites[count - 1];
+      const float previous_f = horizontal[previous * width + x];
+      boundary               = ((f + static_cast<float>(y * y)) -
+                  (previous_f + static_cast<float>(previous * previous))) /
+                 (2.0f * (static_cast<float>(y) - previous));
+      if (boundary > boundaries[count - 1]) break;
+      --count;
+    }
+    sites[count]      = static_cast<int>(y);
+    boundaries[count] = count == 0 ? -1.0e20f : boundary;
+    ++count;
+  }
+  if (count == 0) {
+    for (std::uint32_t y = 0; y < height; ++y) squared_distance[y * width + x] = 1.0e20f;
+    return;
+  }
+  int site_index = 0;
+  for (std::uint32_t y = 0; y < height; ++y) {
+    while (site_index + 1 < count && boundaries[site_index + 1] < y) ++site_index;
+    const int   site                = sites[site_index];
+    const float dy                  = static_cast<float>(static_cast<int>(y) - site);
+    squared_distance[y * width + x] = horizontal[site * width + x] + dy * dy;
+  }
+}
+
+__global__ void ComposeSignedDistanceKernel(const std::uint8_t* source,
+                                            const float*        distance_to_inside,
+                                            const float* distance_to_outside, float* distance,
+                                            std::uint32_t pixel_count) {
+  const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= pixel_count) return;
+  const float coverage = source[index] / 255.0f;
+  const bool  inside   = coverage >= 0.5f;
+  const float exact    = sqrtf(inside ? distance_to_outside[index] : distance_to_inside[index]);
+  if (coverage > 0.0f && coverage < 1.0f) {
+    distance[index] = coverage - 0.5f;
+  } else {
+    const float to_boundary = fmaxf(exact - 0.5f, 0.0f);
+    distance[index]         = inside ? to_boundary : -to_boundary;
+  }
+}
+
+__global__ void FeatherSampleKernel(const float* distance, std::uint32_t source_width,
+                                    std::uint32_t source_height, std::uint8_t* output,
+                                    std::uint32_t output_width, std::uint32_t output_height,
+                                    Matrix3x3 render_to_uv, float radius_texels, bool invert) {
+  const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= output_width * output_height) return;
+  const auto  x     = index % output_width;
+  const auto  y     = index / output_width;
+  const auto  uv    = Transform(render_to_uv.m, x + 0.5f, y + 0.5f);
+  const float d     = SampleF32(distance, source_width, source_height, uv.x, uv.y);
+  float       value = radius_texels <= 0.0f ? (d >= 0.0f ? 1.0f : 0.0f)
+                                            : fminf(fmaxf(0.5f + d / (2.0f * radius_texels), 0.0f), 1.0f);
+  value             = value * value * (3.0f - 2.0f * value);
+  if (invert) value = 1.0f - value;
+  output[index] = static_cast<std::uint8_t>(value * 255.0f + 0.5f);
+}
+
+__global__ void AnalyticMaskKernel(std::uint8_t* output, std::uint32_t width, std::uint32_t height,
+                                   Matrix3x3 render_to_reference, Extent2D reference_extent,
+                                   AnalyticMaskKind kind, RadialMaskParams radial,
+                                   GraduatedNdMaskParams graduated) {
+  const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= width * height) return;
+  const auto  x         = index % width;
+  const auto  y         = index / width;
+  const auto  reference = Transform(render_to_reference.m, x + 0.5f, y + 0.5f);
+  const float nx        = reference.x / reference_extent.width;
+  const float ny        = reference.y / reference_extent.height;
+  float       value     = 0.0f;
+  bool        invert    = false;
+  if (kind == AnalyticMaskKind::Radial) {
+    const float c      = cosf(radial.rotation);
+    const float s      = sinf(radial.rotation);
+    const float dx     = nx - radial.center_x;
+    const float dy     = ny - radial.center_y;
+    const float rx     = (c * dx + s * dy) / fmaxf(radial.major_radius, 1.0e-6f);
+    const float ry     = (-s * dx + c * dy) / fmaxf(radial.minor_radius, 1.0e-6f);
+    const float radius = sqrtf(rx * rx + ry * ry);
+    const float inner  = fmaxf(0.0f, 1.0f - radial.inner_feather);
+    const float outer  = 1.0f + radial.outer_feather;
+    value  = 1.0f - fminf(fmaxf((radius - inner) / fmaxf(outer - inner, 1.0e-6f), 0.0f), 1.0f);
+    invert = radial.invert;
+  } else {
+    const float normal_length = hypotf(graduated.normal_x, graduated.normal_y);
+    const float normal_x      = graduated.normal_x / fmaxf(normal_length, 1.0e-6f);
+    const float normal_y      = graduated.normal_y / fmaxf(normal_length, 1.0e-6f);
+    const float distance =
+        (nx - graduated.origin_x) * normal_x + (ny - graduated.origin_y) * normal_y;
+    const float t =
+        fminf(fmaxf(distance / fmaxf(graduated.transition_distance, 1.0e-6f) + 0.5f, 0.0f), 1.0f);
+    value  = graduated.start_value + (graduated.end_value - graduated.start_value) * t;
+    invert = graduated.invert;
+  }
+  if (invert) value = 1.0f - value;
+  output[index] = static_cast<std::uint8_t>(fminf(fmaxf(value * 255.0f + 0.5f, 0.0f), 255.0f));
+}
+
+}  // namespace
+
+auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
+                     const PipelineDocument& document, MaskStore* store,
+                     std::span<const RectI> dirty_rectangles) -> CudaMaskResult {
+  if (!device.Workspace().IsRendering())
+    throw std::runtime_error("ExecuteCudaMask: BeginRender has not been called");
+  if (!plan.primary_grade_mask) throw std::runtime_error("ExecuteCudaMask: plan has no mask");
+  auto&                   workspace     = device.Workspace();
+  auto&                   context       = device.CommandContext();
+  const auto              extent        = plan.geometry.render_extent;
+  auto&                   output        = EnsureOutput(workspace, plan.mask_output, extent);
+  constexpr std::uint32_t block         = 256;
+  const auto              render_pixels = extent.width * extent.height;
+  CudaMaskResult          result{plan.mask_output};
+
+  const auto*             node = document.Graph().FindNode(plan.primary_grade_mask->node_id);
+  if (const auto* analytic = dynamic_cast<const AnalyticMaskNodeModel*>(node)) {
+    AnalyticMaskKernel<<<(render_pixels + block - 1) / block, block, 0, context.Stream()>>>(
+        static_cast<std::uint8_t*>(output.Texture().DevicePointer()), extent.width, extent.height,
+        plan.geometry.render_to_reference, plan.geometry.full_reference_extent, analytic->Kind(),
+        analytic->Radial(), analytic->GraduatedNd());
+  } else if (const auto* raster = dynamic_cast<const RasterMaskNodeModel*>(node)) {
+    if (store == nullptr)
+      throw std::invalid_argument("ExecuteCudaMask: raster mask needs MaskStore");
+    const auto asset  = store->Load(raster->AssetKey());
+    const bool cached = workspace.MaskTextures().Contains(asset->key);
+    auto       source = workspace.MaskTextures().Acquire(asset->key, asset->descriptor.extent);
+    result.persistent_texture_resource_id = source.Texture().ResourceId();
+    result.mip_level_count                = static_cast<std::uint32_t>(source.MipLevelCount());
+    const auto dirty     = UnionDirtyRectangles(dirty_rectangles, asset->descriptor.extent);
+    const bool has_dirty = dirty.width > 0 && dirty.height > 0;
+    if (!cached) {
+      workspace.Device().UploadTexture2D(
+          source.Texture(),
+          std::span<const std::byte>(reinterpret_cast<const std::byte*>(asset->pixels.data()),
+                                     asset->pixels.size()),
+          context);
+      GenerateMipChain(source, context);
+    } else if (has_dirty) {
+      const auto bytes = CopyRectangle(*asset, dirty);
+      workspace.Device().UploadR8TextureRect(source.Texture(), dirty, bytes, context);
+      GenerateMipChain(source, context);
+    }
+    const auto sampling = MakeRasterMaskSamplingPlan(plan.geometry, raster->ReferenceBounds(),
+                                                     asset->descriptor.extent);
+    if (raster->FeatherRadius() <= 0.0f) {
+      const auto selected_level = std::min<std::size_t>(
+          static_cast<std::size_t>(std::max(std::floor(sampling.mip_level), 0.0f)),
+          source.MipLevelCount() - 1);
+      auto& sampled_texture = source.Texture(selected_level);
+      RasterSampleKernel<<<(render_pixels + block - 1) / block, block, 0, context.Stream()>>>(
+          static_cast<const std::uint8_t*>(sampled_texture.DevicePointer()),
+          sampled_texture.Width(), sampled_texture.Height(),
+          static_cast<std::uint8_t*>(output.Texture().DevicePointer()), extent.width, extent.height,
+          sampling.render_to_texture_uv, raster->Invert());
+    } else {
+      const GraphValueId distance_id{raster->Id(), PortId{"signed_distance"}};
+      const GraphValueId horizontal_id{raster->Id(), PortId{"distance.horizontal"}};
+      const GraphValueId inside_id{raster->Id(), PortId{"distance.inside"}};
+      const GraphValueId outside_id{raster->Id(), PortId{"distance.outside"}};
+      auto*              distance       = workspace.Values().Find(distance_id);
+      const auto         distance_bytes = asset->pixels.size() * sizeof(float);
+      const bool         must_compute =
+          distance == nullptr || distance->Bytes() != distance_bytes || !cached || has_dirty;
+      if (distance == nullptr || distance->Bytes() != distance_bytes) {
+        workspace.Values().Store(distance_id, workspace.Device().CreateBuffer(distance_bytes));
+        distance = workspace.Values().Find(distance_id);
+      }
+      if (must_compute) {
+        const auto source_pixels = asset->descriptor.extent.width * asset->descriptor.extent.height;
+        auto*      horizontal    = workspace.Values().Find(horizontal_id);
+        auto*      inside_distance  = workspace.Values().Find(inside_id);
+        auto*      outside_distance = workspace.Values().Find(outside_id);
+        if (horizontal == nullptr || horizontal->Bytes() != distance_bytes) {
+          workspace.Values().Store(horizontal_id, workspace.Device().CreateBuffer(distance_bytes));
+          horizontal = workspace.Values().Find(horizontal_id);
+        }
+        if (inside_distance == nullptr || inside_distance->Bytes() != distance_bytes) {
+          workspace.Values().Store(inside_id, workspace.Device().CreateBuffer(distance_bytes));
+          inside_distance = workspace.Values().Find(inside_id);
+        }
+        if (outside_distance == nullptr || outside_distance->Bytes() != distance_bytes) {
+          workspace.Values().Store(outside_id, workspace.Device().CreateBuffer(distance_bytes));
+          outside_distance = workspace.Values().Find(outside_id);
+        }
+        const auto shared_bytes = asset->descriptor.extent.height * sizeof(int) +
+                                  asset->descriptor.extent.height * sizeof(float);
+        ParallelBandHorizontalKernel<<<asset->descriptor.extent.height, 1, 0, context.Stream()>>>(
+            static_cast<const std::uint8_t*>(source.Texture().DevicePointer()),
+            static_cast<float*>(horizontal->DevicePointer()), asset->descriptor.extent.width,
+            asset->descriptor.extent.height, true);
+        ParallelBandVerticalKernel<<<asset->descriptor.extent.width, 1, shared_bytes,
+                                     context.Stream()>>>(
+            static_cast<const float*>(horizontal->DevicePointer()),
+            static_cast<float*>(inside_distance->DevicePointer()), asset->descriptor.extent.width,
+            asset->descriptor.extent.height);
+        ParallelBandHorizontalKernel<<<asset->descriptor.extent.height, 1, 0, context.Stream()>>>(
+            static_cast<const std::uint8_t*>(source.Texture().DevicePointer()),
+            static_cast<float*>(horizontal->DevicePointer()), asset->descriptor.extent.width,
+            asset->descriptor.extent.height, false);
+        ParallelBandVerticalKernel<<<asset->descriptor.extent.width, 1, shared_bytes,
+                                     context.Stream()>>>(
+            static_cast<const float*>(horizontal->DevicePointer()),
+            static_cast<float*>(outside_distance->DevicePointer()), asset->descriptor.extent.width,
+            asset->descriptor.extent.height);
+        ComposeSignedDistanceKernel<<<(source_pixels + block - 1) / block, block, 0,
+                                      context.Stream()>>>(
+            static_cast<const std::uint8_t*>(source.Texture().DevicePointer()),
+            static_cast<const float*>(inside_distance->DevicePointer()),
+            static_cast<const float*>(outside_distance->DevicePointer()),
+            static_cast<float*>(distance->DevicePointer()), source_pixels);
+      }
+      result.signed_distance_resource_id = distance->ResourceId();
+      const auto  bounds                 = raster->ReferenceBounds();
+      const float x_scale =
+          asset->descriptor.extent.width /
+          (plan.geometry.full_reference_extent.width * std::max(bounds.w, 1.0e-6f));
+      const float y_scale =
+          asset->descriptor.extent.height /
+          (plan.geometry.full_reference_extent.height * std::max(bounds.h, 1.0e-6f));
+      const float radius_texels = raster->FeatherRadius() * 0.5f * (x_scale + y_scale);
+      FeatherSampleKernel<<<(render_pixels + block - 1) / block, block, 0, context.Stream()>>>(
+          static_cast<const float*>(distance->DevicePointer()), asset->descriptor.extent.width,
+          asset->descriptor.extent.height,
+          static_cast<std::uint8_t*>(output.Texture().DevicePointer()), extent.width, extent.height,
+          sampling.render_to_texture_uv, radius_texels, raster->Invert());
+    }
+  } else {
+    throw std::runtime_error("ExecuteCudaMask: compiled mask node does not match document");
+  }
+  if (::cudaGetLastError() != cudaSuccess)
+    throw std::runtime_error("ExecuteCudaMask: CUDA kernel launch failed");
+  return result;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -284,7 +284,7 @@ __global__ void PrimaryGradeKernel(const float4* input, float4* output, std::uin
                                    const unsigned char*         parameter_base,
                                    const CudaAdjustmentCommand* commands,
                                    std::uint32_t command_count, CameraToAp1Params camera,
-                                   float local_reference) {
+                                   float local_reference, const std::uint8_t* mask) {
   const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= pixel_count) return;
   const float4 source = input[index];
@@ -298,10 +298,11 @@ __global__ void PrimaryGradeKernel(const float4* input, float4* output, std::uin
         parameter_base + commands[i].parameter_offset);
     c = ApplyAdjustment(c, *params, index, local_reference);
   }
-  c.x           = converted.x + (c.x - converted.x) * camera.mix;
-  c.y           = converted.y + (c.y - converted.y) * camera.mix;
-  c.z           = converted.z + (c.z - converted.z) * camera.mix;
-  output[index] = make_float4(c.x, c.y, c.z, source.w);
+  const float mix = camera.mix * (mask == nullptr ? 1.0f : mask[index] / 255.0f);
+  c.x             = converted.x + (c.x - converted.x) * mix;
+  c.y             = converted.y + (c.y - converted.y) * mix;
+  c.z             = converted.z + (c.z - converted.z) * mix;
+  output[index]   = make_float4(c.x, c.y, c.z, source.w);
 }
 
 }  // namespace
@@ -398,13 +399,22 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
     throw std::runtime_error("ExecuteCudaPrimaryGrade: workspace image has no CUDA allocation");
   }
   const auto camera = MakeCameraToAp1(color_context, grade->Enabled() ? grade->Mix() : 0.0f);
+  const std::uint8_t* mask_pointer = nullptr;
+  if (plan.primary_grade_mask) {
+    auto* mask = workspace.Images().Find(plan.mask_output);
+    if (mask == nullptr || mask->Empty() || mask->Texture().Format() != TextureFormat::R8 ||
+        mask->Texture().Width() != input_width || mask->Texture().Height() != input_height) {
+      throw std::runtime_error("ExecuteCudaPrimaryGrade: compiled mask output is missing");
+    }
+    mask_pointer = static_cast<const std::uint8_t*>(mask->Texture().DevicePointer());
+  }
   const std::uint32_t     pixels = input_width * input_height;
   constexpr std::uint32_t block  = 256;
   PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
       static_cast<const float4*>(input_pointer), static_cast<float4*>(output_pointer), pixels,
       static_cast<const unsigned char*>(arena.DeviceBuffer().DevicePointer()),
       static_cast<const CudaAdjustmentCommand*>(command_buffer.DevicePointer()),
-      static_cast<std::uint32_t>(commands.size()), camera, 0.18f);
+      static_cast<std::uint32_t>(commands.size()), camera, 0.18f, mask_pointer);
   if (::cudaGetLastError() != cudaSuccess) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: CUDA kernel launch failed");
   }

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -60,10 +60,11 @@ void RequireDefaultEndpoints(const PipelineDocument& document) {
   for (const auto& node : document.Graph().Nodes()) {
     const auto& type = node->Type();
     if (type == type_ids::DevelopNode() || type == type_ids::ColorGradeNode() ||
-        type == type_ids::DrtNode()) {
+        type == type_ids::DrtNode() || type == type_ids::AnalyticMaskNode() ||
+        type == type_ids::RasterMaskNode()) {
       continue;
     }
-    throw std::runtime_error("GraphCompiler: G4 compiles only the default three-node document");
+    throw std::runtime_error("GraphCompiler: unsupported GPU DAG node");
   }
 }
 
@@ -81,6 +82,7 @@ auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompi
   plan.source               = source;
   plan.develop_output       = GraphValueId{NodeId{"develop"}, PortId{"image"}};
   plan.peak_transient_bytes = EstimatePeakTransientBytes(source);
+  const auto* grade         = document.PrimaryGrade();
 
   if (source.kind == DevelopInputKind::DirectRgb) {
     plan.passes.push_back(GpuPassDesc{GpuPassKind::UploadRgb});
@@ -95,9 +97,21 @@ auto GraphCompiler::Compile(const PipelineDocument& document, const DevelopCompi
   plan.passes.push_back(GpuPassDesc{GpuPassKind::Lens});
   plan.passes.push_back(GpuPassDesc{GpuPassKind::GeometryResample});
   plan.passes.push_back(GpuPassDesc{GpuPassKind::CameraToAp1});
+  for (const auto& edge : document.Graph().Edges()) {
+    if (edge.to_node == grade->Id() && edge.to_port == PortId{"mask"}) {
+      const auto* mask = document.Graph().FindNode(edge.from_node);
+      if (mask == nullptr) throw std::runtime_error("GraphCompiler: mask edge has no source");
+      const auto kind = mask->Type() == type_ids::RasterMaskNode() ? CompiledMaskKind::Raster
+                                                                   : CompiledMaskKind::Analytic;
+      plan.primary_grade_mask = CompiledMask{mask->Id(), kind};
+      plan.mask_output        = GraphValueId{mask->Id(), PortId{"mask"}};
+      plan.passes.push_back(GpuPassDesc{GpuPassKind::MaskEvaluate});
+      plan.passes.push_back(GpuPassDesc{GpuPassKind::MaskFeather});
+      break;
+    }
+  }
   plan.passes.push_back(GpuPassDesc{GpuPassKind::PrimaryColorGrade});
 
-  const auto* grade = document.PrimaryGrade();
   for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
     plan.primary_grade_adjustments.push_back(
         {grade->AdjustmentIdAt(index), grade->AdjustmentAt(index).Type()});

--- a/alcedo_studio/src/include/edit/graph/raster_mask_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/raster_mask_node_model.hpp
@@ -9,10 +9,9 @@
 #include <span>
 #include <string>
 
-#include <string_view>
-
 #include "edit/geometry/types.hpp"
 #include "edit/graph/i_node_model.hpp"
+#include "edit/mask/mask_asset.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 
 namespace alcedo {
@@ -32,24 +31,25 @@ class RasterMaskNodeModel final : public INodeModel {
   [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto ToJson() const -> nlohmann::json override;
 
-  [[nodiscard]] auto AssetKey() const -> std::string_view { return asset_key_; }
+  [[nodiscard]] auto AssetKey() const -> const MaskAssetKey& { return asset_key_; }
   [[nodiscard]] auto ReferenceBounds() const -> NormalizedRect { return reference_bounds_; }
   [[nodiscard]] auto FeatherRadius() const -> float { return feather_radius_; }
   [[nodiscard]] auto Invert() const -> bool { return invert_; }
 
-  void SetAssetKey(std::string key) { asset_key_ = std::move(key); }
-  void SetReferenceBounds(NormalizedRect bounds) { reference_bounds_ = bounds; }
-  void SetFeatherRadius(float radius) { feather_radius_ = radius; }
-  void SetInvert(bool invert) { invert_ = invert; }
+  void               SetAssetKey(MaskAssetKey key) { asset_key_ = std::move(key); }
+  void               SetAssetKey(std::string key) { asset_key_ = MaskAssetKey{std::move(key)}; }
+  void               SetReferenceBounds(NormalizedRect bounds) { reference_bounds_ = bounds; }
+  void               SetFeatherRadius(float radius) { feather_radius_ = radius; }
+  void               SetInvert(bool invert) { invert_ = invert; }
 
-  static auto FromJson(const nlohmann::json& json) -> std::unique_ptr<RasterMaskNodeModel>;
+  static auto        FromJson(const nlohmann::json& json) -> std::unique_ptr<RasterMaskNodeModel>;
 
  private:
-  NodeId         id_;
-  std::string    asset_key_;
-  NormalizedRect reference_bounds_{};
-  float          feather_radius_ = 0.0f;
-  bool           invert_         = false;
+  NodeId                        id_;
+  MaskAssetKey                  asset_key_;
+  NormalizedRect                reference_bounds_{};
+  float                         feather_radius_ = 0.0f;
+  bool                          invert_         = false;
   std::array<PortDescriptor, 1> outputs_;
 };
 

--- a/alcedo_studio/src/include/edit/mask/mask_asset.hpp
+++ b/alcedo_studio/src/include/edit/mask/mask_asset.hpp
@@ -1,0 +1,55 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+
+namespace alcedo {
+
+inline constexpr std::uint32_t kMaximumRasterMaskAxis = 4096;
+
+/** @brief Stable serialized identifier for one persistent raster mask. */
+class MaskAssetKey {
+ public:
+  MaskAssetKey() = default;
+  explicit MaskAssetKey(std::string value) : value_(std::move(value)) {}
+
+  [[nodiscard]] auto Value() const -> std::string_view { return value_; }
+  [[nodiscard]] auto Empty() const -> bool { return value_.empty(); }
+
+  friend auto        operator==(const MaskAssetKey&, const MaskAssetKey&) -> bool = default;
+  friend auto        operator<(const MaskAssetKey& lhs, const MaskAssetKey& rhs) -> bool {
+    return lhs.value_ < rhs.value_;
+  }
+
+ private:
+  std::string value_;
+};
+
+/** @brief GPU-free metadata stored with tightly packed R8 pixels. */
+struct MaskAssetDescriptor {
+  Extent2D       extent{};
+  NormalizedRect reference_bounds{};
+};
+
+/** @brief Persistent R8 raster mask value. */
+struct MaskAsset {
+  MaskAssetKey              key;
+  MaskAssetDescriptor       descriptor;
+  std::vector<std::uint8_t> pixels;
+
+  [[nodiscard]] auto        ByteSize() const -> std::size_t { return pixels.size(); }
+};
+
+/** @brief Validates key, dimensions, and tightly packed R8 byte count. */
+void ValidateMaskAsset(const MaskAsset& asset);
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/mask_store.hpp
+++ b/alcedo_studio/src/include/edit/mask/mask_store.hpp
@@ -1,0 +1,56 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <list>
+#include <map>
+#include <memory>
+
+#include "edit/mask/mask_asset.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Persistent R8 mask repository with a byte-budgeted host LRU.
+ *
+ * Contains no GPU types. Save writes a complete sibling file and atomically replaces the target.
+ * Instances are not thread-safe. The configured root is created on first save.
+ */
+class MaskStore {
+ public:
+  explicit MaskStore(std::filesystem::path root, std::size_t host_cache_budget_bytes = 0);
+
+  [[nodiscard]] auto Root() const -> const std::filesystem::path& { return root_; }
+  void               SetHostCacheBudget(std::size_t bytes);
+  [[nodiscard]] auto HostCacheBytes() const -> std::size_t { return cache_bytes_; }
+  [[nodiscard]] auto HostCacheEntryCount() const -> std::size_t { return cache_.size(); }
+
+  /** @brief Atomically persist one validated R8 asset and refresh its host-cache entry. */
+  void               Save(const MaskAsset& asset);
+
+  /** @brief Load and validate one asset. Returns a shared immutable host-cache value. */
+  [[nodiscard]] auto Load(const MaskAssetKey& key) -> std::shared_ptr<const MaskAsset>;
+
+  [[nodiscard]] auto PathFor(const MaskAssetKey& key) const -> std::filesystem::path;
+
+ private:
+  struct CacheEntry {
+    std::shared_ptr<const MaskAsset>  asset;
+    std::list<MaskAssetKey>::iterator lru;
+  };
+
+  void                               StoreInCache(std::shared_ptr<const MaskAsset> asset);
+  void                               EvictHostCache();
+
+  std::filesystem::path              root_;
+  std::size_t                        host_cache_budget_bytes_ = 0;
+  std::size_t                        cache_bytes_             = 0;
+  std::map<MaskAssetKey, CacheEntry> cache_;
+  std::list<MaskAssetKey>            lru_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 
 #include "edit/runtime/graph_image_cache.hpp"
+#include "edit/runtime/mask_texture_cache.hpp"
 #include "edit/runtime/node_result_cache.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/texture_pool.hpp"
@@ -25,9 +26,9 @@ namespace alcedo {
 template <class Backend>
 class BasicRenderWorkspace {
  public:
-  using Buffer          = typename Backend::Buffer;
-  using Texture2D       = typename Backend::Texture2D;
-  using CommandContext  = typename Backend::CommandContext;
+  using Buffer         = typename Backend::Buffer;
+  using Texture2D      = typename Backend::Texture2D;
+  using CommandContext = typename Backend::CommandContext;
 
   BasicRenderWorkspace()
       : parameters_(backend_),
@@ -35,8 +36,8 @@ class BasicRenderWorkspace {
         textures_(backend_),
         mask_textures_(backend_) {}
 
-  BasicRenderWorkspace(const BasicRenderWorkspace&)            = delete;
-  auto operator=(const BasicRenderWorkspace&) -> BasicRenderWorkspace& = delete;
+  BasicRenderWorkspace(const BasicRenderWorkspace&)                                  = delete;
+  auto               operator=(const BasicRenderWorkspace&) -> BasicRenderWorkspace& = delete;
 
   [[nodiscard]] auto Device() -> Backend& { return backend_; }
   [[nodiscard]] auto Device() const -> const Backend& { return backend_; }
@@ -44,7 +45,7 @@ class BasicRenderWorkspace {
   [[nodiscard]] auto Parameters() -> ParameterArena<Backend>& { return parameters_; }
   [[nodiscard]] auto TransientBuffers() -> TransientBufferArena<Backend>& { return transients_; }
   [[nodiscard]] auto Textures() -> TexturePool<Backend>& { return textures_; }
-  [[nodiscard]] auto MaskTextures() -> TexturePool<Backend>& { return mask_textures_; }
+  [[nodiscard]] auto MaskTextures() -> MaskTextureCache<Backend>& { return mask_textures_; }
   [[nodiscard]] auto Values() -> NodeResultCache<Backend>& { return values_; }
   [[nodiscard]] auto Images() -> GraphImageCache<Backend>& { return images_; }
   [[nodiscard]] auto Images() const -> const GraphImageCache<Backend>& { return images_; }
@@ -53,7 +54,7 @@ class BasicRenderWorkspace {
    * @brief Wait the previous submission, rewind transients, start a new submission id.
    * @throws std::runtime_error if called re-entrantly.
    */
-  void BeginRender(CommandContext& command_context) {
+  void               BeginRender(CommandContext& command_context) {
     if (rendering_) {
       throw std::runtime_error("BasicRenderWorkspace::BeginRender: already rendering");
     }
@@ -81,14 +82,14 @@ class BasicRenderWorkspace {
   [[nodiscard]] auto IsRendering() const -> bool { return rendering_; }
 
  private:
-  Backend                        backend_{};
-  ParameterArena<Backend>        parameters_;
-  TransientBufferArena<Backend>  transients_;
-  TexturePool<Backend>           textures_;
-  TexturePool<Backend>           mask_textures_;
-  NodeResultCache<Backend>       values_{};
-  GraphImageCache<Backend>       images_{};
-  bool                           rendering_ = false;
+  Backend                       backend_{};
+  ParameterArena<Backend>       parameters_;
+  TransientBufferArena<Backend> transients_;
+  TexturePool<Backend>          textures_;
+  MaskTextureCache<Backend>     mask_textures_;
+  NodeResultCache<Backend>      values_{};
+  GraphImageCache<Backend>      images_{};
+  bool                          rendering_ = false;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -4,13 +4,14 @@
 
 #pragma once
 
+#include <cuda_runtime.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <span>
 #include <vector>
 
-#include <cuda_runtime.h>
-
+#include "edit/geometry/types.hpp"
 #include "edit/runtime/byte_range.hpp"
 #include "edit/runtime/texture_format.hpp"
 
@@ -26,10 +27,10 @@ class CudaCommandContext {
   CudaCommandContext();
   ~CudaCommandContext();
 
-  CudaCommandContext(const CudaCommandContext&)            = delete;
+  CudaCommandContext(const CudaCommandContext&)                    = delete;
   auto operator=(const CudaCommandContext&) -> CudaCommandContext& = delete;
   CudaCommandContext(CudaCommandContext&& other) noexcept;
-  auto operator=(CudaCommandContext&& other) noexcept -> CudaCommandContext&;
+  auto               operator=(CudaCommandContext&& other) noexcept -> CudaCommandContext&;
 
   [[nodiscard]] auto Stream() const -> cudaStream_t { return stream_; }
   [[nodiscard]] auto Event() const -> cudaEvent_t { return event_; }
@@ -37,7 +38,7 @@ class CudaCommandContext {
   void               SetSubmissionId(std::uint64_t id) { submission_id_ = id; }
 
  private:
-  void Destroy() noexcept;
+  void          Destroy() noexcept;
 
   cudaStream_t  stream_        = nullptr;
   cudaEvent_t   event_         = nullptr;
@@ -58,17 +59,17 @@ class CudaBackend {
     Buffer(CudaBackend* owner, void* ptr, std::size_t bytes, std::uint64_t id);
     ~Buffer();
 
-    Buffer(const Buffer&)            = delete;
+    Buffer(const Buffer&)                    = delete;
     auto operator=(const Buffer&) -> Buffer& = delete;
     Buffer(Buffer&& other) noexcept;
-    auto operator=(Buffer&& other) noexcept -> Buffer&;
+    auto               operator=(Buffer&& other) noexcept -> Buffer&;
 
     [[nodiscard]] auto DevicePointer() const -> void* { return ptr_; }
     [[nodiscard]] auto Bytes() const -> std::size_t { return bytes_; }
     [[nodiscard]] auto ResourceId() const -> std::uint64_t { return resource_id_; }
     [[nodiscard]] auto Empty() const -> bool { return ptr_ == nullptr; }
 
-    void Reset() noexcept;
+    void               Reset() noexcept;
 
    private:
     CudaBackend*  owner_       = nullptr;
@@ -84,10 +85,10 @@ class CudaBackend {
               std::uint32_t height, TextureFormat format, std::uint64_t id);
     ~Texture2D();
 
-    Texture2D(const Texture2D&)            = delete;
+    Texture2D(const Texture2D&)                    = delete;
     auto operator=(const Texture2D&) -> Texture2D& = delete;
     Texture2D(Texture2D&& other) noexcept;
-    auto operator=(Texture2D&& other) noexcept -> Texture2D&;
+    auto               operator=(Texture2D&& other) noexcept -> Texture2D&;
 
     [[nodiscard]] auto DevicePointer() const -> void* { return ptr_; }
     [[nodiscard]] auto Bytes() const -> std::size_t { return bytes_; }
@@ -96,7 +97,7 @@ class CudaBackend {
     [[nodiscard]] auto Format() const -> TextureFormat { return format_; }
     [[nodiscard]] auto ResourceId() const -> std::uint64_t { return resource_id_; }
 
-    void Reset() noexcept;
+    void               Reset() noexcept;
 
    private:
     CudaBackend*  owner_       = nullptr;
@@ -108,14 +109,14 @@ class CudaBackend {
     std::uint64_t resource_id_ = 0;
   };
 
-  using Slab            = Buffer;
-  using CommandContext  = CudaCommandContext;
+  using Slab                                                       = Buffer;
+  using CommandContext                                             = CudaCommandContext;
 
-  CudaBackend()  = default;
-  ~CudaBackend() = default;
+  CudaBackend()                                                    = default;
+  ~CudaBackend()                                                   = default;
 
-  CudaBackend(const CudaBackend&)            = delete;
-  auto operator=(const CudaBackend&) -> CudaBackend& = delete;
+  CudaBackend(const CudaBackend&)                                  = delete;
+  auto               operator=(const CudaBackend&) -> CudaBackend& = delete;
 
   [[nodiscard]] auto CreateBuffer(std::size_t bytes) -> Buffer;
   [[nodiscard]] auto CreateSlab(std::size_t bytes) -> Buffer { return CreateBuffer(bytes); }
@@ -133,6 +134,9 @@ class CudaBackend {
    */
   void UploadTexture2D(Texture2D& texture, std::span<const std::byte> bytes,
                        CommandContext& command_context);
+  /** @brief Upload a tightly packed R8 rectangle into an R8 texture. */
+  void UploadR8TextureRect(Texture2D& texture, RectI rectangle, std::span<const std::byte> bytes,
+                           CommandContext& command_context);
   void DownloadTexture2D(const Texture2D& texture, std::span<std::byte> out,
                          CommandContext& command_context) const;
 
@@ -142,25 +146,20 @@ class CudaBackend {
   void UploadDeviceMemory(void* dst, std::span<const std::byte> bytes,
                           CommandContext& command_context);
 
-  /// G6 will generate mips. G2 keeps the entry and does nothing.
-  void GenerateMaskMipLevels(Texture2D& texture);
-
   void Submit(CommandContext& command_context);
   void Wait(CommandContext& command_context);
 
-  [[nodiscard]] auto HasInFlightSubmission() const -> bool {
-    return in_flight_submission_ != 0;
-  }
+  [[nodiscard]] auto HasInFlightSubmission() const -> bool { return in_flight_submission_ != 0; }
   [[nodiscard]] auto IsResourceBusy(std::uint64_t submitted_on) const -> bool {
     return submitted_on != 0 && submitted_on > completed_submission_;
   }
   [[nodiscard]] auto NextSubmissionId() -> std::uint64_t { return ++next_submission_; }
 
-  void NoteFree() noexcept { ++free_count_; }
+  void               NoteFree() noexcept { ++free_count_; }
 
-  void ResetCounters();
-  void FailNextUpload();
-  void NoteHostToDeviceBegin() { last_h2d_ranges_.clear(); }
+  void               ResetCounters();
+  void               FailNextUpload();
+  void               NoteHostToDeviceBegin() { last_h2d_ranges_.clear(); }
 
   [[nodiscard]] auto MallocCount() const -> std::uint64_t { return malloc_count_; }
   [[nodiscard]] auto FreeCount() const -> std::uint64_t { return free_count_; }
@@ -169,23 +168,27 @@ class CudaBackend {
   [[nodiscard]] auto LastHostToDeviceRanges() const -> const std::vector<ByteRange>& {
     return last_h2d_ranges_;
   }
+  [[nodiscard]] auto LastTextureRectangles() const -> const std::vector<RectI>& {
+    return last_texture_rectangles_;
+  }
 
  private:
   friend class Buffer;
   friend class Texture2D;
 
-  void NoteMalloc() noexcept { ++malloc_count_; }
+  void                   NoteMalloc() noexcept { ++malloc_count_; }
 
-  std::uint64_t         malloc_count_          = 0;
-  std::uint64_t         free_count_            = 0;
-  std::uint64_t         h2d_copy_count_        = 0;
-  std::uint64_t         h2d_bytes_             = 0;
-  std::uint64_t         next_resource_id_      = 1;
-  std::uint64_t         next_submission_       = 0;
-  std::uint64_t         in_flight_submission_  = 0;
-  std::uint64_t         completed_submission_  = 0;
-  bool                  fail_next_upload_      = false;
+  std::uint64_t          malloc_count_         = 0;
+  std::uint64_t          free_count_           = 0;
+  std::uint64_t          h2d_copy_count_       = 0;
+  std::uint64_t          h2d_bytes_            = 0;
+  std::uint64_t          next_resource_id_     = 1;
+  std::uint64_t          next_submission_      = 0;
+  std::uint64_t          in_flight_submission_ = 0;
+  std::uint64_t          completed_submission_ = 0;
+  bool                   fail_next_upload_     = false;
   std::vector<ByteRange> last_h2d_ranges_;
+  std::vector<RectI>     last_texture_rectangles_;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_mask_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_mask_pass.hpp
@@ -1,0 +1,35 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/mask/mask_store.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/execution_plan.hpp"
+
+namespace alcedo {
+
+struct CudaMaskResult {
+  GraphValueId  output;
+  std::uint64_t persistent_texture_resource_id = 0;
+  std::uint64_t signed_distance_resource_id    = 0;
+  std::uint32_t mip_level_count                = 0;
+};
+
+/**
+ * @brief Evaluate the optional compiled analytic or raster mask into RenderSpace R8.
+ *
+ * Raster source textures and signed-distance buffers are workspace resources. Dirty rectangles
+ * are unioned before upload. Changing only feather radius reuses signed distance. No CPU image
+ * processing fallback is used.
+ */
+[[nodiscard]] auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
+                                   const PipelineDocument& document, MaskStore* store = nullptr,
+                                   std::span<const RectI> dirty_rectangles = {}) -> CudaMaskResult;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <vector>
 
 #include "edit/geometry/resolved_render_geometry.hpp"
@@ -24,6 +25,13 @@ struct CompiledAdjustment {
   OperatorTypeId       type;
 };
 
+enum class CompiledMaskKind : std::uint8_t { Analytic, Raster };
+
+struct CompiledMask {
+  NodeId           node_id;
+  CompiledMaskKind kind = CompiledMaskKind::Analytic;
+};
+
 /**
  * @brief Compiled backend work for one graph. Does not own GPU memory.
  *
@@ -38,6 +46,8 @@ struct ExecutionPlan {
   bool                            encode_geometry_resample = false;
   std::size_t                     peak_transient_bytes     = 0;
   std::vector<CompiledAdjustment> primary_grade_adjustments;
+  std::optional<CompiledMask>     primary_grade_mask;
+  GraphValueId                    mask_output{NodeId{""}, PortId{"mask"}};
 
   [[nodiscard]] auto              Contains(GpuPassKind kind) const -> bool {
     for (const auto& pass : passes) {

--- a/alcedo_studio/src/include/edit/runtime/mask_texture_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/mask_texture_cache.hpp
@@ -1,0 +1,223 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "edit/mask/mask_asset.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+
+template <class Backend>
+class MaskTextureCache;
+
+/** @brief Move-only pin preventing eviction of a keyed workspace mask texture. */
+template <class Backend>
+class MaskTextureLease {
+ public:
+  MaskTextureLease() = default;
+  MaskTextureLease(MaskTextureCache<Backend>* cache, MaskAssetKey key)
+      : cache_(cache), key_(std::move(key)) {}
+  MaskTextureLease(const MaskTextureLease&)                    = delete;
+  auto operator=(const MaskTextureLease&) -> MaskTextureLease& = delete;
+  MaskTextureLease(MaskTextureLease&& other) noexcept
+      : cache_(other.cache_), key_(std::move(other.key_)) {
+    other.cache_ = nullptr;
+  }
+  auto operator=(MaskTextureLease&& other) noexcept -> MaskTextureLease& {
+    if (this != &other) {
+      Release();
+      cache_       = other.cache_;
+      key_         = std::move(other.key_);
+      other.cache_ = nullptr;
+    }
+    return *this;
+  }
+  ~MaskTextureLease() { Release(); }
+
+  [[nodiscard]] auto Texture() -> typename Backend::Texture2D&;
+  [[nodiscard]] auto Texture() const -> const typename Backend::Texture2D&;
+  [[nodiscard]] auto Texture(std::size_t mip_level) -> typename Backend::Texture2D&;
+  [[nodiscard]] auto MipLevelCount() const -> std::size_t;
+  [[nodiscard]] auto Key() const -> const MaskAssetKey& { return key_; }
+  [[nodiscard]] auto Empty() const -> bool { return cache_ == nullptr; }
+  void               Release();
+
+ private:
+  MaskTextureCache<Backend>* cache_ = nullptr;
+  MaskAssetKey               key_;
+};
+
+/** @brief Workspace-only byte-budget LRU keyed by persistent MaskAssetKey. */
+template <class Backend>
+class MaskTextureCache {
+ public:
+  explicit MaskTextureCache(Backend& backend) : backend_(&backend) {}
+  MaskTextureCache(const MaskTextureCache&)                    = delete;
+  auto operator=(const MaskTextureCache&) -> MaskTextureCache& = delete;
+
+  void SetByteBudget(std::size_t bytes) {
+    budget_bytes_ = bytes;
+    EvictUntil(0);
+  }
+  [[nodiscard]] auto UsedBytes() const -> std::size_t { return used_bytes_; }
+  [[nodiscard]] auto EntryCount() const -> std::size_t { return entries_.size(); }
+
+  void               BeginFrame() {
+    for (auto& [key, entry] : entries_) entry.used_this_frame = false;
+  }
+
+  [[nodiscard]] auto Acquire(const MaskAssetKey& key, Extent2D extent)
+      -> MaskTextureLease<Backend> {
+    if (key.Empty() || extent.Empty()) throw std::invalid_argument("Invalid mask texture request");
+    if (auto found = entries_.find(key); found != entries_.end()) {
+      if (found->second.extent != extent) {
+        if (found->second.lease_count != 0 ||
+            backend_->IsResourceBusy(found->second.submitted_on)) {
+          throw std::runtime_error("Cannot replace active mask texture with a new extent");
+        }
+        used_bytes_ -= found->second.bytes;
+        entries_.erase(found);
+      } else {
+        return TakeLease(key, found->second);
+      }
+    }
+    EvictUntil(MipChainBytes(extent));
+    Entry entry;
+    entry.extent      = extent;
+    auto level_extent = extent;
+    while (true) {
+      entry.mip_levels.push_back(
+          backend_->CreateTexture2D(level_extent.width, level_extent.height, TextureFormat::R8));
+      entry.bytes += entry.mip_levels.back().Bytes();
+      if (level_extent.width == 1 && level_extent.height == 1) break;
+      level_extent.width  = std::max<std::uint32_t>(level_extent.width / 2, 1);
+      level_extent.height = std::max<std::uint32_t>(level_extent.height / 2, 1);
+    }
+    used_bytes_ += entry.bytes;
+    auto it = entries_.emplace(key, std::move(entry)).first;
+    return TakeLease(it->first, it->second);
+  }
+
+  [[nodiscard]] auto Contains(const MaskAssetKey& key) const -> bool {
+    return entries_.contains(key);
+  }
+
+  void MarkSubmitted(std::uint64_t submission_id) {
+    for (auto& [key, entry] : entries_) {
+      if (entry.used_this_frame || entry.lease_count != 0) entry.submitted_on = submission_id;
+    }
+  }
+
+  void EvictUntil(std::size_t needed_bytes) {
+    if (budget_bytes_ == 0) return;
+    while (used_bytes_ + needed_bytes > budget_bytes_) {
+      auto victim = entries_.end();
+      auto oldest = (std::numeric_limits<std::uint64_t>::max)();
+      for (auto it = entries_.begin(); it != entries_.end(); ++it) {
+        const auto& entry = it->second;
+        if (entry.lease_count != 0 || entry.used_this_frame ||
+            backend_->IsResourceBusy(entry.submitted_on))
+          continue;
+        if (entry.lru_tick < oldest) {
+          oldest = entry.lru_tick;
+          victim = it;
+        }
+      }
+      if (victim == entries_.end()) break;
+      used_bytes_ -= victim->second.bytes;
+      entries_.erase(victim);
+    }
+  }
+
+  [[nodiscard]] auto TextureAt(const MaskAssetKey& key) -> typename Backend::Texture2D& {
+    return entries_.at(key).mip_levels.front();
+  }
+  [[nodiscard]] auto TextureAt(const MaskAssetKey& key) const -> const
+      typename Backend::Texture2D& {
+    return entries_.at(key).mip_levels.front();
+  }
+  [[nodiscard]] auto TextureAt(const MaskAssetKey& key, std::size_t level) ->
+      typename Backend::Texture2D& {
+    return entries_.at(key).mip_levels.at(level);
+  }
+  [[nodiscard]] auto MipLevelCount(const MaskAssetKey& key) const -> std::size_t {
+    return entries_.at(key).mip_levels.size();
+  }
+  void Release(const MaskAssetKey& key) {
+    if (auto found = entries_.find(key); found != entries_.end() && found->second.lease_count != 0)
+      --found->second.lease_count;
+  }
+
+ private:
+  friend class MaskTextureLease<Backend>;
+  struct Entry {
+    std::vector<typename Backend::Texture2D> mip_levels;
+    Extent2D                                 extent{};
+    std::size_t                              bytes           = 0;
+    std::uint32_t                            lease_count     = 0;
+    std::uint64_t                            submitted_on    = 0;
+    std::uint64_t                            lru_tick        = 0;
+    bool                                     used_this_frame = false;
+  };
+  static auto MipChainBytes(Extent2D extent) -> std::size_t {
+    std::size_t bytes = 0;
+    while (true) {
+      bytes += static_cast<std::size_t>(extent.width) * extent.height;
+      if (extent.width == 1 && extent.height == 1) return bytes;
+      extent.width  = std::max<std::uint32_t>(extent.width / 2, 1);
+      extent.height = std::max<std::uint32_t>(extent.height / 2, 1);
+    }
+  }
+  auto TakeLease(const MaskAssetKey& key, Entry& entry) -> MaskTextureLease<Backend> {
+    ++entry.lease_count;
+    entry.used_this_frame = true;
+    entry.lru_tick        = ++lru_clock_;
+    return MaskTextureLease<Backend>{this, key};
+  }
+  Backend*                      backend_ = nullptr;
+  std::map<MaskAssetKey, Entry> entries_;
+  std::size_t                   budget_bytes_ = 0;
+  std::size_t                   used_bytes_   = 0;
+  std::uint64_t                 lru_clock_    = 0;
+};
+
+template <class Backend>
+auto MaskTextureLease<Backend>::Texture() -> typename Backend::Texture2D& {
+  if (cache_ == nullptr) throw std::runtime_error("MaskTextureLease is empty");
+  return cache_->TextureAt(key_);
+}
+template <class Backend>
+auto MaskTextureLease<Backend>::Texture() const -> const typename Backend::Texture2D& {
+  if (cache_ == nullptr) throw std::runtime_error("MaskTextureLease is empty");
+  return cache_->TextureAt(key_);
+}
+template <class Backend>
+auto MaskTextureLease<Backend>::Texture(std::size_t mip_level) -> typename Backend::Texture2D& {
+  if (cache_ == nullptr) throw std::runtime_error("MaskTextureLease is empty");
+  return cache_->TextureAt(key_, mip_level);
+}
+template <class Backend>
+auto MaskTextureLease<Backend>::MipLevelCount() const -> std::size_t {
+  if (cache_ == nullptr) return 0;
+  return cache_->MipLevelCount(key_);
+}
+template <class Backend>
+void MaskTextureLease<Backend>::Release() {
+  if (cache_ != nullptr) {
+    cache_->Release(key_);
+    cache_ = nullptr;
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/pass_kind.hpp
+++ b/alcedo_studio/src/include/edit/runtime/pass_kind.hpp
@@ -26,7 +26,9 @@ enum class GpuPassKind : std::uint8_t {
   Lens              = 7,
   GeometryResample  = 8,
   CameraToAp1       = 9,
-  PrimaryColorGrade = 10,
+  MaskEvaluate      = 10,
+  MaskFeather       = 11,
+  PrimaryColorGrade = 12,
 };
 
 [[nodiscard]] inline auto GpuPassKindName(GpuPassKind kind) -> const char* {
@@ -51,6 +53,10 @@ enum class GpuPassKind : std::uint8_t {
       return "GeometryResample";
     case GpuPassKind::CameraToAp1:
       return "CameraToAp1";
+    case GpuPassKind::MaskEvaluate:
+      return "MaskEvaluate";
+    case GpuPassKind::MaskFeather:
+      return "MaskFeather";
     case GpuPassKind::PrimaryColorGrade:
       return "PrimaryColorGrade";
   }

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -254,6 +254,15 @@ gtest_discover_tests(GpuDagGeometryTest TEST_PREFIX "GpuDagGeometryTest."
   PROPERTIES LABELS "ci_core_flow;edit;geometry")
 alcedo_register_test_target(GpuDagGeometryTest edit)
 
+# GPU DAG Phase G6: persistent R8 repository and GPU-free host cache.
+add_executable(GpuDagMaskStoreTest
+  ${ALCEDO_TEST_ROOT}/edit/mask/mask_store_test.cpp)
+target_include_directories(GpuDagMaskStoreTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(GpuDagMaskStoreTest PRIVATE GTest::gtest_main EditMaskStore)
+gtest_discover_tests(GpuDagMaskStoreTest TEST_PREFIX "GpuDagMaskStoreTest."
+  PROPERTIES LABELS "ci_core_flow;edit;mask")
+alcedo_register_test_target(GpuDagMaskStoreTest edit)
+
 # GPU DAG Phase G3: CUDA GeometryResamplePass.
 if(ALCEDO_CUDA_ENABLED)
   add_executable(GpuDagCudaGeometryTest
@@ -296,6 +305,14 @@ if(ALCEDO_CUDA_ENABLED)
   gtest_discover_tests(GpuDagCudaPrimaryGradeTest TEST_PREFIX "GpuDagCudaPrimaryGradeTest."
     PROPERTIES LABELS "gpu;edit;runtime")
   alcedo_register_test_target(GpuDagCudaPrimaryGradeTest gpu)
+
+  add_executable(GpuDagCudaMaskTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_mask_test.cpp)
+  target_include_directories(GpuDagCudaMaskTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagCudaMaskTest PRIVATE GTest::gtest_main EditRuntimeCuda EditInput)
+  gtest_discover_tests(GpuDagCudaMaskTest TEST_PREFIX "GpuDagCudaMaskTest."
+    PROPERTIES LABELS "gpu;edit;runtime;mask")
+  alcedo_register_test_target(GpuDagCudaMaskTest gpu)
 
   add_executable(GpuDagCudaWorkspaceTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/parameter_arena_test.cpp

--- a/alcedo_studio/tests/edit/graph/json_roundtrip_test.cpp
+++ b/alcedo_studio/tests/edit/graph/json_roundtrip_test.cpp
@@ -7,20 +7,35 @@
 #include <string>
 
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 
 namespace alcedo {
 
-TEST(GpuDagModelGraph, PipelineDocumentRoundTripPreservesNodeIdsEdgesAndAdjustmentOrder) {
+TEST(GpuDagModelGraph, RasterMaskRoundTripPreservesMaskAssetKey) {
   auto document = CreateDefaultPipelineDocument();
+  auto mask     = std::make_unique<RasterMaskNodeModel>(NodeId{"mask.persisted"});
+  mask->SetAssetKey(MaskAssetKey{"asset_01"});
+  document.Graph().AddNode(std::move(mask));
+  document.Graph().Connect(NodeId{"mask.persisted"}, PortId{"mask"}, NodeId{"grade.primary"},
+                           PortId{"mask"});
+  const auto  restored = PipelineDocument::FromJson(document.ToJson());
+  const auto* restored_mask =
+      dynamic_cast<const RasterMaskNodeModel*>(restored.Graph().FindNode("mask.persisted"));
+  ASSERT_NE(restored_mask, nullptr);
+  EXPECT_EQ(restored_mask->AssetKey(), MaskAssetKey{"asset_01"});
+}
+
+TEST(GpuDagModelGraph, PipelineDocumentRoundTripPreservesNodeIdsEdgesAndAdjustmentOrder) {
+  auto  document = CreateDefaultPipelineDocument();
   auto* exposure = dynamic_cast<ExposureModel*>(
       document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
   ASSERT_NE(exposure, nullptr);
   exposure->SetValue(1.25f);
   document.PrimaryGrade()->MoveAdjustment(AdjustmentInstanceId{"grade.primary.film_grain"}, 8);
 
-  const auto json     = document.ToJson();
+  const auto json = document.ToJson();
   EXPECT_EQ(json["format_version"], 2);
   EXPECT_FALSE(json.dump().find("stage") != std::string::npos && json.contains("stage"));
   EXPECT_FALSE(json.contains("priority"));
@@ -40,8 +55,7 @@ TEST(GpuDagModelGraph, PipelineDocumentRoundTripPreservesNodeIdsEdgesAndAdjustme
   const auto* grade = restored.PrimaryGrade();
   ASSERT_EQ(grade->AdjustmentCount(), 17u);
   EXPECT_EQ(std::string{grade->AdjustmentIdAt(8).Value()}, "grade.primary.film_grain");
-  const auto* restored_exposure =
-      dynamic_cast<const ExposureModel*>(&grade->AdjustmentAt(1));
+  const auto* restored_exposure = dynamic_cast<const ExposureModel*>(&grade->AdjustmentAt(1));
   ASSERT_NE(restored_exposure, nullptr);
   EXPECT_FLOAT_EQ(restored_exposure->Value(), 1.25f);
   EXPECT_TRUE(restored.Graph().Validate().empty());

--- a/alcedo_studio/tests/edit/mask/mask_store_test.cpp
+++ b/alcedo_studio/tests/edit/mask/mask_store_test.cpp
@@ -1,0 +1,98 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/mask_store.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace alcedo {
+namespace {
+
+auto TestRoot(std::string_view name) -> std::filesystem::path {
+  return std::filesystem::path{"build/tmp/g6_mask_store"} / name;
+}
+
+auto MakeAsset(std::string key, std::uint32_t width = 4, std::uint32_t height = 3,
+               std::uint8_t value = 17) -> MaskAsset {
+  MaskAsset asset;
+  asset.key                         = MaskAssetKey{std::move(key)};
+  asset.descriptor.extent           = {width, height};
+  asset.descriptor.reference_bounds = {0.1f, 0.2f, 0.7f, 0.6f};
+  asset.pixels.assign(static_cast<std::size_t>(width) * height, value);
+  return asset;
+}
+
+class MaskStoreFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    root_ = TestRoot(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    std::error_code ignored;
+    std::filesystem::remove_all(root_, ignored);
+  }
+
+  std::filesystem::path root_;
+};
+
+TEST_F(MaskStoreFixture, MaskStoreRejectsRasterMaskLargerThan4096OnEitherAxis) {
+  MaskStore store(root_);
+  auto      too_wide = MakeAsset("wide", 4097, 1);
+  auto      too_tall = MakeAsset("tall", 1, 4097);
+  EXPECT_THROW(store.Save(too_wide), std::invalid_argument);
+  EXPECT_THROW(store.Save(too_tall), std::invalid_argument);
+  EXPECT_FALSE(std::filesystem::exists(store.PathFor(too_wide.key)));
+}
+
+TEST_F(MaskStoreFixture, MaskStoreRoundTripPreservesR8PixelsDescriptorAndKey) {
+  const auto expected = MakeAsset("round_trip");
+  MaskStore  store(root_);
+  store.Save(expected);
+  MaskStore  reopened(root_);
+  const auto actual = reopened.Load(expected.key);
+  EXPECT_EQ(actual->key, expected.key);
+  EXPECT_EQ(actual->descriptor.extent, expected.descriptor.extent);
+  EXPECT_FLOAT_EQ(actual->descriptor.reference_bounds.x, expected.descriptor.reference_bounds.x);
+  EXPECT_FLOAT_EQ(actual->descriptor.reference_bounds.y, expected.descriptor.reference_bounds.y);
+  EXPECT_FLOAT_EQ(actual->descriptor.reference_bounds.w, expected.descriptor.reference_bounds.w);
+  EXPECT_FLOAT_EQ(actual->descriptor.reference_bounds.h, expected.descriptor.reference_bounds.h);
+  EXPECT_EQ(actual->pixels, expected.pixels);
+}
+
+TEST_F(MaskStoreFixture, MaskStoreUsesConfiguredRoot) {
+  MaskStore  store(root_ / "configured");
+  const auto asset = MakeAsset("root");
+  store.Save(asset);
+  EXPECT_EQ(store.Root(), root_ / "configured");
+  EXPECT_TRUE(std::filesystem::exists(store.PathFor(asset.key)));
+}
+
+TEST_F(MaskStoreFixture, MaskStoreReplacesFileOnlyAfterCompleteWrite) {
+  MaskStore store(root_);
+  auto      original = MakeAsset("replace", 2, 2, 31);
+  store.Save(original);
+  auto invalid = MakeAsset("replace", 2, 2, 99);
+  invalid.pixels.pop_back();
+  EXPECT_THROW(store.Save(invalid), std::invalid_argument);
+  MaskStore reopened(root_);
+  EXPECT_EQ(reopened.Load(original.key)->pixels, original.pixels);
+}
+
+TEST_F(MaskStoreFixture, MaskHostCacheEvictsByBytesWithoutDeletingMaskFile) {
+  MaskStore  store(root_, 8);
+  const auto first  = MakeAsset("first", 3, 2, 1);
+  const auto second = MakeAsset("second", 3, 2, 2);
+  store.Save(first);
+  store.Save(second);
+  EXPECT_LE(store.HostCacheBytes(), 8U);
+  EXPECT_EQ(store.HostCacheEntryCount(), 1U);
+  EXPECT_TRUE(std::filesystem::exists(store.PathFor(first.key)));
+  MaskStore reopened(root_);
+  EXPECT_EQ(reopened.Load(first.key)->pixels, first.pixels);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
@@ -1,0 +1,324 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/runtime/cuda/cuda_develop_pass.hpp"
+#include "edit/runtime/cuda/cuda_mask_pass.hpp"
+#include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+class CudaMaskFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+    SetExtent(16, 12);
+    root_ = std::filesystem::path{"build/tmp/g6_cuda_mask"} /
+            ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    std::error_code ignored;
+    std::filesystem::remove_all(root_, ignored);
+    store_ = std::make_unique<MaskStore>(root_);
+  }
+
+  void SetExtent(std::uint32_t width, std::uint32_t height) {
+    width_    = width;
+    height_   = height;
+    prepared_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(width, height),
+                                              gpu_dag_test::FullSensor(width, height));
+    document_ = CreateDefaultPipelineDocument();
+  }
+
+  auto MakeRaster(std::string key, std::uint8_t fill = 0) -> MaskAsset {
+    MaskAsset asset;
+    asset.key                         = MaskAssetKey{std::move(key)};
+    asset.descriptor.extent           = {width_, height_};
+    asset.descriptor.reference_bounds = {};
+    asset.pixels.assign(static_cast<std::size_t>(width_) * height_, fill);
+    return asset;
+  }
+
+  auto AttachRaster(MaskAsset asset, float feather = 0.0f) -> RasterMaskNodeModel& {
+    store_->Save(asset);
+    auto node = std::make_unique<RasterMaskNodeModel>(NodeId{"mask.raster"});
+    node->SetAssetKey(asset.key);
+    node->SetReferenceBounds({});
+    node->SetFeatherRadius(feather);
+    auto* result = node.get();
+    document_.Graph().AddNode(std::move(node));
+    document_.Graph().Connect(NodeId{"mask.raster"}, PortId{"mask"}, NodeId{"grade.primary"},
+                              PortId{"mask"});
+    document_.MarkTopologyDirty();
+    return *result;
+  }
+
+  auto AttachAnalytic(AnalyticMaskKind kind) -> AnalyticMaskNodeModel& {
+    auto  node   = std::make_unique<AnalyticMaskNodeModel>(NodeId{"mask.analytic"}, kind);
+    auto* result = node.get();
+    document_.Graph().AddNode(std::move(node));
+    document_.Graph().Connect(NodeId{"mask.analytic"}, PortId{"mask"}, NodeId{"grade.primary"},
+                              PortId{"mask"});
+    document_.MarkTopologyDirty();
+    return *result;
+  }
+
+  void Compile(RenderRequest request = {}) {
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), request);
+  }
+
+  auto RenderMask(std::span<const RectI> dirty = {}) -> CudaMaskResult {
+    device_.BeginRender();
+    auto result = ExecuteCudaMask(device_, plan_, document_, store_.get(), dirty);
+    device_.EndRender();
+    device_.WaitIdle();
+    return result;
+  }
+
+  auto RenderGrade() -> CudaPrimaryGradeResult {
+    device_.BeginRender();
+    (void)ExecuteCudaDevelop(device_, plan_, prepared_, document_);
+    (void)ExecuteCudaMask(device_, plan_, document_, store_.get());
+    auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
+    device_.EndRender();
+    device_.WaitIdle();
+    return result;
+  }
+
+  auto DownloadMask() -> std::vector<std::uint8_t> {
+    auto* lease = device_.Workspace().Images().Find(plan_.mask_output);
+    EXPECT_NE(lease, nullptr);
+    if (lease == nullptr) return {};
+    std::vector<std::uint8_t> pixels(lease->Texture().Bytes());
+    device_.Workspace().Device().DownloadTexture2D(
+        lease->Texture(),
+        std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()), pixels.size()),
+        device_.CommandContext());
+    return pixels;
+  }
+
+  struct Rgba {
+    float r, g, b, a;
+  };
+  auto DownloadImage(const GraphValueId& id) -> std::vector<Rgba> {
+    auto* lease = device_.Workspace().Images().Find(id);
+    EXPECT_NE(lease, nullptr);
+    if (lease == nullptr) return {};
+    std::vector<Rgba> pixels(static_cast<std::size_t>(lease->Texture().Width()) *
+                             lease->Texture().Height());
+    device_.Workspace().Device().DownloadTexture2D(
+        lease->Texture(),
+        std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                             pixels.size() * sizeof(Rgba)),
+        device_.CommandContext());
+    return pixels;
+  }
+
+  std::uint32_t              width_  = 0;
+  std::uint32_t              height_ = 0;
+  std::filesystem::path      root_;
+  std::unique_ptr<MaskStore> store_;
+  PreparedRawInput           prepared_;
+  PipelineDocument           document_;
+  ExecutionPlan              plan_;
+  CudaRenderDevice           device_;
+};
+
+TEST_F(CudaMaskFixture, CudaMaskTextureCacheReusesTextureForSameMaskAssetKey) {
+  AttachRaster(MakeRaster("reuse", 255));
+  Compile();
+  const auto first = RenderMask();
+  EXPECT_GT(first.mip_level_count, 1U);
+  RenderRequest request;
+  request.resolution.render_scale = 0.5f;
+  Compile(request);
+  const auto second = RenderMask();
+  EXPECT_EQ(first.persistent_texture_resource_id, second.persistent_texture_resource_id);
+}
+
+TEST_F(CudaMaskFixture, CudaMaskTextureCacheDoesNotEvictTextureUsedByActiveSubmission) {
+  auto& cache = device_.Workspace().MaskTextures();
+  cache.SetByteBudget(1);
+  device_.BeginRender();
+  {
+    auto active = cache.Acquire(MaskAssetKey{"active"}, {2, 2});
+  }
+  device_.EndRender();
+  {
+    auto next = cache.Acquire(MaskAssetKey{"next"}, {2, 2});
+  }
+  EXPECT_TRUE(cache.Contains(MaskAssetKey{"active"}));
+  EXPECT_TRUE(cache.Contains(MaskAssetKey{"next"}));
+  device_.WaitIdle();
+}
+
+TEST_F(CudaMaskFixture, CudaRasterMaskUploadsOnlyUnionedDirtyRectangle) {
+  auto asset = MakeRaster("dirty", 0);
+  AttachRaster(asset);
+  Compile();
+  RenderMask();
+  std::fill(asset.pixels.begin(), asset.pixels.end(), 200);
+  store_->Save(asset);
+  device_.Workspace().Device().ResetCounters();
+  const RectI dirty[] = {{1, 2, 3, 2}, {3, 1, 2, 4}};
+  RenderMask(dirty);
+  ASSERT_EQ(device_.Workspace().Device().LastTextureRectangles().size(), 1U);
+  EXPECT_EQ(device_.Workspace().Device().LastTextureRectangles().front(), (RectI{1, 1, 4, 4}));
+  EXPECT_EQ(device_.Workspace().Device().HostToDeviceBytes(), 16U);
+}
+
+TEST_F(CudaMaskFixture, CudaRadialMaskMatchesReferenceSpaceEllipseAtPreviewScales) {
+  auto&            node = AttachAnalytic(AnalyticMaskKind::Radial);
+  RadialMaskParams radial;
+  radial.major_radius = 0.3f;
+  radial.minor_radius = 0.2f;
+  node.SetRadial(radial);
+  Compile();
+  RenderMask();
+  const auto full = DownloadMask();
+  EXPECT_GT(full[(height_ / 2) * width_ + width_ / 2], 240);
+  EXPECT_LT(full.front(), 10);
+  RenderRequest request;
+  request.resolution.render_scale = 0.5f;
+  Compile(request);
+  RenderMask();
+  const auto preview = DownloadMask();
+  EXPECT_GT(preview[(plan_.geometry.render_extent.height / 2) * plan_.geometry.render_extent.width +
+                    plan_.geometry.render_extent.width / 2],
+            230);
+  EXPECT_LT(preview.front(), 20);
+}
+
+TEST_F(CudaMaskFixture, CudaGraduatedNdMaskFollowsReferenceSpaceNormal) {
+  auto&                 node = AttachAnalytic(AnalyticMaskKind::GraduatedNd);
+  GraduatedNdMaskParams params;
+  params.normal_x            = 0.0f;
+  params.normal_y            = 1.0f;
+  params.transition_distance = 1.0f;
+  node.SetGraduatedNd(params);
+  Compile();
+  RenderMask();
+  const auto pixels = DownloadMask();
+  EXPECT_GT(pixels[width_ / 2], pixels[(height_ - 1) * width_ + width_ / 2]);
+}
+
+TEST_F(CudaMaskFixture, CudaFeatherPreservesZeroAndOnePlateaus) {
+  auto asset = MakeRaster("plateaus", 0);
+  for (std::uint32_t y = 3; y < 9; ++y)
+    for (std::uint32_t x = 4; x < 12; ++x) asset.pixels[y * width_ + x] = 255;
+  AttachRaster(asset, 1.0f);
+  Compile();
+  RenderMask();
+  const auto pixels = DownloadMask();
+  EXPECT_EQ(pixels.front(), 0);
+  EXPECT_EQ(pixels[6 * width_ + 8], 255);
+}
+
+TEST_F(CudaMaskFixture, CudaSignedDistanceFeatherMatchesExactEuclideanReferenceWithinTolerance) {
+  SetExtent(9, 9);
+  auto asset = MakeRaster("exact", 0);
+  for (std::uint32_t y = 3; y <= 5; ++y)
+    for (std::uint32_t x = 3; x <= 5; ++x) asset.pixels[y * width_ + x] = 255;
+  AttachRaster(asset, 2.0f);
+  Compile();
+  RenderMask();
+  const auto pixels = DownloadMask();
+  EXPECT_NEAR(pixels[4 * width_ + 2], 81, 8);
+  EXPECT_NEAR(pixels[2 * width_ + 2], 46, 10);
+  EXPECT_GT(pixels[4 * width_ + 4], 240);
+}
+
+TEST_F(CudaMaskFixture, CudaFeatherPreservesAntialiasedSourceBoundary) {
+  auto asset                   = MakeRaster("antialias", 0);
+  asset.pixels[6 * width_ + 8] = 128;
+  AttachRaster(asset, 2.0f);
+  Compile();
+  RenderMask();
+  const auto pixels = DownloadMask();
+  EXPECT_NEAR(pixels[6 * width_ + 8], 128, 8);
+}
+
+TEST_F(CudaMaskFixture, CudaFeatherRadiusIsStableAcrossDynamicRenderScales) {
+  auto asset = MakeRaster("scale", 0);
+  for (std::uint32_t y = 0; y < height_; ++y)
+    for (std::uint32_t x = 8; x < width_; ++x) asset.pixels[y * width_ + x] = 255;
+  AttachRaster(asset, 3.0f);
+  Compile();
+  RenderMask();
+  const auto    full       = DownloadMask();
+  const auto    full_value = full[6 * width_ + 7];
+  RenderRequest request;
+  request.resolution.render_scale = 0.5f;
+  Compile(request);
+  RenderMask();
+  const auto half       = DownloadMask();
+  const auto half_value = half[3 * plan_.geometry.render_extent.width + 3];
+  EXPECT_NEAR(full_value, half_value, 35);
+}
+
+TEST_F(CudaMaskFixture, ChangingFeatherRadiusReusesSignedDistanceTexture) {
+  auto asset = MakeRaster("radius", 0);
+  for (std::uint32_t y = 3; y < 9; ++y)
+    for (std::uint32_t x = 4; x < 12; ++x) asset.pixels[y * width_ + x] = 255;
+  auto& node = AttachRaster(asset, 1.0f);
+  Compile();
+  const auto first = RenderMask();
+  node.SetFeatherRadius(4.0f);
+  const auto second = RenderMask();
+  EXPECT_NE(first.signed_distance_resource_id, 0U);
+  EXPECT_EQ(first.signed_distance_resource_id, second.signed_distance_resource_id);
+}
+
+TEST_F(CudaMaskFixture, CudaColorGradeMixUsesInputAtMaskZeroAndAdjustedAtMaskOne) {
+  auto asset = MakeRaster("mix", 255);
+  AttachRaster(asset);
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document_.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(1.0f);
+  Compile();
+  const auto full_result = RenderGrade();
+  const auto full        = DownloadImage(full_result.output);
+  for (std::uint32_t y = 0; y < height_; ++y)
+    for (std::uint32_t x = 0; x < width_ / 2; ++x) asset.pixels[y * width_ + x] = 0;
+  store_->Save(asset);
+  device_.BeginRender();
+  (void)ExecuteCudaDevelop(device_, plan_, prepared_, document_);
+  const RectI dirty{0, 0, static_cast<std::int32_t>(width_ / 2),
+                    static_cast<std::int32_t>(height_)};
+  (void)ExecuteCudaMask(device_, plan_, document_, store_.get(), std::span{&dirty, 1});
+  const auto result = ExecuteCudaPrimaryGrade(device_, plan_, prepared_.color_context, document_);
+  device_.EndRender();
+  device_.WaitIdle();
+  const auto source = DownloadImage(plan_.develop_output);
+  const auto output = DownloadImage(result.output);
+  ASSERT_EQ(source.size(), output.size());
+  const auto left  = 5 * width_ + 2;
+  const auto right = 5 * width_ + width_ - 2;
+  EXPECT_NEAR(output[left].r, source[left].r, 1.0e-6f);
+  EXPECT_NEAR(output[right].r, full[right].r, 1.0e-6f);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 
-Status: G5 complete (CUDA Primary Color Grade and Camera-to-AP1 runtime).
+Status: G6 complete (persistent R8 MaskStore, CUDA masks, exact feather, and Normal Mix).
 
 Delivery: Stacked PR。当前文档分支 `feature/gpu-pipeline-dag-redesign` 是整个堆栈的根。
 
@@ -2533,6 +2533,110 @@ CudaColorGradeMixUsesInputAtMaskZeroAndAdjustedAtMaskOne
 - 改变 feather radius 不重新计算 signed distance；
 - dynamic resolution 不重新创建持久 mask texture。
 
+##### Phase G6 completion record (2026-08-22)
+
+**Status:** complete — 持久 R8 MaskStore、可配置 root、主存 LRU、workspace CUDA mask
+texture/mip LRU、dirty rectangle upload、analytic/raster mask、精确 signed Euclidean distance
+feather 和 Color Grade Normal Mix 已接入同一 GPU DAG。
+
+**Primary success call chain:**
+
+```text
+PipelineDocument mask edge + serialized MaskAssetKey + RenderRequest
+  -> GraphCompiler::Compile
+  -> ExecutionPlan(MaskEvaluate, MaskFeather, PrimaryColorGrade)
+  -> ExecuteCudaMask
+  -> MaskStore::Load -> host R8 byte-budget LRU
+  -> BasicRenderWorkspace::MaskTextures -> keyed R8 mip chain + submission lease
+  -> full or unioned dirty-rectangle upload
+  -> analytic evaluation or raster TextureSamplingPlan
+  -> parallel-band exact signed Euclidean distance -> cached distance buffer -> feather sample
+  -> RenderSpace R8 mask
+  -> ExecuteCudaPrimaryGrade -> per-pixel Normal Mix
+  -> scene-linear output
+```
+
+**Primary failure call chain:**
+
+```text
+empty key / axis outside [1, 4096] / wrong R8 byte count
+  -> ValidateMaskAsset rejects before temporary-file creation
+  -> existing persistent mask remains unchanged
+
+incomplete or invalid R8 file / missing MaskStore / invalid dirty rectangle / CUDA failure
+  -> MaskStore or ExecuteCudaMask throws
+  -> active-submission leases prevent texture eviction
+  -> caller receives GPU runtime failure; no CPU image-processing fallback
+```
+
+**Files added:**
+
+- `alcedo_studio/src/include/edit/mask/mask_asset.hpp`
+- `alcedo_studio/src/include/edit/mask/mask_store.hpp`
+- `alcedo_studio/src/edit/mask/mask_store.cpp`
+- `alcedo_studio/src/include/edit/runtime/mask_texture_cache.hpp`
+- `alcedo_studio/src/include/edit/runtime/cuda/cuda_mask_pass.hpp`
+- `alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu`
+- `alcedo_studio/tests/edit/mask/mask_store_test.cpp`
+- `alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp`
+
+**Files removed:** none.
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MaskStoreRejectsRasterMaskLargerThan4096OnEitherAxis` | `GpuDagMaskStoreTest` | PASS |
+| `MaskStoreRoundTripPreservesR8PixelsDescriptorAndKey` | `GpuDagMaskStoreTest` | PASS |
+| `MaskStoreUsesConfiguredRoot` | `GpuDagMaskStoreTest` | PASS |
+| `MaskStoreReplacesFileOnlyAfterCompleteWrite` | `GpuDagMaskStoreTest` | PASS |
+| `MaskHostCacheEvictsByBytesWithoutDeletingMaskFile` | `GpuDagMaskStoreTest` | PASS |
+| `CudaMaskTextureCacheReusesTextureForSameMaskAssetKey` | `GpuDagCudaMaskTest` | PASS |
+| `CudaMaskTextureCacheDoesNotEvictTextureUsedByActiveSubmission` | `GpuDagCudaMaskTest` | PASS |
+| `CudaRasterMaskUploadsOnlyUnionedDirtyRectangle` | `GpuDagCudaMaskTest` | PASS |
+| `CudaRadialMaskMatchesReferenceSpaceEllipseAtPreviewScales` | `GpuDagCudaMaskTest` | PASS |
+| `CudaGraduatedNdMaskFollowsReferenceSpaceNormal` | `GpuDagCudaMaskTest` | PASS |
+| `CudaFeatherPreservesZeroAndOnePlateaus` | `GpuDagCudaMaskTest` | PASS |
+| `CudaSignedDistanceFeatherMatchesExactEuclideanReferenceWithinTolerance` | `GpuDagCudaMaskTest` | PASS |
+| `CudaFeatherPreservesAntialiasedSourceBoundary` | `GpuDagCudaMaskTest` | PASS |
+| `CudaFeatherRadiusIsStableAcrossDynamicRenderScales` | `GpuDagCudaMaskTest` | PASS |
+| `ChangingFeatherRadiusReusesSignedDistanceTexture` | `GpuDagCudaMaskTest` | PASS |
+| `CudaColorGradeMixUsesInputAtMaskZeroAndAdjustedAtMaskOne` | `GpuDagCudaMaskTest` | PASS |
+| serialized `MaskAssetKey` read/write | `GpuDagModelGraphTest` | PASS |
+| G1–G5 graph, geometry, input, Develop, grade, and workspace regression | nine GPU DAG targets | PASS |
+| exact-distance and Normal Mix CUDA memory access | `compute-sanitizer --tool memcheck` | PASS, 0 errors |
+| not-yet-migrated backend compatibility | `Operators` | BUILD PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug
+cmd /c scripts\msvc_env.cmd --build build\debug --target GpuDagMaskStoreTest GpuDagCudaMaskTest GpuDagCudaPrimaryGradeTest GpuDagCudaWorkspaceTest Operators --parallel 4
+ctest --test-dir build/debug --output-on-failure -R "GpuDagCudaMaskTest|GpuDagCudaWorkspaceTest|GpuDagCudaPrimaryGradeTest|GpuDagMaskStoreTest|GpuDagModelGraphTest|GpuDagRawInputTest|GpuDagCudaDevelopTest|GpuDagGeometryTest|GpuDagCudaGeometryTest"
+compute-sanitizer --tool memcheck --print-limit 10 build\debug\alcedo_studio\tests\edit\GpuDagCudaMaskTest_runtime\GpuDagCudaMaskTest.exe --gtest_filter=CudaMaskFixture.CudaSignedDistanceFeatherMatchesExactEuclideanReferenceWithinTolerance:CudaMaskFixture.CudaColorGradeMixUsesInputAtMaskZeroAndAdjustedAtMaskOne
+```
+
+Suite totals: G6 required tests `16/16` PASS; combined affected GPU DAG tests `83/83` PASS;
+memcheck `2/2` PASS with `0` errors.
+
+**Checklist / exit condition:** all G6 checks complete. MaskStore contains no GPU type. Persistent
+raster data is R8 and rejects either axis above 4096. Host and GPU caches enforce byte budgets;
+the GPU cache exists only in BasicRenderWorkspace and retains active-submission resources. Raster
+textures build keyed mip chains, dirty edits upload one union rectangle, and viewport/dynamic scale
+changes reuse the persistent texture. Feather uses an exact signed Euclidean distance transform;
+radius-only changes reuse its workspace buffer. Color Grade applies one per-pixel Normal Mix.
+
+**Performance and allocation evidence:** dynamic-scale renders retained the same persistent mask
+texture resource id. Feather-radius changes retained the same signed-distance resource id. The mip
+chain and exact-distance work buffers are allocated on first use and retained in the workspace;
+active submissions block LRU eviction.
+
+**LOC note (grill-code-review):** `cuda_mask_pass.cu` 423 lines; `cuda_mask_test.cpp` 324 lines;
+`mask_texture_cache.hpp` 223 lines; `mask_store.cpp` 179 lines. No changed file exceeds 1000 lines.
+
+**Residual gaps:** CUDA DRT and product pipeline routing are G7 scope. OpenCL and Metal mask
+runtimes remain on their existing paths until G8 and G9.
+
 ## 40. Phase G7 — CUDA DRT 和产品管线路径
 
 Branch: `feature/gpu-dag-cuda-drt-product`
@@ -2839,7 +2943,7 @@ ctest --test-dir build/macos-debug --output-on-failure
 - [ ] 默认 PipelineDocument 有且只有 Develop、Primary Color Grade 和 DRT 三个节点。
 - [ ] Geometry 是全局 Model 和内部 Pass，不是第四个用户节点。
 - [ ] MaskNode 是独立节点。
-- [ ] ColorGradeNode 有可选 mask 输入和单一 Normal Mix。
+- [x] ColorGradeNode 有可选 mask 输入和单一 Normal Mix。
 - [ ] PipelineStage 全部删除。
 - [ ] OperatorParams 总结构全部删除。
 - [ ] operators 只保存参数 Model、DTO 和序列化逻辑。
@@ -2860,7 +2964,7 @@ ctest --test-dir build/macos-debug --output-on-failure
 - [ ] 每个 RenderDevice 只有一份 ParameterArena。
 - [ ] 稳定渲染不创建或销毁 GPU buffer 和 texture。
 - [ ] LLF 不管理自己的内存池。
-- [ ] Mask GPU LRU 只存在于 workspace。
+- [x] Mask GPU LRU 只存在于 workspace。
 
 ### 46.4 RAW 和颜色
 
@@ -2874,13 +2978,13 @@ ctest --test-dir build/macos-debug --output-on-failure
 
 - [ ] crop、rotation、view ROI 和 dynamic resolution 只执行一次图像重采样。
 - [ ] LLF 和 mask 使用相同的 RenderGeometry 数据。
-- [ ] Rasterized Mask 使用 R8。
-- [ ] Rasterized Mask 任意一条边不大于 4096。
-- [ ] Rasterized Mask 作为 GPU texture 采样。
-- [ ] Rasterized Mask feather 使用 GPU exact signed Euclidean distance field。
-- [ ] 改变 feather radius 复用 signed distance texture。
-- [ ] view 或 render scale 变化不重新创建不变的 mask texture。
-- [ ] MaskStore root 可以由用户配置。
+- [x] Rasterized Mask 使用 R8。
+- [x] Rasterized Mask 任意一条边不大于 4096。
+- [x] Rasterized Mask 作为 GPU texture 采样。
+- [x] Rasterized Mask feather 使用 GPU exact signed Euclidean distance field。
+- [x] 改变 feather radius 复用 signed distance texture。
+- [x] view 或 render scale 变化不重新创建不变的 mask texture。
+- [x] MaskStore root 可以由用户配置。
 
 ### 46.6 后端
 


### PR DESCRIPTION
## Summary

- Add persistent R8 `MaskStore`, raster mask assets, and the GPU mask texture LRU.
- Add CUDA `MaskEvaluate` and `MaskFeather` passes, then Mix on Primary Color Grade.
- Keep masks off the default three-node graph until a mask node is connected.

## Stack

Layer G6 of GitHub stack #99.

- Base: #98
- Next layer: #101

## Validation

- Adds `MaskStore` and CUDA mask runtime tests on top of G5.
- Default graph stays Develop → Primary Color Grade → DRT until a mask is wired.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
