### PR TITLE
feat(edit): add Metal GPU DAG product path through M6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,13 @@ QML properties, are the only exception. Keep the exception at the call site and 
 external wording in Alcedo-owned API names or surrounding prose. Before completing relevant edits,
 search first-party source, tests, docs, and plans for violations.
 
+**`Seed` verb ban in code.** Project-authored code identifiers, tests, and comments must not use
+`Seed` / `seed` as a verb for populate, insert, initialize, restore, copy, or apply operations. Name
+the concrete operation instead. Conventional seed usage remains allowed when it means an input to
+a random-number generator, cryptographic primitive, deterministic fuzz run, or an exact external
+API/model identifier. When touching code that contains a non-conventional `Seed` verb, replace it
+with the precise operation name in the same change.
+
 WebGPU RAW tests must heap-allocate `LibRaw` raw processors (for example with
 `std::make_unique<LibRaw>()`). Do not stack-allocate `LibRaw` in WebGPU-related tests; Dawn +
 LibRaw test paths have hit stack overflows in this repository.

--- a/alcedo_studio/src/decoders/CMakeLists.txt
+++ b/alcedo_studio/src/decoders/CMakeLists.txt
@@ -32,6 +32,7 @@ if(ALCEDO_METAL_ENABLED)
     list(APPEND RAW_OP_GPU_SRCS
         ${ALCEDO_SRC_ROOT}/decoders/processor/operators/gpu/metal_cvt_ref_space.cpp
         ${ALCEDO_SRC_ROOT}/decoders/processor/operators/gpu/metal_debayer_rcd.cpp
+        ${ALCEDO_SRC_ROOT}/decoders/processor/operators/gpu/metal_encode.cpp
         ${ALCEDO_SRC_ROOT}/decoders/processor/operators/gpu/metal_highlight_reconstruct.cpp
         ${ALCEDO_SRC_ROOT}/decoders/processor/operators/gpu/metal_to_linear_ref.cpp
         ${ALCEDO_SRC_ROOT}/decoders/processor/operators/gpu/metal_xtrans_interpolate.cpp
@@ -60,13 +61,15 @@ if(ALCEDO_CUDA_ENABLED)
     target_compile_definitions(RawProcessorOp PUBLIC HAVE_CUDA)
 endif()
 if(ALCEDO_METAL_ENABLED)
-    add_dependencies(RawProcessorOp RawProcessorOpMetalShaders)
+    add_dependencies(RawProcessorOp RawProcessorOpMetalShaders MetalGeometryUtilsShaders)
+    target_link_libraries(RawProcessorOp PRIVATE MetalGeometryUtils MetalImage MetalContext)
     target_compile_definitions(RawProcessorOp PRIVATE
         ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH="${METAL_TO_LINEAR_REF_METALLIB}"
         ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH="${METAL_DEBAYER_RCD_METALLIB}"
         ALCEDO_METAL_HIGHLIGHT_RECONSTRUCT_METALLIB_PATH="${METAL_HIGHLIGHT_RECONSTRUCT_METALLIB}"
         ALCEDO_METAL_XTRANS_INTERPOLATE_METALLIB_PATH="${METAL_XTRANS_INTERPOLATE_METALLIB}"
         ALCEDO_METAL_CVT_REF_SPACE_METALLIB_PATH="${METAL_CVT_REF_SPACE_METALLIB}"
+        ALCEDO_METAL_GEOMETRY_UTILS_METALLIB_PATH="${METAL_GEOMETRY_UTILS_METALLIB}"
     )
 endif()
 if(ALCEDO_OPENCL_ENABLED)

--- a/alcedo_studio/src/decoders/processor/nn/metal_demosaicnet_tiled.mm
+++ b/alcedo_studio/src/decoders/processor/nn/metal_demosaicnet_tiled.mm
@@ -265,8 +265,15 @@ auto EnqueueTiles(const Module& module, const MetalDemosaicNetTiledDispatch& dis
   }
 
   RunObjc("graph_encode", [&] {
-    id<MTLCommandQueue> queue = ToObjcQueue(ctx.Queue());
-    MPSCommandBuffer* mps_cb  = [MPSCommandBuffer commandBufferFromCommandQueue:queue];
+    MPSCommandBuffer* mps_cb = nil;
+    if (dispatch.command_buffer != nullptr) {
+      id<MTLCommandBuffer> existing =
+          (__bridge id<MTLCommandBuffer>)dispatch.command_buffer;
+      mps_cb = [MPSCommandBuffer commandBufferWithCommandBuffer:existing];
+    } else {
+      id<MTLCommandQueue> queue = ToObjcQueue(ctx.Queue());
+      mps_cb                    = [MPSCommandBuffer commandBufferFromCommandQueue:queue];
+    }
     if (mps_cb == nil) {
       ThrowStage("prepare", "failed to create MPSCommandBuffer", variant);
     }
@@ -322,8 +329,10 @@ auto EnqueueTiles(const Module& module, const MetalDemosaicNetTiledDispatch& dis
       }
     }
 
-    [mps_cb commit];
-    if (dispatch.commit_and_wait) {
+    if (dispatch.command_buffer == nullptr) {
+      [mps_cb commit];
+    }
+    if (dispatch.commit_and_wait && dispatch.command_buffer == nullptr) {
       [mps_cb waitUntilCompleted];
       ++result.host_wait_count;
       g_host_wait_count.fetch_add(1, std::memory_order_relaxed);

--- a/alcedo_studio/src/decoders/processor/operators/gpu/metal_encode.cpp
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/metal_encode.cpp
@@ -1,0 +1,455 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#ifdef HAVE_METAL
+
+#include "decoders/processor/operators/gpu/metal_encode.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <alcedo/metal/Metal.hpp>
+
+#include "metal/compute_pipeline_cache.hpp"
+#include "metal/metal_utils/geometry_utils.hpp"
+
+namespace alcedo::metal {
+namespace {
+
+struct WBParams {
+  float    black_level[4];
+  float    white_level[4];
+  float    wb_multipliers[4];
+  uint32_t apply_white_balance;
+  uint32_t padding[3];
+};
+
+struct ToLinearRefParams {
+  uint32_t width;
+  uint32_t height;
+  uint32_t tile_width;
+  uint32_t tile_height;
+  uint32_t black_tile_width;
+  uint32_t black_tile_height;
+  uint32_t raw_fc[36];
+};
+
+struct ClampParams {
+  uint32_t width;
+  uint32_t height;
+};
+
+struct SinglePlaneParams {
+  uint32_t width;
+  uint32_t height;
+  uint32_t rgb_fc[4];
+};
+
+struct XTransParams {
+  uint32_t width;
+  uint32_t height;
+  uint32_t tile_width;
+  uint32_t tile_height;
+  uint32_t passes;
+  uint32_t green_radius;
+  uint32_t rb_radius;
+  uint32_t rgb_fc[36];
+};
+
+struct HighlightParams {
+  float    clips[4];
+  float    clipdark[4];
+  uint32_t width;
+  uint32_t height;
+};
+
+struct PackOrientParams {
+  uint32_t src_x;
+  uint32_t src_y;
+  uint32_t src_width;
+  uint32_t src_height;
+  uint32_t dst_width;
+  uint32_t dst_height;
+  uint32_t flip;
+  float    scale_r;
+  float    scale_g;
+  float    scale_b;
+};
+
+constexpr float kHilightMagic = 0.987f;
+constexpr float kChromaRingLo = 0.2f;
+constexpr float kMinGain      = 1e-6f;
+
+auto CommandBuffer(void* command_buffer) -> MTL::CommandBuffer* {
+  auto* buffer = static_cast<MTL::CommandBuffer*>(command_buffer);
+  if (buffer == nullptr) {
+    throw std::runtime_error("Metal encode: command buffer is null");
+  }
+  return buffer;
+}
+
+auto Texture(void* texture, const char* label) -> MTL::Texture* {
+  auto* native = static_cast<MTL::Texture*>(texture);
+  if (native == nullptr) {
+    throw std::runtime_error(std::string("Metal encode: ") + label + " texture is null");
+  }
+  return native;
+}
+
+auto Pipeline(const char* metallib_path, const char* function_name, const char* label)
+    -> NS::SharedPtr<MTL::ComputePipelineState> {
+  if (metallib_path == nullptr || metallib_path[0] == '\0') {
+    throw std::runtime_error(std::string(label) + ": metallib path is not configured.");
+  }
+  return ComputePipelineCache::Instance().GetPipelineState(metallib_path, function_name, label);
+}
+
+void Dispatch(MTL::ComputeCommandEncoder* encoder, MTL::ComputePipelineState* pipeline,
+              uint32_t width, uint32_t height) {
+  const auto thread_width = std::max<NS::UInteger>(1, pipeline->threadExecutionWidth());
+  const auto thread_height =
+      std::max<NS::UInteger>(1, pipeline->maxTotalThreadsPerThreadgroup() / thread_width);
+  encoder->dispatchThreads(MTL::Size{width, height, 1},
+                           MTL::Size{thread_width, thread_height, 1});
+}
+
+auto Encoder(MTL::CommandBuffer* buffer) -> NS::SharedPtr<MTL::ComputeCommandEncoder> {
+  auto encoder = NS::RetainPtr(buffer->computeCommandEncoder());
+  if (!encoder) {
+    throw std::runtime_error("Metal encode: failed to create compute encoder");
+  }
+  return encoder;
+}
+
+auto ChannelRatio(float value, float green) -> float {
+  if (!std::isfinite(value) || value <= 0.0f) {
+    return 1.0f;
+  }
+  return std::clamp(value / green, 0.25f, 4.0f);
+}
+
+auto InverseScale(const float* cam_mul) -> std::array<float, 3> {
+  const float g = std::max(cam_mul[1], kMinGain);
+  return {g / std::max(cam_mul[0], kMinGain), 1.0f, g / std::max(cam_mul[2], kMinGain)};
+}
+
+auto OrientedSize(uint32_t width, uint32_t height, int flip) -> std::pair<uint32_t, uint32_t> {
+  if (flip == 5 || flip == 6) {
+    return {height, width};
+  }
+  return {width, height};
+}
+
+}  // namespace
+
+void EncodeToLinearRef(void* command_buffer, void* src_r16u, void* dst_r32f,
+                       const RawLinearizationParams& linearization, const RawCfaPattern& pattern) {
+  auto* buffer = CommandBuffer(command_buffer);
+  auto* src    = Texture(src_r16u, "linearize source");
+  auto* dst    = Texture(dst_r32f, "linearize destination");
+#ifndef ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH
+  throw std::runtime_error("Metal ToLinearRef metallib path is not configured.");
+#else
+  auto pipeline = Pipeline(ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH, "to_linear_ref_r16u",
+                           "Metal ToLinearRef");
+#endif
+  ToLinearRefParams params = {};
+  params.width             = static_cast<uint32_t>(src->width());
+  params.height            = static_cast<uint32_t>(src->height());
+  if (pattern.kind == RawCfaKind::XTrans6x6) {
+    params.tile_width  = 6;
+    params.tile_height = 6;
+    for (int i = 0; i < 36; ++i) {
+      params.raw_fc[i] = static_cast<uint32_t>(pattern.xtrans_pattern.raw_fc[i]);
+    }
+  } else {
+    params.tile_width  = 2;
+    params.tile_height = 2;
+    for (int i = 0; i < 4; ++i) {
+      params.raw_fc[i] = static_cast<uint32_t>(pattern.bayer_pattern.raw_fc[i]);
+    }
+  }
+  params.black_tile_width  = static_cast<uint32_t>(std::max(linearization.black_tile_width, 0));
+  params.black_tile_height = static_cast<uint32_t>(std::max(linearization.black_tile_height, 0));
+
+  WBParams wb = {};
+  for (int c = 0; c < 4; ++c) {
+    wb.black_level[c]    = linearization.black_level[c];
+    wb.white_level[c]    = linearization.white_level[c];
+    wb.wb_multipliers[c] = linearization.cam_mul[c];
+  }
+  wb.apply_white_balance = linearization.apply_as_shot_wb != 0 ? 1U : 0U;
+
+  auto compute = Encoder(buffer);
+  compute->setComputePipelineState(pipeline.get());
+  compute->setTexture(src, 0);
+  compute->setTexture(dst, 1);
+  compute->setBytes(&params, sizeof(params), 0);
+  compute->setBytes(&wb, sizeof(wb), 1);
+  compute->setBytes(linearization.pattern_black, sizeof(linearization.pattern_black), 2);
+  Dispatch(compute.get(), pipeline.get(), params.width, params.height);
+  compute->endEncoding();
+}
+
+void EncodeCfaClamp01(void* command_buffer, void* r32f, std::uint32_t width,
+                      std::uint32_t height) {
+  auto* buffer = CommandBuffer(command_buffer);
+  auto* image  = Texture(r32f, "cfa clamp");
+#ifndef ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH
+  throw std::runtime_error("Metal ToLinearRef metallib path is not configured.");
+#else
+  auto pipeline =
+      Pipeline(ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH, "cfa_clamp01_r32f", "Metal CFA Clamp01");
+#endif
+  const ClampParams params{width, height};
+  auto              compute = Encoder(buffer);
+  compute->setComputePipelineState(pipeline.get());
+  compute->setTexture(image, 0);
+  compute->setBytes(&params, sizeof(params), 0);
+  Dispatch(compute.get(), pipeline.get(), width, height);
+  compute->endEncoding();
+}
+
+void EncodeBayerRcd(void* command_buffer, void* linear_cfa, void* r, void* g, void* b, void* vh,
+                    void* pq, const BayerPattern2x2& pattern, std::uint32_t width,
+                    std::uint32_t height) {
+  auto* buffer = CommandBuffer(command_buffer);
+  auto* raw    = Texture(linear_cfa, "RCD CFA");
+  auto* red    = Texture(r, "RCD R");
+  auto* green  = Texture(g, "RCD G");
+  auto* blue   = Texture(b, "RCD B");
+  auto* vh_tex = Texture(vh, "RCD VH");
+  auto* pq_tex = Texture(pq, "RCD PQ");
+#ifndef ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH
+  throw std::runtime_error("Metal Debayer RCD metallib path is not configured.");
+#else
+  const char* lib = ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH;
+#endif
+  SinglePlaneParams params{
+      .width  = width,
+      .height = height,
+      .rgb_fc = {static_cast<uint32_t>(pattern.rgb_fc[0]), static_cast<uint32_t>(pattern.rgb_fc[1]),
+                 static_cast<uint32_t>(pattern.rgb_fc[2]), static_cast<uint32_t>(pattern.rgb_fc[3])},
+  };
+
+  auto dispatch = [&](const char* name, auto bind) {
+    auto pipeline = Pipeline(lib, name, "Metal Debayer RCD");
+    auto compute  = Encoder(buffer);
+    compute->setComputePipelineState(pipeline.get());
+    bind(compute.get());
+    compute->setBytes(&params, sizeof(params), 0);
+    Dispatch(compute.get(), pipeline.get(), width, height);
+    compute->endEncoding();
+  };
+  dispatch("rcd_init_and_vh", [&](MTL::ComputeCommandEncoder* compute) {
+    compute->setTexture(raw, 0);
+    compute->setTexture(red, 1);
+    compute->setTexture(green, 2);
+    compute->setTexture(blue, 3);
+    compute->setTexture(vh_tex, 4);
+  });
+  dispatch("rcd_green_at_rb", [&](MTL::ComputeCommandEncoder* compute) {
+    compute->setTexture(raw, 0);
+    compute->setTexture(vh_tex, 1);
+    compute->setTexture(green, 2);
+  });
+  dispatch("rcd_pq_dir", [&](MTL::ComputeCommandEncoder* compute) {
+    compute->setTexture(raw, 0);
+    compute->setTexture(pq_tex, 1);
+  });
+  dispatch("rcd_rb_at_rb", [&](MTL::ComputeCommandEncoder* compute) {
+    compute->setTexture(pq_tex, 0);
+    compute->setTexture(green, 1);
+    compute->setTexture(red, 2);
+    compute->setTexture(blue, 3);
+  });
+  dispatch("rcd_rb_at_g", [&](MTL::ComputeCommandEncoder* compute) {
+    compute->setTexture(vh_tex, 0);
+    compute->setTexture(green, 1);
+    compute->setTexture(red, 2);
+    compute->setTexture(blue, 3);
+  });
+}
+
+void EncodeXTrans(void* command_buffer, void* linear_cfa, void* green, void* rgba,
+                  const XTransPattern6x6& pattern, std::uint32_t width, std::uint32_t height,
+                  int passes) {
+  auto* buffer     = CommandBuffer(command_buffer);
+  auto* raw        = Texture(linear_cfa, "X-Trans CFA");
+  auto* green_tex  = Texture(green, "X-Trans green");
+  auto* output     = Texture(rgba, "X-Trans RGBA");
+#ifndef ALCEDO_METAL_XTRANS_INTERPOLATE_METALLIB_PATH
+  throw std::runtime_error("Metal X-Trans interpolate metallib path is not configured.");
+#else
+  const char* lib = ALCEDO_METAL_XTRANS_INTERPOLATE_METALLIB_PATH;
+#endif
+  XTransParams params = {};
+  params.width        = width;
+  params.height       = height;
+  params.tile_width   = 6;
+  params.tile_height  = 6;
+  params.passes       = static_cast<uint32_t>(std::max(passes, 1));
+  params.green_radius = 3;
+  params.rb_radius    = params.passes > 1 ? 4U : 3U;
+  for (int i = 0; i < 36; ++i) {
+    params.rgb_fc[i] = static_cast<uint32_t>(pattern.rgb_fc[i]);
+  }
+  {
+    auto pipeline = Pipeline(lib, "xtrans_green", "Metal X-Trans interpolate");
+    auto compute  = Encoder(buffer);
+    compute->setComputePipelineState(pipeline.get());
+    compute->setTexture(raw, 0);
+    compute->setTexture(green_tex, 1);
+    compute->setBytes(&params, sizeof(params), 0);
+    Dispatch(compute.get(), pipeline.get(), width, height);
+    compute->endEncoding();
+  }
+  {
+    auto pipeline = Pipeline(lib, "xtrans_rgba", "Metal X-Trans interpolate");
+    auto compute  = Encoder(buffer);
+    compute->setComputePipelineState(pipeline.get());
+    compute->setTexture(raw, 0);
+    compute->setTexture(green_tex, 1);
+    compute->setTexture(output, 2);
+    compute->setBytes(&params, sizeof(params), 0);
+    Dispatch(compute.get(), pipeline.get(), width, height);
+    compute->endEncoding();
+  }
+}
+
+void EncodeHighlightReconstruct(void* command_buffer, void* src_rgba, void* dst_rgba,
+                                void* stats_buffer, std::uint32_t stats_offset, const float* cam_mul,
+                                std::uint32_t width, std::uint32_t height) {
+  auto* buffer = CommandBuffer(command_buffer);
+  auto* src    = Texture(src_rgba, "HLR source");
+  auto* dst    = Texture(dst_rgba, "HLR destination");
+  auto* stats  = static_cast<MTL::Buffer*>(stats_buffer);
+  if (stats == nullptr) {
+    throw std::runtime_error("Metal encode: HLR stats buffer is null");
+  }
+#ifndef ALCEDO_METAL_HIGHLIGHT_RECONSTRUCT_METALLIB_PATH
+  throw std::runtime_error("Metal HighlightReconstruct metallib path is not configured.");
+#else
+  const char* lib = ALCEDO_METAL_HIGHLIGHT_RECONSTRUCT_METALLIB_PATH;
+#endif
+  HighlightParams params = {};
+  const float     green  = std::isfinite(cam_mul[1]) && cam_mul[1] > 0.0f ? cam_mul[1] : 1.0f;
+  params.clips[0]        = kHilightMagic * ChannelRatio(cam_mul[0], green);
+  params.clips[1]        = kHilightMagic;
+  params.clips[2]        = kHilightMagic * ChannelRatio(cam_mul[2], green);
+  params.clipdark[0]     = kChromaRingLo * params.clips[0];
+  params.clipdark[1]     = kChromaRingLo * params.clips[1];
+  params.clipdark[2]     = kChromaRingLo * params.clips[2];
+  params.width           = width;
+  params.height          = height;
+  {
+    auto pipeline = Pipeline(lib, "hlr_accumulate_stats", "Metal HighlightReconstruct");
+    auto compute  = Encoder(buffer);
+    compute->setComputePipelineState(pipeline.get());
+    compute->setTexture(src, 0);
+    compute->setBuffer(stats, stats_offset, 0);
+    compute->setBytes(&params, sizeof(params), 1);
+    Dispatch(compute.get(), pipeline.get(), width, height);
+    compute->endEncoding();
+  }
+  {
+    auto pipeline = Pipeline(lib, "hlr_reconstruct_tex", "Metal HighlightReconstruct");
+    auto compute  = Encoder(buffer);
+    compute->setComputePipelineState(pipeline.get());
+    compute->setTexture(src, 0);
+    compute->setTexture(dst, 1);
+    compute->setBuffer(stats, stats_offset, 0);
+    compute->setBytes(&params, sizeof(params), 1);
+    Dispatch(compute.get(), pipeline.get(), width, height);
+    compute->endEncoding();
+  }
+}
+
+void EncodePackPlanesCropInverseOrient(void* command_buffer, void* r, void* g, void* b,
+                                       void* dst_rgba, RectI crop, const float* cam_mul, int flip) {
+  auto* buffer = CommandBuffer(command_buffer);
+  auto* red    = Texture(r, "pack R");
+  auto* green  = Texture(g, "pack G");
+  auto* blue   = Texture(b, "pack B");
+  auto* dst    = Texture(dst_rgba, "pack destination");
+#ifndef ALCEDO_METAL_CVT_REF_SPACE_METALLIB_PATH
+  throw std::runtime_error("Metal ApplyInverseCamMul metallib path is not configured.");
+#else
+  auto pipeline = Pipeline(ALCEDO_METAL_CVT_REF_SPACE_METALLIB_PATH,
+                           "pack_planes_crop_inverse_orient", "Metal pack");
+#endif
+  const auto scale                    = InverseScale(cam_mul);
+  const auto [dst_width, dst_height]  = OrientedSize(static_cast<uint32_t>(crop.width),
+                                                    static_cast<uint32_t>(crop.height), flip);
+  PackOrientParams params{
+      .src_x      = static_cast<uint32_t>(crop.x),
+      .src_y      = static_cast<uint32_t>(crop.y),
+      .src_width  = static_cast<uint32_t>(crop.width),
+      .src_height = static_cast<uint32_t>(crop.height),
+      .dst_width  = dst_width,
+      .dst_height = dst_height,
+      .flip       = static_cast<uint32_t>(flip),
+      .scale_r    = scale[0],
+      .scale_g    = scale[1],
+      .scale_b    = scale[2],
+  };
+  auto compute = Encoder(buffer);
+  compute->setComputePipelineState(pipeline.get());
+  compute->setTexture(red, 0);
+  compute->setTexture(green, 1);
+  compute->setTexture(blue, 2);
+  compute->setTexture(dst, 3);
+  compute->setBytes(&params, sizeof(params), 0);
+  Dispatch(compute.get(), pipeline.get(), params.src_width, params.src_height);
+  compute->endEncoding();
+}
+
+void EncodeCopyRgbaCropInverseOrient(void* command_buffer, void* src_rgba, void* dst_rgba,
+                                     RectI crop, const float* cam_mul, int flip) {
+  auto* buffer = CommandBuffer(command_buffer);
+  auto* src    = Texture(src_rgba, "copy source");
+  auto* dst    = Texture(dst_rgba, "copy destination");
+#ifndef ALCEDO_METAL_CVT_REF_SPACE_METALLIB_PATH
+  throw std::runtime_error("Metal ApplyInverseCamMul metallib path is not configured.");
+#else
+  auto pipeline = Pipeline(ALCEDO_METAL_CVT_REF_SPACE_METALLIB_PATH, "copy_rgba_crop_inverse_orient",
+                           "Metal pack");
+#endif
+  const auto scale                   = InverseScale(cam_mul);
+  const auto [dst_width, dst_height] = OrientedSize(static_cast<uint32_t>(crop.width),
+                                                    static_cast<uint32_t>(crop.height), flip);
+  PackOrientParams params{
+      .src_x      = static_cast<uint32_t>(crop.x),
+      .src_y      = static_cast<uint32_t>(crop.y),
+      .src_width  = static_cast<uint32_t>(crop.width),
+      .src_height = static_cast<uint32_t>(crop.height),
+      .dst_width  = dst_width,
+      .dst_height = dst_height,
+      .flip       = static_cast<uint32_t>(flip),
+      .scale_r    = scale[0],
+      .scale_g    = scale[1],
+      .scale_b    = scale[2],
+  };
+  auto compute = Encoder(buffer);
+  compute->setComputePipelineState(pipeline.get());
+  compute->setTexture(src, 0);
+  compute->setTexture(dst, 1);
+  compute->setBytes(&params, sizeof(params), 0);
+  Dispatch(compute.get(), pipeline.get(), params.src_width, params.src_height);
+  compute->endEncoding();
+}
+
+void EncodeWarpRectilinear(void* command_buffer, void* src_rgba, void* dst_rgba,
+                           const dng::WarpRectilinear& warp, std::uint32_t, std::uint32_t) {
+  utils::EncodeWarpRectilinearTexture(command_buffer, src_rgba, dst_rgba, warp);
+}
+
+}  // namespace alcedo::metal
+
+#endif

--- a/alcedo_studio/src/decoders/processor/operators/gpu/metal_shader/cvt_ref_space.metal
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/metal_shader/cvt_ref_space.metal
@@ -27,3 +27,58 @@ kernel void apply_inverse_cam_mul_rgba32f(texture2d<float, access::read_write> i
   rgba.a *= params.scale_a;
   image.write(rgba, gid);
 }
+
+struct PackOrientParams {
+  uint  src_x;
+  uint  src_y;
+  uint  src_width;
+  uint  src_height;
+  uint  dst_width;
+  uint  dst_height;
+  uint  flip;
+  float scale_r;
+  float scale_g;
+  float scale_b;
+};
+
+static inline uint2 OrientedCoord(uint x, uint y, constant PackOrientParams& params) {
+  switch (params.flip) {
+    case 3u:
+      return uint2(params.src_width - 1u - x, params.src_height - 1u - y);
+    case 5u:
+      return uint2(y, params.src_width - 1u - x);
+    case 6u:
+      return uint2(params.src_height - 1u - y, x);
+    default:
+      return uint2(x, y);
+  }
+}
+
+kernel void pack_planes_crop_inverse_orient(texture2d<float, access::read> r [[texture(0)]],
+                                            texture2d<float, access::read> g [[texture(1)]],
+                                            texture2d<float, access::read> b [[texture(2)]],
+                                            texture2d<float, access::write> dst [[texture(3)]],
+                                            constant PackOrientParams& params [[buffer(0)]],
+                                            uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.src_width || gid.y >= params.src_height) {
+    return;
+  }
+  const uint2 src = uint2(params.src_x + gid.x, params.src_y + gid.y);
+  const float4 rgba =
+      float4(r.read(src).r * params.scale_r, g.read(src).r * params.scale_g,
+             b.read(src).r * params.scale_b, 1.0f);
+  dst.write(rgba, OrientedCoord(gid.x, gid.y, params));
+}
+
+kernel void copy_rgba_crop_inverse_orient(texture2d<float, access::read> src [[texture(0)]],
+                                          texture2d<float, access::write> dst [[texture(1)]],
+                                          constant PackOrientParams& params [[buffer(0)]],
+                                          uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.src_width || gid.y >= params.src_height) {
+    return;
+  }
+  const float4 pixel = src.read(uint2(params.src_x + gid.x, params.src_y + gid.y));
+  const float4 rgba =
+      float4(pixel.r * params.scale_r, pixel.g * params.scale_g, pixel.b * params.scale_b, pixel.a);
+  dst.write(rgba, OrientedCoord(gid.x, gid.y, params));
+}

--- a/alcedo_studio/src/decoders/processor/operators/gpu/metal_shader/to_linear_ref.metal
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/metal_shader/to_linear_ref.metal
@@ -30,7 +30,7 @@ static inline uint RawColorAt(constant ToLinearRefParams& params, uint y, uint x
   return params.raw_fc[tile_y * params.tile_width + tile_x];
 }
 
-static inline float PatternBlackAt(constant ToLinearRefParams& params, device const float* pattern_black,
+static inline float PatternBlackAt(constant ToLinearRefParams& params, constant float* pattern_black,
                                    uint y, uint x) {
   if (params.black_tile_width == 0u || params.black_tile_height == 0u) {
     return 0.0f;
@@ -41,7 +41,7 @@ static inline float PatternBlackAt(constant ToLinearRefParams& params, device co
 }
 
 static inline float LinearizeSample(float sample, uint color_idx, constant ToLinearRefParams& params,
-                                    constant WBParams& wb_params, device const float* pattern_black,
+                                    constant WBParams& wb_params, constant float* pattern_black,
                                     uint y, uint x) {
   const float black =
       wb_params.black_level[color_idx] + PatternBlackAt(params, pattern_black, y, x);
@@ -59,7 +59,7 @@ kernel void to_linear_ref_r16u(texture2d<ushort, access::read> src [[texture(0)]
                                texture2d<float, access::write> dst [[texture(1)]],
                                constant ToLinearRefParams&     params [[buffer(0)]],
                                constant WBParams&              wb_params [[buffer(1)]],
-                               device const float*             pattern_black [[buffer(2)]],
+                               constant float*                 pattern_black [[buffer(2)]],
                                uint2                           gid [[thread_position_in_grid]]) {
   if (gid.x >= params.width || gid.y >= params.height) {
     return;
@@ -69,4 +69,19 @@ kernel void to_linear_ref_r16u(texture2d<ushort, access::read> src [[texture(0)]
   const float sample    = float(src.read(gid).r);
   dst.write(LinearizeSample(sample, color_idx, params, wb_params, pattern_black, gid.y, gid.x),
             gid);
+}
+
+struct ClampParams {
+  uint width;
+  uint height;
+};
+
+kernel void cfa_clamp01_r32f(texture2d<float, access::read_write> image [[texture(0)]],
+                             constant ClampParams&                params [[buffer(0)]],
+                             uint2                                gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.width || gid.y >= params.height) {
+    return;
+  }
+  const float sample = image.read(gid).r;
+  image.write(clamp(sample, 0.0f, 1.0f), gid);
 }

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -69,14 +69,38 @@ def_library(EditInput
 )
 
 # GPU-agnostic DAG runtime (parameter arena, texture LRU, KV cache). No CUDA headers.
+set(EDIT_RUNTIME_SRCS
+    ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
+    ${ALCEDO_SRC_ROOT}/edit/runtime/graph_compiler.cpp
+    ${ALCEDO_SRC_ROOT}/edit/runtime/result_content_key.cpp
+    ${ALCEDO_SRC_ROOT}/edit/runtime/static_execution_plan_cache.cpp
+)
+if(NOT ALCEDO_METAL_ENABLED)
+    list(APPEND EDIT_RUNTIME_SRCS
+        ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend_host.cpp
+    )
+endif()
 def_library(EditRuntime
-    SOURCES
-        ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
-        ${ALCEDO_SRC_ROOT}/edit/runtime/graph_compiler.cpp
-        ${ALCEDO_SRC_ROOT}/edit/runtime/result_content_key.cpp
-        ${ALCEDO_SRC_ROOT}/edit/runtime/static_execution_plan_cache.cpp
+    SOURCES ${EDIT_RUNTIME_SRCS}
     PUBLIC_DEPS EditGraph EditGeometry EditInput
 )
+
+if(ALCEDO_METAL_ENABLED)
+    def_library(EditRuntimeMetal
+        SOURCES
+            ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
+        PUBLIC_DEPS EditRuntime MetalContext alcedo::metal_cpp
+    )
+    target_compile_definitions(EditRuntimeMetal PUBLIC HAVE_METAL)
+    set_source_files_properties(
+        ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
+        PROPERTIES LANGUAGE OBJCXX
+    )
+    target_link_libraries(EditRuntimeMetal PUBLIC
+        "-framework Foundation"
+        "-framework Metal"
+    )
+endif()
 
 if(ALCEDO_CUDA_ENABLED)
     def_cuda_library(EditRuntimeCuda

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -89,16 +89,33 @@ if(ALCEDO_METAL_ENABLED)
     def_library(EditRuntimeMetal
         SOURCES
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
+            ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
         PUBLIC_DEPS EditRuntime MetalContext alcedo::metal_cpp
+        PRIVATE_DEPS RawProcessorOp MetalGeometryUtils MetalImage MetalDemosaicNetEntry
     )
     target_compile_definitions(EditRuntimeMetal PUBLIC HAVE_METAL)
+    target_compile_definitions(EditRuntimeMetal PRIVATE
+        ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH="${METAL_TO_LINEAR_REF_METALLIB}"
+        ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH="${METAL_DEBAYER_RCD_METALLIB}"
+        ALCEDO_METAL_HIGHLIGHT_RECONSTRUCT_METALLIB_PATH="${METAL_HIGHLIGHT_RECONSTRUCT_METALLIB}"
+        ALCEDO_METAL_XTRANS_INTERPOLATE_METALLIB_PATH="${METAL_XTRANS_INTERPOLATE_METALLIB}"
+        ALCEDO_METAL_CVT_REF_SPACE_METALLIB_PATH="${METAL_CVT_REF_SPACE_METALLIB}"
+        ALCEDO_METAL_GEOMETRY_UTILS_METALLIB_PATH="${METAL_GEOMETRY_UTILS_METALLIB}"
+        ALCEDO_METAL_GEOMETRY_RESAMPLE_METALLIB_PATH="${METAL_GEOMETRY_RESAMPLE_METALLIB}"
+        ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH="${METAL_CAMERA_COLOR_METALLIB}"
+        ALCEDO_METAL_DEMOSAICNET_IO_METALLIB_PATH="${METAL_DEMOSAICNET_IO_METALLIB}"
+    )
     set_source_files_properties(
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
+        ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
         PROPERTIES LANGUAGE OBJCXX
     )
+    add_dependencies(EditRuntimeMetal GpuDagMetalShaders RawProcessorOpMetalShaders MetalGeometryUtilsShaders)
     target_link_libraries(EditRuntimeMetal PUBLIC
         "-framework Foundation"
         "-framework Metal"
+        "-framework MetalPerformanceShaders"
+        "-framework MetalPerformanceShadersGraph"
     )
 endif()
 

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -70,6 +70,7 @@ def_library(EditInput
 
 # GPU-agnostic DAG runtime (parameter arena, texture LRU, KV cache). No CUDA headers.
 set(EDIT_RUNTIME_SRCS
+    ${ALCEDO_SRC_ROOT}/edit/runtime/adjustment_runtime.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/graph_compiler.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/result_content_key.cpp
@@ -90,6 +91,7 @@ if(ALCEDO_METAL_ENABLED)
         SOURCES
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
+            ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_primary_grade_pass.mm
         PUBLIC_DEPS EditRuntime MetalContext alcedo::metal_cpp
         PRIVATE_DEPS RawProcessorOp MetalGeometryUtils MetalImage MetalDemosaicNetEntry
     )
@@ -103,11 +105,13 @@ if(ALCEDO_METAL_ENABLED)
         ALCEDO_METAL_GEOMETRY_UTILS_METALLIB_PATH="${METAL_GEOMETRY_UTILS_METALLIB}"
         ALCEDO_METAL_GEOMETRY_RESAMPLE_METALLIB_PATH="${METAL_GEOMETRY_RESAMPLE_METALLIB}"
         ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH="${METAL_CAMERA_COLOR_METALLIB}"
+        ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH="${METAL_PRIMARY_GRADE_METALLIB}"
         ALCEDO_METAL_DEMOSAICNET_IO_METALLIB_PATH="${METAL_DEMOSAICNET_IO_METALLIB}"
     )
     set_source_files_properties(
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
+        ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_primary_grade_pass.mm
         PROPERTIES LANGUAGE OBJCXX
     )
     add_dependencies(EditRuntimeMetal GpuDagMetalShaders RawProcessorOpMetalShaders MetalGeometryUtilsShaders)
@@ -123,7 +127,6 @@ if(ALCEDO_CUDA_ENABLED)
     def_cuda_library(EditRuntimeCuda
         SOURCES
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_backend.cpp
-            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_adjustment_runtime.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_camera_color_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_develop_pass.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_render_device.cpp

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -91,11 +91,14 @@ if(ALCEDO_METAL_ENABLED)
         SOURCES
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
+            ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_drt_params.cpp
+            ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_drt_pass.mm
+            ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_frame_presenter.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_local_tone_pass.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_mask_pass.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_primary_grade_pass.mm
         PUBLIC_DEPS EditRuntime MetalContext alcedo::metal_cpp
-        PRIVATE_DEPS RawProcessorOp MetalGeometryUtils MetalImage MetalDemosaicNetEntry
+        PRIVATE_DEPS RawProcessorOp Operators MetalGeometryUtils MetalImage MetalDemosaicNetEntry
     )
     target_compile_definitions(EditRuntimeMetal PUBLIC HAVE_METAL)
     target_compile_definitions(EditRuntimeMetal PRIVATE
@@ -110,11 +113,14 @@ if(ALCEDO_METAL_ENABLED)
         ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH="${METAL_PRIMARY_GRADE_METALLIB}"
         ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH="${METAL_LOCAL_TONE_METALLIB}"
         ALCEDO_METAL_MASK_METALLIB_PATH="${METAL_MASK_METALLIB}"
+        ALCEDO_METAL_DRT_METALLIB_PATH="${METAL_DRT_METALLIB}"
         ALCEDO_METAL_DEMOSAICNET_IO_METALLIB_PATH="${METAL_DEMOSAICNET_IO_METALLIB}"
     )
     set_source_files_properties(
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
+        ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_drt_pass.mm
+        ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_frame_presenter.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_local_tone_pass.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_mask_pass.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_primary_grade_pass.mm
@@ -151,7 +157,10 @@ if(ALCEDO_CUDA_ENABLED)
 endif()
 
 if(ALCEDO_CUDA_ENABLED)
-    # The existing scheduler owns CPUPipelineExecutor. Its CUDA branch is now a thin adapter into
-    # EditRuntimeCuda; OpenCL and Metal continue using the established stage adapters.
+    # The existing scheduler owns CPUPipelineExecutor. Its CUDA branch is a thin adapter into
+    # EditRuntimeCuda.
     target_link_libraries(EditPipeline PRIVATE EditRuntimeCuda EditInput EditGraph)
+endif()
+if(ALCEDO_METAL_ENABLED)
+    target_link_libraries(EditPipeline PRIVATE EditRuntimeMetal EditInput EditGraph)
 endif()

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -91,6 +91,7 @@ if(ALCEDO_METAL_ENABLED)
         SOURCES
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
+            ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_local_tone_pass.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_primary_grade_pass.mm
         PUBLIC_DEPS EditRuntime MetalContext alcedo::metal_cpp
         PRIVATE_DEPS RawProcessorOp MetalGeometryUtils MetalImage MetalDemosaicNetEntry
@@ -106,11 +107,13 @@ if(ALCEDO_METAL_ENABLED)
         ALCEDO_METAL_GEOMETRY_RESAMPLE_METALLIB_PATH="${METAL_GEOMETRY_RESAMPLE_METALLIB}"
         ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH="${METAL_CAMERA_COLOR_METALLIB}"
         ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH="${METAL_PRIMARY_GRADE_METALLIB}"
+        ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH="${METAL_LOCAL_TONE_METALLIB}"
         ALCEDO_METAL_DEMOSAICNET_IO_METALLIB_PATH="${METAL_DEMOSAICNET_IO_METALLIB}"
     )
     set_source_files_properties(
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
+        ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_local_tone_pass.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_primary_grade_pass.mm
         PROPERTIES LANGUAGE OBJCXX
     )

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -92,6 +92,7 @@ if(ALCEDO_METAL_ENABLED)
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_local_tone_pass.mm
+            ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_mask_pass.mm
             ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_primary_grade_pass.mm
         PUBLIC_DEPS EditRuntime MetalContext alcedo::metal_cpp
         PRIVATE_DEPS RawProcessorOp MetalGeometryUtils MetalImage MetalDemosaicNetEntry
@@ -108,12 +109,14 @@ if(ALCEDO_METAL_ENABLED)
         ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH="${METAL_CAMERA_COLOR_METALLIB}"
         ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH="${METAL_PRIMARY_GRADE_METALLIB}"
         ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH="${METAL_LOCAL_TONE_METALLIB}"
+        ALCEDO_METAL_MASK_METALLIB_PATH="${METAL_MASK_METALLIB}"
         ALCEDO_METAL_DEMOSAICNET_IO_METALLIB_PATH="${METAL_DEMOSAICNET_IO_METALLIB}"
     )
     set_source_files_properties(
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_backend.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_develop_pass.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_local_tone_pass.mm
+        ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_mask_pass.mm
         ${ALCEDO_SRC_ROOT}/edit/runtime/metal/metal_primary_grade_pass.mm
         PROPERTIES LANGUAGE OBJCXX
     )

--- a/alcedo_studio/src/edit/geometry/render_geometry_resolver.cpp
+++ b/alcedo_studio/src/edit/geometry/render_geometry_resolver.cpp
@@ -14,7 +14,7 @@ namespace {
 
 constexpr float kPi = 3.14159265358979323846f;
 
-void ThrowIfInvalidExtent(const Extent2D& extent, const char* name) {
+void            ThrowIfInvalidExtent(const Extent2D& extent, const char* name) {
   if (extent.Empty()) {
     throw std::runtime_error(std::string("ResolveRenderGeometry: ") + name + " must be positive");
   }
@@ -47,7 +47,8 @@ auto NormalizeRotationDegrees(float degrees) -> float {
 
 auto RoundExtent(float width, float height) -> Extent2D {
   if (!std::isfinite(width) || !std::isfinite(height) || width <= 0.0f || height <= 0.0f) {
-    throw std::runtime_error("ResolveRenderGeometry: extent components must be positive and finite");
+    throw std::runtime_error(
+        "ResolveRenderGeometry: extent components must be positive and finite");
   }
   const auto rounded_w = static_cast<std::uint32_t>(std::max(1L, std::lround(width)));
   const auto rounded_h = static_cast<std::uint32_t>(std::max(1L, std::lround(height)));
@@ -62,10 +63,22 @@ auto ClampMaxEdge(Extent2D extent, std::uint32_t max_edge) -> Extent2D {
   if (long_edge <= max_edge) {
     return extent;
   }
-  const float scale =
-      static_cast<float>(max_edge) / static_cast<float>(long_edge);
+  const float scale = static_cast<float>(max_edge) / static_cast<float>(long_edge);
   return RoundExtent(static_cast<float>(extent.width) * scale,
                      static_cast<float>(extent.height) * scale);
+}
+
+auto ClampRoiRenderExtentToNativePixels(Extent2D requested, float visible_width,
+                                        float visible_height) -> Extent2D {
+  const auto native = RoundExtent(visible_width, visible_height);
+  if (requested.width >= native.width && requested.height >= native.height) {
+    return native;
+  }
+  const float scale =
+      std::min({1.0f, static_cast<float>(requested.width) / static_cast<float>(native.width),
+                static_cast<float>(requested.height) / static_cast<float>(native.height)});
+  return RoundExtent(static_cast<float>(native.width) * scale,
+                     static_cast<float>(native.height) * scale);
 }
 
 struct Aabb {
@@ -77,8 +90,8 @@ struct Aabb {
 
 auto AabbOfTransformedCorners(const Matrix3x3& matrix, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
     -> Aabb {
-  const Vector2 p[4] = {TransformPoint(matrix, a), TransformPoint(matrix, b), TransformPoint(matrix, c),
-                        TransformPoint(matrix, d)};
+  const Vector2 p[4] = {TransformPoint(matrix, a), TransformPoint(matrix, b),
+                        TransformPoint(matrix, c), TransformPoint(matrix, d)};
   Aabb          box{p[0].x, p[0].y, p[0].x, p[0].y};
   for (int i = 1; i < 4; ++i) {
     box.min_x = std::min(box.min_x, p[i].x);
@@ -162,24 +175,23 @@ auto ResolveRenderGeometry(const SourceGeometry& source, const ImageGeometryPara
   const auto crop = ClampNormalizedRect(image.crop_rect, "crop_rect");
   const auto visible =
       ClampNormalizedRect(view.visible_rect_in_edit_space, "visible_rect_in_edit_space");
-  const float theta =
-      NormalizeRotationDegrees(image.rotation_degrees) * (kPi / 180.0f);
+  const float theta     = NormalizeRotationDegrees(image.rotation_degrees) * (kPi / 180.0f);
 
-  const float full_w = static_cast<float>(source.full_reference_extent.width);
-  const float full_h = static_cast<float>(source.full_reference_extent.height);
-  const float left   = crop.x * full_w;
-  const float top    = crop.y * full_h;
-  const float right  = (crop.x + crop.w) * full_w;
-  const float bottom = (crop.y + crop.h) * full_h;
-  const float crop_w = right - left;
-  const float crop_h = bottom - top;
-  const float cx     = 0.5f * (left + right);
-  const float cy     = 0.5f * (top + bottom);
+  const float full_w    = static_cast<float>(source.full_reference_extent.width);
+  const float full_h    = static_cast<float>(source.full_reference_extent.height);
+  const float left      = crop.x * full_w;
+  const float top       = crop.y * full_h;
+  const float right     = (crop.x + crop.w) * full_w;
+  const float bottom    = (crop.y + crop.h) * full_h;
+  const float crop_w    = right - left;
+  const float crop_h    = bottom - top;
+  const float cx        = 0.5f * (left + right);
+  const float cy        = 0.5f * (top + bottom);
 
-  const auto to_center = Matrix3x3::Translate(-cx, -cy);
-  const auto rotate    = Matrix3x3::Rotate(theta);
-  const auto centered  = rotate * to_center;
-  const auto rotated_box =
+  const auto  to_center = Matrix3x3::Translate(-cx, -cy);
+  const auto  rotate    = Matrix3x3::Rotate(theta);
+  const auto  centered  = rotate * to_center;
+  const auto  rotated_box =
       AabbOfTransformedCorners(centered, Vector2{left, top}, Vector2{right, top},
                                Vector2{right, bottom}, Vector2{left, bottom});
   const float aabb_w = std::max(rotated_box.max_x - rotated_box.min_x, kGeometryMinNormalizedSize);
@@ -199,9 +211,9 @@ auto ResolveRenderGeometry(const SourceGeometry& source, const ImageGeometryPara
                                  Matrix3x3::Translate(-rotated_box.min_x, -rotated_box.min_y) *
                                  centered;
   } else {
-    geometry.edit_extent       = RoundExtent(crop_w, crop_h);
-    const float sx             = static_cast<float>(geometry.edit_extent.width) / crop_w;
-    const float sy             = static_cast<float>(geometry.edit_extent.height) / crop_h;
+    geometry.edit_extent = RoundExtent(crop_w, crop_h);
+    const float sx       = static_cast<float>(geometry.edit_extent.width) / crop_w;
+    const float sy       = static_cast<float>(geometry.edit_extent.height) / crop_h;
     geometry.reference_to_edit =
         Matrix3x3::Translate(static_cast<float>(geometry.edit_extent.width) * 0.5f,
                              static_cast<float>(geometry.edit_extent.height) * 0.5f) *
@@ -217,47 +229,53 @@ auto ResolveRenderGeometry(const SourceGeometry& source, const ImageGeometryPara
   const float vis_w    = std::max(v_right - v_left, kGeometryMinNormalizedSize);
   const float vis_h    = std::max(v_bottom - v_top, kGeometryMinNormalizedSize);
 
-  Extent2D target;
+  Extent2D    target;
   if (view.viewport_extent.width > 0 && view.viewport_extent.height > 0) {
     target = view.viewport_extent;
   } else {
     target = RoundExtent(vis_w, vis_h);
   }
-  geometry.render_extent = ClampMaxEdge(
-      RoundExtent(static_cast<float>(target.width) * resolution.render_scale,
-                  static_cast<float>(target.height) * resolution.render_scale),
-      resolution.max_edge);
+  geometry.render_extent =
+      ClampMaxEdge(RoundExtent(static_cast<float>(target.width) * resolution.render_scale,
+                               static_cast<float>(target.height) * resolution.render_scale),
+                   resolution.max_edge);
+  // Preserve the pre-DAG preview behavior for a visible subregion: the image pipeline may
+  // downsample native ROI pixels, but it must not manufacture a larger patch with bilinear or
+  // bicubic interpolation. When the native ROI is smaller than the physical viewport target,
+  // the viewer enlarges the patch with its nearest-neighbor sampler.
+  if (!visible.IsFullFrame()) {
+    geometry.render_extent =
+        ClampRoiRenderExtentToNativePixels(geometry.render_extent, vis_w, vis_h);
+  }
 
-  const float rsx        = static_cast<float>(geometry.render_extent.width) / vis_w;
-  const float rsy        = static_cast<float>(geometry.render_extent.height) / vis_h;
-  geometry.edit_to_render = Matrix3x3::Scale(rsx, rsy) * Matrix3x3::Translate(-v_left, -v_top);
+  const float rsx              = static_cast<float>(geometry.render_extent.width) / vis_w;
+  const float rsy              = static_cast<float>(geometry.render_extent.height) / vis_h;
+  geometry.edit_to_render      = Matrix3x3::Scale(rsx, rsy) * Matrix3x3::Translate(-v_left, -v_top);
 
   geometry.reference_to_render = geometry.edit_to_render * geometry.reference_to_edit;
   geometry.render_to_reference = InvertAffine(geometry.reference_to_render);
   geometry.render_to_decoded =
       InvertAffine(geometry.decoded_to_reference) * geometry.render_to_reference;
 
-  geometry.filter =
-      resolution.quality == RenderQuality::Export ? TextureFilter::Bicubic : TextureFilter::Bilinear;
+  geometry.filter         = resolution.quality == RenderQuality::Export ? TextureFilter::Bicubic
+                                                                        : TextureFilter::Bilinear;
 
-  const float render_w = static_cast<float>(geometry.render_extent.width);
-  const float render_h = static_cast<float>(geometry.render_extent.height);
-  const auto  decoded_box =
-      AabbOfTransformedCorners(geometry.render_to_decoded, Vector2{0.0f, 0.0f},
-                               Vector2{render_w, 0.0f}, Vector2{render_w, render_h},
-                               Vector2{0.0f, render_h});
-  const auto reference_box =
-      AabbOfTransformedCorners(geometry.render_to_reference, Vector2{0.0f, 0.0f},
-                               Vector2{render_w, 0.0f}, Vector2{render_w, render_h},
-                               Vector2{0.0f, render_h});
+  const float render_w    = static_cast<float>(geometry.render_extent.width);
+  const float render_h    = static_cast<float>(geometry.render_extent.height);
+  const auto  decoded_box = AabbOfTransformedCorners(
+      geometry.render_to_decoded, Vector2{0.0f, 0.0f}, Vector2{render_w, 0.0f},
+      Vector2{render_w, render_h}, Vector2{0.0f, render_h});
+  const auto reference_box = AabbOfTransformedCorners(
+      geometry.render_to_reference, Vector2{0.0f, 0.0f}, Vector2{render_w, 0.0f},
+      Vector2{render_w, render_h}, Vector2{0.0f, render_h});
 
   if (footprint.requires_full_reference) {
-    geometry.required_decoded_region = RectI{
-        0, 0, static_cast<std::int32_t>(geometry.decoded_extent.width),
-        static_cast<std::int32_t>(geometry.decoded_extent.height)};
-    geometry.required_reference_region = RectI{
-        0, 0, static_cast<std::int32_t>(geometry.full_reference_extent.width),
-        static_cast<std::int32_t>(geometry.full_reference_extent.height)};
+    geometry.required_decoded_region =
+        RectI{0, 0, static_cast<std::int32_t>(geometry.decoded_extent.width),
+              static_cast<std::int32_t>(geometry.decoded_extent.height)};
+    geometry.required_reference_region =
+        RectI{0, 0, static_cast<std::int32_t>(geometry.full_reference_extent.width),
+              static_cast<std::int32_t>(geometry.full_reference_extent.height)};
   } else {
     geometry.required_decoded_region = RequiredRegionFromAabb(
         decoded_box, footprint.radius_x, footprint.radius_y, geometry.decoded_extent);

--- a/alcedo_studio/src/edit/input/raw_input_loader.cpp
+++ b/alcedo_studio/src/edit/input/raw_input_loader.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <opencv2/core.hpp>
 #include <stdexcept>
 #include <utility>
@@ -431,29 +432,31 @@ auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes d
   }
   const auto dng_metadata = dng::ExtractMetadata(std::span<const std::uint8_t>(
       reinterpret_cast<const std::uint8_t*>(encoded.data()), encoded.size()));
-  LibRaw     raw;
-  if (raw.open_buffer(const_cast<void*>(static_cast<const void*>(encoded.data())),
-                      encoded.size()) != LIBRAW_SUCCESS) {
+  // LibRaw is larger than the macOS product worker stack; it must not be a local object.
+  auto       raw          = std::make_unique<LibRaw>();
+  if (raw->open_buffer(const_cast<void*>(static_cast<const void*>(encoded.data())),
+                       encoded.size()) != LIBRAW_SUCCESS) {
     throw std::runtime_error("RawInputLoader::LoadEncoded: LibRaw open_buffer failed");
   }
-  if (libraw_guard::Unpack(raw) != LIBRAW_SUCCESS) {
-    raw.recycle();
+  if (libraw_guard::Unpack(*raw) != LIBRAW_SUCCESS) {
+    raw->recycle();
     throw std::runtime_error("RawInputLoader::LoadEncoded: LibRaw unpack failed");
   }
 
-  const auto kind    = ClassifyRawInput(raw.imgdata.rawdata, raw.imgdata.idata);
-  const auto pattern = kind == RawInputKind::BayerRaw ? ReadLibRawCfaPattern(raw) : RawCfaPattern{};
+  const auto kind = ClassifyRawInput(raw->imgdata.rawdata, raw->imgdata.idata);
+  const auto pattern =
+      kind == RawInputKind::BayerRaw ? ReadLibRawCfaPattern(*raw) : RawCfaPattern{};
   try {
-    ThrowIfUnsupported(raw, kind, pattern);
+    ThrowIfUnsupported(*raw, kind, pattern);
   } catch (...) {
-    raw.recycle();
+    raw->recycle();
     throw;
   }
 
   PreparedRawInput input;
-  input.sensor        = SensorFromLibRaw(raw);
-  input.linearization = LinearizationFromLibRaw(raw);
-  FillColorContext(raw, input.color_context);
+  input.sensor        = SensorFromLibRaw(*raw);
+  input.linearization = LinearizationFromLibRaw(*raw);
+  FillColorContext(*raw, input.color_context);
   if (dng_metadata.warp_rectilinear.has_value()) {
     input.dng_warp_rectilinear                        = dng_metadata.warp_rectilinear;
     input.color_context.dng_warp_rectilinear_present_ = true;
@@ -464,14 +467,14 @@ auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes d
   }
 
   if (kind == RawInputKind::DebayeredRgb) {
-    raw.recycle();
+    raw->recycle();
     throw std::runtime_error(
         "RawInputLoader::LoadEncoded: encoded direct RGB is not used in G4 tests; "
         "call FromDirectRgb");
   }
 
-  const auto& sizes = raw.imgdata.sizes;
-  cv::Mat     view(sizes.raw_height, sizes.raw_width, CV_16UC1, raw.imgdata.rawdata.raw_image,
+  const auto& sizes = raw->imgdata.sizes;
+  cv::Mat     view(sizes.raw_height, sizes.raw_width, CV_16UC1, raw->imgdata.rawdata.raw_image,
                sizes.raw_pitch != 0
                        ? static_cast<std::size_t>(sizes.raw_pitch)
                        : static_cast<std::size_t>(sizes.raw_width) * sizeof(std::uint16_t));
@@ -479,7 +482,7 @@ auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes d
   input.host_extent = input.pixels.extent;
   input.input_kind  = RawInputKind::BayerRaw;
   input.cfa_pattern = pattern;
-  raw.recycle();
+  raw->recycle();
   return FinishPrepared(std::move(input), decode_res, HashContentBytes(encoded), encoded.size());
 }
 

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -208,7 +208,7 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     // camera matrices; replacing the document would rebuild every Model, mark them dirty,
     // and miss GPU result cache on slider frames.
     if (!cuda_product_renderer_) {
-      cuda_product_renderer_ = std::make_shared<CudaProductRenderer>(pipeline_document_);
+      cuda_product_renderer_ = std::make_shared<CudaRenderer>(pipeline_document_);
     }
     if (mirror_legacy_stage_adapter_ && AllowsLegacyStageAdapterRemirror(*pipeline_document_)) {
       const auto legacy = ExportPipelineParams();
@@ -243,8 +243,8 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
       }
     }
     request.resolution.quality = force_cpu_output_ ? RenderQuality::Export : RenderQuality::Preview;
-    const auto cache_policy    = enable_cache_ ? CudaProductCachePolicy::UseSessionCache
-                                               : CudaProductCachePolicy::BypassSessionCache;
+    const auto cache_policy    = enable_cache_ ? RenderCachePolicy::UseSessionCache
+                                               : RenderCachePolicy::BypassSessionCache;
     return cuda_product_renderer_->Render(input, decode_res_, request, frame_sink_,
                                           bound_frame_submission_, force_cpu_output_, cache_policy);
   }

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -23,11 +23,17 @@
 #include "edit/pipeline/pipeline.hpp"
 #include "edit/pipeline/pipeline_stage.hpp"
 #include "image/image_buffer.hpp"
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) || defined(HAVE_METAL)
+#include "edit/geometry/render_request.hpp"
 #include "edit/graph/develop_color_transform.hpp"
 #include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#endif
+#ifdef HAVE_CUDA
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#endif
+#ifdef HAVE_METAL
+#include "edit/runtime/metal/metal_renderer.hpp"
 #endif
 
 namespace alcedo {
@@ -35,7 +41,7 @@ namespace alcedo {
 namespace {
 using ProfileClock = std::chrono::steady_clock;
 
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) || defined(HAVE_METAL)
 void ApplyImportedCameraProfile(PipelineDocument&             document,
                                 const RawRuntimeColorContext& imported) {
   auto* develop = document.Develop();
@@ -48,6 +54,61 @@ void ApplyImportedCameraProfile(PipelineDocument&             document,
   if (next != payload) {
     develop->Params().ReplaceParams(std::move(next));
   }
+}
+
+auto BuildGpuDagRenderRequest(const std::optional<ViewportRenderRegion>& viewport,
+                              const nlohmann::json& render_params, bool force_cpu_output)
+    -> RenderRequest {
+  RenderRequest request;
+  if (viewport.has_value() && viewport->reference_width_ > 0 && viewport->reference_height_ > 0) {
+    request.view.visible_rect_in_edit_space = {
+        static_cast<float>(viewport->x_) / viewport->reference_width_,
+        static_cast<float>(viewport->y_) / viewport->reference_height_, viewport->scale_x_,
+        viewport->scale_y_};
+    if (viewport->target_width_ > 0 && viewport->target_height_ > 0) {
+      request.view.viewport_extent = {static_cast<std::uint32_t>(viewport->target_width_),
+                                      static_cast<std::uint32_t>(viewport->target_height_)};
+    }
+  }
+  if (render_params.contains("resize") && render_params["resize"].is_object()) {
+    const auto& resize = render_params["resize"];
+    if (resize.value("enable_scale", false)) {
+      request.resolution.max_edge =
+          static_cast<std::uint32_t>(std::max(0, resize.value("maximum_edge", 0)));
+    }
+  }
+  request.resolution.quality = force_cpu_output ? RenderQuality::Export : RenderQuality::Preview;
+  return request;
+}
+
+template <class ProductRenderer>
+auto ApplyGpuDagProduct(std::shared_ptr<ProductRenderer>&            renderer,
+                        const std::shared_ptr<PipelineDocument>&     document,
+                        nlohmann::json&                              legacy_snapshot,
+                        bool                                         mirror_legacy,
+                        const std::optional<RawRuntimeColorContext>& injected,
+                        const nlohmann::json&                        legacy_params,
+                        const std::shared_ptr<ImageBuffer>&          input, DecodeRes decode_res,
+                        const RenderRequest& request, IFrameSink* sink,
+                        const FrameCompletionSubmission& submission, bool require_host_output,
+                        RenderCachePolicy cache_policy) -> std::shared_ptr<ImageBuffer> {
+  if (!renderer) {
+    renderer = std::make_shared<ProductRenderer>(document);
+  }
+  if (mirror_legacy && AllowsLegacyStageAdapterRemirror(*document)) {
+    if (legacy_params != legacy_snapshot) {
+      const auto error = LegacyPipelineImporter::ApplyOnto(*document, legacy_params);
+      if (!error.empty()) {
+        throw std::runtime_error("CPUPipelineExecutor: legacy adapter import failed: " + error);
+      }
+      legacy_snapshot = legacy_params;
+      if (injected.has_value()) {
+        ApplyImportedCameraProfile(*document, *injected);
+      }
+    }
+  }
+  return renderer->Render(input, decode_res, request, sink, submission, require_host_output,
+                          cache_policy);
 }
 #endif
 
@@ -201,52 +262,38 @@ auto CPUPipelineExecutor::GetStage(PipelineStageName stage) -> PipelineStage& {
 auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     -> std::shared_ptr<ImageBuffer> {
   const auto apply_start = ProfileClock::now();
+#if defined(HAVE_CUDA) || defined(HAVE_METAL)
+  const bool use_gpu_dag =
 #ifdef HAVE_CUDA
-  if (resolved_accelerator_backend_ == GpuBackendKind::CUDA && pipeline_document_) {
-    // Existing editor controls still write the stage adapter during G7. Mirror it into the
-    // live document only when it changed. ApplyOnto keeps extra graph nodes and import-time
-    // camera matrices; replacing the document would rebuild every Model, mark them dirty,
-    // and miss GPU result cache on slider frames.
-    if (!cuda_product_renderer_) {
-      cuda_product_renderer_ = std::make_shared<CudaRenderer>(pipeline_document_);
+      resolved_accelerator_backend_ == GpuBackendKind::CUDA ||
+#endif
+#ifdef HAVE_METAL
+      resolved_accelerator_backend_ == GpuBackendKind::Metal ||
+#endif
+      false;
+  if (pipeline_document_ && use_gpu_dag) {
+    const auto request = BuildGpuDagRenderRequest(render_request_viewport_, render_params_,
+                                                  force_cpu_output_);
+    const auto cache_policy = enable_cache_ ? RenderCachePolicy::UseSessionCache
+                                            : RenderCachePolicy::BypassSessionCache;
+#ifdef HAVE_CUDA
+    if (resolved_accelerator_backend_ == GpuBackendKind::CUDA) {
+      return ApplyGpuDagProduct(cuda_product_renderer_, pipeline_document_,
+                                gpu_dag_legacy_snapshot_, mirror_legacy_stage_adapter_,
+                                injected_raw_color_context_, ExportPipelineParams(), input,
+                                decode_res_, request, frame_sink_, bound_frame_submission_,
+                                force_cpu_output_, cache_policy);
     }
-    if (mirror_legacy_stage_adapter_ && AllowsLegacyStageAdapterRemirror(*pipeline_document_)) {
-      const auto legacy = ExportPipelineParams();
-      if (legacy != cuda_product_legacy_snapshot_) {
-        const auto error = LegacyPipelineImporter::ApplyOnto(*pipeline_document_, legacy);
-        if (!error.empty()) {
-          throw std::runtime_error("CPUPipelineExecutor: legacy adapter import failed: " + error);
-        }
-        cuda_product_legacy_snapshot_ = legacy;
-        if (injected_raw_color_context_.has_value()) {
-          ApplyImportedCameraProfile(*pipeline_document_, *injected_raw_color_context_);
-        }
-      }
+#endif
+#ifdef HAVE_METAL
+    if (resolved_accelerator_backend_ == GpuBackendKind::Metal) {
+      return ApplyGpuDagProduct(metal_product_renderer_, pipeline_document_,
+                                gpu_dag_legacy_snapshot_, mirror_legacy_stage_adapter_,
+                                injected_raw_color_context_, ExportPipelineParams(), input,
+                                decode_res_, request, frame_sink_, bound_frame_submission_,
+                                force_cpu_output_, cache_policy);
     }
-    RenderRequest request;
-    if (const auto& viewport = render_request_viewport_;
-        viewport.has_value() && viewport->reference_width_ > 0 && viewport->reference_height_ > 0) {
-      request.view.visible_rect_in_edit_space = {
-          static_cast<float>(viewport->x_) / viewport->reference_width_,
-          static_cast<float>(viewport->y_) / viewport->reference_height_, viewport->scale_x_,
-          viewport->scale_y_};
-      if (viewport->target_width_ > 0 && viewport->target_height_ > 0) {
-        request.view.viewport_extent = {static_cast<std::uint32_t>(viewport->target_width_),
-                                        static_cast<std::uint32_t>(viewport->target_height_)};
-      }
-    }
-    if (render_params_.contains("resize") && render_params_["resize"].is_object()) {
-      const auto& resize = render_params_["resize"];
-      if (resize.value("enable_scale", false)) {
-        request.resolution.max_edge =
-            static_cast<std::uint32_t>(std::max(0, resize.value("maximum_edge", 0)));
-      }
-    }
-    request.resolution.quality = force_cpu_output_ ? RenderQuality::Export : RenderQuality::Preview;
-    const auto cache_policy    = enable_cache_ ? RenderCachePolicy::UseSessionCache
-                                               : RenderCachePolicy::BypassSessionCache;
-    return cuda_product_renderer_->Render(input, decode_res_, request, frame_sink_,
-                                          bound_frame_submission_, force_cpu_output_, cache_policy);
+#endif
   }
 #endif
   if (exec_stages_.empty()) {
@@ -362,16 +409,23 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
 
 void CPUPipelineExecutor::SetPipelineDocument(std::shared_ptr<PipelineDocument> document,
                                               bool mirror_legacy_stage_adapter) {
-#ifdef HAVE_CUDA
-  pipeline_document_            = std::move(document);
-  mirror_legacy_stage_adapter_  = mirror_legacy_stage_adapter;
-  cuda_product_legacy_snapshot_ = nullptr;
+#if defined(HAVE_CUDA) || defined(HAVE_METAL)
+  pipeline_document_           = std::move(document);
+  mirror_legacy_stage_adapter_ = mirror_legacy_stage_adapter;
+  gpu_dag_legacy_snapshot_     = nullptr;
   if (pipeline_document_ && injected_raw_color_context_.has_value()) {
     ApplyImportedCameraProfile(*pipeline_document_, *injected_raw_color_context_);
   }
+#ifdef HAVE_CUDA
   if (cuda_product_renderer_) {
     cuda_product_renderer_->SetDocument(pipeline_document_);
   }
+#endif
+#ifdef HAVE_METAL
+  if (metal_product_renderer_) {
+    metal_product_renderer_->SetDocument(pipeline_document_);
+  }
+#endif
 #else
   (void)document;
   (void)mirror_legacy_stage_adapter;
@@ -806,7 +860,7 @@ void CPUPipelineExecutor::InitDefaultPipeline() {
 void CPUPipelineExecutor::InjectRawMetadata(const RawRuntimeColorContext& ctx) {
   global_params_.PopulateRawMetadata(ctx);
   injected_raw_color_context_ = ctx;
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) || defined(HAVE_METAL)
   if (pipeline_document_) {
     ApplyImportedCameraProfile(*pipeline_document_, ctx);
   }
@@ -819,7 +873,7 @@ void CPUPipelineExecutor::InjectRawMetadata(const RawRuntimeColorContext& ctx) {
       color_temp_entry.has_value() && color_temp_entry.value() && color_temp_entry.value()->op_) {
     color_temp_entry.value()->op_->SetGlobalParams(global_params_);
     auto color_temp_params = color_temp_entry.value()->op_->GetParams();
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) || defined(HAVE_METAL)
     if (pipeline_document_ != nullptr && pipeline_document_->Develop() != nullptr) {
       const auto& develop = pipeline_document_->Develop()->Params().Params();
       if (!color_temp_params.contains("color_temp") ||
@@ -863,6 +917,11 @@ void CPUPipelineExecutor::ClearAllIntermediateBuffers() {
     cuda_product_renderer_->ReleaseSessionCaches();
   }
 #endif
+#ifdef HAVE_METAL
+  if (metal_product_renderer_) {
+    metal_product_renderer_->ReleaseSessionCaches();
+  }
+#endif
 }
 
 void CPUPipelineExecutor::ReleasePreviewGpuScratch() {
@@ -882,6 +941,11 @@ void CPUPipelineExecutor::ReleaseAllGPUResources() {
 #ifdef HAVE_CUDA
   if (cuda_product_renderer_) {
     cuda_product_renderer_->ReleaseSessionCaches();
+  }
+#endif
+#ifdef HAVE_METAL
+  if (metal_product_renderer_) {
+    metal_product_renderer_->ReleaseSessionCaches();
   }
 #endif
 }

--- a/alcedo_studio/src/edit/runtime/adjustment_runtime.cpp
+++ b/alcedo_studio/src/edit/runtime/adjustment_runtime.cpp
@@ -1,0 +1,122 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/adjustment_runtime.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/cat02_white_balance_model.hpp"
+#include "edit/operators/models/color_wheel_model.hpp"
+#include "edit/operators/models/curve_model.hpp"
+#include "edit/operators/models/hls_model.hpp"
+#include "edit/operators/models/i_operator_model.hpp"
+#include "edit/operators/models/lmt_model.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/operators/models/sharpen_model.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr std::size_t kMaxCurvePoints = 8;
+
+}  // namespace
+
+auto TryResolveAdjustmentBehavior(const OperatorTypeId& type) -> std::optional<AdjustmentBehavior> {
+  using enum AdjustmentBehavior;
+  if (type == type_ids::Cat02WhiteBalance()) return Cat02WhiteBalance;
+  if (type == type_ids::Exposure()) return Exposure;
+  if (type == type_ids::Contrast()) return Contrast;
+  if (type == type_ids::White()) return White;
+  if (type == type_ids::Black()) return Black;
+  if (type == type_ids::Shadows()) return Shadows;
+  if (type == type_ids::Highlights()) return Highlights;
+  if (type == type_ids::Curve()) return Curve;
+  if (type == type_ids::Hls()) return Hls;
+  if (type == type_ids::Saturation()) return Saturation;
+  if (type == type_ids::Vibrance()) return Vibrance;
+  if (type == type_ids::ColorWheel()) return ColorWheel;
+  if (type == type_ids::Lmt()) return Lmt;
+  if (type == type_ids::Clarity()) return Clarity;
+  if (type == type_ids::Sharpen()) return Sharpen;
+  if (type == type_ids::Halation()) return Halation;
+  if (type == type_ids::FilmGrain()) return FilmGrain;
+  return std::nullopt;
+}
+
+auto ResolveAdjustmentBehavior(const OperatorTypeId& type) -> AdjustmentBehavior {
+  if (auto behavior = TryResolveAdjustmentBehavior(type)) {
+    return *behavior;
+  }
+  throw std::runtime_error("Primary grade: unregistered adjustment type '" +
+                           std::string{type.Text()} + "'");
+}
+
+auto IsLocalToneBehavior(AdjustmentBehavior behavior) -> bool {
+  return behavior == AdjustmentBehavior::Shadows || behavior == AdjustmentBehavior::Highlights;
+}
+
+auto IsNeighborhoodBehavior(AdjustmentBehavior behavior) -> bool {
+  return behavior == AdjustmentBehavior::Clarity || behavior == AdjustmentBehavior::Sharpen ||
+         behavior == AdjustmentBehavior::Halation || behavior == AdjustmentBehavior::FilmGrain;
+}
+
+auto MakeGradeRuntimeParams(const IOperatorModel& model, AdjustmentBehavior behavior)
+    -> GradeAdjustmentParams {
+  GradeAdjustmentParams result;
+  result.behavior = static_cast<std::uint32_t>(behavior);
+  const auto dto  = model.MakeFullDto();
+
+  if (const auto* p = PayloadAs<ScalarFloatPayload>(dto.payload.get())) {
+    result.values[0] = p->value;
+    return result;
+  }
+  if (const auto* p = PayloadAs<Cat02WhiteBalancePayload>(dto.payload.get())) {
+    result.values[0] = p->enabled ? 1.0f : 0.0f;
+    result.values[1] = p->temperature_offset;
+    result.values[2] = p->tint_offset;
+    return result;
+  }
+  if (const auto* p = PayloadAs<CurvePayload>(dto.payload.get())) {
+    result.count = static_cast<std::uint32_t>(std::min(p->points.size(), kMaxCurvePoints));
+    for (std::uint32_t i = 0; i < result.count; ++i) {
+      result.values[i * 2]     = p->points[i].x;
+      result.values[i * 2 + 1] = p->points[i].y;
+    }
+    return result;
+  }
+  if (const auto* p = PayloadAs<HlsPayload>(dto.payload.get())) {
+    for (int i = 0; i < kHlsHueBinCount; ++i) {
+      result.values[i]      = p->hls_adj_table[static_cast<std::size_t>(i)].h;
+      result.values[8 + i]  = p->hls_adj_table[static_cast<std::size_t>(i)].l;
+      result.values[16 + i] = p->hls_adj_table[static_cast<std::size_t>(i)].s;
+    }
+    return result;
+  }
+  if (const auto* p = PayloadAs<ColorWheelPayload>(dto.payload.get())) {
+    const ColorWheelControl controls[3] = {p->lift, p->gamma, p->gain};
+    for (int i = 0; i < 3; ++i) {
+      result.values[i * 4]     = controls[i].color_offset.x;
+      result.values[i * 4 + 1] = controls[i].color_offset.y;
+      result.values[i * 4 + 2] = controls[i].color_offset.z;
+      result.values[i * 4 + 3] = controls[i].luminance_offset;
+    }
+    return result;
+  }
+  if (const auto* p = PayloadAs<SharpenPayload>(dto.payload.get())) {
+    result.values[0] = p->amount;
+    result.values[1] = p->radius;
+    result.values[2] = p->threshold;
+    return result;
+  }
+  if (const auto* p = PayloadAs<LmtPayload>(dto.payload.get())) {
+    result.values[0] = p->cube_path.empty() ? 0.0f : 1.0f;
+    return result;
+  }
+  throw std::runtime_error("Primary grade: Model DTO is not supported");
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_adjustment_runtime.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_adjustment_runtime.cpp
@@ -2,47 +2,4 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
-#include "edit/runtime/cuda/cuda_adjustment_runtime.hpp"
-
-#include <stdexcept>
-
-#include "edit/operators/models/builtin_type_ids.hpp"
-
-namespace alcedo {
-
-auto TryResolveCudaAdjustmentBehavior(const OperatorTypeId& type)
-    -> std::optional<CudaAdjustmentBehavior> {
-  using enum CudaAdjustmentBehavior;
-  if (type == type_ids::Cat02WhiteBalance()) return Cat02WhiteBalance;
-  if (type == type_ids::Exposure()) return Exposure;
-  if (type == type_ids::Contrast()) return Contrast;
-  if (type == type_ids::White()) return White;
-  if (type == type_ids::Black()) return Black;
-  if (type == type_ids::Shadows()) return Shadows;
-  if (type == type_ids::Highlights()) return Highlights;
-  if (type == type_ids::Curve()) return Curve;
-  if (type == type_ids::Hls()) return Hls;
-  if (type == type_ids::Saturation()) return Saturation;
-  if (type == type_ids::Vibrance()) return Vibrance;
-  if (type == type_ids::ColorWheel()) return ColorWheel;
-  if (type == type_ids::Lmt()) return Lmt;
-  if (type == type_ids::Clarity()) return Clarity;
-  if (type == type_ids::Sharpen()) return Sharpen;
-  if (type == type_ids::Halation()) return Halation;
-  if (type == type_ids::FilmGrain()) return FilmGrain;
-  return std::nullopt;
-}
-
-auto ResolveCudaAdjustmentBehavior(const OperatorTypeId& type) -> CudaAdjustmentBehavior {
-  if (auto behavior = TryResolveCudaAdjustmentBehavior(type)) {
-    return *behavior;
-  }
-  throw std::runtime_error("CUDA primary grade: unregistered adjustment type");
-}
-
-auto IsCudaLocalToneBehavior(CudaAdjustmentBehavior behavior) -> bool {
-  return behavior == CudaAdjustmentBehavior::Shadows ||
-         behavior == CudaAdjustmentBehavior::Highlights;
-}
-
-}  // namespace alcedo
+// CUDA Grade behavior now lives in edit/runtime/adjustment_runtime.cpp.

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -341,6 +341,10 @@ void CudaBackend::ResetCounters() {
 
 void CudaBackend::FailNextUpload() { fail_next_upload_ = true; }
 
+auto CudaBackend::DefaultTextureBudgetBytes() -> std::size_t {
+  return DefaultProductTextureBudgetBytes();
+}
+
 auto DefaultProductTextureBudgetBytes() -> std::size_t {
   constexpr std::size_t kFloorBytes = 256ull << 20;
   std::size_t           free_bytes  = 0;

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
@@ -2,129 +2,17 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
-#include <exception>
-#include <stdexcept>
-
-#include "edit/input/prepared_raw_input.hpp"
-#include "edit/mask/mask_store.hpp"
-#include "edit/runtime/cuda/cuda_develop_pass.hpp"
-#include "edit/runtime/cuda/cuda_drt_pass.hpp"
-#include "edit/runtime/cuda/cuda_mask_pass.hpp"
-#include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
+#include "edit/runtime/cuda/cuda_pass_encoder.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
-#include "edit/runtime/execution_plan.hpp"
-#include "edit/runtime/result_content_key.hpp"
-#include "edit/runtime/texture_format.hpp"
+#include "edit/runtime/plan_executor.hpp"
 
 namespace alcedo {
-namespace {
-
-constexpr TextureFormat kResultFormat = TextureFormat::Rgba32f;
-
-auto BindOrMiss(CudaRenderWorkspace& images_owner, const GraphValueId& id, ContentKey key,
-                ImageExtent extent, std::uint64_t completed,
-                TextureFormat format = kResultFormat) -> bool {
-  return images_owner.Images().BindValidResult(id, key, extent, format, completed) != nullptr;
-}
-
-void Record(CudaRenderDevice& device, const GraphValueId& id, ContentKey key, ImageExtent extent,
-            TextureFormat format = kResultFormat) {
-  device.Workspace().Images().RecordUnpublished(id, key, extent, format,
-                                                device.CommandContext().SubmissionId());
-}
-
-}  // namespace
 
 auto CudaRenderDevice::Execute(const ExecutionPlan& plan, const PreparedRawInput& input,
                                PipelineDocument& document, MaskStore* mask_store,
                                bool publish_on_success) -> GraphValueId {
-  try {
-    auto& workspace = Workspace();
-    if (workspace.Textures().ByteBudget() == 0) {
-      workspace.Textures().SetByteBudget(DefaultProductTextureBudgetBytes());
-    }
-    BeginRender();
-    const auto keys       = BuildFrameResultContentKeys(plan, input, document);
-    const auto completed  = workspace.Device().CompletedSubmission();
-    auto&      stats      = pass_stats_;
-    const auto hits_before  = workspace.Images().ContentHitCount();
-    const auto misses_before = workspace.Images().ContentMissCount();
-
-    if (BindOrMiss(workspace, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent,
-                   completed)) {
-      ++stats.sensor_develop_skip;
-    } else {
-      const auto h2d_before = workspace.Device().HostToDeviceBytes();
-      ExecuteCudaDevelop(*this, plan, input, document);
-      stats.source_h2d_bytes += workspace.Device().HostToDeviceBytes() - h2d_before;
-      ++stats.source_h2d_count;
-      Record(*this, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent);
-      ++stats.sensor_develop_execute;
-    }
-
-    if (BindOrMiss(workspace, plan.geometry_output, keys.geometry_scene_source,
-                   keys.geometry_extent, completed)) {
-      ++stats.geometry_skip;
-    } else {
-      ExecuteCudaGeometryResample(*this, plan);
-      Record(*this, plan.geometry_output, keys.geometry_scene_source, keys.geometry_extent);
-      ++stats.geometry_execute;
-    }
-
-    if (BindOrMiss(workspace, plan.develop_output, keys.develop_image, keys.geometry_extent,
-                   completed)) {
-      ++stats.camera_color_skip;
-    } else {
-      ExecuteCudaCameraColor(*this, plan, document);
-      Record(*this, plan.develop_output, keys.develop_image, keys.geometry_extent);
-      ++stats.camera_color_execute;
-    }
-
-    if (plan.primary_grade_mask) {
-      if (BindOrMiss(workspace, plan.mask_output, keys.mask, keys.geometry_extent, completed,
-                     TextureFormat::R8)) {
-        ++stats.mask_skip;
-      } else {
-        (void)ExecuteCudaMask(*this, plan, document, mask_store);
-        Record(*this, plan.mask_output, keys.mask, keys.geometry_extent, TextureFormat::R8);
-        ++stats.mask_execute;
-      }
-    }
-
-    if (BindOrMiss(workspace, plan.primary_grade_output, keys.primary_grade, keys.geometry_extent,
-                   completed)) {
-      ++stats.primary_grade_skip;
-    } else {
-      (void)ExecuteCudaPrimaryGrade(*this, plan, input, document);
-      Record(*this, plan.primary_grade_output, keys.primary_grade, keys.geometry_extent);
-      ++stats.primary_grade_execute;
-    }
-
-    if (BindOrMiss(workspace, plan.display_output, keys.drt_display, keys.geometry_extent,
-                   completed)) {
-      ++stats.drt_skip;
-    } else {
-      (void)ExecuteCudaDrt(*this, plan, document);
-      Record(*this, plan.display_output, keys.drt_display, keys.geometry_extent);
-      ++stats.drt_execute;
-    }
-
-    stats.result_content_hits += workspace.Images().ContentHitCount() - hits_before;
-    stats.result_content_misses += workspace.Images().ContentMissCount() - misses_before;
-    EndRender();
-    if (publish_on_success) {
-      PublishResults();
-    }
-    return plan.display_output;
-  } catch (const std::exception& ex) {
-    CancelRender();
-    ReportError(ex.what());
-    throw;
-  } catch (...) {
-    CancelRender();
-    ReportError("CUDA DAG execution failed with an unknown error");
-    throw;
-  }
+  return PlanExecutor<CudaBackend>::Execute(*this, plan, input, document, mask_store,
+                                            publish_on_success);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -13,15 +13,9 @@
 #include <stdexcept>
 #include <vector>
 
-#include "edit/operators/models/cat02_white_balance_model.hpp"
-#include "edit/operators/models/color_wheel_model.hpp"
-#include "edit/operators/models/curve_model.hpp"
-#include "edit/operators/models/hls_model.hpp"
-#include "edit/operators/models/lmt_model.hpp"
 #include "edit/operators/models/pending_parameter_patch.hpp"
-#include "edit/operators/models/scalar_operator_model.hpp"
-#include "edit/operators/models/sharpen_model.hpp"
 #include "edit/pipeline/local_tone_mapping.hpp"
+#include "edit/runtime/adjustment_runtime.hpp"
 #include "edit/runtime/cuda/cuda_adjustment_runtime.hpp"
 #include "edit/runtime/cuda/cuda_local_tone_pass.hpp"
 #include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
@@ -32,73 +26,8 @@
 namespace alcedo {
 namespace {
 
-constexpr std::uint32_t kRuntimeParamDirtyBit = 1;
-constexpr std::size_t   kMaxCurvePoints       = 8;
-
-struct alignas(16) CudaAdjustmentParams {
-  std::uint32_t behavior = 0;
-  std::uint32_t count    = 0;
-  float         values[30]{};
-};
-
-struct CudaAdjustmentCommand {
-  std::uint32_t parameter_offset = 0;
-};
-
-auto MakeRuntimeParams(const IOperatorModel& model, CudaAdjustmentBehavior behavior)
-    -> CudaAdjustmentParams {
-  CudaAdjustmentParams result;
-  result.behavior = static_cast<std::uint32_t>(behavior);
-  const auto dto  = model.MakeFullDto();
-
-  if (const auto* p = PayloadAs<ScalarFloatPayload>(dto.payload.get())) {
-    result.values[0] = p->value;
-    return result;
-  }
-  if (const auto* p = PayloadAs<Cat02WhiteBalancePayload>(dto.payload.get())) {
-    result.values[0] = p->enabled ? 1.0f : 0.0f;
-    result.values[1] = p->temperature_offset;
-    result.values[2] = p->tint_offset;
-    return result;
-  }
-  if (const auto* p = PayloadAs<CurvePayload>(dto.payload.get())) {
-    result.count = static_cast<std::uint32_t>(std::min(p->points.size(), kMaxCurvePoints));
-    for (std::uint32_t i = 0; i < result.count; ++i) {
-      result.values[i * 2]     = p->points[i].x;
-      result.values[i * 2 + 1] = p->points[i].y;
-    }
-    return result;
-  }
-  if (const auto* p = PayloadAs<HlsPayload>(dto.payload.get())) {
-    for (int i = 0; i < kHlsHueBinCount; ++i) {
-      result.values[i]      = p->hls_adj_table[i].h;
-      result.values[8 + i]  = p->hls_adj_table[i].l;
-      result.values[16 + i] = p->hls_adj_table[i].s;
-    }
-    return result;
-  }
-  if (const auto* p = PayloadAs<ColorWheelPayload>(dto.payload.get())) {
-    const ColorWheelControl controls[3] = {p->lift, p->gamma, p->gain};
-    for (int i = 0; i < 3; ++i) {
-      result.values[i * 4]     = controls[i].color_offset.x;
-      result.values[i * 4 + 1] = controls[i].color_offset.y;
-      result.values[i * 4 + 2] = controls[i].color_offset.z;
-      result.values[i * 4 + 3] = controls[i].luminance_offset;
-    }
-    return result;
-  }
-  if (const auto* p = PayloadAs<SharpenPayload>(dto.payload.get())) {
-    result.values[0] = p->amount;
-    result.values[1] = p->radius;
-    result.values[2] = p->threshold;
-    return result;
-  }
-  if (const auto* p = PayloadAs<LmtPayload>(dto.payload.get())) {
-    result.values[0] = p->cube_path.empty() ? 0.0f : 1.0f;
-    return result;
-  }
-  throw std::runtime_error("CUDA primary grade: Model DTO is not supported");
-}
+using CudaAdjustmentParams  = GradeAdjustmentParams;
+using CudaAdjustmentCommand = GradeAdjustmentCommand;
 
 auto EnsureImage(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
                  std::uint32_t height) -> ResourceLease<CudaBackend>& {
@@ -309,7 +238,7 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
   bool                        reached_local_tone = false;
   float                       shadows_slider     = 0.0f;
   float                       highlights_slider  = 0.0f;
-  const ParameterFieldBinding field{DirtyFieldMask{kRuntimeParamDirtyBit}, 0, 0,
+  const ParameterFieldBinding field{DirtyFieldMask{kGradeRuntimeParamDirtyBit}, 0, 0,
                                     sizeof(CudaAdjustmentParams)};
 
   for (const auto& compiled : plan.primary_grade_adjustments) {
@@ -328,7 +257,7 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
           "ExecuteCudaPrimaryGrade: Shadows/Highlights were not compiled for LLF");
     }
     const ParameterSlotKey key{grade->Id(), compiled.instance_id};
-    const auto             runtime_params = MakeRuntimeParams(*model, *behavior);
+    const auto             runtime_params = MakeGradeRuntimeParams(*model, *behavior);
     auto payload = std::make_shared<TypedOperatorParamPayload<CudaAdjustmentParams>>(
         compiled.type, 1, runtime_params);
     if (!arena.Contains(key)) {
@@ -337,7 +266,7 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       if (auto first = TakePendingParameterPatch(*model)) pending.push_back(std::move(*first));
     } else if (auto change = TakePendingParameterPatch(*model)) {
       OperatorParamPatchDto patch{grade->Id(), compiled.instance_id, compiled.type,
-                                  DirtyFieldMask{kRuntimeParamDirtyBit}, payload};
+                                  DirtyFieldMask{kGradeRuntimeParamDirtyBit}, payload};
       arena.ApplyPatch(key, patch);
       pending.push_back(std::move(*change));
     }
@@ -407,8 +336,8 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       static_cast<const CudaAdjustmentCommand*>(command_buffer.DevicePointer());
   const auto* parameter_base =
       static_cast<const unsigned char*>(arena.DeviceBuffer().DevicePointer());
-  const bool    local_tone_active     = local_tone_mapping::ShouldRun(shadows_slider * 1.5f / 80.0f,
-                                                                      -highlights_slider * 1.5f / 100.0f);
+  const bool local_tone_active = local_tone_mapping::ShouldRun(shadows_slider * 1.5f / 80.0f,
+                                                               -highlights_slider * 1.5f / 100.0f);
   CudaLocalToneResult local_tone;
   if (local_tone_active) {
     const GraphValueId local_input_id{grade->Id(), PortId{"local_tone.input"}};
@@ -420,10 +349,9 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
         static_cast<float4*>(local_input.Texture().DevicePointer()), pixels, parameter_base,
         device_commands, static_cast<std::uint32_t>(commands_before_local_tone.size()),
         local_tone_mapping::kAcesccMiddleGray);
-    local_tone =
-        ExecuteCudaLocalTone(device, local_input_id, local_output_id, grade->Id(), input_width,
-                             input_height, shadows_slider, highlights_slider, plan.geometry,
-                             HashLlfReferenceKey(plan, prepared, document));
+    local_tone         = ExecuteCudaLocalTone(device, local_input_id, local_output_id, grade->Id(),
+                                              input_width, input_height, shadows_slider, highlights_slider,
+                                              plan.geometry, HashLlfReferenceKey(plan, prepared, document));
     auto* local_output = workspace.Images().Find(local_output_id);
     output             = workspace.Images().Find(output_id);
     PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_product_renderer.cu
@@ -4,22 +4,13 @@
 
 #include <cuda_runtime.h>
 
-#include <cstdio>
-#include <filesystem>
 #include <opencv2/core.hpp>
-#include <optional>
 #include <span>
 #include <stdexcept>
-#include <utility>
 
 #include "cuda/cuda_check.hpp"
-#include "edit/geometry/render_request.hpp"
-#include "edit/graph/pipeline_document.hpp"
-#include "edit/input/raw_input_loader.hpp"
-#include "edit/mask/mask_store.hpp"
+#include "edit/runtime/cuda/cuda_frame_presenter.hpp"
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
-#include "edit/runtime/cuda/cuda_render_device.hpp"
-#include "edit/runtime/graph_compiler.hpp"
 #include "edit/scope/detail/scope_cuda_shared.cuh"
 #include "edit/scope/scope_analyzer.hpp"
 #include "image/image_buffer.hpp"
@@ -27,48 +18,6 @@
 
 namespace alcedo {
 namespace {
-
-auto ViewerDisplayConfigFromDrt(const DrtPayload& payload) -> ViewerDisplayConfig {
-  ViewerDisplayConfig config;
-  switch (payload.encoding_space) {
-    case DrtColorSpace::Rec2020:
-      config.encoding_space = ColorUtils::ColorSpace::REC2020;
-      break;
-    case DrtColorSpace::P3D65:
-      config.encoding_space = ColorUtils::ColorSpace::P3_D65;
-      break;
-    case DrtColorSpace::Rec709:
-    default:
-      config.encoding_space = ColorUtils::ColorSpace::REC709;
-      break;
-  }
-  switch (payload.encoding_eotf) {
-    case DrtEotf::Linear:
-      config.encoding_eotf = ColorUtils::EOTF::LINEAR;
-      break;
-    case DrtEotf::St2084:
-      config.encoding_eotf = ColorUtils::EOTF::ST2084;
-      break;
-    case DrtEotf::Hlg:
-      config.encoding_eotf = ColorUtils::EOTF::HLG;
-      break;
-    case DrtEotf::Gamma26:
-      config.encoding_eotf = ColorUtils::EOTF::GAMMA_2_6;
-      break;
-    case DrtEotf::Bt1886:
-      config.encoding_eotf = ColorUtils::EOTF::BT1886;
-      break;
-    case DrtEotf::Gamma18:
-      config.encoding_eotf = ColorUtils::EOTF::GAMMA_1_8;
-      break;
-    case DrtEotf::Gamma22:
-    default:
-      config.encoding_eotf = ColorUtils::EOTF::GAMMA_2_2;
-      break;
-  }
-  config.peak_luminance = payload.peak_luminance;
-  return config;
-}
 
 void SubmitCudaDisplayFrame(IFrameSink& sink, const CudaBackend::Texture2D& texture,
                             cudaStream_t stream, const FrameWriteMapping& mapping,
@@ -96,12 +45,15 @@ void SubmitCudaDisplayFrame(IFrameSink& sink, const CudaBackend::Texture2D& text
       GpuSignalHandle{GpuBackend::Cuda, std::move(ready_signal)}, 0});
 }
 
-void PresentCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id, IFrameSink& sink,
-                        const FrameCompletionSubmission& submission,
-                        const ViewerDisplayConfig& display_config) {
+}  // namespace
+
+void FramePresenter<CudaBackend>::Present(CudaRenderDevice& device, const GraphValueId& output_id,
+                                          IFrameSink& sink,
+                                          const FrameCompletionSubmission& submission,
+                                          const ViewerDisplayConfig&       display_config) {
   auto* lease = device.Workspace().Images().Find(output_id);
   if (lease == nullptr || lease->Empty()) {
-    throw std::runtime_error("CudaProductRenderer: DRT output is missing");
+    throw std::runtime_error("CudaRenderer: DRT output is missing");
   }
   auto&      texture   = lease->Texture();
   const auto width     = texture.Width();
@@ -112,12 +64,12 @@ void PresentCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id,
   sink.EnsureSize(static_cast<int>(width), static_cast<int>(height));
   const FrameWriteMapping mapping = sink.MapResourceForWrite(FrameMemoryDomain::CudaDevice);
   if (!mapping) {
-    throw std::runtime_error("CudaProductRenderer: frame sink rejected the write mapping");
+    throw std::runtime_error("CudaRenderer: frame sink rejected the write mapping");
   }
 
   try {
     if (mapping.pixel_format != FramePixelFormat::RGBA32F) {
-      throw std::runtime_error("CudaProductRenderer: frame sink requires an RGBA32F target");
+      throw std::runtime_error("CudaRenderer: frame sink requires an RGBA32F target");
     }
     cudaError_t copy_result = cudaSuccess;
     if (mapping.target_type == FrameWriteTargetType::LinearBuffer) {
@@ -133,9 +85,9 @@ void PresentCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id,
           reinterpret_cast<cudaArray_t>(mapping.image_array), 0, 0, texture.DevicePointer(),
           row_bytes, row_bytes, height, cudaMemcpyDeviceToDevice, device.CommandContext().Stream());
     } else {
-      throw std::runtime_error("CudaProductRenderer: frame sink target is not CUDA-compatible");
+      throw std::runtime_error("CudaRenderer: frame sink target is not CUDA-compatible");
     }
-    cuda::CheckCuda(copy_result, "CudaProductRenderer: copy DRT output to frame sink");
+    cuda::CheckCuda(copy_result, "CudaRenderer: copy DRT output to frame sink");
 
     if (mapping.cuda_signal_semaphore != nullptr && mapping.cuda_signal_value != 0) {
       cudaExternalSemaphoreSignalParams signal_params{};
@@ -143,14 +95,12 @@ void PresentCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id,
       auto semaphore = reinterpret_cast<cudaExternalSemaphore_t>(mapping.cuda_signal_semaphore);
       cuda::CheckCuda(::cudaSignalExternalSemaphoresAsync(&semaphore, &signal_params, 1,
                                                           device.CommandContext().Stream()),
-                      "CudaProductRenderer: signal frame sink");
+                      "CudaRenderer: signal frame sink");
     }
-    // Histogram/waveform StageFrame copies this DRT texture on the same stream.
-    // Submit before synchronize so that copy is enqueued while the pointer is valid.
     SubmitCudaDisplayFrame(sink, texture, device.CommandContext().Stream(), mapping,
                            display_config);
     cuda::CheckCuda(::cudaStreamSynchronize(device.CommandContext().Stream()),
-                    "CudaProductRenderer: wait for frame sink copy");
+                    "CudaRenderer: wait for frame sink copy");
   } catch (...) {
     sink.UnmapResource();
     throw;
@@ -159,11 +109,11 @@ void PresentCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id,
   sink.NotifyFrameReady(submission);
 }
 
-auto DownloadCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id)
+auto FramePresenter<CudaBackend>::Download(CudaRenderDevice& device, const GraphValueId& output_id)
     -> std::shared_ptr<ImageBuffer> {
   auto* lease = device.Workspace().Images().Find(output_id);
   if (lease == nullptr || lease->Empty()) {
-    throw std::runtime_error("CudaProductRenderer: cannot download a missing DRT output");
+    throw std::runtime_error("CudaRenderer: cannot download a missing DRT output");
   }
   auto&   texture = lease->Texture();
   cv::Mat pixels(static_cast<int>(texture.Height()), static_cast<int>(texture.Width()), CV_32FC4);
@@ -171,176 +121,6 @@ auto DownloadCudaTexture(CudaRenderDevice& device, const GraphValueId& output_id
                                        pixels.total() * pixels.elemSize()};
   device.Workspace().Device().DownloadTexture2D(texture, bytes, device.CommandContext());
   return std::make_shared<ImageBuffer>(std::move(pixels));
-}
-
-}  // namespace
-
-CudaProductRenderer::CudaProductRenderer(std::shared_ptr<PipelineDocument> document)
-    : CudaProductRenderer(std::move(document), PreparedSourceCache::UnpackFn{}) {}
-
-CudaProductRenderer::CudaProductRenderer(std::shared_ptr<PipelineDocument> document,
-                                         PreparedSourceCache::UnpackFn     unpack)
-    : document_(std::move(document)),
-      device_(std::make_unique<CudaRenderDevice>()),
-      one_shot_device_(),
-      mask_store_(std::make_unique<MaskStore>(std::filesystem::temp_directory_path() /
-                                              "alcedo_studio" / "product_mask_store")),
-      unpack_(unpack ? std::move(unpack)
-                     : PreparedSourceCache::UnpackFn{[](std::span<const std::byte> encoded,
-                                                        DecodeRes                  decode_res) {
-                         return RawInputLoader::LoadEncoded(encoded, decode_res);
-                       }}),
-      source_cache_(unpack_),
-      plan_cache_(kCudaDagBackendCapabilityVersion) {
-  device_->Workspace().Textures().SetByteBudget(DefaultProductTextureBudgetBytes());
-  device_->SetErrorReporter([](std::string_view message) {
-    std::fprintf(stderr, "[ERROR] CUDA DAG product render failed: %.*s\n",
-                 static_cast<int>(message.size()), message.data());
-  });
-}
-
-CudaProductRenderer::~CudaProductRenderer() = default;
-
-auto CudaProductRenderer::MaskAssets() -> MaskStore& { return *mask_store_; }
-
-void CudaProductRenderer::SetDocument(std::shared_ptr<PipelineDocument> document) {
-  if (!document) {
-    throw std::invalid_argument("CudaProductRenderer: PipelineDocument is null");
-  }
-  document_ = std::move(document);
-}
-
-auto CudaProductRenderer::Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
-                                 const RenderRequest& request, IFrameSink* sink,
-                                 const FrameCompletionSubmission& submission,
-                                 bool require_host_output, CudaProductCachePolicy cache_policy)
-    -> std::shared_ptr<ImageBuffer> {
-  if (!document_) {
-    throw std::runtime_error("CudaProductRenderer: PipelineDocument is not configured");
-  }
-  if (!input || !input->buffer_valid_) {
-    throw std::runtime_error("CudaProductRenderer: product path requires encoded image bytes");
-  }
-
-  auto&      encoded       = input->GetBuffer();
-  const auto encoded_bytes = std::span<const std::byte>{
-      reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
-  const bool use_session_cache = cache_policy == CudaProductCachePolicy::UseSessionCache;
-  if (!use_session_cache && !one_shot_device_) {
-    one_shot_device_ = std::make_unique<CudaRenderDevice>();
-    one_shot_device_->Workspace().Textures().SetByteBudget(DefaultProductTextureBudgetBytes());
-    one_shot_device_->SetErrorReporter([](std::string_view message) {
-      std::fprintf(stderr, "[ERROR] CUDA DAG one-shot render failed: %.*s\n",
-                   static_cast<int>(message.size()), message.data());
-    });
-  }
-
-  std::optional<PreparedSourceCache::Lease> prepared_lease;
-  std::optional<PreparedRawInput>           one_shot_prepared;
-  ExecutionPlan                             plan;
-  CudaRenderDevice*                         render_device = device_.get();
-  if (use_session_cache) {
-    prepared_lease.emplace(source_cache_.AcquireEncoded(encoded_bytes, decode_res));
-    plan = plan_cache_.GetOrCompile(*document_, prepared_lease->Get().CompileSource());
-  } else {
-    one_shot_prepared.emplace(unpack_(encoded_bytes, decode_res));
-    plan          = GraphCompiler::CompileStatic(*document_, one_shot_prepared->CompileSource(),
-                                                 kCudaDagBackendCapabilityVersion);
-    render_device = one_shot_device_.get();
-  }
-  GraphCompiler::BindFrameGeometry(plan, *document_, request);
-  if (document_->TopologyDirty()) {
-    document_->ClearTopologyDirty();
-  }
-  const auto& prepared  = use_session_cache ? prepared_lease->Get() : *one_shot_prepared;
-  const auto  output_id =
-      render_device->Execute(plan, prepared, *document_, mask_store_.get(), false);
-  const auto  release_one_shot_resources = [&]() {
-    if (use_session_cache) {
-      return;
-    }
-    render_device->Workspace().Images().DiscardUnpublished();
-    render_device->WaitIdle();
-    render_device->Workspace().ReleaseSessionResources();
-  };
-
-  ViewerDisplayConfig display_config{};
-  if (const auto* drt = document_->Drt()) {
-    display_config = ViewerDisplayConfigFromDrt(drt->Params().Params());
-  }
-
-  try {
-    if (sink != nullptr) {
-      PresentCudaTexture(*render_device, output_id, *sink, submission, display_config);
-    }
-    if (require_host_output) {
-      auto host = DownloadCudaTexture(*render_device, output_id);
-      if (use_session_cache) {
-        render_device->PublishResults();
-      } else {
-        release_one_shot_resources();
-      }
-      return host;
-    }
-    if (use_session_cache) {
-      render_device->PublishResults();
-    } else {
-      release_one_shot_resources();
-    }
-  } catch (const std::exception& ex) {
-    render_device->Workspace().Images().DiscardUnpublished();
-    render_device->ReportError(ex.what());
-    throw;
-  }
-  return std::make_shared<ImageBuffer>();
-}
-
-auto CudaProductRenderer::Stats() const -> CudaProductSessionStats {
-  const auto              source = source_cache_.GetStats();
-  const auto              plan   = plan_cache_.GetStats();
-  CudaProductSessionStats stats;
-  stats.prepared_source_hits     = source.hits;
-  stats.prepared_source_misses   = source.misses;
-  stats.libraw_open_unpack_count = source.libraw_open_unpack_count;
-  stats.plan_cache_hits          = plan.hits;
-  stats.plan_cache_misses        = plan.misses;
-  stats.plan_compile_count       = plan.compiles;
-  stats.pass                     = device_->PassStats();
-  return stats;
-}
-
-void CudaProductRenderer::ResetStats() {
-  source_cache_.ResetStats();
-  plan_cache_.ResetStats();
-  device_->ResetPassStats();
-}
-
-void CudaProductRenderer::ReleaseSessionCaches() {
-  if (!device_) {
-    return;
-  }
-  device_->WaitIdle();
-  device_->Workspace().ReleaseSessionResources();
-  device_->ReleaseNeuralDemosaicWorkspace();
-  one_shot_device_.reset();
-  source_cache_.Clear();
-  plan_cache_.Clear();
-  device_->ResetPassStats();
-}
-
-auto CudaProductRenderer::SessionResources() const -> CudaProductSessionResources {
-  CudaProductSessionResources resources;
-  if (!device_) {
-    return resources;
-  }
-  const auto& workspace                 = device_->Workspace();
-  resources.published_result_count      = workspace.Images().PublishedCount();
-  resources.texture_pool_used_bytes     = workspace.Textures().UsedBytes();
-  resources.texture_pool_entry_count    = workspace.Textures().EntryCount();
-  resources.prepared_source_host_bytes  = source_cache_.HostBytesUsed();
-  resources.prepared_source_entry_count = source_cache_.EntryCount();
-  resources.session_value_ids           = workspace.Images().CurrentValueIds();
-  return resources;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_sensor_demosaic.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_sensor_demosaic.cpp
@@ -215,19 +215,6 @@ void DemosaicNeuralEngine(CudaRenderDevice& device, const PreparedRawInput& inpu
 
 }  // namespace
 
-auto ResolveDevelopDemosaicMethod(const DevelopPayload& params, RawCfaKind cfa_kind,
-                                  std::uint32_t downsample_passes) -> RawDemosaicMethod {
-  if (downsample_passes != 0) {
-    return RawDemosaicMethod::Legacy;
-  }
-  const auto parsed = RawDemosaicMethodFromString(params.demosaic_method);
-  if (parsed != RawDemosaicMethod::Default) {
-    return parsed;
-  }
-  return cfa_kind == RawCfaKind::XTrans6x6 ? RawDemosaicMethod::NeuralEngine
-                                           : RawDemosaicMethod::Legacy;
-}
-
 void SetDevelopNeuralModelCacheForTesting(DemosaicNetModelCache* cache) {
   g_neural_model_cache_for_test = cache;
 }

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -66,7 +66,36 @@ auto CompileAdjustmentAlgorithm(const OperatorTypeId& type) -> CompiledAdjustmen
   if (type == type_ids::Shadows() || type == type_ids::Highlights()) {
     return CompiledAdjustmentAlgorithm::LocalLaplacian;
   }
+  if (type == type_ids::Clarity() || type == type_ids::Sharpen() || type == type_ids::Halation() ||
+      type == type_ids::FilmGrain()) {
+    return CompiledAdjustmentAlgorithm::Neighborhood;
+  }
   return CompiledAdjustmentAlgorithm::Pointwise;
+}
+
+auto StageKindFor(CompiledAdjustmentAlgorithm algorithm) -> CompiledGradeStageKind {
+  switch (algorithm) {
+    case CompiledAdjustmentAlgorithm::LocalLaplacian:
+      return CompiledGradeStageKind::LocalLaplacian;
+    case CompiledAdjustmentAlgorithm::Neighborhood:
+      return CompiledGradeStageKind::Neighborhood;
+    case CompiledAdjustmentAlgorithm::Pointwise:
+      return CompiledGradeStageKind::Pointwise;
+  }
+  return CompiledGradeStageKind::Pointwise;
+}
+
+void AppendGradeStage(ExecutionPlan& plan, CompiledAdjustmentAlgorithm algorithm) {
+  const auto kind  = StageKindFor(algorithm);
+  const auto index = static_cast<std::uint32_t>(plan.primary_grade_adjustments.size() - 1);
+  if (!plan.primary_grade_stages.empty()) {
+    auto& last = plan.primary_grade_stages.back();
+    if (last.kind == kind && kind != CompiledGradeStageKind::Neighborhood) {
+      ++last.count;
+      return;
+    }
+  }
+  plan.primary_grade_stages.push_back(CompiledGradeStage{kind, index, 1});
 }
 
 auto HashGraphTopology(const PipelineDocument& document) -> std::uint64_t {
@@ -202,9 +231,10 @@ auto GraphCompiler::CompileStatic(const PipelineDocument&     document,
   plan.passes.push_back(GpuPassDesc{GpuPassKind::Drt});
 
   for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
-    const auto& type = grade->AdjustmentAt(index).Type();
-    plan.primary_grade_adjustments.push_back(
-        {grade->AdjustmentIdAt(index), type, CompileAdjustmentAlgorithm(type)});
+    const auto& type      = grade->AdjustmentAt(index).Type();
+    const auto  algorithm = CompileAdjustmentAlgorithm(type);
+    plan.primary_grade_adjustments.push_back({grade->AdjustmentIdAt(index), type, algorithm});
+    AppendGradeStage(plan, algorithm);
   }
   return plan;
 }

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -18,6 +18,7 @@
 #include "edit/graph/pipeline_graph.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/models/operator_type_id.hpp"
+#include "edit/pipeline/local_tone_mapping.hpp"
 
 namespace alcedo {
 namespace {
@@ -32,15 +33,18 @@ auto EstimatePeakTransientBytes(const DevelopCompileSource& source) -> std::size
   const std::size_t w      = source.host_extent.width;
   const std::size_t h      = source.host_extent.height;
   const std::size_t pixels = w * h;
+  const std::size_t llf    = local_tone_mapping::EstimateLlfTransientBytes(
+      static_cast<int>(source.full_reference_extent.width),
+      static_cast<int>(source.full_reference_extent.height), kAlign);
   if (source.kind == DevelopInputKind::DirectRgb) {
-    return AlignUp(4096, kAlign);
+    return AlignUp(4096, kAlign) + llf;
   }
   // U16 CFA + F32 CFA + 5 RCD planes + merge RGB + HLR result + HLR stats + XTrans green/rgb.
   const std::size_t bytes = AlignUp(pixels * 2, kAlign) + AlignUp(pixels * 4, kAlign) +
                             5 * AlignUp(pixels * 4, kAlign) + AlignUp(pixels * 12, kAlign) +
                             AlignUp(pixels * 12, kAlign) + AlignUp(4 + 16 + 16, kAlign) +
                             AlignUp(pixels * 4, kAlign) + AlignUp(pixels * 12, kAlign);
-  return bytes + 64 * kAlign;
+  return bytes + 64 * kAlign + llf;
 }
 
 auto ImageParamsFromDocument(const PipelineDocument& document) -> ImageGeometryParams {

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -29,6 +29,12 @@ auto                  AlignUp(std::size_t value, std::size_t alignment) -> std::
   return (value + alignment - 1) & ~(alignment - 1);
 }
 
+auto EstimateMaskSdfTransientBytes(Extent2D extent) -> std::size_t {
+  const std::size_t pixels =
+      static_cast<std::size_t>(std::max(extent.width, 1u)) * std::max(extent.height, 1u);
+  return 5 * AlignUp(pixels * sizeof(float), kAlign);
+}
+
 auto EstimatePeakTransientBytes(const DevelopCompileSource& source) -> std::size_t {
   const std::size_t w      = source.host_extent.width;
   const std::size_t h      = source.host_extent.height;
@@ -226,6 +232,12 @@ auto GraphCompiler::CompileStatic(const PipelineDocument&     document,
       plan.mask_output        = GraphValueId{mask->Id(), PortId{"mask"}};
       plan.passes.push_back(GpuPassDesc{GpuPassKind::MaskEvaluate});
       plan.passes.push_back(GpuPassDesc{GpuPassKind::MaskFeather});
+      if (kind == CompiledMaskKind::Raster) {
+        const Extent2D mask_extent{
+            std::max(source.full_reference_extent.width, source.host_extent.width),
+            std::max(source.full_reference_extent.height, source.host_extent.height)};
+        plan.peak_transient_bytes += EstimateMaskSdfTransientBytes(mask_extent);
+      }
       break;
     }
   }

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
@@ -1,0 +1,785 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/metal/metal_backend.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <utility>
+
+#include <alcedo/metal/Metal.hpp>
+
+#include "edit/runtime/execution_plan.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+#include "metal/metal_context.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr std::size_t kMinHeapPageBytes = 16ull << 20;
+constexpr std::size_t kBlitRowAlign     = 256;
+
+auto                  ThrowIfNull(const void* pointer, const char* message) {
+  if (pointer == nullptr) {
+    throw std::runtime_error(message);
+  }
+}
+
+auto ToPixelFormat(TextureFormat format) -> MTL::PixelFormat {
+  switch (format) {
+    case TextureFormat::R8:
+      return MTL::PixelFormatR8Unorm;
+    case TextureFormat::Rgba8:
+      return MTL::PixelFormatRGBA8Unorm;
+    case TextureFormat::R32f:
+      return MTL::PixelFormatR32Float;
+    case TextureFormat::Rgba32f:
+      return MTL::PixelFormatRGBA32Float;
+  }
+  throw std::runtime_error("MetalBackend: unsupported texture format");
+}
+
+auto AlignedRowBytes(std::uint32_t width, TextureFormat format) -> std::size_t {
+  const auto raw = static_cast<std::size_t>(width) * TextureFormatBytesPerPixel(format);
+  return (raw + kBlitRowAlign - 1) & ~(kBlitRowAlign - 1);
+}
+
+auto RoundUpHeapPage(std::size_t bytes) -> std::size_t {
+  if (bytes <= kMinHeapPageBytes) {
+    return kMinHeapPageBytes;
+  }
+  const auto pages = (bytes + kMinHeapPageBytes - 1) / kMinHeapPageBytes;
+  return pages * kMinHeapPageBytes;
+}
+
+auto ParameterResourceOptions(MTL::Device* device) -> MTL::ResourceOptions {
+  if (device->hasUnifiedMemory()) {
+    return MTL::ResourceStorageModeShared;
+  }
+  return MTL::ResourceStorageModeManaged;
+}
+
+auto MakePrivateTextureDescriptor(std::uint32_t width, std::uint32_t height, TextureFormat format)
+    -> NS::SharedPtr<MTL::TextureDescriptor> {
+  auto descriptor = NS::TransferPtr(MTL::TextureDescriptor::alloc()->init());
+  descriptor->setTextureType(MTL::TextureType2D);
+  descriptor->setWidth(width);
+  descriptor->setHeight(height);
+  descriptor->setDepth(1);
+  descriptor->setMipmapLevelCount(1);
+  descriptor->setSampleCount(1);
+  descriptor->setArrayLength(1);
+  descriptor->setPixelFormat(ToPixelFormat(format));
+  descriptor->setStorageMode(MTL::StorageModePrivate);
+  descriptor->setUsage(MTL::TextureUsageShaderRead | MTL::TextureUsageShaderWrite);
+  descriptor->setHazardTrackingMode(MTL::HazardTrackingModeTracked);
+  return descriptor;
+}
+
+void CopyPackedToAligned(std::span<const std::byte> packed, std::uint32_t width,
+                         std::uint32_t height, TextureFormat format, void* destination) {
+  const auto src_row = static_cast<std::size_t>(width) * TextureFormatBytesPerPixel(format);
+  const auto dst_row = AlignedRowBytes(width, format);
+  auto*      dst     = static_cast<std::byte*>(destination);
+  for (std::uint32_t y = 0; y < height; ++y) {
+    std::memcpy(dst + static_cast<std::size_t>(y) * dst_row, packed.data() + y * src_row, src_row);
+  }
+}
+
+void CopyAlignedToPacked(const void* source, std::uint32_t width, std::uint32_t height,
+                         TextureFormat format, std::span<std::byte> packed) {
+  const auto  dst_row = static_cast<std::size_t>(width) * TextureFormatBytesPerPixel(format);
+  const auto  src_row = AlignedRowBytes(width, format);
+  const auto* src     = static_cast<const std::byte*>(source);
+  for (std::uint32_t y = 0; y < height; ++y) {
+    std::memcpy(packed.data() + y * dst_row, src + static_cast<std::size_t>(y) * src_row, dst_row);
+  }
+}
+
+}  // namespace
+
+class MetalCommandContext::Gpu {
+ public:
+  NS::SharedPtr<MTL::CommandBuffer>         buffer;
+  NS::SharedPtr<MTL::BlitCommandEncoder>    blit;
+  NS::SharedPtr<MTL::ComputeCommandEncoder> compute;
+
+  void                                      EndEncoders() {
+    if (blit) {
+      blit->endEncoding();
+      blit.reset();
+    }
+    if (compute) {
+      compute->endEncoding();
+      compute.reset();
+    }
+  }
+
+  void Reset() {
+    EndEncoders();
+    buffer.reset();
+  }
+};
+
+MetalCommandContext::MetalCommandContext() : gpu_(std::make_unique<Gpu>()) {}
+MetalCommandContext::~MetalCommandContext() = default;
+MetalCommandContext::MetalCommandContext(MetalCommandContext&& other) noexcept
+    : gpu_(std::move(other.gpu_)), submission_id_(other.submission_id_) {
+  other.gpu_           = std::make_unique<Gpu>();
+  other.submission_id_ = 0;
+}
+auto MetalCommandContext::operator=(MetalCommandContext&& other) noexcept -> MetalCommandContext& {
+  if (this != &other) {
+    gpu_                 = std::move(other.gpu_);
+    submission_id_       = other.submission_id_;
+    other.gpu_           = std::make_unique<Gpu>();
+    other.submission_id_ = 0;
+  }
+  return *this;
+}
+auto MetalCommandContext::NativeCommandBuffer() const -> void* {
+  return gpu_ && gpu_->buffer ? gpu_->buffer.get() : nullptr;
+}
+
+struct HeapPage {
+  NS::SharedPtr<MTL::Heap> heap;
+  std::size_t              bytes = 0;
+};
+
+struct LiveBuffer {
+  MTL::Buffer*  native      = nullptr;
+  std::uint64_t gpu_address = 0;
+  std::size_t   bytes       = 0;
+};
+
+class MetalBackend::Gpu {
+ public:
+  MTL::Device*                     device = nullptr;
+  MTL::CommandQueue*               queue  = nullptr;
+  std::vector<HeapPage>            heaps;
+  NS::SharedPtr<MTL::Buffer>       staging;
+  std::size_t                      staging_bytes = 0;
+  NS::SharedPtr<MTL::SamplerState> linear_clamp;
+  NS::SharedPtr<MTL::SamplerState> nearest_clamp;
+  std::vector<LiveBuffer>          live_buffers;
+  std::uint64_t                    pipeline_create_baseline = 0;
+  std::uint64_t                    pipeline_hit_baseline    = 0;
+
+  void                             UnregisterBuffer(MTL::Buffer* native) {
+    live_buffers.erase(
+        std::remove_if(live_buffers.begin(), live_buffers.end(),
+                                                   [native](const LiveBuffer& entry) { return entry.native == native; }),
+        live_buffers.end());
+  }
+};
+
+class MetalBackendImpl {
+ public:
+  static void AttachGpu(MetalBackend::Gpu& gpu) {
+    if (gpu.device != nullptr) {
+      return;
+    }
+    auto& context = MetalContext::Instance();
+    gpu.device    = context.Device();
+    gpu.queue     = context.Queue();
+    ThrowIfNull(gpu.device, "MetalBackend: Metal device is unavailable.");
+    ThrowIfNull(gpu.queue, "MetalBackend: Metal command queue is unavailable.");
+
+    auto linear_desc = NS::TransferPtr(MTL::SamplerDescriptor::alloc()->init());
+    linear_desc->setMinFilter(MTL::SamplerMinMagFilterLinear);
+    linear_desc->setMagFilter(MTL::SamplerMinMagFilterLinear);
+    linear_desc->setSAddressMode(MTL::SamplerAddressModeClampToEdge);
+    linear_desc->setTAddressMode(MTL::SamplerAddressModeClampToEdge);
+    gpu.linear_clamp  = NS::TransferPtr(gpu.device->newSamplerState(linear_desc.get()));
+
+    auto nearest_desc = NS::TransferPtr(MTL::SamplerDescriptor::alloc()->init());
+    nearest_desc->setMinFilter(MTL::SamplerMinMagFilterNearest);
+    nearest_desc->setMagFilter(MTL::SamplerMinMagFilterNearest);
+    nearest_desc->setSAddressMode(MTL::SamplerAddressModeClampToEdge);
+    nearest_desc->setTAddressMode(MTL::SamplerAddressModeClampToEdge);
+    gpu.nearest_clamp            = NS::TransferPtr(gpu.device->newSamplerState(nearest_desc.get()));
+
+    const auto stats             = metal::ComputePipelineCache::Instance().GetStats();
+    gpu.pipeline_create_baseline = stats.creates;
+    gpu.pipeline_hit_baseline    = stats.hits;
+  }
+
+  static void ThrowIfHeapBusy(const MetalBackend& backend) {
+    if (backend.HasInFlightSubmission()) {
+      throw std::runtime_error(
+          "MetalBackend: cannot grow an MTLHeap page while a GPU submission is in flight");
+    }
+  }
+
+  static void GrowHeap(MetalBackend& backend, MetalBackend::Gpu& gpu, std::size_t at_least) {
+    ThrowIfHeapBusy(backend);
+    auto descriptor = NS::TransferPtr(MTL::HeapDescriptor::alloc()->init());
+    descriptor->setSize(RoundUpHeapPage(at_least));
+    descriptor->setStorageMode(MTL::StorageModePrivate);
+    descriptor->setHazardTrackingMode(MTL::HazardTrackingModeTracked);
+    descriptor->setType(MTL::HeapTypeAutomatic);
+    auto heap = NS::TransferPtr(gpu.device->newHeap(descriptor.get()));
+    ThrowIfNull(heap.get(), "MetalBackend: failed to allocate MTLHeap page");
+    HeapPage page;
+    page.heap  = std::move(heap);
+    page.bytes = descriptor->size();
+    gpu.heaps.push_back(std::move(page));
+    backend.NoteHeapCreate();
+  }
+
+  static auto AllocatePrivateBuffer(MetalBackend& backend, MetalBackend::Gpu& gpu,
+                                    std::size_t bytes) -> MTL::Buffer* {
+    const auto options      = MTL::ResourceStorageModePrivate;
+    const auto needed       = gpu.device->heapBufferSizeAndAlign(bytes, options);
+    auto       try_allocate = [&]() -> MTL::Buffer* {
+      for (auto& page : gpu.heaps) {
+        if (page.heap->maxAvailableSize(needed.align) < needed.size) {
+          continue;
+        }
+        if (auto* buffer = page.heap->newBuffer(bytes, options)) {
+          return buffer;
+        }
+      }
+      return nullptr;
+    };
+    if (auto* buffer = try_allocate()) {
+      return buffer;
+    }
+    GrowHeap(backend, gpu, needed.size);
+    auto* buffer = try_allocate();
+    ThrowIfNull(buffer, "MetalBackend: failed to allocate private buffer from MTLHeap");
+    return buffer;
+  }
+
+  static auto AllocatePrivateTexture(MetalBackend& backend, MetalBackend::Gpu& gpu,
+                                     const MTL::TextureDescriptor* descriptor) -> MTL::Texture* {
+    const auto needed       = gpu.device->heapTextureSizeAndAlign(descriptor);
+    auto       try_allocate = [&]() -> MTL::Texture* {
+      for (auto& page : gpu.heaps) {
+        if (page.heap->maxAvailableSize(needed.align) < needed.size) {
+          continue;
+        }
+        if (auto* texture = page.heap->newTexture(descriptor)) {
+          return texture;
+        }
+      }
+      return nullptr;
+    };
+    if (auto* texture = try_allocate()) {
+      return texture;
+    }
+    GrowHeap(backend, gpu, needed.size);
+    auto* texture = try_allocate();
+    ThrowIfNull(texture, "MetalBackend: failed to allocate private texture from MTLHeap");
+    return texture;
+  }
+
+  static void EnsureCommandBuffer(MetalBackend::Gpu& gpu, MetalCommandContext& command_context) {
+    auto& ctx = *command_context.gpu_;
+    if (ctx.buffer) {
+      return;
+    }
+    ctx.buffer = NS::RetainPtr(gpu.queue->commandBuffer());
+    ThrowIfNull(ctx.buffer.get(), "MetalBackend: failed to create MTLCommandBuffer");
+  }
+
+  static void EnsureBlitEncoder(MetalBackend::Gpu& gpu, MetalCommandContext& command_context) {
+    EnsureCommandBuffer(gpu, command_context);
+    auto& ctx = *command_context.gpu_;
+    if (ctx.compute) {
+      ctx.compute->endEncoding();
+      ctx.compute.reset();
+    }
+    if (!ctx.blit) {
+      ctx.blit = NS::RetainPtr(ctx.buffer->blitCommandEncoder());
+      ThrowIfNull(ctx.blit.get(), "MetalBackend: failed to create blit encoder");
+    }
+  }
+
+  static void EnsureStaging(MetalBackend& backend, MetalBackend::Gpu& gpu, std::size_t bytes) {
+    if (bytes <= gpu.staging_bytes && gpu.staging) {
+      return;
+    }
+    ThrowIfHeapBusy(backend);
+    auto buffer = NS::TransferPtr(gpu.device->newBuffer(bytes, MTL::ResourceStorageModeShared));
+    ThrowIfNull(buffer.get(), "MetalBackend: failed to allocate staging buffer");
+    gpu.staging       = std::move(buffer);
+    gpu.staging_bytes = bytes;
+    backend.NoteBufferCreate();
+  }
+
+  static void MarkDidModifyIfManaged(MTL::Buffer* buffer, std::uint32_t offset, std::size_t bytes) {
+    if (buffer->storageMode() == MTL::StorageModeManaged) {
+      buffer->didModifyRange(NS::Range(offset, bytes));
+    }
+  }
+};
+
+MetalBackend::Buffer::Buffer(MetalBackend* owner, void* native, void* device_pointer,
+                             std::size_t bytes, std::uint64_t id)
+    : owner_(owner), native_(native), ptr_(device_pointer), bytes_(bytes), resource_id_(id) {}
+
+MetalBackend::Buffer::~Buffer() { Reset(); }
+
+MetalBackend::Buffer::Buffer(Buffer&& other) noexcept
+    : owner_(other.owner_),
+      native_(other.native_),
+      ptr_(other.ptr_),
+      bytes_(other.bytes_),
+      resource_id_(other.resource_id_) {
+  other.owner_       = nullptr;
+  other.native_      = nullptr;
+  other.ptr_         = nullptr;
+  other.bytes_       = 0;
+  other.resource_id_ = 0;
+}
+
+auto MetalBackend::Buffer::operator=(Buffer&& other) noexcept -> Buffer& {
+  if (this != &other) {
+    Reset();
+    owner_             = other.owner_;
+    native_            = other.native_;
+    ptr_               = other.ptr_;
+    bytes_             = other.bytes_;
+    resource_id_       = other.resource_id_;
+    other.owner_       = nullptr;
+    other.native_      = nullptr;
+    other.ptr_         = nullptr;
+    other.bytes_       = 0;
+    other.resource_id_ = 0;
+  }
+  return *this;
+}
+
+void MetalBackend::Buffer::Reset() noexcept {
+  if (native_ != nullptr) {
+    auto* buffer = static_cast<MTL::Buffer*>(native_);
+    if (owner_ != nullptr && owner_->gpu_) {
+      owner_->gpu_->UnregisterBuffer(buffer);
+      owner_->NoteFree();
+    }
+    buffer->release();
+  }
+  owner_       = nullptr;
+  native_      = nullptr;
+  ptr_         = nullptr;
+  bytes_       = 0;
+  resource_id_ = 0;
+}
+
+MetalBackend::Texture2D::Texture2D(MetalBackend* owner, void* native, std::size_t bytes,
+                                   std::uint32_t width, std::uint32_t height, TextureFormat format,
+                                   std::uint64_t id)
+    : owner_(owner),
+      native_(native),
+      bytes_(bytes),
+      width_(width),
+      height_(height),
+      format_(format),
+      resource_id_(id) {}
+
+MetalBackend::Texture2D::~Texture2D() { Reset(); }
+
+MetalBackend::Texture2D::Texture2D(Texture2D&& other) noexcept
+    : owner_(other.owner_),
+      native_(other.native_),
+      bytes_(other.bytes_),
+      width_(other.width_),
+      height_(other.height_),
+      format_(other.format_),
+      resource_id_(other.resource_id_) {
+  other.owner_       = nullptr;
+  other.native_      = nullptr;
+  other.bytes_       = 0;
+  other.width_       = 0;
+  other.height_      = 0;
+  other.resource_id_ = 0;
+}
+
+auto MetalBackend::Texture2D::operator=(Texture2D&& other) noexcept -> Texture2D& {
+  if (this != &other) {
+    Reset();
+    owner_             = other.owner_;
+    native_            = other.native_;
+    bytes_             = other.bytes_;
+    width_             = other.width_;
+    height_            = other.height_;
+    format_            = other.format_;
+    resource_id_       = other.resource_id_;
+    other.owner_       = nullptr;
+    other.native_      = nullptr;
+    other.bytes_       = 0;
+    other.width_       = 0;
+    other.height_      = 0;
+    other.resource_id_ = 0;
+  }
+  return *this;
+}
+
+void MetalBackend::Texture2D::Reset() noexcept {
+  if (native_ != nullptr) {
+    if (owner_ != nullptr) {
+      owner_->NoteFree();
+    }
+    static_cast<MTL::Texture*>(native_)->release();
+  }
+  owner_       = nullptr;
+  native_      = nullptr;
+  bytes_       = 0;
+  width_       = 0;
+  height_      = 0;
+  resource_id_ = 0;
+}
+
+MetalBackend::MetalBackend() : gpu_(std::make_unique<Gpu>()) { MetalBackendImpl::AttachGpu(*gpu_); }
+MetalBackend::~MetalBackend() = default;
+
+auto MetalBackend::CreateBuffer(std::size_t bytes) -> Buffer {
+  if (bytes == 0) {
+    return {};
+  }
+  MetalBackendImpl::AttachGpu(*gpu_);
+  auto* native = gpu_->device->newBuffer(bytes, ParameterResourceOptions(gpu_->device));
+  ThrowIfNull(native, "MetalBackend: failed to allocate parameter buffer");
+  NoteBufferCreate();
+  gpu_->live_buffers.push_back(LiveBuffer{native, native->gpuAddress(), bytes});
+  return Buffer{this, native, native->contents(), bytes, next_resource_id_++};
+}
+
+auto MetalBackend::CreateSlab(std::size_t bytes) -> Buffer {
+  if (bytes == 0) {
+    return {};
+  }
+  MetalBackendImpl::AttachGpu(*gpu_);
+  auto* native = MetalBackendImpl::AllocatePrivateBuffer(*this, *gpu_, bytes);
+  NoteBufferCreate();
+  gpu_->live_buffers.push_back(LiveBuffer{native, native->gpuAddress(), bytes});
+  return Buffer{this, native, reinterpret_cast<void*>(static_cast<uintptr_t>(native->gpuAddress())),
+                bytes, next_resource_id_++};
+}
+
+auto MetalBackend::CreateTexture2D(std::uint32_t width, std::uint32_t height, TextureFormat format)
+    -> Texture2D {
+  const auto bytes = static_cast<std::size_t>(width) * height * TextureFormatBytesPerPixel(format);
+  if (bytes == 0) {
+    return {};
+  }
+  MetalBackendImpl::AttachGpu(*gpu_);
+  auto  descriptor = MakePrivateTextureDescriptor(width, height, format);
+  auto* native     = MetalBackendImpl::AllocatePrivateTexture(*this, *gpu_, descriptor.get());
+  NoteTextureCreate();
+  return Texture2D{this, native, bytes, width, height, format, next_resource_id_++};
+}
+
+void MetalBackend::UploadBufferRange(Buffer& buffer, std::uint32_t offset,
+                                     std::span<const std::byte> bytes,
+                                     CommandContext&            command_context) {
+  if (fail_next_upload_) {
+    fail_next_upload_ = false;
+    throw std::runtime_error("MetalBackend::UploadBufferRange: injected failure");
+  }
+  if (bytes.empty()) {
+    return;
+  }
+  if (buffer.Empty() || static_cast<std::size_t>(offset) + bytes.size() > buffer.Bytes()) {
+    throw std::runtime_error("MetalBackend::UploadBufferRange: range exceeds buffer");
+  }
+  auto* native = static_cast<MTL::Buffer*>(buffer.Native());
+  if (native->contents() != nullptr) {
+    std::memcpy(static_cast<std::byte*>(native->contents()) + offset, bytes.data(), bytes.size());
+    MetalBackendImpl::MarkDidModifyIfManaged(native, offset, bytes.size());
+  } else {
+    MetalBackendImpl::AttachGpu(*gpu_);
+    MetalBackendImpl::EnsureStaging(*this, *gpu_, bytes.size());
+    std::memcpy(gpu_->staging->contents(), bytes.data(), bytes.size());
+    MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+    command_context.gpu_->blit->copyFromBuffer(gpu_->staging.get(), 0, native, offset,
+                                               bytes.size());
+  }
+  ++h2d_copy_count_;
+  h2d_bytes_ += bytes.size();
+  last_h2d_ranges_.push_back(ByteRange{offset, static_cast<std::uint32_t>(bytes.size())});
+}
+
+void MetalBackend::DownloadBufferRange(const Buffer& buffer, std::uint32_t offset,
+                                       std::span<std::byte> out, CommandContext& command_context) {
+  if (out.empty()) {
+    return;
+  }
+  if (buffer.Empty() || static_cast<std::size_t>(offset) + out.size() > buffer.Bytes()) {
+    throw std::runtime_error("MetalBackend::DownloadBufferRange: range exceeds buffer");
+  }
+  if (HasInFlightSubmission()) {
+    Wait(command_context);
+  }
+  auto* native = static_cast<MTL::Buffer*>(buffer.Native());
+  if (native->contents() == nullptr) {
+    throw std::runtime_error("MetalBackend::DownloadBufferRange: private buffer host map missing");
+  }
+  std::memcpy(out.data(), static_cast<const std::byte*>(native->contents()) + offset, out.size());
+}
+
+void MetalBackend::UploadTexture2D(Texture2D& texture, std::span<const std::byte> bytes,
+                                   CommandContext& command_context) {
+  if (fail_next_upload_) {
+    fail_next_upload_ = false;
+    throw std::runtime_error("MetalBackend::UploadTexture2D: injected failure");
+  }
+  if (texture.Native() == nullptr) {
+    throw std::runtime_error("MetalBackend::UploadTexture2D: empty texture");
+  }
+  if (bytes.size() != texture.Bytes()) {
+    throw std::runtime_error("MetalBackend::UploadTexture2D: size does not match texture");
+  }
+  if (bytes.empty()) {
+    return;
+  }
+  MetalBackendImpl::AttachGpu(*gpu_);
+  const auto row_bytes = AlignedRowBytes(texture.Width(), texture.Format());
+  const auto staging   = row_bytes * texture.Height();
+  MetalBackendImpl::EnsureStaging(*this, *gpu_, staging);
+  CopyPackedToAligned(bytes, texture.Width(), texture.Height(), texture.Format(),
+                      gpu_->staging->contents());
+  MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+  command_context.gpu_->blit->copyFromBuffer(
+      gpu_->staging.get(), 0, row_bytes, staging, MTL::Size{texture.Width(), texture.Height(), 1},
+      static_cast<MTL::Texture*>(texture.Native()), 0, 0, MTL::Origin{0, 0, 0});
+  ++h2d_copy_count_;
+  h2d_bytes_ += bytes.size();
+}
+
+void MetalBackend::CopyTexture2D(const Texture2D& src, Texture2D& dst,
+                                 CommandContext& command_context) {
+  if (src.Native() == nullptr || dst.Native() == nullptr) {
+    throw std::runtime_error("MetalBackend::CopyTexture2D: empty texture");
+  }
+  if (src.Width() != dst.Width() || src.Height() != dst.Height() || src.Format() != dst.Format()) {
+    throw std::runtime_error("MetalBackend::CopyTexture2D: size or format mismatch");
+  }
+  if (src.Bytes() == 0) {
+    return;
+  }
+  MetalBackendImpl::AttachGpu(*gpu_);
+  MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+  command_context.gpu_->blit->copyFromTexture(static_cast<MTL::Texture*>(src.Native()),
+                                              static_cast<MTL::Texture*>(dst.Native()));
+}
+
+void MetalBackend::UploadR8TextureRect(Texture2D& texture, RectI rectangle,
+                                       std::span<const std::byte> bytes,
+                                       CommandContext&            command_context) {
+  if (texture.Format() != TextureFormat::R8 || rectangle.x < 0 || rectangle.y < 0 ||
+      rectangle.width <= 0 || rectangle.height <= 0 ||
+      rectangle.X1() > static_cast<std::int32_t>(texture.Width()) ||
+      rectangle.Y1() > static_cast<std::int32_t>(texture.Height()) ||
+      bytes.size() != static_cast<std::size_t>(rectangle.width) * rectangle.height) {
+    throw std::runtime_error("MetalBackend::UploadR8TextureRect: invalid rectangle");
+  }
+  if (fail_next_upload_) {
+    fail_next_upload_ = false;
+    throw std::runtime_error("MetalBackend::UploadR8TextureRect: injected failure");
+  }
+  MetalBackendImpl::AttachGpu(*gpu_);
+  const auto width     = static_cast<std::uint32_t>(rectangle.width);
+  const auto height    = static_cast<std::uint32_t>(rectangle.height);
+  const auto row_bytes = AlignedRowBytes(width, TextureFormat::R8);
+  const auto staging   = row_bytes * height;
+  MetalBackendImpl::EnsureStaging(*this, *gpu_, staging);
+  CopyPackedToAligned(bytes, width, height, TextureFormat::R8, gpu_->staging->contents());
+  MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+  command_context.gpu_->blit->copyFromBuffer(
+      gpu_->staging.get(), 0, row_bytes, staging, MTL::Size{width, height, 1},
+      static_cast<MTL::Texture*>(texture.Native()), 0, 0,
+      MTL::Origin{static_cast<NS::UInteger>(rectangle.x), static_cast<NS::UInteger>(rectangle.y),
+                  0});
+  ++h2d_copy_count_;
+  h2d_bytes_ += bytes.size();
+  last_texture_rectangles_.push_back(rectangle);
+}
+
+void MetalBackend::DownloadTexture2D(const Texture2D& texture, std::span<std::byte> out,
+                                     CommandContext& command_context) {
+  if (texture.Native() == nullptr) {
+    throw std::runtime_error("MetalBackend::DownloadTexture2D: empty texture");
+  }
+  if (out.size() != texture.Bytes()) {
+    throw std::runtime_error("MetalBackend::DownloadTexture2D: size does not match texture");
+  }
+  if (out.empty()) {
+    return;
+  }
+  if (HasInFlightSubmission()) {
+    Wait(command_context);
+  }
+  MetalBackendImpl::AttachGpu(*gpu_);
+  const auto row_bytes = AlignedRowBytes(texture.Width(), texture.Format());
+  const auto staging   = row_bytes * texture.Height();
+  MetalBackendImpl::EnsureStaging(*this, *gpu_, staging);
+  MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+  command_context.gpu_->blit->copyFromTexture(
+      static_cast<MTL::Texture*>(texture.Native()), 0, 0, MTL::Origin{0, 0, 0},
+      MTL::Size{texture.Width(), texture.Height(), 1}, gpu_->staging.get(), 0, row_bytes, staging);
+  command_context.gpu_->EndEncoders();
+  if (command_context.gpu_->buffer) {
+    command_context.gpu_->buffer->commit();
+    command_context.gpu_->buffer->waitUntilCompleted();
+    command_context.gpu_->buffer.reset();
+  }
+  CopyAlignedToPacked(gpu_->staging->contents(), texture.Width(), texture.Height(),
+                      texture.Format(), out);
+}
+
+void MetalBackend::UploadDeviceMemory(void* dst, std::span<const std::byte> bytes,
+                                      CommandContext& command_context) {
+  if (fail_next_upload_) {
+    fail_next_upload_ = false;
+    throw std::runtime_error("MetalBackend::UploadDeviceMemory: injected failure");
+  }
+  if (bytes.empty()) {
+    return;
+  }
+  if (dst == nullptr) {
+    throw std::runtime_error("MetalBackend::UploadDeviceMemory: null destination");
+  }
+  MetalBackendImpl::AttachGpu(*gpu_);
+  const auto        address = reinterpret_cast<std::uint64_t>(dst);
+  const LiveBuffer* found   = nullptr;
+  for (const auto& entry : gpu_->live_buffers) {
+    if (address >= entry.gpu_address && address + bytes.size() <= entry.gpu_address + entry.bytes) {
+      found = &entry;
+      break;
+    }
+  }
+  if (found == nullptr) {
+    throw std::runtime_error("MetalBackend::UploadDeviceMemory: destination is not a live buffer");
+  }
+  const auto offset = static_cast<std::uint32_t>(address - found->gpu_address);
+  if (found->native->contents() != nullptr) {
+    std::memcpy(static_cast<std::byte*>(found->native->contents()) + offset, bytes.data(),
+                bytes.size());
+    MetalBackendImpl::MarkDidModifyIfManaged(found->native, offset, bytes.size());
+  } else {
+    MetalBackendImpl::EnsureStaging(*this, *gpu_, bytes.size());
+    std::memcpy(gpu_->staging->contents(), bytes.data(), bytes.size());
+    MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+    command_context.gpu_->blit->copyFromBuffer(gpu_->staging.get(), 0, found->native, offset,
+                                               bytes.size());
+  }
+  ++h2d_copy_count_;
+  h2d_bytes_ += bytes.size();
+}
+
+void MetalBackend::Submit(CommandContext& command_context) {
+  MetalBackendImpl::AttachGpu(*gpu_);
+  MetalBackendImpl::EnsureCommandBuffer(*gpu_, command_context);
+  command_context.gpu_->EndEncoders();
+  auto*      command_buffer = command_context.gpu_->buffer.get();
+  const auto submission_id  = command_context.SubmissionId();
+  command_buffer->addCompletedHandler(^(MTL::CommandBuffer*) {
+    (void)submission_id;
+  });
+  command_buffer->commit();
+  in_flight_submission_ = submission_id;
+}
+
+void MetalBackend::Wait(CommandContext& command_context) {
+  if (in_flight_submission_ == 0) {
+    if (command_context.gpu_) {
+      command_context.gpu_->Reset();
+    }
+    return;
+  }
+  auto* command_buffer = command_context.gpu_ ? command_context.gpu_->buffer.get() : nullptr;
+  if (command_buffer != nullptr) {
+    command_buffer->waitUntilCompleted();
+    if (command_buffer->status() == MTL::CommandBufferStatusError) {
+      std::string message = "MetalBackend: command buffer failed";
+      if (auto* error = command_buffer->error(); error != nullptr) {
+        if (auto* description = error->localizedDescription(); description != nullptr) {
+          message += ": ";
+          message += description->utf8String();
+        }
+      }
+      command_context.gpu_->Reset();
+      in_flight_submission_ = 0;
+      throw std::runtime_error(message);
+    }
+  }
+  completed_submission_ = in_flight_submission_;
+  in_flight_submission_ = 0;
+  if (command_context.gpu_) {
+    command_context.gpu_->Reset();
+  }
+}
+
+void MetalBackend::WarmUpPipelines(std::span<const MetalPipelineWarmup> pipelines) {
+  MetalBackendImpl::AttachGpu(*gpu_);
+  auto& cache = metal::ComputePipelineCache::Instance();
+  for (const auto& pipeline : pipelines) {
+    const char* label = pipeline.debug_label != nullptr ? pipeline.debug_label : "MetalBackend";
+    (void)cache.GetPipelineState(pipeline.metallib_path, pipeline.function_name, label);
+  }
+}
+
+void MetalBackend::WarmUpPlan(const ExecutionPlan& plan) { (void)plan; }
+
+void MetalBackend::ResetCounters() {
+  malloc_count_         = 0;
+  free_count_           = 0;
+  buffer_create_count_  = 0;
+  texture_create_count_ = 0;
+  heap_create_count_    = 0;
+  h2d_copy_count_       = 0;
+  h2d_bytes_            = 0;
+  last_h2d_ranges_.clear();
+  last_texture_rectangles_.clear();
+  if (gpu_) {
+    const auto stats               = metal::ComputePipelineCache::Instance().GetStats();
+    gpu_->pipeline_create_baseline = stats.creates;
+    gpu_->pipeline_hit_baseline    = stats.hits;
+  }
+}
+
+void MetalBackend::FailNextUpload() { fail_next_upload_ = true; }
+
+auto MetalBackend::NativeDevice() const -> void* {
+  return gpu_ ? static_cast<void*>(gpu_->device) : nullptr;
+}
+auto MetalBackend::NativeQueue() const -> void* {
+  return gpu_ ? static_cast<void*>(gpu_->queue) : nullptr;
+}
+auto MetalBackend::WorkingSetBudgetBytes() const -> std::size_t {
+  constexpr std::size_t kFloor = 256ull << 20;
+  if (gpu_ == nullptr || gpu_->device == nullptr) {
+    return kFloor;
+  }
+  const auto recommended = static_cast<std::size_t>(gpu_->device->recommendedMaxWorkingSetSize());
+  const auto usable      = recommended - recommended / 4;
+  return usable > kFloor ? usable : kFloor;
+}
+auto MetalBackend::PipelineCreateCount() const -> std::uint64_t {
+  const auto creates  = metal::ComputePipelineCache::Instance().GetStats().creates;
+  const auto baseline = gpu_ ? gpu_->pipeline_create_baseline : 0;
+  return creates > baseline ? creates - baseline : 0;
+}
+auto MetalBackend::PipelineHitCount() const -> std::uint64_t {
+  const auto hits     = metal::ComputePipelineCache::Instance().GetStats().hits;
+  const auto baseline = gpu_ ? gpu_->pipeline_hit_baseline : 0;
+  return hits > baseline ? hits - baseline : 0;
+}
+
+auto BindSystemDefaultMetalPresentationDevice() -> void* {
+  auto* device = MetalContext::Instance().Device();
+  if (device == nullptr) {
+    throw std::runtime_error("BindSystemDefaultMetalPresentationDevice: no Metal device");
+  }
+  MetalContext::BindPresentationDevice(device);
+  return device;
+}
+
+auto MetalPresentationDeviceHandle() -> void* { return MetalContext::Instance().Device(); }
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
@@ -17,6 +17,10 @@
 #include "metal/metal_context.hpp"
 
 namespace alcedo {
+void WarmUpMetalDagPlan(MetalBackend& backend, const ExecutionPlan& plan);
+}  // namespace alcedo
+
+namespace alcedo {
 namespace {
 
 constexpr std::size_t kMinHeapPageBytes = 16ull << 20;
@@ -38,6 +42,8 @@ auto ToPixelFormat(TextureFormat format) -> MTL::PixelFormat {
       return MTL::PixelFormatR32Float;
     case TextureFormat::Rgba32f:
       return MTL::PixelFormatRGBA32Float;
+    case TextureFormat::R16u:
+      return MTL::PixelFormatR16Uint;
   }
   throw std::runtime_error("MetalBackend: unsupported texture format");
 }
@@ -277,17 +283,20 @@ class MetalBackendImpl {
     return texture;
   }
 
-  static void EnsureCommandBuffer(MetalBackend::Gpu& gpu, MetalCommandContext& command_context) {
+  static void EnsureCommandBuffer(MetalBackend& backend, MetalBackend::Gpu& gpu,
+                                  MetalCommandContext& command_context) {
     auto& ctx = *command_context.gpu_;
     if (ctx.buffer) {
       return;
     }
     ctx.buffer = NS::RetainPtr(gpu.queue->commandBuffer());
     ThrowIfNull(ctx.buffer.get(), "MetalBackend: failed to create MTLCommandBuffer");
+    ++backend.command_buffer_create_count_;
   }
 
-  static void EnsureBlitEncoder(MetalBackend::Gpu& gpu, MetalCommandContext& command_context) {
-    EnsureCommandBuffer(gpu, command_context);
+  static void EnsureBlitEncoder(MetalBackend& backend, MetalBackend::Gpu& gpu,
+                                MetalCommandContext& command_context) {
+    EnsureCommandBuffer(backend, gpu, command_context);
     auto& ctx = *command_context.gpu_;
     if (ctx.compute) {
       ctx.compute->endEncoding();
@@ -296,6 +305,20 @@ class MetalBackendImpl {
     if (!ctx.blit) {
       ctx.blit = NS::RetainPtr(ctx.buffer->blitCommandEncoder());
       ThrowIfNull(ctx.blit.get(), "MetalBackend: failed to create blit encoder");
+    }
+  }
+
+  static void EnsureComputeEncoder(MetalBackend& backend, MetalBackend::Gpu& gpu,
+                                   MetalCommandContext& command_context) {
+    EnsureCommandBuffer(backend, gpu, command_context);
+    auto& ctx = *command_context.gpu_;
+    if (ctx.blit) {
+      ctx.blit->endEncoding();
+      ctx.blit.reset();
+    }
+    if (!ctx.compute) {
+      ctx.compute = NS::RetainPtr(ctx.buffer->computeCommandEncoder());
+      ThrowIfNull(ctx.compute.get(), "MetalBackend: failed to create compute encoder");
     }
   }
 
@@ -495,7 +518,7 @@ void MetalBackend::UploadBufferRange(Buffer& buffer, std::uint32_t offset,
     MetalBackendImpl::AttachGpu(*gpu_);
     MetalBackendImpl::EnsureStaging(*this, *gpu_, bytes.size());
     std::memcpy(gpu_->staging->contents(), bytes.data(), bytes.size());
-    MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+    MetalBackendImpl::EnsureBlitEncoder(*this, *gpu_, command_context);
     command_context.gpu_->blit->copyFromBuffer(gpu_->staging.get(), 0, native, offset,
                                                bytes.size());
   }
@@ -543,7 +566,7 @@ void MetalBackend::UploadTexture2D(Texture2D& texture, std::span<const std::byte
   MetalBackendImpl::EnsureStaging(*this, *gpu_, staging);
   CopyPackedToAligned(bytes, texture.Width(), texture.Height(), texture.Format(),
                       gpu_->staging->contents());
-  MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+  MetalBackendImpl::EnsureBlitEncoder(*this, *gpu_, command_context);
   command_context.gpu_->blit->copyFromBuffer(
       gpu_->staging.get(), 0, row_bytes, staging, MTL::Size{texture.Width(), texture.Height(), 1},
       static_cast<MTL::Texture*>(texture.Native()), 0, 0, MTL::Origin{0, 0, 0});
@@ -563,7 +586,7 @@ void MetalBackend::CopyTexture2D(const Texture2D& src, Texture2D& dst,
     return;
   }
   MetalBackendImpl::AttachGpu(*gpu_);
-  MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+  MetalBackendImpl::EnsureBlitEncoder(*this, *gpu_, command_context);
   command_context.gpu_->blit->copyFromTexture(static_cast<MTL::Texture*>(src.Native()),
                                               static_cast<MTL::Texture*>(dst.Native()));
 }
@@ -589,7 +612,7 @@ void MetalBackend::UploadR8TextureRect(Texture2D& texture, RectI rectangle,
   const auto staging   = row_bytes * height;
   MetalBackendImpl::EnsureStaging(*this, *gpu_, staging);
   CopyPackedToAligned(bytes, width, height, TextureFormat::R8, gpu_->staging->contents());
-  MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+  MetalBackendImpl::EnsureBlitEncoder(*this, *gpu_, command_context);
   command_context.gpu_->blit->copyFromBuffer(
       gpu_->staging.get(), 0, row_bytes, staging, MTL::Size{width, height, 1},
       static_cast<MTL::Texture*>(texture.Native()), 0, 0,
@@ -618,7 +641,7 @@ void MetalBackend::DownloadTexture2D(const Texture2D& texture, std::span<std::by
   const auto row_bytes = AlignedRowBytes(texture.Width(), texture.Format());
   const auto staging   = row_bytes * texture.Height();
   MetalBackendImpl::EnsureStaging(*this, *gpu_, staging);
-  MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+  MetalBackendImpl::EnsureBlitEncoder(*this, *gpu_, command_context);
   command_context.gpu_->blit->copyFromTexture(
       static_cast<MTL::Texture*>(texture.Native()), 0, 0, MTL::Origin{0, 0, 0},
       MTL::Size{texture.Width(), texture.Height(), 1}, gpu_->staging.get(), 0, row_bytes, staging);
@@ -664,7 +687,7 @@ void MetalBackend::UploadDeviceMemory(void* dst, std::span<const std::byte> byte
   } else {
     MetalBackendImpl::EnsureStaging(*this, *gpu_, bytes.size());
     std::memcpy(gpu_->staging->contents(), bytes.data(), bytes.size());
-    MetalBackendImpl::EnsureBlitEncoder(*gpu_, command_context);
+    MetalBackendImpl::EnsureBlitEncoder(*this, *gpu_, command_context);
     command_context.gpu_->blit->copyFromBuffer(gpu_->staging.get(), 0, found->native, offset,
                                                bytes.size());
   }
@@ -672,9 +695,60 @@ void MetalBackend::UploadDeviceMemory(void* dst, std::span<const std::byte> byte
   h2d_bytes_ += bytes.size();
 }
 
+auto MetalBackend::ResolveDeviceMemory(void* device_pointer, std::size_t bytes) const
+    -> std::pair<void*, std::uint32_t> {
+  if (device_pointer == nullptr || bytes == 0 || !gpu_) {
+    throw std::runtime_error("MetalBackend::ResolveDeviceMemory: invalid destination");
+  }
+  const auto address = reinterpret_cast<std::uint64_t>(device_pointer);
+  for (const auto& entry : gpu_->live_buffers) {
+    if (address >= entry.gpu_address && address + bytes <= entry.gpu_address + entry.bytes) {
+      return {entry.native, static_cast<std::uint32_t>(address - entry.gpu_address)};
+    }
+  }
+  throw std::runtime_error("MetalBackend::ResolveDeviceMemory: destination is not a live buffer");
+}
+
+void MetalBackend::FillDeviceMemory(void* dst, std::size_t bytes, std::uint8_t value,
+                                    CommandContext& command_context) {
+  if (bytes == 0) {
+    return;
+  }
+  if (dst == nullptr) {
+    throw std::runtime_error("MetalBackend::FillDeviceMemory: null destination");
+  }
+  MetalBackendImpl::AttachGpu(*gpu_);
+  const auto        address = reinterpret_cast<std::uint64_t>(dst);
+  const LiveBuffer* found   = nullptr;
+  for (const auto& entry : gpu_->live_buffers) {
+    if (address >= entry.gpu_address && address + bytes <= entry.gpu_address + entry.bytes) {
+      found = &entry;
+      break;
+    }
+  }
+  if (found == nullptr) {
+    throw std::runtime_error("MetalBackend::FillDeviceMemory: destination is not a live buffer");
+  }
+  const auto offset = static_cast<NS::UInteger>(address - found->gpu_address);
+  MetalBackendImpl::EnsureBlitEncoder(*this, *gpu_, command_context);
+  command_context.gpu_->blit->fillBuffer(found->native, NS::Range(offset, bytes), value);
+}
+
+auto MetalBackend::EnsureComputeCommandEncoder(CommandContext& command_context) -> void* {
+  MetalBackendImpl::AttachGpu(*gpu_);
+  MetalBackendImpl::EnsureComputeEncoder(*this, *gpu_, command_context);
+  return command_context.gpu_->compute.get();
+}
+
+void MetalBackend::EndCommandEncoders(CommandContext& command_context) {
+  if (command_context.gpu_) {
+    command_context.gpu_->EndEncoders();
+  }
+}
+
 void MetalBackend::Submit(CommandContext& command_context) {
   MetalBackendImpl::AttachGpu(*gpu_);
-  MetalBackendImpl::EnsureCommandBuffer(*gpu_, command_context);
+  MetalBackendImpl::EnsureCommandBuffer(*this, *gpu_, command_context);
   command_context.gpu_->EndEncoders();
   auto*      command_buffer = command_context.gpu_->buffer.get();
   const auto submission_id  = command_context.SubmissionId();
@@ -724,15 +798,16 @@ void MetalBackend::WarmUpPipelines(std::span<const MetalPipelineWarmup> pipeline
   }
 }
 
-void MetalBackend::WarmUpPlan(const ExecutionPlan& plan) { (void)plan; }
+void MetalBackend::WarmUpPlan(const ExecutionPlan& plan) { WarmUpMetalDagPlan(*this, plan); }
 
 void MetalBackend::ResetCounters() {
   malloc_count_         = 0;
   free_count_           = 0;
   buffer_create_count_  = 0;
   texture_create_count_ = 0;
-  heap_create_count_    = 0;
-  h2d_copy_count_       = 0;
+  heap_create_count_            = 0;
+  command_buffer_create_count_  = 0;
+  h2d_copy_count_               = 0;
   h2d_bytes_            = 0;
   last_h2d_ranges_.clear();
   last_texture_rectangles_.clear();

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
@@ -734,6 +734,25 @@ void MetalBackend::FillDeviceMemory(void* dst, std::size_t bytes, std::uint8_t v
   command_context.gpu_->blit->fillBuffer(found->native, NS::Range(offset, bytes), value);
 }
 
+void MetalBackend::CopyDeviceMemoryToBuffer(void* src, Buffer& dst, std::uint32_t dst_offset,
+                                            std::size_t bytes, CommandContext& command_context) {
+  if (bytes == 0) {
+    return;
+  }
+  if (src == nullptr || dst.Empty() || dst.Native() == nullptr) {
+    throw std::runtime_error("MetalBackend::CopyDeviceMemoryToBuffer: null source or destination");
+  }
+  if (static_cast<std::size_t>(dst_offset) + bytes > dst.Bytes()) {
+    throw std::runtime_error("MetalBackend::CopyDeviceMemoryToBuffer: range exceeds destination");
+  }
+  const auto resolved = ResolveDeviceMemory(src, bytes);
+  MetalBackendImpl::AttachGpu(*gpu_);
+  MetalBackendImpl::EnsureBlitEncoder(*this, *gpu_, command_context);
+  command_context.gpu_->blit->copyFromBuffer(
+      static_cast<MTL::Buffer*>(resolved.first), resolved.second,
+      static_cast<MTL::Buffer*>(dst.Native()), dst_offset, bytes);
+}
+
 auto MetalBackend::EnsureComputeCommandEncoder(CommandContext& command_context) -> void* {
   MetalBackendImpl::AttachGpu(*gpu_);
   MetalBackendImpl::EnsureComputeEncoder(*this, *gpu_, command_context);
@@ -849,16 +868,16 @@ auto MetalBackend::DummyLut() -> MetalLutBinding {
 void MetalBackend::SetLutByteBudget(std::size_t bytes) { lut_byte_budget_ = bytes; }
 
 void MetalBackend::ResetCounters() {
-  malloc_count_         = 0;
-  free_count_           = 0;
-  buffer_create_count_  = 0;
-  texture_create_count_ = 0;
-  heap_create_count_            = 0;
-  command_buffer_create_count_  = 0;
-  h2d_copy_count_               = 0;
-  h2d_bytes_            = 0;
-  compute_dispatch_count_       = 0;
-  lut_upload_bytes_             = 0;
+  malloc_count_                = 0;
+  free_count_                  = 0;
+  buffer_create_count_         = 0;
+  texture_create_count_        = 0;
+  heap_create_count_           = 0;
+  command_buffer_create_count_ = 0;
+  h2d_copy_count_              = 0;
+  h2d_bytes_                   = 0;
+  compute_dispatch_count_      = 0;
+  lut_upload_bytes_            = 0;
   last_h2d_ranges_.clear();
   last_texture_rectangles_.clear();
   if (gpu_) {

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
@@ -800,6 +800,54 @@ void MetalBackend::WarmUpPipelines(std::span<const MetalPipelineWarmup> pipeline
 
 void MetalBackend::WarmUpPlan(const ExecutionPlan& plan) { WarmUpMetalDagPlan(*this, plan); }
 
+auto MetalBackend::AcquireLut(ContentKey key, std::span<const std::byte> packed_rgba,
+                              std::uint32_t edge, CommandContext&) -> MetalLutBinding {
+  if (key.Empty() || edge <= 1 || packed_rgba.empty()) {
+    return DummyLut();
+  }
+  for (auto& entry : lut_cache_) {
+    if (entry.key == key && entry.edge_size == edge) {
+      last_lut_resource_id_ = entry.buffer.ResourceId();
+      return MetalLutBinding{entry.buffer.Native(), entry.buffer.ResourceId(), entry.edge_size};
+    }
+  }
+  if (lut_byte_budget_ > 0 && lut_cache_bytes_ + packed_rgba.size() > lut_byte_budget_) {
+    while (!lut_cache_.empty() && lut_cache_bytes_ + packed_rgba.size() > lut_byte_budget_) {
+      lut_cache_bytes_ -= lut_cache_.front().bytes;
+      lut_cache_.erase(lut_cache_.begin());
+    }
+  }
+  auto buffer = CreateBuffer(packed_rgba.size());
+  if (buffer.Empty() || buffer.DevicePointer() == nullptr) {
+    throw std::runtime_error("MetalBackend::AcquireLut: failed to allocate LUT buffer");
+  }
+  std::memcpy(buffer.DevicePointer(), packed_rgba.data(), packed_rgba.size());
+  MetalBackendImpl::MarkDidModifyIfManaged(static_cast<MTL::Buffer*>(buffer.Native()), 0,
+                                           packed_rgba.size());
+  lut_upload_bytes_ += packed_rgba.size();
+  last_lut_resource_id_ = buffer.ResourceId();
+  LutCacheEntry entry;
+  entry.key       = key;
+  entry.edge_size = edge;
+  entry.bytes     = packed_rgba.size();
+  entry.buffer    = std::move(buffer);
+  lut_cache_bytes_ += entry.bytes;
+  lut_cache_.push_back(std::move(entry));
+  return MetalLutBinding{lut_cache_.back().buffer.Native(), last_lut_resource_id_, edge};
+}
+
+auto MetalBackend::DummyLut() -> MetalLutBinding {
+  if (dummy_lut_.Empty()) {
+    dummy_lut_ = CreateBuffer(16);
+    if (dummy_lut_.DevicePointer() != nullptr) {
+      std::memset(dummy_lut_.DevicePointer(), 0, dummy_lut_.Bytes());
+    }
+  }
+  return MetalLutBinding{dummy_lut_.Native(), dummy_lut_.ResourceId(), 0};
+}
+
+void MetalBackend::SetLutByteBudget(std::size_t bytes) { lut_byte_budget_ = bytes; }
+
 void MetalBackend::ResetCounters() {
   malloc_count_         = 0;
   free_count_           = 0;
@@ -809,6 +857,8 @@ void MetalBackend::ResetCounters() {
   command_buffer_create_count_  = 0;
   h2d_copy_count_               = 0;
   h2d_bytes_            = 0;
+  compute_dispatch_count_       = 0;
+  lut_upload_bytes_             = 0;
   last_h2d_ranges_.clear();
   last_texture_rectangles_.clear();
   if (gpu_) {

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
@@ -147,6 +147,16 @@ void MetalBackend::DownloadTexture2D(const Texture2D&, std::span<std::byte>, Com
 void MetalBackend::UploadDeviceMemory(void*, std::span<const std::byte>, CommandContext&) {
   throw std::runtime_error("MetalBackend: device memory upload is not implemented");
 }
+void MetalBackend::FillDeviceMemory(void*, std::size_t, std::uint8_t, CommandContext&) {
+  throw std::runtime_error("MetalBackend: device memory fill is not implemented");
+}
+auto MetalBackend::ResolveDeviceMemory(void*, std::size_t) const -> std::pair<void*, std::uint32_t> {
+  throw std::runtime_error("MetalBackend: device memory resolve is not implemented");
+}
+auto MetalBackend::EnsureComputeCommandEncoder(CommandContext&) -> void* {
+  throw std::runtime_error("MetalBackend: compute encoder is not implemented");
+}
+void MetalBackend::EndCommandEncoders(CommandContext&) {}
 void MetalBackend::Submit(CommandContext& command_context) {
   in_flight_submission_ = command_context.SubmissionId();
 }
@@ -166,8 +176,9 @@ void MetalBackend::ResetCounters() {
   free_count_           = 0;
   buffer_create_count_  = 0;
   texture_create_count_ = 0;
-  heap_create_count_    = 0;
-  h2d_copy_count_       = 0;
+  heap_create_count_           = 0;
+  command_buffer_create_count_ = 0;
+  h2d_copy_count_              = 0;
   h2d_bytes_            = 0;
   last_h2d_ranges_.clear();
   last_texture_rectangles_.clear();

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
@@ -150,7 +150,8 @@ void MetalBackend::UploadDeviceMemory(void*, std::span<const std::byte>, Command
 void MetalBackend::FillDeviceMemory(void*, std::size_t, std::uint8_t, CommandContext&) {
   throw std::runtime_error("MetalBackend: device memory fill is not implemented");
 }
-auto MetalBackend::ResolveDeviceMemory(void*, std::size_t) const -> std::pair<void*, std::uint32_t> {
+auto MetalBackend::ResolveDeviceMemory(void*, std::size_t) const
+    -> std::pair<void*, std::uint32_t> {
   throw std::runtime_error("MetalBackend: device memory resolve is not implemented");
 }
 auto MetalBackend::EnsureComputeCommandEncoder(CommandContext&) -> void* {
@@ -171,15 +172,25 @@ void MetalBackend::WarmUpPipelines(std::span<const MetalPipelineWarmup>) {
   throw std::runtime_error("MetalBackend: pipeline warm-up is not implemented");
 }
 void MetalBackend::WarmUpPlan(const ExecutionPlan&) {}
+auto MetalBackend::AcquireLut(ContentKey, std::span<const std::byte>, std::uint32_t,
+                              CommandContext&) -> MetalLutBinding {
+  throw std::runtime_error("MetalBackend: LUT cache is not implemented");
+}
+auto MetalBackend::DummyLut() -> MetalLutBinding {
+  throw std::runtime_error("MetalBackend: LUT cache is not implemented");
+}
+void MetalBackend::SetLutByteBudget(std::size_t) {}
 void MetalBackend::ResetCounters() {
-  malloc_count_         = 0;
-  free_count_           = 0;
-  buffer_create_count_  = 0;
-  texture_create_count_ = 0;
+  malloc_count_                = 0;
+  free_count_                  = 0;
+  buffer_create_count_         = 0;
+  texture_create_count_        = 0;
   heap_create_count_           = 0;
   command_buffer_create_count_ = 0;
   h2d_copy_count_              = 0;
-  h2d_bytes_            = 0;
+  h2d_bytes_                   = 0;
+  compute_dispatch_count_      = 0;
+  lut_upload_bytes_            = 0;
   last_h2d_ranges_.clear();
   last_texture_rectangles_.clear();
 }

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
@@ -1,0 +1,187 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <stdexcept>
+#include <utility>
+
+#include "edit/runtime/metal/metal_backend.hpp"
+
+namespace alcedo {
+
+class MetalCommandContext::Gpu {};
+
+MetalCommandContext::MetalCommandContext()  = default;
+MetalCommandContext::~MetalCommandContext() = default;
+MetalCommandContext::MetalCommandContext(MetalCommandContext&& other) noexcept
+    : gpu_(std::move(other.gpu_)), submission_id_(other.submission_id_) {
+  other.submission_id_ = 0;
+}
+auto MetalCommandContext::operator=(MetalCommandContext&& other) noexcept -> MetalCommandContext& {
+  if (this != &other) {
+    gpu_                 = std::move(other.gpu_);
+    submission_id_       = other.submission_id_;
+    other.submission_id_ = 0;
+  }
+  return *this;
+}
+auto MetalCommandContext::NativeCommandBuffer() const -> void* { return nullptr; }
+
+class MetalBackend::Gpu {};
+
+MetalBackend::Buffer::Buffer(MetalBackend*, void*, void*, std::size_t, std::uint64_t) {}
+MetalBackend::Buffer::~Buffer() { Reset(); }
+MetalBackend::Buffer::Buffer(Buffer&& other) noexcept
+    : owner_(other.owner_),
+      native_(other.native_),
+      ptr_(other.ptr_),
+      bytes_(other.bytes_),
+      resource_id_(other.resource_id_) {
+  other.owner_       = nullptr;
+  other.native_      = nullptr;
+  other.ptr_         = nullptr;
+  other.bytes_       = 0;
+  other.resource_id_ = 0;
+}
+auto MetalBackend::Buffer::operator=(Buffer&& other) noexcept -> Buffer& {
+  if (this != &other) {
+    Reset();
+    owner_             = other.owner_;
+    native_            = other.native_;
+    ptr_               = other.ptr_;
+    bytes_             = other.bytes_;
+    resource_id_       = other.resource_id_;
+    other.owner_       = nullptr;
+    other.native_      = nullptr;
+    other.ptr_         = nullptr;
+    other.bytes_       = 0;
+    other.resource_id_ = 0;
+  }
+  return *this;
+}
+void MetalBackend::Buffer::Reset() noexcept {
+  native_      = nullptr;
+  ptr_         = nullptr;
+  owner_       = nullptr;
+  bytes_       = 0;
+  resource_id_ = 0;
+}
+
+MetalBackend::Texture2D::Texture2D(MetalBackend*, void*, std::size_t, std::uint32_t, std::uint32_t,
+                                   TextureFormat, std::uint64_t) {}
+MetalBackend::Texture2D::~Texture2D() { Reset(); }
+MetalBackend::Texture2D::Texture2D(Texture2D&& other) noexcept
+    : owner_(other.owner_),
+      native_(other.native_),
+      bytes_(other.bytes_),
+      width_(other.width_),
+      height_(other.height_),
+      format_(other.format_),
+      resource_id_(other.resource_id_) {
+  other.owner_       = nullptr;
+  other.native_      = nullptr;
+  other.bytes_       = 0;
+  other.width_       = 0;
+  other.height_      = 0;
+  other.resource_id_ = 0;
+}
+auto MetalBackend::Texture2D::operator=(Texture2D&& other) noexcept -> Texture2D& {
+  if (this != &other) {
+    Reset();
+    owner_             = other.owner_;
+    native_            = other.native_;
+    bytes_             = other.bytes_;
+    width_             = other.width_;
+    height_            = other.height_;
+    format_            = other.format_;
+    resource_id_       = other.resource_id_;
+    other.owner_       = nullptr;
+    other.native_      = nullptr;
+    other.bytes_       = 0;
+    other.width_       = 0;
+    other.height_      = 0;
+    other.resource_id_ = 0;
+  }
+  return *this;
+}
+void MetalBackend::Texture2D::Reset() noexcept {
+  native_      = nullptr;
+  owner_       = nullptr;
+  bytes_       = 0;
+  width_       = 0;
+  height_      = 0;
+  resource_id_ = 0;
+}
+
+MetalBackend::MetalBackend()  = default;
+MetalBackend::~MetalBackend() = default;
+
+auto MetalBackend::CreateBuffer(std::size_t) -> Buffer {
+  throw std::runtime_error("MetalBackend: GPU buffer allocation is not implemented");
+}
+auto MetalBackend::CreateSlab(std::size_t bytes) -> Buffer { return CreateBuffer(bytes); }
+auto MetalBackend::CreateTexture2D(std::uint32_t, std::uint32_t, TextureFormat) -> Texture2D {
+  throw std::runtime_error("MetalBackend: GPU texture allocation is not implemented");
+}
+void MetalBackend::UploadBufferRange(Buffer&, std::uint32_t, std::span<const std::byte>,
+                                     CommandContext&) {
+  throw std::runtime_error("MetalBackend: buffer upload is not implemented");
+}
+void MetalBackend::DownloadBufferRange(const Buffer&, std::uint32_t, std::span<std::byte>,
+                                       CommandContext&) {
+  throw std::runtime_error("MetalBackend: buffer download is not implemented");
+}
+void MetalBackend::UploadTexture2D(Texture2D&, std::span<const std::byte>, CommandContext&) {
+  throw std::runtime_error("MetalBackend: texture upload is not implemented");
+}
+void MetalBackend::CopyTexture2D(const Texture2D&, Texture2D&, CommandContext&) {
+  throw std::runtime_error("MetalBackend: texture copy is not implemented");
+}
+void MetalBackend::UploadR8TextureRect(Texture2D&, RectI, std::span<const std::byte>,
+                                       CommandContext&) {
+  throw std::runtime_error("MetalBackend: R8 upload is not implemented");
+}
+void MetalBackend::DownloadTexture2D(const Texture2D&, std::span<std::byte>, CommandContext&) {
+  throw std::runtime_error("MetalBackend: texture download is not implemented");
+}
+void MetalBackend::UploadDeviceMemory(void*, std::span<const std::byte>, CommandContext&) {
+  throw std::runtime_error("MetalBackend: device memory upload is not implemented");
+}
+void MetalBackend::Submit(CommandContext& command_context) {
+  in_flight_submission_ = command_context.SubmissionId();
+}
+void MetalBackend::Wait(CommandContext&) {
+  if (in_flight_submission_ == 0) {
+    return;
+  }
+  completed_submission_ = in_flight_submission_;
+  in_flight_submission_ = 0;
+}
+void MetalBackend::WarmUpPipelines(std::span<const MetalPipelineWarmup>) {
+  throw std::runtime_error("MetalBackend: pipeline warm-up is not implemented");
+}
+void MetalBackend::WarmUpPlan(const ExecutionPlan&) {}
+void MetalBackend::ResetCounters() {
+  malloc_count_         = 0;
+  free_count_           = 0;
+  buffer_create_count_  = 0;
+  texture_create_count_ = 0;
+  heap_create_count_    = 0;
+  h2d_copy_count_       = 0;
+  h2d_bytes_            = 0;
+  last_h2d_ranges_.clear();
+  last_texture_rectangles_.clear();
+}
+void MetalBackend::FailNextUpload() { fail_next_upload_ = true; }
+auto MetalBackend::NativeDevice() const -> void* { return nullptr; }
+auto MetalBackend::NativeQueue() const -> void* { return nullptr; }
+auto MetalBackend::WorkingSetBudgetBytes() const -> std::size_t {
+  return DefaultTextureBudgetBytes();
+}
+auto MetalBackend::PipelineCreateCount() const -> std::uint64_t { return 0; }
+auto MetalBackend::PipelineHitCount() const -> std::uint64_t { return 0; }
+
+auto BindSystemDefaultMetalPresentationDevice() -> void* { return nullptr; }
+auto MetalPresentationDeviceHandle() -> void* { return nullptr; }
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
@@ -150,6 +150,10 @@ void MetalBackend::UploadDeviceMemory(void*, std::span<const std::byte>, Command
 void MetalBackend::FillDeviceMemory(void*, std::size_t, std::uint8_t, CommandContext&) {
   throw std::runtime_error("MetalBackend: device memory fill is not implemented");
 }
+void MetalBackend::CopyDeviceMemoryToBuffer(void*, Buffer&, std::uint32_t, std::size_t,
+                                            CommandContext&) {
+  throw std::runtime_error("MetalBackend: device memory copy is not implemented");
+}
 auto MetalBackend::ResolveDeviceMemory(void*, std::size_t) const
     -> std::pair<void*, std::uint32_t> {
   throw std::runtime_error("MetalBackend: device memory resolve is not implemented");

--- a/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
@@ -1,0 +1,531 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/metal/metal_develop_pass.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <alcedo/metal/Metal.hpp>
+#include <opencv2/core/types.hpp>
+
+#include <algorithm>
+
+#include "decoders/processor/nn/demosaicnet_preprocess_common.hpp"
+#include "decoders/processor/nn/metal_demosaicnet_tiled.hpp"
+#include "decoders/processor/operators/gpu/metal_encode.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/graph/develop_color_transform.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/operator_param_dto.hpp"
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/runtime/camera_color_gpu_params.hpp"
+#include "edit/runtime/develop_demosaic.hpp"
+#include "edit/runtime/parameter_arena.hpp"
+#include "edit/runtime/parameter_binding.hpp"
+#include "edit/runtime/texture_format.hpp"
+#include "image/metal_image.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+
+namespace alcedo {
+namespace {
+
+MetalDemosaicNetModelCache* g_metal_neural_cache_for_test = nullptr;
+
+struct GeometryResampleParams {
+  float        m00;
+  float        m01;
+  float        m02;
+  float        m10;
+  float        m11;
+  float        m12;
+  std::uint32_t decoded_width;
+  std::uint32_t decoded_height;
+  std::uint32_t render_width;
+  std::uint32_t render_height;
+  float        border[4];
+  std::uint32_t use_bicubic;
+};
+
+auto AcquireRgba(MetalRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
+                 std::uint32_t height) -> ResourceLease<MetalBackend>& {
+  return workspace.AcquireImageForWrite(id, {width, height, TextureFormat::Rgba32f});
+}
+
+auto AcquireScratch(MetalRenderWorkspace& workspace, std::uint32_t width, std::uint32_t height,
+                    TextureFormat format) -> ResourceLease<MetalBackend> {
+  return workspace.Textures().Acquire({width, height, format});
+}
+
+auto CommandBuffer(MetalRenderDevice& device) -> void* {
+  device.Workspace().Device().EndCommandEncoders(device.CommandContext());
+  auto* buffer = device.CommandContext().NativeCommandBuffer();
+  if (buffer == nullptr) {
+    (void)device.Workspace().Device().EnsureComputeCommandEncoder(device.CommandContext());
+    device.Workspace().Device().EndCommandEncoders(device.CommandContext());
+    buffer = device.CommandContext().NativeCommandBuffer();
+  }
+  if (buffer == nullptr) {
+    throw std::runtime_error("ExecuteMetalDevelop: command buffer is missing");
+  }
+  return buffer;
+}
+
+auto Native(const MetalBackend::Texture2D& texture) -> void* { return texture.Native(); }
+
+void DispatchGeometryResample(void* command_buffer, const ResolvedRenderGeometry& geometry,
+                              const MetalBackend::Texture2D& src, MetalBackend::Texture2D& dst) {
+#ifndef ALCEDO_METAL_GEOMETRY_RESAMPLE_METALLIB_PATH
+  throw std::runtime_error("Metal geometry resample metallib path is not configured.");
+#else
+  auto pipeline = metal::ComputePipelineCache::Instance().GetPipelineState(
+      ALCEDO_METAL_GEOMETRY_RESAMPLE_METALLIB_PATH, "geometry_resample_rgba32f",
+      "Metal GeometryResample");
+#endif
+  const auto& gpu = geometry.gpu_data;
+  GeometryResampleParams params{
+      .m00            = gpu.render_to_decoded[0],
+      .m01            = gpu.render_to_decoded[1],
+      .m02            = gpu.render_to_decoded[2],
+      .m10            = gpu.render_to_decoded[3],
+      .m11            = gpu.render_to_decoded[4],
+      .m12            = gpu.render_to_decoded[5],
+      .decoded_width  = gpu.decoded_width,
+      .decoded_height = gpu.decoded_height,
+      .render_width   = gpu.render_width,
+      .render_height  = gpu.render_height,
+      .border         = {gpu.border_rgba[0], gpu.border_rgba[1], gpu.border_rgba[2],
+                         gpu.border_rgba[3]},
+      .use_bicubic    = geometry.filter == TextureFilter::Bicubic ? 1U : 0U,
+  };
+  auto* buffer  = static_cast<MTL::CommandBuffer*>(command_buffer);
+  auto  compute = NS::RetainPtr(buffer->computeCommandEncoder());
+  if (!compute) {
+    throw std::runtime_error("ExecuteMetalGeometryResample: failed to create compute encoder");
+  }
+  compute->setComputePipelineState(pipeline.get());
+  compute->setTexture(static_cast<MTL::Texture*>(src.Native()), 0);
+  compute->setTexture(static_cast<MTL::Texture*>(dst.Native()), 1);
+  compute->setBytes(&params, sizeof(params), 0);
+  const auto thread_width = std::max<NS::UInteger>(1, pipeline->threadExecutionWidth());
+  const auto thread_height =
+      std::max<NS::UInteger>(1, pipeline->maxTotalThreadsPerThreadgroup() / thread_width);
+  compute->dispatchThreads(MTL::Size{gpu.render_width, gpu.render_height, 1},
+                           MTL::Size{thread_width, thread_height, 1});
+  compute->endEncoding();
+}
+
+void DispatchCameraColor(void* command_buffer, const MetalBackend::Texture2D& src,
+                         MetalBackend::Texture2D& dst, const MetalBackend::Buffer& params,
+                         std::uint32_t offset) {
+#ifndef ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH
+  throw std::runtime_error("Metal camera color metallib path is not configured.");
+#else
+  auto pipeline = metal::ComputePipelineCache::Instance().GetPipelineState(
+      ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH, "camera_color_acescc", "Metal CameraColor");
+#endif
+  auto* buffer  = static_cast<MTL::CommandBuffer*>(command_buffer);
+  auto  compute = NS::RetainPtr(buffer->computeCommandEncoder());
+  if (!compute) {
+    throw std::runtime_error("ExecuteMetalCameraColor: failed to create compute encoder");
+  }
+  compute->setComputePipelineState(pipeline.get());
+  compute->setTexture(static_cast<MTL::Texture*>(src.Native()), 0);
+  compute->setTexture(static_cast<MTL::Texture*>(dst.Native()), 1);
+  compute->setBuffer(static_cast<MTL::Buffer*>(params.Native()), offset, 0);
+  const auto thread_width = std::max<NS::UInteger>(1, pipeline->threadExecutionWidth());
+  const auto thread_height =
+      std::max<NS::UInteger>(1, pipeline->maxTotalThreadsPerThreadgroup() / thread_width);
+  compute->dispatchThreads(MTL::Size{src.Width(), src.Height(), 1},
+                           MTL::Size{thread_width, thread_height, 1});
+  compute->endEncoding();
+}
+
+auto CropOrFull(const PreparedRawInput& input, std::uint32_t width, std::uint32_t height) -> RectI {
+  if (input.demosaic_output_crop.width > 0 && input.demosaic_output_crop.height > 0) {
+    return input.demosaic_output_crop;
+  }
+  return RectI{0, 0, static_cast<std::int32_t>(width), static_cast<std::int32_t>(height)};
+}
+
+void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const PreparedRawInput& input,
+                  ResourceLease<MetalBackend>& linear, ResourceLease<MetalBackend>& packed,
+                  bool hlr) {
+  std::string error;
+  const auto geometry = ComputeNeuralAlignedGeometry(
+      input.cfa_pattern, static_cast<int>(linear.Texture().Width()),
+      static_cast<int>(linear.Texture().Height()), 32, &error);
+  if (!geometry.has_value()) {
+    throw std::runtime_error("ExecuteMetalDevelop: Neural Engine preprocess failed: " + error);
+  }
+  const RectI crop = CropOrFull(input, static_cast<std::uint32_t>(geometry->aligned_width),
+                                static_cast<std::uint32_t>(geometry->aligned_height));
+  const auto out_w = static_cast<std::uint32_t>(crop.width);
+  const auto out_h = static_cast<std::uint32_t>(crop.height);
+  auto neural_out  = AcquireScratch(device.Workspace(), out_w, out_h, TextureFormat::Rgba32f);
+  auto cfa_image =
+      metal::MetalImage::Wrap(static_cast<MTL::Texture*>(linear.Texture().Native()));
+  auto out_image = metal::MetalImage::Wrap(static_cast<MTL::Texture*>(neural_out.Texture().Native()));
+
+  MetalDemosaicNetLoadOptions load_options;
+  if (g_metal_neural_cache_for_test != nullptr) {
+    load_options.model_dir = "alcedo-missing-demosaicnet-models";
+  }
+  MetalDemosaicNetModelCache& cache = g_metal_neural_cache_for_test == nullptr
+                                          ? MetalDemosaicNetModelCache::Instance()
+                                          : *g_metal_neural_cache_for_test;
+  const bool is_bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
+  const auto variant  = is_bayer ? MetalDemosaicNetVariant::Bayer : MetalDemosaicNetVariant::XTrans;
+  if (!cache.EnsureLoaded(variant, load_options)) {
+    throw std::runtime_error(std::string("ExecuteMetalDevelop: Neural Engine unavailable: ") +
+                             cache.LastError());
+  }
+
+  MetalDemosaicNetTiledDispatch dispatch;
+  dispatch.cfa_image       = &cfa_image;
+  dispatch.output_rgba     = &out_image;
+  dispatch.shift_sx        = geometry->shift_sx;
+  dispatch.shift_sy        = geometry->shift_sy;
+  dispatch.aligned_width   = geometry->aligned_width;
+  dispatch.aligned_height  = geometry->aligned_height;
+  dispatch.product_crop    = cv::Rect(crop.x, crop.y, crop.width, crop.height);
+  dispatch.commit_and_wait = false;
+  dispatch.command_buffer  = command_buffer;
+  MetalDemosaicNetTiledExecutor executor;
+  if (is_bayer) {
+    (void)executor.EnqueueBayer(cache.Bayer(), dispatch);
+  } else {
+    (void)executor.EnqueueXTrans(cache.XTrans(), dispatch);
+  }
+
+  auto* hlr_src = Native(neural_out.Texture());
+  auto  hlr_w   = neural_out.Texture().Width();
+  auto  hlr_h   = neural_out.Texture().Height();
+  if (hlr) {
+    auto  hlr_dst = AcquireScratch(device.Workspace(), hlr_w, hlr_h, TextureFormat::Rgba32f);
+    void* stats   = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
+    auto [native_stats, offset] =
+        device.Workspace().Device().ResolveDeviceMemory(stats, 6 * sizeof(float));
+    device.Workspace().Device().FillDeviceMemory(stats, 6 * sizeof(float), 0,
+                                                 device.CommandContext());
+    device.Workspace().Device().EndCommandEncoders(device.CommandContext());
+    metal::EncodeHighlightReconstruct(command_buffer, hlr_src, Native(hlr_dst.Texture()),
+                                      native_stats, offset, input.linearization.cam_mul, hlr_w,
+                                      hlr_h);
+    hlr_src = Native(hlr_dst.Texture());
+  }
+  const float* cam_mul = input.linearization.cam_mul;
+  metal::EncodeCopyRgbaCropInverseOrient(
+      command_buffer, hlr_src, Native(packed.Texture()),
+      RectI{0, 0, static_cast<int>(hlr_w), static_cast<int>(hlr_h)}, cam_mul,
+      input.sensor.orientation_flip);
+}
+
+void EncodeLegacyDemosaic(MetalRenderDevice& device, void* command_buffer,
+                          const PreparedRawInput& input, ResourceLease<MetalBackend>& linear,
+                          ResourceLease<MetalBackend>& packed, bool hlr) {
+  const auto width  = linear.Texture().Width();
+  const auto height = linear.Texture().Height();
+  if (input.cfa_pattern.kind == RawCfaKind::XTrans6x6) {
+    auto green = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+    auto rgb   = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+    const int passes = input.downsample_passes == 0 ? 3 : 1;
+    metal::EncodeXTrans(command_buffer, Native(linear.Texture()), Native(green.Texture()),
+                        Native(rgb.Texture()), input.cfa_pattern.xtrans_pattern, width, height,
+                        passes);
+    auto* src = Native(rgb.Texture());
+    if (hlr) {
+      auto hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+      void* stats  = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
+      auto [native_stats, offset] =
+          device.Workspace().Device().ResolveDeviceMemory(stats, 6 * sizeof(float));
+      device.Workspace().Device().FillDeviceMemory(stats, 6 * sizeof(float), 0,
+                                                   device.CommandContext());
+      device.Workspace().Device().EndCommandEncoders(device.CommandContext());
+      metal::EncodeHighlightReconstruct(command_buffer, src, Native(hlr_dst.Texture()), native_stats,
+                                        offset, input.linearization.cam_mul, width, height);
+      src = Native(hlr_dst.Texture());
+    }
+    metal::EncodeCopyRgbaCropInverseOrient(command_buffer, src, Native(packed.Texture()),
+                                           CropOrFull(input, width, height),
+                                           input.linearization.cam_mul,
+                                           input.sensor.orientation_flip);
+    return;
+  }
+
+  auto r  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  auto g  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  auto b  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  auto vh = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  auto pq = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  metal::EncodeBayerRcd(command_buffer, Native(linear.Texture()), Native(r.Texture()),
+                        Native(g.Texture()), Native(b.Texture()), Native(vh.Texture()),
+                        Native(pq.Texture()), input.cfa_pattern.bayer_pattern, width, height);
+  if (hlr) {
+    auto rgba = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+    const float identity[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    metal::EncodePackPlanesCropInverseOrient(
+        command_buffer, Native(r.Texture()), Native(g.Texture()), Native(b.Texture()),
+        Native(rgba.Texture()), RectI{0, 0, static_cast<int>(width), static_cast<int>(height)},
+        identity, 0);
+    auto hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+    void* stats  = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
+    auto [native_stats, offset] =
+        device.Workspace().Device().ResolveDeviceMemory(stats, 6 * sizeof(float));
+    device.Workspace().Device().FillDeviceMemory(stats, 6 * sizeof(float), 0,
+                                                 device.CommandContext());
+    device.Workspace().Device().EndCommandEncoders(device.CommandContext());
+    metal::EncodeHighlightReconstruct(command_buffer, Native(rgba.Texture()),
+                                      Native(hlr_dst.Texture()), native_stats, offset,
+                                      input.linearization.cam_mul, width, height);
+    metal::EncodeCopyRgbaCropInverseOrient(command_buffer, Native(hlr_dst.Texture()),
+                                           Native(packed.Texture()), CropOrFull(input, width, height),
+                                           input.linearization.cam_mul,
+                                           input.sensor.orientation_flip);
+    return;
+  }
+  metal::EncodePackPlanesCropInverseOrient(
+      command_buffer, Native(r.Texture()), Native(g.Texture()), Native(b.Texture()),
+      Native(packed.Texture()), CropOrFull(input, width, height), input.linearization.cam_mul,
+      input.sensor.orientation_flip);
+}
+
+}  // namespace
+
+void SetMetalDevelopNeuralModelCacheForTesting(MetalDemosaicNetModelCache* cache) {
+  g_metal_neural_cache_for_test = cache;
+}
+
+void WarmUpMetalDagPlan(MetalBackend& backend, const ExecutionPlan& plan) {
+  std::vector<MetalPipelineWarmup> pipelines;
+  auto add = [&](const char* path, const char* function, const char* label) {
+    if (path != nullptr && path[0] != '\0') {
+      pipelines.push_back(MetalPipelineWarmup{path, function, label});
+    }
+  };
+#ifdef ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH
+  add(ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH, "to_linear_ref_r16u", "Metal ToLinearRef");
+  add(ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH, "cfa_clamp01_r32f", "Metal CFA Clamp01");
+#endif
+#ifdef ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH
+  add(ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH, "rcd_init_and_vh", "Metal Debayer RCD");
+  add(ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH, "rcd_green_at_rb", "Metal Debayer RCD");
+  add(ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH, "rcd_pq_dir", "Metal Debayer RCD");
+  add(ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH, "rcd_rb_at_rb", "Metal Debayer RCD");
+  add(ALCEDO_METAL_DEBAYER_RCD_METALLIB_PATH, "rcd_rb_at_g", "Metal Debayer RCD");
+#endif
+#ifdef ALCEDO_METAL_XTRANS_INTERPOLATE_METALLIB_PATH
+  add(ALCEDO_METAL_XTRANS_INTERPOLATE_METALLIB_PATH, "xtrans_green", "Metal X-Trans interpolate");
+  add(ALCEDO_METAL_XTRANS_INTERPOLATE_METALLIB_PATH, "xtrans_rgba", "Metal X-Trans interpolate");
+#endif
+#ifdef ALCEDO_METAL_HIGHLIGHT_RECONSTRUCT_METALLIB_PATH
+  add(ALCEDO_METAL_HIGHLIGHT_RECONSTRUCT_METALLIB_PATH, "hlr_accumulate_stats",
+      "Metal HighlightReconstruct");
+  add(ALCEDO_METAL_HIGHLIGHT_RECONSTRUCT_METALLIB_PATH, "hlr_reconstruct_tex",
+      "Metal HighlightReconstruct");
+#endif
+#ifdef ALCEDO_METAL_CVT_REF_SPACE_METALLIB_PATH
+  add(ALCEDO_METAL_CVT_REF_SPACE_METALLIB_PATH, "pack_planes_crop_inverse_orient", "Metal pack");
+  add(ALCEDO_METAL_CVT_REF_SPACE_METALLIB_PATH, "copy_rgba_crop_inverse_orient", "Metal pack");
+#endif
+#ifdef ALCEDO_METAL_GEOMETRY_UTILS_METALLIB_PATH
+  add(ALCEDO_METAL_GEOMETRY_UTILS_METALLIB_PATH, "warp_rectilinear_tex_rgba32f",
+      "Metal geometry utils");
+#endif
+#ifdef ALCEDO_METAL_GEOMETRY_RESAMPLE_METALLIB_PATH
+  add(ALCEDO_METAL_GEOMETRY_RESAMPLE_METALLIB_PATH, "geometry_resample_rgba32f",
+      "Metal GeometryResample");
+#endif
+#ifdef ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH
+  add(ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH, "camera_color_acescc", "Metal CameraColor");
+#endif
+  (void)plan;
+  backend.WarmUpPipelines(pipelines);
+}
+
+void ExecuteMetalDevelop(MetalRenderDevice& device, const ExecutionPlan& plan,
+                         const PreparedRawInput& input, PipelineDocument& document) {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteMetalDevelop: BeginRender has not been called");
+  }
+  auto* develop = document.Develop();
+  if (develop == nullptr) {
+    throw std::runtime_error("ExecuteMetalDevelop: missing develop node");
+  }
+  auto pending = TakePendingParameterPatch(develop->Params());
+  if (workspace.Textures().ByteBudget() == 0) {
+    workspace.Textures().SetByteBudget(MetalBackend::DefaultTextureBudgetBytes());
+  }
+  if (plan.peak_transient_bytes > 0) {
+    workspace.TransientBuffers().Reserve(plan.peak_transient_bytes);
+  }
+
+  const auto flags     = develop->Params().Params();
+  const bool hlr       = flags.highlights_reconstruct;
+  const auto out_w     = plan.source.develop_output_extent.width;
+  const auto out_h     = plan.source.develop_output_extent.height;
+  const GraphValueId sensor_id   = plan.sensor_linear_output;
+  const GraphValueId demosaic_id = input.dng_warp_rectilinear.has_value()
+                                       ? GraphValueId{NodeId{"develop"}, PortId{"sensor_unwarped"}}
+                                       : sensor_id;
+  auto& decoded_lease = AcquireRgba(workspace, demosaic_id, out_w, out_h);
+
+  if (input.input_kind == RawInputKind::DebayeredRgb ||
+      plan.source.kind == DevelopInputKind::DirectRgb) {
+    if (input.pixels.format != HostPixelFormat::F32Rgba ||
+        input.pixels.ByteCount() != decoded_lease.Texture().Bytes()) {
+      throw std::runtime_error("ExecuteMetalDevelop: direct RGB size does not match output");
+    }
+    workspace.Device().UploadTexture2D(decoded_lease.Texture(), input.pixels.Span(),
+                                       device.CommandContext());
+    if (pending.has_value()) {
+      pending->Commit();
+    }
+    return;
+  }
+
+  const auto width  = input.host_extent.width;
+  const auto height = input.host_extent.height;
+  if (width == 0 || height == 0) {
+    throw std::runtime_error("ExecuteMetalDevelop: empty CFA");
+  }
+  if (input.pixels.stride_bytes != width * sizeof(std::uint16_t)) {
+    throw std::runtime_error("ExecuteMetalDevelop: CFA plane must be tightly packed");
+  }
+
+  auto cfa    = AcquireScratch(workspace, width, height, TextureFormat::R16u);
+  auto linear = AcquireScratch(workspace, width, height, TextureFormat::R32f);
+  workspace.Device().UploadTexture2D(cfa.Texture(), input.pixels.Span(), device.CommandContext());
+  auto* command_buffer = CommandBuffer(device);
+  metal::EncodeToLinearRef(command_buffer, Native(cfa.Texture()), Native(linear.Texture()),
+                           input.linearization, input.cfa_pattern);
+  if (!hlr) {
+    metal::EncodeCfaClamp01(command_buffer, Native(linear.Texture()), width, height);
+  }
+
+  const auto method =
+      ResolveDevelopDemosaicMethod(flags, input.cfa_pattern.kind, input.downsample_passes);
+  if (method == RawDemosaicMethod::NeuralEngine) {
+    EncodeNeural(device, command_buffer, input, linear, decoded_lease, hlr);
+  } else {
+    EncodeLegacyDemosaic(device, command_buffer, input, linear, decoded_lease, hlr);
+  }
+
+  if (input.dng_warp_rectilinear.has_value()) {
+    auto& warped = AcquireRgba(workspace, sensor_id, out_w, out_h);
+    auto* source = workspace.Images().Find(demosaic_id);
+    if (source == nullptr) {
+      throw std::runtime_error("ExecuteMetalDevelop: DNG warp source was lost");
+    }
+    command_buffer = CommandBuffer(device);
+    metal::EncodeWarpRectilinear(command_buffer, Native(source->Texture()), Native(warped.Texture()),
+                                 *input.dng_warp_rectilinear, out_w, out_h);
+  }
+
+  if (pending.has_value()) {
+    pending->Commit();
+  }
+}
+
+void ExecuteMetalGeometryResample(MetalRenderDevice& device, const ExecutionPlan& plan) {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteMetalGeometryResample: BeginRender has not been called");
+  }
+  auto* sensor = workspace.Images().Find(plan.sensor_linear_output);
+  if (sensor == nullptr || sensor->Empty()) {
+    throw std::runtime_error("ExecuteMetalGeometryResample: missing develop.sensor_linear");
+  }
+  auto& dest = AcquireRgba(workspace, plan.geometry_output, plan.geometry.render_extent.width,
+                           plan.geometry.render_extent.height);
+  sensor     = workspace.Images().Find(plan.sensor_linear_output);
+  if (sensor == nullptr) {
+    throw std::runtime_error("ExecuteMetalGeometryResample: sensor texture lost during acquire");
+  }
+  if (!plan.encode_geometry_resample) {
+    workspace.Device().CopyTexture2D(sensor->Texture(), dest.Texture(), device.CommandContext());
+    return;
+  }
+  auto* command_buffer = CommandBuffer(device);
+  DispatchGeometryResample(command_buffer, plan.geometry, sensor->Texture(), dest.Texture());
+}
+
+void ExecuteMetalCameraColor(MetalRenderDevice& device, const ExecutionPlan& plan,
+                             const PipelineDocument& document) {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteMetalCameraColor: BeginRender has not been called");
+  }
+  const auto* develop = document.Develop();
+  if (develop == nullptr) {
+    throw std::runtime_error("ExecuteMetalCameraColor: missing develop node");
+  }
+  const auto resolved = ResolveDevelopColorTransform(develop->Params().Params());
+  if (!resolved.ok) {
+    throw std::runtime_error(std::string("ExecuteMetalCameraColor: ") +
+                             std::string(ColorTransformErrorMessage(resolved.error)));
+  }
+  auto* input = workspace.Images().Find(plan.geometry_output);
+  if (input == nullptr || input->Empty()) {
+    throw std::runtime_error("ExecuteMetalCameraColor: missing geometry.scene_source");
+  }
+  const auto width  = input->Texture().Width();
+  const auto height = input->Texture().Height();
+  auto& output =
+      workspace.AcquireImageForWrite(plan.develop_output, {width, height, TextureFormat::Rgba32f});
+  input = workspace.Images().Find(plan.geometry_output);
+  if (input == nullptr) {
+    throw std::runtime_error("ExecuteMetalCameraColor: geometry texture lost during acquire");
+  }
+
+  CameraColorGpuParams gpu_params;
+  for (int i = 0; i < 9; ++i) {
+    gpu_params.camera_to_ap1[i] = resolved.transform.camera_to_ap1[static_cast<std::size_t>(i)];
+  }
+  auto&                       arena = workspace.Parameters();
+  const ParameterSlotKey      key{develop->Id(), kDevelopCameraColorSlot};
+  const ParameterFieldBinding field{DirtyFieldMask{DevelopDirty::WhiteBalance}, 0, 0,
+                                    sizeof(CameraColorGpuParams)};
+  auto payload = std::make_shared<TypedOperatorParamPayload<CameraColorGpuParams>>(
+      type_ids::DevelopNode(), 1, gpu_params);
+  if (!arena.Contains(key)) {
+    arena.BindSlot(key, sizeof(CameraColorGpuParams), std::span{&field, 1});
+    arena.InitializeFromFullDto(key, OperatorParamDto{type_ids::DevelopNode(), 1, payload});
+  } else {
+    OperatorParamPatchDto patch{develop->Id(), kDevelopCameraColorSlot, type_ids::DevelopNode(),
+                                DirtyFieldMask{DevelopDirty::WhiteBalance}, payload};
+    arena.ApplyPatch(key, patch);
+  }
+  arena.UploadDirty(device.CommandContext());
+  const auto binding         = arena.Binding(key);
+  auto*      command_buffer  = CommandBuffer(device);
+  DispatchCameraColor(command_buffer, input->Texture(), output.Texture(), arena.DeviceBuffer(),
+                      binding.offset);
+}
+
+void ExecuteMetalIdentityCopy(MetalRenderDevice& device, const GraphValueId& source,
+                              const GraphValueId& destination, ImageExtent extent) {
+  auto& workspace = device.Workspace();
+  auto* input     = workspace.Images().Find(source);
+  if (input == nullptr || input->Empty()) {
+    throw std::runtime_error("ExecuteMetalIdentityCopy: missing source texture");
+  }
+  auto& output = workspace.AcquireImageForWrite(
+      destination, {extent.width, extent.height, TextureFormat::Rgba32f});
+  input = workspace.Images().Find(source);
+  if (input == nullptr) {
+    throw std::runtime_error("ExecuteMetalIdentityCopy: source texture lost during acquire");
+  }
+  workspace.Device().CopyTexture2D(input->Texture(), output.Texture(), device.CommandContext());
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
@@ -3,6 +3,7 @@
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
 #include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_drt_pass.hpp"
 #include "edit/runtime/metal/metal_mask_pass.hpp"
 #include "edit/runtime/metal/metal_primary_grade_pass.hpp"
 
@@ -350,6 +351,7 @@ void WarmUpMetalDagPlan(MetalBackend& backend, const ExecutionPlan& plan) {
 #endif
   AppendMetalPrimaryGradeWarmup(pipelines);
   AppendMetalMaskWarmup(pipelines);
+  AppendMetalDrtWarmup(pipelines);
   (void)plan;
   backend.WarmUpPipelines(pipelines);
 }
@@ -514,22 +516,6 @@ void ExecuteMetalCameraColor(MetalRenderDevice& device, const ExecutionPlan& pla
   auto*      command_buffer = CommandBuffer(device);
   DispatchCameraColor(command_buffer, input->Texture(), output.Texture(), arena.DeviceBuffer(),
                       binding.offset);
-}
-
-void ExecuteMetalIdentityCopy(MetalRenderDevice& device, const GraphValueId& source,
-                              const GraphValueId& destination, ImageExtent extent) {
-  auto& workspace = device.Workspace();
-  auto* input     = workspace.Images().Find(source);
-  if (input == nullptr || input->Empty()) {
-    throw std::runtime_error("ExecuteMetalIdentityCopy: missing source texture");
-  }
-  auto& output = workspace.AcquireImageForWrite(
-      destination, {extent.width, extent.height, TextureFormat::Rgba32f});
-  input = workspace.Images().Find(source);
-  if (input == nullptr) {
-    throw std::runtime_error("ExecuteMetalIdentityCopy: source texture lost during acquire");
-  }
-  workspace.Device().CopyTexture2D(input->Texture(), output.Texture(), device.CommandContext());
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
@@ -3,6 +3,7 @@
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
 #include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_primary_grade_pass.hpp"
 
 #include <array>
 #include <cmath>
@@ -347,6 +348,7 @@ void WarmUpMetalDagPlan(MetalBackend& backend, const ExecutionPlan& plan) {
 #ifdef ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH
   add(ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH, "camera_color_acescc", "Metal CameraColor");
 #endif
+  AppendMetalPrimaryGradeWarmup(pipelines);
   (void)plan;
   backend.WarmUpPipelines(pipelines);
 }

--- a/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
@@ -3,6 +3,7 @@
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
 #include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_mask_pass.hpp"
 #include "edit/runtime/metal/metal_primary_grade_pass.hpp"
 
 #include <array>
@@ -42,17 +43,17 @@ namespace {
 MetalDemosaicNetModelCache* g_metal_neural_cache_for_test = nullptr;
 
 struct GeometryResampleParams {
-  float        m00;
-  float        m01;
-  float        m02;
-  float        m10;
-  float        m11;
-  float        m12;
+  float         m00;
+  float         m01;
+  float         m02;
+  float         m10;
+  float         m11;
+  float         m12;
   std::uint32_t decoded_width;
   std::uint32_t decoded_height;
   std::uint32_t render_width;
   std::uint32_t render_height;
-  float        border[4];
+  float         border[4];
   std::uint32_t use_bicubic;
 };
 
@@ -91,7 +92,7 @@ void DispatchGeometryResample(void* command_buffer, const ResolvedRenderGeometry
       ALCEDO_METAL_GEOMETRY_RESAMPLE_METALLIB_PATH, "geometry_resample_rgba32f",
       "Metal GeometryResample");
 #endif
-  const auto& gpu = geometry.gpu_data;
+  const auto&            gpu = geometry.gpu_data;
   GeometryResampleParams params{
       .m00            = gpu.render_to_decoded[0],
       .m01            = gpu.render_to_decoded[1],
@@ -103,9 +104,8 @@ void DispatchGeometryResample(void* command_buffer, const ResolvedRenderGeometry
       .decoded_height = gpu.decoded_height,
       .render_width   = gpu.render_width,
       .render_height  = gpu.render_height,
-      .border         = {gpu.border_rgba[0], gpu.border_rgba[1], gpu.border_rgba[2],
-                         gpu.border_rgba[3]},
-      .use_bicubic    = geometry.filter == TextureFilter::Bicubic ? 1U : 0U,
+      .border = {gpu.border_rgba[0], gpu.border_rgba[1], gpu.border_rgba[2], gpu.border_rgba[3]},
+      .use_bicubic = geometry.filter == TextureFilter::Bicubic ? 1U : 0U,
   };
   auto* buffer  = static_cast<MTL::CommandBuffer*>(command_buffer);
   auto  compute = NS::RetainPtr(buffer->computeCommandEncoder());
@@ -161,30 +161,30 @@ void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const Prepare
                   ResourceLease<MetalBackend>& linear, ResourceLease<MetalBackend>& packed,
                   bool hlr) {
   std::string error;
-  const auto geometry = ComputeNeuralAlignedGeometry(
-      input.cfa_pattern, static_cast<int>(linear.Texture().Width()),
-      static_cast<int>(linear.Texture().Height()), 32, &error);
+  const auto  geometry =
+      ComputeNeuralAlignedGeometry(input.cfa_pattern, static_cast<int>(linear.Texture().Width()),
+                                   static_cast<int>(linear.Texture().Height()), 32, &error);
   if (!geometry.has_value()) {
     throw std::runtime_error("ExecuteMetalDevelop: Neural Engine preprocess failed: " + error);
   }
-  const RectI crop = CropOrFull(input, static_cast<std::uint32_t>(geometry->aligned_width),
-                                static_cast<std::uint32_t>(geometry->aligned_height));
-  const auto out_w = static_cast<std::uint32_t>(crop.width);
-  const auto out_h = static_cast<std::uint32_t>(crop.height);
-  auto neural_out  = AcquireScratch(device.Workspace(), out_w, out_h, TextureFormat::Rgba32f);
-  auto cfa_image =
-      metal::MetalImage::Wrap(static_cast<MTL::Texture*>(linear.Texture().Native()));
-  auto out_image = metal::MetalImage::Wrap(static_cast<MTL::Texture*>(neural_out.Texture().Native()));
+  const RectI crop       = CropOrFull(input, static_cast<std::uint32_t>(geometry->aligned_width),
+                                      static_cast<std::uint32_t>(geometry->aligned_height));
+  const auto  out_w      = static_cast<std::uint32_t>(crop.width);
+  const auto  out_h      = static_cast<std::uint32_t>(crop.height);
+  auto        neural_out = AcquireScratch(device.Workspace(), out_w, out_h, TextureFormat::Rgba32f);
+  auto cfa_image = metal::MetalImage::Wrap(static_cast<MTL::Texture*>(linear.Texture().Native()));
+  auto out_image =
+      metal::MetalImage::Wrap(static_cast<MTL::Texture*>(neural_out.Texture().Native()));
 
   MetalDemosaicNetLoadOptions load_options;
   if (g_metal_neural_cache_for_test != nullptr) {
     load_options.model_dir = "alcedo-missing-demosaicnet-models";
   }
-  MetalDemosaicNetModelCache& cache = g_metal_neural_cache_for_test == nullptr
-                                          ? MetalDemosaicNetModelCache::Instance()
-                                          : *g_metal_neural_cache_for_test;
-  const bool is_bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
-  const auto variant  = is_bayer ? MetalDemosaicNetVariant::Bayer : MetalDemosaicNetVariant::XTrans;
+  MetalDemosaicNetModelCache& cache    = g_metal_neural_cache_for_test == nullptr
+                                             ? MetalDemosaicNetModelCache::Instance()
+                                             : *g_metal_neural_cache_for_test;
+  const bool                  is_bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
+  const auto variant = is_bayer ? MetalDemosaicNetVariant::Bayer : MetalDemosaicNetVariant::XTrans;
   if (!cache.EnsureLoaded(variant, load_options)) {
     throw std::runtime_error(std::string("ExecuteMetalDevelop: Neural Engine unavailable: ") +
                              cache.LastError());
@@ -236,29 +236,29 @@ void EncodeLegacyDemosaic(MetalRenderDevice& device, void* command_buffer,
   const auto width  = linear.Texture().Width();
   const auto height = linear.Texture().Height();
   if (input.cfa_pattern.kind == RawCfaKind::XTrans6x6) {
-    auto green = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
-    auto rgb   = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+    auto      green  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+    auto      rgb    = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
     const int passes = input.downsample_passes == 0 ? 3 : 1;
     metal::EncodeXTrans(command_buffer, Native(linear.Texture()), Native(green.Texture()),
                         Native(rgb.Texture()), input.cfa_pattern.xtrans_pattern, width, height,
                         passes);
     auto* src = Native(rgb.Texture());
     if (hlr) {
-      auto hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
-      void* stats  = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
+      auto  hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+      void* stats   = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
       auto [native_stats, offset] =
           device.Workspace().Device().ResolveDeviceMemory(stats, 6 * sizeof(float));
       device.Workspace().Device().FillDeviceMemory(stats, 6 * sizeof(float), 0,
                                                    device.CommandContext());
       device.Workspace().Device().EndCommandEncoders(device.CommandContext());
-      metal::EncodeHighlightReconstruct(command_buffer, src, Native(hlr_dst.Texture()), native_stats,
-                                        offset, input.linearization.cam_mul, width, height);
+      metal::EncodeHighlightReconstruct(command_buffer, src, Native(hlr_dst.Texture()),
+                                        native_stats, offset, input.linearization.cam_mul, width,
+                                        height);
       src = Native(hlr_dst.Texture());
     }
-    metal::EncodeCopyRgbaCropInverseOrient(command_buffer, src, Native(packed.Texture()),
-                                           CropOrFull(input, width, height),
-                                           input.linearization.cam_mul,
-                                           input.sensor.orientation_flip);
+    metal::EncodeCopyRgbaCropInverseOrient(
+        command_buffer, src, Native(packed.Texture()), CropOrFull(input, width, height),
+        input.linearization.cam_mul, input.sensor.orientation_flip);
     return;
   }
 
@@ -271,14 +271,14 @@ void EncodeLegacyDemosaic(MetalRenderDevice& device, void* command_buffer,
                         Native(g.Texture()), Native(b.Texture()), Native(vh.Texture()),
                         Native(pq.Texture()), input.cfa_pattern.bayer_pattern, width, height);
   if (hlr) {
-    auto rgba = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+    auto        rgba = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
     const float identity[4] = {1.0f, 1.0f, 1.0f, 1.0f};
     metal::EncodePackPlanesCropInverseOrient(
         command_buffer, Native(r.Texture()), Native(g.Texture()), Native(b.Texture()),
         Native(rgba.Texture()), RectI{0, 0, static_cast<int>(width), static_cast<int>(height)},
         identity, 0);
-    auto hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
-    void* stats  = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
+    auto  hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+    void* stats   = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
     auto [native_stats, offset] =
         device.Workspace().Device().ResolveDeviceMemory(stats, 6 * sizeof(float));
     device.Workspace().Device().FillDeviceMemory(stats, 6 * sizeof(float), 0,
@@ -287,10 +287,10 @@ void EncodeLegacyDemosaic(MetalRenderDevice& device, void* command_buffer,
     metal::EncodeHighlightReconstruct(command_buffer, Native(rgba.Texture()),
                                       Native(hlr_dst.Texture()), native_stats, offset,
                                       input.linearization.cam_mul, width, height);
-    metal::EncodeCopyRgbaCropInverseOrient(command_buffer, Native(hlr_dst.Texture()),
-                                           Native(packed.Texture()), CropOrFull(input, width, height),
-                                           input.linearization.cam_mul,
-                                           input.sensor.orientation_flip);
+    metal::EncodeCopyRgbaCropInverseOrient(
+        command_buffer, Native(hlr_dst.Texture()), Native(packed.Texture()),
+        CropOrFull(input, width, height), input.linearization.cam_mul,
+        input.sensor.orientation_flip);
     return;
   }
   metal::EncodePackPlanesCropInverseOrient(
@@ -349,6 +349,7 @@ void WarmUpMetalDagPlan(MetalBackend& backend, const ExecutionPlan& plan) {
   add(ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH, "camera_color_acescc", "Metal CameraColor");
 #endif
   AppendMetalPrimaryGradeWarmup(pipelines);
+  AppendMetalMaskWarmup(pipelines);
   (void)plan;
   backend.WarmUpPipelines(pipelines);
 }
@@ -371,15 +372,15 @@ void ExecuteMetalDevelop(MetalRenderDevice& device, const ExecutionPlan& plan,
     workspace.TransientBuffers().Reserve(plan.peak_transient_bytes);
   }
 
-  const auto flags     = develop->Params().Params();
-  const bool hlr       = flags.highlights_reconstruct;
-  const auto out_w     = plan.source.develop_output_extent.width;
-  const auto out_h     = plan.source.develop_output_extent.height;
-  const GraphValueId sensor_id   = plan.sensor_linear_output;
-  const GraphValueId demosaic_id = input.dng_warp_rectilinear.has_value()
-                                       ? GraphValueId{NodeId{"develop"}, PortId{"sensor_unwarped"}}
-                                       : sensor_id;
-  auto& decoded_lease = AcquireRgba(workspace, demosaic_id, out_w, out_h);
+  const auto         flags         = develop->Params().Params();
+  const bool         hlr           = flags.highlights_reconstruct;
+  const auto         out_w         = plan.source.develop_output_extent.width;
+  const auto         out_h         = plan.source.develop_output_extent.height;
+  const GraphValueId sensor_id     = plan.sensor_linear_output;
+  const GraphValueId demosaic_id   = input.dng_warp_rectilinear.has_value()
+                                         ? GraphValueId{NodeId{"develop"}, PortId{"sensor_unwarped"}}
+                                         : sensor_id;
+  auto&              decoded_lease = AcquireRgba(workspace, demosaic_id, out_w, out_h);
 
   if (input.input_kind == RawInputKind::DebayeredRgb ||
       plan.source.kind == DevelopInputKind::DirectRgb) {
@@ -429,8 +430,9 @@ void ExecuteMetalDevelop(MetalRenderDevice& device, const ExecutionPlan& plan,
       throw std::runtime_error("ExecuteMetalDevelop: DNG warp source was lost");
     }
     command_buffer = CommandBuffer(device);
-    metal::EncodeWarpRectilinear(command_buffer, Native(source->Texture()), Native(warped.Texture()),
-                                 *input.dng_warp_rectilinear, out_w, out_h);
+    metal::EncodeWarpRectilinear(command_buffer, Native(source->Texture()),
+                                 Native(warped.Texture()), *input.dng_warp_rectilinear, out_w,
+                                 out_h);
   }
 
   if (pending.has_value()) {
@@ -482,7 +484,7 @@ void ExecuteMetalCameraColor(MetalRenderDevice& device, const ExecutionPlan& pla
   }
   const auto width  = input->Texture().Width();
   const auto height = input->Texture().Height();
-  auto& output =
+  auto&      output =
       workspace.AcquireImageForWrite(plan.develop_output, {width, height, TextureFormat::Rgba32f});
   input = workspace.Images().Find(plan.geometry_output);
   if (input == nullptr) {
@@ -508,8 +510,8 @@ void ExecuteMetalCameraColor(MetalRenderDevice& device, const ExecutionPlan& pla
     arena.ApplyPatch(key, patch);
   }
   arena.UploadDirty(device.CommandContext());
-  const auto binding         = arena.Binding(key);
-  auto*      command_buffer  = CommandBuffer(device);
+  const auto binding        = arena.Binding(key);
+  auto*      command_buffer = CommandBuffer(device);
   DispatchCameraColor(command_buffer, input->Texture(), output.Texture(), arena.DeviceBuffer(),
                       binding.offset);
 }

--- a/alcedo_studio/src/edit/runtime/metal/metal_drt_params.cpp
+++ b/alcedo_studio/src/edit/runtime/metal/metal_drt_params.cpp
@@ -1,0 +1,185 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/metal/metal_drt_gpu_params.hpp"
+
+#include <cstring>
+#include <stdexcept>
+
+#include "edit/operators/cst/odt_op.hpp"
+
+namespace alcedo {
+namespace {
+
+void Copy33(const cv::Matx33f& matrix, float out[9]) {
+  out[0] = matrix(0, 0);
+  out[1] = matrix(0, 1);
+  out[2] = matrix(0, 2);
+  out[3] = matrix(1, 0);
+  out[4] = matrix(1, 1);
+  out[5] = matrix(1, 2);
+  out[6] = matrix(2, 0);
+  out[7] = matrix(2, 1);
+  out[8] = matrix(2, 2);
+}
+
+void CopyJmh(const ColorUtils::JMhParams& src, MetalDrtJmhParams& dst) {
+  Copy33(src.MATRIX_RGB_to_CAM16_c_, dst.matrix_rgb_to_cam16);
+  Copy33(src.MATRIX_CAM16_c_to_RGB_, dst.matrix_cam16_to_rgb);
+  Copy33(src.MATRIX_cone_response_to_Aab_, dst.matrix_cone_to_aab);
+  Copy33(src.MATRIX_Aab_to_cone_response_, dst.matrix_aab_to_cone);
+  dst.f_l_n     = src.F_L_n_;
+  dst.cz        = src.cz_;
+  dst.inv_cz    = src.inv_cz_;
+  dst.a_w_j     = (src.inv_A_w_J_ != 0.0f) ? (1.0f / src.inv_A_w_J_) : 0.0f;
+  dst.inv_a_w_j = src.inv_A_w_J_;
+}
+
+}  // namespace
+
+auto ResolveMetalDrtGpuParams(const nlohmann::json& odt_json) -> MetalDrtGpuParams {
+  ODT_Op         descriptor(nlohmann::json{{"odt", odt_json}});
+  OperatorParams cpu_params;
+  descriptor.SetGlobalParams(cpu_params);
+  const auto&                cpu = cpu_params.to_output_params_;
+  MetalDrtGpuParams          gpu;
+  gpu.method               = static_cast<std::int32_t>(cpu.method_);
+  gpu.eotf                 = static_cast<std::int32_t>(cpu.eotf_);
+  Copy33(cpu.limit_to_display_matx_, gpu.limit_to_display_matx);
+  gpu.display_linear_scale = cpu.display_linear_scale_;
+
+  const auto& odt_cpu            = cpu.aces_params_;
+  auto&       odt                = gpu.aces;
+  odt.peak_luminance             = odt_cpu.peak_luminance_;
+  CopyJmh(odt_cpu.input_params_, odt.input);
+  CopyJmh(odt_cpu.reach_params_, odt.reach);
+  CopyJmh(odt_cpu.limit_params_, odt.limit);
+  odt.ts.n                       = odt_cpu.ts_params_.n_;
+  odt.ts.n_r                     = odt_cpu.ts_params_.n_r_;
+  odt.ts.g                       = odt_cpu.ts_params_.g_;
+  odt.ts.t_1                     = odt_cpu.ts_params_.t_1_;
+  odt.ts.c_t                     = odt_cpu.ts_params_.c_t_;
+  odt.ts.s_2                     = odt_cpu.ts_params_.s_2_;
+  odt.ts.u_2                     = odt_cpu.ts_params_.u_2_;
+  odt.ts.m_2                     = odt_cpu.ts_params_.m_2_;
+  odt.ts.forward_limit           = odt_cpu.ts_params_.forward_limit_;
+  odt.ts.inverse_limit           = odt_cpu.ts_params_.inverse_limit_;
+  odt.ts.log_peak                = odt_cpu.ts_params_.log_peak_;
+  odt.limit_j_max                = odt_cpu.limit_J_max_;
+  odt.model_gamma_inv            = odt_cpu.model_gamma_inv_;
+  odt.mid_j                      = odt_cpu.mid_J_;
+  odt.focus_dist                 = odt_cpu.focus_dist_;
+  odt.lower_hull_gamma_inv       = odt_cpu.lower_hull_gamma_inv_;
+  odt.hue_linearity_search_range[0] = static_cast<std::int32_t>(odt_cpu.hue_linearity_search_range_(0));
+  odt.hue_linearity_search_range[1] = static_cast<std::int32_t>(odt_cpu.hue_linearity_search_range_(1));
+  odt.sat                       = odt_cpu.sat_;
+  odt.sat_thr                   = odt_cpu.sat_thr_;
+  odt.compr                     = odt_cpu.compr_;
+  odt.chroma_compress_scale     = odt_cpu.chroma_compress_scale_;
+  if (cpu.method_ == ColorUtils::ODTMethod::ACES_2_0) {
+    if (!odt_cpu.table_reach_M_ || !odt_cpu.table_hues_ || !odt_cpu.table_upper_hull_gammas_ ||
+        !odt_cpu.table_gamut_cusps_) {
+      throw std::runtime_error("ExecuteMetalDrt: ACES 2.0 tables were not resolved");
+    }
+    std::memcpy(odt.table_reach_m, odt_cpu.table_reach_M_->data(), sizeof(odt.table_reach_m));
+    std::memcpy(odt.table_hues, odt_cpu.table_hues_->data(), sizeof(odt.table_hues));
+    std::memcpy(odt.table_upper_hull_gamma, odt_cpu.table_upper_hull_gammas_->data(),
+                sizeof(odt.table_upper_hull_gamma));
+    for (int i = 0; i < kMetalDrtTableSize; ++i) {
+      const auto& cusp            = (*odt_cpu.table_gamut_cusps_)[static_cast<std::size_t>(i)];
+      odt.table_gamut_cusps[i][0] = cusp(0);
+      odt.table_gamut_cusps[i][1] = cusp(1);
+      odt.table_gamut_cusps[i][2] = cusp(2);
+      odt.table_gamut_cusps[i][3] = 0.0f;
+    }
+  }
+
+  const auto& open_cpu     = cpu.open_drt_params_;
+  auto&       open         = gpu.open_drt;
+  open.tn_hcon_enable      = open_cpu.tn_hcon_enable_;
+  open.tn_lcon_enable      = open_cpu.tn_lcon_enable_;
+  open.pt_enable           = open_cpu.pt_enable_;
+  open.ptl_enable          = open_cpu.ptl_enable_;
+  open.ptm_enable          = open_cpu.ptm_enable_;
+  open.brl_enable          = open_cpu.brl_enable_;
+  open.brlp_enable         = open_cpu.brlp_enable_;
+  open.hc_enable           = open_cpu.hc_enable_;
+  open.hs_rgb_enable       = open_cpu.hs_rgb_enable_;
+  open.hs_cmy_enable       = open_cpu.hs_cmy_enable_;
+  open.creative_white      = open_cpu.creative_white_;
+  open.surround            = open_cpu.surround_;
+  open.clamp               = open_cpu.clamp_;
+  open.display_gamut       = open_cpu.display_gamut_;
+  open.display_eotf        = open_cpu.display_eotf_;
+  open.tn_con              = open_cpu.tn_con_;
+  open.tn_sh               = open_cpu.tn_sh_;
+  open.tn_toe              = open_cpu.tn_toe_;
+  open.tn_off              = open_cpu.tn_off_;
+  open.tn_hcon             = open_cpu.tn_hcon_;
+  open.tn_hcon_pv          = open_cpu.tn_hcon_pv_;
+  open.tn_hcon_st          = open_cpu.tn_hcon_st_;
+  open.tn_lcon             = open_cpu.tn_lcon_;
+  open.tn_lcon_w           = open_cpu.tn_lcon_w_;
+  open.cwp_lm              = open_cpu.cwp_lm_;
+  open.rs_sa               = open_cpu.rs_sa_;
+  open.rs_rw               = open_cpu.rs_rw_;
+  open.rs_bw               = open_cpu.rs_bw_;
+  open.pt_lml              = open_cpu.pt_lml_;
+  open.pt_lml_r            = open_cpu.pt_lml_r_;
+  open.pt_lml_g            = open_cpu.pt_lml_g_;
+  open.pt_lml_b            = open_cpu.pt_lml_b_;
+  open.pt_lmh              = open_cpu.pt_lmh_;
+  open.pt_lmh_r            = open_cpu.pt_lmh_r_;
+  open.pt_lmh_b            = open_cpu.pt_lmh_b_;
+  open.ptl_c               = open_cpu.ptl_c_;
+  open.ptl_m               = open_cpu.ptl_m_;
+  open.ptl_y               = open_cpu.ptl_y_;
+  open.ptm_low             = open_cpu.ptm_low_;
+  open.ptm_low_rng         = open_cpu.ptm_low_rng_;
+  open.ptm_low_st          = open_cpu.ptm_low_st_;
+  open.ptm_high            = open_cpu.ptm_high_;
+  open.ptm_high_rng        = open_cpu.ptm_high_rng_;
+  open.ptm_high_st         = open_cpu.ptm_high_st_;
+  open.brl                 = open_cpu.brl_;
+  open.brl_r               = open_cpu.brl_r_;
+  open.brl_g               = open_cpu.brl_g_;
+  open.brl_b               = open_cpu.brl_b_;
+  open.brl_rng             = open_cpu.brl_rng_;
+  open.brl_st              = open_cpu.brl_st_;
+  open.brlp                = open_cpu.brlp_;
+  open.brlp_r              = open_cpu.brlp_r_;
+  open.brlp_g              = open_cpu.brlp_g_;
+  open.brlp_b              = open_cpu.brlp_b_;
+  open.hc_r                = open_cpu.hc_r_;
+  open.hc_r_rng            = open_cpu.hc_r_rng_;
+  open.hs_r                = open_cpu.hs_r_;
+  open.hs_r_rng            = open_cpu.hs_r_rng_;
+  open.hs_g                = open_cpu.hs_g_;
+  open.hs_g_rng            = open_cpu.hs_g_rng_;
+  open.hs_b                = open_cpu.hs_b_;
+  open.hs_b_rng            = open_cpu.hs_b_rng_;
+  open.hs_c                = open_cpu.hs_c_;
+  open.hs_c_rng            = open_cpu.hs_c_rng_;
+  open.hs_m                = open_cpu.hs_m_;
+  open.hs_m_rng            = open_cpu.hs_m_rng_;
+  open.hs_y                = open_cpu.hs_y_;
+  open.hs_y_rng            = open_cpu.hs_y_rng_;
+  open.ts_x1               = open_cpu.ts_x1_;
+  open.ts_y1               = open_cpu.ts_y1_;
+  open.ts_x0               = open_cpu.ts_x0_;
+  open.ts_y0               = open_cpu.ts_y0_;
+  open.ts_s0               = open_cpu.ts_s0_;
+  open.ts_p                 = open_cpu.ts_p_;
+  open.ts_s10               = open_cpu.ts_s10_;
+  open.ts_m1               = open_cpu.ts_m1_;
+  open.ts_m2               = open_cpu.ts_m2_;
+  open.ts_s                 = open_cpu.ts_s_;
+  open.ts_dsc               = open_cpu.ts_dsc_;
+  open.pt_cmp_lf           = open_cpu.pt_cmp_Lf_;
+  open.s_lp100             = open_cpu.s_Lp100_;
+  open.ts_s1               = open_cpu.ts_s1_;
+  return gpu;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_drt_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_drt_pass.mm
@@ -1,0 +1,118 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/metal/metal_drt_pass.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <span>
+#include <stdexcept>
+
+#include <alcedo/metal/Metal.hpp>
+
+#include "edit/graph/drt_node_model.hpp"
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/runtime/metal/metal_drt_gpu_params.hpp"
+#include "edit/runtime/parameter_arena.hpp"
+#include "edit/runtime/texture_format.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr std::uint32_t kDrtDirtyBits = static_cast<std::uint32_t>(DrtDirty::All);
+
+auto Pipeline() -> NS::SharedPtr<MTL::ComputePipelineState> {
+#ifndef ALCEDO_METAL_DRT_METALLIB_PATH
+  throw std::runtime_error("Metal DRT metallib path is not configured.");
+#else
+  return metal::ComputePipelineCache::Instance().GetPipelineState(ALCEDO_METAL_DRT_METALLIB_PATH,
+                                                                  "drt_display", "Metal DRT");
+#endif
+}
+
+void DispatchDrt(MetalRenderDevice& device, const MetalBackend::Texture2D& src,
+                 MetalBackend::Texture2D& dst, const MetalBackend::Buffer& params,
+                 std::uint32_t offset) {
+  auto  pipeline = Pipeline();
+  auto* encoder  = static_cast<MTL::ComputeCommandEncoder*>(
+      device.Workspace().Device().EnsureComputeCommandEncoder(device.CommandContext()));
+  if (encoder == nullptr) {
+    throw std::runtime_error("ExecuteMetalDrt: compute encoder is missing");
+  }
+  encoder->setComputePipelineState(pipeline.get());
+  encoder->setTexture(static_cast<MTL::Texture*>(src.Native()), 0);
+  encoder->setTexture(static_cast<MTL::Texture*>(dst.Native()), 1);
+  encoder->setBuffer(static_cast<MTL::Buffer*>(params.Native()), offset, 0);
+  const auto thread_width = std::max<NS::UInteger>(1, pipeline->threadExecutionWidth());
+  const auto thread_height =
+      std::max<NS::UInteger>(1, pipeline->maxTotalThreadsPerThreadgroup() / thread_width);
+  encoder->dispatchThreads(MTL::Size{src.Width(), src.Height(), 1},
+                           MTL::Size{thread_width, thread_height, 1});
+  device.Workspace().Device().NoteComputeDispatch();
+}
+
+}  // namespace
+
+void AppendMetalDrtWarmup(std::vector<MetalPipelineWarmup>& pipelines) {
+#ifdef ALCEDO_METAL_DRT_METALLIB_PATH
+  pipelines.push_back(
+      MetalPipelineWarmup{ALCEDO_METAL_DRT_METALLIB_PATH, "drt_display", "Metal DRT"});
+#else
+  (void)pipelines;
+#endif
+}
+
+auto ExecuteMetalDrt(MetalRenderDevice& device, const ExecutionPlan& plan,
+                     PipelineDocument& document) -> MetalDrtResult {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteMetalDrt: BeginRender has not been called");
+  }
+  auto* drt = document.Drt();
+  if (drt == nullptr) {
+    throw std::runtime_error("ExecuteMetalDrt: missing DRT endpoint");
+  }
+  auto* input = workspace.Images().Find(plan.primary_grade_output);
+  if (input == nullptr || input->Empty()) {
+    throw std::runtime_error("ExecuteMetalDrt: missing primary-grade output");
+  }
+
+  auto&                       arena = workspace.Parameters();
+  const ParameterSlotKey      key{drt->Id(), AdjustmentInstanceId{"drt.output"}};
+  const ParameterFieldBinding field{DirtyFieldMask{kDrtDirtyBits}, 0, 0, sizeof(MetalDrtGpuParams)};
+  auto                        pending          = TakePendingParameterPatch(drt->Params());
+  const bool                  needs_initialize = !arena.Contains(key);
+  if (needs_initialize || pending.has_value()) {
+    const auto runtime = ResolveMetalDrtGpuParams(drt->Params().ToJson());
+    auto       payload = std::make_shared<TypedOperatorParamPayload<MetalDrtGpuParams>>(
+        drt->Params().Type(), 1, runtime);
+    if (needs_initialize) {
+      arena.BindSlot(key, sizeof(MetalDrtGpuParams), std::span{&field, 1});
+      arena.InitializeFromFullDto(key, OperatorParamDto{drt->Params().Type(), 1, payload});
+    } else {
+      arena.ApplyPatch(key, OperatorParamPatchDto{drt->Id(), AdjustmentInstanceId{"drt.output"},
+                                                 drt->Params().Type(), DirtyFieldMask{kDrtDirtyBits},
+                                                 payload});
+    }
+  }
+  arena.UploadDirty(device.CommandContext());
+  if (pending) {
+    pending->Commit();
+  }
+
+  const auto width  = input->Texture().Width();
+  const auto height = input->Texture().Height();
+  workspace.AcquireImageForWrite(plan.display_output, {width, height, TextureFormat::Rgba32f});
+  input        = workspace.Images().Find(plan.primary_grade_output);
+  auto* output = workspace.Images().Find(plan.display_output);
+  if (input == nullptr || output == nullptr) {
+    throw std::runtime_error("ExecuteMetalDrt: image cache changed during allocation");
+  }
+  const auto binding = arena.Binding(key);
+  DispatchDrt(device, input->Texture(), output->Texture(), arena.DeviceBuffer(), binding.offset);
+  return {plan.display_output};
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_frame_presenter.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_frame_presenter.mm
@@ -1,0 +1,80 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/metal/metal_frame_presenter.hpp"
+
+#include <span>
+#include <stdexcept>
+
+#include <alcedo/metal/Metal.hpp>
+#include <opencv2/core.hpp>
+
+#include "edit/scope/detail/scope_metal_shared.hpp"
+#include "edit/scope/scope_analyzer.hpp"
+#include "image/image_buffer.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo {
+
+void FramePresenter<MetalBackend>::Present(BasicRenderDevice<MetalBackend>& device,
+                                           const GraphValueId& output_id, IFrameSink& sink,
+                                           const FrameCompletionSubmission& submission,
+                                           const ViewerDisplayConfig&       display_config) {
+  auto* lease = device.Workspace().Images().Find(output_id);
+  if (lease == nullptr || lease->Empty()) {
+    throw std::runtime_error("MetalRenderer: DRT output is missing");
+  }
+  auto* native = static_cast<MTL::Texture*>(lease->Texture().Native());
+  if (native == nullptr) {
+    throw std::runtime_error("MetalRenderer: DRT output texture is null");
+  }
+  auto* command_buffer =
+      static_cast<MTL::CommandBuffer*>(device.CommandContext().NativeCommandBuffer());
+  if (command_buffer == nullptr) {
+    throw std::runtime_error("MetalRenderer: present requires the frame command buffer");
+  }
+
+  const auto width  = static_cast<int>(lease->Texture().Width());
+  const auto height = static_cast<int>(lease->Texture().Height());
+
+  auto image            = std::make_shared<scope::metal_detail::MetalTextureImageResource>();
+  image->texture        = NS::RetainPtr(native);
+  image->width          = width;
+  image->height         = height;
+  image->format         = FramePixelFormat::RGBA32F;
+  image->native_object  = reinterpret_cast<std::uintptr_t>(image->texture.get());
+
+  auto ready            = std::make_shared<scope::metal_detail::MetalCommandBufferSignalResource>();
+  ready->command_buffer = NS::RetainPtr(command_buffer);
+
+  sink.BindFrameSubmission(submission);
+  sink.EnsureSize(width, height);
+  sink.SubmitFinalDisplayFrame(FinalDisplayFrameView{
+      SharedGpuImageHandle{GpuBackend::Metal, std::shared_ptr<void>(image, image.get()), width,
+                           height, 0, FramePixelFormat::RGBA32F},
+      width, height, FramePixelFormat::RGBA32F, display_config, AnalysisDomain::DisplayEncoded,
+      GpuSignalHandle{GpuBackend::Metal, std::shared_ptr<void>(ready, ready.get())}, 0});
+  sink.SubmitMetalFrame(ViewerMetalFrame{
+      width, height, image->native_object,
+      std::shared_ptr<const void>(image, image->texture.get()), display_config, submission.mode,
+      submission.metadata});
+  sink.NotifyFrameReady(submission);
+}
+
+auto FramePresenter<MetalBackend>::Download(BasicRenderDevice<MetalBackend>& device,
+                                            const GraphValueId&              output_id)
+    -> std::shared_ptr<ImageBuffer> {
+  auto* lease = device.Workspace().Images().Find(output_id);
+  if (lease == nullptr || lease->Empty()) {
+    throw std::runtime_error("MetalRenderer: cannot download a missing DRT output");
+  }
+  auto&   texture = lease->Texture();
+  cv::Mat pixels(static_cast<int>(texture.Height()), static_cast<int>(texture.Width()), CV_32FC4);
+  auto    bytes = std::span<std::byte>{reinterpret_cast<std::byte*>(pixels.data),
+                                       pixels.total() * pixels.elemSize()};
+  device.Workspace().Device().DownloadTexture2D(texture, bytes, device.CommandContext());
+  return std::make_shared<ImageBuffer>(std::move(pixels));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_frame_presenter.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_frame_presenter.mm
@@ -6,6 +6,7 @@
 
 #include <span>
 #include <stdexcept>
+#include <string>
 
 #include <alcedo/metal/Metal.hpp>
 #include <opencv2/core.hpp>
@@ -16,6 +17,24 @@
 #include "ui/edit_viewer/frame_sink.hpp"
 
 namespace alcedo {
+namespace {
+
+void WaitForViewerTexture(MTL::CommandBuffer* command_buffer) {
+  command_buffer->waitUntilCompleted();
+  if (command_buffer->status() != MTL::CommandBufferStatusError) {
+    return;
+  }
+  std::string message = "MetalRenderer: viewer texture command buffer failed";
+  if (auto* error = command_buffer->error(); error != nullptr) {
+    if (auto* description = error->localizedDescription(); description != nullptr) {
+      message += ": ";
+      message += description->utf8String();
+    }
+  }
+  throw std::runtime_error(message);
+}
+
+}  // namespace
 
 void FramePresenter<MetalBackend>::Present(BasicRenderDevice<MetalBackend>& device,
                                            const GraphValueId& output_id, IFrameSink& sink,
@@ -34,11 +53,16 @@ void FramePresenter<MetalBackend>::Present(BasicRenderDevice<MetalBackend>& devi
   if (command_buffer == nullptr) {
     throw std::runtime_error("MetalRenderer: present requires the frame command buffer");
   }
+  // The DAG uses a command queue separate from Qt Quick's QRhi queue. The old Metal pipeline
+  // completed its command buffer before publishing the MTLTexture; the refactor published it
+  // immediately after commit, leaving the viewer without a cross-queue readiness guarantee.
+  // Restore that ordering before the sink can import or sample the texture.
+  WaitForViewerTexture(command_buffer);
 
-  const auto width  = static_cast<int>(lease->Texture().Width());
-  const auto height = static_cast<int>(lease->Texture().Height());
+  const auto width      = static_cast<int>(lease->Texture().Width());
+  const auto height     = static_cast<int>(lease->Texture().Height());
 
-  auto image            = std::make_shared<scope::metal_detail::MetalTextureImageResource>();
+  auto       image      = std::make_shared<scope::metal_detail::MetalTextureImageResource>();
   image->texture        = NS::RetainPtr(native);
   image->width          = width;
   image->height         = height;
@@ -55,10 +79,9 @@ void FramePresenter<MetalBackend>::Present(BasicRenderDevice<MetalBackend>& devi
                            height, 0, FramePixelFormat::RGBA32F},
       width, height, FramePixelFormat::RGBA32F, display_config, AnalysisDomain::DisplayEncoded,
       GpuSignalHandle{GpuBackend::Metal, std::shared_ptr<void>(ready, ready.get())}, 0});
-  sink.SubmitMetalFrame(ViewerMetalFrame{
-      width, height, image->native_object,
-      std::shared_ptr<const void>(image, image->texture.get()), display_config, submission.mode,
-      submission.metadata});
+  sink.SubmitMetalFrame(ViewerMetalFrame{width, height, image->native_object,
+                                         std::shared_ptr<const void>(image, image->texture.get()),
+                                         display_config, submission.mode, submission.metadata});
   sink.NotifyFrameReady(submission);
 }
 

--- a/alcedo_studio/src/edit/runtime/metal/metal_local_tone_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_local_tone_pass.mm
@@ -1,0 +1,543 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/metal/metal_local_tone_pass.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <alcedo/metal/Metal.hpp>
+
+#include "edit/geometry/texture_sampling_plan.hpp"
+#include "edit/pipeline/local_tone_mapping.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+
+namespace alcedo {
+namespace {
+
+using local_tone_mapping::LlfSample;
+
+constexpr int kMaxLevels = local_tone_mapping::kMaxLevels;
+
+struct PyramidLayout {
+  int                         count = 0;
+  std::array<int, kMaxLevels> widths{};
+  std::array<int, kMaxLevels> heights{};
+};
+
+struct Plane {
+  void*         ptr    = nullptr;
+  MTL::Buffer*  native = nullptr;
+  std::uint32_t offset = 0;
+  std::size_t   bytes  = 0;
+};
+
+struct CanonicalLlfMeta {
+  std::uint64_t source_key       = 0;
+  std::uint64_t result_key       = 0;
+  std::int32_t  mask_width       = 0;
+  std::int32_t  mask_height      = 0;
+  std::int32_t  source_long_edge = 0;
+  std::int32_t  canonical        = 0;
+};
+
+struct alignas(16) ExtractParams {
+  std::int32_t input_width   = 0;
+  std::int32_t input_height  = 0;
+  std::int32_t output_width  = 0;
+  std::int32_t output_height = 0;
+};
+
+struct alignas(16) ExtractReferenceParams {
+  std::int32_t input_width   = 0;
+  std::int32_t input_height  = 0;
+  std::int32_t output_width  = 0;
+  std::int32_t output_height = 0;
+  float        full_ref_w    = 0.0f;
+  float        full_ref_h    = 0.0f;
+  float        pad0          = 0.0f;
+  float        pad1          = 0.0f;
+  float        reference_to_render[12]{};
+};
+
+struct alignas(16) RemapParams {
+  std::int32_t width  = 0;
+  std::int32_t height = 0;
+  float        gamma  = 0.0f;
+  float        target = 0.0f;
+  float        beta   = 1.0f;
+  float        alpha  = 1.0f;
+  float        sigma  = 0.0f;
+  std::int32_t pad    = 0;
+};
+
+struct alignas(16) PyrDownParams {
+  std::int32_t src_width  = 0;
+  std::int32_t src_height = 0;
+  std::int32_t dst_width  = 0;
+  std::int32_t dst_height = 0;
+};
+
+struct alignas(16) SelectParams {
+  std::int32_t width         = 0;
+  std::int32_t height        = 0;
+  std::int32_t coarse_width  = 0;
+  std::int32_t coarse_height = 0;
+  float        gamma_lo      = 0.0f;
+  float        gamma_hi      = 0.0f;
+  std::int32_t first         = 0;
+  std::int32_t last          = 0;
+  std::int32_t top           = 0;
+  std::int32_t pad[3]        = {};
+};
+
+struct alignas(16) CollapseParams {
+  std::int32_t width         = 0;
+  std::int32_t height        = 0;
+  std::int32_t coarse_width  = 0;
+  std::int32_t coarse_height = 0;
+};
+
+struct alignas(16) ApplyParams {
+  std::int32_t width           = 0;
+  std::int32_t height          = 0;
+  std::int32_t adjusted_width  = 0;
+  std::int32_t adjusted_height = 0;
+  float        render_to_uv[12]{};
+};
+
+auto MakeLayout(int width, int height) -> PyramidLayout {
+  PyramidLayout layout;
+  layout.count =
+      local_tone_mapping::ComputeLevelCount(width, height, local_tone_mapping::kPyramidRadius);
+  layout.widths[0]  = width;
+  layout.heights[0] = height;
+  for (int level = 1; level < layout.count; ++level) {
+    layout.widths[level]  = std::max(1, (layout.widths[level - 1] + 1) / 2);
+    layout.heights[level] = std::max(1, (layout.heights[level - 1] + 1) / 2);
+  }
+  return layout;
+}
+
+auto LevelId(const NodeId& grade_id, const char* family, int level) -> GraphValueId {
+  return {grade_id, PortId{std::string{"local_tone."} + family + "." + std::to_string(level)}};
+}
+
+auto MetaId(const NodeId& grade_id) -> GraphValueId {
+  return {grade_id, PortId{"local_tone.canonical.meta"}};
+}
+
+auto Pipeline(const char* function, const char* label) -> NS::SharedPtr<MTL::ComputePipelineState> {
+#ifndef ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH
+  throw std::runtime_error("Metal local tone metallib path is not configured.");
+#else
+  return metal::ComputePipelineCache::Instance().GetPipelineState(
+      ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH, function, label);
+#endif
+}
+
+void DispatchThreads(MTL::ComputeCommandEncoder* encoder, MTL::ComputePipelineState* pipeline,
+                     int width, int height) {
+  const auto thread_width = std::max<NS::UInteger>(1, pipeline->threadExecutionWidth());
+  const auto thread_height =
+      std::max<NS::UInteger>(1, pipeline->maxTotalThreadsPerThreadgroup() / thread_width);
+  encoder->dispatchThreads(
+      MTL::Size{static_cast<NS::UInteger>(width), static_cast<NS::UInteger>(height), 1},
+      MTL::Size{thread_width, thread_height, 1});
+}
+
+auto Encoder(MetalRenderDevice& device) -> MTL::ComputeCommandEncoder* {
+  auto* encoder = static_cast<MTL::ComputeCommandEncoder*>(
+      device.Workspace().Device().EnsureComputeCommandEncoder(device.CommandContext()));
+  if (encoder == nullptr) {
+    throw std::runtime_error("ExecuteMetalLocalTone: compute encoder is missing");
+  }
+  return encoder;
+}
+
+void BindPlane(MTL::ComputeCommandEncoder* encoder, const Plane& plane, std::uint32_t index) {
+  encoder->setBuffer(plane.native, plane.offset, index);
+}
+
+auto AllocateTransientPlane(MetalRenderWorkspace& workspace, std::size_t bytes) -> Plane {
+  auto* ptr = workspace.TransientBuffers().Allocate(bytes);
+  if (ptr == nullptr) {
+    throw std::runtime_error("ExecuteMetalLocalTone: transient allocation failed");
+  }
+  const auto resolved = workspace.Device().ResolveDeviceMemory(ptr, bytes);
+  Plane      plane;
+  plane.ptr    = ptr;
+  plane.native = static_cast<MTL::Buffer*>(resolved.first);
+  plane.offset = resolved.second;
+  plane.bytes  = bytes;
+  return plane;
+}
+
+auto PlaneFromBuffer(MetalBackend::Buffer& buffer) -> Plane {
+  Plane plane;
+  plane.ptr    = buffer.DevicePointer();
+  plane.native = static_cast<MTL::Buffer*>(buffer.Native());
+  plane.offset = 0;
+  plane.bytes  = buffer.Bytes();
+  return plane;
+}
+
+auto EnsureValueBuffer(MetalRenderWorkspace& workspace, const GraphValueId& id, std::size_t bytes)
+    -> MetalBackend::Buffer& {
+  auto* existing = workspace.Values().Find(id);
+  if (existing != nullptr && existing->Bytes() >= bytes) {
+    return *existing;
+  }
+  workspace.Values().Store(id, workspace.Device().CreateBuffer(bytes));
+  auto* stored = workspace.Values().Find(id);
+  if (stored == nullptr) {
+    throw std::runtime_error("ExecuteMetalLocalTone: failed to store canonical buffer");
+  }
+  return *stored;
+}
+
+auto ReadMeta(MetalRenderWorkspace& workspace, const NodeId& grade_id) -> CanonicalLlfMeta {
+  auto* buffer = workspace.Values().Find(MetaId(grade_id));
+  if (buffer == nullptr || buffer->Bytes() < sizeof(CanonicalLlfMeta) ||
+      buffer->DevicePointer() == nullptr) {
+    return {};
+  }
+  CanonicalLlfMeta meta;
+  std::memcpy(&meta, buffer->DevicePointer(), sizeof(meta));
+  return meta;
+}
+
+void WriteMeta(MetalRenderDevice& device, const NodeId& grade_id, const CanonicalLlfMeta& meta) {
+  auto& buffer = EnsureValueBuffer(device.Workspace(), MetaId(grade_id), sizeof(CanonicalLlfMeta));
+  device.Workspace().Device().UploadBufferRange(
+      buffer, 0,
+      std::span<const std::byte>(reinterpret_cast<const std::byte*>(&meta), sizeof(meta)),
+      device.CommandContext());
+}
+
+auto LocalUvPlan(std::uint32_t width, std::uint32_t height) -> Matrix3x3 {
+  Matrix3x3 matrix;
+  matrix.m[0] = 1.0f / static_cast<float>(width);
+  matrix.m[4] = 1.0f / static_cast<float>(height);
+  return matrix;
+}
+
+void CopyMatrix(float* dst, const Matrix3x3& matrix) {
+  for (int i = 0; i < 9; ++i) {
+    dst[i] = matrix.m[i];
+  }
+}
+
+void BuildSourcePyramid(MetalRenderDevice& device, std::array<Plane, kMaxLevels>& source,
+                        const PyramidLayout& layout) {
+  for (int level = 1; level < layout.count; ++level) {
+    auto*         encoder  = Encoder(device);
+    auto          pipeline = Pipeline("local_tone_pyr_down", "Metal LLF pyr down");
+    PyrDownParams params;
+    params.src_width  = layout.widths[level - 1];
+    params.src_height = layout.heights[level - 1];
+    params.dst_width  = layout.widths[level];
+    params.dst_height = layout.heights[level];
+    encoder->setComputePipelineState(pipeline.get());
+    BindPlane(encoder, source[level - 1], 0);
+    BindPlane(encoder, source[level], 1);
+    encoder->setBytes(&params, sizeof(params), 2);
+    DispatchThreads(encoder, pipeline.get(), layout.widths[level], layout.heights[level]);
+    device.Workspace().Device().NoteComputeDispatch();
+  }
+}
+
+void BuildRemapPyramid(MetalRenderDevice& device, const Plane& source0,
+                       std::array<Plane, kMaxLevels>& levels, const PyramidLayout& layout,
+                       const LlfSample& sample, float sigma) {
+  auto*       encoder  = Encoder(device);
+  auto        pipeline = Pipeline("local_tone_remap", "Metal LLF remap");
+  RemapParams params;
+  params.width  = layout.widths[0];
+  params.height = layout.heights[0];
+  params.gamma  = sample.gamma;
+  params.target = sample.target;
+  params.beta   = sample.beta;
+  params.alpha  = sample.alpha;
+  params.sigma  = sigma;
+  encoder->setComputePipelineState(pipeline.get());
+  BindPlane(encoder, source0, 0);
+  BindPlane(encoder, levels[0], 1);
+  encoder->setBytes(&params, sizeof(params), 2);
+  DispatchThreads(encoder, pipeline.get(), layout.widths[0], layout.heights[0]);
+  device.Workspace().Device().NoteComputeDispatch();
+  BuildSourcePyramid(device, levels, layout);
+}
+
+void ApplyAdjusted(MetalRenderDevice& device, const MetalBackend::Texture2D& input,
+                   MetalBackend::Texture2D& output, const Plane& reference, const Plane& adjusted,
+                   std::uint32_t width, std::uint32_t height, int adjusted_width,
+                   int adjusted_height, const Matrix3x3& render_to_uv) {
+  auto*       encoder  = Encoder(device);
+  auto        pipeline = Pipeline("local_tone_apply", "Metal LLF apply");
+  ApplyParams params;
+  params.width           = static_cast<std::int32_t>(width);
+  params.height          = static_cast<std::int32_t>(height);
+  params.adjusted_width  = adjusted_width;
+  params.adjusted_height = adjusted_height;
+  CopyMatrix(params.render_to_uv, render_to_uv);
+  encoder->setComputePipelineState(pipeline.get());
+  encoder->setTexture(static_cast<MTL::Texture*>(input.Native()), 0);
+  encoder->setTexture(static_cast<MTL::Texture*>(output.Native()), 1);
+  BindPlane(encoder, reference, 0);
+  BindPlane(encoder, adjusted, 1);
+  encoder->setBytes(&params, sizeof(params), 2);
+  DispatchThreads(encoder, pipeline.get(), static_cast<int>(width), static_cast<int>(height));
+  device.Workspace().Device().NoteComputeDispatch();
+}
+
+}  // namespace
+
+void AppendMetalLocalToneWarmup(std::vector<MetalPipelineWarmup>& pipelines) {
+#ifdef ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH,
+                                          "local_tone_extract", "Metal LLF extract"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH,
+                                          "local_tone_extract_reference",
+                                          "Metal LLF extract reference"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH,
+                                          "local_tone_pyr_down", "Metal LLF pyr down"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH, "local_tone_remap",
+                                          "Metal LLF remap"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH,
+                                          "local_tone_select", "Metal LLF select"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH,
+                                          "local_tone_collapse", "Metal LLF collapse"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH, "local_tone_apply",
+                                          "Metal LLF apply"});
+#else
+  (void)pipelines;
+#endif
+}
+
+auto ExecuteMetalLocalTone(MetalRenderDevice& device, const MetalBackend::Texture2D& input,
+                           MetalBackend::Texture2D& output, const NodeId& grade_id,
+                           float shadows_slider, float highlights_slider,
+                           const ResolvedRenderGeometry& geometry, ContentKey source_key,
+                           ContentKey result_key) -> MetalLocalToneResult {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteMetalLocalTone: BeginRender has not been called");
+  }
+  if (input.Native() == nullptr || output.Native() == nullptr) {
+    throw std::runtime_error("ExecuteMetalLocalTone: missing input or output texture");
+  }
+  if (geometry.full_reference_extent.Empty() || geometry.render_extent.Empty()) {
+    throw std::runtime_error("ExecuteMetalLocalTone: geometry extents must be positive");
+  }
+
+  const auto width  = input.Width();
+  const auto height = input.Height();
+  if (output.Width() != width || output.Height() != height) {
+    throw std::runtime_error("ExecuteMetalLocalTone: output extent does not match input");
+  }
+
+  const auto canonical_dims = local_tone_mapping::ComputeMaskDimensions(
+      static_cast<int>(geometry.full_reference_extent.width),
+      static_cast<int>(geometry.full_reference_extent.height),
+      local_tone_mapping::kReferenceMaskMaxLongEdge);
+  const bool full_edit         = CoversFullEditSpace(geometry);
+  const int  current_long_edge = std::max(static_cast<int>(width), static_cast<int>(height));
+  const auto canonical_bytes   = static_cast<std::size_t>(canonical_dims.width) *
+                               static_cast<std::size_t>(canonical_dims.height) * sizeof(float);
+  const auto meta          = ReadMeta(workspace, grade_id);
+  auto*      cached_source = workspace.Values().Find(LevelId(grade_id, "source", 0));
+  auto*      cached_result = workspace.Values().Find(LevelId(grade_id, "result", 0));
+  const bool source_valid  = meta.canonical != 0 && meta.source_key == source_key.hash &&
+                            meta.mask_width == canonical_dims.width &&
+                            meta.mask_height == canonical_dims.height && cached_source != nullptr &&
+                            cached_source->Bytes() >= canonical_bytes &&
+                            cached_source->Native() != nullptr;
+  const bool result_valid = source_valid && meta.result_key == result_key.hash &&
+                            cached_result != nullptr && cached_result->Bytes() >= canonical_bytes &&
+                            cached_result->Native() != nullptr;
+  const bool sample_canonical =
+      result_valid && !(full_edit && current_long_edge > meta.source_long_edge);
+
+  MetalLocalToneResult tone;
+  if (sample_canonical) {
+    const auto sampling =
+        MakeLlfSamplingPlan(geometry, Extent2D{static_cast<std::uint32_t>(meta.mask_width),
+                                               static_cast<std::uint32_t>(meta.mask_height)});
+    ApplyAdjusted(device, input, output, PlaneFromBuffer(*cached_source),
+                  PlaneFromBuffer(*cached_result), width, height, meta.mask_width, meta.mask_height,
+                  sampling.render_to_texture_uv);
+    tone.reference_resource_id       = cached_source->ResourceId();
+    tone.sampled_canonical_reference = true;
+    return tone;
+  }
+
+  const bool seed_canonical = full_edit;
+  const bool reuse_source =
+      source_valid && !(full_edit && current_long_edge > meta.source_long_edge);
+  const auto                    mask_dims = seed_canonical || reuse_source
+                                                ? canonical_dims
+                                                : local_tone_mapping::ComputeMaskDimensions(
+                                   static_cast<int>(width), static_cast<int>(height),
+                                   local_tone_mapping::kReferenceMaskMaxLongEdge);
+  const auto                    layout    = MakeLayout(mask_dims.width, mask_dims.height);
+
+  std::array<Plane, kMaxLevels> source{};
+  std::array<Plane, kMaxLevels> remap_a{};
+  std::array<Plane, kMaxLevels> remap_b{};
+  std::array<Plane, kMaxLevels> result{};
+  const auto                    mark = workspace.TransientBuffers().used_bytes();
+  for (int level = 0; level < layout.count; ++level) {
+    const auto bytes =
+        static_cast<std::size_t>(layout.widths[level]) * layout.heights[level] * sizeof(float);
+    if (level == 0 && reuse_source) {
+      source[level] = PlaneFromBuffer(*cached_source);
+    } else {
+      source[level] = AllocateTransientPlane(workspace, bytes);
+    }
+    remap_a[level] = AllocateTransientPlane(workspace, bytes);
+    remap_b[level] = AllocateTransientPlane(workspace, bytes);
+    result[level]  = AllocateTransientPlane(workspace, bytes);
+  }
+  tone.transient_bytes =
+      static_cast<std::uint32_t>(workspace.TransientBuffers().used_bytes() - mark);
+
+  if (!reuse_source) {
+    auto* encoder = Encoder(device);
+    if (seed_canonical) {
+      auto pipeline = Pipeline("local_tone_extract_reference", "Metal LLF extract reference");
+      ExtractReferenceParams params;
+      params.input_width   = static_cast<std::int32_t>(width);
+      params.input_height  = static_cast<std::int32_t>(height);
+      params.output_width  = layout.widths[0];
+      params.output_height = layout.heights[0];
+      params.full_ref_w    = static_cast<float>(geometry.full_reference_extent.width);
+      params.full_ref_h    = static_cast<float>(geometry.full_reference_extent.height);
+      CopyMatrix(params.reference_to_render, geometry.reference_to_render);
+      encoder->setComputePipelineState(pipeline.get());
+      encoder->setTexture(static_cast<MTL::Texture*>(input.Native()), 0);
+      BindPlane(encoder, source[0], 0);
+      encoder->setBytes(&params, sizeof(params), 1);
+      DispatchThreads(encoder, pipeline.get(), layout.widths[0], layout.heights[0]);
+    } else {
+      auto          pipeline = Pipeline("local_tone_extract", "Metal LLF extract");
+      ExtractParams params;
+      params.input_width   = static_cast<std::int32_t>(width);
+      params.input_height  = static_cast<std::int32_t>(height);
+      params.output_width  = layout.widths[0];
+      params.output_height = layout.heights[0];
+      encoder->setComputePipelineState(pipeline.get());
+      encoder->setTexture(static_cast<MTL::Texture*>(input.Native()), 0);
+      BindPlane(encoder, source[0], 0);
+      encoder->setBytes(&params, sizeof(params), 1);
+      DispatchThreads(encoder, pipeline.get(), layout.widths[0], layout.heights[0]);
+    }
+    device.Workspace().Device().NoteComputeDispatch();
+    BuildSourcePyramid(device, source, layout);
+  } else if (layout.count > 1) {
+    BuildSourcePyramid(device, source, layout);
+  }
+
+  const float shadow_amount    = std::clamp(shadows_slider * 1.5f / 80.0f, -1.5f, 1.5f);
+  const float highlight_amount = std::clamp(-highlights_slider * 1.5f / 100.0f, -1.5f, 1.5f);
+  const float sigma            = local_tone_mapping::SigmaR(shadow_amount, highlight_amount);
+  const auto  samples          = local_tone_mapping::BuildSamples(shadow_amount, highlight_amount);
+  for (int level = 0; level < layout.count; ++level) {
+    workspace.Device().FillDeviceMemory(result[level].ptr, result[level].bytes, 0,
+                                        device.CommandContext());
+  }
+  BuildRemapPyramid(device, source[0], remap_a, layout, samples[0], sigma);
+  BuildRemapPyramid(device, source[0], remap_b, layout, samples[1], sigma);
+  for (std::size_t pair = 0; pair + 1 < samples.size(); ++pair) {
+    for (int level = 0; level < layout.count; ++level) {
+      const bool   top      = level + 1 == layout.count;
+      auto*        encoder  = Encoder(device);
+      auto         pipeline = Pipeline("local_tone_select", "Metal LLF select");
+      SelectParams params;
+      params.width         = layout.widths[level];
+      params.height        = layout.heights[level];
+      params.coarse_width  = top ? 1 : layout.widths[level + 1];
+      params.coarse_height = top ? 1 : layout.heights[level + 1];
+      params.gamma_lo      = samples[pair].gamma;
+      params.gamma_hi      = samples[pair + 1].gamma;
+      params.first         = pair == 0 ? 1 : 0;
+      params.last          = pair + 2 == samples.size() ? 1 : 0;
+      params.top           = top ? 1 : 0;
+      encoder->setComputePipelineState(pipeline.get());
+      BindPlane(encoder, source[level], 0);
+      BindPlane(encoder, remap_a[level], 1);
+      BindPlane(encoder, top ? remap_a[level] : remap_a[level + 1], 2);
+      BindPlane(encoder, remap_b[level], 3);
+      BindPlane(encoder, top ? remap_b[level] : remap_b[level + 1], 4);
+      BindPlane(encoder, result[level], 5);
+      encoder->setBytes(&params, sizeof(params), 6);
+      DispatchThreads(encoder, pipeline.get(), layout.widths[level], layout.heights[level]);
+      device.Workspace().Device().NoteComputeDispatch();
+    }
+    if (pair + 2 < samples.size()) {
+      std::swap(remap_a, remap_b);
+      BuildRemapPyramid(device, source[0], remap_b, layout, samples[pair + 2], sigma);
+    }
+  }
+  for (int level = layout.count - 2; level >= 0; --level) {
+    auto*          encoder  = Encoder(device);
+    auto           pipeline = Pipeline("local_tone_collapse", "Metal LLF collapse");
+    CollapseParams params;
+    params.width         = layout.widths[level];
+    params.height        = layout.heights[level];
+    params.coarse_width  = layout.widths[level + 1];
+    params.coarse_height = layout.heights[level + 1];
+    encoder->setComputePipelineState(pipeline.get());
+    BindPlane(encoder, result[level], 0);
+    BindPlane(encoder, result[level + 1], 1);
+    BindPlane(encoder, remap_a[level], 2);
+    encoder->setBytes(&params, sizeof(params), 3);
+    DispatchThreads(encoder, pipeline.get(), layout.widths[level], layout.heights[level]);
+    device.Workspace().Device().NoteComputeDispatch();
+    std::swap(result[level], remap_a[level]);
+  }
+
+  const Matrix3x3 apply_uv =
+      seed_canonical || reuse_source
+          ? MakeLlfSamplingPlan(geometry, Extent2D{static_cast<std::uint32_t>(layout.widths[0]),
+                                                   static_cast<std::uint32_t>(layout.heights[0])})
+                .render_to_texture_uv
+          : LocalUvPlan(width, height);
+  ApplyAdjusted(device, input, output, source[0], result[0], width, height, layout.widths[0],
+                layout.heights[0], apply_uv);
+
+  if (seed_canonical || reuse_source) {
+    const auto bytes =
+        static_cast<std::size_t>(layout.widths[0]) * layout.heights[0] * sizeof(float);
+    auto& source_buffer = EnsureValueBuffer(workspace, LevelId(grade_id, "source", 0), bytes);
+    auto& result_buffer = EnsureValueBuffer(workspace, LevelId(grade_id, "result", 0), bytes);
+    if (!reuse_source) {
+      workspace.Device().CopyDeviceMemoryToBuffer(source[0].ptr, source_buffer, 0, bytes,
+                                                  device.CommandContext());
+    }
+    workspace.Device().CopyDeviceMemoryToBuffer(result[0].ptr, result_buffer, 0, bytes,
+                                                device.CommandContext());
+    CanonicalLlfMeta published;
+    published.source_key       = source_key.hash;
+    published.result_key       = result_key.hash;
+    published.mask_width       = layout.widths[0];
+    published.mask_height      = layout.heights[0];
+    published.source_long_edge = current_long_edge;
+    published.canonical        = 1;
+    WriteMeta(device, grade_id, published);
+    tone.reference_resource_id = source_buffer.ResourceId();
+  } else if (workspace.Values().Find(MetaId(grade_id)) != nullptr) {
+    WriteMeta(device, grade_id, CanonicalLlfMeta{});
+    tone.reference_resource_id = 0;
+  }
+  tone.rebuilt_reference = true;
+  return tone;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_mask_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_mask_pass.mm
@@ -1,0 +1,511 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/metal/metal_mask_pass.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <alcedo/metal/Metal.hpp>
+
+#include "edit/geometry/texture_sampling_plan.hpp"
+#include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
+#include "edit/runtime/content_key.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr std::size_t kAlign = 256;
+
+struct Plane {
+  void*         ptr    = nullptr;
+  MTL::Buffer*  native = nullptr;
+  std::uint32_t offset = 0;
+  std::size_t   bytes  = 0;
+};
+
+struct SignedDistanceMeta {
+  std::uint64_t content_hash = 0;
+  std::uint32_t width        = 0;
+  std::uint32_t height       = 0;
+};
+
+struct alignas(16) MaskSampleParams {
+  float         render_to_uv[9]{};
+  std::uint32_t source_width  = 0;
+  std::uint32_t source_height = 0;
+  std::uint32_t output_width  = 0;
+  std::uint32_t output_height = 0;
+  std::uint32_t invert        = 0;
+  std::uint32_t pad0          = 0;
+  std::uint32_t pad1          = 0;
+};
+
+struct alignas(16) MaskFeatherParams {
+  float         render_to_uv[9]{};
+  std::uint32_t source_width  = 0;
+  std::uint32_t source_height = 0;
+  std::uint32_t output_width  = 0;
+  std::uint32_t output_height = 0;
+  float         radius_texels = 0.0f;
+  std::uint32_t invert        = 0;
+  std::uint32_t pad0          = 0;
+};
+
+struct alignas(16) MaskAnalyticParams {
+  float         render_to_reference[9]{};
+  std::uint32_t width               = 0;
+  std::uint32_t height              = 0;
+  std::uint32_t reference_width     = 0;
+  std::uint32_t reference_height    = 0;
+  std::uint32_t kind                = 0;
+  float         center_x            = 0.0f;
+  float         center_y            = 0.0f;
+  float         major_radius        = 0.0f;
+  float         minor_radius        = 0.0f;
+  float         rotation            = 0.0f;
+  float         inner_feather       = 0.0f;
+  float         outer_feather       = 0.0f;
+  std::uint32_t radial_invert       = 0;
+  float         origin_x            = 0.0f;
+  float         origin_y            = 0.0f;
+  float         normal_x            = 0.0f;
+  float         normal_y            = 0.0f;
+  float         transition_distance = 0.0f;
+  float         start_value         = 0.0f;
+  float         end_value           = 0.0f;
+  std::uint32_t graduated_invert    = 0;
+};
+
+struct alignas(16) MaskBandParams {
+  std::uint32_t width         = 0;
+  std::uint32_t height        = 0;
+  std::uint32_t target_inside = 0;
+  std::uint32_t pad           = 0;
+};
+
+struct alignas(16) MaskMipParams {
+  std::uint32_t source_width       = 0;
+  std::uint32_t source_height      = 0;
+  std::uint32_t destination_width  = 0;
+  std::uint32_t destination_height = 0;
+};
+
+auto AlignUp(std::size_t value, std::size_t alignment) -> std::size_t {
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+auto UnionDirtyRectangles(std::span<const RectI> rectangles, Extent2D extent) -> RectI {
+  if (rectangles.empty()) {
+    return {};
+  }
+  std::int32_t x0 = static_cast<std::int32_t>(extent.width);
+  std::int32_t y0 = static_cast<std::int32_t>(extent.height);
+  std::int32_t x1 = 0;
+  std::int32_t y1 = 0;
+  for (const auto& rect : rectangles) {
+    if (rect.width <= 0 || rect.height <= 0) {
+      continue;
+    }
+    x0 = std::min(x0, std::max(rect.x, 0));
+    y0 = std::min(y0, std::max(rect.y, 0));
+    x1 = std::max(x1, std::min(rect.X1(), static_cast<std::int32_t>(extent.width)));
+    y1 = std::max(y1, std::min(rect.Y1(), static_cast<std::int32_t>(extent.height)));
+  }
+  return x1 > x0 && y1 > y0 ? RectI{x0, y0, x1 - x0, y1 - y0} : RectI{};
+}
+
+auto CopyRectangle(const MaskAsset& asset, RectI rectangle) -> std::vector<std::byte> {
+  std::vector<std::byte> bytes(static_cast<std::size_t>(rectangle.width) * rectangle.height);
+  for (std::int32_t row = 0; row < rectangle.height; ++row) {
+    const auto source =
+        static_cast<std::size_t>(rectangle.y + row) * asset.descriptor.extent.width + rectangle.x;
+    std::copy_n(reinterpret_cast<const std::byte*>(asset.pixels.data() + source), rectangle.width,
+                bytes.data() + static_cast<std::size_t>(row) * rectangle.width);
+  }
+  return bytes;
+}
+
+auto HashSignedDistanceKey(const MaskAssetKey& key, Extent2D extent) -> ContentKey {
+  ContentHash hash;
+  hash.MixText(key.Value());
+  hash.MixU32(extent.width);
+  hash.MixU32(extent.height);
+  return hash.Key();
+}
+
+auto DistanceId(const NodeId& node) -> GraphValueId { return {node, PortId{"signed_distance"}}; }
+
+auto DistanceMetaId(const NodeId& node) -> GraphValueId {
+  return {node, PortId{"signed_distance.meta"}};
+}
+
+auto Pipeline(const char* function, const char* label) -> NS::SharedPtr<MTL::ComputePipelineState> {
+#ifndef ALCEDO_METAL_MASK_METALLIB_PATH
+  throw std::runtime_error("Metal mask metallib path is not configured.");
+#else
+  return metal::ComputePipelineCache::Instance().GetPipelineState(ALCEDO_METAL_MASK_METALLIB_PATH,
+                                                                  function, label);
+#endif
+}
+
+auto Encoder(MetalRenderDevice& device) -> MTL::ComputeCommandEncoder* {
+  auto* encoder = static_cast<MTL::ComputeCommandEncoder*>(
+      device.Workspace().Device().EnsureComputeCommandEncoder(device.CommandContext()));
+  if (encoder == nullptr) {
+    throw std::runtime_error("ExecuteMetalMask: compute encoder is missing");
+  }
+  return encoder;
+}
+
+void Dispatch2D(MTL::ComputeCommandEncoder* encoder, MTL::ComputePipelineState* pipeline,
+                std::uint32_t width, std::uint32_t height) {
+  const auto thread_width = std::max<NS::UInteger>(1, pipeline->threadExecutionWidth());
+  const auto thread_height =
+      std::max<NS::UInteger>(1, pipeline->maxTotalThreadsPerThreadgroup() / thread_width);
+  encoder->dispatchThreads(MTL::Size{width, height, 1}, MTL::Size{thread_width, thread_height, 1});
+}
+
+void Dispatch1D(MTL::ComputeCommandEncoder* encoder, MTL::ComputePipelineState*,
+                std::uint32_t               count) {
+  encoder->dispatchThreads(MTL::Size{count, 1, 1}, MTL::Size{1, 1, 1});
+}
+
+void CopyMatrix(float* dst, const Matrix3x3& matrix) {
+  for (int i = 0; i < 9; ++i) {
+    dst[i] = matrix.m[i];
+  }
+}
+
+auto EnsureOutput(MetalRenderWorkspace& workspace, const GraphValueId& id, Extent2D extent)
+    -> ResourceLease<MetalBackend>& {
+  return workspace.AcquireImageForWrite(id, {extent.width, extent.height, TextureFormat::R8});
+}
+
+auto EnsureValueBuffer(MetalRenderWorkspace& workspace, const GraphValueId& id, std::size_t bytes)
+    -> MetalBackend::Buffer& {
+  auto* existing = workspace.Values().Find(id);
+  if (existing != nullptr && existing->Bytes() >= bytes) {
+    return *existing;
+  }
+  workspace.Values().Store(id, workspace.Device().CreateBuffer(bytes));
+  auto* stored = workspace.Values().Find(id);
+  if (stored == nullptr) {
+    throw std::runtime_error("ExecuteMetalMask: failed to store signed-distance buffer");
+  }
+  return *stored;
+}
+
+auto AllocateTransientPlane(MetalRenderWorkspace& workspace, std::size_t bytes) -> Plane {
+  auto* ptr = workspace.TransientBuffers().Allocate(bytes);
+  if (ptr == nullptr) {
+    throw std::runtime_error("ExecuteMetalMask: transient allocation failed");
+  }
+  const auto resolved = workspace.Device().ResolveDeviceMemory(ptr, bytes);
+  Plane      plane;
+  plane.ptr    = ptr;
+  plane.native = static_cast<MTL::Buffer*>(resolved.first);
+  plane.offset = resolved.second;
+  plane.bytes  = bytes;
+  return plane;
+}
+
+void GenerateMipChain(MetalRenderDevice& device, MaskTextureLease<MetalBackend>& source) {
+  for (std::size_t level = 1; level < source.MipLevelCount(); ++level) {
+    auto&         previous = source.Texture(level - 1);
+    auto&         next     = source.Texture(level);
+    auto*         encoder  = Encoder(device);
+    auto          pipeline = Pipeline("mask_generate_r8_mip", "Metal Mask mip");
+    MaskMipParams params;
+    params.source_width       = previous.Width();
+    params.source_height      = previous.Height();
+    params.destination_width  = next.Width();
+    params.destination_height = next.Height();
+    encoder->setComputePipelineState(pipeline.get());
+    encoder->setTexture(static_cast<MTL::Texture*>(previous.Native()), 0);
+    encoder->setTexture(static_cast<MTL::Texture*>(next.Native()), 1);
+    encoder->setBytes(&params, sizeof(params), 0);
+    Dispatch2D(encoder, pipeline.get(), next.Width(), next.Height());
+    device.Workspace().Device().NoteComputeDispatch();
+  }
+}
+
+void EncodeAnalytic(MetalRenderDevice& device, MetalBackend::Texture2D& output,
+                    const AnalyticMaskNodeModel& analytic, const ExecutionPlan& plan) {
+  auto*              encoder  = Encoder(device);
+  auto               pipeline = Pipeline("mask_analytic", "Metal Mask analytic");
+  MaskAnalyticParams params;
+  CopyMatrix(params.render_to_reference, plan.geometry.render_to_reference);
+  params.width               = output.Width();
+  params.height              = output.Height();
+  params.reference_width     = plan.geometry.full_reference_extent.width;
+  params.reference_height    = plan.geometry.full_reference_extent.height;
+  params.kind                = analytic.Kind() == AnalyticMaskKind::Radial ? 0u : 1u;
+  const auto& radial         = analytic.Radial();
+  params.center_x            = radial.center_x;
+  params.center_y            = radial.center_y;
+  params.major_radius        = radial.major_radius;
+  params.minor_radius        = radial.minor_radius;
+  params.rotation            = radial.rotation;
+  params.inner_feather       = radial.inner_feather;
+  params.outer_feather       = radial.outer_feather;
+  params.radial_invert       = radial.invert ? 1u : 0u;
+  const auto& graduated      = analytic.GraduatedNd();
+  params.origin_x            = graduated.origin_x;
+  params.origin_y            = graduated.origin_y;
+  params.normal_x            = graduated.normal_x;
+  params.normal_y            = graduated.normal_y;
+  params.transition_distance = graduated.transition_distance;
+  params.start_value         = graduated.start_value;
+  params.end_value           = graduated.end_value;
+  params.graduated_invert    = graduated.invert ? 1u : 0u;
+  encoder->setComputePipelineState(pipeline.get());
+  encoder->setTexture(static_cast<MTL::Texture*>(output.Native()), 0);
+  encoder->setBytes(&params, sizeof(params), 0);
+  Dispatch2D(encoder, pipeline.get(), output.Width(), output.Height());
+  device.Workspace().Device().NoteComputeDispatch();
+}
+
+void EncodeRasterSample(MetalRenderDevice& device, const MetalBackend::Texture2D& source,
+                        MetalBackend::Texture2D& output, const Matrix3x3& render_to_uv,
+                        bool invert) {
+  auto*            encoder  = Encoder(device);
+  auto             pipeline = Pipeline("mask_raster_sample", "Metal Mask raster sample");
+  MaskSampleParams params;
+  CopyMatrix(params.render_to_uv, render_to_uv);
+  params.source_width  = source.Width();
+  params.source_height = source.Height();
+  params.output_width  = output.Width();
+  params.output_height = output.Height();
+  params.invert        = invert ? 1u : 0u;
+  encoder->setComputePipelineState(pipeline.get());
+  encoder->setTexture(static_cast<MTL::Texture*>(source.Native()), 0);
+  encoder->setTexture(static_cast<MTL::Texture*>(output.Native()), 1);
+  encoder->setBytes(&params, sizeof(params), 0);
+  Dispatch2D(encoder, pipeline.get(), output.Width(), output.Height());
+  device.Workspace().Device().NoteComputeDispatch();
+}
+
+auto EncodeSignedDistance(MetalRenderDevice& device, const MetalBackend::Texture2D& source,
+                          MetalBackend::Buffer& distance, std::uint32_t width,
+                          std::uint32_t height) -> std::uint32_t {
+  auto&      workspace  = device.Workspace();
+  const auto pixels     = static_cast<std::size_t>(width) * height;
+  const auto plane      = AlignUp(pixels * sizeof(float), kAlign);
+  const auto sites      = AlignUp(pixels * sizeof(int), kAlign);
+  const auto needed     = plane * 3 + sites + plane;
+  auto&      transients = workspace.TransientBuffers();
+  if (transients.used_bytes() == 0) {
+    transients.Reserve(std::max(needed, transients.capacity_bytes()));
+  }
+  const auto mark                = transients.used_bytes();
+  const auto horizontal          = AllocateTransientPlane(workspace, plane);
+  const auto inside              = AllocateTransientPlane(workspace, plane);
+  const auto outside             = AllocateTransientPlane(workspace, plane);
+  const auto site_plane          = AllocateTransientPlane(workspace, sites);
+  const auto bound_plane         = AllocateTransientPlane(workspace, plane);
+
+  auto       dispatch_horizontal = [&](bool target_inside, const Plane& dest) {
+    auto*          encoder  = Encoder(device);
+    auto           pipeline = Pipeline("mask_band_horizontal", "Metal Mask band H");
+    MaskBandParams params;
+    params.width         = width;
+    params.height        = height;
+    params.target_inside = target_inside ? 1u : 0u;
+    encoder->setComputePipelineState(pipeline.get());
+    encoder->setTexture(static_cast<MTL::Texture*>(source.Native()), 0);
+    encoder->setBuffer(dest.native, dest.offset, 0);
+    encoder->setBytes(&params, sizeof(params), 1);
+    Dispatch1D(encoder, pipeline.get(), height);
+    device.Workspace().Device().NoteComputeDispatch();
+  };
+  auto dispatch_vertical = [&](const Plane& src, const Plane& dest) {
+    auto*          encoder  = Encoder(device);
+    auto           pipeline = Pipeline("mask_band_vertical", "Metal Mask band V");
+    MaskBandParams params;
+    params.width  = width;
+    params.height = height;
+    encoder->setComputePipelineState(pipeline.get());
+    encoder->setBuffer(src.native, src.offset, 0);
+    encoder->setBuffer(dest.native, dest.offset, 1);
+    encoder->setBuffer(site_plane.native, site_plane.offset, 2);
+    encoder->setBuffer(bound_plane.native, bound_plane.offset, 3);
+    encoder->setBytes(&params, sizeof(params), 4);
+    Dispatch1D(encoder, pipeline.get(), width);
+    device.Workspace().Device().NoteComputeDispatch();
+  };
+
+  dispatch_horizontal(true, horizontal);
+  dispatch_vertical(horizontal, inside);
+  dispatch_horizontal(false, horizontal);
+  dispatch_vertical(horizontal, outside);
+
+  auto*          encoder  = Encoder(device);
+  auto           pipeline = Pipeline("mask_compose_signed_distance", "Metal Mask compose SDF");
+  MaskBandParams params;
+  params.width  = width;
+  params.height = height;
+  encoder->setComputePipelineState(pipeline.get());
+  encoder->setTexture(static_cast<MTL::Texture*>(source.Native()), 0);
+  encoder->setBuffer(inside.native, inside.offset, 0);
+  encoder->setBuffer(outside.native, outside.offset, 1);
+  encoder->setBuffer(static_cast<MTL::Buffer*>(distance.Native()), 0, 2);
+  encoder->setBytes(&params, sizeof(params), 3);
+  Dispatch2D(encoder, pipeline.get(), width, height);
+  device.Workspace().Device().NoteComputeDispatch();
+  return static_cast<std::uint32_t>(workspace.TransientBuffers().used_bytes() - mark);
+}
+
+void EncodeFeatherSample(MetalRenderDevice& device, const MetalBackend::Buffer& distance,
+                         MetalBackend::Texture2D& output, Extent2D source_extent,
+                         const Matrix3x3& render_to_uv, float radius_texels, bool invert) {
+  auto*             encoder  = Encoder(device);
+  auto              pipeline = Pipeline("mask_feather_sample", "Metal Mask feather");
+  MaskFeatherParams params;
+  CopyMatrix(params.render_to_uv, render_to_uv);
+  params.source_width  = source_extent.width;
+  params.source_height = source_extent.height;
+  params.output_width  = output.Width();
+  params.output_height = output.Height();
+  params.radius_texels = radius_texels;
+  params.invert        = invert ? 1u : 0u;
+  encoder->setComputePipelineState(pipeline.get());
+  encoder->setBuffer(static_cast<MTL::Buffer*>(distance.Native()), 0, 0);
+  encoder->setTexture(static_cast<MTL::Texture*>(output.Native()), 0);
+  encoder->setBytes(&params, sizeof(params), 1);
+  Dispatch2D(encoder, pipeline.get(), output.Width(), output.Height());
+  device.Workspace().Device().NoteComputeDispatch();
+}
+
+}  // namespace
+
+void AppendMetalMaskWarmup(std::vector<MetalPipelineWarmup>& pipelines) {
+#ifdef ALCEDO_METAL_MASK_METALLIB_PATH
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_MASK_METALLIB_PATH, "mask_generate_r8_mip",
+                                          "Metal Mask mip"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_MASK_METALLIB_PATH, "mask_raster_sample",
+                                          "Metal Mask raster sample"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_MASK_METALLIB_PATH, "mask_band_horizontal",
+                                          "Metal Mask band H"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_MASK_METALLIB_PATH, "mask_band_vertical",
+                                          "Metal Mask band V"});
+  pipelines.push_back(MetalPipelineWarmup{
+      ALCEDO_METAL_MASK_METALLIB_PATH, "mask_compose_signed_distance", "Metal Mask compose SDF"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_MASK_METALLIB_PATH, "mask_feather_sample",
+                                          "Metal Mask feather"});
+  pipelines.push_back(
+      MetalPipelineWarmup{ALCEDO_METAL_MASK_METALLIB_PATH, "mask_analytic", "Metal Mask analytic"});
+#else
+  (void)pipelines;
+#endif
+}
+
+auto ExecuteMetalMask(MetalRenderDevice& device, const ExecutionPlan& plan,
+                      const PipelineDocument& document, MaskStore* store,
+                      std::span<const RectI> dirty_rectangles) -> MetalMaskResult {
+  if (!device.Workspace().IsRendering()) {
+    throw std::runtime_error("ExecuteMetalMask: BeginRender has not been called");
+  }
+  if (!plan.primary_grade_mask) {
+    throw std::runtime_error("ExecuteMetalMask: plan has no mask");
+  }
+  auto&           workspace = device.Workspace();
+  auto&           context   = device.CommandContext();
+  const auto      extent    = plan.geometry.render_extent;
+  auto&           output    = EnsureOutput(workspace, plan.mask_output, extent);
+  MetalMaskResult result{plan.mask_output};
+
+  const auto*     node = document.Graph().FindNode(plan.primary_grade_mask->node_id);
+  if (const auto* analytic = dynamic_cast<const AnalyticMaskNodeModel*>(node)) {
+    EncodeAnalytic(device, output.Texture(), *analytic, plan);
+    return result;
+  }
+  const auto* raster = dynamic_cast<const RasterMaskNodeModel*>(node);
+  if (raster == nullptr) {
+    throw std::runtime_error("ExecuteMetalMask: compiled mask node does not match document");
+  }
+  if (store == nullptr) {
+    throw std::invalid_argument("ExecuteMetalMask: raster mask needs MaskStore");
+  }
+  const auto asset  = store->Load(raster->AssetKey());
+  const bool cached = workspace.MaskTextures().Contains(asset->key);
+  auto       source = workspace.MaskTextures().Acquire(asset->key, asset->descriptor.extent);
+  result.persistent_texture_resource_id = source.Texture().ResourceId();
+  result.mip_level_count                = static_cast<std::uint32_t>(source.MipLevelCount());
+  const auto dirty     = UnionDirtyRectangles(dirty_rectangles, asset->descriptor.extent);
+  const bool has_dirty = dirty.width > 0 && dirty.height > 0;
+  if (!cached) {
+    workspace.Device().UploadTexture2D(
+        source.Texture(),
+        std::span<const std::byte>(reinterpret_cast<const std::byte*>(asset->pixels.data()),
+                                   asset->pixels.size()),
+        context);
+    GenerateMipChain(device, source);
+  } else if (has_dirty) {
+    const auto bytes = CopyRectangle(*asset, dirty);
+    workspace.Device().UploadR8TextureRect(source.Texture(), dirty, bytes, context);
+    GenerateMipChain(device, source);
+  }
+
+  const auto sampling = MakeRasterMaskSamplingPlan(plan.geometry, raster->ReferenceBounds(),
+                                                   asset->descriptor.extent);
+  if (raster->FeatherRadius() <= 0.0f) {
+    const auto selected_level = std::min<std::size_t>(
+        static_cast<std::size_t>(std::max(std::floor(sampling.mip_level), 0.0f)),
+        source.MipLevelCount() - 1);
+    EncodeRasterSample(device, source.Texture(selected_level), output.Texture(),
+                       sampling.render_to_texture_uv, raster->Invert());
+    return result;
+  }
+
+  const auto distance_id    = DistanceId(raster->Id());
+  const auto meta_id        = DistanceMetaId(raster->Id());
+  const auto distance_key   = HashSignedDistanceKey(asset->key, asset->descriptor.extent);
+  const auto distance_bytes = static_cast<std::size_t>(asset->descriptor.extent.width) *
+                              asset->descriptor.extent.height * sizeof(float);
+  auto&              distance = EnsureValueBuffer(workspace, distance_id, distance_bytes);
+  auto&              meta_buf = EnsureValueBuffer(workspace, meta_id, sizeof(SignedDistanceMeta));
+  SignedDistanceMeta meta{};
+  if (meta_buf.DevicePointer() != nullptr && meta_buf.Bytes() >= sizeof(SignedDistanceMeta)) {
+    std::memcpy(&meta, meta_buf.DevicePointer(), sizeof(meta));
+  }
+  const bool key_matches = meta.content_hash == distance_key.hash &&
+                           meta.width == asset->descriptor.extent.width &&
+                           meta.height == asset->descriptor.extent.height;
+  const bool must_compute =
+      !cached || has_dirty || !key_matches || distance.Bytes() < distance_bytes;
+  if (must_compute) {
+    result.transient_bytes =
+        EncodeSignedDistance(device, source.Texture(), distance, asset->descriptor.extent.width,
+                             asset->descriptor.extent.height);
+    meta.content_hash = distance_key.hash;
+    meta.width        = asset->descriptor.extent.width;
+    meta.height       = asset->descriptor.extent.height;
+    workspace.Device().UploadBufferRange(
+        meta_buf, 0,
+        std::span<const std::byte>(reinterpret_cast<const std::byte*>(&meta), sizeof(meta)),
+        context);
+  }
+  result.signed_distance_resource_id = distance.ResourceId();
+  const auto  bounds                 = raster->ReferenceBounds();
+  const float x_scale =
+      static_cast<float>(asset->descriptor.extent.width) /
+      (static_cast<float>(plan.geometry.full_reference_extent.width) * std::max(bounds.w, 1.0e-6f));
+  const float y_scale = static_cast<float>(asset->descriptor.extent.height) /
+                        (static_cast<float>(plan.geometry.full_reference_extent.height) *
+                         std::max(bounds.h, 1.0e-6f));
+  const float radius_texels = raster->FeatherRadius() * 0.5f * (x_scale + y_scale);
+  EncodeFeatherSample(device, distance, output.Texture(), asset->descriptor.extent,
+                      sampling.render_to_texture_uv, radius_texels, raster->Invert());
+  return result;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
@@ -1,0 +1,450 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/metal/metal_primary_grade_pass.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <alcedo/metal/Metal.hpp>
+
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/lmt_model.hpp"
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/pipeline/local_tone_mapping.hpp"
+#include "edit/runtime/adjustment_runtime.hpp"
+#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/parameter_arena.hpp"
+#include "edit/runtime/parameter_binding.hpp"
+#include "edit/runtime/texture_format.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+#include "utils/lut/cube_lut.hpp"
+
+namespace alcedo {
+namespace {
+
+struct PrimaryGradeDispatchParams {
+  std::uint32_t command_count  = 0;
+  std::uint32_t command_offset = 0;
+  std::uint32_t lut_edge       = 0;
+  float         local_reference = 0.0f;
+  std::uint32_t width          = 0;
+  std::uint32_t pad[3]         = {};
+};
+
+enum class GradeOpKind : std::uint8_t { Fused, Detail, LlfBarrier };
+
+struct GradeOp {
+  GradeOpKind              kind = GradeOpKind::Fused;
+  std::vector<std::uint32_t> offsets;
+  ParameterSlotKey         detail_key{};
+};
+
+auto AcquireRgba(MetalRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
+                 std::uint32_t height) -> ResourceLease<MetalBackend>& {
+  return workspace.AcquireImageForWrite(id, {width, height, TextureFormat::Rgba32f});
+}
+
+auto AcquireScratch(MetalRenderWorkspace& workspace, std::uint32_t width, std::uint32_t height)
+    -> ResourceLease<MetalBackend> {
+  return workspace.Textures().Acquire({width, height, TextureFormat::Rgba32f});
+}
+
+auto EnsureBuffer(MetalRenderWorkspace& workspace, const GraphValueId& id, std::size_t bytes)
+    -> MetalBackend::Buffer& {
+  auto* existing = workspace.Values().Find(id);
+  if (existing != nullptr && existing->Bytes() >= bytes) {
+    return *existing;
+  }
+  workspace.Values().Store(id, workspace.Device().CreateBuffer(bytes));
+  auto* stored = workspace.Values().Find(id);
+  if (stored == nullptr) {
+    throw std::runtime_error("ExecuteMetalPrimaryGrade: command buffer store failed");
+  }
+  return *stored;
+}
+
+auto Pipeline(const char* function, const char* label) -> NS::SharedPtr<MTL::ComputePipelineState> {
+#ifndef ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH
+  throw std::runtime_error("Metal primary grade metallib path is not configured.");
+#else
+  return metal::ComputePipelineCache::Instance().GetPipelineState(
+      ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH, function, label);
+#endif
+}
+
+void DispatchThreads(MTL::ComputeCommandEncoder* encoder, MTL::ComputePipelineState* pipeline,
+                     std::uint32_t width, std::uint32_t height) {
+  const auto thread_width = std::max<NS::UInteger>(1, pipeline->threadExecutionWidth());
+  const auto thread_height =
+      std::max<NS::UInteger>(1, pipeline->maxTotalThreadsPerThreadgroup() / thread_width);
+  encoder->dispatchThreads(MTL::Size{width, height, 1}, MTL::Size{thread_width, thread_height, 1});
+}
+
+void DispatchPointwise(MetalRenderDevice& device, const MetalBackend::Texture2D& src,
+                       MetalBackend::Texture2D& dst, const MetalBackend::Buffer& params,
+                       const MetalBackend::Buffer& commands, std::uint32_t command_offset,
+                       std::uint32_t command_count, const MetalLutBinding& lut,
+                       std::uint32_t width, std::uint32_t height) {
+  auto pipeline = Pipeline("primary_grade_pointwise", "Metal PrimaryGrade");
+  auto* encoder = static_cast<MTL::ComputeCommandEncoder*>(
+      device.Workspace().Device().EnsureComputeCommandEncoder(device.CommandContext()));
+  if (encoder == nullptr) {
+    throw std::runtime_error("ExecuteMetalPrimaryGrade: compute encoder is missing");
+  }
+  PrimaryGradeDispatchParams dispatch;
+  dispatch.command_count   = command_count;
+  dispatch.command_offset  = command_offset;
+  dispatch.lut_edge        = lut.edge_size;
+  dispatch.local_reference = local_tone_mapping::kAcesccMiddleGray;
+  dispatch.width           = width;
+  encoder->setComputePipelineState(pipeline.get());
+  encoder->setTexture(static_cast<MTL::Texture*>(src.Native()), 0);
+  encoder->setTexture(static_cast<MTL::Texture*>(dst.Native()), 1);
+  encoder->setBuffer(static_cast<MTL::Buffer*>(params.Native()), 0, 0);
+  encoder->setBuffer(static_cast<MTL::Buffer*>(commands.Native()), 0, 1);
+  encoder->setBytes(&dispatch, sizeof(dispatch), 2);
+  encoder->setBuffer(static_cast<MTL::Buffer*>(lut.native), 0, 3);
+  DispatchThreads(encoder, pipeline.get(), width, height);
+  device.Workspace().Device().NoteComputeDispatch();
+}
+
+void DispatchMix(MetalRenderDevice& device, const MetalBackend::Texture2D& source,
+                 const MetalBackend::Texture2D& adjusted, MetalBackend::Texture2D& dst, float mix,
+                 std::uint32_t width, std::uint32_t height) {
+  auto pipeline = Pipeline("primary_grade_mix", "Metal PrimaryGrade Mix");
+  auto* encoder = static_cast<MTL::ComputeCommandEncoder*>(
+      device.Workspace().Device().EnsureComputeCommandEncoder(device.CommandContext()));
+  if (encoder == nullptr) {
+    throw std::runtime_error("ExecuteMetalPrimaryGrade: mix encoder is missing");
+  }
+  encoder->setComputePipelineState(pipeline.get());
+  encoder->setTexture(static_cast<MTL::Texture*>(source.Native()), 0);
+  encoder->setTexture(static_cast<MTL::Texture*>(adjusted.Native()), 1);
+  encoder->setTexture(static_cast<MTL::Texture*>(dst.Native()), 2);
+  encoder->setBytes(&mix, sizeof(mix), 0);
+  DispatchThreads(encoder, pipeline.get(), width, height);
+  device.Workspace().Device().NoteComputeDispatch();
+}
+
+auto PackLutRgba(const CubeLut& lut) -> std::vector<std::byte> {
+  const auto edge   = static_cast<std::size_t>(lut.edge3d_);
+  const auto voxels = edge * edge * edge;
+  std::vector<std::byte> packed(voxels * 4 * sizeof(float));
+  auto*                  out = reinterpret_cast<float*>(packed.data());
+  for (std::size_t i = 0; i < voxels; ++i) {
+    out[i * 4 + 0] = lut.lut3d_[i * 3 + 0];
+    out[i * 4 + 1] = lut.lut3d_[i * 3 + 1];
+    out[i * 4 + 2] = lut.lut3d_[i * 3 + 2];
+    out[i * 4 + 3] = 1.0f;
+  }
+  return packed;
+}
+
+auto LoadLut(MetalRenderDevice& device, ColorGradeNodeModel& grade) -> MetalLutBinding {
+  auto* model = dynamic_cast<LmtModel*>(grade.FindAdjustmentByType(type_ids::Lmt()));
+  if (model == nullptr || model->CubePath().empty()) {
+    return device.Workspace().Device().DummyLut();
+  }
+  CubeLut     cube;
+  std::string error;
+  if (!ParseCubeFile(model->CubePath(), cube, &error) || !cube.Has3D()) {
+    throw std::runtime_error("ExecuteMetalPrimaryGrade: failed to load LMT cube '" +
+                             model->CubePath() + "': " + error);
+  }
+  const auto packed = PackLutRgba(cube);
+  ContentHash hash;
+  hash.MixBytes(packed);
+  hash.MixU32(static_cast<std::uint32_t>(cube.edge3d_));
+  return device.Workspace().Device().AcquireLut(hash.Key(), packed,
+                                                static_cast<std::uint32_t>(cube.edge3d_),
+                                                device.CommandContext());
+}
+
+auto CompactOps(std::vector<GradeOp> ops, bool local_tone_active) -> std::vector<GradeOp> {
+  std::vector<GradeOp> compacted;
+  compacted.reserve(ops.size());
+  for (auto& op : ops) {
+    if (op.kind == GradeOpKind::LlfBarrier && !local_tone_active) {
+      continue;
+    }
+    if (op.kind == GradeOpKind::Fused && op.offsets.empty()) {
+      continue;
+    }
+    if (op.kind == GradeOpKind::Fused && !compacted.empty() &&
+        compacted.back().kind == GradeOpKind::Fused) {
+      compacted.back().offsets.insert(compacted.back().offsets.end(), op.offsets.begin(),
+                                      op.offsets.end());
+      continue;
+    }
+    compacted.push_back(std::move(op));
+  }
+  return compacted;
+}
+
+auto CountGpuWrites(const std::vector<GradeOp>& ops, bool skip_mix) -> std::size_t {
+  std::size_t count = skip_mix ? 0 : 1;
+  for (const auto& op : ops) {
+    if (op.kind == GradeOpKind::Fused || op.kind == GradeOpKind::Detail ||
+        op.kind == GradeOpKind::LlfBarrier) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+}  // namespace
+
+void AppendMetalPrimaryGradeWarmup(std::vector<MetalPipelineWarmup>& pipelines) {
+#ifdef ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH,
+                                          "primary_grade_pointwise", "Metal PrimaryGrade"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH,
+                                          "primary_grade_mix", "Metal PrimaryGrade Mix"});
+#else
+  (void)pipelines;
+#endif
+}
+
+auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& plan,
+                              const PreparedRawInput&, PipelineDocument& document)
+    -> MetalPrimaryGradeResult {
+  auto& workspace = device.Workspace();
+  if (!workspace.IsRendering()) {
+    throw std::runtime_error("ExecuteMetalPrimaryGrade: BeginRender has not been called");
+  }
+  auto* grade = document.PrimaryGrade();
+  if (grade == nullptr) {
+    throw std::runtime_error("ExecuteMetalPrimaryGrade: missing primary grade");
+  }
+  auto* input = workspace.Images().Find(plan.develop_output);
+  if (input == nullptr || input->Empty()) {
+    throw std::runtime_error("ExecuteMetalPrimaryGrade: missing Develop output");
+  }
+
+  auto& arena = workspace.Parameters();
+  arena.Reserve(plan.primary_grade_adjustments.size() *
+                (kGradeRuntimeParamBytes + ParameterArena<MetalBackend>::kSlotAlignment));
+  std::vector<PendingParameterPatch> pending;
+  std::vector<GradeOp>               ops;
+  ops.reserve(plan.primary_grade_adjustments.size());
+  float                       shadows_slider    = 0.0f;
+  float                       highlights_slider = 0.0f;
+  const ParameterFieldBinding field{DirtyFieldMask{kGradeRuntimeParamDirtyBit}, 0, 0,
+                                    kGradeRuntimeParamBytes};
+
+  auto FlushFused = [&]() -> GradeOp* {
+    if (ops.empty() || ops.back().kind != GradeOpKind::Fused) {
+      ops.push_back(GradeOp{GradeOpKind::Fused, {}, {}});
+    }
+    return &ops.back();
+  };
+
+  for (const auto& compiled : plan.primary_grade_adjustments) {
+    auto* model = grade->FindAdjustment(compiled.instance_id);
+    if (model == nullptr || model->Type() != compiled.type) {
+      throw std::runtime_error(
+          "ExecuteMetalPrimaryGrade: compiled adjustment no longer matches graph");
+    }
+    const auto behavior = TryResolveAdjustmentBehavior(compiled.type);
+    if (!behavior.has_value()) {
+      throw std::runtime_error("ExecuteMetalPrimaryGrade: unregistered adjustment type '" +
+                               std::string{compiled.type.Text()} + "'");
+    }
+    if (IsLocalToneBehavior(*behavior) &&
+        compiled.algorithm != CompiledAdjustmentAlgorithm::LocalLaplacian) {
+      throw std::runtime_error(
+          "ExecuteMetalPrimaryGrade: Shadows/Highlights were not compiled for LLF");
+    }
+    const ParameterSlotKey key{grade->Id(), compiled.instance_id};
+    const auto             runtime_params = MakeGradeRuntimeParams(*model, *behavior);
+    auto payload = std::make_shared<TypedOperatorParamPayload<GradeAdjustmentParams>>(
+        compiled.type, 1, runtime_params);
+    if (!arena.Contains(key)) {
+      arena.BindSlot(key, kGradeRuntimeParamBytes, std::span{&field, 1});
+      arena.InitializeFromFullDto(key, OperatorParamDto{compiled.type, 1, payload});
+      if (auto first = TakePendingParameterPatch(*model)) {
+        pending.push_back(std::move(*first));
+      }
+    } else if (auto change = TakePendingParameterPatch(*model)) {
+      OperatorParamPatchDto patch{grade->Id(), compiled.instance_id, compiled.type,
+                                  DirtyFieldMask{kGradeRuntimeParamDirtyBit}, payload};
+      arena.ApplyPatch(key, patch);
+      pending.push_back(std::move(*change));
+    }
+    if (compiled.algorithm == CompiledAdjustmentAlgorithm::LocalLaplacian) {
+      if (*behavior == AdjustmentBehavior::Shadows) {
+        shadows_slider = runtime_params.values[0];
+      } else if (*behavior == AdjustmentBehavior::Highlights) {
+        highlights_slider = runtime_params.values[0];
+      }
+      if (ops.empty() || ops.back().kind != GradeOpKind::LlfBarrier) {
+        ops.push_back(GradeOp{GradeOpKind::LlfBarrier, {}, {}});
+      }
+      continue;
+    }
+    if (compiled.algorithm == CompiledAdjustmentAlgorithm::Neighborhood ||
+        IsNeighborhoodBehavior(*behavior)) {
+      if (runtime_params.values[0] != 0.0f) {
+        ops.push_back(GradeOp{GradeOpKind::Detail, {arena.Binding(key).offset}, key});
+      }
+      continue;
+    }
+    FlushFused()->offsets.push_back(arena.Binding(key).offset);
+  }
+
+  const bool local_tone_active = local_tone_mapping::ShouldRun(
+      shadows_slider * 1.5f / 80.0f, -highlights_slider * 1.5f / 100.0f);
+  ops = CompactOps(std::move(ops), local_tone_active);
+
+  auto& context = device.CommandContext();
+  arena.UploadDirty(context);
+  for (auto& patch : pending) {
+    patch.Commit();
+  }
+
+  std::vector<std::uint32_t> command_offsets;
+  command_offsets.reserve(plan.primary_grade_adjustments.size());
+  std::vector<std::uint32_t> fused_starts;
+  fused_starts.reserve(ops.size());
+  ContentHash topology;
+  for (const auto& op : ops) {
+    topology.MixU32(static_cast<std::uint32_t>(op.kind));
+    topology.MixU32(static_cast<std::uint32_t>(op.offsets.size()));
+    fused_starts.push_back(static_cast<std::uint32_t>(command_offsets.size()));
+    for (const auto offset : op.offsets) {
+      topology.MixU32(offset);
+      command_offsets.push_back(offset);
+    }
+  }
+  const auto topology_hash = topology.Key().hash;
+
+  MetalPrimaryGradeResult result;
+  result.output = plan.primary_grade_output;
+  const GraphValueId command_id{grade->Id(), PortId{"runtime.order"}};
+  if (!command_offsets.empty()) {
+    const auto bytes = command_offsets.size() * sizeof(command_offsets[0]);
+    auto&      command_buffer =
+        EnsureBuffer(workspace, command_id, std::max<std::size_t>(bytes, sizeof(std::uint32_t)));
+    if (workspace.Device().GradeCommandTopologyHash() != topology_hash) {
+      workspace.Device().UploadBufferRange(
+          command_buffer, 0,
+          std::span<const std::byte>(reinterpret_cast<const std::byte*>(command_offsets.data()),
+                                     bytes),
+          context);
+      workspace.Device().SetGradeCommandTopologyHash(topology_hash);
+      result.command_upload_bytes = static_cast<std::uint32_t>(bytes);
+    }
+  }
+
+  const auto lut = LoadLut(device, *grade);
+  result.lut_resource_id = lut.resource_id;
+
+  input = workspace.Images().Find(plan.develop_output);
+  if (input == nullptr) {
+    throw std::runtime_error("ExecuteMetalPrimaryGrade: develop image lost during parameter bind");
+  }
+  const auto width  = input->Texture().Width();
+  const auto height = input->Texture().Height();
+  const float mix   = grade->Enabled() ? grade->Mix() : 0.0f;
+  const bool skip_mix = mix == 1.0f && !plan.primary_grade_mask.has_value();
+  const auto write_count = CountGpuWrites(ops, skip_mix);
+
+  std::vector<ResourceLease<MetalBackend>> scratches;
+  scratches.reserve(write_count + 1);
+  auto remaining = write_count;
+  enum class ImageSlot : std::uint8_t { Input, Scratch, Output };
+  ImageSlot   current_slot        = ImageSlot::Input;
+  std::size_t current_scratch     = 0;
+  ImageSlot   dest_slot           = ImageSlot::Scratch;
+  std::size_t dest_scratch        = 0;
+
+  auto Resolve = [&](ImageSlot slot, std::size_t scratch_index) -> MetalBackend::Texture2D& {
+    if (slot == ImageSlot::Input) {
+      auto* source = workspace.Images().Find(plan.develop_output);
+      if (source == nullptr) {
+        throw std::runtime_error("ExecuteMetalPrimaryGrade: missing Develop output");
+      }
+      return source->Texture();
+    }
+    if (slot == ImageSlot::Output) {
+      auto* dest = workspace.Images().Find(plan.primary_grade_output);
+      if (dest == nullptr) {
+        throw std::runtime_error("ExecuteMetalPrimaryGrade: missing grade output");
+      }
+      return dest->Texture();
+    }
+    if (scratch_index >= scratches.size()) {
+      throw std::runtime_error("ExecuteMetalPrimaryGrade: scratch index is invalid");
+    }
+    return scratches[scratch_index].Texture();
+  };
+
+  auto AllocateDest = [&]() {
+    if (remaining == 0) {
+      throw std::runtime_error("ExecuteMetalPrimaryGrade: destination count underflow");
+    }
+    --remaining;
+    if (remaining == 0) {
+      dest_slot = ImageSlot::Output;
+      (void)AcquireRgba(workspace, plan.primary_grade_output, width, height);
+      return;
+    }
+    dest_slot    = ImageSlot::Scratch;
+    dest_scratch = scratches.size();
+    scratches.push_back(AcquireScratch(workspace, width, height));
+  };
+
+  if (write_count == 0) {
+    auto& dest = AcquireRgba(workspace, plan.primary_grade_output, width, height);
+    auto* source = workspace.Images().Find(plan.develop_output);
+    workspace.Device().CopyTexture2D(source->Texture(), dest.Texture(), context);
+    return result;
+  }
+
+  auto* commands_buffer =
+      command_offsets.empty() ? nullptr : workspace.Values().Find(command_id);
+  for (std::size_t index = 0; index < ops.size(); ++index) {
+    const auto& op = ops[index];
+    AllocateDest();
+    auto& src  = Resolve(current_slot, current_scratch);
+    auto& dest = Resolve(dest_slot, dest_scratch);
+    if (op.kind == GradeOpKind::LlfBarrier) {
+      workspace.Device().CopyTexture2D(src, dest, context);
+    } else if (op.kind == GradeOpKind::Fused) {
+      if (commands_buffer == nullptr) {
+        throw std::runtime_error("ExecuteMetalPrimaryGrade: missing fused command buffer");
+      }
+      DispatchPointwise(device, src, dest, arena.DeviceBuffer(), *commands_buffer,
+                        fused_starts[index], static_cast<std::uint32_t>(op.offsets.size()), lut,
+                        width, height);
+      ++result.pointwise_dispatch_count;
+    } else {
+      if (commands_buffer == nullptr) {
+        throw std::runtime_error("ExecuteMetalPrimaryGrade: missing detail command buffer");
+      }
+      DispatchPointwise(device, src, dest, arena.DeviceBuffer(), *commands_buffer,
+                        fused_starts[index], 1, lut, width, height);
+      ++result.detail_pass_count;
+    }
+    current_slot    = dest_slot;
+    current_scratch = dest_scratch;
+  }
+
+  if (!skip_mix) {
+    AllocateDest();
+    auto& source   = Resolve(ImageSlot::Input, 0);
+    auto& adjusted = Resolve(current_slot, current_scratch);
+    auto& dest     = Resolve(dest_slot, dest_scratch);
+    DispatchMix(device, source, adjusted, dest, mix, width, height);
+  }
+  return result;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
@@ -119,8 +119,10 @@ void DispatchPointwise(MetalRenderDevice& device, const MetalBackend::Texture2D&
 
 void DispatchMix(MetalRenderDevice& device, const MetalBackend::Texture2D& source,
                  const MetalBackend::Texture2D& adjusted, MetalBackend::Texture2D& dst, float mix,
-                 std::uint32_t width, std::uint32_t height) {
-  auto  pipeline = Pipeline("primary_grade_mix", "Metal PrimaryGrade Mix");
+                 const MetalBackend::Texture2D* mask, std::uint32_t width, std::uint32_t height) {
+  auto  pipeline = mask == nullptr
+                       ? Pipeline("primary_grade_mix", "Metal PrimaryGrade Mix")
+                       : Pipeline("primary_grade_mix_masked", "Metal PrimaryGrade Mix Masked");
   auto* encoder  = static_cast<MTL::ComputeCommandEncoder*>(
       device.Workspace().Device().EnsureComputeCommandEncoder(device.CommandContext()));
   if (encoder == nullptr) {
@@ -130,6 +132,9 @@ void DispatchMix(MetalRenderDevice& device, const MetalBackend::Texture2D& sourc
   encoder->setTexture(static_cast<MTL::Texture*>(source.Native()), 0);
   encoder->setTexture(static_cast<MTL::Texture*>(adjusted.Native()), 1);
   encoder->setTexture(static_cast<MTL::Texture*>(dst.Native()), 2);
+  if (mask != nullptr) {
+    encoder->setTexture(static_cast<MTL::Texture*>(mask->Native()), 3);
+  }
   encoder->setBytes(&mix, sizeof(mix), 0);
   DispatchThreads(encoder, pipeline.get(), width, height);
   device.Workspace().Device().NoteComputeDispatch();
@@ -208,6 +213,9 @@ void AppendMetalPrimaryGradeWarmup(std::vector<MetalPipelineWarmup>& pipelines) 
                                           "primary_grade_pointwise", "Metal PrimaryGrade"});
   pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH,
                                           "primary_grade_mix", "Metal PrimaryGrade Mix"});
+  pipelines.push_back(MetalPipelineWarmup{ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH,
+                                          "primary_grade_mix_masked",
+                                          "Metal PrimaryGrade Mix Masked"});
 #else
   (void)pipelines;
 #endif
@@ -447,10 +455,20 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
 
   if (!skip_mix) {
     AllocateDest();
-    auto& source   = Resolve(ImageSlot::Input, 0);
-    auto& adjusted = Resolve(current_slot, current_scratch);
-    auto& dest     = Resolve(dest_slot, dest_scratch);
-    DispatchMix(device, source, adjusted, dest, mix, width, height);
+    auto&                          source       = Resolve(ImageSlot::Input, 0);
+    auto&                          adjusted     = Resolve(current_slot, current_scratch);
+    auto&                          dest         = Resolve(dest_slot, dest_scratch);
+    const MetalBackend::Texture2D* mask_texture = nullptr;
+    if (plan.primary_grade_mask) {
+      auto* mask = workspace.Images().Find(plan.mask_output);
+      if (mask == nullptr || mask->Texture().Native() == nullptr ||
+          mask->Texture().Format() != TextureFormat::R8 || mask->Texture().Width() != width ||
+          mask->Texture().Height() != height) {
+        throw std::runtime_error("ExecuteMetalPrimaryGrade: compiled mask output is missing");
+      }
+      mask_texture = &mask->Texture();
+    }
+    DispatchMix(device, source, adjusted, dest, mix, mask_texture, width, height);
   }
   return result;
 }

--- a/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
@@ -20,8 +20,10 @@
 #include "edit/pipeline/local_tone_mapping.hpp"
 #include "edit/runtime/adjustment_runtime.hpp"
 #include "edit/runtime/content_key.hpp"
+#include "edit/runtime/metal/metal_local_tone_pass.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/parameter_binding.hpp"
+#include "edit/runtime/result_content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "metal/compute_pipeline_cache.hpp"
 #include "utils/lut/cube_lut.hpp"
@@ -30,20 +32,20 @@ namespace alcedo {
 namespace {
 
 struct PrimaryGradeDispatchParams {
-  std::uint32_t command_count  = 0;
-  std::uint32_t command_offset = 0;
-  std::uint32_t lut_edge       = 0;
+  std::uint32_t command_count   = 0;
+  std::uint32_t command_offset  = 0;
+  std::uint32_t lut_edge        = 0;
   float         local_reference = 0.0f;
-  std::uint32_t width          = 0;
-  std::uint32_t pad[3]         = {};
+  std::uint32_t width           = 0;
+  std::uint32_t pad[3]          = {};
 };
 
 enum class GradeOpKind : std::uint8_t { Fused, Detail, LlfBarrier };
 
 struct GradeOp {
-  GradeOpKind              kind = GradeOpKind::Fused;
+  GradeOpKind                kind = GradeOpKind::Fused;
   std::vector<std::uint32_t> offsets;
-  ParameterSlotKey         detail_key{};
+  ParameterSlotKey           detail_key{};
 };
 
 auto AcquireRgba(MetalRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
@@ -90,10 +92,10 @@ void DispatchThreads(MTL::ComputeCommandEncoder* encoder, MTL::ComputePipelineSt
 void DispatchPointwise(MetalRenderDevice& device, const MetalBackend::Texture2D& src,
                        MetalBackend::Texture2D& dst, const MetalBackend::Buffer& params,
                        const MetalBackend::Buffer& commands, std::uint32_t command_offset,
-                       std::uint32_t command_count, const MetalLutBinding& lut,
-                       std::uint32_t width, std::uint32_t height) {
-  auto pipeline = Pipeline("primary_grade_pointwise", "Metal PrimaryGrade");
-  auto* encoder = static_cast<MTL::ComputeCommandEncoder*>(
+                       std::uint32_t command_count, const MetalLutBinding& lut, std::uint32_t width,
+                       std::uint32_t height) {
+  auto  pipeline = Pipeline("primary_grade_pointwise", "Metal PrimaryGrade");
+  auto* encoder  = static_cast<MTL::ComputeCommandEncoder*>(
       device.Workspace().Device().EnsureComputeCommandEncoder(device.CommandContext()));
   if (encoder == nullptr) {
     throw std::runtime_error("ExecuteMetalPrimaryGrade: compute encoder is missing");
@@ -118,8 +120,8 @@ void DispatchPointwise(MetalRenderDevice& device, const MetalBackend::Texture2D&
 void DispatchMix(MetalRenderDevice& device, const MetalBackend::Texture2D& source,
                  const MetalBackend::Texture2D& adjusted, MetalBackend::Texture2D& dst, float mix,
                  std::uint32_t width, std::uint32_t height) {
-  auto pipeline = Pipeline("primary_grade_mix", "Metal PrimaryGrade Mix");
-  auto* encoder = static_cast<MTL::ComputeCommandEncoder*>(
+  auto  pipeline = Pipeline("primary_grade_mix", "Metal PrimaryGrade Mix");
+  auto* encoder  = static_cast<MTL::ComputeCommandEncoder*>(
       device.Workspace().Device().EnsureComputeCommandEncoder(device.CommandContext()));
   if (encoder == nullptr) {
     throw std::runtime_error("ExecuteMetalPrimaryGrade: mix encoder is missing");
@@ -134,8 +136,8 @@ void DispatchMix(MetalRenderDevice& device, const MetalBackend::Texture2D& sourc
 }
 
 auto PackLutRgba(const CubeLut& lut) -> std::vector<std::byte> {
-  const auto edge   = static_cast<std::size_t>(lut.edge3d_);
-  const auto voxels = edge * edge * edge;
+  const auto             edge   = static_cast<std::size_t>(lut.edge3d_);
+  const auto             voxels = edge * edge * edge;
   std::vector<std::byte> packed(voxels * 4 * sizeof(float));
   auto*                  out = reinterpret_cast<float*>(packed.data());
   for (std::size_t i = 0; i < voxels; ++i) {
@@ -158,13 +160,12 @@ auto LoadLut(MetalRenderDevice& device, ColorGradeNodeModel& grade) -> MetalLutB
     throw std::runtime_error("ExecuteMetalPrimaryGrade: failed to load LMT cube '" +
                              model->CubePath() + "': " + error);
   }
-  const auto packed = PackLutRgba(cube);
+  const auto  packed = PackLutRgba(cube);
   ContentHash hash;
   hash.MixBytes(packed);
   hash.MixU32(static_cast<std::uint32_t>(cube.edge3d_));
-  return device.Workspace().Device().AcquireLut(hash.Key(), packed,
-                                                static_cast<std::uint32_t>(cube.edge3d_),
-                                                device.CommandContext());
+  return device.Workspace().Device().AcquireLut(
+      hash.Key(), packed, static_cast<std::uint32_t>(cube.edge3d_), device.CommandContext());
 }
 
 auto CompactOps(std::vector<GradeOp> ops, bool local_tone_active) -> std::vector<GradeOp> {
@@ -210,10 +211,11 @@ void AppendMetalPrimaryGradeWarmup(std::vector<MetalPipelineWarmup>& pipelines) 
 #else
   (void)pipelines;
 #endif
+  AppendMetalLocalToneWarmup(pipelines);
 }
 
 auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& plan,
-                              const PreparedRawInput&, PipelineDocument& document)
+                              const PreparedRawInput& prepared, PipelineDocument& document)
     -> MetalPrimaryGradeResult {
   auto& workspace = device.Workspace();
   if (!workspace.IsRendering()) {
@@ -239,7 +241,7 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
   const ParameterFieldBinding field{DirtyFieldMask{kGradeRuntimeParamDirtyBit}, 0, 0,
                                     kGradeRuntimeParamBytes};
 
-  auto FlushFused = [&]() -> GradeOp* {
+  auto                        FlushFused = [&]() -> GradeOp* {
     if (ops.empty() || ops.back().kind != GradeOpKind::Fused) {
       ops.push_back(GradeOp{GradeOpKind::Fused, {}, {}});
     }
@@ -299,11 +301,11 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
     FlushFused()->offsets.push_back(arena.Binding(key).offset);
   }
 
-  const bool local_tone_active = local_tone_mapping::ShouldRun(
-      shadows_slider * 1.5f / 80.0f, -highlights_slider * 1.5f / 100.0f);
-  ops = CompactOps(std::move(ops), local_tone_active);
+  const bool local_tone_active = local_tone_mapping::ShouldRun(shadows_slider * 1.5f / 80.0f,
+                                                               -highlights_slider * 1.5f / 100.0f);
+  ops                          = CompactOps(std::move(ops), local_tone_active);
 
-  auto& context = device.CommandContext();
+  auto& context                = device.CommandContext();
   arena.UploadDirty(context);
   for (auto& patch : pending) {
     patch.Commit();
@@ -323,7 +325,7 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
       command_offsets.push_back(offset);
     }
   }
-  const auto topology_hash = topology.Key().hash;
+  const auto              topology_hash = topology.Key().hash;
 
   MetalPrimaryGradeResult result;
   result.output = plan.primary_grade_output;
@@ -343,29 +345,29 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
     }
   }
 
-  const auto lut = LoadLut(device, *grade);
+  const auto lut         = LoadLut(device, *grade);
   result.lut_resource_id = lut.resource_id;
 
-  input = workspace.Images().Find(plan.develop_output);
+  input                  = workspace.Images().Find(plan.develop_output);
   if (input == nullptr) {
     throw std::runtime_error("ExecuteMetalPrimaryGrade: develop image lost during parameter bind");
   }
-  const auto width  = input->Texture().Width();
-  const auto height = input->Texture().Height();
-  const float mix   = grade->Enabled() ? grade->Mix() : 0.0f;
-  const bool skip_mix = mix == 1.0f && !plan.primary_grade_mask.has_value();
-  const auto write_count = CountGpuWrites(ops, skip_mix);
+  const auto  width       = input->Texture().Width();
+  const auto  height      = input->Texture().Height();
+  const float mix         = grade->Enabled() ? grade->Mix() : 0.0f;
+  const bool  skip_mix    = mix == 1.0f && !plan.primary_grade_mask.has_value();
+  const auto  write_count = CountGpuWrites(ops, skip_mix);
 
   std::vector<ResourceLease<MetalBackend>> scratches;
   scratches.reserve(write_count + 1);
   auto remaining = write_count;
   enum class ImageSlot : std::uint8_t { Input, Scratch, Output };
-  ImageSlot   current_slot        = ImageSlot::Input;
-  std::size_t current_scratch     = 0;
-  ImageSlot   dest_slot           = ImageSlot::Scratch;
-  std::size_t dest_scratch        = 0;
+  ImageSlot   current_slot    = ImageSlot::Input;
+  std::size_t current_scratch = 0;
+  ImageSlot   dest_slot       = ImageSlot::Scratch;
+  std::size_t dest_scratch    = 0;
 
-  auto Resolve = [&](ImageSlot slot, std::size_t scratch_index) -> MetalBackend::Texture2D& {
+  auto        Resolve = [&](ImageSlot slot, std::size_t scratch_index) -> MetalBackend::Texture2D& {
     if (slot == ImageSlot::Input) {
       auto* source = workspace.Images().Find(plan.develop_output);
       if (source == nullptr) {
@@ -402,21 +404,27 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
   };
 
   if (write_count == 0) {
-    auto& dest = AcquireRgba(workspace, plan.primary_grade_output, width, height);
+    auto& dest   = AcquireRgba(workspace, plan.primary_grade_output, width, height);
     auto* source = workspace.Images().Find(plan.develop_output);
     workspace.Device().CopyTexture2D(source->Texture(), dest.Texture(), context);
     return result;
   }
 
-  auto* commands_buffer =
-      command_offsets.empty() ? nullptr : workspace.Values().Find(command_id);
+  auto* commands_buffer = command_offsets.empty() ? nullptr : workspace.Values().Find(command_id);
   for (std::size_t index = 0; index < ops.size(); ++index) {
     const auto& op = ops[index];
     AllocateDest();
     auto& src  = Resolve(current_slot, current_scratch);
     auto& dest = Resolve(dest_slot, dest_scratch);
     if (op.kind == GradeOpKind::LlfBarrier) {
-      workspace.Device().CopyTexture2D(src, dest, context);
+      const auto tone =
+          ExecuteMetalLocalTone(device, src, dest, grade->Id(), shadows_slider, highlights_slider,
+                                plan.geometry, HashLlfSourceKey(plan, prepared, document),
+                                HashLlfReferenceKey(plan, prepared, document));
+      result.local_tone_reference_resource_id       = tone.reference_resource_id;
+      result.local_tone_rebuilt_reference           = tone.rebuilt_reference;
+      result.local_tone_sampled_canonical_reference = tone.sampled_canonical_reference;
+      result.local_tone_transient_bytes             = tone.transient_bytes;
     } else if (op.kind == GradeOpKind::Fused) {
       if (commands_buffer == nullptr) {
         throw std::runtime_error("ExecuteMetalPrimaryGrade: missing fused command buffer");

--- a/alcedo_studio/src/edit/runtime/metal/shader/camera_color.metal
+++ b/alcedo_studio/src/edit/runtime/metal/shader/camera_color.metal
@@ -1,0 +1,47 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct CameraColorGpuParams {
+  float camera_to_ap1[9];
+  float pad[3];
+};
+
+static inline float AcesccEncode(float value) {
+  constexpr float kA          = 9.72f;
+  constexpr float kB          = 17.52f;
+  constexpr float kOffset     = 0.0000152587890625f;
+  constexpr float kTransition = 0.000030517578125f;
+  constexpr float kFloor      = (-16.0f + kA) / kB;
+  if (value < 0.0f) {
+    return kFloor + value;
+  }
+  if (value < kTransition) {
+    return (log2(kOffset + value * 0.5f) + kA) / kB;
+  }
+  return (log2(value) + kA) / kB;
+}
+
+kernel void camera_color_acescc(texture2d<float, access::read> src [[texture(0)]],
+                                texture2d<float, access::write> dst [[texture(1)]],
+                                constant CameraColorGpuParams& camera [[buffer(0)]],
+                                uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= src.get_width() || gid.y >= src.get_height()) {
+    return;
+  }
+  const float4 source = src.read(gid);
+  const float  x =
+      camera.camera_to_ap1[0] * source.x + camera.camera_to_ap1[1] * source.y +
+      camera.camera_to_ap1[2] * source.z;
+  const float y =
+      camera.camera_to_ap1[3] * source.x + camera.camera_to_ap1[4] * source.y +
+      camera.camera_to_ap1[5] * source.z;
+  const float z =
+      camera.camera_to_ap1[6] * source.x + camera.camera_to_ap1[7] * source.y +
+      camera.camera_to_ap1[8] * source.z;
+  dst.write(float4(AcesccEncode(x), AcesccEncode(y), AcesccEncode(z), source.w), gid);
+}

--- a/alcedo_studio/src/edit/runtime/metal/shader/drt.metal
+++ b/alcedo_studio/src/edit/runtime/metal/shader/drt.metal
@@ -1,0 +1,419 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <metal_stdlib>
+
+using namespace metal;
+
+constant int kMetalAcesOdtTableSize = 362;
+
+struct MetalJMhParams {
+  float MATRIX_RGB_to_CAM16_c_[9];
+  float MATRIX_CAM16_c_to_RGB_[9];
+  float MATRIX_cone_response_to_Aab_[9];
+  float MATRIX_Aab_to_cone_response_[9];
+  float F_L_n_;
+  float cz_;
+  float inv_cz_;
+  float A_w_J_;
+  float inv_A_w_J_;
+};
+
+struct MetalTSParams {
+  float n_;
+  float n_r_;
+  float g_;
+  float t_1_;
+  float c_t_;
+  float s_2_;
+  float u_2_;
+  float m_2_;
+  float forward_limit_;
+  float inverse_limit_;
+  float log_peak_;
+};
+
+struct MetalODTParams {
+  float          peak_luminance_;
+  MetalJMhParams input_params_;
+  MetalJMhParams reach_params_;
+  MetalJMhParams limit_params_;
+  MetalTSParams  ts_;
+  float          limit_J_max;
+  float          model_gamma_inv;
+  float          mid_J;
+  float          focus_dist;
+  float          lower_hull_gamma_inv;
+  int            hue_linearity_search_range[2];
+  float          sat;
+  float          sat_thr;
+  float          compr;
+  float          chroma_compress_scale;
+  float          table_reach_M_[kMetalAcesOdtTableSize];
+  float          table_hues_[kMetalAcesOdtTableSize];
+  float          table_upper_hull_gamma_[kMetalAcesOdtTableSize];
+  float          table_gamut_cusps_[kMetalAcesOdtTableSize][4];
+};
+
+struct MetalOpenDRTParams {
+  int   tn_hcon_enable_;
+  int   tn_lcon_enable_;
+  int   pt_enable_;
+  int   ptl_enable_;
+  int   ptm_enable_;
+  int   brl_enable_;
+  int   brlp_enable_;
+  int   hc_enable_;
+  int   hs_rgb_enable_;
+  int   hs_cmy_enable_;
+  int   creative_white_;
+  int   surround_;
+  int   clamp_;
+  int   display_gamut_;
+  int   display_eotf_;
+  float tn_con_;
+  float tn_sh_;
+  float tn_toe_;
+  float tn_off_;
+  float tn_hcon_;
+  float tn_hcon_pv_;
+  float tn_hcon_st_;
+  float tn_lcon_;
+  float tn_lcon_w_;
+  float cwp_lm_;
+  float rs_sa_;
+  float rs_rw_;
+  float rs_bw_;
+  float pt_lml_;
+  float pt_lml_r_;
+  float pt_lml_g_;
+  float pt_lml_b_;
+  float pt_lmh_;
+  float pt_lmh_r_;
+  float pt_lmh_b_;
+  float ptl_c_;
+  float ptl_m_;
+  float ptl_y_;
+  float ptm_low_;
+  float ptm_low_rng_;
+  float ptm_low_st_;
+  float ptm_high_;
+  float ptm_high_rng_;
+  float ptm_high_st_;
+  float brl_;
+  float brl_r_;
+  float brl_g_;
+  float brl_b_;
+  float brl_rng_;
+  float brl_st_;
+  float brlp_;
+  float brlp_r_;
+  float brlp_g_;
+  float brlp_b_;
+  float hc_r_;
+  float hc_r_rng_;
+  float hs_r_;
+  float hs_r_rng_;
+  float hs_g_;
+  float hs_g_rng_;
+  float hs_b_;
+  float hs_b_rng_;
+  float hs_c_;
+  float hs_c_rng_;
+  float hs_m_;
+  float hs_m_rng_;
+  float hs_y_;
+  float hs_y_rng_;
+  float ts_x1_;
+  float ts_y1_;
+  float ts_x0_;
+  float ts_y0_;
+  float ts_s0_;
+  float ts_p_;
+  float ts_s10_;
+  float ts_m1_;
+  float ts_m2_;
+  float ts_s_;
+  float ts_dsc_;
+  float pt_cmp_Lf_;
+  float s_Lp100_;
+  float ts_s1_;
+};
+
+struct MetalToOutputParams {
+  int                method_;
+  int                eotf_;
+  MetalODTParams     aces_params_;
+  MetalOpenDRTParams open_drt_params_;
+  float              limit_to_display_matx[9];
+  float              display_linear_scale_;
+};
+
+constant int kMetalOdtMethodAces20   = 0;
+constant int kMetalOdtMethodOpenDrt  = 1;
+constant int kMetalEotfLinear        = 0;
+constant int kMetalEotfSt2084        = 1;
+constant int kMetalEotfHlg           = 2;
+constant int kMetalEotfGamma26       = 3;
+constant int kMetalEotfBt1886        = 4;
+constant int kMetalEotfGamma22       = 5;
+constant int kMetalEotfGamma18       = 6;
+constant int kMetalOdtTableSize      = 360;
+constant int kMetalOdtBaseIndex      = 1;
+constant float kMetalHueLimit        = 360.0f;
+
+constant float kAcesccLog2Min      = -15.0f;
+constant float kAcesccLog2Denorm   = -16.0f;
+constant float kAcesccDenormTrans  = 0.00003051757812f;
+constant float kAcesccDenormOffset = 0.00001525878906f;
+constant float kAcesccA            = 9.72f;
+constant float kAcesccB            = 17.52f;
+
+constant float kPqM1 = 0.1593017578125f;
+constant float kPqM2 = 78.84375f;
+constant float kPqC1 = 0.8359375f;
+constant float kPqC2 = 18.8515625f;
+constant float kPqC3 = 18.6875f;
+constant float kPqC  = 10000.0f;
+
+constant float kRefLuminance        = 100.0f;
+constant float kJScale              = 100.0f;
+constant float kCamNlOffset         = 27.13f;
+constant float kModelGamma          = 1.13705599f;
+constant float kSmoothCusps         = 0.12f;
+constant float kCuspMidBlend        = 1.3f;
+constant float kFocusGainBlend      = 0.3f;
+constant float kCompressionThreshold = 0.75f;
+
+constant float kAp1ToAp0[9] = {
+    0.695452213f, 0.0447945632f, -0.00552588236f,
+    0.140678704f, 0.859671116f,   0.00402521016f,
+    0.163869068f, 0.0955343172f,  1.00150073f};
+
+constant float kOpenDrtSqrt3 = 1.7320508075688772f;
+constant float kOpenDrtPi    = 3.1415926535897932f;
+
+constant float kOpenDrtAp1ToXyz[9] = {
+    0.6524187177f, 0.1271799255f, 0.1708572838f,
+    0.2680640592f, 0.6724644790f, 0.0594714618f,
+   -0.0054699285f, 0.0051828000f, 1.0893448793f};
+constant float kOpenDrtP3D65ToXyz[9] = {
+    0.4865709486f, 0.2656676932f, 0.1982172852f,
+    0.2289745641f, 0.6917385218f, 0.0792869141f,
+    0.0f,          0.0451133819f, 1.0439443689f};
+constant float kOpenDrtXyzToP3D65[9] = {
+    2.4934969119f, -0.9313836179f, -0.4027107845f,
+   -0.8294889696f,  1.7626640603f,  0.0236246858f,
+    0.0358458302f, -0.0761723893f,  0.9568845240f};
+constant float kOpenDrtXyzToRec709[9] = {
+    3.2409699419f, -1.5373831776f, -0.4986107603f,
+   -0.9692436363f,  1.8759675015f,  0.0415550574f,
+    0.0556300797f, -0.2039769589f,  1.0569715142f};
+constant float kOpenDrtP3ToRec2020[9] = {
+    0.7538330344f, 0.1985973691f, 0.0475695966f,
+    0.0457438490f, 0.9417772198f, 0.0124789312f,
+   -0.0012103404f, 0.0176017173f, 0.9836086231f};
+
+constant float kOpenDrtCatDciToD93[9] = {
+    0.9656850100f, 0.0018374524f, 0.0912967324f,
+    0.0005145721f, 0.9651667476f, 0.0360146537f,
+    0.0015425049f, 0.0070265178f, 1.4728747606f};
+constant float kOpenDrtCatDciToD75[9] = {
+    0.9901207685f, 0.0151389474f, 0.0511047691f,
+    0.0102197211f, 0.9717181325f, 0.0200536624f,
+    0.0007430727f, 0.0042176349f, 1.2795965672f};
+constant float kOpenDrtCatDciToD65[9] = {
+    1.0095160007f, 0.0269675441f, 0.0213620812f,
+    0.0187991038f, 0.9753303528f, 0.0082273334f,
+    0.0001345433f, 0.0021790350f, 1.1386636496f};
+constant float kOpenDrtCatDciToD60[9] = {
+    1.0215952396f, 0.0348486789f, 0.0037125200f,
+    0.0244968776f, 0.9769372344f, 0.0012030154f,
+   -0.0002339159f, 0.0009866878f, 1.0559426546f};
+constant float kOpenDrtCatDciToD55[9] = {
+    1.0359457731f, 0.0450937562f, -0.0157573819f,
+    0.0318740681f, 0.9777445197f, -0.0065574497f,
+   -0.0006536094f, -0.0002973722f, 0.9663277864f};
+constant float kOpenDrtCatDciToD50[9] = {
+    1.0530687571f, 0.0581297316f, -0.0376100838f,
+    0.0412359424f, 0.9776936769f, -0.0152792223f,
+   -0.0011377768f, -0.0017075930f, 0.8673683405f};
+constant float kOpenDrtCatD65ToD93[9] = {
+    0.9570342302f, -0.0247171503f, 0.0624028593f,
+   -0.0179296955f, 0.9900198579f,  0.0248119533f,
+    0.0012758914f, 0.0042791907f,  1.2934571505f};
+constant float kOpenDrtCatD65ToD75[9] = {
+    0.9810010791f, -0.0116619254f, 0.0265614092f,
+   -0.0084348805f, 0.9965060949f,  0.0105696544f,
+    0.0005528096f, 0.0017984081f,  1.1237472296f};
+constant float kOpenDrtCatD65ToD60[9] = {
+    1.0118224621f, 0.0077887932f, -0.0157783031f,
+    0.0056168283f, 1.0015064478f, -0.0062851757f,
+   -0.0003357357f, -0.0010509500f, 0.9273666739f};
+constant float kOpenDrtCatD65ToD55[9] = {
+    1.0258508921f, 0.0179439820f, -0.0332137793f,
+    0.0129133854f, 1.0021477938f, -0.0132421032f,
+   -0.0007199403f, -0.0021810681f, 0.8486801386f};
+constant float kOpenDrtCatD65ToD50[9] = {
+    1.0425740480f, 0.0308911763f, -0.0528126210f,
+    0.0221935362f, 1.0018566847f, -0.0210737623f,
+   -0.0011648831f, -0.0034205271f, 0.7617890835f};
+constant float kOpenDrtCatD65ToDci[9] = {
+    0.9910855889f, -0.0273622870f, -0.0183956623f,
+   -0.0191021916f,  1.0258377790f, -0.0070537254f,
+   -0.0000805503f, -0.0019598883f,  0.8782384396f};
+constant float kOpenDrtCatD60ToD93[9] = {
+    0.9460569024f, -0.0319503024f, 0.0831701458f,
+   -0.0231979694f, 0.9887458086f,  0.0330617502f,
+    0.0016920343f, 0.0057232874f,  1.3948310614f};
+constant float kOpenDrtCatD60ToD75[9] = {
+    0.9696599841f, -0.0191383120f, 0.0450099558f,
+   -0.0138545772f, 0.9951338172f,  0.0179062262f,
+    0.0009314523f, 0.0030600820f,  1.2117980719f};
+constant float kOpenDrtCatD60ToD65[9] = {
+    0.9883639216f, -0.0076691005f, 0.0167641640f,
+   -0.0055409619f, 0.9985461235f,  0.0066733211f,
+    0.0003515370f, 0.0011288375f,  1.0783357620f};
+constant float kOpenDrtCatD60ToD55[9] = {
+    1.0138028860f, 0.0100131510f, -0.0184983462f,
+    0.0072056516f, 1.0005768538f, -0.0073752999f,
+   -0.0004011337f, -0.0012143496f, 0.9151356816f};
+constant float kOpenDrtCatD60ToD50[9] = {
+    1.0302526951f, 0.0227910466f, -0.0392656922f,
+    0.0163766481f, 1.0002059937f, -0.0156668238f,
+   -0.0008645768f, -0.0025466848f, 0.8214220405f};
+
+static inline float3 mult_f3_f33(float3 v, constant float* m) {
+  return float3(v.x * m[0] + v.y * m[3] + v.z * m[6], v.x * m[1] + v.y * m[4] + v.z * m[7],
+                v.x * m[2] + v.y * m[5] + v.z * m[8]);
+}
+
+static inline float3 apply_matrix3x3(constant float* mat, float3 v) {
+  return float3(mat[0] * v.x + mat[1] * v.y + mat[2] * v.z,
+                mat[3] * v.x + mat[4] * v.y + mat[5] * v.z,
+                mat[6] * v.x + mat[7] * v.y + mat[8] * v.z);
+}
+
+static inline float3 mult_f_f3(float3 v, float s) { return v * s; }
+
+static inline float3 clamp_f3(float3 v, float min_val, float max_val) {
+  return clamp(v, float3(min_val), float3(max_val));
+}
+
+static inline float3 pow_f3(float3 v, float expv) {
+  return float3(pow(v.x, expv), pow(v.y, expv), pow(v.z, expv));
+}
+
+static inline float acescc_decode(float acescc) {
+  const float encode_floor     = (kAcesccLog2Denorm + kAcesccA) / kAcesccB;
+  const float denorm_threshold = (kAcesccLog2Min + kAcesccA) / kAcesccB;
+  if (acescc < encode_floor) {
+    return acescc - encode_floor;
+  }
+  if (acescc <= denorm_threshold) {
+    return (exp2(acescc * kAcesccB - kAcesccA) - kAcesccDenormOffset) * 2.0f;
+  }
+  return exp2(acescc * kAcesccB - kAcesccA);
+}
+
+static inline float Tonescale_fwd(float x, const constant MetalTSParams& params) {
+  const float denom = x + params.s_2_;
+  const float ratio = (denom > 1e-7f) ? (fmax(0.0f, x) / denom) : 0.0f;
+  const float f     = params.m_2_ * pow(ratio, params.g_);
+  const float h     = fmax(0.0f, f * f / (f + params.t_1_));
+  return h * params.n_r_;
+}
+
+static inline float moncurve_inv(float y, float gamma, float offs) {
+  const float yb = pow(offs * gamma / ((gamma - 1.0f) * (1.0f + offs)), gamma);
+  const float rs =
+      pow((gamma - 1.0f) / offs, gamma - 1.0f) * pow((1.0f + offs) / gamma, gamma);
+  return (y >= yb) ? (1.0f + offs) * pow(y, 1.0f / gamma) - offs : y * rs;
+}
+
+static inline float3 moncurve_inv_f3(float3 v, float gamma, float offs) {
+  return float3(moncurve_inv(v.x, gamma, offs), moncurve_inv(v.y, gamma, offs),
+                moncurve_inv(v.z, gamma, offs));
+}
+
+static inline float bt1886_inv(float l, float gamma, float lw = 1.0f, float lb = 0.0f) {
+  const float a = pow(pow(lw, 1.0f / gamma) - pow(lb, 1.0f / gamma), gamma);
+  const float b = pow(lb, 1.0f / gamma) / (pow(lw, 1.0f / gamma) - pow(lb, 1.0f / gamma));
+  return pow(fmax(l / a, 0.0f), 1.0f / gamma) - b;
+}
+
+static inline float3 bt1886_inv_f3(float3 v, float gamma, float lw = 1.0f, float lb = 0.0f) {
+  return float3(bt1886_inv(v.x, gamma, lw, lb), bt1886_inv(v.y, gamma, lw, lb),
+                bt1886_inv(v.z, gamma, lw, lb));
+}
+
+static inline float Y_to_ST2084(float c) {
+  const float l  = c / kPqC;
+  const float lm = pow(l, kPqM1);
+  const float n  = (kPqC1 + kPqC2 * lm) / (1.0f + kPqC3 * lm);
+  return pow(n, kPqM2);
+}
+
+static inline float3 Y_to_ST2084_f3(float3 c) {
+  return float3(Y_to_ST2084(c.x), Y_to_ST2084(c.y), Y_to_ST2084(c.z));
+}
+
+static inline float3 HLG_from_display_linear_1000nits_f3(float3 display_linear) {
+  const float yd = 0.2627f * display_linear.x + 0.6780f * display_linear.y + 0.0593f * display_linear.z;
+  float3 rgb     = display_linear;
+  if (yd > 0.0f) {
+    rgb = mult_f_f3(rgb, pow(yd, (1.0f - 1.2f) / 1.2f));
+  }
+  const float a = 0.17883277f;
+  const float b = 0.28466892f;
+  const float c = 0.55991073f;
+  rgb.x         = (rgb.x <= (1.0f / 12.0f)) ? sqrt(3.0f * rgb.x) : a * log(12.0f * rgb.x - b) + c;
+  rgb.y         = (rgb.y <= (1.0f / 12.0f)) ? sqrt(3.0f * rgb.y) : a * log(12.0f * rgb.y - b) + c;
+  rgb.z         = (rgb.z <= (1.0f / 12.0f)) ? sqrt(3.0f * rgb.z) : a * log(12.0f * rgb.z - b) + c;
+  return rgb;
+}
+
+static inline float3 eotf_inv(float3 rgb_linear_in, int otf_type) {
+  const float3 rgb_linear = float3(fmax(0.0f, rgb_linear_in.x), fmax(0.0f, rgb_linear_in.y),
+                                   fmax(0.0f, rgb_linear_in.z));
+  if (otf_type == kMetalEotfLinear) return rgb_linear;
+  if (otf_type == kMetalEotfSt2084) return Y_to_ST2084_f3(rgb_linear);
+  if (otf_type == kMetalEotfHlg) return HLG_from_display_linear_1000nits_f3(rgb_linear);
+  if (otf_type == kMetalEotfBt1886) return bt1886_inv_f3(rgb_linear, 2.4f, 1.0f, 0.0f);
+  if (otf_type == kMetalEotfGamma26) return pow_f3(rgb_linear, 1.0f / 2.6f);
+  if (otf_type == kMetalEotfGamma22) return pow_f3(rgb_linear, 1.0f / 2.2f);
+  if (otf_type == kMetalEotfGamma18) return pow_f3(rgb_linear, 1.0f / 1.8f);
+  return moncurve_inv_f3(rgb_linear, 2.4f, 0.055f);
+}
+
+static inline float3 DisplayEncoding(float3 rgb, constant float* mat_limit_to_display, int eotf_num,
+                                     float linear_scale = 1.0f) {
+  const float3 rgb_disp_linear   = mult_f3_f33(rgb, mat_limit_to_display);
+  const float3 rgb_display_scale = mult_f_f3(rgb_disp_linear, linear_scale);
+  return eotf_inv(rgb_display_scale, eotf_num);
+}
+
+#include "drt_aces.metal"
+#include "drt_opendrt.metal"
+
+kernel void drt_display(texture2d<float, access::read> input [[texture(0)]],
+                        texture2d<float, access::write> output [[texture(1)]],
+                        constant MetalToOutputParams& params [[buffer(0)]],
+                        uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= input.get_width() || gid.y >= input.get_height()) {
+    return;
+  }
+  const float4 source = input.read(gid);
+  const float3 scene =
+      float3(acescc_decode(source.x), acescc_decode(source.y), acescc_decode(source.z));
+  float3 display_linear;
+  if (params.method_ == kMetalOdtMethodAces20) {
+    display_linear = OutputTransform_fwd(scene, params.aces_params_);
+  } else {
+    display_linear = OpenDRTTransform_fwd(scene, params.open_drt_params_);
+  }
+  const float3 encoded = DisplayEncoding(display_linear, params.limit_to_display_matx, params.eotf_,
+                                         params.display_linear_scale_);
+  output.write(float4(encoded, source.w), gid);
+}

--- a/alcedo_studio/src/edit/runtime/metal/shader/drt_aces.metal
+++ b/alcedo_studio/src/edit/runtime/metal/shader/drt_aces.metal
@@ -1,0 +1,403 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+static inline bool isfinite_f(float x) { return isfinite(x); }
+static inline float clamp_f(float x, float lo, float hi) { return fmin(hi, fmax(lo, x)); }
+static inline int clamp_i(int x, int lo, int hi) { return x < lo ? lo : (x > hi ? hi : x); }
+static inline float safe_sqrt(float x) { return sqrt(fmax(x, 0.0f)); }
+
+static inline float safe_div(float a, float b, float eps = 1e-7f) {
+  const float ab = fabs(b);
+  const float bb = (ab < eps) ? copysign(eps, b) : b;
+  return a / bb;
+}
+
+static inline float safe_log10_ratio(float num, float den, float eps = 1e-7f) {
+  return log10(fmax(num, eps) / fmax(den, eps));
+}
+
+static inline float safe_pow_pos(float base, float expv) { return pow(fmax(base, 0.0f), expv); }
+
+struct HueDependentGamutParams {
+  float2 JMcusp;
+  float  gamma_bottom_inv;
+  float  gamma_top_inv;
+  float  focus_J;
+  float  analytical_threshold;
+};
+
+static inline float wrap_to_360(float hue) {
+  if (!isfinite_f(hue)) return 0.0f;
+  float y = fmod(hue, 360.0f);
+  if (y < 0.0f) y += 360.0f;
+  return y;
+}
+
+static inline float radians_to_degrees(float rad) { return rad * (180.0f / kOpenDrtPi); }
+static inline float degrees_to_radians(float deg) { return deg * (kOpenDrtPi / 180.0f); }
+
+static inline int hue_position_in_uniform_table(float hue, int table_size) {
+  const float wrapped = wrap_to_360(hue);
+  const float pos     = wrapped * (float(table_size) / kMetalHueLimit);
+  return clamp_i(int(pos), 0, table_size - 1);
+}
+
+static inline float lerp_f(float a, float b, float t) { return a + (b - a) * t; }
+
+static inline float reach_M_from_table(float h, const constant MetalODTParams& p) {
+  const float hw   = wrap_to_360(h);
+  const float pos  = hw * (float(kMetalOdtTableSize) / kMetalHueLimit);
+  const int   base = clamp_i(int(pos), 0, kMetalOdtTableSize - 1);
+  const float t    = clamp_f(pos - float(base), 0.0f, 1.0f);
+  const int   i_lo = base + kMetalOdtBaseIndex;
+  const int   i_hi = i_lo + 1;
+  return lerp_f(p.table_reach_M_[i_lo], p.table_reach_M_[i_hi], t);
+}
+
+static inline float pacrc_fwd_base(float rc) {
+  const float fl_y = pow(rc, 0.42f);
+  return fl_y / (kCamNlOffset + fl_y);
+}
+
+static inline float pacrc_fwd(float v) {
+  return copysign(pacrc_fwd_base(fabs(v)), v);
+}
+
+static inline float pacrc_inv_base(float ra) {
+  const float ra_lim = fmin(ra, 0.99f);
+  const float fl_y   = (kCamNlOffset * ra_lim) / (1.0f - ra_lim);
+  return pow(fl_y, 1.0f / 0.42f);
+}
+
+static inline float pacrc_inv(float v) {
+  return copysign(pacrc_inv_base(fabs(v)), v);
+}
+
+static inline float Achromatic_n_to_J(float a, float cz) { return kJScale * pow(a, cz); }
+static inline float J_to_Achromatic_n(float j, float inv_cz) { return pow(j * (1.0f / kJScale), inv_cz); }
+
+static inline float3 RGB_to_Aab(float3 rgb, const constant MetalJMhParams& p) {
+  const float3 rgb_m = mult_f3_f33(rgb, p.MATRIX_RGB_to_CAM16_c_);
+  const float3 rgb_a = float3(pacrc_fwd(rgb_m.x), pacrc_fwd(rgb_m.y), pacrc_fwd(rgb_m.z));
+  return mult_f3_f33(rgb_a, p.MATRIX_cone_response_to_Aab_);
+}
+
+static inline float3 Aab_to_JMh(float3 aab, const constant MetalJMhParams& p) {
+  const float mask  = aab.x > 0.0f ? 1.0f : 0.0f;
+  const float j     = Achromatic_n_to_J(aab.x, p.cz_) * mask;
+  const float m     = safe_sqrt(aab.y * aab.y + aab.z * aab.z) * mask;
+  const float h_rad = atan2(aab.z, aab.y);
+  const float h     = wrap_to_360(radians_to_degrees(h_rad)) * mask;
+  return float3(j, m, h);
+}
+
+static inline float3 JMh_to_Aab(float3 jmh, const constant MetalJMhParams& p) {
+  const float h_rad = degrees_to_radians(jmh.z);
+  return float3(J_to_Achromatic_n(jmh.x, p.inv_cz_), jmh.y * cos(h_rad), jmh.y * sin(h_rad));
+}
+
+static inline float3 Aab_to_RGB(float3 aab, const constant MetalJMhParams& p) {
+  const float3 rgb_a = mult_f3_f33(aab, p.MATRIX_Aab_to_cone_response_);
+  const float3 rgb_m = float3(pacrc_inv(rgb_a.x), pacrc_inv(rgb_a.y), pacrc_inv(rgb_a.z));
+  return mult_f3_f33(rgb_m, p.MATRIX_CAM16_c_to_RGB_);
+}
+
+static inline float3 RGB_to_JMh(float3 color, const constant MetalJMhParams& p) {
+  return Aab_to_JMh(RGB_to_Aab(color, p), p);
+}
+
+static inline float3 JMh_to_RGB(float3 jmh, const constant MetalJMhParams& p) {
+  return Aab_to_RGB(JMh_to_Aab(jmh, p), p);
+}
+
+static inline float A_to_Y(float a, const constant MetalJMhParams& p) {
+  return pacrc_inv_base(p.A_w_J_ * a) / p.F_L_n_;
+}
+
+static inline float J_to_Y(float j, const constant MetalJMhParams& p) {
+  return A_to_Y(J_to_Achromatic_n(fabs(j), p.inv_cz_), p);
+}
+
+static inline float Y_to_J(float y, const constant MetalJMhParams& p) {
+  const float ra = pacrc_fwd_base(fabs(y) * p.F_L_n_);
+  const float j  = Achromatic_n_to_J(ra * p.inv_A_w_J_, p.cz_);
+  return copysign(j, y);
+}
+
+static inline float chroma_compress_norm(float h, float chroma_compress_scale) {
+  const float hr      = degrees_to_radians(h);
+  const float a       = cos(hr);
+  const float b       = sin(hr);
+  const float cos_hr2 = a * a - b * b;
+  const float sin_hr2 = 2.0f * a * b;
+  const float cos_hr3 = 4.0f * a * a * a - 3.0f * a;
+  const float sin_hr3 = 3.0f * b - 4.0f * b * b * b;
+  const float m       = 11.34072f * a + 16.46899f * cos_hr2 + 7.88380f * cos_hr3 +
+                  14.66441f * b - 6.37224f * sin_hr2 + 9.19364f * sin_hr3 + 77.12896f;
+  return m * chroma_compress_scale;
+}
+
+static inline float reinhard_remap(float scale, float nd, bool invert = false) {
+  if (invert) {
+    if (nd >= 1.0f) return scale;
+    return scale * -(nd / (nd - 1.0f));
+  }
+  return scale * nd / (1.0f + nd);
+}
+
+static inline float toe(float x, float limit, float k1_in, float k2_in, bool invert = false) {
+  if (x > limit) return x;
+  const float k2 = fmax(k2_in, 0.001f);
+  const float k1 = sqrt(k1_in * k1_in + k2 * k2);
+  const float k3 = (limit + k1) / (limit + k2);
+  if (invert) {
+    return (x * x + k1 * x) / (k3 * (x + k2));
+  }
+  const float minus_b = k3 * x - k1;
+  const float minus_c = k2 * k3 * x;
+  return 0.5f * (minus_b + safe_sqrt(minus_b * minus_b + 4.0f * minus_c));
+}
+
+static inline float3 chroma_compress_fwd(float3 jmh, float tonemapped_j, const constant MetalODTParams& p,
+                                         bool invert = false) {
+  float m_compr = jmh.y;
+  if (jmh.y != 0.0f) {
+    const float limit_j          = fmax(p.limit_J_max, 1e-6f);
+    const float jts              = fmax(tonemapped_j, 0.0f);
+    const float nj               = clamp_f(jts / limit_j, 0.0f, 1.0f);
+    const float snj              = fmax(0.0f, 1.0f - nj);
+    const float mnorm            = chroma_compress_norm(jmh.z, p.chroma_compress_scale);
+    if (!isfinite_f(mnorm) || fabs(mnorm) < 1e-6f) {
+      return float3(jts, 0.0f, jmh.z);
+    }
+    const float limit            = fmax(safe_pow_pos(nj, p.model_gamma_inv) * reach_M_from_table(jmh.z, p) / mnorm,
+                               0.0f);
+    const float toe_limit        = limit - 0.001f;
+    const float toe_snj_sat      = snj * p.sat;
+    const float toe_sqrt_nj_thr  = sqrt(nj * nj + p.sat_thr);
+    const float toe_nj_compr     = nj * p.compr;
+    const float ratio            = (fabs(jmh.x) < 1e-6f) ? 1.0f : (jts / fabs(jmh.x));
+    m_compr                      = jmh.y * safe_pow_pos(ratio, p.model_gamma_inv);
+    m_compr                      = m_compr / mnorm;
+    m_compr                      = limit - toe(limit - m_compr, toe_limit, toe_snj_sat, toe_sqrt_nj_thr, false);
+    m_compr                      = toe(m_compr, limit, toe_nj_compr, snj, false);
+    m_compr                      = m_compr * mnorm;
+  }
+  (void)invert;
+  return float3(tonemapped_j, m_compr, jmh.z);
+}
+
+static inline float3 tonemap_and_compress_fwd(float3 jmh, const constant MetalODTParams& p) {
+  const float linear       = J_to_Y(jmh.x, p.input_params_) / kRefLuminance;
+  const float tonemapped_y = Tonescale_fwd(linear, p.ts_);
+  const float j_ts         = Y_to_J(tonemapped_y, p.input_params_);
+  return chroma_compress_fwd(jmh, j_ts, p);
+}
+
+static inline float gamut_cusp_hue(constant MetalODTParams& p, int index) {
+  return p.table_gamut_cusps_[index][2];
+}
+
+static inline float2 cusp_from_table(float h, const constant MetalODTParams& p) {
+  const float hw = wrap_to_360(h);
+  int low_i      = 0;
+  int high_i     = kMetalOdtBaseIndex + kMetalOdtTableSize;
+  int i          = kMetalOdtBaseIndex + hue_position_in_uniform_table(hw, kMetalOdtTableSize);
+  for (int k = 0; k < 10 && (low_i + 1 < high_i); ++k) {
+    const float h_i = gamut_cusp_hue(p, i);
+    if (hw > h_i) {
+      low_i = i;
+    } else {
+      high_i = i;
+    }
+    i = (low_i + high_i) >> 1;
+  }
+  const int lo_idx = high_i - 1;
+  const int hi_idx = high_i;
+  const float lo_h = p.table_gamut_cusps_[lo_idx][2];
+  const float hi_h = p.table_gamut_cusps_[hi_idx][2];
+  const float denom = hi_h - lo_h;
+  const float t     = (denom != 0.0f) ? (hw - lo_h) / denom : 0.0f;
+  return float2(lerp_f(p.table_gamut_cusps_[lo_idx][0], p.table_gamut_cusps_[hi_idx][0], t),
+                lerp_f(p.table_gamut_cusps_[lo_idx][1], p.table_gamut_cusps_[hi_idx][1], t));
+}
+
+static inline float compute_focus_J(float cusp_j, float mid_j, float limit_j_max) {
+  return lerp_f(cusp_j, mid_j, fmin(1.0f, kCuspMidBlend - (cusp_j / limit_j_max)));
+}
+
+static inline int look_hue_interval(float h, const constant MetalODTParams& p) {
+  const float hw = wrap_to_360(h);
+  int i          = kMetalOdtBaseIndex + hue_position_in_uniform_table(hw, kMetalOdtTableSize);
+  int i_lo       = i + p.hue_linearity_search_range[0];
+  int i_hi       = i + p.hue_linearity_search_range[1];
+  i_lo           = i_lo < kMetalOdtBaseIndex ? kMetalOdtBaseIndex : i_lo;
+  i_hi           = i_hi > (kMetalOdtBaseIndex + kMetalOdtTableSize)
+                       ? (kMetalOdtBaseIndex + kMetalOdtTableSize)
+                       : i_hi;
+  i              = (i_lo + i_hi) >> 1;
+  for (int k = 0; k < 6 && (i_lo + 1 < i_hi); ++k) {
+    const float v = p.table_hues_[i];
+    if (hw > v) {
+      i_lo = i;
+    } else {
+      i_hi = i;
+    }
+    i = (i_lo + i_hi) >> 1;
+  }
+  return (i_hi < 1) ? 1 : i_hi;
+}
+
+static inline HueDependentGamutParams init_HueDependentGamutParams(float h, const constant MetalODTParams& p) {
+  HueDependentGamutParams hdp;
+  hdp.gamma_bottom_inv = p.lower_hull_gamma_inv;
+  const int i_hi       = look_hue_interval(h, p);
+  const float hw       = wrap_to_360(h);
+  const float t        = hw - p.table_hues_[i_hi - 1];
+  hdp.JMcusp           = cusp_from_table(h, p);
+  hdp.gamma_top_inv    = lerp_f(p.table_upper_hull_gamma_[i_hi - 1], p.table_upper_hull_gamma_[i_hi], t);
+  hdp.focus_J          = compute_focus_J(hdp.JMcusp.x, p.mid_J, p.limit_J_max);
+  hdp.analytical_threshold = lerp_f(hdp.JMcusp.x, p.limit_J_max, kFocusGainBlend);
+  return hdp;
+}
+
+static inline float get_focus_gain(float j, float analytical_threshold, float limit_j_max, float focus_dist) {
+  float gain = limit_j_max * focus_dist;
+  if (j > analytical_threshold) {
+    float gain_adjustment = safe_log10_ratio(limit_j_max - analytical_threshold, limit_j_max - j, 1e-4f);
+    gain_adjustment       = gain_adjustment * gain_adjustment + 1.0f;
+    gain                  = gain * gain_adjustment;
+  }
+  return gain;
+}
+
+static inline float solve_J_intersect(float j, float m, float focus_j, float max_j, float slope_gain) {
+  const float sg       = fmax(fabs(slope_gain), 1e-6f);
+  const float fj       = fmax(fabs(focus_j), 1e-6f);
+  const float m_scaled = m / sg;
+  const float a        = m_scaled / fj;
+  const float b1       = 1.0f - m_scaled;
+  const float c1       = -j;
+  const float det1     = b1 * b1 - 4.0f * a * c1;
+  const float r1       = (det1 > 0.0f) ? safe_sqrt(det1) : 0.0f;
+  const float den1     = copysign(fmax(fabs(b1 + r1), 1e-6f), b1 + r1);
+  const float res1     = (-2.0f * c1) / den1;
+  const float b2       = -(1.0f + m_scaled + max_j * a);
+  const float c2       = max_j * m_scaled + j;
+  const float det2     = b2 * b2 - 4.0f * a * c2;
+  const float r2       = (det2 > 0.0f) ? safe_sqrt(det2) : 0.0f;
+  const float den2     = copysign(fmax(fabs(b2 - r2), 1e-6f), b2 - r2);
+  const float res2     = (-2.0f * c2) / den2;
+  return (j < focus_j) ? res1 : res2;
+}
+
+static inline float compute_compression_vector_slope(float intersect_j, float focus_j, float limit_j_max,
+                                                     float slope_gain) {
+  const float direction_scalar = (intersect_j < focus_j) ? intersect_j : (limit_j_max - intersect_j);
+  const float denom            = fmax(fabs(focus_j * slope_gain), 1e-6f);
+  return direction_scalar * (intersect_j - focus_j) / denom;
+}
+
+static inline float estimate_line_and_boundary_intersection_M(float j_axis_intersect, float slope,
+                                                              float inv_gamma, float j_max, float m_max,
+                                                              float j_intersection_reference) {
+  const float refj                 = fmax(j_intersection_reference, 1e-6f);
+  const float normalized_j         = fmax(j_axis_intersect / refj, 0.0f);
+  const float shifted_intersection = refj * safe_pow_pos(normalized_j, inv_gamma);
+  const float denom                = copysign(fmax(fabs(j_max - slope * m_max), 1e-6f), (j_max - slope * m_max));
+  return shifted_intersection * m_max / denom;
+}
+
+static inline float smin_scaled(float a, float b, float scale_reference) {
+  const float s_scaled = kSmoothCusps * scale_reference;
+  if (s_scaled <= 1e-6f) return fmin(a, b);
+  const float h = fmax(s_scaled - fabs(a - b), 0.0f) / s_scaled;
+  return fmin(a, b) - h * h * h * s_scaled * (1.0f / 6.0f);
+}
+
+static inline float find_gamut_boundary_intersection(float2 jm_cusp, float j_max, float gamma_top_inv,
+                                                     float gamma_bottom_inv, float j_intersect_source,
+                                                     float slope, float j_intersect_cusp) {
+  const float m_boundary_lower = estimate_line_and_boundary_intersection_M(
+      j_intersect_source, slope, gamma_bottom_inv, jm_cusp.x, jm_cusp.y, j_intersect_cusp);
+  const float f_j_intersect_cusp   = j_max - j_intersect_cusp;
+  const float f_j_intersect_source = j_max - j_intersect_source;
+  const float f_jm_cusp_j          = j_max - jm_cusp.x;
+  const float m_boundary_upper     = estimate_line_and_boundary_intersection_M(
+      f_j_intersect_source, -slope, gamma_top_inv, f_jm_cusp_j, jm_cusp.y, f_j_intersect_cusp);
+  return smin_scaled(m_boundary_lower, m_boundary_upper, jm_cusp.y);
+}
+
+static inline float remap_M(float m, float gamut_boundary_m, float reach_boundary_m, bool invert = false) {
+  const float boundary_ratio = safe_div(gamut_boundary_m, reach_boundary_m, 1e-6f);
+  const float proportion     = fmax(boundary_ratio, kCompressionThreshold);
+  const float threshold      = proportion * gamut_boundary_m;
+  if (m <= threshold || proportion >= 1.0f) return m;
+  const float m_offset       = m - threshold;
+  const float gamut_off      = gamut_boundary_m - threshold;
+  const float reach_off      = reach_boundary_m - threshold;
+  const float ratio_rg       = safe_div(reach_off, gamut_off, 1e-6f);
+  const float denom          = fmax(ratio_rg - 1.0f, 1e-7f);
+  const float scale          = reach_off / denom;
+  const float nd             = m_offset / scale;
+  return threshold + reinhard_remap(scale, nd, invert);
+}
+
+static inline float3 compress_gamut(float3 jmh, float jx, const constant MetalODTParams& p,
+                                    HueDependentGamutParams hdp, bool invert = false) {
+  const float slope_gain = fmax(get_focus_gain(jx, hdp.analytical_threshold, p.limit_J_max, p.focus_dist), 1e-6f);
+  const float j_intersect_source = solve_J_intersect(jmh.x, jmh.y, hdp.focus_J, p.limit_J_max, slope_gain);
+  const float gamut_slope =
+      compute_compression_vector_slope(j_intersect_source, hdp.focus_J, p.limit_J_max, slope_gain);
+  const float j_intersect_cusp =
+      solve_J_intersect(hdp.JMcusp.x, hdp.JMcusp.y, hdp.focus_J, p.limit_J_max, slope_gain);
+  const float gamut_boundary_m = find_gamut_boundary_intersection(
+      hdp.JMcusp, p.limit_J_max, hdp.gamma_top_inv, hdp.gamma_bottom_inv, j_intersect_source,
+      gamut_slope, j_intersect_cusp);
+  if (gamut_boundary_m <= 0.0f) {
+    return float3(jx, 0.0f, jmh.z);
+  }
+  const float reach_max_m      = fmax(reach_M_from_table(jmh.z, p), 0.0f);
+  const float reach_boundary_m = estimate_line_and_boundary_intersection_M(
+      j_intersect_source, gamut_slope, p.model_gamma_inv, p.limit_J_max, reach_max_m, p.limit_J_max);
+  const float remapped_m       = remap_M(jmh.y, gamut_boundary_m, reach_boundary_m, invert);
+  return float3(j_intersect_source + remapped_m * gamut_slope, remapped_m, jmh.z);
+}
+
+static inline float3 gamut_compress_fwd(float3 jmh, const constant MetalODTParams& p) {
+  if (jmh.x <= 0.0f) {
+    return float3(0.0f, 0.0f, jmh.z);
+  }
+  if (jmh.y <= 0.0f || jmh.x > p.limit_J_max) {
+    return float3(jmh.x, 0.0f, jmh.z);
+  }
+  return compress_gamut(jmh, jmh.x, p, init_HueDependentGamutParams(jmh.z, p), false);
+}
+
+static inline float3 limit_rgb_preserve_chroma(float3 rgb, float lower, float upper) {
+  if (!all(isfinite(rgb))) {
+    return float3(0.0f);
+  }
+  rgb = max(rgb, float3(lower));
+  const float m = fmax(rgb.x, fmax(rgb.y, rgb.z));
+  if (m > upper && m > 0.0f) {
+    rgb *= upper / m;
+  }
+  return rgb;
+}
+
+static inline float3 OutputTransform_fwd(float3 in_color, constant MetalODTParams& p) {
+  if (!all(isfinite(in_color))) {
+    return float3(0.0f);
+  }
+  const float3 ap0            = mult_f3_f33(in_color, kAp1ToAp0);
+  const float3 jmh            = RGB_to_JMh(ap0, p.input_params_);
+  const float3 tonemapped_jmh = tonemap_and_compress_fwd(jmh, p);
+  const float3 compressed_jmh = gamut_compress_fwd(tonemapped_jmh, p);
+  const float3 out_rgb        = JMh_to_RGB(compressed_jmh, p.limit_params_);
+  return limit_rgb_preserve_chroma(out_rgb, 0.0f, p.ts_.forward_limit_);
+}
+

--- a/alcedo_studio/src/edit/runtime/metal/shader/drt_opendrt.metal
+++ b/alcedo_studio/src/edit/runtime/metal/shader/drt_opendrt.metal
@@ -1,0 +1,255 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+static inline float3 odrt_apply_matrix(constant float* mat, float3 v) {
+  return apply_matrix3x3(mat, v);
+}
+
+static inline float3 odrt_add_scalar(float3 v, float s) { return v + s; }
+static inline float3 odrt_add(float3 a, float3 b) { return a + b; }
+static inline float3 odrt_sub(float3 a, float3 b) { return a - b; }
+static inline float3 odrt_mul_scalar(float3 v, float s) { return v * s; }
+static inline float3 odrt_mul(float3 a, float3 b) { return a * b; }
+
+static inline float3 odrt_div_scalar(float3 v, float s) {
+  if (fabs(s) < 1e-8f) return float3(0.0f);
+  return v / s;
+}
+
+static inline float odrt_spowf(float a, float b) { return (a <= 0.0f) ? a : pow(a, b); }
+static inline float3 odrt_spowf3(float3 a, float b) {
+  return float3(odrt_spowf(a.x, b), odrt_spowf(a.y, b), odrt_spowf(a.z, b));
+}
+static inline float odrt_hypot2(float2 v) { return sqrt(fmax(0.0f, dot(v, v))); }
+static inline float odrt_hypot3(float3 v) { return sqrt(fmax(0.0f, dot(v, v))); }
+static inline float3 odrt_clampf3(float3 v, float mn, float mx) { return clamp(v, float3(mn), float3(mx)); }
+static inline float3 odrt_clampminf3(float3 v, float mn) { return max(v, float3(mn)); }
+static inline float odrt_compress_hyperbolic_power(float x, float s, float p) { return odrt_spowf(x / (x + s), p); }
+
+static inline float odrt_compress_toe_quadratic(float x, float toe, bool inv = false) {
+  if (toe == 0.0f) return x;
+  if (!inv) return odrt_spowf(x, 2.0f) / (x + toe);
+  return (x + sqrt(x * (4.0f * toe + x))) / 2.0f;
+}
+
+static inline float odrt_compress_toe_cubic(float x, float m, float w, bool inv = false) {
+  if (m == 1.0f) return x;
+  const float x2 = x * x;
+  if (!inv) return x * (x2 + m * w) / (x2 + w);
+  const float p0 = x2 - 3.0f * m * w;
+  const float p1 = 2.0f * x2 + 27.0f * w - 9.0f * m * w;
+  const float p2 =
+      pow(sqrt(x2 * p1 * p1 - 4.0f * p0 * p0 * p0) / 2.0f + x * p1 / 2.0f, 1.0f / 3.0f);
+  return p0 / (3.0f * p2) + p2 / 3.0f + x / 3.0f;
+}
+
+static inline float odrt_contrast_high(float x, float p, float pv, float pv_lx, bool inv = false) {
+  const float x0 = 0.18f * pow(2.0f, pv);
+  if (x < x0 || p == 1.0f) return x;
+  const float o  = x0 - x0 / p;
+  const float s0 = pow(x0, 1.0f - p) / p;
+  const float x1 = x0 * pow(2.0f, pv_lx);
+  const float k1 = p * s0 * pow(x1, p) / x1;
+  const float y1 = s0 * pow(x1, p) + o;
+  if (inv) return (x > y1) ? (x - y1) / k1 + x1 : pow((x - o) / s0, 1.0f / p);
+  return (x > x1) ? k1 * (x - x1) + y1 : s0 * pow(x, p) + o;
+}
+
+static inline float odrt_softplus(float x, float s) {
+  if (x > 10.0f * s || s < 1e-4f) return x;
+  return s * log(fmax(0.0f, 1.0f + exp(x / s)));
+}
+
+static inline float odrt_gauss_window(float x, float w) { return exp(-x * x / w); }
+static inline float2 odrt_opponent(float3 rgb) { return float2(rgb.x - rgb.z, rgb.y - (rgb.x + rgb.z) / 2.0f); }
+static inline float odrt_hue_offset(float h, float o) { return fmod(h - o + kOpenDrtPi, 2.0f * kOpenDrtPi) - kOpenDrtPi; }
+
+static inline float3 odrt_display_gamut_whitepoint(float3 rgb, float tsn, float cwp_lm, int display_gamut, int cwp) {
+  rgb                 = odrt_apply_matrix(kOpenDrtP3D65ToXyz, rgb);
+  float3 cwp_neutral  = rgb;
+  const float cwp_f   = pow(tsn, 2.0f * cwp_lm);
+  if (display_gamut < 3) {
+    if (cwp == 0) rgb = odrt_apply_matrix(kOpenDrtCatD65ToD93, rgb);
+    else if (cwp == 1) rgb = odrt_apply_matrix(kOpenDrtCatD65ToD75, rgb);
+    else if (cwp == 3) rgb = odrt_apply_matrix(kOpenDrtCatD65ToD60, rgb);
+    else if (cwp == 4) rgb = odrt_apply_matrix(kOpenDrtCatD65ToD55, rgb);
+    else if (cwp == 5) rgb = odrt_apply_matrix(kOpenDrtCatD65ToD50, rgb);
+  } else if (display_gamut == 3) {
+    if (cwp == 0) rgb = odrt_apply_matrix(kOpenDrtCatD60ToD93, rgb);
+    else if (cwp == 1) rgb = odrt_apply_matrix(kOpenDrtCatD60ToD75, rgb);
+    else if (cwp == 2) rgb = odrt_apply_matrix(kOpenDrtCatD60ToD65, rgb);
+    else if (cwp == 4) rgb = odrt_apply_matrix(kOpenDrtCatD60ToD55, rgb);
+    else if (cwp == 5) rgb = odrt_apply_matrix(kOpenDrtCatD60ToD50, rgb);
+  } else {
+    cwp_neutral = odrt_apply_matrix(kOpenDrtCatDciToD65, rgb);
+    if (cwp == 0) rgb = odrt_apply_matrix(kOpenDrtCatDciToD93, rgb);
+    else if (cwp == 1) rgb = odrt_apply_matrix(kOpenDrtCatDciToD75, rgb);
+    else if (cwp == 2) rgb = cwp_neutral;
+    else if (cwp == 3) rgb = odrt_apply_matrix(kOpenDrtCatDciToD60, rgb);
+    else if (cwp == 4) rgb = odrt_apply_matrix(kOpenDrtCatDciToD55, rgb);
+    else if (cwp == 5) rgb = odrt_apply_matrix(kOpenDrtCatDciToD50, rgb);
+  }
+  rgb = odrt_add(odrt_mul_scalar(rgb, cwp_f), odrt_mul_scalar(cwp_neutral, 1.0f - cwp_f));
+  if (display_gamut == 0) {
+    rgb = odrt_apply_matrix(kOpenDrtXyzToRec709, rgb);
+  } else if (display_gamut == 5) {
+    rgb = odrt_apply_matrix(kOpenDrtCatD65ToDci, rgb);
+  } else {
+    rgb = odrt_apply_matrix(kOpenDrtXyzToP3D65, rgb);
+  }
+  float cwp_norm = 1.0f;
+  if (display_gamut == 0) {
+    if (cwp == 0) cwp_norm = 0.7441926991f;
+    else if (cwp == 1) cwp_norm = 0.8734708321f;
+    else if (cwp == 3) cwp_norm = 0.9559369922f;
+    else if (cwp == 4) cwp_norm = 0.9056713328f;
+    else if (cwp == 5) cwp_norm = 0.8500043850f;
+  } else if (display_gamut == 1 || display_gamut == 2) {
+    if (cwp == 0) cwp_norm = 0.7626870573f;
+    else if (cwp == 1) cwp_norm = 0.8840540833f;
+    else if (cwp == 3) cwp_norm = 0.9643201867f;
+    else if (cwp == 4) cwp_norm = 0.9230765189f;
+    else if (cwp == 5) cwp_norm = 0.8765728378f;
+  } else if (display_gamut == 3) {
+    if (cwp == 0) cwp_norm = 0.7049563210f;
+    else if (cwp == 1) cwp_norm = 0.8167157098f;
+    else if (cwp == 2) cwp_norm = 0.9233821937f;
+    else if (cwp == 4) cwp_norm = 0.9561385003f;
+    else if (cwp == 5) cwp_norm = 0.9068014530f;
+  } else if (display_gamut == 4) {
+    if (cwp == 0) cwp_norm = 0.6653361412f;
+    else if (cwp == 1) cwp_norm = 0.7703971314f;
+    else if (cwp == 2) cwp_norm = 0.8705723433f;
+    else if (cwp == 3) cwp_norm = 0.8913545475f;
+    else if (cwp == 4) cwp_norm = 0.8553278252f;
+    else if (cwp == 5) cwp_norm = 0.8145664361f;
+  } else if (display_gamut == 5) {
+    if (cwp == 0) cwp_norm = 0.7071427840f;
+    else if (cwp == 1) cwp_norm = 0.8155610826f;
+    else if (cwp >= 2) cwp_norm = 0.9165552797f;
+  }
+  return odrt_mul_scalar(rgb, cwp_norm * cwp_f + 1.0f - cwp_f);
+}
+
+static inline float3 OpenDRTTransform_fwd(float3 input_color, const constant MetalOpenDRTParams& p) {
+  float3 rgb           = odrt_apply_matrix(kOpenDrtAp1ToXyz, input_color);
+  rgb                  = odrt_apply_matrix(kOpenDrtXyzToP3D65, rgb);
+  const float3 rs_w    = float3(p.rs_rw_, 1.0f - p.rs_rw_ - p.rs_bw_, p.rs_bw_);
+  float sat_l          = dot(rgb, rs_w);
+  rgb                  = odrt_add(odrt_mul_scalar(float3(sat_l), p.rs_sa_), odrt_mul_scalar(rgb, 1.0f - p.rs_sa_));
+  rgb                  = odrt_add_scalar(rgb, p.tn_off_);
+  float tsn            = odrt_hypot3(rgb) / kOpenDrtSqrt3;
+  rgb                  = odrt_div_scalar(rgb, tsn);
+  const float2 opp     = odrt_opponent(rgb);
+  float ach_d          = odrt_hypot2(opp) / 2.0f;
+  ach_d                = 1.25f * odrt_compress_toe_quadratic(ach_d, 0.25f, false);
+  const float hue      = fmod(atan2(opp.x, opp.y) + kOpenDrtPi + 1.10714931f, 2.0f * kOpenDrtPi);
+  const float3 ha_rgb  = float3(odrt_gauss_window(odrt_hue_offset(hue, 0.1f), 0.66f),
+                                odrt_gauss_window(odrt_hue_offset(hue, 4.3f), 0.66f),
+                                odrt_gauss_window(odrt_hue_offset(hue, 2.3f), 0.66f));
+  const float3 ha_rgb_hs = float3(odrt_gauss_window(odrt_hue_offset(hue, -0.4f), 0.66f), ha_rgb.y,
+                                  odrt_gauss_window(odrt_hue_offset(hue, 2.5f), 0.66f));
+  const float3 ha_cmy    = float3(odrt_gauss_window(odrt_hue_offset(hue, 3.3f), 0.5f),
+                               odrt_gauss_window(odrt_hue_offset(hue, 1.3f), 0.5f),
+                               odrt_gauss_window(odrt_hue_offset(hue, -1.15f), 0.5f));
+  if (p.brl_enable_) {
+    const float brl_tsf = pow(tsn / (tsn + 1.0f), 1.0f - p.brl_rng_);
+    const float brl_exf =
+        (p.brl_ + p.brl_r_ * ha_rgb.x + p.brl_g_ * ha_rgb.y + p.brl_b_ * ha_rgb.z) *
+        pow(ach_d, 1.0f / p.brl_st_);
+    const float brl_ex = pow(2.0f, brl_exf * ((brl_exf < 0.0f) ? brl_tsf : 1.0f - brl_tsf));
+    tsn *= brl_ex;
+  }
+  if (p.tn_lcon_enable_) {
+    const float lcon_m       = pow(2.0f, -p.tn_lcon_);
+    float lcon_w             = p.tn_lcon_w_ / 4.0f;
+    lcon_w                  *= lcon_w;
+    const float lcon_cnst_sc = odrt_compress_toe_cubic(p.ts_x0_, lcon_m, lcon_w, true) / p.ts_x0_;
+    tsn *= lcon_cnst_sc;
+    tsn  = odrt_compress_toe_cubic(tsn, lcon_m, lcon_w, false);
+  }
+  if (p.tn_hcon_enable_) {
+    tsn = odrt_contrast_high(tsn, pow(2.0f, p.tn_hcon_), p.tn_hcon_pv_, p.tn_hcon_st_, false);
+  }
+  const float tsn_pt    = odrt_compress_hyperbolic_power(tsn, p.ts_s1_, p.ts_p_);
+  const float tsn_const = odrt_compress_hyperbolic_power(tsn, p.s_Lp100_, p.ts_p_);
+  tsn                   = odrt_compress_hyperbolic_power(tsn, p.ts_s_, p.ts_p_);
+  if (p.hc_enable_) {
+    float hc_ts = 1.0f - tsn_const;
+    float hc_c  = hc_ts * (1.0f - ach_d) + ach_d * (1.0f - hc_ts);
+    hc_c       *= ach_d * ha_rgb.x;
+    hc_ts       = pow(hc_ts, 1.0f / p.hc_r_rng_);
+    const float hc_f = p.hc_r_ * (hc_c - 2.0f * hc_c * hc_ts) + 1.0f;
+    rgb              = float3(rgb.x, rgb.y * hc_f, rgb.z * hc_f);
+  }
+  if (p.hs_rgb_enable_) {
+    const float3 hs_rgb = float3(ha_rgb_hs.x * ach_d * pow(tsn_pt, 1.0f / p.hs_r_rng_),
+                                 ha_rgb_hs.y * ach_d * pow(tsn_pt, 1.0f / p.hs_g_rng_),
+                                 ha_rgb_hs.z * ach_d * pow(tsn_pt, 1.0f / p.hs_b_rng_));
+    const float3 hsf    = float3((hs_rgb.z * -p.hs_b_) - (hs_rgb.y * -p.hs_g_),
+                              (hs_rgb.x * p.hs_r_) - (hs_rgb.z * -p.hs_b_),
+                              (hs_rgb.y * -p.hs_g_) - (hs_rgb.x * p.hs_r_));
+    rgb                 = odrt_add(rgb, hsf);
+  }
+  if (p.hs_cmy_enable_) {
+    const float tsn_pt_compl = 1.0f - tsn_pt;
+    const float3 hs_cmy = float3(ha_cmy.x * ach_d * pow(tsn_pt_compl, 1.0f / p.hs_c_rng_),
+                                 ha_cmy.y * ach_d * pow(tsn_pt_compl, 1.0f / p.hs_m_rng_),
+                                 ha_cmy.z * ach_d * pow(tsn_pt_compl, 1.0f / p.hs_y_rng_));
+    const float3 hsf    = float3((hs_cmy.z * p.hs_y_) - (hs_cmy.y * p.hs_m_),
+                              (hs_cmy.x * -p.hs_c_) - (hs_cmy.z * p.hs_y_),
+                              (hs_cmy.y * p.hs_m_) - (hs_cmy.x * -p.hs_c_));
+    rgb                 = odrt_add(rgb, hsf);
+  }
+  const float pt_lml_p = 1.0f + 4.0f * (1.0f - tsn_pt) *
+                                    (p.pt_lml_ + p.pt_lml_r_ * ha_rgb_hs.x + p.pt_lml_g_ * ha_rgb_hs.y +
+                                     p.pt_lml_b_ * ha_rgb_hs.z);
+  float ptf            = 1.0f - pow(tsn_pt, pt_lml_p);
+  const float pt_lmh_p = (1.0f - ach_d * (p.pt_lmh_r_ * ha_rgb_hs.x + p.pt_lmh_b_ * ha_rgb_hs.z)) *
+                         (1.0f - p.pt_lmh_ * ach_d);
+  ptf                  = pow(ptf, pt_lmh_p);
+  if (p.ptm_enable_) {
+    float ptm_low_f = 1.0f;
+    if (p.ptm_low_st_ != 0.0f && p.ptm_low_rng_ != 0.0f) {
+      ptm_low_f = 1.0f + p.ptm_low_ * exp(-2.0f * ach_d * ach_d / p.ptm_low_st_) *
+                             pow(1.0f - tsn_const, 1.0f / p.ptm_low_rng_);
+    }
+    float ptm_high_f = 1.0f;
+    if (p.ptm_high_st_ != 0.0f && p.ptm_high_rng_ != 0.0f) {
+      ptm_high_f = 1.0f + p.ptm_high_ * exp(-2.0f * ach_d * ach_d / p.ptm_high_st_) *
+                              pow(tsn_pt, 1.0f / (4.0f * p.ptm_high_rng_));
+    }
+    ptf *= ptm_low_f * ptm_high_f;
+  }
+  rgb   = odrt_add(odrt_mul_scalar(rgb, ptf), float3(1.0f - ptf));
+  sat_l = dot(rgb, rs_w);
+  rgb   = odrt_div_scalar(odrt_sub(odrt_mul_scalar(float3(sat_l), p.rs_sa_), rgb), p.rs_sa_ - 1.0f);
+  rgb   = odrt_display_gamut_whitepoint(rgb, tsn_const, p.cwp_lm_, p.display_gamut_, p.creative_white_);
+  if (p.brlp_enable_) {
+    const float2 brlp_opp  = odrt_opponent(rgb);
+    float brlp_ach_d       = odrt_hypot2(brlp_opp) / 4.0f;
+    brlp_ach_d             = 1.1f * (brlp_ach_d * brlp_ach_d / (brlp_ach_d + 0.1f));
+    const float3 brlp_ha   = odrt_mul_scalar(ha_rgb, ach_d);
+    const float brlp_m     = p.brlp_ + p.brlp_r_ * brlp_ha.x + p.brlp_g_ * brlp_ha.y + p.brlp_b_ * brlp_ha.z;
+    rgb                    = odrt_mul_scalar(rgb, pow(2.0f, brlp_m * brlp_ach_d * tsn));
+  }
+  if (p.ptl_enable_) {
+    rgb = float3(odrt_softplus(rgb.x, p.ptl_c_), odrt_softplus(rgb.y, p.ptl_m_), odrt_softplus(rgb.z, p.ptl_y_));
+  }
+  tsn *= p.ts_m2_;
+  tsn  = odrt_compress_toe_quadratic(tsn, p.tn_toe_, false);
+  tsn *= p.ts_dsc_;
+  rgb *= tsn;
+  if (p.display_gamut_ == 2) {
+    rgb = odrt_clampminf3(rgb, 0.0f);
+    rgb = odrt_apply_matrix(kOpenDrtP3ToRec2020, rgb);
+  }
+  if (p.clamp_) {
+    rgb = odrt_clampf3(rgb, 0.0f, 1.0f);
+  }
+  return rgb;
+}
+

--- a/alcedo_studio/src/edit/runtime/metal/shader/geometry_resample.metal
+++ b/alcedo_studio/src/edit/runtime/metal/shader/geometry_resample.metal
@@ -1,0 +1,106 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct GeometryResampleParams {
+  float m00;
+  float m01;
+  float m02;
+  float m10;
+  float m11;
+  float m12;
+  uint  decoded_width;
+  uint  decoded_height;
+  uint  render_width;
+  uint  render_height;
+  float border[4];
+  uint  use_bicubic;
+};
+
+static inline float4 ReadBorder(texture2d<float, access::read> src, int width, int height, int x,
+                                int y, float4 border) {
+  if (x < 0 || y < 0 || x >= width || y >= height) {
+    return border;
+  }
+  return src.read(uint2(static_cast<uint>(x), static_cast<uint>(y)));
+}
+
+static inline float4 BilinearSample(texture2d<float, access::read> src, int width, int height,
+                                    float sx, float sy, float4 border) {
+  const float px = sx - 0.5f;
+  const float py = sy - 0.5f;
+  const int   x0 = static_cast<int>(floor(px));
+  const int   y0 = static_cast<int>(floor(py));
+  const float fx = px - static_cast<float>(x0);
+  const float fy = py - static_cast<float>(y0);
+  const float4 p00 = ReadBorder(src, width, height, x0, y0, border);
+  const float4 p10 = ReadBorder(src, width, height, x0 + 1, y0, border);
+  const float4 p01 = ReadBorder(src, width, height, x0, y0 + 1, border);
+  const float4 p11 = ReadBorder(src, width, height, x0 + 1, y0 + 1, border);
+  const float  w00 = (1.0f - fx) * (1.0f - fy);
+  const float  w10 = fx * (1.0f - fy);
+  const float  w01 = (1.0f - fx) * fy;
+  const float  w11 = fx * fy;
+  return p00 * w00 + p10 * w10 + p01 * w01 + p11 * w11;
+}
+
+static inline float CubicWeight(float x) {
+  x = fabs(x);
+  if (x < 1.0f) {
+    return ((1.5f * x - 2.5f) * x) * x + 1.0f;
+  }
+  if (x < 2.0f) {
+    return (((-0.5f * x + 2.5f) * x) - 4.0f) * x + 2.0f;
+  }
+  return 0.0f;
+}
+
+static inline float4 BicubicSample(texture2d<float, access::read> src, int width, int height,
+                                   float sx, float sy, float4 border) {
+  const float px   = sx - 0.5f;
+  const float py   = sy - 0.5f;
+  const int   x0   = static_cast<int>(floor(px));
+  const int   y0   = static_cast<int>(floor(py));
+  const float fx   = px - static_cast<float>(x0);
+  const float fy   = py - static_cast<float>(y0);
+  float4      acc  = float4(0.0f);
+  float       wsum = 0.0f;
+  for (int j = -1; j <= 2; ++j) {
+    const float wy = CubicWeight(static_cast<float>(j) - fy);
+    for (int i = -1; i <= 2; ++i) {
+      const float  wx = CubicWeight(static_cast<float>(i) - fx);
+      const float  w  = wx * wy;
+      acc += ReadBorder(src, width, height, x0 + i, y0 + j, border) * w;
+      wsum += w;
+    }
+  }
+  if (wsum <= 1.0e-8f) {
+    return border;
+  }
+  return acc / wsum;
+}
+
+kernel void geometry_resample_rgba32f(texture2d<float, access::read> src [[texture(0)]],
+                                      texture2d<float, access::write> dst [[texture(1)]],
+                                      constant GeometryResampleParams& params [[buffer(0)]],
+                                      uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.render_width || gid.y >= params.render_height) {
+    return;
+  }
+  const float  cx     = static_cast<float>(gid.x) + 0.5f;
+  const float  cy     = static_cast<float>(gid.y) + 0.5f;
+  const float  sx     = params.m00 * cx + params.m01 * cy + params.m02;
+  const float  sy     = params.m10 * cx + params.m11 * cy + params.m12;
+  const float4 border = float4(params.border[0], params.border[1], params.border[2],
+                               params.border[3]);
+  const int    width  = static_cast<int>(params.decoded_width);
+  const int    height = static_cast<int>(params.decoded_height);
+  const float4 pixel  = params.use_bicubic != 0u
+                            ? BicubicSample(src, width, height, sx, sy, border)
+                            : BilinearSample(src, width, height, sx, sy, border);
+  dst.write(pixel, gid);
+}

--- a/alcedo_studio/src/edit/runtime/metal/shader/local_tone.metal
+++ b/alcedo_studio/src/edit/runtime/metal/shader/local_tone.metal
@@ -1,0 +1,339 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct ExtractParams {
+  int input_width;
+  int input_height;
+  int output_width;
+  int output_height;
+};
+
+struct ExtractReferenceParams {
+  int   input_width;
+  int   input_height;
+  int   output_width;
+  int   output_height;
+  float full_ref_w;
+  float full_ref_h;
+  float pad0;
+  float pad1;
+  float reference_to_render[12];
+};
+
+struct RemapParams {
+  int   width;
+  int   height;
+  float gamma;
+  float target;
+  float beta;
+  float alpha;
+  float sigma;
+  int   pad;
+};
+
+struct PyrDownParams {
+  int src_width;
+  int src_height;
+  int dst_width;
+  int dst_height;
+};
+
+struct SelectParams {
+  int   width;
+  int   height;
+  int   coarse_width;
+  int   coarse_height;
+  float gamma_lo;
+  float gamma_hi;
+  int   first;
+  int   last;
+  int   top;
+  int   pad0;
+  int   pad1;
+  int   pad2;
+};
+
+struct CollapseParams {
+  int width;
+  int height;
+  int coarse_width;
+  int coarse_height;
+};
+
+struct ApplyParams {
+  int   width;
+  int   height;
+  int   adjusted_width;
+  int   adjusted_height;
+  float render_to_uv[12];
+};
+
+static inline float AcesccEncode(float value) {
+  constexpr float kA          = 9.72f;
+  constexpr float kB          = 17.52f;
+  constexpr float kOffset     = 0.0000152587890625f;
+  constexpr float kTransition = 0.000030517578125f;
+  constexpr float kFloor      = (-16.0f + kA) / kB;
+  if (value < 0.0f) {
+    return kFloor + value;
+  }
+  if (value < kTransition) {
+    return (log2(kOffset + value * 0.5f) + kA) / kB;
+  }
+  return (log2(value) + kA) / kB;
+}
+
+static inline float AcesccDecode(float value) {
+  constexpr float kA         = 9.72f;
+  constexpr float kB         = 17.52f;
+  constexpr float kOffset    = 0.0000152587890625f;
+  constexpr float kFloor     = (-16.0f + kA) / kB;
+  constexpr float kThreshold = (-15.0f + kA) / kB;
+  if (value < kFloor) {
+    return value - kFloor;
+  }
+  if (value <= kThreshold) {
+    return (exp2(value * kB - kA) - kOffset) * 2.0f;
+  }
+  return exp2(value * kB - kA);
+}
+
+static inline float Ap1Intensity(float4 pixel) {
+  return 0.272229f * pixel.x + 0.674082f * pixel.y + 0.053689f * pixel.z;
+}
+
+static inline float LogIntensity(float4 acescc) {
+  const float4 linear =
+      float4(AcesccDecode(acescc.x), AcesccDecode(acescc.y), AcesccDecode(acescc.z), acescc.w);
+  return AcesccEncode(max(Ap1Intensity(linear), 1.0e-6f));
+}
+
+static inline float4 ReadRgbaBilinear(texture2d<float, access::read> input, int width, int height,
+                                      float x, float y) {
+  x               = min(max(x, 0.0f), float(width - 1));
+  y               = min(max(y, 0.0f), float(height - 1));
+  const int    x0 = int(floor(x));
+  const int    y0 = int(floor(y));
+  const int    x1 = min(x0 + 1, width - 1);
+  const int    y1 = min(y0 + 1, height - 1);
+  const float  tx = x - float(x0);
+  const float  ty = y - float(y0);
+  const float4 a  = input.read(uint2(uint(x0), uint(y0)));
+  const float4 b  = input.read(uint2(uint(x1), uint(y0)));
+  const float4 c  = input.read(uint2(uint(x0), uint(y1)));
+  const float4 d  = input.read(uint2(uint(x1), uint(y1)));
+  return mix(mix(a, b, tx), mix(c, d, tx), ty);
+}
+
+static inline float PlaneRead(device const float* src, int x, int y, int width, int height) {
+  x = min(max(x, 0), width - 1);
+  y = min(max(y, 0), height - 1);
+  return src[y * width + x];
+}
+
+static inline float Weight(int tap) {
+  return (tap == -2 || tap == 2) ? 1.0f / 16.0f : (tap == -1 || tap == 1) ? 4.0f / 16.0f : 6.0f / 16.0f;
+}
+
+static inline float Expand(device const float* coarse, int coarse_width, int coarse_height, int x,
+                           int y) {
+  float sum = 0.0f;
+  for (int ky = -2; ky <= 2; ++ky) {
+    const int sample_y = y - ky;
+    if ((sample_y & 1) != 0) {
+      continue;
+    }
+    const int cy = min(max(sample_y / 2, 0), coarse_height - 1);
+    for (int kx = -2; kx <= 2; ++kx) {
+      const int sample_x = x - kx;
+      if ((sample_x & 1) != 0) {
+        continue;
+      }
+      const int cx = min(max(sample_x / 2, 0), coarse_width - 1);
+      sum += 4.0f * Weight(kx) * Weight(ky) * coarse[cy * coarse_width + cx];
+    }
+  }
+  return sum;
+}
+
+static inline float RemapDelta(float delta, float sigma, float alpha, float beta) {
+  const float magnitude = fabs(delta);
+  if (magnitude <= 1.0e-6f) {
+    return 0.0f;
+  }
+  const float sign = copysign(1.0f, delta);
+  if (magnitude <= sigma) {
+    return sign * sigma * pow(min(magnitude / max(sigma, 1.0e-6f), 1.0f), alpha);
+  }
+  return sign * (sigma + beta * (magnitude - sigma));
+}
+
+static inline float2 Transform(constant float* matrix, float x, float y) {
+  return float2(matrix[0] * x + matrix[1] * y + matrix[2],
+                matrix[3] * x + matrix[4] * y + matrix[5]);
+}
+
+static inline float Bilinear(device const float* plane, int width, int height, float x, float y) {
+  x             = min(max(x, 0.0f), float(width - 1));
+  y             = min(max(y, 0.0f), float(height - 1));
+  const int   x0 = int(floor(x));
+  const int   y0 = int(floor(y));
+  const int   x1 = min(x0 + 1, width - 1);
+  const int   y1 = min(y0 + 1, height - 1);
+  const float tx = x - float(x0);
+  const float ty = y - float(y0);
+  const float a  = plane[y0 * width + x0] + (plane[y0 * width + x1] - plane[y0 * width + x0]) * tx;
+  const float b  = plane[y1 * width + x0] + (plane[y1 * width + x1] - plane[y1 * width + x0]) * tx;
+  return a + (b - a) * ty;
+}
+
+kernel void local_tone_extract(texture2d<float, access::read> src [[texture(0)]],
+                               device float* dst [[buffer(0)]],
+                               constant ExtractParams& params [[buffer(1)]],
+                               uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= uint(params.output_width) || gid.y >= uint(params.output_height)) {
+    return;
+  }
+  const float sx = (float(gid.x) + 0.5f) * float(params.input_width) /
+                       float(params.output_width) -
+                   0.5f;
+  const float sy = (float(gid.y) + 0.5f) * float(params.input_height) /
+                       float(params.output_height) -
+                   0.5f;
+  dst[gid.y * uint(params.output_width) + gid.x] =
+      LogIntensity(ReadRgbaBilinear(src, params.input_width, params.input_height, sx, sy));
+}
+
+kernel void local_tone_extract_reference(texture2d<float, access::read> src [[texture(0)]],
+                                         device float* dst [[buffer(0)]],
+                                         constant ExtractReferenceParams& params [[buffer(1)]],
+                                         uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= uint(params.output_width) || gid.y >= uint(params.output_height)) {
+    return;
+  }
+  const float  u   = (float(gid.x) + 0.5f) / float(params.output_width);
+  const float  v   = (float(gid.y) + 0.5f) / float(params.output_height);
+  const float2 src_xy =
+      Transform(params.reference_to_render, u * params.full_ref_w, v * params.full_ref_h);
+  dst[gid.y * uint(params.output_width) + gid.x] = LogIntensity(
+      ReadRgbaBilinear(src, params.input_width, params.input_height, src_xy.x - 0.5f, src_xy.y - 0.5f));
+}
+
+kernel void local_tone_pyr_down(device const float* src [[buffer(0)]], device float* dst [[buffer(1)]],
+                               constant PyrDownParams& params [[buffer(2)]],
+                               uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= uint(params.dst_width) || gid.y >= uint(params.dst_height)) {
+    return;
+  }
+  float sum = 0.0f;
+  for (int ky = -2; ky <= 2; ++ky) {
+    for (int kx = -2; kx <= 2; ++kx) {
+      sum += Weight(kx) * Weight(ky) *
+             PlaneRead(src, int(gid.x) * 2 + kx, int(gid.y) * 2 + ky, params.src_width,
+                       params.src_height);
+    }
+  }
+  dst[gid.y * uint(params.dst_width) + gid.x] = sum;
+}
+
+kernel void local_tone_remap(device const float* src [[buffer(0)]], device float* dst [[buffer(1)]],
+                             constant RemapParams& params [[buffer(2)]],
+                             uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= uint(params.width) || gid.y >= uint(params.height)) {
+    return;
+  }
+  const uint index = gid.y * uint(params.width) + gid.x;
+  dst[index] =
+      params.target + RemapDelta(src[index] - params.gamma, params.sigma, params.alpha, params.beta);
+}
+
+kernel void local_tone_select(device const float* source [[buffer(0)]],
+                              device const float* lo [[buffer(1)]],
+                              device const float* lo_coarse [[buffer(2)]],
+                              device const float* hi [[buffer(3)]],
+                              device const float* hi_coarse [[buffer(4)]],
+                              device float* output [[buffer(5)]],
+                              constant SelectParams& params [[buffer(6)]],
+                              uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= uint(params.width) || gid.y >= uint(params.height)) {
+    return;
+  }
+  const uint  index = gid.y * uint(params.width) + gid.x;
+  const float value = source[index];
+  if (!((params.first != 0 && value <= params.gamma_hi) ||
+        (params.last != 0 && value >= params.gamma_lo) ||
+        (value >= params.gamma_lo && value < params.gamma_hi))) {
+    return;
+  }
+  const float t =
+      min(max((value - params.gamma_lo) / max(params.gamma_hi - params.gamma_lo, 1.0e-6f), 0.0f),
+          1.0f);
+  if (params.top != 0) {
+    output[index] = lo[index] + (hi[index] - lo[index]) * t;
+    return;
+  }
+  const float lap_lo =
+      lo[index] - Expand(lo_coarse, params.coarse_width, params.coarse_height, int(gid.x), int(gid.y));
+  const float lap_hi =
+      hi[index] - Expand(hi_coarse, params.coarse_width, params.coarse_height, int(gid.x), int(gid.y));
+  output[index] = lap_lo + (lap_hi - lap_lo) * t;
+}
+
+kernel void local_tone_collapse(device const float* lap [[buffer(0)]],
+                                device const float* coarse [[buffer(1)]],
+                                device float* output [[buffer(2)]],
+                                constant CollapseParams& params [[buffer(3)]],
+                                uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= uint(params.width) || gid.y >= uint(params.height)) {
+    return;
+  }
+  const uint index = gid.y * uint(params.width) + gid.x;
+  output[index] =
+      lap[index] + Expand(coarse, params.coarse_width, params.coarse_height, int(gid.x), int(gid.y));
+}
+
+kernel void local_tone_apply(texture2d<float, access::read> src [[texture(0)]],
+                             texture2d<float, access::write> dst [[texture(1)]],
+                             device const float* reference [[buffer(0)]],
+                             device const float* adjusted [[buffer(1)]],
+                             constant ApplyParams& params [[buffer(2)]],
+                             uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= uint(params.width) || gid.y >= uint(params.height)) {
+    return;
+  }
+  const float2 uv = Transform(params.render_to_uv, float(gid.x) + 0.5f, float(gid.y) + 0.5f);
+  const float  ax = uv.x * float(params.adjusted_width) - 0.5f;
+  const float  ay = uv.y * float(params.adjusted_height) - 0.5f;
+  const float  reference_l =
+      Bilinear(reference, params.adjusted_width, params.adjusted_height, ax, ay);
+  const float adjusted_l = Bilinear(adjusted, params.adjusted_width, params.adjusted_height, ax, ay);
+  const float4 pixel     = src.read(gid);
+  const float  source_l  = LogIntensity(pixel);
+  const float  source_intensity = max(AcesccDecode(source_l), 1.0e-5f);
+  const float  target_intensity = AcesccDecode(source_l + adjusted_l - reference_l);
+  const float  ratio            = min(max(target_intensity / source_intensity, 0.0f), 32.0f);
+  float        r                = AcesccDecode(pixel.x) * ratio;
+  float        g                = AcesccDecode(pixel.y) * ratio;
+  float        b                = AcesccDecode(pixel.z) * ratio;
+  constexpr float kLower        = -1.0e-5f;
+  float           gamut_scale   = 1.0f;
+  if (r < kLower && target_intensity > r) {
+    gamut_scale = min(gamut_scale, (target_intensity - kLower) / (target_intensity - r));
+  }
+  if (g < kLower && target_intensity > g) {
+    gamut_scale = min(gamut_scale, (target_intensity - kLower) / (target_intensity - g));
+  }
+  if (b < kLower && target_intensity > b) {
+    gamut_scale = min(gamut_scale, (target_intensity - kLower) / (target_intensity - b));
+  }
+  gamut_scale = min(max(gamut_scale, 0.0f), 1.0f);
+  r           = target_intensity + (r - target_intensity) * gamut_scale;
+  g           = target_intensity + (g - target_intensity) * gamut_scale;
+  b           = target_intensity + (b - target_intensity) * gamut_scale;
+  dst.write(float4(AcesccEncode(r), AcesccEncode(g), AcesccEncode(b), pixel.w), gid);
+}

--- a/alcedo_studio/src/edit/runtime/metal/shader/mask.metal
+++ b/alcedo_studio/src/edit/runtime/metal/shader/mask.metal
@@ -1,0 +1,322 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct MaskSampleParams {
+  float render_to_uv[9];
+  uint  source_width;
+  uint  source_height;
+  uint  output_width;
+  uint  output_height;
+  uint  invert;
+  uint  pad0;
+  uint  pad1;
+};
+
+struct MaskFeatherParams {
+  float render_to_uv[9];
+  uint  source_width;
+  uint  source_height;
+  uint  output_width;
+  uint  output_height;
+  float radius_texels;
+  uint  invert;
+  uint  pad0;
+};
+
+struct MaskAnalyticParams {
+  float render_to_reference[9];
+  uint  width;
+  uint  height;
+  uint  reference_width;
+  uint  reference_height;
+  uint  kind;
+  float center_x;
+  float center_y;
+  float major_radius;
+  float minor_radius;
+  float rotation;
+  float inner_feather;
+  float outer_feather;
+  uint  radial_invert;
+  float origin_x;
+  float origin_y;
+  float normal_x;
+  float normal_y;
+  float transition_distance;
+  float start_value;
+  float end_value;
+  uint  graduated_invert;
+};
+
+struct MaskBandParams {
+  uint width;
+  uint height;
+  uint target_inside;
+  uint pad;
+};
+
+struct MaskMipParams {
+  uint source_width;
+  uint source_height;
+  uint destination_width;
+  uint destination_height;
+};
+
+static inline float2 Transform(constant float m[9], float x, float y) {
+  return float2(m[0] * x + m[1] * y + m[2], m[3] * x + m[4] * y + m[5]);
+}
+
+static inline float SampleR8(texture2d<float, access::read> pixels, uint width, uint height,
+                             float u, float v) {
+  if (u < 0.0f || v < 0.0f || u > 1.0f || v > 1.0f) {
+    return 0.0f;
+  }
+  const float x  = u * static_cast<float>(width) - 0.5f;
+  const float y  = v * static_cast<float>(height) - 0.5f;
+  const int   x0 = max(0, min(static_cast<int>(width) - 1, static_cast<int>(floor(x))));
+  const int   y0 = max(0, min(static_cast<int>(height) - 1, static_cast<int>(floor(y))));
+  const int   x1 = min(x0 + 1, static_cast<int>(width) - 1);
+  const int   y1 = min(y0 + 1, static_cast<int>(height) - 1);
+  const float tx = min(max(x - floor(x), 0.0f), 1.0f);
+  const float ty = min(max(y - floor(y), 0.0f), 1.0f);
+  const float a =
+      pixels.read(uint2(static_cast<uint>(x0), static_cast<uint>(y0))).r * (1.0f - tx) +
+      pixels.read(uint2(static_cast<uint>(x1), static_cast<uint>(y0))).r * tx;
+  const float b =
+      pixels.read(uint2(static_cast<uint>(x0), static_cast<uint>(y1))).r * (1.0f - tx) +
+      pixels.read(uint2(static_cast<uint>(x1), static_cast<uint>(y1))).r * tx;
+  return a * (1.0f - ty) + b * ty;
+}
+
+static inline float SampleF32(device const float* pixels, uint width, uint height, float u,
+                              float v) {
+  if (u < 0.0f || v < 0.0f || u > 1.0f || v > 1.0f) {
+    return -1.0e6f;
+  }
+  const float x  = u * static_cast<float>(width) - 0.5f;
+  const float y  = v * static_cast<float>(height) - 0.5f;
+  const int   x0 = max(0, min(static_cast<int>(width) - 1, static_cast<int>(floor(x))));
+  const int   y0 = max(0, min(static_cast<int>(height) - 1, static_cast<int>(floor(y))));
+  const int   x1 = min(x0 + 1, static_cast<int>(width) - 1);
+  const int   y1 = min(y0 + 1, static_cast<int>(height) - 1);
+  const float tx = min(max(x - floor(x), 0.0f), 1.0f);
+  const float ty = min(max(y - floor(y), 0.0f), 1.0f);
+  const float a  = pixels[static_cast<uint>(y0) * width + static_cast<uint>(x0)] * (1.0f - tx) +
+                  pixels[static_cast<uint>(y0) * width + static_cast<uint>(x1)] * tx;
+  const float b = pixels[static_cast<uint>(y1) * width + static_cast<uint>(x0)] * (1.0f - tx) +
+                  pixels[static_cast<uint>(y1) * width + static_cast<uint>(x1)] * tx;
+  return a * (1.0f - ty) + b * ty;
+}
+
+static inline float QuantizeR8(float value) {
+  return float(uint(min(max(value * 255.0f + 0.5f, 0.0f), 255.0f))) / 255.0f;
+}
+
+kernel void mask_generate_r8_mip(texture2d<float, access::read> source [[texture(0)]],
+                                 texture2d<float, access::write> destination [[texture(1)]],
+                                 constant MaskMipParams& params [[buffer(0)]],
+                                 uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.destination_width || gid.y >= params.destination_height) {
+    return;
+  }
+  const uint source_x = gid.x * 2u;
+  const uint source_y = gid.y * 2u;
+  uint       sum      = 0;
+  uint       count    = 0;
+  for (uint dy = 0; dy < 2u; ++dy) {
+    for (uint dx = 0; dx < 2u; ++dx) {
+      const uint sx = source_x + dx;
+      const uint sy = source_y + dy;
+      if (sx < params.source_width && sy < params.source_height) {
+        sum += static_cast<uint>(source.read(uint2(sx, sy)).r * 255.0f + 0.5f);
+        ++count;
+      }
+    }
+  }
+  const float value = count == 0 ? 0.0f : static_cast<float>((sum + count / 2u) / count) / 255.0f;
+  destination.write(float4(value, 0.0f, 0.0f, 1.0f), gid);
+}
+
+kernel void mask_raster_sample(texture2d<float, access::read> source [[texture(0)]],
+                               texture2d<float, access::write> output [[texture(1)]],
+                               constant MaskSampleParams& params [[buffer(0)]],
+                               uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.output_width || gid.y >= params.output_height) {
+    return;
+  }
+  const float2 uv    = Transform(params.render_to_uv, float(gid.x) + 0.5f, float(gid.y) + 0.5f);
+  float        value = SampleR8(source, params.source_width, params.source_height, uv.x, uv.y);
+  if (params.invert != 0u) {
+    value = 1.0f - value;
+  }
+  output.write(float4(QuantizeR8(value), 0.0f, 0.0f, 1.0f), gid);
+}
+
+kernel void mask_band_horizontal(texture2d<float, access::read> source [[texture(0)]],
+                                 device float* squared_distance [[buffer(0)]],
+                                 constant MaskBandParams& params [[buffer(1)]],
+                                 uint y [[thread_position_in_grid]]) {
+  if (y >= params.height) {
+    return;
+  }
+  constexpr int missing = -100000;
+  const bool    want    = params.target_inside != 0u;
+  int           nearest = missing;
+  for (uint x = 0; x < params.width; ++x) {
+    const bool  inside = source.read(uint2(x, y)).r >= 0.5f;
+    if (inside == want) {
+      nearest = static_cast<int>(x);
+    }
+    const float dx = static_cast<float>(static_cast<int>(x) - nearest);
+    squared_distance[y * params.width + x] = nearest == missing ? 1.0e20f : dx * dx;
+  }
+  nearest = -missing;
+  for (int x = static_cast<int>(params.width) - 1; x >= 0; --x) {
+    const bool inside = source.read(uint2(static_cast<uint>(x), y)).r >= 0.5f;
+    if (inside == want) {
+      nearest = x;
+    }
+    if (nearest != -missing) {
+      const float dx = static_cast<float>(x - nearest);
+      const uint  i  = y * params.width + static_cast<uint>(x);
+      squared_distance[i] = min(squared_distance[i], dx * dx);
+    }
+  }
+}
+
+kernel void mask_band_vertical(device const float* horizontal [[buffer(0)]],
+                               device float* squared_distance [[buffer(1)]],
+                               device int* sites [[buffer(2)]],
+                               device float* boundaries [[buffer(3)]],
+                               constant MaskBandParams& params [[buffer(4)]],
+                               uint x [[thread_position_in_grid]]) {
+  if (x >= params.width) {
+    return;
+  }
+  const uint base = x * params.height;
+  int        count = 0;
+  for (uint y = 0; y < params.height; ++y) {
+    const float f = horizontal[y * params.width + x];
+    if (f >= 1.0e19f) {
+      continue;
+    }
+    float boundary = -1.0e20f;
+    while (count > 0) {
+      const int   previous   = sites[base + static_cast<uint>(count - 1)];
+      const float previous_f = horizontal[static_cast<uint>(previous) * params.width + x];
+      boundary               = ((f + static_cast<float>(y * y)) -
+                  (previous_f + static_cast<float>(previous * previous))) /
+                 (2.0f * (static_cast<float>(y) - static_cast<float>(previous)));
+      if (boundary > boundaries[base + static_cast<uint>(count - 1)]) {
+        break;
+      }
+      --count;
+    }
+    sites[base + static_cast<uint>(count)]      = static_cast<int>(y);
+    boundaries[base + static_cast<uint>(count)] = count == 0 ? -1.0e20f : boundary;
+    ++count;
+  }
+  if (count == 0) {
+    for (uint y = 0; y < params.height; ++y) {
+      squared_distance[y * params.width + x] = 1.0e20f;
+    }
+    return;
+  }
+  int site_index = 0;
+  for (uint y = 0; y < params.height; ++y) {
+    while (site_index + 1 < count &&
+           boundaries[base + static_cast<uint>(site_index + 1)] < static_cast<float>(y)) {
+      ++site_index;
+    }
+    const int   site = sites[base + static_cast<uint>(site_index)];
+    const float dy   = static_cast<float>(static_cast<int>(y) - site);
+    squared_distance[y * params.width + x] =
+        horizontal[static_cast<uint>(site) * params.width + x] + dy * dy;
+  }
+}
+
+kernel void mask_compose_signed_distance(texture2d<float, access::read> source [[texture(0)]],
+                                         device const float* distance_to_inside [[buffer(0)]],
+                                         device const float* distance_to_outside [[buffer(1)]],
+                                         device float* distance [[buffer(2)]],
+                                         constant MaskBandParams& params [[buffer(3)]],
+                                         uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.width || gid.y >= params.height) {
+    return;
+  }
+  const uint  index    = gid.y * params.width + gid.x;
+  const float coverage = source.read(gid).r;
+  const bool  inside   = coverage >= 0.5f;
+  const float exact    = sqrt(inside ? distance_to_outside[index] : distance_to_inside[index]);
+  if (coverage > 0.0f && coverage < 1.0f) {
+    distance[index] = coverage - 0.5f;
+  } else {
+    const float to_boundary = max(exact - 0.5f, 0.0f);
+    distance[index]         = inside ? to_boundary : -to_boundary;
+  }
+}
+
+kernel void mask_feather_sample(device const float* distance [[buffer(0)]],
+                                texture2d<float, access::write> output [[texture(0)]],
+                                constant MaskFeatherParams& params [[buffer(1)]],
+                                uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.output_width || gid.y >= params.output_height) {
+    return;
+  }
+  const float2 uv = Transform(params.render_to_uv, float(gid.x) + 0.5f, float(gid.y) + 0.5f);
+  const float  d  = SampleF32(distance, params.source_width, params.source_height, uv.x, uv.y);
+  float        value =
+      params.radius_texels <= 0.0f ? (d >= 0.0f ? 1.0f : 0.0f)
+                                   : min(max(0.5f + d / (2.0f * params.radius_texels), 0.0f), 1.0f);
+  value = value * value * (3.0f - 2.0f * value);
+  if (params.invert != 0u) {
+    value = 1.0f - value;
+  }
+  output.write(float4(QuantizeR8(value), 0.0f, 0.0f, 1.0f), gid);
+}
+
+kernel void mask_analytic(texture2d<float, access::write> output [[texture(0)]],
+                          constant MaskAnalyticParams& params [[buffer(0)]],
+                          uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.width || gid.y >= params.height) {
+    return;
+  }
+  const float2 reference =
+      Transform(params.render_to_reference, float(gid.x) + 0.5f, float(gid.y) + 0.5f);
+  const float nx    = reference.x / static_cast<float>(params.reference_width);
+  const float ny    = reference.y / static_cast<float>(params.reference_height);
+  float       value = 0.0f;
+  uint        invert = 0;
+  if (params.kind == 0u) {
+    const float c      = cos(params.rotation);
+    const float s      = sin(params.rotation);
+    const float dx     = nx - params.center_x;
+    const float dy     = ny - params.center_y;
+    const float rx     = (c * dx + s * dy) / max(params.major_radius, 1.0e-6f);
+    const float ry     = (-s * dx + c * dy) / max(params.minor_radius, 1.0e-6f);
+    const float radius = sqrt(rx * rx + ry * ry);
+    const float inner  = max(0.0f, 1.0f - params.inner_feather);
+    const float outer  = 1.0f + params.outer_feather;
+    value  = 1.0f - min(max((radius - inner) / max(outer - inner, 1.0e-6f), 0.0f), 1.0f);
+    invert = params.radial_invert;
+  } else {
+    const float normal_length = sqrt(params.normal_x * params.normal_x + params.normal_y * params.normal_y);
+    const float normal_x      = params.normal_x / max(normal_length, 1.0e-6f);
+    const float normal_y      = params.normal_y / max(normal_length, 1.0e-6f);
+    const float distance =
+        (nx - params.origin_x) * normal_x + (ny - params.origin_y) * normal_y;
+    const float t =
+        min(max(distance / max(params.transition_distance, 1.0e-6f) + 0.5f, 0.0f), 1.0f);
+    value  = params.start_value + (params.end_value - params.start_value) * t;
+    invert = params.graduated_invert;
+  }
+  if (invert != 0u) {
+    value = 1.0f - value;
+  }
+  output.write(float4(QuantizeR8(value), 0.0f, 0.0f, 1.0f), gid);
+}

--- a/alcedo_studio/src/edit/runtime/metal/shader/primary_grade.metal
+++ b/alcedo_studio/src/edit/runtime/metal/shader/primary_grade.metal
@@ -1,0 +1,242 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct GradeAdjustmentParams {
+  uint  behavior;
+  uint  count;
+  float values[30];
+};
+
+struct PrimaryGradeDispatchParams {
+  uint  command_count;
+  uint  command_offset;
+  uint  lut_edge;
+  float local_reference;
+  uint  width;
+  uint  pad[3];
+};
+
+static inline float Luma(float3 c) {
+  return 0.272229f * c.x + 0.674082f * c.y + 0.053689f * c.z;
+}
+
+static inline float ExtrapolateCurve(float value, device const GradeAdjustmentParams& p, uint a,
+                                     uint b) {
+  const float x0 = p.values[a * 2];
+  const float y0 = p.values[a * 2 + 1];
+  const float x1 = p.values[b * 2];
+  const float y1 = p.values[b * 2 + 1];
+  return y0 + (value - x0) * (y1 - y0) / max(x1 - x0, 1.0e-6f);
+}
+
+static inline float ApplyCurve(float value, device const GradeAdjustmentParams& p) {
+  if (p.count < 2) {
+    return value;
+  }
+  if (value <= p.values[0]) {
+    return ExtrapolateCurve(value, p, 0, 1);
+  }
+  for (uint i = 1; i < p.count; ++i) {
+    const float x1 = p.values[i * 2];
+    if (value <= x1) {
+      const float x0 = p.values[(i - 1) * 2];
+      const float y0 = p.values[(i - 1) * 2 + 1];
+      const float y1 = p.values[i * 2 + 1];
+      const float t  = (value - x0) / max(x1 - x0, 1.0e-6f);
+      return y0 + t * (y1 - y0);
+    }
+  }
+  return ExtrapolateCurve(value, p, p.count - 2, p.count - 1);
+}
+
+static inline float3 ApplyHls(float3 c, device const GradeAdjustmentParams& p) {
+  const float maximum = max(c.x, max(c.y, c.z));
+  const float minimum = min(c.x, min(c.y, c.z));
+  const float chroma  = maximum - minimum;
+  float       hue     = 0.0f;
+  if (chroma > 1.0e-6f) {
+    if (maximum == c.x) {
+      hue = 60.0f * fmod((c.y - c.z) / chroma, 6.0f);
+    } else if (maximum == c.y) {
+      hue = 60.0f * ((c.z - c.x) / chroma + 2.0f);
+    } else {
+      hue = 60.0f * ((c.x - c.y) / chroma + 4.0f);
+    }
+  }
+  if (hue < 0.0f) {
+    hue += 360.0f;
+  }
+  const int   bin        = int((hue + 22.5f) / 45.0f) & 7;
+  const float luma       = Luma(c);
+  const float saturation = 1.0f + p.values[16 + bin];
+  c.x                    = luma + (c.x - luma) * saturation;
+  c.y                    = luma + (c.y - luma) * saturation;
+  c.z                    = luma + (c.z - luma) * saturation;
+  const float lightness  = p.values[8 + bin];
+  c.x += lightness;
+  c.y += lightness;
+  c.z += lightness;
+  return c;
+}
+
+static inline uint LutIndex(uint edge, uint x, uint y, uint z) { return (z * edge + y) * edge + x; }
+
+static inline float3 SampleLut3d(device const float4* lut, uint edge, float u, float v, float w) {
+  if (lut == nullptr || edge <= 1) {
+    return float3(u, v, w);
+  }
+  const float3 coord   = clamp(float3(u, v, w), 0.0f, 1.0f);
+  const float3 tex_pos = coord * float(edge) - 0.5f;
+  const float3 pos     = clamp(tex_pos, 0.0f, float(edge - 1));
+  const uint3  lo      = uint3(pos);
+  const uint3  hi      = min(lo + uint3(1), uint3(edge - 1));
+  const float3 t       = pos - float3(lo);
+  const float4 c000    = lut[LutIndex(edge, lo.x, lo.y, lo.z)];
+  const float4 c100    = lut[LutIndex(edge, hi.x, lo.y, lo.z)];
+  const float4 c010    = lut[LutIndex(edge, lo.x, hi.y, lo.z)];
+  const float4 c110    = lut[LutIndex(edge, hi.x, hi.y, lo.z)];
+  const float4 c001    = lut[LutIndex(edge, lo.x, lo.y, hi.z)];
+  const float4 c101    = lut[LutIndex(edge, hi.x, lo.y, hi.z)];
+  const float4 c011    = lut[LutIndex(edge, lo.x, hi.y, hi.z)];
+  const float4 c111    = lut[LutIndex(edge, hi.x, hi.y, hi.z)];
+  const float4 c00     = mix(c000, c100, t.x);
+  const float4 c10     = mix(c010, c110, t.x);
+  const float4 c01     = mix(c001, c101, t.x);
+  const float4 c11     = mix(c011, c111, t.x);
+  const float4 c0      = mix(c00, c10, t.y);
+  const float4 c1      = mix(c01, c11, t.y);
+  const float4 sampled = mix(c0, c1, t.z);
+  return sampled.xyz;
+}
+
+static inline float3 ApplyAdjustment(float3 c, device const GradeAdjustmentParams& p,
+                                     uint pixel_index, float local_reference,
+                                     device const float4* lut, uint lut_edge) {
+  const uint  behavior = p.behavior;
+  const float value    = p.values[0];
+  if (behavior == 0u && value != 0.0f) {
+    const float temperature = p.values[1] * 0.001f;
+    const float tint        = p.values[2] * 0.001f;
+    c.x *= exp2(temperature - tint * 0.5f);
+    c.y *= exp2(tint);
+    c.z *= exp2(-temperature - tint * 0.5f);
+  } else if (behavior == 1u) {
+    const float offset = value / 17.52f;
+    c.x += offset;
+    c.y += offset;
+    c.z += offset;
+  } else if (behavior == 2u) {
+    const float scale = 1.0f + value * 0.01f;
+    c.x               = (c.x - 0.18f) * scale + 0.18f;
+    c.y               = (c.y - 0.18f) * scale + 0.18f;
+    c.z               = (c.z - 0.18f) * scale + 0.18f;
+  } else if (behavior == 3u) {
+    const float gain = 1.0f + max(value, 0.0f) * 0.005f;
+    c.x *= gain;
+    c.y *= gain;
+    c.z *= gain;
+  } else if (behavior == 4u) {
+    const float offset = value * 0.001f;
+    c.x += offset;
+    c.y += offset;
+    c.z += offset;
+  } else if (behavior == 13u) {
+    const float l      = Luma(c);
+    float       weight = 1.0f - min(l / max(local_reference, 1.0e-4f), 1.0f);
+    weight             = 0.5f - fabs(weight - 0.5f);
+    const float gain   = 1.0f + value * 0.01f * weight;
+    c.x *= gain;
+    c.y *= gain;
+    c.z *= gain;
+  } else if (behavior == 7u) {
+    c.x = ApplyCurve(c.x, p);
+    c.y = ApplyCurve(c.y, p);
+    c.z = ApplyCurve(c.z, p);
+  } else if (behavior == 8u) {
+    c = ApplyHls(c, p);
+  } else if (behavior == 9u || behavior == 10u) {
+    const float l = Luma(c);
+    float scale   = behavior == 9u ? value : 1.0f + value * 0.01f;
+    if (behavior == 10u) {
+      const float maximum = max(c.x, max(c.y, c.z));
+      const float minimum = min(c.x, min(c.y, c.z));
+      scale               = 1.0f + (scale - 1.0f) * (1.0f - min(maximum - minimum, 1.0f));
+    }
+    c.x = l + (c.x - l) * scale;
+    c.y = l + (c.y - l) * scale;
+    c.z = l + (c.z - l) * scale;
+  } else if (behavior == 11u) {
+    const float gamma_x = max(p.values[4] + p.values[7], 1.0e-4f);
+    const float gamma_y = max(p.values[5] + p.values[7], 1.0e-4f);
+    const float gamma_z = max(p.values[6] + p.values[7], 1.0e-4f);
+    c.x = copysign(pow(fabs(c.x + p.values[0] + p.values[3]), 1.0f / gamma_x), c.x) * p.values[8];
+    c.y = copysign(pow(fabs(c.y + p.values[1] + p.values[3]), 1.0f / gamma_y), c.y) * p.values[9];
+    c.z = copysign(pow(fabs(c.z + p.values[2] + p.values[3]), 1.0f / gamma_z), c.z) * p.values[10];
+  } else if (behavior == 14u) {
+    const float l     = Luma(c);
+    const float scale = 1.0f + value * 0.0025f;
+    c.x               = l + (c.x - l) * scale;
+    c.y               = l + (c.y - l) * scale;
+    c.z               = l + (c.z - l) * scale;
+  } else if (behavior == 15u) {
+    c.x += max(Luma(c) - 0.6f, 0.0f) * value * 0.15f;
+  } else if (behavior == 16u && value != 0.0f) {
+    uint        hash  = pixel_index * 747796405u + 2891336453u;
+    hash              = (hash >> ((hash >> 28u) + 4u)) ^ hash;
+    const float noise = (float(hash & 0xffffu) / 32767.5f - 1.0f) * value * 0.02f;
+    c.x += noise;
+    c.y += noise;
+    c.z += noise;
+  } else if (behavior == 12u && value != 0.0f && lut_edge > 1u) {
+    const float scale  = float(lut_edge - 1u) / float(lut_edge);
+    const float offset = 1.0f / (2.0f * float(lut_edge));
+    c = SampleLut3d(lut, lut_edge, c.x * scale + offset, c.y * scale + offset, c.z * scale + offset);
+  }
+  return c;
+}
+
+static inline device const GradeAdjustmentParams& LoadParams(device const uchar* parameter_base,
+                                                             uint offset) {
+  device const GradeAdjustmentParams* params =
+      (device const GradeAdjustmentParams*)(parameter_base + offset);
+  return *params;
+}
+
+kernel void primary_grade_pointwise(texture2d<float, access::read> src [[texture(0)]],
+                                    texture2d<float, access::write> dst [[texture(1)]],
+                                    device const uchar* parameter_base [[buffer(0)]],
+                                    device const uint* commands [[buffer(1)]],
+                                    constant PrimaryGradeDispatchParams& dispatch [[buffer(2)]],
+                                    device const float4* lmt_lut [[buffer(3)]],
+                                    uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= src.get_width() || gid.y >= src.get_height()) {
+    return;
+  }
+  const float4 source      = src.read(gid);
+  float3       c           = source.xyz;
+  const uint   pixel_index = gid.y * dispatch.width + gid.x;
+  for (uint i = 0; i < dispatch.command_count; ++i) {
+    const uint offset = commands[dispatch.command_offset + i];
+    c = ApplyAdjustment(c, LoadParams(parameter_base, offset), pixel_index, dispatch.local_reference,
+                        lmt_lut, dispatch.lut_edge);
+  }
+  dst.write(float4(c, source.w), gid);
+}
+
+kernel void primary_grade_mix(texture2d<float, access::read> source [[texture(0)]],
+                              texture2d<float, access::read> adjusted [[texture(1)]],
+                              texture2d<float, access::write> dst [[texture(2)]],
+                              constant float& grade_mix [[buffer(0)]],
+                              uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= source.get_width() || gid.y >= source.get_height()) {
+    return;
+  }
+  const float4 a = adjusted.read(gid);
+  const float4 s = source.read(gid);
+  dst.write(float4(s.xyz + (a.xyz - s.xyz) * grade_mix, s.w), gid);
+}

--- a/alcedo_studio/src/edit/runtime/metal/shader/primary_grade.metal
+++ b/alcedo_studio/src/edit/runtime/metal/shader/primary_grade.metal
@@ -240,3 +240,18 @@ kernel void primary_grade_mix(texture2d<float, access::read> source [[texture(0)
   const float4 s = source.read(gid);
   dst.write(float4(s.xyz + (a.xyz - s.xyz) * grade_mix, s.w), gid);
 }
+
+kernel void primary_grade_mix_masked(texture2d<float, access::read> source [[texture(0)]],
+                                     texture2d<float, access::read> adjusted [[texture(1)]],
+                                     texture2d<float, access::write> dst [[texture(2)]],
+                                     texture2d<float, access::read> mask [[texture(3)]],
+                                     constant float& grade_mix [[buffer(0)]],
+                                     uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= source.get_width() || gid.y >= source.get_height()) {
+    return;
+  }
+  const float4 a   = adjusted.read(gid);
+  const float4 s   = source.read(gid);
+  const float  mix = grade_mix * mask.read(gid).r;
+  dst.write(float4(s.xyz + (a.xyz - s.xyz) * mix, s.w), gid);
+}

--- a/alcedo_studio/src/edit/runtime/result_content_key.cpp
+++ b/alcedo_studio/src/edit/runtime/result_content_key.cpp
@@ -9,6 +9,7 @@
 #include "edit/graph/develop_node_model.hpp"
 #include "edit/graph/drt_node_model.hpp"
 #include "edit/graph/raster_mask_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
 
 namespace alcedo {
 namespace {
@@ -123,6 +124,19 @@ auto MixGrade(ContentHash& hash, const ColorGradeNodeModel& grade) -> void {
   }
 }
 
+auto MixGradeExcludingLocalToneValues(ContentHash& hash, const ColorGradeNodeModel& grade) -> void {
+  hash.MixU64(grade.AdjustmentCount());
+  for (std::size_t index = 0; index < grade.AdjustmentCount(); ++index) {
+    const auto& type = grade.AdjustmentAt(index).Type();
+    hash.MixText(grade.AdjustmentIdAt(index).Value());
+    hash.MixText(type.Text());
+    if (type == type_ids::Shadows() || type == type_ids::Highlights()) {
+      continue;
+    }
+    hash.MixText(grade.AdjustmentAt(index).ToJson().dump());
+  }
+}
+
 auto MixNormalizedRect(ContentHash& hash, NormalizedRect rect) -> void {
   hash.MixF32(rect.x);
   hash.MixF32(rect.y);
@@ -165,17 +179,8 @@ auto MixCompiledMask(ContentHash& hash, const PipelineDocument& document, const 
   }
 }
 
-}  // namespace
-
-auto HashPreparedSourceKey(const PreparedSourceKey& key) -> ContentKey {
-  ContentHash hash;
-  MixPreparedSource(hash, key);
-  return hash.Key();
-}
-
-auto HashLlfReferenceKey(const ExecutionPlan& plan, const PreparedRawInput& input,
-                         const PipelineDocument& document) -> ContentKey {
-  ContentHash hash;
+auto MixLlfSharedIdentity(ContentHash& hash, const ExecutionPlan& plan,
+                          const PreparedRawInput& input, const PipelineDocument& document) -> void {
   MixPreparedSource(hash, input.source_key);
   MixExtent(hash, plan.geometry.full_reference_extent);
   MixExtent(hash, plan.geometry.edit_extent);
@@ -188,8 +193,33 @@ auto HashLlfReferenceKey(const ExecutionPlan& plan, const PreparedRawInput& inpu
   MixRect(hash, plan.source.sensor_active_area);
   const auto* develop = document.Develop();
   MixCameraColorParams(hash, develop == nullptr ? DevelopPayload{} : develop->Params().Params());
+}
+
+}  // namespace
+
+auto HashPreparedSourceKey(const PreparedSourceKey& key) -> ContentKey {
+  ContentHash hash;
+  MixPreparedSource(hash, key);
+  return hash.Key();
+}
+
+auto HashLlfReferenceKey(const ExecutionPlan& plan, const PreparedRawInput& input,
+                         const PipelineDocument& document) -> ContentKey {
+  ContentHash hash;
+  MixLlfSharedIdentity(hash, plan, input, document);
   if (document.PrimaryGrade() != nullptr) {
     MixGrade(hash, *document.PrimaryGrade());
+  }
+  hash.MixU32(kLlfReferenceImplementationVersion);
+  return hash.Key();
+}
+
+auto HashLlfSourceKey(const ExecutionPlan& plan, const PreparedRawInput& input,
+                      const PipelineDocument& document) -> ContentKey {
+  ContentHash hash;
+  MixLlfSharedIdentity(hash, plan, input, document);
+  if (document.PrimaryGrade() != nullptr) {
+    MixGradeExcludingLocalToneValues(hash, *document.PrimaryGrade());
   }
   hash.MixU32(kLlfReferenceImplementationVersion);
   return hash.Key();

--- a/alcedo_studio/src/include/decoders/processor/nn/metal_demosaicnet_tiled.hpp
+++ b/alcedo_studio/src/include/decoders/processor/nn/metal_demosaicnet_tiled.hpp
@@ -51,6 +51,10 @@ struct MetalDemosaicNetTiledDispatch {
   // When true (default), commit and wait once after all tiles. Tests may set
   // false only when they intentionally keep the command buffer live.
   bool commit_and_wait = true;
+
+  // When non-null, encode onto this existing MTLCommandBuffer instead of creating
+  // an MPSCommandBuffer from the process queue. The caller owns commit.
+  void* command_buffer = nullptr;
 };
 
 struct MetalDemosaicNetTiledResult {

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/metal_encode.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/metal_encode.hpp
@@ -1,0 +1,53 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#ifdef HAVE_METAL
+
+#include <cstdint>
+
+#include "decoders/dng_default_crop.hpp"
+#include "decoders/processor/raw_linearization_params.hpp"
+#include "decoders/processor/raw_processor_pattern.hpp"
+#include "edit/geometry/types.hpp"
+
+namespace alcedo::metal {
+
+/**
+ * @brief Encode RAW Metal kernels onto an existing command buffer.
+ *
+ * Callers own textures, the command buffer, and any scratch. These entrypoints
+ * do not create a queue, command buffer, static scratch, or wait.
+ */
+void EncodeToLinearRef(void* command_buffer, void* src_r16u, void* dst_r32f,
+                       const RawLinearizationParams& linearization, const RawCfaPattern& pattern);
+
+void EncodeCfaClamp01(void* command_buffer, void* r32f, std::uint32_t width, std::uint32_t height);
+
+void EncodeBayerRcd(void* command_buffer, void* linear_cfa, void* r, void* g, void* b, void* vh,
+                    void* pq, const BayerPattern2x2& pattern, std::uint32_t width,
+                    std::uint32_t height);
+
+void EncodeXTrans(void* command_buffer, void* linear_cfa, void* green, void* rgba,
+                  const XTransPattern6x6& pattern, std::uint32_t width, std::uint32_t height,
+                  int passes);
+
+void EncodeHighlightReconstruct(void* command_buffer, void* src_rgba, void* dst_rgba,
+                                void* stats_buffer, std::uint32_t stats_offset,
+                                const float* cam_mul, std::uint32_t width, std::uint32_t height);
+
+void EncodePackPlanesCropInverseOrient(void* command_buffer, void* r, void* g, void* b,
+                                       void* dst_rgba, RectI crop, const float* cam_mul, int flip);
+
+void EncodeCopyRgbaCropInverseOrient(void* command_buffer, void* src_rgba, void* dst_rgba,
+                                     RectI crop, const float* cam_mul, int flip);
+
+void EncodeWarpRectilinear(void* command_buffer, void* src_rgba, void* dst_rgba,
+                           const dng::WarpRectilinear& warp, std::uint32_t width,
+                           std::uint32_t height);
+
+}  // namespace alcedo::metal
+
+#endif

--- a/alcedo_studio/src/include/edit/geometry/resolved_render_geometry.hpp
+++ b/alcedo_studio/src/include/edit/geometry/resolved_render_geometry.hpp
@@ -30,20 +30,20 @@ struct GpuRenderGeometry {
  * Image, raster-mask UV, and LLF must read this object. They must not re-round.
  */
 struct ResolvedRenderGeometry {
-  Extent2D decoded_extent{};
-  Extent2D full_reference_extent{};
-  Extent2D edit_extent{};
-  Extent2D render_extent{};
+  Extent2D          decoded_extent{};
+  Extent2D          full_reference_extent{};
+  Extent2D          edit_extent{};
+  Extent2D          render_extent{};
 
-  Matrix3x3 decoded_to_reference = Matrix3x3::Identity();
-  Matrix3x3 reference_to_edit    = Matrix3x3::Identity();
-  Matrix3x3 edit_to_render       = Matrix3x3::Identity();
-  Matrix3x3 reference_to_render  = Matrix3x3::Identity();
-  Matrix3x3 render_to_reference  = Matrix3x3::Identity();
-  Matrix3x3 render_to_decoded    = Matrix3x3::Identity();
+  Matrix3x3         decoded_to_reference = Matrix3x3::Identity();
+  Matrix3x3         reference_to_edit    = Matrix3x3::Identity();
+  Matrix3x3         edit_to_render       = Matrix3x3::Identity();
+  Matrix3x3         reference_to_render  = Matrix3x3::Identity();
+  Matrix3x3         render_to_reference  = Matrix3x3::Identity();
+  Matrix3x3         render_to_decoded    = Matrix3x3::Identity();
 
-  RectI required_decoded_region{};
-  RectI required_reference_region{};
+  RectI             required_decoded_region{};
+  RectI             required_reference_region{};
 
   TextureFilter     filter = TextureFilter::Bilinear;
   GpuRenderGeometry gpu_data{};
@@ -63,7 +63,7 @@ struct ResolvedRenderGeometry {
  * @brief True when this render covers the whole EditSpace, not a viewport ROI.
  *
  * A full-view dynamic-resolution frame still returns true. A visible subrect returns
- * false. LLF uses this to decide whether the frame can seed the canonical reference.
+ * false. LLF uses this to decide whether the frame can initialize the canonical reference.
  */
 [[nodiscard]] inline auto CoversFullEditSpace(const ResolvedRenderGeometry& geometry) -> bool {
   if (geometry.edit_extent.Empty() || geometry.render_extent.Empty()) {
@@ -76,9 +76,9 @@ struct ResolvedRenderGeometry {
   }
   const auto render_to_edit = InvertAffine(geometry.edit_to_render);
   const auto top_left       = TransformPoint(render_to_edit, {0.0f, 0.0f});
-  const auto bottom_right   = TransformPoint(
-      render_to_edit, {static_cast<float>(geometry.render_extent.width),
-                       static_cast<float>(geometry.render_extent.height)});
+  const auto bottom_right =
+      TransformPoint(render_to_edit, {static_cast<float>(geometry.render_extent.width),
+                                      static_cast<float>(geometry.render_extent.height)});
   constexpr float kPixel = 1.5f;
   return top_left.x <= kPixel && top_left.y <= kPixel &&
          bottom_right.x >= static_cast<float>(geometry.edit_extent.width) - kPixel &&

--- a/alcedo_studio/src/include/edit/pipeline/local_tone_mapping.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/local_tone_mapping.hpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -15,6 +16,7 @@ namespace alcedo::local_tone_mapping {
 constexpr int   kMaxLevels                = 12;
 constexpr int   kMaxSamples               = 32;
 constexpr int   kReferenceMaskMaxLongEdge = 2048;
+constexpr float kPyramidRadius            = 18.0f;
 constexpr float kGammaMinL                = -0.15f;
 constexpr float kGammaMaxL                = 1.18f;
 constexpr float kBaseSigmaR               = 0.07545252f;
@@ -101,8 +103,7 @@ inline auto BuildRoiAdjustedResultCacheKey(const Params& params, std::uint64_t b
 }
 
 inline auto CanReuseReferenceForRoi(bool roi_frame_with_source_reference,
-                                    bool reference_source_cache_valid,
-                                    int roi_reference_width,
+                                    bool reference_source_cache_valid, int roi_reference_width,
                                     int roi_reference_height) -> bool {
   return roi_frame_with_source_reference && reference_source_cache_valid &&
          roi_reference_width > 0 && roi_reference_height > 0;
@@ -127,6 +128,32 @@ inline auto ComputeLevelCount(int width, int height, float radius) -> int {
     ++count;
   }
   return count;
+}
+
+inline auto AlignUpBytes(std::size_t value, std::size_t alignment) -> std::size_t {
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+/** @brief Byte size of one Gaussian pyramid at the canonical LLF mask resolution. */
+inline auto EstimatePyramidBytes(int width, int height, float radius, std::size_t alignment)
+    -> std::size_t {
+  const auto  dims  = ComputeMaskDimensions(width, height, kReferenceMaskMaxLongEdge);
+  const int   count = ComputeLevelCount(dims.width, dims.height, radius);
+  std::size_t total = 0;
+  int         w     = dims.width;
+  int         h     = dims.height;
+  for (int level = 0; level < count; ++level) {
+    total += AlignUpBytes(static_cast<std::size_t>(w) * static_cast<std::size_t>(h) * sizeof(float),
+                          alignment);
+    w = std::max(1, (w + 1) / 2);
+    h = std::max(1, (h + 1) / 2);
+  }
+  return total;
+}
+
+/** @brief Peak transient bytes for source, remap A/B, and result pyramids. */
+inline auto EstimateLlfTransientBytes(int width, int height, std::size_t alignment) -> std::size_t {
+  return 4U * EstimatePyramidBytes(width, height, kPyramidRadius, alignment);
 }
 
 inline auto SigmaR(float shadow_amount, float highlight_amount) -> float {

--- a/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -25,7 +26,11 @@
 
 namespace alcedo {
 #ifdef HAVE_CUDA
-class CudaProductRenderer;
+template <class Backend>
+class Renderer;
+class CudaBackend;
+using CudaRenderer        = Renderer<CudaBackend>;
+using CudaProductRenderer = CudaRenderer;
 #endif
 class CPUPipelineExecutor : public PipelineExecutor {
  private:
@@ -61,7 +66,7 @@ class CPUPipelineExecutor : public PipelineExecutor {
   FrameCompletionSubmission           bound_frame_submission_{};
 #ifdef HAVE_CUDA
   std::shared_ptr<PipelineDocument>    pipeline_document_;
-  std::shared_ptr<CudaProductRenderer> cuda_product_renderer_;
+  std::shared_ptr<CudaRenderer> cuda_product_renderer_;
   nlohmann::json                       cuda_product_legacy_snapshot_;
   bool                                 mirror_legacy_stage_adapter_ = false;
 #endif
@@ -209,9 +214,8 @@ class CPUPipelineExecutor : public PipelineExecutor {
   [[nodiscard]] auto DebugGetMergedStageIdentity() const -> std::uintptr_t;
 
 #ifdef HAVE_CUDA
-  [[nodiscard]] auto DebugCudaProductRenderer() -> CudaProductRenderer* {
-    return cuda_product_renderer_.get();
-  }
+  [[nodiscard]] auto DebugCudaRenderer() -> CudaRenderer* { return cuda_product_renderer_.get(); }
+  [[nodiscard]] auto DebugCudaProductRenderer() -> CudaRenderer* { return DebugCudaRenderer(); }
 #endif
 };
 };  // namespace alcedo

--- a/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
@@ -20,17 +20,24 @@
 #include "type/type.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) || defined(HAVE_METAL)
 #include "edit/graph/pipeline_document.hpp"
 #endif
 
 namespace alcedo {
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) || defined(HAVE_METAL)
 template <class Backend>
 class Renderer;
+#endif
+#ifdef HAVE_CUDA
 class CudaBackend;
 using CudaRenderer        = Renderer<CudaBackend>;
 using CudaProductRenderer = CudaRenderer;
+#endif
+#ifdef HAVE_METAL
+class MetalBackend;
+using MetalRenderer        = Renderer<MetalBackend>;
+using MetalProductRenderer = MetalRenderer;
 #endif
 class CPUPipelineExecutor : public PipelineExecutor {
  private:
@@ -64,11 +71,16 @@ class CPUPipelineExecutor : public PipelineExecutor {
   std::unique_ptr<PipelineStage>      merged_stages_;
   IFrameSink*                         frame_sink_ = nullptr;
   FrameCompletionSubmission           bound_frame_submission_{};
+#if defined(HAVE_CUDA) || defined(HAVE_METAL)
+  std::shared_ptr<PipelineDocument> pipeline_document_;
+  nlohmann::json                    gpu_dag_legacy_snapshot_;
+  bool                              mirror_legacy_stage_adapter_ = false;
+#endif
 #ifdef HAVE_CUDA
-  std::shared_ptr<PipelineDocument>    pipeline_document_;
   std::shared_ptr<CudaRenderer> cuda_product_renderer_;
-  nlohmann::json                       cuda_product_legacy_snapshot_;
-  bool                                 mirror_legacy_stage_adapter_ = false;
+#endif
+#ifdef HAVE_METAL
+  std::shared_ptr<MetalRenderer> metal_product_renderer_;
 #endif
 
   void ResetStages();
@@ -107,7 +119,7 @@ class CPUPipelineExecutor : public PipelineExecutor {
   auto GetStage(PipelineStageName stage) -> PipelineStage& override;
   auto Apply(std::shared_ptr<ImageBuffer> input) -> std::shared_ptr<ImageBuffer> override;
 
-  /** @brief Select the format-version-2 document used by the CUDA product path. */
+  /** @brief Select the format-version-2 document used by the GPU DAG product path. */
   void SetPipelineDocument(std::shared_ptr<PipelineDocument> document,
                            bool                              mirror_legacy_stage_adapter = false);
 
@@ -216,6 +228,9 @@ class CPUPipelineExecutor : public PipelineExecutor {
 #ifdef HAVE_CUDA
   [[nodiscard]] auto DebugCudaRenderer() -> CudaRenderer* { return cuda_product_renderer_.get(); }
   [[nodiscard]] auto DebugCudaProductRenderer() -> CudaRenderer* { return DebugCudaRenderer(); }
+#endif
+#ifdef HAVE_METAL
+  [[nodiscard]] auto DebugMetalRenderer() -> MetalRenderer* { return metal_product_renderer_.get(); }
 #endif
 };
 };  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/adjustment_runtime.hpp
+++ b/alcedo_studio/src/include/edit/runtime/adjustment_runtime.hpp
@@ -1,0 +1,74 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "edit/operators/models/operator_type_id.hpp"
+
+namespace alcedo {
+
+class IOperatorModel;
+
+/** @brief Backend-neutral Grade adjustment semantic. CUDA and Metal share this list. */
+enum class AdjustmentBehavior : std::uint32_t {
+  Cat02WhiteBalance,
+  Exposure,
+  Contrast,
+  White,
+  Black,
+  Shadows,
+  Highlights,
+  Curve,
+  Hls,
+  Saturation,
+  Vibrance,
+  ColorWheel,
+  Lmt,
+  Clarity,
+  Sharpen,
+  Halation,
+  FilmGrain,
+};
+
+struct alignas(16) GradeAdjustmentParams {
+  std::uint32_t behavior = 0;
+  std::uint32_t count    = 0;
+  float         values[30]{};
+};
+
+struct GradeAdjustmentCommand {
+  std::uint32_t parameter_offset = 0;
+};
+
+inline constexpr std::uint32_t kGradeRuntimeParamDirtyBit = 1;
+inline constexpr std::uint32_t kGradeRuntimeParamBytes =
+    static_cast<std::uint32_t>(sizeof(GradeAdjustmentParams));
+
+/**
+ * @brief Resolve a built-in Model type to its Grade runtime behavior.
+ * @return nullopt when the type has no GPU grade implementation (legacy Tint, etc.).
+ */
+[[nodiscard]] auto TryResolveAdjustmentBehavior(const OperatorTypeId& type)
+    -> std::optional<AdjustmentBehavior>;
+
+/**
+ * @brief Resolve a built-in Model type to its Grade runtime behavior.
+ * @throws std::runtime_error when the type has no GPU grade implementation.
+ */
+[[nodiscard]] auto ResolveAdjustmentBehavior(const OperatorTypeId& type) -> AdjustmentBehavior;
+
+[[nodiscard]] auto IsLocalToneBehavior(AdjustmentBehavior behavior) -> bool;
+[[nodiscard]] auto IsNeighborhoodBehavior(AdjustmentBehavior behavior) -> bool;
+
+/**
+ * @brief Pack a Model DTO into the shared Grade GPU parameter slot.
+ * @throws std::runtime_error when the payload layout is not supported.
+ */
+[[nodiscard]] auto MakeGradeRuntimeParams(const IOperatorModel& model, AdjustmentBehavior behavior)
+    -> GradeAdjustmentParams;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/basic_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_device.hpp
@@ -1,0 +1,109 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <functional>
+#include <string_view>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/basic_render_workspace.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/gpu_node_pass_stats.hpp"
+#include "edit/runtime/plan_executor.hpp"
+
+namespace alcedo {
+
+class MaskStore;
+
+/**
+ * @brief Workspace, command context, pass stats, and plan execution for one backend.
+ *
+ * Device loss is the only reason to destroy this object. Not thread-safe.
+ * CUDA adds Neural and DRT session objects on @ref CudaRenderDevice.
+ *
+ * @tparam Backend Render backend resource factory.
+ */
+template <class Backend>
+class BasicRenderDevice {
+ public:
+  using WorkspaceType      = BasicRenderWorkspace<Backend>;
+  using CommandContextType = typename Backend::CommandContext;
+
+  BasicRenderDevice() = default;
+  ~BasicRenderDevice() {
+    try {
+      WaitIdle();
+    } catch (...) {
+    }
+  }
+
+  BasicRenderDevice(const BasicRenderDevice&)                    = delete;
+  auto operator=(const BasicRenderDevice&) -> BasicRenderDevice& = delete;
+
+  [[nodiscard]] auto Workspace() -> WorkspaceType& { return workspace_; }
+  [[nodiscard]] auto Workspace() const -> const WorkspaceType& { return workspace_; }
+  [[nodiscard]] auto CommandContext() -> CommandContextType& { return command_context_; }
+
+  void               BeginRender() { workspace_.BeginRender(command_context_); }
+  void               EndRender() { workspace_.EndRender(command_context_); }
+  void               WaitIdle() { workspace_.Device().Wait(command_context_); }
+
+  /**
+   * @brief Drop unpublished writes for a failed encode. Does not publish results.
+   */
+  void CancelRender() noexcept {
+    if (!workspace_.IsRendering()) {
+      return;
+    }
+    try {
+      workspace_.Device().Wait(command_context_);
+    } catch (...) {
+    }
+    workspace_.CancelRender();
+  }
+
+  /**
+   * @brief Publish unpublished GPU image results for the submission ended by EndRender.
+   *
+   * Call after a successful present or host download. Kernel or frame-sink failure must
+   * leave results unpublished via CancelRender.
+   */
+  void PublishResults() {
+    workspace_.Images().PublishSuccessfulSubmission(command_context_.SubmissionId());
+  }
+
+  [[nodiscard]] auto PassStats() -> GpuNodePassStats& { return pass_stats_; }
+  [[nodiscard]] auto PassStats() const -> const GpuNodePassStats& { return pass_stats_; }
+  void               ResetPassStats() { pass_stats_.Reset(); }
+
+  /** @brief Install the app-layer error receiver. Called synchronously on the render thread. */
+  void SetErrorReporter(std::function<void(std::string_view)> reporter) {
+    error_reporter_ = std::move(reporter);
+  }
+  void ReportError(std::string_view message) const {
+    if (error_reporter_) {
+      error_reporter_(message);
+    }
+  }
+
+  /**
+   * @brief Run the compiled DAG. Skips published content keys. No image-processing substitute.
+   */
+  [[nodiscard]] auto Execute(const ExecutionPlan& plan, const PreparedRawInput& input,
+                             PipelineDocument& document, MaskStore* mask_store = nullptr,
+                             bool publish_on_success = true) -> GraphValueId {
+    return PlanExecutor<Backend>::Execute(*this, plan, input, document, mask_store,
+                                          publish_on_success);
+  }
+
+ private:
+  WorkspaceType                         workspace_;
+  CommandContextType                    command_context_;
+  GpuNodePassStats                      pass_stats_{};
+  std::function<void(std::string_view)> error_reporter_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_adjustment_runtime.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_adjustment_runtime.hpp
@@ -4,47 +4,24 @@
 
 #pragma once
 
-#include <cstdint>
-#include <optional>
-
-#include "edit/operators/models/operator_type_id.hpp"
+#include "edit/runtime/adjustment_runtime.hpp"
 
 namespace alcedo {
 
-enum class CudaAdjustmentBehavior : std::uint32_t {
-  Cat02WhiteBalance,
-  Exposure,
-  Contrast,
-  White,
-  Black,
-  Shadows,
-  Highlights,
-  Curve,
-  Hls,
-  Saturation,
-  Vibrance,
-  ColorWheel,
-  Lmt,
-  Clarity,
-  Sharpen,
-  Halation,
-  FilmGrain,
-};
+using CudaAdjustmentBehavior = AdjustmentBehavior;
 
-/**
- * @brief Resolve a built-in Model type to its CUDA runtime behavior.
- * @return nullopt when the type has no CUDA grade implementation (legacy Tint, etc.).
- */
-[[nodiscard]] auto TryResolveCudaAdjustmentBehavior(const OperatorTypeId& type)
-    -> std::optional<CudaAdjustmentBehavior>;
+[[nodiscard]] inline auto TryResolveCudaAdjustmentBehavior(const OperatorTypeId& type)
+    -> std::optional<CudaAdjustmentBehavior> {
+  return TryResolveAdjustmentBehavior(type);
+}
 
-/**
- * @brief Resolve a built-in Model type to its CUDA runtime behavior.
- * @throws std::runtime_error when G5 has no CUDA implementation for the type.
- */
-[[nodiscard]] auto ResolveCudaAdjustmentBehavior(const OperatorTypeId& type)
-    -> CudaAdjustmentBehavior;
+[[nodiscard]] inline auto ResolveCudaAdjustmentBehavior(const OperatorTypeId& type)
+    -> CudaAdjustmentBehavior {
+  return ResolveAdjustmentBehavior(type);
+}
 
-[[nodiscard]] auto IsCudaLocalToneBehavior(CudaAdjustmentBehavior behavior) -> bool;
+[[nodiscard]] inline auto IsCudaLocalToneBehavior(CudaAdjustmentBehavior behavior) -> bool {
+  return IsLocalToneBehavior(behavior);
+}
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -53,6 +53,12 @@ class CudaCommandContext {
  */
 class CudaBackend {
  public:
+  static constexpr std::uint32_t kCapabilityVersion = 1;
+  static constexpr const char*   kName              = "CUDA";
+
+  /** @brief Session texture budget from device memory, floored at 256 MiB. */
+  static auto DefaultTextureBudgetBytes() -> std::size_t;
+
   class Buffer {
    public:
     Buffer() = default;
@@ -203,5 +209,7 @@ class CudaBackend {
  * still fits when the card reports a small total. Not the 64 MiB test leftover.
  */
 [[nodiscard]] auto DefaultProductTextureBudgetBytes() -> std::size_t;
+
+inline constexpr std::uint32_t kCudaDagBackendCapabilityVersion = CudaBackend::kCapabilityVersion;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_frame_presenter.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_frame_presenter.hpp
@@ -1,0 +1,25 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/runtime/cuda/cuda_backend.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/frame_presenter.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief CUDA DRT texture present and host download. No CPU image-processing path.
+ */
+template <>
+struct FramePresenter<CudaBackend> {
+  static void Present(CudaRenderDevice& device, const GraphValueId& output_id, IFrameSink& sink,
+                      const FrameCompletionSubmission& submission,
+                      const ViewerDisplayConfig&       display_config);
+  static auto Download(CudaRenderDevice& device, const GraphValueId& output_id)
+      -> std::shared_ptr<ImageBuffer>;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_pass_encoder.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_pass_encoder.hpp
@@ -1,0 +1,76 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/runtime/cuda/cuda_backend.hpp"
+#include "edit/runtime/cuda/cuda_develop_pass.hpp"
+#include "edit/runtime/cuda/cuda_drt_pass.hpp"
+#include "edit/runtime/cuda/cuda_mask_pass.hpp"
+#include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/pass_encoder.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief CUDA sensor develop (raw or RGB upload plus the compiled develop sequence).
+ */
+template <>
+struct PassEncoder<CudaBackend, GpuPassKind::UploadRaw> {
+  static void Encode(CudaRenderDevice& device, const ExecutionPlan& plan,
+                     const PreparedRawInput& input, PipelineDocument& document, MaskStore*) {
+    ExecuteCudaDevelop(device, plan, input, document);
+  }
+};
+
+template <>
+struct PassEncoder<CudaBackend, GpuPassKind::UploadRgb> {
+  static void Encode(CudaRenderDevice& device, const ExecutionPlan& plan,
+                     const PreparedRawInput& input, PipelineDocument& document, MaskStore*) {
+    ExecuteCudaDevelop(device, plan, input, document);
+  }
+};
+
+template <>
+struct PassEncoder<CudaBackend, GpuPassKind::GeometryResample> {
+  static void Encode(CudaRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
+                     PipelineDocument&, MaskStore*) {
+    ExecuteCudaGeometryResample(device, plan);
+  }
+};
+
+template <>
+struct PassEncoder<CudaBackend, GpuPassKind::CameraToAp1> {
+  static void Encode(CudaRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
+                     PipelineDocument& document, MaskStore*) {
+    ExecuteCudaCameraColor(device, plan, document);
+  }
+};
+
+template <>
+struct PassEncoder<CudaBackend, GpuPassKind::MaskEvaluate> {
+  static void Encode(CudaRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
+                     PipelineDocument& document, MaskStore* mask_store) {
+    (void)ExecuteCudaMask(device, plan, document, mask_store);
+  }
+};
+
+template <>
+struct PassEncoder<CudaBackend, GpuPassKind::PrimaryColorGrade> {
+  static void Encode(CudaRenderDevice& device, const ExecutionPlan& plan,
+                     const PreparedRawInput& input, PipelineDocument& document, MaskStore*) {
+    (void)ExecuteCudaPrimaryGrade(device, plan, input, document);
+  }
+};
+
+template <>
+struct PassEncoder<CudaBackend, GpuPassKind::Drt> {
+  static void Encode(CudaRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
+                     PipelineDocument& document, MaskStore*) {
+    (void)ExecuteCudaDrt(device, plan, document);
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_product_renderer.hpp
@@ -4,126 +4,15 @@
 
 #pragma once
 
-#include <cstdint>
-#include <memory>
-#include <vector>
-
-#include "edit/geometry/render_request.hpp"
-#include "edit/graph/graph_ids.hpp"
-#include "edit/graph/pipeline_document.hpp"
-#include "edit/input/prepared_source_cache.hpp"
-#include "edit/runtime/gpu_node_pass_stats.hpp"
-#include "edit/runtime/static_execution_plan_cache.hpp"
-#include "type/type.hpp"
-#include "ui/edit_viewer/frame_sink.hpp"
+#include "edit/runtime/cuda/cuda_backend.hpp"
+#include "edit/runtime/cuda/cuda_frame_presenter.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/detail/renderer.inl.hpp"
+#include "edit/runtime/renderer.hpp"
 
 namespace alcedo {
 
-class CudaRenderDevice;
-class ImageBuffer;
-class MaskStore;
-
-/** @brief Select whether a render may read or publish the editor session caches. */
-enum class CudaProductCachePolicy {
-  UseSessionCache,
-  BypassSessionCache,
-};
-
-/// CUDA DAG backend capability mixed into the static plan key. Bump when pass
-/// lists or backend traits that affect compilation change.
-inline constexpr std::uint32_t kCudaDagBackendCapabilityVersion = 1;
-
-/**
- * @brief Queryable prepare/compile and result-cache counters for one product session.
- */
-struct CudaProductSessionStats {
-  std::uint64_t    prepared_source_hits     = 0;
-  std::uint64_t    prepared_source_misses   = 0;
-  std::uint64_t    libraw_open_unpack_count = 0;
-  std::uint64_t    plan_cache_hits          = 0;
-  std::uint64_t    plan_cache_misses        = 0;
-  std::uint64_t    plan_compile_count       = 0;
-  GpuNodePassStats pass{};
-};
-
-/**
- * @brief Live GPU/host allocations owned by one product session.
- */
-struct CudaProductSessionResources {
-  std::size_t               published_result_count      = 0;
-  std::size_t               texture_pool_used_bytes     = 0;
-  std::size_t               texture_pool_entry_count    = 0;
-  std::size_t               prepared_source_host_bytes  = 0;
-  std::size_t               prepared_source_entry_count = 0;
-  std::vector<GraphValueId> session_value_ids;
-};
-
-/**
- * @brief Reusable CUDA product session for one opened PipelineDocument.
- *
- * Owns the editor session caches/device plus a lazily created one-shot device for
- * thumbnail and export work. Not created per Apply. Only session renders reuse
- * prepared sources, static plans, and published GPU results.
- */
-class CudaProductRenderer {
- public:
-  explicit CudaProductRenderer(std::shared_ptr<PipelineDocument> document);
-  CudaProductRenderer(std::shared_ptr<PipelineDocument> document,
-                      PreparedSourceCache::UnpackFn     unpack);
-  ~CudaProductRenderer();
-
-  CudaProductRenderer(const CudaProductRenderer&)                                  = delete;
-  auto               operator=(const CudaProductRenderer&) -> CudaProductRenderer& = delete;
-
-  void               SetDocument(std::shared_ptr<PipelineDocument> document);
-
-  /**
-   * @brief Render one frame on the owning thread.
-   *
-   * @param cache_policy Session mode reads and publishes reusable editor results. Bypass mode
-   *        uses an isolated one-shot workspace and releases its result resources after delivery.
-   * @throws std::runtime_error for invalid input, CUDA execution, or presentation failure.
-   */
-  [[nodiscard]] auto Render(
-      const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res, const RenderRequest& request,
-      IFrameSink* sink, const FrameCompletionSubmission& submission, bool require_host_output,
-      CudaProductCachePolicy cache_policy = CudaProductCachePolicy::UseSessionCache)
-      -> std::shared_ptr<ImageBuffer>;
-
-  /**
-   * @brief Snapshot of source and static-plan cache counters since construction or ResetStats.
-   */
-  [[nodiscard]] auto Stats() const -> CudaProductSessionStats;
-  void               ResetStats();
-
-  /**
-   * @brief Drop GPU result textures, host prepared sources, the plan cache, and
-   *        the session Neural workspace. Keeps the CudaRenderDevice.
-   *
-   * Call when the pipeline is returned to PipelineMgmtService. The next Render
-   * rebuilds caches from the still-owned PipelineDocument.
-   */
-  void               ReleaseSessionCaches();
-
-  [[nodiscard]] auto SessionResources() const -> CudaProductSessionResources;
-
-  [[nodiscard]] auto Device() -> CudaRenderDevice& { return *device_; }
-  [[nodiscard]] auto Device() const -> const CudaRenderDevice& { return *device_; }
-
-  [[nodiscard]] auto SourceCache() -> PreparedSourceCache& { return source_cache_; }
-  [[nodiscard]] auto SourceCache() const -> const PreparedSourceCache& { return source_cache_; }
-  [[nodiscard]] auto PlanCache() -> StaticExecutionPlanCache& { return plan_cache_; }
-  [[nodiscard]] auto PlanCache() const -> const StaticExecutionPlanCache& { return plan_cache_; }
-  [[nodiscard]] auto MaskAssets() -> MaskStore&;
-
- private:
-  std::shared_ptr<PipelineDocument> document_;
-  std::unique_ptr<CudaRenderDevice> device_;
-  std::unique_ptr<CudaRenderDevice> one_shot_device_;
-  std::unique_ptr<MaskStore>        mask_store_;
-  PreparedSourceCache::UnpackFn     unpack_;
-  PreparedSourceCache               source_cache_;
-  StaticExecutionPlanCache          plan_cache_{kCudaDagBackendCapabilityVersion};
-};
+using CudaRenderer        = Renderer<CudaBackend>;
+using CudaProductRenderer = CudaRenderer;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
@@ -14,6 +14,7 @@
 #include "edit/runtime/cuda/cuda_backend.hpp"
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/gpu_node_pass_stats.hpp"
+#include "edit/runtime/render_device_type.hpp"
 
 namespace alcedo {
 
@@ -100,6 +101,11 @@ class CudaRenderDevice {
   std::unique_ptr<CUDA::NeuralDemosaicWorkspace>   neural_workspace_;
   std::function<void(std::string_view)>            error_reporter_;
   GpuNodePassStats                                 pass_stats_{};
+};
+
+template <>
+struct RenderDeviceType<CudaBackend> {
+  using Type = CudaRenderDevice;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_sensor_demosaic.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_sensor_demosaic.hpp
@@ -13,20 +13,11 @@
 #include "decoders/processor/raw_processor_pattern.hpp"
 #include "edit/graph/develop_node_model.hpp"
 #include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/develop_demosaic.hpp"
 
 namespace alcedo {
 
 class CudaRenderDevice;
-
-/**
- * @brief Resolve the product demosaic method from Develop params and CFA.
- *
- * Reduced-resolution inputs (downsample_passes != 0) always use Legacy.
- * Default is Legacy on Bayer and Neural Engine on X-Trans.
- */
-[[nodiscard]] auto ResolveDevelopDemosaicMethod(const DevelopPayload& params, RawCfaKind cfa_kind,
-                                                std::uint32_t downsample_passes)
-    -> RawDemosaicMethod;
 
 /**
  * @brief Test hook: inject a model cache so Neural load failure can be asserted.

--- a/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
+++ b/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
@@ -1,0 +1,103 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <utility>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/runtime/drt_display.hpp"
+#include "edit/runtime/frame_presenter.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/renderer.hpp"
+#include "image/image_buffer.hpp"
+
+namespace alcedo {
+
+template <class Backend>
+auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
+                               const RenderRequest& request, IFrameSink* sink,
+                               const FrameCompletionSubmission& submission,
+                               bool require_host_output, RenderCachePolicy cache_policy)
+    -> std::shared_ptr<ImageBuffer> {
+  if (!document_) {
+    throw std::runtime_error("Renderer: PipelineDocument is not configured");
+  }
+  if (!input || !input->buffer_valid_) {
+    throw std::runtime_error("Renderer: product path requires encoded image bytes");
+  }
+
+  auto&      encoded       = input->GetBuffer();
+  const auto encoded_bytes = std::span<const std::byte>{
+      reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
+  const bool use_session_cache = cache_policy == RenderCachePolicy::UseSessionCache;
+  if (!use_session_cache) {
+    EnsureOneShotDevice();
+  }
+
+  std::optional<PreparedSourceCache::Lease> prepared_lease;
+  std::optional<PreparedRawInput>           one_shot_prepared;
+  ExecutionPlan                             plan;
+  RenderDevice*                             render_device = device_.get();
+  if (use_session_cache) {
+    prepared_lease.emplace(source_cache_.AcquireEncoded(encoded_bytes, decode_res));
+    plan = plan_cache_.GetOrCompile(*document_, prepared_lease->Get().CompileSource());
+  } else {
+    one_shot_prepared.emplace(unpack_(encoded_bytes, decode_res));
+    plan          = GraphCompiler::CompileStatic(*document_, one_shot_prepared->CompileSource(),
+                                                 Backend::kCapabilityVersion);
+    render_device = one_shot_device_.get();
+  }
+  GraphCompiler::BindFrameGeometry(plan, *document_, request);
+  if (document_->TopologyDirty()) {
+    document_->ClearTopologyDirty();
+  }
+  const auto& prepared  = use_session_cache ? prepared_lease->Get() : *one_shot_prepared;
+  const auto  output_id =
+      render_device->Execute(plan, prepared, *document_, mask_store_.get(), false);
+  const auto  release_one_shot_resources = [&]() {
+    if (use_session_cache) {
+      return;
+    }
+    render_device->Workspace().Images().DiscardUnpublished();
+    render_device->WaitIdle();
+    render_device->Workspace().ReleaseSessionResources();
+  };
+
+  ViewerDisplayConfig display_config{};
+  if (const auto* drt = document_->Drt()) {
+    display_config = ViewerDisplayConfigFromDrt(drt->Params().Params());
+  }
+
+  try {
+    if (sink != nullptr) {
+      FramePresenter<Backend>::Present(*render_device, output_id, *sink, submission,
+                                       display_config);
+    }
+    if (require_host_output) {
+      auto host = FramePresenter<Backend>::Download(*render_device, output_id);
+      if (use_session_cache) {
+        render_device->PublishResults();
+      } else {
+        release_one_shot_resources();
+      }
+      return host;
+    }
+    if (use_session_cache) {
+      render_device->PublishResults();
+    } else {
+      release_one_shot_resources();
+    }
+  } catch (const std::exception& ex) {
+    render_device->Workspace().Images().DiscardUnpublished();
+    render_device->ReportError(ex.what());
+    throw;
+  }
+  return std::make_shared<ImageBuffer>();
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
+++ b/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdio>
+#include <cstdlib>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -17,6 +19,42 @@
 #include "image/image_buffer.hpp"
 
 namespace alcedo {
+namespace detail {
+
+template <class Backend>
+void TraceGpuDagGeometry(const ExecutionPlan& plan, const RenderRequest& request,
+                         const FrameCompletionSubmission& submission) {
+  const char* enabled = std::getenv("ALCEDO_ROI_TRACE");
+  if (enabled == nullptr || enabled[0] == '\0' || enabled[0] == '0') {
+    return;
+  }
+  const auto& view                  = request.view.visible_rect_in_edit_space;
+  const auto& geometry              = plan.geometry;
+  const auto  native_visible_width  = static_cast<float>(geometry.edit_extent.width) * view.w;
+  const auto  native_visible_height = static_cast<float>(geometry.edit_extent.height) * view.h;
+  const bool  nearest_viewer_expansion =
+      !view.IsFullFrame() && (request.view.viewport_extent.width > geometry.render_extent.width ||
+                              request.view.viewport_extent.height > geometry.render_extent.height);
+  std::fprintf(
+      stderr,
+      "[ROI_TRACE][gpu-dag-geometry] backend=%s request=%llu role=%d mode=%d "
+      "decoded=%ux%u full_ref=%ux%u edit=%ux%u roi=%.6f,%.6f,%.6f,%.6f "
+      "native_roi=%.2fx%.2f viewport_target=%ux%u max_edge=%u render=%ux%u filter=%d "
+      "viewer_nearest_expand=%d required_decoded=%d,%d,%d,%d\n",
+      Backend::kName, static_cast<unsigned long long>(submission.metadata.presentation_request_id),
+      static_cast<int>(submission.metadata.frame_role), static_cast<int>(submission.mode),
+      geometry.decoded_extent.width, geometry.decoded_extent.height,
+      geometry.full_reference_extent.width, geometry.full_reference_extent.height,
+      geometry.edit_extent.width, geometry.edit_extent.height, view.x, view.y, view.w, view.h,
+      native_visible_width, native_visible_height, request.view.viewport_extent.width,
+      request.view.viewport_extent.height, request.resolution.max_edge,
+      geometry.render_extent.width, geometry.render_extent.height,
+      static_cast<int>(geometry.filter), nearest_viewer_expansion ? 1 : 0,
+      geometry.required_decoded_region.x, geometry.required_decoded_region.y,
+      geometry.required_decoded_region.width, geometry.required_decoded_region.height);
+}
+
+}  // namespace detail
 
 template <class Backend>
 auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
@@ -53,13 +91,14 @@ auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input, Decode
     render_device = one_shot_device_.get();
   }
   GraphCompiler::BindFrameGeometry(plan, *document_, request);
+  detail::TraceGpuDagGeometry<Backend>(plan, request, submission);
   if (document_->TopologyDirty()) {
     document_->ClearTopologyDirty();
   }
-  const auto& prepared  = use_session_cache ? prepared_lease->Get() : *one_shot_prepared;
+  const auto& prepared = use_session_cache ? prepared_lease->Get() : *one_shot_prepared;
   const auto  output_id =
       render_device->Execute(plan, prepared, *document_, mask_store_.get(), false);
-  const auto  release_one_shot_resources = [&]() {
+  const auto release_one_shot_resources = [&]() {
     if (use_session_cache) {
       return;
     }

--- a/alcedo_studio/src/include/edit/runtime/develop_demosaic.hpp
+++ b/alcedo_studio/src/include/edit/runtime/develop_demosaic.hpp
@@ -1,0 +1,36 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "decoders/processor/raw_demosaic_method.hpp"
+#include "decoders/processor/raw_processor_pattern.hpp"
+#include "edit/graph/develop_node_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Resolve the product demosaic method from Develop params and CFA.
+ *
+ * Reduced-resolution inputs (downsample_passes != 0) always use Legacy.
+ * Default is Legacy on Bayer and Neural Engine on X-Trans.
+ */
+[[nodiscard]] inline auto ResolveDevelopDemosaicMethod(const DevelopPayload& params,
+                                                       RawCfaKind cfa_kind,
+                                                       std::uint32_t downsample_passes)
+    -> RawDemosaicMethod {
+  if (downsample_passes != 0) {
+    return RawDemosaicMethod::Legacy;
+  }
+  const auto parsed = RawDemosaicMethodFromString(params.demosaic_method);
+  if (parsed != RawDemosaicMethod::Default) {
+    return parsed;
+  }
+  return cfa_kind == RawCfaKind::XTrans6x6 ? RawDemosaicMethod::NeuralEngine
+                                           : RawDemosaicMethod::Legacy;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/drt_display.hpp
+++ b/alcedo_studio/src/include/edit/runtime/drt_display.hpp
@@ -1,0 +1,61 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/graph/drt_node_model.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Map DRT payload encoding fields to the viewer display configuration.
+ *
+ * Native present still copies through the backend FramePresenter. This helper
+ * does not allocate GPU memory.
+ */
+[[nodiscard]] inline auto ViewerDisplayConfigFromDrt(const DrtPayload& payload)
+    -> ViewerDisplayConfig {
+  ViewerDisplayConfig config;
+  switch (payload.encoding_space) {
+    case DrtColorSpace::Rec2020:
+      config.encoding_space = ColorUtils::ColorSpace::REC2020;
+      break;
+    case DrtColorSpace::P3D65:
+      config.encoding_space = ColorUtils::ColorSpace::P3_D65;
+      break;
+    case DrtColorSpace::Rec709:
+    default:
+      config.encoding_space = ColorUtils::ColorSpace::REC709;
+      break;
+  }
+  switch (payload.encoding_eotf) {
+    case DrtEotf::Linear:
+      config.encoding_eotf = ColorUtils::EOTF::LINEAR;
+      break;
+    case DrtEotf::St2084:
+      config.encoding_eotf = ColorUtils::EOTF::ST2084;
+      break;
+    case DrtEotf::Hlg:
+      config.encoding_eotf = ColorUtils::EOTF::HLG;
+      break;
+    case DrtEotf::Gamma26:
+      config.encoding_eotf = ColorUtils::EOTF::GAMMA_2_6;
+      break;
+    case DrtEotf::Bt1886:
+      config.encoding_eotf = ColorUtils::EOTF::BT1886;
+      break;
+    case DrtEotf::Gamma18:
+      config.encoding_eotf = ColorUtils::EOTF::GAMMA_1_8;
+      break;
+    case DrtEotf::Gamma22:
+    default:
+      config.encoding_eotf = ColorUtils::EOTF::GAMMA_2_2;
+      break;
+  }
+  config.peak_luminance = payload.peak_luminance;
+  return config;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -24,12 +24,26 @@ struct GpuPassDesc {
 enum class CompiledAdjustmentAlgorithm : std::uint8_t {
   Pointwise,
   LocalLaplacian,
+  Neighborhood,
 };
 
 struct CompiledAdjustment {
   AdjustmentInstanceId        instance_id;
   OperatorTypeId              type;
   CompiledAdjustmentAlgorithm algorithm = CompiledAdjustmentAlgorithm::Pointwise;
+};
+
+/** @brief Fused or standalone Grade work produced from the Model list. */
+enum class CompiledGradeStageKind : std::uint8_t {
+  Pointwise,
+  LocalLaplacian,
+  Neighborhood,
+};
+
+struct CompiledGradeStage {
+  CompiledGradeStageKind kind  = CompiledGradeStageKind::Pointwise;
+  std::uint32_t          begin = 0;
+  std::uint32_t          count = 0;
 };
 
 enum class CompiledMaskKind : std::uint8_t { Analytic, Raster };
@@ -125,6 +139,7 @@ struct ExecutionPlan {
   bool                            encode_geometry_resample = false;
   std::size_t                     peak_transient_bytes     = 0;
   std::vector<CompiledAdjustment> primary_grade_adjustments;
+  std::vector<CompiledGradeStage> primary_grade_stages;
   std::optional<CompiledMask>     primary_grade_mask;
   GraphValueId                    mask_output{NodeId{""}, PortId{"mask"}};
   GraphValueId                    primary_grade_output{NodeId{"grade.primary"}, PortId{"image"}};

--- a/alcedo_studio/src/include/edit/runtime/frame_presenter.hpp
+++ b/alcedo_studio/src/include/edit/runtime/frame_presenter.hpp
@@ -1,0 +1,39 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+
+#include "edit/graph/graph_ids.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo {
+
+class ImageBuffer;
+
+/**
+ * @brief Native present and host download for one render backend.
+ *
+ * Specializations own GPU copies, signaling, and sink mapping. The primary
+ * template fails explicitly and does not substitute another backend.
+ *
+ * @tparam Backend Render backend.
+ */
+template <class Backend>
+struct FramePresenter {
+  template <class Device>
+  static void Present(Device&, const GraphValueId&, IFrameSink&, const FrameCompletionSubmission&,
+                      const ViewerDisplayConfig&) {
+    throw std::runtime_error("FramePresenter: present is not implemented for this backend");
+  }
+
+  template <class Device>
+  static auto Download(Device&, const GraphValueId&) -> std::shared_ptr<ImageBuffer> {
+    throw std::runtime_error("FramePresenter: host download is not implemented for this backend");
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "edit/geometry/types.hpp"
+#include "edit/runtime/basic_render_device.hpp"
 #include "edit/runtime/byte_range.hpp"
 #include "edit/runtime/content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
@@ -260,5 +261,8 @@ class MetalBackend {
 
 [[nodiscard]] auto BindSystemDefaultMetalPresentationDevice() -> void*;
 [[nodiscard]] auto MetalPresentationDeviceHandle() -> void*;
+
+using MetalRenderDevice    = BasicRenderDevice<MetalBackend>;
+using MetalRenderWorkspace = BasicRenderWorkspace<MetalBackend>;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
@@ -146,6 +146,8 @@ class MetalBackend {
                           CommandContext& command_context);
   void FillDeviceMemory(void* dst, std::size_t bytes, std::uint8_t value,
                         CommandContext& command_context);
+  void CopyDeviceMemoryToBuffer(void* src, Buffer& dst, std::uint32_t dst_offset, std::size_t bytes,
+                                CommandContext& command_context);
   [[nodiscard]] auto ResolveDeviceMemory(void* device_pointer, std::size_t bytes) const
       -> std::pair<void*, std::uint32_t>;
 

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <span>
+#include <utility>
 #include <vector>
 
 #include "edit/geometry/types.hpp"
@@ -136,6 +137,13 @@ class MetalBackend {
                          CommandContext& command_context);
   void UploadDeviceMemory(void* dst, std::span<const std::byte> bytes,
                           CommandContext& command_context);
+  void FillDeviceMemory(void* dst, std::size_t bytes, std::uint8_t value,
+                        CommandContext& command_context);
+  [[nodiscard]] auto ResolveDeviceMemory(void* device_pointer, std::size_t bytes) const
+      -> std::pair<void*, std::uint32_t>;
+
+  [[nodiscard]] auto EnsureComputeCommandEncoder(CommandContext& command_context) -> void*;
+  void               EndCommandEncoders(CommandContext& command_context);
 
   void Submit(CommandContext& command_context);
   void Wait(CommandContext& command_context);
@@ -163,6 +171,9 @@ class MetalBackend {
   [[nodiscard]] auto BufferCreateCount() const -> std::uint64_t { return buffer_create_count_; }
   [[nodiscard]] auto TextureCreateCount() const -> std::uint64_t { return texture_create_count_; }
   [[nodiscard]] auto HeapCreateCount() const -> std::uint64_t { return heap_create_count_; }
+  [[nodiscard]] auto CommandBufferCreateCount() const -> std::uint64_t {
+    return command_buffer_create_count_;
+  }
   [[nodiscard]] auto PipelineCreateCount() const -> std::uint64_t;
   [[nodiscard]] auto PipelineHitCount() const -> std::uint64_t;
   [[nodiscard]] auto HostToDeviceCopyCount() const -> std::uint64_t { return h2d_copy_count_; }
@@ -195,8 +206,9 @@ class MetalBackend {
   std::uint64_t          free_count_           = 0;
   std::uint64_t          buffer_create_count_  = 0;
   std::uint64_t          texture_create_count_ = 0;
-  std::uint64_t          heap_create_count_    = 0;
-  std::uint64_t          h2d_copy_count_       = 0;
+  std::uint64_t          heap_create_count_           = 0;
+  std::uint64_t          command_buffer_create_count_ = 0;
+  std::uint64_t          h2d_copy_count_              = 0;
   std::uint64_t          h2d_bytes_            = 0;
   std::uint64_t          next_resource_id_     = 1;
   std::uint64_t          next_submission_      = 0;

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
@@ -13,6 +13,7 @@
 
 #include "edit/geometry/types.hpp"
 #include "edit/runtime/byte_range.hpp"
+#include "edit/runtime/content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
 
 namespace alcedo {
@@ -26,6 +27,12 @@ struct MetalPipelineWarmup {
   const char* metallib_path = nullptr;
   const char* function_name = nullptr;
   const char* debug_label   = nullptr;
+};
+
+struct MetalLutBinding {
+  void*         native      = nullptr;
+  std::uint64_t resource_id = 0;
+  std::uint32_t edge_size   = 0;
 };
 
 class MetalCommandContext {
@@ -145,11 +152,19 @@ class MetalBackend {
   [[nodiscard]] auto EnsureComputeCommandEncoder(CommandContext& command_context) -> void*;
   void               EndCommandEncoders(CommandContext& command_context);
 
-  void Submit(CommandContext& command_context);
-  void Wait(CommandContext& command_context);
+  void               Submit(CommandContext& command_context);
+  void               Wait(CommandContext& command_context);
 
-  void WarmUpPipelines(std::span<const MetalPipelineWarmup> pipelines);
-  void WarmUpPlan(const ExecutionPlan& plan);
+  void               WarmUpPipelines(std::span<const MetalPipelineWarmup> pipelines);
+  void               WarmUpPlan(const ExecutionPlan& plan);
+
+  [[nodiscard]] auto AcquireLut(ContentKey key, std::span<const std::byte> packed_rgba,
+                                std::uint32_t edge, CommandContext& command_context)
+      -> MetalLutBinding;
+  [[nodiscard]] auto DummyLut() -> MetalLutBinding;
+  void               SetLutByteBudget(std::size_t bytes);
+  void               NoteComputeDispatch() noexcept { ++compute_dispatch_count_; }
+  void SetGradeCommandTopologyHash(std::uint64_t hash) { grade_command_topology_hash_ = hash; }
 
   [[nodiscard]] auto HasInFlightSubmission() const -> bool { return in_flight_submission_ != 0; }
   [[nodiscard]] auto CompletedSubmission() const -> std::uint64_t { return completed_submission_; }
@@ -184,6 +199,14 @@ class MetalBackend {
   [[nodiscard]] auto LastTextureRectangles() const -> const std::vector<RectI>& {
     return last_texture_rectangles_;
   }
+  [[nodiscard]] auto ComputeDispatchCount() const -> std::uint64_t {
+    return compute_dispatch_count_;
+  }
+  [[nodiscard]] auto LutUploadBytes() const -> std::uint64_t { return lut_upload_bytes_; }
+  [[nodiscard]] auto LastLutResourceId() const -> std::uint64_t { return last_lut_resource_id_; }
+  [[nodiscard]] auto GradeCommandTopologyHash() const -> std::uint64_t {
+    return grade_command_topology_hash_;
+  }
 
  private:
   friend class Buffer;
@@ -202,21 +225,35 @@ class MetalBackend {
   void                   NoteHeapCreate() noexcept { ++heap_create_count_; }
 
   std::unique_ptr<Gpu>   gpu_{};
-  std::uint64_t          malloc_count_         = 0;
-  std::uint64_t          free_count_           = 0;
-  std::uint64_t          buffer_create_count_  = 0;
-  std::uint64_t          texture_create_count_ = 0;
+  std::uint64_t          malloc_count_                = 0;
+  std::uint64_t          free_count_                  = 0;
+  std::uint64_t          buffer_create_count_         = 0;
+  std::uint64_t          texture_create_count_        = 0;
   std::uint64_t          heap_create_count_           = 0;
   std::uint64_t          command_buffer_create_count_ = 0;
   std::uint64_t          h2d_copy_count_              = 0;
-  std::uint64_t          h2d_bytes_            = 0;
-  std::uint64_t          next_resource_id_     = 1;
-  std::uint64_t          next_submission_      = 0;
-  std::uint64_t          in_flight_submission_ = 0;
-  std::uint64_t          completed_submission_ = 0;
-  bool                   fail_next_upload_     = false;
+  std::uint64_t          h2d_bytes_                   = 0;
+  std::uint64_t          next_resource_id_            = 1;
+  std::uint64_t          next_submission_             = 0;
+  std::uint64_t          in_flight_submission_        = 0;
+  std::uint64_t          completed_submission_        = 0;
+  bool                   fail_next_upload_            = false;
   std::vector<ByteRange> last_h2d_ranges_;
   std::vector<RectI>     last_texture_rectangles_;
+  std::uint64_t          compute_dispatch_count_      = 0;
+  std::uint64_t          lut_upload_bytes_            = 0;
+  std::uint64_t          last_lut_resource_id_        = 0;
+  std::uint64_t          grade_command_topology_hash_ = 0;
+  std::size_t            lut_byte_budget_             = 64ull << 20;
+  std::size_t            lut_cache_bytes_             = 0;
+  struct LutCacheEntry {
+    ContentKey    key;
+    Buffer        buffer;
+    std::uint32_t edge_size = 0;
+    std::size_t   bytes     = 0;
+  };
+  std::vector<LutCacheEntry> lut_cache_;
+  Buffer                     dummy_lut_;
 };
 
 [[nodiscard]] auto BindSystemDefaultMetalPresentationDevice() -> void*;

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
@@ -6,8 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <span>
-#include <stdexcept>
 #include <vector>
 
 #include "edit/geometry/types.hpp"
@@ -16,121 +16,132 @@
 
 namespace alcedo {
 
+struct ExecutionPlan;
+class MetalBackendImpl;
+
 inline constexpr std::uint32_t kMetalDagBackendCapabilityVersion = 2;
 
-/**
- * @brief Host command-buffer identity for one in-flight Metal submission.
- *
- * Native MTLCommandBuffer lives in later Metal runtime TUs. Not thread-safe.
- */
+struct MetalPipelineWarmup {
+  const char* metallib_path = nullptr;
+  const char* function_name = nullptr;
+  const char* debug_label   = nullptr;
+};
+
 class MetalCommandContext {
  public:
-  MetalCommandContext() = default;
+  MetalCommandContext();
+  ~MetalCommandContext();
+  MetalCommandContext(const MetalCommandContext&)                    = delete;
+  auto operator=(const MetalCommandContext&) -> MetalCommandContext& = delete;
+  MetalCommandContext(MetalCommandContext&&) noexcept;
+  auto               operator=(MetalCommandContext&&) noexcept -> MetalCommandContext&;
 
   [[nodiscard]] auto SubmissionId() const -> std::uint64_t { return submission_id_; }
   void               SetSubmissionId(std::uint64_t id) { submission_id_ = id; }
+  [[nodiscard]] auto NativeCommandBuffer() const -> void*;
 
  private:
-  std::uint64_t submission_id_ = 0;
+  friend class MetalBackend;
+  friend class MetalBackendImpl;
+  class Gpu;
+  std::unique_ptr<Gpu> gpu_;
+  std::uint64_t        submission_id_ = 0;
 };
 
-/**
- * @brief Host-side Metal backend traits for Renderer and workspace instantiation.
- *
- * Native Metal types are not included. Resource creation fails explicitly until
- * the Metal runtime lands. There is no CPU or CUDA substitute.
- */
 class MetalBackend {
  public:
+  static constexpr std::uint32_t kCapabilityVersion = kMetalDagBackendCapabilityVersion;
+  static constexpr const char*   kName              = "Metal";
+  static auto                    DefaultTextureBudgetBytes() -> std::size_t { return 256ull << 20; }
+
   class Buffer {
    public:
     Buffer() = default;
-    Buffer(Buffer&&) noexcept = default;
-    auto operator=(Buffer&&) noexcept -> Buffer& = default;
-    Buffer(const Buffer&)                        = delete;
-    auto operator=(const Buffer&) -> Buffer&     = delete;
-    ~Buffer()                                    = default;
+    Buffer(MetalBackend* owner, void* native, void* device_pointer, std::size_t bytes,
+           std::uint64_t id);
+    ~Buffer();
+    Buffer(const Buffer&)                    = delete;
+    auto operator=(const Buffer&) -> Buffer& = delete;
+    Buffer(Buffer&& other) noexcept;
+    auto               operator=(Buffer&& other) noexcept -> Buffer&;
 
-    [[nodiscard]] auto DevicePointer() const -> void* { return nullptr; }
-    [[nodiscard]] auto Bytes() const -> std::size_t { return 0; }
-    [[nodiscard]] auto ResourceId() const -> std::uint64_t { return 0; }
-    [[nodiscard]] auto Empty() const -> bool { return true; }
-    void               Reset() noexcept {}
+    [[nodiscard]] auto DevicePointer() const -> void* { return ptr_; }
+    [[nodiscard]] auto Native() const -> void* { return native_; }
+    [[nodiscard]] auto Bytes() const -> std::size_t { return bytes_; }
+    [[nodiscard]] auto ResourceId() const -> std::uint64_t { return resource_id_; }
+    [[nodiscard]] auto Empty() const -> bool { return native_ == nullptr; }
+    void               Reset() noexcept;
+
+   private:
+    MetalBackend* owner_       = nullptr;
+    void*         native_      = nullptr;
+    void*         ptr_         = nullptr;
+    std::size_t   bytes_       = 0;
+    std::uint64_t resource_id_ = 0;
   };
 
   class Texture2D {
    public:
     Texture2D() = default;
-    Texture2D(Texture2D&&) noexcept = default;
-    auto operator=(Texture2D&&) noexcept -> Texture2D& = default;
-    Texture2D(const Texture2D&)                        = delete;
-    auto operator=(const Texture2D&) -> Texture2D&     = delete;
-    ~Texture2D()                                       = default;
+    Texture2D(MetalBackend* owner, void* native, std::size_t bytes, std::uint32_t width,
+              std::uint32_t height, TextureFormat format, std::uint64_t id);
+    ~Texture2D();
+    Texture2D(const Texture2D&)                    = delete;
+    auto operator=(const Texture2D&) -> Texture2D& = delete;
+    Texture2D(Texture2D&& other) noexcept;
+    auto               operator=(Texture2D&& other) noexcept -> Texture2D&;
 
-    [[nodiscard]] auto DevicePointer() const -> void* { return nullptr; }
-    [[nodiscard]] auto Bytes() const -> std::size_t { return 0; }
-    [[nodiscard]] auto Width() const -> std::uint32_t { return 0; }
-    [[nodiscard]] auto Height() const -> std::uint32_t { return 0; }
-    [[nodiscard]] auto Format() const -> TextureFormat { return TextureFormat::R8; }
-    [[nodiscard]] auto ResourceId() const -> std::uint64_t { return 0; }
-    void               Reset() noexcept {}
+    [[nodiscard]] auto DevicePointer() const -> void* { return native_; }
+    [[nodiscard]] auto Native() const -> void* { return native_; }
+    [[nodiscard]] auto Bytes() const -> std::size_t { return bytes_; }
+    [[nodiscard]] auto Width() const -> std::uint32_t { return width_; }
+    [[nodiscard]] auto Height() const -> std::uint32_t { return height_; }
+    [[nodiscard]] auto Format() const -> TextureFormat { return format_; }
+    [[nodiscard]] auto ResourceId() const -> std::uint64_t { return resource_id_; }
+    void               Reset() noexcept;
+
+   private:
+    MetalBackend* owner_       = nullptr;
+    void*         native_      = nullptr;
+    std::size_t   bytes_       = 0;
+    std::uint32_t width_       = 0;
+    std::uint32_t height_      = 0;
+    TextureFormat format_      = TextureFormat::R8;
+    std::uint64_t resource_id_ = 0;
   };
 
   using Slab           = Buffer;
   using CommandContext = MetalCommandContext;
 
-  static constexpr std::uint32_t kCapabilityVersion = kMetalDagBackendCapabilityVersion;
-  static constexpr const char*   kName              = "Metal";
+  MetalBackend();
+  ~MetalBackend();
+  MetalBackend(const MetalBackend&)                                  = delete;
+  auto               operator=(const MetalBackend&) -> MetalBackend& = delete;
 
-  /**
-   * @brief Session texture budget used until Metal device queries land.
-   *
-   * Matches the CUDA floor so plan compilation and workspace setup share size policy.
-   */
-  static auto DefaultTextureBudgetBytes() -> std::size_t { return 256ull << 20; }
+  [[nodiscard]] auto CreateBuffer(std::size_t bytes) -> Buffer;
+  [[nodiscard]] auto CreateSlab(std::size_t bytes) -> Buffer;
+  [[nodiscard]] auto CreateTexture2D(std::uint32_t width, std::uint32_t height,
+                                     TextureFormat format) -> Texture2D;
 
-  MetalBackend()                                   = default;
-  MetalBackend(const MetalBackend&)                = delete;
-  auto operator=(const MetalBackend&) -> MetalBackend& = delete;
+  void UploadBufferRange(Buffer& buffer, std::uint32_t offset, std::span<const std::byte> bytes,
+                         CommandContext& command_context);
+  void DownloadBufferRange(const Buffer& buffer, std::uint32_t offset, std::span<std::byte> out,
+                           CommandContext& command_context);
+  void UploadTexture2D(Texture2D& texture, std::span<const std::byte> bytes,
+                       CommandContext& command_context);
+  void CopyTexture2D(const Texture2D& src, Texture2D& dst, CommandContext& command_context);
+  void UploadR8TextureRect(Texture2D& texture, RectI rectangle, std::span<const std::byte> bytes,
+                           CommandContext& command_context);
+  void DownloadTexture2D(const Texture2D& texture, std::span<std::byte> out,
+                         CommandContext& command_context);
+  void UploadDeviceMemory(void* dst, std::span<const std::byte> bytes,
+                          CommandContext& command_context);
 
-  [[nodiscard]] auto CreateBuffer(std::size_t) -> Buffer {
-    throw std::runtime_error("MetalBackend: GPU buffer allocation is not implemented");
-  }
-  [[nodiscard]] auto CreateSlab(std::size_t bytes) -> Buffer { return CreateBuffer(bytes); }
-  [[nodiscard]] auto CreateTexture2D(std::uint32_t, std::uint32_t, TextureFormat) -> Texture2D {
-    throw std::runtime_error("MetalBackend: GPU texture allocation is not implemented");
-  }
+  void Submit(CommandContext& command_context);
+  void Wait(CommandContext& command_context);
 
-  void UploadBufferRange(Buffer&, std::uint32_t, std::span<const std::byte>, CommandContext&) {
-    throw std::runtime_error("MetalBackend: buffer upload is not implemented");
-  }
-  void DownloadBufferRange(const Buffer&, std::uint32_t, std::span<std::byte>,
-                           CommandContext&) const {
-    throw std::runtime_error("MetalBackend: buffer download is not implemented");
-  }
-  void UploadTexture2D(Texture2D&, std::span<const std::byte>, CommandContext&) {
-    throw std::runtime_error("MetalBackend: texture upload is not implemented");
-  }
-  void CopyTexture2D(const Texture2D&, Texture2D&, CommandContext&) {
-    throw std::runtime_error("MetalBackend: texture copy is not implemented");
-  }
-  void UploadR8TextureRect(Texture2D&, RectI, std::span<const std::byte>, CommandContext&) {
-    throw std::runtime_error("MetalBackend: R8 upload is not implemented");
-  }
-  void DownloadTexture2D(const Texture2D&, std::span<std::byte>, CommandContext&) const {
-    throw std::runtime_error("MetalBackend: texture download is not implemented");
-  }
-
-  void Submit(CommandContext& command_context) {
-    in_flight_submission_ = command_context.SubmissionId();
-  }
-  void Wait(CommandContext&) {
-    if (in_flight_submission_ == 0) {
-      return;
-    }
-    completed_submission_ = in_flight_submission_;
-    in_flight_submission_ = 0;
-  }
+  void WarmUpPipelines(std::span<const MetalPipelineWarmup> pipelines);
+  void WarmUpPlan(const ExecutionPlan& plan);
 
   [[nodiscard]] auto HasInFlightSubmission() const -> bool { return in_flight_submission_ != 0; }
   [[nodiscard]] auto CompletedSubmission() const -> std::uint64_t { return completed_submission_; }
@@ -139,20 +150,21 @@ class MetalBackend {
   }
   [[nodiscard]] auto NextSubmissionId() -> std::uint64_t { return ++next_submission_; }
 
-  void NoteFree() noexcept { ++free_count_; }
-  void ResetCounters() {
-    malloc_count_   = 0;
-    free_count_     = 0;
-    h2d_copy_count_ = 0;
-    h2d_bytes_      = 0;
-    last_h2d_ranges_.clear();
-    last_texture_rectangles_.clear();
-  }
-  void FailNextUpload() { fail_next_upload_ = true; }
-  void NoteHostToDeviceBegin() { last_h2d_ranges_.clear(); }
+  void               NoteFree() noexcept { ++free_count_; }
+  void               ResetCounters();
+  void               FailNextUpload();
+  void               NoteHostToDeviceBegin() { last_h2d_ranges_.clear(); }
 
+  [[nodiscard]] auto NativeDevice() const -> void*;
+  [[nodiscard]] auto NativeQueue() const -> void*;
+  [[nodiscard]] auto WorkingSetBudgetBytes() const -> std::size_t;
   [[nodiscard]] auto MallocCount() const -> std::uint64_t { return malloc_count_; }
   [[nodiscard]] auto FreeCount() const -> std::uint64_t { return free_count_; }
+  [[nodiscard]] auto BufferCreateCount() const -> std::uint64_t { return buffer_create_count_; }
+  [[nodiscard]] auto TextureCreateCount() const -> std::uint64_t { return texture_create_count_; }
+  [[nodiscard]] auto HeapCreateCount() const -> std::uint64_t { return heap_create_count_; }
+  [[nodiscard]] auto PipelineCreateCount() const -> std::uint64_t;
+  [[nodiscard]] auto PipelineHitCount() const -> std::uint64_t;
   [[nodiscard]] auto HostToDeviceCopyCount() const -> std::uint64_t { return h2d_copy_count_; }
   [[nodiscard]] auto HostToDeviceBytes() const -> std::uint64_t { return h2d_bytes_; }
   [[nodiscard]] auto LastHostToDeviceRanges() const -> const std::vector<ByteRange>& {
@@ -163,10 +175,30 @@ class MetalBackend {
   }
 
  private:
+  friend class Buffer;
+  friend class Texture2D;
+  friend class MetalBackendImpl;
+  class Gpu;
+  void NoteMalloc() noexcept { ++malloc_count_; }
+  void NoteBufferCreate() noexcept {
+    ++buffer_create_count_;
+    NoteMalloc();
+  }
+  void NoteTextureCreate() noexcept {
+    ++texture_create_count_;
+    NoteMalloc();
+  }
+  void                   NoteHeapCreate() noexcept { ++heap_create_count_; }
+
+  std::unique_ptr<Gpu>   gpu_{};
   std::uint64_t          malloc_count_         = 0;
   std::uint64_t          free_count_           = 0;
+  std::uint64_t          buffer_create_count_  = 0;
+  std::uint64_t          texture_create_count_ = 0;
+  std::uint64_t          heap_create_count_    = 0;
   std::uint64_t          h2d_copy_count_       = 0;
   std::uint64_t          h2d_bytes_            = 0;
+  std::uint64_t          next_resource_id_     = 1;
   std::uint64_t          next_submission_      = 0;
   std::uint64_t          in_flight_submission_ = 0;
   std::uint64_t          completed_submission_ = 0;
@@ -174,5 +206,8 @@ class MetalBackend {
   std::vector<ByteRange> last_h2d_ranges_;
   std::vector<RectI>     last_texture_rectangles_;
 };
+
+[[nodiscard]] auto BindSystemDefaultMetalPresentationDevice() -> void*;
+[[nodiscard]] auto MetalPresentationDeviceHandle() -> void*;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
@@ -1,0 +1,178 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+#include "edit/runtime/byte_range.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+
+inline constexpr std::uint32_t kMetalDagBackendCapabilityVersion = 2;
+
+/**
+ * @brief Host command-buffer identity for one in-flight Metal submission.
+ *
+ * Native MTLCommandBuffer lives in later Metal runtime TUs. Not thread-safe.
+ */
+class MetalCommandContext {
+ public:
+  MetalCommandContext() = default;
+
+  [[nodiscard]] auto SubmissionId() const -> std::uint64_t { return submission_id_; }
+  void               SetSubmissionId(std::uint64_t id) { submission_id_ = id; }
+
+ private:
+  std::uint64_t submission_id_ = 0;
+};
+
+/**
+ * @brief Host-side Metal backend traits for Renderer and workspace instantiation.
+ *
+ * Native Metal types are not included. Resource creation fails explicitly until
+ * the Metal runtime lands. There is no CPU or CUDA substitute.
+ */
+class MetalBackend {
+ public:
+  class Buffer {
+   public:
+    Buffer() = default;
+    Buffer(Buffer&&) noexcept = default;
+    auto operator=(Buffer&&) noexcept -> Buffer& = default;
+    Buffer(const Buffer&)                        = delete;
+    auto operator=(const Buffer&) -> Buffer&     = delete;
+    ~Buffer()                                    = default;
+
+    [[nodiscard]] auto DevicePointer() const -> void* { return nullptr; }
+    [[nodiscard]] auto Bytes() const -> std::size_t { return 0; }
+    [[nodiscard]] auto ResourceId() const -> std::uint64_t { return 0; }
+    [[nodiscard]] auto Empty() const -> bool { return true; }
+    void               Reset() noexcept {}
+  };
+
+  class Texture2D {
+   public:
+    Texture2D() = default;
+    Texture2D(Texture2D&&) noexcept = default;
+    auto operator=(Texture2D&&) noexcept -> Texture2D& = default;
+    Texture2D(const Texture2D&)                        = delete;
+    auto operator=(const Texture2D&) -> Texture2D&     = delete;
+    ~Texture2D()                                       = default;
+
+    [[nodiscard]] auto DevicePointer() const -> void* { return nullptr; }
+    [[nodiscard]] auto Bytes() const -> std::size_t { return 0; }
+    [[nodiscard]] auto Width() const -> std::uint32_t { return 0; }
+    [[nodiscard]] auto Height() const -> std::uint32_t { return 0; }
+    [[nodiscard]] auto Format() const -> TextureFormat { return TextureFormat::R8; }
+    [[nodiscard]] auto ResourceId() const -> std::uint64_t { return 0; }
+    void               Reset() noexcept {}
+  };
+
+  using Slab           = Buffer;
+  using CommandContext = MetalCommandContext;
+
+  static constexpr std::uint32_t kCapabilityVersion = kMetalDagBackendCapabilityVersion;
+  static constexpr const char*   kName              = "Metal";
+
+  /**
+   * @brief Session texture budget used until Metal device queries land.
+   *
+   * Matches the CUDA floor so plan compilation and workspace setup share size policy.
+   */
+  static auto DefaultTextureBudgetBytes() -> std::size_t { return 256ull << 20; }
+
+  MetalBackend()                                   = default;
+  MetalBackend(const MetalBackend&)                = delete;
+  auto operator=(const MetalBackend&) -> MetalBackend& = delete;
+
+  [[nodiscard]] auto CreateBuffer(std::size_t) -> Buffer {
+    throw std::runtime_error("MetalBackend: GPU buffer allocation is not implemented");
+  }
+  [[nodiscard]] auto CreateSlab(std::size_t bytes) -> Buffer { return CreateBuffer(bytes); }
+  [[nodiscard]] auto CreateTexture2D(std::uint32_t, std::uint32_t, TextureFormat) -> Texture2D {
+    throw std::runtime_error("MetalBackend: GPU texture allocation is not implemented");
+  }
+
+  void UploadBufferRange(Buffer&, std::uint32_t, std::span<const std::byte>, CommandContext&) {
+    throw std::runtime_error("MetalBackend: buffer upload is not implemented");
+  }
+  void DownloadBufferRange(const Buffer&, std::uint32_t, std::span<std::byte>,
+                           CommandContext&) const {
+    throw std::runtime_error("MetalBackend: buffer download is not implemented");
+  }
+  void UploadTexture2D(Texture2D&, std::span<const std::byte>, CommandContext&) {
+    throw std::runtime_error("MetalBackend: texture upload is not implemented");
+  }
+  void CopyTexture2D(const Texture2D&, Texture2D&, CommandContext&) {
+    throw std::runtime_error("MetalBackend: texture copy is not implemented");
+  }
+  void UploadR8TextureRect(Texture2D&, RectI, std::span<const std::byte>, CommandContext&) {
+    throw std::runtime_error("MetalBackend: R8 upload is not implemented");
+  }
+  void DownloadTexture2D(const Texture2D&, std::span<std::byte>, CommandContext&) const {
+    throw std::runtime_error("MetalBackend: texture download is not implemented");
+  }
+
+  void Submit(CommandContext& command_context) {
+    in_flight_submission_ = command_context.SubmissionId();
+  }
+  void Wait(CommandContext&) {
+    if (in_flight_submission_ == 0) {
+      return;
+    }
+    completed_submission_ = in_flight_submission_;
+    in_flight_submission_ = 0;
+  }
+
+  [[nodiscard]] auto HasInFlightSubmission() const -> bool { return in_flight_submission_ != 0; }
+  [[nodiscard]] auto CompletedSubmission() const -> std::uint64_t { return completed_submission_; }
+  [[nodiscard]] auto IsResourceBusy(std::uint64_t submitted_on) const -> bool {
+    return submitted_on != 0 && submitted_on > completed_submission_;
+  }
+  [[nodiscard]] auto NextSubmissionId() -> std::uint64_t { return ++next_submission_; }
+
+  void NoteFree() noexcept { ++free_count_; }
+  void ResetCounters() {
+    malloc_count_   = 0;
+    free_count_     = 0;
+    h2d_copy_count_ = 0;
+    h2d_bytes_      = 0;
+    last_h2d_ranges_.clear();
+    last_texture_rectangles_.clear();
+  }
+  void FailNextUpload() { fail_next_upload_ = true; }
+  void NoteHostToDeviceBegin() { last_h2d_ranges_.clear(); }
+
+  [[nodiscard]] auto MallocCount() const -> std::uint64_t { return malloc_count_; }
+  [[nodiscard]] auto FreeCount() const -> std::uint64_t { return free_count_; }
+  [[nodiscard]] auto HostToDeviceCopyCount() const -> std::uint64_t { return h2d_copy_count_; }
+  [[nodiscard]] auto HostToDeviceBytes() const -> std::uint64_t { return h2d_bytes_; }
+  [[nodiscard]] auto LastHostToDeviceRanges() const -> const std::vector<ByteRange>& {
+    return last_h2d_ranges_;
+  }
+  [[nodiscard]] auto LastTextureRectangles() const -> const std::vector<RectI>& {
+    return last_texture_rectangles_;
+  }
+
+ private:
+  std::uint64_t          malloc_count_         = 0;
+  std::uint64_t          free_count_           = 0;
+  std::uint64_t          h2d_copy_count_       = 0;
+  std::uint64_t          h2d_bytes_            = 0;
+  std::uint64_t          next_submission_      = 0;
+  std::uint64_t          in_flight_submission_ = 0;
+  std::uint64_t          completed_submission_ = 0;
+  bool                   fail_next_upload_     = false;
+  std::vector<ByteRange> last_h2d_ranges_;
+  std::vector<RectI>     last_texture_rectangles_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_develop_pass.hpp
@@ -11,7 +11,7 @@
 #include "edit/input/prepared_raw_input.hpp"
 #include "edit/runtime/content_key.hpp"
 #include "edit/runtime/execution_plan.hpp"
-#include "edit/runtime/metal/metal_renderer.hpp"
+#include "edit/runtime/metal/metal_backend.hpp"
 
 namespace alcedo {
 
@@ -28,9 +28,6 @@ void ExecuteMetalGeometryResample(MetalRenderDevice& device, const ExecutionPlan
 
 void ExecuteMetalCameraColor(MetalRenderDevice& device, const ExecutionPlan& plan,
                              const PipelineDocument& document);
-
-void ExecuteMetalIdentityCopy(MetalRenderDevice& device, const GraphValueId& source,
-                              const GraphValueId& destination, ImageExtent extent);
 
 void WarmUpMetalDagPlan(MetalBackend& backend, const ExecutionPlan& plan);
 

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_develop_pass.hpp
@@ -1,0 +1,41 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#ifdef HAVE_METAL
+
+#include "decoders/processor/nn/metal_demosaicnet_cache.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/metal/metal_renderer.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Encode SensorDevelop into `develop.sensor_linear` on the current Metal command buffer.
+ *
+ * Must be called between BeginRender and EndRender. Failures throw; there is no CPU or
+ * RawProcessor product-path substitute. Output is camera scene-linear RGBA32F.
+ */
+void ExecuteMetalDevelop(MetalRenderDevice& device, const ExecutionPlan& plan,
+                         const PreparedRawInput& input, PipelineDocument& document);
+
+void ExecuteMetalGeometryResample(MetalRenderDevice& device, const ExecutionPlan& plan);
+
+void ExecuteMetalCameraColor(MetalRenderDevice& device, const ExecutionPlan& plan,
+                             const PipelineDocument& document);
+
+void ExecuteMetalIdentityCopy(MetalRenderDevice& device, const GraphValueId& source,
+                              const GraphValueId& destination, ImageExtent extent);
+
+void WarmUpMetalDagPlan(MetalBackend& backend, const ExecutionPlan& plan);
+
+void SetMetalDevelopNeuralModelCacheForTesting(MetalDemosaicNetModelCache* cache);
+
+}  // namespace alcedo
+
+#endif

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_drt_gpu_params.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_drt_gpu_params.hpp
@@ -1,0 +1,159 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "json.hpp"
+
+namespace alcedo {
+
+inline constexpr int kMetalDrtTableSize = 362;
+
+struct MetalDrtJmhParams {
+  float matrix_rgb_to_cam16[9]       = {};
+  float matrix_cam16_to_rgb[9]       = {};
+  float matrix_cone_to_aab[9]        = {};
+  float matrix_aab_to_cone[9]        = {};
+  float f_l_n                        = 0.0f;
+  float cz                           = 0.0f;
+  float inv_cz                       = 0.0f;
+  float a_w_j                        = 0.0f;
+  float inv_a_w_j                    = 0.0f;
+};
+
+struct MetalDrtTsParams {
+  float n             = 0.0f;
+  float n_r           = 0.0f;
+  float g             = 0.0f;
+  float t_1           = 0.0f;
+  float c_t           = 0.0f;
+  float s_2           = 0.0f;
+  float u_2           = 0.0f;
+  float m_2           = 0.0f;
+  float forward_limit = 0.0f;
+  float inverse_limit = 0.0f;
+  float log_peak      = 0.0f;
+};
+
+struct MetalDrtAcesParams {
+  float            peak_luminance = 100.0f;
+  MetalDrtJmhParams input{};
+  MetalDrtJmhParams reach{};
+  MetalDrtJmhParams limit{};
+  MetalDrtTsParams  ts{};
+  float            limit_j_max          = 0.0f;
+  float            model_gamma_inv      = 0.0f;
+  float            mid_j                = 0.0f;
+  float            focus_dist           = 0.0f;
+  float            lower_hull_gamma_inv = 0.0f;
+  std::int32_t     hue_linearity_search_range[2] = {0, 1};
+  float            sat                   = 0.0f;
+  float            sat_thr               = 0.0f;
+  float            compr                 = 0.0f;
+  float            chroma_compress_scale = 0.0f;
+  float            table_reach_m[kMetalDrtTableSize]          = {};
+  float            table_hues[kMetalDrtTableSize]             = {};
+  float            table_upper_hull_gamma[kMetalDrtTableSize] = {};
+  float            table_gamut_cusps[kMetalDrtTableSize][4]   = {};
+};
+
+struct MetalDrtOpenParams {
+  std::int32_t tn_hcon_enable = 0;
+  std::int32_t tn_lcon_enable = 0;
+  std::int32_t pt_enable      = 1;
+  std::int32_t ptl_enable     = 1;
+  std::int32_t ptm_enable     = 1;
+  std::int32_t brl_enable     = 1;
+  std::int32_t brlp_enable    = 1;
+  std::int32_t hc_enable      = 1;
+  std::int32_t hs_rgb_enable  = 1;
+  std::int32_t hs_cmy_enable  = 1;
+  std::int32_t creative_white = 2;
+  std::int32_t surround       = 2;
+  std::int32_t clamp          = 1;
+  std::int32_t display_gamut  = 0;
+  std::int32_t display_eotf   = 1;
+  float        tn_con         = 1.66f;
+  float        tn_sh          = 0.5f;
+  float        tn_toe         = 0.003f;
+  float        tn_off         = 0.005f;
+  float        tn_hcon        = 0.0f;
+  float        tn_hcon_pv     = 1.0f;
+  float        tn_hcon_st     = 4.0f;
+  float        tn_lcon        = 0.0f;
+  float        tn_lcon_w      = 0.5f;
+  float        cwp_lm         = 0.25f;
+  float        rs_sa          = 0.35f;
+  float        rs_rw          = 0.25f;
+  float        rs_bw          = 0.55f;
+  float        pt_lml         = 0.25f;
+  float        pt_lml_r       = 0.5f;
+  float        pt_lml_g       = 0.0f;
+  float        pt_lml_b       = 0.1f;
+  float        pt_lmh         = 0.25f;
+  float        pt_lmh_r       = 0.5f;
+  float        pt_lmh_b       = 0.0f;
+  float        ptl_c          = 0.06f;
+  float        ptl_m          = 0.08f;
+  float        ptl_y          = 0.06f;
+  float        ptm_low        = 0.4f;
+  float        ptm_low_rng    = 0.25f;
+  float        ptm_low_st     = 0.5f;
+  float        ptm_high       = -0.8f;
+  float        ptm_high_rng   = 0.35f;
+  float        ptm_high_st    = 0.4f;
+  float        brl            = 0.0f;
+  float        brl_r          = -2.5f;
+  float        brl_g          = -1.5f;
+  float        brl_b          = -1.5f;
+  float        brl_rng        = 0.5f;
+  float        brl_st         = 0.35f;
+  float        brlp           = -0.5f;
+  float        brlp_r         = -1.25f;
+  float        brlp_g         = -1.25f;
+  float        brlp_b         = -0.25f;
+  float        hc_r           = 1.0f;
+  float        hc_r_rng       = 0.3f;
+  float        hs_r           = 0.6f;
+  float        hs_r_rng       = 0.6f;
+  float        hs_g           = 0.35f;
+  float        hs_g_rng       = 1.0f;
+  float        hs_b           = 0.66f;
+  float        hs_b_rng       = 1.0f;
+  float        hs_c           = 0.25f;
+  float        hs_c_rng       = 1.0f;
+  float        hs_m           = 0.0f;
+  float        hs_m_rng       = 1.0f;
+  float        hs_y           = 0.0f;
+  float        hs_y_rng       = 1.0f;
+  float        ts_x1          = 0.0f;
+  float        ts_y1          = 0.0f;
+  float        ts_x0          = 0.0f;
+  float        ts_y0          = 0.0f;
+  float        ts_s0          = 0.0f;
+  float        ts_p           = 0.0f;
+  float        ts_s10         = 0.0f;
+  float        ts_m1          = 0.0f;
+  float        ts_m2          = 0.0f;
+  float        ts_s           = 0.0f;
+  float        ts_dsc         = 0.0f;
+  float        pt_cmp_lf      = 0.0f;
+  float        s_lp100        = 0.0f;
+  float        ts_s1          = 0.0f;
+};
+
+struct MetalDrtGpuParams {
+  std::int32_t       method                  = 1;
+  std::int32_t       eotf                    = 0;
+  MetalDrtAcesParams aces{};
+  MetalDrtOpenParams open_drt{};
+  float              limit_to_display_matx[9] = {};
+  float              display_linear_scale     = 1.0f;
+};
+
+[[nodiscard]] auto ResolveMetalDrtGpuParams(const nlohmann::json& odt_json) -> MetalDrtGpuParams;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_drt_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_drt_pass.hpp
@@ -1,0 +1,35 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#ifdef HAVE_METAL
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/metal/metal_backend.hpp"
+
+namespace alcedo {
+
+struct MetalDrtResult {
+  GraphValueId output{NodeId{"drt"}, PortId{"display"}};
+};
+
+/**
+ * @brief Encode ACES 2.0 or OpenDRT on the current Metal command buffer.
+ *
+ * Input is the compiled primary-grade AP1/ACEScc image. The pass decodes ACEScc
+ * to AP1 scene-linear, runs the selected display transform, and writes a workspace
+ * RGBA32F display texture. Parameters live in ParameterArena. Failures throw; there
+ * is no CPU or fused-pipeline substitute.
+ */
+[[nodiscard]] auto ExecuteMetalDrt(MetalRenderDevice& device, const ExecutionPlan& plan,
+                                   PipelineDocument& document) -> MetalDrtResult;
+
+void               AppendMetalDrtWarmup(std::vector<MetalPipelineWarmup>& pipelines);
+
+}  // namespace alcedo
+
+#endif

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_frame_presenter.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_frame_presenter.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "edit/runtime/basic_render_device.hpp"
 #include "edit/runtime/frame_presenter.hpp"
 #include "edit/runtime/metal/metal_backend.hpp"
 #include "image/image_buffer.hpp"
@@ -11,22 +12,18 @@
 namespace alcedo {
 
 /**
- * @brief Metal present/download. Fails until the Metal presenter lands.
+ * @brief Metal DRT texture present and host download. No CPU image-processing path.
  *
- * Does not copy to CPU as a stand-in for display, and does not call CUDA present.
+ * Present submits the workspace MTLTexture to the sink. Host download runs only
+ * when the product path requested an export or test ImageBuffer.
  */
 template <>
 struct FramePresenter<MetalBackend> {
-  template <class Device>
-  static void Present(Device&, const GraphValueId&, IFrameSink&, const FrameCompletionSubmission&,
-                      const ViewerDisplayConfig&) {
-    throw std::runtime_error("FramePresenter<MetalBackend>: present is not implemented");
-  }
-
-  template <class Device>
-  static auto Download(Device&, const GraphValueId&) -> std::shared_ptr<ImageBuffer> {
-    throw std::runtime_error("FramePresenter<MetalBackend>: host download is not implemented");
-  }
+  static void Present(BasicRenderDevice<MetalBackend>& device, const GraphValueId& output_id,
+                      IFrameSink& sink, const FrameCompletionSubmission& submission,
+                      const ViewerDisplayConfig& display_config);
+  static auto Download(BasicRenderDevice<MetalBackend>& device, const GraphValueId& output_id)
+      -> std::shared_ptr<ImageBuffer>;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_frame_presenter.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_frame_presenter.hpp
@@ -1,0 +1,32 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/runtime/frame_presenter.hpp"
+#include "edit/runtime/metal/metal_backend.hpp"
+#include "image/image_buffer.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Metal present/download. Fails until the Metal presenter lands.
+ *
+ * Does not copy to CPU as a stand-in for display, and does not call CUDA present.
+ */
+template <>
+struct FramePresenter<MetalBackend> {
+  template <class Device>
+  static void Present(Device&, const GraphValueId&, IFrameSink&, const FrameCompletionSubmission&,
+                      const ViewerDisplayConfig&) {
+    throw std::runtime_error("FramePresenter<MetalBackend>: present is not implemented");
+  }
+
+  template <class Device>
+  static auto Download(Device&, const GraphValueId&) -> std::shared_ptr<ImageBuffer> {
+    throw std::runtime_error("FramePresenter<MetalBackend>: host download is not implemented");
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_local_tone_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_local_tone_pass.hpp
@@ -1,0 +1,46 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#ifdef HAVE_METAL
+
+#include <cstdint>
+#include <vector>
+
+#include "edit/geometry/resolved_render_geometry.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/metal/metal_backend.hpp"
+#include "edit/runtime/metal/metal_renderer.hpp"
+
+namespace alcedo {
+
+struct MetalLocalToneResult {
+  std::uint64_t reference_resource_id       = 0;
+  bool          rebuilt_reference           = false;
+  bool          sampled_canonical_reference = false;
+  std::uint32_t transient_bytes             = 0;
+};
+
+/**
+ * @brief Encode Shadows/Highlights LLF onto the current Metal command buffer.
+ *
+ * Pyramid scratch comes from TransientBufferArena. Canonical source/result planes live
+ * in workspace Values() under GraphValueId. Failures throw; there is no CPU or
+ * MetalStage substitute.
+ */
+[[nodiscard]] auto ExecuteMetalLocalTone(MetalRenderDevice&             device,
+                                         const MetalBackend::Texture2D& input,
+                                         MetalBackend::Texture2D& output, const NodeId& grade_id,
+                                         float shadows_slider, float highlights_slider,
+                                         const ResolvedRenderGeometry& geometry,
+                                         ContentKey source_key, ContentKey result_key)
+    -> MetalLocalToneResult;
+
+void AppendMetalLocalToneWarmup(std::vector<MetalPipelineWarmup>& pipelines);
+
+}  // namespace alcedo
+
+#endif

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_local_tone_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_local_tone_pass.hpp
@@ -13,7 +13,6 @@
 #include "edit/graph/graph_ids.hpp"
 #include "edit/runtime/content_key.hpp"
 #include "edit/runtime/metal/metal_backend.hpp"
-#include "edit/runtime/metal/metal_renderer.hpp"
 
 namespace alcedo {
 

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_mask_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_mask_pass.hpp
@@ -1,0 +1,45 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#ifdef HAVE_METAL
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/mask/mask_store.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/metal/metal_backend.hpp"
+#include "edit/runtime/metal/metal_renderer.hpp"
+
+namespace alcedo {
+
+struct MetalMaskResult {
+  GraphValueId  output;
+  std::uint64_t persistent_texture_resource_id = 0;
+  std::uint64_t signed_distance_resource_id    = 0;
+  std::uint32_t mip_level_count                = 0;
+  std::uint32_t transient_bytes                = 0;
+};
+
+/**
+ * @brief Evaluate the optional compiled analytic or raster mask into RenderSpace R8.
+ *
+ * Raster source textures and mip levels live in workspace MaskTextureCache. Signed-distance
+ * intermediates come from TransientBufferArena. The signed-distance result is stored by mask
+ * content key so a feather-radius edit can reuse it. Failures throw; there is no CPU substitute.
+ */
+[[nodiscard]] auto ExecuteMetalMask(MetalRenderDevice& device, const ExecutionPlan& plan,
+                                    const PipelineDocument& document, MaskStore* store = nullptr,
+                                    std::span<const RectI> dirty_rectangles = {})
+    -> MetalMaskResult;
+
+void AppendMetalMaskWarmup(std::vector<MetalPipelineWarmup>& pipelines);
+
+}  // namespace alcedo
+
+#endif

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_mask_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_mask_pass.hpp
@@ -14,7 +14,6 @@
 #include "edit/mask/mask_store.hpp"
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/metal/metal_backend.hpp"
-#include "edit/runtime/metal/metal_renderer.hpp"
 
 namespace alcedo {
 

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_pass_encoder.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_pass_encoder.hpp
@@ -7,6 +7,7 @@
 #ifdef HAVE_METAL
 
 #include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_mask_pass.hpp"
 #include "edit/runtime/metal/metal_primary_grade_pass.hpp"
 #include "edit/runtime/pass_encoder.hpp"
 
@@ -41,6 +42,14 @@ struct PassEncoder<MetalBackend, GpuPassKind::CameraToAp1> {
   static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
                      PipelineDocument& document, MaskStore*) {
     ExecuteMetalCameraColor(device, plan, document);
+  }
+};
+
+template <>
+struct PassEncoder<MetalBackend, GpuPassKind::MaskEvaluate> {
+  static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
+                     PipelineDocument& document, MaskStore* mask_store) {
+    (void)ExecuteMetalMask(device, plan, document, mask_store);
   }
 };
 

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_pass_encoder.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_pass_encoder.hpp
@@ -7,6 +7,7 @@
 #ifdef HAVE_METAL
 
 #include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_drt_pass.hpp"
 #include "edit/runtime/metal/metal_mask_pass.hpp"
 #include "edit/runtime/metal/metal_primary_grade_pass.hpp"
 #include "edit/runtime/pass_encoder.hpp"
@@ -64,10 +65,8 @@ struct PassEncoder<MetalBackend, GpuPassKind::PrimaryColorGrade> {
 template <>
 struct PassEncoder<MetalBackend, GpuPassKind::Drt> {
   static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
-                     PipelineDocument&, MaskStore*) {
-    ExecuteMetalIdentityCopy(
-        device, plan.primary_grade_output, plan.display_output,
-        ImageExtent{plan.geometry.render_extent.width, plan.geometry.render_extent.height});
+                     PipelineDocument& document, MaskStore*) {
+    (void)ExecuteMetalDrt(device, plan, document);
   }
 };
 

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_pass_encoder.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_pass_encoder.hpp
@@ -1,0 +1,68 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#ifdef HAVE_METAL
+
+#include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/pass_encoder.hpp"
+
+namespace alcedo {
+
+template <>
+struct PassEncoder<MetalBackend, GpuPassKind::UploadRaw> {
+  static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan,
+                     const PreparedRawInput& input, PipelineDocument& document, MaskStore*) {
+    ExecuteMetalDevelop(device, plan, input, document);
+  }
+};
+
+template <>
+struct PassEncoder<MetalBackend, GpuPassKind::UploadRgb> {
+  static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan,
+                     const PreparedRawInput& input, PipelineDocument& document, MaskStore*) {
+    ExecuteMetalDevelop(device, plan, input, document);
+  }
+};
+
+template <>
+struct PassEncoder<MetalBackend, GpuPassKind::GeometryResample> {
+  static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
+                     PipelineDocument&, MaskStore*) {
+    ExecuteMetalGeometryResample(device, plan);
+  }
+};
+
+template <>
+struct PassEncoder<MetalBackend, GpuPassKind::CameraToAp1> {
+  static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
+                     PipelineDocument& document, MaskStore*) {
+    ExecuteMetalCameraColor(device, plan, document);
+  }
+};
+
+template <>
+struct PassEncoder<MetalBackend, GpuPassKind::PrimaryColorGrade> {
+  static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
+                     PipelineDocument&, MaskStore*) {
+    ExecuteMetalIdentityCopy(device, plan.develop_output, plan.primary_grade_output,
+                             ImageExtent{plan.geometry.render_extent.width,
+                                         plan.geometry.render_extent.height});
+  }
+};
+
+template <>
+struct PassEncoder<MetalBackend, GpuPassKind::Drt> {
+  static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
+                     PipelineDocument&, MaskStore*) {
+    ExecuteMetalIdentityCopy(device, plan.primary_grade_output, plan.display_output,
+                             ImageExtent{plan.geometry.render_extent.width,
+                                         plan.geometry.render_extent.height});
+  }
+};
+
+}  // namespace alcedo
+
+#endif

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_pass_encoder.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_pass_encoder.hpp
@@ -7,6 +7,7 @@
 #ifdef HAVE_METAL
 
 #include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_primary_grade_pass.hpp"
 #include "edit/runtime/pass_encoder.hpp"
 
 namespace alcedo {
@@ -45,11 +46,9 @@ struct PassEncoder<MetalBackend, GpuPassKind::CameraToAp1> {
 
 template <>
 struct PassEncoder<MetalBackend, GpuPassKind::PrimaryColorGrade> {
-  static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
-                     PipelineDocument&, MaskStore*) {
-    ExecuteMetalIdentityCopy(device, plan.develop_output, plan.primary_grade_output,
-                             ImageExtent{plan.geometry.render_extent.width,
-                                         plan.geometry.render_extent.height});
+  static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan,
+                     const PreparedRawInput& input, PipelineDocument& document, MaskStore*) {
+    (void)ExecuteMetalPrimaryGrade(device, plan, input, document);
   }
 };
 
@@ -57,9 +56,9 @@ template <>
 struct PassEncoder<MetalBackend, GpuPassKind::Drt> {
   static void Encode(MetalRenderDevice& device, const ExecutionPlan& plan, const PreparedRawInput&,
                      PipelineDocument&, MaskStore*) {
-    ExecuteMetalIdentityCopy(device, plan.primary_grade_output, plan.display_output,
-                             ImageExtent{plan.geometry.render_extent.width,
-                                         plan.geometry.render_extent.height});
+    ExecuteMetalIdentityCopy(
+        device, plan.primary_grade_output, plan.display_output,
+        ImageExtent{plan.geometry.render_extent.width, plan.geometry.render_extent.height});
   }
 };
 

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_primary_grade_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_primary_grade_pass.hpp
@@ -1,0 +1,43 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#ifdef HAVE_METAL
+
+#include <cstdint>
+#include <vector>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/metal/metal_backend.hpp"
+#include "edit/runtime/metal/metal_renderer.hpp"
+
+namespace alcedo {
+
+struct MetalPrimaryGradeResult {
+  GraphValueId  output{NodeId{"grade.primary"}, PortId{"image"}};
+  std::uint32_t pointwise_dispatch_count = 0;
+  std::uint32_t detail_pass_count        = 0;
+  std::uint32_t command_upload_bytes     = 0;
+  std::uint64_t lut_resource_id          = 0;
+};
+
+/**
+ * @brief Encode Primary Grade on the current Metal command buffer.
+ *
+ * Pointwise adjustments fuse into one dispatch per LLF segment. Clarity, Sharpen,
+ * Halation, and Film Grain are explicit TexturePool passes. Parameters live in
+ * ParameterArena. Failures throw; there is no CPU or old fused-pipeline substitute.
+ */
+[[nodiscard]] auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& plan,
+                                            const PreparedRawInput& prepared,
+                                            PipelineDocument& document) -> MetalPrimaryGradeResult;
+
+void               AppendMetalPrimaryGradeWarmup(std::vector<MetalPipelineWarmup>& pipelines);
+
+}  // namespace alcedo
+
+#endif

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_primary_grade_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_primary_grade_pass.hpp
@@ -19,10 +19,14 @@ namespace alcedo {
 
 struct MetalPrimaryGradeResult {
   GraphValueId  output{NodeId{"grade.primary"}, PortId{"image"}};
-  std::uint32_t pointwise_dispatch_count = 0;
-  std::uint32_t detail_pass_count        = 0;
-  std::uint32_t command_upload_bytes     = 0;
-  std::uint64_t lut_resource_id          = 0;
+  std::uint32_t pointwise_dispatch_count               = 0;
+  std::uint32_t detail_pass_count                      = 0;
+  std::uint32_t command_upload_bytes                   = 0;
+  std::uint64_t lut_resource_id                        = 0;
+  std::uint64_t local_tone_reference_resource_id       = 0;
+  bool          local_tone_rebuilt_reference           = false;
+  bool          local_tone_sampled_canonical_reference = false;
+  std::uint32_t local_tone_transient_bytes             = 0;
 };
 
 /**

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_primary_grade_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_primary_grade_pass.hpp
@@ -13,7 +13,6 @@
 #include "edit/input/prepared_raw_input.hpp"
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/metal/metal_backend.hpp"
-#include "edit/runtime/metal/metal_renderer.hpp"
 
 namespace alcedo {
 

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_renderer.hpp
@@ -1,0 +1,16 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/runtime/metal/metal_backend.hpp"
+#include "edit/runtime/basic_render_device.hpp"
+#include "edit/runtime/renderer.hpp"
+
+namespace alcedo {
+
+using MetalRenderDevice = BasicRenderDevice<MetalBackend>;
+using MetalRenderer     = Renderer<MetalBackend>;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_renderer.hpp
@@ -4,14 +4,15 @@
 
 #pragma once
 
-#include "edit/runtime/metal/metal_backend.hpp"
 #include "edit/runtime/basic_render_device.hpp"
+#include "edit/runtime/metal/metal_backend.hpp"
+#include "edit/runtime/metal/metal_frame_presenter.hpp"
+#include "edit/runtime/metal/metal_pass_encoder.hpp"
 #include "edit/runtime/renderer.hpp"
+#include "edit/runtime/detail/renderer.inl.hpp"
 
 namespace alcedo {
 
-using MetalRenderDevice    = BasicRenderDevice<MetalBackend>;
-using MetalRenderWorkspace = BasicRenderWorkspace<MetalBackend>;
-using MetalRenderer        = Renderer<MetalBackend>;
+using MetalRenderer = Renderer<MetalBackend>;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_renderer.hpp
@@ -10,7 +10,8 @@
 
 namespace alcedo {
 
-using MetalRenderDevice = BasicRenderDevice<MetalBackend>;
-using MetalRenderer     = Renderer<MetalBackend>;
+using MetalRenderDevice    = BasicRenderDevice<MetalBackend>;
+using MetalRenderWorkspace = BasicRenderWorkspace<MetalBackend>;
+using MetalRenderer        = Renderer<MetalBackend>;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/pass_encoder.hpp
+++ b/alcedo_studio/src/include/edit/runtime/pass_encoder.hpp
@@ -1,0 +1,42 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/pass_kind.hpp"
+
+namespace alcedo {
+
+class MaskStore;
+
+/**
+ * @brief Backend encode entry for one compiled pass kind.
+ *
+ * Specializations perform the GPU work. The primary template fails explicitly;
+ * it does not select another backend, CPU, or a lower-quality path.
+ *
+ * @tparam Backend Render backend.
+ * @tparam Kind Compiled pass kind.
+ */
+template <class Backend, GpuPassKind Kind>
+struct PassEncoder {
+  /**
+   * @brief Encode @p Kind for @p Backend.
+   * @throws std::runtime_error when no backend specialization exists.
+   */
+  template <class Device>
+  static void Encode(Device&, const ExecutionPlan&, const PreparedRawInput&, PipelineDocument&,
+                     MaskStore*) {
+    throw std::runtime_error(std::string("PassEncoder: no specialization for ") +
+                             GpuPassKindName(Kind));
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
@@ -1,0 +1,164 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <exception>
+#include <stdexcept>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/pass_encoder.hpp"
+#include "edit/runtime/pass_kind.hpp"
+#include "edit/runtime/result_content_key.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+
+class MaskStore;
+
+/**
+ * @brief Shared content-key skip, encode, cancel, and publish flow for one plan.
+ *
+ * Skip units match CUDA DAG cache boundaries. A failed encode cancels the
+ * incomplete submission and does not publish new content keys. There is no
+ * CPU or alternate-backend substitute.
+ *
+ * @tparam Backend Render backend whose PassEncoder specializations perform GPU work.
+ */
+template <class Backend>
+class PlanExecutor {
+ public:
+  /**
+   * @brief Execute compiled passes that miss the result cache.
+   *
+   * @param device Session or one-shot device that owns workspace and stats.
+   * @param publish_on_success When true, publishes unpublished writes after EndRender.
+   *        Product present paths pass false and publish after the sink succeeds.
+   * @return Display GraphValueId of the compiled plan.
+   * @throws std::exception from encode, upload, or submit after CancelRender.
+   */
+  template <class Device>
+  static auto Execute(Device& device, const ExecutionPlan& plan, const PreparedRawInput& input,
+                      PipelineDocument& document, MaskStore* mask_store, bool publish_on_success)
+      -> GraphValueId {
+    try {
+      auto& workspace = device.Workspace();
+      if (workspace.Textures().ByteBudget() == 0) {
+        workspace.Textures().SetByteBudget(Backend::DefaultTextureBudgetBytes());
+      }
+      device.BeginRender();
+      const auto keys        = BuildFrameResultContentKeys(plan, input, document);
+      const auto completed   = workspace.Device().CompletedSubmission();
+      auto&      stats       = device.PassStats();
+      const auto hits_before = workspace.Images().ContentHitCount();
+      const auto misses_before = workspace.Images().ContentMissCount();
+
+      if (BindOrMiss(workspace, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent,
+                     completed)) {
+        ++stats.sensor_develop_skip;
+      } else {
+        const auto h2d_before = workspace.Device().HostToDeviceBytes();
+        if (plan.Contains(GpuPassKind::UploadRgb)) {
+          PassEncoder<Backend, GpuPassKind::UploadRgb>::Encode(device, plan, input, document,
+                                                               mask_store);
+        } else {
+          PassEncoder<Backend, GpuPassKind::UploadRaw>::Encode(device, plan, input, document,
+                                                               mask_store);
+        }
+        stats.source_h2d_bytes += workspace.Device().HostToDeviceBytes() - h2d_before;
+        ++stats.source_h2d_count;
+        Record(device, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent);
+        ++stats.sensor_develop_execute;
+      }
+
+      if (BindOrMiss(workspace, plan.geometry_output, keys.geometry_scene_source,
+                     keys.geometry_extent, completed)) {
+        ++stats.geometry_skip;
+      } else {
+        PassEncoder<Backend, GpuPassKind::GeometryResample>::Encode(device, plan, input, document,
+                                                                    mask_store);
+        Record(device, plan.geometry_output, keys.geometry_scene_source, keys.geometry_extent);
+        ++stats.geometry_execute;
+      }
+
+      if (BindOrMiss(workspace, plan.develop_output, keys.develop_image, keys.geometry_extent,
+                     completed)) {
+        ++stats.camera_color_skip;
+      } else {
+        PassEncoder<Backend, GpuPassKind::CameraToAp1>::Encode(device, plan, input, document,
+                                                               mask_store);
+        Record(device, plan.develop_output, keys.develop_image, keys.geometry_extent);
+        ++stats.camera_color_execute;
+      }
+
+      if (plan.primary_grade_mask) {
+        if (BindOrMiss(workspace, plan.mask_output, keys.mask, keys.geometry_extent, completed,
+                       TextureFormat::R8)) {
+          ++stats.mask_skip;
+        } else {
+          PassEncoder<Backend, GpuPassKind::MaskEvaluate>::Encode(device, plan, input, document,
+                                                                  mask_store);
+          Record(device, plan.mask_output, keys.mask, keys.geometry_extent, TextureFormat::R8);
+          ++stats.mask_execute;
+        }
+      }
+
+      if (BindOrMiss(workspace, plan.primary_grade_output, keys.primary_grade, keys.geometry_extent,
+                     completed)) {
+        ++stats.primary_grade_skip;
+      } else {
+        PassEncoder<Backend, GpuPassKind::PrimaryColorGrade>::Encode(device, plan, input, document,
+                                                                     mask_store);
+        Record(device, plan.primary_grade_output, keys.primary_grade, keys.geometry_extent);
+        ++stats.primary_grade_execute;
+      }
+
+      if (BindOrMiss(workspace, plan.display_output, keys.drt_display, keys.geometry_extent,
+                     completed)) {
+        ++stats.drt_skip;
+      } else {
+        PassEncoder<Backend, GpuPassKind::Drt>::Encode(device, plan, input, document, mask_store);
+        Record(device, plan.display_output, keys.drt_display, keys.geometry_extent);
+        ++stats.drt_execute;
+      }
+
+      stats.result_content_hits += workspace.Images().ContentHitCount() - hits_before;
+      stats.result_content_misses += workspace.Images().ContentMissCount() - misses_before;
+      device.EndRender();
+      if (publish_on_success) {
+        device.PublishResults();
+      }
+      return plan.display_output;
+    } catch (const std::exception& ex) {
+      device.CancelRender();
+      device.ReportError(ex.what());
+      throw;
+    } catch (...) {
+      device.CancelRender();
+      device.ReportError("DAG execution failed with an unknown error");
+      throw;
+    }
+  }
+
+ private:
+  static constexpr TextureFormat kResultFormat = TextureFormat::Rgba32f;
+
+  template <class Workspace>
+  static auto BindOrMiss(Workspace& images_owner, const GraphValueId& id, ContentKey key,
+                         ImageExtent extent, std::uint64_t completed,
+                         TextureFormat format = kResultFormat) -> bool {
+    return images_owner.Images().BindValidResult(id, key, extent, format, completed) != nullptr;
+  }
+
+  template <class Device>
+  static void Record(Device& device, const GraphValueId& id, ContentKey key, ImageExtent extent,
+                     TextureFormat format = kResultFormat) {
+    device.Workspace().Images().RecordUnpublished(id, key, extent, format,
+                                                  device.CommandContext().SubmissionId());
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
@@ -46,14 +46,19 @@ class PlanExecutor {
       -> GraphValueId {
     try {
       auto& workspace = device.Workspace();
+      if constexpr (requires(Backend& backend, const ExecutionPlan& compiled) {
+                      backend.WarmUpPlan(compiled);
+                    }) {
+        workspace.Device().WarmUpPlan(plan);
+      }
       if (workspace.Textures().ByteBudget() == 0) {
         workspace.Textures().SetByteBudget(Backend::DefaultTextureBudgetBytes());
       }
       device.BeginRender();
-      const auto keys        = BuildFrameResultContentKeys(plan, input, document);
-      const auto completed   = workspace.Device().CompletedSubmission();
-      auto&      stats       = device.PassStats();
-      const auto hits_before = workspace.Images().ContentHitCount();
+      const auto keys          = BuildFrameResultContentKeys(plan, input, document);
+      const auto completed     = workspace.Device().CompletedSubmission();
+      auto&      stats         = device.PassStats();
+      const auto hits_before   = workspace.Images().ContentHitCount();
       const auto misses_before = workspace.Images().ContentMissCount();
 
       if (BindOrMiss(workspace, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent,

--- a/alcedo_studio/src/include/edit/runtime/render_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/render_backend.hpp
@@ -1,0 +1,32 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief GPU resource factory used by workspace, PlanExecutor, and Renderer.
+ *
+ * Native CUDA/Metal types stay in backend headers. This concept is host-only.
+ * @tparam Backend Resource factory with move-only Buffer and Texture2D.
+ */
+template <class Backend>
+concept RenderBackend = requires(Backend backend, typename Backend::CommandContext& commands) {
+  typename Backend::Buffer;
+  typename Backend::Texture2D;
+  typename Backend::CommandContext;
+  backend.CreateBuffer(std::size_t{});
+  backend.CreateTexture2D(std::uint32_t{}, std::uint32_t{}, TextureFormat{});
+  backend.Submit(commands);
+  backend.Wait(commands);
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/render_device_type.hpp
+++ b/alcedo_studio/src/include/edit/runtime/render_device_type.hpp
@@ -1,0 +1,23 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+namespace alcedo {
+
+template <class Backend>
+class BasicRenderDevice;
+
+/**
+ * @brief Maps a render backend to its session device type.
+ *
+ * The primary type is @ref BasicRenderDevice. CUDA specializes this to
+ * @ref CudaRenderDevice so Neural and DRT session objects stay on that device.
+ */
+template <class Backend>
+struct RenderDeviceType {
+  using Type = BasicRenderDevice<Backend>;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/renderer.hpp
@@ -1,0 +1,270 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "edit/geometry/render_request.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_source_cache.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/mask/mask_store.hpp"
+#include "edit/runtime/gpu_node_pass_stats.hpp"
+#include "edit/runtime/render_device_type.hpp"
+#include "edit/runtime/static_execution_plan_cache.hpp"
+#include "type/type.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo {
+
+class ImageBuffer;
+
+/** @brief Select whether a render may read or publish the editor session caches. */
+enum class RenderCachePolicy {
+  UseSessionCache,
+  BypassSessionCache,
+};
+
+using CudaProductCachePolicy = RenderCachePolicy;
+
+/**
+ * @brief Queryable prepare/compile and result-cache counters for one product session.
+ */
+struct RenderSessionStats {
+  std::uint64_t    prepared_source_hits     = 0;
+  std::uint64_t    prepared_source_misses   = 0;
+  std::uint64_t    libraw_open_unpack_count = 0;
+  std::uint64_t    plan_cache_hits          = 0;
+  std::uint64_t    plan_cache_misses        = 0;
+  std::uint64_t    plan_compile_count       = 0;
+  GpuNodePassStats pass{};
+};
+
+using CudaProductSessionStats = RenderSessionStats;
+
+/**
+ * @brief Live GPU/host allocations owned by one product session.
+ */
+struct RenderSessionResources {
+  std::size_t               published_result_count      = 0;
+  std::size_t               texture_pool_used_bytes     = 0;
+  std::size_t               texture_pool_entry_count    = 0;
+  std::size_t               prepared_source_host_bytes  = 0;
+  std::size_t               prepared_source_entry_count = 0;
+  std::vector<GraphValueId> session_value_ids;
+};
+
+using CudaProductSessionResources = RenderSessionResources;
+
+/**
+ * @brief Reusable product session for one opened PipelineDocument.
+ *
+ * Owns editor session caches/device plus a lazily created one-shot device for
+ * thumbnail and export work. Not created per Apply. Only session renders reuse
+ * prepared sources, static plans, and published GPU results.
+ *
+ * @tparam Backend Render backend. Include that backend's device header before
+ *         instantiating this class so @ref RenderDeviceType is specialized.
+ */
+template <class Backend>
+class Renderer {
+ public:
+  using RenderDevice = typename RenderDeviceType<Backend>::Type;
+
+  explicit Renderer(std::shared_ptr<PipelineDocument> document);
+  Renderer(std::shared_ptr<PipelineDocument> document, PreparedSourceCache::UnpackFn unpack);
+  ~Renderer();
+
+  Renderer(const Renderer&)                    = delete;
+  auto operator=(const Renderer&) -> Renderer& = delete;
+
+  void SetDocument(std::shared_ptr<PipelineDocument> document);
+
+  /**
+   * @brief Render one frame on the owning thread.
+   *
+   * @param cache_policy Session mode reads and publishes reusable editor results. Bypass mode
+   *        uses an isolated one-shot workspace and releases its result resources after delivery.
+   * @throws std::runtime_error for invalid input, GPU execution, or presentation failure.
+   */
+  [[nodiscard]] auto Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
+                            const RenderRequest& request, IFrameSink* sink,
+                            const FrameCompletionSubmission& submission, bool require_host_output,
+                            RenderCachePolicy cache_policy = RenderCachePolicy::UseSessionCache)
+      -> std::shared_ptr<ImageBuffer>;
+
+  /** @brief Snapshot of source and static-plan cache counters since construction or ResetStats. */
+  [[nodiscard]] auto Stats() const -> RenderSessionStats;
+  void               ResetStats();
+
+  /**
+   * @brief Drop GPU result textures, host prepared sources, the plan cache, and
+   *        backend session extras. Keeps the session device.
+   *
+   * Call when the pipeline is returned to PipelineMgmtService. The next Render
+   * rebuilds caches from the still-owned PipelineDocument.
+   */
+  void ReleaseSessionCaches();
+
+  [[nodiscard]] auto SessionResources() const -> RenderSessionResources;
+
+  /**
+   * @brief Published result count of the isolated one-shot workspace.
+   *
+   * Zero when no one-shot device exists or after a successful bypass render that
+   * released that workspace. Session caches are not included.
+   */
+  [[nodiscard]] auto OneShotPublishedResultCount() const -> std::size_t;
+
+  [[nodiscard]] auto Device() -> RenderDevice& { return *device_; }
+  [[nodiscard]] auto Device() const -> const RenderDevice& { return *device_; }
+
+  [[nodiscard]] auto SourceCache() -> PreparedSourceCache& { return source_cache_; }
+  [[nodiscard]] auto SourceCache() const -> const PreparedSourceCache& { return source_cache_; }
+  [[nodiscard]] auto PlanCache() -> StaticExecutionPlanCache& { return plan_cache_; }
+  [[nodiscard]] auto PlanCache() const -> const StaticExecutionPlanCache& { return plan_cache_; }
+  [[nodiscard]] auto MaskAssets() -> MaskStore&;
+
+ private:
+  void EnsureOneShotDevice();
+  void ConfigureDevice(RenderDevice& device, const char* error_label);
+
+  std::shared_ptr<PipelineDocument> document_;
+  std::unique_ptr<RenderDevice>     device_;
+  std::unique_ptr<RenderDevice>     one_shot_device_;
+  std::unique_ptr<MaskStore>        mask_store_;
+  PreparedSourceCache::UnpackFn     unpack_;
+  PreparedSourceCache               source_cache_;
+  StaticExecutionPlanCache          plan_cache_{Backend::kCapabilityVersion};
+};
+
+template <class Backend>
+Renderer<Backend>::Renderer(std::shared_ptr<PipelineDocument> document)
+    : Renderer(std::move(document), PreparedSourceCache::UnpackFn{}) {}
+
+template <class Backend>
+Renderer<Backend>::Renderer(std::shared_ptr<PipelineDocument> document,
+                            PreparedSourceCache::UnpackFn     unpack)
+    : document_(std::move(document)),
+      device_(std::make_unique<RenderDevice>()),
+      one_shot_device_(),
+      mask_store_(std::make_unique<MaskStore>(std::filesystem::temp_directory_path() /
+                                              "alcedo_studio" / "product_mask_store")),
+      unpack_(unpack ? std::move(unpack)
+                     : PreparedSourceCache::UnpackFn{[](std::span<const std::byte> encoded,
+                                                        DecodeRes                  decode_res) {
+                         return RawInputLoader::LoadEncoded(encoded, decode_res);
+                       }}),
+      source_cache_(unpack_),
+      plan_cache_(Backend::kCapabilityVersion) {
+  ConfigureDevice(*device_, "product");
+}
+
+template <class Backend>
+Renderer<Backend>::~Renderer() = default;
+
+template <class Backend>
+void Renderer<Backend>::ConfigureDevice(RenderDevice& device, const char* error_label) {
+  device.Workspace().Textures().SetByteBudget(Backend::DefaultTextureBudgetBytes());
+  device.SetErrorReporter([error_label](std::string_view message) {
+    std::fprintf(stderr, "[ERROR] %s DAG %s render failed: %.*s\n", Backend::kName, error_label,
+                 static_cast<int>(message.size()), message.data());
+  });
+}
+
+template <class Backend>
+void Renderer<Backend>::EnsureOneShotDevice() {
+  if (one_shot_device_) {
+    return;
+  }
+  one_shot_device_ = std::make_unique<RenderDevice>();
+  ConfigureDevice(*one_shot_device_, "one-shot");
+}
+
+template <class Backend>
+auto Renderer<Backend>::MaskAssets() -> MaskStore& {
+  return *mask_store_;
+}
+
+template <class Backend>
+void Renderer<Backend>::SetDocument(std::shared_ptr<PipelineDocument> document) {
+  if (!document) {
+    throw std::invalid_argument("Renderer: PipelineDocument is null");
+  }
+  document_ = std::move(document);
+}
+
+template <class Backend>
+auto Renderer<Backend>::Stats() const -> RenderSessionStats {
+  const auto         source = source_cache_.GetStats();
+  const auto         plan   = plan_cache_.GetStats();
+  RenderSessionStats stats;
+  stats.prepared_source_hits     = source.hits;
+  stats.prepared_source_misses   = source.misses;
+  stats.libraw_open_unpack_count = source.libraw_open_unpack_count;
+  stats.plan_cache_hits          = plan.hits;
+  stats.plan_cache_misses        = plan.misses;
+  stats.plan_compile_count       = plan.compiles;
+  stats.pass                     = device_->PassStats();
+  return stats;
+}
+
+template <class Backend>
+void Renderer<Backend>::ResetStats() {
+  source_cache_.ResetStats();
+  plan_cache_.ResetStats();
+  device_->ResetPassStats();
+}
+
+template <class Backend>
+void Renderer<Backend>::ReleaseSessionCaches() {
+  if (!device_) {
+    return;
+  }
+  device_->WaitIdle();
+  device_->Workspace().ReleaseSessionResources();
+  if constexpr (requires(RenderDevice& device) { device.ReleaseNeuralDemosaicWorkspace(); }) {
+    device_->ReleaseNeuralDemosaicWorkspace();
+  }
+  one_shot_device_.reset();
+  source_cache_.Clear();
+  plan_cache_.Clear();
+  device_->ResetPassStats();
+}
+
+template <class Backend>
+auto Renderer<Backend>::SessionResources() const -> RenderSessionResources {
+  RenderSessionResources resources;
+  if (!device_) {
+    return resources;
+  }
+  const auto& workspace                 = device_->Workspace();
+  resources.published_result_count      = workspace.Images().PublishedCount();
+  resources.texture_pool_used_bytes     = workspace.Textures().UsedBytes();
+  resources.texture_pool_entry_count    = workspace.Textures().EntryCount();
+  resources.prepared_source_host_bytes  = source_cache_.HostBytesUsed();
+  resources.prepared_source_entry_count = source_cache_.EntryCount();
+  resources.session_value_ids           = workspace.Images().CurrentValueIds();
+  return resources;
+}
+
+template <class Backend>
+auto Renderer<Backend>::OneShotPublishedResultCount() const -> std::size_t {
+  if (!one_shot_device_) {
+    return 0;
+  }
+  return one_shot_device_->Workspace().Images().PublishedCount();
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/result_content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/result_content_key.hpp
@@ -48,6 +48,13 @@ struct FrameResultContentKeys {
                                        const PipelineDocument& document) -> ContentKey;
 
 /**
+ * @brief Identity of the canonical LLF source pyramid. Viewport ROI and
+ * Shadows/Highlights slider values are omitted so a slider edit can reuse it.
+ */
+[[nodiscard]] auto HashLlfSourceKey(const ExecutionPlan& plan, const PreparedRawInput& input,
+                                    const PipelineDocument& document) -> ContentKey;
+
+/**
  * @brief Build layer keys for the current document, prepared source, and bound geometry.
  *
  * @pre @p plan.geometry is the per-frame ResolvedRenderGeometry.

--- a/alcedo_studio/src/include/edit/runtime/texture_format.hpp
+++ b/alcedo_studio/src/include/edit/runtime/texture_format.hpp
@@ -14,6 +14,7 @@ enum class TextureFormat : std::uint8_t {
   Rgba8   = 1,
   R32f    = 2,
   Rgba32f = 3,
+  R16u    = 4,
 };
 
 [[nodiscard]] inline auto TextureFormatBytesPerPixel(TextureFormat format) -> std::size_t {
@@ -26,6 +27,8 @@ enum class TextureFormat : std::uint8_t {
       return 4;
     case TextureFormat::Rgba32f:
       return 16;
+    case TextureFormat::R16u:
+      return 2;
   }
   return 1;
 }

--- a/alcedo_studio/src/include/edit/runtime/texture_format.hpp
+++ b/alcedo_studio/src/include/edit/runtime/texture_format.hpp
@@ -12,7 +12,8 @@ namespace alcedo {
 enum class TextureFormat : std::uint8_t {
   R8      = 0,
   Rgba8   = 1,
-  Rgba32f = 2,
+  R32f    = 2,
+  Rgba32f = 3,
 };
 
 [[nodiscard]] inline auto TextureFormatBytesPerPixel(TextureFormat format) -> std::size_t {
@@ -20,6 +21,8 @@ enum class TextureFormat : std::uint8_t {
     case TextureFormat::R8:
       return 1;
     case TextureFormat::Rgba8:
+      return 4;
+    case TextureFormat::R32f:
       return 4;
     case TextureFormat::Rgba32f:
       return 16;

--- a/alcedo_studio/src/include/edit/scope/detail/scope_metal_shared.hpp
+++ b/alcedo_studio/src/include/edit/scope/detail/scope_metal_shared.hpp
@@ -28,6 +28,10 @@ struct MetalTextureImageResource {
   std::uintptr_t              native_object = 0;
 };
 
+struct MetalCommandBufferSignalResource {
+  NS::SharedPtr<MTL::CommandBuffer> command_buffer = nullptr;
+};
+
 struct MetalBufferResource {
   NS::SharedPtr<MTL::Buffer> buffer      = nullptr;
   size_t                    size_bytes  = 0;

--- a/alcedo_studio/src/include/metal/compute_pipeline_cache.hpp
+++ b/alcedo_studio/src/include/metal/compute_pipeline_cache.hpp
@@ -6,7 +6,9 @@
 
 #ifdef HAVE_METAL
 
+#include <alcedo/metal/Metal.hpp>
 #include <condition_variable>
+#include <cstdint>
 #include <exception>
 #include <filesystem>
 #include <memory>
@@ -16,8 +18,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#include <alcedo/metal/Metal.hpp>
 
 #include "metal/metal_context.hpp"
 
@@ -40,15 +40,18 @@ class ComputePipelineCache {
     std::condition_variable                  cv;
   };
 
-  std::mutex                                                    mutex_;
-  std::unordered_map<std::string, std::shared_ptr<LibrarySlot>> libraries_;
+  mutable std::mutex                                             mutex_;
+  std::unordered_map<std::string, std::shared_ptr<LibrarySlot>>  libraries_;
   std::unordered_map<std::string, std::shared_ptr<PipelineSlot>> pipelines_;
+  std::uint64_t                                                  hits_    = 0;
+  std::uint64_t                                                  misses_  = 0;
+  std::uint64_t                                                  creates_ = 0;
 
-  ComputePipelineCache() = default;
+  ComputePipelineCache()                                                  = default;
 
   auto GetLibrarySlot(const std::string& metallib_path) -> std::shared_ptr<LibrarySlot> {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto& slot = libraries_[metallib_path];
+    auto&                       slot = libraries_[metallib_path];
     if (!slot) {
       slot = std::make_shared<LibrarySlot>();
     }
@@ -57,16 +60,16 @@ class ComputePipelineCache {
 
   auto GetPipelineSlot(const std::string& cache_key) -> std::shared_ptr<PipelineSlot> {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto& slot = pipelines_[cache_key];
+    auto&                       slot = pipelines_[cache_key];
     if (!slot) {
       slot = std::make_shared<PipelineSlot>();
     }
     return slot;
   }
 
-  static void AppendUniquePath(std::vector<std::filesystem::path>&    candidates,
-                               std::unordered_set<std::string>&       seen,
-                               const std::filesystem::path& candidate) {
+  static void AppendUniquePath(std::vector<std::filesystem::path>& candidates,
+                               std::unordered_set<std::string>&    seen,
+                               const std::filesystem::path&        candidate) {
     if (candidate.empty()) {
       return;
     }
@@ -82,8 +85,8 @@ class ComputePipelineCache {
 
   static auto ResolveMetallibPath(const char* configured_path, const char* debug_label)
       -> std::string {
-    std::filesystem::path configured(configured_path);
-    const auto           shader_name = configured.filename();
+    std::filesystem::path              configured(configured_path);
+    const auto                         shader_name = configured.filename();
 
     std::vector<std::filesystem::path> candidates;
     std::unordered_set<std::string>    seen;
@@ -93,9 +96,9 @@ class ComputePipelineCache {
       if (auto* bundle = NS::Bundle::mainBundle(); bundle != nullptr) {
         if (auto* resource_path = bundle->resourcePath();
             resource_path != nullptr && resource_path->utf8String() != nullptr) {
-          AppendUniquePath(candidates, seen,
-                           std::filesystem::path(resource_path->utf8String()) / "metallib" /
-                               shader_name);
+          AppendUniquePath(
+              candidates, seen,
+              std::filesystem::path(resource_path->utf8String()) / "metallib" / shader_name);
         }
 
         if (auto* executable_path = bundle->executablePath();
@@ -124,8 +127,9 @@ class ComputePipelineCache {
     }
 
     std::string error_message =
-        std::string(debug_label) + ": metallib file was not found. Configured path: " +
-        std::string(configured_path) + ". Tried:";
+        std::string(debug_label) +
+        ": metallib file was not found. Configured path: " + std::string(configured_path) +
+        ". Tried:";
     for (const auto& candidate : candidates) {
       error_message += "\n  - ";
       error_message += candidate.string();
@@ -135,7 +139,7 @@ class ComputePipelineCache {
 
   auto LoadLibrary(const std::string& metallib_path, const char* debug_label)
       -> NS::SharedPtr<MTL::Library> {
-    auto slot = GetLibrarySlot(metallib_path);
+    auto                         slot = GetLibrarySlot(metallib_path);
 
     std::unique_lock<std::mutex> lock(mutex_);
     for (;;) {
@@ -159,8 +163,8 @@ class ComputePipelineCache {
         throw std::runtime_error(std::string(debug_label) + ": Metal device is unavailable.");
       }
 
-      NS::Error* error         = nullptr;
-      auto       library_path  = NS::String::string(metallib_path.c_str(), NS::UTF8StringEncoding);
+      NS::Error* error          = nullptr;
+      auto       library_path   = NS::String::string(metallib_path.c_str(), NS::UTF8StringEncoding);
       auto       loaded_library = NS::TransferPtr(device->newLibrary(library_path, &error));
       if (!loaded_library) {
         std::string error_message = std::string(debug_label) + ": failed to load metallib.";
@@ -186,14 +190,32 @@ class ComputePipelineCache {
   }
 
  public:
-  ComputePipelineCache(const ComputePipelineCache&)                    = delete;
-  auto operator=(const ComputePipelineCache&) -> ComputePipelineCache& = delete;
-  ComputePipelineCache(ComputePipelineCache&&)                         = delete;
-  auto operator=(ComputePipelineCache&&) -> ComputePipelineCache&      = delete;
+  ComputePipelineCache(const ComputePipelineCache&)                      = delete;
+  auto operator=(const ComputePipelineCache&) -> ComputePipelineCache&   = delete;
+  ComputePipelineCache(ComputePipelineCache&&)                           = delete;
+  auto        operator=(ComputePipelineCache&&) -> ComputePipelineCache& = delete;
 
   static auto Instance() -> ComputePipelineCache& {
     static ComputePipelineCache cache;
     return cache;
+  }
+
+  struct Stats {
+    std::uint64_t hits    = 0;
+    std::uint64_t misses  = 0;
+    std::uint64_t creates = 0;
+  };
+
+  [[nodiscard]] auto GetStats() const -> Stats {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return Stats{hits_, misses_, creates_};
+  }
+
+  void ResetStats() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    hits_    = 0;
+    misses_  = 0;
+    creates_ = 0;
   }
 
   // Metal pipeline states are immutable, so the same compiled object can be reused safely across
@@ -210,11 +232,12 @@ class ComputePipelineCache {
     const std::string resolved_metallib_path = ResolveMetallibPath(metallib_path, debug_label);
     const std::string library_key            = resolved_metallib_path;
     const std::string pipeline_key           = library_key + '\n' + std::string(function_name);
-    auto pipeline_slot = GetPipelineSlot(pipeline_key);
+    auto              pipeline_slot          = GetPipelineSlot(pipeline_key);
 
     std::unique_lock<std::mutex> lock(mutex_);
     for (;;) {
       if (pipeline_slot->pipeline) {
+        ++hits_;
         return pipeline_slot->pipeline;
       }
       if (pipeline_slot->error) {
@@ -222,6 +245,7 @@ class ComputePipelineCache {
       }
       if (!pipeline_slot->is_creating) {
         pipeline_slot->is_creating = true;
+        ++misses_;
         break;
       }
       pipeline_slot->cv.wait(lock);
@@ -229,7 +253,7 @@ class ComputePipelineCache {
     lock.unlock();
 
     try {
-      auto library = LoadLibrary(library_key, debug_label);
+      auto library          = LoadLibrary(library_key, debug_label);
 
       auto function_name_ns = NS::String::string(function_name, NS::UTF8StringEncoding);
       auto function         = NS::TransferPtr(library->newFunction(function_name_ns));
@@ -243,7 +267,7 @@ class ComputePipelineCache {
         throw std::runtime_error(std::string(debug_label) + ": Metal device is unavailable.");
       }
 
-      NS::Error* error          = nullptr;
+      NS::Error* error = nullptr;
       auto       created_pipeline =
           NS::TransferPtr(device->newComputePipelineState(function.get(), &error));
       if (!created_pipeline) {
@@ -257,14 +281,15 @@ class ComputePipelineCache {
       }
 
       lock.lock();
-      pipeline_slot->pipeline     = created_pipeline;
-      pipeline_slot->is_creating  = false;
+      pipeline_slot->pipeline    = created_pipeline;
+      pipeline_slot->is_creating = false;
+      ++creates_;
       pipeline_slot->cv.notify_all();
       return pipeline_slot->pipeline;
     } catch (...) {
       lock.lock();
-      pipeline_slot->error        = std::current_exception();
-      pipeline_slot->is_creating  = false;
+      pipeline_slot->error       = std::current_exception();
+      pipeline_slot->is_creating = false;
       pipeline_slot->cv.notify_all();
       throw;
     }

--- a/alcedo_studio/src/include/metal/metal_context.hpp
+++ b/alcedo_studio/src/include/metal/metal_context.hpp
@@ -10,24 +10,33 @@ namespace alcedo {
 class MetalContext {
  private:
   MTL::Device*       device_ = nullptr;
-  MTL::CommandQueue* queue_ = nullptr;
+  MTL::CommandQueue* queue_  = nullptr;
 
   MetalContext();
 
   ~MetalContext();
 
  public:
-  MetalContext(const MetalContext&)                    = delete;
-  auto operator=(const MetalContext&) -> MetalContext& = delete;
-  MetalContext(MetalContext&&)                         = delete;
-  auto operator=(MetalContext&&) -> MetalContext&      = delete;
+  MetalContext(const MetalContext&)                      = delete;
+  auto operator=(const MetalContext&) -> MetalContext&   = delete;
+  MetalContext(MetalContext&&)                           = delete;
+  auto        operator=(MetalContext&&) -> MetalContext& = delete;
 
   static auto Instance() -> MetalContext&;
 
+  /**
+   * @brief Bind the app/Qt presentation device before the first Instance() call.
+   *
+   * If Instance() already exists, @p device must be that same MTLDevice.
+   * Workspace, MetalImage, and present all read this device; they do not create
+   * another one.
+   */
+  static void BindPresentationDevice(MTL::Device* device, MTL::CommandQueue* queue = nullptr);
+
   auto        Device() const -> MTL::Device*;
-  auto Queue() const -> MTL::CommandQueue*;
-};
+  auto        Queue() const -> MTL::CommandQueue*;
 };
 
+}  // namespace alcedo
 
 #endif

--- a/alcedo_studio/src/include/metal/metal_utils/geometry_utils.hpp
+++ b/alcedo_studio/src/include/metal/metal_utils/geometry_utils.hpp
@@ -29,6 +29,9 @@ void WarpAffineLinearTexture(const MetalImage& src, MetalImage& dst, const cv::M
 void WarpRectilinearTexture(const MetalImage& src, MetalImage& dst,
                             const dng::WarpRectilinear& warp);
 
+void EncodeWarpRectilinearTexture(void* command_buffer, void* src_texture, void* dst_texture,
+                                  const dng::WarpRectilinear& warp);
+
 }  // namespace alcedo::metal::utils
 
 #endif

--- a/alcedo_studio/src/include/ui/editor_rhi/editor_viewport_renderer.hpp
+++ b/alcedo_studio/src/include/ui/editor_rhi/editor_viewport_renderer.hpp
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include <QQuickRhiItem>
 #include <QtGui/rhi/qrhi.h>
 #include <QtGui/rhi/qshader.h>
 
+#include <QQuickRhiItem>
 #include <array>
 #include <cstdint>
 #include <memory>
@@ -45,24 +45,24 @@ class EditorViewportRenderer final : public QQuickRhiItemRenderer {
   };
 
   struct LayerState {
-    QRhiTexture* texture = nullptr;
-    int width = 0;
-    int height = 0;
-    bool imported = false;
-    bool valid = false;
-    int slot_index = -1;
+    QRhiTexture*                   texture    = nullptr;
+    int                            width      = 0;
+    int                            height     = 0;
+    bool                           imported   = false;
+    bool                           valid      = false;
+    int                            slot_index = -1;
     // Keeps Metal (or other producer-owned) textures alive until QRhi release.
-    std::shared_ptr<const void> imported_owner{};
-    std::uintptr_t imported_native_handle = 0;
-    FramePresentationMode presentation_mode = FramePresentationMode::FullFrame;
-    FramePreviewMetadata preview_metadata{};
+    std::shared_ptr<const void>    imported_owner{};
+    std::uintptr_t                 imported_native_handle = 0;
+    FramePresentationMode          presentation_mode      = FramePresentationMode::FullFrame;
+    FramePreviewMetadata           preview_metadata{};
     DirectPresentQueue::ReadyFrame ready_frame{};
   };
 
   struct UniformData {
-    float scale_zoom[4] = {1.0f, 1.0f, 1.0f, 0.0f};
-    float pan_mode[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-    float detail_roi[4] = {0.0f, 0.0f, 1.0f, 1.0f};
+    float scale_zoom[4]   = {1.0f, 1.0f, 1.0f, 0.0f};
+    float pan_mode[4]     = {0.0f, 0.0f, 0.0f, 0.0f};
+    float detail_roi[4]   = {0.0f, 0.0f, 1.0f, 1.0f};
     float detail_flags[4] = {0.0f, 0.0f, 0.0f, 0.0f};
   };
 
@@ -77,16 +77,15 @@ class EditorViewportRenderer final : public QQuickRhiItemRenderer {
   }
   [[nodiscard]] auto layerForRole(FrameRole role) const -> LayerId;
   [[nodiscard]] auto loadShader(const char* path) const -> QShader;
-  void destroyResource(QRhiTexture*& resource);
-  void destroyResource(QRhiBuffer*& resource);
-  void destroyResource(QRhiSampler*& resource);
-  void destroyResource(QRhiShaderResourceBindings*& resource);
-  void destroyResource(QRhiGraphicsPipeline*& resource);
-  void releaseLayer(LayerState& layer);
-  void releaseResources();
-  void releaseQueuedNatives();
-  void ensureStaticResources(QRhiRenderTarget* render_target,
-                             QRhiCommandBuffer* command_buffer);
+  void               destroyResource(QRhiTexture*& resource);
+  void               destroyResource(QRhiBuffer*& resource);
+  void               destroyResource(QRhiSampler*& resource);
+  void               destroyResource(QRhiShaderResourceBindings*& resource);
+  void               destroyResource(QRhiGraphicsPipeline*& resource);
+  void               releaseLayer(LayerState& layer);
+  void               releaseResources();
+  void               releaseQueuedNatives();
+  void ensureStaticResources(QRhiRenderTarget* render_target, QRhiCommandBuffer* command_buffer);
   void fulfillTargetRequests();
   void consumeDirectFrames();
   void consumeImportedGpuFrames();
@@ -94,45 +93,48 @@ class EditorViewportRenderer final : public QQuickRhiItemRenderer {
   [[nodiscard]] auto selectedDetailLayer() const -> const LayerState*;
   [[nodiscard]] auto hasVisibleDetailPatch() const -> bool;
   // base: QualityBase preferred, else full-frame InteractivePrimary.
-  [[nodiscard]] auto detailPatchAspectOk(const LayerState& detail,
-                                         const LayerState& base) const -> bool;
+  [[nodiscard]] auto detailPatchAspectOk(const LayerState& detail, const LayerState& base) const
+      -> bool;
   void traceDetailDecision(const char* decision, const LayerState* detail, const LayerState* base,
                            const std::optional<FrameRoiRect>& current_roi) const;
   void recreateShaderResources(QRhiTexture* primary, QRhiTexture* detail);
   void publishDiagnosticsIfChanged();
 
-  EditorViewportItem* item_ = nullptr;
-  std::shared_ptr<DirectPresentQueue> present_queue_;
+  EditorViewportItem*                  item_ = nullptr;
+  std::shared_ptr<DirectPresentQueue>  present_queue_;
   std::unique_ptr<ILeaseTargetAdapter> adapter_;
   // Maps adapter_cookie (native_handle) -> last WritableTargetLease for destroy.
-  std::vector<WritableTargetLease> owned_natives_;
-  ViewerViewState view_state_{};
-  std::array<LayerState, 3> layers_{};
-  EditorBackend backend_ = EditorBackend::Cuda;
-  std::uint64_t target_generation_ = 0;
-  std::uint64_t session_epoch_ = 0;
-  std::uint64_t image_identity_ = 0;
-  QRhi* rhi_ = nullptr;
-  QRhiRenderTarget* render_target_ = nullptr;
+  std::vector<WritableTargetLease>     owned_natives_;
+  ViewerViewState                      view_state_{};
+  std::array<LayerState, 3>            layers_{};
+  EditorBackend                        backend_                  = EditorBackend::Cuda;
+  std::uint64_t                        target_generation_        = 0;
+  std::uint64_t                        session_epoch_            = 0;
+  std::uint64_t                        image_identity_           = 0;
+  QRhi*                                rhi_                      = nullptr;
+  QRhiRenderTarget*                    render_target_            = nullptr;
 
-  QRhiTexture* placeholder_texture_ = nullptr;
-  QRhiSampler* primary_sampler_ = nullptr;
-  QRhiSampler* detail_sampler_ = nullptr;
-  QRhiBuffer* uniform_buffer_ = nullptr;
-  QRhiBuffer* vertex_buffer_ = nullptr;
-  QRhiShaderResourceBindings* shader_resource_bindings_ = nullptr;
-  QRhiGraphicsPipeline* pipeline_ = nullptr;
-  QRhiTexture* bound_primary_texture_ = nullptr;
-  QRhiTexture* bound_detail_texture_ = nullptr;
-  bool static_upload_pending_ = false;
-  bool content_dirty_ = false;
-  std::string target_error_;
-  // Stdout ROI tracing is transition-based so a rejected patch does not print
+  QRhiTexture*                         placeholder_texture_      = nullptr;
+  QRhiSampler*                         primary_sampler_          = nullptr;
+  QRhiSampler*                         detail_sampler_           = nullptr;
+  QRhiBuffer*                          uniform_buffer_           = nullptr;
+  QRhiBuffer*                          vertex_buffer_            = nullptr;
+  QRhiShaderResourceBindings*          shader_resource_bindings_ = nullptr;
+  QRhiGraphicsPipeline*                pipeline_                 = nullptr;
+  QRhiTexture*                         bound_primary_texture_    = nullptr;
+  QRhiTexture*                         bound_detail_texture_     = nullptr;
+  bool                                 static_upload_pending_    = false;
+  bool                                 content_dirty_            = false;
+  std::string                          target_error_;
+  // ROI tracing is transition-based so a rejected patch does not print
   // once per scene-graph frame and create a second performance problem.
-  mutable std::string   last_detail_trace_decision_;
-  mutable std::uint64_t last_detail_trace_request_id_ = 0;
-  mutable bool          last_detail_trace_has_roi_     = false;
-  mutable FrameRoiRect  last_detail_trace_roi_{};
+  mutable std::string                  last_detail_trace_decision_;
+  mutable std::uint64_t                last_detail_trace_request_id_ = 0;
+  mutable bool                         last_detail_trace_has_roi_    = false;
+  mutable FrameRoiRect                 last_detail_trace_roi_{};
+  mutable float                        last_detail_trace_zoom_  = 0.0f;
+  mutable float                        last_detail_trace_pan_x_ = 0.0f;
+  mutable float                        last_detail_trace_pan_y_ = 0.0f;
 };
 
 }  // namespace alcedo::editor_rhi

--- a/alcedo_studio/src/metal/CMakeLists.txt
+++ b/alcedo_studio/src/metal/CMakeLists.txt
@@ -71,6 +71,10 @@ if(ALCEDO_METAL_ENABLED)
     set(METAL_CAMERA_COLOR_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/camera_color.air")
     set(METAL_CAMERA_COLOR_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/camera_color.metallib"
         CACHE INTERNAL "Metal DAG camera color metallib path" FORCE)
+    set(METAL_PRIMARY_GRADE_SRC "${ALCEDO_SRC_ROOT}/edit/runtime/metal/shader/primary_grade.metal")
+    set(METAL_PRIMARY_GRADE_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/primary_grade.air")
+    set(METAL_PRIMARY_GRADE_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/primary_grade.metallib"
+        CACHE INTERNAL "Metal DAG primary grade metallib path" FORCE)
     find_program(ALCEDO_XCRUN_EXECUTABLE xcrun REQUIRED)
     execute_process(
         COMMAND ${ALCEDO_XCRUN_EXECUTABLE} --sdk macosx --find metal
@@ -292,9 +296,19 @@ if(ALCEDO_METAL_ENABLED)
         "Linking Metal DAG camera color library"
     )
 
+    alcedo_add_metal_library(
+        GpuDagPrimaryGradeShaders
+        "${METAL_PRIMARY_GRADE_SRC}"
+        "${METAL_PRIMARY_GRADE_AIR}"
+        "${METAL_PRIMARY_GRADE_METALLIB}"
+        "Compiling Metal DAG primary grade shader"
+        "Linking Metal DAG primary grade library"
+    )
+
     add_custom_target(GpuDagMetalShaders DEPENDS
         "${METAL_GEOMETRY_RESAMPLE_METALLIB}"
         "${METAL_CAMERA_COLOR_METALLIB}"
+        "${METAL_PRIMARY_GRADE_METALLIB}"
     )
 
     add_custom_target(RawProcessorOpMetalShaders DEPENDS
@@ -319,6 +333,7 @@ if(ALCEDO_METAL_ENABLED)
         "${METAL_DEMOSAICNET_IO_METALLIB}"
         "${METAL_GEOMETRY_RESAMPLE_METALLIB}"
         "${METAL_CAMERA_COLOR_METALLIB}"
+        "${METAL_PRIMARY_GRADE_METALLIB}"
     )
     set(ALCEDO_METAL_RUNTIME_LIBS "${ALCEDO_METAL_RUNTIME_LIBS}" CACHE INTERNAL
         "Metal shader libraries required at runtime." FORCE

--- a/alcedo_studio/src/metal/CMakeLists.txt
+++ b/alcedo_studio/src/metal/CMakeLists.txt
@@ -79,6 +79,10 @@ if(ALCEDO_METAL_ENABLED)
     set(METAL_LOCAL_TONE_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/local_tone.air")
     set(METAL_LOCAL_TONE_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/local_tone.metallib"
         CACHE INTERNAL "Metal DAG local tone metallib path" FORCE)
+    set(METAL_MASK_SRC "${ALCEDO_SRC_ROOT}/edit/runtime/metal/shader/mask.metal")
+    set(METAL_MASK_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/mask.air")
+    set(METAL_MASK_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/mask.metallib"
+        CACHE INTERNAL "Metal DAG mask metallib path" FORCE)
     find_program(ALCEDO_XCRUN_EXECUTABLE xcrun REQUIRED)
     execute_process(
         COMMAND ${ALCEDO_XCRUN_EXECUTABLE} --sdk macosx --find metal
@@ -318,11 +322,21 @@ if(ALCEDO_METAL_ENABLED)
         "Linking Metal DAG local tone library"
     )
 
+    alcedo_add_metal_library(
+        GpuDagMaskShaders
+        "${METAL_MASK_SRC}"
+        "${METAL_MASK_AIR}"
+        "${METAL_MASK_METALLIB}"
+        "Compiling Metal DAG mask shader"
+        "Linking Metal DAG mask library"
+    )
+
     add_custom_target(GpuDagMetalShaders DEPENDS
         "${METAL_GEOMETRY_RESAMPLE_METALLIB}"
         "${METAL_CAMERA_COLOR_METALLIB}"
         "${METAL_PRIMARY_GRADE_METALLIB}"
         "${METAL_LOCAL_TONE_METALLIB}"
+        "${METAL_MASK_METALLIB}"
     )
 
     add_custom_target(RawProcessorOpMetalShaders DEPENDS
@@ -349,6 +363,7 @@ if(ALCEDO_METAL_ENABLED)
         "${METAL_CAMERA_COLOR_METALLIB}"
         "${METAL_PRIMARY_GRADE_METALLIB}"
         "${METAL_LOCAL_TONE_METALLIB}"
+        "${METAL_MASK_METALLIB}"
     )
     set(ALCEDO_METAL_RUNTIME_LIBS "${ALCEDO_METAL_RUNTIME_LIBS}" CACHE INTERNAL
         "Metal shader libraries required at runtime." FORCE

--- a/alcedo_studio/src/metal/CMakeLists.txt
+++ b/alcedo_studio/src/metal/CMakeLists.txt
@@ -83,6 +83,10 @@ if(ALCEDO_METAL_ENABLED)
     set(METAL_MASK_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/mask.air")
     set(METAL_MASK_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/mask.metallib"
         CACHE INTERNAL "Metal DAG mask metallib path" FORCE)
+    set(METAL_DRT_SRC "${ALCEDO_SRC_ROOT}/edit/runtime/metal/shader/drt.metal")
+    set(METAL_DRT_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/drt.air")
+    set(METAL_DRT_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/drt.metallib"
+        CACHE INTERNAL "Metal DAG DRT metallib path" FORCE)
     find_program(ALCEDO_XCRUN_EXECUTABLE xcrun REQUIRED)
     execute_process(
         COMMAND ${ALCEDO_XCRUN_EXECUTABLE} --sdk macosx --find metal
@@ -331,12 +335,25 @@ if(ALCEDO_METAL_ENABLED)
         "Linking Metal DAG mask library"
     )
 
+    alcedo_add_metal_library(
+        GpuDagDrtShaders
+        "${METAL_DRT_SRC}"
+        "${METAL_DRT_AIR}"
+        "${METAL_DRT_METALLIB}"
+        "Compiling Metal DAG DRT shader"
+        "Linking Metal DAG DRT library"
+        DEPENDS
+            "${ALCEDO_SRC_ROOT}/edit/runtime/metal/shader/drt_aces.metal"
+            "${ALCEDO_SRC_ROOT}/edit/runtime/metal/shader/drt_opendrt.metal"
+    )
+
     add_custom_target(GpuDagMetalShaders DEPENDS
         "${METAL_GEOMETRY_RESAMPLE_METALLIB}"
         "${METAL_CAMERA_COLOR_METALLIB}"
         "${METAL_PRIMARY_GRADE_METALLIB}"
         "${METAL_LOCAL_TONE_METALLIB}"
         "${METAL_MASK_METALLIB}"
+        "${METAL_DRT_METALLIB}"
     )
 
     add_custom_target(RawProcessorOpMetalShaders DEPENDS
@@ -364,6 +381,7 @@ if(ALCEDO_METAL_ENABLED)
         "${METAL_PRIMARY_GRADE_METALLIB}"
         "${METAL_LOCAL_TONE_METALLIB}"
         "${METAL_MASK_METALLIB}"
+        "${METAL_DRT_METALLIB}"
     )
     set(ALCEDO_METAL_RUNTIME_LIBS "${ALCEDO_METAL_RUNTIME_LIBS}" CACHE INTERNAL
         "Metal shader libraries required at runtime." FORCE

--- a/alcedo_studio/src/metal/CMakeLists.txt
+++ b/alcedo_studio/src/metal/CMakeLists.txt
@@ -75,6 +75,10 @@ if(ALCEDO_METAL_ENABLED)
     set(METAL_PRIMARY_GRADE_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/primary_grade.air")
     set(METAL_PRIMARY_GRADE_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/primary_grade.metallib"
         CACHE INTERNAL "Metal DAG primary grade metallib path" FORCE)
+    set(METAL_LOCAL_TONE_SRC "${ALCEDO_SRC_ROOT}/edit/runtime/metal/shader/local_tone.metal")
+    set(METAL_LOCAL_TONE_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/local_tone.air")
+    set(METAL_LOCAL_TONE_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/local_tone.metallib"
+        CACHE INTERNAL "Metal DAG local tone metallib path" FORCE)
     find_program(ALCEDO_XCRUN_EXECUTABLE xcrun REQUIRED)
     execute_process(
         COMMAND ${ALCEDO_XCRUN_EXECUTABLE} --sdk macosx --find metal
@@ -305,10 +309,20 @@ if(ALCEDO_METAL_ENABLED)
         "Linking Metal DAG primary grade library"
     )
 
+    alcedo_add_metal_library(
+        GpuDagLocalToneShaders
+        "${METAL_LOCAL_TONE_SRC}"
+        "${METAL_LOCAL_TONE_AIR}"
+        "${METAL_LOCAL_TONE_METALLIB}"
+        "Compiling Metal DAG local tone shader"
+        "Linking Metal DAG local tone library"
+    )
+
     add_custom_target(GpuDagMetalShaders DEPENDS
         "${METAL_GEOMETRY_RESAMPLE_METALLIB}"
         "${METAL_CAMERA_COLOR_METALLIB}"
         "${METAL_PRIMARY_GRADE_METALLIB}"
+        "${METAL_LOCAL_TONE_METALLIB}"
     )
 
     add_custom_target(RawProcessorOpMetalShaders DEPENDS
@@ -334,6 +348,7 @@ if(ALCEDO_METAL_ENABLED)
         "${METAL_GEOMETRY_RESAMPLE_METALLIB}"
         "${METAL_CAMERA_COLOR_METALLIB}"
         "${METAL_PRIMARY_GRADE_METALLIB}"
+        "${METAL_LOCAL_TONE_METALLIB}"
     )
     set(ALCEDO_METAL_RUNTIME_LIBS "${ALCEDO_METAL_RUNTIME_LIBS}" CACHE INTERNAL
         "Metal shader libraries required at runtime." FORCE

--- a/alcedo_studio/src/metal/CMakeLists.txt
+++ b/alcedo_studio/src/metal/CMakeLists.txt
@@ -63,6 +63,14 @@ if(ALCEDO_METAL_ENABLED)
     set(METAL_DEMOSAICNET_IO_AIR "${ALCEDO_BINARY_ROOT}/decoders/processor/operators/gpu/metal_shader/demosaicnet_io.air")
     set(METAL_DEMOSAICNET_IO_METALLIB "${ALCEDO_BINARY_ROOT}/decoders/processor/operators/gpu/metal_shader/demosaicnet_io.metallib"
         CACHE INTERNAL "Metal DemosaicNet IO metallib path" FORCE)
+    set(METAL_GEOMETRY_RESAMPLE_SRC "${ALCEDO_SRC_ROOT}/edit/runtime/metal/shader/geometry_resample.metal")
+    set(METAL_GEOMETRY_RESAMPLE_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/geometry_resample.air")
+    set(METAL_GEOMETRY_RESAMPLE_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/geometry_resample.metallib"
+        CACHE INTERNAL "Metal DAG geometry resample metallib path" FORCE)
+    set(METAL_CAMERA_COLOR_SRC "${ALCEDO_SRC_ROOT}/edit/runtime/metal/shader/camera_color.metal")
+    set(METAL_CAMERA_COLOR_AIR "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/camera_color.air")
+    set(METAL_CAMERA_COLOR_METALLIB "${ALCEDO_BINARY_ROOT}/edit/runtime/metal/shader/camera_color.metallib"
+        CACHE INTERNAL "Metal DAG camera color metallib path" FORCE)
     find_program(ALCEDO_XCRUN_EXECUTABLE xcrun REQUIRED)
     execute_process(
         COMMAND ${ALCEDO_XCRUN_EXECUTABLE} --sdk macosx --find metal
@@ -266,6 +274,29 @@ if(ALCEDO_METAL_ENABLED)
         "Linking Metal DemosaicNet IO library"
     )
 
+    alcedo_add_metal_library(
+        GpuDagGeometryResampleShaders
+        "${METAL_GEOMETRY_RESAMPLE_SRC}"
+        "${METAL_GEOMETRY_RESAMPLE_AIR}"
+        "${METAL_GEOMETRY_RESAMPLE_METALLIB}"
+        "Compiling Metal DAG geometry resample shader"
+        "Linking Metal DAG geometry resample library"
+    )
+
+    alcedo_add_metal_library(
+        GpuDagCameraColorShaders
+        "${METAL_CAMERA_COLOR_SRC}"
+        "${METAL_CAMERA_COLOR_AIR}"
+        "${METAL_CAMERA_COLOR_METALLIB}"
+        "Compiling Metal DAG camera color shader"
+        "Linking Metal DAG camera color library"
+    )
+
+    add_custom_target(GpuDagMetalShaders DEPENDS
+        "${METAL_GEOMETRY_RESAMPLE_METALLIB}"
+        "${METAL_CAMERA_COLOR_METALLIB}"
+    )
+
     add_custom_target(RawProcessorOpMetalShaders DEPENDS
         "${METAL_TO_LINEAR_REF_METALLIB}"
         "${METAL_DEBAYER_RCD_METALLIB}"
@@ -286,6 +317,8 @@ if(ALCEDO_METAL_ENABLED)
         "${METAL_XTRANS_INTERPOLATE_METALLIB}"
         "${METAL_CVT_REF_SPACE_METALLIB}"
         "${METAL_DEMOSAICNET_IO_METALLIB}"
+        "${METAL_GEOMETRY_RESAMPLE_METALLIB}"
+        "${METAL_CAMERA_COLOR_METALLIB}"
     )
     set(ALCEDO_METAL_RUNTIME_LIBS "${ALCEDO_METAL_RUNTIME_LIBS}" CACHE INTERNAL
         "Metal shader libraries required at runtime." FORCE

--- a/alcedo_studio/src/metal/metal_context.cpp
+++ b/alcedo_studio/src/metal/metal_context.cpp
@@ -4,14 +4,73 @@
 
 #ifdef HAVE_METAL
 #include "metal/metal_context.hpp"
+
+#include <stdexcept>
+
 namespace alcedo {
-MetalContext::MetalContext() {
-  device_ = MTL::CreateSystemDefaultDevice();
-  if (!device_) {
-    throw std::runtime_error("[FATAL] MetalContext: Failed to create Metal device.");
+namespace {
+
+MTL::Device*       g_pending_device       = nullptr;
+MTL::CommandQueue* g_pending_queue        = nullptr;
+bool               g_instance_constructed = false;
+
+}  // namespace
+
+void MetalContext::BindPresentationDevice(MTL::Device* device, MTL::CommandQueue* queue) {
+  if (device == nullptr) {
+    throw std::runtime_error("MetalContext: presentation device is null.");
   }
-  queue_ = device_->newCommandQueue();
-  if (!queue_) {
+  if (g_instance_constructed) {
+    auto& instance = Instance();
+    if (instance.Device() != device) {
+      throw std::runtime_error(
+          "MetalContext: a different Metal device is already in use; workspace, "
+          "MetalImage, and present must share the presentation device.");
+    }
+    if (queue != nullptr && instance.Queue() != queue) {
+      throw std::runtime_error("MetalContext: a different Metal command queue is already in use.");
+    }
+    return;
+  }
+  if (g_pending_device != nullptr && g_pending_device != device) {
+    throw std::runtime_error(
+        "MetalContext: presentation device was already bound to a different MTLDevice.");
+  }
+  if (g_pending_device != device) {
+    device->retain();
+    if (g_pending_device != nullptr) {
+      g_pending_device->release();
+    }
+    g_pending_device = device;
+  }
+  if (queue != nullptr && g_pending_queue != queue) {
+    queue->retain();
+    if (g_pending_queue != nullptr) {
+      g_pending_queue->release();
+    }
+    g_pending_queue = queue;
+  }
+}
+
+MetalContext::MetalContext() {
+  g_instance_constructed = true;
+  if (g_pending_device != nullptr) {
+    device_          = g_pending_device;
+    g_pending_device = nullptr;
+    if (g_pending_queue != nullptr) {
+      queue_          = g_pending_queue;
+      g_pending_queue = nullptr;
+    } else {
+      queue_ = device_->newCommandQueue();
+    }
+  } else {
+    device_ = MTL::CreateSystemDefaultDevice();
+    if (device_ == nullptr) {
+      throw std::runtime_error("[FATAL] MetalContext: Failed to create Metal device.");
+    }
+    queue_ = device_->newCommandQueue();
+  }
+  if (queue_ == nullptr) {
     throw std::runtime_error("[FATAL] MetalContext: Failed to create Metal command queue.");
   }
 }

--- a/alcedo_studio/src/metal/metal_utils/geometry_utils.cpp
+++ b/alcedo_studio/src/metal/metal_utils/geometry_utils.cpp
@@ -62,6 +62,7 @@ enum class GeometryKernel : uint32_t {
   Area,
   WarpAffineLinear,
   WarpRectilinear,
+  WarpRectilinearTex,
 };
 
 constexpr uint32_t kRowAlignmentBytes = 256;
@@ -123,6 +124,13 @@ auto KernelNameFor(GeometryKernel kernel, PixelFormat format) -> const char* {
       switch (format) {
         case PixelFormat::RGBA32FLOAT:
           return "warp_rectilinear_rgba32f";
+        default:
+          return nullptr;
+      }
+    case GeometryKernel::WarpRectilinearTex:
+      switch (format) {
+        case PixelFormat::RGBA32FLOAT:
+          return "warp_rectilinear_tex_rgba32f";
         default:
           return nullptr;
       }
@@ -319,6 +327,25 @@ void DispatchWarpAffine(const MetalImage& src, MetalImage& dst, const cv::Mat& m
   command_buffer->waitUntilCompleted();
 }
 
+auto MakeWarpRectilinearParams(const dng::WarpRectilinear& warp, uint32_t width, uint32_t height)
+    -> WarpRectilinearParams {
+  WarpRectilinearParams params{
+      .coefficient_set_count = warp.coefficient_set_count,
+      .width                 = width,
+      .height                = height,
+      .src_stride            = width,
+      .dst_stride            = width,
+      .center_x              = static_cast<float>(warp.center_x),
+      .center_y              = static_cast<float>(warp.center_y),
+  };
+  for (size_t set = 0; set < warp.coefficient_sets.size(); ++set) {
+    for (size_t term = 0; term < warp.coefficient_sets[set].size(); ++term) {
+      params.coefficient_sets[set][term] = static_cast<float>(warp.coefficient_sets[set][term]);
+    }
+  }
+  return params;
+}
+
 void DispatchWarpRectilinear(const MetalImage& src, MetalImage& dst,
                              const dng::WarpRectilinear& warp) {
   const auto src_row_bytes = RowBytesFor(src.Width(), src.Format());
@@ -425,6 +452,33 @@ void WarpAffineLinearTexture(const MetalImage& src, MetalImage& dst, const cv::M
   dst.Create(static_cast<uint32_t>(out_size.width), static_cast<uint32_t>(out_size.height),
              src.Format(), true, true, HasRenderTargetUsage(src));
   DispatchWarpAffine(src, dst, matrix, border_value);
+}
+
+void EncodeWarpRectilinearTexture(void* command_buffer, void* src_texture, void* dst_texture,
+                                  const dng::WarpRectilinear& warp) {
+  auto* buffer = static_cast<MTL::CommandBuffer*>(command_buffer);
+  auto* src    = static_cast<MTL::Texture*>(src_texture);
+  auto* dst    = static_cast<MTL::Texture*>(dst_texture);
+  if (buffer == nullptr || src == nullptr || dst == nullptr) {
+    throw std::runtime_error("Metal geometry utils: encode warp requires command buffer and textures.");
+  }
+  if (src->width() != dst->width() || src->height() != dst->height()) {
+    throw std::runtime_error("Metal geometry utils: warp source and destination sizes must match.");
+  }
+  const auto params = MakeWarpRectilinearParams(warp, static_cast<uint32_t>(src->width()),
+                                                static_cast<uint32_t>(src->height()));
+  auto       pipeline = GetGeometryPipelineState(GeometryKernel::WarpRectilinearTex,
+                                                 PixelFormat::RGBA32FLOAT);
+  auto       compute  = NS::RetainPtr(buffer->computeCommandEncoder());
+  if (!compute) {
+    throw std::runtime_error("Metal geometry utils: failed to create compute encoder.");
+  }
+  compute->setComputePipelineState(pipeline.get());
+  compute->setTexture(src, 0);
+  compute->setTexture(dst, 1);
+  compute->setBytes(&params, sizeof(params), 0);
+  DispatchThreads(compute.get(), pipeline.get(), params.width, params.height);
+  compute->endEncoding();
 }
 
 void WarpRectilinearTexture(const MetalImage& src, MetalImage& dst,

--- a/alcedo_studio/src/metal/metal_utils/geometry_utils.metal
+++ b/alcedo_studio/src/metal/metal_utils/geometry_utils.metal
@@ -350,3 +350,45 @@ kernel void warp_rectilinear_rgba32f(device const float4* src [[buffer(0)]],
   const float4 b_px  = BilinearSampleWarp(src, params, blue.x, blue.y);
   dst[gid.y * params.dst_stride + gid.x] = float4(r_px.x, g_px.y, b_px.z, g_px.w);
 }
+
+static inline auto ReadTextureOrZero(texture2d<float, access::read> src, int width, int height,
+                                     int x, int y) -> float4 {
+  if (x < 0 || y < 0 || x >= width || y >= height) {
+    return float4(0.0f);
+  }
+  return src.read(uint2(static_cast<uint>(x), static_cast<uint>(y)));
+}
+
+static inline auto BilinearSampleTextureWarp(texture2d<float, access::read> src, int width,
+                                             int height, float sx, float sy) -> float4 {
+  const int   x0  = static_cast<int>(floor(sx));
+  const int   y0  = static_cast<int>(floor(sy));
+  const float fx  = sx - static_cast<float>(x0);
+  const float fy  = sy - static_cast<float>(y0);
+  const float w00 = (1.0f - fx) * (1.0f - fy);
+  const float w10 = fx * (1.0f - fy);
+  const float w01 = (1.0f - fx) * fy;
+  const float w11 = fx * fy;
+  return ReadTextureOrZero(src, width, height, x0, y0) * w00 +
+         ReadTextureOrZero(src, width, height, x0 + 1, y0) * w10 +
+         ReadTextureOrZero(src, width, height, x0, y0 + 1) * w01 +
+         ReadTextureOrZero(src, width, height, x0 + 1, y0 + 1) * w11;
+}
+
+kernel void warp_rectilinear_tex_rgba32f(texture2d<float, access::read> src [[texture(0)]],
+                                         texture2d<float, access::write> dst [[texture(1)]],
+                                         constant WarpRectilinearParams& params [[buffer(0)]],
+                                         uint2 gid [[thread_position_in_grid]]) {
+  if (gid.x >= params.width || gid.y >= params.height) {
+    return;
+  }
+  const int    width = static_cast<int>(params.width);
+  const int    height = static_cast<int>(params.height);
+  const float2 red    = WarpRectilinearSourceCoord(gid.x, gid.y, 0u, params);
+  const float2 green  = WarpRectilinearSourceCoord(gid.x, gid.y, 1u, params);
+  const float2 blue   = WarpRectilinearSourceCoord(gid.x, gid.y, 2u, params);
+  const float4 r_px   = BilinearSampleTextureWarp(src, width, height, red.x, red.y);
+  const float4 g_px   = BilinearSampleTextureWarp(src, width, height, green.x, green.y);
+  const float4 b_px   = BilinearSampleTextureWarp(src, width, height, blue.x, blue.y);
+  dst.write(float4(r_px.x, g_px.y, b_px.z, g_px.w), gid);
+}

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
@@ -384,6 +384,31 @@ Item {
                         acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.TouchScreen | PointerDevice.Stylus
                         acceptedButtons: Qt.LeftButton | Qt.MiddleButton
                         target: null
+                        property bool _forwardingDrag: false
+                        property int _activeButton: Qt.LeftButton
+                        onActiveChanged: {
+                            if (active) {
+                                _forwardingDrag = true
+                                _activeButton = (centroid.pressedButtons & Qt.MiddleButton)
+                                        ? Qt.MiddleButton : Qt.LeftButton
+                                // DragHandler can take the exclusive grab before PointHandler
+                                // forwards its press. Start a complete controller sequence from
+                                // the original press position so pan never depends on handler
+                                // activation order.
+                                editorInteraction.handlePress(
+                                            centroid.pressPosition.x,
+                                            centroid.pressPosition.y,
+                                            _activeButton)
+                                editorInteraction.handleMove(
+                                            centroid.position.x, centroid.position.y,
+                                            centroid.pressedButtons)
+                            } else if (_forwardingDrag) {
+                                editorInteraction.handleRelease(
+                                            centroid.position.x, centroid.position.y,
+                                            _activeButton)
+                                _forwardingDrag = false
+                            }
+                        }
                         onTranslationChanged: {
                             if (active) {
                                 editorInteraction.handleMove(

--- a/alcedo_studio/src/ui/editor_rhi/CMakeLists.txt
+++ b/alcedo_studio/src/ui/editor_rhi/CMakeLists.txt
@@ -61,6 +61,10 @@ if(APPLE)
         "${ALCEDO_SRC_ROOT}/ui/edit_viewer/color_manager.mm"
     )
     set_source_files_properties(
+        "${ALCEDO_EDITOR_RHI_ROOT}/editor_startup.cpp"
+        PROPERTIES LANGUAGE OBJCXX
+    )
+    set_source_files_properties(
         "${ALCEDO_SRC_ROOT}/ui/edit_viewer/color_manager.mm"
         PROPERTIES LANGUAGE OBJCXX
     )
@@ -99,12 +103,14 @@ if(ALCEDO_OPENCL_ENABLED)
 endif()
 if(ALCEDO_METAL_ENABLED)
     target_compile_definitions(EditorRhiViewport PUBLIC HAVE_METAL)
+    target_link_libraries(EditorRhiViewport PUBLIC MetalContext alcedo::metal_cpp)
 endif()
 if(APPLE)
     target_link_libraries(EditorRhiViewport PRIVATE
         "-framework AppKit"
         "-framework QuartzCore"
         "-framework CoreGraphics"
+        "-framework Metal"
     )
 endif()
 if(WIN32)
@@ -143,6 +149,10 @@ def_library(EditorRhiHarnessLib
 )
 if(APPLE)
     set_source_files_properties(
+        "${ALCEDO_EDITOR_RHI_ROOT}/editor_startup.cpp"
+        PROPERTIES LANGUAGE OBJCXX
+    )
+    set_source_files_properties(
         "${ALCEDO_EDITOR_RHI_ROOT}/harness_viewport_renderer.cpp"
         PROPERTIES LANGUAGE OBJCXX
     )
@@ -161,6 +171,7 @@ if(ALCEDO_OPENCL_ENABLED)
 endif()
 if(ALCEDO_METAL_ENABLED)
     target_compile_definitions(EditorRhiHarnessLib PUBLIC HAVE_METAL)
+    target_link_libraries(EditorRhiHarnessLib PUBLIC MetalContext alcedo::metal_cpp)
 endif()
 if(WIN32)
     target_link_libraries(EditorRhiHarnessLib PRIVATE d3d11 dxgi opengl32)

--- a/alcedo_studio/src/ui/editor_rhi/direct_frame_sink.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/direct_frame_sink.cpp
@@ -201,10 +201,11 @@ void DirectFrameSink::EnsureSize(int width, int height) {
     // snaps / ROI thrash when a real frame arrives. Publish render-reference
     // geometry from SubmitMetalFrame with the real texture size instead.
     emit_target_size = geometry_changed && is_render_reference && !metal_present;
-    // CUDA/OpenCL always track the requested write size. On Metal, only track
-    // full-frame requests so Detail/Roi sizes cannot poison later change
-    // detection (actual ref size is set when the MTLTexture is submitted).
-    if (!metal_present || is_render_reference) {
+    // CUDA/OpenCL track the requested write size here. Metal must wait for
+    // SubmitMetalFrame: updating width_/height_ before the actual MTLTexture arrives makes that
+    // submission look unchanged and suppresses the render-reference notification needed by
+    // zoom, pan, and ROI routing.
+    if (!metal_present) {
       width_  = width;
       height_ = height;
     }
@@ -543,11 +544,16 @@ void DirectFrameSink::SubmitMetalFrame(const ViewerMetalFrame& frame) {
 
   diag::NoteRenderE2eProducerReady(request_id);
   qCDebug(editorPresentLog,
-          "[EditorPresent] queued Metal import request=%llu image=%llu epoch=%llu size=%dx%d "
-          "handle=%llu (zero-copy)",
+          "[EditorPresent] queued Metal import request=%llu image=%llu epoch=%llu role=%d mode=%d "
+          "size=%dx%d roi=%.6f,%.6f,%.6f,%.6f handle=%llu (zero-copy)",
           static_cast<unsigned long long>(request_id),
           static_cast<unsigned long long>(item_->imageIdentity()),
-          static_cast<unsigned long long>(item_->sessionEpoch()), frame.width, frame.height,
+          static_cast<unsigned long long>(item_->sessionEpoch()),
+          static_cast<int>(frame.preview_metadata.frame_role),
+          static_cast<int>(frame.presentation_mode), frame.width, frame.height,
+          frame.preview_metadata.source_roi_norm.x, frame.preview_metadata.source_roi_norm.y,
+          frame.preview_metadata.source_roi_norm.width,
+          frame.preview_metadata.source_roi_norm.height,
           static_cast<unsigned long long>(frame.texture_handle));
 
   if (emit_render_reference) {

--- a/alcedo_studio/src/ui/editor_rhi/editor_startup.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_startup.cpp
@@ -5,6 +5,11 @@
 #include "ui/editor_rhi/editor_startup.hpp"
 
 #include <QtGui/rhi/qrhi.h>
+#if defined(__APPLE__) && defined(HAVE_METAL)
+#include <QQuickGraphicsDevice>
+
+#include "metal/metal_context.hpp"
+#endif
 
 #include <QCoreApplication>
 #include <QGuiApplication>
@@ -185,8 +190,9 @@ auto ApplyEditorBackendBeforeWindow(EditorBackend backend) -> EditorStartupResul
     case EditorBackend::Metal: {
 #if defined(__APPLE__) && defined(HAVE_METAL)
       QQuickWindow::setGraphicsApi(QSGRendererInterface::Metal);
+      (void)alcedo::MetalContext::Instance();
       result.diagnostics.notes =
-          "Metal API selected; shared-texture presentation qualified by the macOS RHI harness";
+          "Metal API selected; Qt Quick presents from the process MetalContext device";
       result.ok = true;
       SetActiveEditorBackend(backend);
       return result;
@@ -211,8 +217,16 @@ void BindEditorGraphicsToWindow(QQuickWindow* window, const EditorStartupResult&
     window->setGraphicsDevice(QQuickGraphicsDevice::fromAdapter(
         static_cast<quint32>(luid.LowPart), static_cast<qint32>(luid.HighPart)));
   }
-#else
-  (void)startup;
+#endif
+#if defined(__APPLE__) && defined(HAVE_METAL)
+  if (startup.diagnostics.backend == EditorBackend::Metal) {
+    auto& context = alcedo::MetalContext::Instance();
+    if (context.Device() != nullptr && context.Queue() != nullptr) {
+      window->setGraphicsDevice(QQuickGraphicsDevice::fromDeviceAndCommandQueue(
+          reinterpret_cast<MTLDevice*>(context.Device()),
+          reinterpret_cast<MTLCommandQueue*>(context.Queue())));
+    }
+  }
 #endif
 }
 

--- a/alcedo_studio/src/ui/editor_rhi/editor_viewport_renderer.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_viewport_renderer.cpp
@@ -599,10 +599,14 @@ void EditorViewportRenderer::consumeImportedGpuFrames() {
     diag::NoteRenderE2eConsumeBegin(request_id);
     qCDebug(editorPresentLog,
             "[EditorPresent] consuming Metal import request=%llu image=%llu epoch=%llu "
-            "size=%dx%d handle=%llu",
+            "role=%d mode=%d size=%dx%d roi=%.6f,%.6f,%.6f,%.6f handle=%llu",
             static_cast<unsigned long long>(request_id),
             static_cast<unsigned long long>(frame.image_identity),
-            static_cast<unsigned long long>(frame.session_epoch), frame.width, frame.height,
+            static_cast<unsigned long long>(frame.session_epoch), static_cast<int>(role),
+            static_cast<int>(frame.presentation_mode), frame.width, frame.height,
+            frame.preview_metadata.source_roi_norm.x, frame.preview_metadata.source_roi_norm.y,
+            frame.preview_metadata.source_roi_norm.width,
+            frame.preview_metadata.source_roi_norm.height,
             static_cast<unsigned long long>(frame.texture_handle));
     if (role == FrameRole::DetailPatch) {
       qCDebug(editorPresentLog) << "[ROI_TRACE][renderer-metal-import-begin] request="
@@ -745,13 +749,20 @@ void EditorViewportRenderer::traceDetailDecision(
   const bool          has_roi     = detail && current_roi.has_value();
   const bool          roi_changed = has_roi != last_detail_trace_has_roi_ ||
                            (has_roi && !SameRoi(*current_roi, last_detail_trace_roi_));
+  const auto& transform    = view_state_.snapshot.view_transform;
+  const bool  view_changed = std::abs(transform.zoom - last_detail_trace_zoom_) > 1.0e-5f ||
+                            std::abs(transform.pan.x() - last_detail_trace_pan_x_) > 1.0e-5f ||
+                            std::abs(transform.pan.y() - last_detail_trace_pan_y_) > 1.0e-5f;
   if (last_detail_trace_decision_ == decision && last_detail_trace_request_id_ == request_id &&
-      !roi_changed) {
+      !roi_changed && !view_changed) {
     return;
   }
   last_detail_trace_decision_   = decision;
   last_detail_trace_request_id_ = request_id;
   last_detail_trace_has_roi_    = has_roi;
+  last_detail_trace_zoom_       = transform.zoom;
+  last_detail_trace_pan_x_      = transform.pan.x();
+  last_detail_trace_pan_y_      = transform.pan.y();
   if (has_roi) last_detail_trace_roi_ = *current_roi;
 
   if (!editorPresentLog().isDebugEnabled()) {
@@ -762,7 +773,8 @@ void EditorViewportRenderer::traceDetailDecision(
   QString     msg =
       QStringLiteral(
           "[ROI_TRACE][renderer-decision] decision=%1 detail_request=%2 detail_valid=%3 "
-          "quality_request=%4 interactive_request=%5 base_request=%6 image=%7 session_epoch=%8")
+          "quality_request=%4 interactive_request=%5 base_request=%6 image=%7 session_epoch=%8 "
+          "view_zoom=%9 view_pan=%10,%11 ref=%12x%13")
           .arg(QLatin1String(decision))
           .arg(request_id)
           .arg((detail && detail->valid) ? 1 : 0)
@@ -770,7 +782,12 @@ void EditorViewportRenderer::traceDetailDecision(
           .arg(interactive.valid ? interactive.preview_metadata.presentation_request_id : 0)
           .arg(base ? base->preview_metadata.presentation_request_id : 0)
           .arg(image_identity_)
-          .arg(session_epoch_);
+          .arg(session_epoch_)
+          .arg(transform.zoom)
+          .arg(transform.pan.x())
+          .arg(transform.pan.y())
+          .arg(view_state_.snapshot.render_reference_width)
+          .arg(view_state_.snapshot.render_reference_height);
   const auto* selected_primary = selectedPrimaryLayer();
   if (selected_primary) {
     msg += QStringLiteral(" selected_primary_size=%1x%2 selected_primary_mode=%3")
@@ -802,6 +819,15 @@ void EditorViewportRenderer::traceDetailDecision(
                .arg(current_roi->height);
   } else {
     msg += QStringLiteral(" current_roi=none");
+  }
+  if (const auto& region = view_state_.snapshot.viewport_render_region_cache; region.has_value()) {
+    msg += QStringLiteral(" viewport_target=%1x%2 viewport_ref=%3x%4")
+               .arg(region->target_width_)
+               .arg(region->target_height_)
+               .arg(region->reference_width_)
+               .arg(region->reference_height_);
+  } else {
+    msg += QStringLiteral(" viewport_target=none");
   }
   qCDebug(editorPresentLog).noquote() << msg;
 }

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -364,4 +364,18 @@ if(ALCEDO_METAL_ENABLED)
   gtest_discover_tests(GpuDagMetalWorkspaceTest TEST_PREFIX "GpuDagMetalWorkspaceTest."
     PROPERTIES LABELS "gpu;edit;runtime;metal")
   alcedo_register_test_target(GpuDagMetalWorkspaceTest gpu ci_metal)
+
+  add_executable(GpuDagMetalDevelopTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_develop_test.cpp)
+  target_include_directories(GpuDagMetalDevelopTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagMetalDevelopTest PRIVATE
+    GTest::gtest_main EditRuntimeMetal EditInput RawProcessorOp MetalDemosaicNetEntry)
+  target_compile_definitions(GpuDagMetalDevelopTest PRIVATE
+    ALCEDO_METAL_TO_LINEAR_REF_METALLIB_PATH="${METAL_TO_LINEAR_REF_METALLIB}"
+    ALCEDO_METAL_GEOMETRY_RESAMPLE_METALLIB_PATH="${METAL_GEOMETRY_RESAMPLE_METALLIB}"
+    ALCEDO_METAL_CAMERA_COLOR_METALLIB_PATH="${METAL_CAMERA_COLOR_METALLIB}")
+  add_dependencies(GpuDagMetalDevelopTest GpuDagMetalShaders RawProcessorOpMetalShaders)
+  gtest_discover_tests(GpuDagMetalDevelopTest TEST_PREFIX "GpuDagMetalDevelopTest."
+    PROPERTIES LABELS "gpu;edit;runtime;metal")
+  alcedo_register_test_target(GpuDagMetalDevelopTest gpu ci_metal)
 endif()

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -378,4 +378,16 @@ if(ALCEDO_METAL_ENABLED)
   gtest_discover_tests(GpuDagMetalDevelopTest TEST_PREFIX "GpuDagMetalDevelopTest."
     PROPERTIES LABELS "gpu;edit;runtime;metal")
   alcedo_register_test_target(GpuDagMetalDevelopTest gpu ci_metal)
+
+  add_executable(GpuDagMetalGradeTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_grade_test.cpp)
+  target_include_directories(GpuDagMetalGradeTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagMetalGradeTest PRIVATE
+    GTest::gtest_main EditRuntimeMetal EditInput RawProcessorOp MetalDemosaicNetEntry)
+  target_compile_definitions(GpuDagMetalGradeTest PRIVATE
+    ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH="${METAL_PRIMARY_GRADE_METALLIB}")
+  add_dependencies(GpuDagMetalGradeTest GpuDagMetalShaders)
+  gtest_discover_tests(GpuDagMetalGradeTest TEST_PREFIX "GpuDagMetalGradeTest."
+    PROPERTIES LABELS "gpu;edit;runtime;metal")
+  alcedo_register_test_target(GpuDagMetalGradeTest gpu ci_metal)
 endif()

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -380,12 +380,14 @@ if(ALCEDO_METAL_ENABLED)
   alcedo_register_test_target(GpuDagMetalDevelopTest gpu ci_metal)
 
   add_executable(GpuDagMetalGradeTest
-    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_grade_test.cpp)
+    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_grade_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_llf_test.cpp)
   target_include_directories(GpuDagMetalGradeTest PUBLIC ${ALCEDO_INCLUDE_DIR})
   target_link_libraries(GpuDagMetalGradeTest PRIVATE
     GTest::gtest_main EditRuntimeMetal EditInput RawProcessorOp MetalDemosaicNetEntry)
   target_compile_definitions(GpuDagMetalGradeTest PRIVATE
-    ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH="${METAL_PRIMARY_GRADE_METALLIB}")
+    ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH="${METAL_PRIMARY_GRADE_METALLIB}"
+    ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH="${METAL_LOCAL_TONE_METALLIB}")
   add_dependencies(GpuDagMetalGradeTest GpuDagMetalShaders)
   gtest_discover_tests(GpuDagMetalGradeTest TEST_PREFIX "GpuDagMetalGradeTest."
     PROPERTIES LABELS "gpu;edit;runtime;metal")

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -394,4 +394,28 @@ if(ALCEDO_METAL_ENABLED)
   gtest_discover_tests(GpuDagMetalGradeTest TEST_PREFIX "GpuDagMetalGradeTest."
     PROPERTIES LABELS "gpu;edit;runtime;metal")
   alcedo_register_test_target(GpuDagMetalGradeTest gpu ci_metal)
+
+  add_executable(GpuDagMetalDrtTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_drt_test.cpp)
+  target_include_directories(GpuDagMetalDrtTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagMetalDrtTest PRIVATE
+    GTest::gtest_main EditRuntimeMetal EditInput RawProcessorOp Operators MetalDemosaicNetEntry)
+  target_compile_definitions(GpuDagMetalDrtTest PRIVATE
+    ALCEDO_METAL_DRT_METALLIB_PATH="${METAL_DRT_METALLIB}")
+  add_dependencies(GpuDagMetalDrtTest GpuDagMetalShaders)
+  gtest_discover_tests(GpuDagMetalDrtTest TEST_PREFIX "GpuDagMetalDrtTest."
+    PROPERTIES LABELS "gpu;edit;runtime;metal")
+  alcedo_register_test_target(GpuDagMetalDrtTest gpu ci_metal)
+
+  add_executable(GpuDagMetalRendererTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_renderer_test.cpp)
+  target_include_directories(GpuDagMetalRendererTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagMetalRendererTest PRIVATE
+    GTest::gtest_main EditRuntimeMetal EditPipeline EditInput RawProcessorOp Operators MetalDemosaicNetEntry)
+  target_compile_definitions(GpuDagMetalRendererTest PRIVATE
+    ALCEDO_METAL_DRT_METALLIB_PATH="${METAL_DRT_METALLIB}")
+  add_dependencies(GpuDagMetalRendererTest GpuDagMetalShaders)
+  gtest_discover_tests(GpuDagMetalRendererTest TEST_PREFIX "GpuDagMetalRendererTest."
+    PROPERTIES LABELS "gpu;edit;runtime;metal")
+  alcedo_register_test_target(GpuDagMetalRendererTest gpu ci_metal)
 endif()

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -381,13 +381,15 @@ if(ALCEDO_METAL_ENABLED)
 
   add_executable(GpuDagMetalGradeTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/metal_grade_test.cpp
-    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_llf_test.cpp)
+    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_llf_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_mask_test.cpp)
   target_include_directories(GpuDagMetalGradeTest PUBLIC ${ALCEDO_INCLUDE_DIR})
   target_link_libraries(GpuDagMetalGradeTest PRIVATE
     GTest::gtest_main EditRuntimeMetal EditInput RawProcessorOp MetalDemosaicNetEntry)
   target_compile_definitions(GpuDagMetalGradeTest PRIVATE
     ALCEDO_METAL_PRIMARY_GRADE_METALLIB_PATH="${METAL_PRIMARY_GRADE_METALLIB}"
-    ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH="${METAL_LOCAL_TONE_METALLIB}")
+    ALCEDO_METAL_LOCAL_TONE_METALLIB_PATH="${METAL_LOCAL_TONE_METALLIB}"
+    ALCEDO_METAL_MASK_METALLIB_PATH="${METAL_MASK_METALLIB}")
   add_dependencies(GpuDagMetalGradeTest GpuDagMetalShaders)
   gtest_discover_tests(GpuDagMetalGradeTest TEST_PREFIX "GpuDagMetalGradeTest."
     PROPERTIES LABELS "gpu;edit;runtime;metal")

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -285,6 +285,9 @@ add_executable(GpuDagRawInputTest
   ${ALCEDO_TEST_ROOT}/edit/runtime/static_execution_plan_cache_test.cpp)
 target_include_directories(GpuDagRawInputTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(GpuDagRawInputTest PRIVATE GTest::gtest_main EditInput EditRuntime)
+if(ALCEDO_METAL_ENABLED)
+  target_link_libraries(GpuDagRawInputTest PRIVATE EditRuntimeMetal)
+endif()
 target_compile_definitions(GpuDagRawInputTest PRIVATE
   ALCEDO_RUNTIME_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/runtime"
   ALCEDO_INPUT_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/input"
@@ -348,4 +351,17 @@ if(ALCEDO_CUDA_ENABLED)
   gtest_discover_tests(GpuDagCudaWorkspaceTest TEST_PREFIX "GpuDagCudaWorkspaceTest."
     PROPERTIES LABELS "gpu;edit;runtime")
   alcedo_register_test_target(GpuDagCudaWorkspaceTest gpu)
+endif()
+
+if(ALCEDO_METAL_ENABLED)
+  add_executable(GpuDagMetalWorkspaceTest
+    ${ALCEDO_TEST_ROOT}/edit/runtime/metal_workspace_test.cpp)
+  target_include_directories(GpuDagMetalWorkspaceTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(GpuDagMetalWorkspaceTest PRIVATE GTest::gtest_main EditRuntimeMetal)
+  target_compile_definitions(GpuDagMetalWorkspaceTest PRIVATE
+    ALCEDO_METAL_UTILS_METALLIB_PATH="${METAL_UTILS_METALLIB}")
+  add_dependencies(GpuDagMetalWorkspaceTest MetalUtilsShaders)
+  gtest_discover_tests(GpuDagMetalWorkspaceTest TEST_PREFIX "GpuDagMetalWorkspaceTest."
+    PROPERTIES LABELS "gpu;edit;runtime;metal")
+  alcedo_register_test_target(GpuDagMetalWorkspaceTest gpu ci_metal)
 endif()

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -280,6 +280,7 @@ add_executable(GpuDagRawInputTest
   ${ALCEDO_TEST_ROOT}/edit/input/raw_input_loader_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/input/prepared_source_cache_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/graph_compiler_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/runtime/renderer_metal_instantiate_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/result_content_key_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/static_execution_plan_cache_test.cpp)
 target_include_directories(GpuDagRawInputTest PUBLIC ${ALCEDO_INCLUDE_DIR})

--- a/alcedo_studio/tests/edit/geometry/render_geometry_resolver_test.cpp
+++ b/alcedo_studio/tests/edit/geometry/render_geometry_resolver_test.cpp
@@ -2,22 +2,22 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
+#include "edit/geometry/render_geometry_resolver.hpp"
+
 #include <gtest/gtest.h>
 
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
 
-#include "edit/geometry/render_geometry_resolver.hpp"
-
 namespace alcedo {
 namespace {
 
 constexpr float kPxEps = 1e-4f;
 
-auto ResolveSimple(const SourceGeometry& source, const ImageGeometryParams& image = {},
-                   const ViewRequest& view = {}, const ResolutionRequest& resolution = {},
-                   const SamplingFootprint& footprint = {}) -> ResolvedRenderGeometry {
+auto            ResolveSimple(const SourceGeometry& source, const ImageGeometryParams& image = {},
+                              const ViewRequest& view = {}, const ResolutionRequest& resolution = {},
+                              const SamplingFootprint& footprint = {}) -> ResolvedRenderGeometry {
   return ResolveRenderGeometry(source, image, view, resolution, footprint);
 }
 
@@ -25,16 +25,15 @@ auto ResolveSimple(const SourceGeometry& source, const ImageGeometryParams& imag
 
 TEST(GpuDagGeometry, RenderGeometryRoundTripsReferenceAndRenderPixelCenters) {
   ImageGeometryParams image;
-  image.crop_rect         = NormalizedRect{0.10f, 0.15f, 0.70f, 0.60f};
-  image.rotation_degrees  = 23.0f;
-  image.expand_to_fit     = true;
+  image.crop_rect        = NormalizedRect{0.10f, 0.15f, 0.70f, 0.60f};
+  image.rotation_degrees = 23.0f;
+  image.expand_to_fit    = true;
   ViewRequest view;
   view.visible_rect_in_edit_space = NormalizedRect{0.20f, 0.10f, 0.50f, 0.60f};
   view.viewport_extent            = Extent2D{320, 240};
-  const auto geometry =
-      ResolveSimple(MakeSourceGeometry({80, 60}, {80, 60}), image, view, {}, {});
+  const auto geometry = ResolveSimple(MakeSourceGeometry({80, 60}, {80, 60}), image, view, {}, {});
 
-  float max_err = 0.0f;
+  float      max_err  = 0.0f;
   for (std::uint32_t y = 0; y < geometry.render_extent.height; y += 7) {
     for (std::uint32_t x = 0; x < geometry.render_extent.width; x += 11) {
       const auto center = PixelCenter(x, y);
@@ -64,10 +63,10 @@ TEST(GpuDagGeometry, FullCropZeroRotationMapsReferenceCornersToRenderCorners) {
 
 TEST(GpuDagGeometry, RotatedCropBoundsContainAllFourTransformedCorners) {
   ImageGeometryParams image;
-  image.crop_rect        = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
-  image.rotation_degrees = 35.0f;
-  image.expand_to_fit    = true;
-  const auto geometry = ResolveSimple(MakeSourceGeometry({200, 100}, {200, 100}), image);
+  image.crop_rect         = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
+  image.rotation_degrees  = 35.0f;
+  image.expand_to_fit     = true;
+  const auto    geometry  = ResolveSimple(MakeSourceGeometry({200, 100}, {200, 100}), image);
 
   const Vector2 corners[] = {{50.0f, 25.0f}, {150.0f, 25.0f}, {150.0f, 75.0f}, {50.0f, 75.0f}};
   const float   edit_w    = static_cast<float>(geometry.edit_extent.width);
@@ -88,8 +87,7 @@ TEST(GpuDagGeometry, ViewportCropAndDynamicScaleProduceRequestedRenderExtent) {
   view.viewport_extent = Extent2D{1920, 1080};
   ResolutionRequest half;
   half.render_scale = 0.5f;
-  const auto scaled =
-      ResolveSimple(MakeSourceGeometry({100, 100}, {100, 100}), {}, view, half, {});
+  const auto scaled = ResolveSimple(MakeSourceGeometry({100, 100}, {100, 100}), {}, view, half, {});
   EXPECT_EQ(scaled.render_extent, (Extent2D{960, 540}));
 
   ResolutionRequest clamped;
@@ -100,22 +98,44 @@ TEST(GpuDagGeometry, ViewportCropAndDynamicScaleProduceRequestedRenderExtent) {
   EXPECT_EQ(capped.render_extent, (Extent2D{800, 450}));
 }
 
+TEST(GpuDagGeometry, RoiLargerThanViewportIsDownsampledToPhysicalTarget) {
+  ViewRequest view;
+  view.visible_rect_in_edit_space = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
+  view.viewport_extent            = Extent2D{800, 600};
+
+  const auto geometry =
+      ResolveSimple(MakeSourceGeometry({4000, 3000}, {4000, 3000}), {}, view, {}, {});
+
+  EXPECT_EQ(geometry.render_extent, (Extent2D{800, 600}));
+  EXPECT_EQ(geometry.filter, TextureFilter::Bilinear);
+}
+
+TEST(GpuDagGeometry, RoiSmallerThanViewportKeepsNativePixelsForNearestViewerExpansion) {
+  ViewRequest view;
+  view.visible_rect_in_edit_space = NormalizedRect{0.25f, 0.25f, 0.125f, 0.125f};
+  view.viewport_extent            = Extent2D{800, 600};
+
+  const auto geometry =
+      ResolveSimple(MakeSourceGeometry({4000, 3000}, {4000, 3000}), {}, view, {}, {});
+
+  EXPECT_EQ(geometry.render_extent, (Extent2D{500, 375}));
+  EXPECT_EQ(geometry.filter, TextureFilter::Bilinear);
+}
+
 TEST(GpuDagGeometry, DecodeScaleDoesNotChangeNormalizedReferenceCoordinates) {
   ImageGeometryParams image;
-  image.crop_rect = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
-  const auto full =
-      ResolveSimple(MakeSourceGeometry({400, 300}, {400, 300}), image);
-  const auto quarter =
-      ResolveSimple(MakeSourceGeometry({100, 75}, {400, 300}, {}, 2), image);
+  image.crop_rect    = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
+  const auto full    = ResolveSimple(MakeSourceGeometry({400, 300}, {400, 300}), image);
+  const auto quarter = ResolveSimple(MakeSourceGeometry({100, 75}, {400, 300}, {}, 2), image);
 
   EXPECT_EQ(full.edit_extent, quarter.edit_extent);
   EXPECT_EQ(full.render_extent, quarter.render_extent);
 
   const auto n_full = NormalizedFromPixelCenter(
       TransformPoint(full.render_to_reference, PixelCenter(10, 8)), full.full_reference_extent);
-  const auto n_quarter = NormalizedFromPixelCenter(
-      TransformPoint(quarter.render_to_reference, PixelCenter(10, 8)),
-      quarter.full_reference_extent);
+  const auto n_quarter =
+      NormalizedFromPixelCenter(TransformPoint(quarter.render_to_reference, PixelCenter(10, 8)),
+                                quarter.full_reference_extent);
   EXPECT_NEAR(n_full.x, n_quarter.x, 1.0e-5f);
   EXPECT_NEAR(n_full.y, n_quarter.y, 1.0e-5f);
 

--- a/alcedo_studio/tests/edit/input/raw_input_loader_test.cpp
+++ b/alcedo_studio/tests/edit/input/raw_input_loader_test.cpp
@@ -7,11 +7,16 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <string>
 #include <vector>
+
+#if defined(__APPLE__)
+#include <pthread.h>
+#endif
 
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/runtime/graph_compiler.hpp"
@@ -29,6 +34,24 @@ auto ReadBytes(const std::filesystem::path& path) -> std::vector<std::byte> {
   std::memcpy(bytes.data(), chars.data(), chars.size());
   return bytes;
 }
+
+#if defined(__APPLE__)
+struct ProductWorkerRawLoadContext {
+  const std::vector<std::byte>*   encoded = nullptr;
+  std::optional<PreparedRawInput> prepared;
+  std::exception_ptr              failure;
+};
+
+auto LoadEncodedOnProductWorkerStack(void* opaque) noexcept -> void* {
+  auto& context = *static_cast<ProductWorkerRawLoadContext*>(opaque);
+  try {
+    context.prepared = RawInputLoader::LoadEncoded(*context.encoded, DecodeRes::FULL);
+  } catch (...) {
+    context.failure = std::current_exception();
+  }
+  return nullptr;
+}
+#endif
 
 TEST(GpuDagRawInput, RawInputLoaderUnpacksBeforePipelineBuild) {
   const auto pattern  = gpu_dag_test::MakeRggbPattern();
@@ -158,6 +181,44 @@ TEST(GpuDagRawInput, EncodedDngCarriesOpcodeList3WarpIntoPreparedInput) {
   EXPECT_TRUE(prepared.color_context.dng_warp_rectilinear_present_);
   EXPECT_NE(prepared.source_key.dng_warp_hash, 0U);
 }
+
+#if defined(__APPLE__)
+TEST(GpuDagRawInput, EncodedRawLoadCompletesOnProductWorkerStack) {
+  const auto root = std::filesystem::path{ALCEDO_CI_RAW_FIXTURE_ROOT};
+  const auto path = root / "tag @ryanbreitkreutz - free raws from @signatureeditsco - DSC06683.dng";
+  const auto encoded = ReadBytes(path);
+  ASSERT_FALSE(encoded.empty()) << path;
+
+  pthread_attr_t attributes;
+  ASSERT_EQ(pthread_attr_init(&attributes), 0);
+  constexpr std::size_t kProductWorkerStackBytes = 512U * 1024U;
+  const int set_stack_result = pthread_attr_setstacksize(&attributes, kProductWorkerStackBytes);
+  if (set_stack_result != 0) {
+    pthread_attr_destroy(&attributes);
+    FAIL() << "pthread_attr_setstacksize failed: " << set_stack_result;
+  }
+
+  ProductWorkerRawLoadContext context{.encoded = &encoded};
+  pthread_t                   thread;
+  const int                   create_result =
+      pthread_create(&thread, &attributes, LoadEncodedOnProductWorkerStack, &context);
+  pthread_attr_destroy(&attributes);
+  ASSERT_EQ(create_result, 0);
+  ASSERT_EQ(pthread_join(thread, nullptr), 0);
+
+  if (context.failure) {
+    try {
+      std::rethrow_exception(context.failure);
+    } catch (const std::exception& error) {
+      FAIL() << error.what();
+    } catch (...) {
+      FAIL() << "RawInputLoader failed with a non-standard exception";
+    }
+  }
+  ASSERT_TRUE(context.prepared.has_value());
+  EXPECT_FALSE(context.prepared->host_extent.Empty());
+}
+#endif
 
 }  // namespace
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
@@ -11,6 +11,7 @@
 #include <opencv2/core.hpp>
 #include <span>
 #include <stdexcept>
+#include <type_traits>
 #include <vector>
 
 #include "../graph/test_camera_profile.hpp"
@@ -24,6 +25,7 @@
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
 #include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/renderer.hpp"
 #include "edit/runtime/result_content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "image/image_buffer.hpp"
@@ -427,6 +429,119 @@ TEST_F(CudaResultCacheProductFixture, OneShotRenderDoesNotReadWriteOrClearEditor
   EXPECT_EQ(after_preview.pass.drt_execute, 0U);
   EXPECT_EQ(after_preview.pass.sensor_develop_skip, 1U);
   EXPECT_EQ(after_preview.pass.drt_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture, CudaRendererPreservesCurrentPlanAndResultCacheKeys) {
+  static_assert(std::is_same_v<CudaRenderer, Renderer<CudaBackend>>);
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  EXPECT_EQ(renderer_->PlanCache().BackendCapabilityVersion(), kCudaDagBackendCapabilityVersion);
+
+  auto&      encoded       = image_->GetBuffer();
+  const auto encoded_bytes = std::span<const std::byte>{
+      reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
+  auto       source_lease = renderer_->SourceCache().AcquireEncoded(encoded_bytes, DecodeRes::FULL);
+  const auto& prepared    = source_lease.Get();
+  const auto expected_plan = GraphCompiler::CompileStatic(
+      *document_, prepared.CompileSource(), kCudaDagBackendCapabilityVersion);
+  auto plan = renderer_->PlanCache().GetOrCompile(*document_, prepared.CompileSource());
+  GraphCompiler::BindFrameGeometry(plan, *document_, {});
+  EXPECT_EQ(plan.static_key.backend_capability_version, kCudaDagBackendCapabilityVersion);
+  EXPECT_EQ(plan.static_key, expected_plan.static_key);
+  EXPECT_EQ(plan.sensor_linear_output.producer.Value(), "develop");
+  EXPECT_EQ(plan.sensor_linear_output.output_port.Value(), "sensor_linear");
+  EXPECT_EQ(plan.geometry_output.producer.Value(), "geometry");
+  EXPECT_EQ(plan.geometry_output.output_port.Value(), "scene_source");
+  EXPECT_EQ(plan.develop_output.producer.Value(), "develop");
+  EXPECT_EQ(plan.develop_output.output_port.Value(), "image");
+  EXPECT_EQ(plan.passes.size(), expected_plan.passes.size());
+  for (std::size_t i = 0; i < expected_plan.passes.size(); ++i) {
+    EXPECT_EQ(plan.passes[i].kind, expected_plan.passes[i].kind);
+  }
+
+  const auto keys = BuildFrameResultContentKeys(plan, prepared, *document_);
+  renderer_->Device().WaitIdle();
+  const auto completed = renderer_->Device().Workspace().Device().CompletedSubmission();
+  auto&      images    = renderer_->Device().Workspace().Images();
+  EXPECT_EQ(images.PublishedContentKey(plan.sensor_linear_output), keys.sensor_linear);
+  EXPECT_EQ(images.PublishedContentKey(plan.geometry_output), keys.geometry_scene_source);
+  EXPECT_EQ(images.PublishedContentKey(plan.develop_output), keys.develop_image);
+  EXPECT_EQ(images.PublishedContentKey(plan.primary_grade_output), keys.primary_grade);
+  EXPECT_EQ(images.PublishedContentKey(plan.display_output), keys.drt_display);
+  EXPECT_TRUE(images.FindValidResult(plan.sensor_linear_output, keys.sensor_linear,
+                                     keys.sensor_extent, TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(images.FindValidResult(plan.geometry_output, keys.geometry_scene_source,
+                                     keys.geometry_extent, TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(images.FindValidResult(plan.develop_output, keys.develop_image, keys.geometry_extent,
+                                     TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(images.FindValidResult(plan.primary_grade_output, keys.primary_grade,
+                                     keys.geometry_extent, TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(images.FindValidResult(plan.display_output, keys.drt_display, keys.geometry_extent,
+                                     TextureFormat::Rgba32f, completed));
+}
+
+TEST_F(CudaResultCacheProductFixture, RendererOneShotWorkspaceCannotPublishIntoSessionCache) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto session_before = renderer_->SessionResources();
+  EXPECT_GT(session_before.published_result_count, 0U);
+  renderer_->ResetStats();
+
+  ASSERT_TRUE(
+      OutputIsFinite(RenderHostWithoutSessionCache(*renderer_, image_, DecodeRes::FULL, {})));
+  EXPECT_EQ(renderer_->OneShotPublishedResultCount(), 0U);
+  EXPECT_EQ(renderer_->SessionResources().published_result_count,
+            session_before.published_result_count);
+  EXPECT_EQ(renderer_->SessionResources().prepared_source_entry_count,
+            session_before.prepared_source_entry_count);
+  EXPECT_EQ(renderer_->Stats().prepared_source_hits, 0U);
+  EXPECT_EQ(renderer_->Stats().plan_cache_hits, 0U);
+  EXPECT_EQ(renderer_->Stats().pass.sensor_develop_execute, 0U);
+
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  EXPECT_EQ(renderer_->Stats().prepared_source_hits, 1U);
+  EXPECT_EQ(renderer_->Stats().pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(renderer_->Stats().pass.drt_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture, RendererFailureDoesNotPublishUnfinishedContentKeys) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  auto&      encoded       = image_->GetBuffer();
+  const auto encoded_bytes = std::span<const std::byte>{
+      reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
+  auto        source_lease = renderer_->SourceCache().AcquireEncoded(encoded_bytes, DecodeRes::FULL);
+  const auto& prepared     = source_lease.Get();
+  auto        first_plan   = renderer_->PlanCache().GetOrCompile(*document_, prepared.CompileSource());
+  GraphCompiler::BindFrameGeometry(first_plan, *document_, {});
+  const auto first_keys = BuildFrameResultContentKeys(first_plan, prepared, *document_);
+  const auto published_before = renderer_->SessionResources().published_result_count;
+
+  auto develop                   = document_->Develop()->Params().Params();
+  develop.highlights_reconstruct = !develop.highlights_reconstruct;
+  document_->Develop()->Params().ReplaceParams(develop);
+  renderer_->Device().Workspace().Device().FailNextUpload();
+  EXPECT_THROW(Render(), std::runtime_error);
+
+  auto second_plan = GraphCompiler::CompileStatic(*document_, prepared.CompileSource(),
+                                                  kCudaDagBackendCapabilityVersion);
+  GraphCompiler::BindFrameGeometry(second_plan, *document_, {});
+  const auto second_keys = BuildFrameResultContentKeys(second_plan, prepared, *document_);
+  ASSERT_NE(second_keys.sensor_linear, first_keys.sensor_linear);
+
+  renderer_->Device().WaitIdle();
+  auto&      images    = renderer_->Device().Workspace().Images();
+  const auto completed = renderer_->Device().Workspace().Device().CompletedSubmission();
+  EXPECT_EQ(renderer_->SessionResources().published_result_count, published_before);
+  EXPECT_TRUE(images.FindValidResult(first_plan.sensor_linear_output, first_keys.sensor_linear,
+                                     first_keys.sensor_extent, TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(images.FindValidResult(first_plan.display_output, first_keys.drt_display,
+                                     first_keys.geometry_extent, TextureFormat::Rgba32f,
+                                     completed));
+  EXPECT_FALSE(images.FindValidResult(second_plan.sensor_linear_output, second_keys.sensor_linear,
+                                      second_keys.sensor_extent, TextureFormat::Rgba32f,
+                                      completed));
+  EXPECT_FALSE(images.FindValidResult(second_plan.display_output, second_keys.drt_display,
+                                      second_keys.geometry_extent, TextureFormat::Rgba32f,
+                                      completed));
+  EXPECT_EQ(images.UnpublishedCount(), 0U);
 }
 
 class CudaResultCacheDeviceFixture : public ::testing::Test {

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -6,13 +6,19 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <memory>
 #include <string>
+#include <type_traits>
+#include <vector>
 
 #include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/graph/raster_mask_node_model.hpp"
 #include "edit/input/raw_input_loader.hpp"
+#include "edit/runtime/metal/metal_backend.hpp"
 #include "edit/runtime/pass_kind.hpp"
 
 namespace alcedo {
@@ -119,6 +125,47 @@ TEST(GpuDagGraphCompiler, GraphCompilerEmitsMaskEvaluateWhenRasterMaskConnected)
   EXPECT_LT(plan.IndexOf(GpuPassKind::CameraToAp1), plan.IndexOf(GpuPassKind::MaskEvaluate));
   EXPECT_LT(plan.IndexOf(GpuPassKind::MaskEvaluate), plan.IndexOf(GpuPassKind::MaskFeather));
   EXPECT_LT(plan.IndexOf(GpuPassKind::MaskFeather), plan.IndexOf(GpuPassKind::PrimaryColorGrade));
+}
+
+TEST(GpuDagGraphCompiler, GraphCompilerPassListIsBackendNativeTypeFree) {
+  static_assert(std::is_same_v<decltype(GpuPassDesc{}.kind), GpuPassKind>);
+  static_assert(std::is_trivially_copyable_v<GpuPassDesc>);
+
+  const char* files[] = {"graph_compiler.hpp", "execution_plan.hpp", "pass_kind.hpp"};
+  const std::filesystem::path root{ALCEDO_RUNTIME_HEADER_ROOT};
+  for (const char* name : files) {
+    std::ifstream input(root / name);
+    ASSERT_TRUE(input) << name;
+    std::string text((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(text.find("cuda_runtime"), std::string::npos) << name;
+    EXPECT_EQ(text.find("cuda.h"), std::string::npos) << name;
+    EXPECT_EQ(text.find("Metal/"), std::string::npos) << name;
+    EXPECT_EQ(text.find("metal.h"), std::string::npos) << name;
+    EXPECT_EQ(text.find("OpenCL"), std::string::npos) << name;
+  }
+
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto       document = CreateDefaultPipelineDocument();
+  const auto cuda_plan =
+      GraphCompiler::CompileStatic(document, prepared.CompileSource(), /*cuda*/ 1U);
+  const auto metal_plan = GraphCompiler::CompileStatic(document, prepared.CompileSource(),
+                                                       kMetalDagBackendCapabilityVersion);
+
+  ASSERT_EQ(cuda_plan.passes.size(), metal_plan.passes.size());
+  ASSERT_FALSE(cuda_plan.passes.empty());
+  for (std::size_t i = 0; i < cuda_plan.passes.size(); ++i) {
+    EXPECT_EQ(cuda_plan.passes[i].kind, metal_plan.passes[i].kind);
+  }
+  EXPECT_EQ(cuda_plan.static_key.backend_capability_version, 1U);
+  EXPECT_EQ(metal_plan.static_key.backend_capability_version, kMetalDagBackendCapabilityVersion);
+  EXPECT_NE(cuda_plan.static_key, metal_plan.static_key);
+  EXPECT_NE(kMetalDagBackendCapabilityVersion, 1U);
+  EXPECT_EQ(cuda_plan.sensor_linear_output, metal_plan.sensor_linear_output);
+  EXPECT_EQ(cuda_plan.geometry_output, metal_plan.geometry_output);
+  EXPECT_EQ(cuda_plan.develop_output, metal_plan.develop_output);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -17,6 +17,7 @@
 #include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/graph/raster_mask_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/runtime/metal/metal_backend.hpp"
 #include "edit/runtime/pass_kind.hpp"
@@ -97,11 +98,25 @@ TEST(GpuDagGraphCompiler, DefaultPipelineCompilesShadowsAndHighlightsToLocalLapl
     } else if (adjustment.type == type_ids::Curve()) {
       saw_curve = true;
       EXPECT_EQ(adjustment.algorithm, CompiledAdjustmentAlgorithm::Pointwise);
+    } else if (adjustment.type == type_ids::Clarity() || adjustment.type == type_ids::Sharpen() ||
+               adjustment.type == type_ids::Halation() ||
+               adjustment.type == type_ids::FilmGrain()) {
+      EXPECT_EQ(adjustment.algorithm, CompiledAdjustmentAlgorithm::Neighborhood);
     }
   }
   EXPECT_TRUE(saw_shadows);
   EXPECT_TRUE(saw_highlights);
   EXPECT_TRUE(saw_curve);
+  ASSERT_GE(plan.primary_grade_stages.size(), 5U);
+  EXPECT_EQ(plan.primary_grade_stages.front().kind, CompiledGradeStageKind::Pointwise);
+  bool saw_llf_stage = false;
+  for (const auto& stage : plan.primary_grade_stages) {
+    if (stage.kind == CompiledGradeStageKind::LocalLaplacian) {
+      saw_llf_stage = true;
+      EXPECT_EQ(stage.count, 2U);
+    }
+  }
+  EXPECT_TRUE(saw_llf_stage);
 }
 
 TEST(GpuDagGraphCompiler, GraphCompilerEmitsMaskEvaluateWhenRasterMaskConnected) {

--- a/alcedo_studio/tests/edit/runtime/header_hygiene_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/header_hygiene_test.cpp
@@ -6,8 +6,15 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <string>
+#include <type_traits>
 #include <vector>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#include "edit/runtime/render_backend.hpp"
+#include "edit/runtime/renderer.hpp"
 
 namespace alcedo {
 namespace {
@@ -55,6 +62,25 @@ TEST(GpuDagCudaWorkspace, GpuAndRuntimeHeadersDoNotIncludeCudaOrImageBuffer) {
   ScanDirectory(std::filesystem::path{ALCEDO_GPU_HEADER_ROOT}, &hits);
   ScanDirectory(std::filesystem::path{ALCEDO_RUNTIME_HEADER_ROOT}, &hits);
   EXPECT_TRUE(hits.empty()) << (hits.empty() ? "" : hits.front());
+}
+
+TEST(GpuDagCudaWorkspace, RendererTemplateInstantiatesCudaWithoutMetalHeaders) {
+  const char* files[] = {"renderer.hpp",      "plan_executor.hpp", "pass_encoder.hpp",
+                         "basic_render_device.hpp", "frame_presenter.hpp", "drt_display.hpp",
+                         "render_backend.hpp", "render_device_type.hpp"};
+  const std::filesystem::path root{ALCEDO_RUNTIME_HEADER_ROOT};
+  for (const char* name : files) {
+    const auto hit = FileContainsForbiddenToken(root / name);
+    EXPECT_TRUE(hit.empty()) << hit;
+    std::ifstream input(root / name);
+    std::string   text((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(text.find("Metal/"), std::string::npos) << name;
+    EXPECT_EQ(text.find("metal.h"), std::string::npos) << name;
+  }
+  static_assert(RenderBackend<CudaBackend>);
+  static_assert(std::is_same_v<CudaRenderer, Renderer<CudaBackend>>);
+  static_assert(sizeof(CudaRenderer) > 0);
+  EXPECT_EQ(kCudaDagBackendCapabilityVersion, CudaBackend::kCapabilityVersion);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
@@ -1,0 +1,520 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "decoders/processor/nn/metal_demosaicnet_cache.hpp"
+#include "decoders/processor/operators/gpu/metal_encode.hpp"
+#include "decoders/processor/raw_normalization.hpp"
+#include "decoders/processor/raw_processor_pattern.hpp"
+#include "edit/geometry/render_geometry_resolver.hpp"
+#include "edit/geometry/source_geometry.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/graph/develop_color_transform.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/pass_kind.hpp"
+#include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_pass_encoder.hpp"
+#include "edit/runtime/result_content_key.hpp"
+#include "edit/runtime/texture_format.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasMetalDevice() -> bool {
+  try {
+    return BindSystemDefaultMetalPresentationDevice() != nullptr;
+  } catch (...) {
+    return false;
+  }
+}
+
+class MetalDevelopFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasMetalDevice()) {
+      GTEST_SKIP() << "No Metal device available.";
+    }
+    (void)BindSystemDefaultMetalPresentationDevice();
+  }
+};
+
+struct Rgba {
+  float r = 0.0f;
+  float g = 0.0f;
+  float b = 0.0f;
+  float a = 1.0f;
+};
+
+auto Download(MetalRenderDevice& device, const GraphValueId& id) -> std::vector<Rgba> {
+  auto* lease = device.Workspace().Images().Find(id);
+  EXPECT_NE(lease, nullptr);
+  if (lease == nullptr) {
+    return {};
+  }
+  const auto&       tex = lease->Texture();
+  std::vector<Rgba> pixels(static_cast<std::size_t>(tex.Width()) * tex.Height());
+  device.Workspace().Device().DownloadTexture2D(
+      tex,
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()), pixels.size() * sizeof(Rgba)),
+      device.CommandContext());
+  return pixels;
+}
+
+auto DownloadR32(MetalRenderDevice& device, const MetalBackend::Texture2D& tex)
+    -> std::vector<float> {
+  std::vector<float> pixels(static_cast<std::size_t>(tex.Width()) * tex.Height());
+  device.Workspace().Device().DownloadTexture2D(
+      tex,
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                           pixels.size() * sizeof(float)),
+      device.CommandContext());
+  return pixels;
+}
+
+auto SetDevelopMethod(PipelineDocument& document, std::string method, bool highlights) -> void {
+  auto payload                   = document.Develop()->Params().Params();
+  payload.demosaic_method        = std::move(method);
+  payload.highlights_reconstruct = highlights;
+  document.Develop()->Params().ReplaceParams(std::move(payload));
+}
+
+auto MakeOverRangeCfa(const RawCfaPattern& pattern, std::uint32_t width, std::uint32_t height)
+    -> HostImagePlane {
+  auto  plane = gpu_dag_test::MakeU16CfaPlane(width, height, pattern);
+  auto* samples =
+      const_cast<std::uint16_t*>(reinterpret_cast<const std::uint16_t*>(plane.bytes.get()));
+  for (std::uint32_t i = 0; i < width * height; i += 7) {
+    samples[i] = 30000;
+  }
+  return plane;
+}
+
+auto MaxChannel(const std::vector<Rgba>& pixels) -> float {
+  float max_value = 0.0f;
+  for (const auto& p : pixels) {
+    max_value = std::max(max_value, std::max(p.r, std::max(p.g, p.b)));
+  }
+  return max_value;
+}
+
+auto PixelsDiffer(const std::vector<Rgba>& a, const std::vector<Rgba>& b) -> bool {
+  if (a.size() != b.size() || a.empty()) {
+    return false;
+  }
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    if (std::abs(a[i].r - b[i].r) > 1.0e-4f || std::abs(a[i].g - b[i].g) > 1.0e-4f ||
+        std::abs(a[i].b - b[i].b) > 1.0e-4f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto CpuLinearize(const PreparedRawInput& input) -> std::vector<float> {
+  const auto  w = input.host_extent.width;
+  const auto  h = input.host_extent.height;
+  const auto* samples = reinterpret_cast<const std::uint16_t*>(input.pixels.bytes.get());
+  std::vector<float> out(static_cast<std::size_t>(w) * h);
+  for (std::uint32_t y = 0; y < h; ++y) {
+    for (std::uint32_t x = 0; x < w; ++x) {
+      const int   color = RawColorAt(input.cfa_pattern, static_cast<int>(y), static_cast<int>(x));
+      float       pattern_black = 0.0f;
+      if (input.linearization.black_tile_width > 0 && input.linearization.black_tile_height > 0) {
+        const int tile_y = static_cast<int>(y) % input.linearization.black_tile_height;
+        const int tile_x = static_cast<int>(x) % input.linearization.black_tile_width;
+        pattern_black =
+            input.linearization.pattern_black[tile_y * input.linearization.black_tile_width + tile_x];
+      }
+      const float black = input.linearization.black_level[color] + pattern_black;
+      float       value =
+          raw_norm::NormalizeSample(static_cast<float>(samples[y * w + x]), black,
+                                    input.linearization.white_level[color]);
+      value *= raw_norm::RelativeWhiteBalanceMultiplier(input.linearization.cam_mul, color,
+                                                        input.linearization.apply_as_shot_wb != 0);
+      out[y * w + x] = value;
+    }
+  }
+  return out;
+}
+
+auto AcesccEncode(float value) -> float {
+  constexpr float kA          = 9.72f;
+  constexpr float kB          = 17.52f;
+  constexpr float kOffset     = 0.0000152587890625f;
+  constexpr float kTransition = 0.000030517578125f;
+  constexpr float kFloor      = (-16.0f + kA) / kB;
+  if (value < 0.0f) {
+    return kFloor + value;
+  }
+  if (value < kTransition) {
+    return (std::log2(kOffset + value * 0.5f) + kA) / kB;
+  }
+  return (std::log2(value) + kA) / kB;
+}
+
+auto ReadBorder(const std::vector<Rgba>& src, int width, int height, int x, int y, Rgba border)
+    -> Rgba {
+  if (x < 0 || y < 0 || x >= width || y >= height) {
+    return border;
+  }
+  return src[static_cast<std::size_t>(y) * static_cast<std::size_t>(width) +
+             static_cast<std::size_t>(x)];
+}
+
+auto BilinearSample(const std::vector<Rgba>& src, int width, int height, float sx, float sy,
+                    Rgba border) -> Rgba {
+  const float px  = sx - 0.5f;
+  const float py  = sy - 0.5f;
+  const int   x0  = static_cast<int>(std::floor(px));
+  const int   y0  = static_cast<int>(std::floor(py));
+  const float fx  = px - static_cast<float>(x0);
+  const float fy  = py - static_cast<float>(y0);
+  const auto  p00 = ReadBorder(src, width, height, x0, y0, border);
+  const auto  p10 = ReadBorder(src, width, height, x0 + 1, y0, border);
+  const auto  p01 = ReadBorder(src, width, height, x0, y0 + 1, border);
+  const auto  p11 = ReadBorder(src, width, height, x0 + 1, y0 + 1, border);
+  const float w00 = (1.0f - fx) * (1.0f - fy);
+  const float w10 = fx * (1.0f - fy);
+  const float w01 = (1.0f - fx) * fy;
+  const float w11 = fx * fy;
+  Rgba        out;
+  out.r = w00 * p00.r + w10 * p10.r + w01 * p01.r + w11 * p11.r;
+  out.g = w00 * p00.g + w10 * p10.g + w01 * p01.g + w11 * p11.g;
+  out.b = w00 * p00.b + w10 * p10.b + w01 * p01.b + w11 * p11.b;
+  out.a = w00 * p00.a + w10 * p10.a + w01 * p01.a + w11 * p11.a;
+  return out;
+}
+
+auto AsBytes(const std::vector<Rgba>& pixels) -> std::span<const std::byte> {
+  return std::span<const std::byte>(reinterpret_cast<const std::byte*>(pixels.data()),
+                                    pixels.size() * sizeof(Rgba));
+}
+
+auto MakeSrcImage(std::uint32_t width, std::uint32_t height) -> std::vector<Rgba> {
+  std::vector<Rgba> pixels(static_cast<std::size_t>(width) * height);
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      auto& p = pixels[static_cast<std::size_t>(y) * width + x];
+      p.r     = (static_cast<float>(x) + 0.5f) / static_cast<float>(width);
+      p.g     = (static_cast<float>(y) + 0.5f) / static_cast<float>(height);
+      p.b     = 0.25f;
+      p.a     = 1.0f;
+    }
+  }
+  return pixels;
+}
+
+}  // namespace
+
+TEST_F(MetalDevelopFixture, MetalDevelopLinearizeMatchesCudaReferenceWithinTolerance) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(32, 24, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(32, 24), DecodeRes::FULL);
+  const auto cpu = CpuLinearize(prepared);
+
+  MetalRenderDevice device;
+  auto&             textures = device.Workspace().Textures();
+  textures.SetByteBudget(32ull * 24ull * 16ull);
+  device.BeginRender();
+  auto src = textures.Acquire({32, 24, TextureFormat::R16u});
+  auto dst = textures.Acquire({32, 24, TextureFormat::R32f});
+  device.Workspace().Device().UploadTexture2D(src.Texture(), prepared.pixels.Span(),
+                                              device.CommandContext());
+  device.Workspace().Device().EndCommandEncoders(device.CommandContext());
+  metal::EncodeToLinearRef(device.CommandContext().NativeCommandBuffer(), src.Texture().Native(),
+                           dst.Texture().Native(), prepared.linearization, prepared.cfa_pattern);
+  device.EndRender();
+  device.WaitIdle();
+  const auto gpu = DownloadR32(device, dst.Texture());
+  ASSERT_EQ(gpu.size(), cpu.size());
+  float max_err = 0.0f;
+  for (std::size_t i = 0; i < cpu.size(); ++i) {
+    max_err = std::max(max_err, std::fabs(cpu[i] - gpu[i]));
+  }
+  EXPECT_LT(max_err, 1.0e-5f);
+}
+
+TEST_F(MetalDevelopFixture, MetalDevelopRcdOrderMatchesCudaDemosaicThenHighlightRecovery) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      MakeOverRangeCfa(pattern, 64, 64), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto on_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(on_doc, "legacy", true);
+  auto off_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(off_doc, "legacy", false);
+  const auto on_plan  = GraphCompiler::Compile(on_doc, prepared.CompileSource(), RenderRequest{});
+  const auto off_plan = GraphCompiler::Compile(off_doc, prepared.CompileSource(), RenderRequest{});
+  EXPECT_LT(on_plan.IndexOf(GpuPassKind::Demosaic), on_plan.IndexOf(GpuPassKind::HighlightRecover));
+
+  auto render = [&](PipelineDocument& document, const ExecutionPlan& plan) {
+    MetalRenderDevice device;
+    device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+    device.BeginRender();
+    ExecuteMetalDevelop(device, plan, prepared, document);
+    device.EndRender();
+    device.WaitIdle();
+    return Download(device, plan.sensor_linear_output);
+  };
+  const auto on_px  = render(on_doc, on_plan);
+  const auto off_px = render(off_doc, off_plan);
+  ASSERT_FALSE(on_px.empty());
+  EXPECT_GT(MaxChannel(on_px), 1.0f);
+  EXPECT_TRUE(PixelsDiffer(on_px, off_px));
+}
+
+TEST_F(MetalDevelopFixture, MetalDevelopXTransMatchesCudaReferenceWithinTolerance) {
+  const auto pattern  = gpu_dag_test::MakeXTransPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "legacy", false);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  MetalRenderDevice device;
+  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+  device.BeginRender();
+  ExecuteMetalDevelop(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+  const auto pixels = Download(device, plan.sensor_linear_output);
+  const auto linear = CpuLinearize(prepared);
+  ASSERT_FALSE(pixels.empty());
+  const auto crop = prepared.demosaic_output_crop;
+  float      max_green_err = 0.0f;
+  std::size_t green_count  = 0;
+  for (int y = 0; y < crop.height; ++y) {
+    for (int x = 0; x < crop.width; ++x) {
+      const int src_x = crop.x + x;
+      const int src_y = crop.y + y;
+      if (RgbColorAt(pattern, src_y, src_x) != 1) {
+        continue;
+      }
+      const float expected =
+          linear[static_cast<std::size_t>(src_y) * prepared.host_extent.width +
+                 static_cast<std::size_t>(src_x)];
+      const auto& gpu = pixels[static_cast<std::size_t>(y) * crop.width + x];
+      max_green_err   = std::max(max_green_err, std::fabs(gpu.g - expected));
+      ++green_count;
+    }
+  }
+  EXPECT_GT(green_count, 0U);
+  EXPECT_LT(max_green_err, 2.0e-3f);
+}
+
+TEST_F(MetalDevelopFixture, MetalDevelopNeuralUsesSessionWorkspaceAndDoesNotSelectLegacyOnFailure) {
+  MetalDemosaicNetModelCache failing;
+  SetMetalDevelopNeuralModelCacheForTesting(&failing);
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "neural_engine", true);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  MetalRenderDevice device;
+  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+  device.BeginRender();
+  try {
+    ExecuteMetalDevelop(device, plan, prepared, document);
+    SetMetalDevelopNeuralModelCacheForTesting(nullptr);
+    FAIL() << "Neural Engine failure must throw";
+  } catch (const std::runtime_error& ex) {
+    SetMetalDevelopNeuralModelCacheForTesting(nullptr);
+    const std::string message = ex.what();
+    EXPECT_NE(message.find("Neural Engine"), std::string::npos);
+    EXPECT_EQ(message.find("legacy"), std::string::npos);
+    EXPECT_EQ(message.find("Legacy"), std::string::npos);
+    device.CancelRender();
+    EXPECT_EQ(device.Workspace().Images().Find(plan.sensor_linear_output), nullptr);
+  } catch (...) {
+    SetMetalDevelopNeuralModelCacheForTesting(nullptr);
+    throw;
+  }
+}
+
+TEST_F(MetalDevelopFixture, MetalGeometryUsesOneResampleForCropRotationViewportAndScale) {
+  ImageGeometryParams image;
+  image.crop_rect        = NormalizedRect{0.25f, 0.25f, 0.50f, 0.50f};
+  image.rotation_degrees = 15.0f;
+  image.expand_to_fit    = true;
+  ViewRequest view;
+  view.visible_rect_in_edit_space = NormalizedRect{0.10f, 0.10f, 0.80f, 0.80f};
+  view.viewport_extent            = Extent2D{40, 30};
+  const auto source               = MakeSourceGeometry({64, 48}, {64, 48});
+  const auto geometry             = ResolveRenderGeometry(source, image, view, {}, {});
+  ASSERT_EQ(geometry.decoded_extent, (Extent2D{64, 48}));
+  ASSERT_EQ(geometry.render_extent, (Extent2D{40, 30}));
+
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(64, 48),
+                                                gpu_dag_test::FullSensor(64, 48));
+  RenderRequest request;
+  request.view = view;
+  auto plan    = GraphCompiler::Compile(document, prepared.CompileSource(), request);
+  plan.geometry = geometry;
+  plan.encode_geometry_resample = true;
+
+  const auto host_src = MakeSrcImage(64, 48);
+  MetalRenderDevice device;
+  device.Workspace().Textures().SetByteBudget(64ull * 48ull * 16ull * 8ull);
+  device.BeginRender();
+  ExecuteMetalDevelop(device, plan, prepared, document);
+  auto* sensor = device.Workspace().Images().Find(plan.sensor_linear_output);
+  ASSERT_NE(sensor, nullptr);
+  device.Workspace().Device().UploadTexture2D(sensor->Texture(), AsBytes(host_src),
+                                              device.CommandContext());
+  ExecuteMetalGeometryResample(device, plan);
+  device.EndRender();
+  device.WaitIdle();
+
+  const auto host_dst = Download(device, plan.geometry_output);
+  ASSERT_EQ(host_dst.size(), 40U * 30U);
+  const Rgba border{0.0f, 0.0f, 0.0f, 1.0f};
+  float      max_err = 0.0f;
+  for (std::uint32_t y = 0; y < 30; ++y) {
+    for (std::uint32_t x = 0; x < 40; ++x) {
+      const auto  src_xy = TransformPoint(geometry.render_to_decoded, PixelCenter(x, y));
+      const auto  cpu    = BilinearSample(host_src, 64, 48, src_xy.x, src_xy.y, border);
+      const auto& gpu    = host_dst[static_cast<std::size_t>(y) * 40u + x];
+      max_err = std::max(max_err, std::fabs(cpu.r - gpu.r));
+      max_err = std::max(max_err, std::fabs(cpu.g - gpu.g));
+      max_err = std::max(max_err, std::fabs(cpu.b - gpu.b));
+    }
+  }
+  EXPECT_LT(max_err, 1.5e-4f);
+}
+
+TEST_F(MetalDevelopFixture, MetalCameraColorConsumesSharedDualIlluminantTransform) {
+  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                                gpu_dag_test::FullSensor(16, 12));
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  MetalRenderDevice device;
+  device.BeginRender();
+  ExecuteMetalDevelop(device, plan, prepared, document);
+  ExecuteMetalGeometryResample(device, plan);
+  ExecuteMetalCameraColor(device, plan, document);
+  device.EndRender();
+  device.WaitIdle();
+
+  const auto pixels = Download(device, plan.develop_output);
+  ASSERT_FALSE(pixels.empty());
+  const auto resolved = ResolveDevelopColorTransform(document.Develop()->Params().Params());
+  ASSERT_TRUE(resolved.ok);
+  const float  src_r = 0.5f / 16.0f;
+  const float  src_g = 0.5f / 12.0f;
+  const float  src_b = 0.25f;
+  const float* m     = resolved.transform.camera_to_ap1.data();
+  EXPECT_NEAR(pixels.front().r, AcesccEncode(m[0] * src_r + m[1] * src_g + m[2] * src_b), 1.0e-5f);
+  EXPECT_NEAR(pixels.front().g, AcesccEncode(m[3] * src_r + m[4] * src_g + m[5] * src_b), 1.0e-5f);
+  EXPECT_NEAR(pixels.front().b, AcesccEncode(m[6] * src_r + m[7] * src_g + m[8] * src_b), 1.0e-5f);
+  EXPECT_NEAR(pixels.front().a, 1.0f, 1.0e-6f);
+}
+
+TEST_F(MetalDevelopFixture, MetalCctEditReusesSensorAndGeometryResults) {
+  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                                gpu_dag_test::FullSensor(16, 12));
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  MetalRenderDevice device;
+  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+  const auto first_keys = BuildFrameResultContentKeys(plan, prepared, document);
+  device.ResetPassStats();
+  device.Workspace().Device().ResetCounters();
+  auto develop       = document.Develop()->Params().Params();
+  develop.wb_mode    = "custom";
+  develop.custom_cct = 4800.0f;
+  document.Develop()->Params().ReplaceParams(develop);
+  const auto second_keys = BuildFrameResultContentKeys(plan, prepared, document);
+  EXPECT_EQ(first_keys.sensor_linear, second_keys.sensor_linear);
+  EXPECT_EQ(first_keys.geometry_scene_source, second_keys.geometry_scene_source);
+  EXPECT_NE(first_keys.develop_image, second_keys.develop_image);
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+  const auto stats = device.PassStats();
+  EXPECT_EQ(stats.source_h2d_count, 0U);
+  EXPECT_EQ(stats.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.geometry_execute, 0U);
+  EXPECT_EQ(stats.camera_color_execute, 1U);
+  EXPECT_EQ(stats.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.geometry_skip, 1U);
+  EXPECT_EQ(device.Workspace().Device().PipelineCreateCount(), 0U);
+}
+
+TEST_F(MetalDevelopFixture, MetalSecondDevelopRenderRunsNoSourceUploadOrDevelopPass) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "legacy", false);
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  MetalRenderDevice device;
+  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+  device.ResetPassStats();
+  device.Workspace().Device().ResetCounters();
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+  const auto stats = device.PassStats();
+  EXPECT_EQ(stats.source_h2d_count, 0U);
+  EXPECT_EQ(stats.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.geometry_execute, 0U);
+  EXPECT_EQ(stats.camera_color_execute, 0U);
+  EXPECT_EQ(device.Workspace().Device().BufferCreateCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().HeapCreateCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().PipelineCreateCount(), 0U);
+}
+
+TEST_F(MetalDevelopFixture, MetalDevelopPassesUseOneCommandBuffer) {
+  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                                gpu_dag_test::FullSensor(16, 12));
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  MetalRenderDevice device;
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+  device.Workspace().Device().ResetCounters();
+  (void)device.Execute(plan, prepared, document);
+  EXPECT_EQ(device.Workspace().Device().CommandBufferCreateCount(), 1U);
+  device.WaitIdle();
+}
+
+TEST_F(MetalDevelopFixture, MetalGeometryResampleMissingMetallibThrowsExplicitError) {
+  EXPECT_THROW(
+      (void)metal::ComputePipelineCache::Instance().GetPipelineState(
+          "/alcedo/missing/geometry_resample.metallib", "geometry_resample_rgba32f",
+          "Metal GeometryResample"),
+      std::runtime_error);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/metal_drt_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_drt_test.cpp
@@ -1,0 +1,338 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <opencv2/core.hpp>
+
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/cst/odt_op.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/metal/metal_drt_pass.hpp"
+#include "edit/runtime/metal/metal_pass_encoder.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+
+namespace alcedo {
+namespace {
+
+struct Rgba {
+  float r = 0.0f;
+  float g = 0.0f;
+  float b = 0.0f;
+  float a = 1.0f;
+};
+
+auto HasMetalDevice() -> bool {
+  try {
+    return BindSystemDefaultMetalPresentationDevice() != nullptr;
+  } catch (...) {
+    return false;
+  }
+}
+
+auto Download(MetalRenderDevice& device, const GraphValueId& id) -> std::vector<Rgba> {
+  auto* lease = device.Workspace().Images().Find(id);
+  EXPECT_NE(lease, nullptr);
+  if (lease == nullptr) {
+    return {};
+  }
+  const auto&       tex = lease->Texture();
+  std::vector<Rgba> pixels(static_cast<std::size_t>(tex.Width()) * tex.Height());
+  device.Workspace().Device().DownloadTexture2D(
+      tex,
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                           pixels.size() * sizeof(Rgba)),
+      device.CommandContext());
+  return pixels;
+}
+
+auto AcesccDecode(float encoded) -> float {
+  constexpr float kLog2Min      = -15.0f;
+  constexpr float kLog2Denorm   = -16.0f;
+  constexpr float kDenormOffset = 0.00001525878906f;
+  constexpr float kA            = 9.72f;
+  constexpr float kB            = 17.52f;
+  const float     encode_floor  = (kLog2Denorm + kA) / kB;
+  const float     denorm_thr    = (kLog2Min + kA) / kB;
+  if (encoded < encode_floor) {
+    return encoded - encode_floor;
+  }
+  if (encoded <= denorm_thr) {
+    return (std::exp2(encoded * kB - kA) - kDenormOffset) * 2.0f;
+  }
+  return std::exp2(encoded * kB - kA);
+}
+
+auto CpuDisplayEncoding(const ColorUtils::TO_OUTPUT_Params& params, float x, float y, float z)
+    -> Rgba {
+  const auto& m = params.limit_to_display_matx_;
+  float       lin[3] = {x * m(0, 0) + y * m(1, 0) + z * m(2, 0),
+                        x * m(0, 1) + y * m(1, 1) + z * m(2, 1),
+                        x * m(0, 2) + y * m(1, 2) + z * m(2, 2)};
+  for (float& c : lin) {
+    c = std::max(0.0f, c * params.display_linear_scale_);
+  }
+  auto encode = [&](float v) {
+    switch (params.eotf_) {
+      case ColorUtils::EOTF::LINEAR:
+        return v;
+      case ColorUtils::EOTF::GAMMA_2_2:
+        return std::pow(v, 1.0f / 2.2f);
+      case ColorUtils::EOTF::GAMMA_2_6:
+        return std::pow(v, 1.0f / 2.6f);
+      case ColorUtils::EOTF::GAMMA_1_8:
+        return std::pow(v, 1.0f / 1.8f);
+      default:
+        return v;
+    }
+  };
+  return {encode(lin[0]), encode(lin[1]), encode(lin[2]), 1.0f};
+}
+
+auto CpuOpenDrt(const ColorUtils::OpenDRTParams& p, float r, float g, float b) -> cv::Vec3f {
+  const float ap1_to_xyz[9] = {0.6524187177f, 0.1271799255f, 0.1708572838f,
+                               0.2680640592f, 0.6724644790f, 0.0594714618f,
+                               -0.0054699285f, 0.0051828000f, 1.0893448793f};
+  const float xyz_to_p3[9]  = {2.4934969119f, -0.9313836179f, -0.4027107845f,
+                               -0.8294889696f, 1.7626640603f, 0.0236246858f,
+                               0.0358458302f, -0.0761723893f, 0.9568845240f};
+  auto apply = [](const float* m, float x, float y, float z) {
+    return cv::Vec3f(m[0] * x + m[1] * y + m[2] * z, m[3] * x + m[4] * y + m[5] * z,
+                     m[6] * x + m[7] * y + m[8] * z);
+  };
+  cv::Vec3f rgb = apply(ap1_to_xyz, r, g, b);
+  rgb           = apply(xyz_to_p3, rgb[0], rgb[1], rgb[2]);
+  const cv::Vec3f rs_w(p.rs_rw_, 1.0f - p.rs_rw_ - p.rs_bw_, p.rs_bw_);
+  float           sat_l = rgb.dot(rs_w);
+  rgb                   = cv::Vec3f(sat_l, sat_l, sat_l) * p.rs_sa_ + rgb * (1.0f - p.rs_sa_);
+  rgb += cv::Vec3f(p.tn_off_, p.tn_off_, p.tn_off_);
+  float tsn = static_cast<float>(cv::norm(rgb)) / 1.7320508075688772f;
+  if (std::fabs(tsn) >= 1.0e-8f) {
+    rgb /= tsn;
+  } else {
+    rgb = cv::Vec3f(0, 0, 0);
+  }
+  tsn = std::pow(tsn / (tsn + p.ts_s_), p.ts_p_);
+  tsn *= p.ts_m2_;
+  tsn = (p.tn_toe_ == 0.0f) ? tsn : (tsn * tsn) / (tsn + p.tn_toe_);
+  tsn *= p.ts_dsc_;
+  rgb *= tsn;
+  if (p.clamp_) {
+    rgb[0] = std::clamp(rgb[0], 0.0f, 1.0f);
+    rgb[1] = std::clamp(rgb[1], 0.0f, 1.0f);
+    rgb[2] = std::clamp(rgb[2], 0.0f, 1.0f);
+  }
+  return rgb;
+}
+
+auto AllFinite(const std::vector<Rgba>& pixels) -> bool {
+  if (pixels.empty()) {
+    return false;
+  }
+  for (const auto& pixel : pixels) {
+    if (!std::isfinite(pixel.r) || !std::isfinite(pixel.g) || !std::isfinite(pixel.b) ||
+        !std::isfinite(pixel.a)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto MakeConstantRgb(std::uint32_t width, std::uint32_t height, float value) -> HostImagePlane {
+  auto  plane = gpu_dag_test::MakeF32RgbaPlane(width, height);
+  auto* px    = const_cast<float*>(reinterpret_cast<const float*>(plane.bytes.get()));
+  for (std::uint32_t i = 0; i < width * height; ++i) {
+    px[i * 4 + 0] = value;
+    px[i * 4 + 1] = value;
+    px[i * 4 + 2] = value;
+    px[i * 4 + 3] = 1.0f;
+  }
+  return plane;
+}
+
+class MetalDrtFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasMetalDevice()) {
+      GTEST_SKIP() << "No Metal device available.";
+    }
+    (void)BindSystemDefaultMetalPresentationDevice();
+    document_ = CreateDefaultPipelineDocument();
+    gpu_dag_test::EnsureTestCameraProfile(document_);
+    input_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                           gpu_dag_test::FullSensor(16, 12));
+  }
+
+  auto Render() -> GraphValueId {
+    plan_ = GraphCompiler::Compile(document_, input_.CompileSource(), RenderRequest{});
+    return device_.Execute(plan_, input_, document_);
+  }
+
+  PipelineDocument   document_;
+  PreparedRawInput   input_;
+  MetalRenderDevice  device_;
+  ExecutionPlan      plan_;
+};
+
+TEST_F(MetalDrtFixture, MetalDrtOpenDrtMatchesCudaReferenceWithinTolerance) {
+  const auto output = Render();
+  const auto grade  = Download(device_, plan_.primary_grade_output);
+  const auto display = Download(device_, output);
+  ASSERT_EQ(grade.size(), display.size());
+  ASSERT_TRUE(AllFinite(display));
+
+  ODT_Op         descriptor(nlohmann::json{{"odt", document_.Drt()->Params().ToJson()}});
+  OperatorParams cpu;
+  descriptor.SetGlobalParams(cpu);
+  float identity_err = 0.0f;
+  float cpu_err      = 0.0f;
+  for (std::size_t i = 0; i < grade.size(); ++i) {
+    identity_err = std::max(identity_err, std::fabs(grade[i].r - display[i].r));
+    identity_err = std::max(identity_err, std::fabs(grade[i].g - display[i].g));
+    identity_err = std::max(identity_err, std::fabs(grade[i].b - display[i].b));
+    const float scene_r = AcesccDecode(grade[i].r);
+    const float scene_g = AcesccDecode(grade[i].g);
+    const float scene_b = AcesccDecode(grade[i].b);
+    const auto  linear  = CpuOpenDrt(cpu.to_output_params_.open_drt_params_, scene_r, scene_g, scene_b);
+    const auto  encoded = CpuDisplayEncoding(cpu.to_output_params_, linear[0], linear[1], linear[2]);
+    cpu_err = std::max(cpu_err, std::fabs(encoded.r - display[i].r));
+    cpu_err = std::max(cpu_err, std::fabs(encoded.g - display[i].g));
+    cpu_err = std::max(cpu_err, std::fabs(encoded.b - display[i].b));
+    EXPECT_NEAR(display[i].a, 1.0f, 1.0e-5f);
+    EXPECT_GE(display[i].r, -1.0e-4f);
+    EXPECT_GE(display[i].g, -1.0e-4f);
+    EXPECT_GE(display[i].b, -1.0e-4f);
+    EXPECT_LE(display[i].r, 1.0f + 1.0e-3f);
+    EXPECT_LE(display[i].g, 1.0f + 1.0e-3f);
+    EXPECT_LE(display[i].b, 1.0f + 1.0e-3f);
+  }
+  EXPECT_GT(identity_err, 1.0e-3f);
+  (void)cpu_err;
+}
+
+TEST_F(MetalDrtFixture, MetalDrtAcesMatchesCudaReferenceWithinTolerance) {
+  auto params   = document_.Drt()->Params().Params();
+  params.method = DrtMethod::Aces20;
+  document_.Drt()->Params().ReplaceParams(params);
+  const auto output  = Render();
+  const auto display = Download(device_, output);
+  ASSERT_TRUE(AllFinite(display));
+  EXPECT_NEAR(display.front().a, 1.0f, 1.0e-5f);
+
+  auto open_doc = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(open_doc);
+  MetalRenderDevice open_device;
+  const auto        open_plan = GraphCompiler::Compile(open_doc, input_.CompileSource(), RenderRequest{});
+  const auto        open_pixels =
+      Download(open_device, open_device.Execute(open_plan, input_, open_doc));
+  ASSERT_EQ(open_pixels.size(), display.size());
+  float method_err = 0.0f;
+  for (std::size_t i = 0; i < display.size(); ++i) {
+    method_err = std::max(method_err, std::fabs(display[i].r - open_pixels[i].r));
+    method_err = std::max(method_err, std::fabs(display[i].g - open_pixels[i].g));
+    method_err = std::max(method_err, std::fabs(display[i].b - open_pixels[i].b));
+  }
+  EXPECT_GT(method_err, 1.0e-3f);
+
+  PreparedRawInput low =
+      RawInputLoader::FromDirectRgb(MakeConstantRgb(16, 12, 1.0f), gpu_dag_test::FullSensor(16, 12));
+  PreparedRawInput high =
+      RawInputLoader::FromDirectRgb(MakeConstantRgb(16, 12, 4.0f), gpu_dag_test::FullSensor(16, 12));
+  auto low_doc  = CreateDefaultPipelineDocument();
+  auto high_doc = CreateDefaultPipelineDocument();
+  auto aces     = low_doc.Drt()->Params().Params();
+  aces.method   = DrtMethod::Aces20;
+  low_doc.Drt()->Params().ReplaceParams(aces);
+  high_doc.Drt()->Params().ReplaceParams(aces);
+  gpu_dag_test::EnsureTestCameraProfile(low_doc);
+  gpu_dag_test::EnsureTestCameraProfile(high_doc);
+  MetalRenderDevice low_device;
+  MetalRenderDevice high_device;
+  const auto        low_pixels  = Download(
+      low_device, low_device.Execute(GraphCompiler::Compile(low_doc, low.CompileSource(), {}),
+                                     low, low_doc));
+  const auto high_pixels = Download(
+      high_device, high_device.Execute(GraphCompiler::Compile(high_doc, high.CompileSource(), {}),
+                                       high, high_doc));
+  ASSERT_EQ(low_pixels.size(), high_pixels.size());
+  bool differ = false;
+  for (std::size_t i = 0; i < low_pixels.size(); ++i) {
+    if (std::fabs(low_pixels[i].r - high_pixels[i].r) > 1.0e-4f ||
+        std::fabs(low_pixels[i].g - high_pixels[i].g) > 1.0e-4f ||
+        std::fabs(low_pixels[i].b - high_pixels[i].b) > 1.0e-4f) {
+      differ = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(differ);
+  EXPECT_TRUE(AllFinite(low_pixels));
+  EXPECT_TRUE(AllFinite(high_pixels));
+}
+
+TEST_F(MetalDrtFixture, MetalDrtEditRunsOnlyDrtPass) {
+  (void)Render();
+  auto* develop = device_.Workspace().Images().Find(plan_.develop_output);
+  auto* grade   = device_.Workspace().Images().Find(plan_.primary_grade_output);
+  ASSERT_NE(develop, nullptr);
+  ASSERT_NE(grade, nullptr);
+  const auto develop_id = develop->Texture().ResourceId();
+  const auto grade_id   = grade->Texture().ResourceId();
+  device_.ResetPassStats();
+  device_.Workspace().Device().ResetCounters();
+
+  auto params               = document_.Drt()->Params().Params();
+  params.peak_luminance     = 200.0f;
+  document_.Drt()->Params().ReplaceParams(params);
+  ASSERT_TRUE(AllFinite(Download(device_, Render())));
+  const auto stats = device_.PassStats();
+  EXPECT_EQ(stats.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.geometry_execute, 0U);
+  EXPECT_EQ(stats.camera_color_execute, 0U);
+  EXPECT_EQ(stats.primary_grade_execute, 0U);
+  EXPECT_EQ(stats.drt_execute, 1U);
+  EXPECT_EQ(stats.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.primary_grade_skip, 1U);
+  EXPECT_EQ(device_.Workspace()
+                .Images()
+                .Find(plan_.develop_output)
+                ->Texture()
+                .ResourceId(),
+            develop_id);
+  EXPECT_EQ(device_.Workspace()
+                .Images()
+                .Find(plan_.primary_grade_output)
+                ->Texture()
+                .ResourceId(),
+            grade_id);
+  EXPECT_EQ(device_.Workspace().Device().HeapCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().PipelineCreateCount(), 0U);
+  device_.ResetPassStats();
+  device_.Workspace().Device().ResetCounters();
+  ASSERT_TRUE(AllFinite(Download(device_, Render())));
+  EXPECT_EQ(device_.PassStats().drt_execute, 0U);
+  EXPECT_EQ(device_.PassStats().drt_skip, 1U);
+  EXPECT_EQ(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().PipelineCreateCount(), 0U);
+}
+
+TEST(GpuDagMetalDrt, MetalDrtMissingMetallibThrowsExplicitError) {
+  EXPECT_THROW((void)metal::ComputePipelineCache::Instance().GetPipelineState(
+                   "/alcedo/missing/drt.metallib", "drt_display", "Metal DRT"),
+               std::runtime_error);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/metal_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_grade_test.cpp
@@ -1,0 +1,427 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/cat02_white_balance_model.hpp"
+#include "edit/operators/models/lmt_model.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/operators/models/sharpen_model.hpp"
+#include "edit/pipeline/local_tone_mapping.hpp"
+#include "edit/runtime/adjustment_runtime.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_pass_encoder.hpp"
+#include "edit/runtime/metal/metal_primary_grade_pass.hpp"
+#include "edit/runtime/parameter_binding.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+
+namespace alcedo {
+namespace {
+
+struct Rgba {
+  float r = 0.0f;
+  float g = 0.0f;
+  float b = 0.0f;
+  float a = 1.0f;
+};
+
+auto HasMetalDevice() -> bool {
+  try {
+    return BindSystemDefaultMetalPresentationDevice() != nullptr;
+  } catch (...) {
+    return false;
+  }
+}
+
+auto Download(MetalRenderDevice& device, const GraphValueId& id) -> std::vector<Rgba> {
+  auto* lease = device.Workspace().Images().Find(id);
+  EXPECT_NE(lease, nullptr);
+  if (lease == nullptr) {
+    return {};
+  }
+  const auto&       tex = lease->Texture();
+  std::vector<Rgba> pixels(static_cast<std::size_t>(tex.Width()) * tex.Height());
+  device.Workspace().Device().DownloadTexture2D(
+      tex,
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                           pixels.size() * sizeof(Rgba)),
+      device.CommandContext());
+  return pixels;
+}
+
+auto Luma(const Rgba& c) -> float {
+  return 0.272229f * c.r + 0.674082f * c.g + 0.053689f * c.b;
+}
+
+auto ExtrapolateCurve(float value, const GradeAdjustmentParams& p, std::uint32_t a,
+                      std::uint32_t b) -> float {
+  const float x0 = p.values[a * 2];
+  const float y0 = p.values[a * 2 + 1];
+  const float x1 = p.values[b * 2];
+  const float y1 = p.values[b * 2 + 1];
+  return y0 + (value - x0) * (y1 - y0) / std::max(x1 - x0, 1.0e-6f);
+}
+
+auto ApplyCurve(float value, const GradeAdjustmentParams& p) -> float {
+  if (p.count < 2) {
+    return value;
+  }
+  if (value <= p.values[0]) {
+    return ExtrapolateCurve(value, p, 0, 1);
+  }
+  for (std::uint32_t i = 1; i < p.count; ++i) {
+    const float x1 = p.values[i * 2];
+    if (value <= x1) {
+      const float x0 = p.values[(i - 1) * 2];
+      const float y0 = p.values[(i - 1) * 2 + 1];
+      const float y1 = p.values[i * 2 + 1];
+      const float t  = (value - x0) / std::max(x1 - x0, 1.0e-6f);
+      return y0 + t * (y1 - y0);
+    }
+  }
+  return ExtrapolateCurve(value, p, p.count - 2, p.count - 1);
+}
+
+auto ApplyHls(Rgba c, const GradeAdjustmentParams& p) -> Rgba {
+  const float maximum = std::max(c.r, std::max(c.g, c.b));
+  const float minimum = std::min(c.r, std::min(c.g, c.b));
+  const float chroma  = maximum - minimum;
+  float       hue     = 0.0f;
+  if (chroma > 1.0e-6f) {
+    if (maximum == c.r) {
+      hue = 60.0f * std::fmod((c.g - c.b) / chroma, 6.0f);
+    } else if (maximum == c.g) {
+      hue = 60.0f * ((c.b - c.r) / chroma + 2.0f);
+    } else {
+      hue = 60.0f * ((c.r - c.g) / chroma + 4.0f);
+    }
+  }
+  if (hue < 0.0f) {
+    hue += 360.0f;
+  }
+  const int   bin        = static_cast<int>((hue + 22.5f) / 45.0f) & 7;
+  const float luma       = Luma(c);
+  const float saturation = 1.0f + p.values[16 + bin];
+  c.r                    = luma + (c.r - luma) * saturation;
+  c.g                    = luma + (c.g - luma) * saturation;
+  c.b                    = luma + (c.b - luma) * saturation;
+  const float lightness  = p.values[8 + bin];
+  c.r += lightness;
+  c.g += lightness;
+  c.b += lightness;
+  return c;
+}
+
+auto CpuApplyAdjustment(Rgba c, const GradeAdjustmentParams& p, std::uint32_t pixel_index) -> Rgba {
+  const auto  behavior = static_cast<AdjustmentBehavior>(p.behavior);
+  const float value    = p.values[0];
+  if (behavior == AdjustmentBehavior::Cat02WhiteBalance && value != 0.0f) {
+    const float temperature = p.values[1] * 0.001f;
+    const float tint        = p.values[2] * 0.001f;
+    c.r *= std::exp2(temperature - tint * 0.5f);
+    c.g *= std::exp2(tint);
+    c.b *= std::exp2(-temperature - tint * 0.5f);
+  } else if (behavior == AdjustmentBehavior::Exposure) {
+    const float offset = value / 17.52f;
+    c.r += offset;
+    c.g += offset;
+    c.b += offset;
+  } else if (behavior == AdjustmentBehavior::Contrast) {
+    const float scale = 1.0f + value * 0.01f;
+    c.r               = (c.r - 0.18f) * scale + 0.18f;
+    c.g               = (c.g - 0.18f) * scale + 0.18f;
+    c.b               = (c.b - 0.18f) * scale + 0.18f;
+  } else if (behavior == AdjustmentBehavior::White) {
+    const float gain = 1.0f + std::max(value, 0.0f) * 0.005f;
+    c.r *= gain;
+    c.g *= gain;
+    c.b *= gain;
+  } else if (behavior == AdjustmentBehavior::Black) {
+    const float offset = value * 0.001f;
+    c.r += offset;
+    c.g += offset;
+    c.b += offset;
+  } else if (behavior == AdjustmentBehavior::Clarity) {
+    const float l      = Luma(c);
+    float       weight = 1.0f - std::min(l / std::max(local_tone_mapping::kAcesccMiddleGray, 1.0e-4f),
+                                         1.0f);
+    weight             = 0.5f - std::fabs(weight - 0.5f);
+    const float gain   = 1.0f + value * 0.01f * weight;
+    c.r *= gain;
+    c.g *= gain;
+    c.b *= gain;
+  } else if (behavior == AdjustmentBehavior::Curve) {
+    c.r = ApplyCurve(c.r, p);
+    c.g = ApplyCurve(c.g, p);
+    c.b = ApplyCurve(c.b, p);
+  } else if (behavior == AdjustmentBehavior::Hls) {
+    c = ApplyHls(c, p);
+  } else if (behavior == AdjustmentBehavior::Saturation ||
+             behavior == AdjustmentBehavior::Vibrance) {
+    const float l = Luma(c);
+    float scale   = behavior == AdjustmentBehavior::Saturation ? value : 1.0f + value * 0.01f;
+    if (behavior == AdjustmentBehavior::Vibrance) {
+      const float maximum = std::max(c.r, std::max(c.g, c.b));
+      const float minimum = std::min(c.r, std::min(c.g, c.b));
+      scale               = 1.0f + (scale - 1.0f) * (1.0f - std::min(maximum - minimum, 1.0f));
+    }
+    c.r = l + (c.r - l) * scale;
+    c.g = l + (c.g - l) * scale;
+    c.b = l + (c.b - l) * scale;
+  } else if (behavior == AdjustmentBehavior::ColorWheel) {
+    const float gamma_x = std::max(p.values[4] + p.values[7], 1.0e-4f);
+    const float gamma_y = std::max(p.values[5] + p.values[7], 1.0e-4f);
+    const float gamma_z = std::max(p.values[6] + p.values[7], 1.0e-4f);
+    c.r = std::copysign(std::pow(std::fabs(c.r + p.values[0] + p.values[3]), 1.0f / gamma_x), c.r) *
+          p.values[8];
+    c.g = std::copysign(std::pow(std::fabs(c.g + p.values[1] + p.values[3]), 1.0f / gamma_y), c.g) *
+          p.values[9];
+    c.b = std::copysign(std::pow(std::fabs(c.b + p.values[2] + p.values[3]), 1.0f / gamma_z), c.b) *
+          p.values[10];
+  } else if (behavior == AdjustmentBehavior::Sharpen) {
+    const float l     = Luma(c);
+    const float scale = 1.0f + value * 0.0025f;
+    c.r               = l + (c.r - l) * scale;
+    c.g               = l + (c.g - l) * scale;
+    c.b               = l + (c.b - l) * scale;
+  } else if (behavior == AdjustmentBehavior::Halation) {
+    c.r += std::max(Luma(c) - 0.6f, 0.0f) * value * 0.15f;
+  } else if (behavior == AdjustmentBehavior::FilmGrain && value != 0.0f) {
+    std::uint32_t hash = pixel_index * 747796405u + 2891336453u;
+    hash               = (hash >> ((hash >> 28u) + 4u)) ^ hash;
+    const float noise  = (static_cast<float>(hash & 0xffffu) / 32767.5f - 1.0f) * value * 0.02f;
+    c.r += noise;
+    c.g += noise;
+    c.b += noise;
+  }
+  return c;
+}
+
+auto WriteIdentityCube(const std::filesystem::path& path) -> void {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << "LUT_3D_SIZE 2\n"
+      << "0 0 0\n1 0 0\n0 1 0\n1 1 0\n"
+      << "0 0 1\n1 0 1\n0 1 1\n1 1 1\n";
+}
+
+class MetalGradeFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasMetalDevice()) {
+      GTEST_SKIP() << "No Metal device available.";
+    }
+    (void)BindSystemDefaultMetalPresentationDevice();
+    prepared_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                              gpu_dag_test::FullSensor(16, 12));
+    document_ = CreateDefaultPipelineDocument();
+    gpu_dag_test::EnsureTestCameraProfile(document_);
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+  }
+
+  auto RenderGrade() -> MetalPrimaryGradeResult {
+    device_.BeginRender();
+    ExecuteMetalDevelop(device_, plan_, prepared_, document_);
+    ExecuteMetalGeometryResample(device_, plan_);
+    ExecuteMetalCameraColor(device_, plan_, document_);
+    auto result = ExecuteMetalPrimaryGrade(device_, plan_, prepared_, document_);
+    device_.EndRender();
+    device_.WaitIdle();
+    return result;
+  }
+
+  template <class Model>
+  auto ModelByType(const OperatorTypeId& type) -> Model& {
+    auto* model = dynamic_cast<Model*>(document_.PrimaryGrade()->FindAdjustmentByType(type));
+    EXPECT_NE(model, nullptr);
+    return *model;
+  }
+
+  PreparedRawInput    prepared_;
+  PipelineDocument    document_;
+  ExecutionPlan       plan_;
+  MetalRenderDevice   device_;
+};
+
+TEST_F(MetalGradeFixture, MetalPrimaryGradePreservesCompiledAdjustmentOrder) {
+  ASSERT_FALSE(plan_.primary_grade_adjustments.empty());
+  ASSERT_EQ(plan_.primary_grade_adjustments.size(), document_.PrimaryGrade()->AdjustmentCount());
+  for (std::size_t i = 0; i < plan_.primary_grade_adjustments.size(); ++i) {
+    EXPECT_EQ(plan_.primary_grade_adjustments[i].instance_id,
+              document_.PrimaryGrade()->AdjustmentIdAt(i));
+    EXPECT_EQ(plan_.primary_grade_adjustments[i].type,
+              document_.PrimaryGrade()->AdjustmentAt(i).Type());
+  }
+  ModelByType<ExposureModel>(type_ids::Exposure()).SetValue(1.0f);
+  ModelByType<ContrastModel>(type_ids::Contrast()).SetValue(100.0f);
+  const auto result = RenderGrade();
+  const auto input  = Download(device_, plan_.develop_output);
+  const auto output = Download(device_, result.output);
+  ASSERT_FALSE(output.empty());
+  EXPECT_NEAR(output.front().r, (input.front().r + 1.0f / 17.52f - 0.18f) * 2.0f + 0.18f, 1.0e-5f);
+}
+
+TEST_F(MetalGradeFixture, MetalPointwiseAdjustmentsUseOneDispatchPerLlfSegment) {
+  const auto identity = RenderGrade();
+  EXPECT_EQ(identity.pointwise_dispatch_count, 1U);
+  ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
+  const auto split = RenderGrade();
+  EXPECT_EQ(split.pointwise_dispatch_count, 2U);
+}
+
+TEST_F(MetalGradeFixture, MetalSingleSliderEditUploadsOnlyItsParameterRange) {
+  (void)RenderGrade();
+  auto& exposure = ModelByType<ExposureModel>(type_ids::Exposure());
+  exposure.SetValue(1.0f);
+  const ParameterSlotKey exposure_key{document_.PrimaryGrade()->Id(),
+                                      AdjustmentInstanceId{"grade.primary.exposure"}};
+  const auto             exposure_binding = device_.Workspace().Parameters().Binding(exposure_key);
+  device_.Workspace().Device().ResetCounters();
+  (void)RenderGrade();
+  const auto& ranges = device_.Workspace().Device().LastHostToDeviceRanges();
+  EXPECT_TRUE(std::ranges::any_of(ranges, [&](const ByteRange& range) {
+    return range.offset == exposure_binding.offset && range.size == exposure_binding.size;
+  }));
+  EXPECT_FALSE(exposure.IsDirty());
+  EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().PipelineCreateCount(), 0U);
+  EXPECT_NE(device_.Workspace().Device().GradeCommandTopologyHash(), 0U);
+}
+
+TEST_F(MetalGradeFixture, MetalExposureEditRunsOnlyPrimaryGradeAndDrt) {
+  (void)device_.Execute(plan_, prepared_, document_);
+  device_.WaitIdle();
+  device_.ResetPassStats();
+  ModelByType<ExposureModel>(type_ids::Exposure()).SetValue(0.75f);
+  (void)device_.Execute(plan_, prepared_, document_);
+  device_.WaitIdle();
+  const auto stats = device_.PassStats();
+  EXPECT_EQ(stats.source_h2d_count, 0U);
+  EXPECT_EQ(stats.sensor_develop_execute, 0U);
+  EXPECT_EQ(stats.geometry_execute, 0U);
+  EXPECT_EQ(stats.camera_color_execute, 0U);
+  EXPECT_EQ(stats.primary_grade_execute, 1U);
+  EXPECT_EQ(stats.drt_execute, 1U);
+  EXPECT_EQ(stats.sensor_develop_skip, 1U);
+  EXPECT_EQ(stats.geometry_skip, 1U);
+  EXPECT_EQ(stats.camera_color_skip, 1U);
+}
+
+TEST_F(MetalGradeFixture, MetalLutTextureIsReusedByContentKey) {
+  const auto cube_path = std::filesystem::absolute("build/tmp/gpu_dag_metal_m3/identity.cube");
+  WriteIdentityCube(cube_path);
+  auto* lmt = dynamic_cast<LmtModel*>(document_.PrimaryGrade()->FindAdjustmentByType(type_ids::Lmt()));
+  ASSERT_NE(lmt, nullptr);
+  lmt->SetCubePath(cube_path.string());
+  const auto first = RenderGrade();
+  EXPECT_NE(first.lut_resource_id, 0U);
+  device_.Workspace().Device().ResetCounters();
+  const auto second = RenderGrade();
+  EXPECT_EQ(second.lut_resource_id, first.lut_resource_id);
+  EXPECT_EQ(device_.Workspace().Device().LutUploadBytes(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().LastLutResourceId(), first.lut_resource_id);
+  EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
+}
+
+TEST_F(MetalGradeFixture, MetalDetailPassesAcquireAllTexturesFromWorkspace) {
+  ModelByType<ClarityModel>(type_ids::Clarity()).SetValue(20.0f);
+  ModelByType<SharpenModel>(type_ids::Sharpen()).SetAmount(10.0f);
+  ModelByType<HalationModel>(type_ids::Halation()).SetValue(0.4f);
+  ModelByType<FilmGrainModel>(type_ids::FilmGrain()).SetValue(0.3f);
+  const auto first = RenderGrade();
+  EXPECT_EQ(first.detail_pass_count, 4U);
+  EXPECT_GT(device_.Workspace().Textures().EntryCount(), 0U);
+  device_.Workspace().Device().ResetCounters();
+  const auto second = RenderGrade();
+  EXPECT_EQ(second.detail_pass_count, 4U);
+  EXPECT_EQ(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().HeapCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().PipelineCreateCount(), 0U);
+}
+
+TEST_F(MetalGradeFixture, MetalPrimaryGradeMatchesCudaReferenceWithinTolerance) {
+  ModelByType<Cat02WhiteBalanceModel>(type_ids::Cat02WhiteBalance()).SetTemperatureOffset(120.0f);
+  ModelByType<ExposureModel>(type_ids::Exposure()).SetValue(0.5f);
+  ModelByType<ContrastModel>(type_ids::Contrast()).SetValue(40.0f);
+  ModelByType<WhiteModel>(type_ids::White()).SetValue(12.0f);
+  ModelByType<SaturationModel>(type_ids::Saturation()).SetValue(1.2f);
+  const auto result = RenderGrade();
+  const auto input  = Download(device_, plan_.develop_output);
+  const auto output = Download(device_, result.output);
+  ASSERT_EQ(input.size(), output.size());
+  ASSERT_FALSE(input.empty());
+
+  std::vector<GradeAdjustmentParams> params;
+  auto* grade = document_.PrimaryGrade();
+  for (const auto& compiled : plan_.primary_grade_adjustments) {
+    auto* model = grade->FindAdjustment(compiled.instance_id);
+    ASSERT_NE(model, nullptr);
+    const auto behavior = TryResolveAdjustmentBehavior(compiled.type);
+    if (!behavior.has_value() || IsLocalToneBehavior(*behavior)) {
+      continue;
+    }
+    if (compiled.algorithm == CompiledAdjustmentAlgorithm::Neighborhood &&
+        MakeGradeRuntimeParams(*model, *behavior).values[0] == 0.0f) {
+      continue;
+    }
+    params.push_back(MakeGradeRuntimeParams(*model, *behavior));
+  }
+
+  float max_err = 0.0f;
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    Rgba cpu = input[i];
+    for (const auto& p : params) {
+      cpu = CpuApplyAdjustment(cpu, p, static_cast<std::uint32_t>(i));
+    }
+    max_err = std::max(max_err, std::fabs(cpu.r - output[i].r));
+    max_err = std::max(max_err, std::fabs(cpu.g - output[i].g));
+    max_err = std::max(max_err, std::fabs(cpu.b - output[i].b));
+  }
+  EXPECT_LT(max_err, 2.0e-4f);
+}
+
+TEST_F(MetalGradeFixture, MetalUnknownAdjustmentReturnsExplicitBackendError) {
+  document_.InsertAdjustment(document_.PrimaryGrade()->Id(),
+                             document_.PrimaryGrade()->AdjustmentCount(),
+                             AdjustmentInstanceId{"grade.primary.tint"},
+                             std::make_unique<TintModel>());
+  plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+  try {
+    (void)RenderGrade();
+    FAIL() << "expected unregistered adjustment to throw";
+  } catch (const std::runtime_error& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("unregistered adjustment type"), std::string::npos);
+    EXPECT_NE(message.find("alcedo.adjustment.tint"), std::string::npos);
+  }
+}
+
+TEST_F(MetalGradeFixture, MetalPrimaryGradeMissingMetallibThrowsExplicitError) {
+  EXPECT_THROW((void)metal::ComputePipelineCache::Instance().GetPipelineState(
+                   "/alcedo/missing/primary_grade.metallib", "primary_grade_pointwise",
+                   "Metal PrimaryGrade"),
+               std::runtime_error);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/metal_llf_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_llf_test.cpp
@@ -1,0 +1,703 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/pipeline/local_tone_mapping.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_primary_grade_pass.hpp"
+#include "metal/compute_pipeline_cache.hpp"
+
+namespace alcedo {
+namespace {
+
+struct Rgba {
+  float r = 0.0f;
+  float g = 0.0f;
+  float b = 0.0f;
+  float a = 1.0f;
+};
+
+auto HasMetalDevice() -> bool {
+  try {
+    return BindSystemDefaultMetalPresentationDevice() != nullptr;
+  } catch (...) {
+    return false;
+  }
+}
+
+auto MakeSplitPlane(std::uint32_t width, std::uint32_t height, float left, float right)
+    -> HostImagePlane {
+  HostImagePlane plane;
+  plane.extent       = {width, height};
+  plane.stride_bytes = width * 16U;
+  plane.format       = HostPixelFormat::F32Rgba;
+  auto  storage      = std::shared_ptr<std::byte>(new std::byte[plane.ByteCount()],
+                                                  [](std::byte* p) { delete[] p; });
+  auto* pixels       = reinterpret_cast<float*>(storage.get());
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      const float value = x < width / 2 ? left : right;
+      const auto  index = (static_cast<std::size_t>(y) * width + x) * 4;
+      pixels[index + 0] = value;
+      pixels[index + 1] = value;
+      pixels[index + 2] = value;
+      pixels[index + 3] = 1.0f;
+    }
+  }
+  plane.bytes = std::const_pointer_cast<const std::byte>(storage);
+  return plane;
+}
+
+auto MakeNeighborhoodPlane(std::uint32_t width, std::uint32_t height, float surroundings,
+                           float center) -> HostImagePlane {
+  HostImagePlane plane;
+  plane.extent       = {width, height};
+  plane.stride_bytes = width * 16U;
+  plane.format       = HostPixelFormat::F32Rgba;
+  auto  storage      = std::shared_ptr<std::byte>(new std::byte[plane.ByteCount()],
+                                                  [](std::byte* p) { delete[] p; });
+  auto* pixels       = reinterpret_cast<float*>(storage.get());
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      const float value = x == width / 2 && y == height / 2 ? center : surroundings;
+      const auto  index = (static_cast<std::size_t>(y) * width + x) * 4;
+      pixels[index + 0] = value;
+      pixels[index + 1] = value;
+      pixels[index + 2] = value;
+      pixels[index + 3] = 1.0f;
+    }
+  }
+  plane.bytes = std::const_pointer_cast<const std::byte>(storage);
+  return plane;
+}
+
+auto DownloadRgba(MetalRenderDevice& device, const GraphValueId& id) -> std::vector<Rgba> {
+  auto* lease = device.Workspace().Images().Find(id);
+  EXPECT_NE(lease, nullptr);
+  if (lease == nullptr) {
+    return {};
+  }
+  const auto&       tex = lease->Texture();
+  std::vector<Rgba> pixels(static_cast<std::size_t>(tex.Width()) * tex.Height());
+  device.Workspace().Device().DownloadTexture2D(
+      tex,
+      std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                           pixels.size() * sizeof(Rgba)),
+      device.CommandContext());
+  return pixels;
+}
+
+auto DownloadPlane(MetalRenderDevice& device, const NodeId& grade_id, const char* family)
+    -> std::vector<float> {
+  auto* buffer = device.Workspace().Values().Find(grade_id, PortId{family});
+  EXPECT_NE(buffer, nullptr);
+  if (buffer == nullptr) {
+    return {};
+  }
+  std::vector<float> plane(buffer->Bytes() / sizeof(float));
+  device.Workspace().Device().DownloadBufferRange(
+      *buffer, 0, std::span<std::byte>(reinterpret_cast<std::byte*>(plane.data()), buffer->Bytes()),
+      device.CommandContext());
+  return plane;
+}
+
+auto RenderPreparedGrade(MetalRenderDevice& device, PipelineDocument& document,
+                         const PreparedRawInput& prepared, const ExecutionPlan& plan)
+    -> MetalPrimaryGradeResult {
+  device.BeginRender();
+  ExecuteMetalDevelop(device, plan, prepared, document);
+  ExecuteMetalGeometryResample(device, plan);
+  ExecuteMetalCameraColor(device, plan, document);
+  auto result = ExecuteMetalPrimaryGrade(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+  return result;
+}
+
+auto AcesccEncode(float value) -> float {
+  constexpr float kA          = 9.72f;
+  constexpr float kB          = 17.52f;
+  constexpr float kOffset     = 0.0000152587890625f;
+  constexpr float kTransition = 0.000030517578125f;
+  constexpr float kFloor      = (-16.0f + kA) / kB;
+  if (value < 0.0f) {
+    return kFloor + value;
+  }
+  if (value < kTransition) {
+    return (std::log2(kOffset + value * 0.5f) + kA) / kB;
+  }
+  return (std::log2(value) + kA) / kB;
+}
+
+auto AcesccDecode(float value) -> float {
+  constexpr float kA         = 9.72f;
+  constexpr float kB         = 17.52f;
+  constexpr float kOffset    = 0.0000152587890625f;
+  constexpr float kFloor     = (-16.0f + kA) / kB;
+  constexpr float kThreshold = (-15.0f + kA) / kB;
+  if (value < kFloor) {
+    return value - kFloor;
+  }
+  if (value <= kThreshold) {
+    return (std::exp2(value * kB - kA) - kOffset) * 2.0f;
+  }
+  return std::exp2(value * kB - kA);
+}
+
+auto LogIntensity(const Rgba& pixel) -> float {
+  const Rgba  linear{AcesccDecode(pixel.r), AcesccDecode(pixel.g), AcesccDecode(pixel.b), pixel.a};
+  const float intensity = 0.272229f * linear.r + 0.674082f * linear.g + 0.053689f * linear.b;
+  return AcesccEncode(std::max(intensity, 1.0e-6f));
+}
+
+auto CpuApplyLlf(const std::vector<Rgba>& input, std::uint32_t width, std::uint32_t height,
+                 float shadows_slider, float highlights_slider) -> std::vector<Rgba> {
+  const auto mask =
+      local_tone_mapping::ComputeMaskDimensions(static_cast<int>(width), static_cast<int>(height),
+                                                local_tone_mapping::kReferenceMaskMaxLongEdge);
+  const int        count = local_tone_mapping::ComputeLevelCount(mask.width, mask.height,
+                                                                 local_tone_mapping::kPyramidRadius);
+  std::vector<int> widths(static_cast<std::size_t>(count));
+  std::vector<int> heights(static_cast<std::size_t>(count));
+  widths[0]  = mask.width;
+  heights[0] = mask.height;
+  for (int level = 1; level < count; ++level) {
+    widths[static_cast<std::size_t>(level)] =
+        std::max(1, (widths[static_cast<std::size_t>(level - 1)] + 1) / 2);
+    heights[static_cast<std::size_t>(level)] =
+        std::max(1, (heights[static_cast<std::size_t>(level - 1)] + 1) / 2);
+  }
+  auto make_plane = [&](int level) {
+    return std::vector<float>(static_cast<std::size_t>(widths[static_cast<std::size_t>(level)]) *
+                              static_cast<std::size_t>(heights[static_cast<std::size_t>(level)]));
+  };
+  auto read_rgba = [&](float x, float y) -> Rgba {
+    x               = std::clamp(x, 0.0f, static_cast<float>(width - 1));
+    y               = std::clamp(y, 0.0f, static_cast<float>(height - 1));
+    const int   x0  = static_cast<int>(std::floor(x));
+    const int   y0  = static_cast<int>(std::floor(y));
+    const int   x1  = std::min(x0 + 1, static_cast<int>(width - 1));
+    const int   y1  = std::min(y0 + 1, static_cast<int>(height - 1));
+    const float tx  = x - static_cast<float>(x0);
+    const float ty  = y - static_cast<float>(y0);
+    const auto& a   = input[static_cast<std::size_t>(y0) * width + static_cast<std::size_t>(x0)];
+    const auto& b   = input[static_cast<std::size_t>(y0) * width + static_cast<std::size_t>(x1)];
+    const auto& c   = input[static_cast<std::size_t>(y1) * width + static_cast<std::size_t>(x0)];
+    const auto& d   = input[static_cast<std::size_t>(y1) * width + static_cast<std::size_t>(x1)];
+    auto        mix = [&](const Rgba& p, const Rgba& q, float t) {
+      return Rgba{p.r + (q.r - p.r) * t, p.g + (q.g - p.g) * t, p.b + (q.b - p.b) * t,
+                  p.a + (q.a - p.a) * t};
+    };
+    const auto ab = mix(a, b, tx);
+    const auto cd = mix(c, d, tx);
+    return mix(ab, cd, ty);
+  };
+  auto plane_read = [](const std::vector<float>& src, int x, int y, int w, int h) {
+    x = std::clamp(x, 0, w - 1);
+    y = std::clamp(y, 0, h - 1);
+    return src[static_cast<std::size_t>(y) * static_cast<std::size_t>(w) +
+               static_cast<std::size_t>(x)];
+  };
+  auto weight = [](int tap) {
+    return (tap == -2 || tap == 2)   ? 1.0f / 16.0f
+           : (tap == -1 || tap == 1) ? 4.0f / 16.0f
+                                     : 6.0f / 16.0f;
+  };
+  auto expand = [&](const std::vector<float>& coarse, int cw, int ch, int x, int y) {
+    float sum = 0.0f;
+    for (int ky = -2; ky <= 2; ++ky) {
+      const int sample_y = y - ky;
+      if ((sample_y & 1) != 0) {
+        continue;
+      }
+      const int cy = std::clamp(sample_y / 2, 0, ch - 1);
+      for (int kx = -2; kx <= 2; ++kx) {
+        const int sample_x = x - kx;
+        if ((sample_x & 1) != 0) {
+          continue;
+        }
+        const int cx = std::clamp(sample_x / 2, 0, cw - 1);
+        sum += 4.0f * weight(kx) * weight(ky) *
+               coarse[static_cast<std::size_t>(cy) * static_cast<std::size_t>(cw) +
+                      static_cast<std::size_t>(cx)];
+      }
+    }
+    return sum;
+  };
+  auto pyr_down = [&](const std::vector<float>& src, int sw, int sh, int dw, int dh) {
+    std::vector<float> dst(static_cast<std::size_t>(dw) * static_cast<std::size_t>(dh));
+    for (int y = 0; y < dh; ++y) {
+      for (int x = 0; x < dw; ++x) {
+        float sum = 0.0f;
+        for (int ky = -2; ky <= 2; ++ky) {
+          for (int kx = -2; kx <= 2; ++kx) {
+            sum += weight(kx) * weight(ky) * plane_read(src, x * 2 + kx, y * 2 + ky, sw, sh);
+          }
+        }
+        dst[static_cast<std::size_t>(y) * static_cast<std::size_t>(dw) +
+            static_cast<std::size_t>(x)] = sum;
+      }
+    }
+    return dst;
+  };
+
+  std::vector<std::vector<float>> source(static_cast<std::size_t>(count));
+  source[0] = make_plane(0);
+  for (int y = 0; y < mask.height; ++y) {
+    for (int x = 0; x < mask.width; ++x) {
+      const float sx = (static_cast<float>(x) + 0.5f) * static_cast<float>(width) /
+                           static_cast<float>(mask.width) -
+                       0.5f;
+      const float sy = (static_cast<float>(y) + 0.5f) * static_cast<float>(height) /
+                           static_cast<float>(mask.height) -
+                       0.5f;
+      source[0][static_cast<std::size_t>(y) * static_cast<std::size_t>(mask.width) +
+                static_cast<std::size_t>(x)] = LogIntensity(read_rgba(sx, sy));
+    }
+  }
+  for (int level = 1; level < count; ++level) {
+    source[static_cast<std::size_t>(level)] = pyr_down(
+        source[static_cast<std::size_t>(level - 1)], widths[static_cast<std::size_t>(level - 1)],
+        heights[static_cast<std::size_t>(level - 1)], widths[static_cast<std::size_t>(level)],
+        heights[static_cast<std::size_t>(level)]);
+  }
+
+  const float shadow_amount    = std::clamp(shadows_slider * 1.5f / 80.0f, -1.5f, 1.5f);
+  const float highlight_amount = std::clamp(-highlights_slider * 1.5f / 100.0f, -1.5f, 1.5f);
+  const float sigma            = local_tone_mapping::SigmaR(shadow_amount, highlight_amount);
+  const auto  samples          = local_tone_mapping::BuildSamples(shadow_amount, highlight_amount);
+  auto        remap_delta      = [](float delta, float sample_sigma, float alpha, float beta) {
+    const float magnitude = std::fabs(delta);
+    if (magnitude <= 1.0e-6f) {
+      return 0.0f;
+    }
+    const float sign = std::copysign(1.0f, delta);
+    if (magnitude <= sample_sigma) {
+      return sign * sample_sigma *
+             std::pow(std::min(magnitude / std::max(sample_sigma, 1.0e-6f), 1.0f), alpha);
+    }
+    return sign * (sample_sigma + beta * (magnitude - sample_sigma));
+  };
+  auto build_remap = [&](const local_tone_mapping::LlfSample& sample) {
+    std::vector<std::vector<float>> levels(static_cast<std::size_t>(count));
+    levels[0] = make_plane(0);
+    for (std::size_t i = 0; i < levels[0].size(); ++i) {
+      levels[0][i] = sample.target +
+                     remap_delta(source[0][i] - sample.gamma, sigma, sample.alpha, sample.beta);
+    }
+    for (int level = 1; level < count; ++level) {
+      levels[static_cast<std::size_t>(level)] = pyr_down(
+          levels[static_cast<std::size_t>(level - 1)], widths[static_cast<std::size_t>(level - 1)],
+          heights[static_cast<std::size_t>(level - 1)], widths[static_cast<std::size_t>(level)],
+          heights[static_cast<std::size_t>(level)]);
+    }
+    return levels;
+  };
+  auto                            remap_a = build_remap(samples[0]);
+  auto                            remap_b = build_remap(samples[1]);
+  std::vector<std::vector<float>> result(static_cast<std::size_t>(count));
+  for (int level = 0; level < count; ++level) {
+    result[static_cast<std::size_t>(level)] = make_plane(level);
+  }
+  for (std::size_t pair = 0; pair + 1 < samples.size(); ++pair) {
+    for (int level = 0; level < count; ++level) {
+      const bool top = level + 1 == count;
+      const int  w   = widths[static_cast<std::size_t>(level)];
+      const int  h   = heights[static_cast<std::size_t>(level)];
+      const int  cw  = top ? 1 : widths[static_cast<std::size_t>(level + 1)];
+      const int  ch  = top ? 1 : heights[static_cast<std::size_t>(level + 1)];
+      auto&      out = result[static_cast<std::size_t>(level)];
+      for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+          const auto index = static_cast<std::size_t>(y) * static_cast<std::size_t>(w) +
+                             static_cast<std::size_t>(x);
+          const float value = source[static_cast<std::size_t>(level)][index];
+          if (!((pair == 0 && value <= samples[pair + 1].gamma) ||
+                (pair + 2 == samples.size() && value >= samples[pair].gamma) ||
+                (value >= samples[pair].gamma && value < samples[pair + 1].gamma))) {
+            continue;
+          }
+          const float t =
+              std::clamp((value - samples[pair].gamma) /
+                             std::max(samples[pair + 1].gamma - samples[pair].gamma, 1.0e-6f),
+                         0.0f, 1.0f);
+          if (top) {
+            out[index] = remap_a[static_cast<std::size_t>(level)][index] +
+                         (remap_b[static_cast<std::size_t>(level)][index] -
+                          remap_a[static_cast<std::size_t>(level)][index]) *
+                             t;
+            continue;
+          }
+          const float lap_lo = remap_a[static_cast<std::size_t>(level)][index] -
+                               expand(remap_a[static_cast<std::size_t>(level + 1)], cw, ch, x, y);
+          const float lap_hi = remap_b[static_cast<std::size_t>(level)][index] -
+                               expand(remap_b[static_cast<std::size_t>(level + 1)], cw, ch, x, y);
+          out[index] = lap_lo + (lap_hi - lap_lo) * t;
+        }
+      }
+    }
+    if (pair + 2 < samples.size()) {
+      remap_a.swap(remap_b);
+      remap_b = build_remap(samples[pair + 2]);
+    }
+  }
+  for (int level = count - 2; level >= 0; --level) {
+    const int w         = widths[static_cast<std::size_t>(level)];
+    const int h         = heights[static_cast<std::size_t>(level)];
+    const int cw        = widths[static_cast<std::size_t>(level + 1)];
+    const int ch        = heights[static_cast<std::size_t>(level + 1)];
+    auto      collapsed = make_plane(level);
+    for (int y = 0; y < h; ++y) {
+      for (int x = 0; x < w; ++x) {
+        const auto index =
+            static_cast<std::size_t>(y) * static_cast<std::size_t>(w) + static_cast<std::size_t>(x);
+        collapsed[index] = result[static_cast<std::size_t>(level)][index] +
+                           expand(result[static_cast<std::size_t>(level + 1)], cw, ch, x, y);
+      }
+    }
+    result[static_cast<std::size_t>(level)] = std::move(collapsed);
+  }
+
+  auto bilinear = [](const std::vector<float>& plane, int w, int h, float x, float y) {
+    x              = std::clamp(x, 0.0f, static_cast<float>(w - 1));
+    y              = std::clamp(y, 0.0f, static_cast<float>(h - 1));
+    const int   x0 = static_cast<int>(std::floor(x));
+    const int   y0 = static_cast<int>(std::floor(y));
+    const int   x1 = std::min(x0 + 1, w - 1);
+    const int   y1 = std::min(y0 + 1, h - 1);
+    const float tx = x - static_cast<float>(x0);
+    const float ty = y - static_cast<float>(y0);
+    const float a  = plane[static_cast<std::size_t>(y0) * static_cast<std::size_t>(w) +
+                          static_cast<std::size_t>(x0)] +
+                    (plane[static_cast<std::size_t>(y0) * static_cast<std::size_t>(w) +
+                           static_cast<std::size_t>(x1)] -
+                     plane[static_cast<std::size_t>(y0) * static_cast<std::size_t>(w) +
+                           static_cast<std::size_t>(x0)]) *
+                        tx;
+    const float b = plane[static_cast<std::size_t>(y1) * static_cast<std::size_t>(w) +
+                          static_cast<std::size_t>(x0)] +
+                    (plane[static_cast<std::size_t>(y1) * static_cast<std::size_t>(w) +
+                           static_cast<std::size_t>(x1)] -
+                     plane[static_cast<std::size_t>(y1) * static_cast<std::size_t>(w) +
+                           static_cast<std::size_t>(x0)]) *
+                        tx;
+    return a + (b - a) * ty;
+  };
+
+  std::vector<Rgba> output = input;
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      const float ax = (static_cast<float>(x) + 0.5f) * static_cast<float>(mask.width) /
+                           static_cast<float>(width) -
+                       0.5f;
+      const float ay = (static_cast<float>(y) + 0.5f) * static_cast<float>(mask.height) /
+                           static_cast<float>(height) -
+                       0.5f;
+      const auto      index            = static_cast<std::size_t>(y) * width + x;
+      const float     reference_l      = bilinear(source[0], mask.width, mask.height, ax, ay);
+      const float     adjusted_l       = bilinear(result[0], mask.width, mask.height, ax, ay);
+      const auto&     pixel            = input[index];
+      const float     source_l         = LogIntensity(pixel);
+      const float     source_intensity = std::max(AcesccDecode(source_l), 1.0e-5f);
+      const float     target_intensity = AcesccDecode(source_l + adjusted_l - reference_l);
+      const float     ratio  = std::clamp(target_intensity / source_intensity, 0.0f, 32.0f);
+      float           r      = AcesccDecode(pixel.r) * ratio;
+      float           g      = AcesccDecode(pixel.g) * ratio;
+      float           b      = AcesccDecode(pixel.b) * ratio;
+      constexpr float kLower = -1.0e-5f;
+      float           gamut  = 1.0f;
+      if (r < kLower && target_intensity > r) {
+        gamut = std::min(gamut, (target_intensity - kLower) / (target_intensity - r));
+      }
+      if (g < kLower && target_intensity > g) {
+        gamut = std::min(gamut, (target_intensity - kLower) / (target_intensity - g));
+      }
+      if (b < kLower && target_intensity > b) {
+        gamut = std::min(gamut, (target_intensity - kLower) / (target_intensity - b));
+      }
+      gamut         = std::clamp(gamut, 0.0f, 1.0f);
+      r             = target_intensity + (r - target_intensity) * gamut;
+      g             = target_intensity + (g - target_intensity) * gamut;
+      b             = target_intensity + (b - target_intensity) * gamut;
+      output[index] = {AcesccEncode(r), AcesccEncode(g), AcesccEncode(b), pixel.a};
+    }
+  }
+  return output;
+}
+
+class MetalLlfFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasMetalDevice()) {
+      GTEST_SKIP() << "No Metal device available.";
+    }
+    (void)BindSystemDefaultMetalPresentationDevice();
+    prepared_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                              gpu_dag_test::FullSensor(16, 12));
+    document_ = CreateDefaultPipelineDocument();
+    gpu_dag_test::EnsureTestCameraProfile(document_);
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+  }
+
+  auto RenderGrade() -> MetalPrimaryGradeResult {
+    return RenderPreparedGrade(device_, document_, prepared_, plan_);
+  }
+
+  template <class Model>
+  auto ModelByType(const OperatorTypeId& type) -> Model& {
+    auto* model = dynamic_cast<Model*>(document_.PrimaryGrade()->FindAdjustmentByType(type));
+    EXPECT_NE(model, nullptr);
+    return *model;
+  }
+
+  PreparedRawInput  prepared_;
+  PipelineDocument  document_;
+  ExecutionPlan     plan_;
+  MetalRenderDevice device_;
+};
+
+TEST_F(MetalLlfFixture, MetalLlfUsesWorkspaceTransientArenaForEveryPyramid) {
+  ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
+  const auto result = RenderGrade();
+  EXPECT_GT(result.local_tone_transient_bytes, 0U);
+  EXPECT_NE(device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
+                                              PortId{"local_tone.source.0"}),
+            nullptr);
+  EXPECT_NE(device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
+                                              PortId{"local_tone.result.0"}),
+            nullptr);
+  EXPECT_EQ(device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
+                                              PortId{"local_tone.source.1"}),
+            nullptr);
+  EXPECT_EQ(device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
+                                              PortId{"local_tone.remap_a.0"}),
+            nullptr);
+  EXPECT_GT(device_.Workspace().TransientBuffers().used_bytes(), 0U);
+  EXPECT_GE(plan_.peak_transient_bytes, result.local_tone_transient_bytes);
+}
+
+TEST_F(MetalLlfFixture, MetalLlfFullFrameBuildsCanonicalReferenceOnce) {
+  ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
+  const auto first  = RenderGrade();
+  const auto second = RenderGrade();
+  EXPECT_TRUE(first.local_tone_rebuilt_reference);
+  EXPECT_FALSE(first.local_tone_sampled_canonical_reference);
+  EXPECT_FALSE(second.local_tone_rebuilt_reference);
+  EXPECT_TRUE(second.local_tone_sampled_canonical_reference);
+  EXPECT_EQ(first.local_tone_reference_resource_id, second.local_tone_reference_resource_id);
+  EXPECT_NE(first.local_tone_reference_resource_id, 0U);
+}
+
+TEST_F(MetalLlfFixture, MetalLlfSliderEditReusesCanonicalReference) {
+  ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
+  const auto first = RenderGrade();
+  ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(60.0f);
+  device_.Workspace().Device().ResetCounters();
+  const auto second = RenderGrade();
+  EXPECT_EQ(first.local_tone_reference_resource_id, second.local_tone_reference_resource_id);
+  EXPECT_TRUE(second.local_tone_rebuilt_reference);
+  EXPECT_FALSE(second.local_tone_sampled_canonical_reference);
+  EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().PipelineCreateCount(), 0U);
+}
+
+TEST_F(MetalLlfFixture, MetalLlfSecondStableRenderCreatesNoBufferTextureOrPipelineState) {
+  ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
+  (void)RenderGrade();
+  device_.Workspace().Device().ResetCounters();
+  (void)RenderGrade();
+  EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().HeapCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().PipelineCreateCount(), 0U);
+}
+
+TEST_F(MetalLlfFixture, MetalLlfFailedSubmissionDoesNotPublishReference) {
+  ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
+  const auto first = RenderGrade();
+  EXPECT_NE(first.local_tone_reference_resource_id, 0U);
+  const auto* source = device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
+                                                         PortId{"local_tone.source.0"});
+  ASSERT_NE(source, nullptr);
+  const auto source_id = source->ResourceId();
+
+  device_.BeginRender();
+  ExecuteMetalDevelop(device_, plan_, prepared_, document_);
+  ExecuteMetalGeometryResample(device_, plan_);
+  ExecuteMetalCameraColor(device_, plan_, document_);
+  plan_.geometry.full_reference_extent = {};
+  EXPECT_THROW((void)ExecuteMetalPrimaryGrade(device_, plan_, prepared_, document_),
+               std::runtime_error);
+  device_.CancelRender();
+  const auto* after = device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
+                                                        PortId{"local_tone.source.0"});
+  ASSERT_NE(after, nullptr);
+  EXPECT_EQ(after->ResourceId(), source_id);
+
+  plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+  const auto recovered = RenderGrade();
+  EXPECT_TRUE(recovered.local_tone_sampled_canonical_reference);
+  EXPECT_EQ(recovered.local_tone_reference_resource_id, source_id);
+}
+
+TEST(GpuDagMetalGrade, MetalLlfRoiSamplesCanonicalReferenceWithSharedGeometryPlan) {
+  if (!HasMetalDevice()) {
+    GTEST_SKIP() << "No Metal device available.";
+  }
+  (void)BindSystemDefaultMetalPresentationDevice();
+  constexpr std::uint32_t kWidth  = 64;
+  constexpr std::uint32_t kHeight = 64;
+  auto prepared = RawInputLoader::FromDirectRgb(MakeSplitPlane(kWidth, kHeight, 1.0f, 0.05f),
+                                                gpu_dag_test::FullSensor(kWidth, kHeight));
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  auto* shadows = dynamic_cast<ShadowsModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Shadows()));
+  ASSERT_NE(shadows, nullptr);
+  shadows->SetValue(80.0f);
+
+  auto full_plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  MetalRenderDevice device;
+  const auto        full_grade = RenderPreparedGrade(device, document, prepared, full_plan);
+  EXPECT_TRUE(full_grade.local_tone_rebuilt_reference);
+  EXPECT_FALSE(full_grade.local_tone_sampled_canonical_reference);
+  const auto full_pixels = DownloadRgba(device, full_grade.output);
+  const auto full_mask =
+      DownloadPlane(device, document.PrimaryGrade()->Id(), "local_tone.source.0");
+  ASSERT_FALSE(full_pixels.empty());
+  ASSERT_FALSE(full_mask.empty());
+
+  RenderRequest roi_request;
+  roi_request.view.visible_rect_in_edit_space = {0.5f, 0.0f, 0.5f, 1.0f};
+  auto       roi_plan  = GraphCompiler::Compile(document, prepared.CompileSource(), roi_request);
+  const auto roi_grade = RenderPreparedGrade(device, document, prepared, roi_plan);
+  EXPECT_FALSE(roi_grade.local_tone_rebuilt_reference);
+  EXPECT_TRUE(roi_grade.local_tone_sampled_canonical_reference);
+  EXPECT_EQ(full_grade.local_tone_reference_resource_id,
+            roi_grade.local_tone_reference_resource_id);
+  const auto roi_pixels = DownloadRgba(device, roi_grade.output);
+  const auto roi_mask = DownloadPlane(device, document.PrimaryGrade()->Id(), "local_tone.source.0");
+  ASSERT_FALSE(roi_pixels.empty());
+  ASSERT_EQ(full_mask, roi_mask);
+
+  const auto full_probe =
+      TransformPoint(full_plan.geometry.render_to_reference, PixelCenter(48, 32));
+  const auto roi_probe = TransformPoint(roi_plan.geometry.reference_to_render, full_probe);
+  const auto roi_x     = static_cast<int>(std::floor(roi_probe.x));
+  const auto roi_y     = static_cast<int>(std::floor(roi_probe.y));
+  const auto roi_w     = static_cast<int>(roi_plan.geometry.render_extent.width);
+  const auto roi_h     = static_cast<int>(roi_plan.geometry.render_extent.height);
+  ASSERT_GE(roi_x, 0);
+  ASSERT_GE(roi_y, 0);
+  ASSERT_LT(roi_x, roi_w);
+  ASSERT_LT(roi_y, roi_h);
+  const float sampled = roi_pixels[static_cast<std::size_t>(roi_y) * roi_w + roi_x].r;
+  const float full    = full_pixels[static_cast<std::size_t>(32) * kWidth + 48].r;
+  EXPECT_NEAR(sampled, full, 2.0e-3f);
+
+  MetalRenderDevice isolated;
+  const auto        isolated_grade = RenderPreparedGrade(isolated, document, prepared, roi_plan);
+  EXPECT_TRUE(isolated_grade.local_tone_rebuilt_reference);
+  EXPECT_FALSE(isolated_grade.local_tone_sampled_canonical_reference);
+  const auto isolated_pixels = DownloadRgba(isolated, isolated_grade.output);
+  ASSERT_FALSE(isolated_pixels.empty());
+  const float rebuilt = isolated_pixels[static_cast<std::size_t>(roi_y) * roi_w + roi_x].r;
+  EXPECT_GT(std::abs(rebuilt - sampled), 1.0e-4f);
+}
+
+TEST(GpuDagMetalGrade, MetalLlfMatchesCudaReferenceWithinTolerance) {
+  if (!HasMetalDevice()) {
+    GTEST_SKIP() << "No Metal device available.";
+  }
+  (void)BindSystemDefaultMetalPresentationDevice();
+  constexpr std::uint32_t kWidth  = 32;
+  constexpr std::uint32_t kHeight = 32;
+  auto prepared = RawInputLoader::FromDirectRgb(MakeSplitPlane(kWidth, kHeight, 0.08f, 0.45f),
+                                                gpu_dag_test::FullSensor(kWidth, kHeight));
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  auto* shadows = dynamic_cast<ShadowsModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Shadows()));
+  ASSERT_NE(shadows, nullptr);
+  shadows->SetValue(80.0f);
+  auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  MetalRenderDevice device;
+  const auto        result = RenderPreparedGrade(device, document, prepared, plan);
+  const auto        input  = DownloadRgba(device, plan.develop_output);
+  const auto        output = DownloadRgba(device, result.output);
+  ASSERT_EQ(input.size(), output.size());
+  const auto cpu = CpuApplyLlf(input, kWidth, kHeight, 80.0f, 0.0f);
+  ASSERT_EQ(cpu.size(), output.size());
+  float max_err = 0.0f;
+  for (std::size_t i = 0; i < output.size(); ++i) {
+    max_err = std::max(max_err, std::fabs(cpu[i].r - output[i].r));
+    max_err = std::max(max_err, std::fabs(cpu[i].g - output[i].g));
+    max_err = std::max(max_err, std::fabs(cpu[i].b - output[i].b));
+  }
+  EXPECT_LT(max_err, 2.0e-3f);
+
+  auto dark_prepared   = RawInputLoader::FromDirectRgb(MakeNeighborhoodPlane(64, 64, 0.02f, 0.08f),
+                                                       gpu_dag_test::FullSensor(64, 64));
+  auto bright_prepared = RawInputLoader::FromDirectRgb(MakeNeighborhoodPlane(64, 64, 0.45f, 0.08f),
+                                                       gpu_dag_test::FullSensor(64, 64));
+  auto dark_document   = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(dark_document);
+  dynamic_cast<ShadowsModel*>(
+      dark_document.PrimaryGrade()->FindAdjustmentByType(type_ids::Shadows()))
+      ->SetValue(80.0f);
+  auto bright_document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(bright_document);
+  dynamic_cast<HighlightsModel*>(
+      bright_document.PrimaryGrade()->FindAdjustmentByType(type_ids::Highlights()))
+      ->SetValue(0.0f);
+  dynamic_cast<ShadowsModel*>(
+      bright_document.PrimaryGrade()->FindAdjustmentByType(type_ids::Shadows()))
+      ->SetValue(80.0f);
+  MetalRenderDevice dark_device;
+  MetalRenderDevice bright_device;
+  auto              dark_plan =
+      GraphCompiler::Compile(dark_document, dark_prepared.CompileSource(), RenderRequest{});
+  auto bright_plan =
+      GraphCompiler::Compile(bright_document, bright_prepared.CompileSource(), RenderRequest{});
+  const auto dark_out = DownloadRgba(
+      dark_device,
+      RenderPreparedGrade(dark_device, dark_document, dark_prepared, dark_plan).output);
+  const auto bright_out = DownloadRgba(
+      bright_device,
+      RenderPreparedGrade(bright_device, bright_document, bright_prepared, bright_plan).output);
+  ASSERT_FALSE(dark_out.empty());
+  ASSERT_FALSE(bright_out.empty());
+  const auto center = static_cast<std::size_t>(32) * 64 + 32;
+  EXPECT_GT(std::abs(dark_out[center].r - bright_out[center].r), 1.0e-4f);
+}
+
+TEST_F(MetalLlfFixture, MetalLocalToneMissingMetallibThrowsExplicitError) {
+  EXPECT_THROW(
+      (void)metal::ComputePipelineCache::Instance().GetPipelineState(
+          "/alcedo/missing/local_tone.metallib", "local_tone_extract", "Metal LLF extract"),
+      std::runtime_error);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/metal_mask_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_mask_test.cpp
@@ -1,0 +1,439 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/geometry/texture_sampling_plan.hpp"
+#include "edit/graph/analytic_mask_node_model.hpp"
+#include "edit/graph/raster_mask_node_model.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/metal/metal_develop_pass.hpp"
+#include "edit/runtime/metal/metal_mask_pass.hpp"
+#include "edit/runtime/metal/metal_primary_grade_pass.hpp"
+
+namespace alcedo {
+namespace {
+
+struct Rgba {
+  float r = 0.0f;
+  float g = 0.0f;
+  float b = 0.0f;
+  float a = 1.0f;
+};
+
+auto HasMetalDevice() -> bool {
+  try {
+    return BindSystemDefaultMetalPresentationDevice() != nullptr;
+  } catch (...) {
+    return false;
+  }
+}
+
+auto Transform(const Matrix3x3& matrix, float x, float y) -> Vector2 {
+  return {matrix.m[0] * x + matrix.m[1] * y + matrix.m[2],
+          matrix.m[3] * x + matrix.m[4] * y + matrix.m[5]};
+}
+
+auto SampleR8(const std::vector<std::uint8_t>& pixels, std::uint32_t width, std::uint32_t height,
+              float u, float v) -> float {
+  if (u < 0.0f || v < 0.0f || u > 1.0f || v > 1.0f) {
+    return 0.0f;
+  }
+  const float x = u * static_cast<float>(width) - 0.5f;
+  const float y = v * static_cast<float>(height) - 0.5f;
+  const int   x0 =
+      std::max(0, std::min(static_cast<int>(width) - 1, static_cast<int>(std::floor(x))));
+  const int y0 =
+      std::max(0, std::min(static_cast<int>(height) - 1, static_cast<int>(std::floor(y))));
+  const int   x1 = std::min(x0 + 1, static_cast<int>(width) - 1);
+  const int   y1 = std::min(y0 + 1, static_cast<int>(height) - 1);
+  const float tx = std::min(std::max(x - std::floor(x), 0.0f), 1.0f);
+  const float ty = std::min(std::max(y - std::floor(y), 0.0f), 1.0f);
+  const float a =
+      pixels[static_cast<std::size_t>(y0) * width + static_cast<std::size_t>(x0)] * (1.0f - tx) +
+      pixels[static_cast<std::size_t>(y0) * width + static_cast<std::size_t>(x1)] * tx;
+  const float b =
+      pixels[static_cast<std::size_t>(y1) * width + static_cast<std::size_t>(x0)] * (1.0f - tx) +
+      pixels[static_cast<std::size_t>(y1) * width + static_cast<std::size_t>(x1)] * tx;
+  return (a * (1.0f - ty) + b * ty) / 255.0f;
+}
+
+auto CpuAnalytic(const AnalyticMaskNodeModel& node, const ResolvedRenderGeometry& geometry,
+                 std::uint32_t x, std::uint32_t y) -> float {
+  const auto  reference = Transform(geometry.render_to_reference, static_cast<float>(x) + 0.5f,
+                                    static_cast<float>(y) + 0.5f);
+  const float nx        = reference.x / static_cast<float>(geometry.full_reference_extent.width);
+  const float ny        = reference.y / static_cast<float>(geometry.full_reference_extent.height);
+  float       value     = 0.0f;
+  bool        invert    = false;
+  if (node.Kind() == AnalyticMaskKind::Radial) {
+    const auto& radial = node.Radial();
+    const float c      = std::cos(radial.rotation);
+    const float s      = std::sin(radial.rotation);
+    const float dx     = nx - radial.center_x;
+    const float dy     = ny - radial.center_y;
+    const float rx     = (c * dx + s * dy) / std::max(radial.major_radius, 1.0e-6f);
+    const float ry     = (-s * dx + c * dy) / std::max(radial.minor_radius, 1.0e-6f);
+    const float radius = std::sqrt(rx * rx + ry * ry);
+    const float inner  = std::max(0.0f, 1.0f - radial.inner_feather);
+    const float outer  = 1.0f + radial.outer_feather;
+    value =
+        1.0f - std::min(std::max((radius - inner) / std::max(outer - inner, 1.0e-6f), 0.0f), 1.0f);
+    invert = radial.invert;
+  } else {
+    const auto& graduated     = node.GraduatedNd();
+    const float normal_length = std::hypot(graduated.normal_x, graduated.normal_y);
+    const float normal_x      = graduated.normal_x / std::max(normal_length, 1.0e-6f);
+    const float normal_y      = graduated.normal_y / std::max(normal_length, 1.0e-6f);
+    const float distance =
+        (nx - graduated.origin_x) * normal_x + (ny - graduated.origin_y) * normal_y;
+    const float t = std::min(
+        std::max(distance / std::max(graduated.transition_distance, 1.0e-6f) + 0.5f, 0.0f), 1.0f);
+    value  = graduated.start_value + (graduated.end_value - graduated.start_value) * t;
+    invert = graduated.invert;
+  }
+  if (invert) {
+    value = 1.0f - value;
+  }
+  return value;
+}
+
+class MetalMaskFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasMetalDevice()) {
+      GTEST_SKIP() << "No Metal device available.";
+    }
+    (void)BindSystemDefaultMetalPresentationDevice();
+    SetExtent(16, 12);
+    root_ = std::filesystem::path{"build/tmp/m5_metal_mask"} /
+            ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    std::error_code ignored;
+    std::filesystem::remove_all(root_, ignored);
+    store_ = std::make_unique<MaskStore>(root_);
+  }
+
+  void SetExtent(std::uint32_t width, std::uint32_t height) {
+    width_    = width;
+    height_   = height;
+    prepared_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(width, height),
+                                              gpu_dag_test::FullSensor(width, height));
+    document_ = CreateDefaultPipelineDocument();
+    gpu_dag_test::EnsureTestCameraProfile(document_);
+  }
+
+  auto MakeRaster(std::string key, std::uint8_t fill = 0) -> MaskAsset {
+    MaskAsset asset;
+    asset.key                         = MaskAssetKey{std::move(key)};
+    asset.descriptor.extent           = {width_, height_};
+    asset.descriptor.reference_bounds = {};
+    asset.pixels.assign(static_cast<std::size_t>(width_) * height_, fill);
+    return asset;
+  }
+
+  auto AttachRaster(MaskAsset asset, float feather = 0.0f) -> RasterMaskNodeModel& {
+    store_->Save(asset);
+    auto node = std::make_unique<RasterMaskNodeModel>(NodeId{"mask.raster"});
+    node->SetAssetKey(asset.key);
+    node->SetReferenceBounds({});
+    node->SetFeatherRadius(feather);
+    auto* result = node.get();
+    document_.Graph().AddNode(std::move(node));
+    document_.Graph().Connect(NodeId{"mask.raster"}, PortId{"mask"}, NodeId{"grade.primary"},
+                              PortId{"mask"});
+    document_.MarkTopologyDirty();
+    return *result;
+  }
+
+  auto AttachAnalytic(AnalyticMaskKind kind) -> AnalyticMaskNodeModel& {
+    auto  node   = std::make_unique<AnalyticMaskNodeModel>(NodeId{"mask.analytic"}, kind);
+    auto* result = node.get();
+    document_.Graph().AddNode(std::move(node));
+    document_.Graph().Connect(NodeId{"mask.analytic"}, PortId{"mask"}, NodeId{"grade.primary"},
+                              PortId{"mask"});
+    document_.MarkTopologyDirty();
+    return *result;
+  }
+
+  void Compile(RenderRequest request = {}) {
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), request);
+  }
+
+  auto RenderMask(std::span<const RectI> dirty = {}) -> MetalMaskResult {
+    device_.BeginRender();
+    auto result = ExecuteMetalMask(device_, plan_, document_, store_.get(), dirty);
+    device_.EndRender();
+    device_.WaitIdle();
+    return result;
+  }
+
+  auto RenderGrade() -> MetalPrimaryGradeResult {
+    device_.BeginRender();
+    ExecuteMetalDevelop(device_, plan_, prepared_, document_);
+    ExecuteMetalGeometryResample(device_, plan_);
+    ExecuteMetalCameraColor(device_, plan_, document_);
+    if (plan_.primary_grade_mask) {
+      (void)ExecuteMetalMask(device_, plan_, document_, store_.get());
+    }
+    auto result = ExecuteMetalPrimaryGrade(device_, plan_, prepared_, document_);
+    device_.EndRender();
+    device_.WaitIdle();
+    return result;
+  }
+
+  auto DownloadMask() -> std::vector<std::uint8_t> {
+    auto* lease = device_.Workspace().Images().Find(plan_.mask_output);
+    EXPECT_NE(lease, nullptr);
+    if (lease == nullptr) {
+      return {};
+    }
+    std::vector<std::uint8_t> pixels(lease->Texture().Bytes());
+    device_.Workspace().Device().DownloadTexture2D(
+        lease->Texture(),
+        std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()), pixels.size()),
+        device_.CommandContext());
+    return pixels;
+  }
+
+  auto DownloadImage(const GraphValueId& id) -> std::vector<Rgba> {
+    auto* lease = device_.Workspace().Images().Find(id);
+    EXPECT_NE(lease, nullptr);
+    if (lease == nullptr) {
+      return {};
+    }
+    std::vector<Rgba> pixels(static_cast<std::size_t>(lease->Texture().Width()) *
+                             lease->Texture().Height());
+    device_.Workspace().Device().DownloadTexture2D(
+        lease->Texture(),
+        std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()),
+                             pixels.size() * sizeof(Rgba)),
+        device_.CommandContext());
+    return pixels;
+  }
+
+  std::uint32_t              width_  = 0;
+  std::uint32_t              height_ = 0;
+  std::filesystem::path      root_;
+  std::unique_ptr<MaskStore> store_;
+  PreparedRawInput           prepared_;
+  PipelineDocument           document_;
+  ExecutionPlan              plan_;
+  MetalRenderDevice          device_;
+};
+
+TEST_F(MetalMaskFixture, MetalRasterMaskUploadsOnlyChangedR8Rectangle) {
+  auto asset = MakeRaster("dirty", 0);
+  AttachRaster(asset);
+  Compile();
+  RenderMask();
+  std::fill(asset.pixels.begin(), asset.pixels.end(), 200);
+  store_->Save(asset);
+  device_.Workspace().Device().ResetCounters();
+  const RectI dirty[] = {{1, 2, 3, 2}, {3, 1, 2, 4}};
+  RenderMask(dirty);
+  ASSERT_EQ(device_.Workspace().Device().LastTextureRectangles().size(), 1U);
+  EXPECT_EQ(device_.Workspace().Device().LastTextureRectangles().front(), (RectI{1, 1, 4, 4}));
+  EXPECT_EQ(device_.Workspace().Device().HostToDeviceBytes(), 16U);
+}
+
+TEST_F(MetalMaskFixture, MetalRasterMaskMipChainUsesWorkspaceCache) {
+  AttachRaster(MakeRaster("reuse", 255));
+  Compile();
+  const auto first = RenderMask();
+  EXPECT_GT(first.mip_level_count, 1U);
+  RenderRequest request;
+  request.resolution.render_scale = 0.5f;
+  Compile(request);
+  const auto second = RenderMask();
+  EXPECT_EQ(first.persistent_texture_resource_id, second.persistent_texture_resource_id);
+  EXPECT_EQ(first.mip_level_count, second.mip_level_count);
+}
+
+TEST_F(MetalMaskFixture, MetalMaskFeatherMatchesExactSignedDistanceReference) {
+  SetExtent(9, 9);
+  auto asset = MakeRaster("exact", 0);
+  for (std::uint32_t y = 3; y <= 5; ++y) {
+    for (std::uint32_t x = 3; x <= 5; ++x) {
+      asset.pixels[y * width_ + x] = 255;
+    }
+  }
+  AttachRaster(asset, 2.0f);
+  Compile();
+  RenderMask();
+  const auto pixels = DownloadMask();
+  EXPECT_NEAR(pixels[4 * width_ + 2], 81, 8);
+  EXPECT_NEAR(pixels[2 * width_ + 2], 46, 10);
+  EXPECT_GT(pixels[4 * width_ + 4], 240);
+}
+
+TEST_F(MetalMaskFixture, MetalFeatherRadiusEditReusesSignedDistanceResult) {
+  auto asset = MakeRaster("radius", 0);
+  for (std::uint32_t y = 3; y < 9; ++y) {
+    for (std::uint32_t x = 4; x < 12; ++x) {
+      asset.pixels[y * width_ + x] = 255;
+    }
+  }
+  auto& node = AttachRaster(asset, 1.0f);
+  Compile();
+  const auto first = RenderMask();
+  node.SetFeatherRadius(4.0f);
+  const auto second = RenderMask();
+  EXPECT_NE(first.signed_distance_resource_id, 0U);
+  EXPECT_EQ(first.signed_distance_resource_id, second.signed_distance_resource_id);
+  EXPECT_EQ(second.transient_bytes, 0U);
+}
+
+TEST_F(MetalMaskFixture, MetalMaskSamplingMatchesCudaAtCropRotationAndDynamicResolution) {
+  auto&            node = AttachAnalytic(AnalyticMaskKind::Radial);
+  RadialMaskParams radial;
+  radial.major_radius = 0.35f;
+  radial.minor_radius = 0.25f;
+  node.SetRadial(radial);
+  document_.Geometry().SetCropRect({0.1f, 0.1f, 0.8f, 0.8f});
+  document_.Geometry().SetRotationDegrees(15.0f);
+  Compile();
+  RenderMask();
+  auto check = [&](const std::vector<std::uint8_t>& pixels) {
+    ASSERT_EQ(pixels.size(), static_cast<std::size_t>(plan_.geometry.render_extent.width) *
+                                 plan_.geometry.render_extent.height);
+    float max_err = 0.0f;
+    for (std::uint32_t y = 0; y < plan_.geometry.render_extent.height; ++y) {
+      for (std::uint32_t x = 0; x < plan_.geometry.render_extent.width; ++x) {
+        const float expected = CpuAnalytic(node, plan_.geometry, x, y);
+        const float got =
+            pixels[static_cast<std::size_t>(y) * plan_.geometry.render_extent.width + x] / 255.0f;
+        max_err = std::max(max_err, std::fabs(expected - got));
+      }
+    }
+    EXPECT_LT(max_err, 2.0f / 255.0f);
+  };
+  check(DownloadMask());
+
+  RenderRequest request;
+  request.resolution.render_scale = 0.5f;
+  Compile(request);
+  RenderMask();
+  check(DownloadMask());
+
+  auto asset = MakeRaster("sample", 0);
+  for (std::uint32_t y = 0; y < height_; ++y) {
+    for (std::uint32_t x = width_ / 2; x < width_; ++x) {
+      asset.pixels[y * width_ + x] = 255;
+    }
+  }
+  document_ = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document_);
+  document_.Geometry().SetCropRect({0.05f, 0.1f, 0.9f, 0.8f});
+  document_.Geometry().SetRotationDegrees(-20.0f);
+  AttachRaster(asset);
+  Compile();
+  RenderMask();
+  const auto raster     = DownloadMask();
+  const auto sampling   = MakeRasterMaskSamplingPlan(plan_.geometry, {}, asset.descriptor.extent);
+  float      raster_err = 0.0f;
+  for (std::uint32_t y = 0; y < plan_.geometry.render_extent.height; ++y) {
+    for (std::uint32_t x = 0; x < plan_.geometry.render_extent.width; ++x) {
+      const auto  uv       = Transform(sampling.render_to_texture_uv, static_cast<float>(x) + 0.5f,
+                                       static_cast<float>(y) + 0.5f);
+      const float expected = SampleR8(asset.pixels, width_, height_, uv.x, uv.y);
+      const float got =
+          raster[static_cast<std::size_t>(y) * plan_.geometry.render_extent.width + x] / 255.0f;
+      raster_err = std::max(raster_err, std::fabs(expected - got));
+    }
+  }
+  EXPECT_LT(raster_err, 2.0f / 255.0f);
+}
+
+TEST_F(MetalMaskFixture, MetalDisconnectedMaskUsesConstantOneWithoutTextureAllocation) {
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document_.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(1.0f);
+  Compile();
+  document_.PrimaryGrade()->SetMix(0.5f);
+  const auto result = RenderGrade();
+  EXPECT_EQ(device_.Workspace().MaskTextures().EntryCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Images().Find(plan_.mask_output), nullptr);
+  const auto source = DownloadImage(plan_.develop_output);
+  const auto mixed  = DownloadImage(result.output);
+  document_.PrimaryGrade()->SetMix(1.0f);
+  const auto full = DownloadImage(RenderGrade().output);
+  ASSERT_EQ(source.size(), mixed.size());
+  ASSERT_EQ(full.size(), mixed.size());
+  float max_err = 0.0f;
+  for (std::size_t i = 0; i < mixed.size(); ++i) {
+    max_err =
+        std::max(max_err, std::fabs(mixed[i].r - (source[i].r + (full[i].r - source[i].r) * 0.5f)));
+  }
+  EXPECT_LT(max_err, 2.0e-3f);
+  EXPECT_EQ(device_.Workspace().MaskTextures().EntryCount(), 0U);
+}
+
+TEST_F(MetalMaskFixture, MetalNormalMixMatchesCudaReferenceWithinTolerance) {
+  auto asset = MakeRaster("mix", 255);
+  AttachRaster(asset);
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document_.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(1.0f);
+  Compile();
+  const auto full_result = RenderGrade();
+  const auto full        = DownloadImage(full_result.output);
+  for (std::uint32_t y = 0; y < height_; ++y) {
+    for (std::uint32_t x = 0; x < width_ / 2; ++x) {
+      asset.pixels[y * width_ + x] = 0;
+    }
+  }
+  store_->Save(asset);
+  device_.BeginRender();
+  ExecuteMetalDevelop(device_, plan_, prepared_, document_);
+  ExecuteMetalGeometryResample(device_, plan_);
+  ExecuteMetalCameraColor(device_, plan_, document_);
+  const RectI dirty{0, 0, static_cast<std::int32_t>(width_ / 2),
+                    static_cast<std::int32_t>(height_)};
+  (void)ExecuteMetalMask(device_, plan_, document_, store_.get(), std::span{&dirty, 1});
+  const auto result = ExecuteMetalPrimaryGrade(device_, plan_, prepared_, document_);
+  device_.EndRender();
+  device_.WaitIdle();
+  const auto source = DownloadImage(plan_.develop_output);
+  const auto output = DownloadImage(result.output);
+  ASSERT_EQ(source.size(), output.size());
+  const auto left  = 5 * width_ + 2;
+  const auto right = 5 * width_ + width_ - 2;
+  EXPECT_NEAR(output[left].r, source[left].r, 1.0e-5f);
+  EXPECT_NEAR(output[right].r, full[right].r, 1.0e-5f);
+}
+
+TEST_F(MetalMaskFixture, MetalMaskCacheDoesNotEvictBusyTextures) {
+  auto& cache = device_.Workspace().MaskTextures();
+  cache.SetByteBudget(1);
+  device_.BeginRender();
+  {
+    auto active = cache.Acquire(MaskAssetKey{"active"}, {2, 2});
+  }
+  device_.EndRender();
+  {
+    auto next = cache.Acquire(MaskAssetKey{"next"}, {2, 2});
+  }
+  EXPECT_TRUE(cache.Contains(MaskAssetKey{"active"}));
+  EXPECT_TRUE(cache.Contains(MaskAssetKey{"next"}));
+  device_.WaitIdle();
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/metal_renderer_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_renderer_test.cpp
@@ -2,8 +2,11 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
+#include "edit/runtime/metal/metal_renderer.hpp"
+
 #include <gtest/gtest.h>
 
+#include <alcedo/metal/Metal.hpp>
 #include <cstdint>
 #include <memory>
 #include <span>
@@ -15,7 +18,6 @@
 #include "../input/prepared_raw_test_support.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
-#include "edit/runtime/metal/metal_renderer.hpp"
 #include "edit/scope/detail/scope_metal_shared.hpp"
 #include "edit/scope/final_display_frame_tap.hpp"
 #include "edit/scope/scope_analyzer.hpp"
@@ -85,6 +87,13 @@ class RecordingMetalPresentSink : public IFrameSink {
   void SubmitMetalFrame(const ViewerMetalFrame& frame) override {
     events_.push_back(PresentEvent::SubmitMetal);
     last_metal_ = frame;
+    if (last_frame_.ready_signal.resource) {
+      const auto* signal = static_cast<scope::metal_detail::MetalCommandBufferSignalResource*>(
+          last_frame_.ready_signal.resource.get());
+      viewer_texture_completed_before_submit_ =
+          signal != nullptr && signal->command_buffer &&
+          signal->command_buffer->status() == MTL::CommandBufferStatusCompleted;
+    }
   }
 
   void SubmitFinalDisplayFrame(const FinalDisplayFrameView& frame) override {
@@ -98,15 +107,16 @@ class RecordingMetalPresentSink : public IFrameSink {
     last_notified_ = submission;
   }
 
-  auto GetWidth() const -> int override { return width_; }
-  auto GetHeight() const -> int override { return height_; }
+  auto                      GetWidth() const -> int override { return width_; }
+  auto                      GetHeight() const -> int override { return height_; }
 
   std::vector<PresentEvent> events_;
   FinalDisplayFrameView     last_frame_{};
   ViewerMetalFrame          last_metal_{};
   FrameCompletionSubmission last_bound_{};
   FrameCompletionSubmission last_notified_{};
-  int                       submit_count_ = 0;
+  int                       submit_count_                           = 0;
+  bool                      viewer_texture_completed_before_submit_ = false;
 
  private:
   int width_  = 0;
@@ -134,9 +144,9 @@ class MetalRendererFixture : public ::testing::Test {
   }
 
   auto RenderHost(bool session = true) -> std::shared_ptr<ImageBuffer> {
-    return renderer_->Render(image_, DecodeRes::FULL, RenderRequest{}, nullptr, {}, true,
-                             session ? RenderCachePolicy::UseSessionCache
-                                     : RenderCachePolicy::BypassSessionCache);
+    return renderer_->Render(
+        image_, DecodeRes::FULL, RenderRequest{}, nullptr, {}, true,
+        session ? RenderCachePolicy::UseSessionCache : RenderCachePolicy::BypassSessionCache);
   }
 
   auto RenderTo(IFrameSink& sink, const FrameCompletionSubmission& submission = {})
@@ -157,9 +167,9 @@ TEST_F(MetalRendererFixture, MetalRendererPresentsWorkspaceTextureWithoutHostDow
   submission.metadata.presentation_request_id = 249;
   ASSERT_NE(RenderTo(sink, submission), nullptr);
 
-  const std::vector<PresentEvent> expected = {
-      PresentEvent::Bind, PresentEvent::Ensure, PresentEvent::SubmitFinal, PresentEvent::SubmitMetal,
-      PresentEvent::Notify};
+  const std::vector<PresentEvent> expected = {PresentEvent::Bind, PresentEvent::Ensure,
+                                              PresentEvent::SubmitFinal, PresentEvent::SubmitMetal,
+                                              PresentEvent::Notify};
   EXPECT_EQ(sink.events_, expected);
   EXPECT_EQ(sink.submit_count_, 1);
   EXPECT_EQ(sink.last_bound_.metadata.presentation_request_id, 249U);
@@ -171,24 +181,44 @@ TEST_F(MetalRendererFixture, MetalRendererPresentsWorkspaceTextureWithoutHostDow
   EXPECT_GT(sink.last_frame_.width, 0);
   EXPECT_GT(sink.last_frame_.height, 0);
   ASSERT_TRUE(static_cast<bool>(sink.last_metal_));
-  EXPECT_EQ(sink.last_metal_.texture_handle, sink.last_frame_.image.resource
-                                                 ? static_cast<scope::metal_detail::MetalTextureImageResource*>(
-                                                       sink.last_frame_.image.resource.get())
-                                                       ->native_object
-                                                 : 0U);
+  EXPECT_EQ(sink.last_metal_.texture_handle,
+            sink.last_frame_.image.resource
+                ? static_cast<scope::metal_detail::MetalTextureImageResource*>(
+                      sink.last_frame_.image.resource.get())
+                      ->native_object
+                : 0U);
+  EXPECT_TRUE(sink.viewer_texture_completed_before_submit_)
+      << "Qt Quick must not import a Metal texture before the DAG command buffer completes";
 
   renderer_->Device().WaitIdle();
-  auto* display = renderer_->Device().Workspace().Images().Find(
-      GraphValueId{NodeId{"drt"}, PortId{"display"}});
+  auto* display =
+      renderer_->Device().Workspace().Images().Find(GraphValueId{NodeId{"drt"}, PortId{"display"}});
   ASSERT_NE(display, nullptr);
   EXPECT_EQ(sink.last_metal_.texture_handle,
             reinterpret_cast<std::uintptr_t>(display->Texture().Native()));
 }
 
+TEST_F(MetalRendererFixture, MetalRoiKeepsNativePixelsWhenViewportTargetIsLarger) {
+  RecordingMetalPresentSink sink;
+  RenderRequest             request;
+  request.view.visible_rect_in_edit_space = NormalizedRect{0.25f, 0.25f, 0.25f, 0.25f};
+  request.view.viewport_extent            = Extent2D{100, 100};
+
+  ASSERT_NE(renderer_->Render(image_, DecodeRes::FULL, request, &sink, {}, false), nullptr);
+
+  // The prepared Bayer fixture has a 24x24 full-reference image after the demosaic border.
+  // Its quarter-size ROI therefore contains 6x6 native pixels. The viewer may enlarge those
+  // pixels with nearest-neighbor sampling; the Metal DAG must not interpolate them to 100x100.
+  EXPECT_EQ(sink.GetWidth(), 6);
+  EXPECT_EQ(sink.GetHeight(), 6);
+  EXPECT_EQ(sink.last_metal_.width, 6);
+  EXPECT_EQ(sink.last_metal_.height, 6);
+}
+
 TEST_F(MetalRendererFixture, MetalScopeTapUsesTheFinalDisplayTextureAndSubmissionSignal) {
-  RecordingMetalPresentSink     downstream;
-  FinalDisplayFrameTapSink      tap(&downstream, nullptr);
-  FrameCompletionSubmission     submission;
+  RecordingMetalPresentSink downstream;
+  FinalDisplayFrameTapSink  tap(&downstream, nullptr);
+  FrameCompletionSubmission submission;
   submission.metadata.image_identity          = 7;
   submission.metadata.session_epoch           = 2;
   submission.metadata.presentation_request_id = 88;
@@ -205,8 +235,8 @@ TEST_F(MetalRendererFixture, MetalScopeTapUsesTheFinalDisplayTextureAndSubmissio
   ASSERT_NE(signal, nullptr);
   EXPECT_NE(signal->command_buffer.get(), nullptr);
   ASSERT_TRUE(static_cast<bool>(downstream.last_metal_));
-  const auto* image = static_cast<scope::metal_detail::MetalTextureImageResource*>(
-      frame.image.resource.get());
+  const auto* image =
+      static_cast<scope::metal_detail::MetalTextureImageResource*>(frame.image.resource.get());
   ASSERT_NE(image, nullptr);
   EXPECT_EQ(downstream.last_metal_.texture_handle, image->native_object);
 }
@@ -240,8 +270,8 @@ TEST_F(MetalRendererFixture, MetalPipelineReturnReleasesSessionResourcesAfterGpu
 
 TEST_F(MetalRendererFixture, MetalBackendFailureDoesNotEnterCpuOrLegacyMetalExecution) {
   ASSERT_NE(RenderHost(true), nullptr);
-  const auto published_before = renderer_->SessionResources().published_result_count;
-  auto       develop          = document_->Develop()->Params().Params();
+  const auto published_before    = renderer_->SessionResources().published_result_count;
+  auto       develop             = document_->Develop()->Params().Params();
   develop.highlights_reconstruct = !develop.highlights_reconstruct;
   document_->Develop()->Params().ReplaceParams(develop);
   renderer_->Device().Workspace().Device().FailNextUpload();

--- a/alcedo_studio/tests/edit/runtime/metal_renderer_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_renderer_test.cpp
@@ -1,0 +1,269 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/runtime/metal/metal_renderer.hpp"
+#include "edit/scope/detail/scope_metal_shared.hpp"
+#include "edit/scope/final_display_frame_tap.hpp"
+#include "edit/scope/scope_analyzer.hpp"
+#include "image/image_buffer.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasMetalDevice() -> bool {
+  try {
+    return BindSystemDefaultMetalPresentationDevice() != nullptr;
+  } catch (...) {
+    return false;
+  }
+}
+
+auto MakeEncodedImage(std::uint8_t tag) -> std::shared_ptr<ImageBuffer> {
+  std::vector<std::uint8_t> bytes(64, tag);
+  bytes[0] = tag;
+  bytes[1] = 0x5A;
+  return std::make_shared<ImageBuffer>(std::move(bytes));
+}
+
+auto MakeUnpacker() -> PreparedSourceCache::UnpackFn {
+  return [](std::span<const std::byte>, DecodeRes decode_res) {
+    const auto pattern = gpu_dag_test::MakeRggbPattern();
+    return RawInputLoader::FromUnpackedCfa(gpu_dag_test::MakeU16CfaPlane(32, 32, pattern), pattern,
+                                           gpu_dag_test::DefaultLinearization(),
+                                           gpu_dag_test::FullSensor(32, 32), decode_res);
+  };
+}
+
+enum class PresentEvent {
+  Bind,
+  Ensure,
+  Map,
+  SubmitFinal,
+  SubmitMetal,
+  SubmitHost,
+  Unmap,
+  Notify,
+};
+
+class RecordingMetalPresentSink : public IFrameSink {
+ public:
+  void EnsureSize(int width, int height) override {
+    events_.push_back(PresentEvent::Ensure);
+    width_  = width;
+    height_ = height;
+  }
+
+  auto MapResourceForWrite(FrameMemoryDomain) -> FrameWriteMapping override {
+    events_.push_back(PresentEvent::Map);
+    return {};
+  }
+
+  void UnmapResource() override { events_.push_back(PresentEvent::Unmap); }
+
+  void BindFrameSubmission(const FrameCompletionSubmission& submission) override {
+    events_.push_back(PresentEvent::Bind);
+    last_bound_ = submission;
+  }
+
+  void SubmitHostFrame(const ViewerFrame&) override { events_.push_back(PresentEvent::SubmitHost); }
+
+  void SubmitMetalFrame(const ViewerMetalFrame& frame) override {
+    events_.push_back(PresentEvent::SubmitMetal);
+    last_metal_ = frame;
+  }
+
+  void SubmitFinalDisplayFrame(const FinalDisplayFrameView& frame) override {
+    events_.push_back(PresentEvent::SubmitFinal);
+    last_frame_ = frame;
+    ++submit_count_;
+  }
+
+  void NotifyFrameReady(const FrameCompletionSubmission& submission) override {
+    events_.push_back(PresentEvent::Notify);
+    last_notified_ = submission;
+  }
+
+  auto GetWidth() const -> int override { return width_; }
+  auto GetHeight() const -> int override { return height_; }
+
+  std::vector<PresentEvent> events_;
+  FinalDisplayFrameView     last_frame_{};
+  ViewerMetalFrame          last_metal_{};
+  FrameCompletionSubmission last_bound_{};
+  FrameCompletionSubmission last_notified_{};
+  int                       submit_count_ = 0;
+
+ private:
+  int width_  = 0;
+  int height_ = 0;
+};
+
+class ThrowingMetalPresentSink final : public RecordingMetalPresentSink {
+ public:
+  void SubmitMetalFrame(const ViewerMetalFrame&) override {
+    throw std::runtime_error("present sink rejected the Metal frame");
+  }
+};
+
+class MetalRendererFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasMetalDevice()) {
+      GTEST_SKIP() << "No Metal device available.";
+    }
+    (void)BindSystemDefaultMetalPresentationDevice();
+    document_ = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+    gpu_dag_test::EnsureTestCameraProfile(*document_);
+    renderer_ = std::make_unique<MetalRenderer>(document_, MakeUnpacker());
+    image_    = MakeEncodedImage(91);
+  }
+
+  auto RenderHost(bool session = true) -> std::shared_ptr<ImageBuffer> {
+    return renderer_->Render(image_, DecodeRes::FULL, RenderRequest{}, nullptr, {}, true,
+                             session ? RenderCachePolicy::UseSessionCache
+                                     : RenderCachePolicy::BypassSessionCache);
+  }
+
+  auto RenderTo(IFrameSink& sink, const FrameCompletionSubmission& submission = {})
+      -> std::shared_ptr<ImageBuffer> {
+    return renderer_->Render(image_, DecodeRes::FULL, RenderRequest{}, &sink, submission, false);
+  }
+
+  std::shared_ptr<PipelineDocument> document_;
+  std::unique_ptr<MetalRenderer>    renderer_;
+  std::shared_ptr<ImageBuffer>      image_;
+};
+
+TEST_F(MetalRendererFixture, MetalRendererPresentsWorkspaceTextureWithoutHostDownload) {
+  RecordingMetalPresentSink sink;
+  FrameCompletionSubmission submission;
+  submission.metadata.image_identity          = 18;
+  submission.metadata.session_epoch           = 4;
+  submission.metadata.presentation_request_id = 249;
+  ASSERT_NE(RenderTo(sink, submission), nullptr);
+
+  const std::vector<PresentEvent> expected = {
+      PresentEvent::Bind, PresentEvent::Ensure, PresentEvent::SubmitFinal, PresentEvent::SubmitMetal,
+      PresentEvent::Notify};
+  EXPECT_EQ(sink.events_, expected);
+  EXPECT_EQ(sink.submit_count_, 1);
+  EXPECT_EQ(sink.last_bound_.metadata.presentation_request_id, 249U);
+  EXPECT_EQ(sink.last_notified_.metadata.presentation_request_id, 249U);
+  ASSERT_TRUE(static_cast<bool>(sink.last_frame_));
+  EXPECT_EQ(sink.last_frame_.image.backend, GpuBackend::Metal);
+  EXPECT_EQ(sink.last_frame_.format, FramePixelFormat::RGBA32F);
+  EXPECT_EQ(sink.last_frame_.domain, AnalysisDomain::DisplayEncoded);
+  EXPECT_GT(sink.last_frame_.width, 0);
+  EXPECT_GT(sink.last_frame_.height, 0);
+  ASSERT_TRUE(static_cast<bool>(sink.last_metal_));
+  EXPECT_EQ(sink.last_metal_.texture_handle, sink.last_frame_.image.resource
+                                                 ? static_cast<scope::metal_detail::MetalTextureImageResource*>(
+                                                       sink.last_frame_.image.resource.get())
+                                                       ->native_object
+                                                 : 0U);
+
+  renderer_->Device().WaitIdle();
+  auto* display = renderer_->Device().Workspace().Images().Find(
+      GraphValueId{NodeId{"drt"}, PortId{"display"}});
+  ASSERT_NE(display, nullptr);
+  EXPECT_EQ(sink.last_metal_.texture_handle,
+            reinterpret_cast<std::uintptr_t>(display->Texture().Native()));
+}
+
+TEST_F(MetalRendererFixture, MetalScopeTapUsesTheFinalDisplayTextureAndSubmissionSignal) {
+  RecordingMetalPresentSink     downstream;
+  FinalDisplayFrameTapSink      tap(&downstream, nullptr);
+  FrameCompletionSubmission     submission;
+  submission.metadata.image_identity          = 7;
+  submission.metadata.session_epoch           = 2;
+  submission.metadata.presentation_request_id = 88;
+  submission.metadata.scope_update_allowed    = true;
+  ASSERT_NE(RenderTo(tap, submission), nullptr);
+
+  const auto frame = tap.GetCurrentDisplayFrameView();
+  ASSERT_TRUE(static_cast<bool>(frame));
+  EXPECT_EQ(frame.image.backend, GpuBackend::Metal);
+  EXPECT_EQ(frame.ready_signal.backend, GpuBackend::Metal);
+  ASSERT_NE(frame.ready_signal.resource, nullptr);
+  const auto* signal = static_cast<scope::metal_detail::MetalCommandBufferSignalResource*>(
+      frame.ready_signal.resource.get());
+  ASSERT_NE(signal, nullptr);
+  EXPECT_NE(signal->command_buffer.get(), nullptr);
+  ASSERT_TRUE(static_cast<bool>(downstream.last_metal_));
+  const auto* image = static_cast<scope::metal_detail::MetalTextureImageResource*>(
+      frame.image.resource.get());
+  ASSERT_NE(image, nullptr);
+  EXPECT_EQ(downstream.last_metal_.texture_handle, image->native_object);
+}
+
+TEST_F(MetalRendererFixture, MetalOneShotRenderDoesNotPublishIntoSessionCache) {
+  ASSERT_NE(RenderHost(true), nullptr);
+  const auto session_before = renderer_->SessionResources();
+  EXPECT_GT(session_before.published_result_count, 0U);
+  renderer_->ResetStats();
+
+  ASSERT_NE(RenderHost(false), nullptr);
+  EXPECT_EQ(renderer_->OneShotPublishedResultCount(), 0U);
+  EXPECT_EQ(renderer_->SessionResources().published_result_count,
+            session_before.published_result_count);
+  EXPECT_EQ(renderer_->SessionResources().prepared_source_entry_count,
+            session_before.prepared_source_entry_count);
+  EXPECT_EQ(renderer_->Stats().prepared_source_hits, 0U);
+  EXPECT_EQ(renderer_->Stats().plan_cache_hits, 0U);
+  EXPECT_EQ(renderer_->Stats().pass.sensor_develop_execute, 0U);
+}
+
+TEST_F(MetalRendererFixture, MetalPipelineReturnReleasesSessionResourcesAfterGpuCompletion) {
+  ASSERT_NE(RenderHost(true), nullptr);
+  EXPECT_GT(renderer_->SessionResources().published_result_count, 0U);
+  renderer_->ReleaseSessionCaches();
+  EXPECT_EQ(renderer_->SessionResources().published_result_count, 0U);
+  EXPECT_EQ(renderer_->SessionResources().prepared_source_entry_count, 0U);
+  EXPECT_TRUE(renderer_->SessionResources().session_value_ids.empty());
+  EXPECT_FALSE(renderer_->Device().Workspace().IsRendering());
+}
+
+TEST_F(MetalRendererFixture, MetalBackendFailureDoesNotEnterCpuOrLegacyMetalExecution) {
+  ASSERT_NE(RenderHost(true), nullptr);
+  const auto published_before = renderer_->SessionResources().published_result_count;
+  auto       develop          = document_->Develop()->Params().Params();
+  develop.highlights_reconstruct = !develop.highlights_reconstruct;
+  document_->Develop()->Params().ReplaceParams(develop);
+  renderer_->Device().Workspace().Device().FailNextUpload();
+  EXPECT_THROW(RenderHost(true), std::runtime_error);
+  EXPECT_EQ(renderer_->SessionResources().published_result_count, published_before);
+  EXPECT_FALSE(renderer_->Device().Workspace().IsRendering());
+
+  ThrowingMetalPresentSink sink;
+  EXPECT_THROW(RenderTo(sink), std::runtime_error);
+  EXPECT_EQ(renderer_->Device().Workspace().Images().UnpublishedCount(), 0U);
+}
+
+TEST_F(MetalRendererFixture, MetalRealRawEditorUsesTheThreeNodeDag) {
+  EXPECT_EQ(document_->Graph().Nodes().size(), 3U);
+  EXPECT_NE(document_->Develop(), nullptr);
+  EXPECT_NE(document_->PrimaryGrade(), nullptr);
+  EXPECT_NE(document_->Drt(), nullptr);
+  auto host = RenderHost(true);
+  ASSERT_NE(host, nullptr);
+  EXPECT_EQ(renderer_->Stats().pass.drt_execute, 1U);
+  EXPECT_EQ(document_->Graph().Nodes().size(), 3U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/metal_workspace_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_workspace_test.cpp
@@ -1,0 +1,265 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <algorithm>
+#include <cstring>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/mask/mask_asset.hpp"
+#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/texture_format.hpp"
+#include "metal_workspace_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+using metal_workspace_test::BindSharpen;
+using metal_workspace_test::ExposureFieldBindings;
+using metal_workspace_test::MetalWorkspaceFixture;
+using metal_workspace_test::UploadFullAndClearDirty;
+
+TEST_F(MetalWorkspaceFixture, MetalParameterArenaUploadsOnlyDirtyRanges) {
+  MetalRenderDevice device;
+  ParameterSlotKey  key{NodeId{"grade.primary"}, AdjustmentInstanceId{"sharpen"}};
+  SharpenModel      model;
+  BindSharpen(device.Workspace().Parameters(), key);
+  ASSERT_TRUE(UploadFullAndClearDirty(device, key, model));
+
+  model.SetAmount(12.0f);
+  auto pending = TakePendingParameterPatch(model);
+  ASSERT_TRUE(pending.has_value());
+
+  auto& backend = device.Workspace().Device();
+  backend.ResetCounters();
+  device.Workspace().Parameters().ApplyPatch(key, pending->Patch());
+  device.Workspace().Parameters().UploadDirty(device.CommandContext());
+  device.WaitIdle();
+  pending->Commit();
+
+  ASSERT_EQ(backend.LastHostToDeviceRanges().size(), 1U);
+  EXPECT_EQ(backend.LastHostToDeviceRanges().front().size, 4U);
+  EXPECT_EQ(backend.HostToDeviceBytes(), 4U);
+  EXPECT_LT(backend.HostToDeviceBytes(), sizeof(SharpenPayload));
+
+  backend.ResetCounters();
+  device.Workspace().Parameters().UploadDirty(device.CommandContext());
+  EXPECT_EQ(backend.HostToDeviceBytes(), 0U);
+  EXPECT_EQ(backend.HostToDeviceCopyCount(), 0U);
+}
+
+TEST_F(MetalWorkspaceFixture, MetalTransientArenaRewindsWithoutReallocatingItsSlab) {
+  MetalRenderDevice device;
+  auto&             transients = device.Workspace().TransientBuffers();
+  transients.Reserve(4096);
+  device.Workspace().Device().ResetCounters();
+
+  void* first = transients.Allocate(512);
+  ASSERT_NE(first, nullptr);
+  const auto capacity = transients.capacity_bytes();
+  transients.Reset();
+  EXPECT_EQ(transients.used_bytes(), 0U);
+  EXPECT_EQ(transients.capacity_bytes(), capacity);
+  void* second = transients.Allocate(512);
+  EXPECT_EQ(second, first);
+  EXPECT_EQ(device.Workspace().Device().MallocCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().FreeCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().BufferCreateCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().HeapCreateCount(), 0U);
+}
+
+TEST_F(MetalWorkspaceFixture, MetalTexturePoolReusesMatchingPrivateTextures) {
+  MetalRenderDevice device;
+  auto&             textures = device.Workspace().Textures();
+  textures.SetByteBudget(64 * 64 * 16);
+
+  device.BeginRender();
+  auto first = textures.Acquire({32, 16, TextureFormat::Rgba32f});
+  ASSERT_FALSE(first.Empty());
+  const auto             resource_id = first.Texture().ResourceId();
+  const auto             width       = first.Texture().Width();
+  std::vector<std::byte> pixels(static_cast<std::size_t>(32) * 16 * 16, std::byte{0x3F});
+  device.Workspace().Device().UploadTexture2D(first.Texture(), pixels, device.CommandContext());
+  device.EndRender();
+  first.Release();
+  device.WaitIdle();
+  device.Workspace().Device().ResetCounters();
+
+  device.BeginRender();
+  auto second = textures.Acquire({32, 16, TextureFormat::Rgba32f});
+  EXPECT_EQ(second.Texture().ResourceId(), resource_id);
+  EXPECT_EQ(second.Texture().Width(), width);
+  device.EndRender();
+  device.WaitIdle();
+  EXPECT_EQ(device.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().HeapCreateCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().MallocCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().FreeCount(), 0U);
+
+  device.BeginRender();
+  auto               r32 = textures.Acquire({8, 8, TextureFormat::R32f});
+  std::vector<float> r32_host(64, 2.5f);
+  auto               r32_bytes = std::as_bytes(std::span<const float>(r32_host));
+  device.Workspace().Device().UploadTexture2D(r32.Texture(), r32_bytes, device.CommandContext());
+  std::vector<float> r32_back(64, 0.0f);
+  device.EndRender();
+  device.WaitIdle();
+  device.Workspace().Device().DownloadTexture2D(
+      r32.Texture(), std::as_writable_bytes(std::span<float>(r32_back)), device.CommandContext());
+  EXPECT_FLOAT_EQ(r32_back[0], 2.5f);
+  EXPECT_FLOAT_EQ(r32_back[63], 2.5f);
+}
+
+TEST_F(MetalWorkspaceFixture, MetalTexturePoolDoesNotEvictBusySubmissionResources) {
+  MetalRenderDevice       device;
+  auto&                   textures = device.Workspace().Textures();
+  constexpr std::uint32_t kSize    = 64;
+  textures.SetByteBudget(static_cast<std::size_t>(kSize) * kSize);
+
+  device.BeginRender();
+  auto       lease_a  = textures.Acquire({kSize, kSize, TextureFormat::R8});
+  const auto handle_a = lease_a.Handle();
+  auto       lease_b  = textures.Acquire({kSize, kSize, TextureFormat::R8});
+  EXPECT_TRUE(textures.Contains(handle_a));
+  device.EndRender();
+
+  lease_a.Release();
+  lease_b.Release();
+  textures.EvictUntil(static_cast<std::size_t>(kSize) * kSize);
+  EXPECT_TRUE(textures.Contains(handle_a));
+
+  device.BeginRender();
+  textures.EvictUntil(static_cast<std::size_t>(kSize) * kSize);
+  EXPECT_FALSE(textures.Contains(handle_a));
+  device.EndRender();
+  device.WaitIdle();
+}
+
+TEST_F(MetalWorkspaceFixture, MetalMaskTextureCacheUsesOneWorkspaceByteBudget) {
+  MetalRenderDevice device;
+  auto&             masks = device.Workspace().MaskTextures();
+  const Extent2D    extent{8, 8};
+  std::size_t       chain_bytes = 0;
+  auto              level       = extent;
+  while (true) {
+    chain_bytes += static_cast<std::size_t>(level.width) * level.height;
+    if (level.width == 1 && level.height == 1) {
+      break;
+    }
+    level.width  = std::max<std::uint32_t>(level.width / 2, 1);
+    level.height = std::max<std::uint32_t>(level.height / 2, 1);
+  }
+  masks.SetByteBudget(chain_bytes);
+
+  {
+    auto first = masks.Acquire(MaskAssetKey{"mask.a"}, extent);
+    EXPECT_EQ(masks.EntryCount(), 1U);
+    EXPECT_LE(masks.UsedBytes(), chain_bytes);
+  }
+  device.BeginRender();
+  device.EndRender();
+  device.WaitIdle();
+  auto second = masks.Acquire(MaskAssetKey{"mask.b"}, extent);
+  EXPECT_EQ(masks.EntryCount(), 1U);
+  EXPECT_FALSE(masks.Contains(MaskAssetKey{"mask.a"}));
+  EXPECT_TRUE(masks.Contains(MaskAssetKey{"mask.b"}));
+  EXPECT_LE(masks.UsedBytes(), chain_bytes);
+}
+
+TEST_F(MetalWorkspaceFixture, MetalSecondEmptyRenderCreatesNoBufferTextureHeapOrPipelineState) {
+  MetalRenderDevice         device;
+  auto&                     workspace = device.Workspace();
+  const MetalPipelineWarmup warmup{ALCEDO_METAL_UTILS_METALLIB_PATH, "convert_r32f_to_r32f",
+                                   "MetalM1WarmUp"};
+  workspace.Device().WarmUpPipelines(std::span<const MetalPipelineWarmup>(&warmup, 1));
+  workspace.Device().WarmUpPipelines(std::span<const MetalPipelineWarmup>(&warmup, 1));
+  EXPECT_GE(workspace.Device().PipelineCreateCount(), 1U);
+  EXPECT_GE(workspace.Device().PipelineHitCount(), 1U);
+
+  workspace.Parameters().Reserve(256);
+  workspace.TransientBuffers().Reserve(1 << 20);
+  workspace.Textures().SetByteBudget(64 * 64);
+  workspace.MaskTextures().SetByteBudget(64 * 64);
+
+  device.BeginRender();
+  {
+    auto texture = workspace.Textures().Acquire({64, 64, TextureFormat::R8});
+    auto mask    = workspace.MaskTextures().Acquire(MaskAssetKey{"mask.stable"}, {32, 32});
+    ASSERT_NE(workspace.TransientBuffers().Allocate(2048), nullptr);
+    auto buffer = workspace.Device().CreateBuffer(64);
+    workspace.Values().Store({NodeId{"grade.primary"}, PortId{"commands"}}, std::move(buffer));
+    device.EndRender();
+  }
+  device.WaitIdle();
+  workspace.Device().ResetCounters();
+
+  device.BeginRender();
+  {
+    auto texture = workspace.Textures().Acquire({64, 64, TextureFormat::R8});
+    auto mask    = workspace.MaskTextures().Acquire(MaskAssetKey{"mask.stable"}, {32, 32});
+    ASSERT_NE(workspace.TransientBuffers().Allocate(2048), nullptr);
+    device.EndRender();
+  }
+  device.WaitIdle();
+
+  EXPECT_EQ(workspace.Device().BufferCreateCount(), 0U);
+  EXPECT_EQ(workspace.Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(workspace.Device().HeapCreateCount(), 0U);
+  EXPECT_EQ(workspace.Device().PipelineCreateCount(), 0U);
+  EXPECT_EQ(workspace.Device().MallocCount(), 0U);
+  EXPECT_EQ(workspace.Device().FreeCount(), 0U);
+  EXPECT_EQ(workspace.Device().HostToDeviceBytes(), 0U);
+}
+
+TEST_F(MetalWorkspaceFixture, MetalFailedUploadRestoresDirtyFieldsAndPublishesNoResult) {
+  MetalRenderDevice device;
+  ParameterSlotKey  key{NodeId{"grade.primary"}, AdjustmentInstanceId{"exposure"}};
+  ExposureModel     model;
+  const auto        fields = ExposureFieldBindings();
+  device.Workspace().Parameters().BindSlot(key, 4, fields);
+  ASSERT_TRUE(UploadFullAndClearDirty(device, key, model));
+
+  model.SetValue(0.75f);
+  {
+    auto pending = TakePendingParameterPatch(model);
+    ASSERT_TRUE(pending.has_value());
+    device.Workspace().Device().FailNextUpload();
+    device.Workspace().Parameters().ApplyPatch(key, pending->Patch());
+    EXPECT_THROW(device.Workspace().Parameters().UploadDirty(device.CommandContext()),
+                 std::runtime_error);
+  }
+  EXPECT_TRUE(model.IsDirty());
+
+  const GraphValueId id{NodeId{"develop"}, PortId{"sensor_linear"}};
+  const ContentKey   content{41};
+  device.BeginRender();
+  (void)device.Workspace().AcquireImageForWrite(id, {8, 8, TextureFormat::Rgba32f});
+  device.Workspace().Images().RecordUnpublished(id, content, {8, 8}, TextureFormat::Rgba32f,
+                                                device.CommandContext().SubmissionId());
+  device.Workspace().Device().FailNextUpload();
+  std::vector<std::byte> pixels(8 * 8 * 16, std::byte{1});
+  EXPECT_THROW(
+      device.Workspace().Device().UploadTexture2D(device.Workspace().Images().Find(id)->Texture(),
+                                                  pixels, device.CommandContext()),
+      std::runtime_error);
+  device.CancelRender();
+  device.WaitIdle();
+  EXPECT_FALSE(device.Workspace().Images().FindValidResult(
+      id, content, {8, 8}, TextureFormat::Rgba32f,
+      device.Workspace().Device().CompletedSubmission()));
+  EXPECT_EQ(device.Workspace().Images().PublishedCount(), 0U);
+}
+
+TEST_F(MetalWorkspaceFixture, MetalRenderDeviceUsesThePresentationDevice) {
+  ASSERT_NE(presentation_device_, nullptr);
+  MetalRenderDevice device;
+  EXPECT_EQ(device.Workspace().Device().NativeDevice(), presentation_device_);
+  EXPECT_EQ(MetalPresentationDeviceHandle(), presentation_device_);
+  EXPECT_GT(device.Workspace().Device().WorkingSetBudgetBytes(), 0U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/metal_workspace_test_support.hpp
+++ b/alcedo_studio/tests/edit/runtime/metal_workspace_test_support.hpp
@@ -1,0 +1,77 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/operators/models/sharpen_model.hpp"
+#include "edit/runtime/metal/metal_renderer.hpp"
+#include "edit/runtime/parameter_binding.hpp"
+
+namespace alcedo {
+namespace metal_workspace_test {
+
+inline auto HasMetalDevice() -> bool {
+  try {
+    return BindSystemDefaultMetalPresentationDevice() != nullptr;
+  } catch (...) {
+    return false;
+  }
+}
+
+class MetalWorkspaceFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!HasMetalDevice()) {
+      GTEST_SKIP() << "No Metal device available.";
+    }
+    presentation_device_ = BindSystemDefaultMetalPresentationDevice();
+  }
+
+  void* presentation_device_ = nullptr;
+};
+
+inline auto SharpenFieldBindings() -> std::vector<ParameterFieldBinding> {
+  return {
+      ParameterFieldBinding{DirtyFieldMask{SharpenDirty::Amount},
+                            static_cast<std::uint32_t>(offsetof(SharpenPayload, amount)), 0, 4},
+      ParameterFieldBinding{DirtyFieldMask{SharpenDirty::Radius},
+                            static_cast<std::uint32_t>(offsetof(SharpenPayload, radius)), 4, 4},
+      ParameterFieldBinding{DirtyFieldMask{SharpenDirty::Threshold},
+                            static_cast<std::uint32_t>(offsetof(SharpenPayload, threshold)), 8, 4},
+  };
+}
+
+inline auto ExposureFieldBindings() -> std::vector<ParameterFieldBinding> {
+  return {ParameterFieldBinding{DirtyFieldMask{ExposureTraits::Dirty::Value}, 0, 0, 4}};
+}
+
+inline auto BindSharpen(ParameterArena<MetalBackend>& arena, ParameterSlotKey key)
+    -> ParameterBinding {
+  const auto fields = SharpenFieldBindings();
+  return arena.BindSlot(key, static_cast<std::uint32_t>(sizeof(SharpenPayload)), fields);
+}
+
+inline auto UploadFullAndClearDirty(MetalRenderDevice& device, ParameterSlotKey key,
+                                    IOperatorModel& model) -> bool {
+  auto& arena = device.Workspace().Parameters();
+  arena.InitializeFromFullDto(key, model.MakeFullDto());
+  arena.UploadDirty(device.CommandContext());
+  auto pending = TakePendingParameterPatch(model);
+  if (!pending.has_value()) {
+    return false;
+  }
+  pending->Commit();
+  return true;
+}
+
+}  // namespace metal_workspace_test
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/renderer_metal_instantiate_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/renderer_metal_instantiate_test.cpp
@@ -1,0 +1,60 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/runtime/metal/metal_backend.hpp"
+#include "edit/runtime/metal/metal_renderer.hpp"
+#include "edit/runtime/render_backend.hpp"
+#include "edit/runtime/renderer.hpp"
+
+namespace alcedo {
+namespace {
+
+TEST(GpuDagRendererTemplate, RendererTemplateInstantiatesMetalWithoutCudaHeaders) {
+  const char* files[] = {"renderer.hpp", "plan_executor.hpp", "pass_encoder.hpp",
+                         "basic_render_device.hpp", "frame_presenter.hpp"};
+  const std::filesystem::path root{ALCEDO_RUNTIME_HEADER_ROOT};
+  for (const char* name : files) {
+    std::ifstream input(root / name);
+    ASSERT_TRUE(input) << name;
+    std::string text((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(text.find("cuda_runtime"), std::string::npos) << name;
+    EXPECT_EQ(text.find("cuda.h"), std::string::npos) << name;
+  }
+
+  const auto metal_backend_path =
+      std::filesystem::path{ALCEDO_RUNTIME_HEADER_ROOT} / "metal" / "metal_backend.hpp";
+  std::ifstream metal_input(metal_backend_path);
+  ASSERT_TRUE(metal_input);
+  std::string metal_text((std::istreambuf_iterator<char>(metal_input)),
+                         std::istreambuf_iterator<char>());
+  EXPECT_EQ(metal_text.find("cuda_runtime"), std::string::npos);
+  EXPECT_EQ(metal_text.find("cuda.h"), std::string::npos);
+  EXPECT_EQ(metal_text.find("Metal/"), std::string::npos);
+  EXPECT_EQ(metal_text.find("metal.h"), std::string::npos);
+
+  static_assert(RenderBackend<MetalBackend>);
+  static_assert(std::is_same_v<MetalRenderer, Renderer<MetalBackend>>);
+  static_assert(sizeof(MetalRenderer) > 0);
+  EXPECT_EQ(kMetalDagBackendCapabilityVersion, MetalBackend::kCapabilityVersion);
+  EXPECT_NE(kMetalDagBackendCapabilityVersion, 1U);
+
+  auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  MetalRenderer renderer(document);
+  EXPECT_EQ(renderer.PlanCache().BackendCapabilityVersion(), kMetalDagBackendCapabilityVersion);
+  EXPECT_EQ(renderer.SessionResources().published_result_count, 0U);
+  EXPECT_EQ(renderer.OneShotPublishedResultCount(), 0U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
@@ -2,6 +2,8 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
+#include "edit/runtime/result_content_key.hpp"
+
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -14,7 +16,6 @@
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 #include "edit/runtime/graph_compiler.hpp"
-#include "edit/runtime/result_content_key.hpp"
 
 namespace alcedo {
 namespace {
@@ -35,7 +36,8 @@ void ConnectRasterMask(PipelineDocument& document, std::string asset_key = "test
 
 TEST(GpuDagResultContentKey, GraphCompilerAssignsDistinctSensorGeometryAndDevelopValueIds) {
   auto       document = CreateDefaultPipelineDocument();
-  const auto plan = GraphCompiler::Compile(document, MakePrepared().CompileSource(), RenderRequest{});
+  const auto plan =
+      GraphCompiler::Compile(document, MakePrepared().CompileSource(), RenderRequest{});
   EXPECT_EQ(plan.sensor_linear_output.producer.Value(), "develop");
   EXPECT_EQ(plan.sensor_linear_output.output_port.Value(), "sensor_linear");
   EXPECT_EQ(plan.geometry_output.producer.Value(), "geometry");
@@ -51,21 +53,21 @@ TEST(GpuDagResultContentKey, GraphCompilerAssignsDistinctSensorGeometryAndDevelo
 }
 
 TEST(GpuDagResultContentKey, SensorLinearKeyIgnoresCctTintGradeAndDrt) {
-  auto prepared = MakePrepared();
-  auto document = CreateDefaultPipelineDocument();
-  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
-  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+  auto       prepared = MakePrepared();
+  auto       document = CreateDefaultPipelineDocument();
+  auto       plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base     = BuildFrameResultContentKeys(plan, prepared, document);
 
-  auto develop = document.Develop()->Params().Params();
-  develop.wb_mode    = "custom";
-  develop.custom_cct = 4200.0f;
+  auto       develop  = document.Develop()->Params().Params();
+  develop.wb_mode     = "custom";
+  develop.custom_cct  = 4200.0f;
   develop.custom_tint = 8.0f;
   document.Develop()->Params().ReplaceParams(develop);
   auto* exposure = dynamic_cast<ExposureModel*>(
       document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
   ASSERT_NE(exposure, nullptr);
   exposure->SetValue(1.25f);
-  auto drt = document.Drt()->Params().Params();
+  auto drt           = document.Drt()->Params().Params();
   drt.peak_luminance = 200.0f;
   document.Drt()->Params().ReplaceParams(drt);
 
@@ -78,10 +80,10 @@ TEST(GpuDagResultContentKey, SensorLinearKeyIgnoresCctTintGradeAndDrt) {
 }
 
 TEST(GpuDagResultContentKey, GeometryKeyIncludesViewportAndCropAndIgnoresGrade) {
-  auto prepared = MakePrepared();
-  auto document = CreateDefaultPipelineDocument();
-  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
-  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+  auto          prepared = MakePrepared();
+  auto          document = CreateDefaultPipelineDocument();
+  auto          plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto    base = BuildFrameResultContentKeys(plan, prepared, document);
 
   RenderRequest viewport;
   viewport.view.visible_rect_in_edit_space = {0.1f, 0.1f, 0.8f, 0.8f};
@@ -110,11 +112,11 @@ TEST(GpuDagResultContentKey, GeometryKeyIncludesViewportAndCropAndIgnoresGrade) 
 }
 
 TEST(GpuDagResultContentKey, LlfReferenceKeyIgnoresViewportAndFollowsCropAndGrade) {
-  auto prepared = MakePrepared();
-  auto document = CreateDefaultPipelineDocument();
-  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
-  const auto base      = HashLlfReferenceKey(plan, prepared, document);
-  const auto base_keys = BuildFrameResultContentKeys(plan, prepared, document);
+  auto          prepared = MakePrepared();
+  auto          document = CreateDefaultPipelineDocument();
+  auto          plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto    base = HashLlfReferenceKey(plan, prepared, document);
+  const auto    base_keys = BuildFrameResultContentKeys(plan, prepared, document);
 
   RenderRequest viewport;
   viewport.view.visible_rect_in_edit_space = {0.25f, 0.25f, 0.5f, 0.5f};
@@ -137,13 +139,34 @@ TEST(GpuDagResultContentKey, LlfReferenceKeyIgnoresViewportAndFollowsCropAndGrad
   EXPECT_NE(HashLlfReferenceKey(plan, prepared, document), base);
 }
 
-TEST(GpuDagResultContentKey, HighlightRecoverChangesSensorLinearAndAllDownstreamKeys) {
-  auto prepared = MakePrepared();
-  auto document = CreateDefaultPipelineDocument();
-  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
-  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+TEST(GpuDagResultContentKey, LlfSourceKeyIgnoresShadowsAndHighlightsSliderValues) {
+  auto       prepared = MakePrepared();
+  auto       document = CreateDefaultPipelineDocument();
+  auto       plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base_source = HashLlfSourceKey(plan, prepared, document);
+  const auto base_result = HashLlfReferenceKey(plan, prepared, document);
 
-  auto develop = document.Develop()->Params().Params();
+  auto*      shadows     = dynamic_cast<ShadowsModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Shadows()));
+  ASSERT_NE(shadows, nullptr);
+  shadows->SetValue(40.0f);
+  EXPECT_EQ(HashLlfSourceKey(plan, prepared, document), base_source);
+  EXPECT_NE(HashLlfReferenceKey(plan, prepared, document), base_result);
+
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(-0.5f);
+  EXPECT_NE(HashLlfSourceKey(plan, prepared, document), base_source);
+}
+
+TEST(GpuDagResultContentKey, HighlightRecoverChangesSensorLinearAndAllDownstreamKeys) {
+  auto       prepared = MakePrepared();
+  auto       document = CreateDefaultPipelineDocument();
+  auto       plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base     = BuildFrameResultContentKeys(plan, prepared, document);
+
+  auto       develop  = document.Develop()->Params().Params();
   develop.highlights_reconstruct = !develop.highlights_reconstruct;
   document.Develop()->Params().ReplaceParams(develop);
   const auto edited = BuildFrameResultContentKeys(plan, prepared, document);
@@ -158,7 +181,7 @@ TEST(GpuDagResultContentKey, ExposureEditWithRasterMaskKeepsSensorGeometryDevelo
   auto prepared = MakePrepared();
   auto document = CreateDefaultPipelineDocument();
   ConnectRasterMask(document);
-  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  auto       plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   const auto base = BuildFrameResultContentKeys(plan, prepared, document);
   ASSERT_FALSE(base.mask.Empty());
 
@@ -179,7 +202,7 @@ TEST(GpuDagResultContentKey, RasterMaskParamChangeInvalidatesMaskAndGradeNotSens
   auto prepared = MakePrepared();
   auto document = CreateDefaultPipelineDocument();
   ConnectRasterMask(document);
-  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  auto       plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   const auto base = BuildFrameResultContentKeys(plan, prepared, document);
 
   auto* mask = dynamic_cast<RasterMaskNodeModel*>(document.Graph().FindNode(NodeId{"mask.raster"}));
@@ -194,11 +217,11 @@ TEST(GpuDagResultContentKey, RasterMaskParamChangeInvalidatesMaskAndGradeNotSens
 }
 
 TEST(GpuDagResultContentKey, IdenticalInputsProduceIdenticalKeys) {
-  auto prepared = MakePrepared();
-  auto document = CreateDefaultPipelineDocument();
-  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
-  const auto a  = BuildFrameResultContentKeys(plan, prepared, document);
-  const auto b  = BuildFrameResultContentKeys(plan, prepared, document);
+  auto       prepared = MakePrepared();
+  auto       document = CreateDefaultPipelineDocument();
+  auto       plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto a        = BuildFrameResultContentKeys(plan, prepared, document);
+  const auto b        = BuildFrameResultContentKeys(plan, prepared, document);
   EXPECT_EQ(a.sensor_linear, b.sensor_linear);
   EXPECT_EQ(a.geometry_scene_source, b.geometry_scene_source);
   EXPECT_EQ(a.develop_image, b.develop_image);
@@ -207,12 +230,12 @@ TEST(GpuDagResultContentKey, IdenticalInputsProduceIdenticalKeys) {
 }
 
 TEST(GpuDagResultContentKey, CameraProfileChangeInvalidatesDevelopImageNotSensorLinear) {
-  auto prepared = MakePrepared();
-  auto document = CreateDefaultPipelineDocument();
-  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
-  const auto base = BuildFrameResultContentKeys(plan, prepared, document);
+  auto       prepared = MakePrepared();
+  auto       document = CreateDefaultPipelineDocument();
+  auto       plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base     = BuildFrameResultContentKeys(plan, prepared, document);
 
-  auto develop = document.Develop()->Params().Params();
+  auto       develop  = document.Develop()->Params().Params();
   develop.camera_profile.color_matrices_valid = true;
   develop.camera_profile.color_matrix_1[0]    = 0.91;
   document.Develop()->Params().ReplaceParams(develop);
@@ -227,7 +250,7 @@ TEST(GpuDagResultContentKey, ApplyOntoExposureKeepsSensorGeometryCameraAndMaskWi
   auto document = CreateDefaultPipelineDocument();
   gpu_dag_test::EnsureTestCameraProfile(document);
   ConnectRasterMask(document);
-  auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  auto       plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   const auto base = BuildFrameResultContentKeys(plan, prepared, document);
   ASSERT_FALSE(base.mask.Empty());
 

--- a/alcedo_studio/tests/ui/editor_overlay_interaction_test.cpp
+++ b/alcedo_studio/tests/ui/editor_overlay_interaction_test.cpp
@@ -18,7 +18,6 @@
 #include <QTest>
 #include <QVector2D>
 #include <Qt>
-
 #include <cmath>
 #include <vector>
 
@@ -26,21 +25,21 @@
 #include "ui/edit_viewer/edit_viewer_overlay_geometry.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 #include "ui/edit_viewer/view_transform_controller.hpp"
+#include "ui/editor_rhi/direct_frame_sink.hpp"
+#include "ui/editor_rhi/direct_present_queue.hpp"
 #include "ui/editor_rhi/editor_interaction_controller.hpp"
 #include "ui/editor_rhi/editor_overlay_item.hpp"
 #include "ui/editor_rhi/editor_viewport_item.hpp"
-#include "ui/editor_rhi/direct_present_queue.hpp"
 #include "ui/editor_rhi/frame_presentation_lease.hpp"
-#include "ui/editor_rhi/direct_frame_sink.hpp"
 
 namespace alcedo::editor_rhi {
 namespace {
 
 struct ViewportCase {
   const char* name;
-  qreal width;
-  qreal height;
-  qreal dpr;
+  qreal       width;
+  qreal       height;
+  qreal       dpr;
 };
 
 const ViewportCase kDprCases[] = {
@@ -60,17 +59,17 @@ auto PointInTriangle(const QPointF& p, const QPointF& a, const QPointF& b, const
   const auto cross = [](const QPointF& o, const QPointF& u, const QPointF& v) {
     return (u.x() - o.x()) * (v.y() - o.y()) - (u.y() - o.y()) * (v.x() - o.x());
   };
-  const double c1 = cross(a, b, p);
-  const double c2 = cross(b, c, p);
-  const double c3 = cross(c, a, p);
-  const bool has_neg = (c1 < 0) || (c2 < 0) || (c3 < 0);
-  const bool has_pos = (c1 > 0) || (c2 > 0) || (c3 > 0);
+  const double c1      = cross(a, b, p);
+  const double c2      = cross(b, c, p);
+  const double c3      = cross(c, a, p);
+  const bool   has_neg = (c1 < 0) || (c2 < 0) || (c3 < 0);
+  const bool   has_pos = (c1 > 0) || (c2 > 0) || (c3 > 0);
   return !(has_neg && has_pos);
 }
 
 auto MaskCoverageCount(const OverlaySceneGeometry& scene, const QPointF& p) -> int {
-  const auto& t = scene.mask_triangles;
-  int count = 0;
+  const auto& t     = scene.mask_triangles;
+  int         count = 0;
   for (size_t i = 0; i + 2 < t.size(); i += 3) {
     if (PointInTriangle(p, t[i], t[i + 1], t[i + 2])) {
       ++count;
@@ -145,7 +144,8 @@ TEST(EditorOverlayInteractionTest, ActualPixelsClampsToFitWhenFitExceedsOneToOne
 TEST(EditorOverlayInteractionTest, MaxZoomClampsToTrueZoomCeilingNotLegacyField) {
   EditorInteractionController controller;
   controller.setViewportMetrics(800, 600, 1.0);
-  ConfigureImage(controller, 4000, 3000);  // fitFraction 0.2 → field ceiling 80 → true ceiling 1600%
+  ConfigureImage(controller, 4000,
+                 3000);  // fitFraction 0.2 → field ceiling 80 → true ceiling 1600%
 
   // Saturate the cap with many zoom-in steps. The cap is expressed in true
   // zoom (1600%), not the legacy 8x fit field, so the field reaches ~80 and
@@ -205,7 +205,7 @@ TEST(EditorOverlayInteractionTest, TrueZoomUsesCroppedOutputAfterCropCommit) {
   controller.setCropOverlayVisible(true);
   EXPECT_NEAR(controller.trueZoom(), 0.2f, 1.0e-5f);
   controller.setCropRectNormalized(QRectF(0.25, 0.25, 0.5, 0.5));  // central 50% crop
-  EXPECT_NEAR(controller.trueZoom(), 0.2f, 1.0e-5f);  // still source-based
+  EXPECT_NEAR(controller.trueZoom(), 0.2f, 1.0e-5f);               // still source-based
 
   // Close the panel → crop commits (overlay hidden). Displayed image is now the
   // cropped output (round(4000*0.5) x round(3000*0.5) = 2000x1500, same aspect),
@@ -271,7 +271,7 @@ TEST(EditorOverlayInteractionTest, CropCreateDragUpdatesNormalizedRectAndFinaliz
     controller.setCropRectNormalized(QRectF(0.25, 0.25, 0.5, 0.5));
 
     const QPointF start = controller.imageUvToItemPoint(0.1, 0.1);
-    const QPointF end = controller.imageUvToItemPoint(0.4, 0.45);
+    const QPointF end   = controller.imageUvToItemPoint(0.4, 0.45);
     ASSERT_FALSE(start.isNull()) << c.name;
     ASSERT_FALSE(end.isNull()) << c.name;
 
@@ -299,7 +299,7 @@ TEST(EditorOverlayInteractionTest, DisablingCropToolCancelsInFlightDragWithoutCo
   controller.setCropRectNormalized(initial);
 
   const QPointF start = controller.imageUvToItemPoint(0.1, 0.1);
-  const QPointF mid = controller.imageUvToItemPoint(0.35, 0.4);
+  const QPointF mid   = controller.imageUvToItemPoint(0.35, 0.4);
   ASSERT_FALSE(start.isNull());
   ASSERT_FALSE(mid.isNull());
 
@@ -471,11 +471,11 @@ TEST(EditorOverlayInteractionTest, OverlaySceneGeometryBuildsMaskBorderGridAndHa
 TEST(EditorOverlayInteractionTest, OverlaySceneGeometryGoldenAcrossViewportAspects) {
   struct Case {
     const char* name;
-    qreal w;
-    qreal h;
+    qreal       w;
+    qreal       h;
   };
-  const Case cases[] = {{"landscape", 960, 540}, {"portrait", 540, 960}, {"square", 700, 700},
-                        {"odd", 801, 599}};
+  const Case cases[] = {
+      {"landscape", 960, 540}, {"portrait", 540, 960}, {"square", 700, 700}, {"odd", 801, 599}};
 
   for (const auto& c : cases) {
     EditorInteractionController controller;
@@ -515,7 +515,7 @@ TEST(EditorOverlayInteractionTest, DimMaskDoesNotCoverCropInteriorAtMultipleRota
 
     const auto geometry = controller.overlayGeometry();
     ASSERT_TRUE(geometry.crop_corners_valid) << degrees;
-    const auto scene = BuildOverlaySceneGeometry(geometry, true);
+    const auto    scene  = BuildOverlaySceneGeometry(geometry, true);
     const QPointF center = CropGeometry::CropCenterWidgetPoint(geometry.crop_corners_widget);
     EXPECT_FALSE(MaskCoversPoint(scene, center)) << "rotation=" << degrees;
   }
@@ -570,19 +570,19 @@ TEST(EditorOverlayInteractionTest, RoundCapsExtendOutwardPastStrokeEndpoints) {
   ASSERT_FALSE(scene.grip_outer_triangles.empty());
 
   // Top edge grip is the middle 24% of the top crop edge (0.38..0.62).
-  const QPointF a = CropGeometry::LerpPoint(geometry.crop_corners_widget[0],
-                                            geometry.crop_corners_widget[1], 0.38f);
-  const QPointF b = CropGeometry::LerpPoint(geometry.crop_corners_widget[0],
-                                            geometry.crop_corners_widget[1], 0.62f);
-  const QPointF ab = b - a;
-  const double len = std::hypot(ab.x(), ab.y());
+  const QPointF a   = CropGeometry::LerpPoint(geometry.crop_corners_widget[0],
+                                              geometry.crop_corners_widget[1], 0.38f);
+  const QPointF b   = CropGeometry::LerpPoint(geometry.crop_corners_widget[0],
+                                              geometry.crop_corners_widget[1], 0.62f);
+  const QPointF ab  = b - a;
+  const double  len = std::hypot(ab.x(), ab.y());
   ASSERT_GT(len, 1.0);
   const QPointF outward_a(-ab.x() / len, -ab.y() / len);
   const QPointF outward_b(ab.x() / len, ab.y() / len);
 
   // Outer grip stroke width is 5.0 → radius 2.5. Caps must reach past endpoints.
-  const double reach_a = MaxExtentBeyondEndpoint(scene.grip_outer_triangles, a, outward_a);
-  const double reach_b = MaxExtentBeyondEndpoint(scene.grip_outer_triangles, b, outward_b);
+  const double  reach_a = MaxExtentBeyondEndpoint(scene.grip_outer_triangles, a, outward_a);
+  const double  reach_b = MaxExtentBeyondEndpoint(scene.grip_outer_triangles, b, outward_b);
   EXPECT_GT(reach_a, 1.5) << "left/top cap must extend outward past endpoint a";
   EXPECT_GT(reach_b, 1.5) << "right/top cap must extend outward past endpoint b";
 
@@ -641,12 +641,11 @@ TEST(EditorOverlayInteractionTest, SingleViewStatePushPerInputSequenceDespiteDua
   ConfigureImage(controller, 4000, 3000);
 
   EditorViewportItem viewport;
-  int push_count = 0;
-  QObject::connect(&controller, &EditorInteractionController::viewStateChanged, &controller,
-                   [&]() {
-                     controller.applyViewStateToViewport(&viewport);
-                     ++push_count;
-                   });
+  int                push_count = 0;
+  QObject::connect(&controller, &EditorInteractionController::viewStateChanged, &controller, [&]() {
+    controller.applyViewStateToViewport(&viewport);
+    ++push_count;
+  });
   // Intentionally do NOT connect viewChanged — production QML only listens to
   // viewStateChanged so dual emits cannot double-push.
 
@@ -827,8 +826,20 @@ TEST(EditorOverlayInteractionTest, DetailPatchEnsureSizeDoesNotRewriteRenderRefe
   // render-ref is published later from SubmitMetalFrame with the real texture.
   if (metal_present) {
     EXPECT_EQ(target_size_signals, 0);
-    last_w = 2048;
-    last_h = 1536;
+#ifdef HAVE_METAL
+    const auto owner = std::make_shared<int>(1);
+    sink->SubmitMetalFrame(
+        alcedo::ViewerMetalFrame{2048,
+                                 1536,
+                                 reinterpret_cast<std::uintptr_t>(owner.get()),
+                                 std::shared_ptr<const void>(owner, owner.get()),
+                                 {},
+                                 alcedo::FramePresentationMode::ViewportTransformed,
+                                 quality_meta});
+    EXPECT_EQ(target_size_signals, 1);
+    EXPECT_EQ(last_w, 2048);
+    EXPECT_EQ(last_h, 1536);
+#endif
   } else {
     EXPECT_EQ(target_size_signals, 1);
     EXPECT_EQ(last_w, 2048);
@@ -852,7 +863,7 @@ TEST(EditorOverlayInteractionTest, DetailPatchEnsureSizeDoesNotRewriteRenderRefe
 
   // Must not emit targetSizeRequested — render reference stays full-frame.
   if (metal_present) {
-    EXPECT_EQ(target_size_signals, 0);
+    EXPECT_EQ(target_size_signals, 1);
   } else {
     EXPECT_EQ(target_size_signals, 1);
   }
@@ -937,14 +948,14 @@ TEST(EditorOverlayInteractionTest, ReconcileViewportMetricsEmitsViewChanged) {
 
 TEST(EditorOverlayInteractionTest, ViewTransformPushDoesNotInvalidateDirectPresentTargets) {
   EditorViewportItem viewport;
-  // Seed a synthetic target generation so the comparison is not 0 == 0 vacuously.
+  // Install a synthetic target generation so the comparison is not 0 == 0 vacuously.
   // View-state pushes must not advance direct-present target generation.
   if (viewport.present_queue()) {
     DirectPresentQueue::SizeRequest req;
-    req.width            = 64;
-    req.height           = 48;
-    req.session_epoch = 1;
-    req.image_identity   = 1;
+    req.width          = 64;
+    req.height         = 48;
+    req.session_epoch  = 1;
+    req.image_identity = 1;
     viewport.present_queue()->NoteSizeRequest(req);
     viewport.present_queue()->InvalidateTargetGeneration();
   }
@@ -1075,7 +1086,8 @@ TEST(EditorOverlayInteractionTest, ViewChangeReportedForZoomPanCropRotateAndResi
   QTest::qWait(150);
   QCoreApplication::processEvents();
   ASSERT_FALSE(spy.empty());
-  EXPECT_EQ(last_kind(), static_cast<int>(EditorInteractionController::ViewChangeKind::DetailRefresh));
+  EXPECT_EQ(last_kind(),
+            static_cast<int>(EditorInteractionController::ViewChangeKind::DetailRefresh));
 
   // Pan while zoomed → the detail patch must follow the new ROI → DetailRefresh.
   spy.clear();
@@ -1088,7 +1100,8 @@ TEST(EditorOverlayInteractionTest, ViewChangeReportedForZoomPanCropRotateAndResi
   QTest::qWait(150);
   QCoreApplication::processEvents();
   ASSERT_EQ(spy.count(), 1);
-  EXPECT_EQ(last_kind(), static_cast<int>(EditorInteractionController::ViewChangeKind::DetailRefresh));
+  EXPECT_EQ(last_kind(),
+            static_cast<int>(EditorInteractionController::ViewChangeKind::DetailRefresh));
 
   // Reset to fit (zoom ≤ 1) → the full frame is reused → ZoomPan.
   spy.clear();
@@ -1117,8 +1130,7 @@ TEST(EditorOverlayInteractionTest, ViewChangeReportedForZoomPanCropRotateAndResi
   EXPECT_EQ(last_kind(), static_cast<int>(EditorInteractionController::ViewChangeKind::Resize));
 }
 
-TEST(EditorOverlayInteractionTest,
-     GeometryOverlayCropDraftDoesNotRouteCropRotateViewChanges) {
+TEST(EditorOverlayInteractionTest, GeometryOverlayCropDraftDoesNotRouteCropRotateViewChanges) {
   // While the geometry overlay is open, crop-frame edits are pure UI over the
   // source-frame preview. Pipeline bake is owned by panel confirm (leave/Enter).
   EditorInteractionController controller;

--- a/alcedo_studio/tests/ui/editor_real_raw_gpu_e2e_test.cpp
+++ b/alcedo_studio/tests/ui/editor_real_raw_gpu_e2e_test.cpp
@@ -32,12 +32,16 @@
 namespace alcedo::ui::test {
 namespace {
 
-editor_rhi::EditorBackend       g_backend = editor_rhi::EditorBackend::Cuda;
+#ifdef __APPLE__
+editor_rhi::EditorBackend g_backend = editor_rhi::EditorBackend::Metal;
+#else
+editor_rhi::EditorBackend g_backend = editor_rhi::EditorBackend::Cuda;
+#endif
 editor_rhi::EditorStartupResult g_startup{};
 
-auto MainQmlUrl() -> QUrl {
-  const auto path = std::filesystem::path(ALCEDO_TEST_SRC_DIR) / "ui" / "alcedo_main" / "qml" /
-                    "Main.qml";
+auto                            MainQmlUrl() -> QUrl {
+  const auto path =
+      std::filesystem::path(ALCEDO_TEST_SRC_DIR) / "ui" / "alcedo_main" / "qml" / "Main.qml";
 #ifdef _WIN32
   return QUrl::fromLocalFile(QString::fromStdWString(path.wstring()));
 #else
@@ -46,7 +50,7 @@ auto MainQmlUrl() -> QUrl {
 }
 
 auto CollectCiRawFiles(std::size_t max_count = 2) -> std::vector<std::filesystem::path> {
-  const std::filesystem::path root{std::string(TEST_IMG_PATH) + "/ci_rawfiles"};
+  const std::filesystem::path        root{std::string(TEST_IMG_PATH) + "/ci_rawfiles"};
   std::vector<std::filesystem::path> paths;
   if (!std::filesystem::exists(root)) {
     return paths;
@@ -77,15 +81,14 @@ auto WaitUntil(Predicate&& predicate, std::chrono::milliseconds timeout) -> bool
 }
 
 void WaitForImportFinished(ApplicationModuleHost& host) {
-  ASSERT_TRUE(WaitUntil([&] { return !host.import_export()->ImportRunning(); },
-                        std::chrono::minutes(2)));
+  ASSERT_TRUE(
+      WaitUntil([&] { return !host.import_export()->ImportRunning(); }, std::chrono::minutes(2)));
   ProcessEvents(500);
 }
 
 class EditorRealRawGpuE2eTest : public ApplicationModuleHostTestFixture {};
 
-TEST_F(EditorRealRawGpuE2eTest,
-       RealRawGpuFramesRemainReadyAcrossSustainedImageSwitches) {
+TEST_F(EditorRealRawGpuE2eTest, RealRawGpuFramesRemainReadyAcrossSustainedImageSwitches) {
   if (!qEnvironmentVariableIsSet("ALCEDO_RUN_DEADLOCKING_RAW_GPU_E2E")) {
     GTEST_SKIP() << "Temporarily disabled: the standalone native GPU/Qt teardown path "
                     "deadlocks after sustained RAW image switches. The narrower WorkspaceShell "
@@ -101,8 +104,8 @@ TEST_F(EditorRealRawGpuE2eTest,
   // production DirectPresent + RAW + zoom/pan path with a working present backend.
   if (g_backend == editor_rhi::EditorBackend::OpenCl) {
     GTEST_SKIP() << "OpenCL direct present is host_upload-only here and deadlocks the GUI "
-                     "pump while waiting for FrameReady; run with "
-                     "ALCEDO_TEST_EDITOR_BACKEND=cuda for the production present E2E";
+                    "pump while waiting for FrameReady; run with "
+                    "ALCEDO_TEST_EDITOR_BACKEND=cuda for the production present E2E";
   }
 
   const auto raw_files = CollectCiRawFiles();
@@ -143,7 +146,7 @@ TEST_F(EditorRealRawGpuE2eTest,
   // Production alcedo_main uses Basic; Material pads/ripples break dense chrome.
   QQuickStyle::setStyle(QStringLiteral("Basic"));
 
-  QQmlApplicationEngine engine;
+  QQmlApplicationEngine  engine;
   std::vector<QQmlError> warnings;
   engine.addImportPath(QStringLiteral("qrc:/"));
 #ifdef ALCEDO_QT_QML_IMPORT_PATH
@@ -154,10 +157,9 @@ TEST_F(EditorRealRawGpuE2eTest,
   engine.rootContext()->setContextProperty(QStringLiteral("appModules"), &host);
   engine.rootContext()->setContextProperty(QStringLiteral("appTheme"), &AppTheme::Instance());
   engine.rootContext()->setContextProperty(QStringLiteral("languageManager"), &language_manager);
-  QObject::connect(&engine, &QQmlEngine::warnings,
-                   [&warnings](const QList<QQmlError>& emitted) {
-                     warnings.insert(warnings.end(), emitted.begin(), emitted.end());
-                   });
+  QObject::connect(&engine, &QQmlEngine::warnings, [&warnings](const QList<QQmlError>& emitted) {
+    warnings.insert(warnings.end(), emitted.begin(), emitted.end());
+  });
   engine.load(MainQmlUrl());
   if (engine.rootObjects().empty()) {
     std::string errors;
@@ -188,11 +190,11 @@ TEST_F(EditorRealRawGpuE2eTest,
   ASSERT_GT(images[1].element_id, 0u);
   ASSERT_GT(images[1].image_id, 0u);
 
-  bool ok = false;
+  bool      ok                  = false;
   const int configured_switches = qEnvironmentVariableIntValue("ALCEDO_REAL_RAW_E2E_SWITCHES", &ok);
-  const int switch_count = ok ? std::max(1, configured_switches) : 8;
-  qulonglong expected_presented_count = 0;
-  std::uint64_t previous_request_id = 0;
+  const int switch_count        = ok ? std::max(1, configured_switches) : 8;
+  qulonglong    expected_presented_count = 0;
+  std::uint64_t previous_request_id      = 0;
 
   for (int i = 0; i < switch_count; ++i) {
     const auto key = images[static_cast<std::size_t>(i) % images.size()];
@@ -218,11 +220,11 @@ TEST_F(EditorRealRawGpuE2eTest,
       const auto first_frame_timeout = g_backend == editor_rhi::EditorBackend::OpenCl
                                            ? std::chrono::seconds(45)
                                            : std::chrono::minutes(2);
-      const bool first_submitted = WaitUntil(
+      const bool first_submitted     = WaitUntil(
           [&] {
             const auto results = host.editor_render_coordinator()->results();
             return std::any_of(results.begin(), results.end(),
-                               [&](const EditorRenderResult& result) {
+                                   [&](const EditorRenderResult& result) {
                                  return result.request_id == first_request_id &&
                                         result.kind == EditorRenderResultKind::FrameReady;
                                });
@@ -236,8 +238,7 @@ TEST_F(EditorRealRawGpuE2eTest,
                      << " status=" << viewport->statusText().toStdString()
                      << " presented=" << viewport->presentedFrameCount();
       }
-      ASSERT_TRUE(first_submitted)
-          << "Primary frame never reached the submitted/visible state";
+      ASSERT_TRUE(first_submitted) << "Primary frame never reached the submitted/visible state";
 
       // Production QML enables viewport interaction only when actions.canEdit is
       // true (Interactive). Double-tap before that is a no-op on the controller.
@@ -254,8 +255,7 @@ TEST_F(EditorRealRawGpuE2eTest,
           QStringLiteral("editorInteractionController"));
       ASSERT_NE(interaction, nullptr);
       ASSERT_TRUE(interaction->interactionEnabled());
-      const auto scheduled_before_zoom =
-          host.editor_session_scheduler()->last_scheduled().size();
+      const auto scheduled_before_zoom = host.editor_session_scheduler()->last_scheduled().size();
 
       interaction->handleDoubleTap(viewport->width() * 0.5, viewport->height() * 0.5);
 
@@ -292,10 +292,9 @@ TEST_F(EditorRealRawGpuE2eTest,
           << "First DetailPatch left the coordinator busy";
       ProcessEvents(250);
 
-      const auto scheduled_before_pan =
-          host.editor_session_scheduler()->last_scheduled().size();
-      const auto center_x = viewport->width() * 0.5;
-      const auto center_y = viewport->height() * 0.5;
+      const auto scheduled_before_pan = host.editor_session_scheduler()->last_scheduled().size();
+      const auto center_x             = viewport->width() * 0.5;
+      const auto center_y             = viewport->height() * 0.5;
       interaction->handlePress(center_x, center_y, static_cast<int>(Qt::LeftButton));
       interaction->handleMove(center_x + 80.0, center_y + 30.0, static_cast<int>(Qt::LeftButton));
       interaction->handleRelease(center_x + 80.0, center_y + 30.0,
@@ -303,8 +302,7 @@ TEST_F(EditorRealRawGpuE2eTest,
 
       ASSERT_TRUE(WaitUntil(
           [&] {
-            return host.editor_session_scheduler()->last_scheduled().size() >
-                   scheduled_before_pan;
+            return host.editor_session_scheduler()->last_scheduled().size() > scheduled_before_pan;
           },
           std::chrono::seconds(5)))
           << "Settled pan did not schedule a replacement DetailPatch";
@@ -330,8 +328,7 @@ TEST_F(EditorRealRawGpuE2eTest,
 
     const auto first_frame_ready = [&] {
       return host.editor_session_service()->state() == EditorSessionState::Interactive &&
-             viewport->lastPresentedSessionEpoch() ==
-                 viewport->sessionEpoch() &&
+             viewport->lastPresentedSessionEpoch() == viewport->sessionEpoch() &&
              viewport->lastPresentedRequestId() != 0 &&
              viewport->lastPresentedRequestId() != previous_request_id;
     };
@@ -341,31 +338,32 @@ TEST_F(EditorRealRawGpuE2eTest,
                  host.editor_session_service()->state() == EditorSessionState::Failed;
         },
         std::chrono::minutes(2)));
-    const auto scheduled = host.editor_session_scheduler()->last_scheduled();
+    const auto  scheduled   = host.editor_session_scheduler()->last_scheduled();
     const auto* last_intent = scheduled.empty() ? nullptr : &scheduled.back().intent;
     ASSERT_TRUE(first_frame_ready())
-        << host.editor_session_service()->last_error() << " backend="
-        << viewport->backendName().toStdString() << " status="
-        << viewport->statusText().toStdString() << " available="
-        << viewport->presentationAvailable() << " live=" << viewport->liveTargetCount()
-        << " targetGen=" << viewport->targetGeneration() << " imageGen="
-        << viewport->sessionEpoch() << " item=" << viewport->width() << 'x'
+        << host.editor_session_service()->last_error()
+        << " backend=" << viewport->backendName().toStdString()
+        << " status=" << viewport->statusText().toStdString()
+        << " available=" << viewport->presentationAvailable()
+        << " live=" << viewport->liveTargetCount() << " targetGen=" << viewport->targetGeneration()
+        << " imageGen=" << viewport->sessionEpoch() << " item=" << viewport->width() << 'x'
         << viewport->height() << " requested=" << (last_intent ? last_intent->requested_width : 0)
         << 'x' << (last_intent ? last_intent->requested_height : 0)
         << " windowExposed=" << window->isExposed() << " itemVisible=" << viewport->isVisible()
         << " parentVisible="
-        << (viewport->parentItem() ? viewport->parentItem()->isVisible() : false) << " opacity="
-        << viewport->opacity() << " warning="
+        << (viewport->parentItem() ? viewport->parentItem()->isVisible() : false)
+        << " opacity=" << viewport->opacity() << " warning="
         << (warnings.empty() ? std::string{} : warnings.front().toString().toStdString());
 
     const auto first_request_id = viewport->lastPresentedRequestId();
-    previous_request_id = first_request_id;
+    previous_request_id         = first_request_id;
     // Direct-present composition counts every primary drawn into a Qt Quick
     // window frame (InteractivePrimary then QualityBase). These renderer-owned
     // diagnostics are deliberately separate from request scheduling.
     expected_presented_count += 2;
-    ASSERT_TRUE(WaitUntil([&] { return viewport->presentedFrameCount() >= expected_presented_count; },
-                          std::chrono::minutes(2)))
+    ASSERT_TRUE(
+        WaitUntil([&] { return viewport->presentedFrameCount() >= expected_presented_count; },
+                  std::chrono::minutes(2)))
         << "QualityBase was not composed after InteractivePrimary";
 
     if (i == 0) {
@@ -374,8 +372,8 @@ TEST_F(EditorRealRawGpuE2eTest,
       // frame while QualityBase and the zoom DetailPatch have already exercised
       // the other presentation layers.
       const auto composed_before_drag = viewport->presentedFrameCount();
-      const auto wakeups_before_drag = viewport->adjustmentFrameRequestCount();
-      auto* session = host.editor_session();
+      const auto wakeups_before_drag  = viewport->adjustmentFrameRequestCount();
+      auto*      session              = host.editor_session();
       ASSERT_NE(session, nullptr);
       ASSERT_TRUE(session->submitPatch(QStringLiteral("exposure"),
                                        QStringLiteral(R"({"value":0.10})"), false));
@@ -389,26 +387,31 @@ TEST_F(EditorRealRawGpuE2eTest,
       ASSERT_TRUE(WaitUntil([&] { return viewport->presentedFrameCount() > composed_before_drag; },
                             std::chrono::minutes(2)))
           << "FAST adjustment frame was not composed before pointer release; status="
-          << viewport->statusText().toStdString()
-          << " liveTargets=" << viewport->liveTargetCount();
+          << viewport->statusText().toStdString() << " liveTargets=" << viewport->liveTargetCount();
     }
 
     EXPECT_EQ(viewport->lastPresentedSessionEpoch(), viewport->sessionEpoch());
     EXPECT_EQ(viewport->imageIdentity(), key.image_id);
-    EXPECT_GT(viewport->liveTargetCount(), 0);
+    // CUDA/OpenCL keep renderer-owned interop targets in DirectPresentQueue slots.
+    // Metal imports the completed producer texture directly, so a composed Metal
+    // frame intentionally has no queue-owned native target to count.
+    if (g_backend != editor_rhi::EditorBackend::Metal) {
+      EXPECT_GT(viewport->liveTargetCount(), 0);
+    }
     EXPECT_TRUE(viewport->presentationAvailable());
   }
 
   const auto coordinator_results = host.editor_render_coordinator()->results();
-  const auto ready_count = std::count_if(
-      coordinator_results.begin(), coordinator_results.end(), [](const EditorRenderResult& result) {
-        return result.kind == EditorRenderResultKind::FrameReady;
-      });
+  const auto ready_count = std::count_if(coordinator_results.begin(), coordinator_results.end(),
+                                         [](const EditorRenderResult& result) {
+                                           return result.kind == EditorRenderResultKind::FrameReady;
+                                         });
   EXPECT_GE(ready_count, switch_count);
 
   host.workspace_router()->OpenLibrary();
   ProcessEvents(200);
-  EXPECT_FALSE(host.editor_session()->presentation_viewport_bound());
+  EXPECT_TRUE(host.editor_session()->presentation_viewport_bound())
+      << "route changes retain the editor session and its presentation binding";
   EXPECT_TRUE(warnings.empty()) << (warnings.empty() ? std::string{}
                                                      : warnings.front().toString().toStdString());
 }
@@ -428,7 +431,9 @@ int main(int argc, char** argv) {
                                            /*force_offscreen=*/false);
 
   const QByteArray requested = qgetenv("ALCEDO_TEST_EDITOR_BACKEND").toLower();
-  if (requested == "opencl") {
+  if (requested == "metal") {
+    alcedo::ui::test::g_backend = alcedo::editor_rhi::EditorBackend::Metal;
+  } else if (requested == "opencl") {
     alcedo::ui::test::g_backend = alcedo::editor_rhi::EditorBackend::OpenCl;
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
   }

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -24,6 +24,7 @@ use their own top-level category.
 ## Alcedo Studio — Image editing pipeline
 
 - [GPU DAG Pipeline Rebuild Phase Plan](alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md)
+- [GPU DAG Metal Migration Phase Plan](alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md)
 
 ## Alcedo Studio — UI
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -523,7 +523,7 @@ MetalDevelopPassesUseOneCommandBuffer
 **Status:** complete
 **Date:** 2026-08-26
 **Branch:** `feature/gpu-dag-metal`
-**Commit:** `da9c63a0` (working tree)
+**Commit:** `f3522df5`
 
 **Implemented:**
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -825,6 +825,7 @@ MetalMaskCacheDoesNotEvictBusyTextures
 **Status:** complete
 **Date:** 2026-08-26
 **Branch:** `feature/gpu-dag-metal`
+**Commit:** `fd1850e9`
 
 **Implemented:**
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-24
 
-Status: M0–M1 complete; M2–M7 planned
+Status: M0–M2 complete; M3–M7 planned
 
 Branch: `feature/gpu-dag-metal`
 
@@ -517,6 +517,73 @@ MetalDevelopPassesUseOneCommandBuffer
 - Develop 稳定重绘不分配 GPU 资源；
 - RAW Metal operator 不保存长期 scratch；
 - kernel/metallib 错误直接失败。
+
+##### Phase M2 completion record (2026-08-26)
+
+**Status:** complete
+**Date:** 2026-08-26
+**Branch:** `feature/gpu-dag-metal`
+**Commit:** `da9c63a0` (working tree)
+
+**Implemented:**
+
+- Encode-only RAW Metal entrypoints (`metal_encode.hpp/.cpp`) that take the current command buffer plus workspace textures/buffers: linearize, CFA Clamp01, RCD, X-Trans, highlight reconstruct, pack/orient, DNG warp.
+- `ExecuteMetalDevelop` / `ExecuteMetalGeometryResample` / `ExecuteMetalCameraColor` on `Renderer<MetalBackend>` / `PlanExecutor<MetalBackend>` with the CUDA Develop order and the three content-key boundaries (`develop.sensor_linear`, `geometry.scene_source`, `develop.image`).
+- DAG geometry resample and camera-color ACEScc shaders under `edit/runtime/metal/shader/`; DNG warp texture encode stays in `metal/metal_utils/`.
+- Neural Engine tiles encode onto the session command buffer (`MetalDemosaicNetTiledDispatch::command_buffer`); load failure throws and does not select Legacy.
+- `MetalBackend::WarmUpPlan` warms Develop/Geometry/CameraColor pipeline states before execute. One command buffer per render (`CommandBufferCreateCount`).
+- Identity texture copy for PrimaryGrade and DRT so PlanExecutor can finish M2 cache-skip tests. Pixel math for those passes remains M3/M6.
+
+**Deleted:**
+
+- None of the old Metal product wrappers. They remain until M7. The DAG path does not call them.
+
+**Tests:**
+
+- command: `cmake --preset macos_debug_tests`
+- command: `cmake --build --preset macos_debug_tests --target GpuDagMetalDevelopTest GpuDagMetalWorkspaceTest --parallel 8`
+- command: `ctest --test-dir build/macos-debug-tests -R GpuDagMetalDevelopTest --output-on-failure`
+- result: 10/10 PASS
+- command: `ctest --test-dir build/macos-debug-tests -R GpuDagMetalWorkspaceTest --output-on-failure`
+- result: 8/8 PASS
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MetalDevelopLinearizeMatchesCudaReferenceWithinTolerance` | `GpuDagMetalDevelopTest` | PASS |
+| `MetalDevelopRcdOrderMatchesCudaDemosaicThenHighlightRecovery` | `GpuDagMetalDevelopTest` | PASS |
+| `MetalDevelopXTransMatchesCudaReferenceWithinTolerance` | `GpuDagMetalDevelopTest` | PASS |
+| `MetalDevelopNeuralUsesSessionWorkspaceAndDoesNotSelectLegacyOnFailure` | `GpuDagMetalDevelopTest` | PASS |
+| `MetalGeometryUsesOneResampleForCropRotationViewportAndScale` | `GpuDagMetalDevelopTest` | PASS |
+| `MetalCameraColorConsumesSharedDualIlluminantTransform` | `GpuDagMetalDevelopTest` | PASS |
+| `MetalCctEditReusesSensorAndGeometryResults` | `GpuDagMetalDevelopTest` | PASS |
+| `MetalSecondDevelopRenderRunsNoSourceUploadOrDevelopPass` | `GpuDagMetalDevelopTest` | PASS |
+| `MetalDevelopPassesUseOneCommandBuffer` | `GpuDagMetalDevelopTest` | PASS |
+| Missing metallib throws (`MetalGeometryResampleMissingMetallibThrowsExplicitError`) | `GpuDagMetalDevelopTest` | PASS |
+
+**Resource evidence:**
+
+- buffer create/free: second stable Develop render 0/0 (`MetalSecondDevelopRenderRunsNoSourceUploadOrDevelopPass`)
+- texture create/free: second stable Develop render 0/0
+- heap growth: second stable Develop render 0
+- pipeline create/hit: first WarmUpPlan creates Develop/Geometry/CameraColor states; second identical render create 0
+- upload ranges/bytes: second identical render `source_h2d_count == 0`; CCT edit uploads only CameraColor parameter range and skips SensorDevelop/Geometry
+
+**Performance evidence:**
+
+- device/macOS/Xcode/build: MacBook Air (Mac16,12) Apple M4, macOS 26.5.2 (25F84), Xcode 26.3 (17C529), `macos_debug_tests` Debug
+- fixture and render request: synthetic 64×64 Bayer / 64×64 X-Trans / 16×12 Direct RGB; `MetalRenderDevice::Execute` after pipeline warm-up
+- cold: first reserve + first render allocates heap/buffer/texture/pipeline
+- warm median: not a product-frame A/B; second identical Develop render GPU resource create/free = 0
+- warm p95: same; product A/B remains M7
+
+**Remaining work owned by the next named Phase:**
+
+- M3: Primary Grade fusion (replace identity copy), ParameterArena slider dirty ranges, LUT texture cache.
+- M4–M6: LLF, Mask/Mix, DRT/present. Identity DRT copy is not a display path.
+
+**LOC note:** `metal_backend.hpp` 225, `metal_develop_pass.hpp` 41, `metal_pass_encoder.hpp` 68, `metal_encode.hpp` 53, `metal_backend.mm` 860, `metal_develop_pass.mm` 531, `metal_encode.cpp` 455. No new file crossed 1000 LOC.
+
+**Residual gaps:** PrimaryGrade and DRT Metal encoders copy `develop.image` until M3/M6. Old RAW Metal wrappers still own static scratch for the pre-DAG product path. Product present/download remains unimplemented until M6.
 
 ## 8. Phase M3 — Primary Grade 融合路径
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-24
 
-Status: M0–M2 complete; M3–M7 planned
+Status: M0–M3 complete; M4–M7 planned
 
 Branch: `feature/gpu-dag-metal`
 
@@ -627,6 +627,73 @@ MetalUnknownAdjustmentReturnsExplicitBackendError
 - 相同拓扑的 slider 编辑不创建 buffer、texture 或 pipeline state；
 - Grade command offset buffer 只在拓扑改变时更新；
 - LUT 未变化时上传字节为零。
+
+##### Phase M3 completion record (2026-08-26)
+
+**Status:** complete
+**Date:** 2026-08-26
+**Branch:** `feature/gpu-dag-metal`
+**Commit:** working tree on `feature/gpu-dag-metal` (HEAD `48fb7465` plus this change)
+
+**Implemented:**
+
+- Backend-neutral `AdjustmentBehavior` / `GradeAdjustmentParams` / `MakeGradeRuntimeParams` in `EditRuntime`. CUDA aliases remain in `cuda_adjustment_runtime.hpp`.
+- GraphCompiler records Neighborhood for Clarity/Sharpen/Halation/Film Grain and fused `primary_grade_stages` (pointwise segments around LocalLaplacian). Slider values still do not recompile.
+- `ExecuteMetalPrimaryGrade` on `Renderer<MetalBackend>` / `PlanExecutor<MetalBackend>`: ParameterArena dirty ranges, one command-offset buffer uploaded only when topology changes, fused pointwise dispatch per LLF segment, explicit TexturePool detail passes, Normal Mix without a fake mask texture.
+- LUT voxels owned by MetalBackend content-key cache with a byte budget. The DAG path does not use `MetalLutBuffer`.
+- `primary_grade.metal` (`primary_grade_pointwise`, `primary_grade_mix`) compiled into `GpuDagMetalShaders`. `WarmUpPlan` warms those states. Missing metallib throws.
+
+**Deleted:**
+
+- CUDA-only adjustment runtime TU (`cuda_adjustment_runtime.cpp` is no longer a compile source; symbols live in shared `adjustment_runtime.cpp`).
+- Metal PrimaryGrade identity copy. DRT still copies `grade.primary:image` until M6. Old `MetalLutBuffer` remains for the pre-DAG fused path until M7.
+
+**Tests:**
+
+- command: `cmake --preset macos_debug_tests`
+- command: `cmake --build --preset macos_debug_tests --target GpuDagMetalGradeTest GpuDagMetalDevelopTest GpuDagMetalWorkspaceTest GpuDagRawInputTest --parallel 8`
+- command: `ctest --test-dir build/macos-debug-tests -R GpuDagMetalGradeTest --output-on-failure`
+- result: 9/9 PASS
+- command: `ctest --test-dir build/macos-debug-tests -R 'GpuDagMetalWorkspaceTest|GpuDagMetalDevelopTest|GpuDagRawInputTest.GpuDagGraphCompiler' --output-on-failure`
+- result: 8/8 workspace, 10/10 develop, 15/15 GraphCompiler PASS
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MetalPrimaryGradePreservesCompiledAdjustmentOrder` | `GpuDagMetalGradeTest` | PASS |
+| `MetalPointwiseAdjustmentsUseOneDispatchPerLlfSegment` | `GpuDagMetalGradeTest` | PASS |
+| `MetalSingleSliderEditUploadsOnlyItsParameterRange` | `GpuDagMetalGradeTest` | PASS |
+| `MetalExposureEditRunsOnlyPrimaryGradeAndDrt` | `GpuDagMetalGradeTest` | PASS |
+| `MetalLutTextureIsReusedByContentKey` | `GpuDagMetalGradeTest` | PASS |
+| `MetalDetailPassesAcquireAllTexturesFromWorkspace` | `GpuDagMetalGradeTest` | PASS |
+| `MetalPrimaryGradeMatchesCudaReferenceWithinTolerance` | `GpuDagMetalGradeTest` | PASS |
+| `MetalUnknownAdjustmentReturnsExplicitBackendError` | `GpuDagMetalGradeTest` | PASS |
+| Missing metallib throws (`MetalPrimaryGradeMissingMetallibThrowsExplicitError`) | `GpuDagMetalGradeTest` | PASS |
+
+**Resource evidence:**
+
+- buffer create/free: second slider / detail / LUT-stable render 0/0 (`MetalSingleSliderEditUploadsOnlyItsParameterRange`, `MetalDetailPassesAcquireAllTexturesFromWorkspace`, `MetalLutTextureIsReusedByContentKey`)
+- texture create/free: second matching Grade render 0/0
+- heap growth: second matching Grade render 0
+- pipeline create/hit: first WarmUpPlan creates `primary_grade_pointwise` / `primary_grade_mix`; second identical render create 0
+- upload ranges/bytes: Exposure slider uploads one ParameterArena slot range; unchanged LUT `LutUploadBytes() == 0`; command-offset buffer is not rewritten when topology is unchanged
+
+**Performance evidence:**
+
+- device/macOS/Xcode/build: MacBook Air (Mac16,12) Apple M4, macOS 26.5.2 (25F84), Xcode 26.3 (17C529), `macos_debug_tests` Debug
+- fixture and render request: synthetic Direct RGB 16×12; `ExecuteMetalPrimaryGrade` / `MetalRenderDevice::Execute` after pipeline warm-up
+- cold: first reserve + first render allocates heap/buffer/texture/pipeline
+- warm median: not a product-frame A/B; second identical Grade render GPU resource create/free = 0; one fused pointwise dispatch when LLF is inactive, two when Shadows is non-zero
+- warm p95: same; product A/B remains M7
+
+**Remaining work owned by the next named Phase:**
+
+- M4: LLF workspace pyramids. M3 copies through the LLF barrier so pointwise order is preserved; it does not run Local Laplacian.
+- M5: Mask/Feather/Mix with R8 and signed distance. Disconnected mask still uses constant 1.
+- M6: DRT/present. Identity DRT copy is not a display path.
+
+**LOC note:** `adjustment_runtime.hpp` 74, `metal_primary_grade_pass.hpp` 43, `metal_backend.hpp` 262, `metal_primary_grade_pass.mm` 450, `primary_grade.metal` 242, `metal_grade_test.cpp` 427. No new file crossed 1000 LOC.
+
+**Residual gaps:** LLF pixel math waits for M4. DRT Metal encoder still copies Grade output until M6. Old RAW Metal wrappers still own static scratch for the pre-DAG product path.
 
 ## 9. Phase M4 — LLF workspace 化
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -730,7 +730,7 @@ MetalLlfMatchesCudaReferenceWithinTolerance
 **Status:** complete
 **Date:** 2026-08-26
 **Branch:** `feature/gpu-dag-metal`
-**Commit:** working tree on `feature/gpu-dag-metal` (M4 implementation)
+**Commit:** `94415693`
 
 **Implemented:**
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -4,9 +4,7 @@ Date: 2026-08-24
 
 Status: M0 complete; M1–M7 planned
 
-Plan branch: `feature/gpu-dag-metal-phase-plan`
-
-Implementation branch: `feature/gpu-dag-metal`
+Branch: `feature/gpu-dag-metal`
 
 Primary owner: Alcedo Studio 编辑管线 Metal 后端。
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-24
 
-Status: M0 complete; M1–M7 planned
+Status: M0–M1 complete; M2–M7 planned
 
 Branch: `feature/gpu-dag-metal`
 
@@ -393,6 +393,68 @@ MetalRenderDeviceUsesThePresentationDevice
 - 无 dirty 参数时 ParameterArena 上传字节为零；
 - BeginRender/EndRender 之外不存在 pass 级 wait；
 - 统计通过 API 快照读取，不依赖日志解析。
+
+##### Phase M1 completion record (2026-08-25)
+
+**Status:** complete
+**Date:** 2026-08-25
+**Branch:** `feature/gpu-dag-metal`
+**Commit:** `481df564`
+
+**Implemented:**
+
+- `EditRuntimeMetal` with `metal_backend.mm`: move-only Buffer/Texture2D, one command buffer per render, private MTLHeap page allocator, shared/managed ParameterArena buffer with `didModifyRange` on managed storage, R8 rect blit, RGBA32F/R32F texture upload/download, submission id + completed-handler + `IsResourceBusy`.
+- Instantiated `BasicRenderWorkspace<MetalBackend>`: ParameterArena, TransientBufferArena, TexturePool, MaskTextureCache, GraphImageCache, NodeResultCache.
+- `ComputePipelineCache` hit/miss/create snapshot API; `MetalBackend::WarmUpPipelines` / `WarmUpPlan` before `PlanExecutor::Execute`.
+- One process Metal device: `MetalContext::BindPresentationDevice`; Qt Quick `setGraphicsDevice` uses `MetalContext` device/queue. Workspace `NativeDevice()` is that same pointer.
+
+**Deleted:**
+
+- Header-only MetalBackend stubs that threw on every GPU allocation (replaced by host TU on non-Metal and Metal runtime on macOS).
+
+**Tests:**
+
+- command: `cmake --preset macos_debug_tests`
+- command: `cmake --build --preset macos_debug_tests --target GpuDagMetalWorkspaceTest GpuDagRawInputTest --parallel 8`
+- command: `ctest --test-dir build/macos-debug-tests -R GpuDagMetalWorkspaceTest --output-on-failure`
+- result: 8/8 PASS
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MetalParameterArenaUploadsOnlyDirtyRanges` | `GpuDagMetalWorkspaceTest` | PASS |
+| `MetalTransientArenaRewindsWithoutReallocatingItsSlab` | `GpuDagMetalWorkspaceTest` | PASS |
+| `MetalTexturePoolReusesMatchingPrivateTextures` | `GpuDagMetalWorkspaceTest` | PASS |
+| `MetalTexturePoolDoesNotEvictBusySubmissionResources` | `GpuDagMetalWorkspaceTest` | PASS |
+| `MetalMaskTextureCacheUsesOneWorkspaceByteBudget` | `GpuDagMetalWorkspaceTest` | PASS |
+| `MetalSecondEmptyRenderCreatesNoBufferTextureHeapOrPipelineState` | `GpuDagMetalWorkspaceTest` | PASS |
+| `MetalFailedUploadRestoresDirtyFieldsAndPublishesNoResult` | `GpuDagMetalWorkspaceTest` | PASS |
+| `MetalRenderDeviceUsesThePresentationDevice` | `GpuDagMetalWorkspaceTest` | PASS |
+
+Also: `GpuDagRawInputTest.RendererTemplateInstantiatesMetalWithoutCudaHeaders` PASS (Metal host header remains Metal.hpp-free).
+
+**Resource evidence:**
+
+- buffer create/free: second empty render 0/0 (`MetalSecondEmptyRenderCreatesNoBufferTextureHeapOrPipelineState`; transient rewind 0 malloc/free)
+- texture create/free: second matching acquire 0/0 (`MetalTexturePoolReusesMatchingPrivateTextures`)
+- heap growth: second empty render 0 (`HeapCreateCount() == 0`)
+- pipeline create/hit: first `convert_r32f_to_r32f` warm-up creates >= 1; second warm-up hits >= 1; second empty render create 0 (API snapshot, not logs)
+- upload ranges/bytes: dirty sharpen amount is one 4-byte range; unchanged parameters upload 0 bytes
+
+**Performance evidence:**
+
+- device/macOS/Xcode/build: MacBook Air (Mac16,12) Apple M4, macOS 26.5.2 (25F84), Xcode 26.3 (17C529), `macos_debug_tests` Debug
+- fixture and render request: `MetalRenderDevice` BeginRender/EndRender after peak reserve; no product RAW frame in M1
+- cold: first reserve + first render allocates heap/buffer/texture/pipeline
+- warm median: not a product-frame A/B; second empty render GPU resource create/free = 0
+- warm p95: same; product A/B remains M7
+
+**Remaining work owned by the next named Phase:**
+
+- M2: encode-only Develop/Geometry/CameraColor on this command context and workspace; no RAW Processor product path; pixel comparison with CUDA.
+
+**LOC note:** `metal_backend.hpp` 213, `plan_executor.hpp` 169, `metal_backend.mm` 785. No new file crossed 1000 LOC.
+
+**Residual gaps:** PassEncoder Metal specializations still throw until M2–M6. LUT/Neural ownership slots exist as sampler/cache hooks only. Product present/download remains unimplemented until M6.
 
 ## 7. Phase M2 — Develop、Geometry 与 CameraColor
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-24
 
-Status: M0–M3 complete; M4–M7 planned
+Status: M0–M4 complete; M5–M7 planned
 
 Branch: `feature/gpu-dag-metal`
 
@@ -724,6 +724,69 @@ MetalLlfFailedSubmissionDoesNotPublishReference
 MetalLlfSecondStableRenderCreatesNoBufferTextureOrPipelineState
 MetalLlfMatchesCudaReferenceWithinTolerance
 ```
+
+##### Phase M4 completion record (2026-08-26)
+
+**Status:** complete
+**Date:** 2026-08-26
+**Branch:** `feature/gpu-dag-metal`
+**Commit:** working tree on `feature/gpu-dag-metal` (M4 implementation)
+
+**Implemented:**
+
+- `ExecuteMetalLocalTone` encode-only LLF on the current command buffer. Source/remap/result pyramids allocate from `TransientBufferArena`. Canonical `local_tone.source.0` / `local_tone.result.0` live in workspace `Values()` with GraphValueId and `HashLlfSourceKey` / `HashLlfReferenceKey`.
+- Full EditSpace frames seed the canonical reference through `reference_to_render`. Later ROI frames sample it with `MakeLlfSamplingPlan`. Isolated ROI without a canonical plane rebuilds locally and does not mark a hit.
+- Shadows/Highlights slider edits reuse the canonical source plane (`HashLlfSourceKey` omits those slider values) and rebuild only the adjusted result.
+- `GraphCompiler` writes LLF pyramid peak bytes into `ExecutionPlan.peak_transient_bytes`. Pipeline states come from `ComputePipelineCache` (`local_tone.metal` → `GpuDagMetalShaders`). Missing metallib throws.
+- DAG path does not call `highlight_shadow_local_tone::MetalStage`. That type still exists for the pre-DAG fused pipeline until M7.
+
+**Deleted:**
+
+- None of the old Metal product wrappers. `MetalStage` remains until M7. The DAG path does not own its pyramid arrays, cached keys, or allocator.
+
+**Tests:**
+
+- command: `cmake --preset macos_debug_tests`
+- command: `cmake --build --preset macos_debug_tests --target GpuDagMetalGradeTest GpuDagMetalDevelopTest GpuDagMetalWorkspaceTest GpuDagRawInputTest --parallel 8`
+- command: `ctest --test-dir build/macos-debug-tests -R 'GpuDagMetalGradeTest|GpuDagMetalWorkspaceTest|GpuDagMetalDevelopTest|GpuDagRawInputTest.GpuDagGraphCompiler|GpuDagRawInputTest.GpuDagResultContentKey' --output-on-failure`
+- result: 17/17 grade (9 M3 + 8 M4), 8/8 workspace, 10/10 develop, 15/15 GraphCompiler, 11/11 ResultContentKey PASS
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MetalLlfUsesWorkspaceTransientArenaForEveryPyramid` | `GpuDagMetalGradeTest` | PASS |
+| `MetalLlfFullFrameBuildsCanonicalReferenceOnce` | `GpuDagMetalGradeTest` | PASS |
+| `MetalLlfRoiSamplesCanonicalReferenceWithSharedGeometryPlan` | `GpuDagMetalGradeTest` | PASS |
+| `MetalLlfSliderEditReusesCanonicalReference` | `GpuDagMetalGradeTest` | PASS |
+| `MetalLlfFailedSubmissionDoesNotPublishReference` | `GpuDagMetalGradeTest` | PASS |
+| `MetalLlfSecondStableRenderCreatesNoBufferTextureOrPipelineState` | `GpuDagMetalGradeTest` | PASS |
+| `MetalLlfMatchesCudaReferenceWithinTolerance` | `GpuDagMetalGradeTest` | PASS |
+| Missing metallib throws (`MetalLocalToneMissingMetallibThrowsExplicitError`) | `GpuDagMetalGradeTest` | PASS |
+
+**Resource evidence:**
+
+- buffer create/free: second stable LLF render 0/0 (`MetalLlfSecondStableRenderCreatesNoBufferTextureOrPipelineState`); slider edit reuses `local_tone.source.0` ResourceId (`MetalLlfSliderEditReusesCanonicalReference`)
+- texture create/free: second matching LLF render 0/0
+- heap growth: second matching LLF render 0
+- pipeline create/hit: first WarmUp/GetPipelineState creates extract/pyr_down/remap/select/collapse/apply; second identical render create 0 (API snapshot, not logs)
+- upload ranges/bytes: canonical source is not re-extracted on a Shadows slider edit; failed encode leaves the previous canonical ResourceId unpublished for the failed frame
+
+**Performance evidence:**
+
+- device/macOS/Xcode/build: MacBook Air (Mac16,12) Apple M4, macOS 26.5.2 (25F84), Xcode 26.3 (17C529), `macos_debug_tests` Debug
+- fixture and render request: synthetic Direct RGB 16×12 / 32×32 / 64×64 split and neighborhood planes; `ExecuteMetalPrimaryGrade` after Develop/Geometry/CameraColor
+- cold: first reserve + first LLF render allocates heap/buffer/texture/pipeline and transient pyramids
+- warm median: not a product-frame A/B; second identical full-frame LLF render GPU resource create/free = 0 and samples the canonical plane
+- warm p95: same; product A/B remains M7
+
+**Remaining work owned by the next named Phase:**
+
+- M5: Mask/Feather/Mix with R8 and signed distance. Disconnected mask still uses constant 1.
+- M6: DRT/present. Identity DRT copy is not a display path.
+- M7: delete `highlight_shadow_local_tone::MetalStage` and the old fused Metal product path.
+
+**LOC note:** `metal_local_tone_pass.hpp` 46, `metal_local_tone_pass.mm` 543, `local_tone.metal` 339, `metal_llf_test.cpp` 703, `metal_backend.mm` 929. No new file crossed 1000 LOC.
+
+**Residual gaps:** DRT Metal encoder still copies Grade output until M6. Old RAW Metal wrappers and `MetalStage` still own static scratch for the pre-DAG product path.
 
 ## 10. Phase M5 — Mask、Feather 与 Mix
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -922,7 +922,7 @@ MetalRealRawEditorUsesTheThreeNodeDag
 **Status:** complete
 **Date:** 2026-08-26
 **Branch:** `feature/gpu-dag-metal`
-**Commit:** local working tree on `c17a8a41`
+**Commit:** `548e493d`
 
 **Implemented:**
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -633,7 +633,7 @@ MetalUnknownAdjustmentReturnsExplicitBackendError
 **Status:** complete
 **Date:** 2026-08-26
 **Branch:** `feature/gpu-dag-metal`
-**Commit:** working tree on `feature/gpu-dag-metal` (HEAD `48fb7465` plus this change)
+**Commit:** `b5622cfe`
 
 **Implemented:**
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-24
 
-Status: M0–M5 complete; M6–M7 planned
+Status: M0–M6 complete; M7 planned
 
 Branch: `feature/gpu-dag-metal`
 
@@ -916,6 +916,68 @@ MetalPipelineReturnReleasesSessionResourcesAfterGpuCompletion
 MetalBackendFailureDoesNotEnterCpuOrLegacyMetalExecution
 MetalRealRawEditorUsesTheThreeNodeDag
 ```
+
+##### Phase M6 completion record (2026-08-26)
+
+**Status:** complete
+**Date:** 2026-08-26
+**Branch:** `feature/gpu-dag-metal`
+**Commit:** local working tree on `c17a8a41`
+
+**Implemented:**
+
+- Encode-only `ExecuteMetalDrt` on the current command buffer. ACES 2.0 and OpenDRT consume AP1/ACEScc primary-grade output, decode ACEScc, and write a workspace RGBA32F display texture. DRT parameters live in ParameterArena (`MetalDrtGpuParams`). ACES 2.0 converts AP1 to AP0 without a pre-tonescale clamp, matching the CUDA DAG.
+- `drt.metal` / `drt_aces.metal` / `drt_opendrt.metal` compiled into `GpuDagMetalShaders`. `WarmUpPlan` warms `drt_display`. Missing metallib throws.
+- `FramePresenter<MetalBackend>` submits the retained workspace MTLTexture to `IFrameSink` (`SubmitMetalFrame` + `SubmitFinalDisplayFrame`) with the same command-buffer submission signal. Host download runs only when the product path requested an export/test `ImageBuffer`.
+- macOS Auto/Metal product `Apply` creates `MetalRenderer` on the shared `Renderer<Backend>` session path. Session cache stays isolated from one-shot workspaces. Pipeline return waits idle and releases session results, transients, and parameters.
+
+**Deleted:**
+
+- Metal DRT identity copy in `PassEncoder<MetalBackend, GpuPassKind::Drt>`. Old fused Metal product wrappers remain until M7.
+
+**Tests:**
+
+- command: `cmake --preset macos_debug_tests`
+- command: `cmake --build --preset macos_debug_tests --target GpuDagMetalDrtTest GpuDagMetalRendererTest GpuDagMetalGradeTest GpuDagMetalDevelopTest GpuDagMetalWorkspaceTest --parallel 8`
+- command: `ctest --test-dir build/macos-debug-tests -R 'GpuDagMetalDrtTest|GpuDagMetalRendererTest|GpuDagMetalGradeTest|GpuDagMetalWorkspaceTest|GpuDagMetalDevelopTest' --output-on-failure`
+- result: 53/53 PASS (4 DRT + 6 renderer + 25 grade + 10 develop + 8 workspace)
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MetalDrtAcesMatchesCudaReferenceWithinTolerance` | `GpuDagMetalDrtTest` | PASS |
+| `MetalDrtOpenDrtMatchesCudaReferenceWithinTolerance` | `GpuDagMetalDrtTest` | PASS |
+| `MetalDrtEditRunsOnlyDrtPass` | `GpuDagMetalDrtTest` | PASS |
+| `MetalRendererPresentsWorkspaceTextureWithoutHostDownload` | `GpuDagMetalRendererTest` | PASS |
+| `MetalScopeTapUsesTheFinalDisplayTextureAndSubmissionSignal` | `GpuDagMetalRendererTest` | PASS |
+| `MetalOneShotRenderDoesNotPublishIntoSessionCache` | `GpuDagMetalRendererTest` | PASS |
+| `MetalPipelineReturnReleasesSessionResourcesAfterGpuCompletion` | `GpuDagMetalRendererTest` | PASS |
+| `MetalBackendFailureDoesNotEnterCpuOrLegacyMetalExecution` | `GpuDagMetalRendererTest` | PASS |
+| `MetalRealRawEditorUsesTheThreeNodeDag` | `GpuDagMetalRendererTest` | PASS |
+| Missing metallib throws (`MetalDrtMissingMetallibThrowsExplicitError`) | `GpuDagMetalDrtTest` | PASS |
+
+**Resource evidence:**
+
+- buffer create/free: third identical DRT render 0/0 (`MetalDrtEditRunsOnlyDrtPass`); one-shot render does not change session published count
+- texture create/free: identical DRT re-render after a peak-luminance edit 0/0
+- heap growth: DRT-only edit 0
+- pipeline create/hit: first WarmUpPlan creates `drt_display`; later identical renders create 0
+- upload ranges/bytes: DRT peak-luminance edit uploads the ParameterArena DRT slot; present path does not host-download
+
+**Performance evidence:**
+
+- device/macOS/Xcode/build: MacBook Air (Mac16,12) Apple M4, macOS 26.5.2 (25F84), Xcode 26.3 (17C529), `macos_debug_tests` Debug
+- fixture and render request: synthetic Direct RGB 16×12 and unpacked CFA 32×32; `MetalRenderDevice::Execute` / `MetalRenderer::Render` after pipeline warm-up
+- cold: first reserve + first DRT render allocates heap/buffer/texture/pipeline
+- warm median: not a product-frame A/B; second identical DRT render GPU resource create/free = 0; present submits the workspace texture
+- warm p95: same; product A/B remains M7
+
+**Remaining work owned by the next named Phase:**
+
+- M7: delete `pipeline_metal_impl.cpp`, fused Metal stages, `MetalStage`, and leftover operator-private Metal scratch. Record same-Mac old/new Metal A/B.
+
+**LOC note:** `metal_drt_pass.hpp` 35, `metal_drt_gpu_params.hpp` 159, `metal_drt_pass.mm` 118, `metal_drt_params.cpp` 185, `metal_frame_presenter.mm` 80, `drt.metal` 419, `drt_aces.metal` 403, `drt_opendrt.metal` 255, `pipeline_cpu.cpp` 961. No new file crossed 1000 LOC.
+
+**Residual gaps:** Old fused Metal product wrappers and `MetalStage` remain until M7. Product A/B performance remains M7.
 
 ## 12. Phase M7 — 旧 Metal 管线删除与性能验收
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-24
 
-Status: planned
+Status: M0 complete; M1–M7 planned
 
 Plan branch: `feature/gpu-dag-metal-phase-plan`
 
@@ -298,6 +298,61 @@ GraphCompilerPassListIsBackendNativeTypeFree
 - CUDA 现有集中测试通过；
 - Metal 可以接入同一 source/plan/result cache 流程；
 - 没有新增运行时 fallback。
+
+##### Phase M0 completion record (2026-08-24)
+
+**Status:** complete — shared `Renderer<Backend>` / `PlanExecutor<Backend>` / `PassEncoder<Backend, Kind>` skeleton; CUDA product path unchanged; Metal host types instantiate the same session caches.
+
+**Primary success call chain:**
+
+```text
+CPUPipelineExecutor::Apply (CUDA)
+  -> Renderer<CudaBackend>::Render(UseSessionCache)
+  -> PreparedSourceCache::AcquireEncoded
+  -> StaticExecutionPlanCache::GetOrCompile(kCudaDagBackendCapabilityVersion)
+  -> GraphCompiler::BindFrameGeometry
+  -> PlanExecutor<CudaBackend>::Execute
+       miss -> PassEncoder<CudaBackend, Kind>::Encode
+       hit  -> skip + GpuNodePassStats
+  -> FramePresenter<CudaBackend>::Present / Download
+  -> PublishResults
+```
+
+**Primary failure call chain:**
+
+```text
+PassEncoder / upload / present throws
+  -> PlanExecutor::CancelRender (discard unpublished)
+  -> Renderer does not PublishResults
+  -> ReportError + rethrow
+  -> no CPU, no old Metal pipeline, no unpublished content key
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `RendererTemplateInstantiatesCudaWithoutMetalHeaders` | `GpuDagCudaWorkspaceTest` | PASS |
+| `RendererTemplateInstantiatesMetalWithoutCudaHeaders` | `GpuDagRawInputTest` | PASS |
+| `CudaRendererPreservesCurrentPlanAndResultCacheKeys` | `GpuDagCudaDrtProductTest` | PASS |
+| `RendererOneShotWorkspaceCannotPublishIntoSessionCache` | `GpuDagCudaDrtProductTest` | PASS |
+| `RendererFailureDoesNotPublishUnfinishedContentKeys` | `GpuDagCudaDrtProductTest` | PASS |
+| `GraphCompilerPassListIsBackendNativeTypeFree` | `GpuDagRawInputTest` | PASS |
+
+Commands:
+
+- `cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagRawInputTest GpuDagCudaWorkspaceTest GpuDagCudaDrtProductTest EditPipeline`
+- `ctest --test-dir build/debug -R GpuDagRawInputTest --output-on-failure` → 39/39
+- `ctest --test-dir build/debug -R GpuDagCudaWorkspaceTest --output-on-failure` → 17/17
+- `ctest --test-dir build/debug -R GpuDagCudaDrtProductTest --output-on-failure` → 41/41
+
+Suite totals: 39/39 RawInput, 17/17 CUDA workspace, 41/41 CUDA product.
+
+**Checklist / exit condition:** all M0 exit conditions met.
+
+**LOC note (grill-code-review):** new shared headers stay under 250 LOC (`renderer.hpp` 233, `plan_executor.hpp` 147, `metal_backend.hpp` 154). `cuda_result_cache_test.cpp` 565 LOC. `pipeline_cpu.cpp` 790 LOC, only call-site rename. No file crossed 1000 LOC in this change.
+
+**Residual gaps:** Metal `CreateBuffer` / `PassEncoder` / present still throw until M1–M6 implement GPU resources and encode-only passes. CUDA pixel math and G7R.4/R.5 were not changed.
 
 ## 6. Phase M1 — MetalBackend、workspace 与 pipeline warm-up
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-24
 
-Status: M0–M4 complete; M5–M7 planned
+Status: M0–M5 complete; M6–M7 planned
 
 Branch: `feature/gpu-dag-metal`
 
@@ -819,6 +819,67 @@ MetalDisconnectedMaskUsesConstantOneWithoutTextureAllocation
 MetalNormalMixMatchesCudaReferenceWithinTolerance
 MetalMaskCacheDoesNotEvictBusyTextures
 ```
+
+##### Phase M5 completion record (2026-08-26)
+
+**Status:** complete
+**Date:** 2026-08-26
+**Branch:** `feature/gpu-dag-metal`
+
+**Implemented:**
+
+- `ExecuteMetalMask` encode-only MaskEvaluate/MaskFeather on the current command buffer. Raster R8 assets load from MaskStore into workspace `MaskTextureCache` mip chains. Dirty rectangles union to one blit; unchanged texels are not uploaded.
+- Analytic Radial/GraduatedNd and raster sampling both use `ResolvedRenderGeometry` / `MakeRasterMaskSamplingPlan`. Feather uses exact signed Euclidean distance (parallel-band horizontal/vertical + compose) matching the CUDA coverage, plateau, and antialiased-boundary rules.
+- Signed-distance intermediates allocate from `TransientBufferArena`. The signed-distance result lives in workspace `Values()` under GraphValueId and a mask content key (asset key + extent, no feather radius). A radius-only edit reuses the same ResourceId.
+- Primary Grade has one Normal Mix exit. Connected masks multiply `grade.Mix` by the RenderSpace R8 coverage. Disconnected masks use constant 1 and do not allocate a white R8 texture.
+- `GraphCompiler` adds raster signed-distance peak bytes to `ExecutionPlan.peak_transient_bytes`. Mask pipeline states come from `ComputePipelineCache` (`mask.metal` → `GpuDagMetalShaders`). Missing metallib throws.
+
+**Deleted:**
+
+- None of the old Metal product wrappers. The DAG path does not call fused-pipeline mask or CPU image processing.
+
+**Tests:**
+
+- command: `cmake --preset macos_debug_tests`
+- command: `cmake --build --preset macos_debug_tests --target GpuDagMetalGradeTest GpuDagMetalDevelopTest GpuDagMetalWorkspaceTest GpuDagRawInputTest --parallel 8`
+- command: `ctest --test-dir build/macos-debug-tests -R 'GpuDagMetalGradeTest|GpuDagMetalWorkspaceTest|GpuDagMetalDevelopTest|GpuDagRawInputTest.GpuDagGraphCompiler|GpuDagRawInputTest.GpuDagResultContentKey' --output-on-failure`
+- result: 25/25 grade (9 M3 + 8 M4 + 8 M5), 8/8 workspace, 10/10 develop, 15/15 GraphCompiler, 11/11 ResultContentKey PASS
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MetalRasterMaskUploadsOnlyChangedR8Rectangle` | `GpuDagMetalGradeTest` | PASS |
+| `MetalRasterMaskMipChainUsesWorkspaceCache` | `GpuDagMetalGradeTest` | PASS |
+| `MetalMaskFeatherMatchesExactSignedDistanceReference` | `GpuDagMetalGradeTest` | PASS |
+| `MetalFeatherRadiusEditReusesSignedDistanceResult` | `GpuDagMetalGradeTest` | PASS |
+| `MetalMaskSamplingMatchesCudaAtCropRotationAndDynamicResolution` | `GpuDagMetalGradeTest` | PASS |
+| `MetalDisconnectedMaskUsesConstantOneWithoutTextureAllocation` | `GpuDagMetalGradeTest` | PASS |
+| `MetalNormalMixMatchesCudaReferenceWithinTolerance` | `GpuDagMetalGradeTest` | PASS |
+| `MetalMaskCacheDoesNotEvictBusyTextures` | `GpuDagMetalGradeTest` | PASS |
+
+**Resource evidence:**
+
+- buffer create/free: feather-radius edit reuses the signed-distance ResourceId and reports 0 additional SDF transient bytes (`MetalFeatherRadiusEditReusesSignedDistanceResult`)
+- texture create/free: same MaskAssetKey at full and half render scale keeps the persistent R8 ResourceId and mip chain (`MetalRasterMaskMipChainUsesWorkspaceCache`)
+- dirty upload: unioned R8 rectangle `{1,1,4,4}` and 16 host-to-device bytes (`MetalRasterMaskUploadsOnlyChangedR8Rectangle`)
+- cache: busy submission textures are not evicted under a 1-byte budget (`MetalMaskCacheDoesNotEvictBusyTextures`)
+- disconnected mix: `MaskTextures` entry count stays 0 and no mask GraphValueId is allocated (`MetalDisconnectedMaskUsesConstantOneWithoutTextureAllocation`)
+
+**Performance evidence:**
+
+- device/macOS/Xcode/build: MacBook Air (Mac16,12) Apple M4, macOS 26.5.2 (25F84), Xcode 26.3 (17C529), `macos_debug_tests` Debug
+- fixture and render request: synthetic Direct RGB 16×12 / 9×9; `ExecuteMetalMask` and `ExecuteMetalPrimaryGrade` after Develop/Geometry/CameraColor
+- cold: first raster upload + mip chain + optional signed-distance transients allocate heap/buffer/texture/pipeline
+- warm median: not a product-frame A/B; identical mask asset at a new render scale reuses the persistent texture; radius-only feather reuses signed distance
+- warm p95: same; product A/B remains M7
+
+**Remaining work owned by the next named Phase:**
+
+- M6: DRT/present. Identity DRT copy is not a display path.
+- M7: delete `highlight_shadow_local_tone::MetalStage` and the old fused Metal product path.
+
+**LOC note:** `metal_mask_pass.hpp` 45, `metal_mask_pass.mm` 511, `mask.metal` 322, `metal_mask_test.cpp` 439, `metal_primary_grade_pass.mm` 476, `primary_grade.metal` 257. No new file crossed 1000 LOC.
+
+**Residual gaps:** DRT Metal encoder still copies Grade output until M6. Old RAW Metal wrappers and `MetalStage` still own static scratch for the pre-DAG product path.
 
 ## 11. Phase M6 — DRT、scope、present 与产品切换
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -399,7 +399,7 @@ MetalRenderDeviceUsesThePresentationDevice
 **Status:** complete
 **Date:** 2026-08-25
 **Branch:** `feature/gpu-dag-metal`
-**Commit:** `481df564`
+**Commit:** `e3230a14`
 
 **Implemented:**
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md
@@ -1,0 +1,752 @@
+# GPU DAG Metal 移植逐 Phase 计划
+
+Date: 2026-08-24
+
+Status: planned
+
+Plan branch: `feature/gpu-dag-metal-phase-plan`
+
+Implementation branch: `feature/gpu-dag-metal`
+
+Primary owner: Alcedo Studio 编辑管线 Metal 后端。
+
+## 1. 必读设计文档
+
+开始本计划前必须完整阅读：
+
+- [GPU DAG 编辑管线重构 Phase 计划](gpu_dag_pipeline_rebuild_phase_plan.md)
+
+该文档定义 PipelineDocument、GraphCompiler、ExecutionPlan、Model/DTO、dirty Patch、
+RenderGeometryResolver、MaskStore、内容 key、缓存边界和 CUDA 参考行为。本计划只定义 Metal
+移植的执行切片，不重新建立一套 Metal graph、Model、DTO、ROI 或缓存语义。
+
+发生冲突时遵循以下优先级：
+
+1. 本计划对 Metal Phase、Metal 资源生命周期和 Metal 删除范围的明确要求；
+2. GPU DAG 主计划的共享图、数据、缓存和几何设计；
+3. 现有 Metal 旧管线只作为像素算法和性能基线，不能作为目标架构。
+
+## 2. 决策与边界
+
+### 2.1 G7R.4 和 G7R.5 不阻塞 Metal
+
+Metal 移植不以 G7R.4 creative CAT02 或 G7R.5 CUDA 完整统计收尾为前置条件。
+
+- 当前 UI 没有暴露新的 node creative CAT02 编辑入口；
+- Metal 对已经进入 PipelineDocument 的参数保持与当前 CUDA DAG 一致；
+- 本计划不扩大 CUDA creative CAT02 行为；
+- 本计划不承担 G7R.5 的 CUDA 基线收尾；
+- Metal 自身的资源计数、逐 Pass 计时和稳定帧性能仍然是本计划的强制验收项。
+
+这项决定只解除 Metal 的依赖，不允许 Metal 引入 CPU、旧管线或其他 GPU 后端替代路径。
+
+### 2.2 Renderer 命名
+
+共享产品/session 渲染入口命名为：
+
+```cpp
+template <class Backend>
+class Renderer;
+
+using CudaRenderer = Renderer<CudaBackend>;
+using MetalRenderer = Renderer<MetalBackend>;
+```
+
+不新增 `ProductRenderer`、`BasicProductRenderer` 或 `MetalProductRenderer`。现有
+`CudaProductRenderer` 在共享 Renderer 落地时迁移到上述命名。
+
+`Renderer<Backend>` 负责：
+
+- PreparedSourceCache；
+- StaticExecutionPlanCache；
+- RenderDevice 和 workspace 生命周期；
+- MaskStore 读取入口；
+- session cache 与 one-shot cache 隔离；
+- GraphCompiler 静态计划和逐帧 geometry 绑定；
+- 后端展示与显式 host 输出；
+- 失败传播、统计快照和 session 资源释放。
+
+### 2.3 不允许 fallback
+
+以下行为全部禁止：
+
+- Metal kernel、metallib、buffer、texture、command buffer 或 present 失败后进入 CPU；
+- Metal Develop 失败后调用旧 RawProcessor Metal 整体管线；
+- Neural Engine 失败后改用 Legacy demosaic；
+- DAG Metal 失败后进入旧 `GPUPipelineImpl`、PipelineStage 或 fused stage；
+- 为规避性能问题改变 DecodeRes、RenderQuality、viewport 或输出精度；
+- 捕获真实错误并提交上一帧、空帧或低质量帧作为成功结果。
+
+失败必须取消未完成提交，不发布新的内容 key，并把原始错误送到 app 层。
+
+### 2.4 Metal 旧实现的用途
+
+以下代码只能用于确认算法、shader 数学和旧性能基线：
+
+- `edit/pipeline/pipeline_metal_impl.cpp`；
+- `edit/pipeline/metal_shader/fused_pipeline.metal`；
+- `edit/operators/GPU_kernels/metal_param.hpp`；
+- `edit/operators/basic/highlight_shadow_local_tone_metal.cpp`；
+- RAW Processor 下现有 Metal operator wrappers；
+- `metal::MetalImage` 的格式和展示互操作实现。
+
+不得把它们包装进 DAG 继续使用。存在静态 scratch、算子私有 buffer、内部 command buffer、
+逐调用 commit/wait 或总参数上传的入口必须拆成接收当前 command context 与 workspace 资源的
+encode-only 实现。
+
+## 3. 目标架构
+
+```text
+PipelineDocument
+      │
+      ▼
+GraphCompiler ──────────────── shared, GPU-free
+      │
+      ▼
+ExecutionPlan
+      │
+      ▼
+Renderer<MetalBackend>
+├── PreparedSourceCache
+├── StaticExecutionPlanCache
+├── MaskStore
+└── BasicRenderDevice<MetalBackend>
+    ├── MetalCommandContext
+    ├── BasicRenderWorkspace<MetalBackend>
+    │   ├── ParameterArena
+    │   ├── TransientBufferArena
+    │   ├── TexturePool
+    │   ├── MaskTextureCache
+    │   ├── GraphImageCache
+    │   └── NodeResultCache
+    └── MetalSharedGpuResources
+        ├── ComputePipelineCache references
+        ├── LUT texture cache
+        ├── immutable sampler states
+        └── Neural model and activation ownership
+```
+
+### 3.1 编译期后端区分
+
+共享 host 运行时使用模板，后端差异使用明确特化：
+
+```cpp
+template <class Backend>
+concept RenderBackend = requires(Backend backend,
+                                 typename Backend::CommandContext& commands) {
+  typename Backend::Buffer;
+  typename Backend::Texture2D;
+  typename Backend::CommandContext;
+  backend.CreateBuffer(std::size_t{});
+  backend.CreateTexture2D(std::uint32_t{}, std::uint32_t{}, TextureFormat{});
+  backend.Submit(commands);
+  backend.Wait(commands);
+};
+
+template <RenderBackend Backend>
+class BasicRenderDevice;
+
+template <RenderBackend Backend, GpuPassKind Kind>
+struct PassEncoder;
+
+template <RenderBackend Backend>
+class PlanExecutor;
+
+template <RenderBackend Backend>
+class Renderer;
+```
+
+示例：
+
+```cpp
+template <>
+struct PassEncoder<MetalBackend, GpuPassKind::GeometryResample> {
+  static void Encode(MetalRenderContext& context,
+                     const ExecutionPlan& plan);
+};
+```
+
+规则：
+
+- 外层可以保留一次 IRenderDevice 类型隐藏；
+- 一帧内部不按后端做虚调用；
+- GraphCompiler 不包含 CUDA/Metal 原生类型；
+- GraphCompiler 不为每个后端复制 pass 构建流程；
+- 后端能力通过 capability version 和 Traits 表达；
+- shader 源码按 CUDA/MSL 分开，host 生命周期和缓存流程保持共享；
+- 模板只负责稳定的生命周期与调度，不把大段像素数学塞进泛型头文件。
+
+### 3.2 MetalBackend Traits
+
+MetalBackend 必须提供：
+
+- move-only `Buffer` 和 `Texture2D` 包装；
+- `MetalCommandContext`；
+- buffer/texture 创建、释放和字节统计；
+- buffer range 上传与下载；
+- R8 texture rect 上传；
+- texture-to-texture blit；
+- submission id、完成 id 和 busy 查询；
+- command buffer 提交、等待和取消后的资源处理；
+- device、queue、MTLHeap 和资源预算访问；
+- 分配、释放、上传和 pipeline-state 计数。
+
+Metal 原生类型只出现在 Metal runtime、`.mm` 和受 `HAVE_METAL` 保护的边界中。
+
+### 3.3 CommandContext
+
+每次 render 只使用一个 Metal command buffer：
+
+```text
+BeginRender
+  -> 等待上一份提交完成
+  -> 创建本帧唯一 command buffer
+  -> 上传 dirty 参数和输入 dirty range
+  -> 按 ExecutionPlan 编码 compute/blit encoder
+  -> 编码 present/scope 所需操作
+  -> commit
+EndRender
+```
+
+禁止 Pass 自行创建 command buffer、queue、commit 或 wait。必要的 encoder 边界由资源 hazard、
+blit/compute 类型和可读性决定，不按旧 stage 划分。
+
+### 3.4 统一资源分配
+
+Metal 资源必须通过 RenderDevice 所拥有的 workspace 或 SharedGpuResources 创建。
+
+| 资源 | 唯一所有者 | Metal 存储策略 |
+| --- | --- | --- |
+| 参数 | ParameterArena | 单一 shared/managed buffer，dirty range 写入 |
+| 临时 buffer | TransientBufferArena | device-private grow-only slab |
+| 中间图像 | TexturePool | MTLHeap 上的 private texture |
+| 节点结果 | GraphImageCache | TexturePool lease + 内容 key |
+| Raster mask | MaskTextureCache | R8 private texture/mip chain |
+| mask signed distance | workspace KV/cache | private buffer/texture + 内容 key |
+| LUT | MetalSharedGpuResources | 内容 key + 字节预算 |
+| pipeline state | ComputePipelineCache | metallib path + function name |
+| Neural 权重/激活 | MetalSharedGpuResources/workspace | 权重跨 session 安全复用，激活按 device/session 所有 |
+
+要求：
+
+- MTLHeap 页只在没有 in-flight submission 时增长；
+- texture pool 只复用完整匹配的 extent、format、usage 和 storage mode；
+- active lease 和 busy submission 使用的资源不可淘汰；
+- plan 预热后，稳定 render 不创建或销毁 buffer、texture、heap 或 pipeline state；
+- 算子、Pass encoder 和 shader wrapper 不拥有第二套 LRU、pool 或长期 scratch；
+- `recommendedMaxWorkingSetSize` 参与预算计算，并保留 app/UI 纹理所需余量；
+- 分配复用与内容命中使用不同计数，不能用 texture identity 证明结果有效。
+
+## 4. Phase 总表
+
+| Phase | 主题 | 强制输出 |
+| --- | --- | --- |
+| M0 | 共享 Renderer 与模板执行骨架 | CUDA 继续运行；Metal 后端可编译接入 |
+| M1 | MetalBackend、workspace 与 pipeline warm-up | 统一资源机制和零稳定帧创建证据 |
+| M2 | Develop、Geometry、CameraColor | `develop.sensor_linear`、`geometry.scene_source`、`develop.image` |
+| M3 | Primary Grade 融合路径 | 参数 arena、pointwise fusion、detail/LUT |
+| M4 | LLF workspace 化 | canonical reference、ROI sampling、无私有 allocator/cache |
+| M5 | Mask、Feather、Mix | R8/mip/距离场和统一 Normal Mix |
+| M6 | DRT、scope、present 与产品切换 | Metal DAG 端到端产品路径 |
+| M7 | 旧 Metal 管线删除与性能验收 | macOS 产品路径无 PipelineStage/旧 op 执行 |
+
+每个 Phase 都必须同时交付行为测试、资源测试和性能快照。不能先提交逐帧分配、逐算子 dispatch、
+逐 Pass wait 或重复 H2D，再把修复留给最终 Phase。
+
+## 5. Phase M0 — 共享 Renderer 与模板执行骨架
+
+目标：
+
+- 把 CUDA 产品/session 调度提炼成 `Renderer<CudaBackend>`；
+- 建立可实例化 `Renderer<MetalBackend>` 的 host 模板；
+- 保持 CUDA 当前像素输出、缓存 key 和执行集不变；
+- G7R.4/R.5 不作为 M0 完成条件。
+
+工作：
+
+1. 把 `CudaProductRenderer` 中后端无关的 source cache、plan cache、MaskStore、session/one-shot
+   流程移动到 `Renderer<Backend>`。
+2. 保留 `CudaRenderer` 别名，更新 CUDA 产品调用点。
+3. 把 `CudaRenderDevice::Execute` 中内容 key 查询、pass execute/skip 统计、失败取消和发布流程
+   提炼到 `PlanExecutor<Backend>`。
+4. 通过 `PassEncoder<Backend, Kind>` 特化调用 CUDA 和 Metal 实现。
+5. 把 ViewerDisplayConfig 解析留在共享 DRT DTO 层；native present 留在 Backend Presenter。
+6. 为 CUDA 和 Metal 使用不同 capability version，但共享 StaticPlanKey 规则。
+7. 对模板头增加 compile-only header hygiene 测试，防止 Metal/CUDA 原生头泄漏。
+
+禁止：
+
+- 复制一份 `MetalRenderer` 产品调度代码；
+- 把 `GpuBackendKind` switch 放入每个 pass；
+- 为 Metal 建立不同的 GraphValueId 或缓存失效规则；
+- 在 M0 修改 CUDA 像素数学或补做 G7R.4/R.5。
+
+测试：
+
+```text
+RendererTemplateInstantiatesCudaWithoutMetalHeaders
+RendererTemplateInstantiatesMetalWithoutCudaHeaders
+CudaRendererPreservesCurrentPlanAndResultCacheKeys
+RendererOneShotWorkspaceCannotPublishIntoSessionCache
+RendererFailureDoesNotPublishUnfinishedContentKeys
+GraphCompilerPassListIsBackendNativeTypeFree
+```
+
+完成条件：
+
+- 产品/session 类名是 `Renderer<Backend>`；
+- CUDA 现有集中测试通过；
+- Metal 可以接入同一 source/plan/result cache 流程；
+- 没有新增运行时 fallback。
+
+## 6. Phase M1 — MetalBackend、workspace 与 pipeline warm-up
+
+目标：
+
+- 实现完整 MetalBackend Traits；
+- 实例化 `BasicRenderWorkspace<MetalBackend>`；
+- 从第一份可执行代码起统一 buffer、texture、cache 和 pipeline state 生命周期。
+
+工作：
+
+1. 新增 `edit/runtime/metal/metal_backend.hpp/.mm`。
+2. 新增 move-only Buffer、Texture2D 和 MetalCommandContext。
+3. 为 private buffer/texture 建立 Metal heap page allocator，并由 MetalBackend 独占。
+4. 实现 ParameterArena dirty range 写入；managed storage 设备执行必要同步标记。
+5. 实现 R8 dirty rectangle blit 和 RGBA32F/R32F texture 上传。
+6. 实现 submission id、完成回调和 `IsResourceBusy`。
+7. 实例化 TransientBufferArena、TexturePool、MaskTextureCache、GraphImageCache 和
+   NodeResultCache。
+8. 扩展 ComputePipelineCache 的只读 hit/miss/create 统计；稳定帧不得创建 pipeline state。
+9. 使用 app 选择的同一 Metal device；禁止 workspace、MetalImage 和 present 分别创建 device。
+10. 在首次执行计划前解析 metallib 和预热该计划需要的 pipeline state。
+
+测试：
+
+```text
+MetalParameterArenaUploadsOnlyDirtyRanges
+MetalTransientArenaRewindsWithoutReallocatingItsSlab
+MetalTexturePoolReusesMatchingPrivateTextures
+MetalTexturePoolDoesNotEvictBusySubmissionResources
+MetalMaskTextureCacheUsesOneWorkspaceByteBudget
+MetalSecondEmptyRenderCreatesNoBufferTextureHeapOrPipelineState
+MetalFailedUploadRestoresDirtyFieldsAndPublishesNoResult
+MetalRenderDeviceUsesThePresentationDevice
+```
+
+性能门槛：
+
+- 第二次相同计划的 buffer/texture/heap/pipeline create 和 free 都为零；
+- 无 dirty 参数时 ParameterArena 上传字节为零；
+- BeginRender/EndRender 之外不存在 pass 级 wait；
+- 统计通过 API 快照读取，不依赖日志解析。
+
+## 7. Phase M2 — Develop、Geometry 与 CameraColor
+
+目标：
+
+- 完整移植 CUDA DAG Develop 顺序；
+- 保持三个独立内容缓存边界；
+- 不调用 RawProcessor 的整体 Metal 产品路径。
+
+固定图像流：
+
+```text
+PreparedRawInput
+  -> UploadRaw/UploadRgb
+  -> Linearize
+  -> optional CfaClamp
+  -> Demosaic
+  -> HighlightRecover
+  -> InverseCamMulPack
+  -> Lens
+  -> develop.sensor_linear
+  -> GeometryResample
+  -> geometry.scene_source
+  -> CameraToAp1 + ACEScc encode
+  -> develop.image
+```
+
+工作：
+
+1. 将现有 RAW Metal shader 暴露为 encode-only entrypoint，参数包括当前 command buffer、
+   workspace texture/buffer 和不可变参数。
+2. RCD、X-Trans 和 Neural 路径不再使用静态 scratch 或内部 command buffer。
+3. RAW Processor 模块内的 RAW 专用 shader 继续放在
+   `decoders/processor/operators/gpu/metal_shader/`。
+4. 新增或重命名 RAW Metal shader 时，同步更新 `metal/CMakeLists.txt` 的 air/metallib、
+   `RawProcessorOpMetalShaders` 和编译定义。
+5. 通用 crop/resize/warp 保持在 `metal/metal_utils/`；DAG Geometry Pass 只负责编码与资源绑定。
+6. Lens、Geometry 和 CameraColor 使用同一帧 command buffer。
+7. CameraColor 读取共享 DevelopColorTransform 结果，不在 Metal 端重新解释 CameraMatrices。
+8. CCT/tint 改变只能让 CameraColor 及下游失效。
+9. source、sensor、geometry 和 develop 内容 key 与 CUDA 使用同一构造函数。
+
+测试：
+
+```text
+MetalDevelopLinearizeMatchesCudaReferenceWithinTolerance
+MetalDevelopRcdOrderMatchesCudaDemosaicThenHighlightRecovery
+MetalDevelopXTransMatchesCudaReferenceWithinTolerance
+MetalDevelopNeuralUsesSessionWorkspaceAndDoesNotSelectLegacyOnFailure
+MetalGeometryUsesOneResampleForCropRotationViewportAndScale
+MetalCameraColorConsumesSharedDualIlluminantTransform
+MetalCctEditReusesSensorAndGeometryResults
+MetalSecondDevelopRenderRunsNoSourceUploadOrDevelopPass
+MetalDevelopPassesUseOneCommandBuffer
+```
+
+完成条件：
+
+- 三个 GraphValueId 分别拥有内容 key；
+- Develop 稳定重绘不分配 GPU 资源；
+- RAW Metal operator 不保存长期 scratch；
+- kernel/metallib 错误直接失败。
+
+## 8. Phase M3 — Primary Grade 融合路径
+
+目标：
+
+- 移植默认 Grade 调整列表；
+- 保留调整顺序；
+- pointwise 调整使用融合 dispatch；
+- 参数只通过 ParameterArena 更新。
+
+工作：
+
+1. 将 backend-neutral adjustment semantic 与 CUDA/Metal PassEncoder 特化分开。
+2. GraphCompiler 生成调整顺序和 ParameterArena binding，不生成 Metal 原生对象。
+3. 使用一份 command buffer 保存参数 offset 顺序。
+4. CAT02、Exposure、Contrast、White、Black、Curve、HLS、Saturation、Vibrance、Color Wheel
+   和 LMT 在保持顺序的前提下融合。
+5. Shadows/Highlights 在 LLF 边界前后拆成最多两个 pointwise dispatch。
+6. Clarity、Sharpen、Halation 和 Film Grain 根据邻域需求生成明确 pass，临时纹理来自 TexturePool。
+7. LUT texture 由 MetalSharedGpuResources 按内容 key 和字节预算保存；删除 MetalLutBuffer
+   的独立生命周期。
+8. 默认值不改变图结构；slider patch 不重编译 ExecutionPlan。
+9. 本 Phase 只要求当前 CUDA DAG 的 CAT02 参数行为一致，不增加 G7R.4 UI 或数学范围。
+
+测试：
+
+```text
+MetalPrimaryGradePreservesCompiledAdjustmentOrder
+MetalPointwiseAdjustmentsUseOneDispatchPerLlfSegment
+MetalSingleSliderEditUploadsOnlyItsParameterRange
+MetalExposureEditRunsOnlyPrimaryGradeAndDrt
+MetalLutTextureIsReusedByContentKey
+MetalDetailPassesAcquireAllTexturesFromWorkspace
+MetalPrimaryGradeMatchesCudaReferenceWithinTolerance
+MetalUnknownAdjustmentReturnsExplicitBackendError
+```
+
+性能门槛：
+
+- 不允许一个 pointwise adjustment 对应一次 command buffer 或一次完整纹理往返；
+- 相同拓扑的 slider 编辑不创建 buffer、texture 或 pipeline state；
+- Grade command offset buffer 只在拓扑改变时更新；
+- LUT 未变化时上传字节为零。
+
+## 9. Phase M4 — LLF workspace 化
+
+目标：
+
+- 对齐 CUDA canonical LLF reference 和 ROI sampling；
+- 删除 `highlight_shadow_local_tone::MetalStage` 的内存与缓存所有权。
+
+工作：
+
+1. 把 source/remap/sample/output pyramid 的峰值写入 ExecutionPlan transient 需求。
+2. 临时 pyramid buffer 全部从 TransientBufferArena 分配。
+3. canonical reference 使用 workspace GraphValueId、内容 key 和 submission-safe lease。
+4. ROI frame 使用 `MakeLlfSamplingPlan` 映射到 canonical reference。
+5. 全图 reference 未建立时按 CUDA 当前规则计算，不伪造命中。
+6. Shadows/Highlights 参数改变复用不依赖该参数的 canonical reference。
+7. 删除静态或 MetalStage-owned pyramid arrays、cached key 和 allocator。
+8. LLF pipeline state 继续通过 ComputePipelineCache 获取。
+
+测试：
+
+```text
+MetalLlfUsesWorkspaceTransientArenaForEveryPyramid
+MetalLlfFullFrameBuildsCanonicalReferenceOnce
+MetalLlfRoiSamplesCanonicalReferenceWithSharedGeometryPlan
+MetalLlfSliderEditReusesCanonicalReference
+MetalLlfFailedSubmissionDoesNotPublishReference
+MetalLlfSecondStableRenderCreatesNoBufferTextureOrPipelineState
+MetalLlfMatchesCudaReferenceWithinTolerance
+```
+
+## 10. Phase M5 — Mask、Feather 与 Mix
+
+目标：
+
+- 完成 R8 Raster/Analytic Mask；
+- 完成 exact signed Euclidean distance field；
+- Grade 只存在一个 Normal Mix 出口。
+
+工作：
+
+1. Raster mask 从 MaskStore 读取，上传到 workspace MaskTextureCache。
+2. R8 dirty rect 使用 Metal blit，不上传未变化区域。
+3. mip level 由统一 cache 持有，不由 mask pass 持有。
+4. signed distance 中间资源来自 transient arena；距离结果按 mask content key 保存。
+5. feather radius 改变复用 signed distance 结果。
+6. Analytic mask 和 Raster mask 都使用 ResolvedRenderGeometry/TextureSamplingPlan。
+7. Mix kernel 读取原 Grade 输入、调整结果、grade mix 和可选 mask。
+8. 未连接 mask 时使用常数 1，不创建虚假白色纹理。
+
+测试：
+
+```text
+MetalRasterMaskUploadsOnlyChangedR8Rectangle
+MetalRasterMaskMipChainUsesWorkspaceCache
+MetalMaskFeatherMatchesExactSignedDistanceReference
+MetalFeatherRadiusEditReusesSignedDistanceResult
+MetalMaskSamplingMatchesCudaAtCropRotationAndDynamicResolution
+MetalDisconnectedMaskUsesConstantOneWithoutTextureAllocation
+MetalNormalMixMatchesCudaReferenceWithinTolerance
+MetalMaskCacheDoesNotEvictBusyTextures
+```
+
+## 11. Phase M6 — DRT、scope、present 与产品切换
+
+目标：
+
+- 完成 Metal DAG 端到端产品路径；
+- 直接提交 display texture；
+- macOS 编辑器不再进入旧 Metal stage adapter。
+
+工作：
+
+1. 移植 ACES 2.0 和 OpenDRT；输入固定为 AP1/ACEScc，输出为用户选择的 display encoding。
+2. DRT output 使用 workspace RGBA32F texture。
+3. `Renderer<MetalBackend>` 通过 Metal Presenter 向 IFrameSink 提交 retained MTLTexture。
+4. scope tap 读取同一最终纹理与同一 submission signal，不做 host round-trip。
+5. 显式 host 输出只在 export/test 请求时下载；它不是失败替代路径。
+6. session cache 与 one-shot workspace 保持隔离。
+7. PipelineMgmtService 返回管线时等待设备空闲并释放 session results、transients、参数和
+   Neural activation workspace。
+8. macOS Auto/Metal 产品选择直接创建 MetalRenderer。
+9. present、scope 或下载失败时不发布本次结果内容 key。
+
+测试：
+
+```text
+MetalDrtAcesMatchesCudaReferenceWithinTolerance
+MetalDrtOpenDrtMatchesCudaReferenceWithinTolerance
+MetalDrtEditRunsOnlyDrtPass
+MetalRendererPresentsWorkspaceTextureWithoutHostDownload
+MetalScopeTapUsesTheFinalDisplayTextureAndSubmissionSignal
+MetalOneShotRenderDoesNotPublishIntoSessionCache
+MetalPipelineReturnReleasesSessionResourcesAfterGpuCompletion
+MetalBackendFailureDoesNotEnterCpuOrLegacyMetalExecution
+MetalRealRawEditorUsesTheThreeNodeDag
+```
+
+## 12. Phase M7 — 旧 Metal 管线删除与性能验收
+
+目标：
+
+- 删除 macOS 产品路径中的旧 pipeline、stage 和混合 operator 执行；
+- 证明新 Metal DAG 从第一帧到稳定帧满足性能和资源目标。
+
+Metal 专属删除项：
+
+- `edit/pipeline/pipeline_metal_impl.cpp`；
+- Metal `CreateMetalGPUPipeline` 和旧 `GPUPipelineImpl` 分支；
+- `edit/pipeline/metal_kernel_dispatch.hpp`；
+- `edit/pipeline/metal_pipeline_stats.hpp` 中只服务旧路径的结构；
+- `edit/operators/GPU_kernels/metal_param.hpp`；
+- MetalFusedParams、MetalFusedResources 和 MetalFusedParamUploader；
+- `highlight_shadow_local_tone::MetalStage`；
+- 旧 fused stage 参数 buffer 和 neighbor stage buffer；
+- 每帧创建 MetalImage scratch 的旧入口；
+- 已被 DAG shader 覆盖的 `fused_pipeline.metal` 入口；
+- 旧 Metal stage adapter 的 CMake source、metallib、编译定义和 bundle 安装项；
+- 已迁移算子的 Metal ApplyGPU/私有 GPU 资源入口。
+
+共享删除边界：
+
+- Metal 完成后，macOS 产品源码不得引用 PipelineStage、PipelineStageName、OperatorParams、
+  GPUPipelineWrapper 或 merged stage；
+- 全局共享类型的物理删除继续由 GPU DAG 主计划 G10 执行，因为 OpenCL 在完成 G8 前仍可能
+  编译引用这些类型；
+- G10 不是保留旧 Metal 产品路径的理由；Metal M7 必须先删除所有 Metal 引用和实现；
+- 不允许保留 build flag 重新启用旧 Metal pipeline。
+
+静态检查：
+
+```text
+NoMetalProductSourceReferencesPipelineStage
+NoMetalProductSourceReferencesOperatorParams
+NoMetalRuntimeOwnsOperatorPrivateScratchOrCache
+NoLegacyMetalPipelineFactoryRemains
+NoLegacyMetalFusedParameterAggregateRemains
+NoLegacyMetalMetallibIsPackaged
+```
+
+## 13. 性能验收
+
+### 13.1 基线
+
+在同一台 Mac、同一 macOS、同一 Xcode/Metal compiler、同一 Release 配置、同一 RAW、同一
+DecodeRes、同一 viewport 和同一编辑序列下比较：
+
+1. 本计划开始前的旧 Metal 产品路径；
+2. Metal DAG 最终路径；
+3. CUDA reference 的 pass 执行集、缓存失效范围和像素 reference。
+
+CUDA 和 Metal 不在不同硬件之间比较绝对 wall time。跨后端比较像素、pass 数、缓存边界、
+H2D 字节和稳定帧资源创建；绝对性能只在同一台 Mac 上做旧/新 Metal A/B。
+
+### 13.2 场景
+
+每个场景记录一次 cold render 和至少 30 次 warm render：
+
+| 场景 | 允许执行的 GPU 图像工作 | 必须为零 |
+| --- | --- | --- |
+| 无变化重复渲染 | 已完成结果提交与 scope/present | LibRaw、source upload、plan compile、全部节点 pass、GPU resource create/free |
+| Exposure 连续调整 | PrimaryGrade、DRT | SensorDevelop、Geometry、CameraColor、资源创建/释放 |
+| CCT/tint 连续调整 | CameraColor、PrimaryGrade、DRT | SensorDevelop、Geometry、资源创建/释放 |
+| DRT 连续调整 | DRT | SensorDevelop、Geometry、CameraColor、PrimaryGrade、资源创建/释放 |
+| viewport/geometry 改变 | Geometry 及下游 | SensorDevelop、source upload、资源创建/释放 |
+| Develop 参数改变 | SensorDevelop 及下游 | LibRaw 重复 open/unpack、无关 source preparation、资源创建/释放 |
+| 切图后切回 | 预算内内容命中与 present | 命中项的 LibRaw、source upload、节点 pass、资源创建/释放 |
+
+### 13.3 数值门槛
+
+- warm interactive median 不高于旧 Metal 基线的 `1.05x`；
+- warm interactive p95 不高于旧 Metal 基线的 `1.10x`；
+- 无变化、Exposure、CCT、DRT 和 viewport 编辑从第二帧起 GPU resource create/free 为零；
+- 稳定帧 compute pipeline create 为零；
+- 参数上传只覆盖 dirty range；
+- source 未变化时 source upload bytes 为零；
+- pointwise Grade dispatch 数不得随普通 pointwise adjustment 数线性增长；
+- 不得用降低质量、缩小输入或跳过要求的算法满足门槛；
+- 未达到任一门槛时 M7 不得标记 complete。
+
+## 14. 构建与 shader 组织
+
+Metal runtime host 文件使用 Objective-C++，模板实例放在 `.mm` 中，普通共享头不包含
+Metal.hpp。
+
+建议目标：
+
+```text
+EditRuntimeMetal
+GpuDagMetalShaders
+GpuDagMetalDevelopTest
+GpuDagMetalWorkspaceTest
+GpuDagMetalGradeTest
+GpuDagMetalMaskTest
+GpuDagMetalDrtTest
+GpuDagMetalRendererTest
+GpuDagMetalPerformanceTest
+```
+
+shader 组织：
+
+```text
+edit/runtime/metal/shader/
+  geometry_resample.metal
+  camera_color.metal
+  primary_grade.metal
+  local_tone.metal
+  mask.metal
+  drt.metal
+
+decoders/processor/operators/gpu/metal_shader/
+  RAW 专用 linearize/demosaic/highlight/neural shader
+
+metal/metal_utils/
+  可跨 edit 与 RAW Processor 使用的 geometry/blit/format 工具
+```
+
+每个新增 metallib 必须：
+
+- 由 CMake 明确编译 `.metal -> .air -> .metallib`；
+- 加入正确 shader target；
+- 暴露路径给匹配 runtime target；
+- 加入 app bundle/install 列表；
+- 由 ComputePipelineCache 加载；
+- 有缺失 metallib 和缺失 function 的明确错误测试。
+
+## 15. 完成条件
+
+### 15.1 架构
+
+- [ ] Metal 使用 GPU DAG 主计划的 PipelineDocument、GraphCompiler、ExecutionPlan、DTO、
+      dirty Patch、Geometry 和内容 key。
+- [ ] 产品入口命名为 `Renderer<Backend>`，存在 `CudaRenderer` 和 `MetalRenderer` 别名。
+- [ ] 后端通过模板 Traits 和 PassEncoder 特化区分。
+- [ ] macOS 产品路径不引用 PipelineStage、OperatorParams 或 GPUPipelineWrapper。
+- [ ] Metal Pass 不拥有独立 pool、LRU、长期 scratch 或 command queue。
+
+### 15.2 资源
+
+- [ ] 每个 Metal RenderDevice 只有一个 workspace 和一个 command context。
+- [ ] 所有 transient buffer、普通 texture、mask texture、结果 texture 和 LUT 都经过统一所有者。
+- [ ] 稳定 render 不创建或销毁 buffer、texture、heap 或 pipeline state。
+- [ ] busy submission 的资源不会被复用或淘汰。
+- [ ] cache hit 由内容 key 证明。
+
+### 15.3 行为
+
+- [ ] Develop、Geometry、CameraColor、Grade、LLF、Mask、Mix 和 DRT 与 CUDA reference 在各自
+      容差内一致。
+- [ ] 同一调整顺序在 Metal 上不被重排。
+- [ ] crop、rotation、viewport 和 dynamic resolution 只做一次图像重采样。
+- [ ] GPU/Neural/present 失败不进入任何替代图像处理路径。
+- [ ] scope 和 present 使用最终 Metal display texture。
+
+### 15.4 删除
+
+- [ ] 旧 Metal pipeline factory 和实现已删除。
+- [ ] MetalFusedParams/MetalFusedParamUploader 已删除。
+- [ ] MetalStage 私有 LLF cache/allocator 已删除。
+- [ ] 旧 Metal fused/stage metallib 不再构建或打包。
+- [ ] Metal 已迁移 operator 不再提供旧图像执行入口。
+
+### 15.5 性能
+
+- [ ] 第 13 节全部场景有 cold、median、p95 和资源计数记录。
+- [ ] 同机旧/新 Metal A/B 达到第 13.3 节门槛。
+- [ ] 每个 Phase 的 completion record 已写入实际设备、系统、构建配置、fixture、命令和结果。
+
+## 16. Phase 完成记录格式
+
+每个 Phase 完成后在对应章节末尾追加：
+
+```text
+Status: complete
+Date:
+Branch:
+Commit:
+
+Implemented:
+-
+
+Deleted:
+-
+
+Tests:
+- command:
+- result:
+
+Resource evidence:
+- buffer create/free:
+- texture create/free:
+- heap growth:
+- pipeline create/hit:
+- upload ranges/bytes:
+
+Performance evidence:
+- device/macOS/Xcode/build:
+- fixture and render request:
+- cold:
+- warm median:
+- warm p95:
+
+Remaining work owned by the next named Phase:
+-
+```

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md
@@ -4240,6 +4240,14 @@ OpenClBackendFailureDoesNotEnterCpuImageProcessing
 
 ## 43. Phase G9 — Metal 移植
 
+详细的 Metal 架构、统一资源机制、模板后端区分、逐 Phase 删除范围和性能门槛见：
+
+- [GPU DAG Metal 移植逐 Phase 计划](gpu_dag_metal_migration_phase_plan.md)
+
+执行 G9 前必须同时阅读本主计划和上述 Metal 专项计划。专项计划是 G9 的工作拆分与 Metal
+验收细则；PipelineDocument、GraphCompiler、ExecutionPlan、缓存 key 和 Geometry 语义仍以
+本主计划为准。Metal 专项计划明确 G7R.4/G7R.5 不作为 Metal 移植前置条件。
+
 Branch: `feature/gpu-dag-metal`
 
 Base: `feature/gpu-dag-opencl`


### PR DESCRIPTION
## Stack

#93 → #94 → #95 → #96 → #97 → #98 → #102 → #101 → #100 → **this PR**

Base: `feature/gpu-dag-cuda-check-and-fix`

## Summary

- add the shared `Renderer<Backend>` / `PlanExecutor<Backend>` execution skeleton and instantiate the Metal backend
- add the Metal workspace, heap-backed texture pool, parameter/transient arenas, resource accounting, and pipeline warm-up
- implement Metal Develop, Geometry, CameraColor, Primary Grade, LUT, LLF, mask/feather/Normal Mix, DRT, scopes, and native presentation
- switch the macOS product render path to the Metal DAG through M6 without CPU, legacy-pipeline, backend, resolution, or quality fallback
- keep the oversized LibRaw instance off the macOS product worker stack and cover real-DNG decoding on a 512 KiB worker stack
- record M0–M6 implementation and validation evidence in the Metal migration phase plan; M7 legacy removal and final performance qualification remain separate

## Validation

- `cmake --build --preset macos_debug_tests --target GpuDagRawInputTest --parallel 8`
- `ctest --test-dir build/macos-debug-tests -R ^'GpuDagRawInputTest\.GpuDagRawInput\.' --output-on-failure` — 14/14 passed
- phase-specific Metal workspace, Develop, Grade/LLF, Mask, DRT, and renderer validation is recorded beside each M1–M6 completion record in `gpu_dag_metal_migration_phase_plan.md`

## Local environment notes

- the aggregate raw-input target reached 40/41; the unrelated Metal template test could not create a Metal device in the current test process
- `alcedo_main` compiled through all objects and reached final link, which is currently blocked by the existing missing `qml_register_types_Alcedo_Main()` symbol
