### PR TITLE
fix(edit): sample LUT in CUDA grade and run thumbnails on the DAG

### DIFF
--- a/alcedo_studio/src/app/pipeline_service.cpp
+++ b/alcedo_studio/src/app/pipeline_service.cpp
@@ -1183,13 +1183,24 @@ auto PipelineMgmtService::LoadPipelineSnapshot(sl_element_id_t id, image_id_t im
     }
   }
 
-  // Capture params under the live executor's render lock. This serializes with any
-  // in-flight editor render on the same executor, so the snapshot is coherent.
-  // ExportPipelineParams is const and reads stages_ only.
+  // Capture params and clone the live DAG document under the executor's render
+  // lock. This serializes with any in-flight editor render on the same executor,
+  // so the snapshot's stages and graph stay coherent with each other.
   nlohmann::json params;
+#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
+  std::shared_ptr<PipelineDocument> cloned_live_document;
+  bool                              mirror = true;
+#endif
   try {
     std::unique_lock<std::mutex> rg(live_exec->GetRenderLock());
     params = live_exec->ExportPipelineParams();
+#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
+    if (auto live_doc = live_exec->GpuDagDocument()) {
+      cloned_live_document =
+          std::make_shared<PipelineDocument>(ClonePipelineDocument(*live_doc));
+      mirror = live_exec->MirrorsLegacyStageAdapter();
+    }
+#endif
   } catch (const std::exception& e) {
     if (error) {
       *error = std::format("LoadPipelineSnapshot: export failed for {}: {}", id, e.what());
@@ -1216,6 +1227,17 @@ auto PipelineMgmtService::LoadPipelineSnapshot(sl_element_id_t id, image_id_t im
     snap_exec->SetAcceleratorBackendPreference(accelerator_preference_);
     snap_exec->ImportPipelineParams(params);
     ResetTransientPreviewState(*snap_exec);
+#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
+    std::shared_ptr<PipelineDocument> snap_document = std::move(cloned_live_document);
+    if (!snap_document) {
+      auto imported = LegacyPipelineImporter::Import(params);
+      if (!imported.Ok() || !imported.document) {
+        throw std::runtime_error("GPU DAG import failed: " + imported.error);
+      }
+      snap_document = std::make_shared<PipelineDocument>(std::move(*imported.document));
+    }
+    snap_exec->SetPipelineDocument(std::move(snap_document), mirror);
+#endif
   } catch (const std::exception& e) {
     if (error) {
       *error = std::format("LoadPipelineSnapshot: snapshot build failed for {}: {}", id, e.what());

--- a/alcedo_studio/src/app/thumbnail_service.cpp
+++ b/alcedo_studio/src/app/thumbnail_service.cpp
@@ -48,6 +48,12 @@ constexpr DecodeRes ResolutionToDecodeRes(ThumbnailResolution res) {
   return DecodeRes::QUARTER;
 }
 
+void InjectSnapshotRawContext(CPUPipelineExecutor& exec, const std::shared_ptr<Image>& image) {
+  if (image && image->HasRawColorContext()) {
+    exec.InjectRawMetadata(image->GetRawColorContext());
+  }
+}
+
 void DispatchThumbnailResultCallback(const ThumbnailResultCallback& callback,
                                      const CallbackDispatcher&      dispatcher,
                                      ThumbnailRequestResult         result) {
@@ -465,6 +471,7 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
             false);
       }
 
+      InjectSnapshotRawContext(*executor, img_result);
       task.pipeline_executor_ = std::move(executor);
       task.input_desc_        = std::move(img_result);
       return true;
@@ -784,8 +791,7 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
             std::format("analysis rendition: image with ID {} not found in pool.", image_id));
       }
 
-      // No pre-render color-temp read / post-render dirty check: the snapshot
-      // executor is throwaway, so that live-path dirty check is meaningless.
+      InjectSnapshotRawContext(*exec, img_result);
       t.pipeline_executor_ = exec;
       t.input_desc_        = std::move(img_result);
       return true;

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -72,6 +72,7 @@ def_library(EditInput
 set(EDIT_RUNTIME_SRCS
     ${ALCEDO_SRC_ROOT}/edit/runtime/adjustment_runtime.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/edit_runtime.cpp
+    ${ALCEDO_SRC_ROOT}/edit/runtime/grade_lut.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/graph_compiler.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/result_content_key.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/static_execution_plan_cache.cpp

--- a/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
+++ b/alcedo_studio/src/edit/graph/legacy_pipeline_importer.cpp
@@ -256,6 +256,23 @@ auto ValidateOperators(const std::vector<LegacyOperator>& operators) -> std::str
   return {};
 }
 
+auto LegacyCubePath(const nlohmann::json& params) -> std::string {
+  if (params.contains("ocio_lmt")) {
+    const auto& value = params["ocio_lmt"];
+    if (value.is_string()) {
+      return value.get<std::string>();
+    }
+    if (value.is_object()) {
+      const auto nested = json_util::ReadString(value, "ocio_lmt", {});
+      if (!nested.empty()) {
+        return nested;
+      }
+      return json_util::ReadString(value, "cube_path", {});
+    }
+  }
+  return json_util::ReadString(params, "cube_path", {});
+}
+
 auto ApplyOperators(PipelineDocument& document, const std::vector<LegacyOperator>& operators)
     -> std::string {
   auto* grade = document.PrimaryGrade();
@@ -308,13 +325,7 @@ auto ApplyOperators(PipelineDocument& document, const std::vector<LegacyOperator
   }
   if (const auto* lmt = FindOp(operators, kLegacyLmt)) {
     if (auto* model = grade->FindAdjustmentByType(type_ids::Lmt())) {
-      nlohmann::json json;
-      if (lmt->params.contains("ocio_lmt") && lmt->params["ocio_lmt"].is_string()) {
-        json["cube_path"] = lmt->params["ocio_lmt"].get<std::string>();
-      } else {
-        json["cube_path"] = json_util::ReadString(lmt->params, "cube_path", {});
-      }
-      LoadJsonIfChanged(model, json);
+      LoadJsonIfChanged(model, nlohmann::json{{"cube_path", LegacyCubePath(lmt->params)}});
     }
   }
   if (const auto* sharpen = FindOp(operators, kLegacySharpen)) {

--- a/alcedo_studio/src/edit/graph/pipeline_document.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_document.cpp
@@ -140,6 +140,10 @@ auto CreateDefaultPipelineDocument() -> PipelineDocument {
   return document;
 }
 
+auto ClonePipelineDocument(const PipelineDocument& src) -> PipelineDocument {
+  return PipelineDocument::FromJson(src.ToJson());
+}
+
 auto AllowsLegacyStageAdapterRemirror(const PipelineDocument& document) -> bool {
   return document.Develop() != nullptr && document.PrimaryGrade() != nullptr &&
          document.Drt() != nullptr;

--- a/alcedo_studio/src/edit/input/raw_input_loader.cpp
+++ b/alcedo_studio/src/edit/input/raw_input_loader.cpp
@@ -253,8 +253,149 @@ auto WrapU16Cfa(const HostImagePlane& plane) -> cv::Mat {
                  CV_16UC1, const_cast<std::byte*>(plane.bytes.get()), plane.stride_bytes);
 }
 
+auto WrapF32Rgba(const HostImagePlane& plane) -> cv::Mat {
+  if (plane.format != HostPixelFormat::F32Rgba || !plane.bytes) {
+    throw std::runtime_error("RawInputLoader: expected F32 RGBA plane");
+  }
+  return cv::Mat(static_cast<int>(plane.extent.height), static_cast<int>(plane.extent.width),
+                 CV_32FC4, const_cast<std::byte*>(plane.bytes.get()), plane.stride_bytes);
+}
+
+auto Rgb32fToRgbaPlane(const cv::Mat& rgb) -> HostImagePlane {
+  if (rgb.type() != CV_32FC3 || rgb.empty()) {
+    throw std::runtime_error("RawInputLoader: expected F32 RGB mat");
+  }
+  HostImagePlane plane;
+  plane.extent =
+      Extent2D{static_cast<std::uint32_t>(rgb.cols), static_cast<std::uint32_t>(rgb.rows)};
+  plane.stride_bytes      = plane.extent.width * 4U * static_cast<std::uint32_t>(sizeof(float));
+  plane.format            = HostPixelFormat::F32Rgba;
+  const std::size_t bytes = plane.ByteCount();
+  auto              storage =
+      std::shared_ptr<std::byte>(new std::byte[bytes], std::default_delete<std::byte[]>());
+  auto* out = reinterpret_cast<float*>(storage.get());
+  for (int y = 0; y < rgb.rows; ++y) {
+    const auto* row = rgb.ptr<float>(y);
+    for (int x = 0; x < rgb.cols; ++x) {
+      const auto pixel = static_cast<std::size_t>(y) * plane.extent.width + static_cast<std::size_t>(x);
+      out[pixel * 4 + 0] = row[static_cast<std::size_t>(x) * 3 + 0];
+      out[pixel * 4 + 1] = row[static_cast<std::size_t>(x) * 3 + 1];
+      out[pixel * 4 + 2] = row[static_cast<std::size_t>(x) * 3 + 2];
+      out[pixel * 4 + 3] = 1.0f;
+    }
+  }
+  plane.bytes = std::const_pointer_cast<const std::byte>(storage);
+  return plane;
+}
+
+auto ExtractRgb32f(const cv::Mat& src) -> cv::Mat {
+  if (src.type() == CV_32FC3) {
+    return src;
+  }
+  if (src.type() == CV_32FC4) {
+    cv::Mat rgb(src.rows, src.cols, CV_32FC3);
+    const int from_to[] = {0, 0, 1, 1, 2, 2};
+    cv::mixChannels(&src, 1, &rgb, 1, from_to, 3);
+    return rgb;
+  }
+  throw std::runtime_error("RawInputLoader: expected 3 or 4 channel F32 RGB");
+}
+
+auto CropMatToDecodeArea(const cv::Mat& src, const RawSensorGeometry& sensor) -> cv::Mat {
+  const Extent2D host{static_cast<std::uint32_t>(src.cols), static_cast<std::uint32_t>(src.rows)};
+  const RectI    crop = BuildDecodeCropRect(sensor, host, 1);
+  const cv::Rect rect(crop.x, crop.y, crop.width, crop.height);
+  if (rect.x == 0 && rect.y == 0 && rect.width == src.cols && rect.height == src.rows) {
+    return src.clone();
+  }
+  return src(rect).clone();
+}
+
+auto CopyDebayeredRgbPlane(LibRaw& raw, const RawSensorGeometry& sensor) -> HostImagePlane {
+  const auto& raw_data   = raw.imgdata.rawdata;
+  const auto& idata      = raw.imgdata.idata;
+  const auto& sizes      = raw.imgdata.sizes;
+  const int   raw_width  = static_cast<int>(sizes.raw_width);
+  const int   raw_height = static_cast<int>(sizes.raw_height);
+
+  cv::Mat rgb32f;
+  if (raw_data.color3_image != nullptr) {
+    const std::size_t row_step = sizes.raw_pitch != 0
+                                     ? static_cast<std::size_t>(sizes.raw_pitch)
+                                     : static_cast<std::size_t>(raw_width) * sizeof(std::uint16_t) * 3;
+    cv::Mat           view(raw_height, raw_width, CV_16UC3, raw_data.color3_image, row_step);
+    CropMatToDecodeArea(view, sensor).convertTo(rgb32f, CV_32FC3, 1.0 / 65535.0);
+  } else if (raw_data.float3_image != nullptr) {
+    const std::size_t row_step = sizes.raw_pitch != 0
+                                     ? static_cast<std::size_t>(sizes.raw_pitch)
+                                     : static_cast<std::size_t>(raw_width) * sizeof(float) * 3;
+    cv::Mat           view(raw_height, raw_width, CV_32FC3, raw_data.float3_image, row_step);
+    rgb32f = CropMatToDecodeArea(view, sensor);
+  } else if (raw_data.color4_image != nullptr && idata.colors == 3) {
+    const std::size_t row_step = sizes.raw_pitch != 0
+                                     ? static_cast<std::size_t>(sizes.raw_pitch)
+                                     : static_cast<std::size_t>(raw_width) * sizeof(std::uint16_t) * 4;
+    cv::Mat           view(raw_height, raw_width, CV_16UC4, raw_data.color4_image, row_step);
+    cv::Mat           rgb16;
+    CropMatToDecodeArea(view, sensor).convertTo(rgb16, CV_32FC4, 1.0 / 65535.0);
+    rgb32f = ExtractRgb32f(rgb16);
+  } else if (raw_data.float4_image != nullptr && idata.colors == 3) {
+    const std::size_t row_step = sizes.raw_pitch != 0
+                                     ? static_cast<std::size_t>(sizes.raw_pitch)
+                                     : static_cast<std::size_t>(raw_width) * sizeof(float) * 4;
+    cv::Mat           view(raw_height, raw_width, CV_32FC4, raw_data.float4_image, row_step);
+    rgb32f = ExtractRgb32f(CropMatToDecodeArea(view, sensor));
+  } else {
+    throw std::runtime_error("RawInputLoader: direct RGB input is missing a 3-channel source");
+  }
+  return Rgb32fToRgbaPlane(rgb32f);
+}
+
+void CollapseSensorToHost(RawSensorGeometry& sensor, Extent2D host) {
+  const auto width  = static_cast<std::int32_t>(host.width);
+  const auto height = static_cast<std::int32_t>(host.height);
+  sensor.raw_width    = width;
+  sensor.raw_height   = height;
+  sensor.width        = width;
+  sensor.height       = height;
+  sensor.left_margin  = 0;
+  sensor.top_margin   = 0;
+  sensor.default_crop[0] = 0;
+  sensor.default_crop[1] = 0;
+  sensor.default_crop[2] = static_cast<std::uint16_t>(std::min(width, 65535));
+  sensor.default_crop[3] = static_cast<std::uint16_t>(std::min(height, 65535));
+}
+
+auto DownsampleRgba2x(const cv::Mat& src) -> cv::Mat {
+  const int out_rows = src.rows / 2;
+  const int out_cols = src.cols / 2;
+  if (out_rows < 1 || out_cols < 1) {
+    throw std::runtime_error("RawInputLoader: RGB too small to downsample");
+  }
+  cv::Mat dst(out_rows, out_cols, CV_32FC4);
+  for (int y = 0; y < out_rows; ++y) {
+    const auto* row0 = src.ptr<cv::Vec4f>(2 * y);
+    const auto* row1 = src.ptr<cv::Vec4f>(2 * y + 1);
+    auto*       dest = dst.ptr<cv::Vec4f>(y);
+    for (int x = 0; x < out_cols; ++x) {
+      dest[x] = (row0[2 * x] + row0[2 * x + 1] + row1[2 * x] + row1[2 * x + 1]) * 0.25f;
+    }
+  }
+  return dst;
+}
+
 void DownsampleInPlace(PreparedRawInput& input, std::uint8_t passes) {
-  if (passes == 0 || input.input_kind == RawInputKind::DebayeredRgb) {
+  if (passes == 0) {
+    return;
+  }
+  if (input.input_kind == RawInputKind::DebayeredRgb) {
+    cv::Mat current = WrapF32Rgba(input.pixels).clone();
+    for (std::uint8_t i = 0; i < passes; ++i) {
+      current = DownsampleRgba2x(current);
+    }
+    input.pixels            = CopyPlane(current, HostPixelFormat::F32Rgba);
+    input.host_extent       = input.pixels.extent;
+    input.downsample_passes = passes;
     return;
   }
   cv::Mat current = WrapU16Cfa(input.pixels).clone();
@@ -467,10 +608,12 @@ auto RawInputLoader::LoadEncoded(std::span<const std::byte> encoded, DecodeRes d
   }
 
   if (kind == RawInputKind::DebayeredRgb) {
+    input.pixels      = CopyDebayeredRgbPlane(*raw, input.sensor);
+    input.host_extent = input.pixels.extent;
+    input.input_kind  = RawInputKind::DebayeredRgb;
+    CollapseSensorToHost(input.sensor, input.host_extent);
     raw->recycle();
-    throw std::runtime_error(
-        "RawInputLoader::LoadEncoded: encoded direct RGB is not used in G4 tests; "
-        "call FromDirectRgb");
+    return FinishPrepared(std::move(input), decode_res, HashContentBytes(encoded), encoded.size());
   }
 
   const auto& sizes = raw->imgdata.sizes;

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -452,6 +452,30 @@ void CPUPipelineExecutor::SetPipelineDocument(std::shared_ptr<PipelineDocument> 
 #endif
 }
 
+auto CPUPipelineExecutor::HasGpuDagDocument() const -> bool {
+#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
+  return static_cast<bool>(pipeline_document_);
+#else
+  return false;
+#endif
+}
+
+auto CPUPipelineExecutor::GpuDagDocument() const -> std::shared_ptr<PipelineDocument> {
+#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
+  return pipeline_document_;
+#else
+  return nullptr;
+#endif
+}
+
+auto CPUPipelineExecutor::MirrorsLegacyStageAdapter() const -> bool {
+#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
+  return mirror_legacy_stage_adapter_;
+#else
+  return false;
+#endif
+}
+
 [[deprecated("SetPreviewMode is deprecated, set from pipeline scheduler instead")]] void
 CPUPipelineExecutor::SetPreviewMode(bool) {
   // is_thumbnail_  = is_thumbnail;

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -4,6 +4,7 @@
 
 #include "edit/runtime/cuda/cuda_backend.hpp"
 
+#include <limits>
 #include <stdexcept>
 #include <utility>
 
@@ -335,11 +336,93 @@ void CudaBackend::SynchronizeRecordedWork(CommandContext& command_context) {
                   "CudaBackend::SynchronizeRecordedWork");
 }
 
+auto CudaBackend::AcquireLut(ContentKey key, std::span<const std::byte> packed_rgba,
+                             std::uint32_t edge, CommandContext& command_context)
+    -> CudaLutBinding {
+  if (key.Empty() || edge <= 1 || packed_rgba.empty()) {
+    return DummyLut();
+  }
+  for (auto& entry : lut_cache_) {
+    if (entry.key == key && entry.edge_size == edge) {
+      entry.lru_tick             = ++lut_lru_clock_;
+      entry.last_used_submission = command_context.SubmissionId();
+      last_lut_resource_id_      = entry.buffer.ResourceId();
+      return CudaLutBinding{entry.buffer.DevicePointer(), entry.buffer.ResourceId(),
+                            entry.edge_size};
+    }
+  }
+  if (lut_byte_budget_ > 0 && lut_cache_bytes_ + packed_rgba.size() > lut_byte_budget_) {
+    while (!lut_cache_.empty() && lut_cache_bytes_ + packed_rgba.size() > lut_byte_budget_) {
+      std::size_t victim_index = lut_cache_.size();
+      auto        oldest       = (std::numeric_limits<std::uint64_t>::max)();
+      for (std::size_t index = 0; index < lut_cache_.size(); ++index) {
+        const auto& entry = lut_cache_[index];
+        if (IsResourceBusy(entry.last_used_submission) || entry.lru_tick >= oldest) {
+          continue;
+        }
+        oldest       = entry.lru_tick;
+        victim_index = index;
+      }
+      if (victim_index == lut_cache_.size()) {
+        break;
+      }
+      lut_cache_bytes_ -= lut_cache_[victim_index].bytes;
+      lut_cache_.erase(lut_cache_.begin() + static_cast<std::ptrdiff_t>(victim_index));
+    }
+  }
+  auto buffer = CreateBuffer(packed_rgba.size());
+  UploadBufferRange(buffer, 0, packed_rgba, command_context);
+  lut_upload_bytes_ += packed_rgba.size();
+  last_lut_resource_id_ = buffer.ResourceId();
+  LutCacheEntry entry;
+  entry.key                  = key;
+  entry.edge_size            = edge;
+  entry.bytes                = packed_rgba.size();
+  entry.lru_tick             = ++lut_lru_clock_;
+  entry.last_used_submission = command_context.SubmissionId();
+  entry.buffer               = std::move(buffer);
+  lut_cache_bytes_ += entry.bytes;
+  lut_cache_.push_back(std::move(entry));
+  return CudaLutBinding{lut_cache_.back().buffer.DevicePointer(), last_lut_resource_id_, edge};
+}
+
+auto CudaBackend::DummyLut() -> CudaLutBinding {
+  if (dummy_lut_.Empty()) {
+    dummy_lut_ = CreateBuffer(16);
+  }
+  return CudaLutBinding{dummy_lut_.DevicePointer(), dummy_lut_.ResourceId(), 0};
+}
+
+void CudaBackend::SetLutByteBudget(std::size_t bytes) {
+  lut_byte_budget_ = bytes;
+  if (lut_byte_budget_ == 0) {
+    return;
+  }
+  while (lut_cache_bytes_ > lut_byte_budget_ && !lut_cache_.empty()) {
+    std::size_t victim_index = lut_cache_.size();
+    auto        oldest       = (std::numeric_limits<std::uint64_t>::max)();
+    for (std::size_t index = 0; index < lut_cache_.size(); ++index) {
+      const auto& entry = lut_cache_[index];
+      if (IsResourceBusy(entry.last_used_submission) || entry.lru_tick >= oldest) {
+        continue;
+      }
+      oldest       = entry.lru_tick;
+      victim_index = index;
+    }
+    if (victim_index == lut_cache_.size()) {
+      break;
+    }
+    lut_cache_bytes_ -= lut_cache_[victim_index].bytes;
+    lut_cache_.erase(lut_cache_.begin() + static_cast<std::ptrdiff_t>(victim_index));
+  }
+}
+
 void CudaBackend::ResetCounters() {
-  malloc_count_   = 0;
-  free_count_     = 0;
-  h2d_copy_count_ = 0;
-  h2d_bytes_      = 0;
+  malloc_count_     = 0;
+  free_count_       = 0;
+  h2d_copy_count_   = 0;
+  h2d_bytes_        = 0;
+  lut_upload_bytes_ = 0;
   last_h2d_ranges_.clear();
   last_texture_rectangles_.clear();
 }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <stdexcept>
 #include <vector>
@@ -17,9 +18,11 @@
 #include "edit/operators/models/pending_parameter_patch.hpp"
 #include "edit/pipeline/local_tone_mapping.hpp"
 #include "edit/runtime/adjustment_runtime.hpp"
+#include "edit/runtime/content_key.hpp"
 #include "edit/runtime/cuda/cuda_adjustment_runtime.hpp"
 #include "edit/runtime/cuda/cuda_local_tone_pass.hpp"
 #include "edit/runtime/cuda/cuda_primary_grade_pass.hpp"
+#include "edit/runtime/grade_lut.hpp"
 #include "edit/runtime/parameter_binding.hpp"
 #include "edit/runtime/result_content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
@@ -71,6 +74,18 @@ auto CompactOps(std::vector<GradeOp> ops, bool local_tone_active) -> std::vector
     compacted.push_back(std::move(op));
   }
   return compacted;
+}
+
+auto LoadLut(CudaRenderDevice& device, ColorGradeNodeModel& grade) -> CudaLutBinding {
+  const auto packed = TryPackGradeLut(grade);
+  if (!packed.has_value()) {
+    return device.Workspace().Device().DummyLut();
+  }
+  ContentHash hash;
+  hash.MixBytes(packed->rgba);
+  hash.MixU32(packed->edge);
+  return device.Workspace().Device().AcquireLut(hash.Key(), packed->rgba, packed->edge,
+                                                device.CommandContext());
 }
 
 auto NeighborVerticalRadius(const GradeNeighborParams& params) -> std::uint32_t {
@@ -139,7 +154,59 @@ __device__ auto ApplyHls(float3 c, const CudaAdjustmentParams& p) -> float3 {
   return c;
 }
 
-__device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p) -> float3 {
+__device__ auto LutIndex(std::uint32_t edge, std::uint32_t x, std::uint32_t y, std::uint32_t z)
+    -> std::uint32_t {
+  return (z * edge + y) * edge + x;
+}
+
+__device__ auto SampleLut3d(const float4* lut, std::uint32_t edge, float u, float v, float w)
+    -> float3 {
+  u                   = fminf(fmaxf(u, 0.0f), 1.0f);
+  v                   = fminf(fmaxf(v, 0.0f), 1.0f);
+  w                   = fminf(fmaxf(w, 0.0f), 1.0f);
+  const float  tex_x  = u * static_cast<float>(edge) - 0.5f;
+  const float  tex_y  = v * static_cast<float>(edge) - 0.5f;
+  const float  tex_z  = w * static_cast<float>(edge) - 0.5f;
+  const float  max_i  = static_cast<float>(edge - 1U);
+  const float  pos_x  = fminf(fmaxf(tex_x, 0.0f), max_i);
+  const float  pos_y  = fminf(fmaxf(tex_y, 0.0f), max_i);
+  const float  pos_z  = fminf(fmaxf(tex_z, 0.0f), max_i);
+  const auto   lo_x   = static_cast<std::uint32_t>(pos_x);
+  const auto   lo_y   = static_cast<std::uint32_t>(pos_y);
+  const auto   lo_z   = static_cast<std::uint32_t>(pos_z);
+  const auto   hi_x   = lo_x + 1U < edge ? lo_x + 1U : edge - 1U;
+  const auto   hi_y   = lo_y + 1U < edge ? lo_y + 1U : edge - 1U;
+  const auto   hi_z   = lo_z + 1U < edge ? lo_z + 1U : edge - 1U;
+  const float  tx     = pos_x - static_cast<float>(lo_x);
+  const float  ty     = pos_y - static_cast<float>(lo_y);
+  const float  tz     = pos_z - static_cast<float>(lo_z);
+  const float4 c000   = lut[LutIndex(edge, lo_x, lo_y, lo_z)];
+  const float4 c100   = lut[LutIndex(edge, hi_x, lo_y, lo_z)];
+  const float4 c010   = lut[LutIndex(edge, lo_x, hi_y, lo_z)];
+  const float4 c110   = lut[LutIndex(edge, hi_x, hi_y, lo_z)];
+  const float4 c001   = lut[LutIndex(edge, lo_x, lo_y, hi_z)];
+  const float4 c101   = lut[LutIndex(edge, hi_x, lo_y, hi_z)];
+  const float4 c011   = lut[LutIndex(edge, lo_x, hi_y, hi_z)];
+  const float4 c111   = lut[LutIndex(edge, hi_x, hi_y, hi_z)];
+  const float4 c00    = make_float4(c000.x + (c100.x - c000.x) * tx, c000.y + (c100.y - c000.y) * tx,
+                                    c000.z + (c100.z - c000.z) * tx, c000.w + (c100.w - c000.w) * tx);
+  const float4 c10    = make_float4(c010.x + (c110.x - c010.x) * tx, c010.y + (c110.y - c010.y) * tx,
+                                    c010.z + (c110.z - c010.z) * tx, c010.w + (c110.w - c010.w) * tx);
+  const float4 c01    = make_float4(c001.x + (c101.x - c001.x) * tx, c001.y + (c101.y - c001.y) * tx,
+                                    c001.z + (c101.z - c001.z) * tx, c001.w + (c101.w - c001.w) * tx);
+  const float4 c11    = make_float4(c011.x + (c111.x - c011.x) * tx, c011.y + (c111.y - c011.y) * tx,
+                                    c011.z + (c111.z - c011.z) * tx, c011.w + (c111.w - c011.w) * tx);
+  const float4 c0     = make_float4(c00.x + (c10.x - c00.x) * ty, c00.y + (c10.y - c00.y) * ty,
+                                    c00.z + (c10.z - c00.z) * ty, c00.w + (c10.w - c00.w) * ty);
+  const float4 c1     = make_float4(c01.x + (c11.x - c01.x) * ty, c01.y + (c11.y - c01.y) * ty,
+                                    c01.z + (c11.z - c01.z) * ty, c01.w + (c11.w - c01.w) * ty);
+  const float4 sampled = make_float4(c0.x + (c1.x - c0.x) * tz, c0.y + (c1.y - c0.y) * tz,
+                                     c0.z + (c1.z - c0.z) * tz, c0.w + (c1.w - c0.w) * tz);
+  return make_float3(sampled.x, sampled.y, sampled.z);
+}
+
+__device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p, const float4* lut,
+                                std::uint32_t lut_edge) -> float3 {
   const auto  behavior = static_cast<CudaAdjustmentBehavior>(p.behavior);
   const float value    = p.values[0];
   if (behavior == CudaAdjustmentBehavior::Cat02WhiteBalance && value != 0.0f) {
@@ -196,6 +263,11 @@ __device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p) -> floa
         copysignf(powf(fabsf(c.y + p.values[1] + p.values[3]), 1.0f / gamma_y), c.y) * p.values[9];
     c.z =
         copysignf(powf(fabsf(c.z + p.values[2] + p.values[3]), 1.0f / gamma_z), c.z) * p.values[10];
+  } else if (behavior == CudaAdjustmentBehavior::Lmt && value != 0.0f && lut_edge > 1U &&
+             lut != nullptr) {
+    const float scale  = static_cast<float>(lut_edge - 1U) / static_cast<float>(lut_edge);
+    const float offset = 1.0f / (2.0f * static_cast<float>(lut_edge));
+    c = SampleLut3d(lut, lut_edge, c.x * scale + offset, c.y * scale + offset, c.z * scale + offset);
   }
   return c;
 }
@@ -203,7 +275,8 @@ __device__ auto ApplyAdjustment(float3 c, const CudaAdjustmentParams& p) -> floa
 __global__ void PrimaryGradeKernel(const float4* input, float4* output, std::uint32_t pixel_count,
                                    const unsigned char*         parameter_base,
                                    const CudaAdjustmentCommand* commands,
-                                   std::uint32_t                command_count) {
+                                   std::uint32_t command_count, const float4* lut,
+                                   std::uint32_t lut_edge) {
   const std::uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= pixel_count) return;
   const float4 source = input[index];
@@ -211,7 +284,7 @@ __global__ void PrimaryGradeKernel(const float4* input, float4* output, std::uin
   for (std::uint32_t i = 0; i < command_count; ++i) {
     const auto* params = reinterpret_cast<const CudaAdjustmentParams*>(
         parameter_base + commands[i].parameter_offset);
-    c = ApplyAdjustment(c, *params);
+    c = ApplyAdjustment(c, *params, lut, lut_edge);
   }
   output[index] = make_float4(c.x, c.y, c.z, source.w);
 }
@@ -369,6 +442,7 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       static_cast<const CudaAdjustmentCommand*>(command_buffer.DevicePointer());
   const auto* parameter_base =
       static_cast<const unsigned char*>(arena.DeviceBuffer().DevicePointer());
+  const auto lut = LoadLut(device, *grade);
 
   CudaLocalToneResult local_tone;
 
@@ -376,7 +450,7 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
     auto& output = EnsureImage(workspace, output_id, input_width, input_height);
     input        = workspace.Images().Find(plan.develop_output);
     workspace.Device().CopyTexture2D(input->Texture(), output.Texture(), context);
-    return {output_id, 0, false, false};
+    return {output_id, lut.resource_id, 0, false, false};
   }
 
   const float        grade_mix        = grade->Enabled() ? grade->Mix() : 0.0f;
@@ -439,7 +513,8 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
       PrimaryGradeKernel<<<(pixels + block - 1) / block, block, 0, context.Stream()>>>(
           static_cast<const float4*>(src.DevicePointer()),
           static_cast<float4*>(dest.DevicePointer()), pixels, parameter_base,
-          device_commands + command_starts[index], static_cast<std::uint32_t>(op.offsets.size()));
+          device_commands + command_starts[index], static_cast<std::uint32_t>(op.offsets.size()),
+          static_cast<const float4*>(lut.device_pointer), lut.edge_size);
     }
     current_id = dest_id;
   }
@@ -462,8 +537,8 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
   if (::cudaGetLastError() != cudaSuccess) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: CUDA kernel launch failed");
   }
-  return {output_id, local_tone.reference_resource_id, local_tone.rebuilt_reference,
-          local_tone.sampled_canonical_reference};
+  return {output_id, lut.resource_id, local_tone.reference_resource_id,
+          local_tone.rebuilt_reference, local_tone.sampled_canonical_reference};
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/grade_lut.cpp
+++ b/alcedo_studio/src/edit/runtime/grade_lut.cpp
@@ -1,0 +1,48 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/grade_lut.hpp"
+
+#include <stdexcept>
+#include <string>
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/lmt_model.hpp"
+
+namespace alcedo {
+
+auto PackCubeLutRgba(const CubeLut& lut) -> std::vector<std::byte> {
+  const auto             edge   = static_cast<std::size_t>(lut.edge3d_);
+  const auto             voxels = edge * edge * edge;
+  std::vector<std::byte> packed(voxels * 4 * sizeof(float));
+  auto*                  out = reinterpret_cast<float*>(packed.data());
+  for (std::size_t i = 0; i < voxels; ++i) {
+    out[i * 4 + 0] = lut.lut3d_[i * 3 + 0];
+    out[i * 4 + 1] = lut.lut3d_[i * 3 + 1];
+    out[i * 4 + 2] = lut.lut3d_[i * 3 + 2];
+    out[i * 4 + 3] = 1.0f;
+  }
+  return packed;
+}
+
+auto TryPackGradeLut(const ColorGradeNodeModel& grade) -> std::optional<PackedGradeLut> {
+  const auto* model = dynamic_cast<const LmtModel*>(grade.FindAdjustmentByType(type_ids::Lmt()));
+  if (model == nullptr || model->CubePath().empty()) {
+    return std::nullopt;
+  }
+
+  CubeLut     cube;
+  std::string error;
+  if (!ParseCubeFile(model->CubePath(), cube, &error) || !cube.Has3D()) {
+    throw std::runtime_error("Primary grade: failed to load LMT cube '" + model->CubePath() +
+                             "': " + error);
+  }
+  PackedGradeLut packed;
+  packed.rgba = PackCubeLutRgba(cube);
+  packed.edge = static_cast<std::uint32_t>(cube.edge3d_);
+  return packed;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
@@ -15,18 +15,17 @@
 #include <alcedo/metal/Metal.hpp>
 
 #include "edit/operators/models/builtin_type_ids.hpp"
-#include "edit/operators/models/lmt_model.hpp"
 #include "edit/operators/models/pending_parameter_patch.hpp"
 #include "edit/pipeline/local_tone_mapping.hpp"
 #include "edit/runtime/adjustment_runtime.hpp"
 #include "edit/runtime/content_key.hpp"
+#include "edit/runtime/grade_lut.hpp"
 #include "edit/runtime/metal/metal_local_tone_pass.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/parameter_binding.hpp"
 #include "edit/runtime/result_content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "metal/compute_pipeline_cache.hpp"
-#include "utils/lut/cube_lut.hpp"
 
 namespace alcedo {
 namespace {
@@ -140,37 +139,16 @@ void DispatchMix(MetalRenderDevice& device, const MetalBackend::Texture2D& sourc
   device.Workspace().Device().NoteComputeDispatch();
 }
 
-auto PackLutRgba(const CubeLut& lut) -> std::vector<std::byte> {
-  const auto             edge   = static_cast<std::size_t>(lut.edge3d_);
-  const auto             voxels = edge * edge * edge;
-  std::vector<std::byte> packed(voxels * 4 * sizeof(float));
-  auto*                  out = reinterpret_cast<float*>(packed.data());
-  for (std::size_t i = 0; i < voxels; ++i) {
-    out[i * 4 + 0] = lut.lut3d_[i * 3 + 0];
-    out[i * 4 + 1] = lut.lut3d_[i * 3 + 1];
-    out[i * 4 + 2] = lut.lut3d_[i * 3 + 2];
-    out[i * 4 + 3] = 1.0f;
-  }
-  return packed;
-}
-
 auto LoadLut(MetalRenderDevice& device, ColorGradeNodeModel& grade) -> MetalLutBinding {
-  auto* model = dynamic_cast<LmtModel*>(grade.FindAdjustmentByType(type_ids::Lmt()));
-  if (model == nullptr || model->CubePath().empty()) {
+  const auto packed = TryPackGradeLut(grade);
+  if (!packed.has_value()) {
     return device.Workspace().Device().DummyLut();
   }
-  CubeLut     cube;
-  std::string error;
-  if (!ParseCubeFile(model->CubePath(), cube, &error) || !cube.Has3D()) {
-    throw std::runtime_error("ExecuteMetalPrimaryGrade: failed to load LMT cube '" +
-                             model->CubePath() + "': " + error);
-  }
-  const auto  packed = PackLutRgba(cube);
   ContentHash hash;
-  hash.MixBytes(packed);
-  hash.MixU32(static_cast<std::uint32_t>(cube.edge3d_));
-  return device.Workspace().Device().AcquireLut(
-      hash.Key(), packed, static_cast<std::uint32_t>(cube.edge3d_), device.CommandContext());
+  hash.MixBytes(packed->rgba);
+  hash.MixU32(packed->edge);
+  return device.Workspace().Device().AcquireLut(hash.Key(), packed->rgba, packed->edge,
+                                                device.CommandContext());
 }
 
 auto CompactOps(std::vector<GradeOp> ops, bool local_tone_active) -> std::vector<GradeOp> {

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_primary_grade_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_primary_grade_pass.cpp
@@ -17,12 +17,12 @@
 
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
-#include "edit/operators/models/lmt_model.hpp"
 #include "edit/operators/models/operator_param_dto.hpp"
 #include "edit/operators/models/pending_parameter_patch.hpp"
 #include "edit/pipeline/local_tone_mapping.hpp"
 #include "edit/runtime/adjustment_runtime.hpp"
 #include "edit/runtime/content_key.hpp"
+#include "edit/runtime/grade_lut.hpp"
 #include "edit/runtime/opencl/opencl_dag_programs.hpp"
 #include "edit/runtime/opencl/opencl_local_tone_pass.hpp"
 #include "edit/runtime/parameter_arena.hpp"
@@ -32,7 +32,6 @@
 #include "opencl/opencl_api_counters.hpp"
 #include "opencl/opencl_check.hpp"
 #include "opencl/opencl_kernel_cache.hpp"
-#include "utils/lut/cube_lut.hpp"
 
 namespace alcedo {
 namespace {
@@ -212,38 +211,16 @@ void DispatchMix(OpenClRenderDevice& device, const OpenClBackend::Texture2D& sou
   DispatchKernel(device, kernel, width, height);
 }
 
-auto PackLutRgba(const CubeLut& lut) -> std::vector<std::byte> {
-  const auto             edge   = static_cast<std::size_t>(lut.edge3d_);
-  const auto             voxels = edge * edge * edge;
-  std::vector<std::byte> packed(voxels * 4 * sizeof(float));
-  auto*                  out = reinterpret_cast<float*>(packed.data());
-  for (std::size_t i = 0; i < voxels; ++i) {
-    out[i * 4 + 0] = lut.lut3d_[i * 3 + 0];
-    out[i * 4 + 1] = lut.lut3d_[i * 3 + 1];
-    out[i * 4 + 2] = lut.lut3d_[i * 3 + 2];
-    out[i * 4 + 3] = 1.0f;
-  }
-  return packed;
-}
-
 auto LoadLut(OpenClRenderDevice& device, ColorGradeNodeModel& grade) -> OpenClLutBinding {
-  auto* model = dynamic_cast<LmtModel*>(grade.FindAdjustmentByType(type_ids::Lmt()));
-  if (model == nullptr || model->CubePath().empty()) {
+  const auto packed = TryPackGradeLut(grade);
+  if (!packed.has_value()) {
     return device.Workspace().Device().DummyLut();
   }
-
-  CubeLut     cube;
-  std::string error;
-  if (!ParseCubeFile(model->CubePath(), cube, &error) || !cube.Has3D()) {
-    throw std::runtime_error("ExecuteOpenClPrimaryGrade: failed to load LMT cube '" +
-                             model->CubePath() + "': " + error);
-  }
-  const auto  packed = PackLutRgba(cube);
   ContentHash hash;
-  hash.MixBytes(packed);
-  hash.MixU32(static_cast<std::uint32_t>(cube.edge3d_));
-  return device.Workspace().Device().AcquireLut(
-      hash.Key(), packed, static_cast<std::uint32_t>(cube.edge3d_), device.CommandContext());
+  hash.MixBytes(packed->rgba);
+  hash.MixU32(packed->edge);
+  return device.Workspace().Device().AcquireLut(hash.Key(), packed->rgba, packed->edge,
+                                                device.CommandContext());
 }
 
 auto CompactOps(std::vector<GradeOp> ops, bool local_tone_active) -> std::vector<GradeOp> {

--- a/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
@@ -65,6 +65,11 @@ class PipelineDocument {
 [[nodiscard]] auto CreateDefaultPipelineDocument() -> PipelineDocument;
 
 /**
+ * @brief Deep copy via JSON round-trip. The clone does not share Model pointers.
+ */
+[[nodiscard]] auto ClonePipelineDocument(const PipelineDocument& src) -> PipelineDocument;
+
+/**
  * @brief True when Apply may remirror the legacy stage adapter into this document.
  *
  * Requires the canonical Develop, Primary Color Grade, and DRT nodes. Extra nodes such as

--- a/alcedo_studio/src/include/edit/input/prepared_raw_input.hpp
+++ b/alcedo_studio/src/include/edit/input/prepared_raw_input.hpp
@@ -18,8 +18,8 @@
 
 namespace alcedo {
 
-/// Bumped when LibRaw unpack, CFA downsample, or active-area mapping rules change.
-inline constexpr std::uint32_t kRawInputPreparationVersion = 2;
+/// Bumped when LibRaw unpack, CFA/RGB downsample, or active-area mapping rules change.
+inline constexpr std::uint32_t kRawInputPreparationVersion = 3;
 
 /**
  * @brief FNV-1a 64-bit hash of opaque bytes. Used for encoded-source identity, not pixels.

--- a/alcedo_studio/src/include/edit/input/raw_input_loader.hpp
+++ b/alcedo_studio/src/include/edit/input/raw_input_loader.hpp
@@ -21,7 +21,8 @@ namespace alcedo {
 class RawInputLoader {
  public:
   /**
-   * @brief Open encoded bytes, unpack, downsample, then recycle LibRaw.
+   * @brief Open encoded bytes, unpack CFA or already-demosaiced RGB, downsample, then recycle
+   *        LibRaw.
    * @throws std::runtime_error on LibRaw failure or unsupported CFA.
    */
   [[nodiscard]] static auto LoadEncoded(std::span<const std::byte> encoded, DecodeRes decode_res)

--- a/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
@@ -25,6 +25,7 @@
 #endif
 
 namespace alcedo {
+class PipelineDocument;
 #if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
 template <class Backend>
 class Renderer;
@@ -130,6 +131,9 @@ class CPUPipelineExecutor : public PipelineExecutor {
   /** @brief Select the format-version-2 document used by the GPU DAG product path. */
   void SetPipelineDocument(std::shared_ptr<PipelineDocument> document,
                            bool                              mirror_legacy_stage_adapter = false);
+  [[nodiscard]] auto HasGpuDagDocument() const -> bool;
+  [[nodiscard]] auto GpuDagDocument() const -> std::shared_ptr<PipelineDocument>;
+  [[nodiscard]] auto MirrorsLegacyStageAdapter() const -> bool;
 
   void SetPreviewMode(bool is_preview);
 

--- a/alcedo_studio/src/include/edit/runtime/content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/content_key.hpp
@@ -20,8 +20,8 @@ inline constexpr std::uint32_t kSensorDevelopImplementationVersion = 2;
 inline constexpr std::uint32_t kGeometryImplementationVersion      = 1;
 /// Bumped when CameraColorPass math changes. Version 3 encodes its AP1 result as ACEScc.
 inline constexpr std::uint32_t kCameraColorImplementationVersion   = 3;
-/// Bumped when Primary Grade pixel rules change. Version 3 samples canonical LLF on ROI.
-inline constexpr std::uint32_t kPrimaryGradeImplementationVersion  = 3;
+/// Bumped when Primary Grade pixel rules change. Version 4 samples the LMT cube in fused pointwise.
+inline constexpr std::uint32_t kPrimaryGradeImplementationVersion  = 4;
 /// Bumped when the canonical LLF reference identity or sampling rules change.
 inline constexpr std::uint32_t kLlfReferenceImplementationVersion  = 1;
 /// Bumped when DRT pixel rules change. Version 3 decodes AP1/ACEScc before the DRT.

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_backend.hpp
@@ -13,10 +13,17 @@
 
 #include "edit/geometry/types.hpp"
 #include "edit/runtime/byte_range.hpp"
+#include "edit/runtime/content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
+
+struct CudaLutBinding {
+  const void*   device_pointer = nullptr;
+  std::uint64_t resource_id    = 0;
+  std::uint32_t edge_size      = 0;
+};
 
 /**
  * @brief CUDA stream plus a recorded completion event for one in-flight submission.
@@ -167,6 +174,12 @@ class CudaBackend {
    */
   void SynchronizeRecordedWork(CommandContext& command_context);
 
+  [[nodiscard]] auto AcquireLut(ContentKey key, std::span<const std::byte> packed_rgba,
+                                std::uint32_t edge, CommandContext& command_context)
+      -> CudaLutBinding;
+  [[nodiscard]] auto DummyLut() -> CudaLutBinding;
+  void               SetLutByteBudget(std::size_t bytes);
+
   [[nodiscard]] auto HasInFlightSubmission() const -> bool { return in_flight_submission_ != 0; }
   [[nodiscard]] auto CompletedSubmission() const -> std::uint64_t { return completed_submission_; }
   [[nodiscard]] auto IsResourceBusy(std::uint64_t submitted_on) const -> bool {
@@ -190,6 +203,8 @@ class CudaBackend {
   [[nodiscard]] auto LastTextureRectangles() const -> const std::vector<RectI>& {
     return last_texture_rectangles_;
   }
+  [[nodiscard]] auto LutUploadBytes() const -> std::uint64_t { return lut_upload_bytes_; }
+  [[nodiscard]] auto LastLutResourceId() const -> std::uint64_t { return last_lut_resource_id_; }
 
   [[nodiscard]] auto QueryDeviceMemory() const -> GpuDeviceMemorySnapshot;
 
@@ -210,6 +225,21 @@ class CudaBackend {
   bool                   fail_next_upload_     = false;
   std::vector<ByteRange> last_h2d_ranges_;
   std::vector<RectI>     last_texture_rectangles_;
+  std::uint64_t          lut_upload_bytes_     = 0;
+  std::uint64_t          last_lut_resource_id_ = 0;
+  std::size_t            lut_byte_budget_      = 64ull << 20;
+  std::size_t            lut_cache_bytes_      = 0;
+  std::uint64_t          lut_lru_clock_        = 0;
+  struct LutCacheEntry {
+    ContentKey    key;
+    Buffer        buffer;
+    std::uint32_t edge_size            = 0;
+    std::size_t   bytes                = 0;
+    std::uint64_t lru_tick             = 0;
+    std::uint64_t last_used_submission = 0;
+  };
+  std::vector<LutCacheEntry> lut_cache_;
+  Buffer                     dummy_lut_;
 };
 
 /**

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_primary_grade_pass.hpp
@@ -15,6 +15,7 @@ namespace alcedo {
 
 struct CudaPrimaryGradeResult {
   GraphValueId  output{NodeId{"grade.primary"}, PortId{"image"}};
+  std::uint64_t lut_resource_id                        = 0;
   std::uint64_t local_tone_reference_resource_id       = 0;
   bool          local_tone_rebuilt_reference           = false;
   bool          local_tone_sampled_canonical_reference = false;

--- a/alcedo_studio/src/include/edit/runtime/grade_lut.hpp
+++ b/alcedo_studio/src/include/edit/runtime/grade_lut.hpp
@@ -1,0 +1,36 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "utils/lut/cube_lut.hpp"
+
+namespace alcedo {
+
+class ColorGradeNodeModel;
+
+struct PackedGradeLut {
+  std::vector<std::byte> rgba;
+  std::uint32_t          edge = 0;
+};
+
+/**
+ * @brief Pack a parsed 3D cube as tightly packed RGBA32F voxels, X varying fastest.
+ */
+[[nodiscard]] auto PackCubeLutRgba(const CubeLut& lut) -> std::vector<std::byte>;
+
+/**
+ * @brief Load the ColorGrade LMT cube when a path is set.
+ * @return nullopt when the node has no LMT model or the path is empty.
+ * @throws std::runtime_error when a path is set but the cube cannot be parsed as 3D.
+ */
+[[nodiscard]] auto TryPackGradeLut(const ColorGradeNodeModel& grade)
+    -> std::optional<PackedGradeLut>;
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/pipeline_service_test.cpp
+++ b/alcedo_studio/tests/app/pipeline_service_test.cpp
@@ -22,6 +22,8 @@
 #include "edit/operators/op_base.hpp"
 #include "edit/operators/operator_registeration.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
+#include "edit/pipeline/pipeline_cpu.hpp"
+#include "edit/operators/models/lmt_model.hpp"
 #include "sleeve/storage.hpp"
 #include "storage/store/edit_history/commit_graph_store.hpp"
 #include "utils/clock/time_provider.hpp"
@@ -622,6 +624,9 @@ TEST_F(PipelineMapperTests, LoadPipelineSnapshotClonesParamsAndDoesNotTouchLiveG
     EXPECT_NE(&snap->executor_->GetRenderLock(), &g1->pipeline_->GetRenderLock());
     EXPECT_EQ(snap->pipeline_params_, params_v1);                   // captured current params
     EXPECT_EQ(snap->executor_->ExportPipelineParams(), params_v1);  // snapshot holds them
+    EXPECT_TRUE(g1->pipeline_->HasGpuDagDocument());
+    EXPECT_TRUE(snap->executor_->HasGpuDagDocument());
+    EXPECT_NE(snap->executor_->GpuDagDocument(), g1->pipeline_->GpuDagDocument());
 
     // Acceptance: the live guard is untouched by the capture.
     EXPECT_EQ(g1->dirty_, true);                                  // dirty NOT cleared
@@ -677,6 +682,33 @@ TEST_F(PipelineMapperTests, LoadPipelineSnapshotFallbackRepairsAndReleasesPin) {
   ps.SavePipeline(g);
 
   EXPECT_NO_THROW(ps.ReleasePipelineSnapshot(snap));
+}
+
+TEST_F(PipelineMapperTests, LoadPipelineSnapshotClonesGpuDagDocumentIndependently) {
+  ProjectService      project(db_path_, meta_path_);
+  PipelineMgmtService ps(project.GetStorage());
+  auto                live = ps.LoadPipeline(1);
+  ASSERT_NE(live, nullptr);
+  ASSERT_NE(live->pipeline_, nullptr);
+  ASSERT_TRUE(live->pipeline_->HasGpuDagDocument());
+  auto* live_lmt = dynamic_cast<LmtModel*>(
+      live->pipeline_->GpuDagDocument()->PrimaryGrade()->FindAdjustmentByType(type_ids::Lmt()));
+  ASSERT_NE(live_lmt, nullptr);
+  live_lmt->SetCubePath("C:/looks/live.cube");
+
+  std::string err;
+  auto        snap = ps.LoadPipelineSnapshot(1, 0, &err);
+  ASSERT_NE(snap, nullptr) << err;
+  ASSERT_NE(snap->executor_, nullptr);
+  ASSERT_TRUE(snap->executor_->HasGpuDagDocument());
+  auto* snap_lmt = dynamic_cast<LmtModel*>(
+      snap->executor_->GpuDagDocument()->PrimaryGrade()->FindAdjustmentByType(type_ids::Lmt()));
+  ASSERT_NE(snap_lmt, nullptr);
+  EXPECT_EQ(snap_lmt->CubePath(), "C:/looks/live.cube");
+  live_lmt->SetCubePath("C:/looks/changed.cube");
+  EXPECT_EQ(snap_lmt->CubePath(), "C:/looks/live.cube");
+  ps.ReleasePipelineSnapshot(snap);
+  ps.SavePipeline(live);
 }
 
 TEST_F(PipelineMapperTests, EditorLoadUsesMatchingSerializedStateWithoutReconstruction) {

--- a/alcedo_studio/tests/app/thumbnail_service_test.cpp
+++ b/alcedo_studio/tests/app/thumbnail_service_test.cpp
@@ -17,6 +17,7 @@
 #include <future>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <opencv2/highgui.hpp>
 #include <opencv2/opencv.hpp>
 #include <random>
@@ -32,6 +33,7 @@
 #include "edit/history/edit_commit.hpp"
 #include "edit/operators/operator_registeration.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
+#include "edit/pipeline/pipeline_cpu.hpp"
 #include "io/image/image_loader.hpp"
 #include "renderer/pipeline_scheduler.hpp"
 #include "storage/store/edit_history/commit_graph_store.hpp"
@@ -1134,6 +1136,36 @@ TEST_F(ThumbnailServiceTests, OrdinaryThumbnailRendersWithoutUsingLiveEditorExec
   ASSERT_NE(live_guard->pipeline_, nullptr);
   live_guard->dirty_ = true;
   ASSERT_EQ(live_guard->pin_count_, size_t{1});
+  EXPECT_TRUE(live_guard->pipeline_->HasGpuDagDocument());
+
+  std::string snap_err;
+  auto        snap = pipeline_service->LoadPipelineSnapshot(element_id, image_id, &snap_err);
+  ASSERT_NE(snap, nullptr) << snap_err;
+  ASSERT_NE(snap->executor_, nullptr);
+  EXPECT_TRUE(snap->executor_->HasGpuDagDocument());
+
+  auto img = img_pool->Read<std::shared_ptr<Image>>(
+      image_id, [](const std::shared_ptr<Image>& image) { return image; });
+  ASSERT_NE(img, nullptr);
+  ASSERT_TRUE(img->HasRawColorContext());
+  snap->executor_->InjectRawMetadata(img->GetRawColorContext());
+  snap->executor_->SetForceCPUOutput(true);
+  snap->executor_->SetEnableCache(false);
+  snap->executor_->SetDecodeRes(DecodeRes::EIGHTH);
+  snap->executor_->SetRenderRes(false, 256);
+  auto encoded = ByteBufferLoader::LoadByteBufferFromImage(img);
+  auto input   = std::make_shared<ImageBuffer>(std::move(encoded));
+  std::shared_ptr<ImageBuffer> dag_output;
+  try {
+    std::unique_lock<std::mutex> render_lock(snap->executor_->GetRenderLock());
+    dag_output = snap->executor_->Apply(input);
+  } catch (const std::exception& e) {
+    FAIL() << e.what();
+  }
+  ASSERT_NE(dag_output, nullptr);
+  EXPECT_TRUE(dag_output->cpu_data_valid_);
+
+  pipeline_service->ReleasePipelineSnapshot(snap);
 
   auto thumbnail = GetThumbnailBlocking(thumbnail_service, element_id, image_id, true,
                                         ThumbnailResolution::k256);

--- a/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
+++ b/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
@@ -11,6 +11,7 @@
 #include "edit/graph/raster_mask_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/models/cat02_white_balance_model.hpp"
+#include "edit/operators/models/lmt_model.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 #include "test_camera_profile.hpp"
 
@@ -49,6 +50,8 @@ auto MakeLegacyStageJson() -> nlohmann::json {
       {"type", 2}, {"enable", true}, {"params", {{"exposure", 1.5}}}};
   json["Color Adjustment"]["Color Adjustment"]["saturation"] = {
       {"type", 10}, {"enable", true}, {"params", {{"saturation", 30.0}}}};
+  json["Color Adjustment"]["Color Adjustment"]["ocio_lmt"] = {
+      {"type", 16}, {"enable", true}, {"params", {{"ocio_lmt", "C:/looks/teal.cube"}}}};
   json["Color Adjustment"]["Color Adjustment"]["tint"] = {
       {"type", 11}, {"enable", true}, {"params", {{"tint", 12.0}}}};
   json["Output Transform"]["Output Transform"]["odt"] = {
@@ -102,6 +105,11 @@ TEST(GpuDagModelGraph, LegacyStageJsonMapsRawGradeGeometryAndDrtToNewDocument) {
       document.PrimaryGrade()->FindAdjustmentByType(type_ids::Saturation()));
   ASSERT_NE(saturation, nullptr);
   EXPECT_FLOAT_EQ(saturation->Value(), 1.3f);
+
+  const auto* lmt = dynamic_cast<const LmtModel*>(
+      document.PrimaryGrade()->FindAdjustmentByType(type_ids::Lmt()));
+  ASSERT_NE(lmt, nullptr);
+  EXPECT_EQ(lmt->CubePath(), "C:/looks/teal.cube");
 
   EXPECT_EQ(document.Drt()->Params().Params().method, DrtMethod::Aces20);
   EXPECT_FLOAT_EQ(document.Drt()->Params().Params().peak_luminance, 200.0f);

--- a/alcedo_studio/tests/edit/input/raw_input_loader_test.cpp
+++ b/alcedo_studio/tests/edit/input/raw_input_loader_test.cpp
@@ -182,6 +182,26 @@ TEST(GpuDagRawInput, EncodedDngCarriesOpcodeList3WarpIntoPreparedInput) {
   EXPECT_NE(prepared.source_key.dng_warp_hash, 0U);
 }
 
+#if defined(TEST_IMG_PATH)
+TEST(GpuDagRawInput, LoadEncodedUnpacksLinearDngAsDirectRgbAndHonorsDecodeRes) {
+  const auto path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
+  const auto encoded = ReadBytes(path);
+  if (encoded.empty()) {
+    GTEST_SKIP() << "Sample linear DNG is missing: " << path.string();
+  }
+
+  const auto full    = RawInputLoader::LoadEncoded(encoded, DecodeRes::FULL);
+  const auto eighth  = RawInputLoader::LoadEncoded(encoded, DecodeRes::EIGHTH);
+  EXPECT_EQ(full.input_kind, RawInputKind::DebayeredRgb);
+  EXPECT_EQ(full.pixels.format, HostPixelFormat::F32Rgba);
+  EXPECT_EQ(full.CompileSource().kind, DevelopInputKind::DirectRgb);
+  EXPECT_EQ(eighth.downsample_passes, 3);
+  EXPECT_EQ(eighth.full_reference_extent, full.full_reference_extent);
+  EXPECT_LT(eighth.host_extent.width, full.host_extent.width);
+  EXPECT_FALSE(eighth.host_extent.Empty());
+}
+#endif
+
 #if defined(__APPLE__)
 TEST(GpuDagRawInput, EncodedRawLoadCompletesOnProductWorkerStack) {
   const auto root = std::filesystem::path{ALCEDO_CI_RAW_FIXTURE_ROOT};

--- a/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_primary_grade_test.cpp
@@ -9,6 +9,8 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -21,6 +23,7 @@
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/input/raw_input_loader.hpp"
 #include "edit/operators/models/cat02_white_balance_model.hpp"
+#include "edit/operators/models/lmt_model.hpp"
 #include "edit/operators/models/scalar_operator_model.hpp"
 #include "edit/operators/models/sharpen_model.hpp"
 #include "edit/runtime/cuda/cuda_develop_pass.hpp"
@@ -111,6 +114,23 @@ auto RenderLocalToneCenter(float surroundings, float center, float shadows_value
                            pixels.size() * sizeof(Rgba)),
       device.CommandContext());
   return pixels[static_cast<std::size_t>(height / 2) * width + width / 2].r;
+}
+
+void WriteConstantRgbCube(const std::filesystem::path& path, float r, float g, float b) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << "LUT_3D_SIZE 2\n";
+  for (int i = 0; i < 8; ++i) {
+    out << r << ' ' << g << ' ' << b << '\n';
+  }
+}
+
+void WriteIdentityCube(const std::filesystem::path& path) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << "LUT_3D_SIZE 2\n"
+      << "0 0 0\n1 0 0\n0 1 0\n1 1 0\n"
+      << "0 0 1\n1 0 1\n0 1 1\n1 1 1\n";
 }
 
 class CudaPrimaryGradeFixture : public ::testing::Test {
@@ -604,6 +624,40 @@ TEST(GpuDagCudaPrimaryGrade, RoiFrameSamplesCanonicalLlfReferenceInsteadOfRebuil
   ASSERT_FALSE(isolated_pixels.empty());
   const float rebuilt = isolated_pixels[static_cast<std::size_t>(roi_y) * roi_w + roi_x].r;
   EXPECT_GT(std::abs(rebuilt - sampled), 1.0e-4f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaLutRemapChangesGradePixels) {
+  const auto cube_path = std::filesystem::absolute("build/tmp/gpu_dag_cuda_lut/red.cube");
+  WriteConstantRgbCube(cube_path, 1.0f, 0.0f, 0.0f);
+  auto& lmt = ModelByType<LmtModel>(type_ids::Lmt());
+  lmt.SetCubePath(cube_path.string());
+  const auto result = Render();
+  const auto input  = Download(plan_.develop_output);
+  const auto output = Download(result.output);
+  ASSERT_FALSE(output.empty());
+  ASSERT_EQ(input.size(), output.size());
+  EXPECT_NE(result.lut_resource_id, 0U);
+  EXPECT_NEAR(output.front().r, 1.0f, 1.0e-4f);
+  EXPECT_NEAR(output.front().g, 0.0f, 1.0e-4f);
+  EXPECT_NEAR(output.front().b, 0.0f, 1.0e-4f);
+  EXPECT_GT(std::abs(output.front().r - input.front().r) + std::abs(output.front().g - input.front().g) +
+                std::abs(output.front().b - input.front().b),
+            1.0e-3f);
+}
+
+TEST_F(CudaPrimaryGradeFixture, CudaLutResourceIsReusedByContentKey) {
+  const auto cube_path = std::filesystem::absolute("build/tmp/gpu_dag_cuda_lut/identity.cube");
+  WriteIdentityCube(cube_path);
+  auto& lmt = ModelByType<LmtModel>(type_ids::Lmt());
+  lmt.SetCubePath(cube_path.string());
+  const auto first = Render();
+  EXPECT_NE(first.lut_resource_id, 0U);
+  ModelByType<ExposureModel>(type_ids::Exposure()).SetValue(0.25f);
+  device_.Workspace().Device().ResetCounters();
+  const auto second = Render();
+  EXPECT_EQ(second.lut_resource_id, first.lut_resource_id);
+  EXPECT_EQ(device_.Workspace().Device().LutUploadBytes(), 0U);
+  EXPECT_EQ(device_.Workspace().Device().LastLutResourceId(), first.lut_resource_id);
 }
 
 TEST(GpuDagCudaPrimaryGrade, ExecuteCudaCameraColorRejectsMissingCameraMatrices) {

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -89,6 +89,7 @@ TEST(GpuDagGraphCompiler, DefaultPipelineCompilesShadowsAndHighlightsToLocalLapl
   bool       saw_shadows    = false;
   bool       saw_highlights = false;
   bool       saw_curve      = false;
+  bool       saw_lmt        = false;
   for (const auto& adjustment : plan.primary_grade_adjustments) {
     if (adjustment.type == type_ids::Shadows()) {
       saw_shadows = true;
@@ -99,6 +100,9 @@ TEST(GpuDagGraphCompiler, DefaultPipelineCompilesShadowsAndHighlightsToLocalLapl
     } else if (adjustment.type == type_ids::Curve()) {
       saw_curve = true;
       EXPECT_EQ(adjustment.algorithm, CompiledAdjustmentAlgorithm::Pointwise);
+    } else if (adjustment.type == type_ids::Lmt()) {
+      saw_lmt = true;
+      EXPECT_EQ(adjustment.algorithm, CompiledAdjustmentAlgorithm::Pointwise);
     } else if (adjustment.type == type_ids::Clarity() || adjustment.type == type_ids::Sharpen() ||
                adjustment.type == type_ids::Halation() ||
                adjustment.type == type_ids::FilmGrain()) {
@@ -108,6 +112,7 @@ TEST(GpuDagGraphCompiler, DefaultPipelineCompilesShadowsAndHighlightsToLocalLapl
   EXPECT_TRUE(saw_shadows);
   EXPECT_TRUE(saw_highlights);
   EXPECT_TRUE(saw_curve);
+  EXPECT_TRUE(saw_lmt);
   ASSERT_GE(plan.primary_grade_stages.size(), 5U);
   EXPECT_EQ(plan.primary_grade_stages.front().kind, CompiledGradeStageKind::Pointwise);
   bool saw_llf_stage = false;

--- a/alcedo_studio/tests/edit/runtime/opencl_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_grade_test.cpp
@@ -512,6 +512,15 @@ void WriteIdentityCube(const std::filesystem::path& path) {
       << "0 0 1\n1 0 1\n0 1 1\n1 1 1\n";
 }
 
+void WriteConstantRgbCube(const std::filesystem::path& path, float r, float g, float b) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << "LUT_3D_SIZE 2\n";
+  for (int i = 0; i < 8; ++i) {
+    out << r << ' ' << g << ' ' << b << '\n';
+  }
+}
+
 auto DownloadR32f(OpenClRenderDevice& device, const GraphValueId& id) -> std::vector<float> {
   auto* lease = device.Workspace().Images().Find(id);
   EXPECT_NE(lease, nullptr);
@@ -674,6 +683,26 @@ TEST_F(OpenClGradeFixture, OpenClExposureEditRunsOnlyPrimaryGradeAndDrt) {
   EXPECT_EQ(stats.sensor_develop_skip, 1U);
   EXPECT_EQ(stats.geometry_skip, 1U);
   EXPECT_EQ(stats.camera_color_skip, 1U);
+}
+
+TEST_F(OpenClGradeFixture, OpenClLutRemapChangesGradePixels) {
+  const auto cube_path = std::filesystem::absolute("build/tmp/gpu_dag_opencl_lut/red.cube");
+  WriteConstantRgbCube(cube_path, 1.0f, 0.0f, 0.0f);
+  auto* lmt =
+      dynamic_cast<LmtModel*>(document_.PrimaryGrade()->FindAdjustmentByType(type_ids::Lmt()));
+  ASSERT_NE(lmt, nullptr);
+  lmt->SetCubePath(cube_path.string());
+  const auto result = RenderGrade();
+  ASSERT_FALSE(last_output_pixels_.empty());
+  ASSERT_FALSE(last_develop_pixels_.empty());
+  EXPECT_NE(result.lut_resource_id, 0U);
+  EXPECT_NEAR(last_output_pixels_.front().r, 1.0f, 1.0e-4f);
+  EXPECT_NEAR(last_output_pixels_.front().g, 0.0f, 1.0e-4f);
+  EXPECT_NEAR(last_output_pixels_.front().b, 0.0f, 1.0e-4f);
+  EXPECT_GT(std::abs(last_output_pixels_.front().r - last_develop_pixels_.front().r) +
+                std::abs(last_output_pixels_.front().g - last_develop_pixels_.front().g) +
+                std::abs(last_output_pixels_.front().b - last_develop_pixels_.front().b),
+            1.0e-3f);
 }
 
 TEST_F(OpenClGradeFixture, OpenClLutResourceIsReusedByContentKey) {


### PR DESCRIPTION
## Stack

#93 → #94 → #95 → #96 → #97 → #98 → #102 → #101 → #100 → #103 → #104 → #105 → #108 → **this PR**

Base: `fix/neighbor-operator-ping-pong`

## Summary

- Sample the fused LMT cube in CUDA primary grade the same way OpenCL and Metal already do.
- Clone the live GPU DAG document into snapshots, and unpack linear DNG RGB in LoadEncoded so background thumbnail renders use the editor product path.

## Test plan

- [ ] `ctest --test-dir build/debug -R GpuDagCudaPrimaryGradeTest --output-on-failure`
- [ ] `ctest --test-dir build/debug -R GpuDagOpenClGradeTest --output-on-failure`
- [ ] `ctest --test-dir build/debug -R PipelineServiceTest --output-on-failure`
- [ ] `ctest --test-dir build/debug -R ThumbnailServiceTest --output-on-failure`
- [ ] Apply a Look LUT on CUDA DAG and confirm album thumbnails match the editor grade.