### PR TITLE
fix(edit): scale DAG neighbor kernels with render resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@ This file provides guidance to AI agents (Kimi, Claude, Codex, etc.) when workin
 
 Agents working in this repository must be decisive and implementation-driven. Do not respond to product or engineering direction with passive staged deferrals such as "first avoid this", "later maybe add this", "medium term", "long term", or similar framing that delays the requested capability after the user has made the product goal clear.
 
+## Branch naming
+
+Branch names must describe the feature, fix, refactor, or other engineering purpose of the work.
+Do not include `codex` in a branch name. Use a functional name such as
+`fix/neighbor-operator-ping-pong` or `feature/opencl-program-cache`.
+
 When the user names a concrete integration or capability, treat it as the target and work out the implementation path, constraints, tests, and risks directly. If there are real blockers, state them as concrete engineering facts and propose the closest viable implementation, not a soft retreat to a weaker product.
 
 ## No fallback unless the user explicitly allows it

--- a/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
+++ b/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
@@ -132,6 +132,23 @@ void ApplyScalar(IOperatorModel* model, const nlohmann::json& value, const char*
   LoadJsonIfChanged(model, json);
 }
 
+
+void ApplyLegacyPercentScalar(IOperatorModel* model, const nlohmann::json& value,
+                              const char* new_key) {
+  if (model == nullptr) {
+    return;
+  }
+  float legacy_percent = 0.0f;
+  if (value.is_number()) {
+    legacy_percent = value.get<float>();
+  } else if (value.is_object() && value.contains(new_key) && value[new_key].is_number()) {
+    legacy_percent = value[new_key].get<float>();
+  } else {
+    return;
+  }
+  LoadJsonIfChanged(model,
+                    nlohmann::json{{new_key, std::clamp(legacy_percent / 100.0f, 0.0f, 1.0f)}});
+}
 void ApplyCrop(ImageGeometryModel& geometry, const LegacyOperator& op) {
   const auto crop = NestedOrSelf(op.params, "crop_rotate");
   if (!op.enable || (crop.contains("enabled") && crop["enabled"].is_boolean() && !crop["enabled"].get<bool>())) {
@@ -314,13 +331,13 @@ auto ApplyOperators(PipelineDocument& document, const std::vector<LegacyOperator
   if (const auto* grain = FindOp(operators, kLegacyFilmGrain)) {
     if (auto* model = grade->FindAdjustmentByType(type_ids::FilmGrain())) {
       const auto nested = NestedOrSelf(grain->params, "film_grain");
-      ApplyScalar(model, nested, "strength");
+      ApplyLegacyPercentScalar(model, nested, "strength");
     }
   }
   if (const auto* halo = FindOp(operators, kLegacyHalation)) {
     if (auto* model = grade->FindAdjustmentByType(type_ids::Halation())) {
       const auto nested = NestedOrSelf(halo->params, "halation");
-      ApplyScalar(model, nested, "strength");
+      ApplyLegacyPercentScalar(model, nested, "strength");
     }
   }
   if (const auto* tint = FindOp(operators, kLegacyTint)) {

--- a/alcedo_studio/src/edit/runtime/adjustment_runtime.cpp
+++ b/alcedo_studio/src/edit/runtime/adjustment_runtime.cpp
@@ -5,9 +5,12 @@
 #include "edit/runtime/adjustment_runtime.hpp"
 
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 
+#include "edit/geometry/resolved_render_geometry.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/models/cat02_white_balance_model.hpp"
 #include "edit/operators/models/color_wheel_model.hpp"
@@ -21,7 +24,62 @@
 namespace alcedo {
 namespace {
 
-constexpr std::size_t kMaxCurvePoints = 8;
+constexpr std::size_t   kMaxCurvePoints        = 8;
+constexpr float         kHalationSigma         = 7.0f;
+constexpr float         kHalationStrengthScale = 2.0f;
+constexpr float         kHalationRedshift[3]   = {1.0f, 0.05f, 0.02f};
+constexpr std::uint64_t kFilmGrainSeed         = 0x6a09e667f3bcc909ULL;
+
+void BuildGaussianWeights(float sigma, std::uint32_t max_radius, GradeNeighborParams& result) {
+  if (!(sigma > 0.0f)) {
+    return;
+  }
+  const float safe_sigma = std::max(sigma, 1.0e-4f);
+  result.radius =
+      std::clamp<std::uint32_t>(static_cast<std::uint32_t>(std::ceil(3.0f * safe_sigma)), 1U,
+                                std::min(max_radius, kGradeNeighborMaxTapCount - 1U));
+  result.tap_count = result.radius + 1U;
+
+  const double inv_two_sigma_squared =
+      0.5 / (static_cast<double>(safe_sigma) * static_cast<double>(safe_sigma));
+  double full_weight = 1.0;
+  result.weights[0]  = 1.0f;
+  for (std::uint32_t tap = 1; tap <= result.radius; ++tap) {
+    const auto   distance = static_cast<double>(tap);
+    const double weight   = std::exp(-(distance * distance) * inv_two_sigma_squared);
+    result.weights[tap]   = static_cast<float>(weight);
+    full_weight += 2.0 * weight;
+  }
+  for (std::uint32_t tap = 0; tap <= result.radius; ++tap) {
+    result.weights[tap] =
+        static_cast<float>(static_cast<double>(result.weights[tap]) / full_weight);
+  }
+}
+
+auto RenderAxisScale(const ResolvedRenderGeometry& geometry, bool horizontal) -> float {
+  const auto& matrix                            = geometry.render_to_reference.m;
+  const float dx                                = horizontal ? matrix[0] : matrix[1];
+  const float dy                                = horizontal ? matrix[3] : matrix[4];
+  const float reference_pixels_per_render_pixel = std::hypot(dx, dy);
+  if (!(reference_pixels_per_render_pixel > 0.0f) ||
+      !std::isfinite(reference_pixels_per_render_pixel)) {
+    return 1.0f;
+  }
+  return std::clamp(1.0f / reference_pixels_per_render_pixel, 1.0e-4f, 1.0f);
+}
+
+void CopyRenderMapping(const ResolvedRenderGeometry& geometry, GradeNeighborParams& result) {
+  const auto& matrix               = geometry.render_to_reference.m;
+  result.render_to_reference[0]    = matrix[0];
+  result.render_to_reference[1]    = matrix[1];
+  result.render_to_reference[2]    = matrix[2];
+  result.render_to_reference[3]    = matrix[3];
+  result.render_to_reference[4]    = matrix[4];
+  result.render_to_reference[5]    = matrix[5];
+  result.use_reference_coordinates = CoversFullEditSpace(geometry) ? 1U : 0U;
+  result.reference_width  = static_cast<std::int32_t>(geometry.full_reference_extent.width);
+  result.reference_height = static_cast<std::int32_t>(geometry.full_reference_extent.height);
+}
 
 }  // namespace
 
@@ -117,6 +175,57 @@ auto MakeGradeRuntimeParams(const IOperatorModel& model, AdjustmentBehavior beha
     return result;
   }
   throw std::runtime_error("Primary grade: Model DTO is not supported");
+}
+
+auto MakeGradeNeighborParams(const IOperatorModel& model, AdjustmentBehavior behavior,
+                             const ResolvedRenderGeometry& geometry) -> GradeNeighborParams {
+  if (!IsNeighborhoodBehavior(behavior)) {
+    throw std::runtime_error("Primary grade: adjustment is not a neighborhood operator");
+  }
+
+  GradeNeighborParams result;
+  result.behavior = static_cast<std::uint32_t>(behavior);
+  CopyRenderMapping(geometry, result);
+  const auto dto = model.MakeFullDto();
+
+  if (behavior == AdjustmentBehavior::Sharpen) {
+    const auto* sharpen = PayloadAs<SharpenPayload>(dto.payload.get());
+    if (sharpen == nullptr) {
+      throw std::runtime_error("Primary grade: Sharpen payload is invalid");
+    }
+    result.amount    = std::clamp(sharpen->amount / 100.0f, 0.0f, 1.0f);
+    result.threshold = std::clamp(sharpen->threshold, 0.0f, 1.0f);
+    result.enabled   = result.amount > 0.0f ? 1U : 0U;
+    BuildGaussianWeights(sharpen->radius, 15U, result);
+    return result;
+  }
+
+  const auto* scalar = PayloadAs<ScalarFloatPayload>(dto.payload.get());
+  if (scalar == nullptr) {
+    throw std::runtime_error("Primary grade: neighborhood scalar payload is invalid");
+  }
+
+  if (behavior == AdjustmentBehavior::Clarity) {
+    result.amount  = std::clamp(scalar->value / 100.0f, -1.0f, 1.0f);
+    result.enabled = result.amount != 0.0f ? 1U : 0U;
+    BuildGaussianWeights(15.0f, 60U, result);
+    return result;
+  }
+
+  if (behavior == AdjustmentBehavior::Halation) {
+    result.amount  = std::clamp(scalar->value, 0.0f, 1.0f) * kHalationStrengthScale;
+    result.enabled = result.amount > 0.0f ? 1U : 0U;
+    result.sigma_x = kHalationSigma * RenderAxisScale(geometry, true);
+    result.sigma_y = kHalationSigma * RenderAxisScale(geometry, false);
+    std::copy_n(kHalationRedshift, 3, result.redshift);
+    return result;
+  }
+
+  result.amount  = std::clamp(scalar->value, 0.0f, 1.0f) / 3.0f;
+  result.enabled = result.amount > 0.0f ? 1U : 0U;
+  result.seed_lo = static_cast<std::uint32_t>(kFilmGrainSeed & 0xffffffffULL);
+  result.seed_hi = static_cast<std::uint32_t>((kFilmGrainSeed >> 32U) & 0xffffffffULL);
+  return result;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/adjustment_runtime.cpp
+++ b/alcedo_studio/src/edit/runtime/adjustment_runtime.cpp
@@ -24,11 +24,16 @@
 namespace alcedo {
 namespace {
 
-constexpr std::size_t   kMaxCurvePoints        = 8;
-constexpr float         kHalationSigma         = 7.0f;
-constexpr float         kHalationStrengthScale = 2.0f;
-constexpr float         kHalationRedshift[3]   = {1.0f, 0.05f, 0.02f};
-constexpr std::uint64_t kFilmGrainSeed         = 0x6a09e667f3bcc909ULL;
+constexpr std::size_t   kMaxCurvePoints             = 8;
+constexpr float         kHalationSigma              = 7.0f;
+constexpr float         kHalationStrengthScale      = 2.0f;
+constexpr float         kHalationRedshift[3]        = {1.0f, 0.05f, 0.02f};
+constexpr float         kClarityNeighborhoodSigma   = 15.0f;
+constexpr float         kFilmGrainDyeCloudSigma     = 0.8f;
+constexpr std::uint32_t kSharpenMaxRadius           = 15U;
+constexpr std::uint32_t kClarityMaxRadius           = 60U;
+constexpr std::uint32_t kFilmGrainMaxRadius         = 3U;
+constexpr std::uint64_t kFilmGrainSeed              = 0x6a09e667f3bcc909ULL;
 
 void BuildGaussianWeights(float sigma, std::uint32_t max_radius, GradeNeighborParams& result) {
   if (!(sigma > 0.0f)) {
@@ -66,6 +71,11 @@ auto RenderAxisScale(const ResolvedRenderGeometry& geometry, bool horizontal) ->
     return 1.0f;
   }
   return std::clamp(1.0f / reference_pixels_per_render_pixel, 1.0e-4f, 1.0f);
+}
+
+/** @brief Mean of the X/Y render-to-reference scales, clamped like the per-axis helper. */
+auto NeighborhoodRenderScale(const ResolvedRenderGeometry& geometry) -> float {
+  return 0.5f * (RenderAxisScale(geometry, true) + RenderAxisScale(geometry, false));
 }
 
 void CopyRenderMapping(const ResolvedRenderGeometry& geometry, GradeNeighborParams& result) {
@@ -188,6 +198,8 @@ auto MakeGradeNeighborParams(const IOperatorModel& model, AdjustmentBehavior beh
   CopyRenderMapping(geometry, result);
   const auto dto = model.MakeFullDto();
 
+  const float render_scale = NeighborhoodRenderScale(geometry);
+
   if (behavior == AdjustmentBehavior::Sharpen) {
     const auto* sharpen = PayloadAs<SharpenPayload>(dto.payload.get());
     if (sharpen == nullptr) {
@@ -196,7 +208,9 @@ auto MakeGradeNeighborParams(const IOperatorModel& model, AdjustmentBehavior beh
     result.amount    = std::clamp(sharpen->amount / 100.0f, 0.0f, 1.0f);
     result.threshold = std::clamp(sharpen->threshold, 0.0f, 1.0f);
     result.enabled   = result.amount > 0.0f ? 1U : 0U;
-    BuildGaussianWeights(sharpen->radius, 15U, result);
+    result.sigma_x   = sharpen->radius * render_scale;
+    result.sigma_y   = result.sigma_x;
+    BuildGaussianWeights(result.sigma_x, kSharpenMaxRadius, result);
     return result;
   }
 
@@ -208,7 +222,9 @@ auto MakeGradeNeighborParams(const IOperatorModel& model, AdjustmentBehavior beh
   if (behavior == AdjustmentBehavior::Clarity) {
     result.amount  = std::clamp(scalar->value / 100.0f, -1.0f, 1.0f);
     result.enabled = result.amount != 0.0f ? 1U : 0U;
-    BuildGaussianWeights(15.0f, 60U, result);
+    result.sigma_x = kClarityNeighborhoodSigma * render_scale;
+    result.sigma_y = result.sigma_x;
+    BuildGaussianWeights(result.sigma_x, kClarityMaxRadius, result);
     return result;
   }
 
@@ -223,8 +239,11 @@ auto MakeGradeNeighborParams(const IOperatorModel& model, AdjustmentBehavior beh
 
   result.amount  = std::clamp(scalar->value, 0.0f, 1.0f) / 3.0f;
   result.enabled = result.amount > 0.0f ? 1U : 0U;
+  result.sigma_x = kFilmGrainDyeCloudSigma * render_scale;
+  result.sigma_y = result.sigma_x;
   result.seed_lo = static_cast<std::uint32_t>(kFilmGrainSeed & 0xffffffffULL);
   result.seed_hi = static_cast<std::uint32_t>((kFilmGrainSeed >> 32U) & 0xffffffffULL);
+  BuildGaussianWeights(result.sigma_x, kFilmGrainMaxRadius, result);
   return result;
 }
 

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_neighbor_grade.cuh
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_neighbor_grade.cuh
@@ -119,39 +119,21 @@ __device__ __forceinline__ auto FilmBlurHorizontal(const float4* src, int x, int
     -> float4 {
   float result[3]{};
   for (int channel = 0; channel < 3; ++channel) {
-    result[channel] =
-        CUDA::FilmGrainGaussian7(FilmSampleAt(src, x, y, channel, width, height, params),
-                                 FilmSampleAt(src, x - 1, y, channel, width, height, params),
-                                 FilmSampleAt(src, x + 1, y, channel, width, height, params),
-                                 FilmSampleAt(src, x - 2, y, channel, width, height, params),
-                                 FilmSampleAt(src, x + 2, y, channel, width, height, params),
-                                 FilmSampleAt(src, x - 3, y, channel, width, height, params),
-                                 FilmSampleAt(src, x + 3, y, channel, width, height, params));
+    float acc = FilmSampleAt(src, x, y, channel, width, height, params) * params.weights[0];
+    for (int tap = 1; tap < static_cast<int>(params.tap_count); ++tap) {
+      acc += (FilmSampleAt(src, x - tap, y, channel, width, height, params) +
+              FilmSampleAt(src, x + tap, y, channel, width, height, params)) *
+             params.weights[tap];
+    }
+    result[channel] = acc;
   }
   return make_float4(result[0], result[1], result[2], ReadClamped(src, x, y, width, height).w);
-}
-
-__device__ __forceinline__ auto FilmBlurVertical(const float4* src, int x, int y, int width,
-                                                 int height) -> float4 {
-  const auto c0 = ReadClamped(src, x, y, width, height);
-  const auto n1 = ReadClamped(src, x, y - 1, width, height);
-  const auto p1 = ReadClamped(src, x, y + 1, width, height);
-  const auto n2 = ReadClamped(src, x, y - 2, width, height);
-  const auto p2 = ReadClamped(src, x, y + 2, width, height);
-  const auto n3 = ReadClamped(src, x, y - 3, width, height);
-  const auto p3 = ReadClamped(src, x, y + 3, width, height);
-  return make_float4(CUDA::FilmGrainGaussian7(c0.x, n1.x, p1.x, n2.x, p2.x, n3.x, p3.x),
-                     CUDA::FilmGrainGaussian7(c0.y, n1.y, p1.y, n2.y, p2.y, n3.y, p3.y),
-                     CUDA::FilmGrainGaussian7(c0.z, n1.z, p1.z, n2.z, p2.z, n3.z, p3.z), c0.w);
 }
 
 __device__ __forceinline__ auto VerticalRadius(const GradeNeighborParams& params) -> int {
   const auto behavior = static_cast<AdjustmentBehavior>(params.behavior);
   if (behavior == AdjustmentBehavior::Halation) {
     return HalationRadius(params.sigma_y);
-  }
-  if (behavior == AdjustmentBehavior::FilmGrain) {
-    return 3;
   }
   return static_cast<int>(params.radius);
 }
@@ -269,17 +251,17 @@ __global__ void ApplyVertical(const float4* original, const float4* blur_horizon
   }
 
   const auto c0 = tile[center];
-  const auto n1 = tile[center - tile_width];
-  const auto p1 = tile[center + tile_width];
-  const auto n2 = tile[center - 2 * tile_width];
-  const auto p2 = tile[center + 2 * tile_width];
-  const auto n3 = tile[center - 3 * tile_width];
-  const auto p3 = tile[center + 3 * tile_width];
-  const auto blur =
-      make_float4(CUDA::FilmGrainGaussian7(c0.x, n1.x, p1.x, n2.x, p2.x, n3.x, p3.x),
-                  CUDA::FilmGrainGaussian7(c0.y, n1.y, p1.y, n2.y, p2.y, n3.y, p3.y),
-                  CUDA::FilmGrainGaussian7(c0.z, n1.z, p1.z, n2.z, p2.z, n3.z, p3.z), c0.w);
-  dst[index] = CUDA::FilmGrainApplyDyeClouds(source, blur, params.amount);
+  float4     blur = Scale(c0, params.weights[0]);
+  for (int tap = 1; tap < static_cast<int>(params.tap_count); ++tap) {
+    const auto top    = tile[center - tap * tile_width];
+    const auto bottom = tile[center + tap * tile_width];
+    const auto weight = params.weights[tap];
+    blur.x += (top.x + bottom.x) * weight;
+    blur.y += (top.y + bottom.y) * weight;
+    blur.z += (top.z + bottom.z) * weight;
+  }
+  blur.w       = c0.w;
+  dst[index]   = CUDA::FilmGrainApplyDyeClouds(source, blur, params.amount);
 }
 
 }  // namespace alcedo::cuda_neighbor_grade

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_neighbor_grade.cuh
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_neighbor_grade.cuh
@@ -1,0 +1,285 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "cuda/prng.hpp"
+#include "cuda_acescc.cuh"
+#include "edit/operators/GPU_kernels/detail.cuh"
+#include "edit/operators/GPU_kernels/film_grain.cuh"
+#include "edit/runtime/adjustment_runtime.hpp"
+
+namespace alcedo::cuda_neighbor_grade {
+
+__device__ __forceinline__ auto ReadClamped(const float4* src, int x, int y, int width, int height)
+    -> float4 {
+  const int clamped_x = min(max(x, 0), width - 1);
+  const int clamped_y = min(max(y, 0), height - 1);
+  return src[static_cast<std::size_t>(clamped_y) * width + clamped_x];
+}
+
+__device__ __forceinline__ auto Scale(float4 value, float factor) -> float4 {
+  return make_float4(value.x * factor, value.y * factor, value.z * factor, value.w * factor);
+}
+
+__device__ __forceinline__ auto HalationRadius(float sigma) -> int {
+  if (!(sigma > 0.0f)) return 0;
+  return min(max(static_cast<int>(ceilf(sigma * 3.0f)), 1),
+             static_cast<int>(kGradeNeighborMaxTapCount - 1U));
+}
+
+__device__ __forceinline__ auto HalationWeight(int tap, float sigma) -> float {
+  return tap == 0 ? 1.0f : expf(-static_cast<float>(tap) / fmaxf(sigma, 1.0e-6f));
+}
+
+__device__ __forceinline__ auto HalationNormalization(int radius, float sigma) -> float {
+  float sum = 1.0f;
+  for (int tap = 1; tap <= radius; ++tap) sum += 2.0f * HalationWeight(tap, sigma);
+  return 1.0f / fmaxf(sum, 1.0e-6f);
+}
+
+__device__ __forceinline__ auto DecodeAcescc(float4 pixel) -> float4 {
+  return make_float4(cuda_acescc::Decode(pixel.x), cuda_acescc::Decode(pixel.y),
+                     cuda_acescc::Decode(pixel.z), pixel.w);
+}
+
+__device__ __forceinline__ auto HalationBlurHorizontal(const float4* src, int x, int y, int width,
+                                                       int                        height,
+                                                       const GradeNeighborParams& params)
+    -> float4 {
+  const int   radius = HalationRadius(params.sigma_x);
+  const float norm   = HalationNormalization(radius, params.sigma_x);
+  const auto  center = DecodeAcescc(ReadClamped(src, x, y, width, height));
+  float4      blur   = make_float4(center.x * norm, center.y * norm, center.z * norm, center.w);
+  for (int tap = 1; tap <= radius; ++tap) {
+    const float weight = HalationWeight(tap, params.sigma_x) * norm;
+    const auto  left   = DecodeAcescc(ReadClamped(src, x - tap, y, width, height));
+    const auto  right  = DecodeAcescc(ReadClamped(src, x + tap, y, width, height));
+    blur.x += (left.x + right.x) * weight;
+    blur.y += (left.y + right.y) * weight;
+    blur.z += (left.z + right.z) * weight;
+  }
+  return blur;
+}
+
+__device__ __forceinline__ auto HalationBlurVertical(const float4* src, int x, int y, int width,
+                                                     int height, const GradeNeighborParams& params)
+    -> float4 {
+  const int   radius = HalationRadius(params.sigma_y);
+  const float norm   = HalationNormalization(radius, params.sigma_y);
+  float4      blur   = ReadClamped(src, x, y, width, height);
+  blur.x *= norm;
+  blur.y *= norm;
+  blur.z *= norm;
+  for (int tap = 1; tap <= radius; ++tap) {
+    const float weight = HalationWeight(tap, params.sigma_y) * norm;
+    const auto  top    = ReadClamped(src, x, y - tap, width, height);
+    const auto  bottom = ReadClamped(src, x, y + tap, width, height);
+    blur.x += (top.x + bottom.x) * weight;
+    blur.y += (top.y + bottom.y) * weight;
+    blur.z += (top.z + bottom.z) * weight;
+  }
+  return blur;
+}
+
+__device__ __forceinline__ auto FilmReferenceCoordinate(int x, int y,
+                                                        const GradeNeighborParams& params) -> int2 {
+  if (params.use_reference_coordinates == 0U) return make_int2(x, y);
+  const float mapped_x = params.render_to_reference[0] * (static_cast<float>(x) + 0.5f) +
+                         params.render_to_reference[1] * (static_cast<float>(y) + 0.5f) +
+                         params.render_to_reference[2] - 0.5f;
+  const float mapped_y = params.render_to_reference[3] * (static_cast<float>(x) + 0.5f) +
+                         params.render_to_reference[4] * (static_cast<float>(y) + 0.5f) +
+                         params.render_to_reference[5] - 0.5f;
+  return make_int2(
+      min(max(static_cast<int>(floorf(mapped_x + 0.5f)), 0), max(params.reference_width, 1) - 1),
+      min(max(static_cast<int>(floorf(mapped_y + 0.5f)), 0), max(params.reference_height, 1) - 1));
+}
+
+__device__ __forceinline__ auto FilmSampleAt(const float4* src, int x, int y, int channel,
+                                             int width, int height,
+                                             const GradeNeighborParams& params) -> float {
+  const int  clamped_x = min(max(x, 0), width - 1);
+  const int  clamped_y = min(max(y, 0), height - 1);
+  const auto signal    = ReadClamped(src, clamped_x, clamped_y, width, height);
+  const auto ref       = FilmReferenceCoordinate(clamped_x, clamped_y, params);
+  const auto prng_seed = (static_cast<std::uint64_t>(params.seed_hi) << 32U) | params.seed_lo;
+  return CUDA::FilmGrainSample(CUDA::FilmGrainChannel(signal, channel), ref.x, ref.y, channel,
+                               prng_seed);
+}
+
+__device__ __forceinline__ auto FilmBlurHorizontal(const float4* src, int x, int y, int width,
+                                                   int height, const GradeNeighborParams& params)
+    -> float4 {
+  float result[3]{};
+  for (int channel = 0; channel < 3; ++channel) {
+    result[channel] =
+        CUDA::FilmGrainGaussian7(FilmSampleAt(src, x, y, channel, width, height, params),
+                                 FilmSampleAt(src, x - 1, y, channel, width, height, params),
+                                 FilmSampleAt(src, x + 1, y, channel, width, height, params),
+                                 FilmSampleAt(src, x - 2, y, channel, width, height, params),
+                                 FilmSampleAt(src, x + 2, y, channel, width, height, params),
+                                 FilmSampleAt(src, x - 3, y, channel, width, height, params),
+                                 FilmSampleAt(src, x + 3, y, channel, width, height, params));
+  }
+  return make_float4(result[0], result[1], result[2], ReadClamped(src, x, y, width, height).w);
+}
+
+__device__ __forceinline__ auto FilmBlurVertical(const float4* src, int x, int y, int width,
+                                                 int height) -> float4 {
+  const auto c0 = ReadClamped(src, x, y, width, height);
+  const auto n1 = ReadClamped(src, x, y - 1, width, height);
+  const auto p1 = ReadClamped(src, x, y + 1, width, height);
+  const auto n2 = ReadClamped(src, x, y - 2, width, height);
+  const auto p2 = ReadClamped(src, x, y + 2, width, height);
+  const auto n3 = ReadClamped(src, x, y - 3, width, height);
+  const auto p3 = ReadClamped(src, x, y + 3, width, height);
+  return make_float4(CUDA::FilmGrainGaussian7(c0.x, n1.x, p1.x, n2.x, p2.x, n3.x, p3.x),
+                     CUDA::FilmGrainGaussian7(c0.y, n1.y, p1.y, n2.y, p2.y, n3.y, p3.y),
+                     CUDA::FilmGrainGaussian7(c0.z, n1.z, p1.z, n2.z, p2.z, n3.z, p3.z), c0.w);
+}
+
+__device__ __forceinline__ auto VerticalRadius(const GradeNeighborParams& params) -> int {
+  const auto behavior = static_cast<AdjustmentBehavior>(params.behavior);
+  if (behavior == AdjustmentBehavior::Halation) {
+    return HalationRadius(params.sigma_y);
+  }
+  if (behavior == AdjustmentBehavior::FilmGrain) {
+    return 3;
+  }
+  return static_cast<int>(params.radius);
+}
+
+__global__ void BlurHorizontal(const float4* src, float4* dst, int width, int height,
+                               GradeNeighborParams params) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+  const auto behavior = static_cast<AdjustmentBehavior>(params.behavior);
+  float4     result;
+  if (behavior == AdjustmentBehavior::Halation) {
+    result = HalationBlurHorizontal(src, x, y, width, height, params);
+  } else if (behavior == AdjustmentBehavior::FilmGrain) {
+    result = FilmBlurHorizontal(src, x, y, width, height, params);
+  } else {
+    result = CUDA::detail_blur_horizontal(x, y, src, width, height, width,
+                                          static_cast<int>(params.tap_count), params.weights);
+  }
+  dst[static_cast<std::size_t>(y) * width + x] = result;
+}
+
+__global__ void ApplyVertical(const float4* original, const float4* blur_horizontal, float4* dst,
+                              int width, int height, GradeNeighborParams params) {
+  extern __shared__ float4 tile[];
+  const int                x            = blockIdx.x * blockDim.x + threadIdx.x;
+  const int                y            = blockIdx.y * blockDim.y + threadIdx.y;
+  const int                radius       = VerticalRadius(params);
+  const int                tile_width   = blockDim.x;
+  const int                tile_height  = blockDim.y + 2 * radius;
+  const int                thread_id    = threadIdx.y * blockDim.x + threadIdx.x;
+  const int                thread_count = blockDim.x * blockDim.y;
+  for (int tile_index = thread_id; tile_index < tile_width * tile_height;
+       tile_index += thread_count) {
+    const int local_x  = tile_index % tile_width;
+    const int local_y  = tile_index / tile_width;
+    const int source_x = blockIdx.x * blockDim.x + local_x;
+    const int source_y = min(max(blockIdx.y * blockDim.y + local_y - radius, 0), height - 1);
+    tile[tile_index]   = source_x < width
+                             ? blur_horizontal[static_cast<std::size_t>(source_y) * width + source_x]
+                             : make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+  }
+  __syncthreads();
+  if (x >= width || y >= height) return;
+  const auto index    = static_cast<std::size_t>(y) * width + x;
+  const auto source   = original[index];
+  const auto behavior = static_cast<AdjustmentBehavior>(params.behavior);
+  const int  center   = (threadIdx.y + radius) * tile_width + threadIdx.x;
+
+  if (behavior == AdjustmentBehavior::Sharpen) {
+    float4 blur = Scale(tile[center], params.weights[0]);
+    for (int tap = 1; tap < static_cast<int>(params.tap_count); ++tap) {
+      const auto top    = tile[center - tap * tile_width];
+      const auto bottom = tile[center + tap * tile_width];
+      const auto weight = params.weights[tap];
+      blur.x += (top.x + bottom.x) * weight;
+      blur.y += (top.y + bottom.y) * weight;
+      blur.z += (top.z + bottom.z) * weight;
+      blur.w += (top.w + bottom.w) * weight;
+    }
+    float4 high = make_float4(source.x - blur.x, source.y - blur.y, source.z - blur.z, 0.0f);
+    if (params.threshold > 0.0f && fabsf(CUDA::detail_luminance(high)) <= params.threshold) {
+      high = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    }
+    dst[index] = make_float4(source.x + high.x * params.amount, source.y + high.y * params.amount,
+                             source.z + high.z * params.amount, source.w);
+    return;
+  }
+
+  if (behavior == AdjustmentBehavior::Clarity) {
+    float4 blur = Scale(tile[center], params.weights[0]);
+    for (int tap = 1; tap < static_cast<int>(params.tap_count); ++tap) {
+      const auto top    = tile[center - tap * tile_width];
+      const auto bottom = tile[center + tap * tile_width];
+      const auto weight = params.weights[tap];
+      blur.x += (top.x + bottom.x) * weight;
+      blur.y += (top.y + bottom.y) * weight;
+      blur.z += (top.z + bottom.z) * weight;
+      blur.w += (top.w + bottom.w) * weight;
+    }
+    const auto  diff = make_float4(source.x - blur.x, source.y - blur.y, source.z - blur.z, 0.0f);
+    const float protect =
+        1.0f - CUDA::detail_smoothstep(0.0f, 0.18f, fabsf(CUDA::detail_luminance(diff)));
+    const float luma     = CUDA::detail_luminance(source);
+    const float centered = (luma - 0.5f) * 2.0f;
+    const float strength = params.amount * protect * fmaxf(1.0f - centered * centered, 0.0f);
+    dst[index] = make_float4(fmaf(diff.x, strength, source.x), fmaf(diff.y, strength, source.y),
+                             fmaf(diff.z, strength, source.z), source.w);
+    return;
+  }
+
+  if (behavior == AdjustmentBehavior::Halation) {
+    const float norm = HalationNormalization(radius, params.sigma_y);
+    float4      blur = tile[center];
+    blur.x *= norm;
+    blur.y *= norm;
+    blur.z *= norm;
+    for (int tap = 1; tap <= radius; ++tap) {
+      const float weight = HalationWeight(tap, params.sigma_y) * norm;
+      const auto  top    = tile[center - tap * tile_width];
+      const auto  bottom = tile[center + tap * tile_width];
+      blur.x += (top.x + bottom.x) * weight;
+      blur.y += (top.y + bottom.y) * weight;
+      blur.z += (top.z + bottom.z) * weight;
+    }
+    const auto  linear  = DecodeAcescc(source);
+    const float spill_r = fmaxf(blur.x - linear.x, 0.0f);
+    const float spill_g = fmaxf(blur.y - linear.y, 0.0f);
+    const float spill_b = fmaxf(blur.z - linear.z, 0.0f);
+    dst[index]          = make_float4(
+        cuda_acescc::Encode(linear.x + spill_r * params.amount * params.redshift[0]),
+        cuda_acescc::Encode(linear.y + spill_g * params.amount * params.redshift[1]),
+        cuda_acescc::Encode(linear.z + spill_b * params.amount * params.redshift[2]), source.w);
+    return;
+  }
+
+  const auto c0 = tile[center];
+  const auto n1 = tile[center - tile_width];
+  const auto p1 = tile[center + tile_width];
+  const auto n2 = tile[center - 2 * tile_width];
+  const auto p2 = tile[center + 2 * tile_width];
+  const auto n3 = tile[center - 3 * tile_width];
+  const auto p3 = tile[center + 3 * tile_width];
+  const auto blur =
+      make_float4(CUDA::FilmGrainGaussian7(c0.x, n1.x, p1.x, n2.x, p2.x, n3.x, p3.x),
+                  CUDA::FilmGrainGaussian7(c0.y, n1.y, p1.y, n2.y, p2.y, n3.y, p3.y),
+                  CUDA::FilmGrainGaussian7(c0.z, n1.z, p1.z, n2.z, p2.z, n3.z, p3.z), c0.w);
+  dst[index] = CUDA::FilmGrainApplyDyeClouds(source, blur, params.amount);
+}
+
+}  // namespace alcedo::cuda_neighbor_grade

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "cuda_neighbor_grade.cuh"
 #include "edit/operators/models/pending_parameter_patch.hpp"
 #include "edit/pipeline/local_tone_mapping.hpp"
 #include "edit/runtime/adjustment_runtime.hpp"
@@ -29,6 +30,14 @@ namespace {
 using CudaAdjustmentParams  = GradeAdjustmentParams;
 using CudaAdjustmentCommand = GradeAdjustmentCommand;
 
+enum class GradeOpKind : std::uint8_t { Fused, Detail, LlfBarrier };
+
+struct GradeOp {
+  GradeOpKind                kind = GradeOpKind::Fused;
+  std::vector<std::uint32_t> offsets;
+  GradeNeighborParams        neighbor{};
+};
+
 auto EnsureImage(CudaRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
                  std::uint32_t height) -> ResourceLease<CudaBackend>& {
   return workspace.AcquireImageForWrite(id, {width, height, TextureFormat::Rgba32f});
@@ -40,6 +49,40 @@ auto EnsureBuffer(CudaRenderWorkspace& workspace, const GraphValueId& id, std::s
   if (existing != nullptr && existing->Bytes() >= bytes) return *existing;
   workspace.Values().Store(id, workspace.Device().CreateBuffer(bytes));
   return *workspace.Values().Find(id);
+}
+
+auto AcquireScratch(CudaRenderWorkspace& workspace, std::uint32_t width, std::uint32_t height)
+    -> ResourceLease<CudaBackend> {
+  return workspace.Textures().Acquire({width, height, TextureFormat::Rgba32f});
+}
+
+auto CompactOps(std::vector<GradeOp> ops, bool local_tone_active) -> std::vector<GradeOp> {
+  std::vector<GradeOp> compacted;
+  compacted.reserve(ops.size());
+  for (auto& op : ops) {
+    if (op.kind == GradeOpKind::LlfBarrier && !local_tone_active) continue;
+    if (op.kind == GradeOpKind::Fused && op.offsets.empty()) continue;
+    if (op.kind == GradeOpKind::Fused && !compacted.empty() &&
+        compacted.back().kind == GradeOpKind::Fused) {
+      compacted.back().offsets.insert(compacted.back().offsets.end(), op.offsets.begin(),
+                                      op.offsets.end());
+      continue;
+    }
+    compacted.push_back(std::move(op));
+  }
+  return compacted;
+}
+
+auto NeighborVerticalRadius(const GradeNeighborParams& params) -> std::uint32_t {
+  const auto behavior = static_cast<AdjustmentBehavior>(params.behavior);
+  if (behavior == AdjustmentBehavior::Halation) {
+    return std::clamp(static_cast<std::uint32_t>(std::ceil(params.sigma_y * 3.0f)), 1U,
+                      kGradeNeighborMaxTapCount - 1U);
+  }
+  if (behavior == AdjustmentBehavior::FilmGrain) {
+    return 3U;
+  }
+  return params.radius;
 }
 
 __device__ auto Luma(const float3& c) -> float {
@@ -99,8 +142,7 @@ __device__ auto ApplyHls(float3 c, const CudaAdjustmentParams& p) -> float3 {
   return c;
 }
 
-__device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p, std::uint32_t pixel_index,
-                                float local_reference) -> float3 {
+__device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p) -> float3 {
   const auto  behavior = static_cast<CudaAdjustmentBehavior>(p.behavior);
   const float value    = p.values[0];
   if (behavior == CudaAdjustmentBehavior::Cat02WhiteBalance && value != 0.0f) {
@@ -129,14 +171,6 @@ __device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p, std::ui
     c.x += offset;
     c.y += offset;
     c.z += offset;
-  } else if (behavior == CudaAdjustmentBehavior::Clarity) {
-    const float l      = Luma(c);
-    float       weight = 1.0f - fminf(l / fmaxf(local_reference, 1.0e-4f), 1.0f);
-    weight             = 0.5f - fabsf(weight - 0.5f);
-    const float gain   = 1.0f + value * 0.01f * weight;
-    c.x *= gain;
-    c.y *= gain;
-    c.z *= gain;
   } else if (behavior == CudaAdjustmentBehavior::Curve) {
     c.x = ApplyCurve(c.x, p);
     c.y = ApplyCurve(c.y, p);
@@ -165,21 +199,6 @@ __device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p, std::ui
         copysignf(powf(fabsf(c.y + p.values[1] + p.values[3]), 1.0f / gamma_y), c.y) * p.values[9];
     c.z =
         copysignf(powf(fabsf(c.z + p.values[2] + p.values[3]), 1.0f / gamma_z), c.z) * p.values[10];
-  } else if (behavior == CudaAdjustmentBehavior::Sharpen) {
-    const float l     = Luma(c);
-    const float scale = 1.0f + value * 0.0025f;
-    c.x               = l + (c.x - l) * scale;
-    c.y               = l + (c.y - l) * scale;
-    c.z               = l + (c.z - l) * scale;
-  } else if (behavior == CudaAdjustmentBehavior::Halation) {
-    c.x += fmaxf(Luma(c) - 0.6f, 0.0f) * value * 0.15f;
-  } else if (behavior == CudaAdjustmentBehavior::FilmGrain && value != 0.0f) {
-    std::uint32_t hash = pixel_index * 747796405u + 2891336453u;
-    hash               = (hash >> ((hash >> 28u) + 4u)) ^ hash;
-    const float noise  = (static_cast<float>(hash & 0xffffu) / 32767.5f - 1.0f) * value * 0.02f;
-    c.x += noise;
-    c.y += noise;
-    c.z += noise;
   }
   return c;
 }
@@ -187,7 +206,7 @@ __device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p, std::ui
 __global__ void PrimaryGradeKernel(const float4* input, float4* output, std::uint32_t pixel_count,
                                    const unsigned char*         parameter_base,
                                    const CudaAdjustmentCommand* commands,
-                                   std::uint32_t command_count, float local_reference) {
+                                   std::uint32_t                command_count) {
   const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= pixel_count) return;
   const float4 source = input[index];
@@ -195,19 +214,20 @@ __global__ void PrimaryGradeKernel(const float4* input, float4* output, std::uin
   for (std::uint32_t i = 0; i < command_count; ++i) {
     const auto* params = reinterpret_cast<const CudaAdjustmentParams*>(
         parameter_base + commands[i].parameter_offset);
-    c = ApplyAdjustment(c, *params, index, local_reference);
+    c = ApplyAdjustment(c, *params);
   }
   output[index] = make_float4(c.x, c.y, c.z, source.w);
 }
 
-__global__ void FinalMixKernel(const float4* source, float4* adjusted, std::uint32_t pixel_count,
-                               float grade_mix, const std::uint8_t* mask) {
+__global__ void FinalMixKernel(const float4* source, const float4* adjusted, float4* destination,
+                               std::uint32_t pixel_count, float grade_mix,
+                               const std::uint8_t* mask) {
   const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= pixel_count) return;
   const float  mix = grade_mix * (mask == nullptr ? 1.0f : mask[index] / 255.0f);
   const float4 a   = adjusted[index];
   const float4 s   = source[index];
-  adjusted[index] =
+  destination[index] =
       make_float4(s.x + (a.x - s.x) * mix, s.y + (a.y - s.y) * mix, s.z + (a.z - s.z) * mix, s.w);
 }
 
@@ -231,15 +251,19 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
   arena.Reserve(plan.primary_grade_adjustments.size() *
                 (sizeof(CudaAdjustmentParams) + ParameterArena<CudaBackend>::kSlotAlignment));
   std::vector<PendingParameterPatch> pending;
-  std::vector<CudaAdjustmentCommand> commands_before_local_tone;
-  std::vector<CudaAdjustmentCommand> commands_after_local_tone;
-  commands_before_local_tone.reserve(plan.primary_grade_adjustments.size());
-  commands_after_local_tone.reserve(plan.primary_grade_adjustments.size());
-  bool                        reached_local_tone = false;
-  float                       shadows_slider     = 0.0f;
-  float                       highlights_slider  = 0.0f;
+  std::vector<GradeOp>               ops;
+  ops.reserve(plan.primary_grade_adjustments.size());
+  float                       shadows_slider    = 0.0f;
+  float                       highlights_slider = 0.0f;
   const ParameterFieldBinding field{DirtyFieldMask{kGradeRuntimeParamDirtyBit}, 0, 0,
                                     sizeof(CudaAdjustmentParams)};
+
+  auto                        FlushFused = [&]() -> GradeOp* {
+    if (ops.empty() || ops.back().kind != GradeOpKind::Fused) {
+      ops.push_back(GradeOp{GradeOpKind::Fused, {}, {}});
+    }
+    return &ops.back();
+  };
 
   for (const auto& compiled : plan.primary_grade_adjustments) {
     auto* model = grade->FindAdjustment(compiled.instance_id);
@@ -249,12 +273,18 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
     }
     const auto behavior = TryResolveCudaAdjustmentBehavior(compiled.type);
     if (!behavior.has_value()) {
-      continue;
+      throw std::runtime_error("ExecuteCudaPrimaryGrade: unregistered adjustment type '" +
+                               std::string{compiled.type.Text()} + "'");
     }
     if (IsCudaLocalToneBehavior(*behavior) &&
         compiled.algorithm != CompiledAdjustmentAlgorithm::LocalLaplacian) {
       throw std::runtime_error(
           "ExecuteCudaPrimaryGrade: Shadows/Highlights were not compiled for LLF");
+    }
+    if (compiled.algorithm == CompiledAdjustmentAlgorithm::LocalLaplacian &&
+        !IsCudaLocalToneBehavior(*behavior)) {
+      throw std::runtime_error(
+          "ExecuteCudaPrimaryGrade: non-local adjustment was compiled for LLF");
     }
     const ParameterSlotKey key{grade->Id(), compiled.instance_id};
     const auto             runtime_params = MakeGradeRuntimeParams(*model, *behavior);
@@ -270,29 +300,49 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       arena.ApplyPatch(key, patch);
       pending.push_back(std::move(*change));
     }
-    if (compiled.algorithm == CompiledAdjustmentAlgorithm::LocalLaplacian &&
-        *behavior == CudaAdjustmentBehavior::Shadows) {
-      shadows_slider     = runtime_params.values[0];
-      reached_local_tone = true;
+    if (compiled.algorithm == CompiledAdjustmentAlgorithm::LocalLaplacian) {
+      if (*behavior == CudaAdjustmentBehavior::Shadows) {
+        shadows_slider = runtime_params.values[0];
+      } else {
+        highlights_slider = runtime_params.values[0];
+      }
+      if (ops.empty() || ops.back().kind != GradeOpKind::LlfBarrier) {
+        ops.push_back(GradeOp{GradeOpKind::LlfBarrier, {}, {}});
+      }
       continue;
     }
-    if (compiled.algorithm == CompiledAdjustmentAlgorithm::LocalLaplacian &&
-        *behavior == CudaAdjustmentBehavior::Highlights) {
-      highlights_slider  = runtime_params.values[0];
-      reached_local_tone = true;
+
+    if (compiled.algorithm == CompiledAdjustmentAlgorithm::Neighborhood ||
+        IsNeighborhoodBehavior(*behavior)) {
+      auto neighbor = MakeGradeNeighborParams(*model, *behavior, plan.geometry);
+      if (neighbor.enabled != 0U) {
+        ops.push_back(GradeOp{GradeOpKind::Detail, {}, neighbor});
+      }
       continue;
     }
-    auto& destination = reached_local_tone ? commands_after_local_tone : commands_before_local_tone;
-    destination.push_back({arena.Binding(key).offset});
+    if (compiled.algorithm != CompiledAdjustmentAlgorithm::Pointwise) {
+      throw std::runtime_error("ExecuteCudaPrimaryGrade: unsupported grade algorithm");
+    }
+    FlushFused()->offsets.push_back(arena.Binding(key).offset);
   }
+
+  const bool local_tone_active = local_tone_mapping::ShouldRun(
+      shadows_slider * local_tone_mapping::kHighlightStrengthScale / 80.0f,
+      -highlights_slider * local_tone_mapping::kHighlightStrengthScale / 100.0f);
+  ops           = CompactOps(std::move(ops), local_tone_active);
 
   auto& context = device.CommandContext();
   arena.UploadDirty(context);
   for (auto& patch : pending) patch.Commit();
 
-  std::vector<CudaAdjustmentCommand> commands = commands_before_local_tone;
-  commands.insert(commands.end(), commands_after_local_tone.begin(),
-                  commands_after_local_tone.end());
+  std::vector<CudaAdjustmentCommand> commands;
+  commands.reserve(plan.primary_grade_adjustments.size());
+  std::vector<std::uint32_t> command_starts;
+  command_starts.reserve(ops.size());
+  for (const auto& op : ops) {
+    command_starts.push_back(static_cast<std::uint32_t>(commands.size()));
+    for (const auto offset : op.offsets) commands.push_back({offset});
+  }
   const GraphValueId command_id{grade->Id(), PortId{"runtime.order"}};
   auto&              command_buffer = EnsureBuffer(
       workspace, command_id, std::max<std::size_t>(commands.size() * sizeof(commands[0]), 1));
@@ -304,23 +354,9 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
         context);
   }
 
-  const GraphValueId output_id{grade->Id(), PortId{"image"}};
-  const auto         input_width  = input->Texture().Width();
-  const auto         input_height = input->Texture().Height();
-  EnsureImage(workspace, output_id, input_width, input_height);
-  input        = workspace.Images().Find(plan.develop_output);
-  auto* output = workspace.Images().Find(output_id);
-  if (input == nullptr || output == nullptr) {
-    throw std::runtime_error("ExecuteCudaPrimaryGrade: image cache changed during allocation");
-  }
-  const void*           input_pointer  = input->Texture().DevicePointer();
-  void*                 output_pointer = output->Texture().DevicePointer();
-  cudaPointerAttributes input_attributes{};
-  cudaPointerAttributes output_attributes{};
-  if (::cudaPointerGetAttributes(&input_attributes, input_pointer) != cudaSuccess ||
-      ::cudaPointerGetAttributes(&output_attributes, output_pointer) != cudaSuccess) {
-    throw std::runtime_error("ExecuteCudaPrimaryGrade: workspace image has no CUDA allocation");
-  }
+  const GraphValueId  output_id    = plan.primary_grade_output;
+  const auto          input_width  = input->Texture().Width();
+  const auto          input_height = input->Texture().Height();
   const std::uint8_t* mask_pointer = nullptr;
   if (plan.primary_grade_mask) {
     auto* mask = workspace.Images().Find(plan.mask_output);
@@ -336,42 +372,96 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       static_cast<const CudaAdjustmentCommand*>(command_buffer.DevicePointer());
   const auto* parameter_base =
       static_cast<const unsigned char*>(arena.DeviceBuffer().DevicePointer());
-  const bool local_tone_active = local_tone_mapping::ShouldRun(shadows_slider * 1.5f / 80.0f,
-                                                               -highlights_slider * 1.5f / 100.0f);
+
   CudaLocalToneResult local_tone;
-  if (local_tone_active) {
-    const GraphValueId local_input_id{grade->Id(), PortId{"local_tone.input"}};
-    const GraphValueId local_output_id{grade->Id(), PortId{"local_tone.output"}};
-    auto& local_input = EnsureImage(workspace, local_input_id, input_width, input_height);
-    input             = workspace.Images().Find(plan.develop_output);
-    PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
-        static_cast<const float4*>(input->Texture().DevicePointer()),
-        static_cast<float4*>(local_input.Texture().DevicePointer()), pixels, parameter_base,
-        device_commands, static_cast<std::uint32_t>(commands_before_local_tone.size()),
-        local_tone_mapping::kAcesccMiddleGray);
-    local_tone         = ExecuteCudaLocalTone(device, local_input_id, local_output_id, grade->Id(),
-                                              input_width, input_height, shadows_slider, highlights_slider,
-                                              plan.geometry, HashLlfReferenceKey(plan, prepared, document));
-    auto* local_output = workspace.Images().Find(local_output_id);
-    output             = workspace.Images().Find(output_id);
-    PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
-        static_cast<const float4*>(local_output->Texture().DevicePointer()),
-        static_cast<float4*>(output->Texture().DevicePointer()), pixels, parameter_base,
-        device_commands + commands_before_local_tone.size(),
-        static_cast<std::uint32_t>(commands_after_local_tone.size()),
-        local_tone_mapping::kAcesccMiddleGray);
-  } else {
-    PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
-        static_cast<const float4*>(input_pointer), static_cast<float4*>(output_pointer), pixels,
-        parameter_base, device_commands, static_cast<std::uint32_t>(commands.size()),
-        local_tone_mapping::kAcesccMiddleGray);
+
+  if (ops.empty()) {
+    auto& output = EnsureImage(workspace, output_id, input_width, input_height);
+    input        = workspace.Images().Find(plan.develop_output);
+    workspace.Device().CopyTexture2D(input->Texture(), output.Texture(), context);
+    return {output_id, 0, false, false};
   }
-  input  = workspace.Images().Find(plan.develop_output);
-  output = workspace.Images().Find(output_id);
-  FinalMixKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
-      static_cast<const float4*>(input->Texture().DevicePointer()),
-      static_cast<float4*>(output->Texture().DevicePointer()), pixels,
-      grade->Enabled() ? grade->Mix() : 0.0f, mask_pointer);
+
+  const float        grade_mix        = grade->Enabled() ? grade->Mix() : 0.0f;
+  const bool         skip_mix         = grade_mix == 1.0f && !plan.primary_grade_mask.has_value();
+  std::size_t        remaining_writes = ops.size() + (skip_mix ? 0U : 1U);
+  const GraphValueId ping_id{grade->Id(), PortId{"runtime.ping"}};
+  const GraphValueId pong_id{grade->Id(), PortId{"runtime.pong"}};
+  GraphValueId       current_id = plan.develop_output;
+
+  auto               Resolve    = [&](const GraphValueId& id) -> CudaBackend::Texture2D& {
+    auto* image = workspace.Images().Find(id);
+    if (image == nullptr || image->Empty()) {
+      throw std::runtime_error("ExecuteCudaPrimaryGrade: stage image is missing");
+    }
+    return image->Texture();
+  };
+  auto AllocateDest = [&]() -> GraphValueId {
+    if (remaining_writes == 0) {
+      throw std::runtime_error("ExecuteCudaPrimaryGrade: destination count underflow");
+    }
+    --remaining_writes;
+    GraphValueId destination = output_id;
+    if (remaining_writes != 0) {
+      destination = current_id == ping_id ? pong_id : ping_id;
+    }
+    (void)EnsureImage(workspace, destination, input_width, input_height);
+    return destination;
+  };
+
+  const dim3 neighbor_block{16, 16};
+  const dim3 neighbor_grid{(input_width + neighbor_block.x - 1) / neighbor_block.x,
+                           (input_height + neighbor_block.y - 1) / neighbor_block.y};
+  for (std::size_t index = 0; index < ops.size(); ++index) {
+    const auto& op      = ops[index];
+    const auto  dest_id = AllocateDest();
+    if (op.kind == GradeOpKind::Detail) {
+      auto  blur_horizontal = AcquireScratch(workspace, input_width, input_height);
+      auto& src             = Resolve(current_id);
+      auto& dest            = Resolve(dest_id);
+      cuda_neighbor_grade::BlurHorizontal<<<neighbor_grid, neighbor_block, 0, context.Stream()>>>(
+          static_cast<const float4*>(src.DevicePointer()),
+          static_cast<float4*>(blur_horizontal.Texture().DevicePointer()),
+          static_cast<int>(input_width), static_cast<int>(input_height), op.neighbor);
+      const auto vertical_radius = NeighborVerticalRadius(op.neighbor);
+      const auto shared_bytes    = static_cast<std::size_t>(neighbor_block.x) *
+                                (neighbor_block.y + 2U * vertical_radius) * sizeof(float4);
+      cuda_neighbor_grade::
+          ApplyVertical<<<neighbor_grid, neighbor_block, shared_bytes, context.Stream()>>>(
+              static_cast<const float4*>(src.DevicePointer()),
+              static_cast<const float4*>(blur_horizontal.Texture().DevicePointer()),
+              static_cast<float4*>(dest.DevicePointer()), static_cast<int>(input_width),
+              static_cast<int>(input_height), op.neighbor);
+    } else if (op.kind == GradeOpKind::LlfBarrier) {
+      local_tone = ExecuteCudaLocalTone(
+          device, current_id, dest_id, grade->Id(), input_width, input_height, shadows_slider,
+          highlights_slider, plan.geometry, HashLlfReferenceKey(plan, prepared, document));
+    } else {
+      auto& src  = Resolve(current_id);
+      auto& dest = Resolve(dest_id);
+      PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
+          static_cast<const float4*>(src.DevicePointer()),
+          static_cast<float4*>(dest.DevicePointer()), pixels, parameter_base,
+          device_commands + command_starts[index], static_cast<std::uint32_t>(op.offsets.size()));
+    }
+    current_id = dest_id;
+  }
+
+  if (!skip_mix) {
+    const auto dest_id     = AllocateDest();
+    auto&      source      = Resolve(plan.develop_output);
+    auto&      adjusted    = Resolve(current_id);
+    auto&      destination = Resolve(dest_id);
+    FinalMixKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
+        static_cast<const float4*>(source.DevicePointer()),
+        static_cast<const float4*>(adjusted.DevicePointer()),
+        static_cast<float4*>(destination.DevicePointer()), pixels, grade_mix, mask_pointer);
+    current_id = dest_id;
+  }
+
+  if (current_id != output_id || remaining_writes != 0) {
+    throw std::runtime_error("ExecuteCudaPrimaryGrade: grade output scheduling failed");
+  }
   if (::cudaGetLastError() != cudaSuccess) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: CUDA kernel launch failed");
   }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -79,9 +79,6 @@ auto NeighborVerticalRadius(const GradeNeighborParams& params) -> std::uint32_t 
     return std::clamp(static_cast<std::uint32_t>(std::ceil(params.sigma_y * 3.0f)), 1U,
                       kGradeNeighborMaxTapCount - 1U);
   }
-  if (behavior == AdjustmentBehavior::FilmGrain) {
-    return 3U;
-  }
   return params.radius;
 }
 

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_backend.cpp
@@ -747,7 +747,10 @@ void OpenClBackend::WarmUpPlan(const ExecutionPlan& plan) {
   }
   if (plan.Contains(GpuPassKind::PrimaryColorGrade)) {
     add(OpenCL::GpuDag::kPrimaryGradeProgramName, OpenCL::GpuDag::kPrimaryGradePointwiseKernelName);
-    add(OpenCL::GpuDag::kPrimaryGradeProgramName, OpenCL::GpuDag::kPrimaryGradeDetailKernelName);
+    add(OpenCL::GpuDag::kPrimaryGradeProgramName,
+        OpenCL::GpuDag::kPrimaryGradeNeighborBlurKernelName);
+    add(OpenCL::GpuDag::kPrimaryGradeProgramName,
+        OpenCL::GpuDag::kPrimaryGradeNeighborApplyKernelName);
     add(OpenCL::GpuDag::kPrimaryGradeProgramName, OpenCL::GpuDag::kPrimaryGradeMixKernelName);
     if (plan.primary_grade_mask.has_value()) {
       add(OpenCL::GpuDag::kPrimaryGradeProgramName,

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_gpu_dag_programs.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_gpu_dag_programs.cpp
@@ -27,7 +27,9 @@ void RegisterOpenClGpuDagPrograms() {
                 },
                 OpenClProgramDescriptor{
                     .name                = OpenCL::GpuDag::kPrimaryGradeProgramName,
-                    .source_paths        = {ALCEDO_OPENCL_DAG_PRIMARY_GRADE_CL},
+                    .source_paths        = {ALCEDO_OPENCL_DAG_PRIMARY_GRADE_CL,
+                                            ALCEDO_OPENCL_PRNG_CL,
+                                            ALCEDO_OPENCL_DAG_PRIMARY_GRADE_NEIGHBOR_CL},
                     .build_options       = "-cl-std=CL1.2",
                     .required_at_startup = false,
                 },

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_primary_grade_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_primary_grade_pass.cpp
@@ -100,9 +100,6 @@ auto NeighborVerticalRadius(const GradeNeighborParams& params) -> std::uint32_t 
     return std::clamp(static_cast<std::uint32_t>(std::ceil(params.sigma_y * 3.0f)), 1U,
                       kGradeNeighborMaxTapCount - 1U);
   }
-  if (behavior == AdjustmentBehavior::FilmGrain) {
-    return 3U;
-  }
   return params.radius;
 }
 

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_primary_grade_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_primary_grade_pass.cpp
@@ -53,6 +53,7 @@ enum class GradeOpKind : std::uint8_t { Fused, Detail, LlfBarrier };
 struct GradeOp {
   GradeOpKind                kind = GradeOpKind::Fused;
   std::vector<std::uint32_t> offsets;
+  GradeNeighborParams        neighbor{};
 };
 
 auto AcquireRgba(OpenClRenderWorkspace& workspace, const GraphValueId& id, std::uint32_t width,
@@ -80,16 +81,29 @@ auto EnsureBuffer(OpenClRenderWorkspace& workspace, const GraphValueId& id, std:
 }
 
 void DispatchKernel(OpenClRenderDevice& device, cl_kernel kernel, std::uint32_t width,
-                    std::uint32_t height) {
-  const std::size_t local[2]  = {16, 16};
-  const std::size_t global[2] = {((static_cast<std::size_t>(width) + 15) / 16) * 16,
-                                 ((static_cast<std::size_t>(height) + 15) / 16) * 16};
-  cl_event          event     = nullptr;
+                    std::uint32_t height, std::size_t local_edge = 16) {
+  const std::size_t local[2]  = {local_edge, local_edge};
+  const std::size_t global[2] = {
+      ((static_cast<std::size_t>(width) + local_edge - 1) / local_edge) * local_edge,
+      ((static_cast<std::size_t>(height) + local_edge - 1) / local_edge) * local_edge};
+  cl_event event = nullptr;
   CheckOpenCl(clEnqueueNDRangeKernel(device.Workspace().Device().NativeQueue(), kernel, 2, nullptr,
                                      global, local, 0, nullptr, &event),
               "OpenCL Primary Grade enqueue");
   NoteOpenClEnqueueNdRange();
   device.Workspace().Device().TrackKernelEvent(device.CommandContext(), event);
+}
+
+auto NeighborVerticalRadius(const GradeNeighborParams& params) -> std::uint32_t {
+  const auto behavior = static_cast<AdjustmentBehavior>(params.behavior);
+  if (behavior == AdjustmentBehavior::Halation) {
+    return std::clamp(static_cast<std::uint32_t>(std::ceil(params.sigma_y * 3.0f)), 1U,
+                      kGradeNeighborMaxTapCount - 1U);
+  }
+  if (behavior == AdjustmentBehavior::FilmGrain) {
+    return 3U;
+  }
+  return params.radius;
 }
 
 void SetImageKernelArgs(cl_kernel kernel, cl_mem src, cl_mem dst) {
@@ -103,9 +117,8 @@ void DispatchPointwise(OpenClRenderDevice& device, const OpenClBackend::Texture2
                        OpenClBackend::Texture2D& dst, const OpenClBackend::Buffer& params,
                        const OpenClBackend::Buffer& commands, std::uint32_t command_offset,
                        std::uint32_t command_count, const OpenClLutBinding& lut,
-                       std::uint32_t width, std::uint32_t height, bool detail) {
-  const auto kernel_name = detail ? OpenCL::GpuDag::kPrimaryGradeDetailKernelName
-                                  : OpenCL::GpuDag::kPrimaryGradePointwiseKernelName;
+                       std::uint32_t width, std::uint32_t height) {
+  const auto kernel_name = OpenCL::GpuDag::kPrimaryGradePointwiseKernelName;
   auto kernel = OpenClKernelCache::Instance().GetKernel(OpenCL::GpuDag::kPrimaryGradeProgramName,
                                                         kernel_name);
   SetImageKernelArgs(kernel, src.Native(), dst.Native());
@@ -133,6 +146,44 @@ void DispatchPointwise(OpenClRenderDevice& device, const OpenClBackend::Texture2
   CheckOpenCl(clSetKernelArg(kernel, 5, sizeof(cl_mem), &lut_mem),
               "OpenCL Primary Grade LUT argument");
   DispatchKernel(device, kernel, width, height);
+}
+
+void DispatchNeighbor(OpenClRenderDevice& device, const OpenClBackend::Texture2D& src,
+                      OpenClBackend::Texture2D& blur_horizontal, OpenClBackend::Texture2D& dst,
+                      const GradeNeighborParams& params, std::uint32_t width,
+                      std::uint32_t height) {
+  auto blur_kernel =
+      OpenClKernelCache::Instance().GetKernel(OpenCL::GpuDag::kPrimaryGradeProgramName,
+                                              OpenCL::GpuDag::kPrimaryGradeNeighborBlurKernelName);
+  auto apply_kernel =
+      OpenClKernelCache::Instance().GetKernel(OpenCL::GpuDag::kPrimaryGradeProgramName,
+                                              OpenCL::GpuDag::kPrimaryGradeNeighborApplyKernelName);
+
+  const auto src_mem  = src.Native();
+  const auto blur_mem = blur_horizontal.Native();
+  const auto dst_mem  = dst.Native();
+  CheckOpenCl(clSetKernelArg(blur_kernel, 0, sizeof(cl_mem), &src_mem),
+              "OpenCL Primary Grade neighbor source argument");
+  CheckOpenCl(clSetKernelArg(blur_kernel, 1, sizeof(cl_mem), &blur_mem),
+              "OpenCL Primary Grade neighbor blur argument");
+  CheckOpenCl(clSetKernelArg(blur_kernel, 2, sizeof(params), &params),
+              "OpenCL Primary Grade neighbor parameters");
+  constexpr std::size_t kLocalEdge = 8;
+  DispatchKernel(device, blur_kernel, width, height, kLocalEdge);
+
+  CheckOpenCl(clSetKernelArg(apply_kernel, 0, sizeof(cl_mem), &src_mem),
+              "OpenCL Primary Grade neighbor apply source argument");
+  CheckOpenCl(clSetKernelArg(apply_kernel, 1, sizeof(cl_mem), &blur_mem),
+              "OpenCL Primary Grade neighbor apply blur argument");
+  CheckOpenCl(clSetKernelArg(apply_kernel, 2, sizeof(cl_mem), &dst_mem),
+              "OpenCL Primary Grade neighbor apply destination argument");
+  CheckOpenCl(clSetKernelArg(apply_kernel, 3, sizeof(params), &params),
+              "OpenCL Primary Grade neighbor apply parameters");
+  const auto radius      = NeighborVerticalRadius(params);
+  const auto local_bytes = kLocalEdge * (kLocalEdge + 2U * radius) * 4U * sizeof(float);
+  CheckOpenCl(clSetKernelArg(apply_kernel, 4, local_bytes, nullptr),
+              "OpenCL Primary Grade neighbor local tile argument");
+  DispatchKernel(device, apply_kernel, width, height, kLocalEdge);
 }
 
 void DispatchMix(OpenClRenderDevice& device, const OpenClBackend::Texture2D& source,
@@ -261,7 +312,7 @@ auto ExecuteOpenClPrimaryGrade(OpenClRenderDevice& device, const ExecutionPlan& 
 
   auto                        FlushFused = [&]() -> GradeOp* {
     if (ops.empty() || ops.back().kind != GradeOpKind::Fused) {
-      ops.push_back(GradeOp{GradeOpKind::Fused, {}});
+      ops.push_back(GradeOp{GradeOpKind::Fused, {}, {}});
     }
     return &ops.back();
   };
@@ -312,15 +363,16 @@ auto ExecuteOpenClPrimaryGrade(OpenClRenderDevice& device, const ExecutionPlan& 
         highlights_slider = runtime_params.values[0];
       }
       if (ops.empty() || ops.back().kind != GradeOpKind::LlfBarrier) {
-        ops.push_back(GradeOp{GradeOpKind::LlfBarrier, {}});
+        ops.push_back(GradeOp{GradeOpKind::LlfBarrier, {}, {}});
       }
       continue;
     }
 
     if (compiled.algorithm == CompiledAdjustmentAlgorithm::Neighborhood ||
         IsNeighborhoodBehavior(*behavior)) {
-      if (runtime_params.values[0] != 0.0f) {
-        ops.push_back(GradeOp{GradeOpKind::Detail, {arena.Binding(key).offset}});
+      auto neighbor = MakeGradeNeighborParams(*model, *behavior, plan.geometry);
+      if (neighbor.enabled != 0U) {
+        ops.push_back(GradeOp{GradeOpKind::Detail, {}, neighbor});
       }
       continue;
     }
@@ -334,7 +386,6 @@ auto ExecuteOpenClPrimaryGrade(OpenClRenderDevice& device, const ExecutionPlan& 
       shadows_slider * local_tone_mapping::kHighlightStrengthScale / 80.0f,
       -highlights_slider * local_tone_mapping::kHighlightStrengthScale / 100.0f);
   ops           = CompactOps(std::move(ops), local_tone_active);
-
   auto& context = device.CommandContext();
   arena.UploadDirty(context);
   for (auto& patch : pending) {
@@ -451,9 +502,15 @@ auto ExecuteOpenClPrimaryGrade(OpenClRenderDevice& device, const ExecutionPlan& 
   for (std::size_t index = 0; index < ops.size(); ++index) {
     const auto& op = ops[index];
     AllocateDest();
-    auto& src  = Resolve(current_slot, current_scratch);
-    auto& dest = Resolve(dest_slot, dest_scratch);
-    if (op.kind == GradeOpKind::LlfBarrier) {
+    if (op.kind == GradeOpKind::Detail) {
+      auto  blur_horizontal = AcquireScratch(workspace, width, height);
+      auto& src             = Resolve(current_slot, current_scratch);
+      auto& dest            = Resolve(dest_slot, dest_scratch);
+      DispatchNeighbor(device, src, blur_horizontal.Texture(), dest, op.neighbor, width, height);
+      ++result.detail_pass_count;
+    } else if (op.kind == GradeOpKind::LlfBarrier) {
+      auto&      src  = Resolve(current_slot, current_scratch);
+      auto&      dest = Resolve(dest_slot, dest_scratch);
       const auto local_tone =
           ExecuteOpenClLocalTone(device, src, dest, grade->Id(), shadows_slider, highlights_slider,
                                  plan.geometry, HashLlfSourceKey(plan, prepared, document),
@@ -463,21 +520,16 @@ auto ExecuteOpenClPrimaryGrade(OpenClRenderDevice& device, const ExecutionPlan& 
       result.local_tone_sampled_canonical_reference = local_tone.sampled_canonical_reference;
       result.local_tone_transient_bytes             = local_tone.transient_bytes;
       ++result.local_tone_pass_count;
-    } else if (op.kind == GradeOpKind::Fused) {
+    } else {
       if (commands_buffer == nullptr) {
         throw std::runtime_error("ExecuteOpenClPrimaryGrade: missing fused command buffer");
       }
+      auto& src  = Resolve(current_slot, current_scratch);
+      auto& dest = Resolve(dest_slot, dest_scratch);
       DispatchPointwise(device, src, dest, arena.DeviceBuffer(), *commands_buffer,
                         command_starts[index], static_cast<std::uint32_t>(op.offsets.size()), lut,
-                        width, height, false);
+                        width, height);
       ++result.pointwise_dispatch_count;
-    } else {
-      if (commands_buffer == nullptr) {
-        throw std::runtime_error("ExecuteOpenClPrimaryGrade: missing detail command buffer");
-      }
-      DispatchPointwise(device, src, dest, arena.DeviceBuffer(), *commands_buffer,
-                        command_starts[index], 1, lut, width, height, true);
-      ++result.detail_pass_count;
     }
     current_slot    = dest_slot;
     current_scratch = dest_scratch;

--- a/alcedo_studio/src/edit/runtime/opencl/shader/primary_grade.cl
+++ b/alcedo_studio/src/edit/runtime/opencl/shader/primary_grade.cl
@@ -19,9 +19,7 @@ typedef struct {
   uint  pad[3];
 } PrimaryGradeDispatchParams;
 
-static inline float Luma(float3 c) {
-  return 0.272229f * c.x + 0.674082f * c.y + 0.053689f * c.z;
-}
+static inline float Luma(float3 c) { return 0.272229f * c.x + 0.674082f * c.y + 0.053689f * c.z; }
 
 static inline float ExtrapolateCurve(float value, __global const GradeAdjustmentParams* p, uint a,
                                      uint b) {
@@ -82,9 +80,7 @@ static inline float3 ApplyHls(float3 c, __global const GradeAdjustmentParams* p)
   return c;
 }
 
-static inline uint LutIndex(uint edge, uint x, uint y, uint z) {
-  return (z * edge + y) * edge + x;
-}
+static inline uint LutIndex(uint edge, uint x, uint y, uint z) { return (z * edge + y) * edge + x; }
 
 static inline float3 SampleLut3d(__global const float4* lut, uint edge, float u, float v, float w) {
   const float3 coord   = clamp((float3)(u, v, w), 0.0f, 1.0f);
@@ -112,7 +108,6 @@ static inline float3 SampleLut3d(__global const float4* lut, uint edge, float u,
 }
 
 static inline float3 ApplyAdjustment(float3 c, __global const GradeAdjustmentParams* p,
-                                     uint pixel_index, float local_reference,
                                      __global const float4* lut, uint lut_edge) {
   const uint  behavior = p->behavior;
   const float value    = p->values[0];
@@ -142,14 +137,6 @@ static inline float3 ApplyAdjustment(float3 c, __global const GradeAdjustmentPar
     c.x += offset;
     c.y += offset;
     c.z += offset;
-  } else if (behavior == 13u) {
-    const float l      = Luma(c);
-    float       weight = 1.0f - min(l / max(local_reference, 1.0e-4f), 1.0f);
-    weight             = 0.5f - fabs(weight - 0.5f);
-    const float gain   = 1.0f + value * 0.01f * weight;
-    c.x *= gain;
-    c.y *= gain;
-    c.z *= gain;
   } else if (behavior == 7u) {
     c.x = ApplyCurve(c.x, p);
     c.y = ApplyCurve(c.y, p);
@@ -157,7 +144,7 @@ static inline float3 ApplyAdjustment(float3 c, __global const GradeAdjustmentPar
   } else if (behavior == 8u) {
     c = ApplyHls(c, p);
   } else if (behavior == 9u || behavior == 10u) {
-    const float l = Luma(c);
+    const float l     = Luma(c);
     float       scale = behavior == 9u ? value : 1.0f + value * 0.01f;
     if (behavior == 10u) {
       const float maximum = max(c.x, max(c.y, c.z));
@@ -171,57 +158,40 @@ static inline float3 ApplyAdjustment(float3 c, __global const GradeAdjustmentPar
     const float gamma_x = max(p->values[4] + p->values[7], 1.0e-4f);
     const float gamma_y = max(p->values[5] + p->values[7], 1.0e-4f);
     const float gamma_z = max(p->values[6] + p->values[7], 1.0e-4f);
-    c.x = copysign(pow(fabs(c.x + p->values[0] + p->values[3]), 1.0f / gamma_x), c.x) *
-          p->values[8];
-    c.y = copysign(pow(fabs(c.y + p->values[1] + p->values[3]), 1.0f / gamma_y), c.y) *
-          p->values[9];
-    c.z = copysign(pow(fabs(c.z + p->values[2] + p->values[3]), 1.0f / gamma_z), c.z) *
-          p->values[10];
-  } else if (behavior == 14u) {
-    const float l     = Luma(c);
-    const float scale = 1.0f + value * 0.0025f;
-    c.x               = l + (c.x - l) * scale;
-    c.y               = l + (c.y - l) * scale;
-    c.z               = l + (c.z - l) * scale;
-  } else if (behavior == 15u) {
-    c.x += max(Luma(c) - 0.6f, 0.0f) * value * 0.15f;
-  } else if (behavior == 16u && value != 0.0f) {
-    uint        hash  = pixel_index * 747796405u + 2891336453u;
-    hash              = (hash >> ((hash >> 28u) + 4u)) ^ hash;
-    const float noise = ((float)(hash & 0xffffu) / 32767.5f - 1.0f) * value * 0.02f;
-    c.x += noise;
-    c.y += noise;
-    c.z += noise;
+    c.x =
+        copysign(pow(fabs(c.x + p->values[0] + p->values[3]), 1.0f / gamma_x), c.x) * p->values[8];
+    c.y =
+        copysign(pow(fabs(c.y + p->values[1] + p->values[3]), 1.0f / gamma_y), c.y) * p->values[9];
+    c.z =
+        copysign(pow(fabs(c.z + p->values[2] + p->values[3]), 1.0f / gamma_z), c.z) * p->values[10];
   } else if (behavior == 12u && value != 0.0f && lut_edge > 1u) {
     const float scale  = (float)(lut_edge - 1u) / (float)lut_edge;
     const float offset = 1.0f / (2.0f * (float)lut_edge);
-    c = SampleLut3d(lut, lut_edge, c.x * scale + offset, c.y * scale + offset,
-                    c.z * scale + offset);
+    c                  = SampleLut3d(lut, lut_edge, c.x * scale + offset, c.y * scale + offset,
+                                     c.z * scale + offset);
   }
   return c;
 }
 
 static inline float4 GradePixel(read_only image2d_t src, __global const uchar* parameter_base,
-                                __global const uint* commands,
-                                PrimaryGradeDispatchParams dispatch, int2 gid,
-                                __global const float4* lut) {
-  const float4 source      = read_imagef(src, kNearestClamp, gid);
-  float3       c           = source.xyz;
-  const uint   pixel_index = (uint)gid.y * dispatch.width + (uint)gid.x;
+                                __global const uint* commands, PrimaryGradeDispatchParams dispatch,
+                                int2 gid, __global const float4* lut) {
+  const float4 source = read_imagef(src, kNearestClamp, gid);
+  float3       c      = source.xyz;
   for (uint i = 0u; i < dispatch.command_count; ++i) {
-    const uint offset = commands[dispatch.command_offset + i];
+    const uint                            offset = commands[dispatch.command_offset + i];
     __global const GradeAdjustmentParams* params =
         (__global const GradeAdjustmentParams*)(parameter_base + offset);
-    c = ApplyAdjustment(c, params, pixel_index, dispatch.local_reference, lut, dispatch.lut_edge);
+    c = ApplyAdjustment(c, params, lut, dispatch.lut_edge);
   }
   return (float4)(c.x, c.y, c.z, source.w);
 }
 
 static inline void WriteGradePixel(read_only image2d_t src, write_only image2d_t dst,
-                                   __global const uchar* parameter_base,
-                                   __global const uint* commands,
-                                   PrimaryGradeDispatchParams dispatch,
-                                   __global const float4* lut, int2 gid) {
+                                   __global const uchar*      parameter_base,
+                                   __global const uint*       commands,
+                                   PrimaryGradeDispatchParams dispatch, __global const float4* lut,
+                                   int2 gid) {
   const int2 size = get_image_dim(dst);
   if (gid.x >= size.x || gid.y >= size.y) {
     return;
@@ -230,19 +200,10 @@ static inline void WriteGradePixel(read_only image2d_t src, write_only image2d_t
 }
 
 __kernel void primary_grade_pointwise_rgba32f(__read_only image2d_t src, __write_only image2d_t dst,
-                                              __global const uchar* parameter_base,
-                                              __global const uint* commands,
+                                              __global const uchar*      parameter_base,
+                                              __global const uint*       commands,
                                               PrimaryGradeDispatchParams dispatch,
-                                              __global const float4* lut) {
-  const int2 gid = (int2)((int)get_global_id(0), (int)get_global_id(1));
-  WriteGradePixel(src, dst, parameter_base, commands, dispatch, lut, gid);
-}
-
-__kernel void primary_grade_detail_rgba32f(__read_only image2d_t src, __write_only image2d_t dst,
-                                           __global const uchar* parameter_base,
-                                           __global const uint* commands,
-                                           PrimaryGradeDispatchParams dispatch,
-                                           __global const float4* lut) {
+                                              __global const float4*     lut) {
   const int2 gid = (int2)((int)get_global_id(0), (int)get_global_id(1));
   WriteGradePixel(src, dst, parameter_base, commands, dispatch, lut, gid);
 }
@@ -255,15 +216,16 @@ __kernel void primary_grade_mix_rgba32f(__read_only image2d_t source,
   if (gid.x >= size.x || gid.y >= size.y) {
     return;
   }
-  const float4 a = read_imagef(adjusted, kNearestClamp, gid);
-  const float4 s = read_imagef(source, kNearestClamp, gid);
-  const float mix = clamp(grade_mix, 0.0f, 1.0f);
+  const float4 a   = read_imagef(adjusted, kNearestClamp, gid);
+  const float4 s   = read_imagef(source, kNearestClamp, gid);
+  const float  mix = clamp(grade_mix, 0.0f, 1.0f);
   write_imagef(dst, gid, (float4)(s.xyz + (a.xyz - s.xyz) * mix, s.w));
 }
 
-__kernel void primary_grade_mix_masked_rgba32f(
-    __read_only image2d_t source, __read_only image2d_t adjusted, __write_only image2d_t dst,
-    __read_only image2d_t mask, float grade_mix) {
+__kernel void primary_grade_mix_masked_rgba32f(__read_only image2d_t  source,
+                                               __read_only image2d_t  adjusted,
+                                               __write_only image2d_t dst,
+                                               __read_only image2d_t mask, float grade_mix) {
   const int2 gid  = (int2)((int)get_global_id(0), (int)get_global_id(1));
   const int2 size = get_image_dim(dst);
   if (gid.x >= size.x || gid.y >= size.y) {

--- a/alcedo_studio/src/edit/runtime/opencl/shader/primary_grade_neighbor.cl
+++ b/alcedo_studio/src/edit/runtime/opencl/shader/primary_grade_neighbor.cl
@@ -1,0 +1,345 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+
+#define GRADE_NEIGHBOR_MAX_TAPS   64
+#define GRADE_BEHAVIOR_CLARITY    13u
+#define GRADE_BEHAVIOR_SHARPEN    14u
+#define GRADE_BEHAVIOR_HALATION   15u
+#define GRADE_BEHAVIOR_FILM_GRAIN 16u
+
+typedef struct {
+  uint  behavior;
+  uint  radius;
+  uint  tap_count;
+  float amount;
+  float threshold;
+  float weights[GRADE_NEIGHBOR_MAX_TAPS];
+  uint  enabled;
+  uint  seed_lo;
+  uint  seed_hi;
+  float sigma_x;
+  float sigma_y;
+  float redshift[3];
+  float render_to_reference[6];
+  uint  use_reference_coordinates;
+  int   reference_width;
+  int   reference_height;
+} GradeNeighborParams;
+
+static inline float4 GradeNeighborRead(read_only image2d_t src, int2 coord) {
+  return read_imagef(src, kNearestClamp, coord);
+}
+
+static inline float GradeNeighborLuma(float4 value) {
+  return value.x * 0.114f + value.y * 0.587f + value.z * 0.299f;
+}
+
+static inline float GradeNeighborSmoothstep(float edge0, float edge1, float value) {
+  const float t = clamp((value - edge0) / fmax(edge1 - edge0, 1.0e-6f), 0.0f, 1.0f);
+  return t * t * (3.0f - 2.0f * t);
+}
+
+static inline float GradeAcesccEncode(float value) {
+  const float k_a         = 9.72f;
+  const float k_b         = 17.52f;
+  const float offset      = 0.0000152587890625f;
+  const float transition  = 0.000030517578125f;
+  const float floor_value = (-16.0f + k_a) / k_b;
+  if (value < 0.0f) return floor_value + value;
+  if (value < transition) return (log2(offset + value * 0.5f) + k_a) / k_b;
+  return (log2(value) + k_a) / k_b;
+}
+
+static inline float GradeAcesccDecode(float value) {
+  const float k_a         = 9.72f;
+  const float k_b         = 17.52f;
+  const float offset      = 0.0000152587890625f;
+  const float floor_value = (-16.0f + k_a) / k_b;
+  const float threshold   = (-15.0f + k_a) / k_b;
+  if (value < floor_value) return value - floor_value;
+  if (value <= threshold) return (exp2(value * k_b - k_a) - offset) * 2.0f;
+  return exp2(value * k_b - k_a);
+}
+
+static inline float4 GradeGaussianHorizontal(read_only image2d_t src, int2 coord,
+                                             const GradeNeighborParams* params) {
+  float4 blur = GradeNeighborRead(src, coord) * params->weights[0];
+  for (uint tap = 1u; tap < params->tap_count; ++tap) {
+    const int distance = (int)tap;
+    blur += (GradeNeighborRead(src, coord + (int2)(distance, 0)) +
+             GradeNeighborRead(src, coord - (int2)(distance, 0))) *
+            params->weights[tap];
+  }
+  return blur;
+}
+
+static inline float4 GradeGaussianVertical(__local const float4* tile, int center, int tile_stride,
+                                           const GradeNeighborParams* params) {
+  float4 blur = tile[center] * params->weights[0];
+  for (uint tap = 1u; tap < params->tap_count; ++tap) {
+    const int distance = (int)tap * tile_stride;
+    blur += (tile[center + distance] + tile[center - distance]) * params->weights[tap];
+  }
+  return blur;
+}
+
+static inline int GradeHalationRadius(float sigma) {
+  if (!(sigma > 0.0f)) return 0;
+  return clamp((int)ceil(sigma * 3.0f), 1, GRADE_NEIGHBOR_MAX_TAPS - 1);
+}
+
+static inline float GradeHalationWeight(int tap, float sigma) {
+  return tap == 0 ? 1.0f : exp(-(float)tap / fmax(sigma, 1.0e-6f));
+}
+
+static inline float GradeHalationNormalization(int radius, float sigma) {
+  float sum = 1.0f;
+  for (int tap = 1; tap <= radius; ++tap) sum += 2.0f * GradeHalationWeight(tap, sigma);
+  return 1.0f / fmax(sum, 1.0e-6f);
+}
+
+static inline float4 GradeHalationDecode(float4 value) {
+  return (float4)(GradeAcesccDecode(value.x), GradeAcesccDecode(value.y),
+                  GradeAcesccDecode(value.z), value.w);
+}
+
+static inline float4 GradeHalationHorizontal(read_only image2d_t src, int2 coord,
+                                             const GradeNeighborParams* params) {
+  const int    radius = GradeHalationRadius(params->sigma_x);
+  const float  norm   = GradeHalationNormalization(radius, params->sigma_x);
+  const float4 center = GradeHalationDecode(GradeNeighborRead(src, coord));
+  float4       blur   = (float4)(center.x * norm, center.y * norm, center.z * norm, center.w);
+  for (int tap = 1; tap <= radius; ++tap) {
+    const float  weight = GradeHalationWeight(tap, params->sigma_x) * norm;
+    const float4 left   = GradeHalationDecode(GradeNeighborRead(src, coord - (int2)(tap, 0)));
+    const float4 right  = GradeHalationDecode(GradeNeighborRead(src, coord + (int2)(tap, 0)));
+    blur.xyz += (left.xyz + right.xyz) * weight;
+  }
+  return blur;
+}
+
+static inline float4 GradeHalationVertical(__local const float4* tile, int center, int tile_stride,
+                                           const GradeNeighborParams* params) {
+  const int   radius = GradeHalationRadius(params->sigma_y);
+  const float norm   = GradeHalationNormalization(radius, params->sigma_y);
+  float4      blur   = tile[center];
+  blur.xyz *= norm;
+  for (int tap = 1; tap <= radius; ++tap) {
+    const float weight = GradeHalationWeight(tap, params->sigma_y) * norm;
+    blur.xyz +=
+        (tile[center - tap * tile_stride].xyz + tile[center + tap * tile_stride].xyz) * weight;
+  }
+  return blur;
+}
+
+static inline int2 GradeFilmReferenceCoord(int2 coord, const GradeNeighborParams* params) {
+  if (params->use_reference_coordinates == 0u) return coord;
+  const float x        = (float)coord.x + 0.5f;
+  const float y        = (float)coord.y + 0.5f;
+  const float mapped_x = params->render_to_reference[0] * x + params->render_to_reference[1] * y +
+                         params->render_to_reference[2] - 0.5f;
+  const float mapped_y = params->render_to_reference[3] * x + params->render_to_reference[4] * y +
+                         params->render_to_reference[5] - 0.5f;
+  return (int2)(clamp((int)floor(mapped_x + 0.5f), 0, max(params->reference_width, 1) - 1),
+                clamp((int)floor(mapped_y + 0.5f), 0, max(params->reference_height, 1) - 1));
+}
+
+static inline float GradeFilmChannel(float4 value, int channel) {
+  return channel == 0 ? value.x : (channel == 1 ? value.y : value.z);
+}
+
+static inline float GradeFilmSample(read_only image2d_t src, int2 coord, int channel,
+                                    const GradeNeighborParams* params) {
+  const int2 size       = get_image_dim(src);
+  coord                 = clamp(coord, (int2)(0), size - (int2)(1));
+  const int2  ref       = GradeFilmReferenceCoord(coord, params);
+  const ulong prng_seed = ((ulong)params->seed_hi << 32u) | (ulong)params->seed_lo;
+  const ulong stream    = opencl_prng_pixel_stream_2d(ref.x, ref.y, (uint)channel);
+  const float draw      = opencl_prng_uniform_float01(prng_seed, stream, 0xd1b54a32d192ed03UL);
+  return draw < clamp(GradeFilmChannel(GradeNeighborRead(src, coord), channel), 0.0f, 1.0f) ? 1.0f
+                                                                                            : 0.0f;
+}
+
+static inline float GradeFilmGaussian7(float c0, float n1, float p1, float n2, float p2, float n3,
+                                       float p3) {
+  return c0 * 0.49867642f + (n1 + p1) * 0.22831073f + (n2 + p2) * 0.02192964f +
+         (n3 + p3) * 0.00042142f;
+}
+
+static inline float4 GradeFilmHorizontal(read_only image2d_t src, int2 coord,
+                                         const GradeNeighborParams* params) {
+  float result[3];
+  for (int channel = 0; channel < 3; ++channel) {
+    result[channel] =
+        GradeFilmGaussian7(GradeFilmSample(src, coord, channel, params),
+                           GradeFilmSample(src, coord + (int2)(-1, 0), channel, params),
+                           GradeFilmSample(src, coord + (int2)(1, 0), channel, params),
+                           GradeFilmSample(src, coord + (int2)(-2, 0), channel, params),
+                           GradeFilmSample(src, coord + (int2)(2, 0), channel, params),
+                           GradeFilmSample(src, coord + (int2)(-3, 0), channel, params),
+                           GradeFilmSample(src, coord + (int2)(3, 0), channel, params));
+  }
+  return (float4)(result[0], result[1], result[2], GradeNeighborRead(src, coord).w);
+}
+
+static inline float4 GradeFilmVertical(__local const float4* tile, int center, int tile_stride) {
+  const float4 c0 = tile[center];
+  const float4 n1 = tile[center - tile_stride];
+  const float4 p1 = tile[center + tile_stride];
+  const float4 n2 = tile[center - 2 * tile_stride];
+  const float4 p2 = tile[center + 2 * tile_stride];
+  const float4 n3 = tile[center - 3 * tile_stride];
+  const float4 p3 = tile[center + 3 * tile_stride];
+  return (float4)(GradeFilmGaussian7(c0.x, n1.x, p1.x, n2.x, p2.x, n3.x, p3.x),
+                  GradeFilmGaussian7(c0.y, n1.y, p1.y, n2.y, p2.y, n3.y, p3.y),
+                  GradeFilmGaussian7(c0.z, n1.z, p1.z, n2.z, p2.z, n3.z, p3.z), c0.w);
+}
+
+static inline float GradeFilmLerp(float a, float b, float t) { return a + (b - a) * t; }
+
+static inline float GradeFilmEvalSigma(float density, const float density_lut[11],
+                                       const float sigma_lut[11]) {
+  if (density <= density_lut[0]) return sigma_lut[0];
+  for (int i = 0; i < 10; ++i) {
+    if (density <= density_lut[i + 1]) {
+      const float t =
+          (density - density_lut[i]) / fmax(density_lut[i + 1] - density_lut[i], 1.0e-6f);
+      return GradeFilmLerp(sigma_lut[i], sigma_lut[i + 1], t);
+    }
+  }
+  return sigma_lut[10];
+}
+
+static inline float GradeFilmGranularity(float signal, int channel) {
+  const float red_density[11]   = {0.22f, 0.22f, 0.25f, 0.42f, 0.78f, 1.19f,
+                                   1.58f, 1.94f, 2.26f, 2.45f, 2.52f};
+  const float red_sigma[11]     = {0.00594f, 0.00565f, 0.00524f, 0.01085f, 0.00844f, 0.00531f,
+                                   0.00486f, 0.00486f, 0.00445f, 0.00440f, 0.00474f};
+  const float green_density[11] = {0.59f, 0.61f, 0.66f, 0.94f, 1.36f, 1.76f,
+                                   2.18f, 2.49f, 2.61f, 2.67f, 2.69f};
+  const float green_sigma[11]   = {0.00517f, 0.00524f, 0.00625f, 0.01085f, 0.00823f, 0.00617f,
+                                   0.00625f, 0.00691f, 0.00602f, 0.00524f, 0.00445f};
+  const float blue_density[11]  = {1.00f, 1.03f, 1.10f, 1.32f, 1.51f, 1.78f,
+                                   2.05f, 2.38f, 2.68f, 2.91f, 3.00f};
+  const float blue_sigma[11]    = {0.01185f, 0.01261f, 0.01485f, 0.01581f, 0.01200f, 0.01099f,
+                                   0.01127f, 0.01058f, 0.00844f, 0.00641f, 0.00418f};
+  const float u                 = clamp(signal, 0.0f, 1.0f);
+  const float density           = channel == 0   ? GradeFilmLerp(0.22f, 2.52f, u)
+                                  : channel == 1 ? GradeFilmLerp(0.59f, 2.69f, u)
+                                                 : GradeFilmLerp(1.00f, 3.00f, u);
+  const float sigma             = channel == 0 ? GradeFilmEvalSigma(density, red_density, red_sigma)
+                                  : channel == 1 ? GradeFilmEvalSigma(density, green_density, green_sigma)
+                                                 : GradeFilmEvalSigma(density, blue_density, blue_sigma);
+  return clamp(sigma / 0.0075f, 0.55f, 2.15f);
+}
+
+static inline float GradeFilmDensityError(float signal, float coverage, int channel) {
+  return (coverage - clamp(signal, 0.0f, 1.0f)) * GradeFilmGranularity(signal, channel);
+}
+
+static inline float4 GradeFilmApply(float4 source, float4 coverage, float amount) {
+  float3      density = (float3)(GradeFilmDensityError(source.x, coverage.x, 0),
+                            GradeFilmDensityError(source.y, coverage.y, 1),
+                            GradeFilmDensityError(source.z, coverage.z, 2));
+  const float neutral = (density.x + density.y + density.z) * (1.0f / 3.0f);
+  const float highlight_signal =
+      (clamp(source.x, 0.0f, 1.0f) + clamp(source.y, 0.0f, 1.0f) + clamp(source.z, 0.0f, 1.0f)) *
+      (1.0f / 3.0f);
+  const float highlight      = GradeNeighborSmoothstep(0.72f, 0.96f, highlight_signal);
+  const float chroma         = GradeFilmLerp(0.68f, 0.18f, highlight);
+  density                    = (float3)(neutral) + chroma * (density - (float3)(neutral));
+  const float brighten_scale = GradeFilmLerp(1.0f, 0.12f, highlight);
+  density.x                  = density.x < 0.0f ? density.x * brighten_scale : density.x;
+  density.y                  = density.y < 0.0f ? density.y * brighten_scale : density.y;
+  density.z                  = density.z < 0.0f ? density.z * brighten_scale : density.z;
+  const float strength       = amount * 1.35f;
+  return (float4)(source.x - source.x * strength * density.x,
+                  source.y - source.y * strength * density.y,
+                  source.z - source.z * strength * density.z, source.w);
+}
+
+static inline int GradeVerticalRadius(const GradeNeighborParams* params) {
+  if (params->behavior == GRADE_BEHAVIOR_HALATION) {
+    return GradeHalationRadius(params->sigma_y);
+  }
+  if (params->behavior == GRADE_BEHAVIOR_FILM_GRAIN) {
+    return 3;
+  }
+  return (int)params->radius;
+}
+
+__kernel void primary_grade_neighbor_blur_h_rgba32f(read_only image2d_t  src,
+                                                    write_only image2d_t dst,
+                                                    GradeNeighborParams  params) {
+  const int2 gid  = (int2)((int)get_global_id(0), (int)get_global_id(1));
+  const int2 size = get_image_dim(dst);
+  if (gid.x >= size.x || gid.y >= size.y) return;
+  float4 result;
+  if (params.behavior == GRADE_BEHAVIOR_HALATION) {
+    result = GradeHalationHorizontal(src, gid, &params);
+  } else if (params.behavior == GRADE_BEHAVIOR_FILM_GRAIN) {
+    result = GradeFilmHorizontal(src, gid, &params);
+  } else {
+    result = GradeGaussianHorizontal(src, gid, &params);
+  }
+  write_imagef(dst, gid, result);
+}
+
+__kernel void primary_grade_neighbor_apply_v_rgba32f(read_only image2d_t  original,
+                                                     read_only image2d_t  blur_horizontal,
+                                                     write_only image2d_t dst,
+                                                     GradeNeighborParams  params,
+                                                     __local float4*      vertical_tile) {
+  const int2 gid         = (int2)((int)get_global_id(0), (int)get_global_id(1));
+  const int2 size        = get_image_dim(dst);
+  const int  radius      = GradeVerticalRadius(&params);
+  const int  tile_width  = (int)get_local_size(0);
+  const int  tile_height = (int)get_local_size(1) + 2 * radius;
+  const int  local_index = (int)get_local_id(1) * tile_width + (int)get_local_id(0);
+  const int  local_count = tile_width * (int)get_local_size(1);
+  for (int tile_index = local_index; tile_index < tile_width * tile_height;
+       tile_index += local_count) {
+    const int tile_x   = tile_index % tile_width;
+    const int tile_y   = tile_index / tile_width;
+    const int source_x = (int)get_group_id(0) * tile_width + tile_x;
+    const int source_y =
+        clamp((int)get_group_id(1) * (int)get_local_size(1) + tile_y - radius, 0, size.y - 1);
+    vertical_tile[tile_index] = source_x < size.x
+                                    ? GradeNeighborRead(blur_horizontal, (int2)(source_x, source_y))
+                                    : (float4)(0.0f);
+  }
+  barrier(CLK_LOCAL_MEM_FENCE);
+  if (gid.x >= size.x || gid.y >= size.y) return;
+  const float4 source = GradeNeighborRead(original, gid);
+  const int    center = ((int)get_local_id(1) + radius) * tile_width + (int)get_local_id(0);
+  if (params.behavior == GRADE_BEHAVIOR_SHARPEN) {
+    const float4 blur = GradeGaussianVertical(vertical_tile, center, tile_width, &params);
+    float4       high = (float4)(source.xyz - blur.xyz, 0.0f);
+    if (params.threshold > 0.0f && fabs(GradeNeighborLuma(high)) <= params.threshold) {
+      high = (float4)(0.0f);
+    }
+    write_imagef(dst, gid, (float4)(source.xyz + high.xyz * params.amount, source.w));
+  } else if (params.behavior == GRADE_BEHAVIOR_CLARITY) {
+    const float4 blur = GradeGaussianVertical(vertical_tile, center, tile_width, &params);
+    const float4 diff = (float4)(source.xyz - blur.xyz, 0.0f);
+    const float  protect =
+        1.0f - GradeNeighborSmoothstep(0.0f, 0.18f, fabs(GradeNeighborLuma(diff)));
+    const float centered = (GradeNeighborLuma(source) - 0.5f) * 2.0f;
+    const float strength = params.amount * protect * fmax(1.0f - centered * centered, 0.0f);
+    write_imagef(dst, gid, (float4)(fma(diff.xyz, (float3)(strength), source.xyz), source.w));
+  } else if (params.behavior == GRADE_BEHAVIOR_HALATION) {
+    const float4 blur   = GradeHalationVertical(vertical_tile, center, tile_width, &params);
+    const float4 linear = GradeHalationDecode(source);
+    const float3 spill  = fmax(blur.xyz - linear.xyz, (float3)(0.0f));
+    const float3 result =
+        linear.xyz + spill * params.amount *
+                         (float3)(params.redshift[0], params.redshift[1], params.redshift[2]);
+    write_imagef(dst, gid,
+                 (float4)(GradeAcesccEncode(result.x), GradeAcesccEncode(result.y),
+                          GradeAcesccEncode(result.z), source.w));
+  } else {
+    write_imagef(dst, gid,
+                 GradeFilmApply(source, GradeFilmVertical(vertical_tile, center, tile_width),
+                                params.amount));
+  }
+}

--- a/alcedo_studio/src/edit/runtime/opencl/shader/primary_grade_neighbor.cl
+++ b/alcedo_studio/src/edit/runtime/opencl/shader/primary_grade_neighbor.cl
@@ -160,39 +160,31 @@ static inline float GradeFilmSample(read_only image2d_t src, int2 coord, int cha
                                                                                             : 0.0f;
 }
 
-static inline float GradeFilmGaussian7(float c0, float n1, float p1, float n2, float p2, float n3,
-                                       float p3) {
-  return c0 * 0.49867642f + (n1 + p1) * 0.22831073f + (n2 + p2) * 0.02192964f +
-         (n3 + p3) * 0.00042142f;
-}
-
 static inline float4 GradeFilmHorizontal(read_only image2d_t src, int2 coord,
                                          const GradeNeighborParams* params) {
   float result[3];
   for (int channel = 0; channel < 3; ++channel) {
-    result[channel] =
-        GradeFilmGaussian7(GradeFilmSample(src, coord, channel, params),
-                           GradeFilmSample(src, coord + (int2)(-1, 0), channel, params),
-                           GradeFilmSample(src, coord + (int2)(1, 0), channel, params),
-                           GradeFilmSample(src, coord + (int2)(-2, 0), channel, params),
-                           GradeFilmSample(src, coord + (int2)(2, 0), channel, params),
-                           GradeFilmSample(src, coord + (int2)(-3, 0), channel, params),
-                           GradeFilmSample(src, coord + (int2)(3, 0), channel, params));
+    float acc = GradeFilmSample(src, coord, channel, params) * params->weights[0];
+    for (uint tap = 1u; tap < params->tap_count; ++tap) {
+      const int distance = (int)tap;
+      acc += (GradeFilmSample(src, coord + (int2)(-distance, 0), channel, params) +
+              GradeFilmSample(src, coord + (int2)(distance, 0), channel, params)) *
+             params->weights[tap];
+    }
+    result[channel] = acc;
   }
   return (float4)(result[0], result[1], result[2], GradeNeighborRead(src, coord).w);
 }
 
-static inline float4 GradeFilmVertical(__local const float4* tile, int center, int tile_stride) {
-  const float4 c0 = tile[center];
-  const float4 n1 = tile[center - tile_stride];
-  const float4 p1 = tile[center + tile_stride];
-  const float4 n2 = tile[center - 2 * tile_stride];
-  const float4 p2 = tile[center + 2 * tile_stride];
-  const float4 n3 = tile[center - 3 * tile_stride];
-  const float4 p3 = tile[center + 3 * tile_stride];
-  return (float4)(GradeFilmGaussian7(c0.x, n1.x, p1.x, n2.x, p2.x, n3.x, p3.x),
-                  GradeFilmGaussian7(c0.y, n1.y, p1.y, n2.y, p2.y, n3.y, p3.y),
-                  GradeFilmGaussian7(c0.z, n1.z, p1.z, n2.z, p2.z, n3.z, p3.z), c0.w);
+static inline float4 GradeFilmVertical(__local const float4* tile, int center, int tile_stride,
+                                       const GradeNeighborParams* params) {
+  float4 blur = tile[center] * params->weights[0];
+  for (uint tap = 1u; tap < params->tap_count; ++tap) {
+    const int distance = (int)tap * tile_stride;
+    blur += (tile[center - distance] + tile[center + distance]) * params->weights[tap];
+  }
+  blur.w = tile[center].w;
+  return blur;
 }
 
 static inline float GradeFilmLerp(float a, float b, float t) { return a + (b - a) * t; }
@@ -261,9 +253,6 @@ static inline float4 GradeFilmApply(float4 source, float4 coverage, float amount
 static inline int GradeVerticalRadius(const GradeNeighborParams* params) {
   if (params->behavior == GRADE_BEHAVIOR_HALATION) {
     return GradeHalationRadius(params->sigma_y);
-  }
-  if (params->behavior == GRADE_BEHAVIOR_FILM_GRAIN) {
-    return 3;
   }
   return (int)params->radius;
 }
@@ -339,7 +328,8 @@ __kernel void primary_grade_neighbor_apply_v_rgba32f(read_only image2d_t  origin
                           GradeAcesccEncode(result.z), source.w));
   } else {
     write_imagef(dst, gid,
-                 GradeFilmApply(source, GradeFilmVertical(vertical_tile, center, tile_width),
+                 GradeFilmApply(source,
+                                GradeFilmVertical(vertical_tile, center, tile_width, &params),
                                 params.amount));
   }
 }

--- a/alcedo_studio/src/include/edit/runtime/adjustment_runtime.hpp
+++ b/alcedo_studio/src/include/edit/runtime/adjustment_runtime.hpp
@@ -12,6 +12,7 @@
 namespace alcedo {
 
 class IOperatorModel;
+struct ResolvedRenderGeometry;
 
 /** @brief Backend-neutral Grade adjustment semantic. CUDA and Metal share this list. */
 enum class AdjustmentBehavior : std::uint32_t {
@@ -44,6 +45,36 @@ struct GradeAdjustmentCommand {
   std::uint32_t parameter_offset = 0;
 };
 
+inline constexpr std::uint32_t kGradeNeighborMaxTapCount = 64;
+
+/**
+ * @brief Per-dispatch parameters for a separable neighborhood adjustment.
+ *
+ * This layout is shared verbatim with CUDA and OpenCL kernels. The horizontal pass writes the
+ * filtered neighborhood to a scratch image. The vertical pass reads that scratch image while
+ * retaining the unfiltered source image for the final operator formula.
+ */
+struct GradeNeighborParams {
+  std::uint32_t behavior  = 0;
+  std::uint32_t radius    = 0;
+  std::uint32_t tap_count = 0;
+  float         amount    = 0.0f;
+  float         threshold = 0.0f;
+  float         weights[kGradeNeighborMaxTapCount]{};
+  std::uint32_t enabled = 0;
+  std::uint32_t seed_lo = 0;
+  std::uint32_t seed_hi = 0;
+  float         sigma_x = 0.0f;
+  float         sigma_y = 0.0f;
+  float         redshift[3]{};
+  float         render_to_reference[6]    = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f};
+  std::uint32_t use_reference_coordinates = 0;
+  std::int32_t  reference_width           = 0;
+  std::int32_t  reference_height          = 0;
+};
+
+static_assert(sizeof(GradeNeighborParams) == 344);
+
 inline constexpr std::uint32_t kGradeRuntimeParamDirtyBit = 1;
 inline constexpr std::uint32_t kGradeRuntimeParamBytes =
     static_cast<std::uint32_t>(sizeof(GradeAdjustmentParams));
@@ -70,5 +101,15 @@ inline constexpr std::uint32_t kGradeRuntimeParamBytes =
  */
 [[nodiscard]] auto MakeGradeRuntimeParams(const IOperatorModel& model, AdjustmentBehavior behavior)
     -> GradeAdjustmentParams;
+
+/**
+ * @brief Build the original separable-neighborhood parameters for one compiled adjustment.
+ *
+ * Slider normalization, hidden effect defaults, Gaussian weights, and render-space scaling are
+ * resolved on the CPU once per dispatch rather than recomputed for every GPU pixel.
+ */
+[[nodiscard]] auto MakeGradeNeighborParams(const IOperatorModel& model, AdjustmentBehavior behavior,
+                                           const ResolvedRenderGeometry& geometry)
+    -> GradeNeighborParams;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/adjustment_runtime.hpp
+++ b/alcedo_studio/src/include/edit/runtime/adjustment_runtime.hpp
@@ -106,7 +106,11 @@ inline constexpr std::uint32_t kGradeRuntimeParamBytes =
  * @brief Build the original separable-neighborhood parameters for one compiled adjustment.
  *
  * Slider normalization, hidden effect defaults, Gaussian weights, and render-space scaling are
- * resolved on the CPU once per dispatch rather than recomputed for every GPU pixel.
+ * resolved on the CPU once per dispatch rather than recomputed for every GPU pixel. Spatial
+ * radii and sigmas are specified in full-reference pixels and scaled by the current
+ * render-to-reference mapping so preview, max-edge, and DecodeRes downscales keep the same
+ * image-space neighborhood as a full-resolution render (the same reference-space rule LLF and
+ * mask sampling use).
  */
 [[nodiscard]] auto MakeGradeNeighborParams(const IOperatorModel& model, AdjustmentBehavior behavior,
                                            const ResolvedRenderGeometry& geometry)

--- a/alcedo_studio/src/include/edit/runtime/opencl/opencl_dag_programs.hpp
+++ b/alcedo_studio/src/include/edit/runtime/opencl/opencl_dag_programs.hpp
@@ -20,7 +20,10 @@ inline constexpr const char* kGeometryResampleKernelName      = "geometry_resamp
 inline constexpr const char* kCameraColorKernelName           = "camera_color_acescc";
 inline constexpr const char* kWarpRectilinearKernelName       = "warp_rectilinear_rgba32f";
 inline constexpr const char* kPrimaryGradePointwiseKernelName = "primary_grade_pointwise_rgba32f";
-inline constexpr const char* kPrimaryGradeDetailKernelName    = "primary_grade_detail_rgba32f";
+inline constexpr const char* kPrimaryGradeNeighborBlurKernelName =
+    "primary_grade_neighbor_blur_h_rgba32f";
+inline constexpr const char* kPrimaryGradeNeighborApplyKernelName =
+    "primary_grade_neighbor_apply_v_rgba32f";
 inline constexpr const char* kPrimaryGradeMixKernelName       = "primary_grade_mix_rgba32f";
 inline constexpr const char* kPrimaryGradeMixMaskedKernelName = "primary_grade_mix_masked_rgba32f";
 inline constexpr const char* kLocalToneExtractKernelName      = "local_tone_extract";

--- a/alcedo_studio/src/opencl/CMakeLists.txt
+++ b/alcedo_studio/src/opencl/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ALCEDO_OPENCL_ENABLED)
     set(OPENCL_SCOPE_ANALYZER_CL "${ALCEDO_SRC_ROOT}/edit/scope/opencl_shader/scope_analyzer.cl")
     set(OPENCL_DAG_GEOMETRY_CAMERA_CL "${ALCEDO_SRC_ROOT}/edit/runtime/opencl/shader/geometry_camera.cl")
     set(OPENCL_DAG_PRIMARY_GRADE_CL "${ALCEDO_SRC_ROOT}/edit/runtime/opencl/shader/primary_grade.cl")
+    set(OPENCL_DAG_PRIMARY_GRADE_NEIGHBOR_CL "${ALCEDO_SRC_ROOT}/edit/runtime/opencl/shader/primary_grade_neighbor.cl")
     set(OPENCL_DAG_LOCAL_TONE_CL "${ALCEDO_SRC_ROOT}/edit/runtime/opencl/shader/local_tone.cl")
     set(OPENCL_DAG_MASK_CL "${ALCEDO_SRC_ROOT}/edit/runtime/opencl/shader/mask.cl")
     set(OPENCL_DAG_DRT_CL "${ALCEDO_SRC_ROOT}/edit/runtime/opencl/shader/drt.cl")
@@ -129,6 +130,7 @@ if(ALCEDO_OPENCL_ENABLED)
         ALCEDO_OPENCL_SCOPE_ANALYZER_CL="${OPENCL_SCOPE_ANALYZER_CL}"
         ALCEDO_OPENCL_DAG_GEOMETRY_CAMERA_CL="${OPENCL_DAG_GEOMETRY_CAMERA_CL}"
         ALCEDO_OPENCL_DAG_PRIMARY_GRADE_CL="${OPENCL_DAG_PRIMARY_GRADE_CL}"
+        ALCEDO_OPENCL_DAG_PRIMARY_GRADE_NEIGHBOR_CL="${OPENCL_DAG_PRIMARY_GRADE_NEIGHBOR_CL}"
         ALCEDO_OPENCL_DAG_LOCAL_TONE_CL="${OPENCL_DAG_LOCAL_TONE_CL}"
         ALCEDO_OPENCL_DAG_MASK_CL="${OPENCL_DAG_MASK_CL}"
         ALCEDO_OPENCL_DAG_DRT_CL="${OPENCL_DAG_DRT_CL}"

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -279,6 +279,7 @@ endif()
 add_executable(GpuDagRawInputTest
   ${ALCEDO_TEST_ROOT}/edit/input/raw_input_loader_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/input/prepared_source_cache_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/runtime/adjustment_runtime_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/graph_compiler_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/renderer_metal_instantiate_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/result_content_key_test.cpp

--- a/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
+++ b/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
@@ -123,6 +123,29 @@ TEST(GpuDagModelGraph, LegacyImportFailsOnUnknownOperatorType) {
   EXPECT_FALSE(result.document.has_value());
 }
 
+TEST(GpuDagModelGraph, LegacyPercentStrengthMapsAcrossFullHalationAndFilmGrainRanges) {
+  auto json = MakeLegacyStageJson();
+  json["Output Transform"]["Output Transform"]["film_grain"] = {
+      {"type", 27},
+      {"enable", true},
+      {"params", {{"film_grain", {{"strength", 25.0}}}}}};
+  json["Output Transform"]["Output Transform"]["halation"] = {
+      {"type", 28},
+      {"enable", true},
+      {"params", {{"halation", {{"strength", 75.0}}}}}};
+
+  const auto result = LegacyPipelineImporter::Import(json);
+  ASSERT_TRUE(result.Ok()) << result.error;
+  const auto* grain = dynamic_cast<const FilmGrainModel*>(
+      result.document->PrimaryGrade()->FindAdjustmentByType(type_ids::FilmGrain()));
+  const auto* halo = dynamic_cast<const HalationModel*>(
+      result.document->PrimaryGrade()->FindAdjustmentByType(type_ids::Halation()));
+  ASSERT_NE(grain, nullptr);
+  ASSERT_NE(halo, nullptr);
+  EXPECT_FLOAT_EQ(grain->Value(), 0.25f);
+  EXPECT_FLOAT_EQ(halo->Value(), 0.75f);
+}
+
 TEST(GpuDagModelGraph, ApplyOntoKeepsRasterMaskCameraProfileAndUpdatesExposure) {
   auto document = CreateDefaultPipelineDocument();
   gpu_dag_test::EnsureTestCameraProfile(document);

--- a/alcedo_studio/tests/edit/runtime/adjustment_runtime_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/adjustment_runtime_test.cpp
@@ -1,0 +1,103 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/adjustment_runtime.hpp"
+
+#include <gtest/gtest.h>
+
+#include "edit/geometry/render_geometry_resolver.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/operators/models/sharpen_model.hpp"
+
+namespace alcedo {
+namespace {
+
+auto MakeGeometry(std::uint32_t extent, const ResolutionRequest& resolution = {},
+                  const ViewRequest& view = {}) -> ResolvedRenderGeometry {
+  return ResolveRenderGeometry(MakeSourceGeometry({extent, extent}, {extent, extent}), {}, view,
+                               resolution, {});
+}
+
+}  // namespace
+
+TEST(GpuDagAdjustmentRuntime, SharpenAndClarityRadiiScaleWithPreviewResolution) {
+  SharpenModel sharpen;
+  sharpen.SetAmount(100.0f);
+  sharpen.SetRadius(8.0f);
+  ClarityModel clarity;
+  clarity.SetValue(80.0f);
+
+  const auto full = MakeGeometry(256);
+  const auto full_sharpen =
+      MakeGradeNeighborParams(sharpen, AdjustmentBehavior::Sharpen, full);
+  const auto full_clarity =
+      MakeGradeNeighborParams(clarity, AdjustmentBehavior::Clarity, full);
+
+  ResolutionRequest half;
+  half.render_scale = 0.5f;
+  const auto half_geometry = MakeGeometry(256, half);
+  const auto half_sharpen =
+      MakeGradeNeighborParams(sharpen, AdjustmentBehavior::Sharpen, half_geometry);
+  const auto half_clarity =
+      MakeGradeNeighborParams(clarity, AdjustmentBehavior::Clarity, half_geometry);
+
+  EXPECT_EQ(full.render_extent, (Extent2D{256, 256}));
+  EXPECT_EQ(half_geometry.render_extent, (Extent2D{128, 128}));
+  EXPECT_NEAR(full_sharpen.sigma_x, 8.0f, 1.0e-5f);
+  EXPECT_NEAR(half_sharpen.sigma_x, 4.0f, 1.0e-4f);
+  EXPECT_EQ(full_sharpen.radius, 15U);
+  EXPECT_EQ(half_sharpen.radius, 12U);
+  EXPECT_NEAR(half_clarity.sigma_x, full_clarity.sigma_x * 0.5f, 1.0e-4f);
+  EXPECT_LT(half_clarity.radius, full_clarity.radius);
+  EXPECT_GT(half_clarity.radius, 0U);
+}
+
+TEST(GpuDagAdjustmentRuntime, HalationAndFilmGrainNeighborhoodsScaleWithMaxEdge) {
+  HalationModel halation;
+  halation.SetValue(1.0f);
+  FilmGrainModel grain;
+  grain.SetValue(0.75f);
+
+  const auto full = MakeGeometry(256);
+  const auto full_halation =
+      MakeGradeNeighborParams(halation, AdjustmentBehavior::Halation, full);
+  const auto full_grain =
+      MakeGradeNeighborParams(grain, AdjustmentBehavior::FilmGrain, full);
+
+  ResolutionRequest preview;
+  preview.max_edge = 64;
+  const auto preview_geometry = MakeGeometry(256, preview);
+  const auto preview_halation =
+      MakeGradeNeighborParams(halation, AdjustmentBehavior::Halation, preview_geometry);
+  const auto preview_grain =
+      MakeGradeNeighborParams(grain, AdjustmentBehavior::FilmGrain, preview_geometry);
+
+  EXPECT_EQ(preview_geometry.render_extent, (Extent2D{64, 64}));
+  EXPECT_NEAR(full_halation.sigma_x, 7.0f, 1.0e-5f);
+  EXPECT_NEAR(preview_halation.sigma_x, 1.75f, 1.0e-4f);
+  EXPECT_NEAR(preview_halation.sigma_y, preview_halation.sigma_x, 1.0e-5f);
+  EXPECT_NEAR(preview_grain.sigma_x, full_grain.sigma_x * 0.25f, 1.0e-4f);
+  EXPECT_LT(preview_grain.radius, full_grain.radius);
+  EXPECT_EQ(full_grain.radius, 3U);
+  EXPECT_EQ(preview_grain.tap_count, preview_grain.radius + 1U);
+}
+
+TEST(GpuDagAdjustmentRuntime, NativeViewportRoiKeepsFullReferenceNeighborhoodSize) {
+  SharpenModel sharpen;
+  sharpen.SetAmount(50.0f);
+  sharpen.SetRadius(6.0f);
+
+  const auto full = MakeGradeNeighborParams(sharpen, AdjustmentBehavior::Sharpen, MakeGeometry(256));
+
+  ViewRequest view;
+  view.visible_rect_in_edit_space = {0.25f, 0.25f, 0.5f, 0.5f};
+  view.viewport_extent            = {128, 128};
+  const auto roi =
+      MakeGradeNeighborParams(sharpen, AdjustmentBehavior::Sharpen, MakeGeometry(256, {}, view));
+
+  EXPECT_NEAR(roi.sigma_x, full.sigma_x, 1.0e-4f);
+  EXPECT_EQ(roi.radius, full.radius);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
@@ -159,11 +159,11 @@ class CudaPrimaryGradeFixture : public ::testing::Test {
   }
 
   void UseNeighborhoodPlane(std::uint32_t width, std::uint32_t height, float surroundings,
-                            float center) {
+                            float center, const RenderRequest& request = {}) {
     prepared_ =
         RawInputLoader::FromDirectRgb(MakeNeighborhoodPlane(width, height, surroundings, center),
                                       gpu_dag_test::FullSensor(width, height));
-    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), request);
   }
 
   PreparedRawInput prepared_;
@@ -277,6 +277,39 @@ TEST_F(CudaPrimaryGradeFixture, CudaSharpenUsesSurroundingPixelsForUnsharpMask) 
   EXPECT_GT(output[center].r, input[center].r);
   EXPECT_LT(output[neighbor_index].r, input[neighbor_index].r);
   EXPECT_NEAR(output[far_index].r, input[far_index].r, 1.0e-6f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaSharpenDarkRingFollowsPreviewResolution) {
+  // Radius 4 is 12 taps at 1:1 and 6 taps at render_scale 0.5. Offset 10 sits between those
+  // radii, so an unscaled kernel would still darken the half-res probe.
+  constexpr std::uint32_t width   = 128;
+  constexpr std::uint32_t height = 128;
+  auto&                   sharpen = ModelByType<SharpenModel>(type_ids::Sharpen());
+  sharpen.SetRadius(4.0f);
+  sharpen.SetThreshold(0.0f);
+
+  UseNeighborhoodPlane(width, height, 0.18f, 0.55f);
+  sharpen.SetAmount(0.0f);
+  const auto full_identity = Download(Render().output);
+  sharpen.SetAmount(100.0f);
+  const auto full_sharpened = Download(Render().output);
+  const auto full_near =
+      static_cast<std::size_t>(height / 2) * width + width / 2 + 1U;
+  ASSERT_EQ(full_identity.size(), full_sharpened.size());
+  EXPECT_GT(full_identity[full_near].r - full_sharpened[full_near].r, 1.0e-4f);
+
+  RenderRequest half_request;
+  half_request.resolution.render_scale = 0.5f;
+  UseNeighborhoodPlane(width, height, 0.18f, 0.55f, half_request);
+  sharpen.SetAmount(0.0f);
+  const auto half_identity = Download(Render().output);
+  sharpen.SetAmount(100.0f);
+  const auto half_sharpened = Download(Render().output);
+  ASSERT_EQ(half_identity.size(), static_cast<std::size_t>(64) * 64);
+  const auto half_near = static_cast<std::size_t>(32) * 64U + 32U + 1U;
+  const auto half_far  = static_cast<std::size_t>(32) * 64U + 32U + 10U;
+  EXPECT_GT(half_identity[half_near].r - half_sharpened[half_near].r, 1.0e-5f);
+  EXPECT_NEAR(half_sharpened[half_far].r, half_identity[half_far].r, 2.0e-3f);
 }
 
 TEST_F(CudaPrimaryGradeFixture, CudaClarityUsesLargeRadiusLocalContrast) {

--- a/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
@@ -14,15 +14,15 @@
 #include <string>
 #include <vector>
 
-#include "edit/geometry/types.hpp"
-
 #include "../graph/test_camera_profile.hpp"
 #include "../input/prepared_raw_test_support.hpp"
+#include "edit/geometry/types.hpp"
 #include "edit/graph/develop_color_transform.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/operators/models/cat02_white_balance_model.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/operators/models/sharpen_model.hpp"
 #include "edit/runtime/cuda/cuda_develop_pass.hpp"
 #include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
 #include "edit/runtime/graph_compiler.hpp"
@@ -158,6 +158,14 @@ class CudaPrimaryGradeFixture : public ::testing::Test {
     return *model;
   }
 
+  void UseNeighborhoodPlane(std::uint32_t width, std::uint32_t height, float surroundings,
+                            float center) {
+    prepared_ =
+        RawInputLoader::FromDirectRgb(MakeNeighborhoodPlane(width, height, surroundings, center),
+                                      gpu_dag_test::FullSensor(width, height));
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+  }
+
   PreparedRawInput prepared_;
   PipelineDocument document_;
   ExecutionPlan    plan_;
@@ -249,6 +257,101 @@ TEST_F(CudaPrimaryGradeFixture, CudaPointAdjustmentsExecuteInSerializedModelOrde
   const auto input  = Download(plan_.develop_output);
   ASSERT_FALSE(output.empty());
   EXPECT_NEAR(output.front().r, (input.front().r + 1.0f / 17.52f - 0.18f) * 2.0f + 0.18f, 1.0e-5f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaSharpenUsesSurroundingPixelsForUnsharpMask) {
+  constexpr std::uint32_t width  = 64;
+  constexpr std::uint32_t height = 64;
+  UseNeighborhoodPlane(width, height, 0.18f, 0.55f);
+  auto& sharpen = ModelByType<SharpenModel>(type_ids::Sharpen());
+  sharpen.SetAmount(100.0f);
+  sharpen.SetRadius(3.0f);
+  sharpen.SetThreshold(0.0f);
+
+  const auto output         = Download(Render().output);
+  const auto input          = Download(plan_.develop_output);
+  const auto center         = static_cast<std::size_t>(height / 2) * width + width / 2;
+  const auto neighbor_index = center - 1;
+  const auto far_index      = static_cast<std::size_t>(height / 2) * width + 2;
+  ASSERT_EQ(input.size(), output.size());
+  EXPECT_GT(output[center].r, input[center].r);
+  EXPECT_LT(output[neighbor_index].r, input[neighbor_index].r);
+  EXPECT_NEAR(output[far_index].r, input[far_index].r, 1.0e-6f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaClarityUsesLargeRadiusLocalContrast) {
+  constexpr std::uint32_t width  = 96;
+  constexpr std::uint32_t height = 96;
+  UseNeighborhoodPlane(width, height, 0.22f, 0.48f);
+  ModelByType<ClarityModel>(type_ids::Clarity()).SetValue(80.0f);
+
+  const auto output         = Download(Render().output);
+  const auto input          = Download(plan_.develop_output);
+  const auto center         = static_cast<std::size_t>(height / 2) * width + width / 2;
+  const auto neighbor_index = center - 1;
+  const auto far_index      = static_cast<std::size_t>(height / 2) * width + 1;
+  ASSERT_EQ(input.size(), output.size());
+  EXPECT_GT(output[center].r, input[center].r);
+  EXPECT_LT(output[neighbor_index].r, input[neighbor_index].r);
+  EXPECT_NEAR(output[far_index].r, input[far_index].r, 1.0e-6f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaHalationSpreadsRedLightIntoDarkNeighbors) {
+  constexpr std::uint32_t width  = 64;
+  constexpr std::uint32_t height = 64;
+  UseNeighborhoodPlane(width, height, 0.02f, 1.0f);
+  ModelByType<HalationModel>(type_ids::Halation()).SetValue(1.0f);
+
+  const auto output         = Download(Render().output);
+  const auto input          = Download(plan_.develop_output);
+  const auto center         = static_cast<std::size_t>(height / 2) * width + width / 2;
+  const auto neighbor_index = center - 1;
+  const auto far_index      = static_cast<std::size_t>(height / 2) * width + 2;
+  ASSERT_EQ(input.size(), output.size());
+  const float red_spill   = output[neighbor_index].r - input[neighbor_index].r;
+  const float green_spill = output[neighbor_index].g - input[neighbor_index].g;
+  EXPECT_GT(red_spill, 1.0e-4f);
+  EXPECT_GT(red_spill, green_spill * 5.0f);
+  EXPECT_NEAR(output[far_index].r, input[far_index].r, 1.0e-6f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaFilmGrainStrengthScalesDeterministicDensityVariation) {
+  constexpr std::uint32_t width  = 64;
+  constexpr std::uint32_t height = 64;
+  UseNeighborhoodPlane(width, height, 0.35f, 0.35f);
+  auto& grain = ModelByType<FilmGrainModel>(type_ids::FilmGrain());
+
+  grain.SetValue(0.25f);
+  const auto low   = Download(Render().output);
+  const auto input = Download(plan_.develop_output);
+  grain.SetValue(0.75f);
+  const auto high       = Download(Render().output);
+  const auto high_again = Download(Render().output);
+  ASSERT_EQ(input.size(), high.size());
+
+  double low_energy  = 0.0;
+  double high_energy = 0.0;
+  for (std::size_t index = 0; index < input.size(); ++index) {
+    low_energy += std::pow(static_cast<double>(low[index].r - input[index].r), 2.0);
+    high_energy += std::pow(static_cast<double>(high[index].r - input[index].r), 2.0);
+    EXPECT_FLOAT_EQ(high[index].r, high_again[index].r);
+    EXPECT_FLOAT_EQ(high[index].g, high_again[index].g);
+    EXPECT_FLOAT_EQ(high[index].b, high_again[index].b);
+  }
+  EXPECT_GT(high_energy, low_energy * 6.0);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaNeighborStagesReuseWorkspaceTexturesAfterFirstRender) {
+  ModelByType<ClarityModel>(type_ids::Clarity()).SetValue(20.0f);
+  ModelByType<SharpenModel>(type_ids::Sharpen()).SetAmount(10.0f);
+  ModelByType<HalationModel>(type_ids::Halation()).SetValue(0.4f);
+  ModelByType<FilmGrainModel>(type_ids::FilmGrain()).SetValue(0.3f);
+  (void)Render();
+
+  device_.Workspace().Device().ResetCounters();
+  (void)Render();
+  EXPECT_EQ(device_.Workspace().Device().MallocCount(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().FreeCount(), 0U);
 }
 
 TEST_F(CudaPrimaryGradeFixture, CudaLocalTonePyramidBuffersReuseAcrossViewportChanges) {
@@ -370,14 +473,14 @@ auto MakeSplitPlane(std::uint32_t width, std::uint32_t height, float left, float
   return plane;
 }
 
-auto DownloadLocalTonePlane(CudaRenderDevice& device, const NodeId& grade_id) -> std::vector<float> {
+auto DownloadLocalTonePlane(CudaRenderDevice& device, const NodeId& grade_id)
+    -> std::vector<float> {
   auto* buffer = device.Workspace().Values().Find(grade_id, PortId{"local_tone.source.0"});
   EXPECT_NE(buffer, nullptr);
   if (buffer == nullptr) return {};
   std::vector<float> plane(buffer->Bytes() / sizeof(float));
   device.Workspace().Device().DownloadBufferRange(
-      *buffer, 0,
-      std::span<std::byte>(reinterpret_cast<std::byte*>(plane.data()), buffer->Bytes()),
+      *buffer, 0, std::span<std::byte>(reinterpret_cast<std::byte*>(plane.data()), buffer->Bytes()),
       device.CommandContext());
   return plane;
 }
@@ -413,9 +516,8 @@ TEST(GpuDagCudaPrimaryGrade, RoiFrameSamplesCanonicalLlfReferenceInsteadOfRebuil
   if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
   constexpr std::uint32_t kWidth  = 64;
   constexpr std::uint32_t kHeight = 64;
-  auto                    prepared =
-      RawInputLoader::FromDirectRgb(MakeSplitPlane(kWidth, kHeight, 1.0f, 0.05f),
-                                    gpu_dag_test::FullSensor(kWidth, kHeight));
+  auto prepared = RawInputLoader::FromDirectRgb(MakeSplitPlane(kWidth, kHeight, 1.0f, 0.05f),
+                                                gpu_dag_test::FullSensor(kWidth, kHeight));
   auto document = CreateDefaultPipelineDocument();
   gpu_dag_test::EnsureTestCameraProfile(document);
   auto* shadows = dynamic_cast<ShadowsModel*>(
@@ -423,7 +525,7 @@ TEST(GpuDagCudaPrimaryGrade, RoiFrameSamplesCanonicalLlfReferenceInsteadOfRebuil
   ASSERT_NE(shadows, nullptr);
   shadows->SetValue(80.0f);
 
-  auto             full_plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  auto full_plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
   CudaRenderDevice device;
   const auto       full_grade = RenderPreparedGrade(device, document, prepared, full_plan);
   EXPECT_TRUE(full_grade.local_tone_rebuilt_reference);
@@ -435,11 +537,12 @@ TEST(GpuDagCudaPrimaryGrade, RoiFrameSamplesCanonicalLlfReferenceInsteadOfRebuil
 
   RenderRequest roi_request;
   roi_request.view.visible_rect_in_edit_space = {0.5f, 0.0f, 0.5f, 1.0f};
-  auto roi_plan = GraphCompiler::Compile(document, prepared.CompileSource(), roi_request);
+  auto       roi_plan  = GraphCompiler::Compile(document, prepared.CompileSource(), roi_request);
   const auto roi_grade = RenderPreparedGrade(device, document, prepared, roi_plan);
   EXPECT_FALSE(roi_grade.local_tone_rebuilt_reference);
   EXPECT_TRUE(roi_grade.local_tone_sampled_canonical_reference);
-  EXPECT_EQ(full_grade.local_tone_reference_resource_id, roi_grade.local_tone_reference_resource_id);
+  EXPECT_EQ(full_grade.local_tone_reference_resource_id,
+            roi_grade.local_tone_reference_resource_id);
   const auto roi_pixels = DownloadGrade(device, roi_grade.output);
   const auto roi_mask   = DownloadLocalTonePlane(device, document.PrimaryGrade()->Id());
   ASSERT_FALSE(roi_pixels.empty());

--- a/alcedo_studio/tests/edit/runtime/opencl_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_grade_test.cpp
@@ -595,11 +595,11 @@ class OpenClGradeFixture : public ::testing::Test {
   }
 
   void UseNeighborhoodPlane(std::uint32_t width, std::uint32_t height, float surroundings,
-                            float center) {
+                            float center, const RenderRequest& request = {}) {
     prepared_ =
         RawInputLoader::FromDirectRgb(MakeNeighborhoodPlane(width, height, surroundings, center),
                                       gpu_dag_test::FullSensor(width, height));
-    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), request);
   }
 
   PreparedRawInput                    prepared_;
@@ -731,6 +731,44 @@ TEST_F(OpenClGradeFixture, OpenClSharpenUsesSurroundingPixelsForUnsharpMask) {
   EXPECT_GT(output[center].r, input[center].r);
   EXPECT_LT(output[neighbor_index].r, input[neighbor_index].r);
   EXPECT_NEAR(output[far_index].r, input[far_index].r, 1.0e-6f);
+}
+
+TEST_F(OpenClGradeFixture, OpenClSharpenDarkRingFollowsPreviewResolution) {
+  // Radius 4 is 12 taps at 1:1 and 6 taps at render_scale 0.5. Offset 10 sits between those
+  // radii, so an unscaled kernel would still darken the half-res probe.
+  constexpr std::uint32_t width   = 128;
+  constexpr std::uint32_t height = 128;
+  auto&                   sharpen = ModelByType<SharpenModel>(type_ids::Sharpen());
+  sharpen.SetRadius(4.0f);
+  sharpen.SetThreshold(0.0f);
+
+  UseNeighborhoodPlane(width, height, 0.18f, 0.55f);
+  sharpen.SetAmount(0.0f);
+  (void)RenderGrade();
+  const auto full_identity = last_output_pixels_;
+  sharpen.SetAmount(100.0f);
+  (void)RenderGrade();
+  const auto full_sharpened = last_output_pixels_;
+  const auto full_near =
+      static_cast<std::size_t>(height / 2) * width + width / 2 + 1U;
+  ASSERT_EQ(full_identity.size(), full_sharpened.size());
+  EXPECT_GT(full_identity[full_near].r - full_sharpened[full_near].r, 1.0e-4f);
+
+  RenderRequest half_request;
+  half_request.resolution.render_scale = 0.5f;
+  UseNeighborhoodPlane(width, height, 0.18f, 0.55f, half_request);
+  sharpen.SetAmount(0.0f);
+  (void)RenderGrade();
+  const auto half_identity = last_output_pixels_;
+  sharpen.SetAmount(100.0f);
+  const auto half_result    = RenderGrade();
+  const auto half_sharpened = last_output_pixels_;
+  ASSERT_EQ(half_identity.size(), static_cast<std::size_t>(64) * 64);
+  EXPECT_EQ(half_result.detail_pass_count, 1U);
+  const auto half_near = static_cast<std::size_t>(32) * 64U + 32U + 1U;
+  const auto half_far  = static_cast<std::size_t>(32) * 64U + 32U + 10U;
+  EXPECT_GT(half_identity[half_near].r - half_sharpened[half_near].r, 1.0e-5f);
+  EXPECT_NEAR(half_sharpened[half_far].r, half_identity[half_far].r, 2.0e-3f);
 }
 
 TEST_F(OpenClGradeFixture, OpenClClarityUsesLargeRadiusLocalContrast) {

--- a/alcedo_studio/tests/edit/runtime/opencl_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_grade_test.cpp
@@ -47,6 +47,29 @@ struct Rgba {
   float a = 1.0f;
 };
 
+auto MakeNeighborhoodPlane(std::uint32_t width, std::uint32_t height, float surroundings,
+                           float center) -> HostImagePlane {
+  HostImagePlane plane;
+  plane.extent       = {width, height};
+  plane.stride_bytes = width * 16U;
+  plane.format       = HostPixelFormat::F32Rgba;
+  auto  storage      = std::shared_ptr<std::byte>(new std::byte[plane.ByteCount()],
+                                                  [](std::byte* pointer) { delete[] pointer; });
+  auto* pixels       = reinterpret_cast<float*>(storage.get());
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      const float value = x == width / 2 && y == height / 2 ? center : surroundings;
+      const auto  index = (static_cast<std::size_t>(y) * width + x) * 4;
+      pixels[index + 0] = value;
+      pixels[index + 1] = value;
+      pixels[index + 2] = value;
+      pixels[index + 3] = 1.0f;
+    }
+  }
+  plane.bytes = std::const_pointer_cast<const std::byte>(storage);
+  return plane;
+}
+
 auto Download(OpenClRenderDevice& device, const GraphValueId& id) -> std::vector<Rgba> {
   auto* lease = device.Workspace().Images().Find(id);
   EXPECT_NE(lease, nullptr);
@@ -124,7 +147,7 @@ auto ApplyHls(Rgba c, const GradeAdjustmentParams& p) -> Rgba {
   return c;
 }
 
-auto CpuApplyAdjustment(Rgba c, const GradeAdjustmentParams& p, std::uint32_t pixel_index) -> Rgba {
+auto CpuApplyAdjustment(Rgba c, const GradeAdjustmentParams& p) -> Rgba {
   const auto  behavior = static_cast<AdjustmentBehavior>(p.behavior);
   const float value    = p.values[0];
   if (behavior == AdjustmentBehavior::Cat02WhiteBalance && value != 0.0f) {
@@ -153,15 +176,6 @@ auto CpuApplyAdjustment(Rgba c, const GradeAdjustmentParams& p, std::uint32_t pi
     c.r += offset;
     c.g += offset;
     c.b += offset;
-  } else if (behavior == AdjustmentBehavior::Clarity) {
-    const float l = Luma(c);
-    float       weight =
-        1.0f - std::min(l / std::max(local_tone_mapping::kAcesccMiddleGray, 1.0e-4f), 1.0f);
-    weight           = 0.5f - std::fabs(weight - 0.5f);
-    const float gain = 1.0f + value * 0.01f * weight;
-    c.r *= gain;
-    c.g *= gain;
-    c.b *= gain;
   } else if (behavior == AdjustmentBehavior::Curve) {
     c.r = ApplyCurve(c.r, p);
     c.g = ApplyCurve(c.g, p);
@@ -190,21 +204,6 @@ auto CpuApplyAdjustment(Rgba c, const GradeAdjustmentParams& p, std::uint32_t pi
           p.values[9];
     c.b = std::copysign(std::pow(std::fabs(c.b + p.values[2] + p.values[3]), 1.0f / gamma_z), c.b) *
           p.values[10];
-  } else if (behavior == AdjustmentBehavior::Sharpen) {
-    const float l     = Luma(c);
-    const float scale = 1.0f + value * 0.0025f;
-    c.r               = l + (c.r - l) * scale;
-    c.g               = l + (c.g - l) * scale;
-    c.b               = l + (c.b - l) * scale;
-  } else if (behavior == AdjustmentBehavior::Halation) {
-    c.r += std::max(Luma(c) - 0.6f, 0.0f) * value * 0.15f;
-  } else if (behavior == AdjustmentBehavior::FilmGrain && value != 0.0f) {
-    std::uint32_t hash = pixel_index * 747796405u + 2891336453u;
-    hash               = (hash >> ((hash >> 28u) + 4u)) ^ hash;
-    const float noise  = (static_cast<float>(hash & 0xffffu) / 32767.5f - 1.0f) * value * 0.02f;
-    c.r += noise;
-    c.g += noise;
-    c.b += noise;
   }
   return c;
 }
@@ -595,6 +594,14 @@ class OpenClGradeFixture : public ::testing::Test {
     return *model;
   }
 
+  void UseNeighborhoodPlane(std::uint32_t width, std::uint32_t height, float surroundings,
+                            float center) {
+    prepared_ =
+        RawInputLoader::FromDirectRgb(MakeNeighborhoodPlane(width, height, surroundings, center),
+                                      gpu_dag_test::FullSensor(width, height));
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), RenderRequest{});
+  }
+
   PreparedRawInput                    prepared_;
   PipelineDocument                    document_;
   ExecutionPlan                       plan_;
@@ -704,6 +711,97 @@ TEST_F(OpenClGradeFixture, OpenClDetailPassesAcquireAllResourcesFromWorkspace) {
   EXPECT_EQ(device_->Workspace().Device().ProgramBuildCount(), 0U);
 }
 
+TEST_F(OpenClGradeFixture, OpenClSharpenUsesSurroundingPixelsForUnsharpMask) {
+  constexpr std::uint32_t width  = 64;
+  constexpr std::uint32_t height = 64;
+  UseNeighborhoodPlane(width, height, 0.18f, 0.55f);
+  auto& sharpen = ModelByType<SharpenModel>(type_ids::Sharpen());
+  sharpen.SetAmount(100.0f);
+  sharpen.SetRadius(3.0f);
+  sharpen.SetThreshold(0.0f);
+
+  const auto  result         = RenderGrade();
+  const auto& input          = last_develop_pixels_;
+  const auto& output         = last_output_pixels_;
+  const auto  center         = static_cast<std::size_t>(height / 2) * width + width / 2;
+  const auto  neighbor_index = center - 1;
+  const auto  far_index      = static_cast<std::size_t>(height / 2) * width + 2;
+  ASSERT_EQ(input.size(), output.size());
+  EXPECT_EQ(result.detail_pass_count, 1U);
+  EXPECT_GT(output[center].r, input[center].r);
+  EXPECT_LT(output[neighbor_index].r, input[neighbor_index].r);
+  EXPECT_NEAR(output[far_index].r, input[far_index].r, 1.0e-6f);
+}
+
+TEST_F(OpenClGradeFixture, OpenClClarityUsesLargeRadiusLocalContrast) {
+  constexpr std::uint32_t width  = 96;
+  constexpr std::uint32_t height = 96;
+  UseNeighborhoodPlane(width, height, 0.22f, 0.48f);
+  ModelByType<ClarityModel>(type_ids::Clarity()).SetValue(80.0f);
+
+  const auto  result         = RenderGrade();
+  const auto& input          = last_develop_pixels_;
+  const auto& output         = last_output_pixels_;
+  const auto  center         = static_cast<std::size_t>(height / 2) * width + width / 2;
+  const auto  neighbor_index = center - 1;
+  const auto  far_index      = static_cast<std::size_t>(height / 2) * width + 1;
+  ASSERT_EQ(input.size(), output.size());
+  EXPECT_EQ(result.detail_pass_count, 1U);
+  EXPECT_GT(output[center].r, input[center].r);
+  EXPECT_LT(output[neighbor_index].r, input[neighbor_index].r);
+  EXPECT_NEAR(output[far_index].r, input[far_index].r, 1.0e-6f);
+}
+
+TEST_F(OpenClGradeFixture, OpenClHalationSpreadsRedLightIntoDarkNeighbors) {
+  constexpr std::uint32_t width  = 64;
+  constexpr std::uint32_t height = 64;
+  UseNeighborhoodPlane(width, height, 0.02f, 1.0f);
+  ModelByType<HalationModel>(type_ids::Halation()).SetValue(1.0f);
+
+  const auto  result         = RenderGrade();
+  const auto& input          = last_develop_pixels_;
+  const auto& output         = last_output_pixels_;
+  const auto  center         = static_cast<std::size_t>(height / 2) * width + width / 2;
+  const auto  neighbor_index = center - 1;
+  const auto  far_index      = static_cast<std::size_t>(height / 2) * width + 2;
+  ASSERT_EQ(input.size(), output.size());
+  EXPECT_EQ(result.detail_pass_count, 1U);
+  const float red_spill   = output[neighbor_index].r - input[neighbor_index].r;
+  const float green_spill = output[neighbor_index].g - input[neighbor_index].g;
+  EXPECT_GT(red_spill, 1.0e-4f);
+  EXPECT_GT(red_spill, green_spill * 5.0f);
+  EXPECT_NEAR(output[far_index].r, input[far_index].r, 1.0e-6f);
+}
+
+TEST_F(OpenClGradeFixture, OpenClFilmGrainStrengthScalesDeterministicDensityVariation) {
+  constexpr std::uint32_t width  = 64;
+  constexpr std::uint32_t height = 64;
+  UseNeighborhoodPlane(width, height, 0.35f, 0.35f);
+  auto& grain = ModelByType<FilmGrainModel>(type_ids::FilmGrain());
+
+  grain.SetValue(0.25f);
+  (void)RenderGrade();
+  const auto low   = last_output_pixels_;
+  const auto input = last_develop_pixels_;
+  grain.SetValue(0.75f);
+  (void)RenderGrade();
+  const auto high = last_output_pixels_;
+  (void)RenderGrade();
+  const auto high_again = last_output_pixels_;
+  ASSERT_EQ(input.size(), high.size());
+
+  double low_energy  = 0.0;
+  double high_energy = 0.0;
+  for (std::size_t index = 0; index < input.size(); ++index) {
+    low_energy += std::pow(static_cast<double>(low[index].r - input[index].r), 2.0);
+    high_energy += std::pow(static_cast<double>(high[index].r - input[index].r), 2.0);
+    EXPECT_FLOAT_EQ(high[index].r, high_again[index].r);
+    EXPECT_FLOAT_EQ(high[index].g, high_again[index].g);
+    EXPECT_FLOAT_EQ(high[index].b, high_again[index].b);
+  }
+  EXPECT_GT(high_energy, low_energy * 6.0);
+}
+
 TEST_F(OpenClGradeFixture, OpenClPrimaryGradeMatchesCudaReferenceWithinTolerance) {
   ModelByType<Cat02WhiteBalanceModel>(type_ids::Cat02WhiteBalance()).SetTemperatureOffset(120.0f);
   ModelByType<ExposureModel>(type_ids::Exposure()).SetValue(0.5f);
@@ -736,7 +834,7 @@ TEST_F(OpenClGradeFixture, OpenClPrimaryGradeMatchesCudaReferenceWithinTolerance
   for (std::size_t i = 0; i < input.size(); ++i) {
     Rgba cpu = input[i];
     for (const auto& p : params) {
-      cpu = CpuApplyAdjustment(cpu, p, static_cast<std::uint32_t>(i));
+      cpu = CpuApplyAdjustment(cpu, p);
     }
     max_err = std::max(max_err, std::fabs(cpu.r - output[i].r));
     max_err = std::max(max_err, std::fabs(cpu.g - output[i].g));


### PR DESCRIPTION
## Stack

#93 → #94 → #95 → #96 → #97 → #98 → #102 → #101 → #100 → #103 → #104 → #105 → **this PR**

Base: `feature/gpu-dag-opencl`

## Summary

- Restore CUDA/OpenCL Clarity, Sharpen, Halation, and Film Grain as true ping-pong neighbor passes instead of folding them into a single-pixel primary-grade kernel.
- Scale those neighborhoods in full-reference space (same rule as LLF) so preview and max-edge downscales match a full-resolution render.

## Test plan

- [ ] `ctest --test-dir build/debug -R GpuDagCudaPrimaryGradeTest --output-on-failure`
- [ ] `ctest --test-dir build/debug -R GpuDagOpenClGradeTest --output-on-failure`
- [ ] `ctest --test-dir build/debug -R AdjustmentRuntimeTest --output-on-failure`
- [ ] In the editor, compare preview vs full-res Clarity/Sharpen/Halation/Film Grain on the OpenCL and CUDA DAG paths.