### PR TITLE
fix(opencl): fit 100MP Neural develop in transient slabs

### DIFF
--- a/alcedo_studio/src/app/pipeline_service.cpp
+++ b/alcedo_studio/src/app/pipeline_service.cpp
@@ -40,9 +40,12 @@ auto LoadPipelineDocument(ElementStore& store, sl_element_id_t id,
     -> LoadedPipelineDocument {
   const auto stored = store.GetPipelineJsonByElementId(id);
   if (stored && stored->is_object() && stored->value("format_version", 0) == 2) {
+    // Live CPU stages (history + QML patches) remain the editor source of truth.
+    // Remirror onto the format-2 graph even when the saved JSON omitted the nested
+    // adapter blob (SyncPipelineDocument writes document ToJson only).
     return FinishLoadedDocument(
         std::make_shared<PipelineDocument>(PipelineDocument::FromJson(*stored)),
-        stored->contains("legacy_stage_adapter"));
+        legacy != nullptr);
   }
   if (legacy) {
     auto imported = LegacyPipelineImporter::Import(legacy->ExportPipelineParams());
@@ -55,6 +58,18 @@ auto LoadPipelineDocument(ElementStore& store, sl_element_id_t id,
   }
   return FinishLoadedDocument(
       std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument()), true);
+}
+
+void RemirrorGpuDagDocument(PipelineGuard& pipeline) {
+  if (!pipeline.document_ || !pipeline.pipeline_ ||
+      !pipeline.pipeline_->MirrorsLegacyStageAdapter()) {
+    return;
+  }
+  const auto error = LegacyPipelineImporter::ApplyOnto(*pipeline.document_,
+                                                       pipeline.pipeline_->ExportPipelineParams());
+  if (!error.empty()) {
+    throw std::runtime_error("PipelineMgmtService: GPU DAG remirror failed: " + error);
+  }
 }
 
 void ResetToDefaults(OperatorParams& params) {
@@ -487,6 +502,10 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
   pipeline_guard->document_ = std::move(loaded_document.document);
   pipeline_guard->pipeline_->SetPipelineDocument(pipeline_guard->document_,
                                                  loaded_document.mirror_legacy_stage_adapter);
+  {
+    std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
+    RemirrorGpuDagDocument(*pipeline_guard);
+  }
   pipeline_guard->id_        = id;
   pipeline_guard->pinned_    = true;
   pipeline_guard->pin_count_ = 1;
@@ -625,6 +644,7 @@ auto PipelineMgmtService::LoadEditorPipeline(sl_element_id_t id) -> std::shared_
           ImportSerializedPipelineState(*pipeline->pipeline_, stored->pipeline_params,
                                         root_state->raw_color_context, accelerator_preference_);
           pipeline->pipeline_->SetExecutionStages();
+          RemirrorGpuDagDocument(*pipeline);
           accepted_serialized_state = true;
         } catch (...) {
           // Checkpoint params cannot build an executor. Rebuild from history; write back later.
@@ -637,6 +657,7 @@ auto PipelineMgmtService::LoadEditorPipeline(sl_element_id_t id) -> std::shared_
       ++editor_pipeline_history_rebuild_count_;
       std::unique_lock<std::mutex> render_lock(pipeline->pipeline_->GetRenderLock());
       RebuildPipelineFromRoot(*pipeline->pipeline_, *graph, *root_state, accelerator_preference_);
+      RemirrorGpuDagDocument(*pipeline);
       pipeline->serialized_state_needs_writeback_ = true;
     }
     return pipeline;

--- a/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_cache.cpp
+++ b/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_cache.cpp
@@ -83,6 +83,11 @@ auto OpenClDemosaicNetModelCache::Instance() -> OpenClDemosaicNetModelCache& {
   return instance;
 }
 
+auto OpenClNeuralDecodeMutex() -> std::mutex& {
+  static std::mutex mutex;
+  return mutex;
+}
+
 auto OpenClDemosaicNetModelCache::ResolveModelDir(const OpenClDemosaicNetLoadOptions& options)
     -> fs::path {
   if (!options.model_dir.empty()) {

--- a/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_module.cpp
+++ b/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_module.cpp
@@ -510,8 +510,11 @@ void ForwardImpl(const ModuleState& s, cl_mem input, int batch, int height, int 
   if (!s.loaded) {
     throw std::runtime_error(std::string(module) + ": weights not loaded");
   }
-  if (input == nullptr || output_rgb_hwc == nullptr) {
-    throw std::runtime_error(std::string(module) + ": null input/output buffer");
+  if (input == nullptr) {
+    throw std::runtime_error(std::string(module) + ": null input buffer");
+  }
+  if (output_rgb_hwc == nullptr) {
+    throw std::runtime_error(std::string(module) + ": null output buffer");
   }
   if (batch != 1 || (height % s.pack_factor) != 0 || (width % s.pack_factor) != 0 ||
       height < min_spatial || width < min_spatial) {

--- a/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_module.cpp
+++ b/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_module.cpp
@@ -338,12 +338,14 @@ struct ModuleState {
   // object because clSetKernelArg mutates kernel state.
   KernelHolder         pack;
   KernelHolder         pack_reflect_hwc;
+  KernelHolder         pack_reflect_mono;
   BoundConvKernel      trunk[8];
   BoundConvKernel      residual;
   BoundConvKernel      post;
   BoundConvKernel      output;
   KernelHolder         unpack_concat;
   KernelHolder         unpack_reflect_concat;
+  KernelHolder         unpack_reflect_concat_mono;
   KernelHolder         output_rgb;
 
   int                  depth       = 0;
@@ -378,9 +380,14 @@ void CreateKernels(ModuleState& s, bool is_bayer) {
   s.pack_reflect_hwc =
       KernelHolder(struct_prog, is_bayer ? OpenCL::DemosaicNet::kPackReflectBayerNhwc4KernelName
                                          : OpenCL::DemosaicNet::kPackReflectXTransNhwc4KernelName);
+  s.pack_reflect_mono = KernelHolder(
+      struct_prog, is_bayer ? OpenCL::DemosaicNet::kPackReflectBayerNhwc4MonoKernelName
+                            : OpenCL::DemosaicNet::kPackReflectXTransNhwc4MonoKernelName);
   s.unpack_concat = KernelHolder(struct_prog, OpenCL::DemosaicNet::kUnpackCropConcatKernelName);
   s.unpack_reflect_concat =
       KernelHolder(struct_prog, OpenCL::DemosaicNet::kUnpackReflectConcatKernelName);
+  s.unpack_reflect_concat_mono =
+      KernelHolder(struct_prog, OpenCL::DemosaicNet::kUnpackReflectConcatMonoKernelName);
   s.output_rgb = KernelHolder(struct_prog, OpenCL::DemosaicNet::kOutputRgbHwcKernelName);
 }
 
@@ -479,14 +486,27 @@ void LoadCommonWeights(ModuleState& s, const nn::SafetensorsTensorMap& tensors, 
   return total;
 }
 
-enum class ForwardInputMode { Nchw, ReflectHwc3 };
+enum class ForwardInputMode { Nchw, ReflectHwc3, ReflectMono };
+
+struct ForwardMonoCfa {
+  int    src_width           = 0;
+  int    src_height          = 0;
+  int    crop_x              = 0;
+  int    crop_y              = 0;
+  int    aligned_width       = 0;
+  int    aligned_height      = 0;
+  int    mono_offset_floats  = 0;
+  cl_mem rgb_fc              = nullptr;
+  int    period              = 0;
+};
 
 void ForwardImpl(const ModuleState& s, cl_mem input, int batch, int height, int width,
                  cl_mem output_rgb_hwc, nn_ocl::ActivationSlots& activation_slots,
                  cl_command_queue queue, bool apply_gamma_decode, int (*output_height_fn)(int, int),
                  int (*output_width_fn)(int, int), int min_spatial, const char* module,
                  ForwardInputMode input_mode = ForwardInputMode::Nchw, int frame_height = 0,
-                 int frame_width = 0, int origin_y = 0, int origin_x = 0) {
+                 int frame_width = 0, int origin_y = 0, int origin_x = 0,
+                 const ForwardMonoCfa* mono = nullptr) {
   if (!s.loaded) {
     throw std::runtime_error(std::string(module) + ": weights not loaded");
   }
@@ -540,12 +560,49 @@ void ForwardImpl(const ModuleState& s, cl_mem input, int batch, int height, int 
                 static_cast<size_t>(batch), queue, "pack enqueue");
     }
     nn_ocl::FinishDemosaicNetStage("pack_nchw_to_nhwc4", queue);
+  } else if (input_mode == ForwardInputMode::ReflectMono) {
+    if (mono == nullptr || mono->src_width <= 0 || mono->src_height <= 0 ||
+        mono->aligned_width <= 0 || mono->aligned_height <= 0 || mono->rgb_fc == nullptr ||
+        mono->period <= 0) {
+      throw std::runtime_error(std::string(module) + ": invalid mono CFA tile geometry");
+    }
+    nn_ocl::BeginDemosaicNetStage("reflect_pack_nhwc4_mono");
+    const cl_int src_w     = mono->src_width;
+    const cl_int src_h     = mono->src_height;
+    const cl_int crop_x    = mono->crop_x;
+    const cl_int crop_y    = mono->crop_y;
+    const cl_int aligned_h = mono->aligned_height;
+    const cl_int aligned_w = mono->aligned_width;
+    const cl_int oy        = origin_y;
+    const cl_int ox        = origin_x;
+    const cl_int th        = height;
+    const cl_int tw        = width;
+    const cl_int mono_off  = mono->mono_offset_floats;
+    SetArg(s.pack_reflect_mono.get(), 0, input, "mono pack arg0");
+    SetArg(s.pack_reflect_mono.get(), 1, slot_a, "mono pack arg1");
+    SetArg(s.pack_reflect_mono.get(), 2, src_w, "mono pack arg2");
+    SetArg(s.pack_reflect_mono.get(), 3, src_h, "mono pack arg3");
+    SetArg(s.pack_reflect_mono.get(), 4, crop_x, "mono pack arg4");
+    SetArg(s.pack_reflect_mono.get(), 5, crop_y, "mono pack arg5");
+    SetArg(s.pack_reflect_mono.get(), 6, aligned_h, "mono pack arg6");
+    SetArg(s.pack_reflect_mono.get(), 7, aligned_w, "mono pack arg7");
+    SetArg(s.pack_reflect_mono.get(), 8, oy, "mono pack arg8");
+    SetArg(s.pack_reflect_mono.get(), 9, ox, "mono pack arg9");
+    SetArg(s.pack_reflect_mono.get(), 10, th, "mono pack arg10");
+    SetArg(s.pack_reflect_mono.get(), 11, tw, "mono pack arg11");
+    SetArg(s.pack_reflect_mono.get(), 12, mono_off, "mono pack arg12");
+    if (!s.is_bayer) {
+      const cl_int period = mono->period;
+      SetArg(s.pack_reflect_mono.get(), 13, period, "mono pack arg13");
+      SetArg(s.pack_reflect_mono.get(), 14, mono->rgb_fc, "mono pack arg14");
+    }
+    Enqueue3D(s.pack_reflect_mono.get(), static_cast<size_t>(pw), static_cast<size_t>(ph), 1, queue,
+              "mono reflect pack enqueue");
+    nn_ocl::FinishDemosaicNetStage("reflect_pack_nhwc4_mono", queue);
   } else {
     if (frame_height <= 0 || frame_width <= 0) {
       throw std::runtime_error(std::string(module) + ": invalid reflected tile geometry");
     }
-    // Product path: reflect-101 + signed gamma + variant-specific packing
-    // writes slot_a directly. No intermediate NCHW tile is materialised.
     nn_ocl::BeginDemosaicNetStage("reflect_pack_nhwc4");
     const cl_int fh = frame_height;
     const cl_int fw = frame_width;
@@ -644,6 +701,39 @@ void ForwardImpl(const ModuleState& s, cl_mem input, int batch, int height, int 
       SetArg(kernel, 6, rh, "unpack arg6");
       SetArg(kernel, 7, rw, "unpack arg7");
       SetArg(kernel, 8, rcb, "unpack arg8");
+    } else if (input_mode == ForwardInputMode::ReflectMono) {
+      const cl_int src_w     = mono->src_width;
+      const cl_int src_h     = mono->src_height;
+      const cl_int crop_x    = mono->crop_x;
+      const cl_int crop_y    = mono->crop_y;
+      const cl_int aligned_h = mono->aligned_height;
+      const cl_int aligned_w = mono->aligned_width;
+      const cl_int oy        = origin_y;
+      const cl_int ox        = origin_x;
+      const cl_int th        = height;
+      const cl_int tw        = width;
+      const cl_int mono_off = mono->mono_offset_floats;
+      const cl_int period    = mono->period;
+      kernel                 = s.unpack_reflect_concat_mono.get();
+      SetArg(kernel, 0, input, "mono unpack arg0");
+      SetArg(kernel, 1, residual_buf, "mono unpack arg1");
+      SetArg(kernel, 2, cat_buf, "mono unpack arg2");
+      SetArg(kernel, 3, src_w, "mono unpack arg3");
+      SetArg(kernel, 4, src_h, "mono unpack arg4");
+      SetArg(kernel, 5, crop_x, "mono unpack arg5");
+      SetArg(kernel, 6, crop_y, "mono unpack arg6");
+      SetArg(kernel, 7, aligned_h, "mono unpack arg7");
+      SetArg(kernel, 8, aligned_w, "mono unpack arg8");
+      SetArg(kernel, 9, oy, "mono unpack arg9");
+      SetArg(kernel, 10, ox, "mono unpack arg10");
+      SetArg(kernel, 11, th, "mono unpack arg11");
+      SetArg(kernel, 12, tw, "mono unpack arg12");
+      SetArg(kernel, 13, mono_off, "mono unpack arg13");
+      SetArg(kernel, 14, period, "mono unpack arg14");
+      SetArg(kernel, 15, mono->rgb_fc, "mono unpack arg15");
+      SetArg(kernel, 16, rh, "mono unpack arg16");
+      SetArg(kernel, 17, rw, "mono unpack arg17");
+      SetArg(kernel, 18, rcb, "mono unpack arg18");
     } else {
       const cl_int fh = frame_height;
       const cl_int fw = frame_width;
@@ -817,6 +907,28 @@ void OpenClBayerDemosaicNet::ForwardReflectHwc3ToHwc(cl_mem input_frame_hwc3, in
       ForwardInputMode::ReflectHwc3, frame_height, frame_width, origin_y, origin_x);
 }
 
+void OpenClBayerDemosaicNet::ForwardReflectMonoCfaToHwc(
+    cl_mem input_mono_cfa, int src_width, int src_height, int crop_x, int crop_y,
+    int aligned_width, int aligned_height, int origin_y, int origin_x, int tile_height,
+    int tile_width, int mono_offset_floats, cl_mem rgb_fc, int period, cl_mem output_rgb_hwc,
+    opencl::nn::ActivationSlots& activation_slots, cl_command_queue queue,
+    bool apply_gamma_decode) const {
+  const ForwardMonoCfa mono{.src_width          = src_width,
+                             .src_height         = src_height,
+                             .crop_x             = crop_x,
+                             .crop_y             = crop_y,
+                             .aligned_width      = aligned_width,
+                             .aligned_height     = aligned_height,
+                             .mono_offset_floats = mono_offset_floats,
+                             .rgb_fc             = rgb_fc,
+                             .period             = period};
+  ForwardImpl(
+      impl_->state, input_mono_cfa, 1, tile_height, tile_width, output_rgb_hwc, activation_slots,
+      queue, apply_gamma_decode, [](int h, int w) { return Spec::OutputHeight(h, w); },
+      [](int w, int h) { return Spec::OutputWidth(w, h); }, kMinSpatial, "OpenClBayerDemosaicNet",
+      ForwardInputMode::ReflectMono, aligned_height, aligned_width, origin_y, origin_x, &mono);
+}
+
 auto OpenClBayerDemosaicNet::EstimateActivationSlotBytes(int input_h, int input_w, int batch)
     -> std::size_t {
   return EstimateNhwc4ActivationSlotBytes(input_h, input_w, batch, kPackOutCh, kWidth, kResidualCh,
@@ -899,6 +1011,28 @@ void OpenClXTransDemosaicNet::ForwardReflectHwc3ToHwc(cl_mem input_frame_hwc3, i
       queue, apply_gamma_decode, [](int h, int w) { return Spec::OutputHeight(h, w); },
       [](int w, int h) { return Spec::OutputWidth(w, h); }, kMinSpatial, "OpenClXTransDemosaicNet",
       ForwardInputMode::ReflectHwc3, frame_height, frame_width, origin_y, origin_x);
+}
+
+void OpenClXTransDemosaicNet::ForwardReflectMonoCfaToHwc(
+    cl_mem input_mono_cfa, int src_width, int src_height, int crop_x, int crop_y,
+    int aligned_width, int aligned_height, int origin_y, int origin_x, int tile_height,
+    int tile_width, int mono_offset_floats, cl_mem rgb_fc, int period, cl_mem output_rgb_hwc,
+    opencl::nn::ActivationSlots& activation_slots, cl_command_queue queue,
+    bool apply_gamma_decode) const {
+  const ForwardMonoCfa mono{.src_width          = src_width,
+                             .src_height         = src_height,
+                             .crop_x             = crop_x,
+                             .crop_y             = crop_y,
+                             .aligned_width      = aligned_width,
+                             .aligned_height     = aligned_height,
+                             .mono_offset_floats = mono_offset_floats,
+                             .rgb_fc             = rgb_fc,
+                             .period             = period};
+  ForwardImpl(
+      impl_->state, input_mono_cfa, 1, tile_height, tile_width, output_rgb_hwc, activation_slots,
+      queue, apply_gamma_decode, [](int h, int w) { return Spec::OutputHeight(h, w); },
+      [](int w, int h) { return Spec::OutputWidth(w, h); }, kMinSpatial, "OpenClXTransDemosaicNet",
+      ForwardInputMode::ReflectMono, aligned_height, aligned_width, origin_y, origin_x, &mono);
 }
 
 auto OpenClXTransDemosaicNet::EstimateActivationSlotBytes(int input_h, int input_w, int batch)

--- a/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_tiled.cpp
+++ b/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_tiled.cpp
@@ -135,8 +135,17 @@ auto EnqueueTiles(OpenClDemosaicNetTiledExecutor::Impl& state, const Module& mod
   if (!module.weights_loaded()) {
     throw std::runtime_error("OpenClDemosaicNetTiledExecutor: module weights are not loaded");
   }
-  if (dispatch.input_aligned_hwc == nullptr || dispatch.output_aligned_hwc == nullptr ||
-      dispatch.aligned_width <= 0 || dispatch.aligned_height <= 0) {
+  const bool use_mono = dispatch.input_mono_cfa != nullptr;
+  if (dispatch.output_aligned_hwc == nullptr || dispatch.aligned_width <= 0 ||
+      dispatch.aligned_height <= 0) {
+    throw std::runtime_error("OpenClDemosaicNetTiledExecutor: invalid aligned output");
+  }
+  if (use_mono) {
+    if (dispatch.src_width <= 0 || dispatch.src_height <= 0 || dispatch.rgb_fc == nullptr ||
+        dispatch.period <= 0) {
+      throw std::runtime_error("OpenClDemosaicNetTiledExecutor: invalid mono CFA dispatch");
+    }
+  } else if (dispatch.input_aligned_hwc == nullptr) {
     throw std::runtime_error("OpenClDemosaicNetTiledExecutor: invalid aligned input or output");
   }
   if ((dispatch.aligned_width % Module::kCfaPeriod) != 0 ||
@@ -170,9 +179,17 @@ auto EnqueueTiles(OpenClDemosaicNetTiledExecutor::Impl& state, const Module& mod
     const cl_int origin_x = job.input_origin.x;
     const cl_int tile_h   = job.input_h;
     const cl_int tile_w   = job.input_w;
-    module.ForwardReflectHwc3ToHwc(dispatch.input_aligned_hwc, frame_h, frame_w, origin_y, origin_x,
-                                   tile_h, tile_w, state.tile_output.get(), activation_slots, queue,
-                                   /*apply_gamma_decode=*/true);
+    if (use_mono) {
+      module.ForwardReflectMonoCfaToHwc(
+          dispatch.input_mono_cfa, dispatch.src_width, dispatch.src_height, dispatch.crop_x,
+          dispatch.crop_y, dispatch.aligned_width, dispatch.aligned_height, origin_y, origin_x,
+          tile_h, tile_w, dispatch.mono_offset_floats, dispatch.rgb_fc, dispatch.period,
+          state.tile_output.get(), activation_slots, queue, /*apply_gamma_decode=*/true);
+    } else {
+      module.ForwardReflectHwc3ToHwc(dispatch.input_aligned_hwc, frame_h, frame_w, origin_y,
+                                      origin_x, tile_h, tile_w, state.tile_output.get(),
+                                      activation_slots, queue, /*apply_gamma_decode=*/true);
+    }
 
     const cl_int canvas_w = dispatch.aligned_width;
     const cl_int canvas_h = dispatch.aligned_height;

--- a/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_tiled.cpp
+++ b/alcedo_studio/src/decoders/processor/nn/opencl_demosaicnet_tiled.cpp
@@ -153,6 +153,9 @@ auto EnqueueTiles(OpenClDemosaicNetTiledExecutor::Impl& state, const Module& mod
     throw std::runtime_error(
         "OpenClDemosaicNetTiledExecutor: aligned dimensions violate CFA period");
   }
+  if (dispatch.output_channels != 3 && dispatch.output_channels != 4) {
+    throw std::runtime_error("OpenClDemosaicNetTiledExecutor: output_channels must be 3 or 4");
+  }
 
   const cl_command_queue queue = ResolveQueue(dispatch.queue);
   state.EnsureKernels();
@@ -210,8 +213,12 @@ auto EnqueueTiles(OpenClDemosaicNetTiledExecutor::Impl& state, const Module& mod
     SetArg(state.assemble.get(), 7, dst_y, "tile assemble arg7");
     SetArg(state.assemble.get(), 8, owned_w, "tile assemble arg8");
     SetArg(state.assemble.get(), 9, owned_h, "tile assemble arg9");
+    const cl_int canvas_off = dispatch.output_offset_floats;
+    const cl_int dst_ch     = dispatch.output_channels;
     SetArg(state.assemble.get(), 10, src_x, "tile assemble arg10");
     SetArg(state.assemble.get(), 11, src_y, "tile assemble arg11");
+    SetArg(state.assemble.get(), 12, canvas_off, "tile assemble arg12");
+    SetArg(state.assemble.get(), 13, dst_ch, "tile assemble arg13");
     Enqueue2D(state.assemble.get(), owned_w, owned_h, queue, "tile assembly enqueue");
     opencl::nn::FinishDemosaicNetStage("tile_assembly", queue);
   }

--- a/alcedo_studio/src/decoders/processor/operators/gpu/cuda_demosaicnet.cu
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/cuda_demosaicnet.cu
@@ -127,8 +127,45 @@ __global__ void PackReflectPaddedCfaTileKernel(const cv::cuda::PtrStepSz<float> 
 
 }  // namespace
 
+void NeuralDemosaicWorkspace::BindExternal(float* input, const std::size_t input_numel,
+                                           void* activation, const std::size_t activation_bytes,
+                                           void* rgb, const int rgb_height, const int rgb_width) {
+  if (input == nullptr || activation == nullptr || rgb == nullptr || input_numel == 0 ||
+      activation_bytes == 0 || rgb_height <= 0 || rgb_width <= 0) {
+    throw std::runtime_error("NeuralDemosaicWorkspace::BindExternal: null or empty region");
+  }
+  input_buffer_ = cuda::nn::DeviceBufferF32::Wrap(input, input_numel);
+  activation_workspace_.BindExternalMemory(activation, activation_bytes);
+  rgb_buffer_ = cv::cuda::GpuMat(rgb_height, rgb_width, CV_32FC3, rgb,
+                                 static_cast<std::size_t>(rgb_width) * sizeof(float) * 3);
+  borrowed_ = true;
+  ++allocation_generation_;
+}
+
 void NeuralDemosaicWorkspace::EnsureCapacity(const DemosaicNetVariant variant, const int height,
                                              const int width, const std::size_t input_numel) {
+  const std::size_t activation_bytes =
+      variant == DemosaicNetVariant::Bayer
+          ? BayerDemosaicNet::EstimateWorkspaceBytes(height, width, 1)
+          : XTransDemosaicNet::EstimateWorkspaceBytes(height, width, 1);
+  const int output_height = variant == DemosaicNetVariant::Bayer
+                                ? BayerDemosaicNet::OutputHeight(height, width)
+                                : XTransDemosaicNet::OutputHeight(height, width);
+  const int output_width = variant == DemosaicNetVariant::Bayer
+                               ? BayerDemosaicNet::OutputWidth(width, height)
+                               : XTransDemosaicNet::OutputWidth(width, height);
+
+  if (borrowed_) {
+    if (input_buffer_.size() < input_numel ||
+        activation_workspace_.capacity_bytes() < activation_bytes || rgb_buffer_.empty() ||
+        rgb_buffer_.type() != CV_32FC3 || rgb_buffer_.rows < output_height ||
+        rgb_buffer_.cols < output_width) {
+      throw std::runtime_error(
+          "NeuralDemosaicWorkspace::EnsureCapacity: borrowed develop scratch is too small");
+    }
+    return;
+  }
+
   bool grew = false;
 
   if (input_buffer_.size() < input_numel) {
@@ -136,22 +173,12 @@ void NeuralDemosaicWorkspace::EnsureCapacity(const DemosaicNetVariant variant, c
     grew          = true;
   }
 
-  const std::size_t activation_bytes =
-      variant == DemosaicNetVariant::Bayer
-          ? BayerDemosaicNet::EstimateWorkspaceBytes(height, width, 1)
-          : XTransDemosaicNet::EstimateWorkspaceBytes(height, width, 1);
   const std::size_t prev_activation = activation_workspace_.capacity_bytes();
   activation_workspace_.Reserve(activation_bytes);
   if (activation_workspace_.capacity_bytes() > prev_activation) {
     grew = true;
   }
 
-  const int output_height = variant == DemosaicNetVariant::Bayer
-                                ? BayerDemosaicNet::OutputHeight(height, width)
-                                : XTransDemosaicNet::OutputHeight(height, width);
-  const int output_width = variant == DemosaicNetVariant::Bayer
-                               ? BayerDemosaicNet::OutputWidth(width, height)
-                               : XTransDemosaicNet::OutputWidth(width, height);
   // Grow-only RGB capacity (ragged edges reuse the max 1K workspace without
   // shrinking/reallocating when a boundary job is smaller than an interior job).
   const int prev_rows = rgb_buffer_.rows;

--- a/alcedo_studio/src/decoders/processor/operators/gpu/opencl_demosaicnet.cpp
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/opencl_demosaicnet.cpp
@@ -33,11 +33,6 @@
 namespace alcedo::OpenCL {
 namespace {
 
-// One active Neural decode: mutable cl_kernel arguments and resident scratch are
-// shared on the single in-order queue. Product RAW processing is already serialized;
-// this mutex covers harness/test re-entry as well.
-std::mutex g_neural_decode_mutex;
-
 std::uint64_t g_success_count         = 0;
 std::uint64_t g_fallback_ready_count  = 0;
 std::uint64_t g_host_wait_count       = 0;
@@ -93,7 +88,7 @@ auto StructuralProgram() -> cl_program {
 }
 
 // Context-keyed resident execution state for the product Neural path.
-// Retained across hot decodes under g_neural_decode_mutex:
+// Retained across hot decodes under OpenClNeuralDecodeMutex():
 //   clamp/rgba kernels, CFA lookup, aligned RGB canvas, tiled executor
 //   (tile buffers + pack/assemble kernels), and two activation slots.
 struct ResidentExecutionState {
@@ -223,7 +218,7 @@ void Clamp01(opencl::OpenClImage& image) {
   if (!context.IsInitialized()) {
     context.Initialize();
   }
-  std::lock_guard<std::mutex> lock(g_neural_decode_mutex);
+  std::lock_guard<std::mutex> lock(OpenClNeuralDecodeMutex());
   auto&                       state = ResidentState();
   state.EnsureForContext(context);
   const int channels = CV_MAT_CN(image.Type());
@@ -259,7 +254,7 @@ auto DemosaicWithNeuralEngine(const opencl::OpenClImage& linear_cfa,
   OpenClNeuralDemosaicResult result;
   result.variant = VariantName(camera_pattern.kind);
 
-  std::lock_guard<std::mutex> lock(g_neural_decode_mutex);
+  std::lock_guard<std::mutex> lock(OpenClNeuralDecodeMutex());
 
   try {
     if (linear_cfa.Empty() || linear_cfa.Type() != CV_32FC1) {

--- a/alcedo_studio/src/decoders/processor/operators/gpu/opencl_demosaicnet.cpp
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/opencl_demosaicnet.cpp
@@ -94,12 +94,11 @@ auto StructuralProgram() -> cl_program {
 
 // Context-keyed resident execution state for the product Neural path.
 // Retained across hot decodes under g_neural_decode_mutex:
-//   structural kernels, CFA lookup, full-frame HWC staging, tiled executor
+//   clamp/rgba kernels, CFA lookup, aligned RGB canvas, tiled executor
 //   (tile buffers + pack/assemble kernels), and two activation slots.
 struct ResidentExecutionState {
   cl_context context = nullptr;
 
-  KernelHolder pack_cfa;
   KernelHolder clamp01;
   KernelHolder rgb_to_rgba;
 
@@ -107,20 +106,17 @@ struct ResidentExecutionState {
   int                      cfa_period = -1;
   std::vector<int>         cfa_host;
 
-  opencl::nn::DeviceBuffer mosaic_hwc;
   opencl::nn::DeviceBuffer rgb_hwc;
 
   OpenClDemosaicNetTiledExecutor executor;
   opencl::nn::ActivationSlots    activation_slots;
 
   void Reset() {
-    pack_cfa.Reset();
     clamp01.Reset();
     rgb_to_rgba.Reset();
     cfa_table.Reset();
     cfa_period = -1;
     cfa_host.clear();
-    mosaic_hwc.Reset();
     rgb_hwc.Reset();
     executor         = OpenClDemosaicNetTiledExecutor{};
     activation_slots = opencl::nn::ActivationSlots{};
@@ -133,9 +129,8 @@ struct ResidentExecutionState {
       Reset();
     }
     context = current;
-    if (pack_cfa.empty()) {
+    if (clamp01.empty()) {
       const cl_program program = StructuralProgram();
-      pack_cfa.Create(program, DemosaicNet::kPackCfaMonoToHwc3KernelName);
       clamp01.Create(program, DemosaicNet::kClamp01KernelName);
       rgb_to_rgba.Create(program, DemosaicNet::kRgb3ToRgba4KernelName);
     }
@@ -160,8 +155,7 @@ struct ResidentExecutionState {
     cfa_host   = rgb_fc;
   }
 
-  void EnsureStagingFloats(const std::size_t hwc3_floats) {
-    mosaic_hwc.EnsureBytes(hwc3_floats * sizeof(float));
+  void EnsureRgbStaging(const std::size_t hwc3_floats) {
     rgb_hwc.EnsureBytes(hwc3_floats * sizeof(float));
   }
 };
@@ -187,35 +181,15 @@ void EnqueueClamp01(ResidentExecutionState& state, cl_mem buffer, const int coun
   NoteOpenClEnqueueNdRange();
 }
 
-void EnqueuePackMonoRoiToHwc3(ResidentExecutionState& state, cl_mem mono, cl_mem hwc3,
-                              int src_width, int src_height, int crop_x, int crop_y, int width,
-                              int height, int period, cl_command_queue queue) {
-  SetArg(state.pack_cfa.get(), 0, mono, "pack mono arg0");
-  SetArg(state.pack_cfa.get(), 1, hwc3, "pack mono arg1");
-  SetArg(state.pack_cfa.get(), 2, src_width, "pack mono arg2");
-  SetArg(state.pack_cfa.get(), 3, src_height, "pack mono arg3");
-  SetArg(state.pack_cfa.get(), 4, crop_x, "pack mono arg4");
-  SetArg(state.pack_cfa.get(), 5, crop_y, "pack mono arg5");
-  SetArg(state.pack_cfa.get(), 6, width, "pack mono arg6");
-  SetArg(state.pack_cfa.get(), 7, height, "pack mono arg7");
-  SetArg(state.pack_cfa.get(), 8, period, "pack mono arg8");
-  cl_mem table = state.cfa_table.get();
-  SetArg(state.pack_cfa.get(), 9, table, "pack mono arg9");
-  const size_t                 global[2] = {static_cast<size_t>(width), static_cast<size_t>(height)};
-  opencl::nn::ScopedStageEvent stage_event;
-  opencl::nn::CheckOpenCl(clEnqueueNDRangeKernel(queue, state.pack_cfa.get(), 2, nullptr, global,
-                                                 nullptr, 0, nullptr, stage_event.out()),
-                          "pack mono enqueue");
-  ++opencl::nn::GetDispatchInstrumentation().enqueue_count;
-  NoteOpenClEnqueueNdRange();
-}
-
 void EnqueueRgb3ToRgba4(ResidentExecutionState& state, cl_mem rgb, cl_mem rgba, int width,
                         int height, cl_command_queue queue) {
+  const int zero = 0;
   SetArg(state.rgb_to_rgba.get(), 0, rgb, "rgb2rgba arg0");
   SetArg(state.rgb_to_rgba.get(), 1, rgba, "rgb2rgba arg1");
   SetArg(state.rgb_to_rgba.get(), 2, width, "rgb2rgba arg2");
   SetArg(state.rgb_to_rgba.get(), 3, height, "rgb2rgba arg3");
+  SetArg(state.rgb_to_rgba.get(), 4, zero, "rgb2rgba arg4");
+  SetArg(state.rgb_to_rgba.get(), 5, zero, "rgb2rgba arg5");
   const size_t                 global[2] = {static_cast<size_t>(width), static_cast<size_t>(height)};
   opencl::nn::ScopedStageEvent stage_event;
   opencl::nn::CheckOpenCl(clEnqueueNDRangeKernel(queue, state.rgb_to_rgba.get(), 2, nullptr, global,
@@ -329,7 +303,7 @@ auto DemosaicWithNeuralEngine(const opencl::OpenClImage& linear_cfa,
     result.aligned_width  = geo->aligned_width;
     result.aligned_height = geo->aligned_height;
 
-    // Fused phase crop + HWC pack: no materialised aligned_mono temporary.
+    // Pack each student tile from the original mono CFA (CUDA PackReflectPaddedCfaTile).
     opencl::nn::BeginDemosaicNetStage("phase_crop_and_hwc_pack");
     const RawCfaPattern training = DemosaicNetTrainingPattern(camera_pattern.kind);
     std::vector<int>    rgb_fc;
@@ -339,10 +313,7 @@ auto DemosaicWithNeuralEngine(const opencl::OpenClImage& linear_cfa,
 
     const std::size_t hwc3_floats =
         static_cast<std::size_t>(geo->aligned_width) * geo->aligned_height * 3;
-    state.EnsureStagingFloats(hwc3_floats);
-    EnqueuePackMonoRoiToHwc3(state, linear_cfa.Buffer(), state.mosaic_hwc.get(), linear_cfa.Width(),
-                             linear_cfa.Height(), geo->shift_sx, geo->shift_sy, geo->aligned_width,
-                             geo->aligned_height, period, queue);
+    state.EnsureRgbStaging(hwc3_floats);
     opencl::nn::FinishDemosaicNetStage("phase_crop_and_hwc_pack", queue);
 
     if (options.injected_failure == OpenClNeuralInjectedFailure::ModelLoad) {
@@ -381,10 +352,16 @@ auto DemosaicWithNeuralEngine(const opencl::OpenClImage& linear_cfa,
     }
 
     OpenClDemosaicNetTiledDispatch dispatch;
-    dispatch.input_aligned_hwc  = state.mosaic_hwc.get();
+    dispatch.input_mono_cfa     = linear_cfa.Buffer();
+    dispatch.src_width          = linear_cfa.Width();
+    dispatch.src_height         = linear_cfa.Height();
+    dispatch.crop_x             = geo->shift_sx;
+    dispatch.crop_y             = geo->shift_sy;
     dispatch.output_aligned_hwc = state.rgb_hwc.get();
     dispatch.aligned_width      = geo->aligned_width;
     dispatch.aligned_height     = geo->aligned_height;
+    dispatch.rgb_fc             = state.cfa_table.get();
+    dispatch.period             = period;
     dispatch.queue              = queue;
 
     OpenClDemosaicNetTiledResult tiled;

--- a/alcedo_studio/src/decoders/processor/operators/gpu/opencl_encode.cpp
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/opencl_encode.cpp
@@ -26,14 +26,18 @@ using opencl::OpenClBufferView;
 using opencl::OpenClEncodeQueue;
 using RawProcessor::kCfaClamp01KernelName;
 using RawProcessor::kCopyRgbaCropInverseOrientKernelName;
+using RawProcessor::kCopyRgbCropInverseOrientKernelName;
 using RawProcessor::kCoreProgramName;
 using RawProcessor::kCvtRefSpaceProgramName;
 using RawProcessor::kDebayerRcdProgramName;
 using RawProcessor::kHighlightProgramName;
 using RawProcessor::kHlrBuildMaskKernelName;
+using RawProcessor::kHlrBuildMaskPlanarKernelName;
 using RawProcessor::kHlrChrominanceContribKernelName;
+using RawProcessor::kHlrChrominanceContribPlanarKernelName;
 using RawProcessor::kHlrDilateMaskKernelName;
 using RawProcessor::kHlrReconstructFromStatsKernelName;
+using RawProcessor::kHlrReconstructFromStatsPlanarPackKernelName;
 using RawProcessor::kPackPlanesCropInverseOrientKernelName;
 using RawProcessor::kRcdGreenAtRbKernelName;
 using RawProcessor::kRcdInitAndVhKernelName;
@@ -484,6 +488,96 @@ void EncodeHighlightReconstruct(OpenClEncodeQueue& stream, OpenClBufferView src_
   }
 }
 
+void EncodeHighlightReconstructPlanarAndPack(
+    OpenClEncodeQueue& stream, OpenClBufferView r, OpenClBufferView g, OpenClBufferView b,
+    cl_mem dst_rgba, OpenClBufferView mask, OpenClBufferView dilated_mask, OpenClBufferView sums,
+    OpenClBufferView cnts, OpenClBufferView anyclipped, const float* cam_mul, RectI crop,
+    std::uint32_t plane_width, int flip) {
+  RequireMem(r.native, "HLR R");
+  RequireMem(g.native, "HLR G");
+  RequireMem(b.native, "HLR B");
+  RequireMem(dst_rgba, "HLR destination");
+  RequireMem(mask.native, "HLR mask");
+  RequireMem(dilated_mask.native, "HLR dilated mask");
+  RequireMem(sums.native, "HLR sums");
+  RequireMem(cnts.native, "HLR counts");
+  RequireMem(anyclipped.native, "HLR anyclipped");
+  const auto crop_w    = static_cast<std::uint32_t>(crop.width);
+  const auto crop_h    = static_cast<std::uint32_t>(crop.height);
+  auto       params     = MakeHighlightParams(cam_mul, crop_w, crop_h);
+  params.stride         = plane_width;
+  const auto pack       = MakePackParams(crop, plane_width, plane_width, cam_mul, flip);
+  const auto r_off     = ElementOffset(r, sizeof(float));
+  const auto g_off     = ElementOffset(g, sizeof(float));
+  const auto b_off     = ElementOffset(b, sizeof(float));
+  const auto mask_off   = ElementOffset(mask, sizeof(std::uint8_t));
+  const auto dilate_off = ElementOffset(dilated_mask, sizeof(std::uint8_t));
+  const auto sums_off   = ElementOffset(sums, sizeof(float));
+  const auto cnts_off   = ElementOffset(cnts, sizeof(float));
+  {
+    auto kernel = Kernel(kHighlightProgramName, kHlrBuildMaskPlanarKernelName);
+    SetMem(kernel, 0, r.native, "hlr planar mask arg0");
+    SetMem(kernel, 1, g.native, "hlr planar mask arg1");
+    SetMem(kernel, 2, b.native, "hlr planar mask arg2");
+    SetMem(kernel, 3, mask.native, "hlr planar mask arg3");
+    SetMem(kernel, 4, anyclipped.native, "hlr planar mask arg4");
+    CheckOpenCl(clSetKernelArg(kernel, 5, sizeof(params), &params), "hlr planar mask arg5");
+    SetUInt(kernel, 6, r_off, "hlr planar mask arg6");
+    SetUInt(kernel, 7, g_off, "hlr planar mask arg7");
+    SetUInt(kernel, 8, b_off, "hlr planar mask arg8");
+    SetUInt(kernel, 9, mask_off, "hlr planar mask arg9");
+    SetUInt(kernel, 10, ElementOffset(anyclipped, sizeof(cl_int)), "hlr planar mask arg10");
+    SetUInt(kernel, 11, pack.src_x, "hlr planar mask arg11");
+    SetUInt(kernel, 12, pack.src_y, "hlr planar mask arg12");
+    Dispatch2D(stream, kernel, crop_w, crop_h);
+  }
+  {
+    auto kernel = Kernel(kHighlightProgramName, kHlrDilateMaskKernelName);
+    SetMem(kernel, 0, mask.native, "hlr planar dilate arg0");
+    SetMem(kernel, 1, dilated_mask.native, "hlr planar dilate arg1");
+    CheckOpenCl(clSetKernelArg(kernel, 2, sizeof(params), &params), "hlr planar dilate arg2");
+    SetUInt(kernel, 3, mask_off, "hlr planar dilate arg3");
+    SetUInt(kernel, 4, dilate_off, "hlr planar dilate arg4");
+    Dispatch2D(stream, kernel, crop_w, crop_h);
+  }
+  {
+    auto kernel = Kernel(kHighlightProgramName, kHlrChrominanceContribPlanarKernelName);
+    SetMem(kernel, 0, r.native, "hlr planar chroma arg0");
+    SetMem(kernel, 1, g.native, "hlr planar chroma arg1");
+    SetMem(kernel, 2, b.native, "hlr planar chroma arg2");
+    SetMem(kernel, 3, dilated_mask.native, "hlr planar chroma arg3");
+    SetMem(kernel, 4, sums.native, "hlr planar chroma arg4");
+    SetMem(kernel, 5, cnts.native, "hlr planar chroma arg5");
+    CheckOpenCl(clSetKernelArg(kernel, 6, sizeof(params), &params), "hlr planar chroma arg6");
+    SetUInt(kernel, 7, r_off, "hlr planar chroma arg7");
+    SetUInt(kernel, 8, g_off, "hlr planar chroma arg8");
+    SetUInt(kernel, 9, b_off, "hlr planar chroma arg9");
+    SetUInt(kernel, 10, dilate_off, "hlr planar chroma arg10");
+    SetUInt(kernel, 11, sums_off, "hlr planar chroma arg11");
+    SetUInt(kernel, 12, cnts_off, "hlr planar chroma arg12");
+    SetUInt(kernel, 13, pack.src_x, "hlr planar chroma arg13");
+    SetUInt(kernel, 14, pack.src_y, "hlr planar chroma arg14");
+    Dispatch2D(stream, kernel, crop_w, crop_h);
+  }
+  {
+    auto kernel = Kernel(kHighlightProgramName, kHlrReconstructFromStatsPlanarPackKernelName);
+    SetMem(kernel, 0, r.native, "hlr planar pack arg0");
+    SetMem(kernel, 1, g.native, "hlr planar pack arg1");
+    SetMem(kernel, 2, b.native, "hlr planar pack arg2");
+    SetMem(kernel, 3, dst_rgba, "hlr planar pack arg3");
+    SetMem(kernel, 4, sums.native, "hlr planar pack arg4");
+    SetMem(kernel, 5, cnts.native, "hlr planar pack arg5");
+    CheckOpenCl(clSetKernelArg(kernel, 6, sizeof(params), &params), "hlr planar pack arg6");
+    CheckOpenCl(clSetKernelArg(kernel, 7, sizeof(pack), &pack), "hlr planar pack arg7");
+    SetUInt(kernel, 8, r_off, "hlr planar pack arg8");
+    SetUInt(kernel, 9, g_off, "hlr planar pack arg9");
+    SetUInt(kernel, 10, b_off, "hlr planar pack arg10");
+    SetUInt(kernel, 11, sums_off, "hlr planar pack arg11");
+    SetUInt(kernel, 12, cnts_off, "hlr planar pack arg12");
+    Dispatch2D(stream, kernel, crop_w, crop_h);
+  }
+}
+
 void EncodePackPlanesCropInverseOrient(OpenClEncodeQueue& stream, OpenClBufferView r,
                                        OpenClBufferView g, OpenClBufferView b, cl_mem dst_rgba,
                                        RectI crop, std::uint32_t plane_width, const float* cam_mul,
@@ -516,6 +610,20 @@ void EncodeCopyRgbaCropInverseOrient(OpenClEncodeQueue& stream, OpenClBufferView
   SetMem(kernel, 1, dst_rgba, "copy arg1");
   CheckOpenCl(clSetKernelArg(kernel, 2, sizeof(params), &params), "copy arg2");
   SetUInt(kernel, 3, ElementOffset(src_rgba, sizeof(float) * 4), "copy arg3");
+  Dispatch2D(stream, kernel, params.src_width, params.src_height);
+}
+
+void EncodeCopyRgbCropInverseOrient(OpenClEncodeQueue& stream, OpenClBufferView src_rgb,
+                                     cl_mem dst_rgba, RectI crop, std::uint32_t src_width,
+                                     const float* cam_mul, int flip) {
+  RequireMem(src_rgb.native, "copy rgb source");
+  RequireMem(dst_rgba, "copy rgb destination");
+  const auto params = MakePackParams(crop, src_width, src_width, cam_mul, flip);
+  auto       kernel = Kernel(kCvtRefSpaceProgramName, kCopyRgbCropInverseOrientKernelName);
+  SetMem(kernel, 0, src_rgb.native, "copy rgb arg0");
+  SetMem(kernel, 1, dst_rgba, "copy rgb arg1");
+  CheckOpenCl(clSetKernelArg(kernel, 2, sizeof(params), &params), "copy rgb arg2");
+  SetUInt(kernel, 3, ElementOffset(src_rgb, sizeof(float)), "copy rgb arg3");
   Dispatch2D(stream, kernel, params.src_width, params.src_height);
 }
 

--- a/alcedo_studio/src/decoders/processor/operators/gpu/opencl_shader/cvt_ref_space.cl
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/opencl_shader/cvt_ref_space.cl
@@ -88,3 +88,17 @@ __kernel void copy_rgba_crop_inverse_orient(global const float4* src, __write_on
       (float4)(pixel.x * params.scale_r, pixel.y * params.scale_g, pixel.z * params.scale_b, pixel.w);
   write_imagef(dst, OrientedCoord(x, y, params), rgba);
 }
+
+__kernel void copy_rgb_crop_inverse_orient(global const float* src, __write_only image2d_t dst,
+                                            PackOrientParams params, uint src_off) {
+  const uint x = get_global_id(0);
+  const uint y = get_global_id(1);
+  if (x >= params.src_width || y >= params.src_height) {
+    return;
+  }
+  const uint index =
+      src_off + ((params.src_y + y) * params.src_stride + (params.src_x + x)) * 3u;
+  const float4 rgba = (float4)(src[index] * params.scale_r, src[index + 1u] * params.scale_g,
+                                src[index + 2u] * params.scale_b, 1.0f);
+  write_imagef(dst, OrientedCoord(x, y, params), rgba);
+}

--- a/alcedo_studio/src/decoders/processor/operators/gpu/opencl_shader/demosaicnet_structural.cl
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/opencl_shader/demosaicnet_structural.cl
@@ -599,7 +599,8 @@ __kernel void demosaicnet_assemble_rgb_tile(__global const float* restrict tile,
                                             const int tile_h, const int canvas_w,
                                             const int canvas_h, const int dst_x, const int dst_y,
                                             const int owned_w, const int owned_h, const int src_x0,
-                                            const int src_y0) {
+                                            const int src_y0, const int canvas_offset,
+                                            const int dst_channels) {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if (x >= owned_w || y >= owned_h) {
@@ -616,10 +617,13 @@ __kernel void demosaicnet_assemble_rgb_tile(__global const float* restrict tile,
     return;
   }
   const int src_index = (src_y * tile_w + src_x) * 3;
-  const int dst_index = (dst_yy * canvas_w + dst_xx) * 3;
+  const int dst_index = canvas_offset + (dst_yy * canvas_w + dst_xx) * dst_channels;
   canvas[dst_index + 0] = tile[src_index + 0];
   canvas[dst_index + 1] = tile[src_index + 1];
   canvas[dst_index + 2] = tile[src_index + 2];
+  if (dst_channels == 4) {
+    canvas[dst_index + 3] = 1.0f;
+  }
 }
 
 // Product boundary: clamp linear CFA samples to [0,1] when highlight reconstruction is off.

--- a/alcedo_studio/src/decoders/processor/operators/gpu/opencl_shader/demosaicnet_structural.cl
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/opencl_shader/demosaicnet_structural.cl
@@ -217,6 +217,139 @@ __kernel void demosaicnet_unpack_reflect_concat_nhwc4(
       (float4)(vals[4], vals[5], vals[6], vals[7]);
 }
 
+// CUDA PackReflectPaddedCfaTile equivalent: sample the aligned mono CFA through
+// reflect-101, then sparse-pack by training-origin color. crop_* maps the aligned
+// lattice onto a full-frame plane; mono_off is a float element offset into a slab.
+inline float demosaicnet_sample_aligned_mono(__global const float* restrict mono,
+                                              const int src_w, const int src_h,
+                                              const int crop_x, const int crop_y,
+                                              const int aligned_w, const int aligned_h,
+                                              const int origin_x, const int origin_y,
+                                              const int x, const int y, const int mono_off,
+                                              int* aligned_x, int* aligned_y) {
+  *aligned_x = demosaicnet_reflect101(origin_x + x, aligned_w);
+  *aligned_y = demosaicnet_reflect101(origin_y + y, aligned_h);
+  const int sx = crop_x + *aligned_x;
+  const int sy = crop_y + *aligned_y;
+  if (sx < 0 || sy < 0 || sx >= src_w || sy >= src_h) {
+    return 0.0f;
+  }
+  return mono[mono_off + sy * src_w + sx];
+}
+
+inline int demosaicnet_aligned_rgb_color(__global const int* restrict rgb_fc, const int period,
+                                          const int aligned_x, const int aligned_y) {
+  return rgb_fc[(aligned_y % period) * period + (aligned_x % period)];
+}
+
+__kernel void demosaicnet_pack_reflect_bayer_nhwc4_mono(
+    __global const float* restrict mono, __global float4* restrict output, const int src_w,
+    const int src_h, const int crop_x, const int crop_y, const int aligned_h,
+    const int aligned_w, const int origin_y, const int origin_x, const int tile_h,
+    const int tile_w, const int mono_off) {
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  if (x >= tile_w / 2 || y >= tile_h / 2) {
+    return;
+  }
+
+  float vals[4];
+  for (int py = 0; py < 2; ++py) {
+    for (int px = 0; px < 2; ++px) {
+      int ax = 0;
+      int ay = 0;
+      const float v = demosaicnet_sample_aligned_mono(
+          mono, src_w, src_h, crop_x, crop_y, aligned_w, aligned_h, origin_x, origin_y,
+          x * 2 + px, y * 2 + py, mono_off, &ax, &ay);
+      vals[py * 2 + px] = demosaicnet_signed_gamma_encode(v);
+    }
+  }
+  output[demosaicnet_nhwc4_index(0, y, x, 0, tile_h / 2, tile_w / 2, 1)] =
+      (float4)(vals[0], vals[1], vals[2], vals[3]);
+}
+
+__kernel void demosaicnet_pack_reflect_xtrans_nhwc4_mono(
+    __global const float* restrict mono, __global float4* restrict output, const int src_w,
+    const int src_h, const int crop_x, const int crop_y, const int aligned_h,
+    const int aligned_w, const int origin_y, const int origin_x, const int tile_h,
+    const int tile_w, const int mono_off, const int period,
+    __global const int* restrict rgb_fc) {
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  if (x >= tile_w / 2 || y >= tile_h / 2) {
+    return;
+  }
+
+  for (int cb = 0; cb < 3; ++cb) {
+    float vals[4];
+    for (int lane = 0; lane < 4; ++lane) {
+      const int py = lane / 2;
+      const int px = lane % 2;
+      int ax = 0;
+      int ay = 0;
+      const float v = demosaicnet_sample_aligned_mono(
+          mono, src_w, src_h, crop_x, crop_y, aligned_w, aligned_h, origin_x, origin_y,
+          x * 2 + px, y * 2 + py, mono_off, &ax, &ay);
+      const int color = demosaicnet_aligned_rgb_color(rgb_fc, period, ax, ay);
+      vals[lane] = (color == cb) ? demosaicnet_signed_gamma_encode(v) : 0.0f;
+    }
+    output[demosaicnet_nhwc4_index(0, y, x, cb, tile_h / 2, tile_w / 2, 3)] =
+        (float4)(vals[0], vals[1], vals[2], vals[3]);
+  }
+}
+
+__kernel void demosaicnet_unpack_reflect_concat_nhwc4_mono(
+    __global const float* restrict mono, __global const float4* restrict residual,
+    __global float4* restrict cat, const int src_w, const int src_h, const int crop_x,
+    const int crop_y, const int aligned_h, const int aligned_w, const int origin_y,
+    const int origin_x, const int tile_h, const int tile_w, const int mono_off,
+    const int period, __global const int* restrict rgb_fc, const int residual_h,
+    const int residual_w, const int residual_channel_blocks) {
+  const int up_w = residual_w * 2;
+  const int up_h = residual_h * 2;
+  const int x    = get_global_id(0);
+  const int y    = get_global_id(1);
+  if (x >= up_w || y >= up_h) {
+    return;
+  }
+
+  const int crop_tx = (tile_w - up_w) / 2;
+  const int crop_ty = (tile_h - up_h) / 2;
+  int ax = 0;
+  int ay = 0;
+  const float v = demosaicnet_sample_aligned_mono(
+      mono, src_w, src_h, crop_x, crop_y, aligned_w, aligned_h, origin_x, origin_y,
+      x + crop_tx, y + crop_ty, mono_off, &ax, &ay);
+  const int color = demosaicnet_aligned_rgb_color(rgb_fc, period, ax, ay);
+  const float encoded = demosaicnet_signed_gamma_encode(v);
+
+  float vals[8];
+  vals[0] = (color == 0) ? encoded : 0.0f;
+  vals[1] = (color == 1) ? encoded : 0.0f;
+  vals[2] = (color == 2) ? encoded : 0.0f;
+
+  const int sub_y = y & 1;
+  const int sub_x = x & 1;
+  const int ry    = y / 2;
+  const int rx    = x / 2;
+  for (int g = 0; g < 3; ++g) {
+    const int rc     = g * 4 + sub_y * 2 + sub_x;
+    const int src_cb = rc / 4;
+    const int lane   = rc % 4;
+    vals[3 + g] = demosaicnet_float4_lane(
+        residual[demosaicnet_nhwc4_index(0, ry, rx, src_cb, residual_h, residual_w,
+                                           residual_channel_blocks)],
+        lane);
+  }
+  vals[6] = 0.0f;
+  vals[7] = 0.0f;
+
+  cat[demosaicnet_nhwc4_index(0, y, x, 0, up_h, up_w, 2)] =
+      (float4)(vals[0], vals[1], vals[2], vals[3]);
+  cat[demosaicnet_nhwc4_index(0, y, x, 1, up_h, up_w, 2)] =
+      (float4)(vals[4], vals[5], vals[6], vals[7]);
+}
+
 // Fixed Bayer collapse-colors pack: NCHW [N,3,H,W] → NHWC4 [N,H/2,W/2,C4].
 // out_c = py*2+px sums all three mosaic color planes at that sub-pixel (stride 2).
 __kernel void demosaicnet_pack_bayer_nchw_to_nhwc4(__global const float* restrict mosaic,
@@ -532,14 +665,14 @@ __kernel void demosaicnet_pack_cfa_mono_to_hwc3(__global const float* restrict m
 // Product continuation: HWC3 camera RGB -> HWC4 RGBA with alpha = 1.
 __kernel void demosaicnet_rgb3_to_rgba4(__global const float* restrict rgb,
                                         __global float* restrict rgba, const int width,
-                                        const int height) {
+                                        const int height, const int rgb_off, const int rgba_off) {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if (x >= width || y >= height) {
     return;
   }
-  const int src = (y * width + x) * 3;
-  const int dst = (y * width + x) * 4;
+  const int src = rgb_off + (y * width + x) * 3;
+  const int dst = rgba_off + (y * width + x) * 4;
   rgba[dst + 0] = rgb[src + 0];
   rgba[dst + 1] = rgb[src + 1];
   rgba[dst + 2] = rgb[src + 2];

--- a/alcedo_studio/src/decoders/processor/operators/gpu/opencl_shader/highlight_reconstruct.cl
+++ b/alcedo_studio/src/decoders/processor/operators/gpu/opencl_shader/highlight_reconstruct.cl
@@ -346,3 +346,222 @@ __kernel void hlr_reconstruct_from_stats(global const float4* input,
 
   output[out_index] = (float4)(result.x, result.y, result.z, input_pixel.w);
 }
+
+typedef struct {
+  uint  src_x;
+  uint  src_y;
+  uint  src_width;
+  uint  src_height;
+  uint  dst_width;
+  uint  dst_height;
+  uint  flip;
+  float scale_r;
+  float scale_g;
+  float scale_b;
+  uint  plane_stride;
+  uint  src_stride;
+} PackOrientParams;
+
+static inline int2 OrientedCoord(uint x, uint y, PackOrientParams params) {
+  if (params.flip == 3u) {
+    return (int2)((int)(params.src_width - 1u - x), (int)(params.src_height - 1u - y));
+  }
+  if (params.flip == 5u) {
+    return (int2)((int)y, (int)(params.src_width - 1u - x));
+  }
+  if (params.flip == 6u) {
+    return (int2)((int)(params.src_height - 1u - y), (int)x);
+  }
+  return (int2)((int)x, (int)y);
+}
+
+static inline float4 LoadPlanarRgb(global const float* r, global const float* g,
+                                   global const float* b, uint r_off, uint g_off, uint b_off,
+                                   int row, int col, uint plane_stride) {
+  const uint src = (uint)row * plane_stride + (uint)col;
+  return (float4)(r[r_off + src], g[g_off + src], b[b_off + src], 1.0f);
+}
+
+static inline float4 CalcRefavgPlanar(global const float* r, global const float* g,
+                                       global const float* b, uint r_off, uint g_off, uint b_off,
+                                       int local_row, int local_col, HighlightParams params,
+                                       uint crop_x, uint crop_y) {
+  float valid_sum[3] = {0.0f, 0.0f, 0.0f};
+  float valid_cnt[3] = {0.0f, 0.0f, 0.0f};
+  float all_sum[3]   = {0.0f, 0.0f, 0.0f};
+  float all_cnt[3]   = {0.0f, 0.0f, 0.0f};
+
+  const int dymin = max(0, local_row - 1);
+  const int dxmin = max(0, local_col - 1);
+  const int dymax = min((int)params.height - 1, local_row + 1);
+  const int dxmax = min((int)params.width - 1, local_col + 1);
+
+  for (int dy = dymin; dy <= dymax; ++dy) {
+    for (int dx = dxmin; dx <= dxmax; ++dx) {
+      RefavgAccumulate(valid_sum, valid_cnt, all_sum, all_cnt,
+                       LoadPlanarRgb(r, g, b, r_off, g_off, b_off, (int)crop_y + dy,
+                                     (int)crop_x + dx, params.stride),
+                       params);
+    }
+  }
+
+  float mean[3];
+  for (uint c = 0; c < 3u; ++c) {
+    const float m = (valid_cnt[c] > 0.0f) ? valid_sum[c] / valid_cnt[c]
+                    : (all_cnt[c] > 0.0f)   ? all_sum[c] / all_cnt[c]
+                                            : 0.0f;
+    mean[c] = pow(m, 1.0f / 3.0f);
+  }
+
+  return (float4)(Cube(0.5f * (mean[1] + mean[2])), Cube(0.5f * (mean[0] + mean[2])),
+                  Cube(0.5f * (mean[0] + mean[1])), 0.0f);
+}
+
+__kernel void hlr_build_mask_planar(global const float* r, global const float* g,
+                                      global const float* b, global uchar* mask_buf,
+                                      global int* anyclipped, HighlightParams params, uint r_off,
+                                      uint g_off, uint b_off, uint mask_off, uint anyclipped_off,
+                                      uint crop_x, uint crop_y) {
+  uint x = get_global_id(0);
+  uint y = get_global_id(1);
+  if (x >= params.width || y >= params.height) {
+    return;
+  }
+  const uint   size  = params.width * params.height;
+  const uint   idx   = y * params.width + x;
+  const float4 pixel = MaxRgb(LoadPlanarRgb(r, g, b, r_off, g_off, b_off, (int)crop_y + (int)y,
+                                             (int)crop_x + (int)x, params.stride));
+
+  mask_buf[mask_off + kPlaneBaseR * size + idx] = pixel.x >= params.clips[0] ? 1 : 0;
+  mask_buf[mask_off + kPlaneBaseG * size + idx] = pixel.y >= params.clips[1] ? 1 : 0;
+  mask_buf[mask_off + kPlaneBaseB * size + idx] = pixel.z >= params.clips[2] ? 1 : 0;
+
+  if (pixel.x >= params.clips[0] || pixel.y >= params.clips[1] || pixel.z >= params.clips[2]) {
+    atomic_add(anyclipped + anyclipped_off, 1);
+  }
+}
+
+__kernel void hlr_chrominance_contrib_planar(global const float* r, global const float* g,
+                                              global const float* b, global const uchar* mask_buf,
+                                              global float* global_sums, global float* global_cnts,
+                                              HighlightParams params, uint r_off, uint g_off,
+                                              uint b_off, uint mask_off, uint sums_off,
+                                              uint cnts_off, uint crop_x, uint crop_y) {
+  uint x         = get_global_id(0);
+  uint y         = get_global_id(1);
+  bool in_bounds = x < params.width && y < params.height;
+
+  float4 contrib_value = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+  float4 count_value   = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+
+  if (in_bounds) {
+    const uint   size  = params.width * params.height;
+    const uint   idx   = y * params.width + x;
+    const float4 pixel = MaxRgb(LoadPlanarRgb(r, g, b, r_off, g_off, b_off, (int)crop_y + (int)y,
+                                               (int)crop_x + (int)x, params.stride));
+
+    const bool use_r = mask_buf[mask_off + kPlaneDilatedR * size + idx] &&
+                       pixel.x > params.clipdark[0] && pixel.x < params.clips[0];
+    const bool use_g = mask_buf[mask_off + kPlaneDilatedG * size + idx] &&
+                       pixel.y > params.clipdark[1] && pixel.y < params.clips[1];
+    const bool use_b = mask_buf[mask_off + kPlaneDilatedB * size + idx] &&
+                       pixel.z > params.clipdark[2] && pixel.z < params.clips[2];
+
+    if (use_r || use_g || use_b) {
+      const float4 ref =
+          CalcRefavgPlanar(r, g, b, r_off, g_off, b_off, (int)y, (int)x, params, crop_x, crop_y);
+      if (use_r) {
+        contrib_value.x = pixel.x - ref.x;
+        count_value.x   = 1.0f;
+      }
+      if (use_g) {
+        contrib_value.y = pixel.y - ref.y;
+        count_value.y   = 1.0f;
+      }
+      if (use_b) {
+        contrib_value.z = pixel.z - ref.z;
+        count_value.z   = 1.0f;
+      }
+    }
+  }
+
+  const uint lid = get_local_id(1) * get_local_size(0) + get_local_id(0);
+  const uint lsz = get_local_size(0) * get_local_size(1);
+
+  local float l_contrib_r[256];
+  local float l_contrib_g[256];
+  local float l_contrib_b[256];
+  local float l_cnt_r[256];
+  local float l_cnt_g[256];
+  local float l_cnt_b[256];
+
+  l_contrib_r[lid] = contrib_value.x;
+  l_contrib_g[lid] = contrib_value.y;
+  l_contrib_b[lid] = contrib_value.z;
+  l_cnt_r[lid]     = count_value.x;
+  l_cnt_g[lid]     = count_value.y;
+  l_cnt_b[lid]     = count_value.z;
+
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  for (uint stride = lsz / 2; stride > 0; stride >>= 1) {
+    if (lid < stride) {
+      l_contrib_r[lid] += l_contrib_r[lid + stride];
+      l_contrib_g[lid] += l_contrib_g[lid + stride];
+      l_contrib_b[lid] += l_contrib_b[lid + stride];
+      l_cnt_r[lid] += l_cnt_r[lid + stride];
+      l_cnt_g[lid] += l_cnt_g[lid + stride];
+      l_cnt_b[lid] += l_cnt_b[lid + stride];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  if (lid == 0) {
+    AtomicAddFloat(global_sums + sums_off + 0, l_contrib_r[0]);
+    AtomicAddFloat(global_sums + sums_off + 1, l_contrib_g[0]);
+    AtomicAddFloat(global_sums + sums_off + 2, l_contrib_b[0]);
+    AtomicAddFloat(global_cnts + cnts_off + 0, l_cnt_r[0]);
+    AtomicAddFloat(global_cnts + cnts_off + 1, l_cnt_g[0]);
+    AtomicAddFloat(global_cnts + cnts_off + 2, l_cnt_b[0]);
+  }
+}
+
+__kernel void hlr_reconstruct_from_stats_planar_pack(global const float* r, global const float* g,
+                                                      global const float* b,
+                                                      __write_only image2d_t dst,
+                                                      global const float* sums,
+                                                      global const float* cnts,
+                                                      HighlightParams params, PackOrientParams pack,
+                                                      uint r_off, uint g_off, uint b_off,
+                                                      uint sums_off, uint cnts_off) {
+  uint x = get_global_id(0);
+  uint y = get_global_id(1);
+  if (x >= pack.src_width || y >= pack.src_height) {
+    return;
+  }
+
+  const float4 input_pixel = LoadPlanarRgb(r, g, b, r_off, g_off, b_off, (int)pack.src_y + (int)y,
+                                            (int)pack.src_x + (int)x, pack.plane_stride);
+  const float4 pixel        = MaxRgb(input_pixel);
+  const float3 weight        = (float3)(SoftClipWeight(pixel.x, params.clips[0]),
+                                          SoftClipWeight(pixel.y, params.clips[1]),
+                                          SoftClipWeight(pixel.z, params.clips[2]));
+
+  float chrominance[3];
+  chrominance[0] = (cnts[cnts_off + 0] > 30.0f) ? (sums[sums_off + 0] / cnts[cnts_off + 0]) : 0.0f;
+  chrominance[1] = (cnts[cnts_off + 1] > 30.0f) ? (sums[sums_off + 1] / cnts[cnts_off + 1]) : 0.0f;
+  chrominance[2] = (cnts[cnts_off + 2] > 30.0f) ? (sums[sums_off + 2] / cnts[cnts_off + 2]) : 0.0f;
+
+  float4 result = pixel;
+  if (weight.x > 0.0f || weight.y > 0.0f || weight.z > 0.0f) {
+    const float4 ref = CalcRefavgPlanar(r, g, b, r_off, g_off, b_off, (int)y, (int)x, params,
+                                        pack.src_x, pack.src_y);
+    result.x        = ReconstructChannel(pixel.x, ref.x, chrominance[0], weight.x);
+    result.y        = ReconstructChannel(pixel.y, ref.y, chrominance[1], weight.y);
+    result.z        = ReconstructChannel(pixel.z, ref.z, chrominance[2], weight.z);
+  }
+
+  write_imagef(dst, OrientedCoord(x, y, pack),
+               (float4)(result.x * pack.scale_r, result.y * pack.scale_g, result.z * pack.scale_b,
+                        1.0f));
+}

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -441,6 +441,16 @@ auto CudaBackend::DefaultTextureBudgetBytes() -> std::size_t {
   return DefaultProductTextureBudgetBytes();
 }
 
+auto CudaBackend::MaxTransientBytes() const -> std::size_t {
+  constexpr std::size_t kFloorBytes = 256ull << 20;
+  const auto            memory      = QueryDeviceMemory();
+  if (!memory.valid || memory.total_bytes == 0) {
+    return kFloorBytes;
+  }
+  const auto three_quarters = memory.total_bytes - memory.total_bytes / 4;
+  return three_quarters > kFloorBytes ? three_quarters : kFloorBytes;
+}
+
 auto DefaultProductTextureBudgetBytes() -> std::size_t {
   constexpr std::size_t kFloorBytes = 256ull << 20;
   std::size_t           free_bytes  = 0;

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_develop_pass.cpp
@@ -67,9 +67,6 @@ void ExecuteCudaDevelop(CudaRenderDevice& device, const ExecutionPlan& plan,
   if (workspace.Textures().ByteBudget() == 0) {
     workspace.Textures().SetByteBudget(DefaultProductTextureBudgetBytes());
   }
-  if (plan.peak_transient_bytes > 0) {
-    workspace.TransientBuffers().Reserve(plan.peak_transient_bytes);
-  }
 
   auto&              ctx           = device.CommandContext();
   auto               stream        = WrapStream(ctx.Stream());

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_sensor_demosaic.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_sensor_demosaic.cpp
@@ -10,8 +10,11 @@
 
 #include <opencv2/core/cuda_stream_accessor.hpp>
 
+#include "decoders/processor/nn/demosaicnet_bayer.hpp"
 #include "decoders/processor/nn/demosaicnet_cache.hpp"
 #include "decoders/processor/nn/demosaicnet_preprocess.hpp"
+#include "decoders/processor/nn/demosaicnet_specs.hpp"
+#include "decoders/processor/nn/demosaicnet_xtrans.hpp"
 #include "decoders/processor/neural_tile_jobs.hpp"
 #include "decoders/processor/operators/gpu/cuda_color_space_conv.hpp"
 #include "decoders/processor/operators/gpu/cuda_debayer_rcd.hpp"
@@ -160,16 +163,35 @@ void DemosaicXTransInterpolator(CudaRenderWorkspace& workspace, const PreparedRa
 void DemosaicNeuralEngine(CudaRenderDevice& device, const PreparedRawInput& input,
                           cv::cuda::GpuMat linear, cv::cuda::GpuMat packed, bool hlr,
                           cv::cuda::Stream& stream) {
-  cv::cuda::GpuMat neural_cfa;
-  const auto       prep = PrepareNeuralEngineCfa(linear, input.cfa_pattern, neural_cfa, &stream);
+  std::string error;
+  const bool  is_bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
+  const int   min_spatial =
+      is_bayer ? DemosaicNetBayerSpec::kMinSpatial : DemosaicNetXTransSpec::kMinSpatial;
+  const auto geometry =
+      ComputeNeuralAlignedGeometry(input.cfa_pattern, linear.cols, linear.rows, min_spatial,
+                                   &error);
+  if (!geometry.has_value()) {
+    throw std::runtime_error("ExecuteCudaDevelop: Neural Engine preprocess failed: " + error);
+  }
+
+  auto& workspace = device.Workspace();
+  void* aligned_ptr =
+      AllocateTransient(workspace, static_cast<std::size_t>(geometry->aligned_width) *
+                                       static_cast<std::size_t>(geometry->aligned_height) *
+                                       sizeof(float));
+  cv::cuda::GpuMat neural_cfa =
+      WrapF32C1(aligned_ptr, geometry->aligned_width, geometry->aligned_height);
+  const auto prep = PrepareNeuralEngineCfa(linear, input.cfa_pattern, neural_cfa, &stream);
   if (!prep.succeeded) {
     throw std::runtime_error("ExecuteCudaDevelop: Neural Engine preprocess failed: " + prep.error);
   }
 
-  const bool is_bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
   const auto policy =
       is_bayer ? detail::MakeBayerStudentTilePolicy() : detail::MakeXTransStudentTilePolicy();
-  cv::cuda::GpuMat output_rgb(neural_cfa.size(), CV_32FC3);
+  void* rgb_ptr = AllocateTransient(
+      workspace, static_cast<std::size_t>(neural_cfa.cols) * static_cast<std::size_t>(neural_cfa.rows) *
+                     sizeof(float) * 3);
+  cv::cuda::GpuMat output_rgb = WrapF32C3(rgb_ptr, neural_cfa.cols, neural_cfa.rows);
 
   auto&                         neural_workspace = device.NeuralDemosaicWorkspace();
   CUDA::NeuralDemosaicOptions   neural_options;
@@ -188,11 +210,24 @@ void DemosaicNeuralEngine(CudaRenderDevice& device, const PreparedRawInput& inpu
     throw std::runtime_error("ExecuteCudaDevelop: Neural Engine unavailable: " + cache.LastError());
   }
 
-  const int tile_h = policy.input_tile.height;
-  const int tile_w = policy.input_tile.width;
-  neural_workspace.EnsureCapacity(variant, tile_h, tile_w,
-                                  static_cast<std::size_t>(3) * static_cast<std::size_t>(tile_h) *
-                                      static_cast<std::size_t>(tile_w));
+  const int tile_h      = policy.input_tile.height;
+  const int tile_w      = policy.input_tile.width;
+  const int tile_out_h  = policy.output_tile.height;
+  const int tile_out_w  = policy.output_tile.width;
+  const std::size_t input_numel =
+      static_cast<std::size_t>(3) * static_cast<std::size_t>(tile_h) *
+      static_cast<std::size_t>(tile_w);
+  const std::size_t activation_bytes =
+      is_bayer ? BayerDemosaicNet::EstimateWorkspaceBytes(tile_h, tile_w, 1)
+               : XTransDemosaicNet::EstimateWorkspaceBytes(tile_h, tile_w, 1);
+  void* input_ptr = AllocateTransient(workspace, input_numel * sizeof(float));
+  void* act_ptr   = AllocateTransient(workspace, activation_bytes);
+  void* tile_rgb_ptr =
+      AllocateTransient(workspace, static_cast<std::size_t>(tile_out_h) *
+                                       static_cast<std::size_t>(tile_out_w) * sizeof(float) * 3);
+  neural_workspace.BindExternal(static_cast<float*>(input_ptr), input_numel, act_ptr,
+                                activation_bytes, tile_rgb_ptr, tile_out_h, tile_out_w);
+  neural_workspace.EnsureCapacity(variant, tile_h, tile_w, input_numel);
 
   const auto jobs =
       detail::BuildTileJobs(cv::Rect(0, 0, neural_cfa.cols, neural_cfa.rows), neural_cfa.size(),

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 #include <alcedo/metal/Metal.hpp>
@@ -789,14 +790,15 @@ void MetalBackend::Submit(CommandContext& command_context) {
   in_flight_submission_ = submission_id;
 }
 
-void MetalBackend::SynchronizeRecordedWork(CommandContext& command_context) {
+void MetalBackend::CompleteCurrentCommandBuffer(CommandContext& command_context) {
   if (command_context.gpu_ == nullptr || command_context.gpu_->buffer.get() == nullptr) {
-    ReleaseRecordedWorkScratchResources();
     return;
   }
   command_context.gpu_->EndEncoders();
   auto* command_buffer = command_context.gpu_->buffer.get();
-  command_buffer->commit();
+  if (command_buffer->status() < MTL::CommandBufferStatusCommitted) {
+    command_buffer->commit();
+  }
   command_buffer->waitUntilCompleted();
   if (command_buffer->status() == MTL::CommandBufferStatusError) {
     std::string message = "MetalBackend: recorded work wait failed";
@@ -807,10 +809,18 @@ void MetalBackend::SynchronizeRecordedWork(CommandContext& command_context) {
       }
     }
     command_context.gpu_->Reset();
-    ReleaseRecordedWorkScratchResources();
     throw std::runtime_error(message);
   }
   command_context.gpu_->Reset();
+}
+
+void MetalBackend::SynchronizeRecordedWork(CommandContext& command_context) {
+  try {
+    CompleteCurrentCommandBuffer(command_context);
+  } catch (...) {
+    ReleaseRecordedWorkScratchResources();
+    throw;
+  }
   ReleaseRecordedWorkScratchResources();
 }
 

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend.mm
@@ -497,6 +497,17 @@ auto MetalBackend::CreateTexture2D(std::uint32_t width, std::uint32_t height, Te
   return Texture2D{this, native, bytes, width, height, format, next_resource_id_++};
 }
 
+auto MetalBackend::AcquireRecordedWorkScratchBuffer(std::size_t bytes) -> Buffer& {
+  recorded_work_scratch_buffers_.push_back(CreateSlab(bytes));
+  return recorded_work_scratch_buffers_.back();
+}
+
+auto MetalBackend::AcquireRecordedWorkScratchTexture(std::uint32_t width, std::uint32_t height,
+                                                     TextureFormat format) -> Texture2D& {
+  recorded_work_scratch_textures_.push_back(CreateTexture2D(width, height, format));
+  return recorded_work_scratch_textures_.back();
+}
+
 void MetalBackend::UploadBufferRange(Buffer& buffer, std::uint32_t offset,
                                      std::span<const std::byte> bytes,
                                      CommandContext&            command_context) {
@@ -780,6 +791,7 @@ void MetalBackend::Submit(CommandContext& command_context) {
 
 void MetalBackend::SynchronizeRecordedWork(CommandContext& command_context) {
   if (command_context.gpu_ == nullptr || command_context.gpu_->buffer.get() == nullptr) {
+    ReleaseRecordedWorkScratchResources();
     return;
   }
   command_context.gpu_->EndEncoders();
@@ -787,7 +799,7 @@ void MetalBackend::SynchronizeRecordedWork(CommandContext& command_context) {
   command_buffer->commit();
   command_buffer->waitUntilCompleted();
   if (command_buffer->status() == MTL::CommandBufferStatusError) {
-    std::string message = "MetalBackend: Develop scratch wait failed";
+    std::string message = "MetalBackend: recorded work wait failed";
     if (auto* error = command_buffer->error(); error != nullptr) {
       if (auto* description = error->localizedDescription(); description != nullptr) {
         message += ": ";
@@ -795,9 +807,11 @@ void MetalBackend::SynchronizeRecordedWork(CommandContext& command_context) {
       }
     }
     command_context.gpu_->Reset();
+    ReleaseRecordedWorkScratchResources();
     throw std::runtime_error(message);
   }
   command_context.gpu_->Reset();
+  ReleaseRecordedWorkScratchResources();
 }
 
 void MetalBackend::Wait(CommandContext& command_context) {
@@ -805,6 +819,7 @@ void MetalBackend::Wait(CommandContext& command_context) {
     if (command_context.gpu_) {
       command_context.gpu_->Reset();
     }
+    ReleaseRecordedWorkScratchResources();
     return;
   }
   auto* command_buffer = command_context.gpu_ ? command_context.gpu_->buffer.get() : nullptr;
@@ -820,6 +835,7 @@ void MetalBackend::Wait(CommandContext& command_context) {
       }
       command_context.gpu_->Reset();
       in_flight_submission_ = 0;
+      ReleaseRecordedWorkScratchResources();
       throw std::runtime_error(message);
     }
   }
@@ -828,6 +844,7 @@ void MetalBackend::Wait(CommandContext& command_context) {
   if (command_context.gpu_) {
     command_context.gpu_->Reset();
   }
+  ReleaseRecordedWorkScratchResources();
 }
 
 void MetalBackend::WarmUpPipelines(std::span<const MetalPipelineWarmup> pipelines) {

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
@@ -123,6 +123,15 @@ auto MetalBackend::CreateSlab(std::size_t bytes) -> Buffer { return CreateBuffer
 auto MetalBackend::CreateTexture2D(std::uint32_t, std::uint32_t, TextureFormat) -> Texture2D {
   throw std::runtime_error("MetalBackend: GPU texture allocation is not implemented");
 }
+auto MetalBackend::AcquireRecordedWorkScratchBuffer(std::size_t bytes) -> Buffer& {
+  recorded_work_scratch_buffers_.push_back(CreateSlab(bytes));
+  return recorded_work_scratch_buffers_.back();
+}
+auto MetalBackend::AcquireRecordedWorkScratchTexture(std::uint32_t width, std::uint32_t height,
+                                                     TextureFormat format) -> Texture2D& {
+  recorded_work_scratch_textures_.push_back(CreateTexture2D(width, height, format));
+  return recorded_work_scratch_textures_.back();
+}
 void MetalBackend::UploadBufferRange(Buffer&, std::uint32_t, std::span<const std::byte>,
                                      CommandContext&) {
   throw std::runtime_error("MetalBackend: buffer upload is not implemented");
@@ -167,12 +176,16 @@ void MetalBackend::Submit(CommandContext& command_context) {
 }
 void MetalBackend::Wait(CommandContext&) {
   if (in_flight_submission_ == 0) {
+    ReleaseRecordedWorkScratchResources();
     return;
   }
   completed_submission_ = in_flight_submission_;
   in_flight_submission_ = 0;
+  ReleaseRecordedWorkScratchResources();
 }
-void MetalBackend::SynchronizeRecordedWork(CommandContext&) {}
+void MetalBackend::SynchronizeRecordedWork(CommandContext&) {
+  ReleaseRecordedWorkScratchResources();
+}
 void MetalBackend::WarmUpPipelines(std::span<const MetalPipelineWarmup>) {
   throw std::runtime_error("MetalBackend: pipeline warm-up is not implemented");
 }

--- a/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
+++ b/alcedo_studio/src/edit/runtime/metal/metal_backend_host.cpp
@@ -183,6 +183,7 @@ void MetalBackend::Wait(CommandContext&) {
   in_flight_submission_ = 0;
   ReleaseRecordedWorkScratchResources();
 }
+void MetalBackend::CompleteCurrentCommandBuffer(CommandContext&) {}
 void MetalBackend::SynchronizeRecordedWork(CommandContext&) {
   ReleaseRecordedWorkScratchResources();
 }

--- a/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
@@ -158,7 +158,7 @@ auto CropOrFull(const PreparedRawInput& input, std::uint32_t width, std::uint32_
   return RectI{0, 0, static_cast<std::int32_t>(width), static_cast<std::int32_t>(height)};
 }
 
-void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const PreparedRawInput& input,
+void EncodeNeural(MetalRenderDevice& device, const PreparedRawInput& input,
                   MetalBackend::Texture2D& linear, ResourceLease<MetalBackend>& packed, bool hlr) {
   std::string error;
   const auto  geometry =
@@ -189,6 +189,12 @@ void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const Prepare
                              cache.LastError());
   }
 
+  // MPSGraph encodeToCommandBuffer may commitAndContinue. Do not wrap the DAG command
+  // buffer: later HLR/copy encoders would hit a committed MTLCommandBuffer. Finish
+  // linearization first so Neural's own command buffers cannot race it, then wait
+  // once after the tile loop. Recorded-work scratch stays alive across both waits.
+  device.Workspace().Device().CompleteCurrentCommandBuffer(device.CommandContext());
+
   MetalDemosaicNetTiledDispatch dispatch;
   dispatch.cfa_image       = &cfa_image;
   dispatch.output_rgba     = &out_image;
@@ -197,8 +203,8 @@ void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const Prepare
   dispatch.aligned_width   = geometry->aligned_width;
   dispatch.aligned_height  = geometry->aligned_height;
   dispatch.product_crop    = cv::Rect(crop.x, crop.y, crop.width, crop.height);
-  dispatch.commit_and_wait = false;
-  dispatch.command_buffer  = command_buffer;
+  dispatch.commit_and_wait = true;
+  dispatch.command_buffer  = nullptr;
   MetalDemosaicNetTiledExecutor executor;
   if (is_bayer) {
     (void)executor.EnqueueBayer(cache.Bayer(), dispatch);
@@ -206,9 +212,10 @@ void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const Prepare
     (void)executor.EnqueueXTrans(cache.XTrans(), dispatch);
   }
 
-  auto* hlr_src = Native(neural_out);
-  auto  hlr_w   = neural_out.Width();
-  auto  hlr_h   = neural_out.Height();
+  auto* command_buffer = CommandBuffer(device);
+  auto* hlr_src        = Native(neural_out);
+  auto  hlr_w          = neural_out.Width();
+  auto  hlr_h          = neural_out.Height();
   if (hlr) {
     auto& hlr_dst = AcquireScratch(device.Workspace(), hlr_w, hlr_h, TextureFormat::Rgba32f);
     auto& stats = device.Workspace().Device().AcquireRecordedWorkScratchBuffer(6 * sizeof(float));
@@ -402,7 +409,7 @@ void ExecuteMetalDevelop(MetalRenderDevice& device, const ExecutionPlan& plan,
   const auto method =
       ResolveDevelopDemosaicMethod(flags, input.cfa_pattern.kind, input.downsample_passes);
   if (method == RawDemosaicMethod::NeuralEngine) {
-    EncodeNeural(device, command_buffer, input, linear, decoded_lease, hlr);
+    EncodeNeural(device, input, linear, decoded_lease, hlr);
   } else {
     EncodeLegacyDemosaic(device, command_buffer, input, linear, decoded_lease, hlr);
   }

--- a/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
@@ -64,8 +64,8 @@ auto AcquireRgba(MetalRenderWorkspace& workspace, const GraphValueId& id, std::u
 }
 
 auto AcquireScratch(MetalRenderWorkspace& workspace, std::uint32_t width, std::uint32_t height,
-                    TextureFormat format) -> ResourceLease<MetalBackend> {
-  return workspace.Textures().Acquire({width, height, format});
+                    TextureFormat format) -> MetalBackend::Texture2D& {
+  return workspace.Device().AcquireRecordedWorkScratchTexture(width, height, format);
 }
 
 auto CommandBuffer(MetalRenderDevice& device) -> void* {
@@ -159,12 +159,11 @@ auto CropOrFull(const PreparedRawInput& input, std::uint32_t width, std::uint32_
 }
 
 void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const PreparedRawInput& input,
-                  ResourceLease<MetalBackend>& linear, ResourceLease<MetalBackend>& packed,
-                  bool hlr) {
+                  MetalBackend::Texture2D& linear, ResourceLease<MetalBackend>& packed, bool hlr) {
   std::string error;
   const auto  geometry =
-      ComputeNeuralAlignedGeometry(input.cfa_pattern, static_cast<int>(linear.Texture().Width()),
-                                   static_cast<int>(linear.Texture().Height()), 32, &error);
+      ComputeNeuralAlignedGeometry(input.cfa_pattern, static_cast<int>(linear.Width()),
+                                   static_cast<int>(linear.Height()), 32, &error);
   if (!geometry.has_value()) {
     throw std::runtime_error("ExecuteMetalDevelop: Neural Engine preprocess failed: " + error);
   }
@@ -172,10 +171,9 @@ void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const Prepare
                                       static_cast<std::uint32_t>(geometry->aligned_height));
   const auto  out_w      = static_cast<std::uint32_t>(crop.width);
   const auto  out_h      = static_cast<std::uint32_t>(crop.height);
-  auto        neural_out = AcquireScratch(device.Workspace(), out_w, out_h, TextureFormat::Rgba32f);
-  auto cfa_image = metal::MetalImage::Wrap(static_cast<MTL::Texture*>(linear.Texture().Native()));
-  auto out_image =
-      metal::MetalImage::Wrap(static_cast<MTL::Texture*>(neural_out.Texture().Native()));
+  auto&       neural_out = AcquireScratch(device.Workspace(), out_w, out_h, TextureFormat::Rgba32f);
+  auto        cfa_image  = metal::MetalImage::Wrap(static_cast<MTL::Texture*>(linear.Native()));
+  auto        out_image  = metal::MetalImage::Wrap(static_cast<MTL::Texture*>(neural_out.Native()));
 
   MetalDemosaicNetLoadOptions load_options;
   if (g_metal_neural_cache_for_test != nullptr) {
@@ -208,21 +206,18 @@ void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const Prepare
     (void)executor.EnqueueXTrans(cache.XTrans(), dispatch);
   }
 
-  auto* hlr_src = Native(neural_out.Texture());
-  auto  hlr_w   = neural_out.Texture().Width();
-  auto  hlr_h   = neural_out.Texture().Height();
+  auto* hlr_src = Native(neural_out);
+  auto  hlr_w   = neural_out.Width();
+  auto  hlr_h   = neural_out.Height();
   if (hlr) {
-    auto  hlr_dst = AcquireScratch(device.Workspace(), hlr_w, hlr_h, TextureFormat::Rgba32f);
-    void* stats   = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
-    auto [native_stats, offset] =
-        device.Workspace().Device().ResolveDeviceMemory(stats, 6 * sizeof(float));
-    device.Workspace().Device().FillDeviceMemory(stats, 6 * sizeof(float), 0,
+    auto& hlr_dst = AcquireScratch(device.Workspace(), hlr_w, hlr_h, TextureFormat::Rgba32f);
+    auto& stats = device.Workspace().Device().AcquireRecordedWorkScratchBuffer(6 * sizeof(float));
+    device.Workspace().Device().FillDeviceMemory(stats.DevicePointer(), stats.Bytes(), 0,
                                                  device.CommandContext());
     device.Workspace().Device().EndCommandEncoders(device.CommandContext());
-    metal::EncodeHighlightReconstruct(command_buffer, hlr_src, Native(hlr_dst.Texture()),
-                                      native_stats, offset, input.linearization.cam_mul, hlr_w,
-                                      hlr_h);
-    hlr_src = Native(hlr_dst.Texture());
+    metal::EncodeHighlightReconstruct(command_buffer, hlr_src, Native(hlr_dst), stats.Native(), 0,
+                                      input.linearization.cam_mul, hlr_w, hlr_h);
+    hlr_src = Native(hlr_dst);
   }
   const float* cam_mul = input.linearization.cam_mul;
   metal::EncodeCopyRgbaCropInverseOrient(
@@ -232,30 +227,27 @@ void EncodeNeural(MetalRenderDevice& device, void* command_buffer, const Prepare
 }
 
 void EncodeLegacyDemosaic(MetalRenderDevice& device, void* command_buffer,
-                          const PreparedRawInput& input, ResourceLease<MetalBackend>& linear,
+                          const PreparedRawInput& input, MetalBackend::Texture2D& linear,
                           ResourceLease<MetalBackend>& packed, bool hlr) {
-  const auto width  = linear.Texture().Width();
-  const auto height = linear.Texture().Height();
+  const auto width  = linear.Width();
+  const auto height = linear.Height();
   if (input.cfa_pattern.kind == RawCfaKind::XTrans6x6) {
-    auto      green  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
-    auto      rgb    = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+    auto&     green  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+    auto&     rgb    = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
     const int passes = input.downsample_passes == 0 ? 3 : 1;
-    metal::EncodeXTrans(command_buffer, Native(linear.Texture()), Native(green.Texture()),
-                        Native(rgb.Texture()), input.cfa_pattern.xtrans_pattern, width, height,
-                        passes);
-    auto* src = Native(rgb.Texture());
+    metal::EncodeXTrans(command_buffer, Native(linear), Native(green), Native(rgb),
+                        input.cfa_pattern.xtrans_pattern, width, height, passes);
+    auto* src = Native(rgb);
     if (hlr) {
-      auto  hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
-      void* stats   = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
-      auto [native_stats, offset] =
-          device.Workspace().Device().ResolveDeviceMemory(stats, 6 * sizeof(float));
-      device.Workspace().Device().FillDeviceMemory(stats, 6 * sizeof(float), 0,
+      auto& hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+      auto& stats =
+          device.Workspace().Device().AcquireRecordedWorkScratchBuffer(6 * sizeof(float));
+      device.Workspace().Device().FillDeviceMemory(stats.DevicePointer(), stats.Bytes(), 0,
                                                    device.CommandContext());
       device.Workspace().Device().EndCommandEncoders(device.CommandContext());
-      metal::EncodeHighlightReconstruct(command_buffer, src, Native(hlr_dst.Texture()),
-                                        native_stats, offset, input.linearization.cam_mul, width,
-                                        height);
-      src = Native(hlr_dst.Texture());
+      metal::EncodeHighlightReconstruct(command_buffer, src, Native(hlr_dst), stats.Native(), 0,
+                                        input.linearization.cam_mul, width, height);
+      src = Native(hlr_dst);
     }
     metal::EncodeCopyRgbaCropInverseOrient(
         command_buffer, src, Native(packed.Texture()), CropOrFull(input, width, height),
@@ -263,41 +255,34 @@ void EncodeLegacyDemosaic(MetalRenderDevice& device, void* command_buffer,
     return;
   }
 
-  auto r  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
-  auto g  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
-  auto b  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
-  auto vh = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
-  auto pq = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
-  metal::EncodeBayerRcd(command_buffer, Native(linear.Texture()), Native(r.Texture()),
-                        Native(g.Texture()), Native(b.Texture()), Native(vh.Texture()),
-                        Native(pq.Texture()), input.cfa_pattern.bayer_pattern, width, height);
+  auto& r  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  auto& g  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  auto& b  = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  auto& vh = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  auto& pq = AcquireScratch(device.Workspace(), width, height, TextureFormat::R32f);
+  metal::EncodeBayerRcd(command_buffer, Native(linear), Native(r), Native(g), Native(b), Native(vh),
+                        Native(pq), input.cfa_pattern.bayer_pattern, width, height);
   if (hlr) {
-    auto        rgba = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+    auto&       rgba = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
     const float identity[4] = {1.0f, 1.0f, 1.0f, 1.0f};
     metal::EncodePackPlanesCropInverseOrient(
-        command_buffer, Native(r.Texture()), Native(g.Texture()), Native(b.Texture()),
-        Native(rgba.Texture()), RectI{0, 0, static_cast<int>(width), static_cast<int>(height)},
-        identity, 0);
-    auto  hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
-    void* stats   = device.Workspace().TransientBuffers().Allocate(6 * sizeof(float));
-    auto [native_stats, offset] =
-        device.Workspace().Device().ResolveDeviceMemory(stats, 6 * sizeof(float));
-    device.Workspace().Device().FillDeviceMemory(stats, 6 * sizeof(float), 0,
+        command_buffer, Native(r), Native(g), Native(b), Native(rgba),
+        RectI{0, 0, static_cast<int>(width), static_cast<int>(height)}, identity, 0);
+    auto& hlr_dst = AcquireScratch(device.Workspace(), width, height, TextureFormat::Rgba32f);
+    auto& stats = device.Workspace().Device().AcquireRecordedWorkScratchBuffer(6 * sizeof(float));
+    device.Workspace().Device().FillDeviceMemory(stats.DevicePointer(), stats.Bytes(), 0,
                                                  device.CommandContext());
     device.Workspace().Device().EndCommandEncoders(device.CommandContext());
-    metal::EncodeHighlightReconstruct(command_buffer, Native(rgba.Texture()),
-                                      Native(hlr_dst.Texture()), native_stats, offset,
-                                      input.linearization.cam_mul, width, height);
+    metal::EncodeHighlightReconstruct(command_buffer, Native(rgba), Native(hlr_dst), stats.Native(),
+                                      0, input.linearization.cam_mul, width, height);
     metal::EncodeCopyRgbaCropInverseOrient(
-        command_buffer, Native(hlr_dst.Texture()), Native(packed.Texture()),
-        CropOrFull(input, width, height), input.linearization.cam_mul,
-        input.sensor.orientation_flip);
+        command_buffer, Native(hlr_dst), Native(packed.Texture()), CropOrFull(input, width, height),
+        input.linearization.cam_mul, input.sensor.orientation_flip);
     return;
   }
   metal::EncodePackPlanesCropInverseOrient(
-      command_buffer, Native(r.Texture()), Native(g.Texture()), Native(b.Texture()),
-      Native(packed.Texture()), CropOrFull(input, width, height), input.linearization.cam_mul,
-      input.sensor.orientation_flip);
+      command_buffer, Native(r), Native(g), Native(b), Native(packed.Texture()),
+      CropOrFull(input, width, height), input.linearization.cam_mul, input.sensor.orientation_flip);
 }
 
 }  // namespace
@@ -404,14 +389,14 @@ void ExecuteMetalDevelop(MetalRenderDevice& device, const ExecutionPlan& plan,
     throw std::runtime_error("ExecuteMetalDevelop: CFA plane must be tightly packed");
   }
 
-  auto cfa    = AcquireScratch(workspace, width, height, TextureFormat::R16u);
-  auto linear = AcquireScratch(workspace, width, height, TextureFormat::R32f);
-  workspace.Device().UploadTexture2D(cfa.Texture(), input.pixels.Span(), device.CommandContext());
+  auto& cfa    = AcquireScratch(workspace, width, height, TextureFormat::R16u);
+  auto& linear = AcquireScratch(workspace, width, height, TextureFormat::R32f);
+  workspace.Device().UploadTexture2D(cfa, input.pixels.Span(), device.CommandContext());
   auto* command_buffer = CommandBuffer(device);
-  metal::EncodeToLinearRef(command_buffer, Native(cfa.Texture()), Native(linear.Texture()),
-                           input.linearization, input.cfa_pattern);
+  metal::EncodeToLinearRef(command_buffer, Native(cfa), Native(linear), input.linearization,
+                           input.cfa_pattern);
   if (!hlr) {
-    metal::EncodeCfaClamp01(command_buffer, Native(linear.Texture()), width, height);
+    metal::EncodeCfaClamp01(command_buffer, Native(linear), width, height);
   }
 
   const auto method =

--- a/alcedo_studio/src/edit/runtime/metal/metal_local_tone_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_local_tone_pass.mm
@@ -166,16 +166,12 @@ void BindPlane(MTL::ComputeCommandEncoder* encoder, const Plane& plane, std::uin
 }
 
 auto AllocateTransientPlane(MetalRenderWorkspace& workspace, std::size_t bytes) -> Plane {
-  auto* ptr = workspace.TransientBuffers().Allocate(bytes);
-  if (ptr == nullptr) {
-    throw std::runtime_error("ExecuteMetalLocalTone: transient allocation failed");
-  }
-  const auto resolved = workspace.Device().ResolveDeviceMemory(ptr, bytes);
-  Plane      plane;
-  plane.ptr    = ptr;
-  plane.native = static_cast<MTL::Buffer*>(resolved.first);
-  plane.offset = resolved.second;
-  plane.bytes  = bytes;
+  auto& buffer = workspace.Device().AcquireRecordedWorkScratchBuffer(bytes);
+  Plane plane;
+  plane.ptr    = buffer.DevicePointer();
+  plane.native = static_cast<MTL::Buffer*>(buffer.Native());
+  plane.offset = 0;
+  plane.bytes  = buffer.Bytes();
   return plane;
 }
 
@@ -378,21 +374,21 @@ auto ExecuteMetalLocalTone(MetalRenderDevice& device, const MetalBackend::Textur
     return tone;
   }
 
-  const bool seed_canonical = full_edit;
+  const bool build_canonical = full_edit;
   const bool reuse_source =
       source_valid && !(full_edit && current_long_edge > meta.source_long_edge);
-  const auto                    mask_dims = seed_canonical || reuse_source
-                                                ? canonical_dims
-                                                : local_tone_mapping::ComputeMaskDimensions(
+  const auto mask_dims = build_canonical || reuse_source
+                             ? canonical_dims
+                             : local_tone_mapping::ComputeMaskDimensions(
                                    static_cast<int>(width), static_cast<int>(height),
                                    local_tone_mapping::kReferenceMaskMaxLongEdge);
-  const auto                    layout    = MakeLayout(mask_dims.width, mask_dims.height);
+  const auto layout = MakeLayout(mask_dims.width, mask_dims.height);
 
   std::array<Plane, kMaxLevels> source{};
   std::array<Plane, kMaxLevels> remap_a{};
   std::array<Plane, kMaxLevels> remap_b{};
   std::array<Plane, kMaxLevels> result{};
-  const auto                    mark = workspace.TransientBuffers().used_bytes();
+  const auto mark = workspace.Device().RecordedWorkScratchBufferBytes();
   for (int level = 0; level < layout.count; ++level) {
     const auto bytes =
         static_cast<std::size_t>(layout.widths[level]) * layout.heights[level] * sizeof(float);
@@ -406,11 +402,11 @@ auto ExecuteMetalLocalTone(MetalRenderDevice& device, const MetalBackend::Textur
     result[level]  = AllocateTransientPlane(workspace, bytes);
   }
   tone.transient_bytes =
-      static_cast<std::uint32_t>(workspace.TransientBuffers().used_bytes() - mark);
+      static_cast<std::uint32_t>(workspace.Device().RecordedWorkScratchBufferBytes() - mark);
 
   if (!reuse_source) {
     auto* encoder = Encoder(device);
-    if (seed_canonical) {
+    if (build_canonical) {
       auto pipeline = Pipeline("local_tone_extract_reference", "Metal LLF extract reference");
       ExtractReferenceParams params;
       params.input_width   = static_cast<std::int32_t>(width);
@@ -504,7 +500,7 @@ auto ExecuteMetalLocalTone(MetalRenderDevice& device, const MetalBackend::Textur
   }
 
   const Matrix3x3 apply_uv =
-      seed_canonical || reuse_source
+      build_canonical || reuse_source
           ? MakeLlfSamplingPlan(geometry, Extent2D{static_cast<std::uint32_t>(layout.widths[0]),
                                                    static_cast<std::uint32_t>(layout.heights[0])})
                 .render_to_texture_uv
@@ -512,7 +508,7 @@ auto ExecuteMetalLocalTone(MetalRenderDevice& device, const MetalBackend::Textur
   ApplyAdjusted(device, input, output, source[0], result[0], width, height, layout.widths[0],
                 layout.heights[0], apply_uv);
 
-  if (seed_canonical || reuse_source) {
+  if (build_canonical || reuse_source) {
     const auto bytes =
         static_cast<std::size_t>(layout.widths[0]) * layout.heights[0] * sizeof(float);
     auto& source_buffer = EnsureValueBuffer(workspace, LevelId(grade_id, "source", 0), bytes);

--- a/alcedo_studio/src/edit/runtime/metal/metal_mask_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_mask_pass.mm
@@ -205,16 +205,12 @@ auto EnsureValueBuffer(MetalRenderWorkspace& workspace, const GraphValueId& id, 
 }
 
 auto AllocateTransientPlane(MetalRenderWorkspace& workspace, std::size_t bytes) -> Plane {
-  auto* ptr = workspace.TransientBuffers().Allocate(bytes);
-  if (ptr == nullptr) {
-    throw std::runtime_error("ExecuteMetalMask: transient allocation failed");
-  }
-  const auto resolved = workspace.Device().ResolveDeviceMemory(ptr, bytes);
-  Plane      plane;
-  plane.ptr    = ptr;
-  plane.native = static_cast<MTL::Buffer*>(resolved.first);
-  plane.offset = resolved.second;
-  plane.bytes  = bytes;
+  auto& buffer = workspace.Device().AcquireRecordedWorkScratchBuffer(bytes);
+  Plane plane;
+  plane.ptr    = buffer.DevicePointer();
+  plane.native = static_cast<MTL::Buffer*>(buffer.Native());
+  plane.offset = 0;
+  plane.bytes  = buffer.Bytes();
   return plane;
 }
 
@@ -301,17 +297,12 @@ auto EncodeSignedDistance(MetalRenderDevice& device, const MetalBackend::Texture
   const auto pixels     = static_cast<std::size_t>(width) * height;
   const auto plane      = AlignUp(pixels * sizeof(float), kAlign);
   const auto sites      = AlignUp(pixels * sizeof(int), kAlign);
-  const auto needed     = plane * 3 + sites + plane;
-  auto&      transients = workspace.TransientBuffers();
-  if (transients.used_bytes() == 0) {
-    transients.Reserve(std::max(needed, transients.capacity_bytes()));
-  }
-  const auto mark                = transients.used_bytes();
-  const auto horizontal          = AllocateTransientPlane(workspace, plane);
-  const auto inside              = AllocateTransientPlane(workspace, plane);
-  const auto outside             = AllocateTransientPlane(workspace, plane);
-  const auto site_plane          = AllocateTransientPlane(workspace, sites);
-  const auto bound_plane         = AllocateTransientPlane(workspace, plane);
+  const auto mark        = workspace.Device().RecordedWorkScratchBufferBytes();
+  const auto horizontal  = AllocateTransientPlane(workspace, plane);
+  const auto inside      = AllocateTransientPlane(workspace, plane);
+  const auto outside     = AllocateTransientPlane(workspace, plane);
+  const auto site_plane  = AllocateTransientPlane(workspace, sites);
+  const auto bound_plane = AllocateTransientPlane(workspace, plane);
 
   auto       dispatch_horizontal = [&](bool target_inside, const Plane& dest) {
     auto*          encoder  = Encoder(device);
@@ -361,7 +352,7 @@ auto EncodeSignedDistance(MetalRenderDevice& device, const MetalBackend::Texture
   encoder->setBytes(&params, sizeof(params), 3);
   Dispatch2D(encoder, pipeline.get(), width, height);
   device.Workspace().Device().NoteComputeDispatch();
-  return static_cast<std::uint32_t>(workspace.TransientBuffers().used_bytes() - mark);
+  return static_cast<std::uint32_t>(workspace.Device().RecordedWorkScratchBufferBytes() - mark);
 }
 
 void EncodeFeatherSample(MetalRenderDevice& device, const MetalBackend::Buffer& distance,

--- a/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
@@ -53,8 +53,9 @@ auto AcquireRgba(MetalRenderWorkspace& workspace, const GraphValueId& id, std::u
 }
 
 auto AcquireScratch(MetalRenderWorkspace& workspace, std::uint32_t width, std::uint32_t height)
-    -> ResourceLease<MetalBackend> {
-  return workspace.Textures().Acquire({width, height, TextureFormat::Rgba32f});
+    -> MetalBackend::Texture2D& {
+  return workspace.Device().AcquireRecordedWorkScratchTexture(width, height,
+                                                              TextureFormat::Rgba32f);
 }
 
 auto EnsureBuffer(MetalRenderWorkspace& workspace, const GraphValueId& id, std::size_t bytes)
@@ -344,7 +345,7 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
   const bool  skip_mix    = mix == 1.0f && !plan.primary_grade_mask.has_value();
   const auto  write_count = CountGpuWrites(ops, skip_mix);
 
-  std::vector<ResourceLease<MetalBackend>> scratches;
+  std::vector<MetalBackend::Texture2D*> scratches;
   scratches.reserve(write_count + 1);
   auto remaining = write_count;
   enum class ImageSlot : std::uint8_t { Input, Scratch, Output };
@@ -371,7 +372,7 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
     if (scratch_index >= scratches.size()) {
       throw std::runtime_error("ExecuteMetalPrimaryGrade: scratch index is invalid");
     }
-    return scratches[scratch_index].Texture();
+    return *scratches[scratch_index];
   };
 
   auto AllocateDest = [&]() {
@@ -386,7 +387,7 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
     }
     dest_slot    = ImageSlot::Scratch;
     dest_scratch = scratches.size();
-    scratches.push_back(AcquireScratch(workspace, width, height));
+    scratches.push_back(&AcquireScratch(workspace, width, height));
   };
 
   if (write_count == 0) {

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_backend.cpp
@@ -309,6 +309,12 @@ OpenClBackend::OpenClBackend() {
   queue_   = context.ProductQueue();
   max_slab_bytes_device_ =
       AlignDownSlabBytes(static_cast<std::size_t>(context.Capabilities().max_single_allocation_bytes));
+  CheckOpenCl(clGetDeviceInfo(device_, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof(max_image_width_),
+                                &max_image_width_, nullptr),
+              "OpenClBackend: CL_DEVICE_IMAGE2D_MAX_WIDTH");
+  CheckOpenCl(clGetDeviceInfo(device_, CL_DEVICE_IMAGE2D_MAX_HEIGHT, sizeof(max_image_height_),
+                                &max_image_height_, nullptr),
+              "OpenClBackend: CL_DEVICE_IMAGE2D_MAX_HEIGHT");
   RegisterOpenClBackendPrograms();
   kernel_create_baseline_ = OpenClKernelCache::Instance().CreateCount();
   kernel_hit_baseline_    = OpenClKernelCache::Instance().HitCount();
@@ -349,6 +355,12 @@ auto OpenClBackend::EnqueueMarker(CommandContext& command_context) -> cl_event {
   return event;
 }
 
+void OpenClBackend::FlushQueue() {
+  CheckOpenCl(clFlush(queue_), "OpenClBackend::clFlush");
+  NoteOpenClFlush();
+  ++flush_count_;
+}
+
 auto OpenClBackend::CreateBuffer(std::size_t bytes) -> Buffer {
   if (bytes == 0) {
     return {};
@@ -360,8 +372,15 @@ auto OpenClBackend::CreateBuffer(std::size_t bytes) -> Buffer {
             << " exceeds device max allocation " << max_slab;
     throw std::runtime_error(message.str());
   }
+  if (GpuPoolTraceVerbose()) {
+    std::fprintf(stderr, "[GPU_POOL] OpenCL create buffer begin %.1f MiB\n", GpuPoolMiB(bytes));
+  }
   cl_int error  = CL_SUCCESS;
   cl_mem native = clCreateBuffer(context_, CL_MEM_READ_WRITE, bytes, nullptr, &error);
+  if (GpuPoolTraceVerbose()) {
+    std::fprintf(stderr, "[GPU_POOL] OpenCL create buffer end %.1f MiB status=%d\n",
+                 GpuPoolMiB(bytes), static_cast<int>(error));
+  }
   if (error != CL_SUCCESS) {
     std::ostringstream message;
     message << "OpenClBackend::CreateBuffer: OpenCL error " << error << " size=" << bytes
@@ -384,6 +403,12 @@ auto OpenClBackend::CreateTexture2D(std::uint32_t width, std::uint32_t height, T
   const auto bytes = static_cast<std::size_t>(width) * height * TextureFormatBytesPerPixel(format);
   if (bytes == 0) {
     return {};
+  }
+  if (max_image_width_ > 0 && (width > max_image_width_ || height > max_image_height_)) {
+    std::ostringstream message;
+    message << "OpenClBackend::CreateTexture2D: " << width << "x" << height
+            << " exceeds device IMAGE2D max " << max_image_width_ << "x" << max_image_height_;
+    throw std::runtime_error(message.str());
   }
   const auto    image_format = ImageFormatFor(format);
   cl_image_desc desc         = MakeImageDesc(width, height);
@@ -659,9 +684,7 @@ void OpenClBackend::CopyDeviceMemoryToBuffer(void* src, Buffer& dst, std::uint32
 
 void OpenClBackend::Submit(CommandContext& command_context) {
   EnqueueMarker(command_context);
-  CheckOpenCl(clFlush(queue_), "OpenClBackend::Submit clFlush");
-  NoteOpenClFlush();
-  ++flush_count_;
+  FlushQueue();
   in_flight_submission_ = command_context.SubmissionId();
 }
 
@@ -670,9 +693,7 @@ void OpenClBackend::FinalizePresentation(CommandContext& command_context) {
     throw std::runtime_error("OpenClBackend::FinalizePresentation: missing submission id");
   }
   EnqueueMarker(command_context);
-  CheckOpenCl(clFlush(queue_), "OpenClBackend::FinalizePresentation clFlush");
-  NoteOpenClFlush();
-  ++flush_count_;
+  FlushQueue();
   in_flight_submission_ = command_context.SubmissionId();
 }
 
@@ -686,6 +707,7 @@ void OpenClBackend::Wait(CommandContext& command_context) {
     cl_event last = completing_submission && command_context.FinalEvent() != nullptr
                         ? command_context.FinalEvent()
                         : command_context.live_events_.back();
+    FlushQueue();
     CheckOpenCl(clWaitForEvents(1, &last), "OpenClBackend::Wait");
     NoteOpenClFinalWait();
     ++wait_count_;
@@ -703,6 +725,7 @@ void OpenClBackend::Wait(CommandContext& command_context) {
 
 void OpenClBackend::SynchronizeRecordedWork(CommandContext& command_context) {
   cl_event event = EnqueueMarker(command_context);
+  FlushQueue();
   CheckOpenCl(clWaitForEvents(1, &event), "OpenClBackend::SynchronizeRecordedWork");
   NoteOpenClFinalWait();
   ++wait_count_;
@@ -722,6 +745,7 @@ void OpenClBackend::WarmUpPlan(const ExecutionPlan& plan) {
       add(kCoreProgramName, kCfaClamp01KernelName);
       add(kCvtRefSpaceProgramName, kPackPlanesCropInverseOrientKernelName);
       add(kCvtRefSpaceProgramName, kCopyRgbaCropInverseOrientKernelName);
+      add(kCvtRefSpaceProgramName, kCopyRgbCropInverseOrientKernelName);
       add(kHighlightProgramName, kHlrBuildMaskKernelName);
       add(kHighlightProgramName, kHlrDilateMaskKernelName);
       add(kHighlightProgramName, kHlrChrominanceContribKernelName);

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_backend.cpp
@@ -17,7 +17,7 @@
 #include "edit/runtime/develop_compile_source.hpp"
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/opencl/opencl_dag_programs.hpp"
-#include "edit/runtime/opencl/opencl_develop_pass.hpp"
+#include "edit/runtime/opencl/opencl_neural_session_workspace.hpp"
 #include "edit/runtime/pass_kind.hpp"
 #include "opencl/opencl_api_counters.hpp"
 #include "opencl/opencl_backend_program_registry.hpp"
@@ -322,6 +322,7 @@ OpenClBackend::OpenClBackend() {
 }
 
 OpenClBackend::~OpenClBackend() {
+  neural_workspace_.reset();
   dummy_lut_.Reset();
   lut_cache_.clear();
 }
@@ -697,8 +698,15 @@ void OpenClBackend::FinalizePresentation(CommandContext& command_context) {
   in_flight_submission_ = command_context.SubmissionId();
 }
 
+auto OpenClBackend::NeuralDemosaicWorkspace() -> OpenClNeuralSessionWorkspace& {
+  if (!neural_workspace_) {
+    neural_workspace_ = std::make_unique<OpenClNeuralSessionWorkspace>();
+  }
+  return *neural_workspace_;
+}
+
 void OpenClBackend::ReleaseNeuralDemosaicWorkspace() {
-  ReleaseOpenClDevelopNeuralWorkspace();
+  neural_workspace_.reset();
 }
 
 void OpenClBackend::Wait(CommandContext& command_context) {

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_backend.cpp
@@ -943,6 +943,17 @@ auto OpenClBackend::MaxSlabBytes() const -> std::size_t {
   return max_slab_bytes_device_;
 }
 
+auto OpenClBackend::MaxTransientBytes() const -> std::size_t {
+  auto& context = OpenClContext::Instance();
+  if (!context.IsInitialized()) {
+    return kTextureBudgetFloorBytes;
+  }
+  const auto& cap            = context.Capabilities();
+  const auto  total          = static_cast<std::size_t>(cap.global_memory_bytes);
+  const auto  three_quarters = total - total / 4;
+  return three_quarters > kTextureBudgetFloorBytes ? three_quarters : kTextureBudgetFloorBytes;
+}
+
 void OpenClBackend::SetMaxSlabBytes(std::size_t bytes) { max_slab_bytes_override_ = bytes; }
 
 auto OpenClBackend::WorkingSetBudgetBytes() const -> std::size_t {

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_develop_pass.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -20,7 +21,6 @@
 #include "decoders/processor/nn/demosaicnet_preprocess_common.hpp"
 #include "decoders/processor/nn/demosaicnet_specs.hpp"
 #include "decoders/processor/nn/opencl_demosaicnet_tiled.hpp"
-#include "decoders/processor/operators/gpu/opencl_demosaicnet_programs.hpp"
 #include "decoders/processor/operators/gpu/opencl_encode.hpp"
 #include "edit/geometry/types.hpp"
 #include "edit/graph/develop_color_transform.hpp"
@@ -32,12 +32,11 @@
 #include "edit/runtime/camera_color_gpu_params.hpp"
 #include "edit/runtime/develop_demosaic.hpp"
 #include "edit/runtime/opencl/opencl_dag_programs.hpp"
+#include "edit/runtime/opencl/opencl_neural_session_workspace.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/parameter_binding.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "gpu/gpu_pool_trace.hpp"
-#include "opencl/nn/activation_slots.hpp"
-#include "opencl/nn/device_buffer.hpp"
 #include "opencl/opencl_api_counters.hpp"
 #include "opencl/opencl_check.hpp"
 #include "opencl/opencl_kernel_cache.hpp"
@@ -76,25 +75,6 @@ struct ImageWarpParams {
   float         center_x = 0.5f;
   float         center_y = 0.5f;
 };
-
-struct OpenClNeuralSessionWorkspace {
-  OpenClDemosaicNetTiledExecutor executor;
-  opencl::nn::ActivationSlots    slots;
-  opencl::nn::DeviceBuffer       rgb_hwc;
-  opencl::nn::DeviceBuffer       cfa_table;
-
-  void                           Reset() {
-    executor = {};
-    slots    = {};
-    rgb_hwc.Reset();
-    cfa_table.Reset();
-  }
-};
-
-auto NeuralWorkspace() -> OpenClNeuralSessionWorkspace& {
-  static OpenClNeuralSessionWorkspace workspace;
-  return workspace;
-}
 
 auto AcquireRgba(OpenClRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
                  std::uint32_t height) -> ResourceLease<OpenClBackend>& {
@@ -338,8 +318,9 @@ void EncodeNeural(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
                              cache.LastError());
   }
 
-  auto&      neural  = NeuralWorkspace();
-  auto&      backend = device.Workspace().Device();
+  std::lock_guard<std::mutex> neural_decode(OpenClNeuralDecodeMutex());
+  auto&                       backend = device.Workspace().Device();
+  auto&                       neural  = backend.NeuralDemosaicWorkspace();
   const auto width   = input.host_extent.width;
   const auto height  = input.host_extent.height;
   if (linear.offset_bytes % sizeof(float) != 0) {
@@ -358,62 +339,55 @@ void EncodeNeural(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
   neural.cfa_table.UploadBytes(rgb_fc.data(), rgb_fc.size() * sizeof(int), backend.NativeQueue(),
                                false);
 
-  const std::size_t hwc3 = static_cast<std::size_t>(geometry->aligned_width) *
-                           geometry->aligned_height * 3 * sizeof(float);
-  neural.rgb_hwc.EnsureBytes(hwc3);
+  // Assemble tiles into RGBA. A second full-frame HWC3 plane plus HLR RGBA
+  // exceeds OpenCL MaxTransientBytes on 100MP (CL_DEVICE_MAX_MEM_ALLOC_SIZE
+  // packing), so the DAG path does not keep a 3-channel canvas.
+  const std::size_t rgba_bytes = static_cast<std::size_t>(geometry->aligned_width) *
+                                 geometry->aligned_height * 4 * sizeof(float);
+  void* rgba_ptr = device.Workspace().TransientBuffers().Allocate(rgba_bytes);
+  auto  rgba     = ViewFromPtr(backend, rgba_ptr, rgba_bytes);
+  if (rgba.offset_bytes % sizeof(float) != 0) {
+    throw std::runtime_error("ExecuteOpenClDevelop: Neural RGBA offset is not float-aligned");
+  }
 
   OpenClDemosaicNetTiledDispatch dispatch;
-  dispatch.input_mono_cfa     = linear.native;
-  dispatch.src_width          = static_cast<int>(width);
-  dispatch.src_height         = static_cast<int>(height);
-  dispatch.crop_x             = geometry->shift_sx;
-  dispatch.crop_y             = geometry->shift_sy;
-  dispatch.mono_offset_floats = static_cast<int>(linear.offset_bytes / sizeof(float));
-  dispatch.output_aligned_hwc = neural.rgb_hwc.get();
-  dispatch.aligned_width      = geometry->aligned_width;
-  dispatch.aligned_height     = geometry->aligned_height;
-  dispatch.rgb_fc             = neural.cfa_table.get();
-  dispatch.period             = period;
-  dispatch.queue              = backend.NativeQueue();
+  dispatch.input_mono_cfa       = linear.native;
+  dispatch.src_width            = static_cast<int>(width);
+  dispatch.src_height           = static_cast<int>(height);
+  dispatch.crop_x               = geometry->shift_sx;
+  dispatch.crop_y               = geometry->shift_sy;
+  dispatch.mono_offset_floats   = static_cast<int>(linear.offset_bytes / sizeof(float));
+  dispatch.output_aligned_hwc   = rgba.native;
+  dispatch.output_offset_floats = static_cast<int>(rgba.offset_bytes / sizeof(float));
+  dispatch.output_channels      = 4;
+  dispatch.aligned_width        = geometry->aligned_width;
+  dispatch.aligned_height       = geometry->aligned_height;
+  dispatch.rgb_fc               = neural.cfa_table.get();
+  dispatch.period               = period;
+  dispatch.queue                = backend.NativeQueue();
   if (is_bayer) {
     (void)neural.executor.EnqueueBayer(cache.Bayer(), neural.slots, dispatch);
   } else {
     (void)neural.executor.EnqueueXTrans(cache.XTrans(), neural.slots, dispatch);
   }
 
-  opencl::OpenClBufferView rgb{neural.rgb_hwc.get(), 0};
-  const auto               aligned_w = static_cast<std::uint32_t>(geometry->aligned_width);
-  const auto               aligned_h = static_cast<std::uint32_t>(geometry->aligned_height);
+  const auto aligned_w = static_cast<std::uint32_t>(geometry->aligned_width);
+  const auto aligned_h = static_cast<std::uint32_t>(geometry->aligned_height);
   if (hlr) {
-    auto&      transients = device.Workspace().TransientBuffers();
-    const auto rgba_bytes = static_cast<std::size_t>(aligned_w) * aligned_h * 4 * sizeof(float);
-    void*      rgba_ptr   = transients.Allocate(rgba_bytes);
-    auto       rgba       = ViewFromPtr(backend, rgba_ptr, rgba_bytes);
-    auto       kernel     = OpenClKernelCache::Instance().GetKernel(
-        OpenCL::DemosaicNet::kStructuralProgramName, OpenCL::DemosaicNet::kRgb3ToRgba4KernelName);
-    cl_mem    rgb_mem  = rgb.native;
-    cl_mem    rgba_mem = rgba.native;
-    const int w        = static_cast<int>(aligned_w);
-    const int h        = static_cast<int>(aligned_h);
-    const int rgb_off  = 0;
-    const int rgba_off = static_cast<int>(rgba.offset_bytes / sizeof(float));
-    CheckOpenCl(clSetKernelArg(kernel, 0, sizeof(cl_mem), &rgb_mem), "neural rgba 0");
-    CheckOpenCl(clSetKernelArg(kernel, 1, sizeof(cl_mem), &rgba_mem), "neural rgba 1");
-    CheckOpenCl(clSetKernelArg(kernel, 2, sizeof(int), &w), "neural rgba 2");
-    CheckOpenCl(clSetKernelArg(kernel, 3, sizeof(int), &h), "neural rgba 3");
-    CheckOpenCl(clSetKernelArg(kernel, 4, sizeof(int), &rgb_off), "neural rgba 4");
-    CheckOpenCl(clSetKernelArg(kernel, 5, sizeof(int), &rgba_off), "neural rgba 5");
-    DispatchKernel(device, kernel, aligned_w, aligned_h);
-    void* hlr_ptr = transients.Allocate(rgba_bytes);
-    auto  hlr_dst = ViewFromPtr(backend, hlr_ptr, rgba_bytes);
-    auto  scratch = AllocateHighlightScratch(device, aligned_w, aligned_h);
+    auto& transients = device.Workspace().TransientBuffers();
+    void* hlr_ptr    = transients.Allocate(rgba_bytes);
+    auto  hlr_dst    = ViewFromPtr(backend, hlr_ptr, rgba_bytes);
+    auto  scratch    = AllocateHighlightScratch(device, aligned_w, aligned_h);
     EncodeHighlightFromRgbaAndPack(stream, rgba, packed, input, aligned_w, aligned_h, hlr_dst,
                                    scratch);
-    return;
+  } else {
+    OpenCL::EncodeCopyRgbaCropInverseOrient(
+        stream, rgba, packed, CropOrFull(input, aligned_w, aligned_h), aligned_w,
+        input.linearization.cam_mul, input.sensor.orientation_flip);
   }
-  OpenCL::EncodeCopyRgbCropInverseOrient(
-      stream, rgb, packed, CropOrFull(input, aligned_w, aligned_h), aligned_w,
-      input.linearization.cam_mul, input.sensor.orientation_flip);
+  // Cached module kernels stay bound until this wait. Releasing the decode lock
+  // before the queue drains lets another device Reset those cl_kernel arguments.
+  backend.SynchronizeRecordedWork(device.CommandContext());
 }
 
 }  // namespace
@@ -421,8 +395,6 @@ void EncodeNeural(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
 void SetOpenClDevelopNeuralModelCacheForTesting(OpenClDemosaicNetModelCache* cache) {
   g_opencl_neural_cache_for_test = cache;
 }
-
-void ReleaseOpenClDevelopNeuralWorkspace() { NeuralWorkspace().Reset(); }
 
 void ExecuteOpenClDevelop(OpenClRenderDevice& device, const ExecutionPlan& plan,
                           const PreparedRawInput& input, PipelineDocument& document) {

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_develop_pass.cpp
@@ -13,14 +13,15 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
+#include "decoders/dng_default_crop.hpp"
 #include "decoders/processor/nn/demosaicnet_preprocess_common.hpp"
 #include "decoders/processor/nn/demosaicnet_specs.hpp"
 #include "decoders/processor/nn/opencl_demosaicnet_tiled.hpp"
 #include "decoders/processor/operators/gpu/opencl_demosaicnet_programs.hpp"
 #include "decoders/processor/operators/gpu/opencl_encode.hpp"
-#include "decoders/dng_default_crop.hpp"
 #include "edit/geometry/types.hpp"
 #include "edit/graph/develop_color_transform.hpp"
 #include "edit/graph/develop_node_model.hpp"
@@ -34,6 +35,7 @@
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/parameter_binding.hpp"
 #include "edit/runtime/texture_format.hpp"
+#include "gpu/gpu_pool_trace.hpp"
 #include "opencl/nn/activation_slots.hpp"
 #include "opencl/nn/device_buffer.hpp"
 #include "opencl/opencl_api_counters.hpp"
@@ -44,6 +46,12 @@ namespace alcedo {
 namespace {
 
 OpenClDemosaicNetModelCache* g_opencl_neural_cache_for_test = nullptr;
+
+void                         TraceDevelopStage(const char* stage) {
+  if (GpuPoolTraceVerbose()) {
+    std::fprintf(stderr, "[GPU_POOL] OpenCL Develop %s\n", stage);
+  }
+}
 
 struct GeometryResampleParams {
   float         m00;
@@ -72,19 +80,13 @@ struct ImageWarpParams {
 struct OpenClNeuralSessionWorkspace {
   OpenClDemosaicNetTiledExecutor executor;
   opencl::nn::ActivationSlots    slots;
-  opencl::nn::DeviceBuffer       linear_cfa;
-  opencl::nn::DeviceBuffer       mosaic_hwc;
   opencl::nn::DeviceBuffer       rgb_hwc;
-  opencl::nn::DeviceBuffer       rgba;
   opencl::nn::DeviceBuffer       cfa_table;
 
-  void Reset() {
-    executor  = {};
-    slots     = {};
-    linear_cfa.Reset();
-    mosaic_hwc.Reset();
+  void                           Reset() {
+    executor = {};
+    slots    = {};
     rgb_hwc.Reset();
-    rgba.Reset();
     cfa_table.Reset();
   }
 };
@@ -117,6 +119,26 @@ auto ViewFromPtr(OpenClBackend& backend, void* ptr, std::size_t bytes) -> opencl
   return opencl::OpenClBufferView{native, offset};
 }
 
+struct HighlightScratch {
+  opencl::OpenClBufferView mask;
+  opencl::OpenClBufferView dilated;
+  opencl::OpenClBufferView sums;
+  opencl::OpenClBufferView cnts;
+  opencl::OpenClBufferView clipped;
+};
+
+struct LegacyDemosaicScratch {
+  opencl::OpenClBufferView        green;
+  opencl::OpenClBufferView        rgba;
+  opencl::OpenClBufferView        hlr_rgba;
+  opencl::OpenClBufferView        r;
+  opencl::OpenClBufferView        g;
+  opencl::OpenClBufferView        b;
+  opencl::OpenClBufferView        vh;
+  opencl::OpenClBufferView        pq;
+  std::optional<HighlightScratch> highlight;
+};
+
 auto CropOrFull(const PreparedRawInput& input, std::uint32_t width, std::uint32_t height) -> RectI {
   if (input.demosaic_output_crop.width > 0 && input.demosaic_output_crop.height > 0) {
     return input.demosaic_output_crop;
@@ -137,8 +159,8 @@ void DispatchKernel(OpenClRenderDevice& device, cl_kernel kernel, std::uint32_t 
   device.Workspace().Device().TrackKernelEvent(device.CommandContext(), event);
 }
 
-void EncodeWarp(OpenClRenderDevice& device, cl_mem src, cl_mem dst, const dng::WarpRectilinear& warp,
-                std::uint32_t width, std::uint32_t height) {
+void EncodeWarp(OpenClRenderDevice& device, cl_mem src, cl_mem dst,
+                const dng::WarpRectilinear& warp, std::uint32_t width, std::uint32_t height) {
   ImageWarpParams params{};
   params.coefficient_set_count = warp.coefficient_set_count;
   params.width                 = width;
@@ -158,33 +180,34 @@ void EncodeWarp(OpenClRenderDevice& device, cl_mem src, cl_mem dst, const dng::W
   DispatchKernel(device, kernel, width, height);
 }
 
-void RewindDevelopScratch(OpenClRenderDevice& device) {
-  device.Workspace().Device().SynchronizeRecordedWork(device.CommandContext());
-  device.Workspace().TransientBuffers().Reset();
-}
-
-void EncodeHighlight(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
-                     opencl::OpenClBufferView src, opencl::OpenClBufferView dst,
-                     std::uint32_t width, std::uint32_t height, const float* cam_mul) {
-  auto&             backend    = device.Workspace().Device();
-  auto&             transients = device.Workspace().TransientBuffers();
-  const std::size_t mask_bytes = static_cast<std::size_t>(width) * height * 6;
-  void*             mask_ptr    = transients.Allocate(mask_bytes);
-  void*             dilated_ptr = transients.Allocate(mask_bytes);
-  void*             sums_ptr    = transients.Allocate(4 * sizeof(float));
-  void*             cnts_ptr    = transients.Allocate(4 * sizeof(float));
-  void*             clipped_ptr = transients.Allocate(sizeof(cl_int));
+void FillHighlightScratch(OpenClRenderDevice& device, void* mask_ptr, std::size_t mask_bytes,
+                          void* dilated_ptr, void* sums_ptr, void* cnts_ptr, void* clipped_ptr) {
+  auto& backend = device.Workspace().Device();
   backend.FillDeviceMemory(mask_ptr, mask_bytes, 0, device.CommandContext());
   backend.FillDeviceMemory(dilated_ptr, mask_bytes, 0, device.CommandContext());
   backend.FillDeviceMemory(sums_ptr, 4 * sizeof(float), 0, device.CommandContext());
   backend.FillDeviceMemory(cnts_ptr, 4 * sizeof(float), 0, device.CommandContext());
   backend.FillDeviceMemory(clipped_ptr, sizeof(cl_int), 0, device.CommandContext());
-  OpenCL::EncodeHighlightReconstruct(stream, src, dst, ViewFromPtr(backend, mask_ptr, mask_bytes),
-                                     ViewFromPtr(backend, dilated_ptr, mask_bytes),
-                                     ViewFromPtr(backend, sums_ptr, 4 * sizeof(float)),
-                                     ViewFromPtr(backend, cnts_ptr, 4 * sizeof(float)),
-                                     ViewFromPtr(backend, clipped_ptr, sizeof(cl_int)), cam_mul,
-                                     width, height);
+}
+
+auto AllocateHighlightScratch(OpenClRenderDevice& device, std::uint32_t width, std::uint32_t height)
+    -> HighlightScratch {
+  auto&             backend     = device.Workspace().Device();
+  auto&             transients  = device.Workspace().TransientBuffers();
+  const std::size_t mask_bytes  = static_cast<std::size_t>(width) * height * 6;
+  void*             mask_ptr    = transients.Allocate(mask_bytes);
+  void*             dilated_ptr = transients.Allocate(mask_bytes);
+  void*             sums_ptr    = transients.Allocate(4 * sizeof(float));
+  void*             cnts_ptr    = transients.Allocate(4 * sizeof(float));
+  void*             clipped_ptr = transients.Allocate(sizeof(cl_int));
+  FillHighlightScratch(device, mask_ptr, mask_bytes, dilated_ptr, sums_ptr, cnts_ptr, clipped_ptr);
+  return HighlightScratch{
+      .mask    = ViewFromPtr(backend, mask_ptr, mask_bytes),
+      .dilated = ViewFromPtr(backend, dilated_ptr, mask_bytes),
+      .sums    = ViewFromPtr(backend, sums_ptr, 4 * sizeof(float)),
+      .cnts    = ViewFromPtr(backend, cnts_ptr, 4 * sizeof(float)),
+      .clipped = ViewFromPtr(backend, clipped_ptr, sizeof(cl_int)),
+  };
 }
 
 void CopyRgbaToPacked(opencl::OpenClEncodeQueue& stream, opencl::OpenClBufferView src,
@@ -196,78 +219,93 @@ void CopyRgbaToPacked(opencl::OpenClEncodeQueue& stream, opencl::OpenClBufferVie
       apply_cam_mul ? input.linearization.cam_mul : identity, input.sensor.orientation_flip);
 }
 
-void EncodeHighlightFromRgbaImage(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
-                                  const OpenClBackend::Texture2D& src_image, cl_mem packed,
-                                  const PreparedRawInput& input, std::uint32_t width,
-                                  std::uint32_t height) {
-  auto&      backend    = device.Workspace().Device();
-  auto&      transients = device.Workspace().TransientBuffers();
-  RewindDevelopScratch(device);
-  const auto rgba_bytes = static_cast<std::size_t>(width) * height * 4 * sizeof(float);
-  void*      src_ptr    = transients.Allocate(rgba_bytes);
-  backend.CopyImageToDeviceMemory(src_image, src_ptr, rgba_bytes, device.CommandContext());
-  void* dst_ptr = transients.Allocate(rgba_bytes);
-  auto  src     = ViewFromPtr(backend, src_ptr, rgba_bytes);
-  auto  dst     = ViewFromPtr(backend, dst_ptr, rgba_bytes);
-  EncodeHighlight(device, stream, src, dst, width, height, input.linearization.cam_mul);
-  CopyRgbaToPacked(stream, dst, packed, input, width, height, true);
+void EncodeHighlightFromRgbaAndPack(opencl::OpenClEncodeQueue& stream, opencl::OpenClBufferView src,
+                                    cl_mem packed, const PreparedRawInput& input,
+                                    std::uint32_t src_width, std::uint32_t src_height,
+                                    opencl::OpenClBufferView dst, const HighlightScratch& scratch) {
+  OpenCL::EncodeHighlightReconstruct(stream, src, dst, scratch.mask, scratch.dilated, scratch.sums,
+                                     scratch.cnts, scratch.clipped, input.linearization.cam_mul,
+                                     src_width, src_height);
+  CopyRgbaToPacked(stream, dst, packed, input, src_width, src_height, true);
 }
 
-void EncodeLegacyDemosaic(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
-                          const PreparedRawInput& input, opencl::OpenClBufferView linear,
-                          cl_mem packed, bool hlr) {
-  auto&      backend     = device.Workspace().Device();
+void EncodePlanarHighlightAndPack(opencl::OpenClEncodeQueue& stream, opencl::OpenClBufferView r,
+                                  opencl::OpenClBufferView g, opencl::OpenClBufferView b,
+                                  cl_mem packed, const PreparedRawInput& input,
+                                  std::uint32_t plane_width, std::uint32_t plane_height,
+                                  const HighlightScratch& scratch) {
+  const auto crop = CropOrFull(input, plane_width, plane_height);
+  OpenCL::EncodeHighlightReconstructPlanarAndPack(stream, r, g, b, packed, scratch.mask,
+                                                  scratch.dilated, scratch.sums, scratch.cnts,
+                                                  scratch.clipped, input.linearization.cam_mul,
+                                                  crop, plane_width, input.sensor.orientation_flip);
+}
+
+auto AllocateLegacyDemosaicScratch(OpenClRenderDevice& device, const PreparedRawInput& input,
+                                   bool hlr) -> LegacyDemosaicScratch {
   auto&      transients  = device.Workspace().TransientBuffers();
+  auto&      backend     = device.Workspace().Device();
   const auto width       = input.host_extent.width;
   const auto height      = input.host_extent.height;
   const auto plane_bytes = static_cast<std::size_t>(width) * height * sizeof(float);
   const auto rgba_bytes  = plane_bytes * 4;
+  auto       allocate    = [&](std::size_t bytes) {
+    return ViewFromPtr(backend, transients.Allocate(bytes), bytes);
+  };
+
+  LegacyDemosaicScratch scratch;
+  if (input.cfa_pattern.kind == RawCfaKind::XTrans6x6) {
+    scratch.green = allocate(plane_bytes);
+    scratch.rgba  = allocate(rgba_bytes);
+    if (hlr) {
+      scratch.hlr_rgba  = allocate(rgba_bytes);
+      scratch.highlight = AllocateHighlightScratch(device, width, height);
+    }
+    return scratch;
+  }
+
+  scratch.r  = allocate(plane_bytes);
+  scratch.g  = allocate(plane_bytes);
+  scratch.b  = allocate(plane_bytes);
+  scratch.vh = allocate(plane_bytes);
+  scratch.pq = allocate(plane_bytes);
+  if (hlr) {
+    const auto crop   = CropOrFull(input, width, height);
+    scratch.highlight = AllocateHighlightScratch(device, static_cast<std::uint32_t>(crop.width),
+                                                 static_cast<std::uint32_t>(crop.height));
+  }
+  return scratch;
+}
+
+void EncodeLegacyDemosaic(opencl::OpenClEncodeQueue& stream, const PreparedRawInput& input,
+                          opencl::OpenClBufferView linear, cl_mem packed, bool hlr,
+                          const LegacyDemosaicScratch& scratch) {
+  const auto width  = input.host_extent.width;
+  const auto height = input.host_extent.height;
 
   if (input.cfa_pattern.kind == RawCfaKind::XTrans6x6) {
-    void* green_ptr = transients.Allocate(plane_bytes);
-    void* rgba_ptr  = transients.Allocate(rgba_bytes);
-    auto  rgba      = ViewFromPtr(backend, rgba_ptr, rgba_bytes);
-    OpenCL::EncodeXTrans(stream, linear, ViewFromPtr(backend, green_ptr, plane_bytes), rgba,
+    OpenCL::EncodeXTrans(stream, linear, scratch.green, scratch.rgba,
                          input.cfa_pattern.xtrans_pattern, width, height,
                          input.downsample_passes == 0 ? 3 : 1);
     if (hlr) {
-      auto rgba_image =
-          device.Workspace().Textures().Acquire({width, height, TextureFormat::Rgba32f});
-      backend.CopyDeviceMemoryToImage(rgba_ptr, rgba_image.Texture(), device.CommandContext());
-      EncodeHighlightFromRgbaImage(device, stream, rgba_image.Texture(), packed, input, width,
-                                   height);
+      EncodeHighlightFromRgbaAndPack(stream, scratch.rgba, packed, input, width, height,
+                                     scratch.hlr_rgba, *scratch.highlight);
       return;
     }
-    CopyRgbaToPacked(stream, rgba, packed, input, width, height, true);
+    CopyRgbaToPacked(stream, scratch.rgba, packed, input, width, height, true);
     return;
   }
 
-  void* r_ptr  = transients.Allocate(plane_bytes);
-  void* g_ptr  = transients.Allocate(plane_bytes);
-  void* b_ptr  = transients.Allocate(plane_bytes);
-  void* vh_ptr = transients.Allocate(plane_bytes);
-  void* pq_ptr = transients.Allocate(plane_bytes);
-  auto  r      = ViewFromPtr(backend, r_ptr, plane_bytes);
-  auto  g      = ViewFromPtr(backend, g_ptr, plane_bytes);
-  auto  b      = ViewFromPtr(backend, b_ptr, plane_bytes);
-  OpenCL::EncodeBayerRcd(stream, linear, r, g, b, ViewFromPtr(backend, vh_ptr, plane_bytes),
-                         ViewFromPtr(backend, pq_ptr, plane_bytes), input.cfa_pattern.bayer_pattern,
-                         width, height);
+  OpenCL::EncodeBayerRcd(stream, linear, scratch.r, scratch.g, scratch.b, scratch.vh, scratch.pq,
+                         input.cfa_pattern.bayer_pattern, width, height);
   if (hlr) {
-    const float identity[4] = {1.0f, 1.0f, 1.0f, 1.0f};
-    auto        rgba_image =
-        device.Workspace().Textures().Acquire({width, height, TextureFormat::Rgba32f});
-    OpenCL::EncodePackPlanesCropInverseOrient(
-        stream, r, g, b, rgba_image.Texture().Native(),
-        RectI{0, 0, static_cast<int>(width), static_cast<int>(height)}, width, identity, 0);
-    EncodeHighlightFromRgbaImage(device, stream, rgba_image.Texture(), packed, input, width,
-                                 height);
+    EncodePlanarHighlightAndPack(stream, scratch.r, scratch.g, scratch.b, packed, input, width,
+                                 height, *scratch.highlight);
     return;
   }
-  OpenCL::EncodePackPlanesCropInverseOrient(stream, r, g, b, packed,
-                                            CropOrFull(input, width, height), width,
-                                            input.linearization.cam_mul,
-                                            input.sensor.orientation_flip);
+  OpenCL::EncodePackPlanesCropInverseOrient(
+      stream, scratch.r, scratch.g, scratch.b, packed, CropOrFull(input, width, height), width,
+      input.linearization.cam_mul, input.sensor.orientation_flip);
 }
 
 void EncodeNeural(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
@@ -277,9 +315,9 @@ void EncodeNeural(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
   const int   min_spatial = input.cfa_pattern.kind == RawCfaKind::XTrans6x6
                                 ? DemosaicNetXTransSpec::kMinSpatial
                                 : DemosaicNetBayerSpec::kMinSpatial;
-  const auto geometry = ComputeNeuralAlignedGeometry(
-      input.cfa_pattern, static_cast<int>(input.host_extent.width),
-      static_cast<int>(input.host_extent.height), min_spatial, &error);
+  const auto  geometry =
+      ComputeNeuralAlignedGeometry(input.cfa_pattern, static_cast<int>(input.host_extent.width),
+                                   static_cast<int>(input.host_extent.height), min_spatial, &error);
   if (!geometry.has_value()) {
     throw std::runtime_error("ExecuteOpenClDevelop: Neural Engine preprocess failed: " + error);
   }
@@ -288,11 +326,11 @@ void EncodeNeural(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
   if (g_opencl_neural_cache_for_test != nullptr) {
     load_options.model_dir = "alcedo-missing-demosaicnet-models";
   }
-  OpenClDemosaicNetModelCache& cache = g_opencl_neural_cache_for_test == nullptr
-                                           ? OpenClDemosaicNetModelCache::Instance()
-                                           : *g_opencl_neural_cache_for_test;
-  const bool is_bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
-  const auto variant =
+  OpenClDemosaicNetModelCache& cache    = g_opencl_neural_cache_for_test == nullptr
+                                              ? OpenClDemosaicNetModelCache::Instance()
+                                              : *g_opencl_neural_cache_for_test;
+  const bool                   is_bayer = input.cfa_pattern.kind == RawCfaKind::Bayer2x2;
+  const auto                   variant =
       is_bayer ? OpenClDemosaicNetVariant::Bayer : OpenClDemosaicNetVariant::XTrans;
   load_options.queue = device.Workspace().Device().NativeQueue();
   if (!cache.EnsureLoaded(variant, load_options)) {
@@ -300,17 +338,13 @@ void EncodeNeural(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
                              cache.LastError());
   }
 
-  auto&       neural     = NeuralWorkspace();
-  auto&       backend    = device.Workspace().Device();
-  const auto  width      = input.host_extent.width;
-  const auto  height     = input.host_extent.height;
-  const auto  plane_bytes = static_cast<std::size_t>(width) * height * sizeof(float);
-  neural.linear_cfa.EnsureBytes(plane_bytes);
-  cl_event copy_event = nullptr;
-  CheckOpenCl(clEnqueueCopyBuffer(backend.NativeQueue(), linear.native, neural.linear_cfa.get(),
-                                  linear.offset_bytes, 0, plane_bytes, 0, nullptr, &copy_event),
-              "OpenCL Neural linear copy");
-  backend.TrackKernelEvent(device.CommandContext(), copy_event);
+  auto&      neural  = NeuralWorkspace();
+  auto&      backend = device.Workspace().Device();
+  const auto width   = input.host_extent.width;
+  const auto height  = input.host_extent.height;
+  if (linear.offset_bytes % sizeof(float) != 0) {
+    throw std::runtime_error("ExecuteOpenClDevelop: Neural CFA offset is not float-aligned");
+  }
 
   const RawCfaPattern training = DemosaicNetTrainingPattern(input.cfa_pattern.kind);
   const int           period   = CfaPeriod(training.kind);
@@ -324,39 +358,22 @@ void EncodeNeural(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
   neural.cfa_table.UploadBytes(rgb_fc.data(), rgb_fc.size() * sizeof(int), backend.NativeQueue(),
                                false);
 
-  const std::size_t hwc3 =
-      static_cast<std::size_t>(geometry->aligned_width) * geometry->aligned_height * 3 *
-      sizeof(float);
-  neural.mosaic_hwc.EnsureBytes(hwc3);
+  const std::size_t hwc3 = static_cast<std::size_t>(geometry->aligned_width) *
+                           geometry->aligned_height * 3 * sizeof(float);
   neural.rgb_hwc.EnsureBytes(hwc3);
-  neural.rgba.EnsureBytes(static_cast<std::size_t>(geometry->aligned_width) *
-                          geometry->aligned_height * 4 * sizeof(float));
-
-  auto pack = OpenClKernelCache::Instance().GetKernel(OpenCL::DemosaicNet::kStructuralProgramName,
-                                                      OpenCL::DemosaicNet::kPackCfaMonoToHwc3KernelName);
-  cl_mem linear_mem = neural.linear_cfa.get();
-  cl_mem mosaic_mem = neural.mosaic_hwc.get();
-  cl_mem table_mem  = neural.cfa_table.get();
-  const int src_w   = static_cast<int>(width);
-  const int src_h   = static_cast<int>(height);
-  CheckOpenCl(clSetKernelArg(pack, 0, sizeof(cl_mem), &linear_mem), "neural pack 0");
-  CheckOpenCl(clSetKernelArg(pack, 1, sizeof(cl_mem), &mosaic_mem), "neural pack 1");
-  CheckOpenCl(clSetKernelArg(pack, 2, sizeof(int), &src_w), "neural pack 2");
-  CheckOpenCl(clSetKernelArg(pack, 3, sizeof(int), &src_h), "neural pack 3");
-  CheckOpenCl(clSetKernelArg(pack, 4, sizeof(int), &geometry->shift_sx), "neural pack 4");
-  CheckOpenCl(clSetKernelArg(pack, 5, sizeof(int), &geometry->shift_sy), "neural pack 5");
-  CheckOpenCl(clSetKernelArg(pack, 6, sizeof(int), &geometry->aligned_width), "neural pack 6");
-  CheckOpenCl(clSetKernelArg(pack, 7, sizeof(int), &geometry->aligned_height), "neural pack 7");
-  CheckOpenCl(clSetKernelArg(pack, 8, sizeof(int), &period), "neural pack 8");
-  CheckOpenCl(clSetKernelArg(pack, 9, sizeof(cl_mem), &table_mem), "neural pack 9");
-  DispatchKernel(device, pack, static_cast<std::uint32_t>(geometry->aligned_width),
-                 static_cast<std::uint32_t>(geometry->aligned_height));
 
   OpenClDemosaicNetTiledDispatch dispatch;
-  dispatch.input_aligned_hwc  = neural.mosaic_hwc.get();
+  dispatch.input_mono_cfa     = linear.native;
+  dispatch.src_width          = static_cast<int>(width);
+  dispatch.src_height         = static_cast<int>(height);
+  dispatch.crop_x             = geometry->shift_sx;
+  dispatch.crop_y             = geometry->shift_sy;
+  dispatch.mono_offset_floats = static_cast<int>(linear.offset_bytes / sizeof(float));
   dispatch.output_aligned_hwc = neural.rgb_hwc.get();
   dispatch.aligned_width      = geometry->aligned_width;
   dispatch.aligned_height     = geometry->aligned_height;
+  dispatch.rgb_fc             = neural.cfa_table.get();
+  dispatch.period             = period;
   dispatch.queue              = backend.NativeQueue();
   if (is_bayer) {
     (void)neural.executor.EnqueueBayer(cache.Bayer(), neural.slots, dispatch);
@@ -364,31 +381,39 @@ void EncodeNeural(OpenClRenderDevice& device, opencl::OpenClEncodeQueue& stream,
     (void)neural.executor.EnqueueXTrans(cache.XTrans(), neural.slots, dispatch);
   }
 
-  auto rgb_to_rgba = OpenClKernelCache::Instance().GetKernel(
-      OpenCL::DemosaicNet::kStructuralProgramName, OpenCL::DemosaicNet::kRgb3ToRgba4KernelName);
-  cl_mem rgb_mem  = neural.rgb_hwc.get();
-  cl_mem rgba_mem = neural.rgba.get();
-  CheckOpenCl(clSetKernelArg(rgb_to_rgba, 0, sizeof(cl_mem), &rgb_mem), "neural rgba 0");
-  CheckOpenCl(clSetKernelArg(rgb_to_rgba, 1, sizeof(cl_mem), &rgba_mem), "neural rgba 1");
-  CheckOpenCl(clSetKernelArg(rgb_to_rgba, 2, sizeof(int), &geometry->aligned_width), "neural rgba 2");
-  CheckOpenCl(clSetKernelArg(rgb_to_rgba, 3, sizeof(int), &geometry->aligned_height), "neural rgba 3");
-  DispatchKernel(device, rgb_to_rgba, static_cast<std::uint32_t>(geometry->aligned_width),
-                 static_cast<std::uint32_t>(geometry->aligned_height));
-
-  opencl::OpenClBufferView rgba{neural.rgba.get(), 0};
-  const auto aligned_w = static_cast<std::uint32_t>(geometry->aligned_width);
-  const auto aligned_h = static_cast<std::uint32_t>(geometry->aligned_height);
+  opencl::OpenClBufferView rgb{neural.rgb_hwc.get(), 0};
+  const auto               aligned_w = static_cast<std::uint32_t>(geometry->aligned_width);
+  const auto               aligned_h = static_cast<std::uint32_t>(geometry->aligned_height);
   if (hlr) {
-    RewindDevelopScratch(device);
-    const auto rgba_bytes =
-        static_cast<std::size_t>(aligned_w) * aligned_h * 4 * sizeof(float);
-    void* hlr_ptr = device.Workspace().TransientBuffers().Allocate(rgba_bytes);
+    auto&      transients = device.Workspace().TransientBuffers();
+    const auto rgba_bytes = static_cast<std::size_t>(aligned_w) * aligned_h * 4 * sizeof(float);
+    void*      rgba_ptr   = transients.Allocate(rgba_bytes);
+    auto       rgba       = ViewFromPtr(backend, rgba_ptr, rgba_bytes);
+    auto       kernel     = OpenClKernelCache::Instance().GetKernel(
+        OpenCL::DemosaicNet::kStructuralProgramName, OpenCL::DemosaicNet::kRgb3ToRgba4KernelName);
+    cl_mem    rgb_mem  = rgb.native;
+    cl_mem    rgba_mem = rgba.native;
+    const int w        = static_cast<int>(aligned_w);
+    const int h        = static_cast<int>(aligned_h);
+    const int rgb_off  = 0;
+    const int rgba_off = static_cast<int>(rgba.offset_bytes / sizeof(float));
+    CheckOpenCl(clSetKernelArg(kernel, 0, sizeof(cl_mem), &rgb_mem), "neural rgba 0");
+    CheckOpenCl(clSetKernelArg(kernel, 1, sizeof(cl_mem), &rgba_mem), "neural rgba 1");
+    CheckOpenCl(clSetKernelArg(kernel, 2, sizeof(int), &w), "neural rgba 2");
+    CheckOpenCl(clSetKernelArg(kernel, 3, sizeof(int), &h), "neural rgba 3");
+    CheckOpenCl(clSetKernelArg(kernel, 4, sizeof(int), &rgb_off), "neural rgba 4");
+    CheckOpenCl(clSetKernelArg(kernel, 5, sizeof(int), &rgba_off), "neural rgba 5");
+    DispatchKernel(device, kernel, aligned_w, aligned_h);
+    void* hlr_ptr = transients.Allocate(rgba_bytes);
     auto  hlr_dst = ViewFromPtr(backend, hlr_ptr, rgba_bytes);
-    EncodeHighlight(device, stream, rgba, hlr_dst, aligned_w, aligned_h,
-                    input.linearization.cam_mul);
-    rgba = hlr_dst;
+    auto  scratch = AllocateHighlightScratch(device, aligned_w, aligned_h);
+    EncodeHighlightFromRgbaAndPack(stream, rgba, packed, input, aligned_w, aligned_h, hlr_dst,
+                                   scratch);
+    return;
   }
-  CopyRgbaToPacked(stream, rgba, packed, input, aligned_w, aligned_h, true);
+  OpenCL::EncodeCopyRgbCropInverseOrient(
+      stream, rgb, packed, CropOrFull(input, aligned_w, aligned_h), aligned_w,
+      input.linearization.cam_mul, input.sensor.orientation_flip);
 }
 
 }  // namespace
@@ -413,36 +438,19 @@ void ExecuteOpenClDevelop(OpenClRenderDevice& device, const ExecutionPlan& plan,
   if (workspace.Textures().ByteBudget() == 0) {
     workspace.Textures().SetByteBudget(OpenClBackend::DefaultTextureBudgetBytes());
   }
-  const auto flags = develop->Params().Params();
-  const bool hlr   = flags.highlights_reconstruct;
-  const auto host_pixels =
-      static_cast<std::size_t>(input.host_extent.width) * input.host_extent.height;
-  const bool cfa_input = input.input_kind != RawInputKind::DebayeredRgb &&
-                         plan.source.kind != DevelopInputKind::DirectRgb;
-  std::size_t opencl_need = plan.peak_transient_bytes;
-  if (cfa_input && hlr && host_pixels > 0) {
-    // Exclusive HLR working set after demosaic planes are rewound: RGBA src, RGBA dst,
-    // 6-byte mask + dilated mask, and bump padding. Take the max with the compiled
-    // peak; do not add this on top of LLF, which does not run concurrently.
-    const auto hlr_bytes =
-        host_pixels * 16ull + host_pixels * 16ull + host_pixels * 12ull + (64ull * 256ull);
-    if (hlr_bytes > opencl_need) {
-      opencl_need = hlr_bytes;
-    }
-  }
-  if (opencl_need > 0) {
-    workspace.TransientBuffers().Reserve(opencl_need);
-  }
+  const auto         flags       = develop->Params().Params();
+  const bool         hlr         = flags.highlights_reconstruct;
   const auto         out_w       = plan.source.develop_output_extent.width;
   const auto         out_h       = plan.source.develop_output_extent.height;
   const GraphValueId sensor_id   = plan.sensor_linear_output;
   const GraphValueId demosaic_id = input.dng_warp_rectilinear.has_value()
                                        ? GraphValueId{NodeId{"develop"}, PortId{"sensor_unwarped"}}
                                        : sensor_id;
-  auto& decoded_lease = AcquireRgba(workspace, demosaic_id, out_w, out_h);
-
   if (input.input_kind == RawInputKind::DebayeredRgb ||
       plan.source.kind == DevelopInputKind::DirectRgb) {
+    TraceDevelopStage("acquire output begin");
+    auto& decoded_lease = AcquireRgba(workspace, demosaic_id, out_w, out_h);
+    TraceDevelopStage("acquire output end");
     if (input.pixels.format != HostPixelFormat::F32Rgba ||
         input.pixels.ByteCount() != decoded_lease.Texture().Bytes()) {
       throw std::runtime_error("ExecuteOpenClDevelop: direct RGB size does not match output");
@@ -464,27 +472,45 @@ void ExecuteOpenClDevelop(OpenClRenderDevice& device, const ExecutionPlan& plan,
     throw std::runtime_error("ExecuteOpenClDevelop: CFA plane must be tightly packed");
   }
 
-  auto&       backend      = workspace.Device();
-  auto&       transients   = workspace.TransientBuffers();
-  const auto  u16_bytes    = static_cast<std::size_t>(width) * height * sizeof(std::uint16_t);
-  const auto  f32_bytes    = static_cast<std::size_t>(width) * height * sizeof(float);
-  void*       u16_ptr      = transients.Allocate(u16_bytes);
-  void*       f32_ptr      = transients.Allocate(f32_bytes);
+  auto&      backend    = workspace.Device();
+  auto&      transients = workspace.TransientBuffers();
+  const auto u16_bytes  = static_cast<std::size_t>(width) * height * sizeof(std::uint16_t);
+  const auto f32_bytes  = static_cast<std::size_t>(width) * height * sizeof(float);
+  void*      u16_ptr    = transients.Allocate(u16_bytes);
+  TraceDevelopStage("allocate CFA U16 end");
+  void* f32_ptr = transients.Allocate(f32_bytes);
+  TraceDevelopStage("allocate linear F32 end");
+  const auto method =
+      ResolveDevelopDemosaicMethod(flags, input.cfa_pattern.kind, input.downsample_passes);
+  std::optional<LegacyDemosaicScratch> legacy_scratch;
+  if (method != RawDemosaicMethod::NeuralEngine) {
+    legacy_scratch.emplace(AllocateLegacyDemosaicScratch(device, input, hlr));
+    TraceDevelopStage("allocate legacy scratch end");
+  }
+  TraceDevelopStage("acquire output begin");
+  auto& decoded_lease = AcquireRgba(workspace, demosaic_id, out_w, out_h);
+  TraceDevelopStage("acquire output end");
   backend.UploadDeviceMemory(u16_ptr, input.pixels.Span(), device.CommandContext());
+  TraceDevelopStage("enqueue CFA upload end");
   auto stream = MakeEncodeQueue(device);
   auto linear = ViewFromPtr(backend, f32_ptr, f32_bytes);
   OpenCL::EncodeToLinearRef(stream, ViewFromPtr(backend, u16_ptr, u16_bytes), linear, width, height,
                             input.linearization, input.cfa_pattern);
+  TraceDevelopStage("enqueue linearize end");
   if (!hlr) {
     OpenCL::EncodeCfaClamp01(stream, linear, width, height);
+    TraceDevelopStage("enqueue CFA clamp end");
   }
 
-  const auto method =
-      ResolveDevelopDemosaicMethod(flags, input.cfa_pattern.kind, input.downsample_passes);
   if (method == RawDemosaicMethod::NeuralEngine) {
+    TraceDevelopStage("neural begin");
     EncodeNeural(device, stream, input, linear, decoded_lease.Texture().Native(), hlr);
+    TraceDevelopStage("neural end");
   } else {
-    EncodeLegacyDemosaic(device, stream, input, linear, decoded_lease.Texture().Native(), hlr);
+    TraceDevelopStage("legacy demosaic begin");
+    EncodeLegacyDemosaic(stream, input, linear, decoded_lease.Texture().Native(), hlr,
+                         *legacy_scratch);
+    TraceDevelopStage("legacy demosaic end");
   }
 
   if (input.dng_warp_rectilinear.has_value()) {
@@ -599,8 +625,8 @@ void ExecuteOpenClCameraColor(OpenClRenderDevice& device, const ExecutionPlan& p
   cl_mem     dst_mem       = output.Texture().Native();
   cl_mem     params_mem    = arena.DeviceBuffer().Native();
   const auto offset_floats = binding.offset / static_cast<std::uint32_t>(sizeof(float));
-  auto       kernel        = OpenClKernelCache::Instance().GetKernel(
-      OpenCL::GpuDag::kGeometryCameraProgramName, OpenCL::GpuDag::kCameraColorKernelName);
+  auto kernel = OpenClKernelCache::Instance().GetKernel(OpenCL::GpuDag::kGeometryCameraProgramName,
+                                                        OpenCL::GpuDag::kCameraColorKernelName);
   CheckOpenCl(clSetKernelArg(kernel, 0, sizeof(cl_mem), &src_mem), "camera arg0");
   CheckOpenCl(clSetKernelArg(kernel, 1, sizeof(cl_mem), &dst_mem), "camera arg1");
   CheckOpenCl(clSetKernelArg(kernel, 2, sizeof(cl_mem), &params_mem), "camera arg2");

--- a/alcedo_studio/src/include/cuda/cuda_slab_backend.hpp
+++ b/alcedo_studio/src/include/cuda/cuda_slab_backend.hpp
@@ -22,14 +22,17 @@ struct CudaSlabBackend {
   class Slab {
    public:
     Slab() = default;
-    Slab(void* ptr, std::size_t bytes) : ptr_(ptr), bytes_(bytes) {}
+    Slab(void* ptr, std::size_t bytes, bool owns = true)
+        : ptr_(ptr), bytes_(bytes), owns_(owns) {}
 
     Slab(const Slab&)            = delete;
     auto operator=(const Slab&) -> Slab& = delete;
 
-    Slab(Slab&& other) noexcept : ptr_(other.ptr_), bytes_(other.bytes_) {
+    Slab(Slab&& other) noexcept
+        : ptr_(other.ptr_), bytes_(other.bytes_), owns_(other.owns_) {
       other.ptr_   = nullptr;
       other.bytes_ = 0;
+      other.owns_  = true;
     }
 
     auto operator=(Slab&& other) noexcept -> Slab& {
@@ -37,8 +40,10 @@ struct CudaSlabBackend {
         Reset();
         ptr_         = other.ptr_;
         bytes_       = other.bytes_;
+        owns_        = other.owns_;
         other.ptr_   = nullptr;
         other.bytes_ = 0;
+        other.owns_  = true;
       }
       return *this;
     }
@@ -46,11 +51,12 @@ struct CudaSlabBackend {
     ~Slab() { Reset(); }
 
     void Reset() noexcept {
-      if (ptr_ != nullptr) {
+      if (owns_ && ptr_ != nullptr) {
         ::cudaFree(ptr_);
-        ptr_ = nullptr;
       }
+      ptr_   = nullptr;
       bytes_ = 0;
+      owns_  = true;
     }
 
     [[nodiscard]] auto DevicePointer() const -> void* { return ptr_; }
@@ -59,7 +65,12 @@ struct CudaSlabBackend {
    private:
     void*       ptr_   = nullptr;
     std::size_t bytes_ = 0;
+    bool        owns_  = true;
   };
+
+  [[nodiscard]] auto BorrowSlab(void* ptr, std::size_t bytes) -> Slab {
+    return Slab{ptr, bytes, false};
+  }
 
   [[nodiscard]] auto CreateSlab(std::size_t bytes) -> Slab {
     if (bytes == 0) {

--- a/alcedo_studio/src/include/cuda/nn/device_buffer.hpp
+++ b/alcedo_studio/src/include/cuda/nn/device_buffer.hpp
@@ -42,9 +42,11 @@ class DeviceBuffer {
   DeviceBuffer(const DeviceBuffer&)            = delete;
   DeviceBuffer& operator=(const DeviceBuffer&) = delete;
 
-  DeviceBuffer(DeviceBuffer&& other) noexcept : ptr_(other.ptr_), count_(other.count_) {
+  DeviceBuffer(DeviceBuffer&& other) noexcept
+      : ptr_(other.ptr_), count_(other.count_), owns_(other.owns_) {
     other.ptr_   = nullptr;
     other.count_ = 0;
+    other.owns_  = true;
   }
 
   auto operator=(DeviceBuffer&& other) noexcept -> DeviceBuffer& {
@@ -52,10 +54,21 @@ class DeviceBuffer {
       Reset();
       ptr_         = other.ptr_;
       count_       = other.count_;
+      owns_        = other.owns_;
       other.ptr_   = nullptr;
       other.count_ = 0;
+      other.owns_  = true;
     }
     return *this;
+  }
+
+  /** @brief Non-owning view. Destructor does not cudaFree. */
+  static auto Wrap(T* ptr, std::size_t count) -> DeviceBuffer {
+    DeviceBuffer buffer;
+    buffer.ptr_   = ptr;
+    buffer.count_ = count;
+    buffer.owns_  = false;
+    return buffer;
   }
 
   ~DeviceBuffer() { Reset(); }
@@ -144,11 +157,12 @@ class DeviceBuffer {
 
   // Release device memory early (also called from destructor).
   void Reset() noexcept {
-    if (ptr_ != nullptr) {
+    if (owns_ && ptr_ != nullptr) {
       ::cudaFree(ptr_);
-      ptr_ = nullptr;
     }
+    ptr_   = nullptr;
     count_ = 0;
+    owns_  = true;
   }
 
  private:
@@ -162,6 +176,7 @@ class DeviceBuffer {
 
   T*          ptr_   = nullptr;
   std::size_t count_ = 0;
+  bool        owns_  = true;
 };
 
 // f32 is the only activation/weight dtype for the demosaicnet milestone.

--- a/alcedo_studio/src/include/decoders/processor/nn/metal_demosaicnet_tiled.hpp
+++ b/alcedo_studio/src/include/decoders/processor/nn/metal_demosaicnet_tiled.hpp
@@ -52,8 +52,10 @@ struct MetalDemosaicNetTiledDispatch {
   // false only when they intentionally keep the command buffer live.
   bool commit_and_wait = true;
 
-  // When non-null, encode onto this existing MTLCommandBuffer instead of creating
-  // an MPSCommandBuffer from the process queue. The caller owns commit.
+  // When non-null, wrap this existing MTLCommandBuffer. MPSGraph may
+  // commitAndContinue, so the caller must not keep encoding onto this pointer
+  // after Enqueue*. The product Develop path leaves this null and uses a dedicated
+  // MPSCommandBuffer from the process queue.
   void* command_buffer = nullptr;
 };
 

--- a/alcedo_studio/src/include/decoders/processor/nn/opencl_demosaicnet_cache.hpp
+++ b/alcedo_studio/src/include/decoders/processor/nn/opencl_demosaicnet_cache.hpp
@@ -77,6 +77,15 @@ class OpenClDemosaicNetModelCache {
   std::string                               last_error_;
 };
 
+/**
+ * @brief Serializes one in-flight OpenCL Neural forward (DAG SensorDevelop or RAW).
+ *
+ * Cached module kernels mutate `clSetKernelArg` on shared `cl_kernel` objects.
+ * The DAG tile executor scratch is per-backend, but two forwards still cannot
+ * overlap on those kernels.
+ */
+[[nodiscard]] auto OpenClNeuralDecodeMutex() -> std::mutex&;
+
 }  // namespace alcedo
 
 #endif  // HAVE_OPENCL

--- a/alcedo_studio/src/include/decoders/processor/nn/opencl_demosaicnet_module.hpp
+++ b/alcedo_studio/src/include/decoders/processor/nn/opencl_demosaicnet_module.hpp
@@ -75,6 +75,17 @@ class OpenClBayerDemosaicNet {
                                cl_command_queue queue              = nullptr,
                                bool             apply_gamma_decode = true) const;
 
+  // CUDA student-tile pack: read the original mono CFA (full-frame or cropped
+  // lattice via crop_x/crop_y), reflect-101 in the aligned lattice, and sparse-pack
+  // into the first NHWC4 activation. rgb_fc is the training-origin period table.
+  void ForwardReflectMonoCfaToHwc(cl_mem input_mono_cfa, int src_width, int src_height, int crop_x,
+                                  int crop_y, int aligned_width, int aligned_height, int origin_y,
+                                  int origin_x, int tile_height, int tile_width,
+                                  int mono_offset_floats, cl_mem rgb_fc, int period,
+                                  cl_mem output_rgb_hwc, opencl::nn::ActivationSlots& activation_slots,
+                                  cl_command_queue queue              = nullptr,
+                                  bool             apply_gamma_decode = true) const;
+
   [[nodiscard]] static auto NaturalOutputHeight(int input_h) -> int {
     return Spec::NaturalOutputHeight(input_h);
   }
@@ -159,6 +170,14 @@ class OpenClXTransDemosaicNet {
                                cl_mem output_rgb_hwc, opencl::nn::ActivationSlots& activation_slots,
                                cl_command_queue queue              = nullptr,
                                bool             apply_gamma_decode = true) const;
+
+  void ForwardReflectMonoCfaToHwc(cl_mem input_mono_cfa, int src_width, int src_height, int crop_x,
+                                  int crop_y, int aligned_width, int aligned_height, int origin_y,
+                                  int origin_x, int tile_height, int tile_width,
+                                  int mono_offset_floats, cl_mem rgb_fc, int period,
+                                  cl_mem output_rgb_hwc, opencl::nn::ActivationSlots& activation_slots,
+                                  cl_command_queue queue              = nullptr,
+                                  bool             apply_gamma_decode = true) const;
 
   [[nodiscard]] static auto NaturalOutputHeight(int input_h) -> int {
     return Spec::NaturalOutputHeight(input_h);

--- a/alcedo_studio/src/include/decoders/processor/nn/opencl_demosaicnet_tiled.hpp
+++ b/alcedo_studio/src/include/decoders/processor/nn/opencl_demosaicnet_tiled.hpp
@@ -19,7 +19,8 @@ namespace alcedo {
 // Product CUDA alignment: pack each student tile from the original mono CFA
 // (reflect-101 in the aligned lattice). Tests may still pass a dense HWC3
 // frame via input_aligned_hwc. Tile activations stay tile-sized; RGB is
-// assembled into aligned_rgb_hwc.
+// assembled into output_aligned_hwc as 3-channel HWC (RAW processor) or
+// 4-channel RGBA (DAG SensorDevelop).
 // All commands are queued on one in-order queue; this class intentionally does
 // not wait, finish, or read back inside (or after) its tile loop. Keep this
 // executor and the activation slots alive until the owner performs the final
@@ -33,6 +34,8 @@ struct OpenClDemosaicNetTiledDispatch {
   int              crop_y               = 0;
   int              mono_offset_floats   = 0;
   cl_mem           output_aligned_hwc   = nullptr;
+  int              output_offset_floats = 0;
+  int              output_channels      = 3;
   int              aligned_width         = 0;
   int              aligned_height      = 0;
   cl_mem           rgb_fc                = nullptr;

--- a/alcedo_studio/src/include/decoders/processor/nn/opencl_demosaicnet_tiled.hpp
+++ b/alcedo_studio/src/include/decoders/processor/nn/opencl_demosaicnet_tiled.hpp
@@ -16,20 +16,28 @@ namespace alcedo {
 
 // Device-side product execution for the fixed OpenCL student modules.
 //
-// The input is an already phase-aligned and CFA-period-trimmed HWC3 linear
-// mosaic. Each job is packed with reflect-101 addressing and signed gamma
-// directly into the network's first persistent NHWC4 activation, then
-// assembled directly into aligned_rgb_hwc.
+// Product CUDA alignment: pack each student tile from the original mono CFA
+// (reflect-101 in the aligned lattice). Tests may still pass a dense HWC3
+// frame via input_aligned_hwc. Tile activations stay tile-sized; RGB is
+// assembled into aligned_rgb_hwc.
 // All commands are queued on one in-order queue; this class intentionally does
 // not wait, finish, or read back inside (or after) its tile loop. Keep this
 // executor and the activation slots alive until the owner performs the final
 // queue wait at the Neural-stage boundary.
 struct OpenClDemosaicNetTiledDispatch {
-  cl_mem           input_aligned_hwc  = nullptr;
-  cl_mem           output_aligned_hwc = nullptr;
-  int              aligned_width      = 0;
-  int              aligned_height     = 0;
-  cl_command_queue queue              = nullptr;
+  cl_mem           input_aligned_hwc     = nullptr;
+  cl_mem           input_mono_cfa       = nullptr;
+  int              src_width             = 0;
+  int              src_height           = 0;
+  int              crop_x               = 0;
+  int              crop_y               = 0;
+  int              mono_offset_floats   = 0;
+  cl_mem           output_aligned_hwc   = nullptr;
+  int              aligned_width         = 0;
+  int              aligned_height      = 0;
+  cl_mem           rgb_fc                = nullptr;
+  int              period                = 0;
+  cl_command_queue queue                 = nullptr;
 };
 
 struct OpenClDemosaicNetTiledResult {

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_demosaicnet.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/cuda_demosaicnet.hpp
@@ -24,8 +24,11 @@ namespace alcedo::CUDA {
 // activations, NCHW input boundary buffers, and the HWC tile output are stream-local.
 // Not thread-safe; use one instance for each concurrent CUDA decode.
 //
-// `allocation_generation()` increments whenever an owned device allocation grows.
-// After warm-up, timed hot-path iterations must keep the generation constant.
+// Product SensorDevelop binds these buffers from the exclusive-stage transient arena
+// (`BindExternal`) so tile scratch is discarded with the rest of develop scratch.
+// `EnsureCapacity` without a bind still owns grow-only allocations for RAW-processor
+// and tests. `allocation_generation()` increments whenever owned capacity grows or
+// when BindExternal installs a new borrowed working set.
 class NeuralDemosaicWorkspace {
  public:
   NeuralDemosaicWorkspace()                                          = default;
@@ -38,6 +41,15 @@ class NeuralDemosaicWorkspace {
   }
   [[nodiscard]] auto input_buffer() noexcept -> cuda::nn::DeviceBufferF32& { return input_buffer_; }
   [[nodiscard]] auto rgb_buffer() noexcept -> cv::cuda::GpuMat& { return rgb_buffer_; }
+
+  /**
+   * @brief Borrow tile input, activation bump, and HWC RGB from caller-owned device memory.
+   *
+   * Pointers must stay valid until the last enqueued tile forward completes.
+   * Subsequent @ref EnsureCapacity calls do not cudaMalloc.
+   */
+  void BindExternal(float* input, std::size_t input_numel, void* activation,
+                    std::size_t activation_bytes, void* rgb, int rgb_height, int rgb_width);
 
   // Grow-only reservation for a single forward of the given CFA spatial size.
   // Increments `allocation_generation()` when any owned capacity actually grows.
@@ -56,6 +68,7 @@ class NeuralDemosaicWorkspace {
   cuda::nn::DeviceBufferF32 input_buffer_;
   cv::cuda::GpuMat          rgb_buffer_;
   std::uint64_t             allocation_generation_ = 0;
+  bool                      borrowed_              = false;
 };
 
 struct NeuralDemosaicOptions {

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/opencl_demosaicnet_programs.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/opencl_demosaicnet_programs.hpp
@@ -31,6 +31,12 @@ inline constexpr const char* kPackReflectXTransNhwc4KernelName =
     "demosaicnet_pack_reflect_xtrans_nhwc4";
 inline constexpr const char* kUnpackReflectConcatKernelName =
     "demosaicnet_unpack_reflect_concat_nhwc4";
+inline constexpr const char* kPackReflectBayerNhwc4MonoKernelName =
+    "demosaicnet_pack_reflect_bayer_nhwc4_mono";
+inline constexpr const char* kPackReflectXTransNhwc4MonoKernelName =
+    "demosaicnet_pack_reflect_xtrans_nhwc4_mono";
+inline constexpr const char* kUnpackReflectConcatMonoKernelName =
+    "demosaicnet_unpack_reflect_concat_nhwc4_mono";
 inline constexpr const char* kPackBayerNchwKernelName     = "demosaicnet_pack_bayer_nchw_to_nhwc4";
 inline constexpr const char* kPackXTransNchwKernelName    = "demosaicnet_pack_xtrans_nchw_to_nhwc4";
 inline constexpr const char* kResidualAddCropKernelName   = "demosaicnet_residual_add_crop";

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/opencl_encode.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/opencl_encode.hpp
@@ -77,6 +77,13 @@ void EncodeHighlightReconstruct(opencl::OpenClEncodeQueue& stream, opencl::OpenC
                                 opencl::OpenClBufferView cnts, opencl::OpenClBufferView anyclipped,
                                 const float* cam_mul, std::uint32_t width, std::uint32_t height);
 
+void EncodeHighlightReconstructPlanarAndPack(
+    opencl::OpenClEncodeQueue& stream, opencl::OpenClBufferView r, opencl::OpenClBufferView g,
+    opencl::OpenClBufferView b, cl_mem dst_rgba, opencl::OpenClBufferView mask,
+    opencl::OpenClBufferView dilated_mask, opencl::OpenClBufferView sums,
+    opencl::OpenClBufferView cnts, opencl::OpenClBufferView anyclipped, const float* cam_mul,
+    RectI crop, std::uint32_t plane_width, int flip);
+
 void EncodePackPlanesCropInverseOrient(opencl::OpenClEncodeQueue& stream,
                                        opencl::OpenClBufferView r, opencl::OpenClBufferView g,
                                        opencl::OpenClBufferView b, cl_mem dst_rgba, RectI crop,
@@ -85,6 +92,10 @@ void EncodePackPlanesCropInverseOrient(opencl::OpenClEncodeQueue& stream,
 void EncodeCopyRgbaCropInverseOrient(opencl::OpenClEncodeQueue& stream,
                                      opencl::OpenClBufferView src_rgba, cl_mem dst_rgba, RectI crop,
                                      std::uint32_t src_width, const float* cam_mul, int flip);
+
+void EncodeCopyRgbCropInverseOrient(opencl::OpenClEncodeQueue& stream,
+                                    opencl::OpenClBufferView src_rgb, cl_mem dst_rgba, RectI crop,
+                                    std::uint32_t src_width, const float* cam_mul, int flip);
 
 }  // namespace alcedo::OpenCL
 

--- a/alcedo_studio/src/include/decoders/processor/operators/gpu/opencl_raw_programs.hpp
+++ b/alcedo_studio/src/include/decoders/processor/operators/gpu/opencl_raw_programs.hpp
@@ -33,10 +33,15 @@ inline constexpr const char* kHlrDilateMaskKernelName          = "hlr_dilate_mas
 inline constexpr const char* kHlrChrominanceContribKernelName  = "hlr_chrominance_contrib";
 inline constexpr const char* kHlrReconstructKernelName         = "hlr_reconstruct";
 inline constexpr const char* kHlrReconstructFromStatsKernelName = "hlr_reconstruct_from_stats";
+inline constexpr const char* kHlrBuildMaskPlanarKernelName              = "hlr_build_mask_planar";
+inline constexpr const char* kHlrChrominanceContribPlanarKernelName     = "hlr_chrominance_contrib_planar";
+inline constexpr const char* kHlrReconstructFromStatsPlanarPackKernelName =
+    "hlr_reconstruct_from_stats_planar_pack";
 
 inline constexpr const char* kApplyInverseCamMulKernelName           = "apply_inverse_cam_mul_rgba32f";
 inline constexpr const char* kPackPlanesCropInverseOrientKernelName  = "pack_planes_crop_inverse_orient";
 inline constexpr const char* kCopyRgbaCropInverseOrientKernelName    = "copy_rgba_crop_inverse_orient";
+inline constexpr const char* kCopyRgbCropInverseOrientKernelName     = "copy_rgb_crop_inverse_orient";
 
 }  // namespace alcedo::OpenCL::RawProcessor
 

--- a/alcedo_studio/src/include/edit/runtime/adjustment_runtime.hpp
+++ b/alcedo_studio/src/include/edit/runtime/adjustment_runtime.hpp
@@ -50,7 +50,7 @@ inline constexpr std::uint32_t kGradeNeighborMaxTapCount = 64;
 /**
  * @brief Per-dispatch parameters for a separable neighborhood adjustment.
  *
- * This layout is shared verbatim with CUDA and OpenCL kernels. The horizontal pass writes the
+ * This layout is shared verbatim with GPU neighborhood kernels. The horizontal pass writes the
  * filtered neighborhood to a scratch image. The vertical pass reads that scratch image while
  * retaining the unfiltered source image for the final operator formula.
  */

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <stdexcept>
 
+#include "edit/runtime/develop_transient.hpp"
 #include "edit/runtime/graph_image_cache.hpp"
 #include "edit/runtime/mask_texture_cache.hpp"
 #include "edit/runtime/node_result_cache.hpp"
@@ -52,6 +53,32 @@ class BasicRenderWorkspace {
   [[nodiscard]] auto Values() -> NodeResultCache<Backend>& { return values_; }
   [[nodiscard]] auto Images() -> GraphImageCache<Backend>& { return images_; }
   [[nodiscard]] auto Images() const -> const GraphImageCache<Backend>& { return images_; }
+  [[nodiscard]] auto DevelopTransientHighWater() -> DevelopTransientHighWaterCache& {
+    return develop_high_water_;
+  }
+  [[nodiscard]] auto DevelopTransientHighWater() const -> const DevelopTransientHighWaterCache& {
+    return develop_high_water_;
+  }
+
+  /**
+   * @brief Reserve a conservative exclusive-stage slab from last observed capacity.
+   *
+   * First use of a layout uses @ref ConservativeDevelopInitialBytes. Does not use
+   * compiled peak_transient_bytes.
+   */
+  void PrepareDevelopTransients(const DevelopCompileSource& source,
+                                 std::uint32_t backend_capability_version) {
+    const auto bytes = develop_high_water_.SuggestInitial(source, backend_capability_version);
+    if (bytes == 0) {
+      return;
+    }
+    transients_.Reserve(bytes);
+  }
+
+  void RecordDevelopTransients(const DevelopCompileSource& source,
+                                std::uint32_t backend_capability_version) {
+    develop_high_water_.Record(source, backend_capability_version, transients_.capacity_bytes());
+  }
 
   /**
    * @brief Allocate an unpublished write texture for @p id. See GraphImageCache.
@@ -173,9 +200,10 @@ class BasicRenderWorkspace {
   TransientBufferArena<Backend> transients_;
   TexturePool<Backend>          textures_;
   MaskTextureCache<Backend>     mask_textures_;
-  NodeResultCache<Backend>      values_{};
-  GraphImageCache<Backend>      images_{};
-  bool                          rendering_ = false;
+  NodeResultCache<Backend>       values_{};
+  GraphImageCache<Backend>       images_{};
+  DevelopTransientHighWaterCache develop_high_water_{};
+  bool                           rendering_ = false;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -64,11 +64,14 @@ class BasicRenderWorkspace {
    * @brief Reserve a conservative exclusive-stage slab from last observed capacity.
    *
    * First use of a layout uses @ref ConservativeDevelopInitialBytes. Does not use
-   * compiled peak_transient_bytes.
+   * compiled peak_transient_bytes. @p demosaic_method is part of the high-water
+   * key so Neural Engine and Legacy (RCD) do not share a working-set size.
    */
   void PrepareDevelopTransients(const DevelopCompileSource& source,
-                                 std::uint32_t backend_capability_version) {
-    const auto bytes = develop_high_water_.SuggestInitial(source, backend_capability_version);
+                                 std::uint32_t backend_capability_version,
+                                 RawDemosaicMethod demosaic_method) {
+    const auto bytes =
+        develop_high_water_.SuggestInitial(source, backend_capability_version, demosaic_method);
     if (bytes == 0) {
       return;
     }
@@ -76,8 +79,10 @@ class BasicRenderWorkspace {
   }
 
   void RecordDevelopTransients(const DevelopCompileSource& source,
-                                std::uint32_t backend_capability_version) {
-    develop_high_water_.Record(source, backend_capability_version, transients_.capacity_bytes());
+                                std::uint32_t backend_capability_version,
+                                RawDemosaicMethod demosaic_method) {
+    develop_high_water_.Record(source, backend_capability_version, demosaic_method,
+                               transients_.capacity_bytes());
   }
 
   /**

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -66,6 +66,8 @@ class CudaBackend {
 
   /** @brief Session texture budget from device memory, floored at 256 MiB. */
   static auto DefaultTextureBudgetBytes() -> std::size_t;
+  /** @brief Exclusive-stage transient cap from device memory, floored at 256 MiB. */
+  [[nodiscard]] auto MaxTransientBytes() const -> std::size_t;
 
   class Buffer {
    public:

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
@@ -74,11 +74,13 @@ class CudaRenderDevice {
   [[nodiscard]] auto DrtRuntime() -> CudaDrtRuntimeState&;
 
   /**
-   * @brief Session-owned Neural Engine activation workspace. Created on first use.
+   * @brief Neural Engine tile activation workspace. Created on first Neural develop
+   *        in this render; released with develop scratch after SensorDevelop.
+   *        Weights stay in the process cache.
    */
   [[nodiscard]] auto NeuralDemosaicWorkspace() -> CUDA::NeuralDemosaicWorkspace&;
 
-  /** @brief Drop the session Neural Engine workspace. Weights stay in the process cache. */
+/** @brief Drop Neural Engine tile activations. Weights stay in the process cache. */
   void ReleaseNeuralDemosaicWorkspace();
 
   /**

--- a/alcedo_studio/src/include/edit/runtime/develop_demosaic.hpp
+++ b/alcedo_studio/src/include/edit/runtime/develop_demosaic.hpp
@@ -9,6 +9,7 @@
 #include "decoders/processor/raw_demosaic_method.hpp"
 #include "decoders/processor/raw_processor_pattern.hpp"
 #include "edit/graph/develop_node_model.hpp"
+#include "edit/runtime/develop_compile_source.hpp"
 
 namespace alcedo {
 
@@ -31,6 +32,17 @@ namespace alcedo {
   }
   return cfa_kind == RawCfaKind::XTrans6x6 ? RawDemosaicMethod::NeuralEngine
                                            : RawDemosaicMethod::Legacy;
+}
+
+[[nodiscard]] inline auto ResolveDevelopDemosaicMethod(const DevelopPayload& params,
+                                                       const DevelopCompileSource& source)
+    -> RawDemosaicMethod {
+  if (source.kind == DevelopInputKind::DirectRgb) {
+    return RawDemosaicMethod::Legacy;
+  }
+  const auto cfa_kind = source.kind == DevelopInputKind::XTransCfa ? RawCfaKind::XTrans6x6
+                                                                   : RawCfaKind::Bayer2x2;
+  return ResolveDevelopDemosaicMethod(params, cfa_kind, source.downsample_passes);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/develop_transient.hpp
+++ b/alcedo_studio/src/include/edit/runtime/develop_transient.hpp
@@ -1,0 +1,135 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <string>
+#include <string_view>
+#include <tuple>
+
+#include "edit/runtime/develop_compile_source.hpp"
+
+namespace alcedo {
+
+inline constexpr std::size_t kConservativeDevelopBytesPerPixel = 16;
+
+struct DevelopTransientLayoutKey {
+  DevelopInputKind kind                         = DevelopInputKind::BayerCfa;
+  std::uint32_t     host_width                    = 0;
+  std::uint32_t     host_height                   = 0;
+  std::uint8_t     downsample_passes               = 0;
+  std::uint32_t     backend_capability_version     = 0;
+
+  friend auto operator<(const DevelopTransientLayoutKey& a, const DevelopTransientLayoutKey& b)
+      -> bool {
+    return std::tie(a.kind, a.host_width, a.host_height, a.downsample_passes,
+                    a.backend_capability_version) <
+           std::tie(b.kind, b.host_width, b.host_height, b.downsample_passes,
+                    b.backend_capability_version);
+  }
+};
+
+inline auto MakeDevelopTransientLayoutKey(const DevelopCompileSource& source,
+                                          std::uint32_t backend_capability_version)
+    -> DevelopTransientLayoutKey {
+  return DevelopTransientLayoutKey{
+      .kind                         = source.kind,
+      .host_width                   = source.host_extent.width,
+      .host_height                  = source.host_extent.height,
+      .downsample_passes            = source.downsample_passes,
+      .backend_capability_version  = backend_capability_version,
+  };
+}
+
+inline auto ConservativeDevelopInitialBytes(const DevelopCompileSource& source) -> std::size_t {
+  if (source.kind == DevelopInputKind::DirectRgb) {
+    return 0;
+  }
+  const auto width  = static_cast<std::size_t>(source.host_extent.width);
+  const auto height = static_cast<std::size_t>(source.host_extent.height);
+  if (width == 0 || height == 0) {
+    return 0;
+  }
+  const auto max = (std::numeric_limits<std::size_t>::max)();
+  if (height > max / width) {
+    return max;
+  }
+  const auto pixels = width * height;
+  if (pixels > max / kConservativeDevelopBytesPerPixel) {
+    return max;
+  }
+  return pixels * kConservativeDevelopBytesPerPixel;
+}
+
+inline auto DescribeDevelopTransientFailure(const DevelopCompileSource& source,
+                                             std::string_view method, bool highlights_reconstruct,
+                                             std::string_view what) -> std::string {
+  std::string message = "SensorDevelop transients";
+  message += " extent=";
+  message += std::to_string(source.host_extent.width);
+  message += "x";
+  message += std::to_string(source.host_extent.height);
+  message += " kind=";
+  message += std::to_string(static_cast<unsigned>(source.kind));
+  message += " method=";
+  message += method;
+  message += " hlr=";
+  message += highlights_reconstruct ? "1" : "0";
+  message += ": ";
+  message += what;
+  return message;
+}
+
+inline auto ApplyDevelopTransientSafetyMargin(std::size_t observed_capacity) -> std::size_t {
+  if (observed_capacity == 0) {
+    return 0;
+  }
+  const auto margin = observed_capacity / 20;
+  const auto max     = (std::numeric_limits<std::size_t>::max)();
+  if (observed_capacity > max - margin) {
+    return max;
+  }
+  return observed_capacity + margin;
+}
+
+/**
+ * @brief Last observed Develop transient capacity keyed by source layout.
+ *
+ * Used as the next exclusive-stage Reserve, not as a compiler plane ledger.
+ */
+class DevelopTransientHighWaterCache {
+ public:
+  [[nodiscard]] auto SuggestInitial(const DevelopCompileSource& source,
+                                    std::uint32_t backend_capability_version) const -> std::size_t {
+    const auto key = MakeDevelopTransientLayoutKey(source, backend_capability_version);
+    const auto it  = observed_capacity_.find(key);
+    if (it != observed_capacity_.end()) {
+      return ApplyDevelopTransientSafetyMargin(it->second);
+    }
+    return ConservativeDevelopInitialBytes(source);
+  }
+
+  void Record(const DevelopCompileSource& source, std::uint32_t backend_capability_version,
+              std::size_t capacity) {
+    observed_capacity_[MakeDevelopTransientLayoutKey(source, backend_capability_version)] =
+        capacity;
+  }
+
+  [[nodiscard]] auto ObservedCapacity(const DevelopCompileSource& source,
+                                       std::uint32_t backend_capability_version) const
+      -> std::size_t {
+    const auto it =
+        observed_capacity_.find(MakeDevelopTransientLayoutKey(source, backend_capability_version));
+    return it == observed_capacity_.end() ? 0 : it->second;
+  }
+
+ private:
+  std::map<DevelopTransientLayoutKey, std::size_t> observed_capacity_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/develop_transient.hpp
+++ b/alcedo_studio/src/include/edit/runtime/develop_transient.hpp
@@ -12,37 +12,43 @@
 #include <string_view>
 #include <tuple>
 
+#include "decoders/processor/raw_demosaic_method.hpp"
 #include "edit/runtime/develop_compile_source.hpp"
 
 namespace alcedo {
 
-inline constexpr std::size_t kConservativeDevelopBytesPerPixel = 16;
+inline constexpr std::size_t kConservativeDevelopBytesPerPixel       = 16;
+inline constexpr std::size_t kConservativeNeuralDevelopBytesPerPixel = 24;
+inline constexpr std::size_t kConservativeNeuralTileScratchBytes     = 64ull << 20;
 
 struct DevelopTransientLayoutKey {
-  DevelopInputKind kind                         = DevelopInputKind::BayerCfa;
+  DevelopInputKind  kind                         = DevelopInputKind::BayerCfa;
   std::uint32_t     host_width                    = 0;
   std::uint32_t     host_height                   = 0;
-  std::uint8_t     downsample_passes               = 0;
-  std::uint32_t     backend_capability_version     = 0;
+  std::uint8_t      downsample_passes             = 0;
+  RawDemosaicMethod demosaic_method               = RawDemosaicMethod::Legacy;
+  std::uint32_t     backend_capability_version    = 0;
 
   friend auto operator<(const DevelopTransientLayoutKey& a, const DevelopTransientLayoutKey& b)
       -> bool {
-    return std::tie(a.kind, a.host_width, a.host_height, a.downsample_passes,
+    return std::tie(a.kind, a.host_width, a.host_height, a.downsample_passes, a.demosaic_method,
                     a.backend_capability_version) <
-           std::tie(b.kind, b.host_width, b.host_height, b.downsample_passes,
+           std::tie(b.kind, b.host_width, b.host_height, b.downsample_passes, b.demosaic_method,
                     b.backend_capability_version);
   }
 };
 
 inline auto MakeDevelopTransientLayoutKey(const DevelopCompileSource& source,
-                                          std::uint32_t backend_capability_version)
+                                          std::uint32_t backend_capability_version,
+                                          RawDemosaicMethod demosaic_method)
     -> DevelopTransientLayoutKey {
   return DevelopTransientLayoutKey{
-      .kind                         = source.kind,
-      .host_width                   = source.host_extent.width,
-      .host_height                  = source.host_extent.height,
-      .downsample_passes            = source.downsample_passes,
-      .backend_capability_version  = backend_capability_version,
+      .kind                        = source.kind,
+      .host_width                  = source.host_extent.width,
+      .host_height                 = source.host_extent.height,
+      .downsample_passes           = source.downsample_passes,
+      .demosaic_method             = demosaic_method,
+      .backend_capability_version = backend_capability_version,
   };
 }
 
@@ -64,6 +70,34 @@ inline auto ConservativeDevelopInitialBytes(const DevelopCompileSource& source) 
     return max;
   }
   return pixels * kConservativeDevelopBytesPerPixel;
+}
+
+inline auto ConservativeDevelopInitialBytes(const DevelopCompileSource& source,
+                                            RawDemosaicMethod demosaic_method) -> std::size_t {
+  if (demosaic_method != RawDemosaicMethod::NeuralEngine) {
+    return ConservativeDevelopInitialBytes(source);
+  }
+  if (source.kind == DevelopInputKind::DirectRgb) {
+    return 0;
+  }
+  const auto width  = static_cast<std::size_t>(source.host_extent.width);
+  const auto height = static_cast<std::size_t>(source.host_extent.height);
+  if (width == 0 || height == 0) {
+    return 0;
+  }
+  const auto max = (std::numeric_limits<std::size_t>::max)();
+  if (height > max / width) {
+    return max;
+  }
+  const auto pixels = width * height;
+  if (pixels > max / kConservativeNeuralDevelopBytesPerPixel) {
+    return max;
+  }
+  const auto plane_bytes = pixels * kConservativeNeuralDevelopBytesPerPixel;
+  if (plane_bytes > max - kConservativeNeuralTileScratchBytes) {
+    return max;
+  }
+  return plane_bytes + kConservativeNeuralTileScratchBytes;
 }
 
 inline auto DescribeDevelopTransientFailure(const DevelopCompileSource& source,
@@ -105,26 +139,28 @@ inline auto ApplyDevelopTransientSafetyMargin(std::size_t observed_capacity) -> 
 class DevelopTransientHighWaterCache {
  public:
   [[nodiscard]] auto SuggestInitial(const DevelopCompileSource& source,
-                                    std::uint32_t backend_capability_version) const -> std::size_t {
-    const auto key = MakeDevelopTransientLayoutKey(source, backend_capability_version);
+                                    std::uint32_t backend_capability_version,
+                                    RawDemosaicMethod demosaic_method) const -> std::size_t {
+    const auto key = MakeDevelopTransientLayoutKey(source, backend_capability_version,
+                                                   demosaic_method);
     const auto it  = observed_capacity_.find(key);
     if (it != observed_capacity_.end()) {
       return ApplyDevelopTransientSafetyMargin(it->second);
     }
-    return ConservativeDevelopInitialBytes(source);
+    return ConservativeDevelopInitialBytes(source, demosaic_method);
   }
 
   void Record(const DevelopCompileSource& source, std::uint32_t backend_capability_version,
-              std::size_t capacity) {
-    observed_capacity_[MakeDevelopTransientLayoutKey(source, backend_capability_version)] =
-        capacity;
+              RawDemosaicMethod demosaic_method, std::size_t capacity) {
+    observed_capacity_[MakeDevelopTransientLayoutKey(source, backend_capability_version,
+                                                     demosaic_method)] = capacity;
   }
 
   [[nodiscard]] auto ObservedCapacity(const DevelopCompileSource& source,
-                                       std::uint32_t backend_capability_version) const
-      -> std::size_t {
-    const auto it =
-        observed_capacity_.find(MakeDevelopTransientLayoutKey(source, backend_capability_version));
+                                       std::uint32_t backend_capability_version,
+                                       RawDemosaicMethod demosaic_method) const -> std::size_t {
+    const auto it = observed_capacity_.find(
+        MakeDevelopTransientLayoutKey(source, backend_capability_version, demosaic_method));
     return it == observed_capacity_.end() ? 0 : it->second;
   }
 

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -129,8 +129,9 @@ inline auto operator<(const StaticPlanKey& a, const StaticPlanKey& b) -> bool {
  * encoder aliases `geometry.scene_source` onto `develop.sensor_linear` instead of
  * copying a second full-resolution texture.
  *
- * @ref peak_transient_bytes is the bump-allocator high-water for one exclusive
- * stage (Develop demosaic, mask SDF, or LLF), not the sum of those stages.
+ * @ref peak_transient_bytes is a compiler exclusive-stage upper bound for tests.
+ * SensorDevelop allocation uses a conservative initial slab plus observed high-water,
+ * not this field as a Reserve argument.
  */
 struct ExecutionPlan {
   StaticPlanKey                   static_key{};

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
@@ -189,6 +189,14 @@ class MetalBackend {
   void               Submit(CommandContext& command_context);
   void               Wait(CommandContext& command_context);
   /**
+   * @brief Commit and wait the current command buffer. Recorded-work scratch stays alive.
+   *
+   * The next encode creates a new command buffer. Call this before MPSGraph Neural
+   * Engine work: `encodeToCommandBuffer` may `commitAndContinue`, so it cannot share
+   * this buffer, and later passes must not create encoders on the committed original.
+   */
+  void CompleteCurrentCommandBuffer(CommandContext& command_context);
+  /**
    * @brief Commit recorded Metal work and wait. The next encode gets a new command buffer.
    *
    * Used to finish and release Develop scratch before Geometry runs.

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_backend.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <span>
 #include <utility>
@@ -62,6 +63,8 @@ class MetalBackend {
  public:
   static constexpr std::uint32_t kCapabilityVersion = kMetalDagBackendCapabilityVersion;
   static constexpr const char*   kName              = "Metal";
+  /** @brief Metal Develop allocates command-buffer-owned scratch instead of arena slabs. */
+  static constexpr bool          kUsesDevelopTransientArena = false;
   static auto                    DefaultTextureBudgetBytes() -> std::size_t { return 256ull << 20; }
 
   class Buffer {
@@ -133,6 +136,33 @@ class MetalBackend {
   [[nodiscard]] auto CreateTexture2D(std::uint32_t width, std::uint32_t height,
                                      TextureFormat format) -> Texture2D;
 
+  /**
+   * @brief Create a scratch buffer owned until the recorded command buffer is finished.
+   *
+   * The backend owns the returned buffer. Its reference stays valid until
+   * SynchronizeRecordedWork(), Wait(), or cancellation discards the recorded work.
+   */
+  [[nodiscard]] auto AcquireRecordedWorkScratchBuffer(std::size_t bytes) -> Buffer&;
+  /** @brief Create a scratch texture with the same recorded-work lifetime as a scratch buffer. */
+  [[nodiscard]] auto AcquireRecordedWorkScratchTexture(std::uint32_t width, std::uint32_t height,
+                                                       TextureFormat format) -> Texture2D&;
+  /** @brief Return the number of scratch buffers awaiting recorded-work completion. */
+  [[nodiscard]] auto RecordedWorkScratchBufferCount() const -> std::size_t {
+    return recorded_work_scratch_buffers_.size();
+  }
+  /** @brief Return the total bytes in scratch buffers awaiting recorded-work completion. */
+  [[nodiscard]] auto RecordedWorkScratchBufferBytes() const -> std::size_t {
+    std::size_t bytes = 0;
+    for (const auto& buffer : recorded_work_scratch_buffers_) {
+      bytes += buffer.Bytes();
+    }
+    return bytes;
+  }
+  /** @brief Return the number of scratch textures awaiting recorded-work completion. */
+  [[nodiscard]] auto RecordedWorkScratchTextureCount() const -> std::size_t {
+    return recorded_work_scratch_textures_.size();
+  }
+
   void UploadBufferRange(Buffer& buffer, std::uint32_t offset, std::span<const std::byte> bytes,
                          CommandContext& command_context);
   void DownloadBufferRange(const Buffer& buffer, std::uint32_t offset, std::span<std::byte> out,
@@ -161,7 +191,7 @@ class MetalBackend {
   /**
    * @brief Commit recorded Metal work and wait. The next encode gets a new command buffer.
    *
-   * Used to free Develop scratch before Geometry runs.
+   * Used to finish and release Develop scratch before Geometry runs.
    */
   void SynchronizeRecordedWork(CommandContext& command_context);
 
@@ -233,9 +263,15 @@ class MetalBackend {
     ++texture_create_count_;
     NoteMalloc();
   }
-  void                   NoteHeapCreate() noexcept { ++heap_create_count_; }
+  void NoteHeapCreate() noexcept { ++heap_create_count_; }
+  void ReleaseRecordedWorkScratchResources() noexcept {
+    recorded_work_scratch_buffers_.clear();
+    recorded_work_scratch_textures_.clear();
+  }
 
-  std::unique_ptr<Gpu>   gpu_{};
+  std::unique_ptr<Gpu>  gpu_{};
+  std::deque<Buffer>    recorded_work_scratch_buffers_;
+  std::deque<Texture2D> recorded_work_scratch_textures_;
   std::uint64_t          malloc_count_                = 0;
   std::uint64_t          free_count_                  = 0;
   std::uint64_t          buffer_create_count_         = 0;

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_local_tone_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_local_tone_pass.hpp
@@ -26,9 +26,9 @@ struct MetalLocalToneResult {
 /**
  * @brief Encode Shadows/Highlights LLF onto the current Metal command buffer.
  *
- * Pyramid scratch comes from TransientBufferArena. Canonical source/result planes live
- * in workspace Values() under GraphValueId. Failures throw; there is no CPU or
- * MetalStage substitute.
+ * Pyramid scratch is destroyed after the recorded command buffer completes. Canonical
+ * source/result planes live in workspace Values() under GraphValueId. Failures throw; there is no
+ * CPU or MetalStage substitute.
  */
 [[nodiscard]] auto ExecuteMetalLocalTone(MetalRenderDevice&             device,
                                          const MetalBackend::Texture2D& input,

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_mask_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_mask_pass.hpp
@@ -29,8 +29,9 @@ struct MetalMaskResult {
  * @brief Evaluate the optional compiled analytic or raster mask into RenderSpace R8.
  *
  * Raster source textures and mip levels live in workspace MaskTextureCache. Signed-distance
- * intermediates come from TransientBufferArena. The signed-distance result is stored by mask
- * content key so a feather-radius edit can reuse it. Failures throw; there is no CPU substitute.
+ * intermediates are destroyed after the recorded command buffer completes. The signed-distance
+ * result is stored by mask content key so a feather-radius edit can reuse it. Failures throw;
+ * there is no CPU substitute.
  */
 [[nodiscard]] auto ExecuteMetalMask(MetalRenderDevice& device, const ExecutionPlan& plan,
                                     const PipelineDocument& document, MaskStore* store = nullptr,

--- a/alcedo_studio/src/include/edit/runtime/opencl/opencl_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/opencl/opencl_backend.hpp
@@ -167,6 +167,7 @@ class OpenClBackend {
    * @ref SetMaxSlabBytes; 0 restores the device-reported value.
    */
   [[nodiscard]] auto MaxSlabBytes() const -> std::size_t;
+  [[nodiscard]] auto MaxTransientBytes() const -> std::size_t;
   /**
    * @brief Override @ref MaxSlabBytes. Zero restores the device-reported cap.
    * @param bytes Slab cap in bytes, or 0 for the device default.

--- a/alcedo_studio/src/include/edit/runtime/opencl/opencl_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/opencl/opencl_backend.hpp
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <span>
 #include <utility>
 #include <vector>
@@ -28,6 +29,7 @@
 namespace alcedo {
 
 struct ExecutionPlan;
+struct OpenClNeuralSessionWorkspace;
 
 inline constexpr std::uint32_t kOpenClDagBackendCapabilityVersion = 1;
 
@@ -213,7 +215,9 @@ class OpenClBackend {
   void Submit(CommandContext& command_context);
   /** @brief Append and flush presentation work to the current product submission. */
   void FinalizePresentation(CommandContext& command_context);
-  /** @brief Release backend-owned neural activation workspace after queue completion. */
+  /** @brief Neural Engine tile executor for this backend. Created on first Neural develop. */
+  [[nodiscard]] auto NeuralDemosaicWorkspace() -> OpenClNeuralSessionWorkspace&;
+  /** @brief Release Neural Engine tile activations after develop scratch is discarded. */
   void ReleaseNeuralDemosaicWorkspace();
   void Wait(CommandContext& command_context);
   /**
@@ -348,6 +352,7 @@ class OpenClBackend {
   };
   std::vector<LutCacheEntry> lut_cache_;
   Buffer                     dummy_lut_;
+  std::unique_ptr<OpenClNeuralSessionWorkspace> neural_workspace_;
   std::size_t                max_slab_bytes_device_   = 0;
   std::size_t                max_slab_bytes_override_ = 0;
   std::size_t                max_image_width_         = 0;

--- a/alcedo_studio/src/include/edit/runtime/opencl/opencl_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/opencl/opencl_backend.hpp
@@ -216,10 +216,12 @@ class OpenClBackend {
   void ReleaseNeuralDemosaicWorkspace();
   void Wait(CommandContext& command_context);
   /**
-   * @brief Wait for commands already on the product queue. Used to free Develop scratch.
+   * @brief Flush and wait for commands already on the product queue.
    *
-   * Does not submit or change in-flight submission state. Does not replace product
-   * Submit/Wait with clFinish.
+   * Used to free Develop scratch after SensorDevelop. Flushes before
+   * `clWaitForEvents` so a large in-order dispatch cannot stall forever with
+   * work still sitting in the host queue. Does not replace product Submit/Wait
+   * with `clFinish`.
    */
   void SynchronizeRecordedWork(CommandContext& command_context);
 
@@ -302,6 +304,7 @@ class OpenClBackend {
   void UnregisterBuffer(cl_mem native) noexcept;
   void TrackEnqueueEvent(CommandContext& command_context, cl_event event);
   auto EnqueueMarker(CommandContext& command_context) -> cl_event;
+  void FlushQueue();
 
   cl_device_id           device_  = nullptr;
   cl_context             context_ = nullptr;
@@ -346,6 +349,8 @@ class OpenClBackend {
   Buffer                     dummy_lut_;
   std::size_t                max_slab_bytes_device_   = 0;
   std::size_t                max_slab_bytes_override_ = 0;
+  std::size_t                max_image_width_         = 0;
+  std::size_t                max_image_height_        = 0;
 };
 
 using OpenClRenderDevice    = BasicRenderDevice<OpenClBackend>;

--- a/alcedo_studio/src/include/edit/runtime/opencl/opencl_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/opencl/opencl_develop_pass.hpp
@@ -37,9 +37,6 @@ void ExecuteOpenClCameraColor(OpenClRenderDevice& device, const ExecutionPlan& p
  */
 void SetOpenClDevelopNeuralModelCacheForTesting(OpenClDemosaicNetModelCache* cache);
 
-/** @brief Release the product-path Neural activation workspace after queue completion. */
-void ReleaseOpenClDevelopNeuralWorkspace();
-
 }  // namespace alcedo
 
 #endif

--- a/alcedo_studio/src/include/edit/runtime/opencl/opencl_neural_session_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/opencl/opencl_neural_session_workspace.hpp
@@ -1,0 +1,36 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#ifdef HAVE_OPENCL
+
+#include "decoders/processor/nn/opencl_demosaicnet_tiled.hpp"
+#include "opencl/nn/activation_slots.hpp"
+#include "opencl/nn/device_buffer.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Per-backend Neural tile executor, activation slots, and CFA table.
+ *
+ * Not process-static. Two OpenCL DAG devices (image A still tiling, image B
+ * skipping or starting SensorDevelop) must not Reset each other's tile_output.
+ * Weights stay in OpenClDemosaicNetModelCache.
+ */
+struct OpenClNeuralSessionWorkspace {
+  OpenClDemosaicNetTiledExecutor executor;
+  opencl::nn::ActivationSlots    slots;
+  opencl::nn::DeviceBuffer       cfa_table;
+
+  void                           Reset() {
+    executor = {};
+    slots    = {};
+    cfa_table.Reset();
+  }
+};
+
+}  // namespace alcedo
+
+#endif

--- a/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
@@ -6,9 +6,12 @@
 
 #include <exception>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/develop_transient.hpp"
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/pass_encoder.hpp"
 #include "edit/runtime/pass_kind.hpp"
@@ -65,18 +68,34 @@ class PlanExecutor {
                      completed)) {
         ++stats.sensor_develop_skip;
       } else {
+        workspace.PrepareDevelopTransients(plan.source, Backend::kCapabilityVersion);
         const auto h2d_before = workspace.Device().HostToDeviceBytes();
-        if (plan.Contains(GpuPassKind::UploadRgb)) {
-          PassEncoder<Backend, GpuPassKind::UploadRgb>::Encode(device, plan, input, document,
-                                                               mask_store);
-        } else {
-          PassEncoder<Backend, GpuPassKind::UploadRaw>::Encode(device, plan, input, document,
-                                                               mask_store);
+        try {
+          if (plan.Contains(GpuPassKind::UploadRgb)) {
+            PassEncoder<Backend, GpuPassKind::UploadRgb>::Encode(device, plan, input, document,
+                                                                 mask_store);
+          } else {
+            PassEncoder<Backend, GpuPassKind::UploadRaw>::Encode(device, plan, input, document,
+                                                                 mask_store);
+          }
+        } catch (const std::exception& ex) {
+          const std::string_view what = ex.what();
+          if (what.find("TransientBufferArena") == std::string_view::npos) {
+            throw;
+          }
+          const auto* develop = document.Develop();
+          const auto  method =
+              develop == nullptr ? std::string_view{} : develop->Params().Params().demosaic_method;
+          const bool hlr =
+              develop != nullptr && develop->Params().Params().highlights_reconstruct;
+          throw std::runtime_error(
+              DescribeDevelopTransientFailure(plan.source, method, hlr, ex.what()));
         }
         stats.source_h2d_bytes += workspace.Device().HostToDeviceBytes() - h2d_before;
         ++stats.source_h2d_count;
         Record(device, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent);
         ++stats.sensor_develop_execute;
+        workspace.RecordDevelopTransients(plan.source, Backend::kCapabilityVersion);
         // RCD planes are not a cache. Wait this stream so pack has finished, then
         // cudaFree / Metal free the slab before Geometry allocates display textures.
         workspace.Device().SynchronizeRecordedWork(device.CommandContext());

--- a/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
@@ -68,7 +68,9 @@ class PlanExecutor {
                      completed)) {
         ++stats.sensor_develop_skip;
       } else {
-        workspace.PrepareDevelopTransients(plan.source, Backend::kCapabilityVersion);
+        if constexpr (UsesDevelopTransientArena()) {
+          workspace.PrepareDevelopTransients(plan.source, Backend::kCapabilityVersion);
+        }
         const auto h2d_before = workspace.Device().HostToDeviceBytes();
         try {
           if (plan.Contains(GpuPassKind::UploadRgb)) {
@@ -95,9 +97,11 @@ class PlanExecutor {
         ++stats.source_h2d_count;
         Record(device, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent);
         ++stats.sensor_develop_execute;
-        workspace.RecordDevelopTransients(plan.source, Backend::kCapabilityVersion);
-        // RCD planes are not a cache. Wait this stream so pack has finished, then
-        // cudaFree / Metal free the slab before Geometry allocates display textures.
+        if constexpr (UsesDevelopTransientArena()) {
+          workspace.RecordDevelopTransients(plan.source, Backend::kCapabilityVersion);
+        }
+        // Develop intermediates are not a cache. Finish the recorded work so backend-owned
+        // scratch can be destroyed before Geometry allocates display textures.
         workspace.Device().SynchronizeRecordedWork(device.CommandContext());
       }
       workspace.TransientBuffers().Reset();
@@ -175,6 +179,13 @@ class PlanExecutor {
 
  private:
   static constexpr TextureFormat kResultFormat = TextureFormat::Rgba32f;
+
+  static constexpr auto UsesDevelopTransientArena() -> bool {
+    if constexpr (requires { Backend::kUsesDevelopTransientArena; }) {
+      return Backend::kUsesDevelopTransientArena;
+    }
+    return true;
+  }
 
   template <class Workspace>
   static auto BindOrMiss(Workspace& images_owner, const GraphValueId& id, ContentKey key,

--- a/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
@@ -11,6 +11,7 @@
 
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/prepared_raw_input.hpp"
+#include "edit/runtime/develop_demosaic.hpp"
 #include "edit/runtime/develop_transient.hpp"
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/pass_encoder.hpp"
@@ -68,11 +69,19 @@ class PlanExecutor {
                      completed)) {
         ++stats.sensor_develop_skip;
       } else {
-        if constexpr (UsesDevelopTransientArena()) {
-          workspace.PrepareDevelopTransients(plan.source, Backend::kCapabilityVersion);
-        }
+        const auto* develop_node = document.Develop();
+        const auto  develop_method =
+            develop_node == nullptr
+                ? RawDemosaicMethod::Legacy
+                : ResolveDevelopDemosaicMethod(develop_node->Params().Params(), plan.source);
+        const bool highlights_reconstruct =
+            develop_node != nullptr && develop_node->Params().Params().highlights_reconstruct;
         const auto h2d_before = workspace.Device().HostToDeviceBytes();
         try {
+          if constexpr (UsesDevelopTransientArena()) {
+            workspace.PrepareDevelopTransients(plan.source, Backend::kCapabilityVersion,
+                                               develop_method);
+          }
           if (plan.Contains(GpuPassKind::UploadRgb)) {
             PassEncoder<Backend, GpuPassKind::UploadRgb>::Encode(device, plan, input, document,
                                                                  mask_store);
@@ -85,24 +94,24 @@ class PlanExecutor {
           if (what.find("TransientBufferArena") == std::string_view::npos) {
             throw;
           }
-          const auto* develop = document.Develop();
-          const auto  method =
-              develop == nullptr ? std::string_view{} : develop->Params().Params().demosaic_method;
-          const bool hlr =
-              develop != nullptr && develop->Params().Params().highlights_reconstruct;
-          throw std::runtime_error(
-              DescribeDevelopTransientFailure(plan.source, method, hlr, ex.what()));
+          throw std::runtime_error(DescribeDevelopTransientFailure(
+              plan.source, RawDemosaicMethodToString(develop_method), highlights_reconstruct,
+              ex.what()));
         }
         stats.source_h2d_bytes += workspace.Device().HostToDeviceBytes() - h2d_before;
         ++stats.source_h2d_count;
         Record(device, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent);
         ++stats.sensor_develop_execute;
         if constexpr (UsesDevelopTransientArena()) {
-          workspace.RecordDevelopTransients(plan.source, Backend::kCapabilityVersion);
+          workspace.RecordDevelopTransients(plan.source, Backend::kCapabilityVersion,
+                                            develop_method);
         }
         // Develop intermediates are not a cache. Finish the recorded work so backend-owned
         // scratch can be destroyed before Geometry allocates display textures.
         workspace.Device().SynchronizeRecordedWork(device.CommandContext());
+      }
+      if constexpr (requires(Device& d) { d.ReleaseNeuralDemosaicWorkspace(); }) {
+        device.ReleaseNeuralDemosaicWorkspace();
       }
       workspace.TransientBuffers().Reset();
       workspace.TransientBuffers().ReleaseDeviceMemory();
@@ -168,10 +177,16 @@ class PlanExecutor {
       return plan.display_output;
     } catch (const std::exception& ex) {
       device.CancelRender();
+      if constexpr (requires(Device& d) { d.ReleaseNeuralDemosaicWorkspace(); }) {
+        device.ReleaseNeuralDemosaicWorkspace();
+      }
       device.ReportError(ex.what());
       throw;
     } catch (...) {
       device.CancelRender();
+      if constexpr (requires(Device& d) { d.ReleaseNeuralDemosaicWorkspace(); }) {
+        device.ReleaseNeuralDemosaicWorkspace();
+      }
       device.ReportError("DAG execution failed with an unknown error");
       throw;
     }

--- a/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -16,21 +17,32 @@
 
 namespace alcedo {
 
+struct TransientArenaSnapshot {
+  std::size_t requested_bytes    = 0;
+  std::size_t padding_bytes      = 0;
+  std::size_t used_bytes        = 0;
+  std::size_t capacity_bytes    = 0;
+  std::size_t unused_tail_bytes = 0;
+  std::size_t slab_count        = 0;
+  std::size_t largest_allocation = 0;
+  std::size_t grow_count        = 0;
+};
+
 /**
- * @brief Grow-only bump allocator over device slabs supplied by @p Backend.
+ * @brief Independent device slabs with a local bump pointer in each slab.
  *
  * Backend must provide:
  * - `class Slab` with `DevicePointer()`, `Bytes()`, move-only RAII free
  * - `CreateSlab(std::size_t bytes) -> Slab`
  *
- * Optional: `MaxSlabBytes()` caps each `CreateSlab`. Backends with a per-buffer
- * allocation limit report it here. A single `Allocate` must fit in one slab.
+ * Optional: `MaxSlabBytes()` caps each `CreateSlab`. A single `Allocate` must
+ * fit in one slab; allocations never span slab boundaries and never relocate
+ * live device pointers. Optional `MaxTransientBytes()` caps the sum of slabs.
  *
- * `Reserve` may replace unused slabs. `Allocate` that does not fit the current
- * remainder appends another slab; live pointers stay valid. Develop scratch is
- * exclusive and discarded after SensorDevelop (`ReleaseDeviceMemory`), so extra
- * slabs in that pass are not held across Geometry / Grade / DRT.
- * `Reset()` / `Rewind` do not free slabs. Not thread-safe.
+ * `Reserve` may replace unused slabs. `Allocate` that does not fit any current
+ * remainder appends another slab. Develop scratch is exclusive and discarded
+ * after SensorDevelop (`ReleaseDeviceMemory`). `Reset()` rewinds every local
+ * bump without freeing slabs. Not thread-safe.
  *
  * @tparam Backend Slab factory. Must outlive this arena when passed by reference.
  */
@@ -38,6 +50,10 @@ template <class Backend>
 class TransientBufferArena {
  public:
   static constexpr std::size_t kDefaultAlignment = 256;
+  static constexpr std::size_t kMinSlabBytes    = 16ull << 20;
+  static constexpr std::size_t kSlabQuantumBytes = 64ull << 20;
+
+  using Mark = std::vector<std::size_t>;
 
   TransientBufferArena() : owned_(std::in_place), backend_(&*owned_) {}
 
@@ -76,15 +92,15 @@ class TransientBufferArena {
    * @throws std::runtime_error if bump allocations are live.
    */
   void Reserve(std::size_t bytes) {
-    if (bytes <= capacity_) {
+    if (bytes <= capacity_bytes() && !slabs_.empty()) {
       return;
     }
-    if (offset_ != 0) {
+    if (HasLiveAllocations()) {
       throw std::runtime_error(
           "TransientBufferArena::Reserve: cannot grow while allocations are live; "
           "Reset() first or Reserve peak size before Allocate");
     }
-    const auto previous = capacity_;
+    const auto previous = capacity_bytes();
     EnsureCapacity(bytes);
     if (ShouldTraceGpuPoolAlloc(bytes)) {
       std::fprintf(stderr, "[GPU_POOL] transient reserve %.1f MiB (was %.1f)\n", GpuPoolMiB(bytes),
@@ -96,10 +112,10 @@ class TransientBufferArena {
   }
 
   /**
-   * @brief Bump-allocate @p bytes. Zero returns nullptr.
+   * @brief Bump-allocate @p bytes inside one slab. Zero returns nullptr.
    *
-   * Places into an existing slab when there is room. Otherwise appends a new slab.
-   * @throws std::runtime_error on bad alignment or a request larger than one slab.
+   * Tries each existing slab's local bump. Otherwise appends a new slab sized
+   * for the request. Live pointers stay valid.
    */
   [[nodiscard]] auto Allocate(std::size_t bytes, std::size_t alignment = kDefaultAlignment)
       -> void* {
@@ -111,31 +127,28 @@ class TransientBufferArena {
     }
     const auto max_slab = QueryMaxSlabBytes();
     if (bytes > max_slab) {
-      throw std::runtime_error(
-          "TransientBufferArena::Allocate: request exceeds backend max slab bytes");
+      throw std::runtime_error(FormatLimitError(
+          "TransientBufferArena::Allocate: request exceeds backend max slab bytes", bytes));
     }
 
-    std::size_t aligned_offset = AlignUp(offset_, alignment);
-    if (void* placed = PlaceFrom(aligned_offset, bytes, alignment)) {
+    for (auto& entry : slabs_) {
+      if (void* placed = TryAllocateIn(entry, bytes, alignment)) {
+        NoteAllocation(bytes);
+        return placed;
+      }
+    }
+
+    const auto slab_bytes = SlabBytesForRequest(bytes);
+    AppendSlab(slab_bytes);
+    ++grow_count_;
+    if (void* placed = TryAllocateIn(slabs_.back(), bytes, alignment)) {
+      NoteAllocation(bytes);
       return placed;
     }
-
-    if (offset_ != 0) {
-      return AppendAndPlace(bytes);
-    }
-    const std::size_t end = aligned_offset + bytes;
-    std::size_t new_cap = capacity_ == 0 ? end : capacity_;
-    while (new_cap < end) {
-      const std::size_t doubled = new_cap > (std::size_t{1} << 62) ? end : new_cap * 2;
-      new_cap                   = doubled < end ? end : doubled;
-    }
-    Reserve(new_cap);
-    void* ptr = TryPlace(0, bytes);
-    if (ptr == nullptr) {
-      return AppendAndPlace(bytes);
-    }
-    offset_ = bytes;
-    return ptr;
+    throw std::runtime_error(
+        FormatLimitError("TransientBufferArena::Allocate: new transient slab cannot satisfy "
+                         "allocation",
+                         bytes));
   }
 
   template <typename T>
@@ -143,8 +156,13 @@ class TransientBufferArena {
     return static_cast<T*>(Allocate(count * sizeof(T), alignment));
   }
 
-  /// Rewind bump pointer to zero. Does not free device memory.
-  void Reset() noexcept { offset_ = 0; }
+  /// Rewind every slab bump to zero. Does not free device memory.
+  void Reset() noexcept {
+    for (auto& entry : slabs_) {
+      entry.offset = 0;
+    }
+    ClearStageStats();
+  }
 
   /**
    * @brief Free device slabs. Caller must GPU-synchronize if kernels still read them.
@@ -152,8 +170,9 @@ class TransientBufferArena {
    * Develop scratch is released after SensorDevelop, not kept for later frames.
    */
   void ReleaseDeviceMemory() noexcept {
-    if (capacity_ > 0 && ShouldTraceGpuPoolAlloc(capacity_)) {
-      std::fprintf(stderr, "[GPU_POOL] transient release %.1f MiB\n", GpuPoolMiB(capacity_));
+    const auto capacity = capacity_bytes();
+    if (capacity > 0 && ShouldTraceGpuPoolAlloc(capacity)) {
+      std::fprintf(stderr, "[GPU_POOL] transient release %.1f MiB\n", GpuPoolMiB(capacity));
       if constexpr (requires(const Backend& backend) { backend.QueryDeviceMemory(); }) {
         PrintGpuDeviceMemory(backend_->QueryDeviceMemory());
       }
@@ -161,35 +180,78 @@ class TransientBufferArena {
     ResetSlab();
   }
 
-  void Rewind(std::size_t mark_bytes) {
-    if (mark_bytes > offset_) {
-      throw std::runtime_error("TransientBufferArena::Rewind: mark is past current offset");
+  [[nodiscard]] auto CaptureMark() const -> Mark {
+    Mark mark;
+    mark.reserve(slabs_.size());
+    for (const auto& entry : slabs_) {
+      mark.push_back(entry.offset);
     }
-    offset_ = mark_bytes;
+    return mark;
   }
 
-  void RewindUnchecked(std::size_t mark_bytes) noexcept {
-    offset_ = mark_bytes < offset_ ? mark_bytes : offset_;
+  void RewindToMark(const Mark& mark) noexcept {
+    for (std::size_t i = 0; i < slabs_.size(); ++i) {
+      slabs_[i].offset = i < mark.size() ? mark[i] : 0;
+    }
   }
 
-  [[nodiscard]] auto capacity_bytes() const noexcept -> std::size_t { return capacity_; }
-  [[nodiscard]] auto used_bytes() const noexcept -> std::size_t { return offset_; }
+  [[nodiscard]] auto capacity_bytes() const noexcept -> std::size_t {
+    std::size_t total = 0;
+    for (const auto& entry : slabs_) {
+      total += entry.size;
+    }
+    return total;
+  }
+  [[nodiscard]] auto used_bytes() const noexcept -> std::size_t {
+    std::size_t total = 0;
+    for (const auto& entry : slabs_) {
+      total += entry.offset;
+    }
+    return total;
+  }
   [[nodiscard]] auto remaining_bytes() const noexcept -> std::size_t {
-    return capacity_ > offset_ ? capacity_ - offset_ : 0;
+    std::size_t total = 0;
+    for (const auto& entry : slabs_) {
+      total += entry.size > entry.offset ? entry.size - entry.offset : 0;
+    }
+    return total;
   }
+  [[nodiscard]] auto slab_count() const noexcept -> std::size_t { return slabs_.size(); }
   [[nodiscard]] auto base() const noexcept -> void* {
     return slabs_.empty() ? nullptr : slabs_.front().slab.DevicePointer();
   }
-  [[nodiscard]] auto empty() const noexcept -> bool { return offset_ == 0; }
+  [[nodiscard]] auto empty() const noexcept -> bool { return used_bytes() == 0; }
+  [[nodiscard]] auto Snapshot() const -> TransientArenaSnapshot {
+    TransientArenaSnapshot snap;
+    snap.requested_bytes    = requested_bytes_;
+    snap.padding_bytes      = padding_bytes_;
+    snap.used_bytes         = used_bytes();
+    snap.capacity_bytes    = capacity_bytes();
+    snap.unused_tail_bytes = remaining_bytes();
+    snap.slab_count        = slabs_.size();
+    snap.largest_allocation = largest_allocation_;
+    snap.grow_count        = grow_count_;
+    return snap;
+  }
 
  private:
   struct SlabEntry {
     typename Backend::Slab slab{};
-    std::size_t            size = 0;
+    std::size_t            size   = 0;
+    std::size_t            offset = 0;
   };
 
   static auto AlignUp(std::size_t value, std::size_t alignment) -> std::size_t {
     return (value + alignment - 1) & ~(alignment - 1);
+  }
+
+  [[nodiscard]] auto HasLiveAllocations() const noexcept -> bool {
+    for (const auto& entry : slabs_) {
+      if (entry.offset != 0) {
+        return true;
+      }
+    }
+    return false;
   }
 
   auto QueryMaxSlabBytes() const -> std::size_t {
@@ -205,87 +267,117 @@ class TransientBufferArena {
     return (std::numeric_limits<std::size_t>::max)();
   }
 
-  auto TryPlace(std::size_t aligned_offset, std::size_t bytes) -> void* {
-    std::size_t origin = 0;
-    for (auto& entry : slabs_) {
-      if (aligned_offset >= origin && aligned_offset + bytes <= origin + entry.size) {
-        return static_cast<char*>(entry.slab.DevicePointer()) + (aligned_offset - origin);
-      }
-      origin += entry.size;
+  auto QueryMaxTransientBytes() const -> std::size_t {
+    if (backend_ == nullptr) {
+      return (std::numeric_limits<std::size_t>::max)();
     }
-    return nullptr;
+    if constexpr (requires(const Backend& backend) { backend.MaxTransientBytes(); }) {
+      const auto cap = backend_->MaxTransientBytes();
+      if (cap != 0) {
+        return cap;
+      }
+    }
+    return (std::numeric_limits<std::size_t>::max)();
   }
 
-  auto NextSlabOrigin(std::size_t aligned_offset) const -> std::size_t {
-    std::size_t origin = 0;
-    for (const auto& entry : slabs_) {
-      const auto end = origin + entry.size;
-      if (aligned_offset < end) {
-        return end;
-      }
-      origin = end;
+  auto SlabBytesForRequest(std::size_t request) const -> std::size_t {
+    const auto max_slab = QueryMaxSlabBytes();
+    std::size_t size     = kMinSlabBytes;
+    if (request > kMinSlabBytes && request <= kSlabQuantumBytes) {
+      size = kSlabQuantumBytes;
+    } else if (request > kSlabQuantumBytes) {
+      size = AlignUp(request, kSlabQuantumBytes);
     }
-    return origin;
+    if (size > max_slab) {
+      size = max_slab;
+    }
+    if (size < request) {
+      size = request;
+    }
+    return size;
   }
 
-  auto PlaceFrom(std::size_t aligned_offset, std::size_t bytes, std::size_t alignment) -> void* {
-    while (true) {
-      if (void* placed = TryPlace(aligned_offset, bytes)) {
-        offset_ = aligned_offset + bytes;
-        return placed;
-      }
-      const auto skipped = NextSlabOrigin(aligned_offset);
-      if (skipped == aligned_offset) {
-        return nullptr;
-      }
-      const auto next = AlignUp(skipped, alignment);
-      if (next <= aligned_offset) {
-        return nullptr;
-      }
-      aligned_offset = next;
+  auto TryAllocateIn(SlabEntry& entry, std::size_t bytes, std::size_t alignment) -> void* {
+    const auto aligned = AlignUp(entry.offset, alignment);
+    if (aligned < entry.offset) {
+      return nullptr;
     }
+    if (bytes > entry.size || aligned > entry.size - bytes) {
+      return nullptr;
+    }
+    padding_bytes_ += aligned - entry.offset;
+    entry.offset = aligned + bytes;
+    return static_cast<char*>(entry.slab.DevicePointer()) + aligned;
   }
 
-  auto AppendAndPlace(std::size_t bytes) -> void* {
-    const auto origin = capacity_;
-    AppendSlab(bytes);
-    void* placed = TryPlace(origin, bytes);
-    if (placed == nullptr) {
-      throw std::runtime_error("TransientBufferArena::Allocate: appended slab did not fit");
+  void NoteAllocation(std::size_t bytes) noexcept {
+    requested_bytes_ += bytes;
+    if (bytes > largest_allocation_) {
+      largest_allocation_ = bytes;
     }
-    offset_ = origin + bytes;
-    return placed;
   }
 
   void AppendSlab(std::size_t bytes) {
-    const auto max_slab = QueryMaxSlabBytes();
-    const auto chunk    = bytes > max_slab ? max_slab : bytes;
-    slabs_.push_back(SlabEntry{backend_->CreateSlab(chunk), chunk});
-    capacity_ += chunk;
+    const auto max_transient = QueryMaxTransientBytes();
+    const auto current        = capacity_bytes();
+    if (bytes > max_transient || current > max_transient - bytes) {
+      throw std::runtime_error(FormatLimitError(
+          "TransientBufferArena: allocation would exceed transient budget", bytes));
+    }
+    if (backend_ == nullptr) {
+      throw std::runtime_error("TransientBufferArena::Allocate: backend is missing");
+    }
+    slabs_.push_back(SlabEntry{backend_->CreateSlab(bytes), bytes, 0});
   }
 
   void EnsureCapacity(std::size_t bytes) {
     // Drop unused slabs first. Creating the replacement before release would
     // keep both working sets alive and double the VRAM occupancy.
     ResetSlab();
-    std::vector<SlabEntry> replacement;
-    std::size_t            total     = 0;
-    const auto             max_slab  = QueryMaxSlabBytes();
-    std::size_t            remaining = bytes;
+    if (bytes == 0) {
+      return;
+    }
+    const auto max_slab  = QueryMaxSlabBytes();
+    std::size_t remaining = bytes;
     while (remaining > 0) {
       const auto chunk = remaining > max_slab ? max_slab : remaining;
-      replacement.push_back(SlabEntry{backend_->CreateSlab(chunk), chunk});
-      total += chunk;
+      AppendSlab(chunk);
       remaining -= chunk;
     }
-    slabs_    = std::move(replacement);
-    capacity_ = total;
+  }
+
+  void ClearStageStats() noexcept {
+    requested_bytes_    = 0;
+    padding_bytes_      = 0;
+    largest_allocation_ = 0;
+    grow_count_         = 0;
   }
 
   void ResetSlab() noexcept {
     slabs_.clear();
-    capacity_ = 0;
-    offset_   = 0;
+    ClearStageStats();
+  }
+
+  auto FormatLimitError(const char* prefix, std::size_t requested) const -> std::string {
+    char buffer[768];
+    std::snprintf(buffer, sizeof(buffer),
+                  "%s: requested=%zu used=%zu capacity=%zu slabs=%zu largest=%zu padding=%zu "
+                  "unused_tail=%zu grow=%zu",
+                  prefix, requested, used_bytes(), capacity_bytes(), slabs_.size(),
+                  largest_allocation_, padding_bytes_, remaining_bytes(), grow_count_);
+    std::string message = buffer;
+    if constexpr (requires(const Backend& backend) { backend.QueryDeviceMemory(); }) {
+      if (backend_ != nullptr) {
+        const auto memory = backend_->QueryDeviceMemory();
+        if (memory.valid) {
+          char extra[256];
+          std::snprintf(extra, sizeof(extra), " device_free=%zu device_total=%zu",
+                        memory.free_bytes, memory.total_bytes);
+          message += extra;
+        }
+      }
+    }
+    return message;
   }
 
   void MoveFrom(TransientBufferArena& other) noexcept {
@@ -297,18 +389,24 @@ class TransientBufferArena {
       backend_       = other.backend_;
       other.backend_ = nullptr;
     }
-    slabs_          = std::move(other.slabs_);
-    capacity_       = other.capacity_;
-    offset_         = other.offset_;
-    other.capacity_ = 0;
-    other.offset_   = 0;
+    slabs_               = std::move(other.slabs_);
+    requested_bytes_     = other.requested_bytes_;
+    padding_bytes_       = other.padding_bytes_;
+    largest_allocation_ = other.largest_allocation_;
+    grow_count_          = other.grow_count_;
+    other.requested_bytes_     = 0;
+    other.padding_bytes_       = 0;
+    other.largest_allocation_ = 0;
+    other.grow_count_          = 0;
   }
 
   std::optional<Backend> owned_;
-  Backend*               backend_ = nullptr;
+  Backend*               backend_            = nullptr;
   std::vector<SlabEntry> slabs_;
-  std::size_t            capacity_ = 0;
-  std::size_t            offset_   = 0;
+  std::size_t            requested_bytes_     = 0;
+  std::size_t            padding_bytes_      = 0;
+  std::size_t            largest_allocation_ = 0;
+  std::size_t            grow_count_         = 0;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
@@ -39,10 +39,13 @@ struct TransientArenaSnapshot {
  * fit in one slab; allocations never span slab boundaries and never relocate
  * live device pointers. Optional `MaxTransientBytes()` caps the sum of slabs.
  *
- * `Reserve` may replace unused slabs. `Allocate` that does not fit any current
- * remainder appends another slab. Develop scratch is exclusive and discarded
- * after SensorDevelop (`ReleaseDeviceMemory`). `Reset()` rewinds every local
- * bump without freeing slabs. Not thread-safe.
+ * `Reserve` may replace unused slabs when the request fits in one slab. Requests
+ * larger than `MaxSlabBytes()` leave the arena empty so `Allocate` can create
+ * request-sized slabs (pre-splitting into a max-slab plus leftover cannot satisfy
+ * a later near-max-slab allocation, then exceeds `MaxTransientBytes`). `Allocate`
+ * that does not fit any current remainder appends another slab. Develop scratch
+ * is exclusive and discarded after SensorDevelop (`ReleaseDeviceMemory`).
+ * `Reset()` rewinds every local bump without freeing slabs. Not thread-safe.
  *
  * @tparam Backend Slab factory. Must outlive this arena when passed by reference.
  */
@@ -162,6 +165,35 @@ class TransientBufferArena {
       entry.offset = 0;
     }
     ClearStageStats();
+  }
+
+  /**
+   * @brief Use caller-owned memory as the only slab. Does not cudaMalloc.
+   *
+   * Develop DemosaicNet tile activations bind a bump region carved from the
+   * exclusive-stage arena so that scratch dies with @ref ReleaseDeviceMemory.
+   */
+  void BindExternalMemory(void* ptr, std::size_t bytes) {
+    if (HasLiveAllocations()) {
+      throw std::runtime_error(
+          "TransientBufferArena::BindExternalMemory: cannot replace slabs while "
+          "allocations are live");
+    }
+    ResetSlab();
+    if (ptr == nullptr || bytes == 0) {
+      return;
+    }
+    if constexpr (requires(Backend& backend, void* p, std::size_t n) {
+                    backend.BorrowSlab(p, n);
+                  }) {
+      if (backend_ == nullptr) {
+        throw std::runtime_error("TransientBufferArena::BindExternalMemory: backend is missing");
+      }
+      slabs_.push_back(SlabEntry{backend_->BorrowSlab(ptr, bytes), bytes, 0});
+      return;
+    }
+    throw std::runtime_error(
+        "TransientBufferArena::BindExternalMemory: backend cannot borrow external memory");
   }
 
   /**
@@ -337,13 +369,19 @@ class TransientBufferArena {
     if (bytes == 0) {
       return;
     }
-    const auto max_slab  = QueryMaxSlabBytes();
-    std::size_t remaining = bytes;
-    while (remaining > 0) {
-      const auto chunk = remaining > max_slab ? max_slab : remaining;
-      AppendSlab(chunk);
-      remaining -= chunk;
+    const auto max_transient = QueryMaxTransientBytes();
+    if (bytes > max_transient) {
+      bytes = max_transient;
     }
+    const auto max_slab = QueryMaxSlabBytes();
+    if (bytes <= max_slab) {
+      AppendSlab(bytes);
+      return;
+    }
+    // Larger than one slab: do not pre-split into max-slab chunks. A remainder
+    // slab cannot satisfy a later near-max-slab Allocate, and appending that
+    // request then exceeds MaxTransientBytes (OpenCL 100MP Neural + HLR).
+    // Allocate() appends request-sized slabs instead.
   }
 
   void ClearStageStats() noexcept {

--- a/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
@@ -238,7 +238,11 @@ class TransientBufferArena {
       if (skipped == aligned_offset) {
         return nullptr;
       }
-      aligned_offset = AlignUp(skipped, alignment);
+      const auto next = AlignUp(skipped, alignment);
+      if (next <= aligned_offset) {
+        return nullptr;
+      }
+      aligned_offset = next;
     }
   }
 
@@ -261,6 +265,9 @@ class TransientBufferArena {
   }
 
   void EnsureCapacity(std::size_t bytes) {
+    // Drop unused slabs first. Creating the replacement before release would
+    // keep both working sets alive and double the VRAM occupancy.
+    ResetSlab();
     std::vector<SlabEntry> replacement;
     std::size_t            total     = 0;
     const auto             max_slab  = QueryMaxSlabBytes();

--- a/alcedo_studio/src/include/gpu/transient_buffer_scope.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_scope.hpp
@@ -4,30 +4,30 @@
 
 #pragma once
 
-#include <cstddef>
 #include <utility>
+#include <vector>
 
 #include "gpu/transient_buffer_arena.hpp"
 
 namespace alcedo {
 
 /**
- * @brief RAII nested bump scope. Rewinds @ref TransientBufferArena to the mark
- * taken at construction. Allocations inside the scope are invalid after Release.
+ * @brief RAII nested bump scope. Rewinds @ref TransientBufferArena to the per-slab
+ * offsets captured at construction. Allocations inside the scope are invalid after Release.
  *
- * LIFO only. Not thread-safe.
+ * LIFO only. Appended slabs stay allocated and are rewound to offset 0. Not thread-safe.
  */
 template <class Backend>
 class TransientBufferScope {
  public:
   explicit TransientBufferScope(TransientBufferArena<Backend>& arena)
-      : arena_(&arena), mark_(arena.used_bytes()) {}
+      : arena_(&arena), mark_(arena.CaptureMark()) {}
 
   TransientBufferScope(const TransientBufferScope&)            = delete;
   auto operator=(const TransientBufferScope&) -> TransientBufferScope& = delete;
 
   TransientBufferScope(TransientBufferScope&& other) noexcept
-      : arena_(other.arena_), mark_(other.mark_) {
+      : arena_(other.arena_), mark_(std::move(other.mark_)) {
     other.arena_ = nullptr;
   }
 
@@ -35,7 +35,7 @@ class TransientBufferScope {
     if (this != &other) {
       Release();
       arena_       = other.arena_;
-      mark_        = other.mark_;
+      mark_        = std::move(other.mark_);
       other.arena_ = nullptr;
     }
     return *this;
@@ -45,16 +45,18 @@ class TransientBufferScope {
 
   void Release() noexcept {
     if (arena_ != nullptr) {
-      arena_->RewindUnchecked(mark_);
+      arena_->RewindToMark(mark_);
       arena_ = nullptr;
     }
   }
 
-  [[nodiscard]] auto mark() const noexcept -> std::size_t { return mark_; }
+  [[nodiscard]] auto mark() const noexcept -> const typename TransientBufferArena<Backend>::Mark& {
+    return mark_;
+  }
 
  private:
-  TransientBufferArena<Backend>* arena_ = nullptr;
-  std::size_t                    mark_  = 0;
+  TransientBufferArena<Backend>*                    arena_ = nullptr;
+  typename TransientBufferArena<Backend>::Mark mark_;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/app/pipeline_service_test.cpp
+++ b/alcedo_studio/tests/app/pipeline_service_test.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <format>
 #include <memory>
+#include <mutex>
 #include <random>
 #include <thread>
 #include <unordered_map>
@@ -709,6 +710,47 @@ TEST_F(PipelineMapperTests, LoadPipelineSnapshotClonesGpuDagDocumentIndependentl
   EXPECT_EQ(snap_lmt->CubePath(), "C:/looks/live.cube");
   ps.ReleasePipelineSnapshot(snap);
   ps.SavePipeline(live);
+}
+
+TEST_F(PipelineMapperTests, ReloadedFormat2GraphWithoutAdapterStillRemirrorsCpuNeuralEngine) {
+  ProjectService      project(db_path_, meta_path_);
+  PipelineMgmtService first(project.GetStorage());
+
+  auto initial = first.LoadEditorPipeline(9102);
+  ASSERT_NE(initial, nullptr);
+  ASSERT_NE(initial->pipeline_, nullptr);
+  ASSERT_NE(initial->document_, nullptr);
+  EXPECT_TRUE(initial->pipeline_->MirrorsLegacyStageAdapter());
+
+  nlohmann::json raw_params = pipeline_defaults::MakeDefaultRawDecodeParams();
+  raw_params["raw"]["method"] = "neural_engine";
+  {
+    std::unique_lock<std::mutex> render_lock(initial->pipeline_->GetRenderLock());
+    initial->pipeline_->GetStage(PipelineStageName::Image_Loading)
+        .SetOperator(OperatorType::RAW_DECODE, raw_params);
+    initial->pipeline_->SetExecutionStages();
+  }
+  EXPECT_EQ(initial->document_->Develop()->Params().Params().demosaic_method, "default");
+
+  first.SyncPipelineDocument(initial);
+  const auto stored = project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(9102);
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->at("format_version"), 2);
+  EXPECT_FALSE(stored->contains("legacy_stage_adapter"));
+
+  initial->serialized_state_needs_writeback_ = true;
+  first.SavePipeline(initial);
+
+  PipelineMgmtService reopened(project.GetStorage());
+  auto                loaded = reopened.LoadEditorPipeline(9102);
+  ASSERT_NE(loaded, nullptr);
+  ASSERT_NE(loaded->document_, nullptr);
+  EXPECT_TRUE(loaded->pipeline_->MirrorsLegacyStageAdapter());
+  EXPECT_EQ(loaded->document_->Develop()->Params().Params().demosaic_method, "neural_engine");
+  const auto exported = loaded->pipeline_->ExportPipelineParams();
+  EXPECT_EQ(exported["Image Loading"]["Image Loading"]["raw_decode"]["params"]["raw"]["method"],
+            "neural_engine");
+  reopened.SavePipeline(loaded);
 }
 
 TEST_F(PipelineMapperTests, EditorLoadUsesMatchingSerializedStateWithoutReconstruction) {

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -441,7 +441,9 @@ if(ALCEDO_OPENCL_ENABLED)
     GTest::gtest_main EditRuntimeOpenCl EditInput RawProcessorOp OpenClDemosaicNetEntry
     OpenClProgramLibrary)
   target_compile_definitions(GpuDagOpenClDevelopTest PRIVATE
-    ALCEDO_OPENCL_SHADER_SOURCE_ROOT="${ALCEDO_SRC_DIR}")
+    ALCEDO_OPENCL_SHADER_SOURCE_ROOT="${ALCEDO_SRC_DIR}"
+    ALCEDO_DEMOASICNET_MODEL_DIR="${CMAKE_SOURCE_DIR}/alcedo_studio/src/config/models"
+    ALCEDO_TEST_IMAGE_ROOT="${ALCEDO_TEST_ROOT}/resources/sample_images")
   gtest_discover_tests(GpuDagOpenClDevelopTest TEST_PREFIX "GpuDagOpenClDevelopTest."
     PROPERTIES LABELS "gpu;edit;runtime;opencl")
   alcedo_register_test_target(GpuDagOpenClDevelopTest gpu)

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -341,6 +341,7 @@ if(ALCEDO_CUDA_ENABLED)
   add_executable(GpuDagCudaWorkspaceTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/parameter_arena_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/transient_and_cache_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/transient_buffer_arena_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/texture_lease_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/graph_image_cache_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/header_hygiene_test.cpp)

--- a/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
+++ b/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
@@ -183,6 +183,15 @@ TEST(GpuDagModelGraph, ApplyOntoKeepsRasterMaskCameraProfileAndUpdatesExposure) 
   EXPECT_FLOAT_EQ(contrast->Value(), 0.0f);
 }
 
+TEST(GpuDagModelGraph, ApplyOntoMapsNeuralEngineDemosaicMethod) {
+  auto document = CreateDefaultPipelineDocument();
+  auto json     = MakeLegacyStageJson();
+  json["Image Loading"]["Image Loading"]["raw_decode"]["params"]["raw"]["method"] =
+      "neural_engine";
+  EXPECT_TRUE(LegacyPipelineImporter::ApplyOnto(document, json).empty());
+  EXPECT_EQ(document.Develop()->Params().Params().demosaic_method, "neural_engine");
+}
+
 TEST(GpuDagModelGraph, ApplyOntoRejectsUnknownTypeWithoutMutatingDocument) {
   auto document = CreateDefaultPipelineDocument();
   document.ClearTopologyDirty();

--- a/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
@@ -22,6 +22,7 @@
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/runtime/cuda/cuda_develop_pass.hpp"
 #include "edit/runtime/cuda/cuda_sensor_demosaic.hpp"
+#include "edit/runtime/develop_transient.hpp"
 #include "edit/runtime/graph_compiler.hpp"
 #include "edit/runtime/texture_format.hpp"
 
@@ -113,9 +114,6 @@ auto RenderDevelop(PipelineDocument& document, const PreparedRawInput& prepared)
     -> std::vector<Rgba> {
   const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   CudaRenderDevice device;
-  if (plan.peak_transient_bytes > 0) {
-    device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
-  }
   device.BeginRender();
   ExecuteCudaDevelop(device, plan, prepared, document);
   device.EndRender();
@@ -188,7 +186,6 @@ TEST_F(CudaDevelopFixture, CudaDevelopUsesWorkspaceForAllTemporaryBuffers) {
   const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
   CudaRenderDevice device;
-  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
   device.BeginRender();
   ExecuteCudaDevelop(device, plan, prepared, document);
   EXPECT_GT(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
@@ -206,7 +203,6 @@ TEST_F(CudaDevelopFixture, CudaDevelopSecondRenderCreatesNoGpuAllocation) {
   const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
   CudaRenderDevice device;
-  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
   device.BeginRender();
   ExecuteCudaDevelop(device, plan, prepared, document);
   device.EndRender();
@@ -443,6 +439,34 @@ TEST_F(CudaDevelopFixture, PlanExecuteFreesDevelopScratchAfterSensorDevelop) {
   EXPECT_NE(device.Workspace().Images().Find(plan.sensor_linear_output), nullptr);
 }
 
+TEST_F(CudaDevelopFixture, PlanExecuteCachesObservedDevelopTransientCapacityForTheNextLayout) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  SetDevelopMethod(document, "legacy", false);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  CudaRenderDevice device;
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+  const auto observed = device.Workspace().DevelopTransientHighWater().ObservedCapacity(
+      plan.source, CudaBackend::kCapabilityVersion);
+  EXPECT_GT(observed, ConservativeDevelopInitialBytes(plan.source));
+  EXPECT_EQ(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
+
+  device.WaitIdle();
+  device.Workspace().ReleaseSessionResources();
+  EXPECT_EQ(device.Workspace().DevelopTransientHighWater().SuggestInitial(
+                plan.source, CudaBackend::kCapabilityVersion),
+            ApplyDevelopTransientSafetyMargin(observed));
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+  EXPECT_EQ(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
+}
+
 TEST_F(CudaDevelopFixture, ViewportGeometryResampleAllocatesADistinctDisplaySizedTexture) {
   const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
@@ -484,7 +508,6 @@ TEST_F(CudaDevelopFixture, CudaDevelopUploadFailureRestoresDirtyAndDoesNotFallba
   const auto plan     = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
 
   CudaRenderDevice device;
-  device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
   device.Workspace().Device().FailNextUpload();
   device.BeginRender();
   EXPECT_THROW(ExecuteCudaDevelop(device, plan, prepared, document), std::runtime_error);

--- a/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_develop_test.cpp
@@ -453,14 +453,14 @@ TEST_F(CudaDevelopFixture, PlanExecuteCachesObservedDevelopTransientCapacityForT
   (void)device.Execute(plan, prepared, document);
   device.WaitIdle();
   const auto observed = device.Workspace().DevelopTransientHighWater().ObservedCapacity(
-      plan.source, CudaBackend::kCapabilityVersion);
+      plan.source, CudaBackend::kCapabilityVersion, RawDemosaicMethod::Legacy);
   EXPECT_GT(observed, ConservativeDevelopInitialBytes(plan.source));
   EXPECT_EQ(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
 
   device.WaitIdle();
   device.Workspace().ReleaseSessionResources();
   EXPECT_EQ(device.Workspace().DevelopTransientHighWater().SuggestInitial(
-                plan.source, CudaBackend::kCapabilityVersion),
+                plan.source, CudaBackend::kCapabilityVersion, RawDemosaicMethod::Legacy),
             ApplyDevelopTransientSafetyMargin(observed));
   (void)device.Execute(plan, prepared, document);
   device.WaitIdle();

--- a/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
@@ -281,6 +281,63 @@ TEST_F(MetalDevelopFixture, MetalDevelopRcdOrderMatchesCudaDemosaicThenHighlight
   EXPECT_TRUE(PixelsDiffer(on_px, off_px));
 }
 
+TEST_F(MetalDevelopFixture, MetalDevelopScratchResourcesReleaseAfterRecordedWorkCompletes) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "legacy", true);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  MetalRenderDevice device;
+  auto&             workspace = device.Workspace();
+  workspace.Device().ResetCounters();
+  device.BeginRender();
+  ExecuteMetalDevelop(device, plan, prepared, document);
+
+  const auto scratch_count = workspace.Device().RecordedWorkScratchTextureCount();
+  ASSERT_GT(scratch_count, 0U);
+  const auto scratch_buffer_count = workspace.Device().RecordedWorkScratchBufferCount();
+  ASSERT_GT(scratch_buffer_count, 0U);
+  EXPECT_EQ(workspace.Textures().EntryCount(), 1U);
+  EXPECT_EQ(workspace.Textures().UsedBytes(),
+            static_cast<std::size_t>(plan.source.develop_output_extent.width) *
+                plan.source.develop_output_extent.height *
+                TextureFormatBytesPerPixel(TextureFormat::Rgba32f));
+  const auto free_before = workspace.Device().FreeCount();
+
+  workspace.Device().SynchronizeRecordedWork(device.CommandContext());
+
+  EXPECT_EQ(workspace.Device().RecordedWorkScratchBufferCount(), 0U);
+  EXPECT_EQ(workspace.Device().RecordedWorkScratchTextureCount(), 0U);
+  EXPECT_EQ(workspace.Device().FreeCount() - free_before, scratch_count + scratch_buffer_count);
+  device.EndRender();
+  device.WaitIdle();
+}
+
+TEST_F(MetalDevelopFixture, MetalPlanExecutorDoesNotReserveDevelopTransientArena) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  SetDevelopMethod(document, "legacy", false);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  MetalRenderDevice device;
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+
+  EXPECT_EQ(device.Workspace().DevelopTransientHighWater().ObservedCapacity(
+                plan.source, MetalBackend::kCapabilityVersion),
+            0U);
+  EXPECT_EQ(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
+  EXPECT_EQ(device.Workspace().Device().RecordedWorkScratchBufferCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().RecordedWorkScratchTextureCount(), 0U);
+}
+
 TEST_F(MetalDevelopFixture, MetalDevelopXTransMatchesCudaReferenceWithinTolerance) {
   const auto pattern  = gpu_dag_test::MakeXTransPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
@@ -343,7 +400,9 @@ TEST_F(MetalDevelopFixture, MetalDevelopNeuralUsesSessionWorkspaceAndDoesNotSele
     EXPECT_NE(message.find("Neural Engine"), std::string::npos);
     EXPECT_EQ(message.find("legacy"), std::string::npos);
     EXPECT_EQ(message.find("Legacy"), std::string::npos);
+    EXPECT_GT(device.Workspace().Device().RecordedWorkScratchTextureCount(), 0U);
     device.CancelRender();
+    EXPECT_EQ(device.Workspace().Device().RecordedWorkScratchTextureCount(), 0U);
     EXPECT_EQ(device.Workspace().Images().Find(plan.sensor_linear_output), nullptr);
   } catch (...) {
     SetMetalDevelopNeuralModelCacheForTesting(nullptr);

--- a/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
@@ -377,6 +377,46 @@ TEST_F(MetalDevelopFixture, MetalDevelopXTransMatchesCudaReferenceWithinToleranc
   EXPECT_LT(max_green_err, 2.0e-3f);
 }
 
+TEST_F(MetalDevelopFixture,
+       MetalDevelopNeuralEngineFinishesWithoutReusingACommittedCommandBuffer) {
+  auto& cache = MetalDemosaicNetModelCache::Instance();
+  if (!cache.EnsureLoaded(MetalDemosaicNetVariant::Bayer)) {
+    GTEST_SKIP() << "Bayer Neural Engine weights are not available: " << cache.LastError();
+  }
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  SetDevelopMethod(document, "neural_engine", true);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+
+  MetalRenderDevice device;
+  (void)device.Execute(plan, prepared, document);
+  device.WaitIdle();
+
+  EXPECT_EQ(device.Workspace().Device().RecordedWorkScratchTextureCount(), 0U);
+  EXPECT_EQ(device.Workspace().Device().RecordedWorkScratchBufferCount(), 0U);
+
+  const auto pixels = Download(device, plan.sensor_linear_output);
+  ASSERT_FALSE(pixels.empty());
+  for (const auto& p : pixels) {
+    EXPECT_TRUE(std::isfinite(p.r) && std::isfinite(p.g) && std::isfinite(p.b));
+    EXPECT_NEAR(p.a, 1.0f, 1.0e-3f);
+  }
+
+  auto legacy_doc = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(legacy_doc);
+  SetDevelopMethod(legacy_doc, "legacy", true);
+  const auto legacy_plan =
+      GraphCompiler::Compile(legacy_doc, prepared.CompileSource(), RenderRequest{});
+  MetalRenderDevice legacy_device;
+  (void)legacy_device.Execute(legacy_plan, prepared, legacy_doc);
+  legacy_device.WaitIdle();
+  EXPECT_TRUE(PixelsDiffer(Download(legacy_device, legacy_plan.sensor_linear_output), pixels));
+}
+
 TEST_F(MetalDevelopFixture, MetalDevelopNeuralUsesSessionWorkspaceAndDoesNotSelectLegacyOnFailure) {
   MetalDemosaicNetModelCache failing;
   SetMetalDevelopNeuralModelCacheForTesting(&failing);

--- a/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_develop_test.cpp
@@ -331,7 +331,7 @@ TEST_F(MetalDevelopFixture, MetalPlanExecutorDoesNotReserveDevelopTransientArena
   device.WaitIdle();
 
   EXPECT_EQ(device.Workspace().DevelopTransientHighWater().ObservedCapacity(
-                plan.source, MetalBackend::kCapabilityVersion),
+                plan.source, MetalBackend::kCapabilityVersion, RawDemosaicMethod::Legacy),
             0U);
   EXPECT_EQ(device.Workspace().TransientBuffers().capacity_bytes(), 0U);
   EXPECT_EQ(device.Workspace().Device().RecordedWorkScratchBufferCount(), 0U);

--- a/alcedo_studio/tests/edit/runtime/metal_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_grade_test.cpp
@@ -370,7 +370,7 @@ TEST_F(MetalGradeFixture, MetalLutRemapChangesGradePixels) {
             1.0e-3f);
 }
 
-TEST_F(MetalGradeFixture, MetalDetailPassesAcquireAllTexturesFromWorkspace) {
+TEST_F(MetalGradeFixture, MetalDetailScratchTexturesAreDestroyedAfterEachCompletedRender) {
   ModelByType<ClarityModel>(type_ids::Clarity()).SetValue(20.0f);
   ModelByType<SharpenModel>(type_ids::Sharpen()).SetAmount(10.0f);
   ModelByType<HalationModel>(type_ids::Halation()).SetValue(0.4f);
@@ -381,7 +381,10 @@ TEST_F(MetalGradeFixture, MetalDetailPassesAcquireAllTexturesFromWorkspace) {
   device_.Workspace().Device().ResetCounters();
   const auto second = RenderGrade();
   EXPECT_EQ(second.detail_pass_count, 4U);
-  EXPECT_EQ(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_GT(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().TextureCreateCount(),
+            device_.Workspace().Device().FreeCount());
+  EXPECT_EQ(device_.Workspace().Device().RecordedWorkScratchTextureCount(), 0U);
   EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
   EXPECT_EQ(device_.Workspace().Device().HeapCreateCount(), 0U);
   EXPECT_EQ(device_.Workspace().Device().PipelineCreateCount(), 0U);

--- a/alcedo_studio/tests/edit/runtime/metal_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_grade_test.cpp
@@ -223,6 +223,15 @@ auto WriteIdentityCube(const std::filesystem::path& path) -> void {
       << "0 0 1\n1 0 1\n0 1 1\n1 1 1\n";
 }
 
+auto WriteConstantRgbCube(const std::filesystem::path& path, float r, float g, float b) -> void {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << "LUT_3D_SIZE 2\n";
+  for (int i = 0; i < 8; ++i) {
+    out << r << ' ' << g << ' ' << b << '\n';
+  }
+}
+
 class MetalGradeFixture : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -340,6 +349,25 @@ TEST_F(MetalGradeFixture, MetalLutTextureIsReusedByContentKey) {
   EXPECT_EQ(device_.Workspace().Device().LutUploadBytes(), 0U);
   EXPECT_EQ(device_.Workspace().Device().LastLutResourceId(), first.lut_resource_id);
   EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
+}
+
+TEST_F(MetalGradeFixture, MetalLutRemapChangesGradePixels) {
+  const auto cube_path = std::filesystem::absolute("build/tmp/gpu_dag_metal_lut/red.cube");
+  WriteConstantRgbCube(cube_path, 1.0f, 0.0f, 0.0f);
+  auto& lmt = ModelByType<LmtModel>(type_ids::Lmt());
+  lmt.SetCubePath(cube_path.string());
+  const auto result = RenderGrade();
+  const auto input  = Download(device_, plan_.develop_output);
+  const auto output = Download(device_, result.output);
+  ASSERT_FALSE(output.empty());
+  ASSERT_EQ(input.size(), output.size());
+  EXPECT_NE(result.lut_resource_id, 0U);
+  EXPECT_NEAR(output.front().r, 1.0f, 1.0e-4f);
+  EXPECT_NEAR(output.front().g, 0.0f, 1.0e-4f);
+  EXPECT_NEAR(output.front().b, 0.0f, 1.0e-4f);
+  EXPECT_GT(std::abs(output.front().r - input.front().r) + std::abs(output.front().g - input.front().g) +
+                std::abs(output.front().b - input.front().b),
+            1.0e-3f);
 }
 
 TEST_F(MetalGradeFixture, MetalDetailPassesAcquireAllTexturesFromWorkspace) {

--- a/alcedo_studio/tests/edit/runtime/metal_llf_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_llf_test.cpp
@@ -476,7 +476,7 @@ class MetalLlfFixture : public ::testing::Test {
   MetalRenderDevice device_;
 };
 
-TEST_F(MetalLlfFixture, MetalLlfUsesWorkspaceTransientArenaForEveryPyramid) {
+TEST_F(MetalLlfFixture, MetalLlfDestroysPyramidScratchAfterCompletedRender) {
   ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
   const auto result = RenderGrade();
   EXPECT_GT(result.local_tone_transient_bytes, 0U);
@@ -492,7 +492,8 @@ TEST_F(MetalLlfFixture, MetalLlfUsesWorkspaceTransientArenaForEveryPyramid) {
   EXPECT_EQ(device_.Workspace().Values().Find(document_.PrimaryGrade()->Id(),
                                               PortId{"local_tone.remap_a.0"}),
             nullptr);
-  EXPECT_GT(device_.Workspace().TransientBuffers().used_bytes(), 0U);
+  EXPECT_EQ(device_.Workspace().TransientBuffers().used_bytes(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().RecordedWorkScratchBufferCount(), 0U);
   EXPECT_GE(plan_.peak_transient_bytes, result.local_tone_transient_bytes);
 }
 
@@ -517,18 +518,25 @@ TEST_F(MetalLlfFixture, MetalLlfSliderEditReusesCanonicalReference) {
   EXPECT_EQ(first.local_tone_reference_resource_id, second.local_tone_reference_resource_id);
   EXPECT_TRUE(second.local_tone_rebuilt_reference);
   EXPECT_FALSE(second.local_tone_sampled_canonical_reference);
-  EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
-  EXPECT_EQ(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_GT(device_.Workspace().Device().BufferCreateCount(), 0U);
+  EXPECT_GT(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().FreeCount(),
+            device_.Workspace().Device().BufferCreateCount() +
+                device_.Workspace().Device().TextureCreateCount());
   EXPECT_EQ(device_.Workspace().Device().PipelineCreateCount(), 0U);
 }
 
-TEST_F(MetalLlfFixture, MetalLlfSecondStableRenderCreatesNoBufferTextureOrPipelineState) {
+TEST_F(MetalLlfFixture, MetalLlfSecondStableRenderRecreatesOnlyDisposableScratch) {
   ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(25.0f);
   (void)RenderGrade();
   device_.Workspace().Device().ResetCounters();
   (void)RenderGrade();
   EXPECT_EQ(device_.Workspace().Device().BufferCreateCount(), 0U);
-  EXPECT_EQ(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_GT(device_.Workspace().Device().TextureCreateCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().FreeCount(),
+            device_.Workspace().Device().TextureCreateCount());
+  EXPECT_EQ(device_.Workspace().Device().RecordedWorkScratchBufferCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().RecordedWorkScratchTextureCount(), 0U);
   EXPECT_EQ(device_.Workspace().Device().HeapCreateCount(), 0U);
   EXPECT_EQ(device_.Workspace().Device().PipelineCreateCount(), 0U);
 }

--- a/alcedo_studio/tests/edit/runtime/opencl_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_develop_test.cpp
@@ -491,6 +491,23 @@ TEST_F(OpenClDevelopFixture,
 }
 
 TEST_F(OpenClDevelopFixture,
+       OpenClDevelopNeuralEngineHighlightRecoveryWritesFiniteRgbFromRgbaTiles) {
+  if (!NeuralEngineAvailable(OpenClDemosaicNetVariant::Bayer)) {
+    GTEST_SKIP() << "Bayer Neural Engine weights are not available.";
+  }
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      MakeOverRangeCfa(pattern, 64, 64), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "neural_engine", true);
+  const auto pixels = RenderDevelop(document, prepared);
+  ASSERT_FALSE(pixels.empty());
+  EXPECT_TRUE(AllFiniteNonZero(pixels));
+  EXPECT_GT(MaxChannel(pixels), 1.0f);
+}
+
+TEST_F(OpenClDevelopFixture,
        OpenClHundredMegapixelBayerFixturesCompleteAndProduceFinitePixels) {
   if (std::getenv("ALCEDO_RUN_100MP_OPENCL_TEST") == nullptr) {
     GTEST_SKIP() << "Set ALCEDO_RUN_100MP_OPENCL_TEST=1 for the bounded real-RAW GPU test.";

--- a/alcedo_studio/tests/edit/runtime/opencl_develop_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_develop_test.cpp
@@ -5,8 +5,13 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -14,6 +19,7 @@
 
 #include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
+#include "decoders/processor/nn/demosaicnet_preprocess_common.hpp"
 #include "decoders/processor/nn/opencl_demosaicnet_cache.hpp"
 #include "decoders/processor/operators/gpu/opencl_encode.hpp"
 #include "decoders/processor/operators/gpu/opencl_raw_programs.hpp"
@@ -135,6 +141,49 @@ auto PixelsDiffer(const std::vector<Rgba>& a, const std::vector<Rgba>& b) -> boo
     }
   }
   return false;
+}
+
+auto NeuralEngineAvailable(OpenClDemosaicNetVariant variant) -> bool {
+  OpenClDemosaicNetLoadOptions options;
+  return OpenClDemosaicNetModelCache::Instance().EnsureLoaded(variant, options);
+}
+
+auto RenderDevelop(PipelineDocument& document, const PreparedRawInput& prepared)
+    -> std::vector<Rgba> {
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  OpenClRenderDevice device;
+  if (plan.peak_transient_bytes > 0) {
+    device.Workspace().TransientBuffers().Reserve(plan.peak_transient_bytes);
+  }
+  device.BeginRender();
+  ExecuteOpenClDevelop(device, plan, prepared, document);
+  device.EndRender();
+  device.WaitIdle();
+  return Download(device, plan.sensor_linear_output);
+}
+
+auto AllFiniteNonZero(const std::vector<Rgba>& pixels) -> bool {
+  bool any = false;
+  for (const auto& p : pixels) {
+    if (!std::isfinite(p.r) || !std::isfinite(p.g) || !std::isfinite(p.b) || !std::isfinite(p.a)) {
+      return false;
+    }
+    any = any || p.r != 0.0f || p.g != 0.0f || p.b != 0.0f;
+  }
+  return any;
+}
+
+auto LoadEncodedFixture(const std::filesystem::path& path) -> std::vector<std::byte> {
+  std::ifstream input(path, std::ios::binary);
+  if (!input) {
+    throw std::runtime_error("Unable to open RAW fixture: " + path.string());
+  }
+  const std::vector<char> chars((std::istreambuf_iterator<char>(input)),
+                                std::istreambuf_iterator<char>());
+  std::vector<std::byte> bytes(chars.size());
+  std::transform(chars.begin(), chars.end(), bytes.begin(),
+                 [](char value) { return static_cast<std::byte>(value); });
+  return bytes;
 }
 
 auto CpuLinearize(const PreparedRawInput& input) -> std::vector<float> {
@@ -300,7 +349,7 @@ TEST_F(OpenClDevelopFixture, OpenClDevelopRcdOrderMatchesCudaDemosaicThenHighlig
 }
 
 TEST_F(OpenClDevelopFixture,
-       OpenClDevelopHighlightRecoveryFitsWhenSingleAllocCapIsBelowPaddedHostPixelReserve) {
+       OpenClDevelopHighlightRecoveryWritesTheOutputTextureWithoutASecondRgbaImage) {
   const auto pattern  = gpu_dag_test::MakeRggbPattern();
   const auto prepared = RawInputLoader::FromUnpackedCfa(
       MakeOverRangeCfa(pattern, 64, 64), pattern, gpu_dag_test::DefaultLinearization(),
@@ -308,20 +357,42 @@ TEST_F(OpenClDevelopFixture,
   auto document = CreateDefaultPipelineDocument();
   SetDevelopMethod(document, "legacy", true);
   const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
-  const auto host_pixels =
-      static_cast<std::size_t>(prepared.host_extent.width) * prepared.host_extent.height;
-  const auto padded =
-      plan.peak_transient_bytes + host_pixels * 16 + host_pixels * 12 + (64ull * 256ull);
-  ASSERT_GT(padded, plan.peak_transient_bytes);
-  const auto cap = (plan.peak_transient_bytes + (padded - plan.peak_transient_bytes) / 2) &
-                   ~std::size_t{255};
-  ASSERT_GT(cap, plan.peak_transient_bytes);
-  ASSERT_LT(cap, padded);
+  ASSERT_GT(plan.peak_transient_bytes, 0U);
+
+  OpenClRenderDevice device;
+  device.Workspace().Device().ResetCounters();
+  device.BeginRender();
+  ExecuteOpenClDevelop(device, plan, prepared, document);
+  EXPECT_LE(device.Workspace().TransientBuffers().used_bytes(), plan.peak_transient_bytes);
+  EXPECT_EQ(device.Workspace().Device().TextureCreateCount(), 1U);
+  EXPECT_EQ(device.Workspace().Textures().EntryCount(), 1U);
+  device.EndRender();
+  device.WaitIdle();
+  const auto pixels = Download(device, plan.sensor_linear_output);
+  ASSERT_FALSE(pixels.empty());
+  EXPECT_GT(MaxChannel(pixels), 1.0f);
+}
+
+TEST_F(OpenClDevelopFixture,
+       OpenClDevelopHighlightRecoveryFitsWhenEachSlabIsCappedBelowCompiledPeak) {
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      MakeOverRangeCfa(pattern, 64, 64), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto document = CreateDefaultPipelineDocument();
+  SetDevelopMethod(document, "legacy", true);
+  const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto cap  = (plan.peak_transient_bytes / 2) & ~std::size_t{255};
+  ASSERT_GT(cap, 64ull * 64ull * 12ull);
+  ASSERT_LT(cap, plan.peak_transient_bytes);
 
   OpenClRenderDevice device;
   device.Workspace().Device().SetMaxSlabBytes(cap);
+  device.Workspace().Device().ResetCounters();
   device.BeginRender();
   ExecuteOpenClDevelop(device, plan, prepared, document);
+  EXPECT_LE(device.Workspace().TransientBuffers().used_bytes(), plan.peak_transient_bytes);
+  EXPECT_EQ(device.Workspace().Device().TextureCreateCount(), 1U);
   device.EndRender();
   device.WaitIdle();
   const auto pixels = Download(device, plan.sensor_linear_output);
@@ -397,6 +468,78 @@ TEST_F(OpenClDevelopFixture,
   } catch (...) {
     SetOpenClDevelopNeuralModelCacheForTesting(nullptr);
     throw;
+  }
+}
+
+TEST_F(OpenClDevelopFixture,
+       OpenClDevelopNeuralEngineWritesFiniteRgbFromMonoCfaTilesAndDiffersFromLegacy) {
+  if (!NeuralEngineAvailable(OpenClDemosaicNetVariant::Bayer)) {
+    GTEST_SKIP() << "Bayer Neural Engine weights are not available.";
+  }
+  const auto pattern  = gpu_dag_test::MakeRggbPattern();
+  const auto prepared = RawInputLoader::FromUnpackedCfa(
+      gpu_dag_test::MakeU16CfaPlane(64, 64, pattern), pattern, gpu_dag_test::DefaultLinearization(),
+      gpu_dag_test::FullSensor(64, 64), DecodeRes::FULL);
+  auto legacy_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(legacy_doc, "legacy", false);
+  auto neural_doc = CreateDefaultPipelineDocument();
+  SetDevelopMethod(neural_doc, "neural_engine", false);
+  const auto neural_pixels = RenderDevelop(neural_doc, prepared);
+  ASSERT_FALSE(neural_pixels.empty());
+  EXPECT_TRUE(AllFiniteNonZero(neural_pixels));
+  EXPECT_TRUE(PixelsDiffer(RenderDevelop(legacy_doc, prepared), neural_pixels));
+}
+
+TEST_F(OpenClDevelopFixture,
+       OpenClHundredMegapixelBayerFixturesCompleteAndProduceFinitePixels) {
+  if (std::getenv("ALCEDO_RUN_100MP_OPENCL_TEST") == nullptr) {
+    GTEST_SKIP() << "Set ALCEDO_RUN_100MP_OPENCL_TEST=1 for the bounded real-RAW GPU test.";
+  }
+  const auto root = std::filesystem::path(ALCEDO_TEST_IMAGE_ROOT) / "raw" / "camera";
+  const std::vector<std::filesystem::path> paths = {
+      root / "fuji" / "gfx100s" / "DSCF0224.RAF",
+      root / "fuji" / "gfx100s" / "DSCF0305.RAF",
+      root / "fuji" / "gfx100s" / "DSCF0337.RAF",
+      root / "hasselblad" / "x2d" / "B0004841.dng",
+  };
+
+  for (const auto& path : paths) {
+    SCOPED_TRACE(path.string());
+    if (!std::filesystem::exists(path)) {
+      GTEST_SKIP() << "100MP fixture is unavailable: " << path.string();
+    }
+    const auto encoded  = LoadEncodedFixture(path);
+    const auto prepared = RawInputLoader::LoadEncoded(encoded, DecodeRes::FULL);
+    ASSERT_EQ(prepared.cfa_pattern.kind, RawCfaKind::Bayer2x2);
+    ASSERT_GT(static_cast<std::uint64_t>(prepared.host_extent.width) * prepared.host_extent.height,
+              100'000'000ULL);
+
+    auto       document = CreateDefaultPipelineDocument();
+    const auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+    OpenClRenderDevice device;
+    const auto         started = std::chrono::steady_clock::now();
+    device.BeginRender();
+    ExecuteOpenClDevelop(device, plan, prepared, document);
+    device.EndRender();
+    device.WaitIdle();
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+
+    auto* output = device.Workspace().Images().Find(plan.sensor_linear_output);
+    ASSERT_NE(output, nullptr);
+    ASSERT_EQ(output->Texture().Width(), plan.source.develop_output_extent.width);
+    ASSERT_EQ(output->Texture().Height(), plan.source.develop_output_extent.height);
+    const std::size_t origin[3] = {output->Texture().Width() / 2,
+                                   output->Texture().Height() / 2, 0};
+    const std::size_t region[3] = {1, 1, 1};
+    Rgba              pixel{};
+    ASSERT_EQ(clEnqueueReadImage(device.Workspace().Device().NativeQueue(),
+                                 output->Texture().Native(), CL_TRUE, origin, region, 0, 0, &pixel,
+                                 0, nullptr, nullptr),
+              CL_SUCCESS);
+    EXPECT_TRUE(std::isfinite(pixel.r));
+    EXPECT_TRUE(std::isfinite(pixel.g));
+    EXPECT_TRUE(std::isfinite(pixel.b));
+    EXPECT_LT(elapsed, std::chrono::minutes(8));
   }
 }
 

--- a/alcedo_studio/tests/edit/runtime/opencl_workspace_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_workspace_test.cpp
@@ -329,11 +329,13 @@ TEST(TransientBufferArena, UnalignedFirstAllocationAppendsAnotherSlabWithoutLoop
     };
 
     std::vector<std::size_t> create_sizes;
+    std::size_t               max_slab_bytes = 512;
 
     auto CreateSlab(std::size_t bytes) -> Slab {
       create_sizes.push_back(bytes);
       return Slab(bytes);
     }
+    [[nodiscard]] auto MaxSlabBytes() const -> std::size_t { return max_slab_bytes; }
   };
 
   AppendRecordingBackend                       backend;
@@ -344,9 +346,11 @@ TEST(TransientBufferArena, UnalignedFirstAllocationAppendsAnotherSlabWithoutLoop
 
   ASSERT_NE(first, nullptr);
   ASSERT_NE(second, nullptr);
-  EXPECT_EQ(backend.create_sizes, (std::vector<std::size_t>{257, 512}));
-  EXPECT_EQ(arena.capacity_bytes(), 769U);
-  EXPECT_EQ(arena.used_bytes(), 769U);
+  EXPECT_NE(first, second);
+  EXPECT_EQ(backend.create_sizes, (std::vector<std::size_t>{512, 512}));
+  EXPECT_EQ(arena.capacity_bytes(), 1024U);
+  EXPECT_EQ(arena.used_bytes(), 257U + 512U);
+  EXPECT_EQ(arena.slab_count(), 2U);
 }
 
 TEST_F(OpenClWorkspaceFixture, OpenClSynchronizeRecordedWorkFlushesTheProductQueueBeforeWait) {

--- a/alcedo_studio/tests/edit/runtime/opencl_workspace_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_workspace_test.cpp
@@ -21,6 +21,7 @@
 #include "edit/runtime/content_key.hpp"
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/opencl/opencl_dag_programs.hpp"
+#include "edit/runtime/opencl/opencl_neural_session_workspace.hpp"
 #include "edit/runtime/pass_kind.hpp"
 #include "edit/runtime/render_backend.hpp"
 #include "edit/runtime/texture_format.hpp"
@@ -141,6 +142,19 @@ TEST_F(OpenClWorkspaceFixture, OpenClMaxSlabBytesUsesDeviceReportedMaxMemAllocSi
   }
 }
 
+TEST_F(OpenClWorkspaceFixture, OpenClNeuralTileWorkspaceIsOwnedByTheRenderBackend) {
+  OpenClRenderDevice first;
+  OpenClRenderDevice second;
+  auto*              a = &first.Workspace().Device().NeuralDemosaicWorkspace();
+  auto*              b = &second.Workspace().Device().NeuralDemosaicWorkspace();
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+  EXPECT_NE(a, b);
+  first.ReleaseNeuralDemosaicWorkspace();
+  EXPECT_EQ(&second.Workspace().Device().NeuralDemosaicWorkspace(), b);
+  EXPECT_NE(&first.Workspace().Device().NeuralDemosaicWorkspace(), b);
+}
+
 TEST_F(OpenClWorkspaceFixture, OpenClBackendUsesThePreparedProcessContextAndProductQueue) {
   auto& ctx = OpenClContext::Instance();
   ASSERT_TRUE(ctx.IsInitialized());
@@ -222,13 +236,14 @@ TEST_F(OpenClWorkspaceFixture, OpenClTransientReserveAboveMaxSlabUsesSeparateDev
   backend.SetMaxSlabBytes(kSlab);
   backend.ResetCounters();
   transients.Reserve(3 << 20);
-  EXPECT_GE(transients.capacity_bytes(), 3U << 20);
-  EXPECT_GE(backend.BufferCreateCount(), 3U);
+  EXPECT_EQ(transients.capacity_bytes(), 0U);
+  EXPECT_EQ(backend.BufferCreateCount(), 0U);
 
   void* first  = transients.Allocate(kChunk);
   void* second = transients.Allocate(kChunk);
   ASSERT_NE(first, nullptr);
   ASSERT_NE(second, nullptr);
+  EXPECT_GE(backend.BufferCreateCount(), 2U);
   const auto a = backend.ResolveDeviceMemory(first, kChunk);
   const auto b = backend.ResolveDeviceMemory(second, kChunk);
   EXPECT_NE(a.first, b.first);

--- a/alcedo_studio/tests/edit/runtime/opencl_workspace_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_workspace_test.cpp
@@ -24,6 +24,7 @@
 #include "edit/runtime/pass_kind.hpp"
 #include "edit/runtime/render_backend.hpp"
 #include "edit/runtime/texture_format.hpp"
+#include "gpu/transient_buffer_arena.hpp"
 #include "opencl/opencl_api_counters.hpp"
 #include "opencl/opencl_backend_program_registry.hpp"
 #include "opencl/opencl_context.hpp"
@@ -255,6 +256,108 @@ TEST_F(OpenClWorkspaceFixture, OpenClTransientAllocateAppendsASlabWhenTheReserve
   const auto b = backend.ResolveDeviceMemory(second, kLarge);
   EXPECT_NE(a.first, b.first);
   EXPECT_GE(transients.capacity_bytes(), kLarge + kLarge);
+}
+
+TEST(TransientBufferArena, ReserveFreesUnusedSlabsBeforeAllocatingReplacements) {
+  struct RecordingBackend {
+    struct Slab {
+      RecordingBackend*          owner = nullptr;
+      std::size_t               bytes  = 0;
+      std::unique_ptr<std::byte[]> storage;
+
+      Slab() = default;
+      Slab(RecordingBackend* owner_ptr, std::size_t n)
+          : owner(owner_ptr), bytes(n), storage(std::make_unique<std::byte[]>(n)) {}
+      Slab(const Slab&)                    = delete;
+      auto operator=(const Slab&) -> Slab& = delete;
+      Slab(Slab&& other) noexcept { *this = std::move(other); }
+      auto operator=(Slab&& other) noexcept -> Slab& {
+        Reset();
+        owner        = other.owner;
+        bytes        = other.bytes;
+        storage      = std::move(other.storage);
+        other.owner  = nullptr;
+        other.bytes  = 0;
+        return *this;
+      }
+      ~Slab() { Reset(); }
+
+      void Reset() noexcept {
+        if (owner != nullptr && storage) {
+          owner->events.push_back("free");
+        }
+        owner = nullptr;
+        storage.reset();
+        bytes = 0;
+      }
+
+      [[nodiscard]] auto DevicePointer() const -> void* { return storage.get(); }
+      [[nodiscard]] auto Bytes() const -> std::size_t { return bytes; }
+    };
+
+    std::vector<std::string> events;
+
+    auto CreateSlab(std::size_t n) -> Slab {
+      events.push_back("create");
+      return Slab(this, n);
+    }
+  };
+
+  RecordingBackend backend;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  arena.Reserve(256);
+  ASSERT_EQ(backend.events, (std::vector<std::string>{"create"}));
+  arena.Reserve(1024);
+  ASSERT_EQ(backend.events, (std::vector<std::string>{"create", "free", "create"}));
+}
+
+TEST(TransientBufferArena, UnalignedFirstAllocationAppendsAnotherSlabWithoutLooping) {
+  struct AppendRecordingBackend {
+    struct Slab {
+      std::unique_ptr<std::byte[]> storage;
+      std::size_t                  bytes = 0;
+
+      Slab() = default;
+      explicit Slab(std::size_t n) : storage(std::make_unique<std::byte[]>(n)), bytes(n) {}
+      Slab(const Slab&)                    = delete;
+      auto operator=(const Slab&) -> Slab& = delete;
+      Slab(Slab&&) noexcept                = default;
+      auto operator=(Slab&&) noexcept -> Slab& = default;
+
+      [[nodiscard]] auto DevicePointer() const -> void* { return storage.get(); }
+      [[nodiscard]] auto Bytes() const -> std::size_t { return bytes; }
+    };
+
+    std::vector<std::size_t> create_sizes;
+
+    auto CreateSlab(std::size_t bytes) -> Slab {
+      create_sizes.push_back(bytes);
+      return Slab(bytes);
+    }
+  };
+
+  AppendRecordingBackend                       backend;
+  TransientBufferArena<AppendRecordingBackend> arena(backend);
+
+  void* first  = arena.Allocate(257, 256);
+  void* second = arena.Allocate(512, 256);
+
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(backend.create_sizes, (std::vector<std::size_t>{257, 512}));
+  EXPECT_EQ(arena.capacity_bytes(), 769U);
+  EXPECT_EQ(arena.used_bytes(), 769U);
+}
+
+TEST_F(OpenClWorkspaceFixture, OpenClSynchronizeRecordedWorkFlushesTheProductQueueBeforeWait) {
+  OpenClRenderDevice device;
+  device.BeginRender();
+  const auto flushes = device.Workspace().Device().FlushCount();
+  const auto waits   = device.Workspace().Device().WaitCount();
+  device.Workspace().Device().SynchronizeRecordedWork(device.CommandContext());
+  EXPECT_GT(device.Workspace().Device().FlushCount(), flushes);
+  EXPECT_GT(device.Workspace().Device().WaitCount(), waits);
+  device.CancelRender();
 }
 
 TEST_F(OpenClWorkspaceFixture, OpenClCreateBufferRejectsSizeAboveMaxSlabWithoutInvalidBufferSize) {

--- a/alcedo_studio/tests/edit/runtime/transient_buffer_arena_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/transient_buffer_arena_test.cpp
@@ -1,0 +1,163 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+#include "edit/runtime/develop_transient.hpp"
+#include "gpu/transient_buffer_arena.hpp"
+#include "gpu/transient_buffer_scope.hpp"
+
+namespace alcedo {
+namespace {
+
+struct RecordingBackend {
+  struct Slab {
+    RecordingBackend*             owner = nullptr;
+    std::size_t                   bytes  = 0;
+    std::unique_ptr<std::byte[]> storage;
+
+    Slab() = default;
+    Slab(RecordingBackend* owner_ptr, std::size_t n)
+        : owner(owner_ptr), bytes(n), storage(std::make_unique<std::byte[]>(n)) {}
+    Slab(const Slab&)                    = delete;
+    auto operator=(const Slab&) -> Slab& = delete;
+    Slab(Slab&& other) noexcept { *this = std::move(other); }
+    auto operator=(Slab&& other) noexcept -> Slab& {
+      Reset();
+      owner       = other.owner;
+      bytes       = other.bytes;
+      storage     = std::move(other.storage);
+      other.owner = nullptr;
+      other.bytes = 0;
+      return *this;
+    }
+    ~Slab() { Reset(); }
+
+    void Reset() noexcept {
+      if (owner != nullptr && storage) {
+        owner->events.push_back("free");
+      }
+      owner = nullptr;
+      storage.reset();
+      bytes = 0;
+    }
+
+    [[nodiscard]] auto DevicePointer() const -> void* { return storage.get(); }
+    [[nodiscard]] auto Bytes() const -> std::size_t { return bytes; }
+  };
+
+  std::vector<std::string>  events;
+  std::vector<std::size_t>  create_sizes;
+  std::size_t                max_slab_bytes      = 0;
+  std::size_t                max_transient_bytes = 0;
+
+  auto CreateSlab(std::size_t n) -> Slab {
+    events.push_back("create");
+    create_sizes.push_back(n);
+    return Slab(this, n);
+  }
+  [[nodiscard]] auto MaxSlabBytes() const -> std::size_t { return max_slab_bytes; }
+  [[nodiscard]] auto MaxTransientBytes() const -> std::size_t { return max_transient_bytes; }
+};
+
+TEST(TransientBufferArena, SmallAllocationsShareAMinimumSlab) {
+  RecordingBackend backend;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  void* first  = arena.Allocate(16, 1);
+  void* second = arena.Allocate(32, 1);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(backend.create_sizes,
+            (std::vector<std::size_t>{TransientBufferArena<RecordingBackend>::kMinSlabBytes}));
+  EXPECT_EQ(arena.slab_count(), 1U);
+  EXPECT_EQ(arena.used_bytes(), 48U);
+}
+
+TEST(TransientBufferArena, LargeRequestRoundsUpToSlabQuantumAndDoesNotSpanSlabs) {
+  RecordingBackend backend;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  constexpr std::size_t kRequest = 20ull << 20;
+  void*                  plane  = arena.Allocate(kRequest);
+  ASSERT_NE(plane, nullptr);
+  ASSERT_EQ(backend.create_sizes.size(), 1U);
+  EXPECT_EQ(backend.create_sizes.front(), TransientBufferArena<RecordingBackend>::kSlabQuantumBytes);
+  EXPECT_GE(backend.create_sizes.front(), kRequest);
+}
+
+TEST(TransientBufferArena, LivePointerStaysValidWhenASecondSlabIsAppended) {
+  RecordingBackend backend;
+  backend.max_slab_bytes = 512;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  void* first = arena.Allocate(257, 256);
+  ASSERT_NE(first, nullptr);
+  static_cast<std::byte*>(first)[0] = std::byte{0x5A};
+  void* second                       = arena.Allocate(512, 256);
+  ASSERT_NE(second, nullptr);
+  EXPECT_NE(first, second);
+  EXPECT_EQ(arena.slab_count(), 2U);
+  EXPECT_EQ(static_cast<std::byte*>(first)[0], std::byte{0x5A});
+}
+
+TEST(TransientBufferArena, TransientBudgetRejectsAnotherSlabWithoutMovingLivePointers) {
+  RecordingBackend backend;
+  backend.max_slab_bytes      = 400;
+  backend.max_transient_bytes = 800;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  void* first  = arena.Allocate(400);
+  void* second = arena.Allocate(400);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(arena.slab_count(), 2U);
+  try {
+    (void)arena.Allocate(400);
+    FAIL() << "expected transient budget error";
+  } catch (const std::runtime_error& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("exceed transient budget"), std::string::npos);
+    EXPECT_NE(message.find("slabs=2"), std::string::npos);
+    EXPECT_NE(message.find("requested=400"), std::string::npos);
+  }
+}
+
+TEST(TransientBufferArena, ScopeRewindsLocalSlabOffsetsWithoutFreeing) {
+  RecordingBackend backend;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  arena.Reserve(4096);
+  void* outer = arena.Allocate(100, 1);
+  ASSERT_NE(outer, nullptr);
+  const auto used_after_outer = arena.used_bytes();
+  backend.events.clear();
+  {
+    TransientBufferScope<RecordingBackend> scope(arena);
+    ASSERT_NE(arena.Allocate(200, 1), nullptr);
+    EXPECT_GT(arena.used_bytes(), used_after_outer);
+  }
+  EXPECT_EQ(arena.used_bytes(), used_after_outer);
+  EXPECT_TRUE(backend.events.empty());
+  void* reused = arena.Allocate(100, 1);
+  EXPECT_NE(reused, nullptr);
+}
+
+TEST(DevelopTransientHighWater, SuggestsConservativeBytesThenObservedCapacityWithMargin) {
+  DevelopCompileSource source;
+  source.kind             = DevelopInputKind::BayerCfa;
+  source.host_extent      = Extent2D{64, 64};
+  DevelopTransientHighWaterCache cache;
+  EXPECT_EQ(cache.SuggestInitial(source, 1), 64U * 64U * kConservativeDevelopBytesPerPixel);
+  cache.Record(source, 1, 200000);
+  EXPECT_EQ(cache.SuggestInitial(source, 1), ApplyDevelopTransientSafetyMargin(200000));
+  EXPECT_EQ(ConservativeDevelopInitialBytes(DevelopCompileSource{.kind = DevelopInputKind::DirectRgb}),
+            0U);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/transient_buffer_arena_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/transient_buffer_arena_test.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "decoders/processor/raw_demosaic_method.hpp"
 #include "edit/geometry/types.hpp"
 #include "edit/runtime/develop_transient.hpp"
 #include "gpu/transient_buffer_arena.hpp"
@@ -147,14 +148,96 @@ TEST(TransientBufferArena, ScopeRewindsLocalSlabOffsetsWithoutFreeing) {
   EXPECT_NE(reused, nullptr);
 }
 
+TEST(TransientBufferArena, ReserveClampsToMaxTransientInsteadOfThrowingOnTheRemainderSlab) {
+  RecordingBackend backend;
+  backend.max_slab_bytes      = 400;
+  backend.max_transient_bytes = 800;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  arena.Reserve(1000);
+  EXPECT_EQ(arena.capacity_bytes(), 0U);
+  EXPECT_TRUE(backend.create_sizes.empty());
+  void* first  = arena.Allocate(400);
+  void* second = arena.Allocate(400);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(arena.capacity_bytes(), 800U);
+  EXPECT_EQ(arena.slab_count(), 2U);
+}
+
+TEST(TransientBufferArena, ReserveLargerThanMaxSlabDoesNotPreSplitIntoUnusableRemainder) {
+  RecordingBackend backend;
+  backend.max_slab_bytes      = 400;
+  backend.max_transient_bytes = 800;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  arena.Reserve(700);
+  EXPECT_EQ(arena.capacity_bytes(), 0U);
+  void* first  = arena.Allocate(350);
+  void* second = arena.Allocate(350);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(arena.slab_count(), 2U);
+  EXPECT_EQ(arena.capacity_bytes(), 800U);
+}
+
+TEST(TransientBufferArena, ReserveWithinOneSlabStillCreatesCapacityUpFront) {
+  RecordingBackend backend;
+  backend.max_slab_bytes      = 400;
+  backend.max_transient_bytes = 800;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  arena.Reserve(300);
+  EXPECT_EQ(arena.capacity_bytes(), 300U);
+  EXPECT_EQ(arena.slab_count(), 1U);
+}
+
+TEST(DevelopTransientFailure, DescribesResolvedDemosaicMethodNotEmptyPayloadString) {
+  DevelopCompileSource source;
+  source.kind        = DevelopInputKind::BayerCfa;
+  source.host_extent = Extent2D{11808, 8754};
+  const auto message = DescribeDevelopTransientFailure(
+      source, RawDemosaicMethodToString(RawDemosaicMethod::NeuralEngine), true,
+      "TransientBufferArena: allocation would exceed transient budget");
+  EXPECT_NE(message.find("extent=11808x8754"), std::string::npos);
+  EXPECT_NE(message.find("kind=0"), std::string::npos);
+  EXPECT_NE(message.find("method=neural_engine"), std::string::npos);
+  EXPECT_NE(message.find("hlr=1"), std::string::npos);
+}
+
+TEST(DevelopTransientHighWater, NeuralAndLegacyLayoutsKeepSeparateObservedCapacity) {
+  DevelopCompileSource source;
+  source.kind        = DevelopInputKind::BayerCfa;
+  source.host_extent = Extent2D{64, 64};
+  DevelopTransientHighWaterCache cache;
+  cache.Record(source, 1, RawDemosaicMethod::Legacy, 400000);
+  cache.Record(source, 1, RawDemosaicMethod::NeuralEngine, 120000);
+  EXPECT_EQ(cache.SuggestInitial(source, 1, RawDemosaicMethod::Legacy),
+            ApplyDevelopTransientSafetyMargin(400000));
+  EXPECT_EQ(cache.SuggestInitial(source, 1, RawDemosaicMethod::NeuralEngine),
+            ApplyDevelopTransientSafetyMargin(120000));
+  EXPECT_EQ(cache.ObservedCapacity(source, 1, RawDemosaicMethod::Legacy), 400000U);
+  EXPECT_EQ(cache.ObservedCapacity(source, 1, RawDemosaicMethod::NeuralEngine), 120000U);
+}
+
+TEST(DevelopTransientHighWater, NeuralConservativeReserveIncludesTileScratch) {
+  DevelopCompileSource source;
+  source.kind        = DevelopInputKind::BayerCfa;
+  source.host_extent = Extent2D{64, 64};
+  DevelopTransientHighWaterCache cache;
+  EXPECT_EQ(cache.SuggestInitial(source, 1, RawDemosaicMethod::NeuralEngine),
+            ConservativeDevelopInitialBytes(source, RawDemosaicMethod::NeuralEngine));
+  EXPECT_GT(cache.SuggestInitial(source, 1, RawDemosaicMethod::NeuralEngine),
+            cache.SuggestInitial(source, 1, RawDemosaicMethod::Legacy));
+}
+
 TEST(DevelopTransientHighWater, SuggestsConservativeBytesThenObservedCapacityWithMargin) {
   DevelopCompileSource source;
   source.kind             = DevelopInputKind::BayerCfa;
   source.host_extent      = Extent2D{64, 64};
   DevelopTransientHighWaterCache cache;
-  EXPECT_EQ(cache.SuggestInitial(source, 1), 64U * 64U * kConservativeDevelopBytesPerPixel);
-  cache.Record(source, 1, 200000);
-  EXPECT_EQ(cache.SuggestInitial(source, 1), ApplyDevelopTransientSafetyMargin(200000));
+  EXPECT_EQ(cache.SuggestInitial(source, 1, RawDemosaicMethod::Legacy),
+            64U * 64U * kConservativeDevelopBytesPerPixel);
+  cache.Record(source, 1, RawDemosaicMethod::Legacy, 200000);
+  EXPECT_EQ(cache.SuggestInitial(source, 1, RawDemosaicMethod::Legacy),
+            ApplyDevelopTransientSafetyMargin(200000));
   EXPECT_EQ(ConservativeDevelopInitialBytes(DevelopCompileSource{.kind = DevelopInputKind::DirectRgb}),
             0U);
 }

--- a/alcedo_studio/tests/ml_ops/CMakeLists.txt
+++ b/alcedo_studio/tests/ml_ops/CMakeLists.txt
@@ -17,3 +17,26 @@ target_compile_definitions(NnSharedUtilsTest PRIVATE
 )
 gtest_discover_tests(NnSharedUtilsTest TEST_PREFIX "NnSharedUtilsTest.")
 alcedo_register_test_target(NnSharedUtilsTest core)
+
+if(ALCEDO_OPENCL_ENABLED)
+  add_executable(OpenClRuntimeTest ${ALCEDO_TEST_ROOT}/opencl/opencl_runtime_test.cpp)
+  target_include_directories(OpenClRuntimeTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(OpenClRuntimeTest PRIVATE GTest::gtest_main OpenClProgramLibrary)
+  target_compile_definitions(OpenClRuntimeTest PRIVATE HAVE_OPENCL)
+  gtest_discover_tests(OpenClRuntimeTest TEST_PREFIX "OpenClRuntimeTest.")
+  alcedo_register_test_target(OpenClRuntimeTest gpu)
+
+  add_executable(OpenClDemosaicNetTest ${ALCEDO_TEST_ROOT}/opencl/opencl_demosaicnet_test.cpp)
+  target_include_directories(OpenClDemosaicNetTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(OpenClDemosaicNetTest PRIVATE
+    GTest::gtest_main
+    OpenClDemosaicNet
+    OpenClProgramLibrary
+    NnSafetensors
+  )
+  target_compile_definitions(OpenClDemosaicNetTest PRIVATE
+    ALCEDO_DEMOASICNET_MODEL_DIR="${CMAKE_SOURCE_DIR}/alcedo_studio/src/config/models"
+  )
+  gtest_discover_tests(OpenClDemosaicNetTest TEST_PREFIX "OpenClDemosaicNetTest.")
+  alcedo_register_test_target(OpenClDemosaicNetTest gpu)
+endif()

--- a/alcedo_studio/tests/ml_ops/workspace_test.cu
+++ b/alcedo_studio/tests/ml_ops/workspace_test.cu
@@ -79,13 +79,14 @@ TEST_F(MlOpsWorkspaceTest, EmptyPoolGrowsOnFirstAllocate) {
   EXPECT_GE(pool.used_bytes(), 1000U * sizeof(float));
 }
 
-TEST_F(MlOpsWorkspaceTest, AllocateWithLiveDataDoesNotGrowSilently) {
+TEST_F(MlOpsWorkspaceTest, AllocateWithLiveDataAppendsAnotherSlab) {
   cuda::nn::WorkspacePool pool;
   pool.Reserve(256);
   void* live = pool.Allocate(128);
   ASSERT_NE(live, nullptr);
-  // Request more than remaining capacity while offset_ != 0.
-  EXPECT_THROW((void)pool.Allocate(pool.capacity_bytes()), std::runtime_error);
+  void* extra = pool.Allocate(pool.capacity_bytes());
+  ASSERT_NE(extra, nullptr);
+  EXPECT_NE(extra, live);
 }
 
 TEST_F(MlOpsWorkspaceTest, ReserveWhileLiveThrows) {

--- a/alcedo_studio/tests/opencl/opencl_demosaicnet_test.cpp
+++ b/alcedo_studio/tests/opencl/opencl_demosaicnet_test.cpp
@@ -392,6 +392,138 @@ TEST_F(OpenClDemosaicNetModuleTest,
 }
 
 TEST_F(OpenClDemosaicNetModuleTest,
+       BayerReflectMonoCfaForwardMatchesSparseHwc3Within1eMinus4) {
+  const auto model_dir = FindModelDir();
+  if (model_dir.empty()) {
+    GTEST_SKIP() << "model dir not found";
+  }
+
+  constexpr int kFrameH = 64;
+  constexpr int kFrameW = 64;
+  constexpr int kTileH  = 64;
+  constexpr int kTileW  = 64;
+  const int     out_h   = OpenClBayerDemosaicNet::OutputHeight(kTileH, kTileW);
+  const int     out_w   = OpenClBayerDemosaicNet::OutputWidth(kTileW, kTileH);
+  const auto    training = DemosaicNetTrainingPattern(RawCfaKind::Bayer2x2);
+  const int     period   = CfaPeriod(training.kind);
+
+  std::vector<float> mono(static_cast<std::size_t>(kFrameH) * kFrameW);
+  std::vector<float> hwc(static_cast<std::size_t>(kFrameH) * kFrameW * 3, 0.0f);
+  std::vector<int>   rgb_fc(static_cast<std::size_t>(period) * period);
+  for (int y = 0; y < period; ++y) {
+    for (int x = 0; x < period; ++x) {
+      rgb_fc[static_cast<std::size_t>(y * period + x)] = RgbColorAt(training, y, x);
+    }
+  }
+  for (int y = 0; y < kFrameH; ++y) {
+    for (int x = 0; x < kFrameW; ++x) {
+      const float v = static_cast<float>((y * 13 + x) % 11) * 0.04f;
+      mono[static_cast<std::size_t>(y) * kFrameW + x] = v;
+      const int color = rgb_fc[static_cast<std::size_t>((y % period) * period + (x % period))];
+      hwc[(static_cast<std::size_t>(y) * kFrameW + x) * 3 + color] = v;
+    }
+  }
+
+  constexpr int kOriginY = -2;
+  constexpr int kOriginX = -4;
+  OpenClBayerDemosaicNet net;
+  net.LoadWeights(nn::LoadSafetensors(model_dir / "bayer.safetensors"));
+  nn_ocl::DeviceBuffer mono_buffer = nn_ocl::DeviceBuffer::Floats(mono.size());
+  nn_ocl::DeviceBuffer hwc_buffer  = nn_ocl::DeviceBuffer::Floats(hwc.size());
+  nn_ocl::DeviceBuffer table(rgb_fc.size() * sizeof(int));
+  table.UploadBytes(rgb_fc.data(), rgb_fc.size() * sizeof(int));
+  nn_ocl::DeviceBuffer mono_out =
+      nn_ocl::DeviceBuffer::Floats(static_cast<std::size_t>(out_h) * out_w * 3);
+  nn_ocl::DeviceBuffer hwc_out =
+      nn_ocl::DeviceBuffer::Floats(static_cast<std::size_t>(out_h) * out_w * 3);
+  mono_buffer.UploadFloats(mono);
+  hwc_buffer.UploadFloats(hwc);
+  nn_ocl::ActivationSlots slots;
+  auto&                   context = OpenClContext::Instance();
+
+  net.ForwardReflectHwc3ToHwc(hwc_buffer.get(), kFrameH, kFrameW, kOriginY, kOriginX, kTileH, kTileW,
+                               hwc_out.get(), slots, context.Queue(), true);
+  nn_ocl::WaitQueue(context.Queue());
+  net.ForwardReflectMonoCfaToHwc(mono_buffer.get(), kFrameW, kFrameH, 0, 0, kFrameW, kFrameH,
+                                    kOriginY, kOriginX, kTileH, kTileW, 0, table.get(), period,
+                                    mono_out.get(), slots, context.Queue(), true);
+  nn_ocl::WaitQueue(context.Queue());
+
+  const auto from_hwc  = hwc_out.DownloadFloats(static_cast<std::size_t>(out_h) * out_w * 3);
+  const auto from_mono = mono_out.DownloadFloats(static_cast<std::size_t>(out_h) * out_w * 3);
+  ASSERT_EQ(from_hwc.size(), from_mono.size());
+  for (std::size_t i = 0; i < from_hwc.size(); ++i) {
+    EXPECT_NEAR(from_hwc[i], from_mono[i], kAbsTol) << "index=" << i;
+  }
+}
+
+TEST_F(OpenClDemosaicNetModuleTest,
+       XTransReflectMonoCfaForwardMatchesSparseHwc3Within1eMinus4) {
+  const auto model_dir = FindModelDir();
+  if (model_dir.empty()) {
+    GTEST_SKIP() << "model dir not found";
+  }
+
+  constexpr int kFrameH = 64;
+  constexpr int kFrameW = 64;
+  constexpr int kTileH  = 64;
+  constexpr int kTileW  = 64;
+  const int     out_h   = OpenClXTransDemosaicNet::OutputHeight(kTileH, kTileW);
+  const int     out_w   = OpenClXTransDemosaicNet::OutputWidth(kTileW, kTileH);
+  const auto    training = DemosaicNetTrainingPattern(RawCfaKind::XTrans6x6);
+  const int     period   = CfaPeriod(training.kind);
+
+  std::vector<float> mono(static_cast<std::size_t>(kFrameH) * kFrameW);
+  std::vector<float> hwc(static_cast<std::size_t>(kFrameH) * kFrameW * 3, 0.0f);
+  std::vector<int>   rgb_fc(static_cast<std::size_t>(period) * period);
+  for (int y = 0; y < period; ++y) {
+    for (int x = 0; x < period; ++x) {
+      rgb_fc[static_cast<std::size_t>(y * period + x)] = RgbColorAt(training, y, x);
+    }
+  }
+  for (int y = 0; y < kFrameH; ++y) {
+    for (int x = 0; x < kFrameW; ++x) {
+      const float v = static_cast<float>((y * 13 + x) % 11) * 0.04f;
+      mono[static_cast<std::size_t>(y) * kFrameW + x] = v;
+      const int color = rgb_fc[static_cast<std::size_t>((y % period) * period + (x % period))];
+      hwc[(static_cast<std::size_t>(y) * kFrameW + x) * 3 + color] = v;
+    }
+  }
+
+  constexpr int kOriginY = -6;
+  constexpr int kOriginX = -6;
+  OpenClXTransDemosaicNet net;
+  net.LoadWeights(nn::LoadSafetensors(model_dir / "xtrans.safetensors"));
+  nn_ocl::DeviceBuffer mono_buffer = nn_ocl::DeviceBuffer::Floats(mono.size());
+  nn_ocl::DeviceBuffer hwc_buffer  = nn_ocl::DeviceBuffer::Floats(hwc.size());
+  nn_ocl::DeviceBuffer table(rgb_fc.size() * sizeof(int));
+  table.UploadBytes(rgb_fc.data(), rgb_fc.size() * sizeof(int));
+  nn_ocl::DeviceBuffer mono_out =
+      nn_ocl::DeviceBuffer::Floats(static_cast<std::size_t>(out_h) * out_w * 3);
+  nn_ocl::DeviceBuffer hwc_out =
+      nn_ocl::DeviceBuffer::Floats(static_cast<std::size_t>(out_h) * out_w * 3);
+  mono_buffer.UploadFloats(mono);
+  hwc_buffer.UploadFloats(hwc);
+  nn_ocl::ActivationSlots slots;
+  auto&                   context = OpenClContext::Instance();
+
+  net.ForwardReflectHwc3ToHwc(hwc_buffer.get(), kFrameH, kFrameW, kOriginY, kOriginX, kTileH, kTileW,
+                               hwc_out.get(), slots, context.Queue(), true);
+  nn_ocl::WaitQueue(context.Queue());
+  net.ForwardReflectMonoCfaToHwc(mono_buffer.get(), kFrameW, kFrameH, 0, 0, kFrameW, kFrameH,
+                                    kOriginY, kOriginX, kTileH, kTileW, 0, table.get(), period,
+                                    mono_out.get(), slots, context.Queue(), true);
+  nn_ocl::WaitQueue(context.Queue());
+
+  const auto from_hwc  = hwc_out.DownloadFloats(static_cast<std::size_t>(out_h) * out_w * 3);
+  const auto from_mono = mono_out.DownloadFloats(static_cast<std::size_t>(out_h) * out_w * 3);
+  ASSERT_EQ(from_hwc.size(), from_mono.size());
+  for (std::size_t i = 0; i < from_hwc.size(); ++i) {
+    EXPECT_NEAR(from_hwc[i], from_mono[i], kAbsTol) << "index=" << i;
+  }
+}
+
+TEST_F(OpenClDemosaicNetModuleTest,
        XTransReflectHwc3ForwardMatchesReferenceNchwInputWithin1eMinus4) {
   const auto model_dir = FindModelDir();
   if (model_dir.empty()) {

--- a/alcedo_studio/tests/opencl/opencl_runtime_test.cpp
+++ b/alcedo_studio/tests/opencl/opencl_runtime_test.cpp
@@ -360,6 +360,8 @@ TEST(OpenClRuntimeTest, BuiltinRawProcessorProgramsCompile) {
       {"raw_processor_debayer_rcd", "rcd_init_and_vh"},
       {"raw_processor_xtrans", "xtrans_green"},
       {"raw_processor_highlight", "hlr_build_mask"},
+      {"raw_processor_highlight", "hlr_build_mask_planar"},
+      {"raw_processor_highlight", "hlr_reconstruct_from_stats_planar_pack"},
       {"raw_processor_cvt_ref_space", "apply_inverse_cam_mul_rgba32f"},
   };
 
@@ -656,6 +658,12 @@ TEST(OpenClRuntimeTest, DemosaicNetProgramsCompileOnceOnFirstUseAndReuse) {
       {OpenCL::DemosaicNet::kStructuralProgramName, OpenCL::DemosaicNet::kOutputGammaHwcKernelName},
       {OpenCL::DemosaicNet::kStructuralProgramName,
        OpenCL::DemosaicNet::kAssembleRgbTileKernelName},
+      {OpenCL::DemosaicNet::kStructuralProgramName,
+       OpenCL::DemosaicNet::kPackReflectBayerNhwc4MonoKernelName},
+      {OpenCL::DemosaicNet::kStructuralProgramName,
+       OpenCL::DemosaicNet::kPackReflectXTransNhwc4MonoKernelName},
+      {OpenCL::DemosaicNet::kStructuralProgramName,
+       OpenCL::DemosaicNet::kUnpackReflectConcatMonoKernelName},
   };
 
   for (const auto& item : demosaicnet_kernels) {

--- a/alcedo_studio/tests/raw/CMakeLists.txt
+++ b/alcedo_studio/tests/raw/CMakeLists.txt
@@ -55,6 +55,24 @@ if(ALCEDO_CUDA_ENABLED)
   alcedo_register_test_target(CudaRawOpsTest raw gpu)
 endif()
 
+# --- OpenCL raw Neural product routing ---
+
+if(ALCEDO_OPENCL_ENABLED)
+  add_executable(OpenClRawNeuralTest ${ALCEDO_TEST_ROOT}/raw/opencl_raw_neural_test.cpp)
+  target_include_directories(OpenClRawNeuralTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(OpenClRawNeuralTest PRIVATE
+    GTest::gtest_main
+    RawProcessor
+    OpenClDemosaicNetEntry
+    ${ALCEDO_TEST_OPENCV_MIN_DEPS}
+  )
+  target_compile_definitions(OpenClRawNeuralTest PRIVATE
+    ALCEDO_DEMOASICNET_MODEL_DIR="${CMAKE_SOURCE_DIR}/alcedo_studio/src/config/models"
+  )
+  gtest_discover_tests(OpenClRawNeuralTest TEST_PREFIX "OpenClRawNeuralTest.")
+  alcedo_register_test_target(OpenClRawNeuralTest raw gpu)
+endif()
+
 # --- OpenCL + CUDA guarded raw targets ---
 
 if(ALCEDO_CUDA_ENABLED AND ALCEDO_OPENCL_ENABLED)

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_opencl_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_opencl_migration_phase_plan.md
@@ -1374,8 +1374,10 @@ Fix:
 - `TransientBufferArena` splits capacity across slabs each `<= Backend::MaxSlabBytes()`.
 - OpenCL `MaxSlabBytes` is `CL_DEVICE_MAX_MEM_ALLOC_SIZE` from context creation, aligned
   down to 256 bytes.
-- Develop reserves `max(compiled peak, exclusive HLR working set)` and rewinds demosaic
-  planes before HLR, so HLR does not sit on top of RCD/LLF.
+- Develop reserved `max(compiled peak, host_pixels * 44)` and rewound demosaic
+  planes before HLR. That 44-byte formula is an OpenCL-only extra working set;
+  CUDA keeps HLR inside the compiled exclusive 12 bytes/pixel peak. See the
+  CUDA-aligned follow-up below.
 - `Allocate` walks every reserved slab, then appends a new slab when the remainder
   cannot hold the next plane. `Reserve` still cannot replace slabs while pointers
   are live. Slab size is `CL_DEVICE_MAX_MEM_ALLOC_SIZE` from context creation,
@@ -1396,10 +1398,161 @@ Tests: `OpenClMaxSlabBytesUsesDeviceReportedMaxMemAllocSize`,
 `OpenClTransientReserveAboveMaxSlabUsesSeparateDeviceBuffers`,
 `OpenClTransientAllocateAppendsASlabWhenTheReservedTailIsTooShort`,
 `OpenClCreateBufferRejectsSizeAboveMaxSlabWithoutInvalidBufferSize`,
-`OpenClDevelopHighlightRecoveryFitsWhenSingleAllocCapIsBelowPaddedHostPixelReserve`,
+`OpenClDevelopHighlightRecoveryWritesTheOutputTextureWithoutASecondRgbaImage`,
 `WorkspaceCannotReplaceReservedSlabWhileTransientPointersAreLive`.
 
-## 11. Phase O6 — 旧 OpenCL 管线删除与性能验收
+##### Phase O5 follow-up (2026-08-28) CUDA-aligned HLR VRAM
+
+Status: HLR VRAM overcommit and missing queue flush fixed. This did not remove the final 100MP
+spinner; the later on-demand scratch follow-up records the allocator-loop root cause and complete
+fix.
+
+Cause:
+
+- CUDA SensorDevelop reserves `plan.peak_transient_bytes` only. Bayer HLR keeps the
+  five RCD planes, binds 12 bytes/pixel exclusive scratch, and
+  `ApplyHighlightCorrectionAndPackRGBAOriented` writes the existing output texture.
+  Merge and HLR are exclusive; the compiler does not add a second full-res RGBA32F.
+- OpenCL acquired a second `Textures().Acquire` RGBA32F, rewound, then copied into
+  two float4 transients because HLR kernels were float4-buffer only. That is
+  `~4.4 GiB` transients plus `~1.55 GiB` output plus `~1.55 GiB` extra image on a
+  100MP Bayer frame.
+- `SynchronizeRecordedWork` waited on a marker without `clFlush`, so a large
+  in-order NVIDIA queue could stall forever.
+
+Fix:
+
+- `ExecuteOpenClDevelop` reserves `plan.peak_transient_bytes` only, matching CUDA.
+- Bayer HLR: planar mask / chroma / reconstruct-and-pack into `develop.sensor_linear`.
+- X-Trans and Neural HLR: reconstruct into an arena RGBA buffer and copy into the
+  existing output image. No second RGBA32F.
+- `OpenClBackend::SynchronizeRecordedWork` and `Wait` flush before `clWaitForEvents`.
+- `TransientBufferArena::EnsureCapacity` frees unused slabs before creating replacements.
+
+Primary call chain:
+
+```text
+EditPipeline::Apply
+  -> Renderer<OpenClBackend>::Render
+  -> ExecuteOpenClDevelop
+  -> TransientBufferArena::Reserve(plan.peak_transient_bytes)
+  -> EncodeBayerRcd
+  -> EncodeHighlightReconstructPlanarAndPack
+     (mask 12 B/px from the same arena, write_imagef into sensor_linear)
+  -> PlanExecutor SynchronizeRecordedWork
+  -> TransientBuffers().ReleaseDeviceMemory
+```
+
+Tests: `OpenClDevelopHighlightRecoveryWritesTheOutputTextureWithoutASecondRgbaImage`,
+`OpenClDevelopHighlightRecoveryFitsWhenEachSlabIsCappedBelowCompiledPeak`,
+`ReserveFreesUnusedSlabsBeforeAllocatingReplacements`,
+`OpenClSynchronizeRecordedWorkFlushesTheProductQueueBeforeWait`.
+
+##### Phase O5 follow-up (2026-08-28) CUDA-aligned Neural tiles
+
+Status: implemented. OpenCL Neural already tiled the network (`OpenClDemosaicNetTiledExecutor` +
+shared `BuildTileJobs`). The sandwich packed a full-frame HWC3 mosaic and a
+full-frame RGBA before packing the output.
+
+CUDA `DemosaicNeuralEngine` packs each student tile from the aligned mono CFA
+(`PackReflectPaddedCfaTile`), keeps activations tile-sized, and assembles into a
+full-frame RGB canvas.
+
+Fix:
+
+- Product OpenCL tiles pack from the original mono CFA (`ForwardReflectMonoCfaToHwc`).
+- DAG `EncodeNeural` no longer copies the linear CFA or materializes `mosaic_hwc` /
+  process-static RGBA. RGB assembly stays one aligned HWC3 canvas (CUDA `output_rgb`).
+- No-HLR packs that RGB into `develop.sensor_linear` with `copy_rgb_crop_inverse_orient`.
+
+Primary call chain:
+
+```text
+ExecuteOpenClDevelop
+  -> EncodeToLinearRef (arena CFA)
+  -> EncodeNeural
+  -> OpenClDemosaicNetTiledExecutor (PackReflect from mono CFA, tile activations)
+  -> EncodeCopyRgbCropInverseOrient into develop.sensor_linear
+```
+
+Tests: `BayerReflectMonoCfaForwardMatchesSparseHwc3Within1eMinus4`,
+`XTransReflectMonoCfaForwardMatchesSparseHwc3Within1eMinus4`,
+`OpenClDevelopNeuralEngineWritesFiniteRgbFromMonoCfaTilesAndDiffersFromLegacy`,
+`OpenClDevelopNeuralUsesSessionWorkspaceAndDoesNotSelectAnotherDemosaicOnFailure`.
+
+##### Phase O5 follow-up (2026-08-28) on-demand Develop scratch and allocator progress
+
+Status: complete. Four real 100MP Bayer fixtures finish through the production OpenCL Develop
+path. The editor spinner and shutdown wait were caused by a CPU allocation loop, not by an
+unfinished OpenCL event.
+
+Cause:
+
+- `TransientBufferArena::PlaceFrom` aligned the next candidate above an unaligned slab end. The
+  subsequent `NextSlabOrigin` call returned that same slab end, and `AlignUp` reproduced the same
+  candidate. The loop therefore made no progress and never reached another `clCreateBuffer` call.
+- A 100MP U16 CFA allocation is not a 256-byte multiple. It deterministically exposed the loop on
+  the following F32 plane allocation. The earlier whole-frame `Reserve(peak_transient_bytes)` also
+  reproduced the same boundary condition when the estimated peak was split by
+  `CL_DEVICE_MAX_MEM_ALLOC_SIZE`.
+- The peak estimate described possible compiler liveness, not the exact runtime demosaic method,
+  HLR branch, alignment padding, and device slab layout. The reserved memory was released after the
+  same render, so eager reservation did not amortize allocation across frames.
+- `QObject::~QObject: Timers cannot be stopped from another thread` was a secondary shutdown
+  symptom: the render worker could not return from the allocator loop, so normal QObject teardown
+  ordering could not complete.
+
+Fix:
+
+- `PlaceFrom` now treats a non-increasing aligned candidate as no fit. `Allocate` can then append a
+  slab and retry instead of looping forever.
+- OpenCL Develop no longer eagerly reserves `plan.peak_transient_bytes`. It requests CFA,
+  linearization, selected demosaic, and HLR scratch from the arena only for the actual execution
+  branch. The arena still owns the allocations and releases them together at frame completion.
+- Legacy demosaic scratch is allocated before the final RGBA image. This keeps exact branch memory
+  visible to the arena and avoids using a coarse estimate as allocation policy.
+- Optional `ALCEDO_GPU_POOL_TRACE` stage and buffer-create diagnostics remain available without
+  changing normal stdout behavior.
+
+Primary success call chain:
+
+```text
+EditPipeline::Apply
+  -> Renderer<OpenClBackend>::Render
+  -> PlanExecutor
+  -> ExecuteOpenClDevelop
+  -> TransientBufferArena::Allocate(actual branch scratch)
+  -> PlaceFrom returns no-fit when the candidate cannot advance
+  -> AppendAndPlace(device-sized slab)
+  -> EncodeBayerRcd
+  -> EncodeHighlightReconstructPlanarAndPack
+  -> SynchronizeRecordedWork (flush, then wait)
+  -> TransientBuffers().ReleaseDeviceMemory
+  -> publish completed frame
+```
+
+Primary allocation failure chain:
+
+```text
+TransientBufferArena::Allocate
+  -> AppendAndPlace
+  -> OpenClBackend::CreateBuffer
+  -> real OpenCL allocation error
+  -> PlanExecutor cancels the render
+  -> no result publication and no backend or quality substitution
+```
+
+Verification:
+
+- `OpenClHundredMegapixelBayerFixturesCompleteAndProduceFinitePixels`: passed in 34.786 s for
+  `DSCF0224.RAF`, `DSCF0305.RAF`, `DSCF0337.RAF`, and `B0004841.dng`; each fixture contains more
+  than 100 million sensor pixels and returns finite RGB from the completed image.
+- `TransientBufferArena.UnalignedFirstAllocationAppendsAnotherSlabWithoutLooping`: passed; a
+  257-byte first allocation followed by a 512-byte aligned allocation exercises the exact
+  no-progress boundary without requiring a multi-gigabyte device.
+- Focused OpenCL workspace and Develop run: 33 discovered, 32 passed, the environment-gated real
+  fixture test skipped by default, zero failed, 40.02 s.
+- `alcedo_main` debug target: built and linked successfully after the production changes.
 
 目标：
 

--- a/docs/roadmap/alcedo_studio/edit/gpu_dag_opencl_migration_phase_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/gpu_dag_opencl_migration_phase_plan.md
@@ -1554,6 +1554,90 @@ Verification:
   fixture test skipped by default, zero failed, 40.02 s.
 - `alcedo_main` debug target: built and linked successfully after the production changes.
 
+##### Phase O5 follow-up (2026-08-29) disposable Metal scratch resources
+
+Status: implemented. Metal Develop, mask evaluation, local tone, and Primary Grade scratch no
+longer enter the reusable texture pool or the retained transient slab arena. Persistent DAG
+outputs, mask source mip chains, signed-distance results, LLF canonical references, LUTs, model
+weights, and Neural Engine fixed tile workspace remain reusable resources.
+
+Cause:
+
+- Develop's CFA, linearization, demosaic planes, HLR intermediates, and Neural output used local
+  `ResourceLease` objects acquired from the general `TexturePool`.
+- Destroying a local lease only removed its pin. The pool retained the underlying `MTLTexture`, so
+  a completed Develop pass could leave several full-resolution scratch textures resident.
+- Mask and LLF temporary planes used `TransientBufferArena`. Resetting the arena changed its
+  logical cursor but retained its `MTLBuffer` slabs after the frame.
+- Metal command buffers use resources asynchronously. Destroying a C++ local immediately after an
+  encode would release the Metal resource before the GPU finished using it.
+
+Fix:
+
+- `MetalBackend` now owns recorded-work scratch buffers and textures directly. Allocation follows
+  the actual Develop, mask, LLF, or grade branch; it does not reserve a compiler peak first.
+- `PlanExecutor` skips Develop transient-arena preparation and high-water recording for Metal.
+- Develop waits for its recorded command buffer before Geometry and then physically destroys its
+  scratch buffers and textures.
+- Mask, LLF, and Primary Grade scratch stays alive through final submission and is physically
+  destroyed by `Wait` after the command buffer completes.
+- Failed encoding uses `CancelRender`; Metal discards unsubmitted recorded work before destroying
+  its scratch resources. A submitted command buffer is waited before destruction.
+- Reusable resources keep their existing caches. In particular, this change does not recreate
+  Neural Engine weights or its fixed tile-sized model workspace per operation.
+
+Primary Develop call chain:
+
+```text
+PlanExecutor
+  -> ExecuteMetalDevelop
+  -> AcquireRecordedWorkScratchTexture / AcquireRecordedWorkScratchBuffer
+  -> encode actual demosaic and HLR branch
+  -> SynchronizeRecordedWork
+  -> waitUntilCompleted
+  -> ReleaseRecordedWorkScratchResources
+  -> Geometry
+```
+
+Primary grade and mask call chain:
+
+```text
+ExecuteMetalMask / ExecuteMetalPrimaryGrade
+  -> AcquireRecordedWorkScratchBuffer / AcquireRecordedWorkScratchTexture
+  -> encode remaining frame passes
+  -> EndRender -> Submit
+  -> WaitIdle -> MetalBackend::Wait
+  -> waitUntilCompleted
+  -> ReleaseRecordedWorkScratchResources
+```
+
+Failure and cancellation call chain:
+
+```text
+Metal pass throws
+  -> PlanExecutor::CancelRender
+  -> MetalBackend::Wait
+  -> discard unsubmitted command buffer or wait submitted work
+  -> ReleaseRecordedWorkScratchResources
+  -> discard unpublished DAG images
+```
+
+Verification:
+
+- Added `MetalDevelopScratchResourcesReleaseAfterRecordedWorkCompletes`; it checks that Develop
+  scratch is outside `TexturePool` and that every recorded-work buffer and texture is physically
+  freed after synchronization.
+- Added `MetalPlanExecutorDoesNotReserveDevelopTransientArena`; it checks the product executor does
+  not create or record an unused Metal transient slab.
+- Extended the Neural Engine failure test to check scratch release through `CancelRender`.
+- Updated Primary Grade and LLF tests to require disposable scratch recreation and zero pending
+  recorded-work resources after GPU completion while persistent results remain cached.
+- Windows host-side `alcedo_main` debug target built and linked successfully. Metal Objective-C++
+  targets and runtime assertions require the macOS Metal runner and were not executable on this
+  Windows host.
+- Implementation and regression tests add 120 net source lines before this plan record; the
+  ownership change is centralized in `MetalBackend` rather than duplicated in each pass.
+
 目标：
 
 - 删除 OpenCL 产品路径中的旧 pipeline、stage、总参数 ABI 和混合 operator 执行；


### PR DESCRIPTION
## Stack

#93 → #94 → #95 → #96 → #97 → #98 → #102 → #101 → #100 → #103 → #104 → #105 → #108 → #109 → **this PR**

Base: `fix/gpu-dag-lut-and-thumbnail`

## Summary

- Fit OpenCL Neural SensorDevelop for ~100MP RAWs inside the device transient budget: assemble DemosaicNet tiles into RGBA so develop does not keep a second full-frame HWC3 plane, clamp `Reserve` to the max slab, and stop pre-splitting leftovers that cannot satisfy a later near-max allocation.
- Bind CUDA Neural tile scratch into the develop arena (discard-after-use) and keep OpenCL Neural tile workspace per render backend, with serialized `clSetKernelArg` forwards, so switching images cannot reset another decode''s `tile_output`.
- Remirror format-2 GPU DAG documents from the CPU pipeline so history `neural_engine` still drives DAG develop after reload.
- Also includes tiled OpenCL 100MP Develop, CUDA slab placement, and Metal DemosaicNet on its own command buffer so later HLR/Geometry do not encode onto a committed MTLCommandBuffer.

## Test plan

- [ ] Rebuild OpenCL debug and switch between two Neural 100MP RAWs: no `TransientBufferArena: allocation would exceed transient budget` and no `OpenClBayerDemosaicNet: null input/output buffer`.
- [ ] Confirm panel/history `neural_engine` still runs Neural on DAG after a format-2 save/reload (not RCD).
- [ ] Run `transient_buffer_arena_test`, `opencl_workspace_test`, `opencl_develop_test`, and `pipeline_service_test`.
- [ ] Optional: `ALCEDO_RUN_100MP_OPENCL_TEST=1` for the gated 100MP OpenCL fixture.
- [ ] Spot-check CUDA Neural 100MP develop (arena-bound CFA/RGB, no leftover-slab packing failure).