### PR TITLE
fix(edit): release Develop scratch and alias identity geometry

### DIFF
--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -330,6 +330,11 @@ void CudaBackend::Wait(CommandContext& command_context) {
   in_flight_submission_ = 0;
 }
 
+void CudaBackend::SynchronizeRecordedWork(CommandContext& command_context) {
+  cuda::CheckCuda(::cudaStreamSynchronize(command_context.Stream()),
+                  "CudaBackend::SynchronizeRecordedWork");
+}
+
 void CudaBackend::ResetCounters() {
   malloc_count_   = 0;
   free_count_     = 0;
@@ -340,6 +345,14 @@ void CudaBackend::ResetCounters() {
 }
 
 void CudaBackend::FailNextUpload() { fail_next_upload_ = true; }
+
+auto CudaBackend::QueryDeviceMemory() const -> GpuDeviceMemorySnapshot {
+  GpuDeviceMemorySnapshot snapshot;
+  if (::cudaMemGetInfo(&snapshot.free_bytes, &snapshot.total_bytes) == cudaSuccess) {
+    snapshot.valid = true;
+  }
+  return snapshot;
+}
 
 auto CudaBackend::DefaultTextureBudgetBytes() -> std::size_t {
   return DefaultProductTextureBudgetBytes();

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
@@ -151,16 +151,16 @@ void ExecuteCudaGeometryResample(CudaRenderDevice& device, const ExecutionPlan& 
   if (sensor == nullptr || sensor->Empty()) {
     throw std::runtime_error("ExecuteCudaGeometryResample: missing develop.sensor_linear");
   }
+  if (!plan.encode_geometry_resample) {
+    workspace.AliasImageFrom(plan.geometry_output, plan.sensor_linear_output);
+    return;
+  }
   const auto width  = plan.geometry.render_extent.width;
   const auto height = plan.geometry.render_extent.height;
   auto&      dest   = AcquireRgba(workspace, plan.geometry_output, width, height);
   sensor            = workspace.Images().Find(plan.sensor_linear_output);
   if (sensor == nullptr) {
     throw std::runtime_error("ExecuteCudaGeometryResample: sensor texture lost during acquire");
-  }
-  if (!plan.encode_geometry_resample) {
-    workspace.Device().CopyTexture2D(sensor->Texture(), dest.Texture(), device.CommandContext());
-    return;
   }
   GeometryResamplePass pass;
   pass.Encode(plan.geometry, sensor->Texture(), dest.Texture(), device.CommandContext());

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -35,22 +35,35 @@ auto EstimateMaskSdfTransientBytes(Extent2D extent) -> std::size_t {
   return 5 * AlignUp(pixels * sizeof(float), kAlign);
 }
 
+auto PlaneBytes(std::size_t pixels, std::size_t bytes_per_pixel) -> std::size_t {
+  return AlignUp(pixels * bytes_per_pixel, kAlign);
+}
+
+auto EstimateDevelopTransientBytes(const DevelopCompileSource& source) -> std::size_t {
+  if (source.kind == DevelopInputKind::DirectRgb) {
+    return AlignUp(4096, kAlign);
+  }
+  const std::size_t pixels =
+      static_cast<std::size_t>(source.host_extent.width) * source.host_extent.height;
+  const std::size_t cfa_u16 = PlaneBytes(pixels, 2);
+  const std::size_t cfa_f32 = PlaneBytes(pixels, 4);
+  const std::size_t stats   = AlignUp(4 + 16 + 16, kAlign);
+  const std::size_t pad     = 64 * kAlign;
+  if (source.kind == DevelopInputKind::XTransCfa) {
+    // U16 CFA + F32 CFA + green + RGB + HLR RGB. HLR coexists with the RGB plane.
+    return cfa_u16 + cfa_f32 + PlaneBytes(pixels, 4) + PlaneBytes(pixels, 12) +
+           PlaneBytes(pixels, 12) + stats + pad;
+  }
+  // Bayer / Neural-on-Bayer: U16 CFA + F32 CFA + 5 RCD planes + merge-or-HLR RGB.
+  // Merge and HLR are exclusive; both are 12 bytes/pixel.
+  return cfa_u16 + cfa_f32 + 5 * PlaneBytes(pixels, 4) + PlaneBytes(pixels, 12) + stats + pad;
+}
+
 auto EstimatePeakTransientBytes(const DevelopCompileSource& source) -> std::size_t {
-  const std::size_t w      = source.host_extent.width;
-  const std::size_t h      = source.host_extent.height;
-  const std::size_t pixels = w * h;
-  const std::size_t llf    = local_tone_mapping::EstimateLlfTransientBytes(
+  const std::size_t llf = local_tone_mapping::EstimateLlfTransientBytes(
       static_cast<int>(source.full_reference_extent.width),
       static_cast<int>(source.full_reference_extent.height), kAlign);
-  if (source.kind == DevelopInputKind::DirectRgb) {
-    return AlignUp(4096, kAlign) + llf;
-  }
-  // U16 CFA + F32 CFA + 5 RCD planes + merge RGB + HLR result + HLR stats + XTrans green/rgb.
-  const std::size_t bytes = AlignUp(pixels * 2, kAlign) + AlignUp(pixels * 4, kAlign) +
-                            5 * AlignUp(pixels * 4, kAlign) + AlignUp(pixels * 12, kAlign) +
-                            AlignUp(pixels * 12, kAlign) + AlignUp(4 + 16 + 16, kAlign) +
-                            AlignUp(pixels * 4, kAlign) + AlignUp(pixels * 12, kAlign);
-  return bytes + 64 * kAlign + llf;
+  return (std::max)(EstimateDevelopTransientBytes(source), llf);
 }
 
 auto ImageParamsFromDocument(const PipelineDocument& document) -> ImageGeometryParams {
@@ -236,7 +249,8 @@ auto GraphCompiler::CompileStatic(const PipelineDocument&     document,
         const Extent2D mask_extent{
             std::max(source.full_reference_extent.width, source.host_extent.width),
             std::max(source.full_reference_extent.height, source.host_extent.height)};
-        plan.peak_transient_bytes += EstimateMaskSdfTransientBytes(mask_extent);
+        plan.peak_transient_bytes =
+            (std::max)(plan.peak_transient_bytes, EstimateMaskSdfTransientBytes(mask_extent));
       }
       break;
     }

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
@@ -778,6 +778,28 @@ void MetalBackend::Submit(CommandContext& command_context) {
   in_flight_submission_ = submission_id;
 }
 
+void MetalBackend::SynchronizeRecordedWork(CommandContext& command_context) {
+  if (command_context.gpu_ == nullptr || command_context.gpu_->buffer.get() == nullptr) {
+    return;
+  }
+  command_context.gpu_->EndEncoders();
+  auto* command_buffer = command_context.gpu_->buffer.get();
+  command_buffer->commit();
+  command_buffer->waitUntilCompleted();
+  if (command_buffer->status() == MTL::CommandBufferStatusError) {
+    std::string message = "MetalBackend: Develop scratch wait failed";
+    if (auto* error = command_buffer->error(); error != nullptr) {
+      if (auto* description = error->localizedDescription(); description != nullptr) {
+        message += ": ";
+        message += description->utf8String();
+      }
+    }
+    command_context.gpu_->Reset();
+    throw std::runtime_error(message);
+  }
+  command_context.gpu_->Reset();
+}
+
 void MetalBackend::Wait(CommandContext& command_context) {
   if (in_flight_submission_ == 0) {
     if (command_context.gpu_) {
@@ -903,6 +925,19 @@ auto MetalBackend::WorkingSetBudgetBytes() const -> std::size_t {
   const auto recommended = static_cast<std::size_t>(gpu_->device->recommendedMaxWorkingSetSize());
   const auto usable      = recommended - recommended / 4;
   return usable > kFloor ? usable : kFloor;
+}
+
+auto MetalBackend::QueryDeviceMemory() const -> GpuDeviceMemorySnapshot {
+  GpuDeviceMemorySnapshot snapshot;
+  if (gpu_ == nullptr || gpu_->device == nullptr) {
+    return snapshot;
+  }
+  snapshot.total_bytes = static_cast<std::size_t>(gpu_->device->recommendedMaxWorkingSetSize());
+  const auto allocated = static_cast<std::size_t>(gpu_->device->currentAllocatedSize());
+  snapshot.free_bytes =
+      snapshot.total_bytes > allocated ? snapshot.total_bytes - allocated : 0;
+  snapshot.valid = snapshot.total_bytes > 0;
+  return snapshot;
 }
 auto MetalBackend::PipelineCreateCount() const -> std::uint64_t {
   const auto creates  = metal::ComputePipelineCache::Instance().GetStats().creates;

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
@@ -172,6 +172,7 @@ void MetalBackend::Wait(CommandContext&) {
   completed_submission_ = in_flight_submission_;
   in_flight_submission_ = 0;
 }
+void MetalBackend::SynchronizeRecordedWork(CommandContext&) {}
 void MetalBackend::WarmUpPipelines(std::span<const MetalPipelineWarmup>) {
   throw std::runtime_error("MetalBackend: pipeline warm-up is not implemented");
 }
@@ -204,6 +205,7 @@ auto MetalBackend::NativeQueue() const -> void* { return nullptr; }
 auto MetalBackend::WorkingSetBudgetBytes() const -> std::size_t {
   return DefaultTextureBudgetBytes();
 }
+auto MetalBackend::QueryDeviceMemory() const -> GpuDeviceMemorySnapshot { return {}; }
 auto MetalBackend::PipelineCreateCount() const -> std::uint64_t { return 0; }
 auto MetalBackend::PipelineHitCount() const -> std::uint64_t { return 0; }
 

--- a/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
@@ -370,9 +370,6 @@ void ExecuteMetalDevelop(MetalRenderDevice& device, const ExecutionPlan& plan,
   if (workspace.Textures().ByteBudget() == 0) {
     workspace.Textures().SetByteBudget(MetalBackend::DefaultTextureBudgetBytes());
   }
-  if (plan.peak_transient_bytes > 0) {
-    workspace.TransientBuffers().Reserve(plan.peak_transient_bytes);
-  }
 
   const auto         flags         = develop->Params().Params();
   const bool         hlr           = flags.highlights_reconstruct;
@@ -451,15 +448,15 @@ void ExecuteMetalGeometryResample(MetalRenderDevice& device, const ExecutionPlan
   if (sensor == nullptr || sensor->Empty()) {
     throw std::runtime_error("ExecuteMetalGeometryResample: missing develop.sensor_linear");
   }
+  if (!plan.encode_geometry_resample) {
+    workspace.AliasImageFrom(plan.geometry_output, plan.sensor_linear_output);
+    return;
+  }
   auto& dest = AcquireRgba(workspace, plan.geometry_output, plan.geometry.render_extent.width,
                            plan.geometry.render_extent.height);
   sensor     = workspace.Images().Find(plan.sensor_linear_output);
   if (sensor == nullptr) {
     throw std::runtime_error("ExecuteMetalGeometryResample: sensor texture lost during acquire");
-  }
-  if (!plan.encode_geometry_resample) {
-    workspace.Device().CopyTexture2D(sensor->Texture(), dest.Texture(), device.CommandContext());
-    return;
   }
   auto* command_buffer = CommandBuffer(device);
   DispatchGeometryResample(command_buffer, plan.geometry, sensor->Texture(), dest.Texture());

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdio>
 #include <stdexcept>
 
 #include "edit/runtime/graph_image_cache.hpp"
@@ -11,6 +12,7 @@
 #include "edit/runtime/node_result_cache.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/texture_pool.hpp"
+#include "gpu/gpu_pool_trace.hpp"
 #include "gpu/transient_buffer_arena.hpp"
 
 namespace alcedo {
@@ -56,7 +58,55 @@ class BasicRenderWorkspace {
    */
   auto AcquireImageForWrite(const GraphValueId& id, const TextureRequest& request)
       -> ResourceLease<Backend>& {
-    return images_.AcquireTextureForWrite(textures_, backend_, id, request);
+    auto&      lease = images_.AcquireTextureForWrite(textures_, backend_, id, request);
+    const auto bytes = static_cast<std::size_t>(request.width) * request.height *
+                       TextureFormatBytesPerPixel(request.format);
+    if (ShouldTraceGpuPoolAlloc(bytes)) {
+      DumpGpuPools("image-write");
+    }
+    return lease;
+  }
+
+  /** @brief Print pool totals. Per-resource lines require ALCEDO_GPU_POOL_TRACE. */
+  void DumpGpuPools(const char* reason) const {
+    GpuDeviceMemorySnapshot device_memory{};
+    if constexpr (requires(const Backend& backend) { backend.QueryDeviceMemory(); }) {
+      device_memory = backend_.QueryDeviceMemory();
+    }
+    const auto device_used =
+        device_memory.valid && device_memory.total_bytes > device_memory.free_bytes
+            ? device_memory.total_bytes - device_memory.free_bytes
+            : 0;
+    std::fprintf(stderr,
+                 "[GPU_POOL] %s textures=%.1f/%.1f MiB n=%zu  transient=%.1f/%.1f MiB  "
+                 "images=pub%zu/write%zu  values=%.1f n=%zu  masks=%.1f n=%zu",
+                 reason == nullptr ? "" : reason, GpuPoolMiB(textures_.UsedBytes()),
+                 GpuPoolMiB(textures_.ByteBudget()), textures_.EntryCount(),
+                 GpuPoolMiB(transients_.used_bytes()), GpuPoolMiB(transients_.capacity_bytes()),
+                 images_.PublishedCount(), images_.UnpublishedCount(),
+                 GpuPoolMiB(values_.UsedBytes()), values_.Size(),
+                 GpuPoolMiB(mask_textures_.UsedBytes()), mask_textures_.EntryCount());
+    if (device_memory.valid) {
+      std::fprintf(stderr, "  device used=%.1f free=%.1f total=%.1f MiB", GpuPoolMiB(device_used),
+                   GpuPoolMiB(device_memory.free_bytes), GpuPoolMiB(device_memory.total_bytes));
+    }
+    std::fprintf(stderr, "\n");
+    if (GpuPoolTraceVerbose()) {
+      textures_.DumpToStderr(reason);
+      images_.DumpToStderr(reason, textures_);
+      values_.DumpToStderr(reason);
+      mask_textures_.DumpToStderr(reason);
+    }
+  }
+
+  /**
+   * @brief Share @p source's current texture as an unpublished write of @p dest.
+   *
+   * Does not copy pixels and does not add a TexturePool allocation.
+   */
+  auto AliasImageFrom(const GraphValueId& dest, const GraphValueId& source)
+      -> ResourceLease<Backend>& {
+    return images_.AliasTextureFrom(textures_, dest, source);
   }
 
   /**

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -14,6 +14,7 @@
 #include "edit/geometry/types.hpp"
 #include "edit/runtime/byte_range.hpp"
 #include "edit/runtime/texture_format.hpp"
+#include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
 
@@ -158,6 +159,13 @@ class CudaBackend {
 
   void Submit(CommandContext& command_context);
   void Wait(CommandContext& command_context);
+  /**
+   * @brief Block until kernels already recorded on this stream have finished.
+   *
+   * Used to free Develop scratch before Geometry runs. Does not submit or change
+   * in-flight submission state.
+   */
+  void SynchronizeRecordedWork(CommandContext& command_context);
 
   [[nodiscard]] auto HasInFlightSubmission() const -> bool { return in_flight_submission_ != 0; }
   [[nodiscard]] auto CompletedSubmission() const -> std::uint64_t { return completed_submission_; }
@@ -182,6 +190,8 @@ class CudaBackend {
   [[nodiscard]] auto LastTextureRectangles() const -> const std::vector<RectI>& {
     return last_texture_rectangles_;
   }
+
+  [[nodiscard]] auto QueryDeviceMemory() const -> GpuDeviceMemorySnapshot;
 
  private:
   friend class Buffer;

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
@@ -27,7 +27,7 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
 /**
  * @brief Write `geometry.scene_source` from `develop.sensor_linear`.
  *
- * Identity geometry copies the sensor texture. Non-identity runs GeometryResamplePass.
+ * Identity geometry aliases the sensor texture. Non-identity runs GeometryResamplePass.
  */
 void ExecuteCudaGeometryResample(CudaRenderDevice& device, const ExecutionPlan& plan);
 

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -125,8 +125,12 @@ inline auto operator<(const StaticPlanKey& a, const StaticPlanKey& b) -> bool {
  *
  * Always includes GeometryResample so a viewport change does not recompile.
  * @ref geometry and @ref encode_geometry_resample are per-frame and are filled by
- * GraphCompiler::BindFrameGeometry. The encoder skips the kernel when
- * @ref encode_geometry_resample is false.
+ * GraphCompiler::BindFrameGeometry. When @ref encode_geometry_resample is false the
+ * encoder aliases `geometry.scene_source` onto `develop.sensor_linear` instead of
+ * copying a second full-resolution texture.
+ *
+ * @ref peak_transient_bytes is the bump-allocator high-water for one exclusive
+ * stage (Develop demosaic, mask SDF, or LLF), not the sum of those stages.
  */
 struct ExecutionPlan {
   StaticPlanKey                   static_key{};

--- a/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <limits>
 #include <map>
 #include <stdexcept>
@@ -15,6 +16,7 @@
 #include "edit/graph/graph_ids.hpp"
 #include "edit/runtime/content_key.hpp"
 #include "edit/runtime/texture_pool.hpp"
+#include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
 
@@ -112,6 +114,40 @@ class GraphImageCache {
     slot.extent  = ImageExtent{request.width, request.height};
     slot.format  = request.format;
     auto [it, inserted] = write_slots_.emplace(id, std::move(slot));
+    (void)inserted;
+    return it->second.texture;
+  }
+
+  /**
+   * @brief Bind @p dest to the current texture of @p source without allocating.
+   *
+   * Used when GeometryResample is identity. Content keys stay independent:
+   * publishing @p dest does not replace @p source. Overwriting a dest write
+   * slot drops its unrecorded identity.
+   *
+   * @throws std::runtime_error when @p dest equals @p source or @p source has
+   *         no current texture.
+   */
+  auto AliasTextureFrom(TexturePool<Backend>& pool, const GraphValueId& dest,
+                        const GraphValueId& source) -> ResourceLease<Backend>& {
+    if (dest == source) {
+      throw std::runtime_error("GraphImageCache::AliasTextureFrom: dest and source are the same");
+    }
+    auto* source_lease = Find(source);
+    if (source_lease == nullptr || source_lease->Empty()) {
+      throw std::runtime_error("GraphImageCache::AliasTextureFrom: source is missing");
+    }
+    if (FindWrite(dest) != nullptr) {
+      write_slots_.erase(dest);
+    }
+    current_.erase(dest);
+
+    const auto& source_tex = source_lease->Texture();
+    WriteSlot   slot;
+    slot.texture = pool.DuplicateLease(source_lease->Handle());
+    slot.extent  = ImageExtent{source_tex.Width(), source_tex.Height()};
+    slot.format  = source_tex.Format();
+    auto [it, inserted] = write_slots_.emplace(dest, std::move(slot));
     (void)inserted;
     return it->second.texture;
   }
@@ -265,7 +301,49 @@ class GraphImageCache {
     return ids;
   }
 
+  /**
+   * @brief Print published and unpublished image results with pool handles.
+   *
+   * @p pool is the TexturePool that owns the leases.
+   */
+  void DumpToStderr(const char* reason, const TexturePool<Backend>& pool) const {
+    (void)pool;
+    std::fprintf(stderr, "[GPU_POOL] images %s published=%zu write=%zu current=%zu\n",
+                 reason == nullptr ? "" : reason, published_.size(), write_slots_.size(),
+                 current_.size());
+    if (!GpuPoolTraceVerbose()) {
+      return;
+    }
+    for (const auto& [id, slot] : write_slots_) {
+      PrintSlot("write", id, slot.key, slot.has_key, slot.extent, slot.format, slot.texture,
+                slot.last_writer, false);
+    }
+    for (const auto& [identity, entry] : published_) {
+      const auto current = current_.find(identity.value_id);
+      const bool is_current =
+          current != current_.end() && current->second == identity.content_key;
+      PrintSlot("published", identity.value_id, identity.content_key, true, entry.extent,
+                entry.format, entry.texture, entry.last_writer, is_current);
+    }
+  }
+
  private:
+  static void PrintSlot(const char* kind, const GraphValueId& id, ContentKey key, bool has_key,
+                        ImageExtent extent, TextureFormat format,
+                        const ResourceLease<Backend>& texture, std::uint64_t last_writer,
+                        bool is_current) {
+    const auto handle = texture.Empty() ? 0 : texture.Handle();
+    std::fprintf(stderr,
+                 "[GPU_POOL]   %-9s %.*s:%.*s %ux%u %s handle=%llu key=%llx writer=%llu "
+                 "has_key=%d current=%d\n",
+                 kind, static_cast<int>(id.producer.Value().size()), id.producer.Value().data(),
+                 static_cast<int>(id.output_port.Value().size()), id.output_port.Value().data(),
+                 extent.width, extent.height, TextureFormatName(format),
+                 static_cast<unsigned long long>(handle),
+                 static_cast<unsigned long long>(has_key ? key.hash : 0),
+                 static_cast<unsigned long long>(last_writer), has_key ? 1 : 0,
+                 is_current ? 1 : 0);
+  }
   struct WriteSlot {
     ResourceLease<Backend> texture;
     ContentKey             key{};

--- a/alcedo_studio/src/include/edit/runtime/mask_texture_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/mask_texture_cache.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <limits>
 #include <map>
 #include <stdexcept>
@@ -15,6 +16,7 @@
 
 #include "edit/mask/mask_asset.hpp"
 #include "edit/runtime/texture_format.hpp"
+#include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
 
@@ -114,7 +116,24 @@ class MaskTextureCache {
     }
     used_bytes_ += entry.bytes;
     auto it = entries_.emplace(key, std::move(entry)).first;
+    if (ShouldTraceGpuPoolAlloc(it->second.bytes) && GpuPoolTraceVerbose()) {
+      DumpToStderr("mask-alloc");
+    }
     return TakeLease(it->first, it->second);
+  }
+
+  void DumpToStderr(const char* reason) const {
+    std::fprintf(stderr, "[GPU_POOL] masks %s entries=%zu used=%.1f MiB\n",
+                 reason == nullptr ? "" : reason, entries_.size(), GpuPoolMiB(used_bytes_));
+    if (!GpuPoolTraceVerbose()) {
+      return;
+    }
+    for (const auto& [key, entry] : entries_) {
+      std::fprintf(stderr, "[GPU_POOL]   mask %.*s %ux%u mips=%zu %.1f MiB leases=%u\n",
+                   static_cast<int>(key.Value().size()), key.Value().data(), entry.extent.width,
+                   entry.extent.height, entry.mip_levels.size(), GpuPoolMiB(entry.bytes),
+                   entry.lease_count);
+    }
   }
 
   [[nodiscard]] auto Contains(const MaskAssetKey& key) const -> bool {

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
@@ -16,6 +16,7 @@
 #include "edit/runtime/byte_range.hpp"
 #include "edit/runtime/content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
+#include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
 
@@ -157,6 +158,12 @@ class MetalBackend {
 
   void               Submit(CommandContext& command_context);
   void               Wait(CommandContext& command_context);
+  /**
+   * @brief Commit recorded Metal work and wait. The next encode gets a new command buffer.
+   *
+   * Used to free Develop scratch before Geometry runs.
+   */
+  void SynchronizeRecordedWork(CommandContext& command_context);
 
   void               WarmUpPipelines(std::span<const MetalPipelineWarmup> pipelines);
   void               WarmUpPlan(const ExecutionPlan& plan);
@@ -184,6 +191,7 @@ class MetalBackend {
   [[nodiscard]] auto NativeDevice() const -> void*;
   [[nodiscard]] auto NativeQueue() const -> void*;
   [[nodiscard]] auto WorkingSetBudgetBytes() const -> std::size_t;
+  [[nodiscard]] auto QueryDeviceMemory() const -> GpuDeviceMemorySnapshot;
   [[nodiscard]] auto MallocCount() const -> std::uint64_t { return malloc_count_; }
   [[nodiscard]] auto FreeCount() const -> std::uint64_t { return free_count_; }
   [[nodiscard]] auto BufferCreateCount() const -> std::uint64_t { return buffer_create_count_; }

--- a/alcedo_studio/src/include/edit/runtime/node_result_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/node_result_cache.hpp
@@ -6,10 +6,12 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <map>
 #include <utility>
 
 #include "edit/graph/graph_ids.hpp"
+#include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
 
@@ -23,7 +25,35 @@ template <class Backend>
 class NodeResultCache {
  public:
   void Store(GraphValueId id, typename Backend::Buffer buffer) {
+    const auto bytes = buffer.Bytes();
     values_.insert_or_assign(std::move(id), std::move(buffer));
+    if (ShouldTraceGpuPoolAlloc(bytes) && GpuPoolTraceVerbose()) {
+      DumpToStderr("value-store");
+    }
+  }
+
+  [[nodiscard]] auto UsedBytes() const -> std::size_t {
+    std::size_t total = 0;
+    for (const auto& [id, buffer] : values_) {
+      (void)id;
+      total += buffer.Bytes();
+    }
+    return total;
+  }
+
+  void DumpToStderr(const char* reason) const {
+    std::fprintf(stderr, "[GPU_POOL] values %s count=%zu total=%.1f MiB\n",
+                 reason == nullptr ? "" : reason, values_.size(), GpuPoolMiB(UsedBytes()));
+    if (!GpuPoolTraceVerbose()) {
+      return;
+    }
+    for (const auto& [id, buffer] : values_) {
+      std::fprintf(stderr, "[GPU_POOL]   value %.*s:%.*s %.1f MiB resource=%llu\n",
+                   static_cast<int>(id.producer.Value().size()), id.producer.Value().data(),
+                   static_cast<int>(id.output_port.Value().size()), id.output_port.Value().data(),
+                   GpuPoolMiB(buffer.Bytes()),
+                   static_cast<unsigned long long>(buffer.ResourceId()));
+    }
   }
 
   [[nodiscard]] auto Find(const GraphValueId& id) -> typename Backend::Buffer* {

--- a/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
@@ -77,7 +77,12 @@ class PlanExecutor {
         ++stats.source_h2d_count;
         Record(device, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent);
         ++stats.sensor_develop_execute;
+        // RCD planes are not a cache. Wait this stream so pack has finished, then
+        // cudaFree / Metal free the slab before Geometry allocates display textures.
+        workspace.Device().SynchronizeRecordedWork(device.CommandContext());
       }
+      workspace.TransientBuffers().Reset();
+      workspace.TransientBuffers().ReleaseDeviceMemory();
 
       if (BindOrMiss(workspace, plan.geometry_output, keys.geometry_scene_source,
                      keys.geometry_extent, completed)) {
@@ -109,6 +114,7 @@ class PlanExecutor {
           Record(device, plan.mask_output, keys.mask, keys.geometry_extent, TextureFormat::R8);
           ++stats.mask_execute;
         }
+        workspace.TransientBuffers().Reset();
       }
 
       if (BindOrMiss(workspace, plan.primary_grade_output, keys.primary_grade, keys.geometry_extent,

--- a/alcedo_studio/src/include/edit/runtime/texture_format.hpp
+++ b/alcedo_studio/src/include/edit/runtime/texture_format.hpp
@@ -17,6 +17,22 @@ enum class TextureFormat : std::uint8_t {
   R16u    = 4,
 };
 
+[[nodiscard]] inline auto TextureFormatName(TextureFormat format) -> const char* {
+  switch (format) {
+    case TextureFormat::R8:
+      return "R8";
+    case TextureFormat::Rgba8:
+      return "Rgba8";
+    case TextureFormat::R32f:
+      return "R32f";
+    case TextureFormat::Rgba32f:
+      return "Rgba32f";
+    case TextureFormat::R16u:
+      return "R16u";
+  }
+  return "?";
+}
+
 [[nodiscard]] inline auto TextureFormatBytesPerPixel(TextureFormat format) -> std::size_t {
   switch (format) {
     case TextureFormat::R8:

--- a/alcedo_studio/src/include/edit/runtime/texture_pool.hpp
+++ b/alcedo_studio/src/include/edit/runtime/texture_pool.hpp
@@ -6,12 +6,14 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <limits>
 #include <stdexcept>
 #include <utility>
 #include <vector>
 
 #include "edit/runtime/texture_format.hpp"
+#include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
 
@@ -119,6 +121,20 @@ class TexturePool {
     return TakeLease(entries_.back());
   }
 
+  /**
+   * @brief Extra lease on an already-leased texture. Does not allocate.
+   *
+   * Identity geometry uses this so `geometry.scene_source` can share
+   * `develop.sensor_linear` without a second device copy.
+   */
+  [[nodiscard]] auto DuplicateLease(std::uint64_t handle) -> ResourceLease<Backend> {
+    auto* entry = Find(handle);
+    if (entry == nullptr || entry->lease_count == 0) {
+      throw std::runtime_error("TexturePool::DuplicateLease: handle is not leased");
+    }
+    return TakeLease(*entry);
+  }
+
   void MarkSubmitted(std::uint64_t submission_id) {
     for (auto& entry : entries_) {
       if (entry.alive && (entry.used_this_frame || entry.lease_count > 0)) {
@@ -181,6 +197,30 @@ class TexturePool {
       used_bytes_ -= entry.bytes;
       entry.texture = {};
       entry.alive   = false;
+    }
+  }
+
+  /** @brief Print texture pool totals. Per-texture lines require ALCEDO_GPU_POOL_TRACE. */
+  void DumpToStderr(const char* reason) const {
+    std::fprintf(stderr, "[GPU_POOL] textures %s entries=%zu used=%.1f budget=%.1f MiB\n",
+                 reason == nullptr ? "" : reason, EntryCount(), GpuPoolMiB(used_bytes_),
+                 GpuPoolMiB(budget_bytes_));
+    if (!GpuPoolTraceVerbose()) {
+      return;
+    }
+    for (const auto& entry : entries_) {
+      if (!entry.alive) {
+        continue;
+      }
+      std::fprintf(stderr,
+                   "[GPU_POOL]   tex handle=%llu %ux%u %s %.1f MiB leases=%u busy_sub=%llu "
+                   "lru=%llu frame=%d\n",
+                   static_cast<unsigned long long>(entry.handle), entry.request.width,
+                   entry.request.height, TextureFormatName(entry.request.format),
+                   GpuPoolMiB(entry.bytes), entry.lease_count,
+                   static_cast<unsigned long long>(entry.submitted_on),
+                   static_cast<unsigned long long>(entry.lru_tick),
+                   entry.used_this_frame ? 1 : 0);
     }
   }
 

--- a/alcedo_studio/src/include/gpu/gpu_pool_trace.hpp
+++ b/alcedo_studio/src/include/gpu/gpu_pool_trace.hpp
@@ -1,0 +1,48 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+
+namespace alcedo {
+
+/** @brief Print pool totals when an alloc is at least this large. */
+inline constexpr std::size_t kGpuPoolTraceMinAllocBytes = 16ull << 20;
+
+struct GpuDeviceMemorySnapshot {
+  std::size_t free_bytes  = 0;
+  std::size_t total_bytes = 0;
+  bool        valid       = false;
+};
+
+inline auto GpuPoolTraceEnvEnabled() -> bool {
+  const char* enabled = std::getenv("ALCEDO_GPU_POOL_TRACE");
+  return enabled != nullptr && enabled[0] != '\0' && enabled[0] != '0';
+}
+
+/** @brief Per-resource lines. Off unless ALCEDO_GPU_POOL_TRACE is set. */
+inline auto GpuPoolTraceVerbose() -> bool { return GpuPoolTraceEnvEnabled(); }
+
+inline auto ShouldTraceGpuPoolAlloc(std::size_t bytes) -> bool {
+  return bytes >= kGpuPoolTraceMinAllocBytes || GpuPoolTraceEnvEnabled();
+}
+
+inline auto GpuPoolMiB(std::size_t bytes) -> double {
+  return static_cast<double>(bytes) / (1024.0 * 1024.0);
+}
+
+inline void PrintGpuDeviceMemory(const GpuDeviceMemorySnapshot& memory) {
+  if (!memory.valid) {
+    return;
+  }
+  const auto used = memory.total_bytes > memory.free_bytes ? memory.total_bytes - memory.free_bytes
+                                                           : 0;
+  std::fprintf(stderr, "[GPU_POOL] device free=%.1f used=%.1f total=%.1f MiB\n",
+               GpuPoolMiB(memory.free_bytes), GpuPoolMiB(used), GpuPoolMiB(memory.total_bytes));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
@@ -5,9 +5,12 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdio>
 #include <optional>
 #include <stdexcept>
 #include <utility>
+
+#include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
 
@@ -19,7 +22,9 @@ namespace alcedo {
  * - `CreateSlab(std::size_t bytes) -> Slab`
  *
  * Capacity grows only when no bump allocations are live (`used_bytes() == 0`).
- * `Reset()` / `Rewind` do not free the slab. Not thread-safe.
+ * `Reset()` / `Rewind` do not free the slab; `ReleaseDeviceMemory()` does.
+ * SensorDevelop scratch must be released after that pass, not held across
+ * Geometry / Grade / DRT. Not thread-safe.
  *
  * @tparam Backend Slab factory. Must outlive this arena when passed by reference.
  */
@@ -73,9 +78,17 @@ class TransientBufferArena {
           "TransientBufferArena::Reserve: cannot grow while allocations are live; "
           "Reset() first or Reserve peak size before Allocate");
     }
-    auto new_slab = backend_->CreateSlab(bytes);
-    slab_         = std::move(new_slab);
-    capacity_     = bytes;
+    const auto previous = capacity_;
+    auto       new_slab = backend_->CreateSlab(bytes);
+    slab_               = std::move(new_slab);
+    capacity_           = bytes;
+    if (ShouldTraceGpuPoolAlloc(bytes)) {
+      std::fprintf(stderr, "[GPU_POOL] transient reserve %.1f MiB (was %.1f)\n", GpuPoolMiB(bytes),
+                   GpuPoolMiB(previous));
+      if constexpr (requires(const Backend& backend) { backend.QueryDeviceMemory(); }) {
+        PrintGpuDeviceMemory(backend_->QueryDeviceMemory());
+      }
+    }
   }
 
   /**
@@ -122,8 +135,20 @@ class TransientBufferArena {
   /// Rewind bump pointer to zero. Does not free device memory.
   void Reset() noexcept { offset_ = 0; }
 
-  /// Free the device slab. Requires no live bump allocations (`used_bytes() == 0`).
-  void ReleaseDeviceMemory() noexcept { ResetSlab(); }
+  /**
+   * @brief Free the device slab. Caller must GPU-synchronize if kernels still read it.
+   *
+   * Develop scratch is released after SensorDevelop, not kept for later frames.
+   */
+  void ReleaseDeviceMemory() noexcept {
+    if (capacity_ > 0 && ShouldTraceGpuPoolAlloc(capacity_)) {
+      std::fprintf(stderr, "[GPU_POOL] transient release %.1f MiB\n", GpuPoolMiB(capacity_));
+      if constexpr (requires(const Backend& backend) { backend.QueryDeviceMemory(); }) {
+        PrintGpuDeviceMemory(backend_->QueryDeviceMemory());
+      }
+    }
+    ResetSlab();
+  }
 
   void Rewind(std::size_t mark_bytes) {
     if (mark_bytes > offset_) {

--- a/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
 #include "decoders/processor/nn/demosaicnet_cache.hpp"
 #include "decoders/processor/nn/demosaicnet_preprocess_common.hpp"
@@ -394,6 +395,84 @@ TEST_F(CudaDevelopFixture,
     SetDevelopNeuralModelCacheForTesting(nullptr);
     throw;
   }
+}
+
+TEST_F(CudaDevelopFixture, IdentityGeometryResampleAliasesSensorLinearWithoutASecondTexture) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(32, 24, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(32, 24), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  SetDevelopMethod(document, "legacy", false);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  ASSERT_FALSE(plan.encode_geometry_resample);
+
+  CudaRenderDevice device;
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+
+  auto* sensor   = device.Workspace().Images().Find(plan.sensor_linear_output);
+  auto* geometry = device.Workspace().Images().Find(plan.geometry_output);
+  auto* develop  = device.Workspace().Images().Find(plan.develop_output);
+  ASSERT_NE(sensor, nullptr);
+  ASSERT_NE(geometry, nullptr);
+  ASSERT_NE(develop, nullptr);
+  EXPECT_EQ(sensor->Texture().ResourceId(), geometry->Texture().ResourceId());
+  EXPECT_NE(sensor->Texture().ResourceId(), develop->Texture().ResourceId());
+  EXPECT_EQ(device.Workspace().TransientBuffers().used_bytes(), 0U);
+  EXPECT_EQ(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
+}
+
+TEST_F(CudaDevelopFixture, PlanExecuteFreesDevelopScratchAfterSensorDevelop) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  SetDevelopMethod(document, "legacy", false);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  ASSERT_GT(plan.peak_transient_bytes, 64U * 64U);
+
+  CudaRenderDevice device;
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+  EXPECT_EQ(device.Workspace().TransientBuffers().used_bytes(), 0U);
+  EXPECT_EQ(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
+  EXPECT_NE(device.Workspace().Images().Find(plan.sensor_linear_output), nullptr);
+}
+
+TEST_F(CudaDevelopFixture, ViewportGeometryResampleAllocatesADistinctDisplaySizedTexture) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(32, 24, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(32, 24), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  SetDevelopMethod(document, "legacy", false);
+  RenderRequest request;
+  request.view.visible_rect_in_edit_space = {0.0f, 0.0f, 1.0f, 1.0f};
+  request.view.viewport_extent            = {16, 12};
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), request);
+  ASSERT_TRUE(plan.encode_geometry_resample);
+  ASSERT_EQ(plan.geometry.render_extent.width, 16U);
+  ASSERT_EQ(plan.geometry.render_extent.height, 12U);
+  ASSERT_NE(plan.source.develop_output_extent, plan.geometry.render_extent);
+
+  CudaRenderDevice device;
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+
+  auto* sensor   = device.Workspace().Images().Find(plan.sensor_linear_output);
+  auto* geometry = device.Workspace().Images().Find(plan.geometry_output);
+  ASSERT_NE(sensor, nullptr);
+  ASSERT_NE(geometry, nullptr);
+  EXPECT_NE(sensor->Texture().ResourceId(), geometry->Texture().ResourceId());
+  EXPECT_EQ(sensor->Texture().Width(), plan.source.develop_output_extent.width);
+  EXPECT_EQ(sensor->Texture().Height(), plan.source.develop_output_extent.height);
+  EXPECT_EQ(geometry->Texture().Width(), plan.geometry.render_extent.width);
+  EXPECT_EQ(geometry->Texture().Height(), plan.geometry.render_extent.height);
 }
 
 TEST_F(CudaDevelopFixture, CudaDevelopUploadFailureRestoresDirtyAndDoesNotFallback) {

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -140,6 +141,79 @@ TEST(GpuDagGraphCompiler, GraphCompilerEmitsMaskEvaluateWhenRasterMaskConnected)
   EXPECT_LT(plan.IndexOf(GpuPassKind::CameraToAp1), plan.IndexOf(GpuPassKind::MaskEvaluate));
   EXPECT_LT(plan.IndexOf(GpuPassKind::MaskEvaluate), plan.IndexOf(GpuPassKind::MaskFeather));
   EXPECT_LT(plan.IndexOf(GpuPassKind::MaskFeather), plan.IndexOf(GpuPassKind::PrimaryColorGrade));
+}
+
+auto Align256(std::size_t value) -> std::size_t { return (value + 255) & ~std::size_t{255}; }
+
+auto PlaneBytes(std::size_t pixels, std::size_t bytes_per_pixel) -> std::size_t {
+  return Align256(pixels * bytes_per_pixel);
+}
+
+auto ExclusiveBayerDevelopBytes(std::size_t pixels) -> std::size_t {
+  return PlaneBytes(pixels, 2) + PlaneBytes(pixels, 4) + 5 * PlaneBytes(pixels, 4) +
+         PlaneBytes(pixels, 12) + Align256(4 + 16 + 16) + 64 * 256;
+}
+
+auto ExclusiveXTransDevelopBytes(std::size_t pixels) -> std::size_t {
+  return PlaneBytes(pixels, 2) + PlaneBytes(pixels, 4) + PlaneBytes(pixels, 4) +
+         PlaneBytes(pixels, 12) + PlaneBytes(pixels, 12) + Align256(4 + 16 + 16) + 64 * 256;
+}
+
+auto SummedExclusiveDemosaicBytes(std::size_t pixels) -> std::size_t {
+  return PlaneBytes(pixels, 2) + PlaneBytes(pixels, 4) + 5 * PlaneBytes(pixels, 4) +
+         PlaneBytes(pixels, 12) + PlaneBytes(pixels, 12) + Align256(4 + 16 + 16) +
+         PlaneBytes(pixels, 4) + PlaneBytes(pixels, 12) + 64 * 256;
+}
+
+TEST(GpuDagGraphCompiler, PeakTransientUsesOneDemosaicPathInsteadOfSummingBayerAndXTrans) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(256, 256, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(256, 256), DecodeRes::FULL);
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  constexpr std::size_t kPixels = 256U * 256U;
+  const auto            bayer   = ExclusiveBayerDevelopBytes(kPixels);
+  const auto            summed  = SummedExclusiveDemosaicBytes(kPixels);
+  EXPECT_EQ(prepared.CompileSource().kind, DevelopInputKind::BayerCfa);
+  EXPECT_EQ(plan.peak_transient_bytes, bayer);
+  EXPECT_LT(plan.peak_transient_bytes, summed);
+  EXPECT_GT(summed - bayer, PlaneBytes(kPixels, 12));
+}
+
+TEST(GpuDagGraphCompiler, PeakTransientForXTransDoesNotReserveBayerRcdPlanes) {
+  const auto pattern  = gpu_dag_test::MakeXTransPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(256, 256, pattern), pattern,
+      gpu_dag_test::DefaultLinearization(), gpu_dag_test::FullSensor(256, 256), DecodeRes::FULL);
+  auto       document = CreateDefaultPipelineDocument();
+  const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  constexpr std::size_t kPixels = 256U * 256U;
+  EXPECT_EQ(prepared.CompileSource().kind, DevelopInputKind::XTransCfa);
+  EXPECT_EQ(plan.peak_transient_bytes, ExclusiveXTransDevelopBytes(kPixels));
+  EXPECT_LT(plan.peak_transient_bytes, ExclusiveBayerDevelopBytes(kPixels));
+}
+
+TEST(GpuDagGraphCompiler, RasterMaskDoesNotAddMaskSdfOnTopOfDevelopTransientPeak) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  const auto without_mask =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  auto node = std::make_unique<RasterMaskNodeModel>(NodeId{"mask.raster"});
+  node->SetAssetKey(MaskAssetKey{"test.raster"});
+  document.Graph().AddNode(std::move(node));
+  document.Graph().Connect(NodeId{"mask.raster"}, PortId{"mask"}, NodeId{"grade.primary"},
+                           PortId{"mask"});
+  const auto with_mask =
+      GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  EXPECT_TRUE(with_mask.Contains(GpuPassKind::MaskEvaluate));
+  EXPECT_EQ(with_mask.peak_transient_bytes, without_mask.peak_transient_bytes);
 }
 
 TEST(GpuDagGraphCompiler, GraphCompilerPassListIsBackendNativeTypeFree) {

--- a/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
@@ -4,6 +4,8 @@
 
 #include "cuda_workspace_test_support.hpp"
 
+#include <stdexcept>
+
 #include "edit/runtime/content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
 
@@ -97,6 +99,56 @@ TEST_F(CudaWorkspaceFixture, CancelledSubmissionKeepsPreviouslyCompletedCacheEnt
   EXPECT_FALSE(workspace.Images().FindValidResult(id, second, {kWidth, kHeight},
                                                   TextureFormat::Rgba32f,
                                                   workspace.Device().CompletedSubmission()));
+}
+
+TEST_F(CudaWorkspaceFixture, AliasTextureFromSharesOneAllocationAcrossTwoValueIds) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  const GraphValueId sensor{NodeId{"develop"}, PortId{"sensor_linear"}};
+  const GraphValueId geometry{NodeId{"geometry"}, PortId{"scene_source"}};
+  const ContentKey   sensor_key{61};
+  const ContentKey   geometry_key{62};
+
+  device.BeginRender();
+  (void)workspace.AcquireImageForWrite(sensor, {kWidth, kHeight, TextureFormat::Rgba32f});
+  workspace.Images().RecordUnpublished(sensor, sensor_key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+                                       device.CommandContext().SubmissionId());
+  const auto used_before = workspace.Textures().UsedBytes();
+  const auto entries_before = workspace.Textures().EntryCount();
+  const auto sensor_id =
+      workspace.Images().Find(sensor)->Texture().ResourceId();
+  (void)workspace.AliasImageFrom(geometry, sensor);
+  workspace.Images().RecordUnpublished(geometry, geometry_key, {kWidth, kHeight},
+                                       TextureFormat::Rgba32f,
+                                       device.CommandContext().SubmissionId());
+  EXPECT_EQ(workspace.Images().Find(geometry)->Texture().ResourceId(), sensor_id);
+  EXPECT_EQ(workspace.Textures().UsedBytes(), used_before);
+  EXPECT_EQ(workspace.Textures().EntryCount(), entries_before);
+  device.EndRender();
+  device.PublishResults();
+  device.WaitIdle();
+
+  const auto completed = workspace.Device().CompletedSubmission();
+  EXPECT_TRUE(workspace.Images().FindValidResult(sensor, sensor_key, {kWidth, kHeight},
+                                                 TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(workspace.Images().FindValidResult(geometry, geometry_key, {kWidth, kHeight},
+                                                 TextureFormat::Rgba32f, completed));
+  EXPECT_EQ(workspace.Images().Find(sensor)->Texture().ResourceId(),
+            workspace.Images().Find(geometry)->Texture().ResourceId());
+  EXPECT_EQ(workspace.Images().PublishedCount(), 2U);
+  EXPECT_EQ(workspace.Textures().EntryCount(), 1U);
+}
+
+TEST_F(CudaWorkspaceFixture, AliasTextureFromRejectsMissingSourceAndSelfAlias) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  const GraphValueId sensor{NodeId{"develop"}, PortId{"sensor_linear"}};
+  const GraphValueId geometry{NodeId{"geometry"}, PortId{"scene_source"}};
+  device.BeginRender();
+  EXPECT_THROW((void)workspace.AliasImageFrom(geometry, sensor), std::runtime_error);
+  (void)workspace.AcquireImageForWrite(sensor, {kWidth, kHeight, TextureFormat::Rgba32f});
+  EXPECT_THROW((void)workspace.AliasImageFrom(sensor, sensor), std::runtime_error);
+  device.CancelRender();
 }
 
 TEST_F(CudaWorkspaceFixture, UnpublishedWriteIsNotAContentHitUntilPublish) {

--- a/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
@@ -432,6 +432,54 @@ TEST_F(MetalDevelopFixture, MetalCameraColorConsumesSharedDualIlluminantTransfor
   EXPECT_NEAR(pixels.front().a, 1.0f, 1.0e-6f);
 }
 
+TEST_F(MetalDevelopFixture, IdentityGeometryResampleAliasesSensorLinearWithoutASecondTexture) {
+  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                                gpu_dag_test::FullSensor(16, 12));
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  ASSERT_FALSE(plan.encode_geometry_resample);
+
+  MetalRenderDevice device;
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+
+  auto* sensor   = device.Workspace().Images().Find(plan.sensor_linear_output);
+  auto* geometry = device.Workspace().Images().Find(plan.geometry_output);
+  auto* develop  = device.Workspace().Images().Find(plan.develop_output);
+  ASSERT_NE(sensor, nullptr);
+  ASSERT_NE(geometry, nullptr);
+  ASSERT_NE(develop, nullptr);
+  EXPECT_EQ(sensor->Texture().ResourceId(), geometry->Texture().ResourceId());
+  EXPECT_NE(sensor->Texture().ResourceId(), develop->Texture().ResourceId());
+}
+
+TEST_F(MetalDevelopFixture, ViewportGeometryResampleAllocatesADistinctDisplaySizedTexture) {
+  auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(32, 24),
+                                                gpu_dag_test::FullSensor(32, 24));
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  RenderRequest request;
+  request.view.visible_rect_in_edit_space = {0.0f, 0.0f, 1.0f, 1.0f};
+  request.view.viewport_extent            = {16, 12};
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), request);
+  ASSERT_TRUE(plan.encode_geometry_resample);
+
+  MetalRenderDevice device;
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+
+  auto* sensor   = device.Workspace().Images().Find(plan.sensor_linear_output);
+  auto* geometry = device.Workspace().Images().Find(plan.geometry_output);
+  ASSERT_NE(sensor, nullptr);
+  ASSERT_NE(geometry, nullptr);
+  EXPECT_NE(sensor->Texture().ResourceId(), geometry->Texture().ResourceId());
+  EXPECT_EQ(sensor->Texture().Width(), 32U);
+  EXPECT_EQ(sensor->Texture().Height(), 24U);
+  EXPECT_EQ(geometry->Texture().Width(), 16U);
+  EXPECT_EQ(geometry->Texture().Height(), 12U);
+}
+
 TEST_F(MetalDevelopFixture, MetalCctEditReusesSensorAndGeometryResults) {
   auto prepared = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
                                                 gpu_dag_test::FullSensor(16, 12));

--- a/alcedo_studio/tests/edit/runtime/transient_and_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/transient_and_cache_test.cpp
@@ -7,6 +7,8 @@
 #include <stdexcept>
 
 #include "edit/graph/graph_ids.hpp"
+#include "edit/runtime/texture_format.hpp"
+#include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
 namespace {
@@ -85,6 +87,29 @@ TEST_F(CudaWorkspaceFixture, SecondRenderUsesNoCudaAllocationAfterPeakReserve) {
 
   EXPECT_EQ(workspace.Device().MallocCount(), 0U);
   EXPECT_EQ(workspace.Device().FreeCount(), 0U);
+}
+
+TEST(GpuDagGpuPoolTrace, LargeAllocThresholdIsSixteenMebibytes) {
+  EXPECT_TRUE(ShouldTraceGpuPoolAlloc(kGpuPoolTraceMinAllocBytes));
+  EXPECT_TRUE(ShouldTraceGpuPoolAlloc(kGpuPoolTraceMinAllocBytes + 1));
+  if (!GpuPoolTraceEnvEnabled()) {
+    EXPECT_FALSE(ShouldTraceGpuPoolAlloc(kGpuPoolTraceMinAllocBytes - 1));
+    EXPECT_FALSE(GpuPoolTraceVerbose());
+  } else {
+    EXPECT_TRUE(GpuPoolTraceVerbose());
+  }
+}
+
+TEST_F(CudaWorkspaceFixture, DumpGpuPoolsPrintsResidentTexturesAndTransientsWithoutThrowing) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  workspace.Textures().SetByteBudget(64 * 64 * 16);
+  device.BeginRender();
+  const GraphValueId id{NodeId{"develop"}, PortId{"sensor_linear"}};
+  (void)workspace.AcquireImageForWrite(id, {8, 8, TextureFormat::Rgba32f});
+  (void)workspace.TransientBuffers().Allocate(512);
+  workspace.DumpGpuPools("test");
+  device.CancelRender();
 }
 
 }  // namespace


### PR DESCRIPTION
## Stack

#93 → #94 → #95 → #96 → #97 → #98 → #102 → #101 → #100 → #103 → **this PR**

Base: `feature/gpu-dag-metal`

## Summary

- estimate peak transients as the max of exclusive demosaic paths, not the sum of Bayer, X-Trans, HLR, and LLF
- wait the current stream after SensorDevelop, then free the transient slab so Geometry / Grade / DRT do not keep a multi-gigabyte empty bump allocation
- alias `geometry.scene_source` onto `develop.sensor_linear` when resample is identity instead of copying a second full-resolution RGBA32F texture
- log GPU pool totals on large allocations; `ALCEDO_GPU_POOL_TRACE` lists individual resources

## Validation

- `ctest --test-dir build/debug --output-on-failure -R "GpuDagCudaDevelopTest|GpuDagCudaDrtProductTest.CudaResultCacheProductFixture|GpuDagCudaDrtProductTest.CudaDrtProductFixture.CudaDefaultPipelineSecondRender"` — 37/37 passed
- `ctest --test-dir build/debug --output-on-failure -R "GpuDagCudaWorkspaceTest"` — 21/21 passed
- Metal identity-geometry tests added; Metal binaries were not run on this Windows host