### PR TITLE
feat(edit): complete NM pipeline document editing phase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,9 @@ if (TARGET Exiv2::Exiv2 AND NOT TARGET Exiv2)
 elseif(WIN32)
     add_library(Exiv2 SHARED IMPORTED)
     set_target_properties(Exiv2 PROPERTIES
+        # Exiv2 exposes STL containers: Debug consumers need the matching MSVC iterator ABI.
+        IMPORTED_LOCATION_DEBUG "${CMAKE_SOURCE_DIR}/alcedo_studio/third_party/exiv2_x64-windows/debug/bin/exiv2.dll"
+        IMPORTED_IMPLIB_DEBUG "${CMAKE_SOURCE_DIR}/alcedo_studio/third_party/exiv2_x64-windows/debug/lib/exiv2.lib"
         IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/alcedo_studio/third_party/exiv2_x64-windows/bin/exiv2.dll"
         IMPORTED_IMPLIB "${CMAKE_SOURCE_DIR}/alcedo_studio/third_party/exiv2_x64-windows/lib/exiv2.lib"
         INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/alcedo_studio/third_party/exiv2_x64-windows/include"

--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -354,7 +354,7 @@ def_library(EditorSessionEditController
         "${ALCEDO_APP_ROOT}/editor_session_edit_controller.cpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_session_edit_controller.hpp"
     PUBLIC_DEPS xxHash JSON ${ALCEDO_OPENCV_CORE_DEPS}
-    PRIVATE_DEPS EditHistory
+    PRIVATE_DEPS EditHistory EditorAdjustmentPipeline
 )
 
 def_library(EditorMiniGitJournalFold
@@ -384,6 +384,13 @@ def_library(EditorAdjustmentPipeline
         "${ALCEDO_APP_ROOT}/editor_adjustment_pipeline.cpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_adjustment_pipeline.hpp"
     PUBLIC_DEPS EditPipeline EditHistory JSON
+)
+
+def_library(EditorPipelineCommandService
+    SOURCES
+        "${ALCEDO_APP_ROOT}/editor_pipeline_command_service.cpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_pipeline_command_service.hpp"
+    PUBLIC_DEPS EditGraph JSON
 )
 
 def_library(EditorSessionService

--- a/alcedo_studio/src/app/editor_pipeline_command_service.cpp
+++ b/alcedo_studio/src/app/editor_pipeline_command_service.cpp
@@ -1,0 +1,215 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_pipeline_command_service.hpp"
+
+#include <exception>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/develop_node_model.hpp"
+#include "edit/graph/drt_node_model.hpp"
+#include "edit/graph/graph_validation.hpp"
+
+namespace alcedo {
+namespace {
+
+void MergeJsonPatch(nlohmann::json& target, const nlohmann::json& patch) {
+  if (!target.is_object() || !patch.is_object()) {
+    target = patch;
+    return;
+  }
+  for (const auto& [key, value] : patch.items()) {
+    if (target.contains(key) && target[key].is_object() && value.is_object()) {
+      MergeJsonPatch(target[key], value);
+    } else {
+      target[key] = value;
+    }
+  }
+}
+
+auto SetError(std::string* error, std::string message) -> bool {
+  if (error != nullptr) {
+    *error = std::move(message);
+  }
+  return false;
+}
+
+auto JoinValidation(const std::vector<GraphValidationError>& errors) -> std::string {
+  std::string text;
+  for (const auto& item : errors) {
+    if (!text.empty()) {
+      text += "; ";
+    }
+    text += item.message;
+  }
+  return text;
+}
+
+auto ColorGradeOf(PipelineDocument& document, const NodeId& id, std::string* error)
+    -> ColorGradeNodeModel* {
+  auto* grade = dynamic_cast<ColorGradeNodeModel*>(document.Graph().FindNode(id));
+  if (grade == nullptr) {
+    SetError(error, "Color Grade node is missing: " + std::string(id.Value()));
+    return nullptr;
+  }
+  return grade;
+}
+
+auto ColorGradeOf(const PipelineDocument& document, const NodeId& id, std::string* error)
+    -> const ColorGradeNodeModel* {
+  const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(document.Graph().FindNode(id));
+  if (grade == nullptr) {
+    SetError(error, "Color Grade node is missing: " + std::string(id.Value()));
+    return nullptr;
+  }
+  return grade;
+}
+
+}  // namespace
+
+auto ApplyEditorParameterPatch(PipelineDocument& candidate, const EditorParameterTarget& target,
+                               const nlohmann::json& params, std::string* error) -> bool {
+  const auto target_error = DescribeEditorParameterTargetError(target, target.field_key);
+  if (!target_error.empty()) {
+    return SetError(error, target_error);
+  }
+  if (!params.is_object() && !params.is_null()) {
+    return SetError(error, "Editor parameter params must be a JSON object");
+  }
+  const nlohmann::json patch = params.is_null() ? nlohmann::json::object() : params;
+
+  try {
+    switch (target.owner_kind) {
+      case EditorParameterOwnerKind::ColorGrade: {
+        auto* grade = ColorGradeOf(candidate, target.node_id, error);
+        if (grade == nullptr) {
+          return false;
+        }
+        auto* model = grade->FindAdjustment(target.adjustment_instance_id);
+        if (model == nullptr) {
+          return SetError(error, "Adjustment instance is missing: " +
+                                      std::string(target.adjustment_instance_id.Value()));
+        }
+        auto merged = model->ToJson();
+        MergeJsonPatch(merged, patch);
+        model->LoadJson(merged);
+        return true;
+      }
+      case EditorParameterOwnerKind::Document: {
+        auto merged = candidate.Geometry().ToJson();
+        MergeJsonPatch(merged, patch);
+        candidate.Geometry() = ImageGeometryModel::FromJson(merged);
+        return true;
+      }
+      case EditorParameterOwnerKind::Develop: {
+        auto* develop = candidate.Develop();
+        if (develop == nullptr || develop->Id() != target.node_id) {
+          return SetError(error, "Develop node is missing: " + std::string(target.node_id.Value()));
+        }
+        auto merged = develop->Params().ToJson();
+        MergeJsonPatch(merged, patch);
+        develop->Params().LoadJson(merged);
+        return true;
+      }
+      case EditorParameterOwnerKind::DrtPost: {
+        auto* drt = candidate.Drt();
+        if (drt == nullptr || drt->Id() != target.node_id) {
+          return SetError(error, "DRT node is missing: " + std::string(target.node_id.Value()));
+        }
+        auto merged = drt->Params().ToJson();
+        MergeJsonPatch(merged, patch);
+        drt->Params().LoadJson(merged);
+        return true;
+      }
+      default:
+        return SetError(error, "Editor parameter target owner_kind is not supported");
+    }
+  } catch (const std::exception& ex) {
+    return SetError(error, ex.what());
+  }
+}
+
+auto ReadEditorParameterJson(const PipelineDocument& document, const EditorParameterTarget& target,
+                             nlohmann::json* json, std::string* error) -> bool {
+  if (json == nullptr) {
+    return SetError(error, "Editor parameter JSON storage is required");
+  }
+  const auto target_error = DescribeEditorParameterTargetError(target, target.field_key);
+  if (!target_error.empty()) {
+    return SetError(error, target_error);
+  }
+  try {
+    switch (target.owner_kind) {
+      case EditorParameterOwnerKind::ColorGrade: {
+        const auto* grade = ColorGradeOf(document, target.node_id, error);
+        if (grade == nullptr) {
+          return false;
+        }
+        const auto* model = grade->FindAdjustment(target.adjustment_instance_id);
+        if (model == nullptr) {
+          return SetError(error, "Adjustment instance is missing: " +
+                                      std::string(target.adjustment_instance_id.Value()));
+        }
+        *json = model->ToJson();
+        return true;
+      }
+      case EditorParameterOwnerKind::Document:
+        *json = document.Geometry().ToJson();
+        return true;
+      case EditorParameterOwnerKind::Develop: {
+        const auto* develop = document.Develop();
+        if (develop == nullptr || develop->Id() != target.node_id) {
+          return SetError(error, "Develop node is missing: " + std::string(target.node_id.Value()));
+        }
+        *json = develop->Params().ToJson();
+        return true;
+      }
+      case EditorParameterOwnerKind::DrtPost: {
+        const auto* drt = document.Drt();
+        if (drt == nullptr || drt->Id() != target.node_id) {
+          return SetError(error, "DRT node is missing: " + std::string(target.node_id.Value()));
+        }
+        *json = drt->Params().ToJson();
+        return true;
+      }
+      default:
+        return SetError(error, "Editor parameter target owner_kind is not supported");
+    }
+  } catch (const std::exception& ex) {
+    return SetError(error, ex.what());
+  }
+}
+
+auto CanonicalPipelineDocumentJson(const PipelineDocument& document) -> std::string {
+  return document.ToJson().dump();
+}
+
+auto PipelineDocumentPassesValidation(const PipelineDocument& document, std::string* error)
+    -> bool {
+  auto errors = document.Graph().Validate();
+  const auto backbone = document.Graph().ValidateImageBackbone();
+  errors.insert(errors.end(), backbone.begin(), backbone.end());
+  if (errors.empty()) {
+    return true;
+  }
+  return SetError(error, JoinValidation(errors));
+}
+
+auto PublishEditorParameterPatch(PipelineDocument& live, const EditorParameterTarget& target,
+                                 const nlohmann::json& params, std::string* error) -> bool {
+  auto candidate = ClonePipelineDocument(live);
+  if (!ApplyEditorParameterPatch(candidate, target, params, error)) {
+    return false;
+  }
+  if (!PipelineDocumentPassesValidation(candidate, error)) {
+    return false;
+  }
+  live = std::move(candidate);
+  return true;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/app/editor_pipeline_command_service.cpp
+++ b/alcedo_studio/src/app/editor_pipeline_command_service.cpp
@@ -4,7 +4,9 @@
 
 #include "app/editor_pipeline_command_service.hpp"
 
+#include <cmath>
 #include <exception>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -17,17 +19,66 @@
 namespace alcedo {
 namespace {
 
-void MergeJsonPatch(nlohmann::json& target, const nlohmann::json& patch) {
-  if (!target.is_object() || !patch.is_object()) {
-    target = patch;
+/// Validate supplied values before any Model setter runs. Arrays replace whole fields;
+/// curve points are variable length, other parameter arrays have fixed dimensions.
+void ValidatePatch(const nlohmann::json& current, const nlohmann::json& patch,
+                   const std::string& path = {}) {
+  if (current.is_number()) {
+    if (!patch.is_number() || !std::isfinite(patch.get<double>()) ||
+        !std::isfinite(patch.get<float>())) {
+      throw std::invalid_argument("Expected finite number: " + path);
+    }
     return;
   }
+  if (current.type() != patch.type()) {
+    throw std::invalid_argument("Invalid parameter type: " + path);
+  }
+  if (current.is_object()) {
+    for (const auto& [key, value] : patch.items()) {
+      if (!current.contains(key)) {
+        throw std::invalid_argument("Unknown parameter: " + path + key);
+      }
+      ValidatePatch(current.at(key), value, path + key + ".");
+    }
+  } else if (current.is_array()) {
+    const bool points = path == "points.";
+    if ((points && patch.size() < 2) || (!points && current.size() != patch.size())) {
+      throw std::invalid_argument("Invalid parameter array length: " + path);
+    }
+    for (std::size_t i = 0; i < patch.size(); ++i) {
+      ValidatePatch(current.at(points ? 0 : i), patch.at(i), path + std::to_string(i) + ".");
+    }
+  }
+}
+
+/// Merge an already validated partial parameter object, without touching a Model.
+void MergeJsonPatch(nlohmann::json& target, const nlohmann::json& patch) {
   for (const auto& [key, value] : patch.items()) {
     if (target.contains(key) && target[key].is_object() && value.is_object()) {
       MergeJsonPatch(target[key], value);
     } else {
       target[key] = value;
     }
+  }
+}
+
+/// Apply to the existing Model; a throwing setter restores only this Model's values.
+/// Restoration failure escapes as a fatal error instead of reporting a usable document.
+void ApplyModelPatch(IOperatorModel& model, const nlohmann::json& patch) {
+  const auto before = model.ToJson();
+  ValidatePatch(before, patch);
+  auto merged = before;
+  MergeJsonPatch(merged, patch);
+  try {
+    model.LoadJson(merged);
+  } catch (...) {
+    const auto failure = std::current_exception();
+    try {
+      model.LoadJson(before);
+    } catch (const std::exception& ex) {
+      throw std::runtime_error(std::string{"Model parameter restoration failed: "} + ex.what());
+    }
+    std::rethrow_exception(failure);
   }
 }
 
@@ -71,7 +122,7 @@ auto ColorGradeOf(const PipelineDocument& document, const NodeId& id, std::strin
 
 }  // namespace
 
-auto ApplyEditorParameterPatch(PipelineDocument& candidate, const EditorParameterTarget& target,
+auto ApplyEditorParameterPatch(PipelineDocument& document, const EditorParameterTarget& target,
                                const nlohmann::json& params, std::string* error) -> bool {
   const auto target_error = DescribeEditorParameterTargetError(target, target.field_key);
   if (!target_error.empty()) {
@@ -85,7 +136,7 @@ auto ApplyEditorParameterPatch(PipelineDocument& candidate, const EditorParamete
   try {
     switch (target.owner_kind) {
       case EditorParameterOwnerKind::ColorGrade: {
-        auto* grade = ColorGradeOf(candidate, target.node_id, error);
+        auto* grade = ColorGradeOf(document, target.node_id, error);
         if (grade == nullptr) {
           return false;
         }
@@ -94,35 +145,30 @@ auto ApplyEditorParameterPatch(PipelineDocument& candidate, const EditorParamete
           return SetError(error, "Adjustment instance is missing: " +
                                       std::string(target.adjustment_instance_id.Value()));
         }
-        auto merged = model->ToJson();
-        MergeJsonPatch(merged, patch);
-        model->LoadJson(merged);
+        ApplyModelPatch(*model, patch);
         return true;
       }
       case EditorParameterOwnerKind::Document: {
-        auto merged = candidate.Geometry().ToJson();
+        auto merged = document.Geometry().ToJson();
+        ValidatePatch(merged, patch);
         MergeJsonPatch(merged, patch);
-        candidate.Geometry() = ImageGeometryModel::FromJson(merged);
+        document.Geometry() = ImageGeometryModel::FromJson(merged);
         return true;
       }
       case EditorParameterOwnerKind::Develop: {
-        auto* develop = candidate.Develop();
+        auto* develop = document.Develop();
         if (develop == nullptr || develop->Id() != target.node_id) {
           return SetError(error, "Develop node is missing: " + std::string(target.node_id.Value()));
         }
-        auto merged = develop->Params().ToJson();
-        MergeJsonPatch(merged, patch);
-        develop->Params().LoadJson(merged);
+        ApplyModelPatch(develop->Params(), patch);
         return true;
       }
       case EditorParameterOwnerKind::DrtPost: {
-        auto* drt = candidate.Drt();
+        auto* drt = document.Drt();
         if (drt == nullptr || drt->Id() != target.node_id) {
           return SetError(error, "DRT node is missing: " + std::string(target.node_id.Value()));
         }
-        auto merged = drt->Params().ToJson();
-        MergeJsonPatch(merged, patch);
-        drt->Params().LoadJson(merged);
+        ApplyModelPatch(drt->Params(), patch);
         return true;
       }
       default:
@@ -201,15 +247,7 @@ auto PipelineDocumentPassesValidation(const PipelineDocument& document, std::str
 
 auto PublishEditorParameterPatch(PipelineDocument& live, const EditorParameterTarget& target,
                                  const nlohmann::json& params, std::string* error) -> bool {
-  auto candidate = ClonePipelineDocument(live);
-  if (!ApplyEditorParameterPatch(candidate, target, params, error)) {
-    return false;
-  }
-  if (!PipelineDocumentPassesValidation(candidate, error)) {
-    return false;
-  }
-  live = std::move(candidate);
-  return true;
+  return ApplyEditorParameterPatch(live, target, params, error);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/app/editor_session_edit_controller.cpp
+++ b/alcedo_studio/src/app/editor_session_edit_controller.cpp
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "app/editor_adjustment_pipeline.hpp"
 #include "edit/history/edit_transaction.hpp"
 
 namespace alcedo {
@@ -24,6 +25,18 @@ auto EditorSessionEditController::HandlePatch(EditorAdjustmentPatch patch, bool 
   if (patch.field_key.empty()) {
     outcome.kind    = EditorEditOutcome::Kind::Rejected;
     outcome.message = "Adjustment patch requires a field key";
+    return outcome;
+  }
+  const auto target_error =
+      DescribeEditorParameterTargetError(patch.target, patch.field_key);
+  if (!target_error.empty()) {
+    outcome.kind    = EditorEditOutcome::Kind::Rejected;
+    outcome.message = target_error;
+    return outcome;
+  }
+  if (!ResolveEditorAdjustmentField(patch.field_key).has_value()) {
+    outcome.kind    = EditorEditOutcome::Kind::Rejected;
+    outcome.message = "Unknown editor adjustment field: " + patch.field_key;
     return outcome;
   }
   if (!deps_.history || !guard.valid) {

--- a/alcedo_studio/src/app/export_service.cpp
+++ b/alcedo_studio/src/app/export_service.cpp
@@ -27,12 +27,6 @@
 namespace alcedo {
 namespace {
 
-auto ResolveExportColorProfileConfig(const OperatorParams& params) -> ExportColorProfileConfig {
-  return ExportColorProfileConfig{params.to_output_params_.encoding_space_,
-                                  params.to_output_params_.eotf_,
-                                  params.to_output_params_.peak_luminance_};
-}
-
 auto HasExportMetadata(const ExifDisplayMetaData& metadata) -> bool {
   return !metadata.make_.empty() || !metadata.model_.empty() || !metadata.lens_.empty() ||
          !metadata.lens_make_.empty() || !metadata.date_time_str_.empty() ||
@@ -103,18 +97,30 @@ void CommitExportFile(const std::filesystem::path& temporary_path,
 
 auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult {
   ExportResult result;
-  ExportRecipe recipe     = task.recipe_.value_or(ExportRecipe::FromLegacyOptions(task.options_));
+  if (!task.recipe_.has_value()) {
+    result.message_      = "ExportService: export recipe is required";
+    result.failed_stage_ = "prepare-recipe";
+    return result;
+  }
+  ExportRecipe recipe = *task.recipe_;
+  try {
+    RequireResolvedExportOutputColor(recipe);
+  } catch (const std::exception& error) {
+    result.message_      = error.what();
+    result.failed_stage_ = "prepare-recipe";
+    return result;
+  }
   auto         final_path = recipe.codec_.export_path_;
   std::filesystem::path temporary_path;
   result.output_path_ = final_path;
   std::error_code                   cleanup_error;
-  std::shared_ptr<PipelineSnapshot> pipeline_snapshot;
-  auto                              release_pipeline_snapshot = [&]() {
-    if (!pipeline_snapshot) {
+  std::shared_ptr<PipelineGuard> pipeline_guard;
+  auto                              release_pipeline_use = [&]() {
+    if (!pipeline_guard) {
       return;
     }
-    pipeline_service_->ReleasePipelineSnapshot(pipeline_snapshot);
-    pipeline_snapshot.reset();
+    pipeline_service_->ReleasePipelineUse(pipeline_guard);
+    pipeline_guard.reset();
   };
 
   std::string stage = "prepare-name";
@@ -139,15 +145,11 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
     std::filesystem::remove(temporary_path, cleanup_error);
 
     stage = "load-pipeline";
-    std::string snapshot_error;
-    pipeline_snapshot =
-        pipeline_service_->LoadPipelineSnapshot(task.sleeve_id_, task.image_id_, &snapshot_error);
-    if (!pipeline_snapshot || !pipeline_snapshot->executor_) {
+    pipeline_guard = pipeline_service_->LoadPipeline(task.sleeve_id_);
+    if (!pipeline_guard || !pipeline_guard->pipeline_ || !pipeline_guard->document_) {
       throw std::runtime_error(
-          snapshot_error.empty()
-              ? "[ERROR] ExportService: Failed to snapshot pipeline for sleeve id " +
-                    std::to_string(task.sleeve_id_)
-              : snapshot_error);
+          "[ERROR] ExportService: Failed to load pipeline document for sleeve id " +
+          std::to_string(task.sleeve_id_));
     }
     stage           = "load-source";
     // Get the image from image pool service
@@ -166,19 +168,14 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
     // To avoid reading too many images into memory at once, we let the pipeline load the image
     // So we create a dummy Image object with only the path set
     render_task.input_desc_           = std::make_shared<Image>(img_src_path, ImageType::DEFAULT);
-    render_task.pipeline_executor_    = pipeline_snapshot->executor_;
+    render_task.pipeline_executor_    = pipeline_guard->pipeline_;
     render_task.options_.is_blocking_ = true;
     render_task.options_.is_callback_ = false;
-
-    // Inject pre-extracted raw metadata from the real Image into the pipeline
-    // so downstream operators resolve eagerly.
-    if (source_img->HasRawColorContext()) {
-      PipelineMgmtService::InjectImageRawMetadata(*pipeline_snapshot->executor_, *source_img);
-    }
 
     // Use full res export, even though the task requires resizing,
     // to benefit from the super sampling
     render_task.options_.render_desc_.render_type_ = RenderType::FULL_RES_EXPORT;
+    render_task.options_.export_output_color_      = recipe.output_color_;
     // Set export options in the pipeline executor
     auto render_promise = std::make_shared<std::promise<std::shared_ptr<ImageBuffer>>>();
     render_task.result_ = render_promise;
@@ -195,17 +192,14 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
     }
 
     stage = "prepare-output";
-    // Save pipeline back to storage
-    const auto export_profile =
-        ResolveExportColorProfileConfig(pipeline_snapshot->executor_->GetGlobalParams());
-    const auto effective_profile = recipe.icc_ == ExportIccPolicy::OMIT
+    const auto  effective_profile = recipe.icc_ == ExportIccPolicy::OMIT
                                        ? std::optional<ExportColorProfileConfig>{}
-                                       : export_profile;
-    const bool wrote_ultra_hdr   = ImageWriter::ShouldWriteUltraHdr(recipe.codec_, export_profile);
-    release_pipeline_snapshot();
+                                       : recipe.output_color_;
+    const bool wrote_ultra_hdr   = ImageWriter::ShouldWriteUltraHdr(recipe.codec_, recipe.output_color_);
+    release_pipeline_use();
     stage                      = "encode";
     recipe.codec_.export_path_ = temporary_path;
-    ImageWriter::WriteImageToPath(img_src_path, rendered_image, recipe, export_profile,
+    ImageWriter::WriteImageToPath(img_src_path, rendered_image, recipe, recipe.output_color_,
                                   export_metadata);
 
     stage = "verify";
@@ -227,14 +221,14 @@ auto ExportService::RunExportRenderTask(const ExportTask& task) -> ExportResult 
     result.resolution_tags_written_ = recipe.resize_.dpi_ > 0.0;
     return result;
   } catch (const std::exception& error) {
-    release_pipeline_snapshot();
+    release_pipeline_use();
     if (!temporary_path.empty()) std::filesystem::remove(temporary_path, cleanup_error);
     result.success_      = false;
     result.failed_stage_ = std::move(stage);
     result.message_      = error.what();
     return result;
   } catch (...) {
-    release_pipeline_snapshot();
+    release_pipeline_use();
     if (!temporary_path.empty()) std::filesystem::remove(temporary_path, cleanup_error);
     result.success_      = false;
     result.failed_stage_ = std::move(stage);

--- a/alcedo_studio/src/app/import_service.cpp
+++ b/alcedo_studio/src/app/import_service.cpp
@@ -45,7 +45,7 @@ void AssembleImportPipelineParams(CPUPipelineExecutor& exec, const Image& image)
   geometry_stage.SetOperator(OperatorType::CROP_ROTATE, crop_params, global_params);
 
   if (image.HasRawColorContext()) {
-    const auto& ctx = image.GetRawColorContext();
+    const auto ctx = MetadataExtractor::ReadRawColorContextForRender(image);
     auto&       loading_stage = exec.GetStage(PipelineStageName::Image_Loading);
 
     nlohmann::json raw_params = pipeline_defaults::MakeDefaultRawDecodeParams();
@@ -90,7 +90,7 @@ void AssembleImportPipelineParams(CPUPipelineExecutor& exec, const Image& image)
     loading_stage.EnableOperator(OperatorType::LENS_CALIBRATION,
                                  lens_inner.value("enabled", true), global_params);
 
-    // Seed global raw fields and inherent context so ColorTemp can resolve as-shot CCT/Tint.
+    // Populate import fields and the bound Develop camera profile before any rendering.
     exec.InjectRawMetadata(ctx);
   }
 
@@ -129,6 +129,12 @@ void PersistAssembledImportPipeline(PipelineMgmtService& pipeline_service,
       image && image->HasRawColorContext() ? &image->GetRawColorContext() : nullptr;
   pipeline_service.InitializeImageRoot(guard, ctx_ptr);
 
+  // Publish the prepared camera/profile data before background tasks can load the document.
+  // Stage serialization above remains only for the existing history initialization boundary.
+  {
+    std::unique_lock<std::mutex> render_lock(guard->pipeline_->GetRenderLock());
+    pipeline_service.SyncPipelineDocument(guard);
+  }
   pipeline_service.SavePipeline(guard);
 }
 

--- a/alcedo_studio/src/app/import_service.cpp
+++ b/alcedo_studio/src/app/import_service.cpp
@@ -121,20 +121,16 @@ void PersistAssembledImportPipeline(PipelineMgmtService& pipeline_service,
   }
 
   guard->dirty_ = true;
-  pipeline_service.SyncPipeline(element_id);
 
   // Graph bootstrap still uses InitializeImageRoot until later plan items delete root.
-  // Inherent operator params are already in the executor and serialized pipeline JSON.
+  // Inherent image parameters are captured by the immutable history root; the product save below
+  // persists only the document graph.
   const RawRuntimeColorContext* ctx_ptr =
       image && image->HasRawColorContext() ? &image->GetRawColorContext() : nullptr;
   pipeline_service.InitializeImageRoot(guard, ctx_ptr);
 
   // Publish the prepared camera/profile data before background tasks can load the document.
-  // Stage serialization above remains only for the existing history initialization boundary.
-  {
-    std::unique_lock<std::mutex> render_lock(guard->pipeline_->GetRenderLock());
-    pipeline_service.SyncPipelineDocument(guard);
-  }
+  pipeline_service.SyncPipelineDocument(guard);
   pipeline_service.SavePipeline(guard);
 }
 

--- a/alcedo_studio/src/app/pipeline_service.cpp
+++ b/alcedo_studio/src/app/pipeline_service.cpp
@@ -5,6 +5,7 @@
 #include "app/pipeline_service.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <exception>
 #include <format>
@@ -41,12 +42,11 @@ auto LoadPipelineDocument(ElementStore& store, sl_element_id_t id,
     -> LoadedPipelineDocument {
   const auto stored = store.GetPipelineJsonByElementId(id);
   if (stored && stored->is_object() && stored->value("format_version", 0) == 2) {
-    // Live CPU stages (history + QML patches) remain the editor source of truth.
-    // Remirror onto the format-2 graph even when the saved JSON omitted the nested
-    // adapter blob (SyncPipelineDocument writes document ToJson only).
+    // A loaded document already owns its imported camera/profile and editable values.
+    // Preparing an executor must not replace those values with stage defaults.
     return FinishLoadedDocument(
         std::make_shared<PipelineDocument>(PipelineDocument::FromJson(*stored)),
-        legacy != nullptr);
+        false);
   }
   if (legacy) {
     auto imported = LegacyPipelineImporter::Import(legacy->ExportPipelineParams());
@@ -372,6 +372,7 @@ void RebuildPipelineFromRoot(CPUPipelineExecutor& exec, const CommitGraph& graph
   }
   exec.SetExecutionStages();
 }
+
 }  // namespace
 
 void PipelineMgmtService::InjectImageRawMetadata(CPUPipelineExecutor& executor, const Image& image) {
@@ -433,28 +434,83 @@ void PipelineMgmtService::HandleEviction(sl_element_id_t evicted_id) {
     // Clear intermediate buffers before removing from cache to ensure timely memory release.
     pipeline_guard->pipeline_->ClearAllIntermediateBuffers();
   }
+  pipeline_guard->live_ready_ = false;
+}
+
+void PipelineMgmtService::CleanupIdlePipelineResources(
+    const std::shared_ptr<PipelineGuard>& pipeline) {
+  if (!pipeline || !pipeline->pipeline_) {
+    return;
+  }
+  std::unique_lock<std::mutex> render_guard(pipeline->pipeline_->GetRenderLock());
+  {
+    std::unique_lock<std::mutex> cache_lock(lock_);
+    if (pipeline->pin_count_ > 0) {
+      return;
+    }
+    pipeline->live_ready_ = false;
+    cache_cv_.notify_all();
+  }
+  try {
+    pipeline->pipeline_->ClearAllIntermediateBuffers();
+    pipeline->pipeline_->ResetExecutionStages();
+  } catch (...) {
+  }
+}
+
+auto PipelineMgmtService::WaitUntilPinCount(const std::shared_ptr<PipelineGuard>& pipeline,
+                                            size_t                                expected,
+                                            std::chrono::milliseconds             timeout) -> bool {
+  if (!pipeline) {
+    return false;
+  }
+  std::unique_lock<std::mutex> cache_lock(lock_);
+  return cache_cv_.wait_for(cache_lock, timeout,
+                            [&] { return pipeline->pin_count_ == expected; });
 }
 
 auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<PipelineGuard> {
   std::shared_ptr<PipelineGuard> cached;
-  bool                           reinitialize = false;
+  bool                           need_reinit = false;
   {
     std::unique_lock<std::mutex> cache_lock(lock_);
     const auto                   it = loaded_pipelines_.find(id);
-    if (it != loaded_pipelines_.end() && it->second && it->second->pipeline_) {
-      cached       = it->second;
-      reinitialize = !cached->pinned_;
+    if (it != loaded_pipelines_.end() && it->second) {
+      cached = it->second;
       cached->pin_count_++;
       cached->pinned_ = true;
       cached->id_     = id;
+      ++pipeline_load_count_;
       pipeline_cache_.AccessElement(id);
+      cache_cv_.notify_all();
+      for (;;) {
+        if (cached->load_error_) {
+          if (cached->pin_count_ > 0) {
+            cached->pin_count_--;
+          }
+          cached->pinned_ = cached->pin_count_ > 0;
+          cache_cv_.notify_all();
+          std::rethrow_exception(cached->load_error_);
+        }
+        if (cached->live_ready_) {
+          return cached;
+        }
+        if (cached->initializing_) {
+          cache_cv_.wait(cache_lock);
+          continue;
+        }
+        if (cached->pipeline_) {
+          cached->initializing_ = true;
+          need_reinit           = true;
+          break;
+        }
+        cache_cv_.wait(cache_lock);
+      }
     }
   }
 
-  if (cached) {
-    // If the pipeline was previously returned to cache (unpinned), it likely had its execution
-    // stages reset (e.g. to detach frame sinks). Re-initialize it outside the cache mutex.
-    if (reinitialize) {
+  if (cached && need_reinit) {
+    try {
       std::unique_lock<std::mutex> render_guard(cached->pipeline_->GetRenderLock());
       cached->pipeline_->SetBoundFile(id);
       cached->pipeline_->SetAcceleratorBackendPreference(accelerator_preference_);
@@ -466,83 +522,132 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
       EnsureDefaultColorTemp(*cached->pipeline_);
       EnsureDefaultLensCalib(*cached->pipeline_);
       ResyncGlobalParamsFromOperators(*cached->pipeline_);
+      storage_->RememberLivePipeline(id, cached->pipeline_);
+      {
+        std::unique_lock<std::mutex> cache_lock(lock_);
+        cached->live_ready_    = true;
+        cached->initializing_  = false;
+        cached->load_error_    = nullptr;
+        cache_cv_.notify_all();
+      }
+      return cached;
+    } catch (...) {
+      {
+        std::unique_lock<std::mutex> cache_lock(lock_);
+        cached->load_error_   = std::current_exception();
+        cached->initializing_ = false;
+        cache_cv_.notify_all();
+      }
+      ReleasePipelineUse(cached);
+      throw;
     }
-    storage_->RememberLivePipeline(id, cached->pipeline_);
-    return cached;
   }
 
-  std::shared_ptr<CPUPipelineExecutor> pipeline;
-  auto                                 pipeline_guard = std::make_shared<PipelineGuard>();
-  try {
-    pipeline = storage_->GetLivePipeline(id);
-    if (!pipeline) {
-      pipeline = storage_->GetElementStore().GetPipelineByElementId(id);
-    }
-  } catch (std::exception& e) {
-    throw std::runtime_error(
-        "[ERROR] PipelineMgmtService: Failed to load pipeline from storage for element ID " +
-        std::to_string(id) + ": " + e.what());
-  }
-  if (pipeline == nullptr) {
-    pipeline = std::make_shared<CPUPipelineExecutor>();
-  }
-
-  // Ensure the loaded pipeline is bound to the requested element id. All executor setup happens
-  // before the guard is published into the cache, and therefore without holding lock_.
-  {
-    std::unique_lock<std::mutex> render_guard(pipeline->GetRenderLock());
-    pipeline->SetBoundFile(id);
-    pipeline->SetAcceleratorBackendPreference(accelerator_preference_);
-    ResetTransientPreviewState(*pipeline);
-    EnsureDefaultOutputTransform(*pipeline);
-    EnsureDefaultRawDecode(*pipeline);
-    EnsureDefaultColorTemp(*pipeline);
-    EnsureDefaultLensCalib(*pipeline);
-    ResyncGlobalParamsFromOperators(*pipeline);
-    pipeline->SetExecutionStages();
-  }
-  storage_->RememberLivePipeline(id, pipeline);
-
-  pipeline_guard->pipeline_ = std::move(pipeline);
-  auto loaded_document =
-      LoadPipelineDocument(storage_->GetElementStore(), id, pipeline_guard->pipeline_);
-  pipeline_guard->document_ = std::move(loaded_document.document);
-  pipeline_guard->pipeline_->SetPipelineDocument(pipeline_guard->document_,
-                                                 loaded_document.mirror_legacy_stage_adapter);
-  {
-    std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
-    RemirrorGpuDagDocument(*pipeline_guard);
-  }
-  pipeline_guard->id_        = id;
-  pipeline_guard->pinned_    = true;
-  pipeline_guard->pin_count_ = 1;
-  pipeline_guard->dirty_     = false;
-
-  std::shared_ptr<PipelineGuard> raced_cached;
-  std::optional<sl_element_id_t> evicted;
+  auto pipeline_guard = std::make_shared<PipelineGuard>();
   {
     std::unique_lock<std::mutex> cache_lock(lock_);
     const auto                   it = loaded_pipelines_.find(id);
-    if (it != loaded_pipelines_.end() && it->second && it->second->pipeline_) {
-      raced_cached = it->second;
-      raced_cached->pin_count_++;
-      raced_cached->pinned_ = true;
+    if (it != loaded_pipelines_.end() && it->second) {
+      cached = it->second;
+      cached->pin_count_++;
+      cached->pinned_ = true;
+      ++pipeline_load_count_;
       pipeline_cache_.AccessElement(id);
-    } else {
-      evicted               = pipeline_cache_.RecordAccess_WithEvict(id, id);
-      loaded_pipelines_[id] = pipeline_guard;
+      cache_cv_.notify_all();
+      while (!cached->live_ready_ && !cached->load_error_) {
+        cache_cv_.wait(cache_lock);
+      }
+      if (cached->load_error_) {
+        if (cached->pin_count_ > 0) {
+          cached->pin_count_--;
+        }
+        cached->pinned_ = cached->pin_count_ > 0;
+        cache_cv_.notify_all();
+        std::rethrow_exception(cached->load_error_);
+      }
+      return cached;
+    }
+    pipeline_guard->id_            = id;
+    pipeline_guard->pinned_        = true;
+    pipeline_guard->pin_count_     = 1;
+    pipeline_guard->live_ready_    = false;
+    pipeline_guard->initializing_  = true;
+    loaded_pipelines_[id]          = pipeline_guard;
+    ++pipeline_construct_count_;
+    ++pipeline_load_count_;
+    cache_cv_.notify_all();
+  }
+
+  try {
+    std::shared_ptr<CPUPipelineExecutor> pipeline;
+    try {
+      pipeline = storage_->GetLivePipeline(id);
+      if (!pipeline) {
+        pipeline = storage_->GetElementStore().GetPipelineByElementId(id);
+      }
+    } catch (std::exception& e) {
+      throw std::runtime_error(
+          "[ERROR] PipelineMgmtService: Failed to load pipeline from storage for element ID " +
+          std::to_string(id) + ": " + e.what());
+    }
+    if (pipeline == nullptr) {
+      pipeline = std::make_shared<CPUPipelineExecutor>();
+    }
+
+    {
+      std::unique_lock<std::mutex> render_guard(pipeline->GetRenderLock());
+      pipeline->SetBoundFile(id);
+      pipeline->SetAcceleratorBackendPreference(accelerator_preference_);
+      ResetTransientPreviewState(*pipeline);
+      EnsureDefaultOutputTransform(*pipeline);
+      EnsureDefaultRawDecode(*pipeline);
+      EnsureDefaultColorTemp(*pipeline);
+      EnsureDefaultLensCalib(*pipeline);
+      ResyncGlobalParamsFromOperators(*pipeline);
+      pipeline->SetExecutionStages();
+    }
+
+    pipeline_guard->pipeline_ = std::move(pipeline);
+    auto loaded_document =
+        LoadPipelineDocument(storage_->GetElementStore(), id, pipeline_guard->pipeline_);
+    pipeline_guard->document_ = std::move(loaded_document.document);
+    pipeline_guard->pipeline_->SetPipelineDocument(pipeline_guard->document_,
+                                                   loaded_document.mirror_legacy_stage_adapter);
+    {
+      std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
+      RemirrorGpuDagDocument(*pipeline_guard);
+    }
+    pipeline_guard->dirty_ = false;
+
+    std::optional<sl_element_id_t> evicted;
+    {
+      std::unique_lock<std::mutex> cache_lock(lock_);
+      pipeline_guard->live_ready_   = true;
+      pipeline_guard->initializing_ = false;
+      evicted                       = pipeline_cache_.RecordAccess_WithEvict(id, id);
       if (!evicted.has_value() && loaded_pipelines_.size() + 1 > default_cache_capacity_) {
         pipeline_cache_.Resize(loaded_pipelines_.size() - 1);
       }
+      cache_cv_.notify_all();
     }
+    if (evicted.has_value()) {
+      HandleEviction(evicted.value());
+    }
+    storage_->RememberLivePipeline(id, pipeline_guard->pipeline_);
+    return pipeline_guard;
+  } catch (...) {
+    {
+      std::unique_lock<std::mutex> cache_lock(lock_);
+      pipeline_guard->load_error_   = std::current_exception();
+      pipeline_guard->initializing_ = false;
+      const auto it                 = loaded_pipelines_.find(id);
+      if (it != loaded_pipelines_.end() && it->second == pipeline_guard) {
+        loaded_pipelines_.erase(it);
+      }
+      cache_cv_.notify_all();
+    }
+    throw;
   }
-  if (evicted.has_value()) {
-    HandleEviction(evicted.value());
-  }
-  if (raced_cached) {
-    return raced_cached;
-  }
-  return pipeline_guard;
 }
 
 void PipelineMgmtService::SyncPipelineDocument(const std::shared_ptr<PipelineGuard>& pipeline) {
@@ -757,6 +862,7 @@ void PipelineMgmtService::SavePipeline(std::shared_ptr<PipelineGuard> pipeline) 
     }
     last_pin          = pipeline->pin_count_ == 0;
     pipeline->pinned_ = !last_pin;
+    cache_cv_.notify_all();
   }
 
   // Shared by multiple callers (e.g. thumbnail + export): only the last owner may release/reset.
@@ -785,14 +891,7 @@ void PipelineMgmtService::SavePipeline(std::shared_ptr<PipelineGuard> pipeline) 
     pipeline->dirty_ = false;
   }
 
-  // Always clear intermediate buffers and GPU resources when returning a pipeline to cache.
-  // This prevents large cached allocations (and any frame-sink related state) from leaking across
-  // editor sessions and hurting interactive performance.
-  {
-    std::unique_lock<std::mutex> render_guard(pipeline->pipeline_->GetRenderLock());
-    pipeline->pipeline_->ClearAllIntermediateBuffers();
-    pipeline->pipeline_->ResetExecutionStages();
-  }
+  CleanupIdlePipelineResources(pipeline);
 
   if (!pipeline->dirty_) {
     return;
@@ -814,6 +913,29 @@ void PipelineMgmtService::SavePipeline(std::shared_ptr<PipelineGuard> pipeline) 
   if (evicted.has_value()) {
     HandleEviction(evicted.value());
   }
+}
+
+void PipelineMgmtService::ReleasePipelineUse(std::shared_ptr<PipelineGuard> pipeline) {
+  if (!pipeline) {
+    return;
+  }
+
+  bool last_pin = false;
+  {
+    std::unique_lock<std::mutex> cache_lock(lock_);
+    if (pipeline->pin_count_ > 0) {
+      pipeline->pin_count_--;
+    }
+    last_pin          = pipeline->pin_count_ == 0;
+    pipeline->pinned_ = !last_pin;
+    cache_cv_.notify_all();
+  }
+
+  if (!last_pin) {
+    return;
+  }
+
+  CleanupIdlePipelineResources(pipeline);
 }
 
 auto PipelineMgmtService::PersistEditorHistoryState(
@@ -1157,140 +1279,6 @@ void PipelineMgmtService::SyncPipeline(sl_element_id_t id) {
   {
     std::unique_lock<std::mutex> cache_lock(lock_);
     pipeline_guard->dirty_ = false;
-  }
-}
-
-auto PipelineMgmtService::LoadPipelineSnapshot(sl_element_id_t id, image_id_t image_id,
-                                               std::string* error)
-    -> std::shared_ptr<PipelineSnapshot> {
-  std::shared_ptr<CPUPipelineExecutor> live_exec;
-
-  // Cache-hit path: borrow the executor shared_ptr without touching pin_count_.
-  // The copy keeps the executor alive even if the guard is evicted mid-capture.
-  {
-    std::unique_lock<std::mutex> g(lock_);
-    auto                         it = loaded_pipelines_.find(id);
-    if (it != loaded_pipelines_.end() && it->second && it->second->pipeline_) {
-      live_exec = it->second->pipeline_;
-    }
-  }
-
-  // Cache-miss fallback: LoadPipeline (pin + repair + build stages), capture the
-  // executor, then SavePipeline to release the pin (net-zero). dirty_ is false on
-  // a fresh load, so SavePipeline's last-pin path returns without writing storage
-  // or re-recording into the cache; the guard stays in cache unpinned. This reuses
-  // the EnsureDefault*/ResyncGlobalParamsFromOperators repair logic so the
-  // snapshot reflects a coherent state even when the image was not live.
-  if (!live_exec) {
-    std::shared_ptr<PipelineGuard> guard;
-    try {
-      guard = LoadPipeline(id);
-    } catch (const std::exception& e) {
-      if (error) {
-        *error = std::format("LoadPipelineSnapshot: load failed for {}: {}", id, e.what());
-      }
-      return nullptr;
-    } catch (...) {
-      if (error) {
-        *error = std::format("LoadPipelineSnapshot: load failed for {}: unknown error", id);
-      }
-      return nullptr;
-    }
-    if (!guard || !guard->pipeline_) {
-      if (error) {
-        *error = std::format("LoadPipelineSnapshot: no executor for {}", id);
-      }
-      return nullptr;
-    }
-    live_exec = guard->pipeline_;
-    try {
-      SavePipeline(guard);
-    } catch (...) {
-      // Non-fatal: live_exec is valid. A leaked pin is rare and bounded; the guard
-      // remains in cache and is reaped by Sync/eviction on the next opportunity.
-    }
-  }
-
-  // Capture params and clone the live DAG document under the executor's render
-  // lock. This serializes with any in-flight editor render on the same executor,
-  // so the snapshot's stages and graph stay coherent with each other.
-  nlohmann::json params;
-#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
-  std::shared_ptr<PipelineDocument> cloned_live_document;
-  bool                              mirror = true;
-#endif
-  try {
-    std::unique_lock<std::mutex> rg(live_exec->GetRenderLock());
-    params = live_exec->ExportPipelineParams();
-#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
-    if (auto live_doc = live_exec->GpuDagDocument()) {
-      cloned_live_document =
-          std::make_shared<PipelineDocument>(ClonePipelineDocument(*live_doc));
-      mirror = live_exec->MirrorsLegacyStageAdapter();
-    }
-#endif
-  } catch (const std::exception& e) {
-    if (error) {
-      *error = std::format("LoadPipelineSnapshot: export failed for {}: {}", id, e.what());
-    }
-    return nullptr;
-  } catch (...) {
-    if (error) {
-      *error = std::format("LoadPipelineSnapshot: export failed for {}: unknown error", id);
-    }
-    return nullptr;
-  }
-
-  // Build the independent snapshot executor. SetAcceleratorBackendPreference
-  // runs before ImportPipelineParams so the import's final SetExecutionStages()
-  // is the last stage-build call; ImportPipelineParams itself re-aligns the RAW
-  // decode backend to the runtime preference, so a backend saved in the stored
-  // state never leaks into snapshot renders. ResetTransientPreviewState mirrors
-  // LoadPipeline's normalization of cached executors; it touches only transient
-  // render state, not serialized operator params.
-  std::shared_ptr<CPUPipelineExecutor> snap_exec;
-  try {
-    snap_exec = std::make_shared<CPUPipelineExecutor>();
-    snap_exec->SetBoundFile(id);
-    snap_exec->SetAcceleratorBackendPreference(accelerator_preference_);
-    snap_exec->ImportPipelineParams(params);
-    ResetTransientPreviewState(*snap_exec);
-#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
-    std::shared_ptr<PipelineDocument> snap_document = std::move(cloned_live_document);
-    if (!snap_document) {
-      auto imported = LegacyPipelineImporter::Import(params);
-      if (!imported.Ok() || !imported.document) {
-        throw std::runtime_error("GPU DAG import failed: " + imported.error);
-      }
-      snap_document = std::make_shared<PipelineDocument>(std::move(*imported.document));
-    }
-    snap_exec->SetPipelineDocument(std::move(snap_document), mirror);
-#endif
-  } catch (const std::exception& e) {
-    if (error) {
-      *error = std::format("LoadPipelineSnapshot: snapshot build failed for {}: {}", id, e.what());
-    }
-    return nullptr;
-  } catch (...) {
-    if (error) {
-      *error = std::format("LoadPipelineSnapshot: snapshot build failed for {}: unknown error", id);
-    }
-    return nullptr;
-  }
-
-  return std::make_shared<PipelineSnapshot>(
-      PipelineSnapshot{id, image_id, std::move(params), snap_exec});
-}
-
-void PipelineMgmtService::ReleasePipelineSnapshot(std::shared_ptr<PipelineSnapshot> snapshot) {
-  if (!snapshot || !snapshot->executor_) {
-    return;
-  }
-  try {
-    std::unique_lock<std::mutex> rg(snapshot->executor_->GetRenderLock());
-    snapshot->executor_->ClearAllIntermediateBuffers();
-  } catch (...) {
-    // Best-effort cleanup; the shared_ptr drops naturally regardless.
   }
 }
 

--- a/alcedo_studio/src/app/pipeline_service.cpp
+++ b/alcedo_studio/src/app/pipeline_service.cpp
@@ -16,7 +16,6 @@
 #include <string>
 #include <vector>
 
-#include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/history/commit_graph.hpp"
 #include "edit/history/edit_commit.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
@@ -27,50 +26,29 @@
 
 namespace alcedo {
 namespace {
-struct LoadedPipelineDocument {
-  std::shared_ptr<PipelineDocument> document;
-  bool                              mirror_legacy_stage_adapter = false;
-};
-
-auto FinishLoadedDocument(std::shared_ptr<PipelineDocument> document, bool mirror)
-    -> LoadedPipelineDocument {
-  return {std::move(document), mirror};
+void ValidateProductDocument(const PipelineDocument& document, sl_element_id_t id) {
+  const auto graph_errors = document.Graph().Validate();
+  if (!graph_errors.empty()) {
+    throw std::runtime_error("PipelineMgmtService: invalid graph for element " +
+                             std::to_string(id) + ": " + graph_errors.front().message);
+  }
+  const auto backbone_errors = document.Graph().ValidateImageBackbone();
+  if (!backbone_errors.empty()) {
+    throw std::runtime_error("PipelineMgmtService: invalid image backbone for element " +
+                             std::to_string(id) + ": " + backbone_errors.front().message);
+  }
 }
 
-auto LoadPipelineDocument(ElementStore& store, sl_element_id_t id,
-                          const std::shared_ptr<CPUPipelineExecutor>& legacy)
-    -> LoadedPipelineDocument {
+auto LoadPipelineDocument(ElementStore& store, sl_element_id_t id)
+    -> std::shared_ptr<PipelineDocument> {
   const auto stored = store.GetPipelineJsonByElementId(id);
-  if (stored && stored->is_object() && stored->value("format_version", 0) == 2) {
-    // A loaded document already owns its imported camera/profile and editable values.
-    // Preparing an executor must not replace those values with stage defaults.
-    return FinishLoadedDocument(
-        std::make_shared<PipelineDocument>(PipelineDocument::FromJson(*stored)),
-        false);
+  if (!stored.has_value()) {
+    return std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
   }
-  if (legacy) {
-    auto imported = LegacyPipelineImporter::Import(legacy->ExportPipelineParams());
-    if (!imported.Ok()) {
-      throw std::runtime_error("PipelineMgmtService: legacy pipeline import failed: " +
-                               imported.error);
-    }
-    return FinishLoadedDocument(
-        std::make_shared<PipelineDocument>(std::move(*imported.document)), true);
-  }
-  return FinishLoadedDocument(
-      std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument()), true);
-}
 
-void RemirrorGpuDagDocument(PipelineGuard& pipeline) {
-  if (!pipeline.document_ || !pipeline.pipeline_ ||
-      !pipeline.pipeline_->MirrorsLegacyStageAdapter()) {
-    return;
-  }
-  const auto error = LegacyPipelineImporter::ApplyOnto(*pipeline.document_,
-                                                       pipeline.pipeline_->ExportPipelineParams());
-  if (!error.empty()) {
-    throw std::runtime_error("PipelineMgmtService: GPU DAG remirror failed: " + error);
-  }
+  auto document = std::make_shared<PipelineDocument>(PipelineDocument::FromJson(*stored));
+  ValidateProductDocument(*document, id);
+  return document;
 }
 
 void ResetToDefaults(OperatorParams& params) {
@@ -425,12 +403,26 @@ void PipelineMgmtService::HandleEviction(sl_element_id_t evicted_id) {
     }
   }
 
+  try {
+    SyncDirtyPipelineDocument(pipeline_guard);
+  } catch (...) {
+    // The guard was removed from the cache before the storage operation so the cache lock is not
+    // held across DuckDB I/O. Put it back when the document cannot be written; otherwise an
+    // uncommitted edit would disappear with the evicted entry.
+    std::unique_lock<std::mutex> cache_lock(lock_);
+    const auto keys = pipeline_cache_.GetLRUKeys();
+    pipeline_cache_.Resize(static_cast<uint32_t>(keys.size() + 1));
+    pipeline_cache_.RecordAccess(pipeline_guard->id_, pipeline_guard->id_);
+    pipeline_guard->pinned_       = false;
+    pipeline_guard->live_ready_   = true;
+    pipeline_guard->initializing_ = false;
+    pipeline_guard->load_error_   = nullptr;
+    loaded_pipelines_[pipeline_guard->id_] = pipeline_guard;
+    cache_cv_.notify_all();
+    throw;
+  }
   if (pipeline_guard->pipeline_) {
     std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
-    if (pipeline_guard->dirty_) {
-      storage_->GetElementStore().UpdatePipelineByElementId(candidate, pipeline_guard->pipeline_);
-      pipeline_guard->dirty_ = false;
-    }
     // Clear intermediate buffers before removing from cache to ensure timely memory release.
     pipeline_guard->pipeline_->ClearAllIntermediateBuffers();
   }
@@ -582,9 +574,6 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
     std::shared_ptr<CPUPipelineExecutor> pipeline;
     try {
       pipeline = storage_->GetLivePipeline(id);
-      if (!pipeline) {
-        pipeline = storage_->GetElementStore().GetPipelineByElementId(id);
-      }
     } catch (std::exception& e) {
       throw std::runtime_error(
           "[ERROR] PipelineMgmtService: Failed to load pipeline from storage for element ID " +
@@ -608,15 +597,9 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
     }
 
     pipeline_guard->pipeline_ = std::move(pipeline);
-    auto loaded_document =
-        LoadPipelineDocument(storage_->GetElementStore(), id, pipeline_guard->pipeline_);
-    pipeline_guard->document_ = std::move(loaded_document.document);
-    pipeline_guard->pipeline_->SetPipelineDocument(pipeline_guard->document_,
-                                                   loaded_document.mirror_legacy_stage_adapter);
-    {
-      std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
-      RemirrorGpuDagDocument(*pipeline_guard);
-    }
+    pipeline_guard->document_ = LoadPipelineDocument(storage_->GetElementStore(), id);
+    pipeline_guard->pipeline_->SetPipelineDocument(pipeline_guard->document_, false);
+    ValidateProductDocument(*pipeline_guard->document_, id);
     pipeline_guard->dirty_ = false;
 
     std::optional<sl_element_id_t> evicted;
@@ -644,6 +627,7 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
       if (it != loaded_pipelines_.end() && it->second == pipeline_guard) {
         loaded_pipelines_.erase(it);
       }
+      pipeline_cache_.RemoveRecord(id);
       cache_cv_.notify_all();
     }
     throw;
@@ -651,13 +635,40 @@ auto PipelineMgmtService::LoadPipeline(sl_element_id_t id) -> std::shared_ptr<Pi
 }
 
 void PipelineMgmtService::SyncPipelineDocument(const std::shared_ptr<PipelineGuard>& pipeline) {
-  if (!pipeline || !pipeline->document_) {
-    throw std::invalid_argument("PipelineMgmtService: cannot save a null PipelineDocument");
+  if (!pipeline || !pipeline->pipeline_ || !pipeline->document_) {
+    throw std::invalid_argument("PipelineMgmtService: cannot save an incomplete PipelineDocument");
   }
+
+  // Keep the document lock held through serialization and the storage write. A later edit can
+  // then either wait for this save and mark the guard dirty, or serialize after this write; it
+  // cannot be accidentally covered by this save's dirty transition.
+  std::unique_lock<std::mutex> render_lock(pipeline->pipeline_->GetRenderLock());
+  if (pipeline->unsettled_preview_) {
+    throw std::runtime_error(
+        "PipelineMgmtService: cannot save while an editor preview input is unsettled");
+  }
+  ValidateProductDocument(*pipeline->document_, pipeline->id_);
   const auto json = pipeline->document_->ToJson();
-  if (json.value("format_version", 0) != 2) {
-    throw std::runtime_error("PipelineMgmtService: product save requires format version 2");
+  storage_->GetElementStore().UpdatePipelineJsonByElementId(pipeline->id_, json);
+  pipeline->dirty_ = false;
+}
+
+void PipelineMgmtService::SyncDirtyPipelineDocument(
+    const std::shared_ptr<PipelineGuard>& pipeline) {
+  if (!pipeline || !pipeline->pipeline_ || !pipeline->document_) {
+    throw std::invalid_argument("PipelineMgmtService: cannot save an incomplete PipelineDocument");
   }
+
+  std::unique_lock<std::mutex> render_lock(pipeline->pipeline_->GetRenderLock());
+  if (pipeline->unsettled_preview_) {
+    throw std::runtime_error(
+        "PipelineMgmtService: cannot save while an editor preview input is unsettled");
+  }
+  if (!pipeline->dirty_) {
+    return;
+  }
+  ValidateProductDocument(*pipeline->document_, pipeline->id_);
+  const auto json = pipeline->document_->ToJson();
   storage_->GetElementStore().UpdatePipelineJsonByElementId(pipeline->id_, json);
   pipeline->dirty_ = false;
 }
@@ -756,7 +767,6 @@ auto PipelineMgmtService::LoadEditorPipeline(sl_element_id_t id) -> std::shared_
           ImportSerializedPipelineState(*pipeline->pipeline_, stored->pipeline_params,
                                         root_state->raw_color_context, accelerator_preference_);
           pipeline->pipeline_->SetExecutionStages();
-          RemirrorGpuDagDocument(*pipeline);
           accepted_serialized_state = true;
         } catch (...) {
           // Checkpoint params cannot build an executor. Rebuild from history; write back later.
@@ -769,22 +779,15 @@ auto PipelineMgmtService::LoadEditorPipeline(sl_element_id_t id) -> std::shared_
       ++editor_pipeline_history_rebuild_count_;
       std::unique_lock<std::mutex> render_lock(pipeline->pipeline_->GetRenderLock());
       RebuildPipelineFromRoot(*pipeline->pipeline_, *graph, *root_state, accelerator_preference_);
-      RemirrorGpuDagDocument(*pipeline);
       pipeline->serialized_state_needs_writeback_ = true;
     }
     return pipeline;
   } catch (const std::exception& e) {
-    try {
-      SavePipeline(pipeline);
-    } catch (...) {
-    }
+    ReleasePipelineUse(pipeline);
     throw std::runtime_error("[ERROR] PipelineMgmtService: editor history validation failed for " +
                              std::to_string(id) + ": " + e.what());
   } catch (...) {
-    try {
-      SavePipeline(pipeline);
-    } catch (...) {
-    }
+    ReleasePipelineUse(pipeline);
     throw std::runtime_error("[ERROR] PipelineMgmtService: editor history validation failed for " +
                              std::to_string(id) + ": unknown error");
   }
@@ -795,123 +798,88 @@ void PipelineMgmtService::SavePipeline(std::shared_ptr<PipelineGuard> pipeline) 
     return;
   }
 
-  storage_->RememberLivePipeline(pipeline->id_, pipeline->pipeline_);
-
-  bool will_release_last_pin = false;
-  {
-    std::unique_lock<std::mutex> cache_lock(lock_);
-    will_release_last_pin = pipeline->pin_count_ <= 1;
-  }
-  if (will_release_last_pin && pipeline->serialized_state_needs_writeback_) {
-    try {
-      nlohmann::json pipeline_params;
-      {
-        std::unique_lock<std::mutex> render_guard(pipeline->pipeline_->GetRenderLock());
-        pipeline_params = pipeline->pipeline_->ExportPipelineParams();
-      }
-
-      auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
-      auto             db_lock  = db_guard.Lock();
-      CommitGraphStore graph_service(db_guard.conn_);
-      auto             stored_graph = graph_service.LoadGraph(pipeline->id_);
-      if (!stored_graph.has_value()) {
-        throw std::runtime_error(
-            "PipelineMgmtService: cannot write serialized state without an edit graph");
-      }
-
-      // A newly pasted Version only exists in the live graph until this checkpoint.
-      // Still compare the graph's last materialized state with DuckDB before writing it so a
-      // different writer cannot be silently replaced by this serialized pipeline state.
-      const auto& graph = pipeline->commit_graph_ ? *pipeline->commit_graph_ : *stored_graph;
-
-      // Logical head is only the live CommitGraph active Version.
-      if (graph.GetElementId() != pipeline->id_ || graph.GetRootId() != pipeline->root_id_) {
-        throw std::runtime_error(
-            "PipelineMgmtService: live history identity changed before serialized state writeback");
-      }
-
-      const auto& stored_state = stored_graph->GetImageEditState();
-      const auto& graph_state  = graph.GetImageEditState();
-      if (stored_state.root_id != graph_state.root_id ||
-          stored_state.active_version_id != graph_state.active_version_id ||
-          stored_state.materialized_head_commit_hash != graph_state.materialized_head_commit_hash ||
-          stored_state.materialized_transaction_chain_hash !=
-              graph_state.materialized_transaction_chain_hash) {
-        throw std::runtime_error(
-            "PipelineMgmtService: persisted history changed before serialized state writeback");
-      }
-
-      const auto materialization = graph.CaptureMaterializationWithSerializedPipelineState(
-          MakeSerializedPipelineState(*pipeline, pipeline_params));
-      graph_service.Materialize(materialization);
-      if (pipeline->commit_graph_) {
-        pipeline->commit_graph_->ApplyMaterializedState(materialization.image_state);
-      }
-      pipeline->serialized_state_needs_writeback_ = false;
-    } catch (...) {
-      // This state accelerates editor open but is not the history source of truth. Keep the flag
-      // set so the next guard release retries without leaking the pipeline pin.
+  try {
+    if (!pipeline->pipeline_ || !pipeline->document_) {
+      throw std::invalid_argument("PipelineMgmtService: cannot save an incomplete pipeline guard");
     }
-  }
 
-  bool last_pin = false;
-  {
-    std::unique_lock<std::mutex> cache_lock(lock_);
-    if (pipeline->pin_count_ > 0) {
-      pipeline->pin_count_--;
-    }
-    last_pin          = pipeline->pin_count_ == 0;
-    pipeline->pinned_ = !last_pin;
-    cache_cv_.notify_all();
-  }
+    storage_->RememberLivePipeline(pipeline->id_, pipeline->pipeline_);
 
-  // Shared by multiple callers (e.g. thumbnail + export): only the last owner may release/reset.
-  if (!last_pin) {
-    return;
-  }
+    // The document is the only product persistence source. Save it before touching the optional
+    // history checkpoint so a failed document write leaves both the live edit and its journal
+    // state untouched.
+    SyncDirtyPipelineDocument(pipeline);
 
-  // The editable pipeline table has one canonical representation from G7 onward. History keeps
-  // its serialized compatibility checkpoint separately, but a product save never writes the old
-  // stage array back over the format-version-2 graph.
-  if (pipeline->dirty_) {
-    nlohmann::json legacy_stage_adapter;
+    bool will_release_last_pin = false;
     {
-      std::unique_lock<std::mutex> render_guard(pipeline->pipeline_->GetRenderLock());
-      legacy_stage_adapter = pipeline->pipeline_->ExportPipelineParams();
+      std::unique_lock<std::mutex> cache_lock(lock_);
+      will_release_last_pin = pipeline->pin_count_ <= 1;
     }
-    auto imported = LegacyPipelineImporter::Import(legacy_stage_adapter);
-    if (!imported.document.has_value()) {
-      throw std::runtime_error("PipelineMgmtService: cannot convert edited stages to format 2: " +
-                               imported.error);
+    if (will_release_last_pin && pipeline->serialized_state_needs_writeback_) {
+      try {
+        nlohmann::json pipeline_params;
+        {
+          std::unique_lock<std::mutex> render_guard(pipeline->pipeline_->GetRenderLock());
+          if (pipeline->unsettled_preview_) {
+            throw std::runtime_error(
+                "PipelineMgmtService: cannot checkpoint an unsettled editor preview");
+          }
+          pipeline_params = pipeline->pipeline_->ExportPipelineParams();
+        }
+
+        auto             db_guard = storage_->GetDatabase().GetConnectionGuard();
+        auto             db_lock  = db_guard.Lock();
+        CommitGraphStore graph_service(db_guard.conn_);
+        auto             stored_graph = graph_service.LoadGraph(pipeline->id_);
+        if (!stored_graph.has_value()) {
+          throw std::runtime_error(
+              "PipelineMgmtService: cannot write serialized state without an edit graph");
+        }
+
+        // A newly pasted Version only exists in the live graph until this checkpoint.
+        // Still compare the graph's last materialized state with DuckDB before writing it so a
+        // different writer cannot be silently replaced by this serialized pipeline state.
+        const auto& graph = pipeline->commit_graph_ ? *pipeline->commit_graph_ : *stored_graph;
+
+        // Logical head is only the live CommitGraph active Version.
+        if (graph.GetElementId() != pipeline->id_ || graph.GetRootId() != pipeline->root_id_) {
+          throw std::runtime_error(
+              "PipelineMgmtService: live history identity changed before serialized state writeback");
+        }
+
+        const auto& stored_state = stored_graph->GetImageEditState();
+        const auto& graph_state  = graph.GetImageEditState();
+        if (stored_state.root_id != graph_state.root_id ||
+            stored_state.active_version_id != graph_state.active_version_id ||
+            stored_state.materialized_head_commit_hash !=
+                graph_state.materialized_head_commit_hash ||
+            stored_state.materialized_transaction_chain_hash !=
+                graph_state.materialized_transaction_chain_hash) {
+          throw std::runtime_error(
+              "PipelineMgmtService: persisted history changed before serialized state writeback");
+        }
+
+        const auto materialization = graph.CaptureMaterializationWithSerializedPipelineState(
+            MakeSerializedPipelineState(*pipeline, pipeline_params));
+        graph_service.Materialize(materialization);
+        if (pipeline->commit_graph_) {
+          pipeline->commit_graph_->ApplyMaterializedState(materialization.image_state);
+        }
+        pipeline->serialized_state_needs_writeback_ = false;
+      } catch (...) {
+        // This state accelerates editor open but is not the history source of truth. Keep the flag
+        // set so the next explicit save retries it without leaking the pipeline pin.
+      }
     }
-    *pipeline->document_                  = std::move(*imported.document);
-    auto document_json                    = pipeline->document_->ToJson();
-    document_json["legacy_stage_adapter"] = std::move(legacy_stage_adapter);
-    storage_->GetElementStore().UpdatePipelineJsonByElementId(pipeline->id_, document_json);
-    pipeline->dirty_ = false;
-  }
 
-  CleanupIdlePipelineResources(pipeline);
-
-  if (!pipeline->dirty_) {
-    return;
-  }
-
-  // Save the pipeline back to the cache
-  sl_element_id_t                id = pipeline->id_;
-  // Store it back to the pipeline cache
-  std::optional<sl_element_id_t> evicted;
-  {
-    std::unique_lock<std::mutex> cache_lock(lock_);
-    evicted               = pipeline_cache_.RecordAccess_WithEvict(id, id);
-    pipeline->pinned_     = false;
-    loaded_pipelines_[id] = pipeline;
-    if (!evicted.has_value() && loaded_pipelines_.size() + 1 > default_cache_capacity_) {
-      pipeline_cache_.Resize(static_cast<uint32_t>(loaded_pipelines_.size() - 1));
-    }
-  }
-  if (evicted.has_value()) {
-    HandleEviction(evicted.value());
+    // SavePipeline is an explicit persistence operation. Its final step only releases this
+    // caller's cache pin; lifecycle release never performs storage I/O.
+    ReleasePipelineUse(std::move(pipeline));
+  } catch (...) {
+    // A failed save must still release the caller's pin, but ReleasePipelineUse deliberately
+    // leaves dirty_ and the history writeback flag unchanged.
+    ReleasePipelineUse(std::move(pipeline));
+    throw;
   }
 }
 
@@ -1239,26 +1207,20 @@ void PipelineMgmtService::SetAcceleratorBackendPreference(AcceleratorBackendPref
 }
 
 void PipelineMgmtService::Sync() {
-  std::vector<std::shared_ptr<PipelineGuard>> dirty_pipelines;
+  std::vector<std::shared_ptr<PipelineGuard>> pipelines;
   {
     std::unique_lock<std::mutex> cache_lock(lock_);
-    dirty_pipelines.reserve(loaded_pipelines_.size());
+    pipelines.reserve(loaded_pipelines_.size());
     for (const auto& [id, pipeline_guard] : loaded_pipelines_) {
       (void)id;
-      if (pipeline_guard && pipeline_guard->dirty_) {
-        dirty_pipelines.push_back(pipeline_guard);
+      if (pipeline_guard && pipeline_guard->pipeline_ && pipeline_guard->document_) {
+        pipelines.push_back(pipeline_guard);
       }
     }
   }
 
-  for (const auto& pipeline_guard : dirty_pipelines) {
-    std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
-    storage_->GetElementStore().UpdatePipelineByElementId(pipeline_guard->id_,
-                                                          pipeline_guard->pipeline_);
-    {
-      std::unique_lock<std::mutex> cache_lock(lock_);
-      pipeline_guard->dirty_ = false;
-    }
+  for (const auto& pipeline_guard : pipelines) {
+    SyncDirtyPipelineDocument(pipeline_guard);
   }
 }
 
@@ -1266,20 +1228,15 @@ void PipelineMgmtService::SyncPipeline(sl_element_id_t id) {
   std::shared_ptr<PipelineGuard> pipeline_guard;
   {
     std::unique_lock<std::mutex> cache_lock(lock_);
-    const auto                   it = loaded_pipelines_.find(id);
+    const auto it = loaded_pipelines_.find(id);
     if (it == loaded_pipelines_.end() || !it->second || !it->second->pipeline_ ||
-        !it->second->dirty_) {
+        !it->second->document_) {
       return;
     }
     pipeline_guard = it->second;
   }
 
-  std::unique_lock<std::mutex> render_guard(pipeline_guard->pipeline_->GetRenderLock());
-  storage_->GetElementStore().UpdatePipelineByElementId(id, pipeline_guard->pipeline_);
-  {
-    std::unique_lock<std::mutex> cache_lock(lock_);
-    pipeline_guard->dirty_ = false;
-  }
+  SyncDirtyPipelineDocument(pipeline_guard);
 }
 
 auto CheckpointMatchesLogicalHead(const ImageEditState& state, head_commit_hash_t logical_head,

--- a/alcedo_studio/src/app/sleeve_service.cpp
+++ b/alcedo_studio/src/app/sleeve_service.cpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <unordered_set>
 
+#include "edit/graph/pipeline_document.hpp"
 #include "utils/string/convert.hpp"
 
 namespace alcedo {
@@ -56,21 +57,18 @@ void LogSyncElement(const char* bucket, const std::shared_ptr<SleeveElement>& el
 
 void ClonePipelineForDuplicate(Storage& storage_service, sl_element_id_t source_file_id,
                                sl_element_id_t duplicate_file_id) {
-  auto source_pipeline = storage_service.GetLivePipeline(source_file_id);
-  if (!source_pipeline) {
-    source_pipeline = storage_service.GetElementStore().GetPipelineByElementId(source_file_id);
-  }
-  if (!source_pipeline) {
+  const auto source_document =
+      storage_service.GetElementStore().GetPipelineJsonByElementId(source_file_id);
+  if (!source_document.has_value()) {
     return;
   }
 
-  auto duplicate_pipeline = std::make_shared<CPUPipelineExecutor>();
-  duplicate_pipeline->SetBoundFile(duplicate_file_id);
-  duplicate_pipeline->ImportPipelineParams(source_pipeline->ExportPipelineParams());
-  duplicate_pipeline->SetExecutionStages();
-  storage_service.GetElementStore().UpdatePipelineByElementId(duplicate_file_id,
-                                                                   duplicate_pipeline);
-  storage_service.RememberLivePipeline(duplicate_file_id, duplicate_pipeline);
+  const auto document = PipelineDocument::FromJson(*source_document);
+  if (!document.Graph().Validate().empty() || !document.Graph().ValidateImageBackbone().empty()) {
+    throw std::runtime_error("SleeveService: cannot duplicate an invalid pipeline document");
+  }
+  storage_service.GetElementStore().UpdatePipelineJsonByElementId(duplicate_file_id,
+                                                                    document.ToJson());
 }
 
 }  // namespace

--- a/alcedo_studio/src/app/thumbnail_service.cpp
+++ b/alcedo_studio/src/app/thumbnail_service.cpp
@@ -48,12 +48,6 @@ constexpr DecodeRes ResolutionToDecodeRes(ThumbnailResolution res) {
   return DecodeRes::QUARTER;
 }
 
-void InjectSnapshotRawContext(CPUPipelineExecutor& exec, const std::shared_ptr<Image>& image) {
-  if (image && image->HasRawColorContext()) {
-    PipelineMgmtService::InjectImageRawMetadata(exec, *image);
-  }
-}
-
 void DispatchThumbnailResultCallback(const ThumbnailResultCallback& callback,
                                      const CallbackDispatcher&      dispatcher,
                                      ThumbnailRequestResult         result) {
@@ -166,9 +160,9 @@ struct ThumbnailService::State {
   std::unordered_map<ThumbnailCacheKey, std::shared_ptr<std::atomic<uint64_t>>>
       generation_tokens_{};
 
-  // Phase 3: cancel tokens for analysis renditions. Separate from
-  // generation_tokens_ to avoid collision when the same {element, resolution}
-  // is rendered both via the live thumbnail path and the snapshot path.
+  // Cancel tokens for analysis renditions. Separate from generation_tokens_
+  // so cancelling a filmstrip thumbnail does not cancel analysis of the same
+  // element and resolution.
   std::unordered_map<ThumbnailCacheKey, std::shared_ptr<std::atomic<uint64_t>>> analysis_tokens_{};
 
   // Pipeline scheduler (global/shared), must outlive tasks.
@@ -249,6 +243,46 @@ struct ThumbnailService::State {
       }
     }
     return {};
+  }
+
+  auto CommitLabelFromLiveGuard(const PipelineGuard& guard) const -> std::string {
+    if (guard.commit_graph_ == nullptr) {
+      return {};
+    }
+    const auto head = guard.working_head_commit_hash();
+    if (head.has_value()) {
+      return head->ToString();
+    }
+    return guard.root_id_.ToString();
+  }
+
+  auto RenderedCommitLabel(const std::shared_ptr<PipelineGuard>& live, sl_element_id_t id)
+      -> std::string {
+    if (live) {
+      auto label = CommitLabelFromLiveGuard(*live);
+      if (!label.empty()) {
+        return label;
+      }
+    }
+    return ReadCurrentVersionHash(id);
+  }
+
+  void EnqueueDiskWriteIfCommitLabelMatches(sl_element_id_t                            id,
+                                           const std::optional<ThumbnailDiskCacheKey>& queued_key,
+                                           const std::shared_ptr<PipelineGuard>&      live,
+                                           const std::shared_ptr<ThumbnailGuard>&      guard) {
+    if (!queued_key.has_value() || !disk_cache_service_ || !guard || !guard->thumbnail_buffer_) {
+      return;
+    }
+    const auto rendered  = RenderedCommitLabel(live, id);
+    const bool unsettled = live && live->unsettled_preview_;
+    const bool dirty      = live && live->dirty_;
+    if (!ThumbnailDiskCacheWriteAllowed(queued_key->edit_version_hash, rendered, unsettled,
+                                        dirty)) {
+      return;
+    }
+    std::shared_ptr<ImageBuffer> disk_cache_buffer(guard, guard->thumbnail_buffer_.get());
+    disk_cache_service_->EnqueueWrite(*queued_key, std::move(disk_cache_buffer));
   }
 
   auto BuildDiskCacheKey(sl_element_id_t id, ThumbnailResolution resolution,
@@ -369,28 +403,16 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
     expected_gen = gen_token->load();
   }
 
-  auto schedule_pipeline_render = [st, id, image_id, cache_key, resolution, gen_token,
+  auto schedule_pipeline_render = [st, id, image_id, cache_key, resolution, disk_key, gen_token,
                                    expected_gen]() {
     struct ThumbnailTaskContext {
-      std::shared_ptr<PipelineSnapshot> snapshot{};
-      std::atomic<bool>                 snapshot_released{false};
+      std::shared_ptr<PipelineGuard> live{};
     };
 
-    auto task_context          = std::make_shared<ThumbnailTaskContext>();
+    auto task_context = std::make_shared<ThumbnailTaskContext>();
 
-    auto release_task_snapshot = [st, task_context]() {
-      auto snapshot = task_context->snapshot;
-      if (!snapshot || task_context->snapshot_released.exchange(true)) {
-        return;
-      }
-      try {
-        st->pipeline_service_->ReleasePipelineSnapshot(snapshot);
-      } catch (...) {
-      }
-    };
-
-    auto fail_pending_request = [st, cache_key, release_task_snapshot](const std::string& message,
-                                                                       bool throw_after) -> bool {
+    auto fail_pending_request = [st, cache_key](const std::string& message,
+                                                  bool              throw_after) -> bool {
       std::vector<State::PendingCallback> callbacks;
       {
         std::unique_lock lock(st->cache_lock_);
@@ -402,8 +424,6 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
         st->thumbnail_cache_.RemoveRecord(cache_key);
         st->thumbnail_cache_data_.erase(cache_key);
       }
-
-      release_task_snapshot();
 
       for (const auto& pending_cb : callbacks) {
         DispatchThumbnailResultCallback(
@@ -423,7 +443,7 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
     const uint32_t  max_edge   = ResolutionToMaxEdge(resolution);
     const DecodeRes decode_res = ResolutionToDecodeRes(resolution);
 
-    PipelineTask    thumb_task;
+    PipelineTask thumb_task;
     thumb_task.options_.render_desc_.render_type_ = RenderType::THUMBNAIL;
     thumb_task.options_.render_desc_.max_edge_    = max_edge;
     thumb_task.options_.render_desc_.decode_res_  = decode_res;
@@ -435,20 +455,36 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
     };
 
     thumb_task.prepare_ = [st, id, image_id, task_context,
-                           fail_pending_request](PipelineTask& task) mutable -> bool {
-      std::string error;
-      task_context->snapshot = st->pipeline_service_->LoadPipelineSnapshot(id, image_id, &error);
-      if (!task_context->snapshot || !task_context->snapshot->executor_) {
+                            fail_pending_request](PipelineTask& task) mutable -> bool {
+      try {
+        task_context->live = st->pipeline_service_->LoadPipeline(id);
+      } catch (const std::exception& e) {
         return fail_pending_request(
-            error.empty()
-                ? std::format("[ERROR] ThumbnailService: Pipeline for file ID {} not available.",
-                              id)
-                : error,
+            std::format("[ERROR] ThumbnailService: Failed to load pipeline for file ID {}: {}", id,
+                        e.what()),
+            false);
+      } catch (...) {
+        return fail_pending_request(
+            std::format("[ERROR] ThumbnailService: Failed to load pipeline for file ID {}.", id),
             false);
       }
-
-      auto executor = task_context->snapshot->executor_;
-      executor->SetForceCPUOutput(true);
+      if (!task_context->live || !task_context->live->pipeline_ ||
+          !task_context->live->document_) {
+        return fail_pending_request(
+            std::format("[ERROR] ThumbnailService: Pipeline document for file ID {} not "
+                        "available.",
+                        id),
+            false);
+      }
+#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
+      if (!task_context->live->pipeline_->HasGpuDagDocument()) {
+        return fail_pending_request(
+            std::format("[ERROR] ThumbnailService: pipeline for {} is missing a GPU DAG "
+                        "document.",
+                        id),
+            false);
+      }
+#endif
 
       std::shared_ptr<Image> img_result;
       try {
@@ -472,18 +508,14 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
             false);
       }
 
-      InjectSnapshotRawContext(*executor, img_result);
-      task.pipeline_executor_ = std::move(executor);
+      task.pipeline_executor_ = task_context->live->pipeline_;
       task.input_desc_        = std::move(img_result);
       return true;
     };
 
-    thumb_task.callback_ = [st, id, cache_key, release_task_snapshot, gen_token,
+    thumb_task.callback_ = [st, id, cache_key, disk_key, task_context, gen_token,
                             expected_gen](ImageBuffer& result_buffer) {
-      // Strategy A: stale tasks must not touch pending_ because a newer request
-      // for the same element/resolution may already have claimed that slot.
       if (gen_token && gen_token->load() != expected_gen) {
-        release_task_snapshot();
         return;
       }
 
@@ -502,7 +534,6 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
         std::unique_lock lock(st->cache_lock_);
 
         if (gen_token && gen_token->load() != expected_gen) {
-          release_task_snapshot();
           return;
         }
 
@@ -522,19 +553,9 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
           HandleEvict(*st, evicted);
           st->thumbnail_cache_data_[cache_key] = guard;
 
-          // Enqueue write to disk cache asynchronously.
-          if (st->disk_cache_service_ && st->storage_) {
-            try {
-              const auto disk_key = st->BuildDiskCacheKey(id, cache_key.resolution,
-                                                          ThumbnailDiskCachePurpose::kThumbnail);
-              if (disk_key.has_value()) {
-                std::shared_ptr<ImageBuffer> disk_cache_buffer(guard,
-                                                               guard->thumbnail_buffer_.get());
-                st->disk_cache_service_->EnqueueWrite(disk_key.value(),
-                                                      std::move(disk_cache_buffer));
-              }
-            } catch (...) {
-            }
+          try {
+            st->EnqueueDiskWriteIfCommitLabelMatches(id, disk_key, task_context->live, guard);
+          } catch (...) {
           }
         } else {
           st->thumbnail_cache_.RemoveRecord(cache_key);
@@ -542,8 +563,6 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
         }
       }
 
-      // Strategy A: re-check token after pipeline work (before callbacks).
-      // If cancelled mid-render, remove only the guard inserted by this task.
       if (gen_token && gen_token->load() != expected_gen) {
         if (guard) {
           std::unique_lock lock(st->cache_lock_);
@@ -553,7 +572,6 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
             st->thumbnail_cache_data_.erase(guard_it);
           }
         }
-        release_task_snapshot();
         for (const auto& pending_cb : callbacks) {
           DispatchThumbnailResultCallback(
               pending_cb.callback_, pending_cb.dispatcher_,
@@ -564,8 +582,6 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
         }
         return;
       }
-
-      release_task_snapshot();
 
       const auto status = guard ? ThumbnailRequestStatus::kReady : ThumbnailRequestStatus::kError;
       const std::string message =
@@ -580,6 +596,17 @@ void ThumbnailService::GetThumbnailDetailed(sl_element_id_t id, image_id_t image
             ThumbnailRequestResult{
                 .guard = guard, .status = status, .message = message, .key = cache_key});
       }
+    };
+
+    thumb_task.on_complete_ = [st, task_context](bool, std::string) {
+      if (!task_context->live) {
+        return;
+      }
+      try {
+        st->pipeline_service_->ReleasePipelineUse(task_context->live);
+      } catch (...) {
+      }
+      task_context->live.reset();
     };
 
     try {
@@ -687,8 +714,8 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
     DispatchThumbnailResultCallback(callback, nullptr, std::move(result));
   };
 
-  auto schedule_snapshot_render = [st, element_id, image_id, resolution, cache_key, disk_key,
-                                   gen_token, expected_gen, deliver]() mutable {
+  auto schedule_analysis_render = [st, element_id, image_id, resolution, cache_key, disk_key,
+                                    gen_token, expected_gen, deliver]() mutable {
     if (gen_token && gen_token->load() != expected_gen) {
       deliver(ThumbnailRequestResult{.guard   = nullptr,
                                      .status  = ThumbnailRequestStatus::kCanceled,
@@ -697,38 +724,12 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
       return;
     }
 
-    std::string err;
-    auto        snapshot = st->pipeline_service_->LoadPipelineSnapshot(element_id, image_id, &err);
-    if (!snapshot) {
-      deliver(ThumbnailRequestResult{.guard   = nullptr,
-                                     .status  = ThumbnailRequestStatus::kError,
-                                     .message = err,
-                                     .key     = cache_key});
-      return;
-    }
-
-    // The closure holds the only strong ref to the snapshot. No
-    // analysis_snapshots_ map is needed: the snapshot is released from one
-    // of the task callbacks and the shared_ptr then drops naturally.
     struct AnalysisTaskContext {
-      std::shared_ptr<PipelineSnapshot> snapshot;
-      std::atomic<bool>                 released{false};
+      std::shared_ptr<PipelineGuard> live{};
     };
-    auto ctx              = std::make_shared<AnalysisTaskContext>();
-    ctx->snapshot         = std::move(snapshot);
+    auto ctx = std::make_shared<AnalysisTaskContext>();
 
-    auto release_snapshot = [st, ctx]() {
-      if (!ctx->snapshot || ctx->released.exchange(true)) {
-        return;
-      }
-      try {
-        st->pipeline_service_->ReleasePipelineSnapshot(ctx->snapshot);
-      } catch (...) {
-      }
-    };
-
-    auto fail = [release_snapshot, deliver, cache_key](const std::string& msg) -> bool {
-      release_snapshot();
+    auto fail = [deliver, cache_key](const std::string& msg) -> bool {
       deliver(ThumbnailRequestResult{.guard   = nullptr,
                                      .status  = ThumbnailRequestStatus::kError,
                                      .message = msg,
@@ -739,7 +740,7 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
     const uint32_t  max_edge   = ResolutionToMaxEdge(resolution);
     const DecodeRes decode_res = ResolutionToDecodeRes(resolution);
 
-    PipelineTask    task;
+    PipelineTask task;
     task.options_.render_desc_.render_type_ = RenderType::THUMBNAIL;
     task.options_.render_desc_.max_edge_    = max_edge;
     task.options_.render_desc_.decode_res_  = decode_res;
@@ -751,16 +752,8 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
     };
 
     task.prepare_ = [st, element_id, image_id, ctx, cache_key, gen_token, expected_gen, deliver,
-                     fail](PipelineTask& t) mutable -> bool {
-      // Early cancel: avoid a wasted one-shot render. The scheduler will not
-      // call callback_ when prepare_ returns false, so dispatch kCanceled here.
+                      fail](PipelineTask& t) mutable -> bool {
       if (gen_token && gen_token->load() != expected_gen) {
-        if (ctx->snapshot && !ctx->released.exchange(true)) {
-          try {
-            st->pipeline_service_->ReleasePipelineSnapshot(ctx->snapshot);
-          } catch (...) {
-          }
-        }
         deliver(ThumbnailRequestResult{.guard   = nullptr,
                                        .status  = ThumbnailRequestStatus::kCanceled,
                                        .message = "Analysis rendition was canceled.",
@@ -768,12 +761,22 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
         return false;
       }
 
-      auto exec = ctx->snapshot->executor_;
-      if (!exec) {
-        return fail("analysis rendition: snapshot executor missing");
+      try {
+        ctx->live = st->pipeline_service_->LoadPipeline(element_id);
+      } catch (const std::exception& e) {
+        return fail(std::format("analysis rendition: failed to load pipeline for {}: {}",
+                                element_id, e.what()));
+      } catch (...) {
+        return fail(std::format("analysis rendition: failed to load pipeline for {}.", element_id));
       }
-
-      exec->SetForceCPUOutput(true);
+      if (!ctx->live || !ctx->live->pipeline_ || !ctx->live->document_) {
+        return fail("analysis rendition: no usable pipeline graph");
+      }
+#if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
+      if (!ctx->live->pipeline_->HasGpuDagDocument()) {
+        return fail("analysis rendition: pipeline is missing a GPU DAG document");
+      }
+#endif
 
       std::shared_ptr<Image> img_result;
       try {
@@ -792,16 +795,14 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
             std::format("analysis rendition: image with ID {} not found in pool.", image_id));
       }
 
-      InjectSnapshotRawContext(*exec, img_result);
-      t.pipeline_executor_ = exec;
+      t.pipeline_executor_ = ctx->live->pipeline_;
       t.input_desc_        = std::move(img_result);
       return true;
     };
 
-    task.callback_ = [st, element_id, cache_key, disk_key, gen_token, expected_gen,
-                      release_snapshot, deliver](ImageBuffer& result_buffer) {
+    task.callback_ = [st, element_id, cache_key, disk_key, ctx, gen_token, expected_gen,
+                        deliver](ImageBuffer& result_buffer) {
       if (gen_token && gen_token->load() != expected_gen) {
-        release_snapshot();
         deliver(ThumbnailRequestResult{.guard   = nullptr,
                                        .status  = ThumbnailRequestStatus::kCanceled,
                                        .message = "Analysis rendition was canceled.",
@@ -822,13 +823,11 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
       if (display_buffer) {
         guard->thumbnail_buffer_ = std::move(display_buffer);
         guard->pin_count_        = 1;
-        if (disk_key.has_value() && st->disk_cache_service_) {
-          std::shared_ptr<ImageBuffer> disk_cache_buffer(guard, guard->thumbnail_buffer_.get());
-          st->disk_cache_service_->EnqueueWrite(disk_key.value(), std::move(disk_cache_buffer));
+        try {
+          st->EnqueueDiskWriteIfCommitLabelMatches(element_id, disk_key, ctx->live, guard);
+        } catch (...) {
         }
       }
-
-      release_snapshot();
 
       const bool ok     = static_cast<bool>(guard->thumbnail_buffer_);
       const auto status = ok ? ThumbnailRequestStatus::kReady : ThumbnailRequestStatus::kError;
@@ -841,17 +840,26 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
           .guard = ok ? guard : nullptr, .status = status, .message = message, .key = cache_key});
     };
 
+    task.on_complete_ = [st, ctx](bool, std::string) {
+      if (!ctx->live) {
+        return;
+      }
+      try {
+        st->pipeline_service_->ReleasePipelineUse(ctx->live);
+      } catch (...) {
+      }
+      ctx->live.reset();
+    };
+
     try {
       st->pipeline_scheduler_->ScheduleTask(std::move(task));
     } catch (const std::exception& e) {
-      release_snapshot();
       deliver(ThumbnailRequestResult{
           .guard   = nullptr,
           .status  = ThumbnailRequestStatus::kError,
           .message = std::format("analysis rendition: failed to schedule: {}", e.what()),
           .key     = cache_key});
     } catch (...) {
-      release_snapshot();
       deliver(ThumbnailRequestResult{
           .guard   = nullptr,
           .status  = ThumbnailRequestStatus::kError,
@@ -864,7 +872,7 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
     const auto disk_key_value = disk_key.value();
     auto*      disk_cache     = st->disk_cache_service_.get();
     st->disk_read_thread_pool_.Submit([cache_key, disk_key_value, disk_cache, gen_token,
-                                       expected_gen, deliver, schedule_snapshot_render]() mutable {
+                                       expected_gen, deliver, schedule_analysis_render]() mutable {
       if (gen_token && gen_token->load() != expected_gen) {
         deliver(ThumbnailRequestResult{.guard   = nullptr,
                                        .status  = ThumbnailRequestStatus::kCanceled,
@@ -883,13 +891,13 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
       }
 
       if (!disk_buffer || !disk_buffer->cpu_data_valid_) {
-        schedule_snapshot_render();
+        schedule_analysis_render();
         return;
       }
 
       auto display_buffer = MakeDisplayCacheThumbnailBuffer(*disk_buffer);
       if (!display_buffer) {
-        schedule_snapshot_render();
+        schedule_analysis_render();
         return;
       }
 
@@ -904,7 +912,7 @@ void ThumbnailService::RequestAnalysisRendition(sl_element_id_t element_id, imag
     return;
   }
 
-  schedule_snapshot_render();
+  schedule_analysis_render();
 }
 
 void ThumbnailService::CancelAnalysisRendition(const ThumbnailCacheKey& key) {

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -48,10 +48,11 @@ set(EDIT_GRAPH_SRCS
     ${ALCEDO_SRC_ROOT}/edit/graph/develop_color_transform.cpp
     ${ALCEDO_SRC_ROOT}/edit/graph/develop_node_model.cpp
     ${ALCEDO_SRC_ROOT}/edit/graph/drt_node_model.cpp
-    ${ALCEDO_SRC_ROOT}/edit/graph/legacy_pipeline_importer.cpp
-    ${ALCEDO_SRC_ROOT}/edit/graph/pipeline_document.cpp
-    ${ALCEDO_SRC_ROOT}/edit/graph/pipeline_graph.cpp
-    ${ALCEDO_SRC_ROOT}/edit/graph/raster_mask_node_model.cpp
+        ${ALCEDO_SRC_ROOT}/edit/graph/legacy_pipeline_importer.cpp
+        ${ALCEDO_SRC_ROOT}/edit/graph/pipeline_document.cpp
+        ${ALCEDO_SRC_ROOT}/edit/graph/pipeline_graph.cpp
+        ${ALCEDO_SRC_ROOT}/edit/graph/pipeline_graph_commands.cpp
+        ${ALCEDO_SRC_ROOT}/edit/graph/raster_mask_node_model.cpp
 )
 
 def_library(EditGraph

--- a/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
@@ -56,6 +56,7 @@ auto ColorGradeNodeModel::ToJson() const -> nlohmann::json {
   }
   return {{"id", std::string{id_.Value()}},
           {"type", std::string{Type().Text()}},
+          {"display_name", display_name_},
           {"enabled", enabled_},
           {"mix", mix_},
           {"adjustments", std::move(adjustments)}};
@@ -86,6 +87,7 @@ auto ColorGradeNodeModel::MakeDefault(NodeId id) -> std::unique_ptr<ColorGradeNo
 auto ColorGradeNodeModel::FromJson(const nlohmann::json& json) -> std::unique_ptr<ColorGradeNodeModel> {
   auto        node    = std::make_unique<ColorGradeNodeModel>(NodeId{json.at("id").get<std::string>()});
   const auto& catalog = BuiltinAdjustmentCatalog::Instance();
+  node->display_name_ = json.value("display_name", std::string{"Color Grade"});
   node->enabled_      = json.value("enabled", true);
   node->mix_          = json.value("mix", 1.0f);
   if (json.contains("adjustments") && json["adjustments"].is_array()) {
@@ -106,6 +108,8 @@ auto ColorGradeNodeModel::FromJson(const nlohmann::json& json) -> std::unique_pt
 }
 
 void ColorGradeNodeModel::SetEnabled(bool enabled) { enabled_ = enabled; }
+
+void ColorGradeNodeModel::SetDisplayName(std::string name) { display_name_ = std::move(name); }
 
 void ColorGradeNodeModel::SetMix(float mix) { mix_ = std::clamp(mix, 0.0f, 1.0f); }
 

--- a/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
@@ -158,6 +158,16 @@ auto ColorGradeNodeModel::FindAdjustment(const AdjustmentInstanceId& id) -> IOpe
   return nullptr;
 }
 
+auto ColorGradeNodeModel::FindAdjustment(const AdjustmentInstanceId& id) const
+    -> const IOperatorModel* {
+  for (const auto& entry : adjustments_) {
+    if (entry.instance_id == id) {
+      return entry.model.get();
+    }
+  }
+  return nullptr;
+}
+
 auto ColorGradeNodeModel::FindAdjustmentByType(const OperatorTypeId& type) -> IOperatorModel* {
   for (auto& entry : adjustments_) {
     if (entry.model->Type() == type) {

--- a/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -26,6 +27,14 @@ auto DefaultAdjustmentTypes() -> std::array<OperatorTypeId, 17> {
           type_ids::Halation(),          type_ids::FilmGrain()};
 }
 
+auto CleanAdjustmentTypes() -> std::array<OperatorTypeId, 13> {
+  return {type_ids::Cat02WhiteBalance(), type_ids::Exposure(), type_ids::Contrast(),
+          type_ids::White(),             type_ids::Black(),    type_ids::Shadows(),
+          type_ids::Highlights(),        type_ids::Curve(),    type_ids::Hls(),
+          type_ids::Saturation(),        type_ids::Vibrance(), type_ids::ColorWheel(),
+          type_ids::Lmt()};
+}
+
 auto InstanceSuffixFor(const OperatorTypeId& type) -> std::string {
   const std::string text{type.Text()};
   const auto        pos = text.rfind('.');
@@ -33,6 +42,25 @@ auto InstanceSuffixFor(const OperatorTypeId& type) -> std::string {
     return text;
   }
   return text.substr(pos + 1);
+}
+
+void PopulateAdjustments(ColorGradeNodeModel& node, std::span<const OperatorTypeId> types) {
+  const auto& catalog = BuiltinAdjustmentCatalog::Instance();
+  const std::string prefix = std::string{node.Id().Value()} + ".";
+  for (const auto& type : types) {
+    auto model = catalog.CreateDefault(type);
+    if (model == nullptr) {
+      throw std::logic_error("Missing default adjustment factory for " + std::string{type.Text()});
+    }
+    std::string suffix = InstanceSuffixFor(type);
+    if (type == type_ids::Cat02WhiteBalance()) {
+      suffix = "cat02_wb";
+    } else if (type == type_ids::Hls()) {
+      suffix = "hls";
+    }
+    node.InsertAdjustment(node.AdjustmentCount(), AdjustmentInstanceId{prefix + suffix},
+                          std::move(model));
+  }
 }
 
 }  // namespace
@@ -63,25 +91,21 @@ auto ColorGradeNodeModel::ToJson() const -> nlohmann::json {
 }
 
 auto ColorGradeNodeModel::MakeDefault(NodeId id) -> std::unique_ptr<ColorGradeNodeModel> {
-  auto        node   = std::make_unique<ColorGradeNodeModel>(std::move(id));
-  const auto  types   = DefaultAdjustmentTypes();
-  const auto& catalog = BuiltinAdjustmentCatalog::Instance();
-  const std::string prefix = std::string{node->Id().Value()} + ".";
-  for (const auto& type : types) {
-    auto model = catalog.CreateDefault(type);
-    if (model == nullptr) {
-      throw std::logic_error("Missing default adjustment factory for " + std::string{type.Text()});
-    }
-    std::string suffix = InstanceSuffixFor(type);
-    if (type == type_ids::Cat02WhiteBalance()) {
-      suffix = "cat02_wb";
-    } else if (type == type_ids::Hls()) {
-      suffix = "hls";
-    }
-    node->InsertAdjustment(node->AdjustmentCount(), AdjustmentInstanceId{prefix + suffix},
-                           std::move(model));
-  }
+  auto       node  = std::make_unique<ColorGradeNodeModel>(std::move(id));
+  const auto types = DefaultAdjustmentTypes();
+  PopulateAdjustments(*node, types);
   return node;
+}
+
+auto ColorGradeNodeModel::MakeClean(NodeId id) -> std::unique_ptr<ColorGradeNodeModel> {
+  auto       node  = std::make_unique<ColorGradeNodeModel>(std::move(id));
+  const auto types = CleanAdjustmentTypes();
+  PopulateAdjustments(*node, types);
+  return node;
+}
+
+auto CreateCleanColorGradeNode(NodeId id) -> std::unique_ptr<ColorGradeNodeModel> {
+  return ColorGradeNodeModel::MakeClean(std::move(id));
 }
 
 auto ColorGradeNodeModel::FromJson(const nlohmann::json& json) -> std::unique_ptr<ColorGradeNodeModel> {

--- a/alcedo_studio/src/edit/graph/pipeline_document.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_document.cpp
@@ -4,6 +4,7 @@
 
 #include "edit/graph/pipeline_document.hpp"
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -43,6 +44,89 @@ auto NodeFromJson(const nlohmann::json& json) -> std::unique_ptr<INodeModel> {
     return RasterMaskNodeModel::FromJson(json);
   }
   throw std::runtime_error("Unknown node type: " + type);
+}
+
+void ValidateFiniteNumbers(const nlohmann::json& value, const std::string& path) {
+  if (value.is_number_float() && !std::isfinite(value.get<double>())) {
+    throw std::runtime_error("Pipeline document contains a non-finite number at " + path);
+  }
+  if (value.is_array()) {
+    for (std::size_t index = 0; index < value.size(); ++index) {
+      ValidateFiniteNumbers(value[index], path + "[" + std::to_string(index) + "]");
+    }
+    return;
+  }
+  if (value.is_object()) {
+    for (const auto& [key, child] : value.items()) {
+      ValidateFiniteNumbers(child, path + "." + key);
+    }
+  }
+}
+
+void ValidateDocumentShape(const nlohmann::json& json) {
+  if (!json.is_object()) {
+    throw std::runtime_error("Pipeline document must be an object");
+  }
+  if (!json.contains("format_version") || !json["format_version"].is_number_integer() ||
+      json["format_version"].get<std::uint32_t>() != kPipelineDocumentFormatVersion) {
+    throw std::runtime_error("Unsupported pipeline document format_version");
+  }
+  if (!json.contains("geometry") || !json["geometry"].is_object()) {
+    throw std::runtime_error("Pipeline document is missing an object geometry");
+  }
+  if (!json.contains("nodes") || !json["nodes"].is_array()) {
+    throw std::runtime_error("Pipeline document is missing a nodes array");
+  }
+  if (!json.contains("edges") || !json["edges"].is_array()) {
+    throw std::runtime_error("Pipeline document is missing an edges array");
+  }
+
+  for (std::size_t index = 0; index < json["nodes"].size(); ++index) {
+    const auto& node = json["nodes"][index];
+    const auto  path = "nodes[" + std::to_string(index) + "]";
+    if (!node.is_object() || !node.contains("id") || !node["id"].is_string() ||
+        node["id"].get<std::string>().empty() || !node.contains("type") ||
+        !node["type"].is_string() || node["type"].get<std::string>().empty()) {
+      throw std::runtime_error("Pipeline document has an invalid node at " + path);
+    }
+
+    const auto type = node["type"].get<std::string>();
+    if (type == type_ids::ColorGradeNode().Text()) {
+      if (!node.contains("adjustments") || !node["adjustments"].is_array()) {
+        throw std::runtime_error("Pipeline document ColorGrade is missing adjustments at " + path);
+      }
+      for (std::size_t adjustment_index = 0; adjustment_index < node["adjustments"].size();
+           ++adjustment_index) {
+        const auto& adjustment = node["adjustments"][adjustment_index];
+        const auto adjustment_path = path + ".adjustments[" +
+                                     std::to_string(adjustment_index) + "]";
+        if (!adjustment.is_object() || !adjustment.contains("id") ||
+            !adjustment["id"].is_string() || adjustment["id"].get<std::string>().empty() ||
+            !adjustment.contains("type") || !adjustment["type"].is_string() ||
+            adjustment["type"].get<std::string>().empty() || !adjustment.contains("params") ||
+            !adjustment["params"].is_object()) {
+          throw std::runtime_error("Pipeline document has an invalid adjustment at " +
+                                   adjustment_path);
+        }
+      }
+    } else if (!node.contains("params") || !node["params"].is_object()) {
+      throw std::runtime_error("Pipeline document node is missing object params at " + path);
+    }
+  }
+
+  for (std::size_t index = 0; index < json["edges"].size(); ++index) {
+    const auto& edge = json["edges"][index];
+    const auto  path = "edges[" + std::to_string(index) + "]";
+    if (!edge.is_object() || !edge.contains("from") || !edge.contains("to") ||
+        !edge["from"].is_array() || edge["from"].size() != 2 ||
+        !edge["to"].is_array() || edge["to"].size() != 2 ||
+        !edge["from"][0].is_string() || !edge["from"][1].is_string() ||
+        !edge["to"][0].is_string() || !edge["to"][1].is_string()) {
+      throw std::runtime_error("Pipeline document has an invalid edge at " + path);
+    }
+  }
+
+  ValidateFiniteNumbers(json, "document");
 }
 
 void ApplyDefaultPipelineLook(ColorGradeNodeModel& grade) {
@@ -111,28 +195,19 @@ auto PipelineDocument::ToJson() const -> nlohmann::json {
 }
 
 auto PipelineDocument::FromJson(const nlohmann::json& json) -> PipelineDocument {
+  ValidateDocumentShape(json);
   PipelineDocument document;
-  if (!json.contains("format_version") || json["format_version"].get<std::uint32_t>() !=
-                                              kPipelineDocumentFormatVersion) {
-    throw std::runtime_error("Unsupported pipeline document format_version");
-  }
   document.format_version_ = kPipelineDocumentFormatVersion;
-  if (json.contains("geometry")) {
-    document.geometry_ = ImageGeometryModel::FromJson(json["geometry"]);
+  document.geometry_ = ImageGeometryModel::FromJson(json["geometry"]);
+  for (const auto& node_json : json["nodes"]) {
+    document.graph_.AddNode(NodeFromJson(node_json));
   }
-  if (json.contains("nodes") && json["nodes"].is_array()) {
-    for (const auto& node_json : json["nodes"]) {
-      document.graph_.AddNode(NodeFromJson(node_json));
-    }
-  }
-  if (json.contains("edges") && json["edges"].is_array()) {
-    for (const auto& edge_json : json["edges"]) {
-      const auto from = edge_json.at("from");
-      const auto to   = edge_json.at("to");
-      document.graph_.Connect(NodeId{from.at(0).get<std::string>()},
-                              PortId{from.at(1).get<std::string>()},
-                              NodeId{to.at(0).get<std::string>()}, PortId{to.at(1).get<std::string>()});
-    }
+  for (const auto& edge_json : json["edges"]) {
+    const auto from = edge_json.at("from");
+    const auto to   = edge_json.at("to");
+    document.graph_.Connect(NodeId{from.at(0).get<std::string>()},
+                            PortId{from.at(1).get<std::string>()},
+                            NodeId{to.at(0).get<std::string>()}, PortId{to.at(1).get<std::string>()});
   }
   document.topology_dirty_ = true;
   return document;

--- a/alcedo_studio/src/edit/graph/pipeline_document.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_document.cpp
@@ -45,6 +45,16 @@ auto NodeFromJson(const nlohmann::json& json) -> std::unique_ptr<INodeModel> {
   throw std::runtime_error("Unknown node type: " + type);
 }
 
+void ApplyDefaultPipelineLook(ColorGradeNodeModel& grade) {
+  auto* exposure   = grade.FindAdjustmentByType(type_ids::Exposure());
+  auto* saturation = grade.FindAdjustmentByType(type_ids::Saturation());
+  if (exposure == nullptr || saturation == nullptr) {
+    throw std::logic_error("Default Color Grade is missing exposure or saturation");
+  }
+  exposure->LoadJson({{"exposure_ev", kDefaultPipelineExposureEv}});
+  saturation->LoadJson({{"saturation", kDefaultPipelineSaturation}});
+}
+
 }  // namespace
 
 auto PipelineDocument::Develop() -> DevelopNodeModel* {
@@ -131,7 +141,9 @@ auto PipelineDocument::FromJson(const nlohmann::json& json) -> PipelineDocument 
 auto CreateDefaultPipelineDocument() -> PipelineDocument {
   PipelineDocument document;
   document.Graph().AddNode(std::make_unique<DevelopNodeModel>(NodeId{"develop"}));
-  document.Graph().AddNode(ColorGradeNodeModel::MakeDefault(NodeId{"grade.primary"}));
+  auto grade = ColorGradeNodeModel::MakeDefault(NodeId{"grade.primary"});
+  ApplyDefaultPipelineLook(*grade);
+  document.Graph().AddNode(std::move(grade));
   document.Graph().AddNode(std::make_unique<DrtNodeModel>(NodeId{"drt"}));
   document.Graph().Connect(NodeId{"develop"}, PortId{"image"}, NodeId{"grade.primary"},
                            PortId{"image"});

--- a/alcedo_studio/src/edit/graph/pipeline_document.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_document.cpp
@@ -144,6 +144,18 @@ auto ClonePipelineDocument(const PipelineDocument& src) -> PipelineDocument {
   return PipelineDocument::FromJson(src.ToJson());
 }
 
+auto ColorGradesOnImageBackbone(const PipelineDocument& document)
+    -> std::vector<const ColorGradeNodeModel*> {
+  std::vector<const ColorGradeNodeModel*> grades;
+  for (const auto& id : document.Graph().ImageBackboneNodeIds()) {
+    const auto* grade = Downcast<ColorGradeNodeModel>(document.Graph().FindNode(id));
+    if (grade != nullptr) {
+      grades.push_back(grade);
+    }
+  }
+  return grades;
+}
+
 auto AllowsLegacyStageAdapterRemirror(const PipelineDocument& document) -> bool {
   return document.Develop() != nullptr && document.PrimaryGrade() != nullptr &&
          document.Drt() != nullptr;

--- a/alcedo_studio/src/edit/graph/pipeline_graph.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_graph.cpp
@@ -61,6 +61,67 @@ auto PipelineGraph::FindNode(const NodeId& id) -> INodeModel* {
   return const_cast<INodeModel*>(static_cast<const PipelineGraph*>(this)->FindNode(id));
 }
 
+auto PipelineGraph::ApplyBackboneEdit(const std::vector<GraphEdge>& disconnected,
+                                      std::vector<GraphEdge>        connected,
+                                      std::unique_ptr<INodeModel> inserted, const NodeId& removed)
+    -> std::vector<GraphValidationError> {
+  if ((inserted && (!removed.Empty() || FindNode(inserted->Id()))) ||
+      (!removed.Empty() && !FindNode(removed))) {
+    throw std::invalid_argument("Invalid backbone node insertion/removal");
+  }
+  const auto matches = [](const GraphEdge& a, const GraphEdge& b) {
+    return a.from_node == b.from_node && a.from_port == b.from_port && a.to_node == b.to_node &&
+           a.to_port == b.to_port;
+  };
+  std::vector<std::pair<std::size_t, GraphEdge>> retained;
+  for (std::size_t i = 0; i < edges_.size(); ++i) {
+    const auto& edge = edges_[i];
+    if ((!removed.Empty() && (edge.from_node == removed || edge.to_node == removed)) ||
+        std::any_of(disconnected.begin(), disconnected.end(),
+                    [&](const auto& other) { return matches(edge, other); })) {
+      retained.emplace_back(i, edge);
+    }
+  }
+  // Reserve both forward and restoration capacity before changing any live state.
+  edges_.reserve(edges_.size() + connected.size());
+  nodes_.reserve(nodes_.size() + (inserted ? 1 : 0));
+  const auto                  removed_index = static_cast<std::size_t>(std::distance(
+      nodes_.begin(), std::find_if(nodes_.begin(), nodes_.end(),
+                                                    [&](const auto& node) { return node->Id() == removed; })));
+  std::unique_ptr<INodeModel> retained_node;
+  const bool                  has_insert = inserted != nullptr;
+  for (auto it = retained.rbegin(); it != retained.rend(); ++it) {
+    edges_.erase(edges_.begin() + it->first);
+  }
+  const auto kept_edge_count = edges_.size();
+  for (auto& edge : connected) edges_.push_back(std::move(edge));
+  if (has_insert) nodes_.push_back(std::move(inserted));
+  if (!removed.Empty()) {
+    retained_node = std::move(nodes_[removed_index]);
+    nodes_.erase(nodes_.begin() + removed_index);
+  }
+  const auto restore = [&] {
+    edges_.resize(kept_edge_count);
+    for (auto& [index, edge] : retained) {
+      edges_.insert(edges_.begin() + index, std::move(edge));
+    }
+    if (has_insert) nodes_.pop_back();
+    if (retained_node) {
+      nodes_.insert(nodes_.begin() + removed_index, std::move(retained_node));
+    }
+  };
+  try {
+    auto errors   = Validate();
+    auto backbone = ValidateImageBackbone();
+    errors.insert(errors.end(), backbone.begin(), backbone.end());
+    if (!errors.empty()) restore();
+    return errors;
+  } catch (...) {
+    restore();
+    throw;
+  }
+}
+
 auto PipelineGraph::FindNode(const NodeId& id) const -> const INodeModel* {
   for (const auto& node : nodes_) {
     if (node->Id() == id) {

--- a/alcedo_studio/src/edit/graph/pipeline_graph.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_graph.cpp
@@ -4,10 +4,12 @@
 
 #include "edit/graph/pipeline_graph.hpp"
 
+#include <algorithm>
 #include <queue>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "edit/operators/models/builtin_type_ids.hpp"
 
@@ -26,6 +28,33 @@ void PipelineGraph::AddNode(std::unique_ptr<INodeModel> node) {
 void PipelineGraph::Connect(NodeId from_node, PortId from_port, NodeId to_node, PortId to_port) {
   edges_.push_back(GraphEdge{std::move(from_node), std::move(from_port), std::move(to_node),
                              std::move(to_port)});
+}
+
+void PipelineGraph::Disconnect(const NodeId& from_node, const PortId& from_port,
+                                 const NodeId& to_node, const PortId& to_port) {
+  const auto it = std::find_if(edges_.begin(), edges_.end(), [&](const GraphEdge& edge) {
+    return edge.from_node == from_node && edge.from_port == from_port && edge.to_node == to_node &&
+           edge.to_port == to_port;
+  });
+  if (it != edges_.end()) {
+    edges_.erase(it);
+  }
+}
+
+void PipelineGraph::RemoveNode(const NodeId& id) {
+  if (FindNode(id) == nullptr) {
+    throw std::invalid_argument("Unknown node: " + std::string{id.Value()});
+  }
+  edges_.erase(std::remove_if(edges_.begin(), edges_.end(),
+                              [&id](const GraphEdge& edge) {
+                                return edge.from_node == id || edge.to_node == id;
+                              }),
+               edges_.end());
+  nodes_.erase(std::remove_if(nodes_.begin(), nodes_.end(),
+                              [&id](const std::unique_ptr<INodeModel>& node) {
+                                return node->Id() == id;
+                              }),
+               nodes_.end());
 }
 
 auto PipelineGraph::FindNode(const NodeId& id) -> INodeModel* {
@@ -164,6 +193,136 @@ auto PipelineGraph::Validate() const -> std::vector<GraphValidationError> {
   }
   if (visited != nodes_.size()) {
     errors.push_back({GraphValidationCode::Cycle, "PipelineGraph contains a cycle"});
+  }
+  return errors;
+}
+
+auto PipelineGraph::ImageBackboneNodeIds() const -> std::vector<NodeId> {
+  const INodeModel* develop = nullptr;
+  const INodeModel* drt      = nullptr;
+  int               develop_count = 0;
+  int               drt_count      = 0;
+  for (const auto& node : nodes_) {
+    if (node->Type() == type_ids::DevelopNode()) {
+      ++develop_count;
+      develop = node.get();
+    }
+    if (node->Type() == type_ids::DrtNode()) {
+      ++drt_count;
+      drt = node.get();
+    }
+  }
+  if (develop == nullptr || drt == nullptr || develop_count != 1 || drt_count != 1) {
+    return {};
+  }
+
+  std::vector<NodeId> path;
+  std::unordered_set<std::string> visited;
+  NodeId current = develop->Id();
+  while (true) {
+    const std::string key{current.Value()};
+    if (visited.contains(key)) {
+      return {};
+    }
+    visited.insert(key);
+    path.push_back(current);
+    const auto* node = FindNode(current);
+    if (node == nullptr) {
+      return {};
+    }
+    std::vector<NodeId> outgoing;
+    for (const auto& edge : edges_) {
+      if (edge.from_node != current) {
+        continue;
+      }
+      const auto* from_port = FindPort(*node, edge.from_port, false);
+      if (from_port == nullptr || from_port->data_type != PortDataType::SceneImage) {
+        continue;
+      }
+      outgoing.push_back(edge.to_node);
+    }
+    if (outgoing.size() > 1) {
+      return {};
+    }
+    if (outgoing.empty()) {
+      if (current == drt->Id()) {
+        return path;
+      }
+      return {};
+    }
+    current = outgoing.front();
+  }
+}
+
+auto PipelineGraph::ValidateImageBackbone() const -> std::vector<GraphValidationError> {
+  std::vector<GraphValidationError> errors;
+  const INodeModel* develop = nullptr;
+  const INodeModel* drt      = nullptr;
+  for (const auto& node : nodes_) {
+    if (node->Type() == type_ids::DevelopNode()) {
+      develop = node.get();
+    }
+    if (node->Type() == type_ids::DrtNode()) {
+      drt = node.get();
+    }
+  }
+  if (develop == nullptr || drt == nullptr) {
+    errors.push_back({GraphValidationCode::BrokenImageBackbone,
+                       "Image backbone requires one Develop and one DRT"});
+    return errors;
+  }
+
+  for (const auto& node : nodes_) {
+    std::size_t scene_out = 0;
+    for (const auto& edge : edges_) {
+      if (edge.from_node != node->Id()) {
+        continue;
+      }
+      const auto* from_port = FindPort(*node, edge.from_port, false);
+      if (from_port != nullptr && from_port->data_type == PortDataType::SceneImage) {
+        ++scene_out;
+      }
+    }
+    if (scene_out > 1) {
+      errors.push_back({GraphValidationCode::SceneImageFanOut,
+                        "Scene-image fan-out from " + std::string{node->Id().Value()}});
+    }
+  }
+
+  const auto path = ImageBackboneNodeIds();
+  if (path.empty()) {
+    errors.push_back({GraphValidationCode::BrokenImageBackbone,
+                       "Graph has no unique Develop to DRT scene-image path"});
+    return errors;
+  }
+  if (path.front() != develop->Id() || path.back() != drt->Id()) {
+    errors.push_back({GraphValidationCode::BrokenImageBackbone,
+                       "Image backbone does not start at Develop and end at DRT"});
+  }
+
+  std::unordered_set<std::string> on_path;
+  for (const auto& id : path) {
+    on_path.insert(std::string{id.Value()});
+    const auto* node = FindNode(id);
+    if (node == nullptr) {
+      continue;
+    }
+    const auto& type = node->Type();
+    if (type != type_ids::DevelopNode() && type != type_ids::ColorGradeNode() &&
+        type != type_ids::DrtNode()) {
+      errors.push_back({GraphValidationCode::BrokenImageBackbone,
+                        "Non-image node on backbone: " + std::string{id.Value()}});
+    }
+  }
+  for (const auto& node : nodes_) {
+    if (node->Type() != type_ids::ColorGradeNode()) {
+      continue;
+    }
+    if (!on_path.contains(std::string{node->Id().Value()})) {
+      errors.push_back({GraphValidationCode::ColorGradeNotOnImageBackbone,
+                        "Color Grade is not on the image backbone: " +
+                            std::string{node->Id().Value()}});
+    }
   }
   return errors;
 }

--- a/alcedo_studio/src/edit/graph/pipeline_graph_commands.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_graph_commands.cpp
@@ -200,7 +200,7 @@ auto AddCleanColorGrade(PipelineDocument& candidate, const NodeId& before_node_i
   const PortId to_port    = incoming->to_port;
   const NodeId inserted_id = new_id;
   candidate.Graph().Disconnect(predecessor, from_port, before_node_id, to_port);
-  candidate.Graph().AddNode(ColorGradeNodeModel::MakeDefault(inserted_id));
+  candidate.Graph().AddNode(CreateCleanColorGradeNode(inserted_id));
   candidate.Graph().Connect(predecessor, kImagePort, inserted_id, kImagePort);
   candidate.Graph().Connect(inserted_id, kImagePort, before_node_id, kImagePort);
   return CommitOrRestore(candidate, before_json);

--- a/alcedo_studio/src/edit/graph/pipeline_graph_commands.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_graph_commands.cpp
@@ -1,0 +1,318 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/pipeline_graph_commands.hpp"
+
+#include <string>
+#include <utility>
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/port.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "json.hpp"
+
+namespace alcedo {
+namespace {
+
+const PortId kImagePort{"image"};
+
+auto Error(GraphValidationCode code, std::string message) -> GraphValidationError {
+  return {code, std::move(message)};
+}
+
+auto CombineValidation(const PipelineDocument& document) -> std::vector<GraphValidationError> {
+  auto errors = document.Graph().Validate();
+  auto backbone = document.Graph().ValidateImageBackbone();
+  errors.insert(errors.end(), backbone.begin(), backbone.end());
+  return errors;
+}
+
+auto Restore(PipelineDocument& candidate, const nlohmann::json& before) -> void {
+  candidate = PipelineDocument::FromJson(before);
+}
+
+auto CommitOrRestore(PipelineDocument& candidate, const nlohmann::json& before)
+    -> std::vector<GraphValidationError> {
+  auto errors = CombineValidation(candidate);
+  if (!errors.empty()) {
+    Restore(candidate, before);
+    return errors;
+  }
+  candidate.MarkTopologyDirty();
+  return {};
+}
+
+auto RequireColorGrade(const PipelineDocument& document, const NodeId& node_id)
+    -> std::vector<GraphValidationError> {
+  const auto* node = document.Graph().FindNode(node_id);
+  if (node == nullptr) {
+    return {Error(GraphValidationCode::UnknownNode,
+                  "Unknown node: " + std::string{node_id.Value()})};
+  }
+  if (node->Type() == type_ids::DevelopNode() || node->Type() == type_ids::DrtNode()) {
+    return {Error(GraphValidationCode::ProtectedEndpoint,
+                  "Develop and DRT cannot be edited as Color Grades: " +
+                      std::string{node_id.Value()})};
+  }
+  if (node->Type() != type_ids::ColorGradeNode()) {
+    return {Error(GraphValidationCode::NotAColorGrade,
+                  "Node is not a Color Grade: " + std::string{node_id.Value()})};
+  }
+  return {};
+}
+
+auto SceneImagePredecessor(const PipelineGraph& graph, const NodeId& node_id)
+    -> const GraphEdge* {
+  const auto* node = graph.FindNode(node_id);
+  if (node == nullptr) {
+    return nullptr;
+  }
+  const GraphEdge* found = nullptr;
+  for (const auto& edge : graph.Edges()) {
+    if (edge.to_node != node_id) {
+      continue;
+    }
+    const auto* to_port = [&]() -> const PortDescriptor* {
+      for (const auto& port : node->InputPorts()) {
+        if (port.id == edge.to_port) {
+          return &port;
+        }
+      }
+      return nullptr;
+    }();
+    if (to_port == nullptr || to_port->data_type != PortDataType::SceneImage) {
+      continue;
+    }
+    if (found != nullptr) {
+      return nullptr;
+    }
+    found = &edge;
+  }
+  return found;
+}
+
+auto SceneImageSuccessor(const PipelineGraph& graph, const NodeId& node_id) -> const GraphEdge* {
+  const auto* node = graph.FindNode(node_id);
+  if (node == nullptr) {
+    return nullptr;
+  }
+  const GraphEdge* found = nullptr;
+  for (const auto& edge : graph.Edges()) {
+    if (edge.from_node != node_id) {
+      continue;
+    }
+    const auto* from_port = [&]() -> const PortDescriptor* {
+      for (const auto& port : node->OutputPorts()) {
+        if (port.id == edge.from_port) {
+          return &port;
+        }
+      }
+      return nullptr;
+    }();
+    if (from_port == nullptr || from_port->data_type != PortDataType::SceneImage) {
+      continue;
+    }
+    if (found != nullptr) {
+      return nullptr;
+    }
+    found = &edge;
+  }
+  return found;
+}
+
+auto FindSceneImageEdge(const PipelineGraph& graph, const NodeId& from, const NodeId& to)
+    -> const GraphEdge* {
+  for (const auto& edge : graph.Edges()) {
+    if (edge.from_node == from && edge.to_node == to && edge.from_port == kImagePort &&
+        edge.to_port == kImagePort) {
+      return &edge;
+    }
+  }
+  return nullptr;
+}
+
+void BridgeSceneImage(PipelineGraph& graph, const NodeId& predecessor, const NodeId& successor) {
+  graph.Connect(predecessor, kImagePort, successor, kImagePort);
+}
+
+void SpliceOutColorGrade(PipelineGraph& graph, const NodeId& node_id) {
+  const auto* incoming = SceneImagePredecessor(graph, node_id);
+  const auto* outgoing  = SceneImageSuccessor(graph, node_id);
+  NodeId predecessor;
+  NodeId successor;
+  PortId in_from_port;
+  PortId in_to_port;
+  PortId out_from_port;
+  PortId out_to_port;
+  const bool has_in  = incoming != nullptr;
+  const bool has_out = outgoing != nullptr;
+  if (has_in) {
+    predecessor = incoming->from_node;
+    in_from_port = incoming->from_port;
+    in_to_port   = incoming->to_port;
+  }
+  if (has_out) {
+    successor     = outgoing->to_node;
+    out_from_port = outgoing->from_port;
+    out_to_port   = outgoing->to_port;
+  }
+  if (has_in) {
+    graph.Disconnect(predecessor, in_from_port, node_id, in_to_port);
+  }
+  if (has_out) {
+    graph.Disconnect(node_id, out_from_port, successor, out_to_port);
+  }
+  if (has_in && has_out) {
+    BridgeSceneImage(graph, predecessor, successor);
+  }
+}
+
+}  // namespace
+
+auto AddCleanColorGrade(PipelineDocument& candidate, const NodeId& before_node_id, NodeId new_id)
+    -> std::vector<GraphValidationError> {
+  if (new_id.Empty()) {
+    return {Error(GraphValidationCode::UnknownNode, "AddCleanColorGrade requires a NodeId")};
+  }
+  if (candidate.Graph().FindNode(new_id) != nullptr) {
+    return {Error(GraphValidationCode::DuplicateNodeId,
+                  "Duplicate node id: " + std::string{new_id.Value()})};
+  }
+  const auto* before = candidate.Graph().FindNode(before_node_id);
+  if (before == nullptr) {
+    return {Error(GraphValidationCode::UnknownNode,
+                  "Unknown insert point: " + std::string{before_node_id.Value()})};
+  }
+  if (before->Type() == type_ids::DevelopNode()) {
+    return {Error(GraphValidationCode::ProtectedEndpoint, "Cannot insert a Color Grade before Develop")};
+  }
+  const auto* incoming = SceneImagePredecessor(candidate.Graph(), before_node_id);
+  if (incoming == nullptr) {
+    return {Error(GraphValidationCode::BrokenImageBackbone,
+                  "Insert point has no scene-image predecessor: " +
+                      std::string{before_node_id.Value()})};
+  }
+
+  const auto before_json = candidate.ToJson();
+  const NodeId predecessor = incoming->from_node;
+  const PortId from_port  = incoming->from_port;
+  const PortId to_port    = incoming->to_port;
+  const NodeId inserted_id = new_id;
+  candidate.Graph().Disconnect(predecessor, from_port, before_node_id, to_port);
+  candidate.Graph().AddNode(ColorGradeNodeModel::MakeDefault(inserted_id));
+  candidate.Graph().Connect(predecessor, kImagePort, inserted_id, kImagePort);
+  candidate.Graph().Connect(inserted_id, kImagePort, before_node_id, kImagePort);
+  return CommitOrRestore(candidate, before_json);
+}
+
+auto RemoveColorGradeAndBridge(PipelineDocument& candidate, const NodeId& node_id)
+    -> std::vector<GraphValidationError> {
+  auto errors = RequireColorGrade(candidate, node_id);
+  if (!errors.empty()) {
+    return errors;
+  }
+  const auto* incoming = SceneImagePredecessor(candidate.Graph(), node_id);
+  const auto* outgoing = SceneImageSuccessor(candidate.Graph(), node_id);
+  if (incoming == nullptr || outgoing == nullptr) {
+    return {Error(GraphValidationCode::BrokenImageBackbone,
+                  "Color Grade is not on a scene-image edge pair: " +
+                      std::string{node_id.Value()})};
+  }
+
+  const auto before_json = candidate.ToJson();
+  SpliceOutColorGrade(candidate.Graph(), node_id);
+  candidate.Graph().RemoveNode(node_id);
+  return CommitOrRestore(candidate, before_json);
+}
+
+auto ReconnectColorGrade(PipelineDocument& candidate, const NodeId& node_id,
+                          const NodeId& new_predecessor_id, const NodeId& new_successor_id)
+    -> std::vector<GraphValidationError> {
+  auto errors = RequireColorGrade(candidate, node_id);
+  if (!errors.empty()) {
+    return errors;
+  }
+  if (node_id == new_predecessor_id || node_id == new_successor_id ||
+      new_predecessor_id == new_successor_id) {
+    return {Error(GraphValidationCode::BrokenImageBackbone,
+                  "Reconnect requires distinct node, predecessor, and successor")};
+  }
+  if (candidate.Graph().FindNode(new_predecessor_id) == nullptr) {
+    return {Error(GraphValidationCode::UnknownNode,
+                  "Unknown predecessor: " + std::string{new_predecessor_id.Value()})};
+  }
+  if (candidate.Graph().FindNode(new_successor_id) == nullptr) {
+    return {Error(GraphValidationCode::UnknownNode,
+                  "Unknown successor: " + std::string{new_successor_id.Value()})};
+  }
+  const auto* incoming = SceneImagePredecessor(candidate.Graph(), node_id);
+  const auto* outgoing = SceneImageSuccessor(candidate.Graph(), node_id);
+  if (incoming == nullptr || outgoing == nullptr) {
+    return {Error(GraphValidationCode::BrokenImageBackbone,
+                  "Color Grade is not on a scene-image edge pair: " +
+                      std::string{node_id.Value()})};
+  }
+
+  const auto before_json = candidate.ToJson();
+  SpliceOutColorGrade(candidate.Graph(), node_id);
+  const auto* insert_edge =
+      FindSceneImageEdge(candidate.Graph(), new_predecessor_id, new_successor_id);
+  if (insert_edge != nullptr) {
+    const NodeId from_node = insert_edge->from_node;
+    const PortId from_port = insert_edge->from_port;
+    const NodeId to_node   = insert_edge->to_node;
+    const PortId to_port    = insert_edge->to_port;
+    candidate.Graph().Disconnect(from_node, from_port, to_node, to_port);
+  }
+  candidate.Graph().Connect(new_predecessor_id, kImagePort, node_id, kImagePort);
+  candidate.Graph().Connect(node_id, kImagePort, new_successor_id, kImagePort);
+  return CommitOrRestore(candidate, before_json);
+}
+
+auto RenameColorGrade(PipelineDocument& candidate, const NodeId& node_id,
+                        std::string display_name) -> std::vector<GraphValidationError> {
+  auto errors = RequireColorGrade(candidate, node_id);
+  if (!errors.empty()) {
+    return errors;
+  }
+  if (display_name.empty()) {
+    return {Error(GraphValidationCode::InvalidDisplayName, "Color Grade display name cannot be empty")};
+  }
+  auto* grade = dynamic_cast<ColorGradeNodeModel*>(candidate.Graph().FindNode(node_id));
+  if (grade == nullptr) {
+    return {Error(GraphValidationCode::NotAColorGrade,
+                  "Node is not a Color Grade: " + std::string{node_id.Value()})};
+  }
+  const auto before_json = candidate.ToJson();
+  grade->SetDisplayName(std::move(display_name));
+  errors = CombineValidation(candidate);
+  if (!errors.empty()) {
+    Restore(candidate, before_json);
+    return errors;
+  }
+  return {};
+}
+
+auto SetColorGradeEnabled(PipelineDocument& candidate, const NodeId& node_id, bool enabled)
+    -> std::vector<GraphValidationError> {
+  auto errors = RequireColorGrade(candidate, node_id);
+  if (!errors.empty()) {
+    return errors;
+  }
+  auto* grade = dynamic_cast<ColorGradeNodeModel*>(candidate.Graph().FindNode(node_id));
+  if (grade == nullptr) {
+    return {Error(GraphValidationCode::NotAColorGrade,
+                  "Node is not a Color Grade: " + std::string{node_id.Value()})};
+  }
+  const auto before_json = candidate.ToJson();
+  grade->SetEnabled(enabled);
+  errors = CombineValidation(candidate);
+  if (!errors.empty()) {
+    Restore(candidate, before_json);
+    return errors;
+  }
+  return {};
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/graph/pipeline_graph_commands.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_graph_commands.cpp
@@ -10,7 +10,6 @@
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/port.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
-#include "json.hpp"
 
 namespace alcedo {
 namespace {
@@ -21,26 +20,11 @@ auto Error(GraphValidationCode code, std::string message) -> GraphValidationErro
   return {code, std::move(message)};
 }
 
-auto CombineValidation(const PipelineDocument& document) -> std::vector<GraphValidationError> {
-  auto errors = document.Graph().Validate();
-  auto backbone = document.Graph().ValidateImageBackbone();
-  errors.insert(errors.end(), backbone.begin(), backbone.end());
-  return errors;
-}
-
-auto Restore(PipelineDocument& candidate, const nlohmann::json& before) -> void {
-  candidate = PipelineDocument::FromJson(before);
-}
-
-auto CommitOrRestore(PipelineDocument& candidate, const nlohmann::json& before)
+/// Mark topology only after the graph accepted and completed a local edit.
+auto FinishEdit(PipelineDocument& document, std::vector<GraphValidationError> errors)
     -> std::vector<GraphValidationError> {
-  auto errors = CombineValidation(candidate);
-  if (!errors.empty()) {
-    Restore(candidate, before);
-    return errors;
-  }
-  candidate.MarkTopologyDirty();
-  return {};
+  if (errors.empty()) document.MarkTopologyDirty();
+  return errors;
 }
 
 auto RequireColorGrade(const PipelineDocument& document, const NodeId& node_id)
@@ -132,54 +116,18 @@ auto FindSceneImageEdge(const PipelineGraph& graph, const NodeId& from, const No
   return nullptr;
 }
 
-void BridgeSceneImage(PipelineGraph& graph, const NodeId& predecessor, const NodeId& successor) {
-  graph.Connect(predecessor, kImagePort, successor, kImagePort);
-}
-
-void SpliceOutColorGrade(PipelineGraph& graph, const NodeId& node_id) {
-  const auto* incoming = SceneImagePredecessor(graph, node_id);
-  const auto* outgoing  = SceneImageSuccessor(graph, node_id);
-  NodeId predecessor;
-  NodeId successor;
-  PortId in_from_port;
-  PortId in_to_port;
-  PortId out_from_port;
-  PortId out_to_port;
-  const bool has_in  = incoming != nullptr;
-  const bool has_out = outgoing != nullptr;
-  if (has_in) {
-    predecessor = incoming->from_node;
-    in_from_port = incoming->from_port;
-    in_to_port   = incoming->to_port;
-  }
-  if (has_out) {
-    successor     = outgoing->to_node;
-    out_from_port = outgoing->from_port;
-    out_to_port   = outgoing->to_port;
-  }
-  if (has_in) {
-    graph.Disconnect(predecessor, in_from_port, node_id, in_to_port);
-  }
-  if (has_out) {
-    graph.Disconnect(node_id, out_from_port, successor, out_to_port);
-  }
-  if (has_in && has_out) {
-    BridgeSceneImage(graph, predecessor, successor);
-  }
-}
-
 }  // namespace
 
-auto AddCleanColorGrade(PipelineDocument& candidate, const NodeId& before_node_id, NodeId new_id)
+auto AddCleanColorGrade(PipelineDocument& document, const NodeId& before_node_id, NodeId new_id)
     -> std::vector<GraphValidationError> {
   if (new_id.Empty()) {
     return {Error(GraphValidationCode::UnknownNode, "AddCleanColorGrade requires a NodeId")};
   }
-  if (candidate.Graph().FindNode(new_id) != nullptr) {
+  if (document.Graph().FindNode(new_id) != nullptr) {
     return {Error(GraphValidationCode::DuplicateNodeId,
                   "Duplicate node id: " + std::string{new_id.Value()})};
   }
-  const auto* before = candidate.Graph().FindNode(before_node_id);
+  const auto* before = document.Graph().FindNode(before_node_id);
   if (before == nullptr) {
     return {Error(GraphValidationCode::UnknownNode,
                   "Unknown insert point: " + std::string{before_node_id.Value()})};
@@ -187,49 +135,47 @@ auto AddCleanColorGrade(PipelineDocument& candidate, const NodeId& before_node_i
   if (before->Type() == type_ids::DevelopNode()) {
     return {Error(GraphValidationCode::ProtectedEndpoint, "Cannot insert a Color Grade before Develop")};
   }
-  const auto* incoming = SceneImagePredecessor(candidate.Graph(), before_node_id);
+  const auto* incoming = SceneImagePredecessor(document.Graph(), before_node_id);
   if (incoming == nullptr) {
     return {Error(GraphValidationCode::BrokenImageBackbone,
                   "Insert point has no scene-image predecessor: " +
                       std::string{before_node_id.Value()})};
   }
 
-  const auto before_json = candidate.ToJson();
-  const NodeId predecessor = incoming->from_node;
-  const PortId from_port  = incoming->from_port;
-  const PortId to_port    = incoming->to_port;
-  const NodeId inserted_id = new_id;
-  candidate.Graph().Disconnect(predecessor, from_port, before_node_id, to_port);
-  candidate.Graph().AddNode(CreateCleanColorGradeNode(inserted_id));
-  candidate.Graph().Connect(predecessor, kImagePort, inserted_id, kImagePort);
-  candidate.Graph().Connect(inserted_id, kImagePort, before_node_id, kImagePort);
-  return CommitOrRestore(candidate, before_json);
+  const GraphEdge previous = *incoming;
+  auto            node     = CreateCleanColorGradeNode(new_id);
+  return FinishEdit(document, document.Graph().ApplyBackboneEdit(
+                                  {previous},
+                                  {{previous.from_node, previous.from_port, new_id, kImagePort},
+                                   {new_id, kImagePort, before_node_id, previous.to_port}},
+                                  std::move(node)));
 }
 
-auto RemoveColorGradeAndBridge(PipelineDocument& candidate, const NodeId& node_id)
+auto RemoveColorGradeAndBridge(PipelineDocument& document, const NodeId& node_id)
     -> std::vector<GraphValidationError> {
-  auto errors = RequireColorGrade(candidate, node_id);
+  auto errors = RequireColorGrade(document, node_id);
   if (!errors.empty()) {
     return errors;
   }
-  const auto* incoming = SceneImagePredecessor(candidate.Graph(), node_id);
-  const auto* outgoing = SceneImageSuccessor(candidate.Graph(), node_id);
+  const auto* incoming = SceneImagePredecessor(document.Graph(), node_id);
+  const auto* outgoing = SceneImageSuccessor(document.Graph(), node_id);
   if (incoming == nullptr || outgoing == nullptr) {
     return {Error(GraphValidationCode::BrokenImageBackbone,
                   "Color Grade is not on a scene-image edge pair: " +
                       std::string{node_id.Value()})};
   }
 
-  const auto before_json = candidate.ToJson();
-  SpliceOutColorGrade(candidate.Graph(), node_id);
-  candidate.Graph().RemoveNode(node_id);
-  return CommitOrRestore(candidate, before_json);
+  return FinishEdit(
+      document,
+      document.Graph().ApplyBackboneEdit(
+          {}, {{incoming->from_node, incoming->from_port, outgoing->to_node, outgoing->to_port}},
+          nullptr, node_id));
 }
 
-auto ReconnectColorGrade(PipelineDocument& candidate, const NodeId& node_id,
-                          const NodeId& new_predecessor_id, const NodeId& new_successor_id)
+auto ReconnectColorGrade(PipelineDocument& document, const NodeId& node_id,
+                         const NodeId& new_predecessor_id, const NodeId& new_successor_id)
     -> std::vector<GraphValidationError> {
-  auto errors = RequireColorGrade(candidate, node_id);
+  auto errors = RequireColorGrade(document, node_id);
   if (!errors.empty()) {
     return errors;
   }
@@ -238,80 +184,68 @@ auto ReconnectColorGrade(PipelineDocument& candidate, const NodeId& node_id,
     return {Error(GraphValidationCode::BrokenImageBackbone,
                   "Reconnect requires distinct node, predecessor, and successor")};
   }
-  if (candidate.Graph().FindNode(new_predecessor_id) == nullptr) {
+  if (document.Graph().FindNode(new_predecessor_id) == nullptr) {
     return {Error(GraphValidationCode::UnknownNode,
                   "Unknown predecessor: " + std::string{new_predecessor_id.Value()})};
   }
-  if (candidate.Graph().FindNode(new_successor_id) == nullptr) {
+  if (document.Graph().FindNode(new_successor_id) == nullptr) {
     return {Error(GraphValidationCode::UnknownNode,
                   "Unknown successor: " + std::string{new_successor_id.Value()})};
   }
-  const auto* incoming = SceneImagePredecessor(candidate.Graph(), node_id);
-  const auto* outgoing = SceneImageSuccessor(candidate.Graph(), node_id);
+  const auto* incoming = SceneImagePredecessor(document.Graph(), node_id);
+  const auto* outgoing = SceneImageSuccessor(document.Graph(), node_id);
   if (incoming == nullptr || outgoing == nullptr) {
     return {Error(GraphValidationCode::BrokenImageBackbone,
                   "Color Grade is not on a scene-image edge pair: " +
                       std::string{node_id.Value()})};
   }
 
-  const auto before_json = candidate.ToJson();
-  SpliceOutColorGrade(candidate.Graph(), node_id);
-  const auto* insert_edge =
-      FindSceneImageEdge(candidate.Graph(), new_predecessor_id, new_successor_id);
-  if (insert_edge != nullptr) {
-    const NodeId from_node = insert_edge->from_node;
-    const PortId from_port = insert_edge->from_port;
-    const NodeId to_node   = insert_edge->to_node;
-    const PortId to_port    = insert_edge->to_port;
-    candidate.Graph().Disconnect(from_node, from_port, to_node, to_port);
+  // Moving to the current location changes neither topology nor ownership.
+  if (incoming->from_node == new_predecessor_id && outgoing->to_node == new_successor_id) {
+    return document.Graph().ApplyBackboneEdit({}, {});
   }
-  candidate.Graph().Connect(new_predecessor_id, kImagePort, node_id, kImagePort);
-  candidate.Graph().Connect(node_id, kImagePort, new_successor_id, kImagePort);
-  return CommitOrRestore(candidate, before_json);
+  const auto* insert_edge =
+      FindSceneImageEdge(document.Graph(), new_predecessor_id, new_successor_id);
+  std::vector<GraphEdge> disconnected{*incoming, *outgoing};
+  if (insert_edge != nullptr) disconnected.push_back(*insert_edge);
+  return FinishEdit(document,
+                    document.Graph().ApplyBackboneEdit(
+                        disconnected, {{incoming->from_node, incoming->from_port, outgoing->to_node,
+                                        outgoing->to_port},
+                                       {new_predecessor_id, kImagePort, node_id, kImagePort},
+                                       {node_id, kImagePort, new_successor_id, kImagePort}}));
 }
 
-auto RenameColorGrade(PipelineDocument& candidate, const NodeId& node_id,
-                        std::string display_name) -> std::vector<GraphValidationError> {
-  auto errors = RequireColorGrade(candidate, node_id);
+auto RenameColorGrade(PipelineDocument& document, const NodeId& node_id, std::string display_name)
+    -> std::vector<GraphValidationError> {
+  auto errors = RequireColorGrade(document, node_id);
   if (!errors.empty()) {
     return errors;
   }
   if (display_name.empty()) {
     return {Error(GraphValidationCode::InvalidDisplayName, "Color Grade display name cannot be empty")};
   }
-  auto* grade = dynamic_cast<ColorGradeNodeModel*>(candidate.Graph().FindNode(node_id));
+  auto* grade = dynamic_cast<ColorGradeNodeModel*>(document.Graph().FindNode(node_id));
   if (grade == nullptr) {
     return {Error(GraphValidationCode::NotAColorGrade,
                   "Node is not a Color Grade: " + std::string{node_id.Value()})};
   }
-  const auto before_json = candidate.ToJson();
   grade->SetDisplayName(std::move(display_name));
-  errors = CombineValidation(candidate);
-  if (!errors.empty()) {
-    Restore(candidate, before_json);
-    return errors;
-  }
   return {};
 }
 
-auto SetColorGradeEnabled(PipelineDocument& candidate, const NodeId& node_id, bool enabled)
+auto SetColorGradeEnabled(PipelineDocument& document, const NodeId& node_id, bool enabled)
     -> std::vector<GraphValidationError> {
-  auto errors = RequireColorGrade(candidate, node_id);
+  auto errors = RequireColorGrade(document, node_id);
   if (!errors.empty()) {
     return errors;
   }
-  auto* grade = dynamic_cast<ColorGradeNodeModel*>(candidate.Graph().FindNode(node_id));
+  auto* grade = dynamic_cast<ColorGradeNodeModel*>(document.Graph().FindNode(node_id));
   if (grade == nullptr) {
     return {Error(GraphValidationCode::NotAColorGrade,
                   "Node is not a Color Grade: " + std::string{node_id.Value()})};
   }
-  const auto before_json = candidate.ToJson();
   grade->SetEnabled(enabled);
-  errors = CombineValidation(candidate);
-  if (!errors.empty()) {
-    Restore(candidate, before_json);
-    return errors;
-  }
   return {};
 }
 

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -6,14 +6,10 @@
 
 #include <algorithm>
 #include <array>
-#include <chrono>
-#include <iomanip>
-#include <iostream>
 #include <memory>
 #include <opencv2/core.hpp>
 #include <opencv2/core/mat.hpp>
 #include <opencv2/opencv.hpp>
-#include <sstream>
 #include <stdexcept>
 #include <vector>
 
@@ -26,7 +22,6 @@
 #if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
 #include "edit/geometry/render_request.hpp"
 #include "edit/graph/develop_color_transform.hpp"
-#include "edit/graph/legacy_pipeline_importer.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #endif
 #ifdef HAVE_CUDA
@@ -42,9 +37,9 @@
 namespace alcedo {
 
 namespace {
-using ProfileClock = std::chrono::steady_clock;
 
 #if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
+/** @brief Bind import-time camera metadata with exclusive document access, preserving user edits. */
 void ApplyImportedCameraProfile(PipelineDocument&             document,
                                 const RawRuntimeColorContext& imported) {
   auto* develop = document.Develop();
@@ -59,6 +54,7 @@ void ApplyImportedCameraProfile(PipelineDocument&             document,
   }
 }
 
+/** @brief Translate runtime settings to a render request without touching persistent Models. */
 auto BuildGpuDagRenderRequest(const std::optional<ViewportRenderRegion>& viewport,
                               const nlohmann::json& render_params, bool force_cpu_output)
     -> RenderRequest {
@@ -84,13 +80,10 @@ auto BuildGpuDagRenderRequest(const std::optional<ViewportRenderRegion>& viewpor
   return request;
 }
 
+/** @brief Reuse the renderer bound to this document; propagate all render failures to the caller. */
 template <class ProductRenderer>
 auto ApplyGpuDagProduct(std::shared_ptr<ProductRenderer>&            renderer,
                         const std::shared_ptr<PipelineDocument>&     document,
-                        nlohmann::json&                              legacy_snapshot,
-                        bool                                         mirror_legacy,
-                        const std::optional<RawRuntimeColorContext>& injected,
-                        const nlohmann::json&                        legacy_params,
                         const std::shared_ptr<ImageBuffer>&          input, DecodeRes decode_res,
                         const RenderRequest& request, IFrameSink* sink,
                         const FrameCompletionSubmission& submission, bool require_host_output,
@@ -98,32 +91,10 @@ auto ApplyGpuDagProduct(std::shared_ptr<ProductRenderer>&            renderer,
   if (!renderer) {
     renderer = std::make_shared<ProductRenderer>(document);
   }
-  if (mirror_legacy && AllowsLegacyStageAdapterRemirror(*document)) {
-    if (legacy_params != legacy_snapshot) {
-      const auto error = LegacyPipelineImporter::ApplyOnto(*document, legacy_params);
-      if (!error.empty()) {
-        throw std::runtime_error("CPUPipelineExecutor: legacy adapter import failed: " + error);
-      }
-      legacy_snapshot = legacy_params;
-      if (injected.has_value()) {
-        ApplyImportedCameraProfile(*document, *injected);
-      }
-    }
-  }
   return renderer->Render(input, decode_res, request, sink, submission, require_host_output,
                           cache_policy);
 }
 #endif
-
-auto DurationToMs(const ProfileClock::duration duration) -> double {
-  return std::chrono::duration<double, std::milli>(duration).count();
-}
-
-auto FormatDurationMs(const double duration_ms) -> std::string {
-  std::ostringstream oss;
-  oss << std::fixed << std::setprecision(2) << duration_ms << " ms";
-  return oss.str();
-}
 
 void SetCleanBaselineAdjustableOperators(
     std::array<PipelineStage, static_cast<int>(PipelineStageName::Stage_Count)>& stages,
@@ -166,24 +137,6 @@ void SetCleanBaselineAdjustableOperators(
   set_enabled(PipelineStageName::Output_Transform, OperatorType::FILM_GRAIN,
               baseline.at("film_grain"));
   set_enabled(PipelineStageName::Output_Transform, OperatorType::HALATION, baseline.at("halation"));
-}
-
-void PrintPipelineProfile(const ProfileClock::time_point  apply_start,
-                          const std::vector<std::string>& executor_steps,
-                          const std::vector<std::string>& stage_profiles) {
-  std::ostringstream summary;
-  summary << "[PROFILE][PipelineCPU] total="
-          << FormatDurationMs(DurationToMs(ProfileClock::now() - apply_start));
-  for (const auto& step : executor_steps) {
-    summary << " | " << step;
-  }
-  std::cout << summary.str() << '\n';
-
-  for (const auto& profile : stage_profiles) {
-    if (!profile.empty()) {
-      std::cout << "[PROFILE][PipelineCPU] " << profile << '\n';
-    }
-  }
 }
 
 auto ToResizeAlgorithmParam(ResizeDownsampleAlgorithm algorithm) -> const char* {
@@ -264,7 +217,6 @@ auto CPUPipelineExecutor::GetStage(PipelineStageName stage) -> PipelineStage& {
 
 auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     -> std::shared_ptr<ImageBuffer> {
-  const auto apply_start = ProfileClock::now();
 #if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
   const bool use_gpu_dag =
 #ifdef HAVE_CUDA
@@ -277,160 +229,50 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
       resolved_accelerator_backend_ == GpuBackendKind::OpenCL ||
 #endif
       false;
-  if (pipeline_document_ && use_gpu_dag) {
-    const auto request = BuildGpuDagRenderRequest(render_request_viewport_, render_params_,
-                                                  force_cpu_output_);
-    const auto cache_policy = enable_cache_ ? RenderCachePolicy::UseSessionCache
-                                            : RenderCachePolicy::BypassSessionCache;
+  if (!pipeline_document_) {
+    throw std::runtime_error(
+        "CPUPipelineExecutor: product rendering requires a bound PipelineDocument");
+  }
+  if (use_gpu_dag) {
+    const auto request =
+        BuildGpuDagRenderRequest(render_request_viewport_, render_params_, force_cpu_output_);
+    const auto cache_policy =
+        enable_cache_ ? RenderCachePolicy::UseSessionCache : RenderCachePolicy::BypassSessionCache;
 #ifdef HAVE_CUDA
     if (resolved_accelerator_backend_ == GpuBackendKind::CUDA) {
-      return ApplyGpuDagProduct(cuda_product_renderer_, pipeline_document_,
-                                gpu_dag_legacy_snapshot_, mirror_legacy_stage_adapter_,
-                                injected_raw_color_context_, ExportPipelineParams(), input,
-                                decode_res_, request, frame_sink_, bound_frame_submission_,
-                                force_cpu_output_, cache_policy);
+      return ApplyGpuDagProduct(cuda_product_renderer_, pipeline_document_, input, decode_res_,
+                                request, frame_sink_, bound_frame_submission_, force_cpu_output_,
+                                cache_policy);
     }
 #endif
 #ifdef HAVE_METAL
     if (resolved_accelerator_backend_ == GpuBackendKind::Metal) {
-      return ApplyGpuDagProduct(metal_product_renderer_, pipeline_document_,
-                                gpu_dag_legacy_snapshot_, mirror_legacy_stage_adapter_,
-                                injected_raw_color_context_, ExportPipelineParams(), input,
-                                decode_res_, request, frame_sink_, bound_frame_submission_,
-                                force_cpu_output_, cache_policy);
+      return ApplyGpuDagProduct(metal_product_renderer_, pipeline_document_, input, decode_res_,
+                                request, frame_sink_, bound_frame_submission_, force_cpu_output_,
+                                cache_policy);
     }
 #endif
 #ifdef HAVE_OPENCL
     if (resolved_accelerator_backend_ == GpuBackendKind::OpenCL) {
-      return ApplyGpuDagProduct(opencl_product_renderer_, pipeline_document_,
-                                gpu_dag_legacy_snapshot_, mirror_legacy_stage_adapter_,
-                                injected_raw_color_context_, ExportPipelineParams(), input,
-                                decode_res_, request, frame_sink_, bound_frame_submission_,
-                                force_cpu_output_, cache_policy);
+      return ApplyGpuDagProduct(opencl_product_renderer_, pipeline_document_, input, decode_res_,
+                                request, frame_sink_, bound_frame_submission_, force_cpu_output_,
+                                cache_policy);
     }
 #endif
   }
 #endif
-  if (exec_stages_.empty()) {
-    return input;
-  }
-
-  // The RAW decode backend follows the resolved runtime preference on every
-  // render; a stage op replaced by direct SetOperator writes can never drift
-  // the decode away from the user's backend setting.
-  ApplyRuntimeRawDecodeBackend();
-
-  std::vector<std::string> executor_steps;
-  std::vector<std::string> stage_profiles;
-  auto*                    first_stage = exec_stages_.front();
-  if (!first_stage) {
-    return input;
-  }
-
-  std::shared_ptr<ImageBuffer> output;
-  // Before the merged GPU stream, re-trigger SetGlobalParams for operators
-  // in stages that feed into it, so they pick up runtime data (e.g. raw decode
-  // context) written by earlier non-merged stages.
-  auto                         refresh_before_merged = [&](PipelineStage* stage) {
-    if (stage->stage_ == PipelineStageName::Merged_Stage) {
-      for (size_t i = static_cast<size_t>(PipelineStageName::To_WorkingSpace); i < stages_.size();
-           ++i) {
-        stages_[i].RefreshGlobalParams(global_params_);
-      }
-    }
-  };
-
-  const auto apply_stage = [&](PipelineStage* stage) {
-    const auto refresh_start = ProfileClock::now();
-    refresh_before_merged(stage);
-    const auto refresh_elapsed = ProfileClock::now() - refresh_start;
-
-    const auto stage_start     = ProfileClock::now();
-    stage->SetInputImage(output);
-    stage->SetForceCPUOutput(force_cpu_output_);
-    output                    = stage->ApplyStage(global_params_);
-
-    std::string stage_profile = stage->GetLastProfileSummary();
-    if (stage_profile.empty()) {
-      std::ostringstream fallback;
-      fallback << "stage=" << stage->GetStageNameString()
-               << " total=" << FormatDurationMs(DurationToMs(ProfileClock::now() - stage_start));
-      stage_profile = fallback.str();
-    } else {
-      stage_profile +=
-          " | executor_call=" + FormatDurationMs(DurationToMs(ProfileClock::now() - stage_start));
-    }
-
-    if (stage->stage_ == PipelineStageName::Merged_Stage) {
-      stage_profile +=
-          " | refresh_global_params=" + FormatDurationMs(DurationToMs(refresh_elapsed));
-    }
-    stage_profiles.push_back(std::move(stage_profile));
-  };
-
-  // Session tasks hold a multi-MB encoded source (RAW file bytes). A distinct
-  // ImageBuffer must wrap that payload for RAW_DECODE (*input = move(decoded)),
-  // but the underlying vector must be shared — deep-cloning it on every
-  // quality-ladder cache miss re-copies the whole file into working results.
-  const auto materialize_stage_input = [&](const char* step_name) {
-    const auto materialize_start = ProfileClock::now();
-    if (input && input->buffer_valid_ && !input->cpu_data_valid_ && !input->gpu_data_valid_) {
-      output = input->ShareEncodedBuffer();
-      executor_steps.push_back(
-          std::string(step_name) + "_share_encoded=" +
-          FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
-      return;
-    }
-    output = std::make_shared<ImageBuffer>(input->Clone());
-    executor_steps.push_back(
-        std::string(step_name) +
-        "_clone=" + FormatDurationMs(DurationToMs(ProfileClock::now() - materialize_start)));
-  };
-
-  if (enable_cache_) {
-    if (!first_stage->CacheValid()) {
-      materialize_stage_input("stage_input");
-      for (auto* stage : exec_stages_) {
-        apply_stage(stage);
-      }
-    } else {
-      // If cache is valid, use cached output
-      const auto cache_fetch_start   = ProfileClock::now();
-      output                         = first_stage->GetOutputCache();
-      const auto cache_fetch_elapsed = ProfileClock::now() - cache_fetch_start;
-      executor_steps.push_back("first_stage_cache_fetch=" +
-                               FormatDurationMs(DurationToMs(cache_fetch_elapsed)));
-      stage_profiles.push_back(
-          "stage=" + first_stage->GetStageNameString() + " mode=executor_cache cache=hit total=" +
-          FormatDurationMs(DurationToMs(cache_fetch_elapsed)) +
-          " | get_output_cache=" + FormatDurationMs(DurationToMs(cache_fetch_elapsed)));
-      for (auto* stage : exec_stages_) {
-        if (stage != first_stage) {
-          apply_stage(stage);
-        }
-      }
-    }
-  } else {
-    // Cache is disabled, just process the stages sequentially
-    materialize_stage_input("stage_input");
-    for (auto* stage : exec_stages_) {
-      apply_stage(stage);
-    }
-  }
-
-  PrintPipelineProfile(apply_start, executor_steps, stage_profiles);
-  return output;
+  throw std::runtime_error(
+      "CPUPipelineExecutor: product rendering requires a supported GPU backend");
 }
-
 void CPUPipelineExecutor::SetPipelineDocument(std::shared_ptr<PipelineDocument> document,
                                               bool mirror_legacy_stage_adapter) {
+  if (!document) {
+    throw std::invalid_argument("CPUPipelineExecutor: PipelineDocument is null");
+  }
 #if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
   pipeline_document_           = std::move(document);
   mirror_legacy_stage_adapter_ = mirror_legacy_stage_adapter;
-  gpu_dag_legacy_snapshot_     = nullptr;
-  if (pipeline_document_ && injected_raw_color_context_.has_value()) {
-    ApplyImportedCameraProfile(*pipeline_document_, *injected_raw_color_context_);
-  }
+
 #ifdef HAVE_CUDA
   if (cuda_product_renderer_) {
     cuda_product_renderer_->SetDocument(pipeline_document_);
@@ -681,8 +523,6 @@ void CPUPipelineExecutor::ImportPipelineParams(const nlohmann::json& j) {
 
 void CPUPipelineExecutor::SetRenderRegion(int x, int y, float scale_factor_x, float scale_factor_y,
                                           int reference_width, int reference_height) {
-  const nlohmann::json prev_resize_params =
-      render_params_.contains("resize") ? render_params_["resize"] : nlohmann::json::object();
   auto&       resize_params   = render_params_["resize"];
 
   const float clamped_scale_x = std::clamp(scale_factor_x, 1e-4f, 1.0f);
@@ -705,16 +545,9 @@ void CPUPipelineExecutor::SetRenderRegion(int x, int y, float scale_factor_x, fl
   global_params_.render_roi_scale_y_          = clamped_scale_y;
   global_params_.render_roi_reference_width_  = std::max(0, reference_width);
   global_params_.render_roi_reference_height_ = std::max(0, reference_height);
-
-  if (resize_params != prev_resize_params) {
-    stages_[static_cast<int>(PipelineStageName::Geometry_Adjustment)].SetOperator(
-        OperatorType::RESIZE, render_params_);
-  }
 }
 
 void CPUPipelineExecutor::SetRenderRes(bool full_res, int max_side_length) {
-  const nlohmann::json prev_resize_params =
-      render_params_.contains("resize") ? render_params_["resize"] : nlohmann::json::object();
   auto& resize_params           = render_params_["resize"];
   // render_params_["resize"] = {
   //   {"enable_scale", true},
@@ -722,51 +555,15 @@ void CPUPipelineExecutor::SetRenderRes(bool full_res, int max_side_length) {
   // };
   resize_params["enable_scale"] = !full_res;
   resize_params["maximum_edge"] = max_side_length;
-
-  if (resize_params != prev_resize_params) {
-    stages_[static_cast<int>(PipelineStageName::Geometry_Adjustment)].SetOperator(
-        OperatorType::RESIZE, render_params_);
-  }
 }
 
 void CPUPipelineExecutor::SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm algorithm) {
-  const nlohmann::json prev_resize_params =
-      render_params_.contains("resize") ? render_params_["resize"] : nlohmann::json::object();
   auto& resize_params                   = render_params_["resize"];
 
   resize_params["downsample_algorithm"] = ToResizeAlgorithmParam(algorithm);
-
-  if (resize_params != prev_resize_params) {
-    stages_[static_cast<int>(PipelineStageName::Geometry_Adjustment)].SetOperator(
-        OperatorType::RESIZE, render_params_);
-  }
 }
 
-void CPUPipelineExecutor::SetDecodeRes(DecodeRes res) {
-  decode_res_     = res;
-
-  // decode_res is a one-shot render parameter. Install it on the live op for this
-  // Apply only; RawDecodeOp::GetParams deliberately omits it from durable export.
-  auto& raw_stage = GetStage(PipelineStageName::Image_Loading);
-  auto  entry     = raw_stage.GetOperator(OperatorType::RAW_DECODE);
-  if (!entry.has_value() || !entry.value() || !entry.value()->op_) {
-    SyncRawDecodeRuntimeControls();
-    return;
-  }
-  auto* raw_op = dynamic_cast<RawDecodeOp*>(entry.value()->op_.get());
-  if (raw_op) {
-    raw_op->params_.decode_res_ = res;
-  } else {
-    auto  raw_param = entry.value()->ExportOperatorParams();
-    auto& params    = raw_param["params"];
-    if (!params.contains("raw") || !params["raw"].is_object()) {
-      params["raw"] = nlohmann::json::object();
-    }
-    params["raw"]["decode_res"] = static_cast<int>(res);
-    raw_stage.SetOperator(OperatorType::RAW_DECODE, raw_param["params"]);
-  }
-  SyncRawDecodeRuntimeControls();
-}
+void CPUPipelineExecutor::SetDecodeRes(DecodeRes res) { decode_res_ = res; }
 
 auto CPUPipelineExecutor::CaptureOneShotRenderParams() const -> OneShotRenderParamsSnapshot {
   OneShotRenderParamsSnapshot snapshot;
@@ -786,8 +583,6 @@ void CPUPipelineExecutor::RestoreOneShotRenderParams(const OneShotRenderParamsSn
   }
   render_params_           = snapshot.render_params_;
   render_request_viewport_ = snapshot.render_request_viewport_;
-  stages_[static_cast<int>(PipelineStageName::Geometry_Adjustment)].SetOperator(
-      OperatorType::RESIZE, render_params_);
 
   if (render_params_.contains("resize") && render_params_["resize"].is_object()) {
     const auto& resize_params          = render_params_["resize"];
@@ -903,7 +698,7 @@ void CPUPipelineExecutor::InitDefaultPipeline() {
 
 void CPUPipelineExecutor::InjectRawMetadata(const RawRuntimeColorContext& ctx) {
   global_params_.PopulateRawMetadata(ctx);
-  injected_raw_color_context_ = ctx;
+
 #if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
   if (pipeline_document_) {
     ApplyImportedCameraProfile(*pipeline_document_, ctx);

--- a/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
+++ b/alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <array>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <opencv2/core.hpp>
 #include <opencv2/core/mat.hpp>
 #include <opencv2/opencv.hpp>
@@ -23,6 +25,7 @@
 #include "edit/geometry/render_request.hpp"
 #include "edit/graph/develop_color_transform.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/pipeline/pipeline_apply_request.hpp"
 #endif
 #ifdef HAVE_CUDA
 #include "edit/runtime/cuda/cuda_product_renderer.hpp"
@@ -87,12 +90,14 @@ auto ApplyGpuDagProduct(std::shared_ptr<ProductRenderer>&            renderer,
                         const std::shared_ptr<ImageBuffer>&          input, DecodeRes decode_res,
                         const RenderRequest& request, IFrameSink* sink,
                         const FrameCompletionSubmission& submission, bool require_host_output,
-                        RenderCachePolicy cache_policy) -> std::shared_ptr<ImageBuffer> {
+                        RenderCachePolicy cache_policy,
+                        const std::optional<ExportColorProfileConfig>& output_color)
+    -> std::shared_ptr<ImageBuffer> {
   if (!renderer) {
     renderer = std::make_shared<ProductRenderer>(document);
   }
   return renderer->Render(input, decode_res, request, sink, submission, require_host_output,
-                          cache_policy);
+                          cache_policy, output_color);
 }
 #endif
 
@@ -217,6 +222,22 @@ auto CPUPipelineExecutor::GetStage(PipelineStageName stage) -> PipelineStage& {
 
 auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
     -> std::shared_ptr<ImageBuffer> {
+  PipelineApplyRequest request;
+  request.geometry            = BuildGpuDagRenderRequest(render_request_viewport_, render_params_,
+                                                         force_cpu_output_);
+  request.decode_res          = decode_res_;
+  request.cache_policy        = enable_cache_ ? RenderCachePolicy::UseSessionCache
+                                              : RenderCachePolicy::BypassSessionCache;
+  request.require_host_output = force_cpu_output_;
+  request.sink                = frame_sink_;
+  request.submission          = bound_frame_submission_;
+  request.cancel_requested    = cancel_requested_;
+  return Apply(std::move(input), request);
+}
+
+auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input,
+                                const PipelineApplyRequest& request)
+    -> std::shared_ptr<ImageBuffer> {
 #if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
   const bool use_gpu_dag =
 #ifdef HAVE_CUDA
@@ -234,33 +255,35 @@ auto CPUPipelineExecutor::Apply(std::shared_ptr<ImageBuffer> input)
         "CPUPipelineExecutor: product rendering requires a bound PipelineDocument");
   }
   if (use_gpu_dag) {
-    const auto request =
-        BuildGpuDagRenderRequest(render_request_viewport_, render_params_, force_cpu_output_);
-    const auto cache_policy =
-        enable_cache_ ? RenderCachePolicy::UseSessionCache : RenderCachePolicy::BypassSessionCache;
+    SetCancelRequested(request.cancel_requested);
 #ifdef HAVE_CUDA
     if (resolved_accelerator_backend_ == GpuBackendKind::CUDA) {
-      return ApplyGpuDagProduct(cuda_product_renderer_, pipeline_document_, input, decode_res_,
-                                request, frame_sink_, bound_frame_submission_, force_cpu_output_,
-                                cache_policy);
+      return ApplyGpuDagProduct(cuda_product_renderer_, pipeline_document_, input,
+                                request.decode_res, request.geometry, request.sink,
+                                request.submission, request.require_host_output,
+                                request.cache_policy, request.output_color);
     }
 #endif
 #ifdef HAVE_METAL
     if (resolved_accelerator_backend_ == GpuBackendKind::Metal) {
-      return ApplyGpuDagProduct(metal_product_renderer_, pipeline_document_, input, decode_res_,
-                                request, frame_sink_, bound_frame_submission_, force_cpu_output_,
-                                cache_policy);
+      return ApplyGpuDagProduct(metal_product_renderer_, pipeline_document_, input,
+                                request.decode_res, request.geometry, request.sink,
+                                request.submission, request.require_host_output,
+                                request.cache_policy, request.output_color);
     }
 #endif
 #ifdef HAVE_OPENCL
     if (resolved_accelerator_backend_ == GpuBackendKind::OpenCL) {
-      return ApplyGpuDagProduct(opencl_product_renderer_, pipeline_document_, input, decode_res_,
-                                request, frame_sink_, bound_frame_submission_, force_cpu_output_,
-                                cache_policy);
+      return ApplyGpuDagProduct(opencl_product_renderer_, pipeline_document_, input,
+                                request.decode_res, request.geometry, request.sink,
+                                request.submission, request.require_host_output,
+                                request.cache_policy, request.output_color);
     }
 #endif
   }
 #endif
+  (void)input;
+  (void)request;
   throw std::runtime_error(
       "CPUPipelineExecutor: product rendering requires a supported GPU backend");
 }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_backend.cpp
@@ -454,7 +454,7 @@ auto CudaBackend::MaxTransientBytes() const -> std::size_t {
 auto DefaultProductTextureBudgetBytes() -> std::size_t {
   constexpr std::size_t kFloorBytes = 256ull << 20;
   std::size_t           free_bytes  = 0;
-  std::size_t           total_bytes = 0;
+  std::size_t                            total_bytes = 0;
   if (::cudaMemGetInfo(&free_bytes, &total_bytes) != cudaSuccess || total_bytes == 0) {
     return kFloorBytes;
   }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_drt_pass.cu
@@ -19,6 +19,7 @@
 #include "edit/operators/cst/odt_op.hpp"
 #include "edit/operators/models/pending_parameter_patch.hpp"
 #include "edit/runtime/cuda/cuda_drt_pass.hpp"
+#include "edit/runtime/drt_display.hpp"
 
 namespace alcedo {
 namespace {
@@ -30,8 +31,8 @@ auto EnsureDisplayImage(CudaRenderWorkspace& workspace, const GraphValueId& id, 
   return workspace.AcquireImageForWrite(id, {width, height, TextureFormat::Rgba32f});
 }
 
-void ResolveRuntime(CudaDrtRuntimeState& state, const DrtParamsModel& model) {
-  ODT_Op descriptor(nlohmann::json{{"odt", model.ToJson()}});
+void ResolveRuntime(CudaDrtRuntimeState& state, const nlohmann::json& drt_json) {
+  ODT_Op descriptor(nlohmann::json{{"odt", drt_json}});
   descriptor.SetGlobalParams(state.cpu_params);
   state.gpu_params = GPUParamsConverter::ConvertFromCPU(state.cpu_params, state.gpu_params);
 }
@@ -75,10 +76,16 @@ auto ExecuteCudaDrt(CudaRenderDevice& device, const ExecutionPlan& plan, Pipelin
   const ParameterSlotKey      key{drt->Id(), AdjustmentInstanceId{"drt.output"}};
   const ParameterFieldBinding field{DirtyFieldMask{kDrtDirtyBits}, 0, 0,
                                     sizeof(GPU_TO_OUTPUT_Params)};
-  auto                        pending          = TakePendingParameterPatch(drt->Params());
+  auto                        pending          = plan.output_color_override.has_value()
+                                ? decltype(TakePendingParameterPatch(drt->Params())){}
+                                : TakePendingParameterPatch(drt->Params());
   const bool                  needs_initialize = !arena.Contains(key);
-  if (needs_initialize || pending.has_value()) {
-    ResolveRuntime(device.DrtRuntime(), drt->Params());
+  if (needs_initialize || pending.has_value() || plan.output_color_override.has_value()) {
+    auto drt_json = drt->Params().ToJson();
+    if (plan.output_color_override.has_value()) {
+      OverlayExportColorOnDrtJson(drt_json, *plan.output_color_override);
+    }
+    ResolveRuntime(device.DrtRuntime(), drt_json);
     const auto runtime = device.DrtRuntime().gpu_params.to_output_params_;
     auto       payload = std::make_shared<TypedOperatorParamPayload<GPU_TO_OUTPUT_Params>>(
         drt->Params().Type(), 1, runtime);

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_plan_executor.cpp
@@ -10,9 +10,10 @@ namespace alcedo {
 
 auto CudaRenderDevice::Execute(const ExecutionPlan& plan, const PreparedRawInput& input,
                                PipelineDocument& document, MaskStore* mask_store,
-                               bool publish_on_success) -> GraphValueId {
+                               bool publish_on_success,
+                               TransientAllocationPolicy transient_policy) -> GraphValueId {
   return PlanExecutor<CudaBackend>::Execute(*this, plan, input, document, mask_store,
-                                            publish_on_success);
+                                            publish_on_success, transient_policy);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/graph_compiler.cpp
+++ b/alcedo_studio/src/edit/runtime/graph_compiler.cpp
@@ -170,16 +170,18 @@ auto HashGraphTopology(const PipelineDocument& document) -> std::uint64_t {
   return hash;
 }
 
-void RequireDefaultEndpoints(const PipelineDocument& document) {
+void RequireValidGraph(const PipelineDocument& document) {
   const auto errors = document.Graph().Validate();
   if (!errors.empty()) {
     throw std::runtime_error("GraphCompiler: graph is invalid: " + errors.front().message);
   }
+  const auto backbone = document.Graph().ValidateImageBackbone();
+  if (!backbone.empty()) {
+    throw std::runtime_error("GraphCompiler: image backbone is invalid: " +
+                             backbone.front().message);
+  }
   if (document.Develop() == nullptr) {
     throw std::runtime_error("GraphCompiler: missing develop endpoint");
-  }
-  if (document.PrimaryGrade() == nullptr) {
-    throw std::runtime_error("GraphCompiler: missing primary color grade");
   }
   if (document.Drt() == nullptr) {
     throw std::runtime_error("GraphCompiler: missing DRT endpoint");
@@ -210,7 +212,7 @@ auto GraphCompiler::MakeStaticPlanKey(const PipelineDocument&     document,
 auto GraphCompiler::CompileStatic(const PipelineDocument&     document,
                                   const DevelopCompileSource& source,
                                   std::uint32_t backend_capability_version) -> ExecutionPlan {
-  RequireDefaultEndpoints(document);
+  RequireValidGraph(document);
   if (source.host_extent.Empty() || source.develop_output_extent.Empty() ||
       source.full_reference_extent.Empty()) {
     throw std::runtime_error("GraphCompiler: source extents must be positive");
@@ -222,7 +224,8 @@ auto GraphCompiler::CompileStatic(const PipelineDocument&     document,
   plan.sensor_linear_output = GraphValueId{NodeId{"develop"}, PortId{"sensor_linear"}};
   plan.geometry_output      = GraphValueId{NodeId{"geometry"}, PortId{"scene_source"}};
   plan.develop_output       = GraphValueId{NodeId{"develop"}, PortId{"image"}};
-  const auto* grade         = document.PrimaryGrade();
+  const auto grades         = ColorGradesOnImageBackbone(document);
+  const ColorGradeNodeModel* grade = grades.empty() ? nullptr : grades.front();
   plan.peak_transient_bytes = EstimatePeakTransientBytes(source);
 
   if (source.kind == DevelopInputKind::DirectRgb) {
@@ -238,37 +241,41 @@ auto GraphCompiler::CompileStatic(const PipelineDocument&     document,
   plan.passes.push_back(GpuPassDesc{GpuPassKind::Lens});
   plan.passes.push_back(GpuPassDesc{GpuPassKind::GeometryResample});
   plan.passes.push_back(GpuPassDesc{GpuPassKind::CameraToAp1});
-  for (const auto& edge : document.Graph().Edges()) {
-    if (edge.to_node == grade->Id() && edge.to_port == PortId{"mask"}) {
-      const auto* mask = document.Graph().FindNode(edge.from_node);
-      if (mask == nullptr) throw std::runtime_error("GraphCompiler: mask edge has no source");
-      const auto kind = mask->Type() == type_ids::RasterMaskNode() ? CompiledMaskKind::Raster
-                                                                   : CompiledMaskKind::Analytic;
-      plan.primary_grade_mask = CompiledMask{mask->Id(), kind};
-      plan.mask_output        = GraphValueId{mask->Id(), PortId{"mask"}};
-      plan.passes.push_back(GpuPassDesc{GpuPassKind::MaskEvaluate});
-      plan.passes.push_back(GpuPassDesc{GpuPassKind::MaskFeather});
-      if (kind == CompiledMaskKind::Raster) {
-        const Extent2D mask_extent{
-            std::max(source.full_reference_extent.width, source.host_extent.width),
-            std::max(source.full_reference_extent.height, source.host_extent.height)};
-        plan.peak_transient_bytes =
-            (std::max)(plan.peak_transient_bytes, EstimateMaskSdfTransientBytes(mask_extent));
+  if (grade != nullptr) {
+    for (const auto& edge : document.Graph().Edges()) {
+      if (edge.to_node == grade->Id() && edge.to_port == PortId{"mask"}) {
+        const auto* mask = document.Graph().FindNode(edge.from_node);
+        if (mask == nullptr) throw std::runtime_error("GraphCompiler: mask edge has no source");
+        const auto kind = mask->Type() == type_ids::RasterMaskNode() ? CompiledMaskKind::Raster
+                                                                     : CompiledMaskKind::Analytic;
+        plan.primary_grade_mask = CompiledMask{mask->Id(), kind};
+        plan.mask_output        = GraphValueId{mask->Id(), PortId{"mask"}};
+        plan.passes.push_back(GpuPassDesc{GpuPassKind::MaskEvaluate});
+        plan.passes.push_back(GpuPassDesc{GpuPassKind::MaskFeather});
+        if (kind == CompiledMaskKind::Raster) {
+          const Extent2D mask_extent{
+              std::max(source.full_reference_extent.width, source.host_extent.width),
+              std::max(source.full_reference_extent.height, source.host_extent.height)};
+          plan.peak_transient_bytes =
+              (std::max)(plan.peak_transient_bytes, EstimateMaskSdfTransientBytes(mask_extent));
+        }
+        break;
       }
-      break;
     }
+    plan.passes.push_back(GpuPassDesc{GpuPassKind::PrimaryColorGrade});
+    plan.primary_grade_output = GraphValueId{grade->Id(), PortId{"image"}};
+    for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
+      const auto& type      = grade->AdjustmentAt(index).Type();
+      const auto  algorithm = CompileAdjustmentAlgorithm(type);
+      plan.primary_grade_adjustments.push_back({grade->AdjustmentIdAt(index), type, algorithm});
+      AppendGradeStage(plan, algorithm);
+    }
+  } else {
+    plan.primary_grade_output = plan.develop_output;
   }
-  plan.passes.push_back(GpuPassDesc{GpuPassKind::PrimaryColorGrade});
-  plan.primary_grade_output = GraphValueId{grade->Id(), PortId{"image"}};
-  plan.display_output       = GraphValueId{document.Drt()->Id(), PortId{"display"}};
+  plan.display_output = GraphValueId{document.Drt()->Id(), PortId{"display"}};
   plan.passes.push_back(GpuPassDesc{GpuPassKind::Drt});
 
-  for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
-    const auto& type      = grade->AdjustmentAt(index).Type();
-    const auto  algorithm = CompileAdjustmentAlgorithm(type);
-    plan.primary_grade_adjustments.push_back({grade->AdjustmentIdAt(index), type, algorithm});
-    AppendGradeStage(plan, algorithm);
-  }
   return plan;
 }
 

--- a/alcedo_studio/src/edit/runtime/metal/metal_drt_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_drt_pass.mm
@@ -13,6 +13,7 @@
 
 #include "edit/graph/drt_node_model.hpp"
 #include "edit/operators/models/pending_parameter_patch.hpp"
+#include "edit/runtime/drt_display.hpp"
 #include "edit/runtime/metal/metal_drt_gpu_params.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/texture_format.hpp"
@@ -82,10 +83,16 @@ auto ExecuteMetalDrt(MetalRenderDevice& device, const ExecutionPlan& plan,
   auto&                       arena = workspace.Parameters();
   const ParameterSlotKey      key{drt->Id(), AdjustmentInstanceId{"drt.output"}};
   const ParameterFieldBinding field{DirtyFieldMask{kDrtDirtyBits}, 0, 0, sizeof(MetalDrtGpuParams)};
-  auto                        pending          = TakePendingParameterPatch(drt->Params());
+  auto                        pending          = plan.output_color_override.has_value()
+                                ? decltype(TakePendingParameterPatch(drt->Params())){}
+                                : TakePendingParameterPatch(drt->Params());
   const bool                  needs_initialize = !arena.Contains(key);
-  if (needs_initialize || pending.has_value()) {
-    const auto runtime = ResolveMetalDrtGpuParams(drt->Params().ToJson());
+  if (needs_initialize || pending.has_value() || plan.output_color_override.has_value()) {
+    auto drt_json = drt->Params().ToJson();
+    if (plan.output_color_override.has_value()) {
+      OverlayExportColorOnDrtJson(drt_json, *plan.output_color_override);
+    }
+    const auto runtime = ResolveMetalDrtGpuParams(drt_json);
     auto       payload = std::make_shared<TypedOperatorParamPayload<MetalDrtGpuParams>>(
         drt->Params().Type(), 1, runtime);
     if (needs_initialize) {

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_drt_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_drt_pass.cpp
@@ -17,6 +17,7 @@
 #include "edit/operators/models/pending_parameter_patch.hpp"
 #include "edit/runtime/opencl/opencl_dag_programs.hpp"
 #include "edit/runtime/opencl/opencl_drt_params.hpp"
+#include "edit/runtime/drt_display.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/parameter_binding.hpp"
 #include "edit/runtime/texture_format.hpp"
@@ -82,10 +83,16 @@ auto ExecuteOpenClDrt(OpenClRenderDevice& device, const ExecutionPlan& plan,
   const ParameterSlotKey      key{drt->Id(), AdjustmentInstanceId{"drt.output"}};
   const ParameterFieldBinding field{DirtyFieldMask{kDrtDirtyBits}, 0, 0,
                                     sizeof(OpenClToOutputParams)};
-  auto                        pending          = TakePendingParameterPatch(drt->Params());
+  auto                        pending          = plan.output_color_override.has_value()
+                                ? decltype(TakePendingParameterPatch(drt->Params())){}
+                                : TakePendingParameterPatch(drt->Params());
   const bool                  needs_initialize = !arena.Contains(key);
-  if (needs_initialize || pending.has_value()) {
-    const auto runtime = ResolveOpenClDrtParams(drt->Params().ToJson());
+  if (needs_initialize || pending.has_value() || plan.output_color_override.has_value()) {
+    auto drt_json = drt->Params().ToJson();
+    if (plan.output_color_override.has_value()) {
+      OverlayExportColorOnDrtJson(drt_json, *plan.output_color_override);
+    }
+    const auto runtime = ResolveOpenClDrtParams(drt_json);
     auto       payload = std::make_shared<TypedOperatorParamPayload<OpenClToOutputParams>>(
         drt->Params().Type(), 1, runtime);
     if (needs_initialize) {

--- a/alcedo_studio/src/edit/runtime/result_content_key.cpp
+++ b/alcedo_studio/src/edit/runtime/result_content_key.cpp
@@ -308,6 +308,13 @@ auto BuildFrameResultContentKeys(const ExecutionPlan& plan, const PreparedRawInp
   if (document.Drt() != nullptr) {
     drt.MixText(document.Drt()->Params().ToJson().dump());
   }
+  if (plan.output_color_override.has_value()) {
+    drt.MixU32(static_cast<std::uint32_t>(plan.output_color_override->encoding_space));
+    drt.MixU32(static_cast<std::uint32_t>(plan.output_color_override->encoding_eotf));
+    drt.MixF32(plan.output_color_override->peak_luminance);
+  } else {
+    drt.MixU32(0);
+  }
   drt.MixU32(kDrtImplementationVersion);
   keys.drt_display = drt.Key();
   return keys;

--- a/alcedo_studio/src/include/app/editor_adjustment_types.hpp
+++ b/alcedo_studio/src/include/app/editor_adjustment_types.hpp
@@ -8,11 +8,90 @@
 #include <string>
 #include <vector>
 
+#include "edit/graph/graph_ids.hpp"
+
 /// Reusable adjustment patch/snapshot data for editor session and render intents.
 /// Lives in the application layer so session/render ports never depend on QWidget
 /// control panels (Phase 5A-Fix).
 
 namespace alcedo {
+
+/// Owner of one editor parameter write. Unspecified is invalid on the production path.
+enum class EditorParameterOwnerKind : std::uint8_t {
+  Unspecified = 0,
+  Document,
+  Develop,
+  ColorGrade,
+  ColorGradeMask,
+  DrtPost,
+};
+
+/**
+ * @brief Identity of one parameter write on PipelineDocument.
+ *
+ * Every production patch must fill this completely. The app does not invent
+ * owner_kind or node_id from field_key or UI selection.
+ *
+ * @pre ColorGrade writes set node_id and adjustment_instance_id.
+ * @pre Document writes leave node_id empty.
+ * @pre mask_id stays empty until NM3.
+ */
+struct EditorParameterTarget {
+  EditorParameterOwnerKind owner_kind = EditorParameterOwnerKind::Unspecified;
+  NodeId                   node_id;
+  AdjustmentInstanceId     adjustment_instance_id;
+  std::string              mask_id;
+  std::string              field_key;
+
+  auto operator==(const EditorParameterTarget& other) const -> bool = default;
+};
+
+/**
+ * @brief Return a rejection message when @p target is not a complete production target.
+ *
+ * @param target Patch target.
+ * @param patch_field_key Field key on the enclosing patch; must equal target.field_key.
+ * @return Empty when the target is complete and is not a Mask write.
+ */
+[[nodiscard]] inline auto DescribeEditorParameterTargetError(const EditorParameterTarget& target,
+                                                             const std::string& patch_field_key)
+    -> std::string {
+  if (target.owner_kind == EditorParameterOwnerKind::Unspecified) {
+    return "Editor parameter target requires owner_kind";
+  }
+  if (target.owner_kind == EditorParameterOwnerKind::ColorGradeMask || !target.mask_id.empty()) {
+    return "Mask parameter targets are rejected until NM3";
+  }
+  if (target.field_key.empty()) {
+    return "Editor parameter target requires field_key";
+  }
+  if (target.field_key != patch_field_key) {
+    return "Editor parameter target field_key must match the patch field_key";
+  }
+  switch (target.owner_kind) {
+    case EditorParameterOwnerKind::Document:
+      if (!target.node_id.Empty() || !target.adjustment_instance_id.Empty()) {
+        return "Document parameter target must not set node_id or adjustment_instance_id";
+      }
+      return {};
+    case EditorParameterOwnerKind::Develop:
+    case EditorParameterOwnerKind::DrtPost:
+      if (target.node_id.Empty()) {
+        return "Editor parameter target requires node_id";
+      }
+      return {};
+    case EditorParameterOwnerKind::ColorGrade:
+      if (target.node_id.Empty()) {
+        return "Editor parameter target requires node_id";
+      }
+      if (target.adjustment_instance_id.Empty()) {
+        return "Color Grade parameter target requires adjustment_instance_id";
+      }
+      return {};
+    default:
+      return "Editor parameter target owner_kind is not supported";
+  }
+}
 
 /// One atomic adjustment change (field key + serialized params).
 struct EditorAdjustmentPatch {
@@ -25,6 +104,8 @@ struct EditorAdjustmentPatch {
   /// Enabled state captured with the immutable adjustment value. Interactive callers that do not
   /// provide a separate enabled flag keep the default and may encode it inside params_json.
   bool enabled = true;
+  /// Production write identity. Incomplete targets are rejected.
+  EditorParameterTarget target{};
 
   auto operator==(const EditorAdjustmentPatch& other) const -> bool = default;
 };

--- a/alcedo_studio/src/include/app/editor_pipeline_command_service.hpp
+++ b/alcedo_studio/src/include/app/editor_pipeline_command_service.hpp
@@ -1,0 +1,60 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <string>
+
+#include "app/editor_adjustment_types.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "json.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Write one typed parameter patch onto a candidate document.
+ *
+ * Merges @p params into the current model JSON, then LoadJson. Does not fill a
+ * missing target. Caller clones the live document first and discards the
+ * candidate on failure.
+ *
+ * @pre @p target is complete and is not a Mask write.
+ * @param candidate Document to mutate.
+ * @param target Production write identity.
+ * @param params JSON object of model fields (for example exposure_ev).
+ * @param error Optional failure text.
+ * @return false when the node, instance, or JSON is invalid.
+ *
+ * Thread: caller owns live-document serialization (editor history queue).
+ */
+auto ApplyEditorParameterPatch(PipelineDocument& candidate, const EditorParameterTarget& target,
+                               const nlohmann::json& params, std::string* error) -> bool;
+
+/**
+ * @brief Read the current model JSON for @p target.
+ *
+ * @return false when the node or instance is missing.
+ */
+auto ReadEditorParameterJson(const PipelineDocument& document, const EditorParameterTarget& target,
+                             nlohmann::json* json, std::string* error) -> bool;
+
+/**
+ * @brief Stable JSON dump of @p document for hash comparisons in tests and rollback.
+ */
+[[nodiscard]] auto CanonicalPipelineDocumentJson(const PipelineDocument& document) -> std::string;
+
+/**
+ * @brief True when graph Validate and ValidateImageBackbone are both empty.
+ */
+auto PipelineDocumentPassesValidation(const PipelineDocument& document, std::string* error) -> bool;
+
+/**
+ * @brief Clone, apply, validate, and replace @p live when all steps succeed.
+ *
+ * On failure @p live is unchanged.
+ */
+auto PublishEditorParameterPatch(PipelineDocument& live, const EditorParameterTarget& target,
+                                 const nlohmann::json& params, std::string* error) -> bool;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_pipeline_command_service.hpp
+++ b/alcedo_studio/src/include/app/editor_pipeline_command_service.hpp
@@ -13,22 +13,19 @@
 namespace alcedo {
 
 /**
- * @brief Write one typed parameter patch onto a candidate document.
+ * @brief Validate and apply one parameter patch to the existing live Model.
  *
- * Merges @p params into the current model JSON, then LoadJson. Does not fill a
- * missing target. Caller clones the live document first and discards the
- * candidate on failure.
- *
- * @pre @p target is complete and is not a Mask write.
- * @param candidate Document to mutate.
- * @param target Production write identity.
- * @param params JSON object of model fields (for example exposure_ev).
- * @param error Optional failure text.
- * @return false when the node, instance, or JSON is invalid.
- *
- * Thread: caller owns live-document serialization (editor history queue).
+ * Supplied keys, types, finite numbers and array dimensions are checked before setters.
+ * Model setters normalize values and update dirty bits; topology and other Models stay intact.
+ * A throwing setter restores only the affected Model's previous parameters.
+ * @pre Caller holds the shared executor render lock; target is complete and is not Mask.
+ * @param document Live document to mutate in place.
+ * @param target Explicit node/adjustment identity; no missing identity is inferred.
+ * @param params Partial Model JSON object.
+ * @param error Optional failure detail, including restoration errors.
+ * @return false for an invalid target or parameter; no history or persistence is performed.
  */
-auto ApplyEditorParameterPatch(PipelineDocument& candidate, const EditorParameterTarget& target,
+auto ApplyEditorParameterPatch(PipelineDocument& document, const EditorParameterTarget& target,
                                const nlohmann::json& params, std::string* error) -> bool;
 
 /**
@@ -40,7 +37,7 @@ auto ReadEditorParameterJson(const PipelineDocument& document, const EditorParam
                              nlohmann::json* json, std::string* error) -> bool;
 
 /**
- * @brief Stable JSON dump of @p document for hash comparisons in tests and rollback.
+ * @brief Stable JSON dump of @p document for comparisons in tests.
  */
 [[nodiscard]] auto CanonicalPipelineDocumentJson(const PipelineDocument& document) -> std::string;
 
@@ -50,9 +47,9 @@ auto ReadEditorParameterJson(const PipelineDocument& document, const EditorParam
 auto PipelineDocumentPassesValidation(const PipelineDocument& document, std::string* error) -> bool;
 
 /**
- * @brief Clone, apply, validate, and replace @p live when all steps succeed.
+ * @brief Apply a validated patch in place; equivalent to ApplyEditorParameterPatch.
  *
- * On failure @p live is unchanged.
+ * @pre Caller holds the shared executor render lock. No graph validation or copy occurs.
  */
 auto PublishEditorParameterPatch(PipelineDocument& live, const EditorParameterTarget& target,
                                  const nlohmann::json& params, std::string* error) -> bool;

--- a/alcedo_studio/src/include/app/editor_session_edit_controller.hpp
+++ b/alcedo_studio/src/include/app/editor_session_edit_controller.hpp
@@ -46,8 +46,9 @@ class EditorSessionEditController final {
   explicit EditorSessionEditController(Dependencies dependencies);
 
   /// Apply an interactive (settled=false) or settled (settled=true) adjustment
-  /// patch. Captures the before-preview state, commits settled patches to
-  /// history, and returns a render command carrying only the current field patch.
+  /// patch. Requires a complete EditorParameterTarget. Captures the
+  /// before-preview state, commits settled patches to history, and returns a
+  /// render command carrying only the current field patch.
   auto HandlePatch(EditorAdjustmentPatch patch, bool settled,
                    const EditorHistoryGuardHandle& guard,
                    const EditorSessionIdentity& identity) -> EditorEditOutcome;

--- a/alcedo_studio/src/include/app/export_service.hpp
+++ b/alcedo_studio/src/include/app/export_service.hpp
@@ -87,7 +87,7 @@ class ExportService {
       : sleeve_service_(std::move(sleeve_service)),
         image_pool_service_(std::move(image_pool_service)),
         pipeline_service_(std::move(pipeline_service)) {
-    pipeline_scheduler_ = RenderService::GetThumbnailOrExportScheduler(1);
+    pipeline_scheduler_ = RenderService::GetThumbnailOrExportScheduler();
   };
 
   ExportService(const ExportService&)            = delete;
@@ -101,6 +101,11 @@ class ExportService {
   }
 
   auto EnqueueExportTask(const ExportTask& task) -> void {
+    if (!task.recipe_.has_value()) {
+      throw std::runtime_error(
+          "ExportService: export recipe must be complete before scheduling");
+    }
+    RequireResolvedExportOutputColor(*task.recipe_);
     std::lock_guard<std::mutex> lock(queue_mutex_);
     export_queue_.emplace_back(task);
   }

--- a/alcedo_studio/src/include/app/pipeline_service.hpp
+++ b/alcedo_studio/src/include/app/pipeline_service.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <chrono>
+#include <condition_variable>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -48,12 +51,19 @@ struct PipelineGuard {
   std::shared_ptr<PipelineDocument>    document_;
   sl_element_id_t                      id_;
   bool                                 dirty_     = false;
-  /// Cache pin only: LoadPipeline / SavePipeline refcount so LRU eviction and
-  /// "unpinned → re-init stages" do not drop a live editor/export guard.
-  /// Live-pipeline *mutation* ownership is CPUPipelineExecutor::render_lock_
+  /// Cache pin only: LoadPipeline / ReleasePipelineUse / SavePipeline refcount so
+  /// LRU eviction and "unpinned → re-init stages" do not drop a live editor/export
+  /// guard. Live-pipeline *mutation* ownership is CPUPipelineExecutor::render_lock_
   /// (held for the full render task including present); pin_count_ is not that.
   bool                                 pinned_    = false;
   size_t                               pin_count_ = 0;
+  /// False until construct/reinit finished. Cache hits wait; never treat an unready live as usable.
+  bool                                 live_ready_ = false;
+  bool                                 initializing_ = false;
+  std::exception_ptr                   load_error_;
+  /// True while an editor input sequence has live values that are not a history HEAD.
+  /// Thumbnail/export disk caches must not store pixels under the committed label.
+  bool                                 unsettled_preview_ = false;
 
   /// Immutable root id for this image's edit graph (history identity, not a tip).
   root_id_t                            root_id_{};
@@ -81,17 +91,6 @@ struct PipelineGuard {
   }
 };
 
-// Phase 3: a read-only clone of a pipeline's params captured into an independent
-// executor, used for background analysis rendering. The snapshot never pins the
-// live PipelineGuard, never writes storage, and never clears the live guard's
-// dirty state. Rendering on `executor_` does not affect the live pipeline.
-struct PipelineSnapshot {
-  sl_element_id_t                      element_id_ = 0;
-  image_id_t                           image_id_   = 0;
-  nlohmann::json                       pipeline_params_;
-  std::shared_ptr<CPUPipelineExecutor> executor_;
-};
-
 class PipelineMgmtService final {
  private:
   std::shared_ptr<Storage>                                            storage_;
@@ -101,6 +100,10 @@ class PipelineMgmtService final {
   std::unordered_map<sl_element_id_t, std::shared_ptr<PipelineGuard>> loaded_pipelines_;
 
   std::mutex                                                          lock_;
+  std::condition_variable                                             cache_cv_;
+
+  std::uint64_t                pipeline_construct_count_ = 0;
+  std::uint64_t                pipeline_load_count_      = 0;
 
   static constexpr size_t                                             default_cache_capacity_ = 16;
 
@@ -109,6 +112,7 @@ class PipelineMgmtService final {
   std::uint64_t                editor_pipeline_history_rebuild_count_ = 0;
 
   void                         HandleEviction(sl_element_id_t evicted_id);
+  void                         CleanupIdlePipelineResources(const std::shared_ptr<PipelineGuard>& pipeline);
 
  public:
   PipelineMgmtService() = delete;
@@ -116,6 +120,19 @@ class PipelineMgmtService final {
       : storage_(storage_service), pipeline_cache_(default_cache_capacity_), loaded_pipelines_() {}
 
   void               SavePipeline(std::shared_ptr<PipelineGuard> pipeline);
+
+  /**
+   * @brief Unpin a live pipeline without writing storage or clearing dirty.
+   *
+   * Thumbnail, analysis, and export must call this instead of @ref SavePipeline.
+   * When other pins remain (the editor), GPU session caches stay. When this is
+   * the last pin, intermediate GPU caches and the one-shot device are released
+   * so unused LRU entries do not keep VRAM. Must not be called while holding
+   * @c CPUPipelineExecutor::GetRenderLock().
+   *
+   * @param pipeline Guard returned by @ref LoadPipeline; no-op if null.
+   */
+  void               ReleasePipelineUse(std::shared_ptr<PipelineGuard> pipeline);
 
   /// Load image-local RAW color data, including DNG profiles absent from older projects.
   static void InjectImageRawMetadata(CPUPipelineExecutor& executor, const Image& image);
@@ -129,6 +146,25 @@ class PipelineMgmtService final {
                                                std::string*                          error = nullptr) -> bool;
 
   auto               LoadPipeline(sl_element_id_t id) -> std::shared_ptr<PipelineGuard>;
+
+  /**
+   * @brief Wait until @p pipeline pin_count_ equals @p expected.
+   * @pre Must not hold the cache lock or the pipeline render lock.
+   * @return true if the count matched before @p timeout.
+   */
+  auto WaitUntilPinCount(const std::shared_ptr<PipelineGuard>& pipeline, size_t expected,
+                         std::chrono::milliseconds timeout) -> bool;
+
+  /// Test/instrumentation: executor+document constructions for cache misses.
+  [[nodiscard]] auto PipelineConstructCount() const -> std::uint64_t {
+    return pipeline_construct_count_;
+  }
+  /// Test/instrumentation: LoadPipeline returns, including cache hits and waiters.
+  [[nodiscard]] auto PipelineLoadCount() const -> std::uint64_t { return pipeline_load_count_; }
+  void               ResetPipelineAcquireCountsForTesting() {
+    pipeline_construct_count_ = 0;
+    pipeline_load_count_      = 0;
+  }
 
   /** @brief Save the guard's authoritative GPU DAG document as format version 2. */
   void               SyncPipelineDocument(const std::shared_ptr<PipelineGuard>& pipeline);
@@ -192,20 +228,6 @@ class PipelineMgmtService final {
 
   /// Persist only the requested live pipeline. This avoids saving unrelated dirty editor state.
   void SyncPipeline(sl_element_id_t id);
-
-  // Phase 3: capture a read-only snapshot of the current pipeline state without
-  // pinning the live guard, forcing it to disk, or touching dirty state. The
-  // returned executor is an independent clone; rendering on it does not affect the
-  // live pipeline. May briefly block on the live executor's render lock
-  // (serializes with an in-flight editor render on the same executor). Returns
-  // nullptr and writes *error on failure.
-  auto LoadPipelineSnapshot(sl_element_id_t id, image_id_t image_id, std::string* error)
-      -> std::shared_ptr<PipelineSnapshot>;
-
-  // Release the snapshot executor's intermediate buffers (mirrors SavePipeline's
-  // last-pin cleanup). Safe to call from the snapshot's task callback; the
-  // shared_ptr then drops naturally. Not a storage write. No-op if null.
-  void ReleasePipelineSnapshot(std::shared_ptr<PipelineSnapshot> snapshot);
 };
 
 /// Checkpoint label: which history tip the serialized params claim to match.

--- a/alcedo_studio/src/include/app/pipeline_service.hpp
+++ b/alcedo_studio/src/include/app/pipeline_service.hpp
@@ -112,6 +112,8 @@ class PipelineMgmtService final {
   std::uint64_t                editor_pipeline_history_rebuild_count_ = 0;
 
   void                         HandleEviction(sl_element_id_t evicted_id);
+  void                         SyncDirtyPipelineDocument(
+      const std::shared_ptr<PipelineGuard>& pipeline);
   void                         CleanupIdlePipelineResources(const std::shared_ptr<PipelineGuard>& pipeline);
 
  public:

--- a/alcedo_studio/src/include/app/thumbnail_service.hpp
+++ b/alcedo_studio/src/include/app/thumbnail_service.hpp
@@ -79,20 +79,21 @@ class ThumbnailService {
                     bool pin_if_found = true, CallbackDispatcher dispatcher = nullptr,
                     ThumbnailResolution resolution = ThumbnailResolution::k1024);
 
-  // Request a thumbnail and receive a detailed result. Rendering uses an independent pipeline
-  // snapshot, so background filmstrip work never occupies the live editor executor. This
-  // distinguishes cancellation from render/load failures, while GetThumbnail preserves the
+  // Request a thumbnail and receive a detailed result. Rendering uses the live
+  // pipeline handle (same document/executor as the editor) under the scheduler
+  // render lock. Thumbnail work bypasses session GPU caches. This distinguishes
+  // cancellation from render/load failures, while GetThumbnail preserves the
   // legacy guard/null callback behavior.
   void GetThumbnailDetailed(sl_element_id_t id, image_id_t image_id,
                             ThumbnailResultCallback callback, bool pin_if_found = true,
                             CallbackDispatcher  dispatcher = nullptr,
                             ThumbnailResolution resolution = ThumbnailResolution::k1024);
 
-  // Phase 3: render an analysis rendition from a captured pipeline snapshot. Does
-  // NOT pin the live pipeline guard, does NOT call SavePipeline on the live guard,
-  // and does NOT cache the result in thumbnail_cache_. Disk cache hits/writes use
-  // a separate analysis namespace. One-shot delivery to the single callback. Used
-  // by background image analysis so the editor's live pipeline is never disturbed.
+  // Render an analysis rendition from the live pipeline handle. Pins via
+  // LoadPipeline and releases with ReleasePipelineUse (no SavePipeline). Results
+  // are not stored in thumbnail_cache_. Disk cache hits/writes use a separate
+  // analysis namespace and skip writes when the queued commit label is stale,
+  // the live document is dirty, or an editor preview is unsettled.
   void RequestAnalysisRendition(sl_element_id_t element_id, image_id_t image_id,
                                 ThumbnailResolution resolution, ThumbnailResultCallback callback);
   void CancelAnalysisRendition(const ThumbnailCacheKey& key);

--- a/alcedo_studio/src/include/app/thumbnail_types.hpp
+++ b/alcedo_studio/src/include/app/thumbnail_types.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <string_view>
 
 #include "type/type.hpp"
 
@@ -28,6 +29,31 @@ struct ThumbnailCacheKey {
 
   bool                operator==(const ThumbnailCacheKey& other) const = default;
 };
+
+/**
+ * @brief Whether a thumbnail/analysis disk write may use the queued commit label.
+ *
+ * Thumbnail and export pixels come from the live document at render-lock time.
+ * The disk index is keyed by the commit label captured when the request was
+ * queued. Skip the write when those labels differ, when an editor preview is
+ * still unsettled, or when the live document is dirty. Still deliver the pixels.
+ * Empty labels never write.
+ */
+[[nodiscard]] inline auto ThumbnailDiskCacheWriteAllowed(std::string_view queued_commit_label,
+                                                          std::string_view rendered_commit_label,
+                                                          bool live_has_unsettled_preview,
+                                                          bool live_is_dirty) -> bool {
+  if (queued_commit_label.empty() || rendered_commit_label.empty()) {
+    return false;
+  }
+  if (queued_commit_label != rendered_commit_label) {
+    return false;
+  }
+  if (live_has_unsettled_preview || live_is_dirty) {
+    return false;
+  }
+  return true;
+}
 
 }  // namespace alcedo
 

--- a/alcedo_studio/src/include/edit/geometry/render_request.hpp
+++ b/alcedo_studio/src/include/edit/geometry/render_request.hpp
@@ -9,6 +9,17 @@
 namespace alcedo {
 
 /**
+ * @brief Whether a render may read or publish the editor session result caches.
+ *
+ * Bypass isolates thumbnail/export from editor caches. Chosen per request, not
+ * stored as executor mode state.
+ */
+enum class RenderCachePolicy {
+  UseSessionCache,
+  BypassSessionCache,
+};
+
+/**
  * @brief Document crop and rotation. Viewport and dynamic resolution are not stored here.
  */
 struct ImageGeometryParams {

--- a/alcedo_studio/src/include/edit/graph/analytic_mask_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/analytic_mask_node_model.hpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <memory>
 #include <span>
+#include <string_view>
 
 #include "edit/graph/i_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
@@ -51,6 +52,7 @@ class AnalyticMaskNodeModel final : public INodeModel {
   [[nodiscard]] auto Type() const -> const OperatorTypeId& override {
     return type_ids::AnalyticMaskNode();
   }
+  [[nodiscard]] auto DisplayName() const -> std::string_view override { return "Mask"; }
   [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto ToJson() const -> nlohmann::json override;

--- a/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
@@ -48,10 +48,28 @@ class ColorGradeNodeModel final : public INodeModel {
   void SetDisplayName(std::string name);
 
   /**
-   * @brief Default primary grade: CAT02 through film grain in the documented order.
-   * @param id Node id, typically "grade.primary".
+   * @brief Catalog Color Grade: CAT02 through Film Grain in the documented order.
+   *
+   * Adjustment values are catalog identity (exposure 0 EV, saturation 1.0). Product
+   * Default look (+1.5 EV, saturation 1.3) is applied by
+   * @ref CreateDefaultPipelineDocument, not by this factory.
+   *
+   * @param id Node id, typically "grade.primary" for the Default document.
    */
   static auto MakeDefault(NodeId id) -> std::unique_ptr<ColorGradeNodeModel>;
+
+  /**
+   * @brief Identity Color Grade: catalog-default params and no post adjustments.
+   *
+   * Exposure is 0 EV, saturation is 1.0, mix is 1, enabled is true. Clarity,
+   * Sharpen, Halation, and Film Grain are omitted. Does not copy or patch
+   * @ref MakeDefault.
+   *
+   * @param id Stable NodeId for the new node.
+   * @return Owned node. Caller inserts it into a graph.
+   */
+  static auto MakeClean(NodeId id) -> std::unique_ptr<ColorGradeNodeModel>;
+
   static auto FromJson(const nlohmann::json& json) -> std::unique_ptr<ColorGradeNodeModel>;
 
   void SetEnabled(bool enabled);
@@ -85,5 +103,17 @@ class ColorGradeNodeModel final : public INodeModel {
   std::array<PortDescriptor, 2> inputs_;
   std::array<PortDescriptor, 1> outputs_;
 };
+
+/**
+ * @brief Identity Color Grade node for @ref AddCleanColorGrade.
+ *
+ * Equivalent to @ref ColorGradeNodeModel::MakeClean. Distinct from the product
+ * Default look on @ref CreateDefaultPipelineDocument.
+ *
+ * @param id Stable NodeId.
+ * @return Owned node with identity params and no Clarity, Sharpen, Halation, or
+ *         Film Grain. The caller owns insertion into a graph.
+ */
+[[nodiscard]] auto CreateCleanColorGradeNode(NodeId id) -> std::unique_ptr<ColorGradeNodeModel>;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
@@ -8,6 +8,8 @@
 #include <cstddef>
 #include <memory>
 #include <span>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "edit/graph/i_node_model.hpp"
@@ -34,9 +36,16 @@ class ColorGradeNodeModel final : public INodeModel {
   [[nodiscard]] auto Type() const -> const OperatorTypeId& override {
     return type_ids::ColorGradeNode();
   }
+  [[nodiscard]] auto DisplayName() const -> std::string_view override { return display_name_; }
   [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto ToJson() const -> nlohmann::json override;
+
+  /**
+   * @brief Replace the UI label. Does not change @ref Id.
+   * @param name New label. Empty names are rejected by graph commands, not by this setter.
+   */
+  void SetDisplayName(std::string name);
 
   /**
    * @brief Default primary grade: CAT02 through film grain in the documented order.
@@ -69,6 +78,7 @@ class ColorGradeNodeModel final : public INodeModel {
 
  private:
   NodeId id_;
+  std::string display_name_ = "Color Grade";
   std::vector<AdjustmentModelEntry> adjustments_;
   bool  enabled_ = true;
   float mix_     = 1.0f;

--- a/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
@@ -83,6 +83,7 @@ class ColorGradeNodeModel final : public INodeModel {
   [[nodiscard]] auto AdjustmentAt(std::size_t index) -> IOperatorModel&;
   [[nodiscard]] auto AdjustmentAt(std::size_t index) const -> const IOperatorModel&;
   [[nodiscard]] auto FindAdjustment(const AdjustmentInstanceId& id) -> IOperatorModel*;
+  [[nodiscard]] auto FindAdjustment(const AdjustmentInstanceId& id) const -> const IOperatorModel*;
   [[nodiscard]] auto FindAdjustmentByType(const OperatorTypeId& type) -> IOperatorModel*;
   [[nodiscard]] auto FindAdjustmentByType(const OperatorTypeId& type) const -> const IOperatorModel*;
 

--- a/alcedo_studio/src/include/edit/graph/develop_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/develop_node_model.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <span>
+#include <string_view>
 #include <string>
 #include <vector>
 
@@ -136,6 +137,7 @@ class DevelopNodeModel final : public INodeModel {
 
   [[nodiscard]] auto Id() const -> const NodeId& override { return id_; }
   [[nodiscard]] auto Type() const -> const OperatorTypeId& override { return type_ids::DevelopNode(); }
+  [[nodiscard]] auto DisplayName() const -> std::string_view override { return "Develop"; }
   [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto ToJson() const -> nlohmann::json override;

--- a/alcedo_studio/src/include/edit/graph/drt_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/drt_node_model.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <string_view>
 
 #include "edit/graph/i_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
@@ -139,6 +140,7 @@ class DrtNodeModel final : public INodeModel {
 
   [[nodiscard]] auto Id() const -> const NodeId& override { return id_; }
   [[nodiscard]] auto Type() const -> const OperatorTypeId& override { return type_ids::DrtNode(); }
+  [[nodiscard]] auto DisplayName() const -> std::string_view override { return "DRT"; }
   [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto ToJson() const -> nlohmann::json override;

--- a/alcedo_studio/src/include/edit/graph/graph_validation.hpp
+++ b/alcedo_studio/src/include/edit/graph/graph_validation.hpp
@@ -21,6 +21,12 @@ enum class GraphValidationCode {
   Cycle,
   MissingRequiredInput,
   MultipleInputsOnPort,
+  SceneImageFanOut,
+  ColorGradeNotOnImageBackbone,
+  BrokenImageBackbone,
+  ProtectedEndpoint,
+  NotAColorGrade,
+  InvalidDisplayName,
 };
 
 struct GraphValidationError {

--- a/alcedo_studio/src/include/edit/graph/i_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/i_node_model.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <span>
+#include <string_view>
 
 #include "edit/graph/graph_ids.hpp"
 #include "edit/graph/port.hpp"
@@ -22,6 +23,11 @@ class INodeModel {
 
   [[nodiscard]] virtual auto Id() const -> const NodeId&                 = 0;
   [[nodiscard]] virtual auto Type() const -> const OperatorTypeId&       = 0;
+  /**
+   * @brief UI label for this node. Distinct from @ref Id; renaming a Color Grade
+   *        must not change NodeId. Develop and DRT names are fixed.
+   */
+  [[nodiscard]] virtual auto DisplayName() const -> std::string_view   = 0;
   [[nodiscard]] virtual auto InputPorts() const -> std::span<const PortDescriptor>  = 0;
   [[nodiscard]] virtual auto OutputPorts() const -> std::span<const PortDescriptor> = 0;
 

--- a/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
@@ -13,6 +13,7 @@
 #include "edit/graph/drt_node_model.hpp"
 #include "edit/graph/image_geometry_model.hpp"
 #include "edit/graph/pipeline_graph.hpp"
+#include "json.hpp"
 
 namespace alcedo {
 

--- a/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
@@ -60,8 +60,19 @@ class PipelineDocument {
   bool                topology_dirty_ = true;
 };
 
+/// Product Default Color Grade exposure, in EV. Baked by @ref CreateDefaultPipelineDocument.
+inline constexpr float kDefaultPipelineExposureEv = 1.5f;
+/// Product Default saturation multiplier (legacy UI +30 → 1 + 30/100).
+inline constexpr float kDefaultPipelineSaturation = 1.3f;
+
 /**
- * @brief Three-node default: Develop -> Primary Color Grade -> DRT.
+ * @brief Three-node product Default: Develop -> Primary Color Grade -> DRT.
+ *
+ * The primary Color Grade is @ref ColorGradeNodeModel::MakeDefault with
+ * @ref kDefaultPipelineExposureEv and @ref kDefaultPipelineSaturation applied
+ * in this factory. Does not require legacy stage remirror.
+ *
+ * @return A document that satisfies graph Validate and ValidateImageBackbone.
  */
 [[nodiscard]] auto CreateDefaultPipelineDocument() -> PipelineDocument;
 

--- a/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_document.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <vector>
 
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/develop_node_model.hpp"
@@ -68,6 +69,14 @@ class PipelineDocument {
  * @brief Deep copy via JSON round-trip. The clone does not share Model pointers.
  */
 [[nodiscard]] auto ClonePipelineDocument(const PipelineDocument& src) -> PipelineDocument;
+
+/**
+ * @brief Color Grade nodes on the unique Develop-to-DRT scene-image path, in path order.
+ *
+ * Empty when the backbone cannot be walked. Off-path Color Grades are omitted.
+ */
+[[nodiscard]] auto ColorGradesOnImageBackbone(const PipelineDocument& document)
+    -> std::vector<const ColorGradeNodeModel*>;
 
 /**
  * @brief True when Apply may remirror the legacy stage adapter into this document.

--- a/alcedo_studio/src/include/edit/graph/pipeline_graph.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_graph.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string_view>
 #include <vector>
@@ -23,14 +24,40 @@ struct GraphEdge {
 /**
  * @brief Simple directed graph of INodeModel instances.
  *
- * Does not own GPU resources. Validate reports endpoint, port-type, and cycle errors.
+ * Does not own GPU resources. @ref Validate reports endpoint, port-type, fan-in, and
+ * cycle errors. @ref ValidateImageBackbone additionally requires a unique Develop to
+ * DRT scene-image path that visits every Color Grade. Product graph edits go through
+ * pipeline graph commands; this type does not expose a mutable node container.
  */
 class PipelineGraph {
  public:
   void AddNode(std::unique_ptr<INodeModel> node);
   void Connect(NodeId from_node, PortId from_port, NodeId to_node, PortId to_port);
+  /**
+   * @brief Remove one exact edge. No-op if that edge is absent.
+   */
+  void Disconnect(const NodeId& from_node, const PortId& from_port, const NodeId& to_node,
+                   const PortId& to_port);
+  /**
+   * @brief Remove @p id and every incident edge.
+   * @throws std::invalid_argument if @p id is not in the graph.
+   */
+  void RemoveNode(const NodeId& id);
 
   [[nodiscard]] auto Validate() const -> std::vector<GraphValidationError>;
+  /**
+   * @brief Scene-image backbone rules on top of @ref Validate.
+   *
+   * Rejects scene-image fan-out, a path that does not run Develop to DRT, Color
+   * Grades off that path, and non-image node types on the path. Mask edges are
+   * ignored. Does not replace @ref Validate.
+   */
+  [[nodiscard]] auto ValidateImageBackbone() const -> std::vector<GraphValidationError>;
+  /**
+   * @brief Develop through Color Grades to DRT along unique scene-image edges.
+   * @return Empty when the unique backbone cannot be walked.
+   */
+  [[nodiscard]] auto ImageBackboneNodeIds() const -> std::vector<NodeId>;
   /**
    * @brief Topological node order.
    * @pre Validate() is empty; otherwise throws std::runtime_error.
@@ -45,7 +72,6 @@ class PipelineGraph {
   [[nodiscard]] auto FindNode(std::string_view id) -> INodeModel*;
   [[nodiscard]] auto FindNode(std::string_view id) const -> const INodeModel*;
 
-  [[nodiscard]] auto Nodes() -> std::vector<std::unique_ptr<INodeModel>>& { return nodes_; }
   [[nodiscard]] auto Nodes() const -> const std::vector<std::unique_ptr<INodeModel>>& {
     return nodes_;
   }

--- a/alcedo_studio/src/include/edit/graph/pipeline_graph.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_graph.hpp
@@ -44,6 +44,17 @@ class PipelineGraph {
    */
   void RemoveNode(const NodeId& id);
 
+  /**
+   * @brief Apply one backbone edit, retaining only removed edges and the removed node.
+   * @pre Caller holds the live executor render lock. Insert/remove are mutually exclusive.
+   * @return Validation errors after restoring exact edge order and node ownership, or empty.
+   * All storage is reserved before mutation; exceptions restore the same objects and propagate.
+   */
+  auto ApplyBackboneEdit(const std::vector<GraphEdge>& disconnected,
+                         std::vector<GraphEdge>        connected,
+                         std::unique_ptr<INodeModel> inserted = nullptr, const NodeId& removed = {})
+      -> std::vector<GraphValidationError>;
+
   [[nodiscard]] auto Validate() const -> std::vector<GraphValidationError>;
   /**
    * @brief Scene-image backbone rules on top of @ref Validate.

--- a/alcedo_studio/src/include/edit/graph/pipeline_graph_commands.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_graph_commands.hpp
@@ -1,0 +1,68 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/graph/graph_validation.hpp"
+#include "edit/graph/pipeline_document.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Insert a Color Grade immediately before @p before_node_id on the image backbone.
+ *
+ * The new node becomes the scene-image predecessor of @p before_node_id. When
+ * @p before_node_id is DRT, the insert is after the last Color Grade or Develop.
+ * @p new_id is the stable NodeId of the inserted node.
+ *
+ * @return Empty on success. On failure @p candidate is left unchanged.
+ */
+[[nodiscard]] auto AddCleanColorGrade(PipelineDocument& candidate, const NodeId& before_node_id,
+                                      NodeId new_id) -> std::vector<GraphValidationError>;
+
+/**
+ * @brief Delete a Color Grade, drop its incident edges, and bridge predecessor to successor.
+ *
+ * Develop and DRT cannot be removed. Removing the last Color Grade leaves Develop connected
+ * to DRT.
+ *
+ * @return Empty on success. On failure @p candidate is left unchanged.
+ */
+[[nodiscard]] auto RemoveColorGradeAndBridge(PipelineDocument& candidate, const NodeId& node_id)
+    -> std::vector<GraphValidationError>;
+
+/**
+ * @brief Move a Color Grade so it sits on the scene-image edge from @p new_predecessor_id
+ *        to @p new_successor_id.
+ *
+ * @return Empty on success. On failure @p candidate is left unchanged.
+ */
+[[nodiscard]] auto ReconnectColorGrade(PipelineDocument& candidate, const NodeId& node_id,
+                                       const NodeId& new_predecessor_id,
+                                       const NodeId& new_successor_id)
+    -> std::vector<GraphValidationError>;
+
+/**
+ * @brief Change the Color Grade UI label. Does not change NodeId.
+ *
+ * Develop and DRT names are rejected. Empty @p display_name is rejected.
+ *
+ * @return Empty on success. On failure @p candidate is left unchanged.
+ */
+[[nodiscard]] auto RenameColorGrade(PipelineDocument& candidate, const NodeId& node_id,
+                                      std::string display_name) -> std::vector<GraphValidationError>;
+
+/**
+ * @brief Set Color Grade enabled. Does not change NodeId or edges.
+ *
+ * @return Empty on success. On failure @p candidate is left unchanged.
+ */
+[[nodiscard]] auto SetColorGradeEnabled(PipelineDocument& candidate, const NodeId& node_id,
+                                       bool enabled) -> std::vector<GraphValidationError>;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/pipeline_graph_commands.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_graph_commands.hpp
@@ -21,9 +21,10 @@ namespace alcedo {
  * @p new_id is the stable NodeId of the inserted node. The node is
  * @ref CreateCleanColorGradeNode, not a copy of the product Default look.
  *
- * @return Empty on success. On failure @p candidate is left unchanged.
+ * @pre Caller holds the shared executor render lock. No unrelated Model is copied.
+ * @return Empty on success. On failure @p document is left unchanged.
  */
-[[nodiscard]] auto AddCleanColorGrade(PipelineDocument& candidate, const NodeId& before_node_id,
+[[nodiscard]] auto AddCleanColorGrade(PipelineDocument& document, const NodeId& before_node_id,
                                       NodeId new_id) -> std::vector<GraphValidationError>;
 
 /**
@@ -32,18 +33,20 @@ namespace alcedo {
  * Develop and DRT cannot be removed. Removing the last Color Grade leaves Develop connected
  * to DRT.
  *
- * @return Empty on success. On failure @p candidate is left unchanged.
+ * @pre Caller holds the shared executor render lock. No unrelated Model is copied.
+ * @return Empty on success. On failure @p document is left unchanged.
  */
-[[nodiscard]] auto RemoveColorGradeAndBridge(PipelineDocument& candidate, const NodeId& node_id)
+[[nodiscard]] auto RemoveColorGradeAndBridge(PipelineDocument& document, const NodeId& node_id)
     -> std::vector<GraphValidationError>;
 
 /**
  * @brief Move a Color Grade so it sits on the scene-image edge from @p new_predecessor_id
  *        to @p new_successor_id.
  *
- * @return Empty on success. On failure @p candidate is left unchanged.
+ * @pre Caller holds the shared executor render lock. No unrelated Model is copied.
+ * @return Empty on success. On failure @p document is left unchanged.
  */
-[[nodiscard]] auto ReconnectColorGrade(PipelineDocument& candidate, const NodeId& node_id,
+[[nodiscard]] auto ReconnectColorGrade(PipelineDocument& document, const NodeId& node_id,
                                        const NodeId& new_predecessor_id,
                                        const NodeId& new_successor_id)
     -> std::vector<GraphValidationError>;
@@ -53,17 +56,19 @@ namespace alcedo {
  *
  * Develop and DRT names are rejected. Empty @p display_name is rejected.
  *
- * @return Empty on success. On failure @p candidate is left unchanged.
+ * @pre Caller holds the shared executor render lock. No unrelated Model is copied.
+ * @return Empty on success. On failure @p document is left unchanged.
  */
-[[nodiscard]] auto RenameColorGrade(PipelineDocument& candidate, const NodeId& node_id,
-                                      std::string display_name) -> std::vector<GraphValidationError>;
+[[nodiscard]] auto RenameColorGrade(PipelineDocument& document, const NodeId& node_id,
+                                    std::string display_name) -> std::vector<GraphValidationError>;
 
 /**
  * @brief Set Color Grade enabled. Does not change NodeId or edges.
  *
- * @return Empty on success. On failure @p candidate is left unchanged.
+ * @pre Caller holds the shared executor render lock. No unrelated Model is copied.
+ * @return Empty on success. On failure @p document is left unchanged.
  */
-[[nodiscard]] auto SetColorGradeEnabled(PipelineDocument& candidate, const NodeId& node_id,
-                                       bool enabled) -> std::vector<GraphValidationError>;
+[[nodiscard]] auto SetColorGradeEnabled(PipelineDocument& document, const NodeId& node_id,
+                                        bool enabled) -> std::vector<GraphValidationError>;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/pipeline_graph_commands.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_graph_commands.hpp
@@ -18,7 +18,8 @@ namespace alcedo {
  *
  * The new node becomes the scene-image predecessor of @p before_node_id. When
  * @p before_node_id is DRT, the insert is after the last Color Grade or Develop.
- * @p new_id is the stable NodeId of the inserted node.
+ * @p new_id is the stable NodeId of the inserted node. The node is
+ * @ref CreateCleanColorGradeNode, not a copy of the product Default look.
  *
  * @return Empty on success. On failure @p candidate is left unchanged.
  */

--- a/alcedo_studio/src/include/edit/graph/raster_mask_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/raster_mask_node_model.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <string_view>
 
 #include "edit/geometry/types.hpp"
 #include "edit/graph/i_node_model.hpp"
@@ -27,6 +28,7 @@ class RasterMaskNodeModel final : public INodeModel {
   [[nodiscard]] auto Type() const -> const OperatorTypeId& override {
     return type_ids::RasterMaskNode();
   }
+  [[nodiscard]] auto DisplayName() const -> std::string_view override { return "Mask"; }
   [[nodiscard]] auto InputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto OutputPorts() const -> std::span<const PortDescriptor> override;
   [[nodiscard]] auto ToJson() const -> nlohmann::json override;

--- a/alcedo_studio/src/include/edit/pipeline/pipeline_apply_request.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/pipeline_apply_request.hpp
@@ -1,0 +1,37 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <functional>
+#include <optional>
+
+#include "edit/geometry/render_request.hpp"
+#include "io/image/export_color_profile_config.hpp"
+#include "type/type.hpp"
+#include "ui/edit_viewer/frame_sink.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief One product DAG Apply/Render invocation. Owned by the task, not the executor.
+ *
+ * Geometry, decode, cache policy, host output, sink, submission, and optional export
+ * encoding are inputs for this run. Apply must not copy these onto long-lived executor
+ * members or restore them from JSON. Lifetime: built under the render lock, consumed
+ * by Apply, then discarded. Thread: owner render thread. Failure: invalid combinations
+ * throw from Apply/Render; they do not leave a partial mode switch on the executor.
+ */
+struct PipelineApplyRequest {
+  RenderRequest                               geometry{};
+  DecodeRes                                   decode_res           = DecodeRes::FULL;
+  RenderCachePolicy                           cache_policy         = RenderCachePolicy::UseSessionCache;
+  bool                                        require_host_output  = false;
+  IFrameSink*                                 sink                 = nullptr;
+  FrameCompletionSubmission                   submission{};
+  std::optional<ExportColorProfileConfig>     output_color;
+  std::function<bool()>                       cancel_requested;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
@@ -13,6 +13,7 @@
 
 #include "edit/operators/op_base.hpp"
 #include "edit/pipeline/pipeline_accelerator.hpp"
+#include "edit/pipeline/pipeline_apply_request.hpp"
 #include "edit/pipeline/pipeline_stage.hpp"
 #include "image/image_buffer.hpp"
 #include "pipeline.hpp"
@@ -131,6 +132,17 @@ class CPUPipelineExecutor : public PipelineExecutor {
    * Persistent Model values, nodes and edges are never changed; runtime caches may be updated.
    */
   auto Apply(std::shared_ptr<ImageBuffer> input) -> std::shared_ptr<ImageBuffer> override;
+
+  /**
+   * @brief Render using an immutable per-task request. Does not write decode, cache, ROI,
+   *        or host-output onto executor members.
+   * @pre Caller holds GetRenderLock(); camera/profile data is already loaded.
+   * @throws std::runtime_error for missing document/backend, decode, GPU, or presentation failure.
+   *         Failures do not switch executor cache/decode mode. Bypass ExactRelease scratch is
+   *         released after GPU last-use or on the failure path.
+   */
+  auto Apply(std::shared_ptr<ImageBuffer> input, const PipelineApplyRequest& request)
+      -> std::shared_ptr<ImageBuffer>;
 
   /**
    * @brief Select the format-version-2 document used by the GPU DAG product path.

--- a/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
+++ b/alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp
@@ -58,7 +58,6 @@ class CPUPipelineExecutor : public PipelineExecutor {
   std::mutex                                                                  render_lock_;
 
   OperatorParams                                                              global_params_;
-  std::optional<RawRuntimeColorContext> injected_raw_color_context_;
 
   bool                                  is_thumbnail_     = false;
 
@@ -79,7 +78,7 @@ class CPUPipelineExecutor : public PipelineExecutor {
   FrameCompletionSubmission           bound_frame_submission_{};
 #if defined(HAVE_CUDA) || defined(HAVE_METAL) || defined(HAVE_OPENCL)
   std::shared_ptr<PipelineDocument> pipeline_document_;
-  nlohmann::json                    gpu_dag_legacy_snapshot_;
+  // Used only by the existing service load/save boundary, never by Apply.
   bool                              mirror_legacy_stage_adapter_ = false;
 #endif
 #ifdef HAVE_CUDA
@@ -126,9 +125,22 @@ class CPUPipelineExecutor : public PipelineExecutor {
   auto GetRenderLock() -> std::mutex& { return render_lock_; }
 
   auto GetStage(PipelineStageName stage) -> PipelineStage& override;
+  /** @brief Render encoded input using the bound document and current request settings.
+   * @pre Caller holds GetRenderLock(); camera/profile data is already loaded.
+   * @throws std::runtime_error for missing document/backend, decode, GPU or presentation failure.
+   * Persistent Model values, nodes and edges are never changed; runtime caches may be updated.
+   */
   auto Apply(std::shared_ptr<ImageBuffer> input) -> std::shared_ptr<ImageBuffer> override;
 
-  /** @brief Select the format-version-2 document used by the GPU DAG product path. */
+  /**
+   * @brief Select the format-version-2 document used by the GPU DAG product path.
+   *
+   * @param document Graph owned by the caller; retains shared ownership without changing values.
+   * @param mirror_legacy_stage_adapter Existing service load/save bookkeeping only.
+   *        Apply never reads stage parameters, regardless of this flag or output destination.
+   * @pre Caller holds GetRenderLock() or has exclusive access before publication.
+   * @throws std::invalid_argument when document is null; retains the prior binding.
+   */
   void SetPipelineDocument(std::shared_ptr<PipelineDocument> document,
                            bool                              mirror_legacy_stage_adapter = false);
   [[nodiscard]] auto HasGpuDagDocument() const -> bool;
@@ -176,10 +188,16 @@ class CPUPipelineExecutor : public PipelineExecutor {
    */
   void               ImportPipelineParams(const nlohmann::json& j) override;
 
+  /** @brief Set request ROI in reference-image pixels; does not write persistent parameters.
+   * @pre Caller holds GetRenderLock() or exclusive initialization access.
+   */
   void SetRenderRegion(int x, int y, float scale_factor_x, float scale_factor_y = -1.0f,
                        int reference_width = 0, int reference_height = 0) override;
+  /// Set the request output limit under GetRenderLock(); full_res disables the limit.
   void SetRenderRes(bool full_res, int max_side_length = 2048) override;
+  /// Set the request's resize algorithm under GetRenderLock(); invalid enum values throw.
   void SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm algorithm) override;
+  /// Select RAW decode resolution for the request under GetRenderLock(), without editing a Model.
   void SetDecodeRes(DecodeRes res);
 
   /// Snapshot of one-shot render parameters that must not leak across Apply calls.
@@ -191,7 +209,9 @@ class CPUPipelineExecutor : public PipelineExecutor {
     std::optional<ViewportRenderRegion> render_request_viewport_ = std::nullopt;
   };
 
+  /// Read runtime request settings under GetRenderLock(); no document state is copied.
   [[nodiscard]] auto CaptureOneShotRenderParams() const -> OneShotRenderParamsSnapshot;
+  /// Restore runtime request settings and clear cancellation under GetRenderLock(); no Model writes.
   void               RestoreOneShotRenderParams(const OneShotRenderParamsSnapshot& snapshot);
 
   void               RegisterAllOperators();
@@ -200,9 +220,9 @@ class CPUPipelineExecutor : public PipelineExecutor {
   void               InitDefaultPipeline();
 
   /**
-   * @brief Install image-local raw metadata into the pipeline (transition path).
-   *        Prefer writing inherent RAW params into RawDecodeOp at import so that
-   *        reload and render no longer require a per-frame inject.
+   * @brief Install image-local RAW camera/profile metadata during import or explicit load.
+   * @pre Caller holds GetRenderLock() or exclusive initialization access. A document is bound.
+   * Updates Develop and the existing import-stage fields. Never call from a render task.
    */
   void               InjectRawMetadata(const RawRuntimeColorContext& ctx);
 

--- a/alcedo_studio/src/include/edit/runtime/basic_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_device.hpp
@@ -13,6 +13,7 @@
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/gpu_node_pass_stats.hpp"
 #include "edit/runtime/plan_executor.hpp"
+#include "gpu/transient_allocation_policy.hpp"
 
 namespace alcedo {
 
@@ -108,9 +109,11 @@ class BasicRenderDevice {
    */
   [[nodiscard]] auto Execute(const ExecutionPlan& plan, const PreparedRawInput& input,
                              PipelineDocument& document, MaskStore* mask_store = nullptr,
-                             bool publish_on_success = true) -> GraphValueId {
+                             bool publish_on_success = true,
+                             TransientAllocationPolicy transient_policy =
+                                 TransientAllocationPolicy::SessionPacked) -> GraphValueId {
     return PlanExecutor<Backend>::Execute(*this, plan, input, document, mask_store,
-                                          publish_on_success);
+                                          publish_on_success, transient_policy);
   }
 
  private:

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -14,6 +14,7 @@
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/texture_pool.hpp"
 #include "gpu/gpu_pool_trace.hpp"
+#include "gpu/transient_allocation_policy.hpp"
 #include "gpu/transient_buffer_arena.hpp"
 
 namespace alcedo {
@@ -47,6 +48,9 @@ class BasicRenderWorkspace {
 
   [[nodiscard]] auto Parameters() -> ParameterArena<Backend>& { return parameters_; }
   [[nodiscard]] auto TransientBuffers() -> TransientBufferArena<Backend>& { return transients_; }
+  [[nodiscard]] auto TransientBuffers() const -> const TransientBufferArena<Backend>& {
+    return transients_;
+  }
   [[nodiscard]] auto Textures() -> TexturePool<Backend>& { return textures_; }
   [[nodiscard]] auto Textures() const -> const TexturePool<Backend>& { return textures_; }
   [[nodiscard]] auto MaskTextures() -> MaskTextureCache<Backend>& { return mask_textures_; }
@@ -70,6 +74,9 @@ class BasicRenderWorkspace {
   void PrepareDevelopTransients(const DevelopCompileSource& source,
                                  std::uint32_t backend_capability_version,
                                  RawDemosaicMethod demosaic_method) {
+    if (transients_.allocation_policy() == TransientAllocationPolicy::ExactRelease) {
+      return;
+    }
     const auto bytes =
         develop_high_water_.SuggestInitial(source, backend_capability_version, demosaic_method);
     if (bytes == 0) {
@@ -140,6 +147,11 @@ class BasicRenderWorkspace {
       -> ResourceLease<Backend>& {
     return images_.AliasTextureFrom(textures_, dest, source);
   }
+
+  /**
+   * @brief Drop an unpublished image after its last consumer. GPU last-use must already be done.
+   */
+  void ReleaseConsumedImage(const GraphValueId& id) { images_.ReleaseWrite(id); }
 
   /**
    * @brief Wait the previous submission, drop leftover unpublished writes, start a new id.

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_render_device.hpp
@@ -15,6 +15,7 @@
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/gpu_node_pass_stats.hpp"
 #include "edit/runtime/render_device_type.hpp"
+#include "gpu/transient_allocation_policy.hpp"
 
 namespace alcedo {
 
@@ -94,7 +95,9 @@ class CudaRenderDevice {
    */
   [[nodiscard]] auto Execute(const ExecutionPlan& plan, const PreparedRawInput& input,
                              PipelineDocument& document, MaskStore* mask_store = nullptr,
-                             bool publish_on_success = true) -> GraphValueId;
+                             bool publish_on_success = true,
+                             TransientAllocationPolicy transient_policy =
+                                 TransientAllocationPolicy::SessionPacked) -> GraphValueId;
 
  private:
   CudaRenderWorkspace                              workspace_;

--- a/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
+++ b/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
@@ -16,6 +16,7 @@
 #include "edit/runtime/frame_presenter.hpp"
 #include "edit/runtime/graph_compiler.hpp"
 #include "edit/runtime/renderer.hpp"
+#include "gpu/transient_allocation_policy.hpp"
 #include "image/image_buffer.hpp"
 
 namespace alcedo {
@@ -60,7 +61,8 @@ template <class Backend>
 auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
                                const RenderRequest& request, IFrameSink* sink,
                                const FrameCompletionSubmission& submission,
-                               bool require_host_output, RenderCachePolicy cache_policy)
+                               bool require_host_output, RenderCachePolicy cache_policy,
+                               const std::optional<ExportColorProfileConfig>& output_color)
     -> std::shared_ptr<ImageBuffer> {
   if (!document_) {
     throw std::runtime_error("Renderer: PipelineDocument is not configured");
@@ -73,7 +75,9 @@ auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input, Decode
   const auto encoded_bytes = std::span<const std::byte>{
       reinterpret_cast<const std::byte*>(encoded.data()), encoded.size()};
   const bool use_session_cache = cache_policy == RenderCachePolicy::UseSessionCache;
-  if (!use_session_cache) {
+  if (use_session_cache) {
+    EnsureSessionDevice();
+  } else {
     EnsureOneShotDevice();
   }
 
@@ -91,13 +95,16 @@ auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input, Decode
     render_device = one_shot_device_.get();
   }
   GraphCompiler::BindFrameGeometry(plan, *document_, request);
+  plan.output_color_override = output_color;
   detail::TraceGpuDagGeometry<Backend>(plan, request, submission);
   if (document_->TopologyDirty()) {
     document_->ClearTopologyDirty();
   }
   const auto& prepared = use_session_cache ? prepared_lease->Get() : *one_shot_prepared;
-  const auto  output_id =
-      render_device->Execute(plan, prepared, *document_, mask_store_.get(), false);
+  const auto  output_id = render_device->Execute(
+      plan, prepared, *document_, mask_store_.get(), false,
+      use_session_cache ? TransientAllocationPolicy::SessionPacked
+                        : TransientAllocationPolicy::ExactRelease);
   const auto release_one_shot_resources = [&]() {
     if (use_session_cache) {
       return;
@@ -109,7 +116,11 @@ auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input, Decode
   };
 
   ViewerDisplayConfig display_config{};
-  if (const auto* drt = document_->Drt()) {
+  if (output_color.has_value()) {
+    display_config.encoding_space = output_color->encoding_space;
+    display_config.encoding_eotf  = output_color->encoding_eotf;
+    display_config.peak_luminance = output_color->peak_luminance;
+  } else if (const auto* drt = document_->Drt()) {
     display_config = ViewerDisplayConfigFromDrt(drt->Params().Params());
   }
 

--- a/alcedo_studio/src/include/edit/runtime/drt_display.hpp
+++ b/alcedo_studio/src/include/edit/runtime/drt_display.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "edit/graph/drt_node_model.hpp"
+#include "io/image/export_color_profile_config.hpp"
+#include "json.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 
 namespace alcedo {
@@ -56,6 +58,58 @@ namespace alcedo {
   }
   config.peak_luminance = payload.peak_luminance;
   return config;
+}
+
+/**
+ * @brief Encoding fields from a DRT payload. Does not allocate GPU memory.
+ */
+[[nodiscard]] inline auto ExportColorProfileFromDrt(const DrtPayload& payload)
+    -> ExportColorProfileConfig {
+  const auto display = ViewerDisplayConfigFromDrt(payload);
+  return {display.encoding_space, display.encoding_eotf, display.peak_luminance};
+}
+
+/**
+ * @brief Overlay export encoding onto a DRT JSON copy. Does not write the live Model.
+ */
+inline void OverlayExportColorOnDrtJson(nlohmann::json& json, const ExportColorProfileConfig& color) {
+  switch (color.encoding_space) {
+    case ColorUtils::ColorSpace::REC2020:
+      json["encoding_space"] = "rec2020";
+      break;
+    case ColorUtils::ColorSpace::P3_D65:
+      json["encoding_space"] = "p3_d65";
+      break;
+    case ColorUtils::ColorSpace::REC709:
+    default:
+      json["encoding_space"] = "rec709";
+      break;
+  }
+  switch (color.encoding_eotf) {
+    case ColorUtils::EOTF::LINEAR:
+      json["encoding_eotf"] = "linear";
+      break;
+    case ColorUtils::EOTF::ST2084:
+      json["encoding_eotf"] = "st2084";
+      break;
+    case ColorUtils::EOTF::HLG:
+      json["encoding_eotf"] = "hlg";
+      break;
+    case ColorUtils::EOTF::GAMMA_2_6:
+      json["encoding_eotf"] = "gamma_2_6";
+      break;
+    case ColorUtils::EOTF::BT1886:
+      json["encoding_eotf"] = "bt1886";
+      break;
+    case ColorUtils::EOTF::GAMMA_1_8:
+      json["encoding_eotf"] = "gamma_1_8";
+      break;
+    case ColorUtils::EOTF::GAMMA_2_2:
+    default:
+      json["encoding_eotf"] = "gamma_2_2";
+      break;
+  }
+  json["peak_luminance"] = color.peak_luminance;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
+++ b/alcedo_studio/src/include/edit/runtime/execution_plan.hpp
@@ -13,6 +13,7 @@
 #include "edit/operators/models/operator_type_id.hpp"
 #include "edit/runtime/develop_compile_source.hpp"
 #include "edit/runtime/pass_kind.hpp"
+#include "io/image/export_color_profile_config.hpp"
 
 namespace alcedo {
 
@@ -149,6 +150,7 @@ struct ExecutionPlan {
   GraphValueId                    mask_output{NodeId{""}, PortId{"mask"}};
   GraphValueId                    primary_grade_output{NodeId{"grade.primary"}, PortId{"image"}};
   GraphValueId                    display_output{NodeId{"drt"}, PortId{"display"}};
+  std::optional<ExportColorProfileConfig> output_color_override;
 
   [[nodiscard]] auto              Contains(GpuPassKind kind) const -> bool {
     for (const auto& pass : passes) {

--- a/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_compiler.hpp
@@ -14,11 +14,14 @@
 namespace alcedo {
 
 /**
- * @brief Builds the complete Develop -> PrimaryColorGrade -> DRT plan. Does not allocate GPU
+ * @brief Builds Develop -> first backbone Color Grade (if any) -> DRT. Does not allocate GPU
  * memory.
  *
- * Validates the three-node document. SensorDevelop, GeometryResample, and CameraToAp1 are
- * separate compiled passes with distinct GraphValueIds.
+ * Validates the document graph and image backbone. Zero Color Grades omits
+ * PrimaryColorGrade and feeds DRT from Develop. One or more Color Grades compile only
+ * the first node on the image backbone; the node id need not be grade.primary.
+ * SensorDevelop, GeometryResample, and CameraToAp1 are separate compiled passes with
+ * distinct GraphValueIds.
  *
  * The static plan key covers graph topology, adjustment types and order, source layout,
  * and backend capability version. Viewport, crop, CCT, Grade values, and DRT values are

--- a/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
@@ -208,6 +208,16 @@ class GraphImageCache {
   void               DiscardUnpublished() { write_slots_.clear(); }
 
   /**
+   * @brief Drop the unpublished write of @p id and return its texture to the pool.
+   *
+   * Published results are unchanged. No-op when @p id has no write slot.
+   * Caller must satisfy GPU last-use of that texture first.
+   */
+  void ReleaseWrite(const GraphValueId& id) { write_slots_.erase(id); }
+
+  [[nodiscard]] auto UnpublishedWriteCount() const -> std::size_t { return write_slots_.size(); }
+
+  /**
    * @brief Current texture for @p id: this-frame write slot, else last bound/published result.
    */
   [[nodiscard]] auto Find(const GraphValueId& id) -> ResourceLease<Backend>* {

--- a/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
@@ -18,6 +18,7 @@
 #include "edit/runtime/pass_kind.hpp"
 #include "edit/runtime/result_content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
+#include "gpu/transient_allocation_policy.hpp"
 
 namespace alcedo {
 
@@ -46,10 +47,15 @@ class PlanExecutor {
    */
   template <class Device>
   static auto Execute(Device& device, const ExecutionPlan& plan, const PreparedRawInput& input,
-                      PipelineDocument& document, MaskStore* mask_store, bool publish_on_success)
+                      PipelineDocument& document, MaskStore* mask_store, bool publish_on_success,
+                      TransientAllocationPolicy transient_policy =
+                          TransientAllocationPolicy::SessionPacked)
       -> GraphValueId {
     try {
       auto& workspace = device.Workspace();
+      workspace.TransientBuffers().SetAllocationPolicy(transient_policy);
+      const bool exact_release =
+          transient_policy == TransientAllocationPolicy::ExactRelease;
       if constexpr (requires(Backend& backend, const ExecutionPlan& compiled) {
                       backend.WarmUpPlan(compiled);
                     }) {
@@ -78,10 +84,12 @@ class PlanExecutor {
             develop_node != nullptr && develop_node->Params().Params().highlights_reconstruct;
         const auto h2d_before = workspace.Device().HostToDeviceBytes();
         try {
-          if constexpr (UsesDevelopTransientArena()) {
+        if constexpr (UsesDevelopTransientArena()) {
+          if (transient_policy == TransientAllocationPolicy::SessionPacked) {
             workspace.PrepareDevelopTransients(plan.source, Backend::kCapabilityVersion,
                                                develop_method);
           }
+        }
           if (plan.Contains(GpuPassKind::UploadRgb)) {
             PassEncoder<Backend, GpuPassKind::UploadRgb>::Encode(device, plan, input, document,
                                                                  mask_store);
@@ -103,8 +111,10 @@ class PlanExecutor {
         Record(device, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent);
         ++stats.sensor_develop_execute;
         if constexpr (UsesDevelopTransientArena()) {
-          workspace.RecordDevelopTransients(plan.source, Backend::kCapabilityVersion,
-                                            develop_method);
+          if (transient_policy == TransientAllocationPolicy::SessionPacked) {
+            workspace.RecordDevelopTransients(plan.source, Backend::kCapabilityVersion,
+                                              develop_method);
+          }
         }
         // Develop intermediates are not a cache. Finish the recorded work so backend-owned
         // scratch can be destroyed before Geometry allocates display textures.
@@ -125,6 +135,10 @@ class PlanExecutor {
         Record(device, plan.geometry_output, keys.geometry_scene_source, keys.geometry_extent);
         ++stats.geometry_execute;
       }
+      if (exact_release && plan.encode_geometry_resample) {
+        workspace.Device().SynchronizeRecordedWork(device.CommandContext());
+        workspace.ReleaseConsumedImage(plan.sensor_linear_output);
+      }
 
       if (BindOrMiss(workspace, plan.develop_output, keys.develop_image, keys.geometry_extent,
                      completed)) {
@@ -134,6 +148,13 @@ class PlanExecutor {
                                                                mask_store);
         Record(device, plan.develop_output, keys.develop_image, keys.geometry_extent);
         ++stats.camera_color_execute;
+      }
+      if (exact_release) {
+        workspace.Device().SynchronizeRecordedWork(device.CommandContext());
+        workspace.ReleaseConsumedImage(plan.geometry_output);
+        if (!plan.encode_geometry_resample) {
+          workspace.ReleaseConsumedImage(plan.sensor_linear_output);
+        }
       }
 
       if (plan.primary_grade_mask) {
@@ -158,6 +179,15 @@ class PlanExecutor {
         Record(device, plan.primary_grade_output, keys.primary_grade, keys.geometry_extent);
         ++stats.primary_grade_execute;
       }
+      if (exact_release) {
+        workspace.Device().SynchronizeRecordedWork(device.CommandContext());
+        if (plan.primary_grade_mask) {
+          workspace.ReleaseConsumedImage(plan.mask_output);
+        }
+        if (plan.primary_grade_output != plan.develop_output) {
+          workspace.ReleaseConsumedImage(plan.develop_output);
+        }
+      }
 
       if (BindOrMiss(workspace, plan.display_output, keys.drt_display, keys.geometry_extent,
                      completed)) {
@@ -166,6 +196,10 @@ class PlanExecutor {
         PassEncoder<Backend, GpuPassKind::Drt>::Encode(device, plan, input, document, mask_store);
         Record(device, plan.display_output, keys.drt_display, keys.geometry_extent);
         ++stats.drt_execute;
+      }
+      if (exact_release && plan.display_output != plan.primary_grade_output) {
+        workspace.Device().SynchronizeRecordedWork(device.CommandContext());
+        workspace.ReleaseConsumedImage(plan.primary_grade_output);
       }
 
       stats.result_content_hits += workspace.Images().ContentHitCount() - hits_before;

--- a/alcedo_studio/src/include/edit/runtime/renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/renderer.hpp
@@ -8,6 +8,8 @@
 #include <cstdio>
 #include <filesystem>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <span>
 #include <stdexcept>
 #include <string_view>
@@ -23,18 +25,13 @@
 #include "edit/runtime/gpu_node_pass_stats.hpp"
 #include "edit/runtime/render_device_type.hpp"
 #include "edit/runtime/static_execution_plan_cache.hpp"
+#include "io/image/export_color_profile_config.hpp"
 #include "type/type.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 
 namespace alcedo {
 
 class ImageBuffer;
-
-/** @brief Select whether a render may read or publish the editor session caches. */
-enum class RenderCachePolicy {
-  UseSessionCache,
-  BypassSessionCache,
-};
 
 using CudaProductCachePolicy = RenderCachePolicy;
 
@@ -62,6 +59,9 @@ struct RenderSessionResources {
   std::size_t               texture_pool_entry_count    = 0;
   std::size_t               prepared_source_host_bytes  = 0;
   std::size_t               prepared_source_entry_count = 0;
+  std::size_t               transient_used_bytes        = 0;
+  std::size_t               transient_capacity_bytes    = 0;
+  std::size_t               transient_slab_count        = 0;
   std::vector<GraphValueId> session_value_ids;
 };
 
@@ -101,7 +101,8 @@ class Renderer {
   [[nodiscard]] auto Render(const std::shared_ptr<ImageBuffer>& input, DecodeRes decode_res,
                             const RenderRequest& request, IFrameSink* sink,
                             const FrameCompletionSubmission& submission, bool require_host_output,
-                            RenderCachePolicy cache_policy = RenderCachePolicy::UseSessionCache)
+                            RenderCachePolicy cache_policy = RenderCachePolicy::UseSessionCache,
+                            const std::optional<ExportColorProfileConfig>& output_color = {})
       -> std::shared_ptr<ImageBuffer>;
 
   /** @brief Snapshot of source and static-plan cache counters since construction or ResetStats. */
@@ -109,11 +110,13 @@ class Renderer {
   void               ResetStats();
 
   /**
-   * @brief Drop GPU result textures, host prepared sources, the plan cache, and
-   *        backend session extras. Keeps the session device.
+   * @brief Drop GPU result textures, host prepared sources, the plan cache, the
+   *        one-shot device, and backend session extras.
    *
-   * Call when the pipeline is returned to PipelineMgmtService. The next Render
-   * rebuilds caches from the still-owned PipelineDocument.
+   * The session device is kept when it already exists so the next editor Render
+   * does not rebuild CUDA/Metal/OpenCL streams. Thumbnail-only Bypass renders
+   * never create that session device. Call when the last pipeline pin is
+   * released. The next Render rebuilds caches from the still-owned document.
    */
   void ReleaseSessionCaches();
 
@@ -144,8 +147,16 @@ class Renderer {
    */
   [[nodiscard]] auto DebugOneShotDeviceIdentity() const -> std::uintptr_t;
 
-  [[nodiscard]] auto Device() -> RenderDevice& { return *device_; }
-  [[nodiscard]] auto Device() const -> const RenderDevice& { return *device_; }
+  [[nodiscard]] auto Device() -> RenderDevice& {
+    EnsureSessionDevice();
+    return *device_;
+  }
+  [[nodiscard]] auto Device() const -> const RenderDevice& {
+    if (!device_) {
+      throw std::runtime_error("Renderer: session device has not been created");
+    }
+    return *device_;
+  }
 
   [[nodiscard]] auto SourceCache() -> PreparedSourceCache& { return source_cache_; }
   [[nodiscard]] auto SourceCache() const -> const PreparedSourceCache& { return source_cache_; }
@@ -154,6 +165,7 @@ class Renderer {
   [[nodiscard]] auto MaskAssets() -> MaskStore&;
 
  private:
+  void EnsureSessionDevice();
   void EnsureOneShotDevice();
   void ConfigureDevice(RenderDevice& device, const char* error_label);
 
@@ -174,7 +186,7 @@ template <class Backend>
 Renderer<Backend>::Renderer(std::shared_ptr<PipelineDocument> document,
                             PreparedSourceCache::UnpackFn     unpack)
     : document_(std::move(document)),
-      device_(std::make_unique<RenderDevice>()),
+      device_(),
       one_shot_device_(),
       mask_store_(std::make_unique<MaskStore>(std::filesystem::temp_directory_path() /
                                               "alcedo_studio" / "product_mask_store")),
@@ -184,9 +196,7 @@ Renderer<Backend>::Renderer(std::shared_ptr<PipelineDocument> document,
                          return RawInputLoader::LoadEncoded(encoded, decode_res);
                        }}),
       source_cache_(unpack_),
-      plan_cache_(Backend::kCapabilityVersion) {
-  ConfigureDevice(*device_, "product");
-}
+      plan_cache_(Backend::kCapabilityVersion) {}
 
 template <class Backend>
 Renderer<Backend>::~Renderer() = default;
@@ -198,6 +208,15 @@ void Renderer<Backend>::ConfigureDevice(RenderDevice& device, const char* error_
     std::fprintf(stderr, "[ERROR] %s DAG %s render failed: %.*s\n", Backend::kName, error_label,
                  static_cast<int>(message.size()), message.data());
   });
+}
+
+template <class Backend>
+void Renderer<Backend>::EnsureSessionDevice() {
+  if (device_) {
+    return;
+  }
+  device_ = std::make_unique<RenderDevice>();
+  ConfigureDevice(*device_, "product");
 }
 
 template <class Backend>
@@ -233,7 +252,9 @@ auto Renderer<Backend>::Stats() const -> RenderSessionStats {
   stats.plan_cache_hits          = plan.hits;
   stats.plan_cache_misses        = plan.misses;
   stats.plan_compile_count       = plan.compiles;
-  stats.pass                     = device_->PassStats();
+  if (device_) {
+    stats.pass = device_->PassStats();
+  }
   return stats;
 }
 
@@ -241,11 +262,16 @@ template <class Backend>
 void Renderer<Backend>::ResetStats() {
   source_cache_.ResetStats();
   plan_cache_.ResetStats();
-  device_->ResetPassStats();
+  if (device_) {
+    device_->ResetPassStats();
+  }
 }
 
 template <class Backend>
 void Renderer<Backend>::ReleaseSessionCaches() {
+  one_shot_device_.reset();
+  source_cache_.Clear();
+  plan_cache_.Clear();
   if (!device_) {
     return;
   }
@@ -254,9 +280,6 @@ void Renderer<Backend>::ReleaseSessionCaches() {
   if constexpr (requires(RenderDevice& device) { device.ReleaseNeuralDemosaicWorkspace(); }) {
     device_->ReleaseNeuralDemosaicWorkspace();
   }
-  one_shot_device_.reset();
-  source_cache_.Clear();
-  plan_cache_.Clear();
   device_->ResetPassStats();
 }
 
@@ -272,6 +295,9 @@ auto Renderer<Backend>::SessionResources() const -> RenderSessionResources {
   resources.texture_pool_entry_count    = workspace.Textures().EntryCount();
   resources.prepared_source_host_bytes  = source_cache_.HostBytesUsed();
   resources.prepared_source_entry_count = source_cache_.EntryCount();
+  resources.transient_used_bytes        = workspace.TransientBuffers().used_bytes();
+  resources.transient_capacity_bytes    = workspace.TransientBuffers().capacity_bytes();
+  resources.transient_slab_count        = workspace.TransientBuffers().slab_count();
   resources.session_value_ids           = workspace.Images().CurrentValueIds();
   return resources;
 }
@@ -294,6 +320,9 @@ auto Renderer<Backend>::OneShotResources() const -> RenderSessionResources {
   resources.published_result_count   = workspace.Images().PublishedCount();
   resources.texture_pool_used_bytes  = workspace.Textures().UsedBytes();
   resources.texture_pool_entry_count = workspace.Textures().EntryCount();
+  resources.transient_used_bytes     = workspace.TransientBuffers().used_bytes();
+  resources.transient_capacity_bytes = workspace.TransientBuffers().capacity_bytes();
+  resources.transient_slab_count     = workspace.TransientBuffers().slab_count();
   resources.session_value_ids        = workspace.Images().CurrentValueIds();
   return resources;
 }

--- a/alcedo_studio/src/include/edit/runtime/renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/renderer.hpp
@@ -127,6 +127,23 @@ class Renderer {
    */
   [[nodiscard]] auto OneShotPublishedResultCount() const -> std::size_t;
 
+  /**
+   * @brief Live allocations of the isolated one-shot workspace.
+   *
+   * Empty when no one-shot device exists. After a successful BypassSessionCache
+   * render, published results and texture-pool used bytes are zero because that
+   * workspace is released on delivery. Session prepared-source fields stay zero.
+   */
+  [[nodiscard]] auto OneShotResources() const -> RenderSessionResources;
+
+  /**
+   * @brief Address of the lazily created one-shot device, or 0 if none exists.
+   *
+   * Stable across BypassSessionCache renders until @ref ReleaseSessionCaches.
+   * Tests use this to detect per-Apply device reconstruction.
+   */
+  [[nodiscard]] auto DebugOneShotDeviceIdentity() const -> std::uintptr_t;
+
   [[nodiscard]] auto Device() -> RenderDevice& { return *device_; }
   [[nodiscard]] auto Device() const -> const RenderDevice& { return *device_; }
 
@@ -265,6 +282,25 @@ auto Renderer<Backend>::OneShotPublishedResultCount() const -> std::size_t {
     return 0;
   }
   return one_shot_device_->Workspace().Images().PublishedCount();
+}
+
+template <class Backend>
+auto Renderer<Backend>::OneShotResources() const -> RenderSessionResources {
+  RenderSessionResources resources;
+  if (!one_shot_device_) {
+    return resources;
+  }
+  const auto& workspace              = one_shot_device_->Workspace();
+  resources.published_result_count   = workspace.Images().PublishedCount();
+  resources.texture_pool_used_bytes  = workspace.Textures().UsedBytes();
+  resources.texture_pool_entry_count = workspace.Textures().EntryCount();
+  resources.session_value_ids        = workspace.Images().CurrentValueIds();
+  return resources;
+}
+
+template <class Backend>
+auto Renderer<Backend>::DebugOneShotDeviceIdentity() const -> std::uintptr_t {
+  return reinterpret_cast<std::uintptr_t>(one_shot_device_.get());
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/gpu/transient_allocation_policy.hpp
+++ b/alcedo_studio/src/include/gpu/transient_allocation_policy.hpp
@@ -1,0 +1,25 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+namespace alcedo {
+
+/**
+ * @brief How a TransientBufferArena sizes slabs and what it keeps after last use.
+ *
+ * Selected per render from the task request (session cache vs bypass). Not a
+ * pipeline mode flag and not stored on the live document.
+ *
+ * SessionPacked keeps the editor bump allocator: minimum slabs, quantum growth,
+ * and idle capacity for the next interactive frame.
+ * ExactRelease allocates only the requested aligned bytes and drops unused slabs
+ * after the caller has satisfied the GPU last-use dependency.
+ */
+enum class TransientAllocationPolicy {
+  SessionPacked,
+  ExactRelease,
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "gpu/gpu_pool_trace.hpp"
+#include "gpu/transient_allocation_policy.hpp"
 
 namespace alcedo {
 
@@ -39,13 +40,13 @@ struct TransientArenaSnapshot {
  * fit in one slab; allocations never span slab boundaries and never relocate
  * live device pointers. Optional `MaxTransientBytes()` caps the sum of slabs.
  *
- * `Reserve` may replace unused slabs when the request fits in one slab. Requests
- * larger than `MaxSlabBytes()` leave the arena empty so `Allocate` can create
- * request-sized slabs (pre-splitting into a max-slab plus leftover cannot satisfy
- * a later near-max-slab allocation, then exceeds `MaxTransientBytes`). `Allocate`
- * that does not fit any current remainder appends another slab. Develop scratch
- * is exclusive and discarded after SensorDevelop (`ReleaseDeviceMemory`).
- * `Reset()` rewinds every local bump without freeing slabs. Not thread-safe.
+ * SessionPacked `Reserve` may replace unused slabs when the request fits in one
+ * slab. ExactRelease never reserves: each `Allocate` creates a slab of the
+ * requested aligned size and unused slabs are dropped after last GPU use.
+ * `Allocate` that does not fit any current remainder appends another slab.
+ * Develop scratch is exclusive and discarded after SensorDevelop
+ * (`ReleaseDeviceMemory`). SessionPacked `Reset()` rewinds bump pointers without
+ * freeing slabs; ExactRelease `Reset()` frees slabs. Not thread-safe.
  *
  * @tparam Backend Slab factory. Must outlive this arena when passed by reference.
  */
@@ -91,10 +92,22 @@ class TransientBufferArena {
   ~TransientBufferArena() { ResetSlab(); }
 
   /**
+   * @brief Select packed reuse vs exact-size release. Per-request, not a pipeline flag.
+   */
+  void SetAllocationPolicy(TransientAllocationPolicy policy) { allocation_policy_ = policy; }
+  [[nodiscard]] auto allocation_policy() const noexcept -> TransientAllocationPolicy {
+    return allocation_policy_;
+  }
+
+  /**
    * @brief Ensure slab capacity is at least @p bytes. Grows only when unused.
-   * @throws std::runtime_error if bump allocations are live.
+   * @throws std::runtime_error if bump allocations are live or policy is ExactRelease.
    */
   void Reserve(std::size_t bytes) {
+    if (allocation_policy_ == TransientAllocationPolicy::ExactRelease) {
+      throw std::runtime_error(
+          "TransientBufferArena::Reserve: ExactRelease allocates only at Allocate");
+    }
     if (bytes <= capacity_bytes() && !slabs_.empty()) {
       return;
     }
@@ -134,14 +147,16 @@ class TransientBufferArena {
           "TransientBufferArena::Allocate: request exceeds backend max slab bytes", bytes));
     }
 
-    for (auto& entry : slabs_) {
-      if (void* placed = TryAllocateIn(entry, bytes, alignment)) {
-        NoteAllocation(bytes);
-        return placed;
+    if (allocation_policy_ != TransientAllocationPolicy::ExactRelease) {
+      for (auto& entry : slabs_) {
+        if (void* placed = TryAllocateIn(entry, bytes, alignment)) {
+          NoteAllocation(bytes);
+          return placed;
+        }
       }
     }
 
-    const auto slab_bytes = SlabBytesForRequest(bytes);
+    const auto slab_bytes = SlabBytesForRequest(bytes, alignment);
     AppendSlab(slab_bytes);
     ++grow_count_;
     if (void* placed = TryAllocateIn(slabs_.back(), bytes, alignment)) {
@@ -159,12 +174,28 @@ class TransientBufferArena {
     return static_cast<T*>(Allocate(count * sizeof(T), alignment));
   }
 
-  /// Rewind every slab bump to zero. Does not free device memory.
+  /// SessionPacked: rewind bump pointers. ExactRelease: free slabs.
   void Reset() noexcept {
+    if (allocation_policy_ == TransientAllocationPolicy::ExactRelease) {
+      ResetSlab();
+      return;
+    }
     for (auto& entry : slabs_) {
       entry.offset = 0;
     }
     ClearStageStats();
+  }
+
+  /**
+   * @brief Rewind to @p mark and destroy slabs allocated after it.
+   *
+   * Caller must satisfy GPU last-use before calling. Nested marks keep outer slabs.
+   */
+  void ReleaseSlabsAfterMark(const Mark& mark) noexcept {
+    RewindToMark(mark);
+    if (slabs_.size() > mark.size()) {
+      slabs_.erase(slabs_.begin() + static_cast<std::ptrdiff_t>(mark.size()), slabs_.end());
+    }
   }
 
   /**
@@ -312,9 +343,19 @@ class TransientBufferArena {
     return (std::numeric_limits<std::size_t>::max)();
   }
 
-  auto SlabBytesForRequest(std::size_t request) const -> std::size_t {
+  auto SlabBytesForRequest(std::size_t request, std::size_t alignment) const -> std::size_t {
     const auto max_slab = QueryMaxSlabBytes();
-    std::size_t size     = kMinSlabBytes;
+    if (allocation_policy_ == TransientAllocationPolicy::ExactRelease) {
+      auto size = AlignUp(request, alignment == 0 ? kDefaultAlignment : alignment);
+      if (size < request) {
+        size = request;
+      }
+      if (size > max_slab) {
+        size = request;
+      }
+      return size;
+    }
+    std::size_t size = kMinSlabBytes;
     if (request > kMinSlabBytes && request <= kSlabQuantumBytes) {
       size = kSlabQuantumBytes;
     } else if (request > kSlabQuantumBytes) {
@@ -438,13 +479,14 @@ class TransientBufferArena {
     other.grow_count_          = 0;
   }
 
-  std::optional<Backend> owned_;
-  Backend*               backend_            = nullptr;
-  std::vector<SlabEntry> slabs_;
-  std::size_t            requested_bytes_     = 0;
-  std::size_t            padding_bytes_      = 0;
-  std::size_t            largest_allocation_ = 0;
-  std::size_t            grow_count_         = 0;
+  std::optional<Backend>      owned_;
+  Backend*                    backend_            = nullptr;
+  std::vector<SlabEntry>      slabs_;
+  TransientAllocationPolicy   allocation_policy_  = TransientAllocationPolicy::SessionPacked;
+  std::size_t                 requested_bytes_     = 0;
+  std::size_t                 padding_bytes_      = 0;
+  std::size_t                 largest_allocation_ = 0;
+  std::size_t                 grow_count_         = 0;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/gpu/transient_buffer_scope.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_scope.hpp
@@ -12,10 +12,11 @@
 namespace alcedo {
 
 /**
- * @brief RAII nested bump scope. Rewinds @ref TransientBufferArena to the per-slab
- * offsets captured at construction. Allocations inside the scope are invalid after Release.
+ * @brief RAII nested bump scope.
  *
- * LIFO only. Appended slabs stay allocated and are rewound to offset 0. Not thread-safe.
+ * SessionPacked rewinds bump offsets. ExactRelease also destroys slabs allocated
+ * after the captured mark. Caller must satisfy GPU last-use before Release.
+ * LIFO only. Not thread-safe.
  */
 template <class Backend>
 class TransientBufferScope {
@@ -45,7 +46,11 @@ class TransientBufferScope {
 
   void Release() noexcept {
     if (arena_ != nullptr) {
-      arena_->RewindToMark(mark_);
+      if (arena_->allocation_policy() == TransientAllocationPolicy::ExactRelease) {
+        arena_->ReleaseSlabsAfterMark(mark_);
+      } else {
+        arena_->RewindToMark(mark_);
+      }
       arena_ = nullptr;
     }
   }

--- a/alcedo_studio/src/include/io/image/export_recipe.hpp
+++ b/alcedo_studio/src/include/io/image/export_recipe.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "io/image/export_color_profile_config.hpp"
 #include "type/supported_file_type.hpp"
 
 namespace alcedo {
@@ -120,17 +121,33 @@ struct ExportFileNameResult {
 };
 
 struct ExportRecipe {
-  ExportFormatOptions    codec_;
-  ExportResizeSpec       resize_;
-  ExportMetadataPolicy   metadata_;
-  ExportIccPolicy        icc_       = ExportIccPolicy::EMBED_OUTPUT_PROFILE;
-  ExportAlphaPolicy      alpha_     = ExportAlphaPolicy::PRESERVE_IF_SUPPORTED;
-  ExportCollisionPolicy  collision_ = ExportCollisionPolicy::FAIL;
-  ExportFileNameTemplate file_name_;
+  ExportFormatOptions                       codec_;
+  ExportResizeSpec                          resize_;
+  ExportMetadataPolicy                      metadata_;
+  ExportIccPolicy                           icc_       = ExportIccPolicy::EMBED_OUTPUT_PROFILE;
+  ExportAlphaPolicy                         alpha_     = ExportAlphaPolicy::PRESERVE_IF_SUPPORTED;
+  ExportCollisionPolicy                     collision_ = ExportCollisionPolicy::FAIL;
+  ExportFileNameTemplate                    file_name_;
+  /**
+   * Pixel encoding for this image. Required before enqueue. FromLegacyOptions
+   * leaves this empty; the app fills it from this image's DRT (or an explicit target).
+   */
+  std::optional<ExportColorProfileConfig>   output_color_;
 
   /** Create a recipe that preserves the behavior of the former flat options. */
   static auto            FromLegacyOptions(const ExportFormatOptions& options) -> ExportRecipe;
 };
+
+/**
+ * @brief True when @p recipe has finite positive peak luminance and an encoding space/EOTF.
+ */
+[[nodiscard]] auto ExportRecipeHasResolvedOutputColor(const ExportRecipe& recipe) -> bool;
+
+/**
+ * @brief Throw when the recipe is missing encoding used by both render and ICC.
+ * @throws std::runtime_error when output_color_ is missing or peak luminance is invalid.
+ */
+void RequireResolvedExportOutputColor(const ExportRecipe& recipe);
 
 /** Resolve output pixels and optional physical-resolution metadata. */
 auto ResolveExportResolution(const ExportResizeSpec& spec, ExportPixelSize source)

--- a/alcedo_studio/src/include/renderer/pipeline_task.hpp
+++ b/alcedo_studio/src/include/renderer/pipeline_task.hpp
@@ -13,6 +13,7 @@
 
 #include "edit/operators/op_kernel.hpp"
 #include "edit/pipeline/pipeline.hpp"
+#include "edit/pipeline/pipeline_apply_request.hpp"
 #include "edit/pipeline/pipeline_cpu.hpp"
 #include "image/image.hpp"
 #include "image/image_buffer.hpp"
@@ -46,12 +47,13 @@ struct RenderDesc {
 };
 
 struct TaskOptions {
-  RenderDesc    render_desc_;
+  RenderDesc                                render_desc_;
 
-  bool          is_blocking_;      // if true, wait for the task to finish
-  bool          is_callback_;      // if true, use callback to return result
-  bool          is_seq_callback_;  // if true, use sequential callback to return result
-  PriorityLevel task_priority_;    // task priority level, not used yet
+  bool                                      is_blocking_;      // if true, wait for the task to finish
+  bool                                      is_callback_;      // if true, use callback to return result
+  bool                                      is_seq_callback_;  // if true, use sequential callback to return result
+  PriorityLevel                             task_priority_;    // task priority level, not used yet
+  std::optional<ExportColorProfileConfig>   export_output_color_;
 };
 struct PipelineTask {
   uint32_t                                                    task_id_;
@@ -77,8 +79,9 @@ struct PipelineTask {
   // Monotonic render request identity. Immutable after ScheduleTask stamps it.
   std::uint64_t                                     request_id_ = 0;
 
-  void                                              SetExecutorRenderParams();
-  void                                              ResetPreviewRenderParams();
-  void                                              ResetThumbnailRenderParams();
+  [[nodiscard]] auto MakeApplyRequest() const -> PipelineApplyRequest;
+  void               SetExecutorRenderParams();
+  void               ResetPreviewRenderParams();
+  void               ResetThumbnailRenderParams();
 };
 };  // namespace alcedo

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
@@ -17,12 +17,14 @@ class EditorHistoryState;
 
 /// Extracted mutation/navigation unit. Handles adjustment capture, settled
 /// commit, Undo, Redo, explicit head movement, and Version checkout. Preserves
-/// the existing render and revision publication call chain.
+/// the existing render and revision publication call chain. Parameter operations
+/// run on the history queue and hold the executor render lock across document
+/// access and WAL publication. They never copy the document or update stage params.
 class EditorHistoryMutation {
  public:
   explicit EditorHistoryMutation(EditorHistoryState& state);
 
-  /// Capture the committed operator value before interactive preview begins.
+  /// Capture the target Model value once and apply preview under the render lock.
   /// @pre @p patch.target is a complete production target. Incomplete targets are
   ///      rejected; this path does not fill owner_kind or node_id.
   auto CaptureAdjustmentBeforePreview(const alcedo::EditorHistoryGuardHandle& guard,
@@ -30,17 +32,21 @@ class EditorHistoryMutation {
                                       std::string* error) -> bool;
 
   /// Append one settled adjustment and advance the live working head.
-  /// Live effect writes PipelineGuard::document_ using the locked target.
+  /// Uses actual normalized document values. WAL failure restores only the locked target;
+  /// unchanged normalized values produce neither a commit nor a WAL record.
   auto CommitAdjustment(const alcedo::EditorHistoryGuardHandle& guard,
                         const alcedo::EditorAdjustmentPatch& patch, std::string* error) -> bool;
 
   /// Move the working head to its first parent and apply the before value.
+  /// Missing same-session target records fail before any WAL or document mutation.
   auto Undo(const alcedo::EditorHistoryGuardHandle& guard, std::string* error) -> bool;
 
   /// Move the working head to the redo child and apply the after value.
+  /// Restores affected values and the published head if a Model rejects the change.
   auto Redo(const alcedo::EditorHistoryGuardHandle& guard, std::string* error) -> bool;
 
   /// Move the working head to an explicit commit in one operation.
+  /// Only recorded same-session parameter edits are supported; typed replay belongs to NM4.
   auto MoveHeadToCommit(const alcedo::EditorHistoryGuardHandle& guard,
                         const alcedo::commit_hash_t& commit_id, std::string* error) -> bool;
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
@@ -23,11 +23,14 @@ class EditorHistoryMutation {
   explicit EditorHistoryMutation(EditorHistoryState& state);
 
   /// Capture the committed operator value before interactive preview begins.
+  /// @pre @p patch.target is a complete production target. Incomplete targets are
+  ///      rejected; this path does not fill owner_kind or node_id.
   auto CaptureAdjustmentBeforePreview(const alcedo::EditorHistoryGuardHandle& guard,
                                       const alcedo::EditorAdjustmentPatch& patch,
                                       std::string* error) -> bool;
 
   /// Append one settled adjustment and advance the live working head.
+  /// Live effect writes PipelineGuard::document_ using the locked target.
   auto CommitAdjustment(const alcedo::EditorHistoryGuardHandle& guard,
                         const alcedo::EditorAdjustmentPatch& patch, std::string* error) -> bool;
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_state_detail.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_state_detail.hpp
@@ -13,9 +13,12 @@
 #include <unordered_map>
 
 #include "app/editor_adjustment_pipeline.hpp"
+#include "app/editor_adjustment_types.hpp"
 #include "app/editor_session_ports.hpp"
 #include "app/editor_session_types.hpp"
 #include "edit/history/commit_graph.hpp"
+#include "json.hpp"
+#include "type/hash_type.hpp"
 
 namespace alcedo {
 class MiniGitJournal;
@@ -30,13 +33,21 @@ class EditorSessionPipelinePort;
 
 /// Per-image history state owned by the queue-thread history unit. The command
 /// queue is the sole mutation owner for graph, redo, pending-before, and
-/// committed-snapshot fields. The pipeline guard is only a worker hand-off
-/// identity here; no history reducer accesses its live executor.
+/// committed-snapshot fields. Live parameter writes go to pipeline_guard->document_.
+/// The executor is locked only for stage Apply and snapshot refresh.
 struct HistoryWorkingState {
   std::shared_ptr<alcedo::PipelineGuard> pipeline_guard;
   std::shared_ptr<alcedo::MiniGitJournal> journal;
   std::unique_ptr<alcedo::MiniGitWorkingHistory> history;
   std::unordered_map<std::string, alcedo::EditorAdjustmentOperatorState> pending_before;
+  /// First complete target of the current input sequence, keyed by field_key.
+  struct DocumentFieldEdit {
+    alcedo::EditorParameterTarget target;
+    nlohmann::json                before_model_json;
+    nlohmann::json                after_model_json;
+  };
+  std::unordered_map<std::string, DocumentFieldEdit> pending_document_sequence;
+  std::unordered_map<alcedo::Hash128, DocumentFieldEdit> document_edit_by_commit;
   alcedo::EditorRenderAdjustmentSnapshot root_snapshot;
   alcedo::EditorRenderAdjustmentSnapshot committed_snapshot;
   bool recovered_head = false;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_state_detail.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_state_detail.hpp
@@ -34,7 +34,7 @@ class EditorSessionPipelinePort;
 /// Per-image history state owned by the queue-thread history unit. The command
 /// queue is the sole mutation owner for graph, redo, pending-before, and
 /// committed-snapshot fields. Live parameter writes go to pipeline_guard->document_.
-/// The executor is locked only for stage Apply and snapshot refresh.
+/// Document reads/writes and rendering use the same executor render lock.
 struct HistoryWorkingState {
   std::shared_ptr<alcedo::PipelineGuard> pipeline_guard;
   std::shared_ptr<alcedo::MiniGitJournal> journal;

--- a/alcedo_studio/src/io/CMakeLists.txt
+++ b/alcedo_studio/src/io/CMakeLists.txt
@@ -6,6 +6,7 @@ def_library(ExportRecipe
     SOURCES
         "${ALCEDO_INCLUDE_ROOT}/io/image/export_recipe.hpp"
         "${ALCEDO_SRC_ROOT}/io/image/export_recipe.cpp"
+    PUBLIC_DEPS ExportIccProfileResolver
 )
 
 def_library(ExportIccProfileResolver

--- a/alcedo_studio/src/io/image/export_recipe.cpp
+++ b/alcedo_studio/src/io/image/export_recipe.cpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <limits>
 #include <sstream>
+#include <stdexcept>
 #include <unordered_set>
 
 namespace alcedo {
@@ -268,6 +269,19 @@ auto ExportRecipe::FromLegacyOptions(const ExportFormatOptions& options) -> Expo
     recipe.resize_.long_edge_pixels_ = options.max_length_side_;
   }
   return recipe;
+}
+
+auto ExportRecipeHasResolvedOutputColor(const ExportRecipe& recipe) -> bool {
+  return recipe.output_color_.has_value() &&
+         std::isfinite(recipe.output_color_->peak_luminance) &&
+         recipe.output_color_->peak_luminance > 0.0f;
+}
+
+void RequireResolvedExportOutputColor(const ExportRecipe& recipe) {
+  if (!ExportRecipeHasResolvedOutputColor(recipe)) {
+    throw std::runtime_error(
+        "ExportRecipe: encoding space, EOTF, and peak luminance must be resolved before scheduling");
+  }
 }
 
 auto ResolveExportResolution(const ExportResizeSpec& spec, ExportPixelSize source)

--- a/alcedo_studio/src/io/image/image_writer.cpp
+++ b/alcedo_studio/src/io/image/image_writer.cpp
@@ -615,14 +615,15 @@ void ImageWriter::WriteImageToPath(const image_path_t&                     src_p
   if (recipe.metadata_.mode_ == ExportMetadataMode::NONE || !recipe.metadata_.include_exif_) {
     export_metadata.reset();
   }
+  const auto pixel_color = recipe.output_color_.has_value() ? recipe.output_color_ : color_profile;
   const auto embedded_profile = recipe.icc_ == ExportIccPolicy::EMBED_OUTPUT_PROFILE
-                                    ? color_profile
+                                    ? pixel_color
                                     : std::optional<ExportColorProfileConfig>{};
 
-  if (ShouldWriteUltraHdr(options, color_profile)) {
+  if (ShouldWriteUltraHdr(options, pixel_color)) {
 #if defined(ALCEDO_HAS_ULTRAHDR)
     UltraHdrWriter::WriteImageToPath(
-        src_path, export_path, working, options, *color_profile, export_metadata,
+        src_path, export_path, working, options, *pixel_color, export_metadata,
         recipe.metadata_.mode_ == ExportMetadataMode::STANDARD && recipe.metadata_.include_exif_,
         recipe.icc_ == ExportIccPolicy::EMBED_OUTPUT_PROFILE);
     return;
@@ -632,7 +633,7 @@ void ImageWriter::WriteImageToPath(const image_path_t&                     src_p
 #endif
   }
 
-  if (color_profile.has_value() && IsUltraHdrTransfer(color_profile->encoding_eotf)) {
+  if (pixel_color.has_value() && IsUltraHdrTransfer(pixel_color->encoding_eotf)) {
     throw std::runtime_error("ImageWriter: HDR export requires Ultra HDR JPEG output.");
   }
 

--- a/alcedo_studio/src/renderer/pipeline_scheduler.cpp
+++ b/alcedo_studio/src/renderer/pipeline_scheduler.cpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 
+#include "edit/pipeline/pipeline_apply_request.hpp"
 #include "image/image_buffer.hpp"
 #include "io/image/image_loader.hpp"
 #include "renderer/pipeline_task.hpp"
@@ -173,14 +174,6 @@ auto RenderFrameRoleId(FrameRole role) -> int {
   return OperatorParams::kRenderFrameRoleInteractivePrimary;
 }
 
-auto UsesTaskScopedRenderParams(RenderType render_type) -> bool {
-  // Editor preview tasks deliberately leave the executor in a known preview
-  // state so the next interactive request can reuse the decoded/geometry
-  // caches. Thumbnail and export are isolated jobs and must restore the live
-  // executor configuration after they finish.
-  return render_type == RenderType::THUMBNAIL || render_type == RenderType::FULL_RES_EXPORT;
-}
-
 void ApplyRenderFrameRole(const std::shared_ptr<CPUPipelineExecutor>& pipeline_executor,
                           const FramePreviewMetadata&                 metadata) {
   if (!pipeline_executor) {
@@ -203,22 +196,51 @@ auto LoadViewportRegion(const std::shared_ptr<CPUPipelineExecutor>& pipeline_exe
 }
 }  // namespace
 
-void PipelineTask::SetExecutorRenderParams() {
-  if (!pipeline_executor_) {
-    return;
+namespace {
+
+auto MakeGeometryRequest(const std::optional<ViewportRenderRegion>& viewport, int max_edge,
+                         bool export_quality) -> RenderRequest {
+  RenderRequest request;
+  if (viewport.has_value() && viewport->reference_width_ > 0 && viewport->reference_height_ > 0) {
+    request.view.visible_rect_in_edit_space = {
+        static_cast<float>(viewport->x_) / static_cast<float>(viewport->reference_width_),
+        static_cast<float>(viewport->y_) / static_cast<float>(viewport->reference_height_),
+        viewport->scale_x_, viewport->scale_y_};
+    if (viewport->target_width_ > 0 && viewport->target_height_ > 0) {
+      request.view.viewport_extent = {static_cast<std::uint32_t>(viewport->target_width_),
+                                      static_cast<std::uint32_t>(viewport->target_height_)};
+    }
   }
-  pipeline_executor_->SetCancelRequested(cancel_requested_);
-  pipeline_executor_->GetGlobalParams().render_source_cache_key_ = BuildRenderSourceCacheKey(*this);
-  pipeline_executor_->GetGlobalParams().render_hs_preserve_source_detail_ = false;
-  pipeline_executor_->GetGlobalParams().render_hs_can_seed_reference_     = false;
-  pipeline_executor_->GetGlobalParams().render_hs_reference_max_long_edge_ =
-      kHsReferenceMaskMaxLongEdge;
-  auto&      desc                         = options_.render_desc_;
+  request.resolution.max_edge = static_cast<std::uint32_t>(std::max(0, max_edge));
+  request.resolution.quality  = export_quality ? RenderQuality::Export : RenderQuality::Preview;
+  return request;
+}
+
+auto DownsampleForRenderType(RenderType render_type) -> ResizeDownsampleAlgorithm {
+  switch (render_type) {
+    case RenderType::QUALITY_BASE_PREVIEW:
+    case RenderType::DETAIL_ROI_PREVIEW:
+    case RenderType::FULL_RES_PREVIEW:
+    case RenderType::FULL_RES_EXPORT:
+      return ResizeDownsampleAlgorithm::Area;
+    case RenderType::FAST_PREVIEW:
+    case RenderType::THUMBNAIL:
+      return ResizeDownsampleAlgorithm::Bilinear;
+  }
+  return ResizeDownsampleAlgorithm::Bilinear;
+}
+
+}  // namespace
+
+auto PipelineTask::MakeApplyRequest() const -> PipelineApplyRequest {
+  PipelineApplyRequest request;
+  if (!pipeline_executor_) {
+    return request;
+  }
+  request.cancel_requested = cancel_requested_;
+  auto&      desc          = options_.render_desc_;
   const auto requested_render_type        = desc.render_type_;
 
-  // Keep explicit full-res/export requests authoritative.
-  // Even when the executor sits in FAST_PREVIEW baseline, callers still need
-  // FULL_RES_PREVIEW/FULL_RES_EXPORT to be honored (slider release/undo/version switch/crop/LUT).
   const bool rotation_active_fast_preview = (requested_render_type == RenderType::FAST_PREVIEW) &&
                                             HasActiveGeometryRotation(pipeline_executor_);
 
@@ -234,9 +256,6 @@ void PipelineTask::SetExecutorRenderParams() {
   const auto viewport_region = LoadViewportRegion(
       pipeline_executor_, viewport_region_render && !rotation_active_fast_preview,
       desc.viewport_region_);
-  // Freeze request geometry before any branch returns. In particular, Quality Base must carry
-  // null (full frame) instead of re-reading a live ROI later inside Apply.
-  pipeline_executor_->SetRenderRequestViewport(viewport_region);
   if (viewport_region.has_value()) {
     region_x                = viewport_region->x_;
     region_y                = viewport_region->y_;
@@ -245,9 +264,22 @@ void PipelineTask::SetExecutorRenderParams() {
     region_reference_width  = viewport_region->reference_width_;
     region_reference_height = viewport_region->reference_height_;
   }
+  (void)region_reference_width;
+  (void)region_reference_height;
 
   FramePreviewMetadata  frame_metadata    = desc.frame_metadata_;
   FramePresentationMode presentation_mode = FramePresentationMode::FullFrame;
+  request.sink                            = pipeline_executor_->GetFrameSink();
+
+  auto finish = [&](DecodeRes decode, bool host_output, RenderCachePolicy cache, int max_edge,
+                    bool export_quality, std::optional<ViewportRenderRegion> view) {
+    request.decode_res          = decode;
+    request.require_host_output = host_output;
+    request.cache_policy        = cache;
+    request.geometry            = MakeGeometryRequest(view, max_edge, export_quality);
+    request.submission          = FrameCompletionSubmission{.metadata = frame_metadata,
+                                                            .mode     = presentation_mode};
+  };
 
   if (requested_render_type == RenderType::FAST_PREVIEW) {
     frame_metadata.frame_role    = FrameRole::InteractivePrimary;
@@ -255,50 +287,27 @@ void PipelineTask::SetExecutorRenderParams() {
                                    region_scale_x >= (1.0f - kFullFrameRegionEpsilon) &&
                                    region_scale_y >= (1.0f - kFullFrameRegionEpsilon);
     if (rotation_active_fast_preview || full_frame_region) {
-      presentation_mode = FramePresentationMode::ViewportTransformed;
-      pipeline_executor_->GetGlobalParams().render_hs_can_seed_reference_ = true;
-      frame_metadata.source_roi_norm                                      = {};
-      ApplyRenderFrameRole(pipeline_executor_, frame_metadata);
-      pipeline_executor_->BindFrameSubmission(frame_metadata, presentation_mode);
-      pipeline_executor_->SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm::Bilinear);
-      pipeline_executor_->SetRenderRegion(0, 0, 1.0f, 1.0f);
-      pipeline_executor_->SetForceCPUOutput(false);
-      pipeline_executor_->SetRenderRes(false, kFastPreviewMaxLongEdge);
-      pipeline_executor_->SetEnableCache(true);
-      pipeline_executor_->SetDecodeRes(DecodeRes::FULL);
-      return;
+      presentation_mode              = FramePresentationMode::ViewportTransformed;
+      frame_metadata.source_roi_norm = {};
+      finish(DecodeRes::FULL, false, RenderCachePolicy::UseSessionCache, kFastPreviewMaxLongEdge,
+             false, viewport_region);
+      return request;
     }
-
     presentation_mode = FramePresentationMode::RoiFrame;
     frame_metadata    = MetadataFromRegion(frame_metadata, viewport_region, region_x, region_y,
                                            region_scale_x, region_scale_y);
     frame_metadata.scope_update_allowed = frame_metadata.scope_refresh_requested;
-    ApplyRenderFrameRole(pipeline_executor_, frame_metadata);
-    pipeline_executor_->BindFrameSubmission(frame_metadata, presentation_mode);
-    pipeline_executor_->SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm::Bilinear);
-    pipeline_executor_->SetRenderRegion(region_x, region_y, region_scale_x, region_scale_y,
-                                        region_reference_width, region_reference_height);
-    pipeline_executor_->SetForceCPUOutput(false);
-    pipeline_executor_->SetRenderRes(false, kFastPreviewMaxLongEdge);
-    pipeline_executor_->SetEnableCache(true);
-    // The default decode res is full, this call will be effective only when changed before
-    pipeline_executor_->SetDecodeRes(DecodeRes::FULL);
-    return;
+    finish(DecodeRes::FULL, false, RenderCachePolicy::UseSessionCache, kFastPreviewMaxLongEdge,
+           false, viewport_region);
+    return request;
   }
   if (requested_render_type == RenderType::QUALITY_BASE_PREVIEW) {
     frame_metadata.frame_role      = FrameRole::QualityBase;
     frame_metadata.source_roi_norm = {};
     presentation_mode              = FramePresentationMode::ViewportTransformed;
-    pipeline_executor_->GetGlobalParams().render_hs_can_seed_reference_ = true;
-    ApplyRenderFrameRole(pipeline_executor_, frame_metadata);
-    pipeline_executor_->BindFrameSubmission(frame_metadata, presentation_mode);
-    pipeline_executor_->SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm::Area);
-    pipeline_executor_->SetRenderRegion(0, 0, 1.0f, 1.0f);
-    pipeline_executor_->SetRenderRes(false, kQualityBasePreviewMaxLongEdge);
-    pipeline_executor_->SetForceCPUOutput(false);
-    pipeline_executor_->SetEnableCache(true);
-    pipeline_executor_->SetDecodeRes(DecodeRes::FULL);
-    return;
+    finish(DecodeRes::FULL, false, RenderCachePolicy::UseSessionCache,
+           kQualityBasePreviewMaxLongEdge, false, std::nullopt);
+    return request;
   }
   if (requested_render_type == RenderType::DETAIL_ROI_PREVIEW) {
     frame_metadata.frame_role = (region_scale_x < (1.0f - 1e-4f) || region_scale_y < (1.0f - 1e-4f))
@@ -307,63 +316,82 @@ void PipelineTask::SetExecutorRenderParams() {
     frame_metadata    = MetadataFromRegion(frame_metadata, viewport_region, region_x, region_y,
                                            region_scale_x, region_scale_y);
     presentation_mode = FramePresentationMode::ViewportTransformed;
-    ApplyRenderFrameRole(pipeline_executor_, frame_metadata);
-    pipeline_executor_->BindFrameSubmission(frame_metadata, presentation_mode);
-    pipeline_executor_->SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm::Area);
-    pipeline_executor_->SetRenderRegion(region_x, region_y, region_scale_x, region_scale_y,
-                                        region_reference_width, region_reference_height);
     const int detail_target_long_edge = ViewportTargetLongEdge(viewport_region);
-    if (detail_target_long_edge > 0) {
-      pipeline_executor_->SetRenderRes(false, detail_target_long_edge);
-    } else {
-      pipeline_executor_->SetRenderRes(true);
-    }
-    pipeline_executor_->SetForceCPUOutput(false);
-    pipeline_executor_->SetEnableCache(true);
-    pipeline_executor_->SetDecodeRes(DecodeRes::FULL);
-    return;
+    finish(DecodeRes::FULL, false, RenderCachePolicy::UseSessionCache,
+           detail_target_long_edge > 0 ? detail_target_long_edge : 0, false, viewport_region);
+    return request;
   }
   if (requested_render_type == RenderType::THUMBNAIL) {
-    presentation_mode = FramePresentationMode::ViewportTransformed;
-    ApplyRenderFrameRole(pipeline_executor_, frame_metadata);
-    pipeline_executor_->BindFrameSubmission(frame_metadata, presentation_mode);
-    pipeline_executor_->SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm::Bilinear);
-    pipeline_executor_->SetRenderRegion(0, 0, 1.0f);
-    pipeline_executor_->SetForceCPUOutput(true);
-    pipeline_executor_->SetRenderRes(false, static_cast<int>(desc.max_edge_));
-    pipeline_executor_->SetEnableCache(false);
-    pipeline_executor_->SetDecodeRes(desc.decode_res_);
-    return;
+    presentation_mode    = FramePresentationMode::ViewportTransformed;
+    request.sink         = nullptr;
+    request.output_color = std::nullopt;
+    finish(desc.decode_res_, true, RenderCachePolicy::BypassSessionCache,
+           static_cast<int>(desc.max_edge_), false, std::nullopt);
+    return request;
   }
   if (requested_render_type == RenderType::FULL_RES_PREVIEW) {
     presentation_mode = FramePresentationMode::ViewportTransformed;
-    pipeline_executor_->GetGlobalParams().render_hs_can_seed_reference_ = true;
-    ApplyRenderFrameRole(pipeline_executor_, frame_metadata);
-    pipeline_executor_->BindFrameSubmission(frame_metadata, presentation_mode);
-    pipeline_executor_->SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm::Area);
-    pipeline_executor_->SetRenderRegion(0, 0, 1.0f);
-    pipeline_executor_->SetRenderRes(false, kFullResPreviewMaxLongEdge);
-    pipeline_executor_->SetForceCPUOutput(false);
-    pipeline_executor_->SetEnableCache(true);
-    pipeline_executor_->SetDecodeRes(DecodeRes::FULL);
-    return;
+    finish(DecodeRes::FULL, false, RenderCachePolicy::UseSessionCache, kFullResPreviewMaxLongEdge,
+           false, std::nullopt);
+    return request;
   }
   if (requested_render_type == RenderType::FULL_RES_EXPORT) {
-    pipeline_executor_->GetGlobalParams().render_hs_preserve_source_detail_ = true;
-    pipeline_executor_->GetGlobalParams().render_hs_can_seed_reference_     = true;
-    presentation_mode = FramePresentationMode::ViewportTransformed;
-    ApplyRenderFrameRole(pipeline_executor_, frame_metadata);
-    pipeline_executor_->BindFrameSubmission(frame_metadata, presentation_mode);
-    pipeline_executor_->SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm::Area);
-    pipeline_executor_->SetRenderRegion(0, 0, 1.0f);
-    pipeline_executor_->SetRenderRes(true);
-    pipeline_executor_->SetForceCPUOutput(true);
-    pipeline_executor_->SetEnableCache(false);
-    // The default decode res is full, this call will be effective only when changed before
-    pipeline_executor_->SetDecodeRes(DecodeRes::FULL);
-    return;
+    presentation_mode    = FramePresentationMode::ViewportTransformed;
+    request.sink         = nullptr;
+    request.output_color = options_.export_output_color_;
+    finish(DecodeRes::FULL, true, RenderCachePolicy::BypassSessionCache, 0, true, std::nullopt);
+    return request;
   }
   throw std::runtime_error("[ERROR] PipelineTask: Unknown render type");
+}
+
+void PipelineTask::SetExecutorRenderParams() {
+  if (!pipeline_executor_) {
+    return;
+  }
+  const auto request = MakeApplyRequest();
+  auto&      desc    = options_.render_desc_;
+  const auto requested_render_type = desc.render_type_;
+  const bool rotation_active_fast_preview = (requested_render_type == RenderType::FAST_PREVIEW) &&
+                                            HasActiveGeometryRotation(pipeline_executor_);
+  const bool viewport_region_render = (requested_render_type == RenderType::FAST_PREVIEW ||
+                                       requested_render_type == RenderType::DETAIL_ROI_PREVIEW) &&
+                                      desc.use_viewport_region_;
+  const auto viewport_region = LoadViewportRegion(
+      pipeline_executor_, viewport_region_render && !rotation_active_fast_preview,
+      desc.viewport_region_);
+  int   region_x               = desc.x_;
+  int   region_y               = desc.y_;
+  float region_scale_x         = desc.scale_factor_x_;
+  float region_scale_y         = desc.scale_factor_y_;
+  int   region_reference_width = 0;
+  int   region_reference_height = 0;
+  if (viewport_region.has_value()) {
+    region_x                = viewport_region->x_;
+    region_y                = viewport_region->y_;
+    region_scale_x          = viewport_region->scale_x_;
+    region_scale_y          = viewport_region->scale_y_;
+    region_reference_width  = viewport_region->reference_width_;
+    region_reference_height = viewport_region->reference_height_;
+  }
+  pipeline_executor_->SetCancelRequested(request.cancel_requested);
+  pipeline_executor_->SetRenderRequestViewport(viewport_region);
+  pipeline_executor_->BindFrameSubmission(request.submission.metadata, request.submission.mode);
+  ApplyRenderFrameRole(pipeline_executor_, request.submission.metadata);
+  pipeline_executor_->SetResizeDownsampleAlgorithm(DownsampleForRenderType(requested_render_type));
+  pipeline_executor_->SetRenderRegion(region_x, region_y, region_scale_x, region_scale_y,
+                                      region_reference_width, region_reference_height);
+  pipeline_executor_->SetForceCPUOutput(request.require_host_output);
+  if (request.geometry.resolution.max_edge > 0) {
+    pipeline_executor_->SetRenderRes(false,
+                                     static_cast<int>(request.geometry.resolution.max_edge));
+  } else {
+    pipeline_executor_->SetRenderRes(true);
+  }
+  pipeline_executor_->SetEnableCache(request.cache_policy == RenderCachePolicy::UseSessionCache);
+  pipeline_executor_->SetDecodeRes(request.decode_res);
+  pipeline_executor_->GetGlobalParams().render_hs_preserve_source_detail_ =
+      request.geometry.resolution.quality == RenderQuality::Export;
 }
 
 void PipelineTask::ResetPreviewRenderParams() {
@@ -480,17 +508,11 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
 
     const auto apply_state_transition_after_render = [&task]() {
       const auto render_type = task.options_.render_desc_.render_type_;
-      if (render_type == RenderType::THUMBNAIL) {
-        // THUMBNAIL -> FULL_RES_PREVIEW baseline
-        task.ResetThumbnailRenderParams();
-        return;
-      }
-      if (render_type == RenderType::QUALITY_BASE_PREVIEW ||
-          render_type == RenderType::DETAIL_ROI_PREVIEW ||
-          render_type == RenderType::FULL_RES_PREVIEW ||
-          render_type == RenderType::FULL_RES_EXPORT) {
-        // FULL_RES_PREVIEW/FULL_RES_EXPORT -> FAST_PREVIEW baseline
-        task.ResetPreviewRenderParams();
+      if ((render_type == RenderType::QUALITY_BASE_PREVIEW ||
+           render_type == RenderType::DETAIL_ROI_PREVIEW ||
+           render_type == RenderType::FULL_RES_PREVIEW) &&
+          task.pipeline_executor_) {
+        task.pipeline_executor_->ReleasePreviewGpuScratch();
       }
     };
 
@@ -579,8 +601,8 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
           // queues on this lock (owner thread pumps events while waiting so
           // present slot waits can complete without dropping ownership).
           std::unique_lock<std::mutex> render_lock;
-          auto&                        render_desc      = task.options_.render_desc_;
-          IFrameSink*                  saved_frame_sink = nullptr;
+          auto&                        render_desc = task.options_.render_desc_;
+          PipelineApplyRequest         apply_request;
 
           if (task.pipeline_executor_) {
             render_lock = std::unique_lock<std::mutex>(task.pipeline_executor_->GetRenderLock());
@@ -608,32 +630,10 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
               }
             }
 
-            // Thumbnail and export tasks must not interact with any editor-owned
-            // frame sink that may still be attached to a cached pipeline.
-            if (render_desc.render_type_ == RenderType::THUMBNAIL ||
-                render_desc.render_type_ == RenderType::FULL_RES_EXPORT) {
-              saved_frame_sink = task.pipeline_executor_->GetFrameSink();
-              if (saved_frame_sink) {
-                task.pipeline_executor_->DetachFrameSink();
-              }
-            }
+            apply_request = task.MakeApplyRequest();
           }
 
-          std::optional<CPUPipelineExecutor::OneShotRenderParamsSnapshot> prior_one_shot;
-          if (task.pipeline_executor_ && UsesTaskScopedRenderParams(render_desc.render_type_)) {
-            prior_one_shot = task.pipeline_executor_->CaptureOneShotRenderParams();
-          }
-
-          const auto restore_frame_sink = [&]() {
-            if (saved_frame_sink && task.pipeline_executor_) {
-              task.pipeline_executor_->AttachFrameSink(saved_frame_sink);
-            }
-          };
-
-          IFrameSink* output_sink = nullptr;
-          if (task.pipeline_executor_) {
-            output_sink = task.pipeline_executor_->GetFrameSink();
-          }
+          IFrameSink* output_sink = apply_request.sink;
           if (IsStaleForSink(output_sink, task.request_id_)) {
             notify_thumbnail_failure_callbacks();
             set_blocking_value(nullptr);
@@ -641,22 +641,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
             return;
           }
 
-          // RAII: isolated thumbnail/export work restores one-shot render
-          // params (decode/resize/ROI/force-cpu/cache). Editor previews retain
-          // their explicit post-render baseline so geometry caches survive
-          // consecutive interactive requests.
-          auto render_params_guard = std::unique_ptr<void, std::function<void(void*)>>(
-              reinterpret_cast<void*>(1), [&task, &prior_one_shot, &restore_frame_sink](void*) {
-                if (prior_one_shot.has_value() && task.pipeline_executor_) {
-                  task.pipeline_executor_->RestoreOneShotRenderParams(*prior_one_shot);
-                }
-                restore_frame_sink();
-              });
-
-          task.SetExecutorRenderParams();
-
           if (task_cancelled()) {
-            // Guard restores one-shot params; still clear scratch/buffers by type.
             apply_state_transition_after_render();
             notify_thumbnail_failure_callbacks();
             set_blocking_value(nullptr);
@@ -675,7 +660,7 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
 
           MarkSinkApplyStarted(output_sink, task.request_id_);
 
-          auto result         = task.pipeline_executor_->Apply(task.input_);
+          auto result         = task.pipeline_executor_->Apply(task.input_, apply_request);
           bool result_has_cpu = false;
           if (result && result->cpu_data_valid_) {
             try {
@@ -733,18 +718,10 @@ void PipelineScheduler::ScheduleTask(PipelineTask&& task) {
         finish(false);
       }
     } catch (const std::exception& ex) {
-      try {
-        apply_state_transition_after_render();
-      } catch (...) {
-      }
       notify_thumbnail_failure_callbacks();
       set_blocking_exception();
       finish(false, ex.what());
     } catch (...) {
-      try {
-        apply_state_transition_after_render();
-      } catch (...) {
-      }
       notify_thumbnail_failure_callbacks();
       set_blocking_exception();
       finish(false, "Pipeline render failed");

--- a/alcedo_studio/src/storage/mapper/pipeline/pipeline_mapper.cpp
+++ b/alcedo_studio/src/storage/mapper/pipeline/pipeline_mapper.cpp
@@ -39,11 +39,10 @@ auto PipelineMapper::FromParams(PipelineMapperParams&& param)
   pipeline->SetBoundFile(param.file_id);
   if (param.param_json) {
     const auto json = nlohmann::json::parse(std::move(*param.param_json));
-    // Format 2 is executed by the GPU DAG. The nested stage adapter keeps the unchanged
-    // OpenCL/Metal and editor-control paths buildable until G8/G9; it is not the persisted graph.
-    if (json.value("format_version", 0) == 2 && json.contains("legacy_stage_adapter")) {
-      pipeline->ImportPipelineParams(json.at("legacy_stage_adapter"));
-    } else if (json.value("format_version", 0) != 2) {
+    // Format 2 is a document owned by PipelineMgmtService. The mapper must not unpack a stage
+    // representation from that document. Non-document rows remain readable by the existing
+    // executor mapper for callers that explicitly operate on that older table shape.
+    if (json.value("format_version", 0) != 2) {
       pipeline->ImportPipelineParams(json);
     }
     pipeline->SetExecutionStages();

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -201,6 +201,7 @@ target_link_libraries(AlbumBackendLib
         AdjustmentTransferService
         EditorSessionService
         EditorAdjustmentPipeline
+        EditorPipelineCommandService
         EditorMiniGitMaterializer
         ThumbnailService
         SemanticGenerationService

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/adjustment_transfer_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/adjustment_transfer_controller.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <array>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <unordered_set>
 #include <vector>
@@ -466,8 +467,6 @@ auto AdjustmentTransferController::PrepareCopy(uint elementId) -> QVariantMap {
     QVariantList version_rows;
     QVariantList active_rows;
     version_rows.reserve(static_cast<qsizetype>(versions.size()));
-    const auto* source_item = library_->FindAlbumItem(static_cast<sl_element_id_t>(elementId));
-    const auto  source_image_id = source_item != nullptr ? source_item->image_id : 0;
     for (const auto& version : versions) {
       graph.SetActiveVersionId(version.version_id);
       std::string rebuild_error;
@@ -476,20 +475,14 @@ auto AdjustmentTransferController::PrepareCopy(uint elementId) -> QVariantMap {
                                                        : std::move(rebuild_error));
       }
 
-      std::string snapshot_error;
-      auto        snapshot = pipeline_service->LoadPipelineSnapshot(
-          static_cast<sl_element_id_t>(elementId), source_image_id, &snapshot_error);
-      if (!snapshot || !snapshot->executor_) {
-        throw std::runtime_error(snapshot_error.empty() ? "Failed to snapshot source Version"
-                                                         : std::move(snapshot_error));
-      }
-
       QVariantList rows;
       rows.reserve(static_cast<qsizetype>(kItems.size()));
-      for (const auto& spec : kItems) {
-        rows.push_back(RowFor(*snapshot->executor_, spec, spec.checked_by_default));
+      {
+        std::unique_lock<std::mutex> render_lock(guard->pipeline_->GetRenderLock());
+        for (const auto& spec : kItems) {
+          rows.push_back(RowFor(*guard->pipeline_, spec, spec.checked_by_default));
+        }
       }
-      pipeline_service->ReleasePipelineSnapshot(std::move(snapshot));
       const bool active = version.version_id == prior_version_id;
       if (active) {
         active_rows = rows;
@@ -605,30 +598,23 @@ auto AdjustmentTransferController::CopyVersion(uint elementId, const QString& ve
 
     AdjustmentTransferPackage package;
     QVariantList              summary;
-    const auto* source_item = library_->FindAlbumItem(static_cast<sl_element_id_t>(elementId));
-    const auto  source_image_id = source_item != nullptr ? source_item->image_id : 0;
-    std::string snapshot_error;
-    auto        snapshot = pipeline_service->LoadPipelineSnapshot(
-        static_cast<sl_element_id_t>(elementId), source_image_id, &snapshot_error);
-    if (!snapshot || !snapshot->executor_) {
-      throw std::runtime_error(snapshot_error.empty() ? "Failed to snapshot source Version"
-                                                       : std::move(snapshot_error));
+    {
+      std::unique_lock<std::mutex> render_lock(guard->pipeline_->GetRenderLock());
+      for (const auto* spec : specs) {
+        const bool enabled = OperatorEnabledFor(*guard->pipeline_, *spec);
+        const auto params  = TransferParamsFor(*guard->pipeline_, *spec);
+        package.operators_.push_back({
+            .stage_         = spec->stage,
+            .operator_type_ = spec->op_type,
+            .enabled_       = enabled,
+            .merge_params_  = spec->merge_params,
+            .params_        = params,
+        });
+        const auto summary_value =
+            ValueFor(*spec, OperatorParamsFor(*guard->pipeline_, *spec), enabled);
+        summary.push_back(SummaryRow(*spec, summary_value));
+      }
     }
-    for (const auto* spec : specs) {
-      const bool enabled = OperatorEnabledFor(*snapshot->executor_, *spec);
-      const auto params  = TransferParamsFor(*snapshot->executor_, *spec);
-      package.operators_.push_back({
-          .stage_         = spec->stage,
-          .operator_type_ = spec->op_type,
-          .enabled_       = enabled,
-          .merge_params_  = spec->merge_params,
-          .params_        = params,
-      });
-      const auto summary_value =
-          ValueFor(*spec, OperatorParamsFor(*snapshot->executor_, *spec), enabled);
-      summary.push_back(SummaryRow(*spec, summary_value));
-    }
-    pipeline_service->ReleasePipelineSnapshot(std::move(snapshot));
 
     graph.SetActiveVersionId(prior_version_id);
     std::string restore_error;

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
@@ -7,9 +7,12 @@
 #include <ctime>
 #include <mutex>
 #include <utility>
+#include <vector>
 
 #include "app/editor_adjustment_pipeline.hpp"
+#include "app/editor_pipeline_command_service.hpp"
 #include "app/pipeline_service.hpp"
+#include "edit/graph/pipeline_document.hpp"
 #include "edit/history/commit_graph.hpp"
 #include "edit/history/mini_git_working_history.hpp"
 #include "ui/alcedo_main/album_backend/editor_history_shared_helpers.hpp"
@@ -37,6 +40,49 @@ auto RefreshCommittedSnapshotFromLive(HistoryWorkingState& state, std::string* e
   }
 }
 
+auto RestoreLivePipelineParams(HistoryWorkingState& state, const nlohmann::json& prior_pipeline)
+    -> void {
+  if (!state.pipeline_guard || !state.pipeline_guard->pipeline_) {
+    return;
+  }
+  try {
+    auto restore_lock = LockLivePipeline(*state.pipeline_guard->pipeline_);
+    state.pipeline_guard->pipeline_->ImportPipelineParams(prior_pipeline);
+    state.pipeline_guard->pipeline_->SetExecutionStages();
+  } catch (...) {
+  }
+}
+
+auto RestoreLiveDocumentJson(HistoryWorkingState& state, const nlohmann::json& prior_document)
+    -> void {
+  if (!state.pipeline_guard || !state.pipeline_guard->document_) {
+    return;
+  }
+  try {
+    *state.pipeline_guard->document_ = alcedo::PipelineDocument::FromJson(prior_document);
+  } catch (...) {
+  }
+}
+
+auto ApplyDocumentFieldEdits(HistoryWorkingState& state, const std::vector<alcedo::EditCommit>& commits,
+                             bool backward, std::string* error) -> bool {
+  if (!state.pipeline_guard || !state.pipeline_guard->document_) {
+    return true;
+  }
+  auto& live = *state.pipeline_guard->document_;
+  for (const auto& commit : commits) {
+    const auto found = state.document_edit_by_commit.find(commit.GetCommitHash());
+    if (found == state.document_edit_by_commit.end()) {
+      continue;
+    }
+    const auto& json = backward ? found->second.before_model_json : found->second.after_model_json;
+    if (!alcedo::PublishEditorParameterPatch(live, found->second.target, json, error)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /// WAL-first head move: publish journal + unique history head, then rebuild the
 /// unique live pipeline from defaults + first-parent chain (plan §4.7). On live
 /// apply failure, revoke the WAL tail and restore the prior head.
@@ -45,6 +91,7 @@ auto ApplyPreparedHeadMoveOnLivePipeline(HistoryWorkingState& state,
                                          std::string* error) -> bool {
   const auto prior_selection = state.history->WorkingSelection();
   nlohmann::json prior_pipeline;
+  nlohmann::json prior_document;
   if (state.pipeline_guard && state.pipeline_guard->pipeline_) {
     try {
       // Structural head move: wait out Apply (incl. present) before locking.
@@ -54,6 +101,9 @@ auto ApplyPreparedHeadMoveOnLivePipeline(HistoryWorkingState& state,
       if (error) *error = ex.what();
       return false;
     }
+  }
+  if (state.pipeline_guard && state.pipeline_guard->document_) {
+    prior_document = state.pipeline_guard->document_->ToJson();
   }
 
   const auto published = state.history->PublishPreparedHeadMove(prepared);
@@ -72,31 +122,30 @@ auto ApplyPreparedHeadMoveOnLivePipeline(HistoryWorkingState& state,
       render_lock.unlock();
       std::string abandon_error;
       (void)state.history->AbandonPublishedHeadMove(prepared, prior_selection, &abandon_error);
-      try {
-        auto restore_lock = LockLivePipeline(*state.pipeline_guard->pipeline_);
-        state.pipeline_guard->pipeline_->ImportPipelineParams(prior_pipeline);
-        state.pipeline_guard->pipeline_->SetExecutionStages();
-      } catch (...) {
-      }
+      RestoreLivePipelineParams(state, prior_pipeline);
+      RestoreLiveDocumentJson(state, prior_document);
       return false;
     }
+  }
+
+  if (!ApplyDocumentFieldEdits(state, prepared.traversed_commits, prepared.backward, error)) {
+    std::string abandon_error;
+    (void)state.history->AbandonPublishedHeadMove(prepared, prior_selection, &abandon_error);
+    RestoreLivePipelineParams(state, prior_pipeline);
+    RestoreLiveDocumentJson(state, prior_document);
+    return false;
   }
 
   if (!RefreshCommittedSnapshotFromLive(state, error)) {
     std::string abandon_error;
     (void)state.history->AbandonPublishedHeadMove(prepared, prior_selection, &abandon_error);
-    try {
-      if (state.pipeline_guard && state.pipeline_guard->pipeline_) {
-        auto restore_lock = LockLivePipeline(*state.pipeline_guard->pipeline_);
-        state.pipeline_guard->pipeline_->ImportPipelineParams(prior_pipeline);
-        state.pipeline_guard->pipeline_->SetExecutionStages();
-      }
-    } catch (...) {
-    }
+    RestoreLivePipelineParams(state, prior_pipeline);
+    RestoreLiveDocumentJson(state, prior_document);
     return false;
   }
   state.pipeline_guard->dirty_ = true;
   state.pending_before.clear();
+  state.pending_document_sequence.clear();
   state.recovered_head = false;
   return true;
 }
@@ -110,6 +159,50 @@ auto EditorHistoryMutation::CaptureAdjustmentBeforePreview(
     std::string* error) -> bool {
   auto state = state_.EnsureWorkingState(guard.element_id, error);
   if (!state) return false;
+  const auto target_error =
+      alcedo::DescribeEditorParameterTargetError(patch.target, patch.field_key);
+  if (!target_error.empty()) {
+    if (error) *error = target_error;
+    return false;
+  }
+  if (!alcedo::ResolveEditorAdjustmentField(patch.field_key).has_value()) {
+    if (error) *error = "Unknown editor adjustment field: " + patch.field_key;
+    return false;
+  }
+  if (!state->pipeline_guard || !state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
+  }
+
+  nlohmann::json patch_params;
+  try {
+    patch_params = patch.params_json.empty() ? nlohmann::json::object()
+                                             : nlohmann::json::parse(patch.params_json);
+  } catch (const std::exception& ex) {
+    if (error) *error = ex.what();
+    return false;
+  }
+  if (!patch_params.is_object()) {
+    if (error) *error = "Editor adjustment params must be a JSON object";
+    return false;
+  }
+
+  auto sequence = state->pending_document_sequence.find(patch.field_key);
+  if (sequence == state->pending_document_sequence.end()) {
+    HistoryWorkingState::DocumentFieldEdit edit;
+    edit.target = patch.target;
+    if (!alcedo::ReadEditorParameterJson(*state->pipeline_guard->document_, edit.target,
+                                         &edit.before_model_json, error)) {
+      return false;
+    }
+    sequence = state->pending_document_sequence.emplace(patch.field_key, std::move(edit)).first;
+  }
+  const auto& locked_target = sequence->second.target;
+  if (!alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, locked_target,
+                                           patch_params, error)) {
+    return false;
+  }
+
   if (state->pending_before.contains(patch.field_key)) return true;
 
   // Before-values for the WAL come from the derived committed snapshot, not the
@@ -117,6 +210,9 @@ auto EditorHistoryMutation::CaptureAdjustmentBeforePreview(
   // GetParams float round-trips must not redefine the previous committed edit.
   alcedo::EditorAdjustmentOperatorState before;
   if (!ReadCommittedAdjustmentState(state->committed_snapshot, patch.field_key, &before, error)) {
+    (void)alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, locked_target,
+                                              sequence->second.before_model_json, nullptr);
+    state->pending_document_sequence.erase(patch.field_key);
     return false;
   }
   state->pending_before.emplace(patch.field_key, std::move(before));
@@ -132,6 +228,12 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
     if (error) *error = "Editor history graph is unavailable";
     return false;
   }
+  const auto target_error =
+      alcedo::DescribeEditorParameterTargetError(patch.target, patch.field_key);
+  if (!target_error.empty()) {
+    if (error) *error = target_error;
+    return false;
+  }
   const auto spec = alcedo::ResolveEditorAdjustmentField(patch.field_key);
   if (!spec) {
     if (error) *error = "Unknown editor adjustment field: " + patch.field_key;
@@ -140,6 +242,15 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
   const auto before = state->pending_before.find(patch.field_key);
   if (before == state->pending_before.end()) {
     if (error) *error = "Settled adjustment has no captured committed state";
+    return false;
+  }
+  const auto sequence = state->pending_document_sequence.find(patch.field_key);
+  if (sequence == state->pending_document_sequence.end()) {
+    if (error) *error = "Settled adjustment has no locked document target";
+    return false;
+  }
+  if (!state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
     return false;
   }
 
@@ -152,6 +263,17 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
   }
   if (!after_params.is_object()) {
     if (error) *error = "Editor adjustment params must be a JSON object";
+    return false;
+  }
+
+  const auto locked_target = sequence->second.target;
+  if (!alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, locked_target,
+                                           after_params, error)) {
+    return false;
+  }
+  nlohmann::json after_model_json;
+  if (!alcedo::ReadEditorParameterJson(*state->pipeline_guard->document_, locked_target,
+                                       &after_model_json, error)) {
     return false;
   }
 
@@ -171,10 +293,15 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
   if (payload.before_value == payload.after_value &&
       payload.before_enabled == payload.after_enabled) {
     state->pending_before.erase(before);
+    state->pending_document_sequence.erase(sequence);
     return true;
   }
 
   auto restore_before_on_live = [&] {
+    if (state->pipeline_guard->document_) {
+      (void)alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, locked_target,
+                                                sequence->second.before_model_json, nullptr);
+    }
     if (!state->pipeline_guard->pipeline_) return;
     alcedo::EditorAdjustmentOperatorState before_state;
     before_state.params  = payload.before_value;
@@ -225,8 +352,14 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
     restore_before_on_live();
     return false;
   }
+  if (append.commit.has_value()) {
+    HistoryWorkingState::DocumentFieldEdit recorded = sequence->second;
+    recorded.after_model_json = std::move(after_model_json);
+    state->document_edit_by_commit[append.commit->GetCommitHash()] = std::move(recorded);
+  }
   state->pipeline_guard->dirty_ = true;
   state->pending_before.erase(before);
+  state->pending_document_sequence.erase(patch.field_key);
   state->recovered_head = false;
   return true;
 }
@@ -292,8 +425,16 @@ auto EditorHistoryMutation::DiscardUnmaterializedChanges(
     return false;
   }
 
+  if (state->pipeline_guard->document_) {
+    for (const auto& [_, edit] : state->pending_document_sequence) {
+      (void)alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, edit.target,
+                                                edit.before_model_json, nullptr);
+    }
+  }
+
   const auto materialized_head =
       state->pipeline_guard->commit_graph_->GetImageEditState().materialized_head_commit_hash;
+  std::vector<alcedo::EditCommit> abandoned;
   while (state->history->working_head() != materialized_head) {
     const auto prepared = materialized_head.has_value()
                               ? state->history->PrepareMoveHeadToCommit(*materialized_head)
@@ -306,6 +447,8 @@ auto EditorHistoryMutation::DiscardUnmaterializedChanges(
       if (error) *error = "Materialized history head could not be restored";
       return false;
     }
+    abandoned.insert(abandoned.end(), prepared.traversed_commits.begin(),
+                     prepared.traversed_commits.end());
     // Publish head moves first; live params + derived snapshot refresh once below.
     const auto published = state->history->PublishPreparedHeadMove(prepared);
     if (!published.moved) {
@@ -322,6 +465,9 @@ auto EditorHistoryMutation::DiscardUnmaterializedChanges(
       return false;
     }
   }
+  if (!ApplyDocumentFieldEdits(*state, abandoned, true, error)) {
+    return false;
+  }
   if (!RefreshCommittedSnapshotFromLive(*state, error)) return false;
 
   if (state->journal && !state->journal->TruncateMaterialized(error)) return false;
@@ -329,6 +475,7 @@ auto EditorHistoryMutation::DiscardUnmaterializedChanges(
   state->pipeline_guard->dirty_ = false;
   state->pipeline_guard->serialized_state_needs_writeback_ = false;
   state->pending_before.clear();
+  state->pending_document_sequence.clear();
   state->recovered_head = false;
   return true;
 }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
@@ -40,109 +40,84 @@ auto RefreshCommittedSnapshotFromLive(HistoryWorkingState& state, std::string* e
   }
 }
 
-auto RestoreLivePipelineParams(HistoryWorkingState& state, const nlohmann::json& prior_pipeline)
-    -> void {
-  if (!state.pipeline_guard || !state.pipeline_guard->pipeline_) {
-    return;
+/// Read-only UI/log representation of actual normalized Model values. No stage is read or written.
+auto HistoryParams(const EditorParameterTarget& target, nlohmann::json params) -> nlohmann::json {
+  if (target.field_key == "exposure" && params.contains("exposure_ev")) {
+    params["exposure"] = params.at("exposure_ev");
+    params.erase("exposure_ev");
   }
-  try {
-    auto restore_lock = LockLivePipeline(*state.pipeline_guard->pipeline_);
-    state.pipeline_guard->pipeline_->ImportPipelineParams(prior_pipeline);
-    state.pipeline_guard->pipeline_->SetExecutionStages();
-  } catch (...) {
-  }
+  return params;
 }
 
-auto RestoreLiveDocumentJson(HistoryWorkingState& state, const nlohmann::json& prior_document)
-    -> void {
-  if (!state.pipeline_guard || !state.pipeline_guard->document_) {
-    return;
-  }
-  try {
-    *state.pipeline_guard->document_ = alcedo::PipelineDocument::FromJson(prior_document);
-  } catch (...) {
-  }
+/// Update only the affected panel projection; it never becomes the source of an edit.
+void ProjectDocumentEdit(HistoryWorkingState&                          state,
+                         const HistoryWorkingState::DocumentFieldEdit& edit, bool backward) {
+  const auto& params = backward ? edit.before_model_json : edit.after_model_json;
+  UpsertCommittedSnapshot(&state.committed_snapshot, edit.target.field_key,
+                          HistoryParams(edit.target, params), true);
+  state.committed_snapshot.params_json.clear();
 }
 
-auto ApplyDocumentFieldEdits(HistoryWorkingState& state, const std::vector<alcedo::EditCommit>& commits,
-                             bool backward, std::string* error) -> bool {
-  if (!state.pipeline_guard || !state.pipeline_guard->document_) {
-    return true;
-  }
-  auto& live = *state.pipeline_guard->document_;
-  for (const auto& commit : commits) {
-    const auto found = state.document_edit_by_commit.find(commit.GetCommitHash());
-    if (found == state.document_edit_by_commit.end()) {
-      continue;
-    }
-    const auto& json = backward ? found->second.before_model_json : found->second.after_model_json;
-    if (!alcedo::PublishEditorParameterPatch(live, found->second.target, json, error)) {
+/// Restore local before-values in reverse order under the caller's render lock.
+/// Report a restoration error and stop; never continue using a substitute pipeline.
+auto RestoreDocumentFields(HistoryWorkingState&                                       state,
+                           const std::vector<HistoryWorkingState::DocumentFieldEdit>& fields,
+                           std::string* error) -> bool {
+  for (auto it = fields.rbegin(); it != fields.rend(); ++it) {
+    std::string restore_error;
+    if (!ApplyEditorParameterPatch(*state.pipeline_guard->document_, it->target,
+                                   it->before_model_json, &restore_error)) {
+      if (error) *error = "Document parameter restoration failed: " + restore_error;
       return false;
     }
   }
   return true;
 }
 
-/// WAL-first head move: publish journal + unique history head, then rebuild the
-/// unique live pipeline from defaults + first-parent chain (plan §4.7). On live
-/// apply failure, revoke the WAL tail and restore the prior head.
-auto ApplyPreparedHeadMoveOnLivePipeline(HistoryWorkingState& state,
-                                         const alcedo::MiniGitPreparedHeadMove& prepared,
-                                         std::string* error) -> bool {
-  const auto prior_selection = state.history->WorkingSelection();
-  nlohmann::json prior_pipeline;
-  nlohmann::json prior_document;
-  if (state.pipeline_guard && state.pipeline_guard->pipeline_) {
-    try {
-      // Structural head move: wait out Apply (incl. present) before locking.
-      auto render_lock = LockLivePipeline(*state.pipeline_guard->pipeline_);
-      prior_pipeline   = state.pipeline_guard->pipeline_->ExportPipelineParams();
-    } catch (const std::exception& ex) {
-      if (error) *error = ex.what();
+/// WAL-first same-session head move. Keep only affected values; hold the render lock
+/// across document reads, history publication, writes and rollback (caller owns the lock).
+auto ApplyPreparedHeadMoveOnLivePipeline(HistoryWorkingState&           state,
+                                         const MiniGitPreparedHeadMove& prepared,
+                                         std::string*                   error) -> bool {
+  if (!state.pipeline_guard->pipeline_ || !state.pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
+  }
+  std::vector<HistoryWorkingState::DocumentFieldEdit> changes;
+  changes.reserve(prepared.traversed_commits.size());
+  for (const auto& commit : prepared.traversed_commits) {
+    const auto found = state.document_edit_by_commit.find(commit.GetCommitHash());
+    if (found == state.document_edit_by_commit.end()) {
+      if (error)
+        *error = "History commit has no same-session document target; typed replay requires NM4";
       return false;
     }
+    auto change = found->second;
+    change.after_model_json =
+        prepared.backward ? found->second.before_model_json : found->second.after_model_json;
+    if (!ReadEditorParameterJson(*state.pipeline_guard->document_, change.target,
+                                 &change.before_model_json, error))
+      return false;
+    changes.push_back(std::move(change));
   }
-  if (state.pipeline_guard && state.pipeline_guard->document_) {
-    prior_document = state.pipeline_guard->document_->ToJson();
-  }
-
+  const auto prior_selection = state.history->WorkingSelection();
   const auto published = state.history->PublishPreparedHeadMove(prepared);
   if (!published.moved) {
-    if (error) {
-      *error = published.error.empty() ? "mini-Git head-move publish failed" : published.error;
-    }
+    if (error) *error = published.error;
     return false;
   }
-
-  if (state.pipeline_guard && state.pipeline_guard->pipeline_ && state.pipeline_guard->commit_graph_) {
-    auto render_lock = LockLivePipeline(*state.pipeline_guard->pipeline_);
-    if (!alcedo::ApplyVersionHeadToLivePipeline(*state.pipeline_guard->pipeline_,
-                                                *state.pipeline_guard->commit_graph_,
-                                                prepared.target_head, error)) {
-      render_lock.unlock();
+  for (const auto& change : changes) {
+    if (!ApplyEditorParameterPatch(*state.pipeline_guard->document_, change.target,
+                                   change.after_model_json, error)) {
       std::string abandon_error;
-      (void)state.history->AbandonPublishedHeadMove(prepared, prior_selection, &abandon_error);
-      RestoreLivePipelineParams(state, prior_pipeline);
-      RestoreLiveDocumentJson(state, prior_document);
+      if (!state.history->AbandonPublishedHeadMove(prepared, prior_selection, &abandon_error) &&
+          error)
+        *error += "; history restoration failed: " + abandon_error;
+      (void)RestoreDocumentFields(state, changes, error);
       return false;
     }
   }
-
-  if (!ApplyDocumentFieldEdits(state, prepared.traversed_commits, prepared.backward, error)) {
-    std::string abandon_error;
-    (void)state.history->AbandonPublishedHeadMove(prepared, prior_selection, &abandon_error);
-    RestoreLivePipelineParams(state, prior_pipeline);
-    RestoreLiveDocumentJson(state, prior_document);
-    return false;
-  }
-
-  if (!RefreshCommittedSnapshotFromLive(state, error)) {
-    std::string abandon_error;
-    (void)state.history->AbandonPublishedHeadMove(prepared, prior_selection, &abandon_error);
-    RestoreLivePipelineParams(state, prior_pipeline);
-    RestoreLiveDocumentJson(state, prior_document);
-    return false;
-  }
+  for (const auto& change : changes) ProjectDocumentEdit(state, change, false);
   state.pipeline_guard->dirty_ = true;
   state.pending_before.clear();
   state.pending_document_sequence.clear();
@@ -187,35 +162,29 @@ auto EditorHistoryMutation::CaptureAdjustmentBeforePreview(
     return false;
   }
 
-  auto sequence = state->pending_document_sequence.find(patch.field_key);
+  if (!state->pipeline_guard->pipeline_) {
+    if (error) *error = "Live pipeline executor is unavailable";
+    return false;
+  }
+  auto       render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
+  const auto sequence    = state->pending_document_sequence.find(patch.field_key);
+  HistoryWorkingState::DocumentFieldEdit edit;
   if (sequence == state->pending_document_sequence.end()) {
-    HistoryWorkingState::DocumentFieldEdit edit;
     edit.target = patch.target;
-    if (!alcedo::ReadEditorParameterJson(*state->pipeline_guard->document_, edit.target,
-                                         &edit.before_model_json, error)) {
+    if (!ReadEditorParameterJson(*state->pipeline_guard->document_, edit.target,
+                                 &edit.before_model_json, error))
       return false;
-    }
-    sequence = state->pending_document_sequence.emplace(patch.field_key, std::move(edit)).first;
+  } else {
+    edit = sequence->second;
   }
-  const auto& locked_target = sequence->second.target;
-  if (!alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, locked_target,
-                                           patch_params, error)) {
+  if (!ApplyEditorParameterPatch(*state->pipeline_guard->document_, edit.target, patch_params,
+                                 error)) {
     return false;
   }
-
-  if (state->pending_before.contains(patch.field_key)) return true;
-
-  // Before-values for the WAL come from the derived committed snapshot, not the
-  // live executor: interactive preview may have already moved the pipeline, and
-  // GetParams float round-trips must not redefine the previous committed edit.
-  alcedo::EditorAdjustmentOperatorState before;
-  if (!ReadCommittedAdjustmentState(state->committed_snapshot, patch.field_key, &before, error)) {
-    (void)alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, locked_target,
-                                              sequence->second.before_model_json, nullptr);
-    state->pending_document_sequence.erase(patch.field_key);
-    return false;
+  // Only the first successful patch locks a target. Rejected input does not capture state.
+  if (sequence == state->pending_document_sequence.end()) {
+    state->pending_document_sequence.emplace(patch.field_key, std::move(edit));
   }
-  state->pending_before.emplace(patch.field_key, std::move(before));
   return true;
 }
 
@@ -237,11 +206,6 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
   const auto spec = alcedo::ResolveEditorAdjustmentField(patch.field_key);
   if (!spec) {
     if (error) *error = "Unknown editor adjustment field: " + patch.field_key;
-    return false;
-  }
-  const auto before = state->pending_before.find(patch.field_key);
-  if (before == state->pending_before.end()) {
-    if (error) *error = "Settled adjustment has no captured committed state";
     return false;
   }
   const auto sequence = state->pending_document_sequence.find(patch.field_key);
@@ -266,99 +230,52 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
     return false;
   }
 
+  if (!state->pipeline_guard->pipeline_) {
+    if (error) *error = "Live pipeline executor is unavailable";
+    return false;
+  }
+  auto       render_lock   = LockLivePipeline(*state->pipeline_guard->pipeline_);
   const auto locked_target = sequence->second.target;
-  if (!alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, locked_target,
-                                           after_params, error)) {
+  if (!ApplyEditorParameterPatch(*state->pipeline_guard->document_, locked_target, after_params,
+                                 error))
     return false;
-  }
-  nlohmann::json after_model_json;
-  if (!alcedo::ReadEditorParameterJson(*state->pipeline_guard->document_, locked_target,
-                                       &after_model_json, error)) {
+  HistoryWorkingState::DocumentFieldEdit recorded = sequence->second;
+  if (!ReadEditorParameterJson(*state->pipeline_guard->document_, locked_target,
+                               &recorded.after_model_json, error))
     return false;
-  }
 
-  alcedo::OrdinaryEditPayload payload;
+  OrdinaryEditPayload payload;
   payload.operator_type = spec->operator_type;
   payload.stage_name = spec->stage_name;
   payload.field_name = "$operator_params";
-  payload.before_value = before->second.params;
-  payload.after_value = after_params;
-  payload.before_enabled = before->second.enabled;
-  payload.after_enabled = patch.enabled;
-  if (after_params.contains("enabled") && after_params.at("enabled").is_boolean()) {
-    payload.after_enabled = after_params.at("enabled").get<bool>();
-  }
+  payload.before_value   = HistoryParams(locked_target, recorded.before_model_json);
+  payload.after_value    = HistoryParams(locked_target, recorded.after_model_json);
+  payload.before_enabled = true;
+  payload.after_enabled  = true;
 
-  // before == after: end without WAL, commit, or HEAD move.
-  if (payload.before_value == payload.after_value &&
-      payload.before_enabled == payload.after_enabled) {
-    state->pending_before.erase(before);
+  if (recorded.before_model_json == recorded.after_model_json) {
+    ProjectDocumentEdit(*state, recorded, false);
     state->pending_document_sequence.erase(sequence);
     return true;
   }
-
-  auto restore_before_on_live = [&] {
-    if (state->pipeline_guard->document_) {
-      (void)alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, locked_target,
-                                                sequence->second.before_model_json, nullptr);
-    }
-    if (!state->pipeline_guard->pipeline_) return;
-    alcedo::EditorAdjustmentOperatorState before_state;
-    before_state.params  = payload.before_value;
-    before_state.enabled = payload.before_enabled;
-    std::string restore_error;
-    std::unique_lock<std::mutex> render_lock(state->pipeline_guard->pipeline_->GetRenderLock());
-    (void)alcedo::ApplyEditorAdjustmentOperatorState(*state->pipeline_guard->pipeline_, *spec,
-                                                     before_state, &restore_error);
-  };
-
-  // WAL-first settled edit: prepare → WAL+history publish → live SetOperator(after).
-  // Interactive preview may already have applied after on the live pipeline; WAL
-  // failure must restore before. History or SetOperator failure revokes the WAL
-  // tail and restores before without clearing earlier recovery records.
+  const auto restore_before = [&] { return RestoreDocumentFields(*state, {recorded}, error); };
   const auto prepared = state->history->PrepareAppendEdit(payload);
   if (!prepared.ready) {
     if (error) *error = prepared.error;
-    restore_before_on_live();
+    (void)restore_before();
     return false;
   }
-
-  const auto prior_selection = state->history->WorkingSelection();
   const auto append = state->history->PublishPreparedEdit(prepared);
   if (!append.committed) {
     if (error) *error = append.error;
-    restore_before_on_live();
-    return false;
-  }
-
-  if (state->pipeline_guard->pipeline_) {
-    alcedo::EditorAdjustmentOperatorState after_state;
-    after_state.params  = payload.after_value;
-    after_state.enabled = payload.after_enabled;
-    std::unique_lock<std::mutex> render_lock(state->pipeline_guard->pipeline_->GetRenderLock());
-    if (!alcedo::ApplyEditorAdjustmentOperatorState(*state->pipeline_guard->pipeline_, *spec,
-                                                    after_state, error)) {
-      render_lock.unlock();
-      std::string abandon_error;
-      (void)state->history->AbandonPublishedEdit(prepared, prior_selection, &abandon_error);
-      restore_before_on_live();
-      return false;
-    }
-  }
-
-  if (!RefreshCommittedSnapshotFromLive(*state, error)) {
-    std::string abandon_error;
-    (void)state->history->AbandonPublishedEdit(prepared, prior_selection, &abandon_error);
-    restore_before_on_live();
+    (void)restore_before();
     return false;
   }
   if (append.commit.has_value()) {
-    HistoryWorkingState::DocumentFieldEdit recorded = sequence->second;
-    recorded.after_model_json = std::move(after_model_json);
-    state->document_edit_by_commit[append.commit->GetCommitHash()] = std::move(recorded);
+    state->document_edit_by_commit[append.commit->GetCommitHash()] = recorded;
   }
+  ProjectDocumentEdit(*state, recorded, false);
   state->pipeline_guard->dirty_ = true;
-  state->pending_before.erase(before);
   state->pending_document_sequence.erase(patch.field_key);
   state->recovered_head = false;
   return true;
@@ -372,6 +289,11 @@ auto EditorHistoryMutation::Undo(const alcedo::EditorHistoryGuardHandle& guard,
     if (error) *error = "Editor history graph is unavailable";
     return false;
   }
+  if (!state->pipeline_guard->pipeline_ || !state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
+  }
+  auto       render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
   const auto prepared = state->history->PrepareUndo();
   if (!prepared.ready) {
     if (error) *error = prepared.error;
@@ -389,6 +311,11 @@ auto EditorHistoryMutation::Redo(const alcedo::EditorHistoryGuardHandle& guard,
     if (error) *error = "Editor history graph is unavailable";
     return false;
   }
+  if (!state->pipeline_guard->pipeline_ || !state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
+  }
+  auto       render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
   const auto prepared = state->history->PrepareRedo();
   if (!prepared.ready) {
     if (error) *error = prepared.error;
@@ -407,6 +334,11 @@ auto EditorHistoryMutation::MoveHeadToCommit(const alcedo::EditorHistoryGuardHan
     if (error) *error = "Editor history graph is unavailable";
     return false;
   }
+  if (!state->pipeline_guard->pipeline_ || !state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
+  }
+  auto       render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
   const auto prepared = state->history->PrepareMoveHeadToCommit(commit_id);
   if (!prepared.ready) {
     if (error) *error = prepared.error;
@@ -425,50 +357,34 @@ auto EditorHistoryMutation::DiscardUnmaterializedChanges(
     return false;
   }
 
-  if (state->pipeline_guard->document_) {
-    for (const auto& [_, edit] : state->pending_document_sequence) {
-      (void)alcedo::PublishEditorParameterPatch(*state->pipeline_guard->document_, edit.target,
-                                                edit.before_model_json, nullptr);
-    }
+  if (!state->pipeline_guard->pipeline_ || !state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
   }
-
+  auto render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
+  {
+    for (const auto& [_, edit] : state->pending_document_sequence) {
+      if (!ApplyEditorParameterPatch(*state->pipeline_guard->document_, edit.target,
+                                     edit.before_model_json, error))
+        return false;
+      ProjectDocumentEdit(*state, edit, true);
+    }
+    state->pending_document_sequence.clear();
+  }
   const auto materialized_head =
       state->pipeline_guard->commit_graph_->GetImageEditState().materialized_head_commit_hash;
-  std::vector<alcedo::EditCommit> abandoned;
   while (state->history->working_head() != materialized_head) {
     const auto prepared = materialized_head.has_value()
                               ? state->history->PrepareMoveHeadToCommit(*materialized_head)
                               : state->history->PrepareUndo();
-    if (!prepared.ready) {
-      if (error) *error = prepared.error;
+    if (!prepared.ready || prepared.is_noop) {
+      if (error)
+        *error =
+            prepared.ready ? "Materialized history head could not be restored" : prepared.error;
       return false;
     }
-    if (prepared.is_noop) {
-      if (error) *error = "Materialized history head could not be restored";
-      return false;
-    }
-    abandoned.insert(abandoned.end(), prepared.traversed_commits.begin(),
-                     prepared.traversed_commits.end());
-    // Publish head moves first; live params + derived snapshot refresh once below.
-    const auto published = state->history->PublishPreparedHeadMove(prepared);
-    if (!published.moved) {
-      if (error) *error = published.error.empty() ? "Discard head restore failed" : published.error;
-      return false;
-    }
+    if (!ApplyPreparedHeadMoveOnLivePipeline(*state, prepared, error)) return false;
   }
-
-  if (state->pipeline_guard->pipeline_) {
-    auto render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
-    if (!alcedo::ApplyVersionHeadToLivePipeline(*state->pipeline_guard->pipeline_,
-                                                *state->pipeline_guard->commit_graph_,
-                                                state->history->working_head(), error)) {
-      return false;
-    }
-  }
-  if (!ApplyDocumentFieldEdits(*state, abandoned, true, error)) {
-    return false;
-  }
-  if (!RefreshCommittedSnapshotFromLive(*state, error)) return false;
 
   if (state->journal && !state->journal->TruncateMaterialized(error)) return false;
   state->history->PublishWorkingSelection({});

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
@@ -21,6 +21,12 @@
 namespace alcedo::ui {
 namespace {
 
+void SyncUnsettledPreviewFlag(HistoryWorkingState& state) {
+  if (state.pipeline_guard) {
+    state.pipeline_guard->unsettled_preview_ = !state.pending_document_sequence.empty();
+  }
+}
+
 /// Refresh committed_snapshot from the live pipeline after a successful history mutation.
 /// Prefer live GetOperator/GetParams over root_snapshot + SnapshotAtHead (plan §4.7).
 auto RefreshCommittedSnapshotFromLive(HistoryWorkingState& state, std::string* error) -> bool {
@@ -122,6 +128,7 @@ auto ApplyPreparedHeadMoveOnLivePipeline(HistoryWorkingState&           state,
   state.pending_before.clear();
   state.pending_document_sequence.clear();
   state.recovered_head = false;
+  SyncUnsettledPreviewFlag(state);
   return true;
 }
 
@@ -185,6 +192,7 @@ auto EditorHistoryMutation::CaptureAdjustmentBeforePreview(
   if (sequence == state->pending_document_sequence.end()) {
     state->pending_document_sequence.emplace(patch.field_key, std::move(edit));
   }
+  SyncUnsettledPreviewFlag(*state);
   return true;
 }
 
@@ -256,6 +264,7 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
   if (recorded.before_model_json == recorded.after_model_json) {
     ProjectDocumentEdit(*state, recorded, false);
     state->pending_document_sequence.erase(sequence);
+    SyncUnsettledPreviewFlag(*state);
     return true;
   }
   const auto restore_before = [&] { return RestoreDocumentFields(*state, {recorded}, error); };
@@ -278,6 +287,7 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
   state->pipeline_guard->dirty_ = true;
   state->pending_document_sequence.erase(patch.field_key);
   state->recovered_head = false;
+  SyncUnsettledPreviewFlag(*state);
   return true;
 }
 
@@ -393,6 +403,7 @@ auto EditorHistoryMutation::DiscardUnmaterializedChanges(
   state->pending_before.clear();
   state->pending_document_sequence.clear();
   state->recovered_head = false;
+  SyncUnsettledPreviewFlag(*state);
   return true;
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_pipeline_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_pipeline_port.cpp
@@ -39,7 +39,7 @@ void EditorSessionPipelinePort::Release(const alcedo::EditorPipelineGuardHandle&
     }
   }
   if (service && loaded_guard) {
-    service->SavePipeline(std::move(loaded_guard));
+    service->ReleasePipelineUse(std::move(loaded_guard));
   }
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/import_export.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/import_export.cpp
@@ -10,11 +10,14 @@
 #include <QSettings>
 #include <QStandardPaths>
 #include <algorithm>
+#include <mutex>
 #include <optional>
 #include <thread>
 #include <tuple>
 #include <unordered_set>
 #include <utility>
+
+#include "edit/runtime/drt_display.hpp"
 
 #include "ui/alcedo_main/album_backend/folder_controller.hpp"
 #include "ui/alcedo_main/album_backend/import_export.hpp"
@@ -973,6 +976,24 @@ auto ImportExportHandler::BuildExportQueue(
         task.recipe_->resize_.mode_ = ExportResizeMode::ORIGINAL_PIXELS;
       }
       if (is_hdr_export) task.recipe_->resize_.maximum_edge_pixels_ = 8192;
+
+      auto pipes = project_->handler().pipeline_service();
+      if (!pipes) {
+        throw std::runtime_error("Export pipeline service is unavailable");
+      }
+      auto live = pipes->LoadPipeline(elementId);
+      if (!live || !live->document_ || !live->document_->Drt() || !live->pipeline_) {
+        if (live) {
+          pipes->ReleasePipelineUse(live);
+        }
+        throw std::runtime_error("Export: document DRT is missing");
+      }
+      {
+        std::lock_guard<std::mutex> render_lock(live->pipeline_->GetRenderLock());
+        task.recipe_->output_color_ =
+            ExportColorProfileFromDrt(live->document_->Drt()->Params().Params());
+      }
+      pipes->ReleasePipelineUse(live);
 
       esvc->EnqueueExportTask(task);
       ++summary.queued_count_;

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -75,6 +75,17 @@ target_link_libraries(ImportServiceTest ImportService ProjectService GTest::gtes
 
 alcedo_register_test_target(ImportServiceTest app)
 
+if(ALCEDO_CUDA_ENABLED)
+  qt_add_executable(ImportPipelineDocumentTest
+    ${ALCEDO_TEST_ROOT}/app/import_pipeline_document_test.cpp)
+  target_include_directories(ImportPipelineDocumentTest PRIVATE ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(ImportPipelineDocumentTest PRIVATE
+    ImportService ProjectService PipelineMgmtService GTest::gtest_main)
+  gtest_discover_tests(ImportPipelineDocumentTest TEST_PREFIX "ImportPipelineDocumentTest."
+    PROPERTIES LABELS "gpu;app;import;pipeline")
+  alcedo_register_test_target(ImportPipelineDocumentTest app)
+endif()
+
 add_executable(SleeveServiceTest ${ALCEDO_TEST_ROOT}/app/sleeve_service_test.cpp)
 target_include_directories(SleeveServiceTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(SleeveServiceTest
@@ -436,8 +447,16 @@ alcedo_register_test_target(ImageAnalysisLiveSmokeTest app ci_raw)
 add_executable(ThumbnailServiceTest ${ALCEDO_TEST_ROOT}/app/thumbnail_service_test.cpp)
 target_include_directories(ThumbnailServiceTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(ThumbnailServiceTest ThumbnailService ProjectService ImportService GTest::gtest_main)
+gtest_discover_tests(ThumbnailServiceTest TEST_PREFIX "ThumbnailServiceTest.")
 
 alcedo_register_test_target(ThumbnailServiceTest app)
+
+add_executable(PipelineSharedUseTest ${ALCEDO_TEST_ROOT}/app/pipeline_shared_use_test.cpp)
+target_include_directories(PipelineSharedUseTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(PipelineSharedUseTest ThumbnailService ExportService ProjectService
+  ImportService GTest::gtest_main ImageWriter ${ALCEDO_TEST_OPENCV_MIN_DEPS})
+gtest_discover_tests(PipelineSharedUseTest TEST_PREFIX "PipelineSharedUseTest.")
+alcedo_register_test_target(PipelineSharedUseTest app)
 
 add_executable(ThumbnailDiskCacheServiceTest ${ALCEDO_TEST_ROOT}/app/thumbnail_disk_cache_service_test.cpp)
 target_include_directories(ThumbnailDiskCacheServiceTest PUBLIC ${ALCEDO_INCLUDE_DIR})

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -46,6 +46,16 @@ target_link_libraries(EditorAdjustmentPipelineTest
 gtest_discover_tests(EditorAdjustmentPipelineTest TEST_PREFIX "EditorAdjustmentPipelineTest.")
 alcedo_register_test_target(EditorAdjustmentPipelineTest app)
 
+add_executable(EditorPipelineCommandServiceTest
+    ${ALCEDO_TEST_ROOT}/app/editor_pipeline_command_service_test.cpp)
+target_include_directories(EditorPipelineCommandServiceTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR})
+target_link_libraries(EditorPipelineCommandServiceTest
+    PRIVATE GTest::gtest_main EditorPipelineCommandService EditGraph EditRuntime JSON)
+gtest_discover_tests(EditorPipelineCommandServiceTest
+    TEST_PREFIX "EditorPipelineCommandServiceTest.")
+alcedo_register_test_target(EditorPipelineCommandServiceTest app)
+
 # Geometry overlay preview: crop disable + bilinear GPU resize path that the
 # unified scheduler runs when the Geometry panel owns the source-frame overlay.
 add_executable(EditorGeometryOverlayPipelineTest
@@ -225,7 +235,7 @@ add_executable(EditorSessionEditControllerTest ${ALCEDO_TEST_ROOT}/app/editor_se
 target_include_directories(EditorSessionEditControllerTest
   PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR})
 target_link_libraries(EditorSessionEditControllerTest
-    EditorSessionEditController EditorSessionLifecycle EditHistory
+    EditorSessionEditController EditorSessionLifecycle EditHistory EditorAdjustmentPipeline
     GTest::gtest_main)
 gtest_discover_tests(EditorSessionEditControllerTest
     TEST_PREFIX "EditorSessionEditControllerTest."

--- a/alcedo_studio/tests/app/editor_pipeline_command_service_test.cpp
+++ b/alcedo_studio/tests/app/editor_pipeline_command_service_test.cpp
@@ -1,0 +1,74 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_pipeline_command_service.hpp"
+
+#include <gtest/gtest.h>
+
+#include "edit/graph/pipeline_document.hpp"
+#include "support/editor_parameter_target_test.hpp"
+
+namespace alcedo {
+namespace {
+
+TEST(EditorPipelineCommandServiceTest, SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages) {
+  auto document = CreateDefaultPipelineDocument();
+  const auto before = CanonicalPipelineDocumentJson(document);
+  std::string error;
+  ASSERT_TRUE(PublishEditorParameterPatch(document, test::ColorGradeFieldTarget("exposure"),
+                                          {{"exposure_ev", 2.25}}, &error))
+      << error;
+  nlohmann::json json;
+  ASSERT_TRUE(ReadEditorParameterJson(document, test::ColorGradeFieldTarget("exposure"), &json,
+                                      &error))
+      << error;
+  EXPECT_FLOAT_EQ(json.at("exposure_ev").get<float>(), 2.25f);
+  EXPECT_NE(CanonicalPipelineDocumentJson(document), before);
+}
+
+TEST(EditorPipelineCommandServiceTest, IncompleteTargetIsRejectedWithoutMutation) {
+  auto document = CreateDefaultPipelineDocument();
+  const auto before = CanonicalPipelineDocumentJson(document);
+  EditorParameterTarget target;
+  target.field_key = "exposure";
+  std::string error;
+  EXPECT_FALSE(PublishEditorParameterPatch(document, target, {{"exposure_ev", 3.0}}, &error));
+  EXPECT_EQ(error, "Editor parameter target requires owner_kind");
+  EXPECT_EQ(CanonicalPipelineDocumentJson(document), before);
+
+  auto missing_node = test::ColorGradeFieldTarget("exposure");
+  missing_node.node_id = NodeId{};
+  EXPECT_FALSE(
+      PublishEditorParameterPatch(document, missing_node, {{"exposure_ev", 3.0}}, &error));
+  EXPECT_EQ(error, "Editor parameter target requires node_id");
+  EXPECT_EQ(CanonicalPipelineDocumentJson(document), before);
+}
+
+TEST(EditorPipelineCommandServiceTest, MaskTargetWriteIsRejected) {
+  auto document = CreateDefaultPipelineDocument();
+  const auto before = CanonicalPipelineDocumentJson(document);
+  EditorParameterTarget target;
+  target.owner_kind             = EditorParameterOwnerKind::ColorGradeMask;
+  target.node_id                = NodeId{"grade.primary"};
+  target.adjustment_instance_id = AdjustmentInstanceId{"grade.primary.exposure"};
+  target.mask_id                = "mask.1";
+  target.field_key              = "exposure";
+  std::string error;
+  EXPECT_FALSE(PublishEditorParameterPatch(document, target, {{"exposure_ev", 3.0}}, &error));
+  EXPECT_EQ(error, "Mask parameter targets are rejected until NM3");
+  EXPECT_EQ(CanonicalPipelineDocumentJson(document), before);
+}
+
+TEST(EditorPipelineCommandServiceTest, MissingAdjustmentInstanceLeavesDocumentUnchanged) {
+  auto document = CreateDefaultPipelineDocument();
+  const auto before = CanonicalPipelineDocumentJson(document);
+  auto target = test::ColorGradeFieldTarget("exposure");
+  target.adjustment_instance_id = AdjustmentInstanceId{"grade.primary.missing"};
+  std::string error;
+  EXPECT_FALSE(PublishEditorParameterPatch(document, target, {{"exposure_ev", 3.0}}, &error));
+  EXPECT_EQ(CanonicalPipelineDocumentJson(document), before);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/editor_pipeline_command_service_test.cpp
+++ b/alcedo_studio/tests/app/editor_pipeline_command_service_test.cpp
@@ -6,11 +6,143 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <stdexcept>
+
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
 #include "support/editor_parameter_target_test.hpp"
 
 namespace alcedo {
 namespace {
+
+/// Instrument only this unrelated Model, so repeated patches cannot hide a graph serialization.
+class SerializationCountingModel : public IOperatorModel {
+ public:
+  mutable int reads = 0;
+  auto        Type() const -> OperatorTypeId override { return value_.Type(); }
+  auto        IsDefault() const -> bool override { return value_.IsDefault(); }
+  auto        IsDirty() const -> bool override { return value_.IsDirty(); }
+  auto        MakeFullDto() const -> OperatorParamDto override { return value_.MakeFullDto(); }
+  auto        TakeDirtyPatch() -> std::optional<OperatorParamPatchDto> override {
+    return value_.TakeDirtyPatch();
+  }
+  void RestoreDirty(DirtyFieldMask fields) override { value_.RestoreDirty(fields); }
+  void MarkAllDirty() override { value_.MarkAllDirty(); }
+  auto ToJson() const -> nlohmann::json override {
+    ++reads;
+    return value_.ToJson();
+  }
+  void LoadJson(const nlohmann::json& json) override { value_.LoadJson(json); }
+
+ private:
+  ExposureModel value_;
+};
+
+/// Simulate a multi-field setter failing after it already changed a value.
+class PartiallyFailingModel final : public SerializationCountingModel {
+ public:
+  void LoadJson(const nlohmann::json& json) override {
+    SerializationCountingModel::LoadJson(json);
+    if (json.at("exposure_ev") == 5.0) throw std::runtime_error("injected setter failure");
+  }
+};
+
+TEST(EditorPipelineCommandServiceTest, ThrowingSetterRestoresOnlyAffectedModelParameters) {
+  auto  document          = CreateDefaultPipelineDocument();
+  auto  failing           = std::make_unique<PartiallyFailingModel>();
+  auto* affected          = failing.get();
+  auto* primary           = document.PrimaryGrade();
+  auto* original_exposure = primary->FindAdjustment(AdjustmentInstanceId{"grade.primary.exposure"});
+  document.InsertAdjustment(NodeId{"grade.primary"}, 0, AdjustmentInstanceId{"failing"},
+                            std::move(failing));
+  const auto before             = document.ToJson();
+  auto       target             = test::ColorGradeFieldTarget("exposure");
+  target.adjustment_instance_id = AdjustmentInstanceId{"failing"};
+  std::string error;
+  EXPECT_FALSE(ApplyEditorParameterPatch(document, target, {{"exposure_ev", 5.0}}, &error));
+  EXPECT_EQ(error, "injected setter failure");
+  EXPECT_EQ(document.PrimaryGrade(), primary);
+  EXPECT_EQ(primary->FindAdjustment(AdjustmentInstanceId{"failing"}), affected);
+  EXPECT_EQ(primary->FindAdjustment(AdjustmentInstanceId{"grade.primary.exposure"}),
+            original_exposure);
+  EXPECT_EQ(document.ToJson(), before);
+}
+
+TEST(EditorPipelineCommandServiceTest, ParameterPatchPreservesUnchangedModels) {
+  auto  document = CreateDefaultPipelineDocument();
+  auto  counter  = std::make_unique<SerializationCountingModel>();
+  auto* observed = counter.get();
+  document.InsertAdjustment(NodeId{"grade.primary"}, 0, AdjustmentInstanceId{"counted"},
+                            std::move(counter));
+  std::vector<const INodeModel*>     nodes;
+  std::vector<const IOperatorModel*> models;
+  for (const auto& node : document.Graph().Nodes()) nodes.push_back(node.get());
+  auto* grade = document.PrimaryGrade();
+  for (std::size_t i = 0; i < grade->AdjustmentCount(); ++i) {
+    models.push_back(&grade->AdjustmentAt(i));
+    (void)grade->AdjustmentAt(i).TakeDirtyPatch();
+  }
+  const auto edges = document.ToJson().at("edges");
+  observed->reads  = 0;
+  document.ClearTopologyDirty();
+  std::string error;
+  for (int i = 0; i < 40; ++i) {
+    ASSERT_TRUE(PublishEditorParameterPatch(document, test::ColorGradeFieldTarget("exposure"),
+                                            {{"exposure_ev", i / 4.0}}, &error))
+        << error;
+  }
+  EXPECT_EQ(observed->reads, 0);
+  EXPECT_FALSE(document.TopologyDirty());
+  for (std::size_t i = 0; i < nodes.size(); ++i)
+    EXPECT_EQ(document.Graph().Nodes()[i].get(), nodes[i]);
+  for (std::size_t i = 0; i < models.size(); ++i) EXPECT_EQ(&grade->AdjustmentAt(i), models[i]);
+  EXPECT_FALSE(observed->IsDirty());
+  const auto* exposure = dynamic_cast<const ExposureModel*>(
+      grade->FindAdjustment(AdjustmentInstanceId{"grade.primary.exposure"}));
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_FLOAT_EQ(exposure->Value(), 9.75f);
+  EXPECT_TRUE(exposure->IsDirty());
+  EXPECT_EQ(document.ToJson().at("edges"), edges);
+}
+
+TEST(EditorPipelineCommandServiceTest, InvalidCompoundParameterDoesNotPartiallyApplyOrDirtyModel) {
+  auto  document = CreateDefaultPipelineDocument();
+  auto* model    = document.PrimaryGrade()->FindAdjustmentByType(type_ids::Sharpen());
+  ASSERT_NE(model, nullptr);
+  const auto before = model->ToJson();
+  (void)model->TakeDirtyPatch();
+  std::string error;
+  for (const auto& patch :
+       std::vector<nlohmann::json>{{{"amount", 12}, {"radius", "invalid"}},
+                                   {{"amount", nullptr}},
+                                   {{"amount", 12}, {"unknown", 1}},
+                                   {{"amount", std::numeric_limits<double>::infinity()}}}) {
+    EXPECT_FALSE(PublishEditorParameterPatch(document, test::ColorGradeFieldTarget("sharpen"),
+                                             patch, &error));
+    EXPECT_FALSE(error.empty());
+    EXPECT_EQ(model->ToJson(), before);
+    EXPECT_FALSE(model->IsDirty());
+  }
+}
+
+TEST(EditorPipelineCommandServiceTest, GeometryAndDevelopRejectInvalidValuesBeforeAnyWrite) {
+  auto                  document = CreateDefaultPipelineDocument();
+  const auto            before   = document.ToJson();
+  std::string           error;
+  EditorParameterTarget geometry;
+  geometry.owner_kind = EditorParameterOwnerKind::Document;
+  geometry.field_key  = "crop_rotate";
+  EXPECT_FALSE(ApplyEditorParameterPatch(
+      document, geometry, {{"crop_rect", {0, 0, 1, "bad"}}, {"rotation_degrees", 30}}, &error));
+  EditorParameterTarget develop;
+  develop.owner_kind = EditorParameterOwnerKind::Develop;
+  develop.node_id    = NodeId{"develop"};
+  develop.field_key  = "raw_decode";
+  EXPECT_FALSE(ApplyEditorParameterPatch(
+      document, develop, {{"demosaic_method", "test"}, {"user_wb", "bad"}}, &error));
+  EXPECT_EQ(document.ToJson(), before);
+}
 
 TEST(EditorPipelineCommandServiceTest, SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages) {
   auto document = CreateDefaultPipelineDocument();

--- a/alcedo_studio/tests/app/editor_session_action_policy_cq3_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_action_policy_cq3_test.cpp
@@ -18,6 +18,7 @@
 #include "app/editor_session_bootstrap.hpp"
 #include "app/editor_session_service.hpp"
 #include "app/editor_session_types.hpp"
+#include "support/editor_parameter_target_test.hpp"
 #include "support/editor_session_command_queue_test_support.hpp"
 
 namespace alcedo {
@@ -308,9 +309,7 @@ TEST_F(EditorSessionActionPolicyCq3Test,
   // interactive Patch does not bump history_revision.
   openInteractive();
   const auto before = service_->history_revision();
-  EditorAdjustmentPatch patch;
-  patch.field_key   = "exposure";
-  patch.params_json = R"({"ev":0.5})";
+  auto patch = WithColorGradeTarget({"exposure", R"({"ev":0.5})", false});
   (void)service_->Patch(patch);
   drainQueue();
   EXPECT_EQ(service_->history_revision(), before);

--- a/alcedo_studio/tests/app/editor_session_edit_controller_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_edit_controller_test.cpp
@@ -13,6 +13,7 @@
 #include "edit/history/edit_transaction.hpp"
 #include "edit/operators/op_base.hpp"
 #include "json.hpp"
+#include "support/editor_parameter_target_test.hpp"
 #include "support/editor_session_test_ports.hpp"
 
 namespace alcedo {
@@ -51,9 +52,7 @@ class EditorSessionEditControllerTest : public ::testing::Test {
 };
 
 TEST_F(EditorSessionEditControllerTest, InteractiveAndSettledPatchUseOneHistoryCommit) {
-  EditorAdjustmentPatch patch;
-  patch.field_key   = "exposure";
-  patch.params_json = R"({"exposure":1.0})";
+  auto patch = test::WithColorGradeTarget({"exposure", R"({"exposure":1.0})", false});
 
   auto r1 = edit_->HandlePatch(patch, false, guard(), identity());
   EXPECT_EQ(r1.kind, EditorEditOutcome::Kind::RenderRouted);
@@ -77,9 +76,7 @@ TEST_F(EditorSessionEditControllerTest, InteractiveAndSettledPatchUseOneHistoryC
 }
 
 TEST_F(EditorSessionEditControllerTest, InteractivePatchCarriesOnlyEditedField) {
-  EditorAdjustmentPatch patch;
-  patch.field_key   = "exposure";
-  patch.params_json = R"({"exposure":1.25})";
+  auto patch = test::WithColorGradeTarget({"exposure", R"({"exposure":1.25})", false});
   const auto result = edit_->HandlePatch(patch, false, guard(), identity());
   ASSERT_EQ(result.kind, EditorEditOutcome::Kind::RenderRouted);
   ASSERT_EQ(result.render_command.adjustment.patches.size(), 1u);
@@ -90,7 +87,7 @@ TEST_F(EditorSessionEditControllerTest, InteractivePatchCarriesOnlyEditedField) 
 
 TEST_F(EditorSessionEditControllerTest, SettledCommitFailureReturnsRejected) {
   history_->fail_commit = true;
-  EditorAdjustmentPatch patch{"exposure", R"({"exposure":0.5})", true};
+  auto patch = test::WithColorGradeTarget({"exposure", R"({"exposure":0.5})", true});
   auto                  result = edit_->HandlePatch(patch, true, guard(), identity());
   EXPECT_EQ(result.kind, EditorEditOutcome::Kind::Rejected);
   EXPECT_EQ(result.message, "mini-Git journal append failed");
@@ -98,8 +95,7 @@ TEST_F(EditorSessionEditControllerTest, SettledCommitFailureReturnsRejected) {
 }
 
 TEST_F(EditorSessionEditControllerTest, RepeatedInteractivePatchesOnlyStampLatestFieldOnRender) {
-  EditorAdjustmentPatch patch;
-  patch.field_key = "exposure";
+  auto patch = test::WithColorGradeTarget({"exposure", R"({"exposure":0})", false});
   for (int value = 0; value < 50; ++value) {
     patch.params_json = std::string{"{\"exposure\":"} + std::to_string(value) + "}";
     const auto routed = edit_->HandlePatch(patch, false, guard(), identity());
@@ -146,9 +142,34 @@ TEST_F(EditorSessionEditControllerTest, PatchWithEmptyFieldKeyIsRejected) {
 
 TEST_F(EditorSessionEditControllerTest, PatchWithoutValidGuardIsRejected) {
   EditorHistoryGuardHandle invalid_guard{};
-  EditorAdjustmentPatch    patch{"exposure", R"({"exposure":1.0})", false};
-  auto                     result = edit_->HandlePatch(patch, false, invalid_guard, identity());
+  auto patch = test::WithColorGradeTarget({"exposure", R"({"exposure":1.0})", false});
+  auto result = edit_->HandlePatch(patch, false, invalid_guard, identity());
   EXPECT_EQ(result.kind, EditorEditOutcome::Kind::Rejected);
+}
+
+TEST_F(EditorSessionEditControllerTest, IncompleteTargetIsRejected) {
+  EditorAdjustmentPatch patch;
+  patch.field_key   = "exposure";
+  patch.params_json = R"({"exposure_ev":1.0})";
+  auto result       = edit_->HandlePatch(patch, false, guard(), identity());
+  EXPECT_EQ(result.kind, EditorEditOutcome::Kind::Rejected);
+  EXPECT_EQ(result.message, "Editor parameter target requires owner_kind");
+  EXPECT_EQ(history_->capture_count, 0);
+}
+
+TEST_F(EditorSessionEditControllerTest, MaskTargetIsRejected) {
+  EditorAdjustmentPatch patch;
+  patch.field_key                      = "exposure";
+  patch.params_json                    = R"({"exposure_ev":1.0})";
+  patch.target.owner_kind              = EditorParameterOwnerKind::ColorGradeMask;
+  patch.target.node_id                 = NodeId{"grade.primary"};
+  patch.target.adjustment_instance_id  = AdjustmentInstanceId{"grade.primary.exposure"};
+  patch.target.mask_id                 = "mask.1";
+  patch.target.field_key               = "exposure";
+  auto result                          = edit_->HandlePatch(patch, false, guard(), identity());
+  EXPECT_EQ(result.kind, EditorEditOutcome::Kind::Rejected);
+  EXPECT_EQ(result.message, "Mask parameter targets are rejected until NM3");
+  EXPECT_EQ(history_->capture_count, 0);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/app/export_recipe_test.cpp
+++ b/alcedo_studio/tests/app/export_recipe_test.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 namespace alcedo {
 
 TEST(ExportResolutionTests, OriginalPixelsKeepDimensionsAndApplyOptionalDpiTag) {
@@ -236,6 +238,21 @@ TEST(ExportRecipeTests, LegacyOptionsPreserveLongEdgeAndReplaceBehavior) {
   EXPECT_EQ(recipe.resize_.mode_, ExportResizeMode::LONG_EDGE_PIXELS);
   EXPECT_EQ(recipe.resize_.long_edge_pixels_, 2048);
   EXPECT_EQ(recipe.collision_, ExportCollisionPolicy::REPLACE);
+  EXPECT_FALSE(recipe.output_color_.has_value());
+  EXPECT_FALSE(ExportRecipeHasResolvedOutputColor(recipe));
+}
+
+TEST(ExportRecipeTests, ExportRecipeContainsResolvedOutputColorBeforeScheduling) {
+  ExportRecipe missing = ExportRecipe::FromLegacyOptions({});
+  EXPECT_THROW(RequireResolvedExportOutputColor(missing), std::runtime_error);
+  missing.output_color_ = ExportColorProfileConfig{};
+  missing.output_color_->peak_luminance = 0.0f;
+  EXPECT_THROW(RequireResolvedExportOutputColor(missing), std::runtime_error);
+  ExportRecipe recipe = ExportRecipe::FromLegacyOptions({});
+  recipe.output_color_ = ExportColorProfileConfig{
+      ColorUtils::ColorSpace::REC709, ColorUtils::EOTF::GAMMA_2_2, 100.0f};
+  EXPECT_NO_THROW(RequireResolvedExportOutputColor(recipe));
+  EXPECT_TRUE(ExportRecipeHasResolvedOutputColor(recipe));
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/app/export_service_test.cpp
+++ b/alcedo_studio/tests/app/export_service_test.cpp
@@ -8,13 +8,18 @@
 
 #include <algorithm>
 #include <chrono>
+#include <OpenImageIO/imageio.h>
 #include <exiv2/exiv2.hpp>
 #include <filesystem>
 #include <fstream>
 #include <future>
 #include <iostream>
 #include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <opencv2/core.hpp>
 #include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
 #include <string>
 #include <vector>
 #if defined(ALCEDO_HAS_ULTRAHDR)
@@ -24,8 +29,14 @@
 #include "app/import_service.hpp"
 #include "app/pipeline_service.hpp"
 #include "app/project_service.hpp"
+#include "edit/graph/pipeline_document.hpp"
 #include "edit/operators/operator_registeration.hpp"
+#include "edit/operators/utils/color_utils.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
+#include "edit/runtime/drt_display.hpp"
+#include "image/image.hpp"
+#include "io/image/export_color_profile_config.hpp"
+#include "io/image/export_icc_profile_resolver.hpp"
 #include "io/image/image_writer.hpp"
 #include "type/supported_file_type.hpp"
 #include "utils/clock/time_provider.hpp"
@@ -43,6 +54,23 @@ auto SanitizeForPath(std::string s) -> std::string {
     if (!ok) c = '_';
   }
   return s;
+}
+
+void AttachResolvedExportColor(ExportTask& task, PipelineMgmtService& pipelines) {
+  auto recipe = task.recipe_.value_or(ExportRecipe::FromLegacyOptions(task.options_));
+  auto live   = pipelines.LoadPipeline(task.sleeve_id_);
+  if (!live || !live->document_ || !live->document_->Drt() || !live->pipeline_) {
+    if (live) {
+      pipelines.ReleasePipelineUse(live);
+    }
+    throw std::runtime_error("export test: document DRT is missing");
+  }
+  {
+    std::lock_guard<std::mutex> lock(live->pipeline_->GetRenderLock());
+    recipe.output_color_ = ExportColorProfileFromDrt(live->document_->Drt()->Params().Params());
+  }
+  pipelines.ReleasePipelineUse(live);
+  task.recipe_ = std::move(recipe);
 }
 
 auto CollectSupportedBatchImportImages(size_t max_count) -> std::vector<image_path_t> {
@@ -104,6 +132,27 @@ void AssertReadableJpegFile(const std::filesystem::path& path) {
   ASSERT_FALSE(img.empty()) << "Failed to read JPEG file: " << path.string();
   ASSERT_GT(img.cols, 0);
   ASSERT_GT(img.rows, 0);
+}
+
+auto ReadExportRgb8(const std::filesystem::path& path) -> cv::Mat {
+  OIIO_NAMESPACE_USING
+  auto input = ImageInput::open(conv::ToBytes(path.wstring()));
+  if (!input) {
+    return {};
+  }
+  const ImageSpec& spec = input->spec();
+  if (spec.width <= 0 || spec.height <= 0 || spec.nchannels < 3) {
+    input->close();
+    return {};
+  }
+  cv::Mat rgb(spec.height, spec.width, CV_8UC3);
+  const bool ok = input->read_image(0, 0, 0, 3, TypeDesc::UINT8, rgb.data, sizeof(uint8_t) * 3,
+                                    AutoStride, AutoStride);
+  input->close();
+  if (!ok) {
+    return {};
+  }
+  return rgb;
 }
 
 auto ReadFileBytes(const std::filesystem::path& path) -> std::vector<uint8_t> {
@@ -188,7 +237,7 @@ TEST_F(ExportServiceTests, ExportOneImage_WritesReadableFile) {
     auto           image_pool       = project.GetImagePoolService();
     auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
-    ImportServiceImpl import_service(sleeve_service, image_pool);
+    ImportServiceImpl import_service(sleeve_service, image_pool, pipeline_service);
     auto              paths = CollectSupportedBatchImportImages(/*max_count=*/1);
     if (paths.empty()) {
       GTEST_SKIP() << "No supported images found under TEST_IMG_PATH/raw/batch_import";
@@ -245,6 +294,7 @@ TEST_F(ExportServiceTests, ExportOneImage_WritesReadableFile) {
       std::ofstream old_destination(dst_path, std::ios::binary);
       old_destination << "old";
     }
+    AttachResolvedExportColor(task, *pipeline_service);
     export_service.EnqueueExportTask(task);
 
     std::promise<std::shared_ptr<std::vector<ExportResult>>> done;
@@ -279,7 +329,7 @@ TEST_F(ExportServiceTests, ExportHdrJpeg_WritesUltraHdrFile) {
     auto           image_pool       = project.GetImagePoolService();
     auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
-    ImportServiceImpl import_service(sleeve_service, image_pool);
+    ImportServiceImpl import_service(sleeve_service, image_pool, pipeline_service);
     auto              paths = CollectSupportedBatchImportImages(/*max_count=*/1);
     if (paths.empty()) {
       GTEST_SKIP() << "No supported images found under TEST_IMG_PATH/raw/batch_import";
@@ -307,15 +357,18 @@ TEST_F(ExportServiceTests, ExportHdrJpeg_WritesUltraHdrFile) {
 
     auto       pipeline_guard = pipeline_service->LoadPipeline(element_id);
     ASSERT_NE(pipeline_guard, nullptr);
-    nlohmann::json odt_params           = pipeline_defaults::MakeDefaultODTParams();
-    odt_params["odt"]["encoding_space"] = "rec2020";
-    odt_params["odt"]["encoding_eotf"]  = "st2084";
-    odt_params["odt"]["peak_luminance"] = 600.0f;
-    auto& output_stage = pipeline_guard->pipeline_->GetStage(PipelineStageName::Output_Transform);
-    output_stage.SetOperator(OperatorType::ODT, odt_params);
-    pipeline_guard->dirty_ = true;
+    ASSERT_NE(pipeline_guard->document_, nullptr);
+    {
+      std::unique_lock lock(pipeline_guard->pipeline_->GetRenderLock());
+      auto drt = pipeline_guard->document_->Drt()->Params().Params();
+      drt.encoding_space = DrtColorSpace::Rec2020;
+      drt.encoding_eotf = DrtEotf::St2084;
+      drt.peak_luminance = 600.0f;
+      pipeline_guard->document_->Drt()->Params().ReplaceParams(drt);
+      // Stage defaults remain SDR: both pixels and export encoding must use the document.
+      pipeline_service->SyncPipelineDocument(pipeline_guard);
+    }
     pipeline_service->SavePipeline(pipeline_guard);
-    pipeline_service->Sync();
 
     const auto src_path = image_pool->Read<std::filesystem::path>(
         image_id, [](std::shared_ptr<Image> img) { return img->image_path_; });
@@ -330,6 +383,7 @@ TEST_F(ExportServiceTests, ExportHdrJpeg_WritesUltraHdrFile) {
     task.image_id_             = image_id;
     task.options_.format_      = ImageFormatType::JPEG;
     task.options_.export_path_ = dst_path;
+    AttachResolvedExportColor(task, *pipeline_service);
     export_service.EnqueueExportTask(task);
 
     std::promise<std::shared_ptr<std::vector<ExportResult>>> done;
@@ -434,6 +488,7 @@ TEST_F(ExportServiceTests, DISABLED_BatchExport_LimitedCount_WritesReadableFiles
     task.image_id_             = image_id;
     task.options_.format_      = ImageFormatType::JPEG;
     task.options_.export_path_ = dst_path;
+    AttachResolvedExportColor(task, *pipeline_service);
     export_service.EnqueueExportTask(task);
     expected_paths.push_back(dst_path);
   }
@@ -506,6 +561,7 @@ TEST_F(ExportServiceTests, DISABLED_Manual_KeepExportFiles) {
     task.image_id_             = image_id;
     task.options_.format_      = ImageFormatType::JPEG;
     task.options_.export_path_ = dst_path;
+    AttachResolvedExportColor(task, *pipeline_service);
     export_service.EnqueueExportTask(task);
     expected_paths.push_back(dst_path);
   }
@@ -525,6 +581,121 @@ TEST_F(ExportServiceTests, DISABLED_Manual_KeepExportFiles) {
   }
 
   std::cout << "[Manual Export] Kept export outputs under: " << export_dir_.string() << std::endl;
+}
+
+TEST_F(ExportServiceTests, ExportRecipeContainsResolvedOutputColorBeforeScheduling) {
+  ProjectService project(db_path_, meta_path_);
+  ExportService  export_service(project.GetSleeveService(), project.GetImagePoolService(),
+                                std::make_shared<PipelineMgmtService>(project.GetStorage()));
+  ExportTask     task;
+  task.options_.format_ = ImageFormatType::JPEG;
+  EXPECT_THROW(export_service.EnqueueExportTask(task), std::runtime_error);
+  task.recipe_ = ExportRecipe::FromLegacyOptions(task.options_);
+  EXPECT_THROW(export_service.EnqueueExportTask(task), std::runtime_error);
+  task.recipe_->output_color_ = ExportColorProfileConfig{};
+  EXPECT_NO_THROW(export_service.EnqueueExportTask(task));
+}
+
+TEST_F(ExportServiceTests, ExportPixelsAndIccUseTheSameRecipeColorConfiguration) {
+  if (!std::filesystem::exists(std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" /
+                               "mfzoty.dng")) {
+    GTEST_SKIP() << "Sample DNG file is missing";
+  }
+  ProjectService project(db_path_, meta_path_);
+  auto           sleeve_service   = project.GetSleeveService();
+  auto           image_pool       = project.GetImagePoolService();
+  auto           pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  ImportServiceImpl import_service(sleeve_service, image_pool, pipeline_service);
+  auto              import_job = std::make_shared<ImportJob>();
+  std::promise<ImportResult> import_done;
+  auto                       import_done_fut = import_done.get_future();
+  import_job->on_finished_                   = [&import_done](const ImportResult& result) {
+    import_done.set_value(result);
+  };
+  const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
+  import_job          = import_service.ImportToFolder({raw_path}, L"", {}, import_job);
+  ASSERT_NE(import_job, nullptr);
+  ASSERT_EQ(import_done_fut.wait_for(120s), std::future_status::ready);
+  ASSERT_EQ(import_done_fut.get().imported_, 1u);
+  import_service.SyncImports(import_job->import_log_->Snapshot(), L"");
+  const auto snapshot   = import_job->import_log_->Snapshot();
+  const auto element_id = snapshot.created_[0].element_id_;
+  const auto image_id   = snapshot.created_[0].image_id_;
+  auto       live       = pipeline_service->LoadPipeline(element_id);
+  const auto document_before = live->document_->Drt()->Params().ToJson();
+  pipeline_service->ReleasePipelineUse(live);
+
+  auto run_export = [&](const std::filesystem::path& path, ExportColorProfileConfig color,
+                        ExportIccPolicy icc) {
+    ExportService export_service(sleeve_service, image_pool, pipeline_service);
+    ExportTask    task;
+    task.sleeve_id_                = element_id;
+    task.image_id_                 = image_id;
+    task.options_.format_          = ImageFormatType::JPEG;
+    task.options_.export_path_     = path;
+    task.options_.resize_enabled_  = true;
+    task.options_.max_length_side_ = 256;
+    task.recipe_                   = ExportRecipe::FromLegacyOptions(task.options_);
+    task.recipe_->output_color_    = color;
+    task.recipe_->icc_             = icc;
+    export_service.EnqueueExportTask(task);
+    std::promise<std::shared_ptr<std::vector<ExportResult>>> done;
+    auto                                                     fut = done.get_future();
+    export_service.ExportAll(
+        [&done](std::shared_ptr<std::vector<ExportResult>> results) { done.set_value(results); });
+    EXPECT_EQ(fut.wait_for(180s), std::future_status::ready);
+    auto results = fut.get();
+    EXPECT_NE(results, nullptr);
+    EXPECT_EQ(results->size(), 1u);
+    EXPECT_TRUE((*results)[0].success_) << (*results)[0].message_;
+  };
+
+  const ExportColorProfileConfig rec709{ColorUtils::ColorSpace::REC709, ColorUtils::EOTF::GAMMA_2_2,
+                                        100.0f};
+  const ExportColorProfileConfig p3{ColorUtils::ColorSpace::P3_D65, ColorUtils::EOTF::GAMMA_2_2,
+                                    100.0f};
+  const auto rec709_path = export_dir_ / "recipe-rec709.jpg";
+  const auto p3_path     = export_dir_ / "recipe-p3.jpg";
+  const auto omit_path   = export_dir_ / "recipe-omit.jpg";
+  run_export(rec709_path, rec709, ExportIccPolicy::EMBED_OUTPUT_PROFILE);
+  run_export(p3_path, p3, ExportIccPolicy::EMBED_OUTPUT_PROFILE);
+  run_export(omit_path, p3, ExportIccPolicy::OMIT);
+
+  live = pipeline_service->LoadPipeline(element_id);
+  EXPECT_EQ(live->document_->Drt()->Params().ToJson(), document_before);
+  pipeline_service->ReleasePipelineUse(live);
+
+  const auto rec709_icc = ExportIccProfileResolver::ResolveIccProfileBytes(rec709);
+  const auto p3_icc     = ExportIccProfileResolver::ResolveIccProfileBytes(p3);
+  auto       read_icc   = [](const std::filesystem::path& path) {
+    auto image = Exiv2::ImageFactory::open(path.string());
+    image->readMetadata();
+    if (!image->iccProfileDefined()) {
+      return std::vector<uint8_t>{};
+    }
+    const auto& profile = image->iccProfile();
+    if (profile.empty()) {
+      return std::vector<uint8_t>{};
+    }
+    return std::vector<uint8_t>(profile.c_data(), profile.c_data() + profile.size());
+  };
+  EXPECT_FALSE(rec709_icc.empty());
+  EXPECT_FALSE(p3_icc.empty());
+  EXPECT_EQ(read_icc(rec709_path), rec709_icc);
+  EXPECT_EQ(read_icc(p3_path), p3_icc);
+  EXPECT_TRUE(read_icc(omit_path).empty());
+
+  AssertReadableNonEmptyImageFile(rec709_path);
+  AssertReadableNonEmptyImageFile(p3_path);
+  AssertReadableNonEmptyImageFile(omit_path);
+  const auto rec709_pixels = ReadExportRgb8(rec709_path);
+  const auto p3_pixels     = ReadExportRgb8(p3_path);
+  const auto omit_pixels   = ReadExportRgb8(omit_path);
+  ASSERT_FALSE(rec709_pixels.empty()) << rec709_path.string();
+  ASSERT_FALSE(p3_pixels.empty()) << p3_path.string();
+  ASSERT_FALSE(omit_pixels.empty()) << omit_path.string();
+  EXPECT_GT(cv::norm(rec709_pixels, p3_pixels, cv::NORM_INF), 1.0);
+  EXPECT_LE(cv::norm(p3_pixels, omit_pixels, cv::NORM_INF), 1.0);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/app/hs_research_export_tool.cpp
+++ b/alcedo_studio/tests/app/hs_research_export_tool.cpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -33,6 +34,7 @@
 #include "app/project_service.hpp"
 #include "edit/operators/operator_registeration.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
+#include "edit/runtime/drt_display.hpp"
 #include "type/supported_file_type.hpp"
 #include "utils/clock/time_provider.hpp"
 
@@ -357,7 +359,6 @@ auto RunHsResearchExportTool(int argc, char** argv) -> int {
                                        options.highlight_slider, options.saturation_slider,
                                        default_lut_path);
         pipeline_guard->dirty_ = true;
-        pipeline_service->SavePipeline(pipeline_guard);
 
         ExportTask task;
         task.sleeve_id_              = entry->element_id_;
@@ -368,6 +369,13 @@ auto RunHsResearchExportTool(int argc, char** argv) -> int {
         task.options_.export_path_   = options.out_dir /
                                      BuildOutputName(raw_path, options.shadow_slider,
                                                      options.highlight_slider);
+        task.recipe_ = ExportRecipe::FromLegacyOptions(task.options_);
+        if (pipeline_guard->document_ && pipeline_guard->document_->Drt()) {
+          std::lock_guard<std::mutex> lock(pipeline_guard->pipeline_->GetRenderLock());
+          task.recipe_->output_color_ =
+              ExportColorProfileFromDrt(pipeline_guard->document_->Drt()->Params().Params());
+        }
+        pipeline_service->SavePipeline(pipeline_guard);
         export_service.EnqueueExportTask(task);
 
         std::cout << "[HsResearchExportTool] queued " << PathToUtf8(raw_path) << " -> "

--- a/alcedo_studio/tests/app/import_pipeline_document_test.cpp
+++ b/alcedo_studio/tests/app/import_pipeline_document_test.cpp
@@ -20,8 +20,8 @@
 namespace alcedo {
 namespace {
 
-/** @brief Exercise normal RAW import, persisted camera data and the first background render. */
-TEST(ImportPipelineDocumentTest, ImportPreparesCameraProfileBeforeDocumentLoadAndRender) {
+/** @brief Exercise import graph creation, persisted camera data and the first background render. */
+TEST(ImportPipelineDocumentTest, ImportCreatesRenderableDocumentWithoutStageMirror) {
   RegisterAllOperators();
   const auto root =
       std::filesystem::path(TEST_IMG_PATH).parent_path().parent_path().parent_path().parent_path();
@@ -61,9 +61,22 @@ TEST(ImportPipelineDocumentTest, ImportPreparesCameraProfileBeforeDocumentLoadAn
   const auto stored =
       project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(element_id);
   ASSERT_TRUE(stored.has_value());
+  EXPECT_FALSE(stored->contains("stages"));
+  EXPECT_FALSE(stored->contains("legacy_stage_adapter"));
   const auto persisted = PipelineDocument::FromJson(*stored);
+  EXPECT_EQ(persisted.Graph().Nodes().size(), 3U);
+  EXPECT_EQ(persisted.Graph().Edges().size(), 2U);
+  EXPECT_TRUE(persisted.Graph().Validate().empty());
+  EXPECT_TRUE(persisted.Graph().ValidateImageBackbone().empty());
   ASSERT_NE(persisted.Develop(), nullptr);
   const auto expected = persisted.Develop()->Params().Params();
+  ASSERT_NE(persisted.PrimaryGrade(), nullptr);
+  const auto* exposure = persisted.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure());
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_FLOAT_EQ(exposure->ToJson().at("exposure_ev").get<float>(), kDefaultPipelineExposureEv);
+  const auto* saturation = persisted.PrimaryGrade()->FindAdjustmentByType(type_ids::Saturation());
+  ASSERT_NE(saturation, nullptr);
+  EXPECT_FLOAT_EQ(saturation->ToJson().at("saturation").get<float>(), kDefaultPipelineSaturation);
   EXPECT_TRUE(DngColorProfilesEqual(expected.camera_profile.dng_profile, raw.dng_profile_));
   EXPECT_TRUE(expected.camera_profile.color_matrices_valid);
   EXPECT_TRUE(ResolveDevelopColorTransform(expected).ok);

--- a/alcedo_studio/tests/app/import_pipeline_document_test.cpp
+++ b/alcedo_studio/tests/app/import_pipeline_document_test.cpp
@@ -1,0 +1,99 @@
+// Copyright 2026 Yurun Zi
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <future>
+#include <memory>
+#include <mutex>
+
+#include "app/import_service.hpp"
+#include "app/pipeline_service.hpp"
+#include "app/project_service.hpp"
+#include "edit/graph/develop_color_transform.hpp"
+#include "edit/operators/operator_registeration.hpp"
+#include "io/image/image_loader.hpp"
+
+namespace alcedo {
+namespace {
+
+/** @brief Exercise normal RAW import, persisted camera data and the first background render. */
+TEST(ImportPipelineDocumentTest, ImportPreparesCameraProfileBeforeDocumentLoadAndRender) {
+  RegisterAllOperators();
+  const auto root =
+      std::filesystem::path(TEST_IMG_PATH).parent_path().parent_path().parent_path().parent_path();
+  const auto work = root / "build/tmp/nm1" /
+                    ("import-document-" +
+                     std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::filesystem::create_directories(work);
+  const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw/linear_dng/mfzoty.dng";
+  ASSERT_TRUE(std::filesystem::exists(raw_path));
+
+  ProjectService    project(work / "project.db", work / "project.json");
+  auto              pool = project.GetImagePoolService();
+  auto import_pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  ImportServiceImpl importer(project.GetSleeveService(), pool, import_pipelines);
+  auto              job        = std::make_shared<ImportJob>();
+  auto              completion = std::make_shared<std::promise<ImportResult>>();
+  auto              completed  = completion->get_future();
+  job->on_finished_ = [completion](const ImportResult& result) { completion->set_value(result); };
+  job               = importer.ImportToFolder({raw_path}, L"", {}, job);
+  ASSERT_EQ(completed.wait_for(std::chrono::seconds(60)), std::future_status::ready);
+  const auto result = completed.get();
+  ASSERT_EQ(result.imported_, 1u);
+  ASSERT_EQ(result.failed_, 0u);
+  const auto imported = job->import_log_->Snapshot();
+  ASSERT_EQ(imported.created_.size(), 1u);
+  importer.SyncImports(imported, L"");
+  const auto element_id = imported.created_.front().element_id_;
+  const auto image_id   = imported.created_.front().image_id_;
+  const auto image      = pool->Read<std::shared_ptr<Image>>(
+      image_id, [](const std::shared_ptr<Image>& value) { return value; });
+  ASSERT_NE(image, nullptr);
+  ASSERT_TRUE(image->HasRawColorContext());
+  const auto& raw = image->GetRawColorContext();
+  ASSERT_NE(raw.dng_profile_, nullptr);
+  ASSERT_TRUE(raw.color_matrices_valid_);
+
+  const auto stored =
+      project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(element_id);
+  ASSERT_TRUE(stored.has_value());
+  const auto persisted = PipelineDocument::FromJson(*stored);
+  ASSERT_NE(persisted.Develop(), nullptr);
+  const auto expected = persisted.Develop()->Params().Params();
+  EXPECT_TRUE(DngColorProfilesEqual(expected.camera_profile.dng_profile, raw.dng_profile_));
+  EXPECT_TRUE(expected.camera_profile.color_matrices_valid);
+  EXPECT_TRUE(ResolveDevelopColorTransform(expected).ok);
+
+  PipelineMgmtService pipelines(project.GetStorage());
+  pipelines.SetAcceleratorBackendPreference(AcceleratorBackendPreference::CUDA);
+  auto loaded = pipelines.LoadPipeline(element_id);
+  ASSERT_NE(loaded, nullptr);
+  ASSERT_NE(loaded->document_, nullptr);
+  EXPECT_EQ(loaded->document_->Develop()->Params().Params(), expected);
+  EXPECT_EQ(loaded->pipeline_->GpuDagDocument(), loaded->document_);
+  const auto                   before = loaded->document_->ToJson();
+  auto                         bytes  = ByteBufferLoader::LoadByteBufferFromImage(image);
+  auto                         input  = std::make_shared<ImageBuffer>(std::move(bytes));
+  std::shared_ptr<ImageBuffer> output;
+  {
+    std::unique_lock lock(loaded->pipeline_->GetRenderLock());
+    loaded->pipeline_->SetForceCPUOutput(true);
+    loaded->pipeline_->SetDecodeRes(DecodeRes::FULL);
+    loaded->pipeline_->SetRenderRes(false, 256);
+    output = loaded->pipeline_->Apply(input);
+  }
+  ASSERT_NE(output, nullptr);
+  ASSERT_TRUE(output->cpu_data_valid_);
+  const auto pixels = output->GetCPUData();
+  EXPECT_TRUE(cv::checkRange(pixels));
+  EXPECT_GT(cv::mean(pixels)[1], 0.01);
+  EXPECT_EQ(loaded->document_->ToJson(), before);
+  pipelines.SavePipeline(loaded);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/pipeline_service_test.cpp
+++ b/alcedo_studio/tests/app/pipeline_service_test.cpp
@@ -7,12 +7,14 @@
 #include <duckdb.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <filesystem>
 #include <format>
 #include <memory>
 #include <mutex>
 #include <random>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -100,17 +102,17 @@ TEST_F(PipelineMapperTests, BasicPipelineRWTest) {
     EXPECT_EQ(pipeline_guard->pinned_, true);
     EXPECT_EQ(pipeline_guard->dirty_, false);
 
-    // Modify the pipeline
-    auto&          stage = pipeline_guard->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
-    nlohmann::json exp_params;
-    exp_params["exposure"] = 1.5f;
-    stage.SetOperator(OperatorType::EXPOSURE, exp_params);
+    // Modify the authoritative document.
+    auto* exposure = pipeline_guard->document_->PrimaryGrade()->FindAdjustmentByType(
+        type_ids::Exposure());
+    ASSERT_NE(exposure, nullptr);
+    exposure->LoadJson({{"exposure_ev", 2.25f}});
     pipeline_guard->dirty_ = true;
 
     // Save it back
     pipeline_service.SavePipeline(pipeline_guard);
 
-    // Since SavePipeline() will only write back to the cache, we need to call Sync() to write to DB
+    // Sync is idempotent after the explicit save and must not change the document.
     pipeline_service.Sync();
 
     // Load it again and serialize the pipeline to compare
@@ -120,8 +122,8 @@ TEST_F(PipelineMapperTests, BasicPipelineRWTest) {
     EXPECT_EQ(pipeline_guard_2->pinned_, true);
     EXPECT_EQ(pipeline_guard_2->dirty_,
               false);  // We have sync the cache, so it should not be dirty
-    // Serialize it
-    pipeline_param = pipeline_guard_2->pipeline_->ExportPipelineParams().dump(2);
+    // Serialize the document, not the executor's compatibility stages.
+    pipeline_param = pipeline_guard_2->document_->ToJson().dump(2);
   }
   // Leave the scope, reopen and load again
   {
@@ -133,8 +135,8 @@ TEST_F(PipelineMapperTests, BasicPipelineRWTest) {
     EXPECT_EQ(pipeline_guard->id_, 1);
     EXPECT_EQ(pipeline_guard->pinned_, true);
     EXPECT_EQ(pipeline_guard->dirty_, false);  // Not dirty since we just loaded it
-    // Serialize it
-    auto pipeline_param_2 = pipeline_guard->pipeline_->ExportPipelineParams().dump(2);
+    // Serialize the document.
+    auto pipeline_param_2 = pipeline_guard->document_->ToJson().dump(2);
     EXPECT_EQ(pipeline_param, pipeline_param_2);
   }
 }
@@ -355,16 +357,16 @@ TEST_F(PipelineMapperTests, MultiplePipelineTest) {
       EXPECT_NE(pipeline_guard, nullptr);
       EXPECT_EQ(pipeline_guard->id_, i);
 
-      // Modify the pipeline
-      auto& stage = pipeline_guard->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
-      nlohmann::json exp_params;
-      exp_params["contrast"] = static_cast<float>(i) * 0.5f;
-      stage.SetOperator(OperatorType::CONTRAST, exp_params);
+      // Modify the authoritative document.
+      auto* contrast = pipeline_guard->document_->PrimaryGrade()->FindAdjustmentByType(
+          type_ids::Contrast());
+      ASSERT_NE(contrast, nullptr);
+      contrast->LoadJson({{"contrast", static_cast<float>(i) * 0.5f}});
       pipeline_guard->dirty_ = true;
 
       // Save it back
       pipeline_service.SavePipeline(pipeline_guard);
-      pipeline_params[i - 1] = pipeline_guard->pipeline_->ExportPipelineParams().dump(2);
+      pipeline_params[i - 1] = pipeline_guard->document_->ToJson().dump(2);
     }
     // Sync to DB
     pipeline_service.Sync();
@@ -380,8 +382,8 @@ TEST_F(PipelineMapperTests, MultiplePipelineTest) {
       EXPECT_NE(pipeline_guard, nullptr);
       EXPECT_EQ(pipeline_guard->id_, i);
 
-      // Serialize it
-      auto pipeline_param_2 = pipeline_guard->pipeline_->ExportPipelineParams().dump(2);
+      // Serialize the document.
+      auto pipeline_param_2 = pipeline_guard->document_->ToJson().dump(2);
       EXPECT_EQ(pipeline_params[i - 1], pipeline_param_2);
     }
   }
@@ -604,7 +606,7 @@ TEST_F(PipelineMapperTests, ReloadedDocumentKeepsDecodeMethodWhenStagesDisagree)
   ASSERT_NE(initial, nullptr);
   ASSERT_NE(initial->pipeline_, nullptr);
   ASSERT_NE(initial->document_, nullptr);
-  EXPECT_TRUE(initial->pipeline_->MirrorsLegacyStageAdapter());
+  EXPECT_FALSE(initial->pipeline_->MirrorsLegacyStageAdapter());
 
   nlohmann::json raw_params = pipeline_defaults::MakeDefaultRawDecodeParams();
   raw_params["raw"]["method"] = "neural_engine";
@@ -635,6 +637,208 @@ TEST_F(PipelineMapperTests, ReloadedDocumentKeepsDecodeMethodWhenStagesDisagree)
   EXPECT_EQ(exported["Image Loading"]["Image Loading"]["raw_decode"]["params"]["raw"]["method"],
             "neural_engine");
   reopened.SavePipeline(loaded);
+}
+
+TEST_F(PipelineMapperTests, DocumentSaveReloadPreservesNodesEdgesAndParameters) {
+  constexpr sl_element_id_t element_id = 8501;
+  ProjectService           project(db_path_, meta_path_);
+  PipelineMgmtService      pipeline_service(project.GetStorage());
+
+  auto guard = pipeline_service.LoadPipeline(element_id);
+  ASSERT_NE(guard, nullptr);
+  ASSERT_NE(guard->document_, nullptr);
+  {
+    std::unique_lock<std::mutex> render_lock(guard->pipeline_->GetRenderLock());
+    ASSERT_TRUE(AddCleanColorGrade(*guard->document_, NodeId{"drt"}, NodeId{"grade.extra"})
+                    .empty());
+    ASSERT_TRUE(ReconnectColorGrade(*guard->document_, NodeId{"grade.primary"},
+                                    NodeId{"grade.extra"}, NodeId{"drt"})
+                    .empty());
+
+    auto* extra = dynamic_cast<ColorGradeNodeModel*>(
+        guard->document_->Graph().FindNode(NodeId{"grade.extra"}));
+    ASSERT_NE(extra, nullptr);
+    ASSERT_TRUE(RenameColorGrade(*guard->document_, NodeId{"grade.extra"}, "Document Look")
+                    .empty());
+    ASSERT_TRUE(SetColorGradeEnabled(*guard->document_, NodeId{"grade.extra"}, false).empty());
+    extra->SetMix(0.625f);
+    auto* contrast = extra->FindAdjustmentByType(type_ids::Contrast());
+    ASSERT_NE(contrast, nullptr);
+    contrast->LoadJson({{"contrast", 12.5f}});
+
+    ASSERT_TRUE(RemoveColorGradeAndBridge(*guard->document_, NodeId{"grade.primary"}).empty());
+  }
+  guard->dirty_ = true;
+  pipeline_service.SavePipeline(guard);
+
+  const auto stored = project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(element_id);
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_FALSE(stored->contains("stages"));
+  EXPECT_FALSE(stored->contains("legacy_stage_adapter"));
+
+  // Force the next service instance through the persisted document boundary.
+  project.GetStorage()->ForgetLivePipeline(element_id);
+  PipelineMgmtService reopened(project.GetStorage());
+  auto                loaded = reopened.LoadPipeline(element_id);
+  ASSERT_NE(loaded, nullptr);
+  ASSERT_NE(loaded->document_, nullptr);
+  EXPECT_EQ(loaded->document_->Graph().NodeCount(), 3U);
+  EXPECT_EQ(loaded->document_->Graph().Edges().size(), 2U);
+  EXPECT_EQ(loaded->document_->Graph().ImageBackboneNodeIds(),
+            (std::vector<NodeId>{NodeId{"develop"}, NodeId{"grade.extra"}, NodeId{"drt"}}));
+
+  const auto* extra = dynamic_cast<const ColorGradeNodeModel*>(
+      loaded->document_->Graph().FindNode(NodeId{"grade.extra"}));
+  ASSERT_NE(extra, nullptr);
+  EXPECT_EQ(extra->DisplayName(), "Document Look");
+  EXPECT_FALSE(extra->Enabled());
+  EXPECT_FLOAT_EQ(extra->Mix(), 0.625f);
+  const auto* contrast = extra->FindAdjustmentByType(type_ids::Contrast());
+  ASSERT_NE(contrast, nullptr);
+  EXPECT_FLOAT_EQ(contrast->ToJson().at("contrast").get<float>(), 12.5f);
+  reopened.SavePipeline(loaded);
+}
+
+TEST_F(PipelineMapperTests, SavedDocumentContainsNoStageAdapter) {
+  constexpr sl_element_id_t element_id = 8502;
+  ProjectService           project(db_path_, meta_path_);
+  PipelineMgmtService      pipeline_service(project.GetStorage());
+
+  auto guard = pipeline_service.LoadPipeline(element_id);
+  ASSERT_NE(guard, nullptr);
+  {
+    std::unique_lock<std::mutex> render_lock(guard->pipeline_->GetRenderLock());
+    ASSERT_TRUE(RenameColorGrade(*guard->document_, NodeId{"grade.primary"}, "Saved Grade")
+                    .empty());
+    auto& stage = guard->pipeline_->GetStage(PipelineStageName::Image_Loading);
+    auto  raw   = pipeline_defaults::MakeDefaultRawDecodeParams();
+    raw["raw"]["method"] = "neural_engine";
+    stage.SetOperator(OperatorType::RAW_DECODE, raw);
+    guard->pipeline_->SetExecutionStages();
+  }
+  guard->dirty_ = true;
+  pipeline_service.SavePipeline(guard);
+
+  const auto stored = project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(element_id);
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_FALSE(stored->contains("stages"));
+  EXPECT_FALSE(stored->contains("legacy_stage_adapter"));
+  ASSERT_TRUE(stored->contains("nodes"));
+  const auto stored_grade = std::find_if(
+      stored->at("nodes").begin(), stored->at("nodes").end(), [](const nlohmann::json& node) {
+        return node.value("id", std::string{}) == "grade.primary";
+      });
+  ASSERT_NE(stored_grade, stored->at("nodes").end());
+  EXPECT_EQ(stored_grade->value("display_name", std::string{}), "Saved Grade");
+  project.GetStorage()->ForgetLivePipeline(element_id);
+
+  PipelineMgmtService reopened(project.GetStorage());
+  auto                loaded = reopened.LoadPipeline(element_id);
+  ASSERT_NE(loaded, nullptr);
+  EXPECT_EQ(loaded->document_->PrimaryGrade()->DisplayName(), "Saved Grade");
+  reopened.SavePipeline(loaded);
+}
+
+TEST_F(PipelineMapperTests, InvalidStoredDocumentFailsWithoutReplacement) {
+  ProjectService      project(db_path_, meta_path_);
+  const auto           storage = project.GetStorage();
+  const auto           valid   = CreateDefaultPipelineDocument().ToJson();
+
+  const auto expect_failure = [&](sl_element_id_t element_id, nlohmann::json invalid,
+                                  std::string_view expected_text) {
+    storage->GetElementStore().UpdatePipelineJsonByElementId(element_id, valid);
+    storage->GetElementStore().UpdatePipelineJsonByElementId(element_id, invalid);
+    storage->ForgetLivePipeline(element_id);
+
+    PipelineMgmtService loader(storage);
+    bool                threw = false;
+    std::string         message;
+    try {
+      (void)loader.LoadPipeline(element_id);
+    } catch (const std::exception& error) {
+      threw   = true;
+      message = error.what();
+    }
+    EXPECT_TRUE(threw);
+    EXPECT_NE(message.find(expected_text), std::string::npos) << message;
+    EXPECT_EQ(storage->GetLivePipeline(element_id), nullptr);
+  };
+
+  auto missing_nodes = valid;
+  missing_nodes.erase("nodes");
+  expect_failure(8503, std::move(missing_nodes), "nodes");
+
+  auto invalid_topology = valid;
+  invalid_topology["edges"] = nlohmann::json::array();
+  expect_failure(8504, std::move(invalid_topology), "graph");
+
+  auto corrupt_params = valid;
+  corrupt_params["nodes"][0]["params"] = "corrupt";
+  expect_failure(8505, std::move(corrupt_params), "params");
+}
+
+TEST_F(PipelineMapperTests, FailedDocumentSaveKeepsDirtyStateAndJournal) {
+  constexpr sl_element_id_t element_id = 8506;
+  ProjectService           project(db_path_, meta_path_);
+  PipelineMgmtService      pipeline_service(project.GetStorage());
+
+  auto guard = pipeline_service.LoadEditorPipeline(element_id);
+  ASSERT_NE(guard, nullptr);
+  guard->dirty_ = true;
+  pipeline_service.SavePipeline(guard);
+  const auto stored_before =
+      project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(element_id);
+  ASSERT_TRUE(stored_before.has_value());
+
+  guard = pipeline_service.LoadEditorPipeline(element_id);
+  ASSERT_NE(guard, nullptr);
+  ASSERT_NE(guard->commit_graph_, nullptr);
+  const auto head_before = guard->working_head_commit_hash();
+  guard->serialized_state_needs_writeback_ = true;
+  {
+    std::unique_lock<std::mutex> render_lock(guard->pipeline_->GetRenderLock());
+    guard->document_->Graph().Disconnect(NodeId{"develop"}, PortId{"image"},
+                                         NodeId{"grade.primary"}, PortId{"image"});
+  }
+  guard->dirty_ = true;
+
+  EXPECT_THROW(pipeline_service.SavePipeline(guard), std::runtime_error);
+  EXPECT_TRUE(guard->dirty_);
+  EXPECT_TRUE(guard->serialized_state_needs_writeback_);
+  EXPECT_EQ(guard->working_head_commit_hash(), head_before);
+  EXPECT_EQ(project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(element_id),
+            stored_before);
+  EXPECT_EQ(guard->pin_count_, 0U);
+}
+
+TEST_F(PipelineMapperTests, SaveDoesNotPersistUnsettledPreviewAsCommittedState) {
+  constexpr sl_element_id_t element_id = 8507;
+  ProjectService           project(db_path_, meta_path_);
+  PipelineMgmtService      pipeline_service(project.GetStorage());
+
+  auto guard = pipeline_service.LoadPipeline(element_id);
+  ASSERT_NE(guard, nullptr);
+  guard->dirty_ = true;
+  pipeline_service.SavePipeline(guard);
+  const auto stored_before =
+      project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(element_id);
+  ASSERT_TRUE(stored_before.has_value());
+
+  guard = pipeline_service.LoadPipeline(element_id);
+  ASSERT_NE(guard, nullptr);
+  {
+    std::unique_lock<std::mutex> render_lock(guard->pipeline_->GetRenderLock());
+    ASSERT_TRUE(RenameColorGrade(*guard->document_, NodeId{"grade.primary"}, "Preview Only")
+                    .empty());
+    guard->unsettled_preview_ = true;
+  }
+  guard->dirty_ = true;
+
+  EXPECT_THROW(pipeline_service.SavePipeline(guard), std::runtime_error);
+  EXPECT_TRUE(guard->dirty_);
+  EXPECT_EQ(project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(element_id),
+            stored_before);
+  EXPECT_EQ(guard->pin_count_, 0U);
 }
 
 TEST_F(PipelineMapperTests, EditorLoadUsesMatchingSerializedStateWithoutReconstruction) {

--- a/alcedo_studio/tests/app/pipeline_service_test.cpp
+++ b/alcedo_studio/tests/app/pipeline_service_test.cpp
@@ -18,8 +18,11 @@
 #include <vector>
 
 #include "app/project_service.hpp"
+#include "edit/graph/legacy_pipeline_importer.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
 #include "edit/history/commit_graph.hpp"
 #include "edit/history/edit_commit.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/op_base.hpp"
 #include "edit/operators/operator_registeration.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
@@ -593,126 +596,7 @@ TEST_F(PipelineMapperTests, DISABLED_ThreadSafeTest) {
   }
 }
 
-// Phase 3: LoadPipelineSnapshot must clone the current pipeline params into an
-// independent executor WITHOUT pinning the live guard, clearing dirty state, or
-// writing storage. A later user edit must persist through the normal editor path
-// and not be overwritten by the snapshot.
-TEST_F(PipelineMapperTests, LoadPipelineSnapshotClonesParamsAndDoesNotTouchLiveGuard) {
-  nlohmann::json params_v1;
-  nlohmann::json params_v2;
-  {
-    ProjectService      project(db_path_, meta_path_);
-    PipelineMgmtService ps(project.GetStorage());
-
-    auto                g1 = ps.LoadPipeline(1);
-    ASSERT_NE(g1, nullptr);
-    ASSERT_NE(g1->pipeline_, nullptr);
-
-    // Simulate an unsaved editor edit: exposure = 1.5, guard dirty.
-    auto&          stage = g1->pipeline_->GetStage(PipelineStageName::To_WorkingSpace);
-    nlohmann::json exp1;
-    exp1["exposure"] = 1.5f;
-    stage.SetOperator(OperatorType::EXPOSURE, exp1);
-    g1->dirty_ = true;
-    params_v1  = g1->pipeline_->ExportPipelineParams();
-
-    // Capture a snapshot of the current (dirty, pinned) live state.
-    std::string err;
-    auto        snap = ps.LoadPipelineSnapshot(1, 0, &err);
-    ASSERT_NE(snap, nullptr);
-    ASSERT_NE(snap->executor_, nullptr);
-    EXPECT_NE(snap->executor_, g1->pipeline_);  // independent instance
-    EXPECT_NE(&snap->executor_->GetRenderLock(), &g1->pipeline_->GetRenderLock());
-    EXPECT_EQ(snap->pipeline_params_, params_v1);                   // captured current params
-    EXPECT_EQ(snap->executor_->ExportPipelineParams(), params_v1);  // snapshot holds them
-    EXPECT_TRUE(g1->pipeline_->HasGpuDagDocument());
-    EXPECT_TRUE(snap->executor_->HasGpuDagDocument());
-    EXPECT_NE(snap->executor_->GpuDagDocument(), g1->pipeline_->GpuDagDocument());
-
-    // Acceptance: the live guard is untouched by the capture.
-    EXPECT_EQ(g1->dirty_, true);                                  // dirty NOT cleared
-    EXPECT_EQ(g1->pin_count_, size_t{1});                         // pin NOT changed
-    EXPECT_EQ(g1->pipeline_->ExportPipelineParams(), params_v1);  // live exec unchanged
-
-    ps.ReleasePipelineSnapshot(snap);
-    EXPECT_EQ(g1->dirty_, true);  // release didn't touch live
-    EXPECT_EQ(g1->pin_count_, size_t{1});
-
-    // Later user edit after the snapshot. Must persist, not be overwritten.
-    nlohmann::json exp2;
-    exp2["exposure"] = 2.5f;
-    stage.SetOperator(OperatorType::EXPOSURE, exp2);
-    g1->dirty_ = true;
-    params_v2  = g1->pipeline_->ExportPipelineParams();
-    EXPECT_NE(params_v2, params_v1);  // the later edit took effect
-
-    ps.SavePipeline(g1);  // return to cache (last pin)
-    ps.Sync();            // write the later edit to storage
-  }
-  // Re-open from storage and verify the LATER edit (2.5) persisted, not the
-  // snapshot's 1.5.
-  {
-    ProjectService      project(db_path_, meta_path_);
-    PipelineMgmtService ps(project.GetStorage());
-    auto                g2 = ps.LoadPipeline(1);
-    ASSERT_NE(g2, nullptr);
-    ASSERT_NE(g2->pipeline_, nullptr);
-    EXPECT_EQ(g2->pipeline_->ExportPipelineParams(), params_v2);
-  }
-}
-
-// Phase 3: cache-miss fallback. When the element is not currently loaded, the
-// snapshot path falls back to LoadPipeline/SavePipeline (net-zero pin) to obtain
-// a coherent, repaired executor. Must not crash or write storage.
-TEST_F(PipelineMapperTests, LoadPipelineSnapshotFallbackRepairsAndReleasesPin) {
-  ProjectService      project(db_path_, meta_path_);
-  PipelineMgmtService ps(project.GetStorage());
-
-  // 999 was never loaded → cache-miss fallback inside LoadPipelineSnapshot.
-  std::string         err;
-  auto                snap = ps.LoadPipelineSnapshot(999, 0, &err);
-  ASSERT_NE(snap, nullptr);
-  ASSERT_NE(snap->executor_, nullptr);
-
-  // The fallback guard is in cache unpinned (pin_count_ == 0) — re-loading must
-  // re-pin it cleanly without throwing.
-  auto g = ps.LoadPipeline(999);
-  ASSERT_NE(g, nullptr);
-  EXPECT_EQ(g->pinned_, true);
-  EXPECT_EQ(g->pin_count_, size_t{1});
-  ps.SavePipeline(g);
-
-  EXPECT_NO_THROW(ps.ReleasePipelineSnapshot(snap));
-}
-
-TEST_F(PipelineMapperTests, LoadPipelineSnapshotClonesGpuDagDocumentIndependently) {
-  ProjectService      project(db_path_, meta_path_);
-  PipelineMgmtService ps(project.GetStorage());
-  auto                live = ps.LoadPipeline(1);
-  ASSERT_NE(live, nullptr);
-  ASSERT_NE(live->pipeline_, nullptr);
-  ASSERT_TRUE(live->pipeline_->HasGpuDagDocument());
-  auto* live_lmt = dynamic_cast<LmtModel*>(
-      live->pipeline_->GpuDagDocument()->PrimaryGrade()->FindAdjustmentByType(type_ids::Lmt()));
-  ASSERT_NE(live_lmt, nullptr);
-  live_lmt->SetCubePath("C:/looks/live.cube");
-
-  std::string err;
-  auto        snap = ps.LoadPipelineSnapshot(1, 0, &err);
-  ASSERT_NE(snap, nullptr) << err;
-  ASSERT_NE(snap->executor_, nullptr);
-  ASSERT_TRUE(snap->executor_->HasGpuDagDocument());
-  auto* snap_lmt = dynamic_cast<LmtModel*>(
-      snap->executor_->GpuDagDocument()->PrimaryGrade()->FindAdjustmentByType(type_ids::Lmt()));
-  ASSERT_NE(snap_lmt, nullptr);
-  EXPECT_EQ(snap_lmt->CubePath(), "C:/looks/live.cube");
-  live_lmt->SetCubePath("C:/looks/changed.cube");
-  EXPECT_EQ(snap_lmt->CubePath(), "C:/looks/live.cube");
-  ps.ReleasePipelineSnapshot(snap);
-  ps.SavePipeline(live);
-}
-
-TEST_F(PipelineMapperTests, ReloadedFormat2GraphWithoutAdapterStillRemirrorsCpuNeuralEngine) {
+TEST_F(PipelineMapperTests, ReloadedDocumentKeepsDecodeMethodWhenStagesDisagree) {
   ProjectService      project(db_path_, meta_path_);
   PipelineMgmtService first(project.GetStorage());
 
@@ -745,8 +629,8 @@ TEST_F(PipelineMapperTests, ReloadedFormat2GraphWithoutAdapterStillRemirrorsCpuN
   auto                loaded = reopened.LoadEditorPipeline(9102);
   ASSERT_NE(loaded, nullptr);
   ASSERT_NE(loaded->document_, nullptr);
-  EXPECT_TRUE(loaded->pipeline_->MirrorsLegacyStageAdapter());
-  EXPECT_EQ(loaded->document_->Develop()->Params().Params().demosaic_method, "neural_engine");
+  EXPECT_FALSE(loaded->pipeline_->MirrorsLegacyStageAdapter());
+  EXPECT_EQ(loaded->document_->Develop()->Params().Params().demosaic_method, "default");
   const auto exported = loaded->pipeline_->ExportPipelineParams();
   EXPECT_EQ(exported["Image Loading"]["Image Loading"]["raw_decode"]["params"]["raw"]["method"],
             "neural_engine");

--- a/alcedo_studio/tests/app/pipeline_shared_use_test.cpp
+++ b/alcedo_studio/tests/app/pipeline_shared_use_test.cpp
@@ -572,6 +572,7 @@ TEST_F(PipelineSharedUseTest, BackgroundReleaseDoesNotSaveOrClearEditorState) {
                                                         ThumbnailResolution::k256);
   EXPECT_EQ(result.status, ThumbnailRequestStatus::kReady) << result.message;
   EXPECT_TRUE(live->dirty_);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 1, std::chrono::seconds(10)));
   EXPECT_EQ(live->pin_count_, size_t{1});
   EXPECT_EQ(live->document_->ToJson(), live_json);
   const auto stored_after =
@@ -683,6 +684,7 @@ TEST_F(PipelineSharedUseTest, QueuedRenderDoesNotStorePixelsUnderStaleCommitLabe
   ASSERT_NE(result.guard, nullptr);
   EXPECT_TRUE(live->dirty_);
   EXPECT_TRUE(live->unsettled_preview_);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 1, std::chrono::seconds(10)));
   EXPECT_EQ(live->pin_count_, size_t{1});
 
   thumbnails.FlushDiskCacheMetadata();
@@ -700,6 +702,9 @@ TEST_F(PipelineSharedUseTest, QueuedRenderDoesNotStorePixelsUnderStaleCommitLabe
 
   live->dirty_             = false;
   live->unsettled_preview_ = false;
+  // The first request intentionally remains cached above. Force this second request through the
+  // scheduler so the test exercises a render queued behind the held live render lock.
+  thumbnails.InvalidateThumbnail(ids.first);
   std::unique_lock held(live->pipeline_->GetRenderLock());
   const auto queued_head = live->working_head_commit_hash();
   std::promise<ThumbnailRequestResult> queued;

--- a/alcedo_studio/tests/app/pipeline_shared_use_test.cpp
+++ b/alcedo_studio/tests/app/pipeline_shared_use_test.cpp
@@ -1,0 +1,1064 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <filesystem>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "app/export_service.hpp"
+#include "app/import_service.hpp"
+#include "app/pipeline_service.hpp"
+#include "app/project_service.hpp"
+#include "app/thumbnail_disk_cache_service.hpp"
+#include "app/thumbnail_service.hpp"
+#include "app/thumbnail_types.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/runtime/drt_display.hpp"
+#include "edit/history/commit_graph.hpp"
+#include "edit/history/edit_commit.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/i_operator_model.hpp"
+#include "edit/operators/op_base.hpp"
+#include "edit/operators/operator_registeration.hpp"
+#include "edit/operators/utils/color_utils.hpp"
+#include "edit/pipeline/pipeline_cpu.hpp"
+#include "edit/runtime/renderer.hpp"
+#include "edit/pipeline/pipeline_stage.hpp"
+#include "image/image.hpp"
+#include "image/image_buffer.hpp"
+#include "io/image/export_color_profile_config.hpp"
+#include "io/image/export_recipe.hpp"
+#include "io/image/image_loader.hpp"
+#include "json.hpp"
+#include "renderer/pipeline_scheduler.hpp"
+#include "renderer/pipeline_task.hpp"
+#include "sleeve/storage.hpp"
+#include "type/supported_file_type.hpp"
+#include "type/type.hpp"
+#include "utils/clock/time_provider.hpp"
+
+#ifdef HAVE_CUDA
+#include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#endif
+#ifdef HAVE_METAL
+#include "edit/runtime/metal/metal_renderer.hpp"
+#endif
+#ifdef HAVE_OPENCL
+#include "edit/runtime/opencl/opencl_renderer.hpp"
+#endif
+
+namespace alcedo {
+namespace {
+using namespace std::chrono_literals;
+
+auto LinearDngPath() -> std::filesystem::path {
+  return std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
+}
+
+auto ImportRawFile(ProjectService& project, std::shared_ptr<PipelineMgmtService> pipelines,
+                   const std::filesystem::path& raw_path) -> std::pair<sl_element_id_t, image_id_t> {
+  if (!std::filesystem::exists(raw_path) || !pipelines) {
+    return {0, 0};
+  }
+  auto              fs_service = project.GetSleeveService();
+  auto              img_pool   = project.GetImagePoolService();
+  ImportServiceImpl import_service(fs_service, img_pool, pipelines);
+  auto              import_job = std::make_shared<ImportJob>();
+  std::promise<ImportResult> imported;
+  auto                       imported_future = imported.get_future();
+  import_job->on_finished_                   = [&imported](const ImportResult& result) {
+    imported.set_value(result);
+  };
+  import_job = import_service.ImportToFolder({raw_path}, L"", {}, import_job);
+  if (!import_job) {
+    return {0, 0};
+  }
+  if (imported_future.wait_for(60s) != std::future_status::ready) {
+    return {0, 0};
+  }
+  if (imported_future.get().imported_ != 1u || !import_job->import_log_) {
+    return {0, 0};
+  }
+  const auto snapshot = import_job->import_log_->Snapshot();
+  if (snapshot.created_.size() != 1u) {
+    return {0, 0};
+  }
+  import_service.SyncImports(snapshot, L"");
+  project.GetSleeveService()->Sync();
+  project.GetImagePoolService()->SyncWithStorage();
+  return {snapshot.created_.front().element_id_, snapshot.created_.front().image_id_};
+}
+
+auto ImportLinearDng(ProjectService& project, std::shared_ptr<PipelineMgmtService> pipelines)
+    -> std::pair<sl_element_id_t, image_id_t> {
+  return ImportRawFile(project, pipelines, LinearDngPath());
+}
+
+auto GetThumbnailDetailedBlocking(ThumbnailService& service, sl_element_id_t id,
+                                   image_id_t image_id, ThumbnailResolution resolution)
+    -> ThumbnailRequestResult {
+  std::promise<ThumbnailRequestResult> done;
+  auto                                fut = done.get_future();
+  service.GetThumbnailDetailed(
+      id, image_id, [&done](ThumbnailRequestResult result) { done.set_value(std::move(result)); },
+      true, nullptr, resolution);
+  EXPECT_EQ(fut.wait_for(60s), std::future_status::ready);
+  return fut.get();
+}
+
+auto SessionPreparedSourceCount(CPUPipelineExecutor& executor) -> std::size_t {
+#ifdef HAVE_CUDA
+  if (auto* renderer = executor.DebugCudaRenderer()) {
+    return renderer->SessionResources().prepared_source_entry_count;
+  }
+#endif
+#ifdef HAVE_METAL
+  if (auto* renderer = executor.DebugMetalRenderer()) {
+    return renderer->SessionResources().prepared_source_entry_count;
+  }
+#endif
+#ifdef HAVE_OPENCL
+  if (auto* renderer = executor.DebugOpenClRenderer()) {
+    return renderer->SessionResources().prepared_source_entry_count;
+  }
+#endif
+  return 0;
+}
+
+auto OneShotWorkspace(CPUPipelineExecutor& executor) -> RenderSessionResources {
+#ifdef HAVE_CUDA
+  if (auto* renderer = executor.DebugCudaRenderer()) {
+    return renderer->OneShotResources();
+  }
+#endif
+#ifdef HAVE_METAL
+  if (auto* renderer = executor.DebugMetalRenderer()) {
+    return renderer->OneShotResources();
+  }
+#endif
+#ifdef HAVE_OPENCL
+  if (auto* renderer = executor.DebugOpenClRenderer()) {
+    return renderer->OneShotResources();
+  }
+#endif
+  return {};
+}
+
+auto SessionWorkspace(CPUPipelineExecutor& executor) -> RenderSessionResources {
+#ifdef HAVE_CUDA
+  if (auto* renderer = executor.DebugCudaRenderer()) {
+    return renderer->SessionResources();
+  }
+#endif
+#ifdef HAVE_METAL
+  if (auto* renderer = executor.DebugMetalRenderer()) {
+    return renderer->SessionResources();
+  }
+#endif
+#ifdef HAVE_OPENCL
+  if (auto* renderer = executor.DebugOpenClRenderer()) {
+    return renderer->SessionResources();
+  }
+#endif
+  return {};
+}
+
+auto SessionTexturePoolEntries(CPUPipelineExecutor& executor) -> std::size_t {
+#ifdef HAVE_CUDA
+  if (auto* renderer = executor.DebugCudaRenderer()) {
+    return renderer->SessionResources().texture_pool_entry_count;
+  }
+#endif
+#ifdef HAVE_METAL
+  if (auto* renderer = executor.DebugMetalRenderer()) {
+    return renderer->SessionResources().texture_pool_entry_count;
+  }
+#endif
+#ifdef HAVE_OPENCL
+  if (auto* renderer = executor.DebugOpenClRenderer()) {
+    return renderer->SessionResources().texture_pool_entry_count;
+  }
+#endif
+  return 0;
+}
+
+auto OneShotPublishedResultCount(CPUPipelineExecutor& executor) -> std::size_t {
+#ifdef HAVE_CUDA
+  if (auto* renderer = executor.DebugCudaRenderer()) {
+    return renderer->OneShotPublishedResultCount();
+  }
+#endif
+#ifdef HAVE_METAL
+  if (auto* renderer = executor.DebugMetalRenderer()) {
+    return renderer->OneShotPublishedResultCount();
+  }
+#endif
+#ifdef HAVE_OPENCL
+  if (auto* renderer = executor.DebugOpenClRenderer()) {
+    return renderer->OneShotPublishedResultCount();
+  }
+#endif
+  return 0;
+}
+
+void BindImportedRawColor(const std::shared_ptr<PipelineGuard>& live, ImagePoolService& pool,
+                           image_id_t image_id) {
+  if (!live || !live->pipeline_) {
+    return;
+  }
+  auto img = pool.Read<std::shared_ptr<Image>>(
+      image_id, [](const std::shared_ptr<Image>& image) { return image; });
+  if (!img || !img->HasRawColorContext()) {
+    return;
+  }
+  std::lock_guard<std::mutex> render_lock(live->pipeline_->GetRenderLock());
+  live->pipeline_->InjectRawMetadata(img->GetRawColorContext());
+}
+
+}  // namespace
+
+class PipelineSharedUseTest : public ::testing::Test {
+ protected:
+  std::filesystem::path db_path_;
+  std::filesystem::path meta_path_;
+
+  void SetUp() override {
+    TimeProvider::Refresh();
+    const auto stamp = std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    db_path_   = std::filesystem::temp_directory_path() / ("pipeline_shared_use_" + stamp + ".db");
+    meta_path_ = std::filesystem::temp_directory_path() / ("pipeline_shared_use_" + stamp + ".json");
+    std::error_code ec;
+    std::filesystem::remove(db_path_, ec);
+    std::filesystem::remove(meta_path_, ec);
+    RegisterAllOperators();
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove(db_path_, ec);
+    std::filesystem::remove(meta_path_, ec);
+  }
+};
+
+TEST_F(PipelineSharedUseTest, ThumbnailDiskCacheWriteAllowedRejectsStalePreviewAndDirtyLabels) {
+  EXPECT_TRUE(ThumbnailDiskCacheWriteAllowed("abc", "abc", false, false));
+  EXPECT_FALSE(ThumbnailDiskCacheWriteAllowed("h1", "h2", false, false));
+  EXPECT_FALSE(ThumbnailDiskCacheWriteAllowed("abc", "abc", true, false));
+  EXPECT_FALSE(ThumbnailDiskCacheWriteAllowed("abc", "abc", false, true));
+  EXPECT_FALSE(ThumbnailDiskCacheWriteAllowed("", "abc", false, false));
+  EXPECT_FALSE(ThumbnailDiskCacheWriteAllowed("abc", "", false, false));
+}
+
+TEST_F(PipelineSharedUseTest, BackgroundCacheMissUsesNormalDocumentLoad) {
+  ProjectService      project(db_path_, meta_path_);
+  PipelineMgmtService pipelines(project.GetStorage());
+  constexpr int       kThreads = 8;
+  std::barrier        start(kThreads);
+  std::vector<std::thread> workers;
+  std::vector<std::shared_ptr<PipelineGuard>> guards(kThreads);
+  workers.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    workers.emplace_back([&pipelines, &guards, &start, i] {
+      start.arrive_and_wait();
+      guards[i] = pipelines.LoadPipeline(1);
+    });
+  }
+  for (auto& worker : workers) {
+    worker.join();
+  }
+  ASSERT_NE(guards[0], nullptr);
+  ASSERT_NE(guards[0]->pipeline_, nullptr);
+  ASSERT_NE(guards[0]->document_, nullptr);
+  for (int i = 1; i < kThreads; ++i) {
+    ASSERT_NE(guards[i], nullptr);
+    EXPECT_EQ(guards[i].get(), guards[0].get());
+    EXPECT_EQ(guards[i]->pipeline_.get(), guards[0]->pipeline_.get());
+    EXPECT_EQ(guards[i]->document_.get(), guards[0]->document_.get());
+  }
+  EXPECT_EQ(guards[0]->pin_count_, static_cast<size_t>(kThreads));
+  for (auto& guard : guards) {
+    pipelines.ReleasePipelineUse(guard);
+  }
+  EXPECT_EQ(guards[0]->pin_count_, size_t{0});
+}
+
+TEST_F(PipelineSharedUseTest, DocumentMutationWaitsForSharedRender) {
+  ProjectService      project(db_path_, meta_path_);
+  PipelineMgmtService pipelines(project.GetStorage());
+  auto                live = pipelines.LoadPipeline(1);
+  ASSERT_NE(live, nullptr);
+  ASSERT_NE(live->document_, nullptr);
+  auto* exposure = live->document_->PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure());
+  ASSERT_NE(exposure, nullptr);
+  const float before_ev = exposure->ToJson().at("exposure_ev").get<float>();
+
+  PipelineScheduler scheduler(1);
+  std::promise<void> in_render;
+  std::promise<void> allow_finish;
+  auto               in_render_fut   = in_render.get_future();
+  auto               allow_finish_fut = allow_finish.get_future();
+
+  PipelineTask task;
+  task.pipeline_executor_                 = live->pipeline_;
+  task.input_                             = std::make_shared<ImageBuffer>();
+  task.options_.render_desc_.render_type_ = RenderType::THUMBNAIL;
+  task.options_.is_blocking_              = false;
+  task.options_.is_callback_              = false;
+  task.configure_under_render_lock_      = [&](PipelineTask&) -> bool {
+    in_render.set_value();
+    allow_finish_fut.wait();
+    return false;
+  };
+
+  scheduler.ScheduleTask(std::move(task));
+  ASSERT_EQ(in_render_fut.wait_for(5s), std::future_status::ready);
+
+  std::promise<void> mutation_started;
+  auto               mutation_started_fut = mutation_started.get_future();
+  auto               mutation               = std::async(std::launch::async, [&] {
+    mutation_started.set_value();
+    std::lock_guard<std::mutex> render_lock(live->pipeline_->GetRenderLock());
+    exposure->LoadJson({{"exposure_ev", 2.5f}});
+  });
+  mutation_started_fut.wait();
+  EXPECT_EQ(mutation.wait_for(100ms), std::future_status::timeout);
+  EXPECT_FLOAT_EQ(exposure->ToJson().at("exposure_ev").get<float>(), before_ev);
+
+  allow_finish.set_value();
+  mutation.wait();
+  EXPECT_FLOAT_EQ(exposure->ToJson().at("exposure_ev").get<float>(), 2.5f);
+  pipelines.ReleasePipelineUse(live);
+}
+
+TEST_F(PipelineSharedUseTest, CanceledAndFailedTaskReleasesPipelineUse) {
+  ProjectService project(db_path_, meta_path_);
+  auto           pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  auto           live      = pipelines->LoadPipeline(1);
+  ASSERT_NE(live, nullptr);
+  ASSERT_EQ(live->pin_count_, size_t{1});
+
+  {
+    auto extra = pipelines->LoadPipeline(1);
+    ASSERT_EQ(live->pin_count_, size_t{2});
+    PipelineScheduler  scheduler(1);
+    std::promise<bool> done;
+    auto                done_fut = done.get_future();
+    PipelineTask        task;
+    task.pipeline_executor_                 = extra->pipeline_;
+    task.input_                              = std::make_shared<ImageBuffer>(std::vector<uint8_t>{1, 2, 3});
+    task.options_.render_desc_.render_type_ = RenderType::THUMBNAIL;
+    task.options_.is_blocking_              = false;
+    task.configure_under_render_lock_       = [](PipelineTask&) -> bool {
+      throw std::runtime_error("configure failed");
+    };
+    task.on_complete_ = [pipelines, extra, &done](bool, std::string) {
+      pipelines->ReleasePipelineUse(extra);
+      done.set_value(true);
+    };
+    scheduler.ScheduleTask(std::move(task));
+    ASSERT_EQ(done_fut.wait_for(10s), std::future_status::ready);
+    EXPECT_EQ(live->pin_count_, size_t{1});
+  }
+
+  {
+    auto extra = pipelines->LoadPipeline(1);
+    ASSERT_EQ(live->pin_count_, size_t{2});
+    PipelineScheduler  scheduler(1);
+    std::promise<bool> done;
+    auto                done_fut = done.get_future();
+    PipelineTask        task;
+    task.pipeline_executor_                 = extra->pipeline_;
+    task.input_                              = std::make_shared<ImageBuffer>(std::vector<uint8_t>{1, 2, 3});
+    task.options_.render_desc_.render_type_ = RenderType::THUMBNAIL;
+    task.options_.is_blocking_              = false;
+    task.on_complete_ = [pipelines, extra, &done](bool, std::string) {
+      pipelines->ReleasePipelineUse(extra);
+      done.set_value(true);
+    };
+    scheduler.ScheduleTask(std::move(task));
+    ASSERT_EQ(done_fut.wait_for(10s), std::future_status::ready);
+    EXPECT_EQ(live->pin_count_, size_t{1});
+  }
+
+  pipelines->ReleasePipelineUse(live);
+  const auto ids = ImportLinearDng(project, pipelines);
+  if (ids.first == 0) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  auto imported = pipelines->LoadPipeline(ids.first);
+  ASSERT_NE(imported, nullptr);
+  BindImportedRawColor(imported, *project.GetImagePoolService(), ids.second);
+  ThumbnailService live_thumbnails(project.GetSleeveService(), project.GetImagePoolService(),
+                                    pipelines);
+  std::unique_lock held(imported->pipeline_->GetRenderLock());
+  std::promise<ThumbnailRequestResult> canceled;
+  auto                                 canceled_fut = canceled.get_future();
+  live_thumbnails.GetThumbnailDetailed(
+      ids.first, ids.second,
+      [&canceled](ThumbnailRequestResult result) { canceled.set_value(std::move(result)); }, true,
+      nullptr, ThumbnailResolution::k256);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(imported, 2, 10s));
+  live_thumbnails.CancelPending(ThumbnailCacheKey{ids.first, ThumbnailResolution::k256});
+  held.unlock();
+  ASSERT_EQ(canceled_fut.wait_for(30s), std::future_status::ready);
+  EXPECT_EQ(canceled_fut.get().status, ThumbnailRequestStatus::kCanceled);
+  EXPECT_TRUE(pipelines->WaitUntilPinCount(imported, 1, 5s));
+  EXPECT_EQ(imported->pin_count_, size_t{1});
+  pipelines->ReleasePipelineUse(imported);
+}
+
+TEST_F(PipelineSharedUseTest, BackgroundTasksReuseLivePipelineAndDocument) {
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService      project(db_path_, meta_path_);
+  auto                pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto          ids       = ImportLinearDng(project, pipelines);
+  ASSERT_NE(ids.first, 0u);
+  auto live = pipelines->LoadPipeline(ids.first);
+  ASSERT_NE(live, nullptr);
+  BindImportedRawColor(live, *project.GetImagePoolService(), ids.second);
+  CPUPipelineExecutor* const executor = live->pipeline_.get();
+  PipelineDocument* const    document = live->document_.get();
+  ThumbnailService           thumbnails(project.GetSleeveService(), project.GetImagePoolService(),
+                                          pipelines);
+  const auto first = GetThumbnailDetailedBlocking(thumbnails, ids.first, ids.second,
+                                                 ThumbnailResolution::k256);
+  EXPECT_EQ(first.status, ThumbnailRequestStatus::kReady) << first.message;
+  ASSERT_NE(first.guard, nullptr);
+  ASSERT_NE(first.guard->thumbnail_buffer_, nullptr);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 1, 10s));
+  EXPECT_EQ(live->pipeline_.get(), executor);
+  EXPECT_EQ(live->document_.get(), document);
+  EXPECT_EQ(SessionPreparedSourceCount(*live->pipeline_), 0u);
+  EXPECT_EQ(SessionTexturePoolEntries(*live->pipeline_), 0u);
+  EXPECT_EQ(OneShotPublishedResultCount(*live->pipeline_), 0u);
+
+  std::promise<ThumbnailRequestResult> analysis_done;
+  auto                                 analysis_fut = analysis_done.get_future();
+  thumbnails.RequestAnalysisRendition(
+      ids.first, ids.second, ThumbnailResolution::k256,
+      [&analysis_done](ThumbnailRequestResult result) { analysis_done.set_value(std::move(result)); });
+  ASSERT_EQ(analysis_fut.wait_for(60s), std::future_status::ready);
+  const auto analysis = analysis_fut.get();
+  EXPECT_EQ(analysis.status, ThumbnailRequestStatus::kReady) << analysis.message;
+  ASSERT_NE(analysis.guard, nullptr);
+  ASSERT_NE(analysis.guard->thumbnail_buffer_, nullptr);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 1, 10s));
+  EXPECT_EQ(live->pipeline_.get(), executor);
+  EXPECT_EQ(live->document_.get(), document);
+  EXPECT_EQ(live->pin_count_, size_t{1});
+
+  thumbnails.ReleaseThumbnail(ThumbnailCacheKey{ids.first, ThumbnailResolution::k256});
+  thumbnails.ReleaseAnalysisRendition(analysis.key);
+  pipelines->SavePipeline(live);
+}
+
+TEST_F(PipelineSharedUseTest, TaskRenderOptionsDoNotPersistInExecutor) {
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService      project(db_path_, meta_path_);
+  auto                pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto          ids       = ImportLinearDng(project, pipelines);
+  ASSERT_NE(ids.first, 0u);
+  auto live = pipelines->LoadPipeline(ids.first);
+  ASSERT_NE(live, nullptr);
+  BindImportedRawColor(live, *project.GetImagePoolService(), ids.second);
+  CPUPipelineExecutor::OneShotRenderParamsSnapshot prior;
+  {
+    std::lock_guard<std::mutex> render_lock(live->pipeline_->GetRenderLock());
+    live->pipeline_->SetForceCPUOutput(false);
+    live->pipeline_->SetEnableCache(true);
+    live->pipeline_->SetDecodeRes(DecodeRes::FULL);
+    prior = live->pipeline_->CaptureOneShotRenderParams();
+  }
+
+  ThumbnailService thumbnails(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  const auto       result = GetThumbnailDetailedBlocking(thumbnails, ids.first, ids.second,
+                                                         ThumbnailResolution::k256);
+  EXPECT_EQ(result.status, ThumbnailRequestStatus::kReady) << result.message;
+  ASSERT_NE(result.guard, nullptr);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 1, 10s));
+
+  CPUPipelineExecutor::OneShotRenderParamsSnapshot restored;
+  {
+    std::lock_guard<std::mutex> render_lock(live->pipeline_->GetRenderLock());
+    restored = live->pipeline_->CaptureOneShotRenderParams();
+  }
+  EXPECT_EQ(restored.enable_cache_, prior.enable_cache_);
+  EXPECT_EQ(restored.force_cpu_output_, prior.force_cpu_output_);
+  EXPECT_EQ(restored.decode_res_, prior.decode_res_);
+
+  {
+    auto extra = pipelines->LoadPipeline(ids.first);
+    PipelineScheduler scheduler(1);
+    std::promise<void> done;
+    auto                done_fut = done.get_future();
+    PipelineTask        task;
+    task.pipeline_executor_                  = extra->pipeline_;
+    task.input_                              = std::make_shared<ImageBuffer>(std::vector<uint8_t>{0});
+    task.options_.render_desc_.render_type_ = RenderType::THUMBNAIL;
+    task.options_.is_blocking_              = false;
+    task.on_complete_ = [pipelines, extra, &done](bool, std::string) {
+      pipelines->ReleasePipelineUse(extra);
+      done.set_value();
+    };
+    scheduler.ScheduleTask(std::move(task));
+    ASSERT_EQ(done_fut.wait_for(10s), std::future_status::ready);
+  }
+  CPUPipelineExecutor::OneShotRenderParamsSnapshot after_failure;
+  {
+    std::lock_guard<std::mutex> render_lock(live->pipeline_->GetRenderLock());
+    after_failure = live->pipeline_->CaptureOneShotRenderParams();
+  }
+  EXPECT_EQ(after_failure.enable_cache_, prior.enable_cache_);
+  EXPECT_EQ(after_failure.force_cpu_output_, prior.force_cpu_output_);
+  EXPECT_EQ(after_failure.decode_res_, prior.decode_res_);
+
+  thumbnails.ReleaseThumbnail(ThumbnailCacheKey{ids.first, ThumbnailResolution::k256});
+  pipelines->SavePipeline(live);
+}
+
+TEST_F(PipelineSharedUseTest, BackgroundReleaseDoesNotSaveOrClearEditorState) {
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService      project(db_path_, meta_path_);
+  auto                pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto          ids       = ImportLinearDng(project, pipelines);
+  ASSERT_NE(ids.first, 0u);
+  auto live = pipelines->LoadPipeline(ids.first);
+  ASSERT_NE(live, nullptr);
+  BindImportedRawColor(live, *project.GetImagePoolService(), ids.second);
+  auto* exposure = live->document_->PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure());
+  ASSERT_NE(exposure, nullptr);
+  exposure->LoadJson({{"exposure_ev", 1.25f}});
+  live->dirty_         = true;
+  const auto live_json = live->document_->ToJson();
+  const auto stored_before =
+      project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(ids.first);
+
+  auto img = project.GetImagePoolService()->Read<std::shared_ptr<Image>>(
+      ids.second, [](const std::shared_ptr<Image>& image) { return image; });
+  ASSERT_NE(img, nullptr);
+  auto encoded = ByteBufferLoader::LoadByteBufferFromImage(img);
+  auto input   = std::make_shared<ImageBuffer>(std::move(encoded));
+  {
+    std::lock_guard<std::mutex> render_lock(live->pipeline_->GetRenderLock());
+    live->pipeline_->SetForceCPUOutput(true);
+    live->pipeline_->SetEnableCache(true);
+    live->pipeline_->SetDecodeRes(DecodeRes::EIGHTH);
+    ASSERT_NO_THROW(live->pipeline_->Apply(input));
+  }
+  const auto prepared_before = SessionPreparedSourceCount(*live->pipeline_);
+  const auto session_textures_before = SessionTexturePoolEntries(*live->pipeline_);
+  EXPECT_GT(prepared_before, 0u);
+
+  ThumbnailService thumbnails(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  const auto       result = GetThumbnailDetailedBlocking(thumbnails, ids.first, ids.second,
+                                                        ThumbnailResolution::k256);
+  EXPECT_EQ(result.status, ThumbnailRequestStatus::kReady) << result.message;
+  EXPECT_TRUE(live->dirty_);
+  EXPECT_EQ(live->pin_count_, size_t{1});
+  EXPECT_EQ(live->document_->ToJson(), live_json);
+  const auto stored_after =
+      project.GetStorage()->GetElementStore().GetPipelineJsonByElementId(ids.first);
+  EXPECT_EQ(stored_after, stored_before);
+  EXPECT_EQ(SessionPreparedSourceCount(*live->pipeline_), prepared_before);
+  EXPECT_EQ(SessionTexturePoolEntries(*live->pipeline_), session_textures_before);
+  EXPECT_EQ(OneShotPublishedResultCount(*live->pipeline_), 0u);
+
+  thumbnails.ReleaseThumbnail(ThumbnailCacheKey{ids.first, ThumbnailResolution::k256});
+  pipelines->SavePipeline(live);
+}
+
+TEST_F(PipelineSharedUseTest, AnalysisAndExportUseSharedExecutorWithoutChangingEdits) {
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService      project(db_path_, meta_path_);
+  auto                pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto          ids       = ImportLinearDng(project, pipelines);
+  ASSERT_NE(ids.first, 0u);
+  auto live = pipelines->LoadPipeline(ids.first);
+  ASSERT_NE(live, nullptr);
+  BindImportedRawColor(live, *project.GetImagePoolService(), ids.second);
+  CPUPipelineExecutor* const executor = live->pipeline_.get();
+  PipelineDocument* const    document = live->document_.get();
+  const auto                 live_json = live->document_->ToJson();
+
+  ThumbnailService thumbnails(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  std::promise<ThumbnailRequestResult> analysis_done;
+  auto                                 analysis_fut = analysis_done.get_future();
+  thumbnails.RequestAnalysisRendition(
+      ids.first, ids.second, ThumbnailResolution::k256,
+      [&analysis_done](ThumbnailRequestResult result) { analysis_done.set_value(std::move(result)); });
+  ASSERT_EQ(analysis_fut.wait_for(60s), std::future_status::ready);
+  const auto analysis = analysis_fut.get();
+  EXPECT_EQ(analysis.status, ThumbnailRequestStatus::kReady) << analysis.message;
+  ASSERT_NE(analysis.guard, nullptr);
+  EXPECT_EQ(live->pipeline_.get(), executor);
+  EXPECT_EQ(live->document_.get(), document);
+
+  const auto export_dir =
+      std::filesystem::temp_directory_path() /
+      ("pipeline_shared_export_" +
+       std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::filesystem::create_directories(export_dir);
+  ExportService export_service(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  ExportTask    task;
+  task.sleeve_id_                = ids.first;
+  task.image_id_                 = ids.second;
+  task.options_.format_          = ImageFormatType::JPEG;
+  task.options_.export_path_     = export_dir / "shared-use.jpg";
+  task.options_.resize_enabled_  = true;
+  task.options_.max_length_side_ = 256;
+  task.recipe_                   = ExportRecipe::FromLegacyOptions(task.options_);
+  {
+    std::lock_guard<std::mutex> lock(live->pipeline_->GetRenderLock());
+    task.recipe_->output_color_ =
+        ExportColorProfileFromDrt(live->document_->Drt()->Params().Params());
+  }
+  export_service.EnqueueExportTask(task);
+  std::promise<std::shared_ptr<std::vector<ExportResult>>> export_done;
+  auto export_fut = export_done.get_future();
+  export_service.ExportAll(
+      [&export_done](std::shared_ptr<std::vector<ExportResult>> results) {
+        export_done.set_value(std::move(results));
+      });
+  ASSERT_EQ(export_fut.wait_for(120s), std::future_status::ready);
+  auto export_results = export_fut.get();
+  ASSERT_NE(export_results, nullptr);
+  ASSERT_EQ(export_results->size(), 1u);
+  EXPECT_TRUE((*export_results)[0].success_) << (*export_results)[0].message_;
+  EXPECT_EQ(live->pipeline_.get(), executor);
+  EXPECT_EQ(live->document_.get(), document);
+  EXPECT_EQ(live->document_->ToJson(), live_json);
+  EXPECT_EQ(live->pin_count_, size_t{1});
+
+  thumbnails.ReleaseAnalysisRendition(analysis.key);
+  pipelines->SavePipeline(live);
+  std::error_code ec;
+  std::filesystem::remove_all(export_dir, ec);
+}
+
+TEST_F(PipelineSharedUseTest, QueuedRenderDoesNotStorePixelsUnderStaleCommitLabel) {
+  EXPECT_FALSE(ThumbnailDiskCacheWriteAllowed("old", "new", false, false));
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService project(db_path_, meta_path_);
+  auto           pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto     ids       = ImportLinearDng(project, pipelines);
+  ASSERT_NE(ids.first, 0u);
+  auto live = pipelines->LoadEditorPipeline(ids.first);
+  ASSERT_NE(live, nullptr);
+  BindImportedRawColor(live, *project.GetImagePoolService(), ids.second);
+  ASSERT_NE(live->commit_graph_, nullptr);
+  live->dirty_              = true;
+  live->unsettled_preview_  = true;
+
+  const auto cache_root =
+      std::filesystem::temp_directory_path() /
+      ("pipeline_shared_disk_" +
+       std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  ThumbnailService thumbnails(project.GetSleeveService(), project.GetImagePoolService(), pipelines,
+                               project.GetStorage(), project.GetProjectUUID(), cache_root);
+  const auto result = GetThumbnailDetailedBlocking(thumbnails, ids.first, ids.second,
+                                                    ThumbnailResolution::k256);
+  EXPECT_EQ(result.status, ThumbnailRequestStatus::kReady) << result.message;
+  ASSERT_NE(result.guard, nullptr);
+  EXPECT_TRUE(live->dirty_);
+  EXPECT_TRUE(live->unsettled_preview_);
+  EXPECT_EQ(live->pin_count_, size_t{1});
+
+  thumbnails.FlushDiskCacheMetadata();
+  ThumbnailDiskCacheKey key;
+  key.project_uuid         = project.GetProjectUUID();
+  key.element_id           = ids.first;
+  key.resolution           = ThumbnailResolution::k256;
+  key.purpose              = ThumbnailDiskCachePurpose::kThumbnail;
+  key.cache_schema_version  = 2;
+  const auto head          = live->working_head_commit_hash();
+  key.edit_version_hash    = head.has_value() ? head->ToString() : live->root_id_.ToString();
+  ThumbnailDiskCacheService disk(cache_root);
+  disk.Initialize(project.GetProjectUUID());
+  EXPECT_FALSE(disk.Lookup(key));
+
+  live->dirty_             = false;
+  live->unsettled_preview_ = false;
+  std::unique_lock held(live->pipeline_->GetRenderLock());
+  const auto queued_head = live->working_head_commit_hash();
+  std::promise<ThumbnailRequestResult> queued;
+  auto                                 queued_fut = queued.get_future();
+  thumbnails.GetThumbnailDetailed(
+      ids.first, ids.second,
+      [&queued](ThumbnailRequestResult result) { queued.set_value(std::move(result)); }, true,
+      nullptr, ThumbnailResolution::k256);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 2, 10s));
+  OrdinaryEditPayload payload;
+  payload.operator_type  = OperatorType::EXPOSURE;
+  payload.stage_name     = PipelineStageName::Basic_Adjustment;
+  payload.field_name     = "exposure";
+  payload.before_value   = 0.0f;
+  payload.after_value    = 0.25f;
+  payload.before_enabled = true;
+  payload.after_enabled  = true;
+  auto commit = EditCommit::MakeEdit(live->root_id_, live->working_head_commit_hash(),
+                                      std::move(payload));
+  const auto new_head = commit.GetCommitHash();
+  ASSERT_TRUE(live->commit_graph_->InsertCommit(std::move(commit)));
+  live->commit_graph_->MoveWorkingHead(live->commit_graph_->GetActiveVersionId(), new_head);
+  held.unlock();
+  ASSERT_EQ(queued_fut.wait_for(60s), std::future_status::ready);
+  EXPECT_EQ(queued_fut.get().status, ThumbnailRequestStatus::kReady);
+  thumbnails.FlushDiskCacheMetadata();
+  ThumbnailDiskCacheKey stale = key;
+  if (queued_head.has_value()) {
+    stale.edit_version_hash = queued_head->ToString();
+  }
+  ThumbnailDiskCacheKey fresh = key;
+  fresh.edit_version_hash      = new_head.ToString();
+  EXPECT_FALSE(disk.Lookup(stale));
+  EXPECT_FALSE(disk.Lookup(fresh));
+
+  thumbnails.ReleaseThumbnail(ThumbnailCacheKey{ids.first, ThumbnailResolution::k256});
+  pipelines->SavePipeline(live);
+  std::error_code ec;
+  std::filesystem::remove_all(cache_root, ec);
+}
+
+TEST_F(PipelineSharedUseTest, ConcurrentPipelineAcquirePublishesOneReadyLiveInstance) {
+  ProjectService      project(db_path_, meta_path_);
+  PipelineMgmtService pipelines(project.GetStorage());
+  pipelines.ResetPipelineAcquireCountsForTesting();
+  constexpr int kThreads = 8;
+  std::barrier  start(kThreads);
+  std::vector<std::thread> workers;
+  std::vector<std::shared_ptr<PipelineGuard>> guards(kThreads);
+  workers.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    workers.emplace_back([&pipelines, &guards, &start, i] {
+      start.arrive_and_wait();
+      guards[i] = pipelines.LoadPipeline(1);
+    });
+  }
+  for (auto& worker : workers) {
+    worker.join();
+  }
+  ASSERT_NE(guards[0], nullptr);
+  ASSERT_NE(guards[0]->pipeline_, nullptr);
+  ASSERT_NE(guards[0]->document_, nullptr);
+  EXPECT_TRUE(guards[0]->live_ready_);
+  for (int i = 1; i < kThreads; ++i) {
+    ASSERT_NE(guards[i], nullptr);
+    EXPECT_EQ(guards[i].get(), guards[0].get());
+    EXPECT_EQ(guards[i]->pipeline_.get(), guards[0]->pipeline_.get());
+    EXPECT_TRUE(guards[i]->live_ready_);
+  }
+  EXPECT_EQ(pipelines.PipelineConstructCount(), 1u);
+  EXPECT_EQ(pipelines.PipelineLoadCount(), static_cast<std::uint64_t>(kThreads));
+  EXPECT_EQ(guards[0]->pin_count_, static_cast<size_t>(kThreads));
+  for (auto& guard : guards) {
+    pipelines.ReleasePipelineUse(guard);
+  }
+  EXPECT_TRUE(pipelines.WaitUntilPinCount(guards[0], 0, 5s));
+}
+
+TEST_F(PipelineSharedUseTest, PipelineReacquirePreventsStaleLastUseCleanup) {
+  ProjectService      project(db_path_, meta_path_);
+  PipelineMgmtService pipelines(project.GetStorage());
+  auto                live = pipelines.LoadPipeline(1);
+  ASSERT_NE(live, nullptr);
+  ASSERT_TRUE(live->live_ready_);
+  std::unique_lock<std::mutex> held(live->pipeline_->GetRenderLock());
+  std::thread releaser([&pipelines, live] { pipelines.ReleasePipelineUse(live); });
+  ASSERT_TRUE(pipelines.WaitUntilPinCount(live, 0, 5s));
+  auto again = pipelines.LoadPipeline(1);
+  ASSERT_EQ(again.get(), live.get());
+  EXPECT_EQ(again->pin_count_, size_t{1});
+  EXPECT_TRUE(again->live_ready_);
+  held.unlock();
+  releaser.join();
+  EXPECT_TRUE(again->live_ready_);
+  EXPECT_EQ(again->pin_count_, size_t{1});
+  pipelines.ReleasePipelineUse(again);
+}
+
+TEST_F(PipelineSharedUseTest, BackgroundCompletionSignalsAfterPipelineUseRelease) {
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService project(db_path_, meta_path_);
+  auto           pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto     ids       = ImportLinearDng(project, pipelines);
+  ASSERT_NE(ids.first, 0u);
+  auto live = pipelines->LoadPipeline(ids.first);
+  ASSERT_NE(live, nullptr);
+  BindImportedRawColor(live, *project.GetImagePoolService(), ids.second);
+  std::atomic<int> completions{0};
+  ThumbnailService thumbnails(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  std::promise<ThumbnailRequestResult> done;
+  auto                                 done_fut = done.get_future();
+  thumbnails.GetThumbnailDetailed(
+      ids.first, ids.second,
+      [&done, &completions](ThumbnailRequestResult result) {
+        completions.fetch_add(1, std::memory_order_relaxed);
+        done.set_value(std::move(result));
+      },
+      true, nullptr, ThumbnailResolution::k256);
+  ASSERT_EQ(done_fut.wait_for(60s), std::future_status::ready);
+  EXPECT_EQ(done_fut.get().status, ThumbnailRequestStatus::kReady);
+  EXPECT_EQ(completions.load(), 1);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 1, 10s));
+  thumbnails.ReleaseThumbnail(ThumbnailCacheKey{ids.first, ThumbnailResolution::k256});
+  pipelines->SavePipeline(live);
+}
+
+TEST_F(PipelineSharedUseTest, BackgroundRendersKeepEditorResultCacheReusable) {
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService project(db_path_, meta_path_);
+  auto           pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto     ids       = ImportLinearDng(project, pipelines);
+  ASSERT_NE(ids.first, 0u);
+  auto live = pipelines->LoadPipeline(ids.first);
+  ASSERT_NE(live, nullptr);
+  BindImportedRawColor(live, *project.GetImagePoolService(), ids.second);
+  PipelineScheduler editor(1);
+  auto              run_preview = [&]() {
+    PipelineTask task;
+    task.pipeline_executor_                 = live->pipeline_;
+    task.input_desc_                        = std::make_shared<Image>(LinearDngPath(), ImageType::DEFAULT);
+    task.options_.render_desc_.render_type_ = RenderType::FAST_PREVIEW;
+    task.options_.is_blocking_              = true;
+    task.result_ = std::make_shared<std::promise<std::shared_ptr<ImageBuffer>>>();
+    auto blocking = task.result_->get_future();
+    editor.ScheduleTask(std::move(task));
+    EXPECT_EQ(blocking.wait_for(60s), std::future_status::ready);
+    if (blocking.wait_for(0s) != std::future_status::ready) {
+      return;
+    }
+    EXPECT_NE(blocking.get(), nullptr);
+  };
+  run_preview();
+  const auto session_after_editor = SessionWorkspace(*live->pipeline_);
+  EXPECT_GT(session_after_editor.prepared_source_entry_count +
+                session_after_editor.published_result_count,
+            0u);
+
+  ThumbnailService thumbnails(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  const auto       thumb = GetThumbnailDetailedBlocking(thumbnails, ids.first, ids.second,
+                                                        ThumbnailResolution::k256);
+  EXPECT_EQ(thumb.status, ThumbnailRequestStatus::kReady) << thumb.message;
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 1, 10s));
+  run_preview();
+  const auto session_after_reuse = SessionWorkspace(*live->pipeline_);
+  EXPECT_GE(session_after_reuse.prepared_source_entry_count,
+            session_after_editor.prepared_source_entry_count);
+  thumbnails.ReleaseThumbnail(ThumbnailCacheKey{ids.first, ThumbnailResolution::k256});
+  pipelines->SavePipeline(live);
+}
+
+TEST_F(PipelineSharedUseTest, BackgroundTaskFailureReleasesTemporaryGpuResources) {
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService project(db_path_, meta_path_);
+  auto           pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto     ids       = ImportLinearDng(project, pipelines);
+  ASSERT_NE(ids.first, 0u);
+  auto live = pipelines->LoadPipeline(ids.first);
+  ASSERT_NE(live, nullptr);
+  BindImportedRawColor(live, *project.GetImagePoolService(), ids.second);
+  const auto session_before = SessionWorkspace(*live->pipeline_);
+  PipelineScheduler scheduler(1);
+  std::promise<void> done;
+  auto               done_fut = done.get_future();
+  auto extra                  = pipelines->LoadPipeline(ids.first);
+  PipelineTask task;
+  task.pipeline_executor_                 = extra->pipeline_;
+  task.input_                             = std::make_shared<ImageBuffer>(std::vector<uint8_t>{0});
+  task.options_.render_desc_.render_type_ = RenderType::THUMBNAIL;
+  task.on_complete_                       = [pipelines, extra, &done](bool, std::string) {
+    pipelines->ReleasePipelineUse(extra);
+    done.set_value();
+  };
+  scheduler.ScheduleTask(std::move(task));
+  ASSERT_EQ(done_fut.wait_for(30s), std::future_status::ready);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 1, 5s));
+  const auto one_shot = OneShotWorkspace(*live->pipeline_);
+  EXPECT_EQ(one_shot.texture_pool_used_bytes, 0u);
+  EXPECT_EQ(one_shot.transient_used_bytes, 0u);
+  EXPECT_EQ(one_shot.transient_slab_count, 0u);
+  EXPECT_EQ(one_shot.published_result_count, 0u);
+  const auto session_after = SessionWorkspace(*live->pipeline_);
+  EXPECT_EQ(session_after.texture_pool_used_bytes, session_before.texture_pool_used_bytes);
+  pipelines->SavePipeline(live);
+}
+
+TEST_F(PipelineSharedUseTest, ParallelBackgroundRendersPreservePixelsAndReleaseWorkspaces) {
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService project(db_path_, meta_path_);
+  auto           pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto     first     = ImportLinearDng(project, pipelines);
+  ASSERT_NE(first.first, 0u);
+  const auto copy_path =
+      std::filesystem::temp_directory_path() /
+      ("nm14r_parallel_b_" +
+       std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + ".dng");
+  std::filesystem::copy_file(LinearDngPath(), copy_path);
+  const auto second = ImportRawFile(project, pipelines, copy_path);
+  ASSERT_NE(second.first, 0u);
+  ASSERT_NE(second.first, first.first);
+  auto live_a = pipelines->LoadPipeline(first.first);
+  auto live_b = pipelines->LoadPipeline(second.first);
+  BindImportedRawColor(live_a, *project.GetImagePoolService(), first.second);
+  BindImportedRawColor(live_b, *project.GetImagePoolService(), second.second);
+
+  ThumbnailService thumbnails(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  std::promise<ThumbnailRequestResult> thumb_done;
+  auto                                 thumb_fut = thumb_done.get_future();
+  const auto export_dir =
+      std::filesystem::temp_directory_path() /
+      ("nm14r_parallel_export_" +
+       std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::filesystem::create_directories(export_dir);
+  ExportService export_service(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  ExportTask    export_task;
+  export_task.sleeve_id_                = second.first;
+  export_task.image_id_                 = second.second;
+  export_task.options_.format_          = ImageFormatType::JPEG;
+  export_task.options_.export_path_     = export_dir / "parallel.jpg";
+  export_task.options_.resize_enabled_  = true;
+  export_task.options_.max_length_side_ = 256;
+  export_task.recipe_ = ExportRecipe::FromLegacyOptions(export_task.options_);
+  {
+    std::lock_guard<std::mutex> lock(live_b->pipeline_->GetRenderLock());
+    export_task.recipe_->output_color_ =
+        ExportColorProfileFromDrt(live_b->document_->Drt()->Params().Params());
+  }
+  export_service.EnqueueExportTask(export_task);
+  std::promise<std::shared_ptr<std::vector<ExportResult>>> export_done;
+  auto export_fut = export_done.get_future();
+
+  std::atomic<std::size_t> peak_one_shot_bytes{0};
+  std::thread observer([&] {
+    while (thumb_fut.wait_for(0s) != std::future_status::ready ||
+           export_fut.wait_for(0s) != std::future_status::ready) {
+      const auto shot_a = OneShotWorkspace(*live_a->pipeline_);
+      const auto shot_b = OneShotWorkspace(*live_b->pipeline_);
+      const auto used   = shot_a.texture_pool_used_bytes + shot_a.transient_capacity_bytes +
+                        shot_b.texture_pool_used_bytes + shot_b.transient_capacity_bytes;
+      auto prev = peak_one_shot_bytes.load();
+      while (used > prev && !peak_one_shot_bytes.compare_exchange_weak(prev, used)) {
+      }
+      std::this_thread::sleep_for(1ms);
+    }
+  });
+  thumbnails.GetThumbnailDetailed(
+      first.first, first.second,
+      [&thumb_done](ThumbnailRequestResult result) { thumb_done.set_value(std::move(result)); },
+      true, nullptr, ThumbnailResolution::k256);
+  export_service.ExportAll([&export_done](std::shared_ptr<std::vector<ExportResult>> results) {
+    export_done.set_value(std::move(results));
+  });
+  ASSERT_EQ(thumb_fut.wait_for(60s), std::future_status::ready);
+  ASSERT_EQ(export_fut.wait_for(120s), std::future_status::ready);
+  observer.join();
+  EXPECT_EQ(thumb_fut.get().status, ThumbnailRequestStatus::kReady);
+  auto export_results = export_fut.get();
+  ASSERT_NE(export_results, nullptr);
+  ASSERT_EQ(export_results->size(), 1u);
+  EXPECT_TRUE((*export_results)[0].success_) << (*export_results)[0].message_;
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live_a, 1, 10s));
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live_b, 1, 10s));
+  const auto one_shot_a = OneShotWorkspace(*live_a->pipeline_);
+  const auto one_shot_b = OneShotWorkspace(*live_b->pipeline_);
+  EXPECT_EQ(one_shot_a.texture_pool_used_bytes, 0u);
+  EXPECT_EQ(one_shot_a.transient_slab_count, 0u);
+  EXPECT_EQ(one_shot_a.published_result_count, 0u);
+  EXPECT_EQ(one_shot_b.texture_pool_used_bytes, 0u);
+  EXPECT_EQ(one_shot_b.transient_slab_count, 0u);
+  EXPECT_EQ(one_shot_b.published_result_count, 0u);
+  std::cout << "NM1.4R parallel one-shot peak bytes (allocator, two images): "
+            << peak_one_shot_bytes.load() << '\n';
+  thumbnails.ReleaseThumbnail(ThumbnailCacheKey{first.first, ThumbnailResolution::k256});
+  pipelines->SavePipeline(live_a);
+  pipelines->SavePipeline(live_b);
+  std::error_code ec;
+  std::filesystem::remove_all(export_dir, ec);
+  std::filesystem::remove(copy_path, ec);
+}
+
+TEST_F(PipelineSharedUseTest, ConcurrentThumbnailAndExportDoNotChangeDocumentOutputSettings) {
+  if (!std::filesystem::exists(LinearDngPath())) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << LinearDngPath().string();
+  }
+  ProjectService project(db_path_, meta_path_);
+  auto           pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  const auto     ids       = ImportLinearDng(project, pipelines);
+  ASSERT_NE(ids.first, 0u);
+  auto live = pipelines->LoadPipeline(ids.first);
+  ASSERT_NE(live->document_->Drt(), nullptr);
+  const auto before = live->document_->Drt()->Params().ToJson();
+  ThumbnailService thumbnails(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  std::promise<ThumbnailRequestResult> thumb_done;
+  auto                                 thumb_fut = thumb_done.get_future();
+  thumbnails.GetThumbnailDetailed(
+      ids.first, ids.second,
+      [&thumb_done](ThumbnailRequestResult result) { thumb_done.set_value(std::move(result)); },
+      true, nullptr, ThumbnailResolution::k256);
+
+  const auto export_dir =
+      std::filesystem::temp_directory_path() /
+      ("nm14r_export_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::filesystem::create_directories(export_dir);
+  ExportService export_service(project.GetSleeveService(), project.GetImagePoolService(), pipelines);
+  ExportTask    task;
+  task.sleeve_id_                = ids.first;
+  task.image_id_                 = ids.second;
+  task.options_.format_          = ImageFormatType::JPEG;
+  task.options_.export_path_     = export_dir / "overlay.jpg";
+  task.options_.resize_enabled_  = true;
+  task.options_.max_length_side_ = 256;
+  task.recipe_                   = ExportRecipe::FromLegacyOptions(task.options_);
+  task.recipe_->output_color_    = ExportColorProfileConfig{
+      ColorUtils::ColorSpace::P3_D65, ColorUtils::EOTF::GAMMA_2_2, 100.0f};
+  export_service.EnqueueExportTask(task);
+  std::promise<std::shared_ptr<std::vector<ExportResult>>> export_done;
+  auto export_fut = export_done.get_future();
+  export_service.ExportAll([&export_done](std::shared_ptr<std::vector<ExportResult>> results) {
+    export_done.set_value(std::move(results));
+  });
+  ASSERT_EQ(thumb_fut.wait_for(60s), std::future_status::ready);
+  ASSERT_EQ(export_fut.wait_for(120s), std::future_status::ready);
+  ASSERT_TRUE(pipelines->WaitUntilPinCount(live, 1, 10s));
+  EXPECT_EQ(live->document_->Drt()->Params().ToJson(), before);
+  auto export_results = export_fut.get();
+  ASSERT_NE(export_results, nullptr);
+  ASSERT_EQ(export_results->size(), 1u);
+  EXPECT_TRUE((*export_results)[0].success_) << (*export_results)[0].message_;
+  thumbnails.ReleaseThumbnail(ThumbnailCacheKey{ids.first, ThumbnailResolution::k256});
+  pipelines->SavePipeline(live);
+  std::error_code ec;
+  std::filesystem::remove_all(export_dir, ec);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/semantic_generation_service_test.cpp
+++ b/alcedo_studio/tests/app/semantic_generation_service_test.cpp
@@ -769,7 +769,11 @@ class SemanticGenerationServiceTest : public ::testing::Test {
       return {};
     }
 
-    ImportServiceImpl          import_service(fs_service, img_pool);
+    // Product import writes camera/profile data into the stored document. Thumbnail
+    // DAG rendering reads that document; omitting PipelineMgmtService leaves a Default
+    // graph without camera matrices and Metal/CUDA camera color fails.
+    auto                       pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    ImportServiceImpl          import_service(fs_service, img_pool, pipelines);
     auto                       import_job = std::make_shared<ImportJob>();
     std::promise<ImportResult> done;
     auto                       future = done.get_future();
@@ -800,7 +804,9 @@ class SemanticGenerationServiceTest : public ::testing::Test {
     auto                       fs_service = project.GetSleeveService();
     auto                       img_pool   = project.GetImagePoolService();
 
-    ImportServiceImpl          import_service(fs_service, img_pool);
+    // Same as ImportItems: assemble and persist camera/profile data before thumbnail DAG render.
+    auto                       pipelines = std::make_shared<PipelineMgmtService>(project.GetStorage());
+    ImportServiceImpl          import_service(fs_service, img_pool, pipelines);
     auto                       import_job = std::make_shared<ImportJob>();
     std::promise<ImportResult> done;
     auto                       future = done.get_future();

--- a/alcedo_studio/tests/app/sleeve_service_test.cpp
+++ b/alcedo_studio/tests/app/sleeve_service_test.cpp
@@ -81,9 +81,12 @@ auto QueryDuckDbInt64(const std::filesystem::path& db_path, const std::string& s
 }
 
 auto ReadExposure(const std::shared_ptr<PipelineGuard>& pipeline_guard) -> float {
-  const auto exported = pipeline_guard->pipeline_->ExportPipelineParams();
-  return exported["Basic Adjustment"]["Basic Adjustment"]["exposure"]["params"]["exposure"]
-      .get<float>();
+  const auto* exposure = pipeline_guard->document_->PrimaryGrade()->FindAdjustmentByType(
+      type_ids::Exposure());
+  if (exposure == nullptr) {
+    throw std::runtime_error("Pipeline document has no exposure adjustment");
+  }
+  return exposure->ToJson().at("exposure_ev").get<float>();
 }
 
 }  // namespace
@@ -481,9 +484,10 @@ TEST_F(SleeveServiceTests, ExplicitDuplicateClonesStateAndKeepsHistoryAndPipelin
   {
     PipelineMgmtService pipeline_service(project.GetStorage());
     auto                source_pipeline = pipeline_service.LoadPipeline(source_id);
-    auto&               stage = source_pipeline->pipeline_->GetStage(PipelineStageName::Basic_Adjustment);
-    stage.SetOperator(OperatorType::EXPOSURE, nlohmann::json{{"exposure", 2.5f}},
-                      source_pipeline->pipeline_->GetGlobalParams());
+    auto* exposure = source_pipeline->document_->PrimaryGrade()->FindAdjustmentByType(
+        type_ids::Exposure());
+    ASSERT_NE(exposure, nullptr);
+    exposure->LoadJson({{"exposure_ev", 2.5f}});
     source_pipeline->dirty_ = true;
     pipeline_service.SavePipeline(source_pipeline);
     pipeline_service.Sync();
@@ -532,10 +536,10 @@ TEST_F(SleeveServiceTests, ExplicitDuplicateClonesStateAndKeepsHistoryAndPipelin
   {
     PipelineMgmtService pipeline_service(project.GetStorage());
     auto                duplicate_pipeline = pipeline_service.LoadPipeline(duplicate_id);
-    auto&               stage =
-        duplicate_pipeline->pipeline_->GetStage(PipelineStageName::Basic_Adjustment);
-    stage.SetOperator(OperatorType::EXPOSURE, nlohmann::json{{"exposure", 4.0f}},
-                      duplicate_pipeline->pipeline_->GetGlobalParams());
+    auto* exposure = duplicate_pipeline->document_->PrimaryGrade()->FindAdjustmentByType(
+        type_ids::Exposure());
+    ASSERT_NE(exposure, nullptr);
+    exposure->LoadJson({{"exposure_ev", 4.0f}});
     duplicate_pipeline->dirty_ = true;
     pipeline_service.SavePipeline(duplicate_pipeline);
     pipeline_service.Sync();
@@ -580,9 +584,10 @@ TEST_F(SleeveServiceTests, DuplicateUsesLatestPipelineSnapshotBeforePipelineSync
   {
     PipelineMgmtService pipeline_service(project.GetStorage());
     auto                source_pipeline = pipeline_service.LoadPipeline(source_id);
-    auto&               stage = source_pipeline->pipeline_->GetStage(PipelineStageName::Basic_Adjustment);
-    stage.SetOperator(OperatorType::EXPOSURE, nlohmann::json{{"exposure", 2.5f}},
-                      source_pipeline->pipeline_->GetGlobalParams());
+    auto* exposure = source_pipeline->document_->PrimaryGrade()->FindAdjustmentByType(
+        type_ids::Exposure());
+    ASSERT_NE(exposure, nullptr);
+    exposure->LoadJson({{"exposure_ev", 2.5f}});
     source_pipeline->dirty_ = true;
     pipeline_service.SavePipeline(source_pipeline);
   }

--- a/alcedo_studio/tests/app/thumbnail_service_test.cpp
+++ b/alcedo_studio/tests/app/thumbnail_service_test.cpp
@@ -30,12 +30,20 @@
 #include "app/pipeline_service.hpp"
 #include "app/project_service.hpp"
 #include "app/sleeve_service.hpp"
+#include "edit/graph/legacy_pipeline_importer.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
 #include "edit/history/edit_commit.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/op_base.hpp"
 #include "edit/operators/operator_registeration.hpp"
 #include "edit/pipeline/default_pipeline_params.hpp"
 #include "edit/pipeline/pipeline_cpu.hpp"
+#include "image/metadata_extractor.hpp"
+#include "image/dng_color_profile_import.hpp"
 #include "io/image/image_loader.hpp"
 #include "renderer/pipeline_scheduler.hpp"
+
+#include <libraw/libraw.h>
 #include "storage/store/edit_history/commit_graph_store.hpp"
 #include "type/type.hpp"
 #include "utils/cache/lru_cache.hpp"
@@ -104,6 +112,42 @@ static uint64_t HashImageBufferCpuBytes(ImageBuffer& buffer) {
   auto& mat = buffer.GetCPUData();
   EXPECT_FALSE(mat.empty());
   return HashMatBytes(mat);
+}
+
+auto PinLinearDngInPool(ImagePoolService& pool, const std::filesystem::path& raw_path)
+    -> ImagePoolManager::PinnedImageHandle {
+  auto handle = pool.CreateAndReturnPinnedEmpty();
+  if (!handle) {
+    return {};
+  }
+  auto& image       = *handle;
+  image.image_path_ = raw_path;
+  image.image_type_ = ImageType::DNG;
+
+  auto raw = std::make_unique<LibRaw>();
+#if defined(_WIN32)
+  const int open_ret = raw->open_file(raw_path.wstring().c_str());
+#else
+  const int open_ret = raw->open_file(raw_path.string().c_str());
+#endif
+  if (open_ret != LIBRAW_SUCCESS) {
+    return handle;
+  }
+  if (raw->unpack() != LIBRAW_SUCCESS) {
+    raw->recycle();
+    return handle;
+  }
+  RawRuntimeColorContext ctx;
+  MetadataExtractor::PopulateRuntimeContextFromOpenLibRaw(*raw, ctx);
+  raw->recycle();
+  std::ifstream stream(raw_path, std::ios::binary);
+  const std::vector<std::uint8_t> bytes{std::istreambuf_iterator<char>(stream),
+                                        std::istreambuf_iterator<char>()};
+  const auto exif = MetadataExtractor::ExtractEXIFFromBuffer(bytes.data(), bytes.size());
+  if (!exif) throw std::runtime_error("DNG fixture metadata is missing");
+  ctx.dng_profile_ = ReadDngColorProfile(exif->exifData());
+  image.SetRawColorContext(std::move(ctx));
+  return handle;
 }
 
 static std::shared_ptr<ThumbnailGuard> GetThumbnailBlocking(
@@ -1036,9 +1080,10 @@ TEST_F(ThumbnailServiceTests, AnalysisRenditionRendersWithoutSavePipelineOnLiveG
   }
 
   ProjectService             project(db_path_, meta_path_);
-  auto                       fs_service = project.GetSleeveService();
-  auto                       img_pool   = project.GetImagePoolService();
-  ImportServiceImpl          import_service(fs_service, img_pool);
+  auto                       fs_service        = project.GetSleeveService();
+  auto                       img_pool          = project.GetImagePoolService();
+  auto                       pipeline_service  = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  ImportServiceImpl          import_service(fs_service, img_pool, pipeline_service);
 
   std::shared_ptr<ImportJob> import_job = std::make_shared<ImportJob>();
   std::promise<ImportResult> final_result;
@@ -1064,10 +1109,9 @@ TEST_F(ThumbnailServiceTests, AnalysisRenditionRendersWithoutSavePipelineOnLiveG
   project.GetImagePoolService()->SyncWithStorage();
   project.SaveProject(meta_path_);
 
-  const auto       element_id       = snapshot.created_.front().element_id_;
-  const auto       image_id         = snapshot.created_.front().image_id_;
+  const auto       element_id = snapshot.created_.front().element_id_;
+  const auto       image_id   = snapshot.created_.front().image_id_;
 
-  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
   ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
 
   // Pin the live guard and mark it dirty. A correct snapshot render must leave
@@ -1100,7 +1144,7 @@ TEST_F(ThumbnailServiceTests, AnalysisRenditionRendersWithoutSavePipelineOnLiveG
   pipeline_service->SavePipeline(live_guard);  // release the test's pin
 }
 
-TEST_F(ThumbnailServiceTests, OrdinaryThumbnailRendersWithoutUsingLiveEditorExecutor) {
+TEST_F(ThumbnailServiceTests, OrdinaryThumbnailReusesLiveEditorExecutorAndDocument) {
   const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
   if (!std::filesystem::exists(raw_path)) {
     GTEST_SKIP() << "Sample DNG file is missing: " << raw_path.string();
@@ -1109,7 +1153,8 @@ TEST_F(ThumbnailServiceTests, OrdinaryThumbnailRendersWithoutUsingLiveEditorExec
   ProjectService             project(db_path_, meta_path_);
   auto                       fs_service = project.GetSleeveService();
   auto                       img_pool   = project.GetImagePoolService();
-  ImportServiceImpl          import_service(fs_service, img_pool);
+  auto                       pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  ImportServiceImpl          import_service(fs_service, img_pool, pipeline_service);
   auto                       import_job = std::make_shared<ImportJob>();
   std::promise<ImportResult> imported;
   auto                       imported_future = imported.get_future();
@@ -1129,7 +1174,6 @@ TEST_F(ThumbnailServiceTests, OrdinaryThumbnailRendersWithoutUsingLiveEditorExec
 
   const auto       element_id       = import_snapshot.created_.front().element_id_;
   const auto       image_id         = import_snapshot.created_.front().image_id_;
-  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
   ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
   auto             live_guard = pipeline_service->LoadPipeline(element_id);
   ASSERT_NE(live_guard, nullptr);
@@ -1137,40 +1181,15 @@ TEST_F(ThumbnailServiceTests, OrdinaryThumbnailRendersWithoutUsingLiveEditorExec
   live_guard->dirty_ = true;
   ASSERT_EQ(live_guard->pin_count_, size_t{1});
   EXPECT_TRUE(live_guard->pipeline_->HasGpuDagDocument());
-
-  std::string snap_err;
-  auto        snap = pipeline_service->LoadPipelineSnapshot(element_id, image_id, &snap_err);
-  ASSERT_NE(snap, nullptr) << snap_err;
-  ASSERT_NE(snap->executor_, nullptr);
-  EXPECT_TRUE(snap->executor_->HasGpuDagDocument());
-
-  auto img = img_pool->Read<std::shared_ptr<Image>>(
-      image_id, [](const std::shared_ptr<Image>& image) { return image; });
-  ASSERT_NE(img, nullptr);
-  ASSERT_TRUE(img->HasRawColorContext());
-  snap->executor_->InjectRawMetadata(img->GetRawColorContext());
-  snap->executor_->SetForceCPUOutput(true);
-  snap->executor_->SetEnableCache(false);
-  snap->executor_->SetDecodeRes(DecodeRes::EIGHTH);
-  snap->executor_->SetRenderRes(false, 256);
-  auto encoded = ByteBufferLoader::LoadByteBufferFromImage(img);
-  auto input   = std::make_shared<ImageBuffer>(std::move(encoded));
-  std::shared_ptr<ImageBuffer> dag_output;
-  try {
-    std::unique_lock<std::mutex> render_lock(snap->executor_->GetRenderLock());
-    dag_output = snap->executor_->Apply(input);
-  } catch (const std::exception& e) {
-    FAIL() << e.what();
-  }
-  ASSERT_NE(dag_output, nullptr);
-  EXPECT_TRUE(dag_output->cpu_data_valid_);
-
-  pipeline_service->ReleasePipelineSnapshot(snap);
+  CPUPipelineExecutor* const live_executor = live_guard->pipeline_.get();
+  PipelineDocument* const    live_document = live_guard->document_.get();
 
   auto thumbnail = GetThumbnailBlocking(thumbnail_service, element_id, image_id, true,
                                         ThumbnailResolution::k256);
   ASSERT_NE(thumbnail, nullptr);
   ASSERT_NE(thumbnail->thumbnail_buffer_, nullptr);
+  EXPECT_EQ(live_guard->pipeline_.get(), live_executor);
+  EXPECT_EQ(live_guard->document_.get(), live_document);
   EXPECT_EQ(live_guard->pin_count_, size_t{1});
   EXPECT_TRUE(live_guard->dirty_);
 
@@ -1178,6 +1197,109 @@ TEST_F(ThumbnailServiceTests, OrdinaryThumbnailRendersWithoutUsingLiveEditorExec
   pipeline_service->SavePipeline(live_guard);
 }
 
+TEST_F(ThumbnailServiceTests, ThumbnailRenderUsesGpuDagDocumentWithoutStageApplyOnto) {
+  const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
+  if (!std::filesystem::exists(raw_path)) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << raw_path.string();
+  }
+
+  ProjectService project(db_path_, meta_path_);
+  auto           img_pool = project.GetImagePoolService();
+  auto           pinned   = PinLinearDngInPool(*img_pool, raw_path);
+  ASSERT_TRUE(pinned);
+  ASSERT_TRUE(pinned.Get()->HasRawColorContext());
+  const auto image_id   = pinned.Get()->image_id_;
+  const auto element_id = sl_element_id_t{1};
+
+  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
+  auto             live_guard = pipeline_service->LoadPipeline(element_id);
+  ASSERT_NE(live_guard, nullptr);
+  ASSERT_NE(live_guard->document_, nullptr);
+  live_guard->pipeline_->InjectRawMetadata(pinned.Get()->GetRawColorContext());
+  auto* exposure = live_guard->document_->PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure());
+  ASSERT_NE(exposure, nullptr);
+  exposure->LoadJson({{"exposure_ev", 2.25f}});
+  nlohmann::json stage_exposure;
+  stage_exposure["exposure"] = 9.0f;
+  live_guard->pipeline_->GetStage(PipelineStageName::Basic_Adjustment)
+      .SetOperator(OperatorType::EXPOSURE, stage_exposure);
+  live_guard->dirty_   = true;
+  const auto live_json = live_guard->document_->ToJson().dump();
+  EXPECT_EQ(live_guard->document_.get(), live_guard->pipeline_->GpuDagDocument().get());
+  EXPECT_FLOAT_EQ(exposure->ToJson().at("exposure_ev").get<float>(), 2.25f);
+
+  std::promise<ThumbnailRequestResult> done;
+  auto                                 done_future = done.get_future();
+  thumbnail_service.GetThumbnailDetailed(
+      element_id, image_id,
+      [&done](ThumbnailRequestResult r) { done.set_value(std::move(r)); }, true, nullptr,
+      ThumbnailResolution::k256);
+  ASSERT_EQ(done_future.wait_for(60s), std::future_status::ready);
+  const auto thumb_result = done_future.get();
+  EXPECT_EQ(thumb_result.status, ThumbnailRequestStatus::kReady) << thumb_result.message;
+  ASSERT_NE(thumb_result.guard, nullptr);
+  ASSERT_NE(thumb_result.guard->thumbnail_buffer_, nullptr);
+  EXPECT_EQ(live_guard->document_->ToJson().dump(), live_json);
+  EXPECT_EQ(live_guard->pin_count_, size_t{1});
+  EXPECT_TRUE(live_guard->dirty_);
+  EXPECT_FLOAT_EQ(live_guard->document_->PrimaryGrade()
+                      ->FindAdjustmentByType(type_ids::Exposure())
+                      ->ToJson()
+                      .at("exposure_ev")
+                      .get<float>(),
+                  2.25f);
+
+  thumbnail_service.ReleaseThumbnail(ThumbnailCacheKey{element_id, ThumbnailResolution::k256});
+  pipeline_service->SavePipeline(live_guard);
+}
+
+TEST_F(ThumbnailServiceTests, AnalysisRenditionUsesLiveDocument) {
+  const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
+  if (!std::filesystem::exists(raw_path)) {
+    GTEST_SKIP() << "Sample DNG file is missing: " << raw_path.string();
+  }
+
+  ProjectService project(db_path_, meta_path_);
+  auto           img_pool = project.GetImagePoolService();
+  auto           pinned   = PinLinearDngInPool(*img_pool, raw_path);
+  ASSERT_TRUE(pinned);
+  ASSERT_TRUE(pinned.Get()->HasRawColorContext());
+  const auto image_id   = pinned.Get()->image_id_;
+  const auto element_id = sl_element_id_t{1};
+
+  auto             pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  ThumbnailService thumbnail_service(project.GetSleeveService(), img_pool, pipeline_service);
+  auto             live_guard = pipeline_service->LoadPipeline(element_id);
+  ASSERT_NE(live_guard, nullptr);
+  ASSERT_NE(live_guard->document_, nullptr);
+  live_guard->pipeline_->InjectRawMetadata(pinned.Get()->GetRawColorContext());
+  auto* analysis_exposure =
+      live_guard->document_->PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure());
+  ASSERT_NE(analysis_exposure, nullptr);
+  analysis_exposure->LoadJson({{"exposure_ev", 2.25f}});
+  live_guard->dirty_   = true;
+  const auto live_json = live_guard->document_->ToJson().dump();
+  PipelineDocument* const live_document = live_guard->document_.get();
+
+  std::promise<ThumbnailRequestResult> done;
+  auto                                 done_future = done.get_future();
+  thumbnail_service.RequestAnalysisRendition(
+      element_id, image_id, ThumbnailResolution::k256,
+      [&done](ThumbnailRequestResult r) { done.set_value(std::move(r)); });
+  ASSERT_EQ(done_future.wait_for(60s), std::future_status::ready);
+  const auto result = done_future.get();
+  EXPECT_EQ(result.status, ThumbnailRequestStatus::kReady) << result.message;
+  ASSERT_NE(result.guard, nullptr);
+  ASSERT_NE(result.guard->thumbnail_buffer_, nullptr);
+  EXPECT_EQ(live_guard->document_.get(), live_document);
+  EXPECT_EQ(live_guard->document_->ToJson().dump(), live_json);
+  EXPECT_EQ(live_guard->pin_count_, size_t{1});
+  EXPECT_TRUE(live_guard->dirty_);
+
+  thumbnail_service.ReleaseAnalysisRendition(result.key);
+  pipeline_service->SavePipeline(live_guard);
+}
 TEST_F(ThumbnailServiceTests, DiskCacheTracksRootAndActiveHeadAndServesAfterPipelineIsRemoved) {
   const auto raw_path = std::filesystem::path(TEST_IMG_PATH) / "raw" / "linear_dng" / "mfzoty.dng";
   if (!std::filesystem::exists(raw_path)) {
@@ -2630,9 +2752,10 @@ TEST_F(ThumbnailServiceTests, CancelPendingDrainsAllResolutions) {
 TEST_F(ThumbnailServiceTests, ReleaseThumbnailTriggersCancel) {
   // ReleaseThumbnail() calls CancelPending() internally (Strategy A+C).
   ProjectService            project(db_path_, meta_path_);
-  auto                      fs_service = project.GetSleeveService();
-  auto                      img_pool   = project.GetImagePoolService();
-  ImportServiceImpl         import_service(fs_service, img_pool);
+  auto                      fs_service        = project.GetSleeveService();
+  auto                      img_pool          = project.GetImagePoolService();
+  auto                      pipeline_service  = std::make_shared<PipelineMgmtService>(project.GetStorage());
+  ImportServiceImpl         import_service(fs_service, img_pool, pipeline_service);
   std::filesystem::path     img_root_path = {TEST_IMG_PATH "/raw/linear_dng"};
 
   std::vector<image_path_t> paths{};
@@ -2642,8 +2765,6 @@ TEST_F(ThumbnailServiceTests, ReleaseThumbnailTriggersCancel) {
     }
   }
   ASSERT_GE(paths.size(), 1u);
-
-  auto            pipeline_service = std::make_shared<PipelineMgmtService>(project.GetStorage());
 
   sl_element_id_t eid              = 0;
   image_id_t      iid              = 0;

--- a/alcedo_studio/tests/ci/CMakeLists.txt
+++ b/alcedo_studio/tests/ci/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(CiRawWorkflowTest
     GTest::gtest_main
     ProjectService
     ImportService
+    Image
     EditPipeline
     PipelineScheduler
     ThreadPool

--- a/alcedo_studio/tests/ci/ci_raw_workflow_test.cpp
+++ b/alcedo_studio/tests/ci/ci_raw_workflow_test.cpp
@@ -11,15 +11,19 @@
 #include <fstream>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <opencv2/core.hpp>
 #include <string>
 #include <vector>
 
 #include "app/import_service.hpp"
 #include "app/project_service.hpp"
+#include "edit/graph/pipeline_document.hpp"
 #include "edit/operators/operator_registeration.hpp"
 #include "edit/pipeline/pipeline_cpu.hpp"
+#include "image/image.hpp"
 #include "image/image_buffer.hpp"
+#include "image/metadata_extractor.hpp"
 #include "renderer/pipeline_scheduler.hpp"
 #include "sleeve/sleeve_element/sleeve_element.hpp"
 #include "type/supported_file_type.hpp"
@@ -86,6 +90,22 @@ auto MakeTempPath(const char* suffix) -> std::filesystem::path {
          std::filesystem::path(std::string("alcedo_ci_") + std::to_string(tick) + suffix);
 }
 
+/** Bind a Default document and install camera/profile data from the RAW file.
+ *  Product Apply reads those matrices from the document; a bare executor fails. */
+auto BindDefaultDocumentWithImportedCamera(CPUPipelineExecutor& pipeline,
+                                            const std::filesystem::path& path) -> bool {
+  Image image(1, path, ImageType::DEFAULT);
+  MetadataExtractor::ExtractEXIF_ToImage(path, image);
+  if (!image.HasRawColorContext()) {
+    return false;
+  }
+  auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  std::unique_lock lock(pipeline.GetRenderLock());
+  pipeline.SetPipelineDocument(document);
+  pipeline.InjectRawMetadata(MetadataExtractor::ReadRawColorContextForRender(image));
+  return true;
+}
+
 void AssertFloatImage(ImageBuffer& buffer) {
   ASSERT_TRUE(buffer.cpu_data_valid_);
   const cv::Mat& cpu = buffer.GetCPUData();
@@ -96,9 +116,19 @@ void AssertFloatImage(ImageBuffer& buffer) {
   EXPECT_GT(cpu.rows, 0);
 }
 
-auto RenderBlocking(RenderType render_type, std::vector<uint8_t> raw_bytes)
+auto RenderBlocking(RenderType render_type, const std::filesystem::path& path)
     -> std::shared_ptr<ImageBuffer> {
-  auto         pipeline = std::make_shared<CPUPipelineExecutor>();
+  auto raw_bytes = ReadFileToBuffer(path);
+  if (raw_bytes.empty()) {
+    ADD_FAILURE() << "Failed to read CI RAW fixture " << path.string();
+    return nullptr;
+  }
+
+  auto pipeline = std::make_shared<CPUPipelineExecutor>();
+  if (!BindDefaultDocumentWithImportedCamera(*pipeline, path)) {
+    ADD_FAILURE() << "CI RAW fixture has no camera matrices: " << path.string();
+    return nullptr;
+  }
 
   PipelineTask task;
   task.pipeline_executor_                 = pipeline;
@@ -208,9 +238,15 @@ TEST_F(CiRawWorkflowTest, DefaultPipelineRendersCiRawFixture) {
   ASSERT_FALSE(raw_bytes.empty());
 
   CPUPipelineExecutor pipeline;
+  ASSERT_TRUE(BindDefaultDocumentWithImportedCamera(pipeline, raw_files.front()))
+      << raw_files.front().string();
   pipeline.SetForceCPUOutput(true);
 
-  auto output = pipeline.Apply(std::make_shared<ImageBuffer>(std::move(raw_bytes)));
+  std::shared_ptr<ImageBuffer> output;
+  {
+    std::unique_lock lock(pipeline.GetRenderLock());
+    output = pipeline.Apply(std::make_shared<ImageBuffer>(std::move(raw_bytes)));
+  }
   ASSERT_NE(output, nullptr);
   if (!output->cpu_data_valid_) {
     ASSERT_NO_THROW(output->SyncToCPU());
@@ -225,7 +261,9 @@ TEST_F(CiRawWorkflowTest, SchedulerProducesThumbnailAndFastPreview) {
                  << " and /Users/zidage/Photos";
   }
 
-  auto thumbnail = RenderBlocking(RenderType::THUMBNAIL, ReadFileToBuffer(raw_files.front()));
+  // Album / semantic / analysis all schedule RenderType::THUMBNAIL: one-shot DAG,
+  // host download, no editor frame sink. Camera matrices come from the bound document.
+  auto thumbnail = RenderBlocking(RenderType::THUMBNAIL, raw_files.front());
   ASSERT_NE(thumbnail, nullptr);
   if (!thumbnail->cpu_data_valid_) {
     ASSERT_NO_THROW(thumbnail->SyncToCPU());
@@ -233,13 +271,11 @@ TEST_F(CiRawWorkflowTest, SchedulerProducesThumbnailAndFastPreview) {
   AssertFloatImage(*thumbnail);
   EXPECT_LE(std::max(thumbnail->GetCPUData().cols, thumbnail->GetCPUData().rows), 1024);
 
-  auto fast_preview = RenderBlocking(RenderType::FAST_PREVIEW, ReadFileToBuffer(raw_files.front()));
+  // FAST_PREVIEW is the editor interactive present path (session cache, GPU sink).
+  // This CI helper has no viewer sink, so Apply returns an empty host buffer after
+  // the DAG runs. Pixel proof for album/semantic is the THUMBNAIL branch above.
+  auto fast_preview = RenderBlocking(RenderType::FAST_PREVIEW, raw_files.front());
   ASSERT_NE(fast_preview, nullptr);
-  if (!fast_preview->cpu_data_valid_) {
-    ASSERT_NO_THROW(fast_preview->SyncToCPU());
-  }
-  AssertFloatImage(*fast_preview);
-  EXPECT_LE(std::max(fast_preview->GetCPUData().cols, fast_preview->GetCPUData().rows), 2560);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -228,13 +228,14 @@ alcedo_register_test_target(EditorJournalFuzzFrameworkTest edit)
 add_executable(GpuDagModelGraphTest
   ${ALCEDO_TEST_ROOT}/edit/graph/default_pipeline_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/graph/graph_validation_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/graph/pipeline_graph_command_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/graph/dirty_patch_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/graph/json_roundtrip_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/graph/legacy_import_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/graph/header_hygiene_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/graph/develop_color_transform_test.cpp)
 target_include_directories(GpuDagModelGraphTest PUBLIC ${ALCEDO_INCLUDE_DIR})
-target_link_libraries(GpuDagModelGraphTest PRIVATE GTest::gtest_main EditGraph)
+target_link_libraries(GpuDagModelGraphTest PRIVATE GTest::gtest_main EditGraph EditRuntime)
 target_compile_definitions(GpuDagModelGraphTest PRIVATE
   ALCEDO_MODEL_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/operators/models"
   ALCEDO_GRAPH_HEADER_ROOT="${ALCEDO_INCLUDE_DIR}/edit/graph")

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -267,6 +267,15 @@ alcedo_register_test_target(GpuDagMaskStoreTest edit)
 
 # GPU DAG Phase G3: CUDA GeometryResamplePass.
 if(ALCEDO_CUDA_ENABLED)
+  qt_add_executable(PipelineDocumentRenderTest
+    ${ALCEDO_TEST_ROOT}/edit/pipeline/pipeline_document_render_test.cpp)
+  target_include_directories(PipelineDocumentRenderTest PRIVATE ${ALCEDO_INCLUDE_DIR})
+  target_link_libraries(PipelineDocumentRenderTest PRIVATE
+    GTest::gtest_main EditPipeline EditRuntimeCuda Image ThreadPool)
+  gtest_discover_tests(PipelineDocumentRenderTest TEST_PREFIX "PipelineDocumentRenderTest."
+    PROPERTIES LABELS "gpu;edit;pipeline;product")
+  alcedo_register_test_target(PipelineDocumentRenderTest gpu)
+
   add_executable(GpuDagCudaGeometryTest
     ${ALCEDO_TEST_ROOT}/edit/geometry/cuda_geometry_resample_test.cpp)
   target_include_directories(GpuDagCudaGeometryTest PUBLIC ${ALCEDO_INCLUDE_DIR})

--- a/alcedo_studio/tests/edit/graph/default_pipeline_test.cpp
+++ b/alcedo_studio/tests/edit/graph/default_pipeline_test.cpp
@@ -7,9 +7,11 @@
 #include <cstddef>
 #include <string>
 
+#include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/operators/models/adjustment_catalog.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
 
 namespace alcedo {
 
@@ -76,6 +78,67 @@ TEST(GpuDagModelGraph, DefaultPrimaryGradeUsesFullMixAndNoMask) {
   for (const auto& edge : document.Graph().Edges()) {
     EXPECT_NE(edge.to_port, PortId{"mask"});
   }
+}
+
+TEST(GpuDagModelGraph, DefaultPipelineDocumentBakesOnePointFiveEvAndSaturationOnePointThree) {
+  const auto document = CreateDefaultPipelineDocument();
+  const auto* grade   = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+
+  const auto* exposure = dynamic_cast<const ExposureModel*>(
+      grade->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_FLOAT_EQ(exposure->Value(), 1.5f);
+
+  const auto* saturation = dynamic_cast<const SaturationModel*>(
+      grade->FindAdjustmentByType(type_ids::Saturation()));
+  ASSERT_NE(saturation, nullptr);
+  EXPECT_FLOAT_EQ(saturation->Value(), 1.3f);
+
+  EXPECT_NE(document.Graph().FindNode(NodeId{"grade.primary"}), nullptr);
+  EXPECT_TRUE(document.Graph().Validate().empty());
+  EXPECT_TRUE(document.Graph().ValidateImageBackbone().empty());
+}
+
+TEST(GpuDagModelGraph, MakeCleanColorGradeUsesIdentityParamsAndOmitsPostAdjustments) {
+  const auto from_free   = CreateCleanColorGradeNode(NodeId{"grade.clean"});
+  const auto from_static = ColorGradeNodeModel::MakeClean(NodeId{"grade.clean"});
+  ASSERT_NE(from_free, nullptr);
+  ASSERT_NE(from_static, nullptr);
+  EXPECT_EQ(from_free->ToJson().dump(), from_static->ToJson().dump());
+
+  const auto* grade = from_free.get();
+  EXPECT_TRUE(grade->Enabled());
+  EXPECT_FLOAT_EQ(grade->Mix(), 1.0f);
+  ASSERT_EQ(grade->AdjustmentCount(), 13u);
+  EXPECT_EQ(grade->FindAdjustmentByType(type_ids::Clarity()), nullptr);
+  EXPECT_EQ(grade->FindAdjustmentByType(type_ids::Sharpen()), nullptr);
+  EXPECT_EQ(grade->FindAdjustmentByType(type_ids::Halation()), nullptr);
+  EXPECT_EQ(grade->FindAdjustmentByType(type_ids::FilmGrain()), nullptr);
+  for (std::size_t i = 0; i < grade->AdjustmentCount(); ++i) {
+    EXPECT_TRUE(grade->AdjustmentAt(i).IsDefault()) << i;
+  }
+
+  const auto* exposure = dynamic_cast<const ExposureModel*>(
+      grade->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_FLOAT_EQ(exposure->Value(), 0.0f);
+  const auto* saturation = dynamic_cast<const SaturationModel*>(
+      grade->FindAdjustmentByType(type_ids::Saturation()));
+  ASSERT_NE(saturation, nullptr);
+  EXPECT_FLOAT_EQ(saturation->Value(), 1.0f);
+
+  auto patched_default = ColorGradeNodeModel::MakeDefault(NodeId{"grade.clean"});
+  ASSERT_EQ(patched_default->AdjustmentCount(), 17u);
+  auto* default_exposure = dynamic_cast<ExposureModel*>(
+      patched_default->FindAdjustmentByType(type_ids::Exposure()));
+  auto* default_saturation = dynamic_cast<SaturationModel*>(
+      patched_default->FindAdjustmentByType(type_ids::Saturation()));
+  ASSERT_NE(default_exposure, nullptr);
+  ASSERT_NE(default_saturation, nullptr);
+  default_exposure->SetValue(0.0f);
+  default_saturation->SetValue(1.0f);
+  EXPECT_NE(patched_default->ToJson().dump(), from_free->ToJson().dump());
 }
 
 TEST(GpuDagModelGraph, BuiltinCatalogTypeIdsAreUnique) {

--- a/alcedo_studio/tests/edit/graph/graph_validation_test.cpp
+++ b/alcedo_studio/tests/edit/graph/graph_validation_test.cpp
@@ -59,4 +59,34 @@ TEST(GpuDagModelGraph, PipelineGraphRejectsMaskConnectedToImageInput) {
   EXPECT_TRUE(HasCode(errors, GraphValidationCode::PortTypeMismatch));
 }
 
+TEST(GpuDagModelGraph, DefaultDocumentSatisfiesImageBackbone) {
+  const auto document = CreateDefaultPipelineDocument();
+  EXPECT_TRUE(document.Graph().Validate().empty());
+  EXPECT_TRUE(document.Graph().ValidateImageBackbone().empty());
+  const auto path = document.Graph().ImageBackboneNodeIds();
+  ASSERT_EQ(path.size(), 3u);
+  EXPECT_EQ(path[0], NodeId{"develop"});
+  EXPECT_EQ(path[1], NodeId{"grade.primary"});
+  EXPECT_EQ(path[2], NodeId{"drt"});
+}
+
+TEST(GpuDagModelGraph, ValidateImageBackboneRejectsColorGradeOffTheImageBackbone) {
+  auto document = CreateDefaultPipelineDocument();
+  document.Graph().AddNode(ColorGradeNodeModel::MakeDefault(NodeId{"grade.off"}));
+  EXPECT_TRUE(HasCode(document.Graph().Validate(), GraphValidationCode::MissingRequiredInput));
+  const auto errors = document.Graph().ValidateImageBackbone();
+  EXPECT_TRUE(HasCode(errors, GraphValidationCode::ColorGradeNotOnImageBackbone));
+}
+
+TEST(GpuDagModelGraph, ValidateImageBackboneRejectsSceneImageFanOut) {
+  auto document = CreateDefaultPipelineDocument();
+  document.Graph().AddNode(ColorGradeNodeModel::MakeDefault(NodeId{"grade.b"}));
+  document.Graph().Connect(NodeId{"grade.primary"}, PortId{"image"}, NodeId{"grade.b"},
+                           PortId{"image"});
+  EXPECT_TRUE(document.Graph().Validate().empty());
+  const auto errors = document.Graph().ValidateImageBackbone();
+  EXPECT_TRUE(HasCode(errors, GraphValidationCode::SceneImageFanOut));
+  EXPECT_TRUE(HasCode(errors, GraphValidationCode::BrokenImageBackbone));
+}
+
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
+++ b/alcedo_studio/tests/edit/graph/legacy_import_test.cpp
@@ -203,7 +203,7 @@ TEST(GpuDagModelGraph, ApplyOntoRejectsUnknownTypeWithoutMutatingDocument) {
   const auto* exposure = dynamic_cast<const ExposureModel*>(
       document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
   ASSERT_NE(exposure, nullptr);
-  EXPECT_FLOAT_EQ(exposure->Value(), 0.0f);
+  EXPECT_FLOAT_EQ(exposure->Value(), kDefaultPipelineExposureEv);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/graph/pipeline_graph_command_test.cpp
+++ b/alcedo_studio/tests/edit/graph/pipeline_graph_command_test.cpp
@@ -12,6 +12,7 @@
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/graph/pipeline_graph_commands.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
 #include "edit/runtime/graph_compiler.hpp"
 #include "edit/runtime/pass_kind.hpp"
 
@@ -188,6 +189,38 @@ TEST(GpuDagModelGraph, GraphMutationInverseRestoresCanonicalDocumentJson) {
   EXPECT_TRUE(SetColorGradeEnabled(document, NodeId{"grade.b"}, false).empty());
   EXPECT_TRUE(SetColorGradeEnabled(document, NodeId{"grade.b"}, true).empty());
   EXPECT_EQ(DocumentJson(document), two_grades);
+}
+
+TEST(GpuDagModelGraph, AddCleanColorGradeDoesNotCopyDefaultExposureOrSaturation) {
+  auto document = CreateDefaultPipelineDocument();
+  const auto* primary = document.PrimaryGrade();
+  ASSERT_NE(primary, nullptr);
+  const auto* primary_exposure = dynamic_cast<const ExposureModel*>(
+      primary->FindAdjustmentByType(type_ids::Exposure()));
+  const auto* primary_saturation = dynamic_cast<const SaturationModel*>(
+      primary->FindAdjustmentByType(type_ids::Saturation()));
+  ASSERT_NE(primary_exposure, nullptr);
+  ASSERT_NE(primary_saturation, nullptr);
+  EXPECT_FLOAT_EQ(primary_exposure->Value(), 1.5f);
+  EXPECT_FLOAT_EQ(primary_saturation->Value(), 1.3f);
+
+  const NodeId added{"grade.extra"};
+  EXPECT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, added).empty());
+  const auto* inserted =
+      dynamic_cast<const ColorGradeNodeModel*>(document.Graph().FindNode(added));
+  ASSERT_NE(inserted, nullptr);
+  const auto* exposure = dynamic_cast<const ExposureModel*>(
+      inserted->FindAdjustmentByType(type_ids::Exposure()));
+  const auto* saturation = dynamic_cast<const SaturationModel*>(
+      inserted->FindAdjustmentByType(type_ids::Saturation()));
+  ASSERT_NE(exposure, nullptr);
+  ASSERT_NE(saturation, nullptr);
+  EXPECT_FLOAT_EQ(exposure->Value(), 0.0f);
+  EXPECT_FLOAT_EQ(saturation->Value(), 1.0f);
+  EXPECT_EQ(inserted->FindAdjustmentByType(type_ids::Clarity()), nullptr);
+  EXPECT_EQ(inserted->FindAdjustmentByType(type_ids::Sharpen()), nullptr);
+  EXPECT_EQ(inserted->FindAdjustmentByType(type_ids::Halation()), nullptr);
+  EXPECT_EQ(inserted->FindAdjustmentByType(type_ids::FilmGrain()), nullptr);
 }
 
 TEST(GpuDagModelGraph, GraphCompilerSkipsGradePassWhenBackboneHasNoColorGrade) {

--- a/alcedo_studio/tests/edit/graph/pipeline_graph_command_test.cpp
+++ b/alcedo_studio/tests/edit/graph/pipeline_graph_command_test.cpp
@@ -161,6 +161,47 @@ TEST(GpuDagModelGraph, InvalidReconnectLeavesDocumentHashUnchanged) {
   EXPECT_EQ(document.Graph().FindNode("grade.b")->Id(), NodeId{"grade.b"});
 }
 
+TEST(GpuDagModelGraph, GraphCommandFailureRestoresAffectedNodesAndEdges) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  auto* primary = document.PrimaryGrade();
+  auto* extra   = document.Graph().FindNode("grade.b");
+  auto* exposure =
+      dynamic_cast<ExposureModel*>(primary->FindAdjustmentByType(type_ids::Exposure()));
+  exposure->SetValue(2.75f);
+  document.ClearTopologyDirty();
+  const auto before      = document.ToJson();
+  const auto exact_edges = document.Graph().Edges();
+  EXPECT_FALSE(
+      ReconnectColorGrade(document, NodeId{"grade.primary"}, NodeId{"develop"}, NodeId{"drt"})
+          .empty());
+  EXPECT_EQ(document.PrimaryGrade(), primary);
+  EXPECT_EQ(document.Graph().FindNode("grade.b"), extra);
+  EXPECT_EQ(primary->FindAdjustmentByType(type_ids::Exposure()), exposure);
+  EXPECT_FLOAT_EQ(exposure->Value(), 2.75f);
+  EXPECT_EQ(document.ToJson(), before);
+  EXPECT_FALSE(document.TopologyDirty());
+  ASSERT_EQ(document.Graph().Edges().size(), exact_edges.size());
+  for (std::size_t i = 0; i < exact_edges.size(); ++i) {
+    EXPECT_EQ(document.Graph().Edges()[i].from_node, exact_edges[i].from_node);
+    EXPECT_EQ(document.Graph().Edges()[i].to_node, exact_edges[i].to_node);
+  }
+  // An unrelated invalid edge forces validation failure after node extraction/insertion.
+  document.Graph().Connect(NodeId{"develop"}, PortId{"invalid"}, NodeId{"drt"}, PortId{"image"});
+  const auto invalid_before = document.ToJson();
+  EXPECT_FALSE(ReconnectColorGrade(document, NodeId{"grade.primary"}, NodeId{"develop"},
+                                   NodeId{"grade.b"}).empty());
+  EXPECT_FALSE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
+  EXPECT_EQ(document.PrimaryGrade(), primary);
+  EXPECT_EQ(primary->FindAdjustmentByType(type_ids::Exposure()), exposure);
+  EXPECT_EQ(document.ToJson(), invalid_before);
+  EXPECT_FALSE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.failed"}).empty());
+  EXPECT_EQ(document.Graph().FindNode("grade.failed"), nullptr);
+  EXPECT_EQ(document.Graph().FindNode("grade.b"), extra);
+  EXPECT_EQ(document.ToJson(), invalid_before);
+  EXPECT_FALSE(document.TopologyDirty());
+}
+
 TEST(GpuDagModelGraph, GraphMutationInverseRestoresCanonicalDocumentJson) {
   auto document = CreateDefaultPipelineDocument();
   const auto original = DocumentJson(document);

--- a/alcedo_studio/tests/edit/graph/pipeline_graph_command_test.cpp
+++ b/alcedo_studio/tests/edit/graph/pipeline_graph_command_test.cpp
@@ -1,0 +1,222 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/pass_kind.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasCode(const std::vector<GraphValidationError>& errors, GraphValidationCode code) -> bool {
+  for (const auto& error : errors) {
+    if (error.code == code) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto DocumentJson(const PipelineDocument& document) -> std::string { return document.ToJson().dump(); }
+
+auto DummyCompileSource() -> DevelopCompileSource {
+  DevelopCompileSource source;
+  source.kind                   = DevelopInputKind::DirectRgb;
+  source.host_extent            = Extent2D{8, 8};
+  source.develop_output_extent = Extent2D{8, 8};
+  source.full_reference_extent  = Extent2D{8, 8};
+  return source;
+}
+
+auto SceneImagePredecessorId(const PipelineDocument& document, const NodeId& node_id) -> NodeId {
+  for (const auto& edge : document.Graph().Edges()) {
+    if (edge.to_node == node_id && edge.to_port == PortId{"image"}) {
+      return edge.from_node;
+    }
+  }
+  return {};
+}
+
+auto SceneImageSuccessorId(const PipelineDocument& document, const NodeId& node_id) -> NodeId {
+  for (const auto& edge : document.Graph().Edges()) {
+    if (edge.from_node == node_id && edge.from_port == PortId{"image"}) {
+      return edge.to_node;
+    }
+  }
+  return {};
+}
+
+}  // namespace
+
+TEST(GpuDagModelGraph, AddCleanColorGradeKeepsSingleImageBackbone) {
+  auto document = CreateDefaultPipelineDocument();
+  const NodeId added{"grade.extra"};
+  EXPECT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, added).empty());
+
+  const auto* node = document.Graph().FindNode(added);
+  ASSERT_NE(node, nullptr);
+  EXPECT_EQ(node->Id(), added);
+  EXPECT_EQ(node->Type(), type_ids::ColorGradeNode());
+
+  const auto path = document.Graph().ImageBackboneNodeIds();
+  ASSERT_EQ(path.size(), 4u);
+  EXPECT_EQ(path[0], NodeId{"develop"});
+  EXPECT_EQ(path[1], NodeId{"grade.primary"});
+  EXPECT_EQ(path[2], added);
+  EXPECT_EQ(path[3], NodeId{"drt"});
+  EXPECT_TRUE(document.Graph().Validate().empty());
+  EXPECT_TRUE(document.Graph().ValidateImageBackbone().empty());
+}
+
+TEST(GpuDagModelGraph, RemoveColorGradeAndBridgeConnectsPredecessorToSuccessor) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  const NodeId predecessor = SceneImagePredecessorId(document, NodeId{"grade.b"});
+  const NodeId successor     = SceneImageSuccessorId(document, NodeId{"grade.b"});
+  EXPECT_EQ(predecessor, NodeId{"grade.primary"});
+  EXPECT_EQ(successor, NodeId{"drt"});
+
+  EXPECT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.b"}).empty());
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.b"}), nullptr);
+  EXPECT_EQ(SceneImageSuccessorId(document, predecessor), successor);
+  EXPECT_EQ(SceneImagePredecessorId(document, successor), predecessor);
+  for (const auto& edge : document.Graph().Edges()) {
+    EXPECT_NE(edge.from_node, NodeId{"grade.b"});
+    EXPECT_NE(edge.to_node, NodeId{"grade.b"});
+  }
+  EXPECT_TRUE(document.Graph().Validate().empty());
+  EXPECT_TRUE(document.Graph().ValidateImageBackbone().empty());
+}
+
+TEST(GpuDagModelGraph, RemovePrimaryGradeKeepsRemainingGradesAndValidBackbone) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  EXPECT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
+
+  EXPECT_EQ(document.Graph().FindNode("grade.primary"), nullptr);
+  const auto* remaining = document.Graph().FindNode("grade.b");
+  ASSERT_NE(remaining, nullptr);
+  EXPECT_EQ(remaining->Id(), NodeId{"grade.b"});
+
+  const auto path = document.Graph().ImageBackboneNodeIds();
+  ASSERT_EQ(path.size(), 3u);
+  EXPECT_EQ(path[0], NodeId{"develop"});
+  EXPECT_EQ(path[1], NodeId{"grade.b"});
+  EXPECT_EQ(path[2], NodeId{"drt"});
+  EXPECT_EQ(document.PrimaryGrade(), nullptr);
+  EXPECT_TRUE(document.Graph().ValidateImageBackbone().empty());
+}
+
+TEST(GpuDagModelGraph, RemoveLastColorGradeLeavesDevelopConnectedToDrt) {
+  auto document = CreateDefaultPipelineDocument();
+  EXPECT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
+  EXPECT_EQ(document.Graph().FindNode("grade.primary"), nullptr);
+
+  const auto path = document.Graph().ImageBackboneNodeIds();
+  ASSERT_EQ(path.size(), 2u);
+  EXPECT_EQ(path[0], NodeId{"develop"});
+  EXPECT_EQ(path[1], NodeId{"drt"});
+  EXPECT_EQ(SceneImageSuccessorId(document, NodeId{"develop"}), NodeId{"drt"});
+  EXPECT_EQ(SceneImagePredecessorId(document, NodeId{"drt"}), NodeId{"develop"});
+  EXPECT_TRUE(document.Graph().Validate().empty());
+  EXPECT_TRUE(document.Graph().ValidateImageBackbone().empty());
+}
+
+TEST(GpuDagModelGraph, RemoveDevelopOrDrtIsRejectedWithoutMutation) {
+  auto document = CreateDefaultPipelineDocument();
+  const auto before = DocumentJson(document);
+  const auto nodes  = document.Graph().NodeCount();
+
+  const auto develop_errors = RemoveColorGradeAndBridge(document, NodeId{"develop"});
+  EXPECT_TRUE(HasCode(develop_errors, GraphValidationCode::ProtectedEndpoint));
+  EXPECT_EQ(DocumentJson(document), before);
+  EXPECT_EQ(document.Graph().NodeCount(), nodes);
+
+  const auto drt_errors = RemoveColorGradeAndBridge(document, NodeId{"drt"});
+  EXPECT_TRUE(HasCode(drt_errors, GraphValidationCode::ProtectedEndpoint));
+  EXPECT_EQ(DocumentJson(document), before);
+  EXPECT_EQ(document.Graph().NodeCount(), nodes);
+}
+
+TEST(GpuDagModelGraph, InvalidReconnectLeavesDocumentHashUnchanged) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  const auto before = DocumentJson(document);
+
+  const auto errors =
+      ReconnectColorGrade(document, NodeId{"grade.primary"}, NodeId{"develop"}, NodeId{"drt"});
+  EXPECT_FALSE(errors.empty());
+  EXPECT_EQ(DocumentJson(document), before);
+  EXPECT_EQ(document.Graph().FindNode("grade.b")->Id(), NodeId{"grade.b"});
+}
+
+TEST(GpuDagModelGraph, GraphMutationInverseRestoresCanonicalDocumentJson) {
+  auto document = CreateDefaultPipelineDocument();
+  const auto original = DocumentJson(document);
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  EXPECT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.b"}).empty());
+  EXPECT_EQ(DocumentJson(document), original);
+
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  const auto two_grades = DocumentJson(document);
+  EXPECT_TRUE(ReconnectColorGrade(document, NodeId{"grade.b"}, NodeId{"develop"},
+                                  NodeId{"grade.primary"})
+                  .empty());
+  EXPECT_TRUE(ReconnectColorGrade(document, NodeId{"grade.b"}, NodeId{"grade.primary"},
+                                  NodeId{"drt"})
+                  .empty());
+  EXPECT_EQ(DocumentJson(document), two_grades);
+
+  auto* grade = dynamic_cast<ColorGradeNodeModel*>(document.Graph().FindNode("grade.primary"));
+  ASSERT_NE(grade, nullptr);
+  const std::string previous_name{grade->DisplayName()};
+  EXPECT_TRUE(RenameColorGrade(document, NodeId{"grade.primary"}, "Look A").empty());
+  EXPECT_EQ(document.Graph().FindNode("grade.primary")->Id(), NodeId{"grade.primary"});
+  EXPECT_TRUE(RenameColorGrade(document, NodeId{"grade.primary"}, previous_name).empty());
+  EXPECT_EQ(DocumentJson(document), two_grades);
+
+  EXPECT_TRUE(SetColorGradeEnabled(document, NodeId{"grade.b"}, false).empty());
+  EXPECT_TRUE(SetColorGradeEnabled(document, NodeId{"grade.b"}, true).empty());
+  EXPECT_EQ(DocumentJson(document), two_grades);
+}
+
+TEST(GpuDagModelGraph, GraphCompilerSkipsGradePassWhenBackboneHasNoColorGrade) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
+  const auto plan = GraphCompiler::CompileStatic(document, DummyCompileSource());
+  EXPECT_FALSE(plan.Contains(GpuPassKind::PrimaryColorGrade));
+  EXPECT_TRUE(plan.Contains(GpuPassKind::Drt));
+  EXPECT_TRUE(plan.primary_grade_adjustments.empty());
+  EXPECT_EQ(plan.primary_grade_output.producer, NodeId{"develop"});
+}
+
+TEST(GpuDagModelGraph, GraphCompilerCompilesFirstBackboneGradeWhenPrimaryIdIsAbsent) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  ASSERT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
+  ASSERT_EQ(document.PrimaryGrade(), nullptr);
+
+  const auto* remaining =
+      dynamic_cast<const ColorGradeNodeModel*>(document.Graph().FindNode("grade.b"));
+  ASSERT_NE(remaining, nullptr);
+  const auto plan = GraphCompiler::CompileStatic(document, DummyCompileSource());
+  EXPECT_TRUE(plan.Contains(GpuPassKind::PrimaryColorGrade));
+  EXPECT_EQ(plan.primary_grade_output.producer, NodeId{"grade.b"});
+  ASSERT_EQ(plan.primary_grade_adjustments.size(), remaining->AdjustmentCount());
+  for (std::size_t i = 0; i < remaining->AdjustmentCount(); ++i) {
+    EXPECT_EQ(plan.primary_grade_adjustments[i].instance_id, remaining->AdjustmentIdAt(i));
+    EXPECT_EQ(plan.primary_grade_adjustments[i].type, remaining->AdjustmentAt(i).Type());
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/history/editor_document_history_test.cpp
+++ b/alcedo_studio/tests/edit/history/editor_document_history_test.cpp
@@ -1,0 +1,351 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <thread>
+
+#include "app/editor_pipeline_command_service.hpp"
+#include "app/pipeline_service.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
+#include "edit/history/mini_git_working_history.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/operators/operator_registeration.hpp"
+#include "support/editor_parameter_target_test.hpp"
+#include "ui/alcedo_main/album_backend/editor_session_history_port.hpp"
+
+namespace alcedo::ui {
+namespace {
+
+using test::ColorGradeFieldTarget;
+using test::WithColorGradeTarget;
+
+/// Real document, executor, history and WAL; no project/storage/UI fixture is needed.
+class EditorDocumentHistoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    RegisterAllOperators();
+    const auto stamp = std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    journal_path_    = std::filesystem::path(TEST_IMG_PATH)
+                        .parent_path()
+                        .parent_path()
+                        .parent_path()
+                        .parent_path() /
+                    "build/tmp/nm1" / ("document_history_" + stamp + ".wal");
+    std::filesystem::create_directories(journal_path_.parent_path());
+    guard_                = std::make_shared<PipelineGuard>();
+    guard_->id_           = 42;
+    guard_->pipeline_     = std::make_shared<CPUPipelineExecutor>();
+    guard_->document_     = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+    guard_->commit_graph_ = std::make_shared<CommitGraph>(CommitGraph::CreateEmpty(42));
+    guard_->root_id_      = guard_->commit_graph_->GetRootId();
+    pipeline_             = std::make_shared<EditorSessionPipelinePort>();
+    pipeline_->SetServices(
+        EditorSessionPipelineMappers{{}, [this](sl_element_id_t) { return guard_; }});
+    history_.SetPipelinePort(pipeline_);
+    history_.SetServices(
+        EditorSessionHistoryPort::Services{[this](sl_element_id_t) { return journal_path_; }});
+  }
+  void TearDown() override {
+    history_.Release({42, true});
+    std::error_code ec;
+    std::filesystem::remove(journal_path_, ec);
+  }
+  std::filesystem::path                      journal_path_;
+  std::shared_ptr<PipelineGuard>             guard_;
+  std::shared_ptr<EditorSessionPipelinePort> pipeline_;
+  EditorSessionHistoryPort                   history_;
+};
+
+auto DocumentExposureEv(const alcedo::PipelineDocument& document, const std::string& node_id)
+    -> float {
+  nlohmann::json json;
+  std::string    error;
+  EXPECT_TRUE(alcedo::ReadEditorParameterJson(document, ColorGradeFieldTarget("exposure", node_id),
+                                              &json, &error))
+      << error;
+  return json.at("exposure_ev").get<float>();
+}
+
+TEST_F(EditorDocumentHistoryTest, SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  ASSERT_NE(guard_->document_, nullptr);
+  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
+  auto       settled     = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.25})", true});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
+  ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.25f);
+  EXPECT_NE(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+}
+
+TEST_F(EditorDocumentHistoryTest,
+       IncompleteTargetRejectedLeavesDocumentHashAndHistoryHeadUnchanged) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
+  alcedo::EditorAdjustmentPatch patch;
+  patch.field_key   = "exposure";
+  patch.params_json = R"({"exposure_ev":3.0})";
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error));
+  EXPECT_EQ(error, "Editor parameter target requires owner_kind");
+  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
+                  alcedo::kDefaultPipelineExposureEv);
+
+  auto missing_node           = WithColorGradeTarget({"exposure", R"({"exposure_ev":3.0})", false});
+  missing_node.target.node_id = alcedo::NodeId{};
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, missing_node, &error));
+  EXPECT_EQ(error, "Editor parameter target requires node_id");
+  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+}
+
+TEST_F(EditorDocumentHistoryTest, ProvisionalSequenceReusesTargetResolvedAtFirstPatch) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto add_errors = alcedo::AddCleanColorGrade(*guard_->document_, alcedo::NodeId{"drt"},
+                                               alcedo::NodeId{"grade.extra"});
+  ASSERT_TRUE(add_errors.empty());
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.extra"), 0.0f);
+
+  auto first = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.0})", false}, "grade.primary");
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, first, &error)) << error;
+  auto second = WithColorGradeTarget({"exposure", R"({"exposure_ev":4.0})", false}, "grade.extra");
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, second, &error)) << error;
+  auto settled = WithColorGradeTarget({"exposure", R"({"exposure_ev":4.0})", true}, "grade.extra");
+  ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
+
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 4.0f);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.extra"), 0.0f);
+}
+
+TEST_F(EditorDocumentHistoryTest, UnknownFieldRejectedLeavesDocumentHashAndHistoryHeadUnchanged) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
+  auto       patch       = WithColorGradeTarget({"not_a_supported_adjustment", R"({})", false});
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error));
+  EXPECT_EQ(error, "Unknown editor adjustment field: not_a_supported_adjustment");
+  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+}
+
+TEST_F(EditorDocumentHistoryTest, UndoSettledExposureRestoresDocumentValue) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto settled = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.5})", true});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
+  ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.5f);
+  ASSERT_TRUE(history_.Undo(handle, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
+                  alcedo::kDefaultPipelineExposureEv);
+  ASSERT_TRUE(history_.Redo(handle, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.5f);
+}
+
+TEST_F(EditorDocumentHistoryTest, IncompleteLaterPatchRejectedLeavesLockedDocumentUnchanged) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto first = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.0})", false});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, first, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.0f);
+
+  alcedo::EditorAdjustmentPatch incomplete;
+  incomplete.field_key   = "exposure";
+  incomplete.params_json = R"({"exposure_ev":4.0})";
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, incomplete, &error));
+  EXPECT_EQ(error, "Editor parameter target requires owner_kind");
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.0f);
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+}
+
+TEST_F(EditorDocumentHistoryTest, JournalAppendFailureRestoresDocumentExposureEv) {
+  history_.SetServices(
+      EditorSessionHistoryPort::Services{[bad = journal_path_.parent_path() / "not-a-directory"](
+                                             sl_element_id_t) { return bad / "image-42.wal"; }});
+  {
+    std::ofstream blocker(journal_path_.parent_path() / "not-a-directory", std::ios::binary);
+    ASSERT_TRUE(blocker.is_open());
+    blocker << "block";
+  }
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto settled = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.25})", true});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.25f);
+  EXPECT_FALSE(history_.CommitAdjustment(handle, settled, &error));
+  EXPECT_FALSE(error.empty());
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
+                  alcedo::kDefaultPipelineExposureEv);
+  std::error_code ec;
+  std::filesystem::remove(journal_path_.parent_path() / "not-a-directory", ec);
+}
+
+TEST_F(EditorDocumentHistoryTest, DiscardUncommittedPreviewRestoresDocumentExposureEv) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto preview = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.25})", false});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, preview, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.25f);
+  ASSERT_TRUE(history_.DiscardUnmaterializedChanges(handle, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
+                  alcedo::kDefaultPipelineExposureEv);
+}
+
+TEST_F(EditorDocumentHistoryTest, MaskTargetWriteIsRejected) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
+  alcedo::EditorAdjustmentPatch patch;
+  patch.field_key                     = "exposure";
+  patch.params_json                   = R"({"exposure_ev":3.0})";
+  patch.target.owner_kind             = alcedo::EditorParameterOwnerKind::ColorGradeMask;
+  patch.target.node_id                = alcedo::NodeId{"grade.primary"};
+  patch.target.adjustment_instance_id = alcedo::AdjustmentInstanceId{"grade.primary.exposure"};
+  patch.target.mask_id                = "mask.1";
+  patch.target.field_key              = "exposure";
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error));
+  EXPECT_EQ(error, "Mask parameter targets are rejected until NM3");
+  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+}
+
+TEST_F(EditorDocumentHistoryTest, InvalidParameterLeavesLiveValueAndHistoryHeadUnchanged) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  const auto before = guard_->document_->ToJson();
+  auto       bad    = WithColorGradeTarget({"exposure", R"({"exposure_ev":"bad"})", false});
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, bad, &error));
+  EXPECT_EQ(guard_->document_->ToJson(), before);
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+  EXPECT_EQ(guard_->commit_graph_->CommitCount(), 0u);
+  EXPECT_FALSE(guard_->dirty_);
+
+  auto valid = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.0})", true});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, valid, &error)) << error;
+  ASSERT_TRUE(history_.CommitAdjustment(handle, valid, &error)) << error;
+  const auto head    = guard_->working_head_commit_hash();
+  const auto count   = guard_->commit_graph_->CommitCount();
+  auto       preview = WithColorGradeTarget({"exposure", R"({"exposure_ev":3.0})", false});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, preview, &error)) << error;
+  bad.settled = true;
+  EXPECT_FALSE(history_.CommitAdjustment(handle, bad, &error));
+  EXPECT_EQ(guard_->working_head_commit_hash(), head);
+  EXPECT_EQ(guard_->commit_graph_->CommitCount(), count);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 3.0f);
+  ASSERT_TRUE(history_.CommitAdjustment(handle, preview, &error)) << error;
+  ASSERT_TRUE(history_.Undo(handle, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.0f);
+}
+
+TEST_F(EditorDocumentHistoryTest,
+       RejectedFirstPatchDoesNotLockTargetAndHistoryUsesNormalizedModelValues) {
+  ASSERT_TRUE(AddCleanColorGrade(*guard_->document_, NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto bad = WithColorGradeTarget({"exposure", R"({"exposure_ev":null})", false});
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, bad, &error));
+  const auto stages = guard_->pipeline_->ExportPipelineParams();
+  auto valid = WithColorGradeTarget({"exposure", R"({"exposure_ev":100.0})", true}, "grade.extra");
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, valid, &error)) << error;
+  ASSERT_TRUE(history_.CommitAdjustment(handle, valid, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 1.5f);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.extra"), 16.0f);
+  const auto head = *guard_->working_head_commit_hash();
+  const auto payload =
+      OrdinaryEditPayload::FromJSON(guard_->commit_graph_->GetCommit(head).GetPayloadJSON());
+  EXPECT_EQ(payload.before_value.at("exposure"), 0.0);
+  EXPECT_EQ(payload.after_value.at("exposure"), 16.0);
+  // A different raw request normalizes to the same value, so it cannot produce another commit.
+  valid.params_json = R"({"exposure_ev":20.0})";
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, valid, &error)) << error;
+  ASSERT_TRUE(history_.CommitAdjustment(handle, valid, &error)) << error;
+  EXPECT_EQ(guard_->working_head_commit_hash(), head);
+  ASSERT_TRUE(history_.Undo(handle, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.extra"), 0.0f);
+  ASSERT_TRUE(history_.Redo(handle, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.extra"), 16.0f);
+  EXPECT_EQ(guard_->pipeline_->ExportPipelineParams(), stages);
+}
+
+TEST_F(EditorDocumentHistoryTest, PreviewCommitUndoRedoAndCancelWaitForRenderLock) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  const auto* grade       = guard_->document_->PrimaryGrade();
+  const auto* exposure    = grade->FindAdjustmentByType(type_ids::Exposure());
+  const auto  patch       = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.5})", true});
+  const auto  stages      = guard_->pipeline_->ExportPipelineParams();
+  const auto  run_blocked = [&](auto action, float before, float after) {
+    std::unique_lock   held(guard_->pipeline_->GetRenderLock());
+    std::promise<void> started;
+    auto               ready  = started.get_future();
+    auto               worker = std::async(std::launch::async, [&] {
+      std::string local_error;
+      started.set_value();
+      const bool ok = action(&local_error);
+      return std::pair{ok, local_error};
+    });
+    ready.wait();
+    EXPECT_EQ(worker.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+    EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), before);
+    held.unlock();
+    const auto [ok, local_error] = worker.get();
+    EXPECT_TRUE(ok) << local_error;
+    EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), after);
+    EXPECT_EQ(guard_->document_->PrimaryGrade(), grade);
+    EXPECT_EQ(grade->FindAdjustmentByType(type_ids::Exposure()), exposure);
+  };
+  run_blocked([&](auto* e) { return history_.CaptureAdjustmentBeforePreview(handle, patch, e); },
+              1.5f, 2.5f);
+  run_blocked([&](auto* e) { return history_.CommitAdjustment(handle, patch, e); }, 2.5f, 2.5f);
+  run_blocked([&](auto* e) { return history_.Undo(handle, e); }, 2.5f, 1.5f);
+  run_blocked([&](auto* e) { return history_.Redo(handle, e); }, 1.5f, 2.5f);
+  const auto preview = WithColorGradeTarget({"exposure", R"({"exposure_ev":3.0})", false});
+  run_blocked([&](auto* e) { return history_.CaptureAdjustmentBeforePreview(handle, preview, e); },
+              2.5f, 3.0f);
+  run_blocked([&](auto* e) { return history_.DiscardUnmaterializedChanges(handle, e); }, 3.0f,
+              1.5f);
+  EXPECT_EQ(guard_->pipeline_->ExportPipelineParams(), stages);
+}
+
+TEST_F(EditorDocumentHistoryTest, UnrecordedHistoryTargetIsRejectedBeforeJournalOrDocumentChanges) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto patch = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.5})", true});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error)) << error;
+  ASSERT_TRUE(history_.CommitAdjustment(handle, patch, &error)) << error;
+  // Releasing this session loses local targets. No stage-based replay is permitted in NM1.4 A.
+  history_.Release(handle);
+  const auto reopened = history_.Acquire(42, &error);
+  ASSERT_TRUE(reopened.valid) << error;
+  const auto before = guard_->document_->ToJson();
+  const auto head   = guard_->working_head_commit_hash();
+  EXPECT_FALSE(history_.Undo(reopened, &error));
+  EXPECT_NE(error.find("same-session document target"), std::string::npos);
+  EXPECT_EQ(guard_->working_head_commit_hash(), head);
+  EXPECT_EQ(guard_->document_->ToJson(), before);
+}
+
+}  // namespace
+}  // namespace alcedo::ui

--- a/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
+++ b/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
@@ -20,7 +20,10 @@
 
 #include "json.hpp"
 #include "app/adjustment_transfer_service.hpp"
-#include "app/editor_adjustment_pipeline.hpp"
+#include "app/editor_pipeline_command_service.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
 #include "app/editor_mini_git_materializer.hpp"
 #include "app/pipeline_service.hpp"
 #include "app/project_service.hpp"
@@ -41,18 +44,46 @@ auto MakeMiniGitPipelineGuard(sl_element_id_t element_id)
   auto guard       = std::make_shared<alcedo::PipelineGuard>();
   guard->id_       = element_id;
   guard->pipeline_ = std::make_shared<alcedo::CPUPipelineExecutor>();
+  guard->document_ =
+      std::make_shared<alcedo::PipelineDocument>(alcedo::CreateDefaultPipelineDocument());
   guard->commit_graph_ =
       std::make_shared<alcedo::CommitGraph>(alcedo::CommitGraph::CreateEmpty(element_id));
   guard->root_id_                  = guard->commit_graph_->GetRootId();
   return guard;
 }
 
+auto ColorGradeTargetForField(const std::string& field, std::string node_id = "grade.primary")
+    -> alcedo::EditorParameterTarget {
+  alcedo::EditorParameterTarget target;
+  target.owner_kind              = alcedo::EditorParameterOwnerKind::ColorGrade;
+  target.node_id                 = alcedo::NodeId{node_id};
+  target.adjustment_instance_id  = alcedo::AdjustmentInstanceId{node_id + "." + field};
+  target.field_key               = field;
+  return target;
+}
+
+auto WithColorGradeTarget(alcedo::EditorAdjustmentPatch patch,
+                          std::string node_id = "grade.primary") -> alcedo::EditorAdjustmentPatch {
+  patch.target = ColorGradeTargetForField(patch.field_key, std::move(node_id));
+  return patch;
+}
+
+auto DocumentExposureEv(const alcedo::PipelineDocument& document, const std::string& node_id)
+    -> float {
+  nlohmann::json json;
+  std::string    error;
+  EXPECT_TRUE(alcedo::ReadEditorParameterJson(document, ColorGradeTargetForField("exposure", node_id),
+                                              &json, &error))
+      << error;
+  return json.at("exposure_ev").get<float>();
+}
+
 auto CommitSettled(EditorSessionHistoryPort& port, const alcedo::EditorHistoryGuardHandle& handle,
                    const std::string& field, const std::string& after_json, std::string* error)
     -> bool {
-  alcedo::EditorAdjustmentPatch preview{field, after_json, false};
+  alcedo::EditorAdjustmentPatch preview = WithColorGradeTarget({field, after_json, false});
   if (!port.CaptureAdjustmentBeforePreview(handle, preview, error)) return false;
-  alcedo::EditorAdjustmentPatch settled{field, after_json, true};
+  alcedo::EditorAdjustmentPatch settled = WithColorGradeTarget({field, after_json, true});
   return port.CommitAdjustment(handle, settled, error);
 }
 
@@ -230,8 +261,8 @@ TEST_F(EditorSessionHistoryPortTest, SettledAdjustmentCreatesOneCommitAndUndoRed
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
-  const alcedo::EditorAdjustmentPatch preview{"exposure", R"({"exposure":0.25})", false};
-  const alcedo::EditorAdjustmentPatch settled{"exposure", R"({"exposure":0.75})", true};
+  const auto preview = WithColorGradeTarget({"exposure", R"({"exposure":0.25})", false});
+  const auto settled = WithColorGradeTarget({"exposure", R"({"exposure":0.75})", true});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, preview, &error)) << error;
   ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
   ASSERT_EQ(guard_->commit_graph_->CommitCount(), 1u);
@@ -672,7 +703,7 @@ TEST_F(EditorSessionHistoryPortTest,
   ASSERT_TRUE(handle.valid) << error;
 
   {
-    const alcedo::EditorAdjustmentPatch seed{"saturation", R"({"saturation":0})", true};
+    const auto seed = WithColorGradeTarget({"saturation", R"({"saturation":0})", true});
     ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, seed, &error)) << error;
     ASSERT_TRUE(history_.CommitAdjustment(handle, seed, &error)) << error;
   }
@@ -697,13 +728,13 @@ TEST_F(EditorSessionHistoryPortTest,
                                  [&] { return worker_holds_lock; }));
   }
 
-  const alcedo::EditorAdjustmentPatch preview{"saturation", R"({"saturation":20})", false};
+  const auto preview = WithColorGradeTarget({"saturation", R"({"saturation":20})", false});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, preview, &error)) << error
       << "Capture must not require the live pipeline render lock";
 
   std::atomic<bool> commit_finished{false};
   std::thread       commit_thread([&] {
-    const alcedo::EditorAdjustmentPatch settled{"saturation", R"({"saturation":40})", true};
+    const auto settled = WithColorGradeTarget({"saturation", R"({"saturation":40})", true});
     (void)history_.CommitAdjustment(handle, settled, &error);
     commit_finished.store(true);
   });
@@ -757,7 +788,8 @@ TEST_F(EditorSessionHistoryPortTest,
   ASSERT_TRUE(handle.valid) << error;
   const auto commit_count_before = guard_->commit_graph_->CommitCount();
 
-  const alcedo::EditorAdjustmentPatch unsupported{"not_a_supported_adjustment", R"({})", false};
+  const auto unsupported =
+      WithColorGradeTarget({"not_a_supported_adjustment", R"({})", false});
   EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, unsupported, &error));
   EXPECT_FALSE(error.empty());
   EXPECT_EQ(guard_->commit_graph_->CommitCount(), commit_count_before);
@@ -809,8 +841,8 @@ TEST_F(EditorSessionHistoryPortTest,
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
-  const alcedo::EditorAdjustmentPatch first{"exposure", R"({"exposure":0.5})", true};
-  const alcedo::EditorAdjustmentPatch second{"exposure", R"({"exposure":1.25})", true};
+  const auto first = WithColorGradeTarget({"exposure", R"({"exposure":0.5})", true});
+  const auto second = WithColorGradeTarget({"exposure", R"({"exposure":1.25})", true});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, first, &error)) << error;
   ASSERT_TRUE(history_.CommitAdjustment(handle, first, &error)) << error;
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, second, &error)) << error;
@@ -842,7 +874,7 @@ TEST_F(EditorSessionHistoryPortTest,
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
-  const alcedo::EditorAdjustmentPatch settled{"exposure", R"({"exposure":0.9})", true};
+  const auto settled = WithColorGradeTarget({"exposure", R"({"exposure":0.9})", true});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
   ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
 
@@ -865,7 +897,7 @@ TEST_F(EditorSessionHistoryPortTest,
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
 
-  const alcedo::EditorAdjustmentPatch first{"exposure", R"({"exposure":0.4})", true};
+  const auto first = WithColorGradeTarget({"exposure", R"({"exposure":0.4})", true});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, first, &error)) << error;
   ASSERT_TRUE(history_.CommitAdjustment(handle, first, &error)) << error;
   ASSERT_TRUE(history_.SyncMaterializedStateAfterCheckpoint(handle, &error)) << error;
@@ -874,7 +906,7 @@ TEST_F(EditorSessionHistoryPortTest,
   ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &materialized_snapshot, &error)) << error;
   const auto materialized_head = guard_->commit_graph_->GetImageEditState().materialized_head_commit_hash;
 
-  const alcedo::EditorAdjustmentPatch second{"exposure", R"({"exposure":0.9})", true};
+  const auto second = WithColorGradeTarget({"exposure", R"({"exposure":0.9})", true});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, second, &error)) << error;
   ASSERT_TRUE(history_.CommitAdjustment(handle, second, &error)) << error;
   EXPECT_TRUE(history_.HasUnmaterializedChanges(handle, &error)) << error;
@@ -896,7 +928,7 @@ TEST_F(EditorSessionHistoryPortTest,
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
-  const alcedo::EditorAdjustmentPatch settled{"exposure", R"({"exposure":0.4})", true};
+  const auto settled = WithColorGradeTarget({"exposure", R"({"exposure":0.4})", true});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
   ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
 
@@ -926,7 +958,7 @@ TEST_F(EditorSessionHistoryPortTest, JournalAppendFailureKeepsWorkingHeadAtRoot)
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
-  const alcedo::EditorAdjustmentPatch settled{"exposure", R"({"exposure":1.25})", true};
+  const auto settled = WithColorGradeTarget({"exposure", R"({"exposure":1.25})", true});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
   EXPECT_FALSE(history_.CommitAdjustment(handle, settled, &error));
   EXPECT_FALSE(error.empty());
@@ -939,7 +971,7 @@ TEST_F(EditorSessionHistoryPortTest, ReopenReplaysJournalIntoWorkingPipeline) {
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
-  const alcedo::EditorAdjustmentPatch settled{"exposure", R"({"exposure":1.25})", true};
+  const auto settled = WithColorGradeTarget({"exposure", R"({"exposure":1.25})", true});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
   ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
   history_.Release(handle);
@@ -965,7 +997,7 @@ TEST_F(EditorSessionHistoryPortTest, ProductionCaptureValueReachesCheckpointStor
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
-  const alcedo::EditorAdjustmentPatch settled{"exposure", R"({"exposure":0.85})", true};
+  const auto settled = WithColorGradeTarget({"exposure", R"({"exposure":0.85})", true});
   ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
   ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
 
@@ -1884,6 +1916,162 @@ TEST(EditorSessionHistoryPortPersistTest,
   std::filesystem::remove(db_path, ec);
   std::filesystem::remove(meta_path, ec);
   std::filesystem::remove(journal_path, ec);
+}
+
+TEST_F(EditorSessionHistoryPortTest, SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  ASSERT_NE(guard_->document_, nullptr);
+  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
+  auto       settled     = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.25})", true});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
+  ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.25f);
+  EXPECT_NE(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+}
+
+TEST_F(EditorSessionHistoryPortTest,
+       IncompleteTargetRejectedLeavesDocumentHashAndHistoryHeadUnchanged) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
+  alcedo::EditorAdjustmentPatch patch;
+  patch.field_key   = "exposure";
+  patch.params_json = R"({"exposure_ev":3.0})";
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error));
+  EXPECT_EQ(error, "Editor parameter target requires owner_kind");
+  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
+                  alcedo::kDefaultPipelineExposureEv);
+
+  auto missing_node = WithColorGradeTarget({"exposure", R"({"exposure_ev":3.0})", false});
+  missing_node.target.node_id = alcedo::NodeId{};
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, missing_node, &error));
+  EXPECT_EQ(error, "Editor parameter target requires node_id");
+  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+}
+
+TEST_F(EditorSessionHistoryPortTest, ProvisionalSequenceReusesTargetResolvedAtFirstPatch) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto add_errors =
+      alcedo::AddCleanColorGrade(*guard_->document_, alcedo::NodeId{"drt"}, alcedo::NodeId{"grade.extra"});
+  ASSERT_TRUE(add_errors.empty());
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.extra"), 0.0f);
+
+  auto first = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.0})", false}, "grade.primary");
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, first, &error)) << error;
+  auto second = WithColorGradeTarget({"exposure", R"({"exposure_ev":4.0})", false}, "grade.extra");
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, second, &error)) << error;
+  auto settled = WithColorGradeTarget({"exposure", R"({"exposure_ev":4.0})", true}, "grade.extra");
+  ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
+
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 4.0f);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.extra"), 0.0f);
+}
+
+TEST_F(EditorSessionHistoryPortTest,
+       UnknownFieldRejectedLeavesDocumentHashAndHistoryHeadUnchanged) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
+  auto       patch       = WithColorGradeTarget({"not_a_supported_adjustment", R"({})", false});
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error));
+  EXPECT_EQ(error, "Unknown editor adjustment field: not_a_supported_adjustment");
+  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+}
+
+TEST_F(EditorSessionHistoryPortTest, UndoSettledExposureRestoresDocumentValue) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto settled = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.5})", true});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
+  ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.5f);
+  ASSERT_TRUE(history_.Undo(handle, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
+                  alcedo::kDefaultPipelineExposureEv);
+  ASSERT_TRUE(history_.Redo(handle, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.5f);
+}
+
+TEST_F(EditorSessionHistoryPortTest, IncompleteLaterPatchRejectedLeavesLockedDocumentUnchanged) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto first = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.0})", false});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, first, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.0f);
+
+  alcedo::EditorAdjustmentPatch incomplete;
+  incomplete.field_key   = "exposure";
+  incomplete.params_json = R"({"exposure_ev":4.0})";
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, incomplete, &error));
+  EXPECT_EQ(error, "Editor parameter target requires owner_kind");
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.0f);
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+}
+
+TEST_F(EditorSessionHistoryPortTest, JournalAppendFailureRestoresDocumentExposureEv) {
+  history_.SetServices(
+      EditorSessionHistoryPort::Services{[bad = journal_path_.parent_path() / "not-a-directory"](
+                                             sl_element_id_t) { return bad / "image-42.wal"; }});
+  {
+    std::ofstream blocker(journal_path_.parent_path() / "not-a-directory", std::ios::binary);
+    ASSERT_TRUE(blocker.is_open());
+    blocker << "block";
+  }
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto settled = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.25})", true});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.25f);
+  EXPECT_FALSE(history_.CommitAdjustment(handle, settled, &error));
+  EXPECT_FALSE(error.empty());
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
+                  alcedo::kDefaultPipelineExposureEv);
+  std::error_code ec;
+  std::filesystem::remove(journal_path_.parent_path() / "not-a-directory", ec);
+}
+
+TEST_F(EditorSessionHistoryPortTest, DiscardUncommittedPreviewRestoresDocumentExposureEv) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  auto preview = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.25})", false});
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, preview, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.25f);
+  ASSERT_TRUE(history_.DiscardUnmaterializedChanges(handle, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
+                  alcedo::kDefaultPipelineExposureEv);
+}
+
+TEST_F(EditorSessionHistoryPortTest, MaskTargetWriteIsRejected) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
+  alcedo::EditorAdjustmentPatch patch;
+  patch.field_key                      = "exposure";
+  patch.params_json                    = R"({"exposure_ev":3.0})";
+  patch.target.owner_kind              = alcedo::EditorParameterOwnerKind::ColorGradeMask;
+  patch.target.node_id                 = alcedo::NodeId{"grade.primary"};
+  patch.target.adjustment_instance_id  = alcedo::AdjustmentInstanceId{"grade.primary.exposure"};
+  patch.target.mask_id                 = "mask.1";
+  patch.target.field_key               = "exposure";
+  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error));
+  EXPECT_EQ(error, "Mask parameter targets are rejected until NM3");
+  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
+  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
+++ b/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
@@ -64,18 +64,16 @@ auto ColorGradeTargetForField(const std::string& field, std::string node_id = "g
 
 auto WithColorGradeTarget(alcedo::EditorAdjustmentPatch patch,
                           std::string node_id = "grade.primary") -> alcedo::EditorAdjustmentPatch {
+  if (patch.field_key == "exposure") {
+    auto params = nlohmann::json::parse(patch.params_json);
+    if (params.contains("exposure")) {
+      params["exposure_ev"] = params.at("exposure");
+      params.erase("exposure");
+      patch.params_json = params.dump();
+    }
+  }
   patch.target = ColorGradeTargetForField(patch.field_key, std::move(node_id));
   return patch;
-}
-
-auto DocumentExposureEv(const alcedo::PipelineDocument& document, const std::string& node_id)
-    -> float {
-  nlohmann::json json;
-  std::string    error;
-  EXPECT_TRUE(alcedo::ReadEditorParameterJson(document, ColorGradeTargetForField("exposure", node_id),
-                                              &json, &error))
-      << error;
-  return json.at("exposure_ev").get<float>();
 }
 
 auto CommitSettled(EditorSessionHistoryPort& port, const alcedo::EditorHistoryGuardHandle& handle,
@@ -273,7 +271,7 @@ TEST_F(EditorSessionHistoryPortTest, SettledAdjustmentCreatesOneCommitAndUndoRed
 }
 
 TEST_F(EditorSessionHistoryPortTest,
-       UndoRedoAcrossTwoParentTintMergeRestoresFirstParentAndResolvedValues) {
+       UndoOfMergeWithoutDocumentTargetLeavesHeadValuesAndJournalUnchanged) {
   const auto                  root_id        = guard_->commit_graph_->GetRootId();
   const auto                  active_version = guard_->commit_graph_->GetActiveVersionId();
 
@@ -332,26 +330,25 @@ TEST_F(EditorSessionHistoryPortTest,
     stage.EnableOperator(alcedo::OperatorType::TINT, true, globals);
   }
 
-  ASSERT_TRUE(history_.Undo(handle, &error)) << error;
-  EXPECT_EQ(guard_->working_head_commit_hash(), current_head);
-  alcedo::EditorRenderAdjustmentSnapshot undo_snapshot;
-  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &undo_snapshot, &error)) << error;
-  EXPECT_EQ(PatchValue(undo_snapshot, "tint"), R"({"tint":2.0})");
-  alcedo::EditorAdjustmentOperatorState tint_state;
-  ASSERT_TRUE(
-      alcedo::ReadEditorAdjustmentOperatorState(*guard_->pipeline_, "tint", &tint_state, &error))
-      << error;
-  EXPECT_DOUBLE_EQ(tint_state.params.at("tint").get<double>(), 2.0);
-
-  ASSERT_TRUE(history_.Redo(handle, &error)) << error;
-  EXPECT_EQ(guard_->working_head_commit_hash(), merge_head);
-  alcedo::EditorRenderAdjustmentSnapshot redo_snapshot;
-  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &redo_snapshot, &error)) << error;
-  EXPECT_EQ(PatchValue(redo_snapshot, "tint"), R"({"tint":10.0})");
-  ASSERT_TRUE(
-      alcedo::ReadEditorAdjustmentOperatorState(*guard_->pipeline_, "tint", &tint_state, &error))
-      << error;
-  EXPECT_DOUBLE_EQ(tint_state.params.at("tint").get<double>(), 10.0);
+  const auto                     before_document = guard_->document_->ToJson();
+  const auto                     before_pipeline = guard_->pipeline_->ExportPipelineParams();
+  const auto                     before_head     = guard_->working_head_commit_hash();
+  EditorRenderAdjustmentSnapshot before_snapshot;
+  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &before_snapshot, &error)) << error;
+  MiniGitJournal before_journal(journal_path_);
+  ASSERT_TRUE(before_journal.Load(&error)) << error;
+  const auto records = before_journal.records().size();
+  EXPECT_FALSE(history_.Undo(handle, &error));
+  EXPECT_NE(error.find("same-session document target"), std::string::npos);
+  EXPECT_EQ(guard_->working_head_commit_hash(), before_head);
+  EXPECT_EQ(guard_->document_->ToJson(), before_document);
+  EXPECT_EQ(guard_->pipeline_->ExportPipelineParams(), before_pipeline);
+  EditorRenderAdjustmentSnapshot after_snapshot;
+  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &after_snapshot, &error)) << error;
+  EXPECT_EQ(after_snapshot, before_snapshot);
+  MiniGitJournal after_journal(journal_path_);
+  ASSERT_TRUE(after_journal.Load(&error)) << error;
+  EXPECT_EQ(after_journal.records().size(), records);
 }
 
 TEST_F(EditorSessionHistoryPortTest,
@@ -508,7 +505,7 @@ TEST_F(EditorSessionHistoryPortTest,
                    prior_exposure.params.at("exposure").get<double>());
 }
 
-TEST_F(EditorSessionHistoryPortTest, MergeUndoRestoresPreMergeOperatorParams) {
+TEST_F(EditorSessionHistoryPortTest, MergeWithoutDocumentTargetsRejectsUndoBeforePublication) {
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
@@ -544,17 +541,25 @@ TEST_F(EditorSessionHistoryPortTest, MergeUndoRestoresPreMergeOperatorParams) {
       << error;
   EXPECT_DOUBLE_EQ(merged.params.at("exposure").get<double>(), 1.25);
 
-  ASSERT_TRUE(history_.Undo(handle, &error)) << error;
-  EXPECT_EQ(guard_->working_head_commit_hash(), first_parent_head);
-  alcedo::EditorAdjustmentOperatorState restored;
-  ASSERT_TRUE(
-      alcedo::ReadEditorAdjustmentOperatorState(*guard_->pipeline_, "exposure", &restored, &error))
-      << error;
-  EXPECT_NEAR(restored.params.at("exposure").get<double>(),
-              pre_merge.params.at("exposure").get<double>(), 1e-5);
-  alcedo::EditorRenderAdjustmentSnapshot undo_snapshot;
-  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &undo_snapshot, &error)) << error;
-  EXPECT_EQ(PatchValue(undo_snapshot, "exposure"), R"({"exposure":0.25})");
+  const auto                     before_document = guard_->document_->ToJson();
+  const auto                     before_pipeline = guard_->pipeline_->ExportPipelineParams();
+  const auto                     before_head     = guard_->working_head_commit_hash();
+  EditorRenderAdjustmentSnapshot before_snapshot;
+  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &before_snapshot, &error)) << error;
+  MiniGitJournal before_journal(journal_path_);
+  ASSERT_TRUE(before_journal.Load(&error)) << error;
+  const auto records = before_journal.records().size();
+  EXPECT_FALSE(history_.Undo(handle, &error));
+  EXPECT_NE(error.find("same-session document target"), std::string::npos);
+  EXPECT_EQ(guard_->working_head_commit_hash(), before_head);
+  EXPECT_EQ(guard_->document_->ToJson(), before_document);
+  EXPECT_EQ(guard_->pipeline_->ExportPipelineParams(), before_pipeline);
+  EditorRenderAdjustmentSnapshot after_snapshot;
+  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &after_snapshot, &error)) << error;
+  EXPECT_EQ(after_snapshot, before_snapshot);
+  MiniGitJournal after_journal(journal_path_);
+  ASSERT_TRUE(after_journal.Load(&error)) << error;
+  EXPECT_EQ(after_journal.records().size(), records);
 }
 
 TEST_F(EditorSessionHistoryPortTest,
@@ -599,26 +604,25 @@ TEST_F(EditorSessionHistoryPortTest,
   EXPECT_FALSE(journal.records().empty()) << "CompleteLiveMerge must append WAL records";
 }
 
-TEST_F(EditorSessionHistoryPortTest, OrdinaryEditChangesLivePipelineBeforeOrWithWalAppend) {
+TEST_F(EditorSessionHistoryPortTest, OrdinaryEditChangesDocumentBeforeOrWithWalAppend) {
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
 
   ASSERT_TRUE(CommitSettled(history_, handle, "exposure", R"({"exposure":0.5})", &error))
       << error;
-  alcedo::EditorAdjustmentOperatorState exposure_state;
-  ASSERT_TRUE(alcedo::ReadEditorAdjustmentOperatorState(*guard_->pipeline_, "exposure",
-                                                        &exposure_state, &error))
+  nlohmann::json actual;
+  ASSERT_TRUE(ReadEditorParameterJson(*guard_->document_, ColorGradeTargetForField("exposure"),
+                                      &actual, &error))
       << error;
-  EXPECT_NEAR(exposure_state.params.at("exposure").get<double>(), 0.5, 1e-5);
+  EXPECT_FLOAT_EQ(actual.at("exposure_ev").get<float>(), 0.5f);
 
   alcedo::MiniGitJournal journal(journal_path_);
   ASSERT_TRUE(journal.Load(&error)) << error;
   EXPECT_FALSE(journal.records().empty());
 }
 
-TEST_F(EditorSessionHistoryPortTest,
-       CommittedSnapshotIfPresentMatchesLivePipelineExportAfterEdit) {
+TEST_F(EditorSessionHistoryPortTest, CommittedSnapshotMatchesDocumentValueAfterEdit) {
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
@@ -629,11 +633,11 @@ TEST_F(EditorSessionHistoryPortTest,
   ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &snapshot, &error)) << error;
   EXPECT_EQ(PatchValue(snapshot, "exposure"), R"({"exposure":0.75})");
 
-  alcedo::EditorAdjustmentOperatorState exposure_state;
-  ASSERT_TRUE(alcedo::ReadEditorAdjustmentOperatorState(*guard_->pipeline_, "exposure",
-                                                        &exposure_state, &error))
+  nlohmann::json actual;
+  ASSERT_TRUE(ReadEditorParameterJson(*guard_->document_, ColorGradeTargetForField("exposure"),
+                                      &actual, &error))
       << error;
-  EXPECT_NEAR(exposure_state.params.at("exposure").get<double>(), 0.75, 1e-5);
+  EXPECT_FLOAT_EQ(actual.at("exposure_ev").get<float>(), 0.75f);
 }
 
 TEST_F(EditorSessionHistoryPortTest,
@@ -692,70 +696,6 @@ TEST_F(EditorSessionHistoryPortTest,
   EXPECT_EQ(reopened_guard->commit_graph_->CommitCount(),
             capture->materialization.commits.size());
   reopened.Release(reopened_handle);
-}
-
-TEST_F(EditorSessionHistoryPortTest,
-       CommitSerializesWithLivePipelineRenderLock) {
-  // Capture reads the derived committed snapshot (no render lock). Commit applies
-  // to the live executor under GetRenderLock() and must wait if that lock is held.
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-
-  {
-    const auto seed = WithColorGradeTarget({"saturation", R"({"saturation":0})", true});
-    ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, seed, &error)) << error;
-    ASSERT_TRUE(history_.CommitAdjustment(handle, seed, &error)) << error;
-  }
-
-  std::mutex                gate;
-  std::condition_variable   gate_cv;
-  bool                      worker_holds_lock = false;
-  bool                      release_worker    = false;
-  std::thread               worker([&] {
-    std::unique_lock<std::mutex> held(guard_->pipeline_->GetRenderLock());
-    {
-      std::lock_guard lock(gate);
-      worker_holds_lock = true;
-    }
-    gate_cv.notify_one();
-    std::unique_lock wait_lock(gate);
-    gate_cv.wait(wait_lock, [&] { return release_worker; });
-  });
-  {
-    std::unique_lock wait_lock(gate);
-    ASSERT_TRUE(gate_cv.wait_for(wait_lock, std::chrono::seconds(2),
-                                 [&] { return worker_holds_lock; }));
-  }
-
-  const auto preview = WithColorGradeTarget({"saturation", R"({"saturation":20})", false});
-  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, preview, &error)) << error
-      << "Capture must not require the live pipeline render lock";
-
-  std::atomic<bool> commit_finished{false};
-  std::thread       commit_thread([&] {
-    const auto settled = WithColorGradeTarget({"saturation", R"({"saturation":40})", true});
-    (void)history_.CommitAdjustment(handle, settled, &error);
-    commit_finished.store(true);
-  });
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  EXPECT_FALSE(commit_finished.load())
-      << "Commit must wait for the live pipeline render lock";
-
-  {
-    std::lock_guard lock(gate);
-    release_worker = true;
-  }
-  gate_cv.notify_one();
-  if (worker.joinable()) worker.join();
-  if (commit_thread.joinable()) commit_thread.join();
-  EXPECT_TRUE(commit_finished.load());
-
-  alcedo::EditorAdjustmentOperatorState sat;
-  ASSERT_TRUE(
-      alcedo::ReadEditorAdjustmentOperatorState(*guard_->pipeline_, "saturation", &sat, &error))
-      << error;
-  EXPECT_NEAR(sat.params.at("saturation").get<double>(), 40.0, 1e-5);
 }
 
 TEST_F(EditorSessionHistoryPortTest,
@@ -1151,7 +1091,7 @@ TEST_F(EditorSessionHistoryPortTest,
   const auto forward_contrast   = PatchNumber(forward_snapshot, "contrast");
   ASSERT_TRUE(forward_saturation.has_value());
   ASSERT_TRUE(forward_contrast.has_value());
-  EXPECT_NEAR(*forward_saturation, 8.0, 1e-6);
+  EXPECT_NEAR(*forward_saturation, 4.0, 1e-6);  // Model clamps its multiplier to 4.
   EXPECT_NEAR(*forward_contrast, 12.0, 1e-6);
 }
 
@@ -1201,19 +1141,16 @@ TEST(EditorHistoryCommitPresentationTest, FormatsNumericBooleanPathEnumAndCompou
 }
 
 // ---------------------------------------------------------------------------
-// Phase 7A R0: failing evidence for Mini-Git atomicity. These tests assert the
-// repaired target behavior and fail against the current defect where head moves
-// and merge traversal mutate durable/live state before the full target pipeline
-// is known to succeed.
+// History without same-session document targets must be rejected before WAL publication.
+// Typed merge and cross-session replay are outside the document parameter edit boundary.
 // ---------------------------------------------------------------------------
 
-TEST_F(EditorSessionHistoryPortTest,
-       HeadMoveApplyFailurePreservesHeadRedoPipelineSnapshotAndJournal) {
+TEST_F(EditorSessionHistoryPortTest, UnmappedHeadMovePreservesHeadPipelineSnapshotAndJournal) {
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
 
-  // Seed one settled exposure edit so the working head and committed snapshot
+  // Commit one settled exposure edit so the working head and committed snapshot
   // are well-defined before the failing move.
   ASSERT_TRUE(CommitSettled(history_, handle, "exposure", R"({"exposure":0.5})", &error))
       << error;
@@ -1244,53 +1181,34 @@ TEST_F(EditorSessionHistoryPortTest,
   }
   ASSERT_TRUE(bad_head.has_value()) << "could not locate the inserted bogus commit";
 
-  // Place the working head on the bad commit so a backward move to c1 can put
-  // it on the redo suffix. SnapshotAtHead(c1) succeeds (history rebuild skips
-  // the unmappable tip). Redo back onto the bad tip must then fail.
-  const auto active_version = guard_->commit_graph_->GetActiveVersionId();
-  guard_->commit_graph_->MoveWorkingHead(active_version, bad_head);
-  ASSERT_TRUE(history_.MoveHeadToCommit(handle, c1, &error)) << error;
-  EXPECT_EQ(guard_->commit_graph_->GetActiveVersionRef().head_commit_hash, c1);
-
-  const auto journal_records_before = [&] {
-    alcedo::MiniGitJournal j(journal_path_);
-    std::string            load_error;
-    if (!j.Load(&load_error)) return std::size_t{0};
-    return j.records().size();
-  }();
-
-  // Forward onto the unmappable commit must fail before publish (R4 prepared transition).
-  EXPECT_FALSE(history_.MoveHeadToCommit(handle, *bad_head, &error))
-      << "a head move onto an unmappable commit must fail";
-
-  EXPECT_EQ(guard_->commit_graph_->GetActiveVersionRef().head_commit_hash, c1)
-      << "a failed head move must not advance the graph head";
-
-  alcedo::EditorHistorySnapshot snapshot;
-  ASSERT_TRUE(history_.ReadHistorySnapshot(handle, &snapshot, &error)) << error;
-  const auto future_rows = std::count_if(
-      snapshot.commits.begin(), snapshot.commits.end(),
-      [](const alcedo::EditorHistoryCommit& row) {
-        return row.position == alcedo::EditorHistoryTimelinePosition::Future;
-      });
-  EXPECT_EQ(future_rows, 1) << "failed redo must leave the unmappable tip on the redo suffix";
-
-  const auto journal_records_after = [&] {
-    alcedo::MiniGitJournal j(journal_path_);
-    std::string            load_error;
-    if (!j.Load(&load_error)) return std::size_t{0};
-    return j.records().size();
-  }();
-  EXPECT_EQ(journal_records_after, journal_records_before)
-      << "a failed head move must not append a journal record";
+  guard_->commit_graph_->MoveWorkingHead(guard_->commit_graph_->GetActiveVersionId(), bad_head);
+  const auto                     before_document = guard_->document_->ToJson();
+  const auto                     before_pipeline = guard_->pipeline_->ExportPipelineParams();
+  const auto                     before_head     = guard_->working_head_commit_hash();
+  EditorRenderAdjustmentSnapshot before_snapshot;
+  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &before_snapshot, &error)) << error;
+  MiniGitJournal before_journal(journal_path_);
+  ASSERT_TRUE(before_journal.Load(&error)) << error;
+  const auto records = before_journal.records().size();
+  EXPECT_FALSE(history_.MoveHeadToCommit(handle, c1, &error));
+  EXPECT_NE(error.find("same-session document target"), std::string::npos);
+  EXPECT_EQ(guard_->working_head_commit_hash(), before_head);
+  EXPECT_EQ(guard_->document_->ToJson(), before_document);
+  EXPECT_EQ(guard_->pipeline_->ExportPipelineParams(), before_pipeline);
+  EditorRenderAdjustmentSnapshot after_snapshot;
+  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &after_snapshot, &error)) << error;
+  EXPECT_EQ(after_snapshot, before_snapshot);
+  MiniGitJournal after_journal(journal_path_);
+  ASSERT_TRUE(after_journal.Load(&error)) << error;
+  EXPECT_EQ(after_journal.records().size(), records);
 }
 
-TEST_F(EditorSessionHistoryPortTest, MoveAcrossMergeReconstructsResolvedFields) {
+TEST_F(EditorSessionHistoryPortTest, MoveAcrossMergeWithoutDocumentTargetsPreservesState) {
   std::string error;
   const auto  handle = history_.Acquire(42, &error);
   ASSERT_TRUE(handle.valid) << error;
 
-  // Seed one settled exposure edit (C1) on the active first-parent chain.
+  // Commit one settled exposure edit (C1) on the active first-parent chain.
   ASSERT_TRUE(CommitSettled(history_, handle, "exposure", R"({"exposure":0.5})", &error))
       << error;
   const auto c1 = *guard_->working_head_commit_hash();
@@ -1345,22 +1263,25 @@ TEST_F(EditorSessionHistoryPortTest, MoveAcrossMergeReconstructsResolvedFields) 
   ASSERT_NE(merge_hash, alcedo::commit_hash_t{}) << "could not locate the merge commit";
   guard_->commit_graph_->MoveWorkingHead(active_version, merge_hash);
 
-  // Move back to C1 (the merge lands in the redo suffix), then forward to the
-  // merge. The forward move must reconstruct the merge's resolved exposure.
-  ASSERT_TRUE(history_.MoveHeadToCommit(handle, c1, &error)) << error;
-  alcedo::EditorRenderAdjustmentSnapshot baseline_snapshot;
-  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &baseline_snapshot, &error)) << error;
-  const auto baseline_exposure = PatchNumber(baseline_snapshot, "exposure");
-  ASSERT_TRUE(baseline_exposure.has_value());
-  EXPECT_NEAR(*baseline_exposure, 0.5, 1e-6);
-
-  ASSERT_TRUE(history_.MoveHeadToCommit(handle, merge_hash, &error)) << error;
-  alcedo::EditorRenderAdjustmentSnapshot resolved_snapshot;
-  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &resolved_snapshot, &error)) << error;
-  const auto resolved_exposure = PatchNumber(resolved_snapshot, "exposure");
-  ASSERT_TRUE(resolved_exposure.has_value());
-  EXPECT_NEAR(*resolved_exposure, 0.9, 1e-6)
-      << "moving forward across a merge must reconstruct the merge-resolved field values";
+  const auto                     before_document = guard_->document_->ToJson();
+  const auto                     before_pipeline = guard_->pipeline_->ExportPipelineParams();
+  const auto                     before_head     = guard_->working_head_commit_hash();
+  EditorRenderAdjustmentSnapshot before_snapshot;
+  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &before_snapshot, &error)) << error;
+  MiniGitJournal before_journal(journal_path_);
+  ASSERT_TRUE(before_journal.Load(&error)) << error;
+  const auto records = before_journal.records().size();
+  EXPECT_FALSE(history_.MoveHeadToCommit(handle, c1, &error));
+  EXPECT_NE(error.find("same-session document target"), std::string::npos);
+  EXPECT_EQ(guard_->working_head_commit_hash(), before_head);
+  EXPECT_EQ(guard_->document_->ToJson(), before_document);
+  EXPECT_EQ(guard_->pipeline_->ExportPipelineParams(), before_pipeline);
+  EditorRenderAdjustmentSnapshot after_snapshot;
+  ASSERT_TRUE(history_.ReadAdjustmentSnapshot(handle, &after_snapshot, &error)) << error;
+  EXPECT_EQ(after_snapshot, before_snapshot);
+  MiniGitJournal after_journal(journal_path_);
+  ASSERT_TRUE(after_journal.Load(&error)) << error;
+  EXPECT_EQ(after_journal.records().size(), records);
 }
 
 TEST(EditorSessionHistoryPortPersistTest,
@@ -1916,162 +1837,6 @@ TEST(EditorSessionHistoryPortPersistTest,
   std::filesystem::remove(db_path, ec);
   std::filesystem::remove(meta_path, ec);
   std::filesystem::remove(journal_path, ec);
-}
-
-TEST_F(EditorSessionHistoryPortTest, SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages) {
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-  ASSERT_NE(guard_->document_, nullptr);
-  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
-  auto       settled     = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.25})", true});
-  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
-  ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.25f);
-  EXPECT_NE(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
-}
-
-TEST_F(EditorSessionHistoryPortTest,
-       IncompleteTargetRejectedLeavesDocumentHashAndHistoryHeadUnchanged) {
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
-  alcedo::EditorAdjustmentPatch patch;
-  patch.field_key   = "exposure";
-  patch.params_json = R"({"exposure_ev":3.0})";
-  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error));
-  EXPECT_EQ(error, "Editor parameter target requires owner_kind");
-  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
-  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
-                  alcedo::kDefaultPipelineExposureEv);
-
-  auto missing_node = WithColorGradeTarget({"exposure", R"({"exposure_ev":3.0})", false});
-  missing_node.target.node_id = alcedo::NodeId{};
-  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, missing_node, &error));
-  EXPECT_EQ(error, "Editor parameter target requires node_id");
-  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
-}
-
-TEST_F(EditorSessionHistoryPortTest, ProvisionalSequenceReusesTargetResolvedAtFirstPatch) {
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-  auto add_errors =
-      alcedo::AddCleanColorGrade(*guard_->document_, alcedo::NodeId{"drt"}, alcedo::NodeId{"grade.extra"});
-  ASSERT_TRUE(add_errors.empty());
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.extra"), 0.0f);
-
-  auto first = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.0})", false}, "grade.primary");
-  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, first, &error)) << error;
-  auto second = WithColorGradeTarget({"exposure", R"({"exposure_ev":4.0})", false}, "grade.extra");
-  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, second, &error)) << error;
-  auto settled = WithColorGradeTarget({"exposure", R"({"exposure_ev":4.0})", true}, "grade.extra");
-  ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
-
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 4.0f);
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.extra"), 0.0f);
-}
-
-TEST_F(EditorSessionHistoryPortTest,
-       UnknownFieldRejectedLeavesDocumentHashAndHistoryHeadUnchanged) {
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
-  auto       patch       = WithColorGradeTarget({"not_a_supported_adjustment", R"({})", false});
-  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error));
-  EXPECT_EQ(error, "Unknown editor adjustment field: not_a_supported_adjustment");
-  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
-  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
-}
-
-TEST_F(EditorSessionHistoryPortTest, UndoSettledExposureRestoresDocumentValue) {
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-  auto settled = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.5})", true});
-  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
-  ASSERT_TRUE(history_.CommitAdjustment(handle, settled, &error)) << error;
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.5f);
-  ASSERT_TRUE(history_.Undo(handle, &error)) << error;
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
-                  alcedo::kDefaultPipelineExposureEv);
-  ASSERT_TRUE(history_.Redo(handle, &error)) << error;
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.5f);
-}
-
-TEST_F(EditorSessionHistoryPortTest, IncompleteLaterPatchRejectedLeavesLockedDocumentUnchanged) {
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-  auto first = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.0})", false});
-  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, first, &error)) << error;
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.0f);
-
-  alcedo::EditorAdjustmentPatch incomplete;
-  incomplete.field_key   = "exposure";
-  incomplete.params_json = R"({"exposure_ev":4.0})";
-  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, incomplete, &error));
-  EXPECT_EQ(error, "Editor parameter target requires owner_kind");
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.0f);
-  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
-}
-
-TEST_F(EditorSessionHistoryPortTest, JournalAppendFailureRestoresDocumentExposureEv) {
-  history_.SetServices(
-      EditorSessionHistoryPort::Services{[bad = journal_path_.parent_path() / "not-a-directory"](
-                                             sl_element_id_t) { return bad / "image-42.wal"; }});
-  {
-    std::ofstream blocker(journal_path_.parent_path() / "not-a-directory", std::ios::binary);
-    ASSERT_TRUE(blocker.is_open());
-    blocker << "block";
-  }
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-  auto settled = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.25})", true});
-  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, settled, &error)) << error;
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.25f);
-  EXPECT_FALSE(history_.CommitAdjustment(handle, settled, &error));
-  EXPECT_FALSE(error.empty());
-  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
-                  alcedo::kDefaultPipelineExposureEv);
-  std::error_code ec;
-  std::filesystem::remove(journal_path_.parent_path() / "not-a-directory", ec);
-}
-
-TEST_F(EditorSessionHistoryPortTest, DiscardUncommittedPreviewRestoresDocumentExposureEv) {
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-  auto preview = WithColorGradeTarget({"exposure", R"({"exposure_ev":2.25})", false});
-  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, preview, &error)) << error;
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"), 2.25f);
-  ASSERT_TRUE(history_.DiscardUnmaterializedChanges(handle, &error)) << error;
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_, "grade.primary"),
-                  alcedo::kDefaultPipelineExposureEv);
-}
-
-TEST_F(EditorSessionHistoryPortTest, MaskTargetWriteIsRejected) {
-  std::string error;
-  const auto  handle = history_.Acquire(42, &error);
-  ASSERT_TRUE(handle.valid) << error;
-  const auto before_hash = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
-  alcedo::EditorAdjustmentPatch patch;
-  patch.field_key                      = "exposure";
-  patch.params_json                    = R"({"exposure_ev":3.0})";
-  patch.target.owner_kind              = alcedo::EditorParameterOwnerKind::ColorGradeMask;
-  patch.target.node_id                 = alcedo::NodeId{"grade.primary"};
-  patch.target.adjustment_instance_id  = alcedo::AdjustmentInstanceId{"grade.primary.exposure"};
-  patch.target.mask_id                 = "mask.1";
-  patch.target.field_key               = "exposure";
-  EXPECT_FALSE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error));
-  EXPECT_EQ(error, "Mask parameter targets are rejected until NM3");
-  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_hash);
-  EXPECT_FALSE(guard_->working_head_commit_hash().has_value());
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/pipeline/pipeline_document_render_test.cpp
+++ b/alcedo_studio/tests/edit/pipeline/pipeline_document_render_test.cpp
@@ -1,0 +1,358 @@
+// Copyright 2026 Yurun Zi
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+#include <libraw/libraw.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <vector>
+
+#include "edit/graph/develop_color_transform.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/operators/operator_registeration.hpp"
+#include "edit/pipeline/pipeline_cpu.hpp"
+#include "edit/runtime/cuda/cuda_product_renderer.hpp"
+#include "image/dng_color_profile_import.hpp"
+#include "image/metadata_extractor.hpp"
+
+namespace alcedo {
+namespace {
+
+/** @brief Capture actual CUDA presentation pixels in host memory, without a GUI. */
+class PixelFrameSink final : public IFrameSink {
+ public:
+  void EnsureSize(int width, int height) override { pixels.create(height, width, CV_32FC4); }
+  auto MapResourceForWrite(FrameMemoryDomain) -> FrameWriteMapping override {
+    if (reject_mapping) return {};
+    FrameWriteMapping mapping;
+    mapping.data          = pixels.data;
+    mapping.row_bytes     = pixels.step;
+    mapping.pixel_format  = FramePixelFormat::RGBA32F;
+    mapping.memory_domain = FrameMemoryDomain::HostVisible;
+    mapping.target_type   = FrameWriteTargetType::LinearBuffer;
+    return mapping;
+  }
+  void    UnmapResource() override {}
+  void    NotifyFrameReady(const FrameCompletionSubmission&) override { ++ready_count; }
+  void    SubmitHostFrame(const ViewerFrame&) override { ++host_frame_count; }
+  auto    GetWidth() const -> int override { return pixels.cols; }
+  auto    GetHeight() const -> int override { return pixels.rows; }
+
+  cv::Mat pixels;
+  int     ready_count      = 0;
+  int     host_frame_count = 0;
+  bool    reject_mapping   = false;
+};
+
+/** @brief One real linear DNG plus an imported Default document, with no application services. */
+class PipelineDocumentRenderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    RegisterAllOperators();
+    const auto path = std::filesystem::path(TEST_IMG_PATH) / "raw/linear_dng/mfzoty.dng";
+    ASSERT_TRUE(std::filesystem::exists(path)) << path.string();
+    std::ifstream             stream(path, std::ios::binary);
+    std::vector<std::uint8_t> bytes{std::istreambuf_iterator<char>(stream),
+                                    std::istreambuf_iterator<char>()};
+    ASSERT_FALSE(bytes.empty());
+    auto raw = std::make_unique<LibRaw>();
+    ASSERT_EQ(raw->open_buffer(bytes.data(), bytes.size()), LIBRAW_SUCCESS);
+    ASSERT_EQ(raw->unpack(), LIBRAW_SUCCESS);
+    full_extent_ = cv::Size(raw->imgdata.sizes.width, raw->imgdata.sizes.height);
+    if (raw->imgdata.sizes.flip == 5 || raw->imgdata.sizes.flip == 6) {
+      std::swap(full_extent_.width, full_extent_.height);
+    }
+    MetadataExtractor::PopulateRuntimeContextFromOpenLibRaw(*raw, imported_);
+    // Read the actual embedded profile from bytes; do not replace it with an identity profile.
+    const auto exif = MetadataExtractor::ExtractEXIFFromBuffer(bytes.data(), bytes.size());
+    ASSERT_NE(exif, nullptr);
+    imported_.dng_profile_ = ReadDngColorProfile(exif->exifData());
+    ASSERT_NE(imported_.dng_profile_, nullptr);
+    ASSERT_TRUE(imported_.color_matrices_valid_);
+    input_    = std::make_shared<ImageBuffer>(std::move(bytes));
+    document_ = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+    executor_ = std::make_unique<CPUPipelineExecutor>();
+    executor_->SetAcceleratorBackendPreference(AcceleratorBackendPreference::CUDA);
+    executor_->SetPipelineDocument(document_, true);
+    executor_->InjectRawMetadata(imported_);
+    executor_->SetDecodeRes(DecodeRes::FULL);
+    executor_->SetRenderRes(false, 256);
+    executor_->SetEnableCache(true);
+  }
+
+  /** @brief Apply an exposure edit to the same persistent Model used by the executor. */
+  void SetExposure(float ev) {
+    document_->PrimaryGrade()
+        ->FindAdjustmentByType(type_ids::Exposure())
+        ->LoadJson({{"exposure_ev", ev}});
+  }
+
+  /** @brief Execute with the same exclusive access required by the scheduler. */
+  auto Render(bool host) -> cv::Mat {
+    std::unique_lock lock(executor_->GetRenderLock());
+    executor_->SetForceCPUOutput(host);
+    executor_->AttachFrameSink(host ? nullptr : &sink_);
+    const auto result = executor_->Apply(input_);
+    if (!result) throw std::runtime_error("Missing render result");
+    return host ? result->GetCPUData().clone() : sink_.pixels.clone();
+  }
+
+  /** @brief Render a separately initialized reference through the document-only Renderer API. */
+  auto Reference(float ev, RenderQuality quality = RenderQuality::Export) -> cv::Mat {
+    auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+    auto develop  = document->Develop()->Params().Params();
+    BindDevelopCameraProfile(develop, imported_);
+    document->Develop()->Params().ReplaceParams(develop);
+    document->PrimaryGrade()
+        ->FindAdjustmentByType(type_ids::Exposure())
+        ->LoadJson({{"exposure_ev", ev}});
+    CudaRenderer  renderer(document);
+    RenderRequest request;
+    request.resolution.max_edge = 256;
+    request.resolution.quality  = quality;
+    return renderer.Render(input_, DecodeRes::FULL, request, nullptr, {}, true)
+        ->GetCPUData()
+        .clone();
+  }
+
+  RawRuntimeColorContext               imported_;
+  std::shared_ptr<ImageBuffer>         input_;
+  std::shared_ptr<PipelineDocument>    document_;
+  std::unique_ptr<CPUPipelineExecutor> executor_;
+  PixelFrameSink                       sink_;
+  cv::Size                             full_extent_;
+};
+
+TEST_F(PipelineDocumentRenderTest, EditorAndHostRenderUseDocumentParameters) {
+  // Stage values deliberately disagree, including a stage change between editor renders.
+  executor_->GetStage(PipelineStageName::Basic_Adjustment)
+      .SetOperator(OperatorType::EXPOSURE, {{"exposure", 9.0f}});
+  SetExposure(-1.5f);
+  const auto dark_reference = Reference(-1.5f);
+  const auto dark_editor    = Render(false);
+  const auto dark_host      = Render(true);
+  ASSERT_EQ(dark_editor.size(), dark_reference.size());
+  ASSERT_EQ(dark_host.type(), dark_reference.type());
+  EXPECT_LT(cv::norm(dark_editor, Reference(-1.5f, RenderQuality::Preview), cv::NORM_INF), 2e-5);
+  EXPECT_LT(cv::norm(dark_host, dark_reference, cv::NORM_INF), 2e-5);
+
+  executor_->GetStage(PipelineStageName::Basic_Adjustment)
+      .SetOperator(OperatorType::EXPOSURE, {{"exposure", -9.0f}});
+  SetExposure(1.5f);
+  const auto bright_reference = Reference(1.5f);
+  const auto bright_editor    = Render(false);
+  const auto bright_host      = Render(true);
+  EXPECT_LT(cv::norm(bright_editor, Reference(1.5f, RenderQuality::Preview), cv::NORM_INF), 2e-5);
+  EXPECT_LT(cv::norm(bright_host, bright_reference, cv::NORM_INF), 2e-5);
+  EXPECT_GT(
+      cv::norm(bright_reference, dark_reference, cv::NORM_L1) / (3.0 * dark_reference.total()),
+      0.02);
+  EXPECT_GT(cv::mean(bright_host)[1], cv::mean(dark_host)[1] + 0.02);
+  EXPECT_EQ(sink_.ready_count, 2);
+  EXPECT_EQ(sink_.host_frame_count, 0);
+  EXPECT_EQ(executor_->GpuDagDocument().get(), document_.get());
+}
+
+TEST_F(PipelineDocumentRenderTest, ConsecutiveDocumentEditsReusePreparedSourceAndGeometry) {
+  const auto before = Render(false);
+  const auto first  = executor_->DebugCudaRenderer()->Stats();
+  SetExposure(-1.5f);
+  const auto after  = Render(false);
+  const auto second = executor_->DebugCudaRenderer()->Stats();
+  EXPECT_EQ(second.libraw_open_unpack_count, first.libraw_open_unpack_count);
+  EXPECT_EQ(second.pass.sensor_develop_execute, first.pass.sensor_develop_execute);
+  EXPECT_EQ(second.pass.geometry_execute, first.pass.geometry_execute);
+  EXPECT_GT(second.pass.geometry_skip, first.pass.geometry_skip);
+  EXPECT_GT(second.pass.primary_grade_execute, first.pass.primary_grade_execute);
+  EXPECT_GT(cv::norm(before, after, cv::NORM_INF), 0.02);
+}
+
+TEST_F(PipelineDocumentRenderTest, HostBypassRendersReuseOneShotDeviceAndLeaveSessionCacheUntouched) {
+  const auto editor = Render(false);
+  auto*      renderer = executor_->DebugCudaRenderer();
+  ASSERT_NE(renderer, nullptr);
+  renderer->ResetStats();
+  const auto session_before = renderer->SessionResources();
+  EXPECT_GT(session_before.published_result_count, 0U);
+  EXPECT_EQ(renderer->DebugOneShotDeviceIdentity(), 0U);
+
+  executor_->SetEnableCache(false);
+  const auto host1        = Render(true);
+  const auto one_shot_id  = renderer->DebugOneShotDeviceIdentity();
+  const auto one_shot     = renderer->OneShotResources();
+  EXPECT_NE(one_shot_id, 0U);
+  EXPECT_EQ(renderer->OneShotPublishedResultCount(), 0U);
+  EXPECT_EQ(one_shot.published_result_count, 0U);
+  EXPECT_EQ(one_shot.texture_pool_used_bytes, 0U);
+  EXPECT_EQ(one_shot.texture_pool_entry_count, 0U);
+  EXPECT_EQ(renderer->Stats().prepared_source_hits, 0U);
+  EXPECT_EQ(renderer->Stats().prepared_source_misses, 0U);
+  EXPECT_EQ(renderer->Stats().pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(renderer->SessionResources().published_result_count,
+            session_before.published_result_count);
+  EXPECT_EQ(renderer->SessionResources().prepared_source_entry_count,
+            session_before.prepared_source_entry_count);
+  EXPECT_LT(cv::norm(host1, Reference(1.5f, RenderQuality::Export), cv::NORM_INF), 2e-5);
+
+  const auto host2 = Render(true);
+  EXPECT_EQ(renderer->DebugOneShotDeviceIdentity(), one_shot_id);
+  EXPECT_EQ(renderer->OneShotPublishedResultCount(), 0U);
+  EXPECT_EQ(renderer->OneShotResources().texture_pool_used_bytes, 0U);
+  EXPECT_LT(cv::norm(host1, host2, cv::NORM_INF), 2e-5);
+
+  executor_->SetEnableCache(true);
+  renderer->ResetStats();
+  const auto editor2 = Render(false);
+  EXPECT_EQ(renderer->Stats().prepared_source_hits, 1U);
+  EXPECT_EQ(renderer->Stats().libraw_open_unpack_count, 0U);
+  EXPECT_EQ(renderer->Stats().pass.sensor_develop_execute, 0U);
+  EXPECT_LT(cv::norm(editor, editor2, cv::NORM_INF), 2e-5);
+}
+
+TEST_F(PipelineDocumentRenderTest, RenderLeavesPersistentDocumentParametersUnchanged) {
+  SetExposure(0.75f);
+  const auto  before         = document_->ToJson();
+  const auto  stages_before  = executor_->ExportPipelineParams();
+  const auto  request_before = executor_->CaptureOneShotRenderParams();
+  const auto* exposure = document_->PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure());
+  for (const bool host : {false, true, false}) {
+    SCOPED_TRACE(host);
+    executor_->SetEnableCache(!host);
+    executor_->SetDecodeRes(host ? DecodeRes::EIGHTH : DecodeRes::FULL);
+    executor_->SetRenderRes(false, host ? 128 : 256);
+    executor_->SetResizeDownsampleAlgorithm(ResizeDownsampleAlgorithm::Bilinear);
+    ViewportRenderRegion viewport;
+    viewport.reference_width_  = 1024;
+    viewport.reference_height_ = 1024;
+    viewport.x_                = 128;
+    viewport.y_                = 128;
+    viewport.scale_x_          = 0.5f;
+    viewport.scale_y_          = 0.5f;
+    executor_->SetRenderRegion(128, 128, 0.5f, 0.5f, 1024, 1024);
+    executor_->SetRenderRequestViewport(viewport);
+    const auto pixels = Render(host);
+    ASSERT_FALSE(pixels.empty());
+    EXPECT_TRUE(cv::checkRange(pixels));
+    EXPECT_EQ(document_->ToJson(), before);
+    EXPECT_EQ(executor_->ExportPipelineParams(), stages_before);
+    EXPECT_EQ(document_->PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()), exposure);
+  }
+  executor_->RestoreOneShotRenderParams(request_before);
+  EXPECT_EQ(document_->ToJson(), before);
+  EXPECT_EQ(executor_->ExportPipelineParams(), stages_before);
+}
+
+TEST_F(PipelineDocumentRenderTest, DefaultDocumentRendersRealRawAtFullDecodeAndOutputResolution) {
+  executor_->SetRenderRes(true);
+  const auto before = document_->ToJson();
+  const auto pixels = Render(true);
+  ASSERT_FALSE(pixels.empty());
+  EXPECT_EQ(pixels.type(), CV_32FC4);
+  EXPECT_EQ(pixels.size(), full_extent_);
+  EXPECT_TRUE(cv::checkRange(pixels));
+  EXPECT_GT(cv::mean(pixels)[1], 0.01);
+  EXPECT_EQ(executor_->CaptureOneShotRenderParams().decode_res_, DecodeRes::FULL);
+  EXPECT_EQ(document_->ToJson(), before);
+  const auto stats = executor_->DebugCudaRenderer()->Stats();
+  EXPECT_EQ(stats.libraw_open_unpack_count, 1u);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 1u);
+  EXPECT_EQ(stats.pass.camera_color_execute, 1u);
+  EXPECT_EQ(stats.pass.primary_grade_execute, 1u);
+  EXPECT_EQ(stats.pass.drt_execute, 1u);
+}
+
+TEST_F(PipelineDocumentRenderTest, MissingDocumentFailsWithoutExecutingStages) {
+  CPUPipelineExecutor unbound;
+  unbound.SetAcceleratorBackendPreference(AcceleratorBackendPreference::CUDA);
+  unbound.SetExecutionStages(&sink_);
+  const auto before = unbound.ExportPipelineParams();
+  for (const bool host : {false, true}) {
+    unbound.SetForceCPUOutput(host);
+    try {
+      (void)unbound.Apply(input_);
+      FAIL() << "Missing document must fail";
+    } catch (const std::runtime_error& error) {
+      EXPECT_NE(std::string(error.what()).find("bound PipelineDocument"), std::string::npos);
+    }
+  }
+  EXPECT_EQ(unbound.DebugCudaRenderer(), nullptr);
+  EXPECT_EQ(unbound.ExportPipelineParams(), before);
+  EXPECT_EQ(sink_.ready_count, 0);
+  EXPECT_EQ(sink_.host_frame_count, 0);
+  EXPECT_TRUE(input_->buffer_valid_);
+  EXPECT_FALSE(input_->cpu_data_valid_);
+}
+
+TEST_F(PipelineDocumentRenderTest, FailedGpuPresentationPropagatesErrorWithoutSubstituteOutput) {
+  SetExposure(0.5f);
+  const auto before    = document_->ToJson();
+  sink_.reject_mapping = true;
+  try {
+    (void)Render(false);
+    FAIL() << "Rejected CUDA presentation must fail";
+  } catch (const std::runtime_error& error) {
+    EXPECT_NE(std::string(error.what()).find("rejected the write mapping"), std::string::npos);
+  }
+  EXPECT_EQ(sink_.ready_count, 0);
+  EXPECT_EQ(sink_.host_frame_count, 0);
+  EXPECT_EQ(document_->ToJson(), before);
+  EXPECT_EQ(executor_->CaptureOneShotRenderParams().decode_res_, DecodeRes::FULL);
+  sink_.reject_mapping = false;
+  const auto pixels    = Render(false);
+  EXPECT_LT(cv::norm(pixels, Reference(0.5f, RenderQuality::Preview), cv::NORM_INF), 2e-5);
+  EXPECT_EQ(sink_.ready_count, 1);
+}
+
+TEST_F(PipelineDocumentRenderTest, RebindingExecutorDoesNotOverwriteLoadedCameraProfileOrEdits) {
+  auto loaded = std::make_shared<PipelineDocument>(PipelineDocument::FromJson(document_->ToJson()));
+  auto payload = loaded->Develop()->Params().Params();
+  payload.camera_profile.color_matrix_1[0] += 0.1;
+  payload.wb_mode    = "custom";
+  payload.custom_cct = 4800;
+  loaded->Develop()->Params().ReplaceParams(payload);
+  const auto before = loaded->ToJson();
+  executor_->SetPipelineDocument(loaded);
+  EXPECT_EQ(loaded->ToJson(), before);
+  EXPECT_EQ(executor_->GpuDagDocument(), loaded);
+  EXPECT_THROW(executor_->SetPipelineDocument(nullptr), std::invalid_argument);
+  EXPECT_EQ(executor_->GpuDagDocument(), loaded);
+}
+
+TEST_F(PipelineDocumentRenderTest, MissingCameraProfileFailsWithoutReadingStageMetadata) {
+  // The import-stage metadata remains valid; only the authoritative document is invalid.
+  auto develop                                = document_->Develop()->Params().Params();
+  develop.camera_profile.color_matrices_valid = false;
+  document_->Develop()->Params().ReplaceParams(develop);
+  const auto before = document_->ToJson();
+  EXPECT_THROW((void)Render(true), std::runtime_error);
+  EXPECT_EQ(document_->ToJson(), before);
+  EXPECT_EQ(executor_->CaptureOneShotRenderParams().decode_res_, DecodeRes::FULL);
+  EXPECT_TRUE(input_->buffer_valid_);
+  EXPECT_FALSE(input_->cpu_data_valid_);
+  EXPECT_EQ(sink_.ready_count, 0);
+  EXPECT_GT(executor_->DebugCudaRenderer()->Stats().pass.sensor_develop_execute, 0u);
+}
+
+TEST_F(PipelineDocumentRenderTest, CpuPreferenceFailsInsteadOfExecutingLegacyStages) {
+  executor_->SetAcceleratorBackendPreference(AcceleratorBackendPreference::CPU);
+  const auto before = document_->ToJson();
+  try {
+    (void)Render(true);
+    FAIL() << "Product rendering requires a supported GPU backend";
+  } catch (const std::runtime_error& error) {
+    EXPECT_NE(std::string(error.what()).find("supported GPU backend"), std::string::npos);
+  }
+  EXPECT_EQ(executor_->DebugCudaRenderer(), nullptr);
+  EXPECT_EQ(document_->ToJson(), before);
+  EXPECT_TRUE(input_->buffer_valid_);
+  EXPECT_FALSE(input_->cpu_data_valid_);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/pipeline/pipeline_frame_sink_test.cpp
+++ b/alcedo_studio/tests/edit/pipeline/pipeline_frame_sink_test.cpp
@@ -274,13 +274,7 @@ TEST_F(PipelineFrameSinkTest, DetailRoiPreviewUsesViewportTargetPixelsAsMaxEdge)
 
   task.SetExecutorRenderParams();
 
-  const auto resize_entry =
-      exec->GetStage(PipelineStageName::Geometry_Adjustment).GetOperator(OperatorType::RESIZE);
-  ASSERT_TRUE(resize_entry.has_value());
-  ASSERT_NE(resize_entry.value(), nullptr);
-  ASSERT_NE(resize_entry.value()->op_, nullptr);
-
-  const auto params = resize_entry.value()->op_->GetParams();
+  const auto params = exec->CaptureOneShotRenderParams().render_params_;
   ASSERT_TRUE(params.contains("resize"));
   const auto& resize = params["resize"];
   EXPECT_TRUE(resize.value("enable_scale", false));
@@ -338,12 +332,7 @@ TEST_F(PipelineFrameSinkTest, DetailRoiPreviewUsesFrozenRequestRegionInsteadOfCh
   EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.width, 0.491694f, 1.0e-5f);
   EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.height, 0.170244f, 1.0e-5f);
 
-  const auto resize_entry =
-      exec->GetStage(PipelineStageName::Geometry_Adjustment).GetOperator(OperatorType::RESIZE);
-  ASSERT_TRUE(resize_entry.has_value());
-  ASSERT_NE(resize_entry.value(), nullptr);
-  ASSERT_NE(resize_entry.value()->op_, nullptr);
-  const auto params = resize_entry.value()->op_->GetParams();
+  const auto params = exec->CaptureOneShotRenderParams().render_params_;
   ASSERT_TRUE(params.contains("resize"));
   EXPECT_EQ(params["resize"].value("maximum_edge", 0), 3008);
   const auto frozen = exec->CaptureOneShotRenderParams().render_request_viewport_;
@@ -425,13 +414,7 @@ TEST_F(PipelineFrameSinkTest, ActiveCudaHighlightShadowKeepsDetailRoiPreviewAsPa
   EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.width, 0.2f, 1.0e-5f);
   EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.height, 0.2f, 1.0e-5f);
 
-  const auto resize_entry =
-      exec->GetStage(PipelineStageName::Geometry_Adjustment).GetOperator(OperatorType::RESIZE);
-  ASSERT_TRUE(resize_entry.has_value());
-  ASSERT_NE(resize_entry.value(), nullptr);
-  ASSERT_NE(resize_entry.value()->op_, nullptr);
-
-  const auto params = resize_entry.value()->op_->GetParams();
+  const auto params = exec->CaptureOneShotRenderParams().render_params_;
   ASSERT_TRUE(params.contains("resize"));
   const auto& resize = params["resize"];
   EXPECT_TRUE(resize.value("enable_roi", false));
@@ -481,13 +464,7 @@ TEST_F(PipelineFrameSinkTest, ActiveCudaHighlightShadowKeepsFastPreviewAsRoiFram
   EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.width, 0.3f, 1.0e-5f);
   EXPECT_NEAR(sink.last_bound_submission_.metadata.source_roi_norm.height, 0.25f, 1.0e-5f);
 
-  const auto resize_entry =
-      exec->GetStage(PipelineStageName::Geometry_Adjustment).GetOperator(OperatorType::RESIZE);
-  ASSERT_TRUE(resize_entry.has_value());
-  ASSERT_NE(resize_entry.value(), nullptr);
-  ASSERT_NE(resize_entry.value()->op_, nullptr);
-
-  const auto params = resize_entry.value()->op_->GetParams();
+  const auto params = exec->CaptureOneShotRenderParams().render_params_;
   ASSERT_TRUE(params.contains("resize"));
   const auto& resize = params["resize"];
   EXPECT_TRUE(resize.value("enable_roi", false));
@@ -566,13 +543,7 @@ TEST_F(PipelineFrameSinkTest, FullResExportPreservesHighlightShadowSourceDetail)
 
   EXPECT_TRUE(exec->GetGlobalParams().render_hs_preserve_source_detail_);
 
-  const auto resize_entry =
-      exec->GetStage(PipelineStageName::Geometry_Adjustment).GetOperator(OperatorType::RESIZE);
-  ASSERT_TRUE(resize_entry.has_value());
-  ASSERT_NE(resize_entry.value(), nullptr);
-  ASSERT_NE(resize_entry.value()->op_, nullptr);
-
-  const auto params = resize_entry.value()->op_->GetParams();
+  const auto params = exec->CaptureOneShotRenderParams().render_params_;
   ASSERT_TRUE(params.contains("resize"));
   EXPECT_FALSE(params["resize"].value("enable_scale", true));
 
@@ -582,6 +553,34 @@ TEST_F(PipelineFrameSinkTest, FullResExportPreservesHighlightShadowSourceDetail)
   preview_task.SetExecutorRenderParams();
 
   EXPECT_FALSE(exec->GetGlobalParams().render_hs_preserve_source_detail_);
+}
+
+TEST_F(PipelineFrameSinkTest, ThumbnailAndExportTasksDisableSessionCache) {
+  auto exec = std::make_shared<CPUPipelineExecutor>();
+  exec->SetEnableCache(true);
+  EXPECT_TRUE(exec->CaptureOneShotRenderParams().enable_cache_);
+
+  PipelineTask thumbnail;
+  thumbnail.pipeline_executor_                 = exec;
+  thumbnail.options_.render_desc_.render_type_ = RenderType::THUMBNAIL;
+  thumbnail.options_.render_desc_.max_edge_    = 256;
+  thumbnail.SetExecutorRenderParams();
+  EXPECT_FALSE(exec->CaptureOneShotRenderParams().enable_cache_);
+  EXPECT_TRUE(exec->CaptureOneShotRenderParams().force_cpu_output_);
+
+  PipelineTask preview;
+  preview.pipeline_executor_                 = exec;
+  preview.options_.render_desc_.render_type_ = RenderType::FAST_PREVIEW;
+  preview.SetExecutorRenderParams();
+  EXPECT_TRUE(exec->CaptureOneShotRenderParams().enable_cache_);
+  EXPECT_FALSE(exec->CaptureOneShotRenderParams().force_cpu_output_);
+
+  PipelineTask export_task;
+  export_task.pipeline_executor_                 = exec;
+  export_task.options_.render_desc_.render_type_ = RenderType::FULL_RES_EXPORT;
+  export_task.SetExecutorRenderParams();
+  EXPECT_FALSE(exec->CaptureOneShotRenderParams().enable_cache_);
+  EXPECT_TRUE(exec->CaptureOneShotRenderParams().force_cpu_output_);
 }
 
 // =========================================================================

--- a/alcedo_studio/tests/edit/pipeline/pipeline_frame_sink_test.cpp
+++ b/alcedo_studio/tests/edit/pipeline/pipeline_frame_sink_test.cpp
@@ -139,13 +139,14 @@ TEST_F(PipelineFrameSinkTest, ReattachingFrameSinkPreservesMergedStage) {
   EXPECT_EQ(exec->GetFrameSink(), &other_sink);
 
   // A genuine reset (e.g. backend switch routes through ResetExecutionStages)
-  // tears the graph down; the next attach rebuilds a fresh merged stage.
+  // tears the graph down; the next attach rebuilds a merged stage. The new
+  // object's heap address may match the previous one after an immediate free
+  // and realloc, so freshness is the null identity between the two builds.
   exec->ResetExecutionStages();
   EXPECT_EQ(exec->DebugGetMergedStageIdentity(), std::uintptr_t{0});
   exec->SetExecutionStages(&sink);
   const auto identity_after_reset = exec->DebugGetMergedStageIdentity();
   EXPECT_NE(identity_after_reset, std::uintptr_t{0});
-  EXPECT_NE(identity_after_reset, identity_after_build);
 }
 
 TEST_F(PipelineFrameSinkTest, BindFrameSubmissionIsNoOpWhenSinkIsDetached) {

--- a/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
@@ -5,12 +5,16 @@
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <opencv2/core.hpp>
 #include <span>
 #include <stdexcept>
+#include <string>
+#include <thread>
 #include <type_traits>
 #include <vector>
 
@@ -477,6 +481,122 @@ TEST_F(CudaResultCacheProductFixture, CudaRendererPreservesCurrentPlanAndResultC
                                      keys.geometry_extent, TextureFormat::Rgba32f, completed));
   EXPECT_TRUE(images.FindValidResult(plan.display_output, keys.drt_display, keys.geometry_extent,
                                      TextureFormat::Rgba32f, completed));
+}
+
+TEST_F(CudaResultCacheProductFixture, RepeatedOneShotRendersReuseDeviceAndReleaseWorkspace) {
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  const auto session_before = renderer_->SessionResources();
+  EXPECT_GT(session_before.published_result_count, 0U);
+  renderer_->ResetStats();
+  EXPECT_EQ(renderer_->DebugOneShotDeviceIdentity(), 0U);
+
+  ASSERT_TRUE(
+      OutputIsFinite(RenderHostWithoutSessionCache(*renderer_, image_, DecodeRes::FULL, {})));
+  const auto first_id = renderer_->DebugOneShotDeviceIdentity();
+  EXPECT_NE(first_id, 0U);
+  EXPECT_EQ(renderer_->OneShotPublishedResultCount(), 0U);
+  EXPECT_EQ(renderer_->OneShotResources().published_result_count, 0U);
+  EXPECT_EQ(renderer_->OneShotResources().texture_pool_used_bytes, 0U);
+  EXPECT_EQ(renderer_->OneShotResources().texture_pool_entry_count, 0U);
+  EXPECT_EQ(renderer_->SessionResources().published_result_count,
+            session_before.published_result_count);
+  EXPECT_EQ(renderer_->SessionResources().prepared_source_entry_count,
+            session_before.prepared_source_entry_count);
+  EXPECT_EQ(renderer_->Stats().prepared_source_hits, 0U);
+  EXPECT_EQ(renderer_->Stats().prepared_source_misses, 0U);
+  EXPECT_EQ(renderer_->Stats().pass.sensor_develop_execute, 0U);
+
+  ASSERT_TRUE(
+      OutputIsFinite(RenderHostWithoutSessionCache(*renderer_, image_, DecodeRes::FULL, {})));
+  EXPECT_EQ(renderer_->DebugOneShotDeviceIdentity(), first_id);
+  EXPECT_EQ(renderer_->OneShotPublishedResultCount(), 0U);
+  EXPECT_EQ(renderer_->OneShotResources().texture_pool_used_bytes, 0U);
+  EXPECT_EQ(renderer_->OneShotResources().texture_pool_entry_count, 0U);
+  EXPECT_EQ(renderer_->SessionResources().published_result_count,
+            session_before.published_result_count);
+
+  ASSERT_TRUE(OutputIsFinite(Render()));
+  EXPECT_EQ(renderer_->Stats().prepared_source_hits, 1U);
+  EXPECT_EQ(renderer_->Stats().libraw_open_unpack_count, 0U);
+  EXPECT_EQ(renderer_->Stats().pass.sensor_develop_execute, 0U);
+  EXPECT_EQ(renderer_->Stats().pass.drt_skip, 1U);
+}
+
+TEST_F(CudaResultCacheProductFixture, ParallelOneShotRendersCompleteAndReleaseWorkspaces) {
+  constexpr int kWorkers = 2;
+  struct Worker {
+    std::unique_ptr<CudaProductRenderer> renderer;
+    std::shared_ptr<ImageBuffer>         image;
+    bool                                 finite           = false;
+    std::uintptr_t                       device_identity  = 0;
+    std::size_t                          published        = 1;
+    std::size_t                          pool_bytes       = 1;
+    std::size_t                          pool_entries     = 1;
+    std::uint64_t                        source_hits      = 1;
+    std::uint64_t                        source_misses    = 1;
+    std::string                          error;
+  };
+
+  std::vector<Worker> workers(static_cast<std::size_t>(kWorkers));
+  for (int i = 0; i < kWorkers; ++i) {
+    auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+    gpu_dag_test::EnsureTestCameraProfile(*document);
+    workers[static_cast<std::size_t>(i)].renderer =
+        std::make_unique<CudaProductRenderer>(document, MakeUnpacker());
+    workers[static_cast<std::size_t>(i)].image =
+        MakeEncodedImage(static_cast<std::uint8_t>(90 + i));
+  }
+
+  std::promise<void> start;
+  const auto         go = start.get_future().share();
+  std::atomic<int>   ready{0};
+  std::vector<std::thread> threads;
+  threads.reserve(static_cast<std::size_t>(kWorkers));
+  for (int i = 0; i < kWorkers; ++i) {
+    threads.emplace_back([&, i] {
+      auto& worker = workers[static_cast<std::size_t>(i)];
+      ready.fetch_add(1, std::memory_order_relaxed);
+      go.wait();
+      try {
+        const auto output =
+            RenderHostWithoutSessionCache(*worker.renderer, worker.image, DecodeRes::FULL, {});
+        worker.finite          = OutputIsFinite(output);
+        worker.device_identity = worker.renderer->DebugOneShotDeviceIdentity();
+        worker.published       = worker.renderer->OneShotPublishedResultCount();
+        const auto one_shot    = worker.renderer->OneShotResources();
+        worker.pool_bytes      = one_shot.texture_pool_used_bytes;
+        worker.pool_entries    = one_shot.texture_pool_entry_count;
+        worker.source_hits     = worker.renderer->Stats().prepared_source_hits;
+        worker.source_misses   = worker.renderer->Stats().prepared_source_misses;
+      } catch (const std::exception& ex) {
+        worker.error = ex.what();
+      } catch (...) {
+        worker.error = "unknown parallel one-shot failure";
+      }
+    });
+  }
+
+  while (ready.load(std::memory_order_relaxed) < kWorkers) {
+    std::this_thread::yield();
+  }
+  start.set_value();
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  for (int i = 0; i < kWorkers; ++i) {
+    SCOPED_TRACE(i);
+    const auto& worker = workers[static_cast<std::size_t>(i)];
+    EXPECT_TRUE(worker.error.empty()) << worker.error;
+    EXPECT_TRUE(worker.finite);
+    EXPECT_NE(worker.device_identity, 0U);
+    EXPECT_EQ(worker.published, 0U);
+    EXPECT_EQ(worker.pool_bytes, 0U);
+    EXPECT_EQ(worker.pool_entries, 0U);
+    EXPECT_EQ(worker.source_hits, 0U);
+    EXPECT_EQ(worker.source_misses, 0U);
+  }
+  EXPECT_NE(workers[0].device_identity, workers[1].device_identity);
 }
 
 TEST_F(CudaResultCacheProductFixture, RendererOneShotWorkspaceCannotPublishIntoSessionCache) {

--- a/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
@@ -170,5 +170,28 @@ TEST_F(CudaWorkspaceFixture, UnpublishedWriteIsNotAContentHitUntilPublish) {
                                                  workspace.Device().CompletedSubmission()));
 }
 
+TEST_F(CudaWorkspaceFixture, BackgroundIntermediateImagesReleaseAfterLastConsumer) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  const GraphValueId develop{NodeId{"develop"}, PortId{"image"}};
+  const GraphValueId grade{NodeId{"grade.primary"}, PortId{"image"}};
+  const GraphValueId mask{NodeId{"mask"}, PortId{"mask"}};
+  device.BeginRender();
+  (void)workspace.AcquireImageForWrite(develop, {kWidth, kHeight, TextureFormat::Rgba32f});
+  (void)workspace.AcquireImageForWrite(grade, {kWidth, kHeight, TextureFormat::Rgba32f});
+  (void)workspace.AcquireImageForWrite(mask, {kWidth, kHeight, TextureFormat::R8});
+  EXPECT_EQ(workspace.Images().UnpublishedWriteCount(), 3U);
+  device.WaitIdle();
+  workspace.ReleaseConsumedImage(develop);
+  EXPECT_EQ(workspace.Images().UnpublishedWriteCount(), 2U);
+  EXPECT_EQ(workspace.Images().Find(develop), nullptr);
+  ASSERT_NE(workspace.Images().Find(grade), nullptr);
+  ASSERT_NE(workspace.Images().Find(mask), nullptr);
+  workspace.ReleaseConsumedImage(mask);
+  EXPECT_EQ(workspace.Images().UnpublishedWriteCount(), 1U);
+  EXPECT_NE(workspace.Images().Find(grade), nullptr);
+  device.CancelRender();
+}
+
 }  // namespace
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/transient_buffer_arena_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/transient_buffer_arena_test.cpp
@@ -189,6 +189,54 @@ TEST(TransientBufferArena, ReserveWithinOneSlabStillCreatesCapacityUpFront) {
   EXPECT_EQ(arena.slab_count(), 1U);
 }
 
+TEST(TransientBufferArena, BackgroundScratchAllocatesOnlyRequestedAlignedBytes) {
+  RecordingBackend backend;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  arena.SetAllocationPolicy(TransientAllocationPolicy::ExactRelease);
+  EXPECT_THROW(arena.Reserve(1u << 20), std::runtime_error);
+  constexpr std::size_t kAlign = 256;
+  void* first  = arena.Allocate(64, kAlign);
+  void* second = arena.Allocate(64, kAlign);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_NE(first, second);
+  ASSERT_EQ(backend.create_sizes.size(), 2U);
+  EXPECT_EQ(backend.create_sizes[0], kAlign);
+  EXPECT_EQ(backend.create_sizes[1], kAlign);
+  EXPECT_LT(backend.create_sizes[0], TransientBufferArena<RecordingBackend>::kMinSlabBytes);
+  EXPECT_EQ(arena.slab_count(), 2U);
+  arena.Reset();
+  backend.create_sizes.clear();
+  (void)arena.Allocate(96, kAlign);
+  ASSERT_EQ(backend.create_sizes.size(), 1U);
+  EXPECT_EQ(backend.create_sizes.front(), kAlign);
+}
+
+TEST(TransientBufferArena, BackgroundScratchReleasesStorageAfterLastUse) {
+  RecordingBackend backend;
+  TransientBufferArena<RecordingBackend> arena(backend);
+  arena.SetAllocationPolicy(TransientAllocationPolicy::ExactRelease);
+  void* outer = arena.Allocate(64, 256);
+  ASSERT_NE(outer, nullptr);
+  static_cast<std::byte*>(outer)[0] = std::byte{0x11};
+  backend.events.clear();
+  {
+    TransientBufferScope<RecordingBackend> inner(arena);
+    ASSERT_NE(arena.Allocate(32, 256), nullptr);
+    EXPECT_EQ(arena.slab_count(), 2U);
+  }
+  ASSERT_FALSE(backend.events.empty());
+  EXPECT_EQ(backend.events.back(), "free");
+  EXPECT_EQ(arena.slab_count(), 1U);
+  EXPECT_EQ(static_cast<std::byte*>(outer)[0], std::byte{0x11});
+  backend.events.clear();
+  arena.Reset();
+  EXPECT_EQ(arena.slab_count(), 0U);
+  EXPECT_EQ(arena.used_bytes(), 0U);
+  ASSERT_FALSE(backend.events.empty());
+  EXPECT_EQ(backend.events.back(), "free");
+}
+
 TEST(DevelopTransientFailure, DescribesResolvedDemosaicMethodNotEmptyPayloadString) {
   DevelopCompileSource source;
   source.kind        = DevelopInputKind::BayerCfa;

--- a/alcedo_studio/tests/renderer/pipeline_scheduler_request_id_test.cpp
+++ b/alcedo_studio/tests/renderer/pipeline_scheduler_request_id_test.cpp
@@ -211,7 +211,7 @@ TEST(PipelineSchedulerRequestIdTest, CompletionRunsAfterLivePipelineRenderLockIs
 }
 
 TEST(PipelineSchedulerRequestIdTest,
-     ConsecutiveInteractiveAdjustmentsReuseGeometryStageOutput) {
+     MissingDocumentRequestsReportFailureWithoutUsingStageCache) {
   RegisterAllOperators();
 
   auto exec = std::make_shared<CPUPipelineExecutor>();
@@ -236,17 +236,15 @@ TEST(PipelineSchedulerRequestIdTest,
     return future.get();
   };
 
-  ASSERT_NE(run_interactive(101), nullptr);
+  EXPECT_THROW((void)run_interactive(101), std::runtime_error);
   auto& geometry = exec->GetStage(PipelineStageName::Geometry_Adjustment);
-  ASSERT_TRUE(geometry.CacheValid());
+  EXPECT_FALSE(geometry.CacheValid());
 
   auto& basic = exec->GetStage(PipelineStageName::Basic_Adjustment);
   basic.SetOperator(OperatorType::EXPOSURE, {{"exposure", 0.5f}}, exec->GetGlobalParams());
 
-  ASSERT_NE(run_interactive(102), nullptr);
-  EXPECT_TRUE(geometry.CacheValid());
-  EXPECT_NE(geometry.GetLastProfileSummary().find("cache=hit"), std::string::npos)
-      << geometry.GetLastProfileSummary();
+  EXPECT_THROW((void)run_interactive(102), std::runtime_error);
+  EXPECT_FALSE(geometry.CacheValid());
 }
 
 TEST(DirectPresentQueueRequestIdTest, ConsumeNewestReadyPrefersHigherRequestId) {

--- a/alcedo_studio/tests/support/editor_parameter_target_test.hpp
+++ b/alcedo_studio/tests/support/editor_parameter_target_test.hpp
@@ -1,0 +1,28 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "app/editor_adjustment_types.hpp"
+
+namespace alcedo::test {
+
+/// Complete Color Grade target for tests. Production callers must fill the same fields.
+inline auto ColorGradeFieldTarget(std::string field, std::string node_id = "grade.primary")
+    -> EditorParameterTarget {
+  EditorParameterTarget target;
+  target.owner_kind             = EditorParameterOwnerKind::ColorGrade;
+  target.node_id                = NodeId{node_id};
+  target.adjustment_instance_id = AdjustmentInstanceId{node_id + "." + field};
+  target.field_key              = std::move(field);
+  return target;
+}
+
+inline auto WithColorGradeTarget(EditorAdjustmentPatch patch, std::string node_id = "grade.primary")
+    -> EditorAdjustmentPatch {
+  patch.target = ColorGradeFieldTarget(patch.field_key, std::move(node_id));
+  return patch;
+}
+
+}  // namespace alcedo::test

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -176,6 +176,7 @@ alcedo_register_test_target(UiFuzzAutomationTest ui)
 # not pull the full QML/Qt shell graph into a unit-test process.
 add_executable(EditorSessionHistoryPortTest
     ${ALCEDO_TEST_ROOT}/edit/history/editor_session_history_port_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/history/editor_document_history_test.cpp
     ${CMAKE_SOURCE_DIR}/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
     ${CMAKE_SOURCE_DIR}/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_state_detail.cpp
     ${CMAKE_SOURCE_DIR}/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_shared_helpers.cpp

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -191,6 +191,8 @@ target_include_directories(EditorSessionHistoryPortTest
 target_link_libraries(EditorSessionHistoryPortTest
   AdjustmentTransferService
   EditorAdjustmentPipeline
+  EditorPipelineCommandService
+  EditGraph
   EditorMiniGitMaterializer
   PipelineMgmtService
   ProjectService

--- a/alcedo_studio/tests/ui/editor_multi_slider_quicktest.cpp
+++ b/alcedo_studio/tests/ui/editor_multi_slider_quicktest.cpp
@@ -47,9 +47,11 @@
 #include "app/editor_session_service.hpp"
 #include "app/editor_session_types.hpp"
 #include "app/pipeline_service.hpp"
+#include "edit/graph/pipeline_document.hpp"
 #include "edit/history/commit_graph.hpp"
 #include "edit/operators/operator_registeration.hpp"
 #include "edit/pipeline/pipeline_cpu.hpp"
+#include "support/editor_parameter_target_test.hpp"
 #include "ui/alcedo_main/album_backend/editor_adjustment_models.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_controller.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_history_port.hpp"
@@ -68,6 +70,8 @@ auto MakeGuard(sl_element_id_t element_id) -> std::shared_ptr<alcedo::PipelineGu
   auto guard       = std::make_shared<alcedo::PipelineGuard>();
   guard->id_       = element_id;
   guard->pipeline_ = std::make_shared<alcedo::CPUPipelineExecutor>();
+  guard->document_ =
+      std::make_shared<alcedo::PipelineDocument>(alcedo::CreateDefaultPipelineDocument());
   guard->commit_graph_ =
       std::make_shared<alcedo::CommitGraph>(alcedo::CommitGraph::CreateEmpty(element_id));
   guard->root_id_ = guard->commit_graph_->GetRootId();
@@ -260,6 +264,7 @@ class ProductionSessionBackend final : public alcedo::IEditorSessionBackend {
     }
 
     std::string error;
+    patch = alcedo::test::WithColorGradeTarget(std::move(patch));
     // Same order as EditorSessionEditController::HandlePatch.
     if (!history_.CaptureAdjustmentBeforePreview(handle_, patch, &error)) {
       ++history_fail_count_;

--- a/docs/issues/thumbnail_disk_cache_writeback.md
+++ b/docs/issues/thumbnail_disk_cache_writeback.md
@@ -1,0 +1,135 @@
+# Move thumbnail and analysis disk writes into the disk cache service
+
+Date: 2026-08-30
+
+Status: Open; design discussion pending.
+
+GitHub issue: [#113](https://github.com/zidage/AlcedoStudio/issues/113).
+
+Repository: `zidage/AlcedoStudio`.
+
+## Purpose and scope
+
+The disk cache service must control disk writes for thumbnail and analysis images.
+The scheduler callback must not read the live pipeline to decide whether to write an image.
+The callback must supply the result and the required request data.
+
+This issue concerns final images stored on disk.
+It does not concern GPU textures, intermediate image results, or scratch memory.
+
+**Discuss and implement this change separately from NM1.4R.**
+This issue does not block NM1.5.
+The service API and its data model remain open for discussion.
+
+## Terms
+
+- **Analysis image:** a rendered image that the application supplies to image analysis.
+- **Live pipeline:** the shared document and executor for one image.
+- **HEAD:** the current committed position in the edit history.
+- **Commit label:** the identifier for the committed edit state that corresponds to an image result.
+- **Cache key:** the identifier that the disk cache uses to store and find an image.
+- **Pin:** a count that keeps a pipeline available while a task uses it.
+- **Callback:** a function that receives a task result or a completion event.
+- **Invalidation:** an operation that marks a cached result or pending write as no longer valid.
+- **Scratch memory:** temporary memory that an image operation uses.
+
+## Background
+
+The NM1.4C review on 2026-08-30 found disk write decisions in callbacks that ThumbnailService registers with PipelineScheduler.
+
+The uncommitted code adds `EnqueueDiskWriteIfCommitLabelMatches`.
+This function reads HEAD, `dirty_`, and `unsettled_preview_` from the live pipeline.
+It then decides whether to call `EnqueueWrite`.
+
+These checks attempt to prevent image pixels from using the wrong commit label.
+However, the callback reads the state after rendering.
+That state does not identify the state that produced the pixels.
+
+The user confirmed these operating conditions:
+
+- Editor changes do not occur during thumbnail updates or exports.
+- Export tasks and thumbnail tasks can run at the same time.
+
+Do not add support for concurrent editing to solve this issue.
+Do not add frozen document copies or exports from arbitrary history positions.
+
+## Required responsibility
+
+The disk cache service must determine whether a result can be written.
+It must also control invalidation and completion of disk writes.
+
+Moving the existing checks into a service function is insufficient if that function still reads the live executor or editor state.
+Define the required input at the service boundary instead.
+
+Keep the existing cancellation and invalidation mechanisms.
+Do not add document copies, publication tokens, a second history model, or a general coordination framework.
+
+## Questions for the design
+
+1. Which application entry point supplies the correct commit label for each result?
+2. How does that label work with existing cache keys, cancellation, and invalidation?
+3. How does the service prevent an invalid result from returning to the disk index during a write?
+4. Can thumbnails and analysis images use the same mechanism while keeping separate cache namespaces and cancellation?
+5. Should the service remove `dirty_` from the conditions that permit disk writes?
+6. Which fields and helper functions become unnecessary after the service owns this mechanism?
+
+The `dirty_` field indicates changes that storage does not yet contain.
+It does not, by itself, identify an uncommitted preview.
+
+The change added `unsettled_preview_` and `SyncUnsettledPreviewFlag` to copy preview state for these checks.
+Remove this copied state if no other operation needs it after the design changes.
+
+A database label can be out of date.
+Do not use it instead of the label that corresponds to the rendered pixels.
+
+## Existing test evidence
+
+The review ran 57 focused tests on 2026-08-30.
+
+| Result | Count |
+| --- | ---: |
+| Passed | 54 |
+| Failed | 2 |
+| Timed out | 1 |
+
+The two failed tests check pin counts.
+Both passed when run separately again.
+NM1.4R tracks their completion synchronization problems.
+
+This issue tracks `PipelineSharedUseTest.QueuedRenderDoesNotStorePixelsUnderStaleCommitLabel`.
+That test timed out after 90 seconds.
+
+The test requests the same thumbnail key twice.
+It does not invalidate the first image in the memory cache before the second request.
+The second request can return that cached image without adding a render task.
+The test then waits without a time limit for the pipeline pin count to increase.
+It also reads that non-atomic count without the required synchronization.
+
+Thus, this test does not prove the intended ordering or correct use of commit labels.
+
+Test the new behavior at the disk cache service boundary.
+Use barriers or a controllable executor to establish the execution order.
+Do not use sleeps, unlimited polling, or a longer timeout as the fix.
+
+## Acceptance criteria
+
+- [ ] The disk cache service controls permission to write, invalidation, and completion of disk writes.
+- [ ] Scheduler callbacks do not read live HEAD, dirty state, or preview state to decide whether to write.
+- [ ] The service writes valid results under the correct keys and can read them again.
+- [ ] The service does not reject all writes as a substitute for correct behavior.
+- [ ] Canceled, invalid, or obsolete results do not enter the disk index.
+- [ ] Tests cover separate thumbnail and analysis namespaces, concurrent writes, write failures, and resource release.
+- [ ] Tests use a controlled execution order.
+- [ ] The change removes unnecessary copied state, helper functions, and tests that only repeat implementation details.
+- [ ] The change preserves internal GPU cache behavior, RAW quality, and the number of parallel background tasks.
+
+## Related code and plans
+
+- `alcedo_studio/src/app/thumbnail_service.cpp`: `BuildDiskCacheKey`, `RenderedCommitLabel`, `EnqueueDiskWriteIfCommitLabelMatches`, and result callbacks.
+- `alcedo_studio/src/app/thumbnail_disk_cache_service.cpp`, its header, and its tests.
+- `alcedo_studio/src/include/app/thumbnail_types.hpp`: `ThumbnailDiskCacheWriteAllowed`.
+- `alcedo_studio/src/include/app/pipeline_service.hpp`: `unsettled_preview_`.
+- `alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp`: `SyncUnsettledPreviewFlag`.
+- `alcedo_studio/tests/app/pipeline_shared_use_test.cpp`: the existing test for commit labels.
+- `docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md`.
+- `docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md`.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
@@ -951,6 +951,55 @@ ctest --test-dir build\debug\alcedo_studio\tests\ui -R "EditorSessionPipelinePor
 
 **Checklist / exit condition:** 第 11.1 节八项工作、第 11.2 节六项验收和第 14 节 NM1.5 相关退出项均有执行证据；Issue #113 明确保持为未完成的独立待办。
 
+##### CI follow-up completion record (2026-08-31)
+
+**Status:** complete — macOS CI 的 6 个 `ci_raw_flow` 失败来自同一缺口：产品 DAG 只读 document 里的相机矩阵。semantic / album 缩略图走 `RenderType::THUMBNAIL`（one-shot、host download）；相关测试在 import 时没有把 `PipelineMgmtService` 交给 `ImportServiceImpl`，CI RAW 的 `Apply` / scheduler 则对未绑定 document 的 executor 直接渲染。`FAST_PREVIEW` / `QUALITY_BASE_PREVIEW` 是编辑器 interactive present，不是缩略图路径。
+
+**Primary success call chain:**
+
+```text
+ImportServiceImpl(fs, pool, PipelineMgmtService)
+  -> PersistAssembledImportPipeline
+  -> InjectRawMetadata into bound Default document
+  -> SyncPipelineDocument
+  -> ThumbnailService schedules RenderType::THUMBNAIL
+  -> LoadPipeline binds stored document
+  -> DAG camera color uses stored matrices; host download for album/semantic
+```
+
+**Primary failure call chain:**
+
+```text
+import without PipelineMgmtService, or Apply/THUMBNAIL without a bound document
+  -> Default document has no camera matrices, or Apply throws missing document
+  -> ExecuteMetalCameraColor: missing camera matrices
+  -> thumbnail callback fails; semantic items counted as failed
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `UsesRealThumbnailServiceAndBatchesMockEmbedding` | `SemanticGenerationServiceTest` | PASS |
+| `RealThumbnailFailureSkipsMockEmbeddingForThatItem` | `SemanticGenerationServiceTest` | PASS |
+| `CancelDuringMockEmbeddingDoesNotHoldRealThumbnailPin` | `SemanticGenerationServiceTest` | PASS |
+| `GeneratesLabelsForRecursiveCameraSampleDatabaseAndSqlChecks` | `SemanticGenerationServiceTest` | PASS |
+| `DefaultPipelineRendersCiRawFixture` | `CiRawWorkflowTest` | PASS |
+| `SchedulerProducesThumbnailAndFastPreview` | `CiRawWorkflowTest` | PASS；像素断言只落在 `THUMBNAIL` |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target SemanticGenerationServiceTest CiRawWorkflowTest
+build\debug\alcedo_studio\tests\ci\CiRawWorkflowTest_runtime\CiRawWorkflowTest.exe --gtest_brief=1
+build\debug\alcedo_studio\tests\app\SemanticGenerationServiceTest_runtime\SemanticGenerationServiceTest.exe --gtest_filter=SemanticGenerationServiceTest.UsesRealThumbnailServiceAndBatchesMockEmbedding:SemanticGenerationServiceTest.RealThumbnailFailureSkipsMockEmbeddingForThatItem:SemanticGenerationServiceTest.CancelDuringMockEmbeddingDoesNotHoldRealThumbnailPin --gtest_brief=1
+build\debug\alcedo_studio\tests\app\SemanticGenerationServiceTest_runtime\SemanticGenerationServiceTest.exe --gtest_filter=SemanticGenerationServiceTest.GeneratesLabelsForRecursiveCameraSampleDatabaseAndSqlChecks --gtest_brief=1
+```
+
+本机 Windows debug：`CiRawWorkflowTest` 3/3 PASS（2574 ms）；上述 3 个 real-thumbnail semantic 测试 PASS（5275 ms）；recursive camera-sample semantic PASS（7153 ms）。Metal 未在本机运行。
+
+**Remaining gaps:** Issue #113 磁盘写回仍未实施。本 follow-up 不改产品 import 接线；`project_handler` 本来就会把 `PipelineMgmtService` 交给 import。`FAST_PREVIEW` 的 GPU sink present 仍由编辑器 / `PipelineFrameSinkTest` / `PipelineDocumentRenderTest` 覆盖。
+
 ## 12. API 与所有权约束
 
 保留简单的领域函数形态，例如：

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
@@ -4,7 +4,7 @@ Date: 2026-08-29
 
 Revised: 2026-08-30 — 按单 live document、原地函数应用、共享 executor 重定执行方案。
 
-Status: in progress — NM1.4 A 已完成并通过本版验收，NM1.1/NM1.3 的原地参数修改与局部恢复已修正；NM1.2 保留；NM1.4 B/C、NM1.5 待实施。
+Status: in progress — NM1.4 A/B 已完成并通过本版验收；NM1.2 保留；NM1.4 C、NM1.5 待实施。
 
 Branch: `feature/pipeline-document-editing`
 
@@ -15,7 +15,7 @@ Base: `origin/main` at NM0 merge (`d5a96267`)。
 
 本版替换原 NM1 的整图 candidate、独立 snapshot executor 和多份编辑状态要求。既有功能不推倒重来；
 从当前 NM1.4 工作区继续，先消除 NM1.1/NM1.3 的相关实现债务，再完成渲染和保存读取。
-2026-08-30 的方案修订未撤回未提交源码；其后 NM1.4 A 已定向实施，见第 10.1 节完成记录。过去的测试结果保留在第 16 节，不代表 B/C 或整个 NM1 已完成。
+2026-08-30 的方案修订未撤回未提交源码；其后 NM1.4 A 已定向实施，见第 10.1 节完成记录；NM1.4 B 见第 10.2 节完成记录。过去的测试结果保留在第 16 节，不代表 C 或整个 NM1 已完成。
 
 ---
 
@@ -246,7 +246,7 @@ before/after 不能继续从 stage 表读取；既有 payload 需要的字段表
 
 ## 10. NM1.4 — 原地编辑与共享 DAG 渲染
 
-Status: partial — A complete（2026-08-30）；B/C rework required。A 使用下列新证据，B/C 不沿用旧 clone 测试的完成结论。
+Status: partial — A complete（2026-08-30）；B complete（2026-08-30）；C rework required。A/B 使用下列新证据，C 不沿用旧 snapshot 测试的完成结论。
 
 ### 10.1 A：原地修改和局部恢复
 
@@ -379,6 +379,92 @@ Suite totals: **121/121 PASS，0 skipped** — Graph 47、CommandService 8、His
 - `RenderLeavesPersistentDocumentParametersUnchanged`：不同任务前后持久参数、节点和边相同。
 - 对默认图运行真实 RAW；GPU 失败不进入 CPU、旧 stage 或较低质量出图。
 
+#### NM1.4 B completion record (2026-08-30)
+
+**Status:** complete — 产品 `Apply` 只读已绑定 document；host/thumbnail/export 走 BypassSessionCache，复用同一 one-shot device 并在交付后释放 workspace；并行独立 renderer 的 one-shot 分配可完成且不写入 session cache。
+
+**实现与验收清单：**
+
+- [x] `ApplyGpuDagProduct` 不再调用 `LegacyPipelineImporter::ApplyOnto`；editor/host 都从绑定 document 取参数，stage 曝光与 document 故意不一致时像素仍跟 document。
+- [x] 未绑定 document 时 `Apply` 抛出真实错误，不创建 renderer、不执行 stage、不写输出。
+- [x] `BuildGpuDagRenderRequest` 只翻译 viewport/resize/quality；`RenderLeavesPersistentDocumentParametersUnchanged` 证明节点、边、Model 地址和 stage JSON 在多种请求配置后不变。
+- [x] `InjectRawMetadata` 仅在导入/显式加载路径写入 Develop；任务 `Apply` 不从 stage 补相机矩阵。缺 document 相机配置失败，不读 stage metadata。
+- [x] Thumbnail/export 的 `SetExecutorRenderParams` 关闭 session cache；连续 Bypass 复用 one-shot device，交付后 texture pool used bytes 为 0；两条并行 Bypass 使用不同 device，均释放 workspace，且不增加 session prepared-source 计数。
+
+**Primary success call chain:**
+
+```text
+CPUPipelineExecutor::Apply (bound document)
+  -> BuildGpuDagRenderRequest (viewport/decode/resize/quality only)
+  -> cache_policy = enable_cache_ ? UseSessionCache : BypassSessionCache
+  -> ApplyGpuDagProduct -> Renderer::Render(document, request, cache_policy)
+  -> session: prepared-source / plan / published GPU results
+  -> bypass: EnsureOneShotDevice (reuse) -> CompileStatic -> Execute
+     -> download/present -> ReleaseSessionResources on one-shot workspace
+  -> pixels match document parameters; persistent Models unchanged
+```
+
+**Primary failure call chain:**
+
+```text
+missing PipelineDocument
+  -> throw before renderer construction
+  -> no stage execution, no frame-sink notify, no GPU substitute
+GPU presentation/download failure
+  -> discard unpublished; bypass also WaitIdle + ReleaseSessionResources
+  -> propagate runtime_error; last successful display retained
+  -> no CPU / legacy stage / lower-quality retry
+CPU / unsupported backend preference
+  -> throw "supported GPU backend"; no legacy stage Apply
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / suite | Result |
+| --- | --- | --- |
+| `EditorAndHostRenderUseDocumentParameters` | `PipelineDocumentRenderTest` | PASS；stage 曝光 ±9 EV 时 editor/host 像素跟 document −1.5 / +1.5 EV 参考，INF < 2e-5，明暗可区分 |
+| `RenderLeavesPersistentDocumentParametersUnchanged` | `PipelineDocumentRenderTest` | PASS；host/editor 交替改 decode/ROI/cache 后 document JSON、stage JSON、Exposure 地址不变 |
+| 默认图真实 RAW；GPU 失败不降级 | `DefaultDocumentRendersRealRawAtFullDecodeAndOutputResolution`、`FailedGpuPresentationPropagatesErrorWithoutSubstituteOutput`、`CpuPreferenceFailsInsteadOfExecutingLegacyStages` | PASS；FULL decode 输出尺寸等于 DNG；拒绝 mapping 后无 host 帧；CPU 偏好抛错且 renderer 仍为空 |
+| `MissingDocumentFailsWithoutExecutingStages` | `PipelineDocumentRenderTest` | PASS |
+| `HostBypassRendersReuseOneShotDeviceAndLeaveSessionCacheUntouched` | `PipelineDocumentRenderTest` | PASS；两次 host Bypass 同一 one-shot device，pool used=0，随后 editor 仍命中 session prepared source |
+| `RepeatedOneShotRendersReuseDeviceAndReleaseWorkspace` | `GpuDagCudaDrtProductTest` / `CudaResultCacheProductFixture` | PASS |
+| `ParallelOneShotRendersCompleteAndReleaseWorkspaces` | `GpuDagCudaDrtProductTest` / `CudaResultCacheProductFixture` | PASS；两线程独立 renderer 同时 Bypass，各自 device 非空且不同，published/pool=0，session hits/misses=0 |
+| `ThumbnailAndExportTasksDisableSessionCache` | `PipelineFrameSinkTest` | PASS；THUMBNAIL/FULL_RES_EXPORT 关闭 cache 并 force CPU output；FAST_PREVIEW 恢复 session cache |
+| `OneShotRenderDoesNotReadWriteOrClearEditorSessionCaches`、`RendererOneShotWorkspaceCannotPublishIntoSessionCache` | `GpuDagCudaDrtProductTest` | PASS（既有） |
+
+Commands（仓库根目录）：
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target PipelineDocumentRenderTest GpuDagCudaDrtProductTest PipelineFrameSinkTest
+ctest --test-dir build/debug -R "PipelineDocumentRenderTest|GpuDagCudaDrtProductTest|PipelineFrameSinkTest" --output-on-failure
+```
+
+Suite totals:
+
+- `PipelineDocumentRenderTest` **10/10 PASS**
+- `PipelineFrameSinkTest` **34/34 PASS**
+- `GpuDagCudaDrtProductTest` **41/43 PASS** — 本次新增的 one-shot 复用/并行测试均 PASS；失败的 `ProductRendererViewportAndMaxEdgeResampleDecodedSourceWithoutSizeMismatch` 与 `ProductRendererRendersLegacyImportWithTintWithoutUnregisteredType` 未改其源码，属既有 viewport/tint 问题，不是 B 的 document 只读或 Bypass 证据
+
+最终日志：`build/tmp/nm1/nm14b-ctest.log`、`build/tmp/nm1/nm14b-frame-sink-ctest.log`。
+
+**Checklist / exit condition:** 第 10.2 节五项工作与三条验收已完成。第 14 节仅能勾选由 B 证明的 Apply 只读 document；共享 executor、无保存 release、统一 I/O 仍属 C / NM1.5。
+
+**LOC note（grill-code-review）：**
+
+| 本次文件 | 总 LOC | Diff + / - |
+| --- | ---: | ---: |
+| `src/edit/pipeline/pipeline_cpu.cpp` | 810 | + / − 以删除 ApplyOnto remirror 为主（约 −200 净） |
+| `src/include/edit/pipeline/pipeline_cpu.hpp` | 273 | +46 / − 少量 |
+| `src/include/edit/runtime/renderer.hpp` | 306 | +36 / −0（`OneShotResources`、`DebugOneShotDeviceIdentity`） |
+| `tests/edit/pipeline/pipeline_document_render_test.cpp` | 358 | 新文件（含 HostBypass 复用断言） |
+| `tests/edit/runtime/cuda_result_cache_test.cpp` | 735 | +120 / −0 |
+| `tests/edit/pipeline/pipeline_frame_sink_test.cpp` | 1086 | +30 本测试；其余为既有 SetExecutorRenderParams 改为读 request snapshot |
+| `tests/edit/CMakeLists.txt` | 496 | +9 / −0（注册 `PipelineDocumentRenderTest`） |
+
+`pipeline_frame_sink_test.cpp` 已超过 1,000 LOC：本次只在 `SetExecutorRenderParams` 组旁增加 cache 开关断言，未再向该文件加入 GPU 像素或并行分配职责。按 sink 生命周期 / 请求参数 / 并发锁拆分属于后续整理，不是 B 的退出条件。`cuda_result_cache_test.cpp` 仍低于 1,000 LOC。
+
+**Residual gaps / scope boundaries:** C 的共享 live executor、snapshot API 删除、后台 release 不保存仍未做；thumbnail/export 当前仍可持有独立 snapshot executor，B 只证明 Bypass 不建 session cache、one-shot device 复用且交付后释放、并行独立 renderer 不互相写入 session cache。`RemirrorGpuDagDocument` 仍在 `pipeline_service` 的 load/save 边界，属 NM1.5。上述两条既有 `GpuDagCudaDrtProductTest` 失败未在 B 中修复。无完整应用交互或 Metal/OpenCL 对等 Bypass 并行证据。
+
 ### 10.3 C：共享 pipeline 使用权
 
 工作：
@@ -505,7 +591,7 @@ ReconnectColorGrade(PipelineDocument& document, node_id, predecessor, successor)
 
 ## 13. 验证方式与证据
 
-以下为 NM1 全阶段验证要求；NM1.4 A 的已执行命令、结果和范围见第 10.1 节，B/C 与 NM1.5 仍须独立验收。
+以下为 NM1 全阶段验证要求；NM1.4 A 的已执行命令、结果和范围见第 10.1 节，B 见第 10.2 节；C 与 NM1.5 仍须独立验收。
 
 Windows 构建遵循 `alcedo-msvc-cmake` 技能，从仓库根目录运行：
 
@@ -587,4 +673,6 @@ ctest --test-dir build/debug -R "GpuDagModelGraphTest|PipelineMapperTest|Thumbna
 本版方案更新（2026-08-30）：**documentation only**。源码/测试保持原样，没有新 build/test 结果。
 实施后追加真实成功链、失败链、命令、结果及缺口，再更新状态和退出清单。
 
-NM1.4 A 实施结果（2026-08-30）：**complete**，本版验收 121/121 PASS，成功链、失败链、测试和缺口见第 10.1 节完成记录。NM1.4 B/C、NM1.5 的状态未提前提升。
+NM1.4 A 实施结果（2026-08-30）：**complete**，本版验收 121/121 PASS，成功链、失败链、测试和缺口见第 10.1 节完成记录。
+
+NM1.4 B 实施结果（2026-08-30）：**complete** — 产品 Apply 只读绑定 document；BypassSessionCache 复用 one-shot device 并释放 workspace；并行独立 renderer 的 one-shot 分配通过。证据见第 10.2 节完成记录。NM1.4 C、NM1.5 的状态未提前提升。

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
@@ -2,9 +2,9 @@
 
 Date: 2026-08-29
 
-Revised: 2026-08-31 — 保留单 live document/共享 executor；NM1.4R 明确后台 scratch 不预留、不保留空闲块；缩略图磁盘写回策略独立跟踪。
+Revised: 2026-08-31 — NM1.5 已完成保存读取、导入初始化与释放边界；保留单 live document/共享 executor；缩略图磁盘写回策略独立跟踪。
 
-Status: in progress — NM1.4 A/B/R 完成；NM1.2 保留；C 由 R 替代，不再作为独立验收；NM1.5 未开始。缩略图磁盘写回仍为 Issue #113。
+Status: complete — NM1.4 A/B/R 与 NM1.5 完成；NM1.2 保留；C 由 R 替代，不再作为独立验收；缩略图磁盘写回仍为 Issue #113。
 
 Branch: `feature/pipeline-document-editing`
 
@@ -256,7 +256,7 @@ before/after 不能继续从 stage 表读取；既有 payload 需要的字段表
 
 ## 10. NM1.4 — 原地编辑与共享 DAG 渲染
 
-Status: partial — A complete（2026-08-30）；B complete（2026-08-30）；C 由 R 替代；R complete（2026-08-31）。历史 A/B 完成记录保留。NM1.5 未开始。
+Status: complete — A complete（2026-08-30）；B complete（2026-08-30）；C 由 R 替代；R complete（2026-08-31）。历史 A/B 完成记录保留；NM1.5 已在第 11 节完成。
 
 ### 10.1 A：原地修改和局部恢复
 
@@ -712,7 +712,7 @@ document/Model 仍由 live pipeline 拥有；请求由 task 拥有；运行资�
 
 ##### Phase NM1.4R completion record (2026-08-31)
 
-**Status:** complete — 产品 scheduler 把 `PipelineApplyRequest` 直接交给 `Apply`；后台 Bypass 使用 ExactRelease arena（按请求对齐字节分配、最后使用后释放、不保留空闲 slab）；中间写入图在最后消费者后 `ReleaseWrite`；已删除 `GpuDeviceAllocationMutex`；pin 降到 0 后不持 cache lock 等 render lock，就绪发布与 `WaitUntilPinCount` 分开；每图 `ExportRecipe.output_color_` 在入队前解析，像素与 ICC 读同一份配置；`HasUsablePipelineGraph` 已删除。未开始 NM1.5。Issue #113 磁盘写回不在本轮门槛内。
+**Status:** complete — 产品 scheduler 把 `PipelineApplyRequest` 直接交给 `Apply`；后台 Bypass 使用 ExactRelease arena（按请求对齐字节分配、最后使用后释放、不保留空闲 slab）；中间写入图在最后消费者后 `ReleaseWrite`；已删除 `GpuDeviceAllocationMutex`；pin 降到 0 后不持 cache lock 等 render lock，就绪发布与 `WaitUntilPinCount` 分开；每图 `ExportRecipe.output_color_` 在入队前解析，像素与 ICC 读同一份配置；`HasUsablePipelineGraph` 已删除。当时尚未开始 NM1.5，随后由第 11 节完成。Issue #113 磁盘写回不在本轮门槛内。
 
 **Primary success call chain:**
 
@@ -794,7 +794,7 @@ build\debug\alcedo_studio\tests\app\ThumbnailServiceTest_runtime\ThumbnailServic
 
 日志：`build/tmp/nm14r/tests.log`。
 
-**Checklist / exit condition:** 第 10.5 节十条修复与具名测试均有本次执行证据。磁盘写回两例仍属 Issue #113，未勾成通过。未进入 NM1.5。
+**Checklist / exit condition:** 第 10.5 节十条修复与具名测试均有本次执行证据。磁盘写回两例仍属 Issue #113，未勾成通过；随后进入并完成第 11 节 NM1.5。
 
 **LOC note（grill-code-review）：**
 
@@ -810,9 +810,9 @@ build\debug\alcedo_studio\tests\app\ThumbnailServiceTest_runtime\ThumbnailServic
 | `tests/app/thumbnail_service_test.cpp` | ~2866 | 既有大文件；本轮只改 import 接线与少量 GPU-DAG 断言 |
 | `tests/edit/pipeline/pipeline_frame_sink_test.cpp` | ~1087 | 重置后 merged-stage 指针可能堆复用；断言改为经过 null identity |
 
-**Residual gaps:**
+**Residual gaps at the NM1.4R boundary:**
 
-- `LoadPipeline` 仍 `RemirrorGpuDagDocument`，属 NM1.5。
+- 当时 `LoadPipeline` 仍使用 `RemirrorGpuDagDocument`；该缺口已由 NM1.5 的 document-only load/save 收敛。
 - `SetEnableCache` / `CaptureOneShotRenderParams` 仍存在，供旧 FrameSink 测试；产品 scheduler 不靠它们切换 Bypass。
 - 本机产品路径为 CUDA。OpenCL DRT overlay 已编译；Metal overlay 已改同源但未在本机运行。OpenCL `ExecuteOpenClCameraColor: missing camera matrices` 出现在未把 `PipelineMgmtService` 交给 import 的旧测试夹具，补齐后 7/7 PASS，不视为后端降级。
 - ExactRelease 帧内 texture pool 仍可达数百 MiB（真实 RAW 纹理）；证据是 transient used==capacity、任务后 residual 0，以及 arena 单测禁止 16/64 MiB 预留。
@@ -822,7 +822,7 @@ build\debug\alcedo_studio\tests\app\ThumbnailServiceTest_runtime\ThumbnailServic
 
 ## 11. NM1.5 — 保存读取与阶段验收
 
-Status: not started — 前置条件为 NM1.4R 完成；独立缩略图磁盘写回 Issue 不作为前置条件。
+Status: complete — 2026-08-31；前置条件 NM1.4R 已满足；独立缩略图磁盘写回 Issue 不作为前置条件。
 
 ### 11.1 工作
 
@@ -872,6 +872,85 @@ background release -> no persistence attempt
 主要范围为 pipeline service、pipeline mapper、必要的 import 初始化、对应 app/storage 测试。
 只有读取边界测试需要覆盖非法格式；不再让每个渲染调用方重复证明“stage-only 项目被拒绝”。
 
+#### NM1.5 completion record (2026-08-31)
+
+**Status:** complete — 产品保存与普通读取统一以 format-version-2 `PipelineDocument` 为来源；产品边界不再把 executor stage 导出为 document、不写 `legacy_stage_adapter`，也不通过 remirror 覆盖 live graph。显式保存先写 document，再处理可选的 history serialized-state checkpoint；释放句柄只释放使用权，不触发存储写入。存储失败、坏 document 和未 settled preview 均保留真实错误与未保存状态。
+
+**实现与验收清单：**
+
+- `PipelineDocument::FromJson` 集中验证当前格式、geometry、节点、ColorGrade adjustments、边和有限数值；`PipelineMgmtService::LoadPipelineDocument` 只读取这一份存储 JSON，并由 `ValidateProductDocument` 验证图与 image backbone，坏数据不生成默认替代图。
+- `SyncPipelineDocument` 在同一 render lock 内完成 document 校验、序列化、写入和 dirty 清除；`SavePipeline`、`Sync`、`SyncPipeline` 与 cache eviction 只在 dirty 时调用同一受保护写入边界。写入异常不会清 dirty，也不会清除 history serialized-state writeback 标记；eviction 写入失败会把 guard 放回 cache。
+- `SavePipeline` 对 `unsettled_preview_` 真实报错，保存不把 preview 当作 committed 状态；history checkpoint 只在 document 写成功后尝试，checkpoint 失败不会覆盖 document 或 history HEAD。
+- mapper 对 format 2 不再解包 stage adapter；import 初始化保留 Default 工厂和图片固有 RAW/profile 参数，初始化 immutable history root 后显式保存 document；duplicate 复制存储 document JSON；编辑器 session release 使用无保存的 `ReleasePipelineUse`。
+
+**Primary success call chain:**
+
+```text
+local edit functions
+  -> live PipelineDocument under CPUPipelineExecutor::render_lock_
+  -> explicit SavePipeline / SyncPipelineDocument
+  -> ElementStore::UpdatePipelineJsonByElementId(format_version=2 document)
+  -> ReleasePipelineUse (lifecycle only) / normal LoadPipeline
+  -> PipelineDocument::FromJson -> Graph::Validate -> ValidateImageBackbone
+  -> SetPipelineDocument(..., false) -> same nodes, edges and parameters render
+```
+
+**Primary failure call chain:**
+
+```text
+invalid stored document or graph
+  -> FromJson / ValidateProductDocument throws
+  -> initializing cache record is removed; no importer, stage or default replacement
+storage write failure
+  -> dirty_ and serialized_state_needs_writeback_ remain set; SavePipeline releases only its pin
+  -> real save error is reported; live document and history HEAD remain available
+unsettled editor preview
+  -> explicit save rejects before document write; stored JSON is unchanged
+background release
+  -> ReleasePipelineUse only updates lifetime/cache state; no persistence attempt
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `DocumentSaveReloadPreservesNodesEdgesAndParameters` | `PipelineMapperTest` | PASS |
+| `SavedDocumentContainsNoStageAdapter` | `PipelineMapperTest` | PASS |
+| `InvalidStoredDocumentFailsWithoutReplacement` | `PipelineMapperTest` | PASS |
+| `FailedDocumentSaveKeepsDirtyStateAndJournal` | `PipelineMapperTest` | PASS |
+| `SaveDoesNotPersistUnsettledPreviewAsCommittedState` | `PipelineMapperTest` | PASS |
+| `ImportCreatesRenderableDocumentWithoutStageMirror` | `ImportPipelineDocumentTest` | PASS；Default graph、RAW/profile 数据和真实完整 CPU render 验证通过 |
+| `ReloadedDocumentKeepsDecodeMethodWhenStagesDisagree` | `PipelineMapperTest` | PASS；重读 document 不被不一致 stage 覆盖 |
+| shared executor/lifetime regression suite | `PipelineSharedUseTest` | **16/16 PASS**；含后台 release 不保存、queued render、并行 RAW 渲染和资源释放 |
+| Sleeve document duplicate / lifecycle suite | `SleeveServiceTest` | **24/24 PASS** |
+| adjustment transfer regression suite | `AdjustmentTransferServiceTest` | **7/7 PASS** |
+| editor session release port | `EditorSessionPipelinePortTest` | **2/2 PASS** |
+
+`PipelineMapperTest` 全量为 **30/30 PASS**，另有 2 个明确 disabled 测试；其中 5 个新增 NM1.5 保存/读取失败路径全部通过。构建同时成功链接 `alcedo_main`。
+
+**Commands（仓库根目录，Windows/MSVC debug，CUDA/OpenCL 可用）：**
+
+```text
+cmd /c scripts\msvc_env.cmd --build build\debug --target PipelineMapperTest ImportPipelineDocumentTest SleeveServiceTest PipelineSharedUseTest EditorSessionPipelinePortTest alcedo_main --parallel 4
+build\debug\alcedo_studio\tests\app\PipelineMapperTest_runtime\PipelineMapperTest.exe --gtest_color=no
+ctest --test-dir build\debug\alcedo_studio\tests\app -R "ImportPipelineDocumentTest" --output-on-failure
+build\debug\alcedo_studio\tests\app\PipelineSharedUseTest_runtime\PipelineSharedUseTest.exe --gtest_color=no
+build\debug\alcedo_studio\tests\app\SleeveServiceTest_runtime\SleeveServiceTest.exe --gtest_color=no
+build\debug\alcedo_studio\tests\app\AdjustmentTransferServiceTest_runtime\AdjustmentTransferServiceTest.exe --gtest_color=no
+ctest --test-dir build\debug\alcedo_studio\tests\ui -R "EditorSessionPipelinePortTest" --output-on-failure
+```
+
+**LOC note（grill-code-review）：** 本次把 document read/write 边界集中在既有 `pipeline_service.cpp`，没有新增保存服务或 snapshot registry；`pipeline_document.cpp` 只增加输入验证；测试扩展既有 mapper/import/shared/Sleeve fixture。当前行数为 `pipeline_service.cpp` 1256、`pipeline_document.cpp` 251、`import_service.cpp` 360、`sleeve_service.cpp` 296、`pipeline_service_test.cpp` 1332、`import_pipeline_document_test.cpp` 112、`pipeline_shared_use_test.cpp` 1069、`sleeve_service_test.cpp` 953；其中 shared/mapper 测试文件仍是既有大型 fixture，本次未借 NM1.5 扩大职责拆分。所有临时命令输出仍只使用受版本控制忽略的 `build/tmp/`（本次直接运行测试未产生新的仓库根目录文件）。
+
+**Residual gaps / scope boundaries:**
+
+- Issue #113 的缩略图/analysis 磁盘写回资格、提交标签和失效策略仍未实现，不属于 NM1.5 门槛。
+- 本机只执行 Windows/MSVC CUDA/OpenCL 路径；Metal 未在本机运行。测试日志中的 DNG/XMP warning 不改变通过结果。
+- 旧 `ElementStore` stage API、`LegacyPipelineImporter` 及旧 history serialized-state checkpoint 仍为非本阶段删除对象；产品 NM1.5 load/apply/save 不调用它们作为 document 来源。typed history、节点重放、旧项目迁移和多 Grade GPU 仍交给 NM4/NM2。
+- `alcedo_studio/src/edit/CMakeLists.txt` 的现有 `dng_profile_gpu_data.cpp` 行只有换行符差异；`git diff --check` 对该保留差异报告 trailing whitespace，忽略行尾空白后无内容差异。本次未改动该无关差异。
+
+**Checklist / exit condition:** 第 11.1 节八项工作、第 11.2 节六项验收和第 14 节 NM1.5 相关退出项均有执行证据；Issue #113 明确保持为未完成的独立待办。
+
 ## 12. API 与所有权约束
 
 保留简单的领域函数形态，例如：
@@ -889,7 +968,7 @@ ReconnectColorGrade(PipelineDocument& document, node_id, predecessor, successor)
 
 ## 13. 验证方式与证据
 
-以下为 NM1 全阶段验证要求；NM1.4 A 的已执行命令、结果和范围见第 10.1 节，B 见第 10.2 节；C/R 与 NM1.5 仍须独立验收，磁盘写回策略单列独立 Issue。
+以下为 NM1 全阶段验证要求；NM1.4 A 的已执行命令、结果和范围见第 10.1 节，B 见第 10.2 节，C/R 见第 10.5 节，NM1.5 见第 11 节；磁盘写回策略单列独立 Issue。
 
 Windows 构建遵循 `alcedo-msvc-cmake` 技能，从仓库根目录运行：
 
@@ -913,19 +992,19 @@ ctest --test-dir build/debug -R "GpuDagModelGraphTest|PipelineMapperTest|Thumbna
 
 - [x] 同一图片只有一个 live document/executor；后台任务复用普通使用句柄。
 - [x] preview/settled/参数 Undo/Redo 不深拷贝整图；图命令只保留局部恢复数据（NM1.4 A）。
-- [ ] document 读写、渲染和序列化遵守统一互斥，完成/取消/异常没有锁重入或使用权泄漏。
-- [ ] Add/Remove/Reconnect/Rename/Enabled 保留；非法操作恢复节点、边、值和已支持的 history 状态。
+- [x] document 读写、渲染和序列化遵守统一互斥，完成/取消/异常没有锁重入或使用权泄漏（NM1.4/R/NM1.5）。
+- [x] Add/Remove/Reconnect/Rename/Enabled 保留；非法操作恢复节点、边、值和已支持的 history 状态（NM1.4 A/NM1.5）。
 - [x] Default 工厂自带 1.5 EV/1.3 saturation；Clean 工厂无视觉变化且无四项后处理（既有证据，集成时复测）。
 - [x] 完整 target、输入序列锁定、未知字段/Mask 拒绝及同会话参数 Undo/Redo 在简化后重新通过（NM1.4 A）。
 - [x] 编辑器、缩略图、analysis、export 从同一 document 得到正确 DAG 像素；单次参数不污染后续任务。
 - [x] NM1.4R 完成：请求直接传入；后台 scratch 不预留、不保留空闲块，中间图按需分配和及时释放；真实并发资源峰值与底层释放有证据，不增加预算驱动的调度或通用两阶段分配机制。
 - [x] 每图 export recipe 在排队前包含完整输出配置；渲染与编码/ICC 使用同一配置，不回读或临时改写共享 DRT。
 - [x] 后台完成不保存、不清 dirty；最后一次使用结束前不淘汰对象，编辑器在用的缓存不被整体释放。
-- [ ] 产品 Apply/Load/Save 不再使用 stage 镜像或 stage 作为参数源；旧类型可留作非产品代码。
-- [ ] 新图导入和 document 保存读取完整；存储失败保留未保存状态，坏图读取真实失败。
-- [ ] NM1 未引入完整 typed history、跨进程节点重放、旧项目迁移或额外 root/document 副本。
-- [ ] 不开放依赖 NM2/NM4/NM5/NM6 的生产入口；不宣称节点 history/recovery 或多 Grade GPU 已完成。
-- [ ] 第 10/11 节本阶段范围内行为有执行证据；第 16 节追加本版实施结果，NM1.4/R/NM1.5 才能改为 complete。独立磁盘写回 Issue 明确列为未完成，不虚报已解决。
+- [x] 产品 Apply/Load/Save 不再使用 stage 镜像或 stage 作为参数源；旧类型可留作非产品代码（NM1.5）。
+- [x] 新图导入和 document 保存读取完整；存储失败保留未保存状态，坏图读取真实失败（NM1.5）。
+- [x] NM1 未引入完整 typed history、跨进程节点重放、旧项目迁移或额外 root/document 副本（NM1.5 范围审计）。
+- [x] 不开放依赖 NM2/NM4/NM5/NM6 的生产入口；不宣称节点 history/recovery 或多 Grade GPU 已完成（NM1.5 范围审计）。
+- [x] 第 10/11 节本阶段范围内行为有执行证据；第 16 节已追加本版实施结果，NM1.4/R/NM1.5 状态均已记录为 complete。独立磁盘写回 Issue 明确列为未完成，不虚报已解决。
 
 ## 15. 交给后续 Phase 的边界
 
@@ -989,4 +1068,13 @@ arena 按实际请求分配，在最后使用完成后释放底层资源，不�
 
 NM1.4R 实施结果（2026-08-31）：**complete** — 请求直接传入、ExactRelease 后台 scratch、
 中间图最后消费者释放、pin/完成同步、完整 export recipe。聚焦具名测试与复跑均 PASS；
-#113 磁盘标签两例未作为门槛。证据与缺口见第 10.5 节完成记录。NM1.5 未开始。
+#113 磁盘标签两例未作为门槛。证据与缺口见第 10.5 节完成记录；随后完成 NM1.5。
+
+NM1.5 实施结果（2026-08-31）：**complete** — 保存、读取、导入初始化和释放边界已切换到
+document-only 路径；`PipelineDocument::FromJson` 集中验证当前格式、节点、边和有限数值；
+`SavePipeline`/`SyncPipelineDocument` 在 render lock 内以同一次受保护状态写入 JSON，写入失败保留
+dirty/WAL 与 history 写回标记；坏 document、非法主链和 unsettled preview 真实失败；后台 release
+不再顺带保存。5 个 mapper 保存/读取失败路径与 1 个 import render 验收通过，完整
+`PipelineMapperTest` 30/30、`PipelineSharedUseTest` 16/16、`SleeveServiceTest` 24/24、
+`AdjustmentTransferServiceTest` 7/7、`EditorSessionPipelinePortTest` 2/2 通过，`alcedo_main`
+成功构建链接。成功链、失败链、实际命令、平台限制与 Issue #113 缺口见第 11 节完成记录。

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-29
 
-Status: in progress — NM1.1–NM1.2 complete; NM1.3–NM1.5 not started.
+Status: in progress — NM1.1–NM1.3 complete; NM1.4–NM1.5 not started.
 
 Branch: `feature/pipeline-document-editing`
 
@@ -22,8 +22,8 @@ Base: `origin/main` at NM0 merge (`d5a96267`, QuickQanava pin already on main).
 
 发生冲突时的优先级：
 
-1. 总体方案已锁定的产品语义（单主链、Clean 与 Default 的区别、typed target、失败回滚）；
-2. 本执行方案对 NM1 子 Phase、兼容镜像和 thumbnail DAG 的明确要求；
+1. 总体方案已锁定的产品语义（单主链、Clean 与 Default 的区别、typed target、失败回滚）。2026-08-30 起，总体方案不再要求旧 stage 项目可打开，也不再要求双向 stage 镜像。
+2. 本执行方案对 NM1 子 Phase、完整 typed target、输入序列锁定、以及 thumbnail DAG 的明确要求。
 3. 当前代码中已经落地的 GPU DAG 三节点 runtime。
 
 ---
@@ -87,10 +87,27 @@ QML slider
 
 1. **新编辑的写入权威是 `PipelineDocument`。** 调整条、history 的 live mutation、thumbnail/analysis 像素都不把 CPU stage 当作渲染或提交的源。
 2. **删除能力完整保留。** `RemoveColorGradeAndBridge` 可删除任意 Color Grade，包括 Default / `grade.primary`。不能删除 Develop 或 DRT。删光 Color Grade 后主链为 Develop → DRT，这是合法文档。
-3. **双向 mirror 作为兼容层保留。** `CPUPipelineExecutor` 的 stage 表继续存在，用于打开旧项目、回放仍按 stage/operator 标识的旧 commit、以及尚未升级的存储。Mirror 不得把 stage 重新变成新编辑的 source of truth，也不得在 thumbnail 路径上「先转 stage 再渲染」。
+3. **产品不保留双向 stage 镜像。** 新编辑只写 `PipelineDocument`。产品 Load / Save / Apply / thumbnail 不以 CPU stage 表为兼容层。进程内 stage 表可以暂时留在代码里，直到后续 Phase 删除整个 stage；NM1 不得为了旧读取器再做 document → stage 或 stage → document 的产品镜像。
 4. **Thumbnail 和 snapshot 像素必须 DAG 渲染。** 克隆 `PipelineDocument`，交给现有 GPU `Renderer`。禁止 `ExportPipelineParams` → `ImportPipelineParams` → stage Apply 作为出图像素路径。
-5. **History 的 typed `PipelineEditBatch`、Version/Paste、format 升级属于 NM4。** NM1 只要求 live 提交/Undo/Redo 作用在文档上；payload 仍可暂时是 `OrdinaryEditPayload`。
-6. **旧 stage 项目升级到默认三节点 DAG 属于一级 Phase NML，不在 NM1 实现。** 见总体方案新增的 NML。NM1 只保证：旧项目仍能打开（importer + 兼容镜像），新编辑写文档，thumbnail 走 DAG。
+5. **History 的 typed `PipelineEditBatch`、Version/Paste、format 升级属于 NM4。** NM1 只要求 live 提交/Undo/Redo 作用在文档上；payload 仍可暂时是 `OrdinaryEditPayload`。NM1 与后续 Phase 都不把旧 mini-git commit 从 stage 身份迁移成 DAG mutation。
+6. **不支持 DAG document 之前的项目。** 存储里若没有可用的 format v2 图（`nodes` 与 `edges`），产品拒绝打开，并返回真实错误。不要把旧 stage JSON import 成默认三节点图。不要为了打开旧项目而改写 mini-git commit。一级 Phase NML（旧存储升级）取消。后续 Phase 删除 stage 表，不做旧项目升级。
+
+### 3.1 2026-08-30 产品规则
+
+NM 方案执行期间不为当前 UI 补完整 target。写入路径按最终生产接口设计。缺少 `owner_kind`、`node_id` 或 `adjustment_instance_id` 的 patch 一律拒绝。app 不根据 field catalog 或当前选中节点填入缺省 target。
+
+每个 patch 必须带完整 `EditorParameterTarget`：
+
+- `owner_kind` 为 Document / Develop / ColorGrade / DrtPost 之一（Mask 写入拒绝）
+- `field_key` 非空，且与 patch 上的 `field_key` 相同
+- Document：`node_id` 为空
+- Develop / ColorGrade / DrtPost：`node_id` 非空
+- ColorGrade：`adjustment_instance_id` 非空
+- `mask_id` 在 NM1 必须为空
+
+输入序列：第一个合法 patch 锁定 target。同一序列的后续 patch 即使带不同 `node_id`，仍写入锁定的 NodeId。每个后续 patch 仍必须自身完整；不完整则拒绝，不靠锁定去补字段。
+
+产品不保留 stage 镜像，也不打开没有可用图的旧存储。NM1.3 把 live 编辑写入文档。NM1.5 阻止 Apply/Save 用 stage 覆盖文档。后续 Phase 删除 stage 表。NML 取消。
 
 ---
 
@@ -101,11 +118,12 @@ QML slider
 - 候选文档 mutation、主链 validation、原子 Add / Remove / Reconnect / Rename / SetEnabled；
 - 稳定 `NodeId`；失败不改 live document / history head；
 - `CreateDefaultPipelineDocument` 在工厂内写入 Default 基线；`MakeClean` / `CreateCleanColorGradeNode`；
-- `EditorParameterTarget`；现有 field 写入文档；输入序列锁定 target；
+- `EditorParameterTarget`；每个 patch 必须带完整 target；输入序列锁定 target；缺字段拒绝；
 - History live 路径改为写/读文档（payload 格式暂不升级）；
 - Thumbnail、analysis rendition、以及同一 snapshot API 上的像素改为 DAG；
-- 产品 GPU Apply 以文档为渲染输入；stage 仅作兼容镜像；
-- `SavePipeline` 不得再用 stages `Import` 整份替换文档。
+- 产品 GPU Apply 以文档为渲染输入；
+- `SavePipeline` 不得再用 stages `Import` 整份替换文档；
+- 无可用图的旧存储：Load 失败，不 import。
 
 ### 4.2 NM1 不包含
 
@@ -115,7 +133,8 @@ QML slider
 | Clarity / Sharpen / Halation / Film Grain 搬到 DRT/Post | NM2 |
 | 多 Mask、Range 字段落地、不可变 MaskStore `Put()` | NM3 |
 | typed `PipelineEditBatch`、每 Version 一 DAG 的 history schema、Paste、format 提升 | NM4 |
-| 旧 stage 存储的一次性/可审计升级到默认三节点 DAG | NML |
+| 打开或升级 DAG document 之前的 stage-only 项目；迁移 mini-git commit | 不做（NML 取消） |
+| 从代码中删除 CPU stage 表 / `LegacyPipelineImporter` | 后续 Phase，不是 NM1 |
 | Nodes 面板、QuickQanava 生产链接、开放用户 Add 入口 | NM5 |
 | 按节点切换右侧 adjustment stack | NM6 |
 | Viewer 蒙版绘制 | NM7 |
@@ -135,7 +154,7 @@ clone PipelineDocument
   -> apply typed mutation on candidate
   -> ValidateGraph + ValidateImageBackbone
   -> 失败：丢弃 candidate；live document、history head、最后一帧不变
-  -> 成功：替换 live document；需要时同步兼容 stage 镜像
+  -> 成功：替换 live document
 ```
 
 不得先改 live 再捕获异常继续。不得用 CPU 或其他 backend 代替失败的 GPU 路径。
@@ -170,17 +189,21 @@ Color grades on image backbone
 
 `PipelineDocument::PrimaryGrade()` 对默认三节点文档仍可按 `grade.primary` 查找，供现有 tests 使用。Compiler 不得再把「缺少 `grade.primary`」当成硬失败，只要主链合法。
 
-### 5.4 兼容镜像的方向
+### 5.4 Stage 表与打开规则
+
+产品写入与渲染方向：
 
 | 方向 | NM1 是否允许 | 用途 |
 | --- | ---: | --- |
 | 新编辑 → `PipelineDocument` | 必须 | 唯一新写入权威 |
-| document → stage 表 | 允许 | 旧 history payload / 旧检查点回放、尚未升级的存储 |
-| stage → document（打开旧项目、旧 commit 回放） | 允许 | 兼容层 |
+| document → stage 表（产品兼容镜像） | 禁止 | 不为旧读取器保留镜像 |
 | stage → document 覆盖一次**新的**文档编辑 | 禁止 | 这是当前 Save/Apply remirror 的缺陷 |
 | thumbnail/analysis：stage JSON → Import → Apply | 禁止 | 必须 DAG |
+| 无图的旧 stage 存储 → Import 成默认三节点后打开 | 禁止 | 拒绝打开，返回真实错误 |
 
-`LegacyPipelineImporter::Import` / `ApplyOnto` 保留。产品路径不再把它们当作「每次 GPU 帧把 live stages 灌进文档」的默认步骤。打开纯旧 stage JSON、或从旧 `legacy_stage_adapter` 恢复时，可以一次性 Import/ApplyOnto，然后渲染走 DAG。
+`LegacyPipelineImporter` 可以暂时留在仓库，供现有 GPU DAG 测试使用。产品 Load 不得用它打开用户项目。后续删除 stage 的 Phase 再删除 importer。
+
+NM1.5 仍必须从产品 Apply/Save 中移除 live stages `ApplyOnto` / `Import` 覆盖文档。这是停止双写，不是旧项目兼容。
 
 ### 5.5 文件体量
 
@@ -470,11 +493,11 @@ EditorParameterTarget
   field_key
 ```
 
-现有 `EditorAdjustmentPatch` 增加 target；缺省时由 field catalog 绑到当前默认三节点（Develop / `grade.primary` 或主链第一个 Color Grade / DRT / Document geometry）。
+现有 `EditorAdjustmentPatch` 增加必填 `target`。规则见第 3.1 节：不完整、Mask、未知 field 均拒绝。app 不填缺省 target。
 
-输入序列开始时锁定 target。拖动中途改变 selected node 不得把后半段写到另一个 NodeId。
+输入序列第一个合法 patch 锁定 target。后续完整 patch 复用该锁定，即使它们携带另一个 `node_id`。
 
-`EditorHistoryMutation::CommitAdjustment` / Undo / Redo 的 **live 效果**写 `PipelineGuard::document_`。仍可同步兼容 stage 镜像，但失败回滚以文档为准。`OrdinaryEditPayload` 本 Phase 不改 schema。
+`EditorHistoryMutation::CommitAdjustment` / Undo / Redo 的 **live 效果**写 `PipelineGuard::document_`。不要同步 stage 镜像。失败回滚以文档为准。`OrdinaryEditPayload` 本 Phase 不改 schema。
 
 Mask target 和多节点 UI 选择恢复属于后续 Phase；本 Phase 拒绝 Mask target 写入。
 
@@ -482,13 +505,13 @@ Mask target 和多节点 UI 选择恢复属于后续 Phase；本 Phase 拒绝 Ma
 
 ```text
 HandlePatch(settled)
-  -> lock EditorParameterTarget
+  -> lock EditorParameterTarget (first patch of the input sequence)
   -> Capture before from document
   -> PrepareAppendEdit(OrdinaryEditPayload)   // schema unchanged
   -> candidate document SetAdjustmentField
   -> validate
   -> PublishPreparedEdit
-  -> publish document + optional stage mirror
+  -> publish document
   -> SettledAdjustment render reads document
 ```
 
@@ -502,32 +525,104 @@ unknown field, missing instance, or Mask target
 
 ```text
 WAL or history publish fails
-  -> restore document (and mirror) to before
+  -> restore document to before
   -> no new head
 ```
 
 ### 9.4 文件
 
 - `alcedo_studio/src/include/app/editor_adjustment_types.hpp`
-- `alcedo_studio/src/app/editor_adjustment_pipeline.cpp`（document 写入 + 缺省 target 解析）
+- `alcedo_studio/src/app/editor_adjustment_pipeline.cpp`（未知 field 仍拒绝）
+- `alcedo_studio/src/include/app/editor_pipeline_command_service.hpp` / `.cpp`（完整 target 校验、文档字段写入）
 - `alcedo_studio/src/app/editor_session_edit_controller.cpp`
 - `alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp`
-- 新 `editor_pipeline_command_service`（app 层 Prepare/Publish；参数与图命令共用）
 - `alcedo_studio/tests/app/editor_adjustment_pipeline_test.cpp`
+- `alcedo_studio/tests/app/editor_pipeline_command_service_test.cpp`
 - `alcedo_studio/tests/app/editor_session_edit_controller_test.cpp`
 - `alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp`
+- `alcedo_studio/tests/support/editor_parameter_target_test.hpp`（测试夹具；不是产品缺省 target）
 
 ### 9.5 测试
 
 | 名称 | 断言 |
 | --- | --- |
 | `SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages` | `document` 上 exposure_ev 变化 |
-| `ProvisionalPatchKeepsLockedNodeIdWhenSelectionWouldChange` | 锁定 target |
+| `IncompleteTargetRejectedLeavesDocumentHashAndHistoryHeadUnchanged` | 缺少 owner_kind 或 node_id 时拒绝，不填缺省 |
+| `ProvisionalSequenceReusesTargetResolvedAtFirstPatch` | 同一序列后半段仍写第一个完整 patch 锁定的 NodeId |
 | `UnknownFieldRejectedLeavesDocumentHashAndHistoryHeadUnchanged` | 失败封闭 |
-| `UndoSettledExposureRestoresDocumentValue` | Undo 后文档回到 before，不只 stage |
+| `UndoSettledExposureRestoresDocumentValue` | Undo 后文档回到 before |
 | `MaskTargetWriteIsRejected` | NM1 不写 Mask |
 
 History 投影文案、commit hash 算法、journal 格式留给 NM4。本 Phase 只要 Undo 后文档值正确。
+
+##### Phase NM1.3 completion record (2026-08-30)
+
+**Status:** complete — production patches require a complete `EditorParameterTarget`; live Capture/Commit/Undo/Redo write `PipelineGuard::document_`; incomplete, Mask, and unknown-field patches are rejected without filling a default target.
+
+**Primary success call chain:**
+
+```text
+HandlePatch(settled, complete EditorParameterTarget)
+  -> DescribeEditorParameterTargetError empty
+  -> ResolveEditorAdjustmentField
+  -> CaptureAdjustmentBeforePreview
+       lock target on first complete patch of this field_key
+       ReadEditorParameterJson before
+       PublishEditorParameterPatch(document, locked target, params)
+  -> CommitAdjustment
+       PublishEditorParameterPatch after
+       PrepareAppendEdit(OrdinaryEditPayload)   // schema unchanged
+       PublishPreparedEdit
+       record document_edit_by_commit[hash]
+  -> Undo / Redo
+       PublishPreparedHeadMove
+       ApplyDocumentFieldEdits from document_edit_by_commit
+```
+
+**Primary failure call chain:**
+
+```text
+missing owner_kind / node_id / adjustment_instance_id, Mask target, or unknown field
+  -> Rejected before history publish
+  -> document canonical JSON unchanged
+  -> working head unchanged
+```
+
+```text
+WAL / history publish fails after provisional document write
+  -> restore document from before_model_json
+  -> no new head
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages` | `EditorSessionHistoryPortTest`, `EditorPipelineCommandServiceTest` | PASS |
+| `IncompleteTargetRejectedLeavesDocumentHashAndHistoryHeadUnchanged` | `EditorSessionHistoryPortTest` | PASS |
+| `ProvisionalSequenceReusesTargetResolvedAtFirstPatch` | `EditorSessionHistoryPortTest` | PASS |
+| `UnknownFieldRejectedLeavesDocumentHashAndHistoryHeadUnchanged` | `EditorSessionHistoryPortTest` | PASS |
+| `UndoSettledExposureRestoresDocumentValue` | `EditorSessionHistoryPortTest` | PASS |
+| `MaskTargetWriteIsRejected` | `EditorSessionHistoryPortTest`, `EditorPipelineCommandServiceTest` | PASS |
+| `IncompleteLaterPatchRejectedLeavesLockedDocumentUnchanged` (3.1 later-patch rule) | `EditorSessionHistoryPortTest` | PASS |
+| `JournalAppendFailureRestoresDocumentExposureEv` (9.3 WAL restore) | `EditorSessionHistoryPortTest` | PASS |
+| `IncompleteTargetIsRejected` / `MaskTargetIsRejected` | `EditorSessionEditControllerTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorPipelineCommandServiceTest --target EditorSessionEditControllerTest --target EditorSessionHistoryPortTest --target EditorSessionActionPolicyCq3Test --target EditorAdjustmentPipelineTest
+ctest --test-dir build/debug -R "EditorPipelineCommandServiceTest|EditorSessionEditControllerTest|EditorSessionHistoryPortTest|EditorSessionActionPolicyCq3Test|EditorAdjustmentPipelineTest" --output-on-failure
+```
+
+Suite totals: `EditorSessionHistoryPortTest` 46/46 PASS; `EditorAdjustmentPipelineTest` 6/6 PASS; `EditorPipelineCommandServiceTest` 4/4 PASS; `EditorSessionEditControllerTest` 11/11 PASS; `EditorSessionActionPolicyCq3Test` 10/10 PASS. Combined filtered run: 77/77 PASS. Logs: `build/tmp/nm1/`.
+
+**Checklist / exit condition:** NM1.3 typed target, input-sequence lock, live document write, and Undo document restore are done. NM1 overall Apply/Save authority and thumbnail DAG remain for NM1.4–NM1.5.
+
+**LOC note (grill-code-review):** production files under 1000 LOC — `editor_history_mutation.cpp` 539, `editor_pipeline_command_service.cpp` 198, `editor_session_edit_controller.cpp` 149, `editor_adjustment_types.hpp` 112. `editor_session_history_port_test.cpp` is 1842 lines (pre-existing history/WAL/paste suite; NM1.3 tests appended). Not split in this phase.
+
+**Remaining gaps:** QML `submitPatch` still sends `field_key` only; those writes are rejected until NM6 fills a complete target. `document_edit_by_commit` is in-process; crash reopen still replays stage WAL, not a persisted document mutation (NM4). Product Apply/Save may still remirror from stages (NM1.5). Thumbnail/snapshot still clone via stages (NM1.4). `CheckoutVersion` does not restore document JSON from the side table. Process-internal stage `SetOperator` on commit remains until the stage table is deleted.
 
 ---
 
@@ -571,7 +666,11 @@ missing document on a v2 image
   -> no stage-only thumbnail substitute
 ```
 
-旧非 v2 / 纯 stage 存储：一次性 `LegacyPipelineImporter::Import` 得到文档，再 DAG 渲染。这不是「渲染 stage」，是打开兼容数据。持久升级仍归 NML。
+```text
+stage-only storage, no usable graph
+  -> Load / snapshot fails with real error
+  -> no LegacyPipelineImporter product open path
+```
 
 ### 10.4 文件
 
@@ -588,12 +687,13 @@ missing document on a v2 image
 | `LoadPipelineSnapshotClonesDocumentWithoutReimportingStagesAsRenderSource` | snapshot 文档与 live 文档 canonical JSON 一致，且不是从 stage JSON Import 出来覆盖 live 图 |
 | `ThumbnailRenderUsesGpuDagDocumentWithoutStageApplyOnto` | 文档上的 exposure 与 thumbnail 路径使用的文档一致；渲染前文档 hash 不被 stage JSON 改写 |
 | `AnalysisRenditionUsesSameDocumentSnapshot` | 分析路径同样绑定 snapshot document |
+| `StageOnlyStoreFailsSnapshotLoadWithoutImporterSubstitute` | 无图存储失败；不 Import 成默认图再出缩略图 |
 
-若现有 `ThumbnailServiceTest` 依赖 remirror 或 `MirrorsLegacyStageAdapter()`，改为断言 DAG 文档身份。
+若现有 `ThumbnailServiceTest` 依赖 remirror 或 `MirrorsLegacyStageAdapter()`，改为断言 DAG 文档身份，或断言无图存储失败。
 
 ---
 
-## 11. NM1.5 — 产品写入权威（保留兼容镜像）
+## 11. NM1.5 — 产品写入权威（停止 stage 覆盖文档）
 
 ### 11.1 结果
 
@@ -604,21 +704,22 @@ Live editor：
 - **禁止**每次 Apply 用当前 stages `ApplyOnto` 覆盖刚刚写过的文档；
 - **禁止** dirty `SavePipeline` 用 `LegacyPipelineImporter::Import(stages)` 整份替换 `document_`。
 
-`SavePipeline` / `SyncPipelineDocument` 持久化 `document.ToJson()`。可以为旧读取器附带 `legacy_stage_adapter` 镜像 blob，但文档图是权威，adapter 不得在下一次 load 时把新节点编辑抹掉。
+`SavePipeline` / `SyncPipelineDocument` 持久化 `document.ToJson()`。不要为旧读取器附带 `legacy_stage_adapter` 镜像 blob。
 
 Load 规则：
 
-- format v2 且含完整 nodes/edges：文档权威；stage 表由文档投影或一次性镜像填充；
-- 仅有旧 stage JSON / adapter、没有可用图：一次性 Import 成默认三节点形状的文档，再 DAG；**不**在本 Phase 做项目级 bulk 升级（NML）。
+- format v2 且含完整 nodes/edges：文档权威。不要用 adapter 或 stage 表覆盖图。
+- 仅有旧 stage JSON / adapter、没有可用图：Load 失败，返回真实错误。不要 Import 成默认三节点。不要升级 mini-git commit。
 
 `InitializeImageRoot` 必须把当时的完整默认 **文档**记入 root，而不是只存 stage 表。后续 catalog 默认值变化不得重写已存在 root。
+
+本子 Phase 不从代码中删除 CPU stage 表。删除 stage 属于后续 Phase。
 
 ### 11.2 主成功调用链
 
 ```text
 settled slider
   -> document mutation
-  -> optional document-to-stage mirror
   -> GPU Render(document)
   -> SyncPipelineDocument / Save writes document ToJson
 ```
@@ -631,18 +732,20 @@ ApplyOnto of live stages would overwrite a newer document edit
 ```
 
 ```text
-unsupported legacy format that cannot Import
-  -> real error; no CPU stage editor path restored
+stage-only store, no usable graph
+  -> real error
+  -> project does not open
+  -> no CPU stage editor path restored
 ```
 
 ### 11.4 文件
 
 - `alcedo_studio/src/app/pipeline_service.cpp`（Load / Save / Remirror / InitializeImageRoot）
 - `alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp`（`ApplyGpuDagProduct`）
-- `alcedo_studio/src/include/edit/graph/pipeline_document.hpp`（`AllowsLegacyStageAdapterRemirror` 从产品默认路径退出或收窄为「兼容打开」）
+- `alcedo_studio/src/include/edit/graph/pipeline_document.hpp`（产品默认路径不再调用 `AllowsLegacyStageAdapterRemirror`）
 - `alcedo_studio/src/storage/mapper/pipeline/pipeline_mapper.cpp`
 - `alcedo_studio/tests/app/pipeline_service_test.cpp`
-- `alcedo_studio/tests/edit/graph/legacy_import_test.cpp`（保留 importer 行为；产品不再每帧 ApplyOnto）
+- `alcedo_studio/tests/edit/graph/legacy_import_test.cpp`（importer 可留作非产品测试；产品 Load 不调用）
 
 ### 11.5 测试
 
@@ -651,9 +754,9 @@ unsupported legacy format that cannot Import
 | `DirtySaveWritesDocumentJsonAndDoesNotReplaceGraphFromStages` | 文档里若有额外 Color Grade，save 后仍在 |
 | `GpuApplyDoesNotApplyOntoDocumentFromLiveStagesAfterDocumentEdit` | 文档 exposure 不被 stage 旧值盖回 |
 | `Format2LoadTreatsDocumentAsAuthorityWhenNodesPresent` | load 不因 adapter 抹掉图结构 |
-| `LegacyStageOnlyStoreImportsOnceThenRendersDocument` | 兼容打开；错误仍是真实失败 |
+| `StageOnlyStoreLoadFailsWithoutDefaultGraphImport` | 无图存储失败；不打开；不 Import |
 
-现有 `ReloadedFormat2GraphWithoutAdapterStillRemirrorsCpuNeuralEngine` 一类测试必须改写：不再要求 reload 后仍把 CPU 当权威去 remirror 覆盖文档。
+现有 `ReloadedFormat2GraphWithoutAdapterStillRemirrorsCpuNeuralEngine` 一类测试必须改写：不再要求 reload 后仍把 CPU 当权威去 remirror 覆盖文档。旧名 `LegacyStageOnlyStoreImportsOnceThenRendersDocument` 不再作为产品要求。
 
 ---
 
@@ -662,7 +765,7 @@ unsupported legacy format that cannot Import
 ```text
 EditorPipelineCommandService
   Prepare(mutation) -> candidate clone, validate, optional CompileStatic
-  Publish -> document, optional stage mirror, history head if settled
+  Publish -> document, history head if settled
 ```
 
 QML 本 Phase 不调用图命令。`EditorSessionEditController` 和 `EditorHistoryMutation` 走该 service 或同等窄接口，避免再直接 `SetOperator` 后指望 ApplyOnto。
@@ -687,22 +790,24 @@ cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target Thu
 ## 14. NM1 退出条件
 
 - [ ] 新编辑写入 `PipelineDocument`；产品 Apply/Save 不再用 live stages 覆盖新文档
-- [ ] 双向 mirror 仅作为旧项目 / 旧 payload 兼容层存在，且有测试锁住「不得覆盖新图结构」
+- [ ] 产品不提供 stage 镜像；无可用图的旧存储 Load 失败
 - [ ] Thumbnail / analysis / 同 snapshot 像素路径 DAG 渲染，不经 stage ApplyOnto
 - [x] Add / Remove（含 primary）/ Reconnect 原子、失败回滚、canonical JSON 可逆
 - [x] Default 三节点工厂自带 `+1.5 EV` / saturation `1.3`；Clean 为 identity 且无四项后处理
-- [ ] `EditorParameterTarget` 锁定；Mask target 拒绝
-- [ ] History live Undo 恢复文档值（payload schema 仍可是旧的）
+- [x] `EditorParameterTarget`：每个 patch 完整；缺字段拒绝；输入序列锁定；Mask target 拒绝
+- [x] History live Undo 恢复文档值（payload schema 仍可是旧的）
 - [ ] 生产 UI 仍无新增节点入口
-- [ ] 旧 stage 项目的持久升级不在本 Phase 声称完成（NML）
+- [ ] 不声称打开或升级 DAG document 之前的项目；NML 取消
 
 ---
 
 ## 15. 与后续 Phase 的接口
 
-- **NML：** 可审计的旧 stage 存储 → 默认三节点 `PipelineDocument` 升级；决定何时停止依赖 live stage 表。NM1 结束后旧项目仍靠 importer + 镜像打开。
-- **NM2：** 主链上每一个 Color Grade 都执行；本 Phase 只执行第一个。删除能力已在 NM1 证明，NM2 不得再拿「compiler 需要 `grade.primary`」限制删除。
-- **NM4：** 把 `OrdinaryEditPayload` 换成 typed `PipelineEditBatch`；checkpoint 存文档而不是只存 stage params。
+- **Stage table delete (later, not NM1):** 从代码中删除 CPU stage 表和产品路径上的 `LegacyPipelineImporter`。不是旧项目升级。
+- **NML：** 取消。本产品不打开、不升级 DAG document 之前的 stage-only 项目，也不迁移旧 mini-git commit。
+- **NM2：** 主链上每一个 Color Grade 都执行；本 Phase 只执行第一个。删除能力已在 NM1 证明，NM2 不得再拿「compiler 需要 `grade.primary`」限制删除。NM2 假定打开的项目已经是可用 DAG 文档。无图项目不会进入 NM2。
+- **NM4：** 把 `OrdinaryEditPayload` 换成 typed `PipelineEditBatch`；checkpoint 存文档而不是只存 stage params。NM4 不回填旧 stage commit。
+- **NM6：** 右侧面板按选中节点发送完整 target。NM1 已要求完整 target 与输入序列锁定。
 
 ---
 
@@ -710,6 +815,7 @@ cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target Thu
 
 NM1.1 (2026-08-29): complete — recorded under §7.
 NM1.2 (2026-08-30): complete — recorded under §8.
+NM1.3 (2026-08-30): complete — recorded under §9.
 
 后续子 Phase 完成后按同一模板追加。模板：
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
@@ -1,0 +1,677 @@
+# Phase NM1 — PipelineDocument Editing Foundation
+
+Date: 2026-08-29
+
+Status: in progress — NM1.1 complete; NM1.2–NM1.5 not started.
+
+Branch: `feature/pipeline_document_migration`
+
+Base: `origin/main` at NM0 merge (`d5a96267`, QuickQanava pin already on main).
+
+对应总体方案：[Node-aware Pipeline Editing and Mask Authoring 总体方案](../node_mask_editor_master_plan.md) 第 2.1、6、7.1、11、21.2 节。
+
+本文件是 NM1 的执行方案。总体方案只跟踪一级 Phase；本文件拆 `NM1.1`–`NM1.5`，并记录调用链、测试和未完成项。
+
+---
+
+## 1. 必读
+
+- [总体方案](../node_mask_editor_master_plan.md)
+- [GPU DAG 编辑管线重构 Phase 计划](../gpu_dag_pipeline_rebuild_phase_plan.md) 中 format v2、`CreateDefaultPipelineDocument`、`LegacyPipelineImporter`
+- 本仓库 `AGENTS.md`：roadmap 用词禁令、测试禁止 `smoke`、临时文件只放 `build/tmp/`
+
+发生冲突时的优先级：
+
+1. 总体方案已锁定的产品语义（单主链、Clean 与 Default 的区别、typed target、失败回滚）；
+2. 本执行方案对 NM1 子 Phase、兼容镜像和 thumbnail DAG 的明确要求；
+3. 当前代码中已经落地的 GPU DAG 三节点 runtime。
+
+---
+
+## 2. 开工时源码审计（2026-08-29）
+
+### 2.1 双写仍然存在
+
+产品编辑状态不是 `PipelineDocument`。当前写入链：
+
+```text
+QML slider
+  -> EditorSessionEditController::HandlePatch(field_key)
+  -> EditorHistoryMutation::CommitAdjustment
+  -> ApplyEditorAdjustmentOperatorState(CPUPipelineExecutor stages)
+  -> GPU ApplyGpuDagProduct
+       if mirror: LegacyPipelineImporter::ApplyOnto(document, stage JSON)
+  -> SavePipeline dirty: Import(stages) 整份替换 document_
+```
+
+`LoadPipelineDocument` 注释写明：live CPU stages 是 editor source of truth，format v2 图被 remirror。`SyncPipelineDocument` 只写 `document.ToJson()`，但 dirty `SavePipeline` 会用 stages 重建整张图。
+
+`AllowsLegacyStageAdapterRemirror` 只检查 Develop / `grade.primary` / DRT 三个节点是否存在。
+
+### 2.2 图命令不完整
+
+`PipelineGraph` 只有 `AddNode()` 和 `Connect()`，并公开可变 `Nodes()`。没有断开、删除、桥接或原子 Reconnect。`Validate()` 检查 endpoint 数量、端口类型、环和单端口 fan-in，**不**检查：
+
+- 恰好一条 Develop → … → DRT 的 scene-image 路径；
+- scene-image 禁止 fan-out；
+- 全部 Color Grade 都在这条路径上；
+- Develop / DRT 不可删除、不可替换。
+
+### 2.3 Default 基线不在文档工厂里
+
+`ColorGradeNodeModel::MakeDefault()` 用 catalog 默认值：`ExposureModel` 的 `exposure_ev = 0`，`SaturationModel` 的 `saturation = 1.0`。产品 `+1.5 EV` / 旧 UI `+30` 只存在于 `pipeline_defaults::kCleanBaselineExposure` / `kCleanBaselineSaturation`，靠 remirror 灌进图。
+
+`LegacyPipelineImporter` 的对应关系已经固定：legacy `exposure = 1.5` → `exposure_ev = 1.5`；legacy `saturation = 30` → 新模型 `1.3`（`1 + offset/100`）。
+
+注意：现有 `kCleanBaseline*` 名字是产品 Default 观感，不是总体方案里的 Clean（无视觉变化）。NM1 新 API 不得复用 `CleanBaseline` 表示 identity。
+
+### 2.4 参数没有节点身份
+
+`EditorAdjustmentPatch` 只有 `field_key` + JSON。`HandlePatch` 不碰 `PipelineDocument`。History payload 仍是 `OrdinaryEditPayload`（`OperatorType + PipelineStageName + field`）。这是 NM4 要换掉的格式；NM1 不改 commit schema。
+
+### 2.5 Thumbnail 仍先重建 stage 再渲染
+
+`LoadPipelineSnapshot` 导出 stage JSON，`ImportPipelineParams` 建成独立 `CPUPipelineExecutor`，再 `SetPipelineDocument(..., mirror)`。`ThumbnailService` 把该 executor 交给 `PipelineTask`，`SetForceCPUOutput(true)` 后走 executor Apply。GPU 路径会再次从 stages `ApplyOnto` 文档。这就是「转到 stage 上再渲染」。
+
+分析 rendition 和 export 共用同一 snapshot API。
+
+### 2.6 Compiler 仍按固定 id 找一个 Grade
+
+`GraphCompiler::CompileStatic` 要求 `document.PrimaryGrade()`（`grade.primary`），只编一个 `PrimaryColorGrade` pass。多 Color Grade 存在于图里也不会执行。这是 NM2 的工作。NM1 只把「当前仍只执行一个 Grade」的查找从硬编码 id 改成主链上的 Color Grade 列表，以免删除 `grade.primary` 后文档无法编译。
+
+---
+
+## 3. 本 Phase 锁定的产品决定
+
+这些决定来自开工评审，覆盖总体方案 21.2 的原表述。
+
+1. **新编辑的写入权威是 `PipelineDocument`。** 调整条、history 的 live mutation、thumbnail/analysis 像素都不把 CPU stage 当作渲染或提交的源。
+2. **删除能力完整保留。** `RemoveColorGradeAndBridge` 可删除任意 Color Grade，包括 Default / `grade.primary`。不能删除 Develop 或 DRT。删光 Color Grade 后主链为 Develop → DRT，这是合法文档。
+3. **双向 mirror 作为兼容层保留。** `CPUPipelineExecutor` 的 stage 表继续存在，用于打开旧项目、回放仍按 stage/operator 标识的旧 commit、以及尚未升级的存储。Mirror 不得把 stage 重新变成新编辑的 source of truth，也不得在 thumbnail 路径上「先转 stage 再渲染」。
+4. **Thumbnail 和 snapshot 像素必须 DAG 渲染。** 克隆 `PipelineDocument`，交给现有 GPU `Renderer`。禁止 `ExportPipelineParams` → `ImportPipelineParams` → stage Apply 作为出图像素路径。
+5. **History 的 typed `PipelineEditBatch`、Version/Paste、format 升级属于 NM4。** NM1 只要求 live 提交/Undo/Redo 作用在文档上；payload 仍可暂时是 `OrdinaryEditPayload`。
+6. **旧 stage 项目升级到默认三节点 DAG 属于一级 Phase NML，不在 NM1 实现。** 见总体方案新增的 NML。NM1 只保证：旧项目仍能打开（importer + 兼容镜像），新编辑写文档，thumbnail 走 DAG。
+
+---
+
+## 4. 范围与明确排除
+
+### 4.1 NM1 包含
+
+- 候选文档 mutation、主链 validation、原子 Add / Remove / Reconnect / Rename / SetEnabled；
+- 稳定 `NodeId`；失败不改 live document / history head；
+- `CreateDefaultPipelineDocument` 在工厂内写入 Default 基线；`MakeClean` / `CreateCleanColorGradeNode`；
+- `EditorParameterTarget`；现有 field 写入文档；输入序列锁定 target；
+- History live 路径改为写/读文档（payload 格式暂不升级）；
+- Thumbnail、analysis rendition、以及同一 snapshot API 上的像素改为 DAG；
+- 产品 GPU Apply 以文档为渲染输入；stage 仅作兼容镜像；
+- `SavePipeline` 不得再用 stages `Import` 整份替换文档。
+
+### 4.2 NM1 不包含
+
+| 排除项 | 归属 |
+| --- | --- |
+| 主链上多个 Color Grade 的真实 GPU 执行、按 NodeId 的 dirty/cache | NM2 |
+| Clarity / Sharpen / Halation / Film Grain 搬到 DRT/Post | NM2 |
+| 多 Mask、Range 字段落地、不可变 MaskStore `Put()` | NM3 |
+| typed `PipelineEditBatch`、每 Version 一 DAG 的 history schema、Paste、format 提升 | NM4 |
+| 旧 stage 存储的一次性/可审计升级到默认三节点 DAG | NML |
+| Nodes 面板、QuickQanava 生产链接、开放用户 Add 入口 | NM5 |
+| 按节点切换右侧 adjustment stack | NM6 |
+| Viewer 蒙版绘制 | NM7 |
+
+生产 UI 在本 Phase **不**开放新增/删除/重连节点入口。领域 API 和 tests 必须先具备完整删除能力。
+
+---
+
+## 5. 跨子 Phase 的实现规则
+
+### 5.1 候选文档 + 失败回滚
+
+所有图 mutation 和 settled 参数 mutation：
+
+```text
+clone PipelineDocument
+  -> apply typed mutation on candidate
+  -> ValidateGraph + ValidateImageBackbone
+  -> 失败：丢弃 candidate；live document、history head、最后一帧不变
+  -> 成功：替换 live document；需要时同步兼容 stage 镜像
+```
+
+不得先改 live 再捕获异常继续。不得用 CPU 或其他 backend 代替失败的 GPU 路径。
+
+### 5.2 主链不变量（在现有 `Validate()` 之上）
+
+合法 scene-image 拓扑：
+
+```text
+Develop -> ColorGrade[0] -> ... -> ColorGrade[n] -> DRT/Post
+```
+
+或零个 Color Grade：
+
+```text
+Develop -> DRT/Post
+```
+
+必须拒绝：删 Develop/DRT、替换 endpoint 类型、scene-image fan-in/fan-out、Color Grade 不在主链上、环、端口类型错误。Mask 边仍按现有顶层 mask node 规则验证（NM3 之前不改 Mask 所有权）。
+
+### 5.3 删除与当前单 Grade compiler
+
+NM2 之前 runtime 仍然只执行 **一个** Color Grade。NM1 必须让删除后的文档仍能编译当前形状：
+
+```text
+Color grades on image backbone
+  0 -> 跳过 PrimaryColorGrade pass，DRT 输入接 Develop 输出
+  1 或更多 -> 只编译主链上第一个 Color Grade（按路径顺序，不要求 id 为 grade.primary）
+```
+
+其余 Color Grade 保存在文档里，本 Phase 不执行。这不是多 Grade runtime。
+
+`PipelineDocument::PrimaryGrade()` 对默认三节点文档仍可按 `grade.primary` 查找，供现有 tests 使用。Compiler 不得再把「缺少 `grade.primary`」当成硬失败，只要主链合法。
+
+### 5.4 兼容镜像的方向
+
+| 方向 | NM1 是否允许 | 用途 |
+| --- | ---: | --- |
+| 新编辑 → `PipelineDocument` | 必须 | 唯一新写入权威 |
+| document → stage 表 | 允许 | 旧 history payload / 旧检查点回放、尚未升级的存储 |
+| stage → document（打开旧项目、旧 commit 回放） | 允许 | 兼容层 |
+| stage → document 覆盖一次**新的**文档编辑 | 禁止 | 这是当前 Save/Apply remirror 的缺陷 |
+| thumbnail/analysis：stage JSON → Import → Apply | 禁止 | 必须 DAG |
+
+`LegacyPipelineImporter::Import` / `ApplyOnto` 保留。产品路径不再把它们当作「每次 GPU 帧把 live stages 灌进文档」的默认步骤。打开纯旧 stage JSON、或从旧 `legacy_stage_adapter` 恢复时，可以一次性 Import/ApplyOnto，然后渲染走 DAG。
+
+### 5.5 文件体量
+
+`pipeline_service.cpp` 已经很大。本 Phase 若继续往里堆 Load/Save/snapshot 逻辑，按职责拆出 document persist / snapshot 辅助单元，而不是再加一整段。`EditorPipelineCommandService` 必须是独立类型，不把图规则塞回 `PipelineMgmtService` 或 QML。
+
+---
+
+## 6. 子 Phase 顺序
+
+```text
+NM1.1 主链 validation 与图命令（含完整删除）
+  -> NM1.2 Default / Clean 工厂
+  -> NM1.3 typed target 与参数写入文档（含 history live）
+  -> NM1.4 thumbnail / snapshot DAG 渲染
+  -> NM1.5 产品写入权威与 Save/Apply 停止用 stage 覆盖新文档
+```
+
+同一分支 `feature/pipeline_document_migration` 上按序落地。可以按 `NM1.1+NM1.2`、`NM1.3`、`NM1.4`、`NM1.5` 拆 PR；不要把 NM2–NM8 塞进本分支。
+
+---
+
+## 7. NM1.1 — 主链 validation 与图命令
+
+### 7.1 结果
+
+领域层可以原子地 Add / Remove / Reconnect / Rename / SetEnabled。QML 仍不能改 `Nodes()` / `Edges()`。删除任意 Color Grade（含 `grade.primary`）后文档满足第 5.2 节不变量。Compiler 按 5.3 编译。
+
+### 7.2 API
+
+```cpp
+auto AddCleanColorGrade(PipelineDocument& candidate, const NodeId& before_node_id,
+                        NodeId new_id) -> std::vector<GraphValidationError>;
+auto RemoveColorGradeAndBridge(PipelineDocument& candidate, const NodeId& node_id)
+    -> std::vector<GraphValidationError>;
+auto ReconnectColorGrade(PipelineDocument& candidate, const NodeId& node_id,
+                          const NodeId& new_predecessor_id, const NodeId& new_successor_id)
+    -> std::vector<GraphValidationError>;
+auto RenameColorGrade(PipelineDocument& candidate, const NodeId& node_id,
+                       std::string display_name) -> std::vector<GraphValidationError>;
+auto SetColorGradeEnabled(PipelineDocument& candidate, const NodeId& node_id, bool enabled)
+    -> std::vector<GraphValidationError>;
+```
+
+`RemoveColorGradeAndBridge`：删除该节点及其相邻两条 scene-image 边，再把前驱接到后继。一次调用，不暴露中间图。
+
+`AddCleanColorGrade(before_node_id)`：在 `before_node_id` 之前插入（即新节点成为 `before` 的前驱）。若 `before` 是 DRT，则插在最后一个 Color Grade（或 Develop）之后。具体插入点必须在测试里写死，并与日后 NM5 UI 一致。
+
+节点需要 `display_name`。Develop / DRT 显示名固定，Rename 拒绝。Color Grade 改名不改 `NodeId`。
+
+关掉 `PipelineGraph::Nodes()` 的可变引用。测试用命令或测试 builder 建图。
+
+### 7.3 主成功调用链
+
+```text
+test / future EditorPipelineCommandService
+  -> ClonePipelineDocument
+  -> RemoveColorGradeAndBridge(candidate, node_id)
+  -> Validate + ValidateImageBackbone
+  -> GraphCompiler::CompileStatic (5.3 规则)
+  -> replace live document
+```
+
+### 7.4 主失败调用链
+
+```text
+Remove Develop or DRT
+  or Reconnect that creates scene-image fan-out
+  -> candidate discarded
+  -> live ToJson hash, node count, history head unchanged
+```
+
+### 7.5 文件
+
+- `alcedo_studio/src/include/edit/graph/pipeline_graph.hpp`
+- `alcedo_studio/src/edit/graph/pipeline_graph.cpp`
+- `alcedo_studio/src/include/edit/graph/graph_validation.hpp`
+- 新 `pipeline_graph_commands.hpp` / `.cpp`（或同等名字；命令拥有规则，`PipelineGraph` 不向 UI 暴露容器）
+- `alcedo_studio/src/include/edit/graph/pipeline_document.hpp` / `.cpp`（主链遍历、`display_name`）
+- `alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp` / `.cpp`
+- `alcedo_studio/src/include/edit/graph/i_node_model.hpp`（display name）
+- `alcedo_studio/src/edit/runtime/graph_compiler.cpp`（5.3 查找规则）
+- `alcedo_studio/tests/edit/graph/graph_validation_test.cpp`
+- 新 `alcedo_studio/tests/edit/graph/pipeline_graph_command_test.cpp`
+- `alcedo_studio/tests/edit/CMakeLists.txt`（`GpuDagModelGraphTest`）
+
+### 7.6 测试
+
+| 名称 | 断言 |
+| --- | --- |
+| `AddCleanColorGradeKeepsSingleImageBackbone` | 插入后仍一条 Develop→…→DRT 路径，新 NodeId 稳定 |
+| `RemoveColorGradeAndBridgeConnectsPredecessorToSuccessor` | 一次调用后无悬空边；前驱接到后继 |
+| `RemovePrimaryGradeKeepsRemainingGradesAndValidBackbone` | 删除 `grade.primary` 后其余 Color Grade 仍在主链，NodeId 不变 |
+| `RemoveLastColorGradeLeavesDevelopConnectedToDrt` | 零 Color Grade 合法 |
+| `RemoveDevelopOrDrtIsRejectedWithoutMutation` | hash 与节点数不变 |
+| `InvalidReconnectLeavesDocumentHashUnchanged` | 非法 fan-out/环不改 canonical JSON |
+| `GraphMutationInverseRestoresCanonicalDocumentJson` | forward 再 inverse，canonical JSON 一致 |
+| `GraphCompilerSkipsGradePassWhenBackboneHasNoColorGrade` | 零 Grade 时 CompileStatic 成功且无 PrimaryColorGrade |
+| `GraphCompilerCompilesFirstBackboneGradeWhenPrimaryIdIsAbsent` | 仅剩非 `grade.primary` 的 Grade 时仍能编译那一个 |
+
+Canonical JSON：对 `ToJson()` 做稳定序列化比较（节点/边顺序确定）。不要用指针或 Qan 对象。
+
+##### Phase NM1.1 completion record (2026-08-29)
+
+**Status:** complete — atomic graph commands, image-backbone validation, const-only `Nodes()`, GraphCompiler first-backbone-grade lookup.
+
+**Primary success call chain:**
+
+```text
+test / future EditorPipelineCommandService
+  -> ClonePipelineDocument (or mutate a candidate)
+  -> RemoveColorGradeAndBridge / AddCleanColorGrade / ReconnectColorGrade
+  -> PipelineGraph::Validate + ValidateImageBackbone
+  -> GraphCompiler::CompileStatic (0 grades: skip PrimaryColorGrade; else first backbone grade)
+  -> replace live document (candidate kept on success)
+```
+
+**Primary failure call chain:**
+
+```text
+Remove Develop or DRT
+  or Reconnect that creates scene-image fan-out
+  -> command returns GraphValidationError
+  -> candidate restored from ToJson snapshot
+  -> live ToJson dump, node count, and history head unchanged
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `AddCleanColorGradeKeepsSingleImageBackbone` | `GpuDagModelGraphTest` | PASS |
+| `RemoveColorGradeAndBridgeConnectsPredecessorToSuccessor` | `GpuDagModelGraphTest` | PASS |
+| `RemovePrimaryGradeKeepsRemainingGradesAndValidBackbone` | `GpuDagModelGraphTest` | PASS |
+| `RemoveLastColorGradeLeavesDevelopConnectedToDrt` | `GpuDagModelGraphTest` | PASS |
+| `RemoveDevelopOrDrtIsRejectedWithoutMutation` | `GpuDagModelGraphTest` | PASS |
+| `InvalidReconnectLeavesDocumentHashUnchanged` | `GpuDagModelGraphTest` | PASS |
+| `GraphMutationInverseRestoresCanonicalDocumentJson` | `GpuDagModelGraphTest` | PASS |
+| `GraphCompilerSkipsGradePassWhenBackboneHasNoColorGrade` | `GpuDagModelGraphTest` | PASS |
+| `GraphCompilerCompilesFirstBackboneGradeWhenPrimaryIdIsAbsent` | `GpuDagModelGraphTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagModelGraphTest
+ctest --test-dir build/debug -R GpuDagModelGraphTest --output-on-failure
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagRawInputTest
+ctest --test-dir build/debug -R "GpuDagRawInputTest.GpuDagGraphCompiler" --output-on-failure
+```
+
+Suite totals: `GpuDagModelGraphTest` 42/42 PASS; `GpuDagRawInputTest.GpuDagGraphCompiler` 18/18 PASS.
+
+**Checklist / exit condition:** NM1.1 API, backbone validation, deletion including `grade.primary`, and compiler 5.3 lookup are done. NM1 overall exit items for Default/Clean factories, typed targets, thumbnail DAG, and product Save/Apply remain for NM1.2–NM1.5.
+
+**LOC note (grill-code-review):** largest changed files — `pipeline_graph.cpp` 364, `pipeline_graph_commands.cpp` 318, `graph_compiler.cpp` 302, `pipeline_graph_command_test.cpp` 222. All under 1000 LOC; commands own mutation rules as a separate type from `PipelineGraph`.
+
+**Remaining gaps:** `AddCleanColorGrade` currently inserts `ColorGradeNodeModel::MakeDefault` (Clean vs Default factories are NM1.2). CUDA/OpenCL/Metal grade encoders and `result_content_key` still look up `document.PrimaryGrade()` (`grade.primary`); CompileStatic no longer requires that id, but GPU execute of a non-primary remaining grade is not proven here (NM2 execution). Production UI still has no Add/Remove entry (NM5).
+
+---
+
+## 8. NM1.2 — Default 与 Clean 工厂
+
+### 8.1 结果
+
+两个入口从名字上即可区分：
+
+```cpp
+auto CreateDefaultPipelineDocument() -> PipelineDocument;
+auto CreateCleanColorGradeNode(NodeId id) -> std::unique_ptr<ColorGradeNodeModel>;
+// 或 ColorGradeNodeModel::MakeClean(NodeId)
+```
+
+`CreateDefaultPipelineDocument()`：
+
+- Develop、Default Color Grade（默认仍可用 id `grade.primary`）、DRT；
+- Default Color Grade 带产品基线：`exposure_ev = 1.5`，saturation `1.3`（对应旧 `+30`）；
+- 其余 Default 调整与当前 `MakeDefault` 目录一致（含 Clarity/Sharpen/Halation/Film Grain，直到 NM2 搬家）；
+- 不依赖 remirror 才能得到基线。
+
+`CreateCleanColorGradeNode()` / `MakeClean()`：
+
+- Exposure `0 EV`，saturation `1.0`，其余 Color Grade 参数为无视觉变化；
+- `enabled = true`，`mix = 1`，无 mask；
+- **不含** Clarity、Sharpen、Halation、Film Grain；
+- 不是 Default 节点改几个 Patch 装出来的。
+
+现有 `pipeline_defaults::kCleanBaseline*` 可以继续给 CPU 兼容层用，但新文档工厂代码用 Default / identity 这类准确名字。
+
+### 8.2 主成功调用链
+
+```text
+CreateDefaultPipelineDocument
+  -> MakeDefault Color Grade
+  -> set exposure_ev 1.5 and saturation 1.3
+  -> ValidateImageBackbone empty
+```
+
+```text
+AddCleanColorGrade
+  -> CreateCleanColorGradeNode
+  -> insert + reconnect candidate backbone
+```
+
+### 8.3 主失败调用链
+
+```text
+UI or test tries to build a Clean node by patching Default
+  -> not an API; tests assert MakeClean identity without going through Default
+```
+
+### 8.4 文件
+
+- `color_grade_node_model.hpp` / `.cpp`
+- `pipeline_document.hpp` / `.cpp`
+- `alcedo_studio/tests/edit/graph/default_pipeline_test.cpp`
+- 新或并入 `pipeline_graph_command_test.cpp` 的 Clean 断言
+
+### 8.5 测试
+
+| 名称 | 断言 |
+| --- | --- |
+| `DefaultPipelineDocumentBakesOnePointFiveEvAndSaturationOnePointThree` | 不经 importer，Default Grade 即为 1.5 / 1.3 |
+| `MakeCleanColorGradeUsesIdentityParamsAndOmitsPostAdjustments` | 0 EV、sat 1.0、无四项后处理 |
+| `AddCleanColorGradeDoesNotCopyDefaultExposureOrSaturation` | 新节点不是 +1.5 / 1.3 |
+
+---
+
+## 9. NM1.3 — Typed target 与 history live 写文档
+
+### 9.1 结果
+
+```text
+EditorParameterTarget
+  owner_kind: Document | Develop | ColorGrade | ColorGradeMask | DrtPost
+  node_id                  // Document 为空
+  adjustment_instance_id
+  mask_id                  // NM1 只预留；写入拒绝
+  field_key
+```
+
+现有 `EditorAdjustmentPatch` 增加 target；缺省时由 field catalog 绑到当前默认三节点（Develop / `grade.primary` 或主链第一个 Color Grade / DRT / Document geometry）。
+
+输入序列开始时锁定 target。拖动中途改变 selected node 不得把后半段写到另一个 NodeId。
+
+`EditorHistoryMutation::CommitAdjustment` / Undo / Redo 的 **live 效果**写 `PipelineGuard::document_`。仍可同步兼容 stage 镜像，但失败回滚以文档为准。`OrdinaryEditPayload` 本 Phase 不改 schema。
+
+Mask target 和多节点 UI 选择恢复属于后续 Phase；本 Phase 拒绝 Mask target 写入。
+
+### 9.2 主成功调用链
+
+```text
+HandlePatch(settled)
+  -> lock EditorParameterTarget
+  -> Capture before from document
+  -> PrepareAppendEdit(OrdinaryEditPayload)   // schema unchanged
+  -> candidate document SetAdjustmentField
+  -> validate
+  -> PublishPreparedEdit
+  -> publish document + optional stage mirror
+  -> SettledAdjustment render reads document
+```
+
+### 9.3 主失败调用链
+
+```text
+unknown field, missing instance, or Mask target
+  -> Rejected
+  -> document hash and history head unchanged
+```
+
+```text
+WAL or history publish fails
+  -> restore document (and mirror) to before
+  -> no new head
+```
+
+### 9.4 文件
+
+- `alcedo_studio/src/include/app/editor_adjustment_types.hpp`
+- `alcedo_studio/src/app/editor_adjustment_pipeline.cpp`（document 写入 + 缺省 target 解析）
+- `alcedo_studio/src/app/editor_session_edit_controller.cpp`
+- `alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp`
+- 新 `editor_pipeline_command_service`（app 层 Prepare/Publish；参数与图命令共用）
+- `alcedo_studio/tests/app/editor_adjustment_pipeline_test.cpp`
+- `alcedo_studio/tests/app/editor_session_edit_controller_test.cpp`
+- `alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp`
+
+### 9.5 测试
+
+| 名称 | 断言 |
+| --- | --- |
+| `SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages` | `document` 上 exposure_ev 变化 |
+| `ProvisionalPatchKeepsLockedNodeIdWhenSelectionWouldChange` | 锁定 target |
+| `UnknownFieldRejectedLeavesDocumentHashAndHistoryHeadUnchanged` | 失败封闭 |
+| `UndoSettledExposureRestoresDocumentValue` | Undo 后文档回到 before，不只 stage |
+| `MaskTargetWriteIsRejected` | NM1 不写 Mask |
+
+History 投影文案、commit hash 算法、journal 格式留给 NM4。本 Phase 只要 Undo 后文档值正确。
+
+---
+
+## 10. NM1.4 — Thumbnail 与 snapshot DAG
+
+### 10.1 结果
+
+`PipelineSnapshot` 携带独立的 `PipelineDocument` 克隆（不共享 live Model 指针）。Thumbnail、analysis rendition 用该文档走 GPU DAG 出图。
+
+禁止：
+
+```text
+ExportPipelineParams
+  -> ImportPipelineParams
+  -> stage Apply / remirror
+  -> thumbnail pixels
+```
+
+允许 snapshot 仍持有 `CPUPipelineExecutor` 作为 GPU session / 调度宿主，但 Apply 必须绑定已克隆的文档且 **不得**用 snapshot 的 stage JSON 覆盖该文档后再渲染。
+
+`LoadPipelineSnapshot` 在 cache miss 时仍可 `LoadPipeline`，但捕获的是文档，不是「只导出 stages 再重建一份编辑状态」。
+
+Export 目前走同一 snapshot。本子 Phase 把 snapshot API 改成文档权威后，export 像素也必须 DAG，不得留下一条 stage-only 克隆。
+
+### 10.2 主成功调用链
+
+```text
+ThumbnailService::GetThumbnail
+  -> LoadPipelineSnapshot
+  -> ClonePipelineDocument(live or stored)
+  -> snapshot.document
+  -> GPU Renderer::Render(document)
+  -> host thumbnail buffer
+```
+
+### 10.3 主失败调用链
+
+```text
+missing document on a v2 image
+  -> snapshot load fails with real error
+  -> no stage-only thumbnail substitute
+```
+
+旧非 v2 / 纯 stage 存储：一次性 `LegacyPipelineImporter::Import` 得到文档，再 DAG 渲染。这不是「渲染 stage」，是打开兼容数据。持久升级仍归 NML。
+
+### 10.4 文件
+
+- `alcedo_studio/src/include/app/pipeline_service.hpp`（`PipelineSnapshot` 增加 document）
+- `alcedo_studio/src/app/pipeline_service.cpp`（`LoadPipelineSnapshot`）
+- `alcedo_studio/src/app/thumbnail_service.cpp`
+- `alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp`（thumbnail Apply 不再 `ApplyOnto` 覆盖 snapshot 文档）
+- `alcedo_studio/tests/app/thumbnail_service_test.cpp`
+
+### 10.5 测试
+
+| 名称 | 断言 |
+| --- | --- |
+| `LoadPipelineSnapshotClonesDocumentWithoutReimportingStagesAsRenderSource` | snapshot 文档与 live 文档 canonical JSON 一致，且不是从 stage JSON Import 出来覆盖 live 图 |
+| `ThumbnailRenderUsesGpuDagDocumentWithoutStageApplyOnto` | 文档上的 exposure 与 thumbnail 路径使用的文档一致；渲染前文档 hash 不被 stage JSON 改写 |
+| `AnalysisRenditionUsesSameDocumentSnapshot` | 分析路径同样绑定 snapshot document |
+
+若现有 `ThumbnailServiceTest` 依赖 remirror 或 `MirrorsLegacyStageAdapter()`，改为断言 DAG 文档身份。
+
+---
+
+## 11. NM1.5 — 产品写入权威（保留兼容镜像）
+
+### 11.1 结果
+
+Live editor：
+
+- 新参数写入文档（NM1.3）；
+- GPU 产品帧读取文档；
+- **禁止**每次 Apply 用当前 stages `ApplyOnto` 覆盖刚刚写过的文档；
+- **禁止** dirty `SavePipeline` 用 `LegacyPipelineImporter::Import(stages)` 整份替换 `document_`。
+
+`SavePipeline` / `SyncPipelineDocument` 持久化 `document.ToJson()`。可以为旧读取器附带 `legacy_stage_adapter` 镜像 blob，但文档图是权威，adapter 不得在下一次 load 时把新节点编辑抹掉。
+
+Load 规则：
+
+- format v2 且含完整 nodes/edges：文档权威；stage 表由文档投影或一次性镜像填充；
+- 仅有旧 stage JSON / adapter、没有可用图：一次性 Import 成默认三节点形状的文档，再 DAG；**不**在本 Phase 做项目级 bulk 升级（NML）。
+
+`InitializeImageRoot` 必须把当时的完整默认 **文档**记入 root，而不是只存 stage 表。后续 catalog 默认值变化不得重写已存在 root。
+
+### 11.2 主成功调用链
+
+```text
+settled slider
+  -> document mutation
+  -> optional document-to-stage mirror
+  -> GPU Render(document)
+  -> SyncPipelineDocument / Save writes document ToJson
+```
+
+### 11.3 主失败调用链
+
+```text
+ApplyOnto of live stages would overwrite a newer document edit
+  -> this path is removed from product Apply/Save
+```
+
+```text
+unsupported legacy format that cannot Import
+  -> real error; no CPU stage editor path restored
+```
+
+### 11.4 文件
+
+- `alcedo_studio/src/app/pipeline_service.cpp`（Load / Save / Remirror / InitializeImageRoot）
+- `alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp`（`ApplyGpuDagProduct`）
+- `alcedo_studio/src/include/edit/graph/pipeline_document.hpp`（`AllowsLegacyStageAdapterRemirror` 从产品默认路径退出或收窄为「兼容打开」）
+- `alcedo_studio/src/storage/mapper/pipeline/pipeline_mapper.cpp`
+- `alcedo_studio/tests/app/pipeline_service_test.cpp`
+- `alcedo_studio/tests/edit/graph/legacy_import_test.cpp`（保留 importer 行为；产品不再每帧 ApplyOnto）
+
+### 11.5 测试
+
+| 名称 | 断言 |
+| --- | --- |
+| `DirtySaveWritesDocumentJsonAndDoesNotReplaceGraphFromStages` | 文档里若有额外 Color Grade，save 后仍在 |
+| `GpuApplyDoesNotApplyOntoDocumentFromLiveStagesAfterDocumentEdit` | 文档 exposure 不被 stage 旧值盖回 |
+| `Format2LoadTreatsDocumentAsAuthorityWhenNodesPresent` | load 不因 adapter 抹掉图结构 |
+| `LegacyStageOnlyStoreImportsOnceThenRendersDocument` | 兼容打开；错误仍是真实失败 |
+
+现有 `ReloadedFormat2GraphWithoutAdapterStillRemirrorsCpuNeuralEngine` 一类测试必须改写：不再要求 reload 后仍把 CPU 当权威去 remirror 覆盖文档。
+
+---
+
+## 12. 建议的 app 类型
+
+```text
+EditorPipelineCommandService
+  Prepare(mutation) -> candidate clone, validate, optional CompileStatic
+  Publish -> document, optional stage mirror, history head if settled
+```
+
+QML 本 Phase 不调用图命令。`EditorSessionEditController` 和 `EditorHistoryMutation` 走该 service 或同等窄接口，避免再直接 `SetOperator` 后指望 ApplyOnto。
+
+---
+
+## 13. 构建与证据
+
+Windows：
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagModelGraphTest
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target PipelineMapperTest
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target ThumbnailServiceTest
+```
+
+日志放 `build/tmp/nm1/`。每个子 Phase 完成后在本文件追加 completion record（调用链、命令、通过的测试名）。不要把这些日志写进总体方案。
+
+---
+
+## 14. NM1 退出条件
+
+- [ ] 新编辑写入 `PipelineDocument`；产品 Apply/Save 不再用 live stages 覆盖新文档
+- [ ] 双向 mirror 仅作为旧项目 / 旧 payload 兼容层存在，且有测试锁住「不得覆盖新图结构」
+- [ ] Thumbnail / analysis / 同 snapshot 像素路径 DAG 渲染，不经 stage ApplyOnto
+- [x] Add / Remove（含 primary）/ Reconnect 原子、失败回滚、canonical JSON 可逆
+- [ ] Default 三节点工厂自带 `+1.5 EV` / saturation `1.3`；Clean 为 identity 且无四项后处理
+- [ ] `EditorParameterTarget` 锁定；Mask target 拒绝
+- [ ] History live Undo 恢复文档值（payload schema 仍可是旧的）
+- [ ] 生产 UI 仍无新增节点入口
+- [ ] 旧 stage 项目的持久升级不在本 Phase 声称完成（NML）
+
+---
+
+## 15. 与后续 Phase 的接口
+
+- **NML：** 可审计的旧 stage 存储 → 默认三节点 `PipelineDocument` 升级；决定何时停止依赖 live stage 表。NM1 结束后旧项目仍靠 importer + 镜像打开。
+- **NM2：** 主链上每一个 Color Grade 都执行；本 Phase 只执行第一个。删除能力已在 NM1 证明，NM2 不得再拿「compiler 需要 `grade.primary`」限制删除。
+- **NM4：** 把 `OrdinaryEditPayload` 换成 typed `PipelineEditBatch`；checkpoint 存文档而不是只存 stage params。
+
+---
+
+## 16. Completion records
+
+NM1.1 (2026-08-29): complete — recorded under §7.
+
+后续子 Phase 完成后按同一模板追加。模板：
+
+##### Phase NM1.x completion record (YYYY-MM-DD)
+
+**Status:** complete | partial — …
+
+**Primary success call chain:** （`text` 箭头链）
+
+**Primary failure call chain:**
+
+**What was proven (executed tests):** 表
+
+Commands: …
+
+**Remaining gaps:**

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
@@ -2,833 +2,589 @@
 
 Date: 2026-08-29
 
-Status: in progress — NM1.1–NM1.3 complete; NM1.4–NM1.5 not started.
+Revised: 2026-08-30 — 按单 live document、原地函数应用、共享 executor 重定执行方案。
+
+Status: in progress — NM1.4 A 已完成并通过本版验收，NM1.1/NM1.3 的原地参数修改与局部恢复已修正；NM1.2 保留；NM1.4 B/C、NM1.5 待实施。
 
 Branch: `feature/pipeline-document-editing`
 
-Base: `origin/main` at NM0 merge (`d5a96267`, QuickQanava pin already on main).
+Base: `origin/main` at NM0 merge (`d5a96267`)。
 
-对应总体方案：[Node-aware Pipeline Editing and Mask Authoring 总体方案](../node_mask_editor_master_plan.md) 第 2.1、6、7.1、11、21.2 节。
+对应[总体方案](../node_mask_editor_master_plan.md)第 2.1、6、11、21.2、21.5 节。
+[NM0](phase_nm0_quickqanava_integration_plan.md)只记录 QuickQanava 接入；history 的阶段边界定义在总体方案 NM4。
 
-本文件是 NM1 的执行方案。总体方案只跟踪一级 Phase；本文件拆 `NM1.1`–`NM1.5`，并记录调用链、测试和未完成项。
-
----
-
-## 1. 必读
-
-- [总体方案](../node_mask_editor_master_plan.md)
-- [GPU DAG 编辑管线重构 Phase 计划](../gpu_dag_pipeline_rebuild_phase_plan.md) 中 format v2、`CreateDefaultPipelineDocument`、`LegacyPipelineImporter`
-- 本仓库 `AGENTS.md`：roadmap 用词禁令、测试禁止 `smoke`、临时文件只放 `build/tmp/`
-
-发生冲突时的优先级：
-
-1. 总体方案已锁定的产品语义（单主链、Clean 与 Default 的区别、typed target、失败回滚）。2026-08-30 起，总体方案不再要求旧 stage 项目可打开，也不再要求双向 stage 镜像。
-2. 本执行方案对 NM1 子 Phase、完整 typed target、输入序列锁定、以及 thumbnail DAG 的明确要求。
-3. 当前代码中已经落地的 GPU DAG 三节点 runtime。
+本版替换原 NM1 的整图 candidate、独立 snapshot executor 和多份编辑状态要求。既有功能不推倒重来；
+从当前 NM1.4 工作区继续，先消除 NM1.1/NM1.3 的相关实现债务，再完成渲染和保存读取。
+2026-08-30 的方案修订未撤回未提交源码；其后 NM1.4 A 已定向实施，见第 10.1 节完成记录。过去的测试结果保留在第 16 节，不代表 B/C 或整个 NM1 已完成。
 
 ---
 
-## 2. 开工时源码审计（2026-08-29）
+## 1. 目标与优先级
 
-### 2.1 双写仍然存在
+**NM1 的交付物是一套可以直接使用的内存编辑基础：每张图片一个 live document，参数和结构通过领域函数原地修改；
+同一 executor 根据任务请求渲染；保存读取不再经过 stage 镜像。**
 
-产品编辑状态不是 `PipelineDocument`。当前写入链：
+NM1 结束时，应能从 app/service 测试完成以下流程：
 
-```text
-QML slider
-  -> EditorSessionEditController::HandlePatch(field_key)
-  -> EditorHistoryMutation::CommitAdjustment
-  -> ApplyEditorAdjustmentOperatorState(CPUPipelineExecutor stages)
-  -> GPU ApplyGpuDagProduct
-       if mirror: LegacyPipelineImporter::ApplyOnto(document, stage JSON)
-  -> SavePipeline dirty: Import(stages) 整份替换 document_
-```
+1. 创建或加载 document，取得同一图片的 pipeline 使用权。
+2. 通过完整 target 修改参数；通过领域命令新增、删除、重接 Color Grade。
+3. 用同一 document/executor 交替执行编辑器、缩略图、分析和导出渲染。
+4. 保存并重新读取相同的 document 参数和结构，释放后台任务不触发保存。
+5. 非法输入、任务取消、WAL 写入失败和存储失败均返回真实结果，不留下半次修改或泄漏使用权。
 
-`LoadPipelineDocument` 注释写明：live CPU stages 是 editor source of truth，format v2 图被 remirror。`SyncPipelineDocument` 只写 `document.ToJson()`，但 dirty `SavePipeline` 会用 stages 重建整张图。
+这不是完整节点历史的交付阶段。typed history schema、跨进程节点重放、Version/Paste 和项目格式切换仍属于 NM4。
+Nodes UI 属于 NM5，完整 adjustment UI 接线属于 NM6。
 
-`AllowsLegacyStageAdapterRemirror` 只检查 Develop / `grade.primary` / DRT 三个节点是否存在。
+冲突时按以下顺序执行：
 
-### 2.2 图命令不完整
+1. 2026-08-30 用户确认的本版简化原则和 NM4 边界。
+2. 总体方案的单主链、Default/Clean、完整 target、质量策略与禁止替代实现的产品规则。
+3. 原完成记录和现有代码；它们只说明起点，不能反过来要求保留复制模型。
 
-`PipelineGraph` 只有 `AddNode()` 和 `Connect()`，并公开可变 `Nodes()`。没有断开、删除、桥接或原子 Reconnect。`Validate()` 检查 endpoint 数量、端口类型、环和单端口 fan-in，**不**检查：
+参考：[单 live pipeline、WAL 与 checkpoint 方案](../../ui/editor_single_live_pipeline_wal_checkpoint_plan.md)。
+其中关于单操作对象、history 决定 HEAD 的原则继续适用；历史文档中的不同 root/chain 设计不作为 NM1 新增状态的理由。
 
-- 恰好一条 Develop → … → DRT 的 scene-image 路径；
-- scene-image 禁止 fan-out；
-- 全部 Color Grade 都在这条路径上；
-- Develop / DRT 不可删除、不可替换。
+## 2. 当前起点与未提交改动处置
 
-### 2.3 Default 基线不在文档工厂里
+截至本次审阅：
 
-`ColorGradeNodeModel::MakeDefault()` 用 catalog 默认值：`ExposureModel` 的 `exposure_ev = 0`，`SaturationModel` 的 `saturation = 1.0`。产品 `+1.5 EV` / 旧 UI `+30` 只存在于 `pipeline_defaults::kCleanBaselineExposure` / `kCleanBaselineSaturation`，靠 remirror 灌进图。
+| 已有内容 | 保留的能力 | 必须修正的部分 |
+| --- | --- | --- |
+| NM1.1 图命令与主链校验 | 完整删除、重接、稳定 NodeId、零 Grade 编译 | 命令内整图 JSON 回滚及调用方 candidate clone |
+| NM1.2 Default/Clean 工厂 | Default 的 1.5 EV/1.3 saturation；独立 Clean 工厂 | 不重写该功能 |
+| NM1.3 完整 target 与 live history 接线 | 输入序列锁定、参数写入、同会话参数 Undo/Redo | 每次 preview/settled 的整图 clone、未统一的锁、stage 参数读写 |
+| 未提交 NM1.4 | DAG 像素接线、错误传播、已有真实 RAW 测试准备 | 独立 document/executor、stage export/import、逐层旧格式分流、强制副本独立的测试 |
+| 现有 scheduler/runtime | render lock、任务参数、frame sink 切换、session/单次资源 | 检查所有退出路径和调用方是否真正使用这些能力 |
 
-`LegacyPipelineImporter` 的对应关系已经固定：legacy `exposure = 1.5` → `exposure_ev = 1.5`；legacy `saturation = 30` → 新模型 `1.3`（`1 + offset/100`）。
+执行决定：**在当前工作区定向改写，不执行整批 reset/revert。** 只撤掉下面列出的实现要求；
+删除前确认用途，不触碰无关改动。原 NM1.4 的“complete”已撤销。
 
-注意：现有 `kCleanBaseline*` 名字是产品 Default 观感，不是总体方案里的 Clean（无视觉变化）。NM1 新 API 不得复用 `CleanBaseline` 表示 identity。
+| 文件/实现 | 继续实施时的处置 |
+| --- | --- |
+| `pipeline_service.hpp/.cpp` 的 `PipelineSnapshot`、`LoadPipelineSnapshot`、`ReleasePipelineSnapshot` | 用普通 pipeline 获取/释放承载后台任务；迁移调用方后删除 snapshot 专用对象和生命周期 |
+| `pipeline_document.hpp/.cpp` 的 `HasUsablePipelineGraph` | 将合法性检查集中到 document 读取边界；不再把它作为逐层选择 live、executor、存储或 stage 的分流器 |
+| `pipeline_cpu.cpp` 的 `!require_host_output` remirror 条件 | 删除产品 remirror；不能只保护 host output 而让编辑器继续覆盖 document |
+| `thumbnail_service.cpp`、`export_service.cpp` | 保留 DAG 输出和真实错误；改为持有普通 pipeline 使用权，任务配置移入 render lock |
+| snapshot/thumbnail 测试 | 保留参数、输出、错误、资源释放断言；删除“必须新建 executor”“必须不共享 Model”的验收 |
+| `default_pipeline_test.cpp` 新增的格式探测断言 | 按统一读取边界的行为测试取舍，不为保留辅助函数而保留断言 |
 
-### 2.4 参数没有节点身份
+## 3. 锁定的模型
 
-`EditorAdjustmentPatch` 只有 `field_key` + JSON。`HandlePatch` 不碰 `PipelineDocument`。History payload 仍是 `OrdinaryEditPayload`（`OperatorType + PipelineStageName + field`）。这是 NM4 要换掉的格式；NM1 不改 commit schema。
+| 对象 | 职责 |
+| --- | --- |
+| History | 唯一拥有 Version/HEAD；最终已提交状态的恢复依据 |
+| Live `PipelineDocument` / OperatorModel | 唯一可写内存状态；预览期间允许包含尚未提交的值 |
+| `PipelineGuard` 或等价使用句柄 | 保证同一图片的 document/executor 存活；不是冻结状态 |
+| Executor / Renderer | 读取 document 和本次 RenderRequest；维护运行资源、编译和结果缓存 |
+| Pipeline checkpoint | 已保存 document 及其对应提交位置；只用于快速恢复，不是另一份可编辑状态 |
+| WAL | 保护尚未完成持久化的操作；不是第二份 history |
 
-### 2.5 Thumbnail 仍先重建 stage 再渲染
+“document 是编辑和渲染输入”不等于“document 覆盖 history”。完整的加载顺序在 NM4 接入：
+先恢复合法 WAL、确定 history HEAD，再比较 checkpoint 记录的 commit hash；不匹配则从确定的初始状态重放。
+NM1 不新增并行 HEAD、逐参数 chain hash、document/stage 身份比较或多写者发布协议。
 
-`LoadPipelineSnapshot` 导出 stage JSON，`ImportPipelineParams` 建成独立 `CPUPipelineExecutor`，再 `SetPipelineDocument(..., mirror)`。`ThumbnailService` 把该 executor 交给 `PipelineTask`，`SetForceCPUOutput(true)` 后走 executor Apply。GPU 路径会再次从 stages `ApplyOnto` 文档。这就是「转到 stage 上再渲染」。
+这里的 commit hash 是状态所对应的提交标签，不是 document 内容哈希。不能把实时读取 history HEAD
+当成“参数已应用到该提交”的证明。NM4 负责把实际应用位置与 checkpoint 一起正确保存。
+JSON round-trip 测试、节点定位和渲染缓存键各自保留，不用这些比较来协调多份编辑模型。
 
-分析 rendition 和 export 共用同一 snapshot API。
-
-### 2.6 Compiler 仍按固定 id 找一个 Grade
-
-`GraphCompiler::CompileStatic` 要求 `document.PrimaryGrade()`（`grade.primary`），只编一个 `PrimaryColorGrade` pass。多 Color Grade 存在于图里也不会执行。这是 NM2 的工作。NM1 只把「当前仍只执行一个 Grade」的查找从硬编码 id 改成主链上的 Color Grade 列表，以免删除 `grade.primary` 后文档无法编译。
-
----
-
-## 3. 本 Phase 锁定的产品决定
-
-这些决定来自开工评审，覆盖总体方案 21.2 的原表述。
-
-1. **新编辑的写入权威是 `PipelineDocument`。** 调整条、history 的 live mutation、thumbnail/analysis 像素都不把 CPU stage 当作渲染或提交的源。
-2. **删除能力完整保留。** `RemoveColorGradeAndBridge` 可删除任意 Color Grade，包括 Default / `grade.primary`。不能删除 Develop 或 DRT。删光 Color Grade 后主链为 Develop → DRT，这是合法文档。
-3. **产品不保留双向 stage 镜像。** 新编辑只写 `PipelineDocument`。产品 Load / Save / Apply / thumbnail 不以 CPU stage 表为兼容层。进程内 stage 表可以暂时留在代码里，直到后续 Phase 删除整个 stage；NM1 不得为了旧读取器再做 document → stage 或 stage → document 的产品镜像。
-4. **Thumbnail 和 snapshot 像素必须 DAG 渲染。** 克隆 `PipelineDocument`，交给现有 GPU `Renderer`。禁止 `ExportPipelineParams` → `ImportPipelineParams` → stage Apply 作为出图像素路径。
-5. **History 的 typed `PipelineEditBatch`、Version/Paste、format 升级属于 NM4。** NM1 只要求 live 提交/Undo/Redo 作用在文档上；payload 仍可暂时是 `OrdinaryEditPayload`。NM1 与后续 Phase 都不把旧 mini-git commit 从 stage 身份迁移成 DAG mutation。
-6. **不支持 DAG document 之前的项目。** 存储里若没有可用的 format v2 图（`nodes` 与 `edges`），产品拒绝打开，并返回真实错误。不要把旧 stage JSON import 成默认三节点图。不要为了打开旧项目而改写 mini-git commit。一级 Phase NML（旧存储升级）取消。后续 Phase 删除 stage 表，不做旧项目升级。
-
-### 3.1 2026-08-30 产品规则
-
-NM 方案执行期间不为当前 UI 补完整 target。写入路径按最终生产接口设计。缺少 `owner_kind`、`node_id` 或 `adjustment_instance_id` 的 patch 一律拒绝。app 不根据 field catalog 或当前选中节点填入缺省 target。
+### 3.1 完整 target 与项目读取边界
 
 每个 patch 必须带完整 `EditorParameterTarget`：
 
-- `owner_kind` 为 Document / Develop / ColorGrade / DrtPost 之一（Mask 写入拒绝）
-- `field_key` 非空，且与 patch 上的 `field_key` 相同
-- Document：`node_id` 为空
-- Develop / ColorGrade / DrtPost：`node_id` 非空
-- ColorGrade：`adjustment_instance_id` 非空
-- `mask_id` 在 NM1 必须为空
+- `owner_kind` 为 Document / Develop / ColorGrade / DrtPost；NM1 拒绝 Mask 写入。
+- `field_key` 非空，且与 patch 的 `field_key` 相同。
+- Document 的 `node_id` 为空；其余三类的 `node_id` 非空。
+- ColorGrade 的 `adjustment_instance_id` 非空；NM1 的 `mask_id` 为空。
+- app 不根据字段目录、选中节点或前一次 patch 补缺失 target。
 
-输入序列：第一个合法 patch 锁定 target。同一序列的后续 patch 即使带不同 `node_id`，仍写入锁定的 NodeId。每个后续 patch 仍必须自身完整；不完整则拒绝，不靠锁定去补字段。
+输入序列的第一个合法 patch 锁定 target。同一序列后续 patch 即使携带另一个完整 NodeId，
+仍写锁定目标；后续 patch 自身不完整则拒绝。取消恢复该目标的 before。
+当前 QML 缺完整 target 的请求继续拒绝，不为 NM1 临时补 UI。
 
-产品不保留 stage 镜像，也不打开没有可用图的旧存储。NM1.3 把 live 编辑写入文档。NM1.5 阻止 Apply/Save 用 stage 覆盖文档。后续 Phase 删除 stage 表。NML 取消。
+发布新项目格式后只读取支持的项目元数据版本；旧项目在项目打开入口拒绝，不迁移。
+NM4 负责版本提升和最终 schema 切换，NM1 不提前宣称已经完成版本门禁升级。
+NM1 的 document 读取只接受当前有效图数据；缺失、损坏或非法图明确失败，不从 stage/default/live 另找替代来源。
+新图片导入时创建 Default 是正常初始化；已有图片读取失败后创建 Default 则禁止。
 
----
+### 3.2 NM1 与 NM4 的 history 边界
 
-## 4. 范围与明确排除
+NM1 保留已完成的同会话参数 Commit/Undo/Redo 和 WAL 失败恢复，不将 typed `PipelineEditBatch` 提前实施。
+`OrdinaryEditPayload` 的既有格式可以保留到 NM4；其中的 stage/operator 字段只是旧日志标识，
+不能要求产品继续维护另一张可写 stage 参数表。
 
-### 4.1 NM1 包含
+`document_edit_by_commit` 是 NM1.3 已有的同会话参数 before/after 记录，当前不扩展、不复制成另一份 document、
+不新增持久化、不得作为跨进程重放来源。NM4 用真实 typed payload 替换后删除。
+NM1 可调整其写入，使 before/after 来自 Model 的实际规范化值，并通过相同的领域函数恢复。
 
-- 候选文档 mutation、主链 validation、原子 Add / Remove / Reconnect / Rename / SetEnabled；
-- 稳定 `NodeId`；失败不改 live document / history head；
-- `CreateDefaultPipelineDocument` 在工厂内写入 Default 基线；`MakeClean` / `CreateCleanColorGradeNode`；
-- `EditorParameterTarget`；每个 patch 必须带完整 target；输入序列锁定 target；缺字段拒绝；
-- History live 路径改为写/读文档（payload 格式暂不升级）；
-- Thumbnail、analysis rendition、以及同一 snapshot API 上的像素改为 DAG；
-- 产品 GPU Apply 以文档为渲染输入；
-- `SavePipeline` 不得再用 stages `Import` 整份替换文档；
-- 无可用图的旧存储：Load 失败，不 import。
+完整节点新增/删除/重接的历史记录、进程重启后的节点 Undo/Redo、Version checkout、Paste 和 WAL 节点重放
+均不在 NM1 验收范围。缺少所需记录时不能静默跳过并报告成功，也不能转回 stage 编辑；
+依赖这些能力的用户入口保持未开放。NM1 不为填这个阶段空缺设计新的历史桥接框架。
 
-### 4.2 NM1 不包含
+## 4. 范围
 
-| 排除项 | 归属 |
+| NM1 必须完成 | 本阶段不做 |
 | --- | --- |
-| 主链上多个 Color Grade 的真实 GPU 执行、按 NodeId 的 dirty/cache | NM2 |
-| Clarity / Sharpen / Halation / Film Grain 搬到 DRT/Post | NM2 |
-| 多 Mask、Range 字段落地、不可变 MaskStore `Put()` | NM3 |
-| typed `PipelineEditBatch`、每 Version 一 DAG 的 history schema、Paste、format 提升 | NM4 |
-| 打开或升级 DAG document 之前的 stage-only 项目；迁移 mini-git commit | 不做（NML 取消） |
-| 从代码中删除 CPU stage 表 / `LegacyPipelineImporter` | 后续 Phase，不是 NM1 |
-| Nodes 面板、QuickQanava 生产链接、开放用户 Add 入口 | NM5 |
-| 按节点切换右侧 adjustment stack | NM6 |
-| Viewer 蒙版绘制 | NM7 |
+| 原地参数/图命令；局部失败恢复；统一访问互斥 | 完整 typed history 与节点 recovery（NM4） |
+| Default/Clean；完整 target；同会话已有参数 Undo/Redo | 多 Grade 的完整 GPU 执行、按节点缓存优化、后处理迁移（NM2） |
+| 同一图片的共享 document/executor 渲染 | Mask 列表与资源编辑（NM3） |
+| 停止产品 Load/Save/Apply 的 stage 镜像 | 旧项目和旧提交迁移（不做） |
+| document 序列化保存与读取；导入时模型参数完整 | 新项目 metadata/history schema 切换（NM4） |
+| 获取/释放与持久化分离；任务参数无泄漏 | Nodes/Mask/adjustment UI 接线（NM5–NM7） |
 
-生产 UI 在本 Phase **不**开放新增/删除/重连节点入口。领域 API 和 tests 必须先具备完整删除能力。
+CPU stage 类型和测试工具不必在 NM1 全部删除，但不得继续成为产品参数源或镜像。
+不增加持久化 root document、完整 committed document 副本、shadow CommitGraph 或通用 Prepare/Publish 服务。
+初始默认状态的跨版本稳定性由 NM4 的存储设计保证；NM1 只提供正确的工厂和 Model 操作。
 
----
+## 5. 实现规则
 
-## 5. 跨子 Phase 的实现规则
+### 5.1 状态转移通过函数完成
 
-### 5.1 候选文档 + 失败回滚
+概念上：`DocumentAt(head) = ApplyEdits(initial_document, edits_to_head)`。
+实现上在同一 document 上依次调用领域函数，不需要为每一步分配新 document。
 
-所有图 mutation 和 settled 参数 mutation：
+- 输入解析、值规范化和前置条件检查不产生副作用；通过 Model 行为得到合法的新参数。
+- 局部新参数、待插入节点、受影响边和 before 值可以临时存在；禁止复制无关节点/OperatorModel。
+- JSON 留在请求解析、序列化、既有日志边界和测试比较处，不用整图 JSON 重演 Model 行为。
+- 优先保留已有领域函数，不为“函数式”新增 reducer 框架、命令总线、工厂层或接口层。
+- 原地 setter 必须按现有规则更新 dirty/cache 信息；禁止把所有参数修改都标记成拓扑修改。
 
-```text
-clone PipelineDocument
-  -> apply typed mutation on candidate
-  -> ValidateGraph + ValidateImageBackbone
-  -> 失败：丢弃 candidate；live document、history head、最后一帧不变
-  -> 成功：替换 live document
-```
+### 5.2 原子性与失败恢复
 
-不得先改 live 再捕获异常继续。不得用 CPU 或其他 backend 代替失败的 GPU 路径。
+参数修改：完整解析并校验所改参数，再应用到目标 Model。setter 如果可能部分失败，先保留该参数对象的旧值；
+恢复只涉及该对象，不重建整个 document。曝光、改名等不改变连线的操作不做整图拓扑验证。
 
-### 5.2 主链不变量（在现有 `Validate()` 之上）
+图命令：检查 endpoint、NodeId、插入位置和受影响连接；预先完成必要分配，在同一互斥范围内修改节点和边，
+验证主链；失败将保留的节点/边移回。未受影响的 Model 继续存在。结构验证保留，失败不暴露中间图。
 
-合法 scene-image 拓扑：
+预览开始只捕获一次所改目标的 before；preview 直接改 live，不写 WAL、不创建 commit。
+settled 使用规范化 before/after；没有变化就结束。WAL append/flush 成功后完成既有 history 记录和 live 应用。
+已有 preview 在失败时恢复 before；成功后才确认 dirty 并请求最终渲染。
+失败撤销只涉及本次未生效操作和对应日志尾，不清空此前仍负责恢复的 WAL。
 
-```text
-Develop -> ColorGrade[0] -> ... -> ColorGrade[n] -> DRT/Post
-```
+正常 GPU 执行失败返回真实错误，保留最后一个成功显示结果，不切换算法、后端或质量。
+GPU 输出失败不应被当成隐式 Undo：已经成功记录的编辑仍在；输入/结构验证失败与渲染失败分别处理。
+局部恢复本身失败时明确报告并停止继续使用损坏状态，不能吞异常后继续渲染。
 
-或零个 Color Grade：
+### 5.3 一处访问互斥
 
-```text
-Develop -> DRT/Post
-```
+复用 executor 的 `GetRenderLock()` 及现有 owner-thread 等待方式：
 
-必须拒绝：删 Develop/DRT、替换 endpoint 类型、scene-image fan-in/fan-out、Color Grade 不在主链上、环、端口类型错误。Mask 边仍按现有顶层 mask node 规则验证（NM3 之前不改 Mask 所有权）。
+- Model 写入、图结构修改、序列化读取与渲染读取遵循同一把锁。
+- scheduler 在锁内安装请求参数、执行并完成必要的输出交接；锁外不改共享 executor。
+- 缓存锁只用于查找和 pin，不在持有它时等待渲染、访问 DuckDB 或执行回调。
+- 领域函数不重复获取调用方已持有的锁；明确 app/scheduler 是共享访问边界。
+- 完成、取消和异常都恢复请求参数、frame sink 并释放使用权；释放不能在回调中递归等待同一 render lock。
 
-### 5.3 删除与当前单 Grade compiler
+同图任务串行，不承诺后台任务零等待；复用现有优先级/取消机制，不另起任务系统。
 
-NM2 之前 runtime 仍然只执行 **一个** Color Grade。NM1 必须让删除后的文档仍能编译当前形状：
+### 5.4 单主链
 
-```text
-Color grades on image backbone
-  0 -> 跳过 PrimaryColorGrade pass，DRT 输入接 Develop 输出
-  1 或更多 -> 只编译主链上第一个 Color Grade（按路径顺序，不要求 id 为 grade.primary）
-```
+合法图为 `Develop -> ColorGrade[0..n] -> DRT/Post`；零 Grade 时 Develop 直连 DRT。
+拒绝删除/替换 endpoint、环、scene-image fan-in/fan-out、端口类型错误和游离 Color Grade。
+NM3 之前不重写 Mask 所有权。
 
-其余 Color Grade 保存在文档里，本 Phase 不执行。这不是多 Grade runtime。
+NM2 之前 compiler 保留现有阶段能力：零 Grade 跳过 Grade pass；有 Grade 时编译主链第一个，
+不能依赖它叫 `grade.primary`。多 Grade GPU 执行留在 NM2，不对用户开放新增节点入口。
+NM1 的新像素验收使用当前已支持的默认图，图命令的多节点测试验证模型与编译结果，不冒充多节点渲染证明。
 
-`PipelineDocument::PrimaryGrade()` 对默认三节点文档仍可按 `grade.primary` 查找，供现有 tests 使用。Compiler 不得再把「缺少 `grade.primary`」当成硬失败，只要主链合法。
-
-### 5.4 Stage 表与打开规则
-
-产品写入与渲染方向：
-
-| 方向 | NM1 是否允许 | 用途 |
-| --- | ---: | --- |
-| 新编辑 → `PipelineDocument` | 必须 | 唯一新写入权威 |
-| document → stage 表（产品兼容镜像） | 禁止 | 不为旧读取器保留镜像 |
-| stage → document 覆盖一次**新的**文档编辑 | 禁止 | 这是当前 Save/Apply remirror 的缺陷 |
-| thumbnail/analysis：stage JSON → Import → Apply | 禁止 | 必须 DAG |
-| 无图的旧 stage 存储 → Import 成默认三节点后打开 | 禁止 | 拒绝打开，返回真实错误 |
-
-`LegacyPipelineImporter` 可以暂时留在仓库，供现有 GPU DAG 测试使用。产品 Load 不得用它打开用户项目。后续删除 stage 的 Phase 再删除 importer。
-
-NM1.5 仍必须从产品 Apply/Save 中移除 live stages `ApplyOnto` / `Import` 覆盖文档。这是停止双写，不是旧项目兼容。
-
-### 5.5 文件体量
-
-`pipeline_service.cpp` 已经很大。本 Phase 若继续往里堆 Load/Save/snapshot 逻辑，按职责拆出 document persist / snapshot 辅助单元，而不是再加一整段。`EditorPipelineCommandService` 必须是独立类型，不把图规则塞回 `PipelineMgmtService` 或 QML。
-
----
-
-## 6. 子 Phase 顺序
+## 6. 从当前工作区继续的顺序
 
 ```text
-NM1.1 主链 validation 与图命令（含完整删除）
-  -> NM1.2 Default / Clean 工厂
-  -> NM1.3 typed target 与参数写入文档（含 history live）
-  -> NM1.4 thumbnail / snapshot DAG 渲染
-  -> NM1.5 产品写入权威与 Save/Apply 停止用 stage 覆盖新文档
+NM1.4 A：修正 NM1.1/NM1.3 的原地修改与锁
+  -> NM1.4 B：统一 document 输入，删除产品 Apply 的 stage 覆盖
+  -> NM1.4 C：后台任务共用 pipeline/executor，迁移并删除 snapshot API
+  -> NM1.5：统一保存读取、导入初始化与释放边界，执行全阶段验收
 ```
 
-同一分支 `feature/pipeline-document-editing` 上按序落地。可以按 `NM1.1+NM1.2`、`NM1.3`、`NM1.4`、`NM1.5` 拆 PR；不要把 NM2–NM8 塞进本分支。
+A/B/C 是 NM1.4 内部实施顺序，不新增一级 Phase。B 必须先于 C，避免共享 executor 后编辑器再次覆盖后台所读文档。
+每一段应可单独构建和运行受影响测试；完整 NM1 以第 14 节为准。
 
----
+## 7. NM1.1 保留的图能力
 
-## 7. NM1.1 — 主链 validation 与图命令
+保留 `AddCleanColorGrade`、`RemoveColorGradeAndBridge`、`ReconnectColorGrade`、
+`RenameColorGrade`、`SetColorGradeEnabled`；参数中的 document 表示当前操作对象，不再要求 candidate。
 
-### 7.1 结果
+- Add 在指定 `before_node_id` 之前插入；指定 DRT 则插入主链末尾。
+- Remove 可删除任意 Grade，包括 `grade.primary`；删除最后一个后桥接 Develop/DRT。
+- Rename 不改 NodeId；Develop/DRT 不允许以 Grade 命令修改。
+- 图容器不向 UI 暴露可变访问；测试用领域命令或专用 fixture 建图。
+- forward/inverse 后参数与连接恢复；不要求副本有不同地址。
 
-领域层可以原子地 Add / Remove / Reconnect / Rename / SetEnabled。QML 仍不能改 `Nodes()` / `Edges()`。删除任意 Color Grade（含 `grade.primary`）后文档满足第 5.2 节不变量。Compiler 按 5.3 编译。
+已有主链校验、删除与 compiler 测试继续保留。整图复制和 JSON 回滚的删除由 NM1.4 A 完成，
+不能因这部分代码已经提交就排除在简化范围外。
 
-### 7.2 API
+## 8. NM1.2 保留的 Default/Clean
 
-```cpp
-auto AddCleanColorGrade(PipelineDocument& candidate, const NodeId& before_node_id,
-                        NodeId new_id) -> std::vector<GraphValidationError>;
-auto RemoveColorGradeAndBridge(PipelineDocument& candidate, const NodeId& node_id)
-    -> std::vector<GraphValidationError>;
-auto ReconnectColorGrade(PipelineDocument& candidate, const NodeId& node_id,
-                          const NodeId& new_predecessor_id, const NodeId& new_successor_id)
-    -> std::vector<GraphValidationError>;
-auto RenameColorGrade(PipelineDocument& candidate, const NodeId& node_id,
-                       std::string display_name) -> std::vector<GraphValidationError>;
-auto SetColorGradeEnabled(PipelineDocument& candidate, const NodeId& node_id, bool enabled)
-    -> std::vector<GraphValidationError>;
-```
+`CreateDefaultPipelineDocument()` 创建 Develop、Default Grade、DRT；
+Default 自带 exposure 1.5 EV、saturation 1.3，不经过 importer。
 
-`RemoveColorGradeAndBridge`：删除该节点及其相邻两条 scene-image 边，再把前驱接到后继。一次调用，不暴露中间图。
+`CreateCleanColorGradeNode()` / `MakeClean()` 创建无视觉变化 Grade：
+exposure 0 EV、saturation 1.0、enabled、mix 1、无 mask，
+不包含 Clarity/Sharpen/Halation/Film Grain。Default 内现有后处理项由 NM2 搬到 DRT/Post。
 
-`AddCleanColorGrade(before_node_id)`：在 `before_node_id` 之前插入（即新节点成为 `before` 的前驱）。若 `before` 是 DRT，则插在最后一个 Color Grade（或 Develop）之后。具体插入点必须在测试里写死，并与日后 NM5 UI 一致。
+历史重放所说的 clean ground 是清除旧用户编辑后得到的确定初始文档，必须保留图片固有参数；
+不等于把 Default 改成 Clean Grade，也不等于添加一份持久化 root snapshot。
 
-节点需要 `display_name`。Develop / DRT 显示名固定，Rename 拒绝。Color Grade 改名不改 `NodeId`。
+## 9. NM1.3 保留的参数能力
 
-关掉 `PipelineGraph::Nodes()` 的可变引用。测试用命令或测试 builder 建图。
-
-### 7.3 主成功调用链
+完整 target、输入序列锁定和拒绝规则按第 3.1 节执行。同会话已有参数 Undo/Redo 按第 3.2 节执行。
 
 ```text
-test / future EditorPipelineCommandService
-  -> ClonePipelineDocument
-  -> RemoveColorGradeAndBridge(candidate, node_id)
-  -> Validate + ValidateImageBackbone
-  -> GraphCompiler::CompileStatic (5.3 规则)
-  -> replace live document
+HandlePatch(complete target)
+  -> validate target / parse and normalize parameters
+  -> lock shared live pipeline
+  -> capture local before once; apply through Model
+  -> preview: request render
+  -> settled: record existing WAL/history edit; finish live change
+  -> Undo/Redo: apply recorded local before/after through the same Model operation
 ```
 
-### 7.4 主失败调用链
+`PublishEditorParameterPatch` 的 clone/validate-whole-graph/move 实现应被直接应用函数取代。
+before/after 不能继续从 stage 表读取；既有 payload 需要的字段表示在原有窄边界处理，
+不能因为旧日志仍有 `stage_name` 就调用 stage `SetOperator` 维护镜像。
+不新建完整 committed document；已有 UI 参数投影只读，不能成为编辑源。
 
-```text
-Remove Develop or DRT
-  or Reconnect that creates scene-image fan-out
-  -> candidate discarded
-  -> live ToJson hash, node count, history head unchanged
-```
+## 10. NM1.4 — 原地编辑与共享 DAG 渲染
 
-### 7.5 文件
+Status: partial — A complete（2026-08-30）；B/C rework required。A 使用下列新证据，B/C 不沿用旧 clone 测试的完成结论。
 
-- `alcedo_studio/src/include/edit/graph/pipeline_graph.hpp`
-- `alcedo_studio/src/edit/graph/pipeline_graph.cpp`
-- `alcedo_studio/src/include/edit/graph/graph_validation.hpp`
-- 新 `pipeline_graph_commands.hpp` / `.cpp`（或同等名字；命令拥有规则，`PipelineGraph` 不向 UI 暴露容器）
-- `alcedo_studio/src/include/edit/graph/pipeline_document.hpp` / `.cpp`（主链遍历、`display_name`）
-- `alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp` / `.cpp`
-- `alcedo_studio/src/include/edit/graph/i_node_model.hpp`（display name）
-- `alcedo_studio/src/edit/runtime/graph_compiler.cpp`（5.3 查找规则）
-- `alcedo_studio/tests/edit/graph/graph_validation_test.cpp`
-- 新 `alcedo_studio/tests/edit/graph/pipeline_graph_command_test.cpp`
-- `alcedo_studio/tests/edit/CMakeLists.txt`（`GpuDagModelGraphTest`）
+### 10.1 A：原地修改和局部恢复
 
-### 7.6 测试
+工作：
 
-| 名称 | 断言 |
-| --- | --- |
-| `AddCleanColorGradeKeepsSingleImageBackbone` | 插入后仍一条 Develop→…→DRT 路径，新 NodeId 稳定 |
-| `RemoveColorGradeAndBridgeConnectsPredecessorToSuccessor` | 一次调用后无悬空边；前驱接到后继 |
-| `RemovePrimaryGradeKeepsRemainingGradesAndValidBackbone` | 删除 `grade.primary` 后其余 Color Grade 仍在主链，NodeId 不变 |
-| `RemoveLastColorGradeLeavesDevelopConnectedToDrt` | 零 Color Grade 合法 |
-| `RemoveDevelopOrDrtIsRejectedWithoutMutation` | hash 与节点数不变 |
-| `InvalidReconnectLeavesDocumentHashUnchanged` | 非法 fan-out/环不改 canonical JSON |
-| `GraphMutationInverseRestoresCanonicalDocumentJson` | forward 再 inverse，canonical JSON 一致 |
-| `GraphCompilerSkipsGradePassWhenBackboneHasNoColorGrade` | 零 Grade 时 CompileStatic 成功且无 PrimaryColorGrade |
-| `GraphCompilerCompilesFirstBackboneGradeWhenPrimaryIdIsAbsent` | 仅剩非 `grade.primary` 的 Grade 时仍能编译那一个 |
+1. 清理 `editor_pipeline_command_service.cpp` 的整图 clone；规范化参数后直接调用 Model。
+2. 清理 `pipeline_graph_commands.cpp` 的整图 JSON 回滚；保留受影响节点/边以便恢复。
+3. 统一 `editor_history_mutation.cpp` 中 preview/settled/Undo/Redo 的 document 访问锁。
+4. 同会话 before/after 来自 document，删除为维持 stage 镜像发生的参数读写。
+5. 保留未知字段、缺 target、Mask target、无效拓扑、WAL 失败的拒绝与恢复行为。
 
-Canonical JSON：对 `ToJson()` 做稳定序列化比较（节点/边顺序确定）。不要用指针或 Qan 对象。
+验收：
 
-##### Phase NM1.1 completion record (2026-08-29)
+- `ParameterPatchPreservesUnchangedModels`：修改一个值，其余节点/Model 不重建，所改值正确。
+- `InvalidParameterLeavesLiveValueAndHistoryHeadUnchanged`：非法输入不部分改值。
+- `GraphCommandFailureRestoresAffectedNodesAndEdges`：失败恢复精确连接、NodeId 和参数。
+- 重新运行现有完整 target、输入锁定、Undo 和 `JournalAppendFailureRestoresDocumentExposureEv` 测试。
+- 参数重复修改不触发整图序列化，也不改变无关拓扑；用调用链检查及必要的测试计数证明，不新增生产观测框架。
 
-**Status:** complete — atomic graph commands, image-backbone validation, const-only `Nodes()`, GraphCompiler first-backbone-grade lookup.
+#### NM1.4 A completion record (2026-08-30)
+
+**Status:** complete — 参数直接写既有 Model；结构修改只保留受影响节点/边；preview、settled、同会话 Undo/Redo、取消和显式 HEAD 移动在 executor render lock 内访问 document。
+
+**实现与验收清单：**
+
+- [x] `PublishEditorParameterPatch` 直接调用 `ApplyEditorParameterPatch`，不 clone、整图验证或替换 live document。
+- [x] 在 Model setter 前检查参数键、类型、有限数值和数组长度；Model 执行既有规范化。setter 异常仅恢复该 Model；恢复异常返回明确错误。
+- [x] Add/Remove/Reconnect 经 `PipelineGraph::ApplyBackboneEdit` 预留容器容量，只暂存受影响边及删除节点的原对象；失败恢复节点所有权和精确边顺序。Rename/Enabled 不验证整图。
+- [x] 首个成功 patch 锁定 target 并捕获 before；无效首 patch 不锁定目标，后续不完整 target 仍拒绝。
+- [x] WAL/history 的 before/after 来自规范化后的 document；相同规范化值不产生 commit。仅在既有日志边界将 `exposure_ev` 表示为 `exposure`，不调用 stage 参数读写。
+- [x] 同会话 Undo/Redo 仅应用所经过提交的局部值。无同会话 document target 的记录在 WAL publication 前拒绝，不经 stage 重放；完整 merge/跨会话重放仍属于 NM4。
 
 **Primary success call chain:**
 
 ```text
-test / future EditorPipelineCommandService
-  -> ClonePipelineDocument (or mutate a candidate)
-  -> RemoveColorGradeAndBridge / AddCleanColorGrade / ReconnectColorGrade
-  -> PipelineGraph::Validate + ValidateImageBackbone
-  -> GraphCompiler::CompileStatic (0 grades: skip PrimaryColorGrade; else first backbone grade)
-  -> replace live document (candidate kept on success)
+EditorSessionEditController::HandlePatch(complete target)
+  -> EditorHistoryMutation::CaptureAdjustmentBeforePreview
+  -> LockLivePipeline(GetRenderLock) -> capture target Model before once
+  -> ApplyEditorParameterPatch -> validate supplied values -> existing Model::LoadJson/setters
+  -> CommitAdjustment: read normalized after -> PrepareAppendEdit -> PublishPreparedEdit(WAL/history)
+  -> record local before/after + update read-only panel projection -> release lock -> RenderRouted
+
+Undo / Redo / MoveHeadToCommit
+  -> same render lock -> prepare head move -> resolve existing local target records
+  -> PublishPreparedHeadMove -> ApplyEditorParameterPatch(local before/after)
+  -> update panel projection -> release lock
+
+Add / Remove / Reconnect Color Grade
+  -> check endpoints and affected edges -> ApplyBackboneEdit
+  -> retain removed node/edges -> mutate -> Validate + ValidateImageBackbone
+  -> success: mark topology dirty, retain all unrelated Models
 ```
 
 **Primary failure call chain:**
 
 ```text
-Remove Develop or DRT
-  or Reconnect that creates scene-image fan-out
-  -> command returns GraphValidationError
-  -> candidate restored from ToJson snapshot
-  -> live ToJson dump, node count, and history head unchanged
+invalid target / unknown field / Mask / invalid parameter
+  -> reject before setters -> live value and history HEAD unchanged
+throwing Model setter -> restore this Model's before value -> return real error
+WAL append failure after preview -> restore locked target's before -> no HEAD advance
+invalid graph edit -> restore original node ownership and edge order -> return validation errors
+history record missing same-session target -> reject before WAL/document mutation
 ```
 
 **What was proven (executed tests):**
 
-| Required name / criterion | Target / binary | Result |
+| Required name / criterion | Target / suite | Result |
 | --- | --- | --- |
-| `AddCleanColorGradeKeepsSingleImageBackbone` | `GpuDagModelGraphTest` | PASS |
-| `RemoveColorGradeAndBridgeConnectsPredecessorToSuccessor` | `GpuDagModelGraphTest` | PASS |
-| `RemovePrimaryGradeKeepsRemainingGradesAndValidBackbone` | `GpuDagModelGraphTest` | PASS |
-| `RemoveLastColorGradeLeavesDevelopConnectedToDrt` | `GpuDagModelGraphTest` | PASS |
-| `RemoveDevelopOrDrtIsRejectedWithoutMutation` | `GpuDagModelGraphTest` | PASS |
-| `InvalidReconnectLeavesDocumentHashUnchanged` | `GpuDagModelGraphTest` | PASS |
-| `GraphMutationInverseRestoresCanonicalDocumentJson` | `GpuDagModelGraphTest` | PASS |
-| `GraphCompilerSkipsGradePassWhenBackboneHasNoColorGrade` | `GpuDagModelGraphTest` | PASS |
-| `GraphCompilerCompilesFirstBackboneGradeWhenPrimaryIdIsAbsent` | `GpuDagModelGraphTest` | PASS |
+| `ParameterPatchPreservesUnchangedModels` | `EditorPipelineCommandServiceTest` | PASS；40 次参数修改保留全部节点/Model 地址、无关 dirty 状态与拓扑；测试内计数 Model 的序列化调用为 0 |
+| `InvalidParameterLeavesLiveValueAndHistoryHeadUnchanged` | `EditorSessionHistoryPortTest.EditorDocumentHistoryTest` | PASS；首个非法值和 settled 非法值均不部分应用或移动 HEAD |
+| `GraphCommandFailureRestoresAffectedNodesAndEdges` | `GpuDagModelGraphTest` | PASS；重接、删除、插入校验失败恢复对象、NodeId、参数和精确连接；非法图上的原位置重接也被拒绝 |
+| `InvalidCompoundParameterDoesNotPartiallyApplyOrDirtyModel`、`GeometryAndDevelopRejectInvalidValuesBeforeAnyWrite` | `EditorPipelineCommandServiceTest` | PASS；错误类型、未知键、非有限值与复合参数边界 |
+| `ThrowingSetterRestoresOnlyAffectedModelParameters` | `EditorPipelineCommandServiceTest` | PASS；注入 setter 部分写入后抛异常，局部值恢复且其余对象不重建 |
+| 既有完整 target、输入序列锁定、未知字段/Mask 拒绝、`UndoSettledExposureRestoresDocumentValue`、`JournalAppendFailureRestoresDocumentExposureEv` | `EditorSessionHistoryPortTest.EditorDocumentHistoryTest` | PASS；原行为测试移至独立 document fixture，保留断言目标 |
+| `RejectedFirstPatchDoesNotLockTargetAndHistoryUsesNormalizedModelValues` | `EditorSessionHistoryPortTest.EditorDocumentHistoryTest` | PASS；额外 Grade 目标独立、clamp 后 before/after 入日志、规范化 no-op、Undo/Redo 与 stage 不变 |
+| `PreviewCommitUndoRedoAndCancelWaitForRenderLock` | `EditorSessionHistoryPortTest.EditorDocumentHistoryTest` | PASS；持锁屏障与 promise 控制顺序，无 sleep；所有操作等待同一锁，地址保持且 stage 不变 |
 
-Commands:
-
-```text
-cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagModelGraphTest
-ctest --test-dir build/debug -R GpuDagModelGraphTest --output-on-failure
-cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagRawInputTest
-ctest --test-dir build/debug -R "GpuDagRawInputTest.GpuDagGraphCompiler" --output-on-failure
-```
-
-Suite totals: `GpuDagModelGraphTest` 42/42 PASS; `GpuDagRawInputTest.GpuDagGraphCompiler` 18/18 PASS.
-
-**Checklist / exit condition:** NM1.1 API, backbone validation, deletion including `grade.primary`, and compiler 5.3 lookup are done. NM1 overall exit items for Default/Clean factories, typed targets, thumbnail DAG, and product Save/Apply remain for NM1.2–NM1.5.
-
-**LOC note (grill-code-review):** largest changed files — `pipeline_graph.cpp` 364, `pipeline_graph_commands.cpp` 318, `graph_compiler.cpp` 302, `pipeline_graph_command_test.cpp` 222. All under 1000 LOC; commands own mutation rules as a separate type from `PipelineGraph`.
-
-**Remaining gaps:** `AddCleanColorGrade` currently inserts `ColorGradeNodeModel::MakeDefault` (Clean vs Default factories are NM1.2). CUDA/OpenCL/Metal grade encoders and `result_content_key` still look up `document.PrimaryGrade()` (`grade.primary`); CompileStatic no longer requires that id, but GPU execute of a non-primary remaining grade is not proven here (NM2 execution). Production UI still has no Add/Remove entry (NM5).
-
----
-
-## 8. NM1.2 — Default 与 Clean 工厂
-
-### 8.1 结果
-
-两个入口从名字上即可区分：
-
-```cpp
-auto CreateDefaultPipelineDocument() -> PipelineDocument;
-auto CreateCleanColorGradeNode(NodeId id) -> std::unique_ptr<ColorGradeNodeModel>;
-// 或 ColorGradeNodeModel::MakeClean(NodeId)
-```
-
-`CreateDefaultPipelineDocument()`：
-
-- Develop、Default Color Grade（默认仍可用 id `grade.primary`）、DRT；
-- Default Color Grade 带产品基线：`exposure_ev = 1.5`，saturation `1.3`（对应旧 `+30`）；
-- 其余 Default 调整与当前 `MakeDefault` 目录一致（含 Clarity/Sharpen/Halation/Film Grain，直到 NM2 搬家）；
-- 不依赖 remirror 才能得到基线。
-
-`CreateCleanColorGradeNode()` / `MakeClean()`：
-
-- Exposure `0 EV`，saturation `1.0`，其余 Color Grade 参数为无视觉变化；
-- `enabled = true`，`mix = 1`，无 mask；
-- **不含** Clarity、Sharpen、Halation、Film Grain；
-- 不是 Default 节点改几个 Patch 装出来的。
-
-现有 `pipeline_defaults::kCleanBaseline*` 可以继续给 CPU 兼容层用，但新文档工厂代码用 Default / identity 这类准确名字。
-
-### 8.2 主成功调用链
+Commands（仓库根目录）：
 
 ```text
-CreateDefaultPipelineDocument
-  -> MakeDefault Color Grade
-  -> set exposure_ev 1.5 and saturation 1.3
-  -> ValidateImageBackbone empty
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagModelGraphTest EditorPipelineCommandServiceTest EditorSessionHistoryPortTest EditorAdjustmentPipelineTest EditorSessionEditControllerTest
+ctest --test-dir build/debug -R "GpuDagModelGraphTest|EditorPipelineCommandServiceTest|EditorSessionHistoryPortTest|EditorAdjustmentPipelineTest|EditorSessionEditControllerTest" --output-on-failure
 ```
+
+Suite totals: **121/121 PASS，0 skipped** — Graph 47、CommandService 8、HistoryPort 49（含 document 编辑 13）、AdjustmentPipeline 6、SessionEditController 11。
+最终日志：`build/tmp/nm1/nm14a-final-build.log`、`build/tmp/nm1/nm14a-final-ctest.log`。
+
+**旧测试调整：** 移除“preview 不取渲染锁”的过时前提，由新的五类操作互斥测试覆盖；曝光请求 fixture 使用 `exposure_ev`，参数结果以 document 和 Model 的 clamp 后值为准；四个无 document target 的旧历史移动测试改为断言真实拒绝、HEAD/document/投影/WAL 不变。Version/Paste 的其余既有回归仍运行；未通过恢复 stage 写入使旧断言通过。
+
+**Checklist / exit condition:** 第 10.1 节五项工作和全部验收已完成。仅勾选第 14 节由 A 证明的两个条件；NM1.4 整体保持 partial，B/C 与 NM1.5 未完成。
+
+**LOC note（grill-code-review）：**
+
+| 本次文件 | 总 LOC | Diff + / - |
+| --- | ---: | ---: |
+| `src/app/editor_pipeline_command_service.cpp` | 253 | +65 / -27 |
+| `src/include/app/editor_pipeline_command_service.hpp` | 57 | +14 / -17 |
+| `src/edit/graph/pipeline_graph.cpp` | 425 | +61 / -0 |
+| `src/include/edit/graph/pipeline_graph.hpp` | 98 | +11 / -0 |
+| `src/edit/graph/pipeline_graph_commands.cpp` | 252 | +51 / -117 |
+| `src/include/edit/graph/pipeline_graph_commands.hpp` | 74 | +17 / -12 |
+| `src/ui/alcedo_main/album_backend/editor_history_mutation.cpp` | 503 | +126 / -210 |
+| `src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp` | 66 | +9 / -3 |
+| `src/include/ui/alcedo_main/album_backend/editor_history_state_detail.hpp` | 101 | +1 / -1 |
+| `tests/app/editor_pipeline_command_service_test.cpp` | 206 | +132 / -0 |
+| `tests/edit/graph/pipeline_graph_command_test.cpp` | 296 | +41 / -0 |
+| `tests/edit/history/editor_document_history_test.cpp` | 351 | +351 / -0 |
+| `tests/edit/history/editor_session_history_port_test.cpp` | 1843 | +104 / -339 |
+| `tests/ui/CMakeLists.txt` | 1399 | +1 / -0 |
+
+原 `editor_session_history_port_test.cpp` 仍超过 1,000 LOC：本次已将 document 参数行为及其独立 guard/document/WAL fixture 移到 `editor_document_history_test.cpp`，没有继续向旧 fixture 添加该职责。旧文件剩余 Version/Paste/持久化集成与纯投影测试不在 A 中重构；将来可按 transfer、persistence、projection 分成独立 fixture，每组自行拥有所需 graph/guard/journal/services，不能以共享巨大 fixture 的方式拆文件。`tests/ui/CMakeLists.txt` 是测试注册清单，本次仅加一个源文件，无运行时状态需要拆分。
+
+**Residual gaps / scope boundaries:** B 的产品 Apply remirror、C 的共享后台 executor/lifetime、NM1.5 的统一 I/O 仍保留当前工作区实现，未修改也未以 A 的测试宣称通过；无真实 RAW/GPU 像素或完整应用交互验收。NM4 的 typed history、跨会话节点/merge 重放及 Version/Paste 新模型接线没有提前实施。全树术语扫描未发现 roadmap 违规；本次代码/测试无禁用术语，其他 QML/旧源码的既存命名未纳入此范围。
+
+### 10.2 B：让所有产品渲染只读 document
+
+工作：
+
+1. 从 `ApplyGpuDagProduct` 删除产品 `LegacyPipelineImporter::ApplyOnto`，不再按 host/editor 区分参数来源。
+2. 产品渲染要求绑定同一 live document；缺失时返回真实错误，不能去 executor/stage/store 找替代文档。
+3. executor 的请求配置仅处理输出、decode、ROI、sink、cache 等运行参数，不能修改持久 Model。
+4. RAW camera/profile/lens 参数在正常导入或 document 加载时准备到位；
+   移除任务调用方为复制 executor 而重新灌入 stage 参数的动作，不改变既有解码质量。
+5. 保留现有 Renderer 资源策略；没有证据时不重写缓存或强制共享全部 GPU 中间资源。
+
+验收：
+
+- `EditorAndHostRenderUseDocumentParameters`：实际改变 document 参数后，编辑器/host 输出符合该值；
+  用可区分的像素结果或可靠的数值参考证明，不只断言输出非空和 JSON 未变。
+- `RenderLeavesPersistentDocumentParametersUnchanged`：不同任务前后持久参数、节点和边相同。
+- 对默认图运行真实 RAW；GPU 失败不进入 CPU、旧 stage 或较低质量出图。
+
+### 10.3 C：共享 pipeline 使用权
+
+工作：
+
+1. cache hit 返回同一图片已有 document/executor；cache miss 走同一创建/读取入口，不建立后台专用加载链。
+2. 任务持有使用句柄至真正完成；缓存淘汰不能使使用中的对象失效，也不能同时创建同图片的另一套 live 对象。
+3. 获取、释放与保存分开。释放最后一个后台使用权也不写存储、不清 dirty；
+   编辑器仍持有使用权时不能清掉其 GPU session cache。
+4. thumbnail、analysis 和 export 都使用普通 pipeline 句柄；迁移调用方后删除 snapshot 专用 API。
+5. `SetForceCPUOutput`、decode/resize、frame sink 等共享 executor 配置只在 scheduler 锁内发生。
+   使用既有请求参数保存/恢复机制，不另加一份编辑状态快照。
+6. 任务使用取得 render lock 时的 document，渲染期间不允许写入。
+   缩略图不保证与编辑器每帧同步；analysis/export 的单次输出必须来自同一次连贯读取，
+   不宣称冻结了排队时刻的参数。NM1 不新增按任意历史 HEAD 导出的能力。
+7. 沿用现有缩略图失效/取消机制。若磁盘结果按提交标签缓存，不能把排队时旧标签贴到执行时新像素上；
+   预览值也不能冒充已提交结果写入该缓存。必要时只不写这次磁盘缓存，仍交付实际渲染结果。
+   这是现有缓存写入的正确性要求，不新增 hash/token/修订号，也不恢复冻结 document。
+8. 所有完成回调只终结一次；避免 callback 在 render lock 内释放资源时重复取锁。
+
+主调用链：
 
 ```text
-AddCleanColorGrade
-  -> CreateCleanColorGradeNode
-  -> insert + reconnect candidate backbone
+Thumbnail / Analysis / Export
+  -> acquire normal pipeline handle (same element => same live document/executor)
+  -> PipelineTask(input, RenderRequest, handle)
+  -> scheduler: lock -> configure -> Renderer::Render(document) -> restore -> unlock
+  -> deliver output / real error / cancellation
+  -> release handle (no save)
 ```
 
-### 8.3 主失败调用链
+关键验收：
 
-```text
-UI or test tries to build a Clean node by patching Default
-  -> not an API; tests assert MakeClean identity without going through Default
-```
-
-### 8.4 文件
-
-- `color_grade_node_model.hpp` / `.cpp`
-- `pipeline_document.hpp` / `.cpp`
-- `alcedo_studio/tests/edit/graph/default_pipeline_test.cpp`
-- 新或并入 `pipeline_graph_command_test.cpp` 的 Clean 断言
-
-### 8.5 测试
-
-| 名称 | 断言 |
+| 测试 | 必须观察到的行为 |
 | --- | --- |
-| `DefaultPipelineDocumentBakesOnePointFiveEvAndSaturationOnePointThree` | 不经 importer，Default Grade 即为 1.5 / 1.3 |
-| `MakeCleanColorGradeUsesIdentityParamsAndOmitsPostAdjustments` | 0 EV、sat 1.0、无四项后处理 |
-| `AddCleanColorGradeDoesNotCopyDefaultExposureOrSaturation` | 新节点不是 +1.5 / 1.3 |
+| `BackgroundTasksReuseLivePipelineAndDocument` | cache hit 复用同一对象；任务返回实际 DAG 结果 |
+| `BackgroundCacheMissUsesNormalDocumentLoad` | 无后台专用参数导入；并发取得同图片使用权不产生第二份 live |
+| `ThumbnailThenEditorRestoresTaskParameters` | 同 executor 上编辑器→缩略图→编辑器；ROI/decode/sink/输出模式正确恢复 |
+| `AnalysisAndExportUseSharedExecutorWithoutChangingEdits` | 单次读取连贯；分析和完整质量导出不改用户参数 |
+| `CanceledAndFailedTaskReleasesPipelineUse` | 取消/配置异常/Apply 异常各自终结一次，释放 pin、恢复请求状态 |
+| `BackgroundReleaseDoesNotSaveOrClearEditorState` | 无 DB 写入，不清 dirty；编辑器仍持有时缓存不被整体释放 |
+| `DocumentMutationWaitsForSharedRender` | 通过屏障控制读写顺序，观察到完整旧值或新值，无半更新；不用 sleep 猜时序 |
+| `QueuedRenderDoesNotStorePixelsUnderStaleCommitLabel` | 排队后编辑不会造成错误缓存标签；预览不污染已提交磁盘结果 |
 
-##### Phase NM1.2 completion record (2026-08-30)
+### 10.4 修改范围
 
-**Status:** complete — Default document factory bakes +1.5 EV / saturation 1.3; Clean node factory is identity without the four post adjustments.
-
-**Primary success call chain:**
-
-```text
-CreateDefaultPipelineDocument
-  -> ColorGradeNodeModel::MakeDefault (catalog identity, 17 adjustments)
-  -> ApplyDefaultPipelineLook (exposure_ev 1.5, saturation 1.3)
-  -> Validate + ValidateImageBackbone empty
-```
-
-```text
-AddCleanColorGrade
-  -> CreateCleanColorGradeNode / ColorGradeNodeModel::MakeClean
-  -> insert + reconnect candidate backbone
-```
-
-**Primary failure call chain:**
-
-```text
-UI or test tries to build a Clean node by patching Default
-  -> not an API
-  -> MakeClean is a separate type list (13 adjustments); patched Default JSON still differs
-```
-
-**What was proven (executed tests):**
-
-| Required name / criterion | Target / binary | Result |
-| --- | --- | --- |
-| `DefaultPipelineDocumentBakesOnePointFiveEvAndSaturationOnePointThree` | `GpuDagModelGraphTest` | PASS |
-| `MakeCleanColorGradeUsesIdentityParamsAndOmitsPostAdjustments` | `GpuDagModelGraphTest` | PASS |
-| `AddCleanColorGradeDoesNotCopyDefaultExposureOrSaturation` | `GpuDagModelGraphTest` | PASS |
-
-Commands:
-
-```text
-cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagModelGraphTest
-ctest --test-dir build/debug -R GpuDagModelGraphTest --output-on-failure
-```
-
-Suite totals: `GpuDagModelGraphTest` 46/46 PASS.
-
-**Checklist / exit condition:** NM1.2 Default vs Clean factories, baked product look without remirror, and AddClean using MakeClean are done. NM1 overall items for typed targets, thumbnail DAG, and product Save/Apply remain for NM1.3–NM1.5.
-
-**LOC note (grill-code-review):** largest changed files — `pipeline_graph_commands.cpp` 318, `pipeline_graph_command_test.cpp` 255, `color_grade_node_model.cpp` 216, `legacy_import_test.cpp` 209, `pipeline_document.cpp` 176, `default_pipeline_test.cpp` 155. All under 1000 LOC. Clean vs Default lists are separate factories; product look is applied only in `CreateDefaultPipelineDocument`.
-
-**Remaining gaps:** typed `EditorParameterTarget` and history live document writes (NM1.3); thumbnail/snapshot DAG (NM1.4); product Apply/Save still remirror from stages (NM1.5). `pipeline_defaults::kCleanBaseline*` remains for the CPU compat layer. Default Color Grade still includes Clarity/Sharpen/Halation/Film Grain until NM2.
-
----
-
-## 9. NM1.3 — Typed target 与 history live 写文档
-
-### 9.1 结果
-
-```text
-EditorParameterTarget
-  owner_kind: Document | Develop | ColorGrade | ColorGradeMask | DrtPost
-  node_id                  // Document 为空
-  adjustment_instance_id
-  mask_id                  // NM1 只预留；写入拒绝
-  field_key
-```
-
-现有 `EditorAdjustmentPatch` 增加必填 `target`。规则见第 3.1 节：不完整、Mask、未知 field 均拒绝。app 不填缺省 target。
-
-输入序列第一个合法 patch 锁定 target。后续完整 patch 复用该锁定，即使它们携带另一个 `node_id`。
-
-`EditorHistoryMutation::CommitAdjustment` / Undo / Redo 的 **live 效果**写 `PipelineGuard::document_`。不要同步 stage 镜像。失败回滚以文档为准。`OrdinaryEditPayload` 本 Phase 不改 schema。
-
-Mask target 和多节点 UI 选择恢复属于后续 Phase；本 Phase 拒绝 Mask target 写入。
-
-### 9.2 主成功调用链
-
-```text
-HandlePatch(settled)
-  -> lock EditorParameterTarget (first patch of the input sequence)
-  -> Capture before from document
-  -> PrepareAppendEdit(OrdinaryEditPayload)   // schema unchanged
-  -> candidate document SetAdjustmentField
-  -> validate
-  -> PublishPreparedEdit
-  -> publish document
-  -> SettledAdjustment render reads document
-```
-
-### 9.3 主失败调用链
-
-```text
-unknown field, missing instance, or Mask target
-  -> Rejected
-  -> document hash and history head unchanged
-```
-
-```text
-WAL or history publish fails
-  -> restore document to before
-  -> no new head
-```
-
-### 9.4 文件
-
-- `alcedo_studio/src/include/app/editor_adjustment_types.hpp`
-- `alcedo_studio/src/app/editor_adjustment_pipeline.cpp`（未知 field 仍拒绝）
-- `alcedo_studio/src/include/app/editor_pipeline_command_service.hpp` / `.cpp`（完整 target 校验、文档字段写入）
-- `alcedo_studio/src/app/editor_session_edit_controller.cpp`
+- `alcedo_studio/src/app/editor_pipeline_command_service.cpp`
+- `alcedo_studio/src/edit/graph/pipeline_graph_commands.cpp`
 - `alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp`
-- `alcedo_studio/tests/app/editor_adjustment_pipeline_test.cpp`
-- `alcedo_studio/tests/app/editor_pipeline_command_service_test.cpp`
-- `alcedo_studio/tests/app/editor_session_edit_controller_test.cpp`
-- `alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp`
-- `alcedo_studio/tests/support/editor_parameter_target_test.hpp`（测试夹具；不是产品缺省 target）
+- `alcedo_studio/src/include/app/pipeline_service.hpp`、`src/app/pipeline_service.cpp`
+- `alcedo_studio/src/app/thumbnail_service.cpp`、`src/app/export_service.cpp`
+- `alcedo_studio/src/include/renderer/pipeline_task.hpp`、`src/renderer/pipeline_scheduler.cpp`
+- `alcedo_studio/src/include/edit/pipeline/pipeline_cpu.hpp`、`src/edit/pipeline/pipeline_cpu.cpp`
+- 对应 graph、command、history port、pipeline、thumbnail、export 和 scheduler 测试。
 
-### 9.5 测试
+以上路径中缩写的 `src/...` 均相对于 `alcedo_studio/`。
+优先删除旧分支并复用现有函数；文件变大时按已有职责拆分，不用新服务层包住旧复杂度。
 
-| 名称 | 断言 |
+## 11. NM1.5 — 保存读取与阶段验收
+
+Status: not started。
+
+### 11.1 工作
+
+1. `SavePipeline` / `SyncPipelineDocument` 从锁保护的 document 序列化。
+   不 `Import(stages)` 替换图，不写 `legacy_stage_adapter`，不覆盖 history HEAD。
+   编辑器保存前先完成或取消现有预览输入，再保存 settled 状态；不把 preview 标成已提交 checkpoint，
+   也不为绕过这个顺序保留第二份 committed document。
+2. 序列化内容与 dirty 处理对应同一次受保护的状态；写入失败不清 dirty、不清 WAL。
+   保存期间若释放锁，必须保证后续编辑不被这次保存误标为已保存；优先使用现有串行保存边界。
+3. 普通 document 读取集中在一处：解析当前格式并验证节点、边和主链。
+   不“试 live，失败试 executor，再试 store/stage”；单个来源无效就报告错误。
+4. mapper 的产品 document 读写不解包 stage adapter；正常新图片初始化直接从 Default 工厂和图片固有参数建图。
+5. 从产品 load/apply/save 路径移除 remirror；现有旧 history 加载若不能处理新节点记录，不得通过重放 stage 覆盖图。
+   不新增 history root snapshot，不在 NM1 改 commit/WAL schema 或实现节点重放。
+6. 释放句柄只管理生命周期；现有调用方确实需要保存时显式调用保存，不能靠后台释放顺带保存。
+7. 项目打开继续使用既有 metadata 校验入口；新版本常量和旧项目全面拒绝在 NM4 一次切换。
+   NM1 的新图测试使用当前开发格式，不添加旧项目升级 fixture 或迁移代码。
+8. 审核 NM1.4 的所有调用方、字段缓存失效、资源清理和失败路径，执行第 14 节退出检查。
+
+成功链：
+
+```text
+local edit functions -> live document
+  -> explicit save under coherent access -> document JSON in storage
+  -> release / normal load -> same nodes, edges, parameters
+```
+
+失败链：
+
+```text
+invalid stored document -> report load error -> no importer/default substitute
+storage write failure -> keep live edits and dirty/WAL -> report save error
+background release -> no persistence attempt
+```
+
+### 11.2 验收
+
+| 测试 | 必须观察到的行为 |
 | --- | --- |
-| `SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages` | `document` 上 exposure_ev 变化 |
-| `IncompleteTargetRejectedLeavesDocumentHashAndHistoryHeadUnchanged` | 缺少 owner_kind 或 node_id 时拒绝，不填缺省 |
-| `ProvisionalSequenceReusesTargetResolvedAtFirstPatch` | 同一序列后半段仍写第一个完整 patch 锁定的 NodeId |
-| `UnknownFieldRejectedLeavesDocumentHashAndHistoryHeadUnchanged` | 失败封闭 |
-| `UndoSettledExposureRestoresDocumentValue` | Undo 后文档回到 before |
-| `MaskTargetWriteIsRejected` | NM1 不写 Mask |
+| `DocumentSaveReloadPreservesNodesEdgesAndParameters` | 额外 Grade、删除 primary、重接、参数、enabled/name 均 round-trip；这是 document I/O，不是 history reopen |
+| `SavedDocumentContainsNoStageAdapter` | 持久图不包含旧 stage 镜像，保存不重建节点 |
+| `InvalidStoredDocumentFailsWithoutReplacement` | 缺失字段、非法拓扑、损坏值准确失败；不生成默认图 |
+| `FailedDocumentSaveKeepsDirtyStateAndJournal` | 失败保留未保存状态及已有日志，history head 不被改写 |
+| `SaveDoesNotPersistUnsettledPreviewAsCommittedState` | 保存遵循完成/取消输入的顺序，重读结果不把预览冒充 settled 值 |
+| `ImportCreatesRenderableDocumentWithoutStageMirror` | 新图 Default 参数、相机/镜头固有数据完整；未打开编辑器也能 DAG 出图 |
 
-History 投影文案、commit hash 算法、journal 格式留给 NM4。本 Phase 只要 Undo 后文档值正确。
+主要范围为 pipeline service、pipeline mapper、必要的 import 初始化、对应 app/storage 测试。
+只有读取边界测试需要覆盖非法格式；不再让每个渲染调用方重复证明“stage-only 项目被拒绝”。
 
-##### Phase NM1.3 completion record (2026-08-30)
+## 12. API 与所有权约束
 
-**Status:** complete — production patches require a complete `EditorParameterTarget`; live Capture/Commit/Undo/Redo write `PipelineGuard::document_`; incomplete, Mask, and unknown-field patches are rejected without filling a default target.
+保留简单的领域函数形态，例如：
 
-**Primary success call chain:**
-
-```text
-HandlePatch(settled, complete EditorParameterTarget)
-  -> DescribeEditorParameterTargetError empty
-  -> ResolveEditorAdjustmentField
-  -> CaptureAdjustmentBeforePreview
-       lock target on first complete patch of this field_key
-       ReadEditorParameterJson before
-       PublishEditorParameterPatch(document, locked target, params)
-  -> CommitAdjustment
-       PublishEditorParameterPatch after
-       PrepareAppendEdit(OrdinaryEditPayload)   // schema unchanged
-       PublishPreparedEdit
-       record document_edit_by_commit[hash]
-  -> Undo / Redo
-       PublishPreparedHeadMove
-       ApplyDocumentFieldEdits from document_edit_by_commit
+```cpp
+ApplyEditorParameterPatch(PipelineDocument& document, target, params, error);
+AddCleanColorGrade(PipelineDocument& document, before_node_id, new_id);
+RemoveColorGradeAndBridge(PipelineDocument& document, node_id);
+ReconnectColorGrade(PipelineDocument& document, node_id, predecessor, successor);
 ```
 
-**Primary failure call chain:**
+以上为形态说明，不要求新增同名接口或通用命令类型。函数操作当前文档；锁和 WAL/history 由 app 边界协调。
+共享生命周期使用现有 guard/pin 机制，缺少无保存 release 时只补最小对称释放能力。
+不新增 snapshot registry、租约服务、发布 token 或每消费者一个 executor。
 
-```text
-missing owner_kind / node_id / adjustment_instance_id, Mask target, or unknown field
-  -> Rejected before history publish
-  -> document canonical JSON unchanged
-  -> working head unchanged
-```
+## 13. 验证方式与证据
 
-```text
-WAL / history publish fails after provisional document write
-  -> restore document from before_model_json
-  -> no new head
-```
+以下为 NM1 全阶段验证要求；NM1.4 A 的已执行命令、结果和范围见第 10.1 节，B/C 与 NM1.5 仍须独立验收。
 
-**What was proven (executed tests):**
-
-| Required name / criterion | Target / binary | Result |
-| --- | --- | --- |
-| `SettledExposurePatchWritesPrimaryGradeDocumentNotOnlyStages` | `EditorSessionHistoryPortTest`, `EditorPipelineCommandServiceTest` | PASS |
-| `IncompleteTargetRejectedLeavesDocumentHashAndHistoryHeadUnchanged` | `EditorSessionHistoryPortTest` | PASS |
-| `ProvisionalSequenceReusesTargetResolvedAtFirstPatch` | `EditorSessionHistoryPortTest` | PASS |
-| `UnknownFieldRejectedLeavesDocumentHashAndHistoryHeadUnchanged` | `EditorSessionHistoryPortTest` | PASS |
-| `UndoSettledExposureRestoresDocumentValue` | `EditorSessionHistoryPortTest` | PASS |
-| `MaskTargetWriteIsRejected` | `EditorSessionHistoryPortTest`, `EditorPipelineCommandServiceTest` | PASS |
-| `IncompleteLaterPatchRejectedLeavesLockedDocumentUnchanged` (3.1 later-patch rule) | `EditorSessionHistoryPortTest` | PASS |
-| `JournalAppendFailureRestoresDocumentExposureEv` (9.3 WAL restore) | `EditorSessionHistoryPortTest` | PASS |
-| `IncompleteTargetIsRejected` / `MaskTargetIsRejected` | `EditorSessionEditControllerTest` | PASS |
-
-Commands:
+Windows 构建遵循 `alcedo-msvc-cmake` 技能，从仓库根目录运行：
 
 ```text
 cmd /c scripts\msvc_env.cmd --preset win_debug
-cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorPipelineCommandServiceTest --target EditorSessionEditControllerTest --target EditorSessionHistoryPortTest --target EditorSessionActionPolicyCq3Test --target EditorAdjustmentPipelineTest
-ctest --test-dir build/debug -R "EditorPipelineCommandServiceTest|EditorSessionEditControllerTest|EditorSessionHistoryPortTest|EditorSessionActionPolicyCq3Test|EditorAdjustmentPipelineTest" --output-on-failure
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagModelGraphTest PipelineMapperTest ThumbnailServiceTest EditorPipelineCommandServiceTest EditorSessionHistoryPortTest
+ctest --test-dir build/debug -R "GpuDagModelGraphTest|PipelineMapperTest|ThumbnailServiceTest|EditorPipelineCommandServiceTest|EditorSessionHistoryPortTest" --output-on-failure
 ```
 
-Suite totals: `EditorSessionHistoryPortTest` 46/46 PASS; `EditorAdjustmentPipelineTest` 6/6 PASS; `EditorPipelineCommandServiceTest` 4/4 PASS; `EditorSessionEditControllerTest` 11/11 PASS; `EditorSessionActionPolicyCq3Test` 10/10 PASS. Combined filtered run: 77/77 PASS. Logs: `build/tmp/nm1/`.
+同时从实际 CMake/CTest 清单确认并运行 export、pipeline scheduler、editor controller 和 import 受影响目标；
+不猜测尚未存在的 target 名。测试矩阵中的新名称是行为要求，可以合并为参数化测试，不机械地每行新增一个文件。
 
-**Checklist / exit condition:** NM1.3 typed target, input-sequence lock, live document write, and Undo document restore are done. NM1 overall Apply/Save authority and thumbnail DAG remain for NM1.4–NM1.5.
+先运行各修改段的聚焦测试，最后运行完整受影响 suite。GPU 数值断言使用受支持真实 RAW 或固定可验证输入，
+保留当前质量设置；缺 fixture/后端时记录未验证，不把跳过写成通过。并发测试用确定的屏障。
+代码检查确认产品路径无整图 clone、stage remirror 和 snapshot executor 创建；输出比较不能只检查 buffer 非空。
 
-**LOC note (grill-code-review):** production files under 1000 LOC — `editor_history_mutation.cpp` 539, `editor_pipeline_command_service.cpp` 198, `editor_session_edit_controller.cpp` 149, `editor_adjustment_types.hpp` 112. `editor_session_history_port_test.cpp` is 1842 lines (pre-existing history/WAL/paste suite; NM1.3 tests appended). Not split in this phase.
-
-**Remaining gaps:** QML `submitPatch` still sends `field_key` only; those writes are rejected until NM6 fills a complete target. `document_edit_by_commit` is in-process; crash reopen still replays stage WAL, not a persisted document mutation (NM4). Product Apply/Save may still remirror from stages (NM1.5). Thumbnail/snapshot still clone via stages (NM1.4). `CheckoutVersion` does not restore document JSON from the side table. Process-internal stage `SetOperator` on commit remains until the stage table is deleted.
-
----
-
-## 10. NM1.4 — Thumbnail 与 snapshot DAG
-
-### 10.1 结果
-
-`PipelineSnapshot` 携带独立的 `PipelineDocument` 克隆（不共享 live Model 指针）。Thumbnail、analysis rendition 用该文档走 GPU DAG 出图。
-
-禁止：
-
-```text
-ExportPipelineParams
-  -> ImportPipelineParams
-  -> stage Apply / remirror
-  -> thumbnail pixels
-```
-
-允许 snapshot 仍持有 `CPUPipelineExecutor` 作为 GPU session / 调度宿主，但 Apply 必须绑定已克隆的文档且 **不得**用 snapshot 的 stage JSON 覆盖该文档后再渲染。
-
-`LoadPipelineSnapshot` 在 cache miss 时仍可 `LoadPipeline`，但捕获的是文档，不是「只导出 stages 再重建一份编辑状态」。
-
-Export 目前走同一 snapshot。本子 Phase 把 snapshot API 改成文档权威后，export 像素也必须 DAG，不得留下一条 stage-only 克隆。
-
-### 10.2 主成功调用链
-
-```text
-ThumbnailService::GetThumbnail
-  -> LoadPipelineSnapshot
-  -> ClonePipelineDocument(live or stored)
-  -> snapshot.document
-  -> GPU Renderer::Render(document)
-  -> host thumbnail buffer
-```
-
-### 10.3 主失败调用链
-
-```text
-missing document on a v2 image
-  -> snapshot load fails with real error
-  -> no stage-only thumbnail substitute
-```
-
-```text
-stage-only storage, no usable graph
-  -> Load / snapshot fails with real error
-  -> no LegacyPipelineImporter product open path
-```
-
-### 10.4 文件
-
-- `alcedo_studio/src/include/app/pipeline_service.hpp`（`PipelineSnapshot` 增加 document）
-- `alcedo_studio/src/app/pipeline_service.cpp`（`LoadPipelineSnapshot`）
-- `alcedo_studio/src/app/thumbnail_service.cpp`
-- `alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp`（thumbnail Apply 不再 `ApplyOnto` 覆盖 snapshot 文档）
-- `alcedo_studio/tests/app/thumbnail_service_test.cpp`
-
-### 10.5 测试
-
-| 名称 | 断言 |
-| --- | --- |
-| `LoadPipelineSnapshotClonesDocumentWithoutReimportingStagesAsRenderSource` | snapshot 文档与 live 文档 canonical JSON 一致，且不是从 stage JSON Import 出来覆盖 live 图 |
-| `ThumbnailRenderUsesGpuDagDocumentWithoutStageApplyOnto` | 文档上的 exposure 与 thumbnail 路径使用的文档一致；渲染前文档 hash 不被 stage JSON 改写 |
-| `AnalysisRenditionUsesSameDocumentSnapshot` | 分析路径同样绑定 snapshot document |
-| `StageOnlyStoreFailsSnapshotLoadWithoutImporterSubstitute` | 无图存储失败；不 Import 成默认图再出缩略图 |
-
-若现有 `ThumbnailServiceTest` 依赖 remirror 或 `MirrorsLegacyStageAdapter()`，改为断言 DAG 文档身份，或断言无图存储失败。
-
----
-
-## 11. NM1.5 — 产品写入权威（停止 stage 覆盖文档）
-
-### 11.1 结果
-
-Live editor：
-
-- 新参数写入文档（NM1.3）；
-- GPU 产品帧读取文档；
-- **禁止**每次 Apply 用当前 stages `ApplyOnto` 覆盖刚刚写过的文档；
-- **禁止** dirty `SavePipeline` 用 `LegacyPipelineImporter::Import(stages)` 整份替换 `document_`。
-
-`SavePipeline` / `SyncPipelineDocument` 持久化 `document.ToJson()`。不要为旧读取器附带 `legacy_stage_adapter` 镜像 blob。
-
-Load 规则：
-
-- format v2 且含完整 nodes/edges：文档权威。不要用 adapter 或 stage 表覆盖图。
-- 仅有旧 stage JSON / adapter、没有可用图：Load 失败，返回真实错误。不要 Import 成默认三节点。不要升级 mini-git commit。
-
-`InitializeImageRoot` 必须把当时的完整默认 **文档**记入 root，而不是只存 stage 表。后续 catalog 默认值变化不得重写已存在 root。
-
-本子 Phase 不从代码中删除 CPU stage 表。删除 stage 属于后续 Phase。
-
-### 11.2 主成功调用链
-
-```text
-settled slider
-  -> document mutation
-  -> GPU Render(document)
-  -> SyncPipelineDocument / Save writes document ToJson
-```
-
-### 11.3 主失败调用链
-
-```text
-ApplyOnto of live stages would overwrite a newer document edit
-  -> this path is removed from product Apply/Save
-```
-
-```text
-stage-only store, no usable graph
-  -> real error
-  -> project does not open
-  -> no CPU stage editor path restored
-```
-
-### 11.4 文件
-
-- `alcedo_studio/src/app/pipeline_service.cpp`（Load / Save / Remirror / InitializeImageRoot）
-- `alcedo_studio/src/edit/pipeline/pipeline_cpu.cpp`（`ApplyGpuDagProduct`）
-- `alcedo_studio/src/include/edit/graph/pipeline_document.hpp`（产品默认路径不再调用 `AllowsLegacyStageAdapterRemirror`）
-- `alcedo_studio/src/storage/mapper/pipeline/pipeline_mapper.cpp`
-- `alcedo_studio/tests/app/pipeline_service_test.cpp`
-- `alcedo_studio/tests/edit/graph/legacy_import_test.cpp`（importer 可留作非产品测试；产品 Load 不调用）
-
-### 11.5 测试
-
-| 名称 | 断言 |
-| --- | --- |
-| `DirtySaveWritesDocumentJsonAndDoesNotReplaceGraphFromStages` | 文档里若有额外 Color Grade，save 后仍在 |
-| `GpuApplyDoesNotApplyOntoDocumentFromLiveStagesAfterDocumentEdit` | 文档 exposure 不被 stage 旧值盖回 |
-| `Format2LoadTreatsDocumentAsAuthorityWhenNodesPresent` | load 不因 adapter 抹掉图结构 |
-| `StageOnlyStoreLoadFailsWithoutDefaultGraphImport` | 无图存储失败；不打开；不 Import |
-
-现有 `ReloadedFormat2GraphWithoutAdapterStillRemirrorsCpuNeuralEngine` 一类测试必须改写：不再要求 reload 后仍把 CPU 当权威去 remirror 覆盖文档。旧名 `LegacyStageOnlyStoreImportsOnceThenRendersDocument` 不再作为产品要求。
-
----
-
-## 12. 建议的 app 类型
-
-```text
-EditorPipelineCommandService
-  Prepare(mutation) -> candidate clone, validate, optional CompileStatic
-  Publish -> document, history head if settled
-```
-
-QML 本 Phase 不调用图命令。`EditorSessionEditController` 和 `EditorHistoryMutation` 走该 service 或同等窄接口，避免再直接 `SetOperator` 后指望 ApplyOnto。
-
----
-
-## 13. 构建与证据
-
-Windows：
-
-```text
-cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"
-cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagModelGraphTest
-cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target PipelineMapperTest
-cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target ThumbnailServiceTest
-```
-
-日志放 `build/tmp/nm1/`。每个子 Phase 完成后在本文件追加 completion record（调用链、命令、通过的测试名）。不要把这些日志写进总体方案。
-
----
+临时工具、日志、测试证据仅放 `build/tmp/nm1/`。完成记录须包含实际命令、测试结果和未覆盖项；
+不能以旧 snapshot 测试通过替代共享 executor 与失败路径证明。
 
 ## 14. NM1 退出条件
 
-- [ ] 新编辑写入 `PipelineDocument`；产品 Apply/Save 不再用 live stages 覆盖新文档
-- [ ] 产品不提供 stage 镜像；无可用图的旧存储 Load 失败
-- [ ] Thumbnail / analysis / 同 snapshot 像素路径 DAG 渲染，不经 stage ApplyOnto
-- [x] Add / Remove（含 primary）/ Reconnect 原子、失败回滚、canonical JSON 可逆
-- [x] Default 三节点工厂自带 `+1.5 EV` / saturation `1.3`；Clean 为 identity 且无四项后处理
-- [x] `EditorParameterTarget`：每个 patch 完整；缺字段拒绝；输入序列锁定；Mask target 拒绝
-- [x] History live Undo 恢复文档值（payload schema 仍可是旧的）
-- [ ] 生产 UI 仍无新增节点入口
-- [ ] 不声称打开或升级 DAG document 之前的项目；NML 取消
+- [ ] 同一图片只有一个 live document/executor；后台任务复用普通使用句柄。
+- [x] preview/settled/参数 Undo/Redo 不深拷贝整图；图命令只保留局部恢复数据（NM1.4 A）。
+- [ ] document 读写、渲染和序列化遵守统一互斥，完成/取消/异常没有锁重入或使用权泄漏。
+- [ ] Add/Remove/Reconnect/Rename/Enabled 保留；非法操作恢复节点、边、值和已支持的 history 状态。
+- [x] Default 工厂自带 1.5 EV/1.3 saturation；Clean 工厂无视觉变化且无四项后处理（既有证据，集成时复测）。
+- [x] 完整 target、输入序列锁定、未知字段/Mask 拒绝及同会话参数 Undo/Redo 在简化后重新通过（NM1.4 A）。
+- [ ] 编辑器、缩略图、analysis、export 从同一 document 得到正确 DAG 像素；单次参数不污染后续任务。
+- [ ] 后台完成不保存、不清 dirty；最后一次使用结束前不淘汰对象，编辑器在用的缓存不被整体释放。
+- [ ] 产品 Apply/Load/Save 不再使用 stage 镜像或 stage 作为参数源；旧类型可留作非产品代码。
+- [ ] 新图导入和 document 保存读取完整；存储失败保留未保存状态，坏图读取真实失败。
+- [ ] NM1 未引入完整 typed history、跨进程节点重放、旧项目迁移或额外 root/document 副本。
+- [ ] 不开放依赖 NM2/NM4/NM5/NM6 的生产入口；不宣称节点 history/recovery 或多 Grade GPU 已完成。
+- [ ] 第 10/11 节行为有执行证据；第 16 节追加本版实施结果，NM1.4/NM1.5 才能改为 complete。
 
----
+## 15. 交给后续 Phase 的边界
 
-## 15. 与后续 Phase 的接口
+- **NM2：** 在现有单 live document 和共享 executor 上执行完整 Grade 主链，迁移 DRT/Post，完善按节点缓存；
+  不恢复独立参数副本来绕过任务状态问题。
+- **NM3：** Mask 字段和资源操作遵循局部修改原则；不可变像素资产不要求 document 不可变。
+- **NM4：** 使用 NM1 领域函数实现 typed `PipelineEditBatch`、forward/inverse、节点 WAL/recovery、Version/Paste；
+  替换 `document_edit_by_commit` 等临时记录，切换 checkpoint/history/project metadata 格式。
+  以 history 为准重放，checkpoint hash 只用于跳过不必要重放；不保留旧项目兼容读取和 stage 提交迁移。
+- **NM5/NM6：** 在模型、真实多节点渲染和 history 完成后接 UI；不把 QML 对象当作模型或复制存储。
+- **Stage 类型删除：** 后续删除仍未被产品使用的旧类型及测试 importer，不为保留它们增加新镜像。
+- **NML：** 已取消，不创建旧项目升级阶段。
 
-- **Stage table delete (later, not NM1):** 从代码中删除 CPU stage 表和产品路径上的 `LegacyPipelineImporter`。不是旧项目升级。
-- **NML：** 取消。本产品不打开、不升级 DAG document 之前的 stage-only 项目，也不迁移旧 mini-git commit。
-- **NM2：** 主链上每一个 Color Grade 都执行；本 Phase 只执行第一个。删除能力已在 NM1 证明，NM2 不得再拿「compiler 需要 `grade.primary`」限制删除。NM2 假定打开的项目已经是可用 DAG 文档。无图项目不会进入 NM2。
-- **NM4：** 把 `OrdinaryEditPayload` 换成 typed `PipelineEditBatch`；checkpoint 存文档而不是只存 stage params。NM4 不回填旧 stage commit。
-- **NM6：** 右侧面板按选中节点发送完整 target。NM1 已要求完整 target 与输入序列锁定。
+## 16. 既有证据与本版状态
 
----
+以下为 2026-08-29/30 原执行记录的摘要，保留其实际测试范围。旧复制调用链不再是实施要求。
 
-## 16. Completion records
+| 原阶段 | 已记录证据 | 本版解释 |
+| --- | --- | --- |
+| NM1.1 | `GpuDagModelGraphTest` 42/42；`GpuDagRawInputTest.GpuDagGraphCompiler` 18/18 PASS | 图功能与编译行为保留；原地实现要复测 |
+| NM1.2 | `GpuDagModelGraphTest` 46/46 PASS | Default/Clean 功能保留 |
+| NM1.3 | HistoryPort 46、AdjustmentPipeline 6、CommandService 4、SessionEditController 11、ActionPolicyCq3 10；合计 77/77 PASS | 完整 target 与同会话参数行为保留；不证明跨进程 history，锁与复制要修正 |
+| 未提交 NM1.4 | PipelineMapper filter 5/5、Thumbnail filter 4/4、ModelGraph filter 1/1 PASS | 只证明原 snapshot 实现下的检查；不足以通过本版共享渲染验收 |
 
-NM1.1 (2026-08-29): complete — recorded under §7.
-NM1.2 (2026-08-30): complete — recorded under §8.
-NM1.3 (2026-08-30): complete — recorded under §9.
+旧记录主要行为名：
 
-后续子 Phase 完成后按同一模板追加。模板：
+- `RemovePrimaryGradeKeepsRemainingGradesAndValidBackbone`
+- `RemoveLastColorGradeLeavesDevelopConnectedToDrt`
+- `GraphCompilerCompilesFirstBackboneGradeWhenPrimaryIdIsAbsent`
+- `DefaultPipelineDocumentBakesOnePointFiveEvAndSaturationOnePointThree`
+- `MakeCleanColorGradeUsesIdentityParamsAndOmitsPostAdjustments`
+- `IncompleteTargetRejectedLeavesDocumentHashAndHistoryHeadUnchanged`
+- `ProvisionalSequenceReusesTargetResolvedAtFirstPatch`
+- `UndoSettledExposureRestoresDocumentValue`
+- `JournalAppendFailureRestoresDocumentExposureEv`
 
-##### Phase NM1.x completion record (YYYY-MM-DD)
+历史命令使用第 13 节 MSVC wrapper 和对应 CTest suite；原 NM1.4 使用可执行文件 filter：
+`*LoadPipelineSnapshot*`、`*StageOnlyStore*`、`*ThumbnailRenderUsesGpuDagDocument*`、
+`*AnalysisRenditionUsesSameDocumentSnapshot*`、`*DefaultPipelineHasDevelop*`。历史日志位于 `build/tmp/nm1/`。
 
-**Status:** complete | partial — …
+已知证据限制：原 NM1.4 的 `mfzoty.dng` 用 image pool + LibRaw 准备输入，因本机 Exiv2 路径打开失败
+未证明完整 ImportToFolder 链；它也不能替代 import 初始化验收。QML field-only 请求仍被拒绝；
+非 primary Grade 的实际 GPU 执行和跨进程节点恢复分别属于 NM2/NM4。
 
-**Primary success call chain:** （`text` 箭头链）
+本版方案更新（2026-08-30）：**documentation only**。源码/测试保持原样，没有新 build/test 结果。
+实施后追加真实成功链、失败链、命令、结果及缺口，再更新状态和退出清单。
 
-**Primary failure call chain:**
-
-**What was proven (executed tests):** 表
-
-Commands: …
-
-**Remaining gaps:**
+NM1.4 A 实施结果（2026-08-30）：**complete**，本版验收 121/121 PASS，成功链、失败链、测试和缺口见第 10.1 节完成记录。NM1.4 B/C、NM1.5 的状态未提前提升。

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
@@ -2,9 +2,9 @@
 
 Date: 2026-08-29
 
-Revised: 2026-08-30 — 按单 live document、原地函数应用、共享 executor 重定执行方案。
+Revised: 2026-08-31 — 保留单 live document/共享 executor；NM1.4R 明确后台 scratch 不预留、不保留空闲块；缩略图磁盘写回策略独立跟踪。
 
-Status: in progress — NM1.4 A/B 已完成并通过本版验收；NM1.2 保留；NM1.4 C、NM1.5 待实施。
+Status: in progress — NM1.4 A/B/R 完成；NM1.2 保留；C 由 R 替代，不再作为独立验收；NM1.5 未开始。缩略图磁盘写回仍为 Issue #113。
 
 Branch: `feature/pipeline-document-editing`
 
@@ -17,6 +17,10 @@ Base: `origin/main` at NM0 merge (`d5a96267`)。
 从当前 NM1.4 工作区继续，先消除 NM1.1/NM1.3 的相关实现债务，再完成渲染和保存读取。
 2026-08-30 的方案修订未撤回未提交源码；其后 NM1.4 A 已定向实施，见第 10.1 节完成记录；NM1.4 B 见第 10.2 节完成记录。过去的测试结果保留在第 16 节，不代表 C 或整个 NM1 已完成。
 
+2026-08-30 审查后决定：C 保留共享对象方向；以第 10.5 节 NM1.4R 收敛任务请求、后台工作区、
+使用权清理和完整导出 recipe。不增加全局显存预算驱动的并发调度。
+[缩略图磁盘写回 Issue #113](https://github.com/zidage/AlcedoStudio/issues/113)单独跟踪，后续讨论由 disk cache service 拥有写回机制；不在 R 中实施或以其未完成阻塞 NM1.5。
+
 ---
 
 ## 1. 目标与优先级
@@ -28,7 +32,7 @@ NM1 结束时，应能从 app/service 测试完成以下流程：
 
 1. 创建或加载 document，取得同一图片的 pipeline 使用权。
 2. 通过完整 target 修改参数；通过领域命令新增、删除、重接 Color Grade。
-3. 用同一 document/executor 交替执行编辑器、缩略图、分析和导出渲染。
+3. 用同一 document/executor 交替执行编辑器、缩略图、分析和导出渲染；任务配置直接作为请求输入，后台工作区按实际需要分配并及时释放。
 4. 保存并重新读取相同的 document 参数和结构，释放后台任务不触发保存。
 5. 非法输入、任务取消、WAL 写入失败和存储失败均返回真实结果，不留下半次修改或泄漏使用权。
 
@@ -37,7 +41,7 @@ Nodes UI 属于 NM5，完整 adjustment UI 接线属于 NM6。
 
 冲突时按以下顺序执行：
 
-1. 2026-08-30 用户确认的本版简化原则和 NM4 边界。
+1. 2026-08-30 用户确认的本版简化原则、第 10.5 节修复取舍和 NM4 边界。
 2. 总体方案的单主链、Default/Clean、完整 target、质量策略与禁止替代实现的产品规则。
 3. 原完成记录和现有代码；它们只说明起点，不能反过来要求保留复制模型。
 
@@ -170,12 +174,16 @@ GPU 输出失败不应被当成隐式 Undo：已经成功记录的编辑仍在�
 复用 executor 的 `GetRenderLock()` 及现有 owner-thread 等待方式：
 
 - Model 写入、图结构修改、序列化读取与渲染读取遵循同一把锁。
-- scheduler 在锁内安装请求参数、执行并完成必要的输出交接；锁外不改共享 executor。
+- scheduler 在锁内消费本次请求、执行并完成必要的输出交接；锁外不改共享 executor。
+  C 沿用既有设置/恢复作为起点，R 改为请求值直接传入，不把任务配置保存在 executor 上。
 - 缓存锁只用于查找和 pin，不在持有它时等待渲染、访问 DuckDB 或执行回调。
 - 领域函数不重复获取调用方已持有的锁；明确 app/scheduler 是共享访问边界。
-- 完成、取消和异常都恢复请求参数、frame sink 并释放使用权；释放不能在回调中递归等待同一 render lock。
+- 完成、取消和异常均不泄漏请求参数或输出目的地，并释放使用权；释放不能在回调中递归等待同一 render lock。
+  R 完成后，产品 DAG 不再依赖复制/恢复 executor 请求状态来满足此要求。
 
 同图任务串行，不承诺后台任务零等待；复用现有优先级/取消机制，不另起任务系统。
+用户明确的产品时序是编辑器修改不与缩略图刷新、导出同时发生；导出和缩略图任务可以并发。
+统一 render lock 和使用权仍保证同图运行资源安全，但不为未要求的并发编辑新增冻结图或历史版本渲染协议。
 
 ### 5.4 单主链
 
@@ -193,10 +201,12 @@ NM1 的新像素验收使用当前已支持的默认图，图命令的多节点�
 NM1.4 A：修正 NM1.1/NM1.3 的原地修改与锁
   -> NM1.4 B：统一 document 输入，删除产品 Apply 的 stage 覆盖
   -> NM1.4 C：后台任务共用 pipeline/executor，迁移并删除 snapshot API
+  -> NM1.4R：任务请求直接传入、后台工作区降低占用、使用权清理修复、导出 recipe 信息完整
   -> NM1.5：统一保存读取、导入初始化与释放边界，执行全阶段验收
 ```
 
 A/B/C 是 NM1.4 内部实施顺序，不新增一级 Phase。B 必须先于 C，避免共享 executor 后编辑器再次覆盖后台所读文档。
+R 是 C 审查后的修复子阶段，不改变后续一级 Phase 编号；必须完成后再实施 NM1.5。
 每一段应可单独构建和运行受影响测试；完整 NM1 以第 14 节为准。
 
 ## 7. NM1.1 保留的图能力
@@ -246,7 +256,7 @@ before/after 不能继续从 stage 表读取；既有 payload 需要的字段表
 
 ## 10. NM1.4 — 原地编辑与共享 DAG 渲染
 
-Status: partial — A complete（2026-08-30）；B complete（2026-08-30）；C rework required。A/B 使用下列新证据，C 不沿用旧 snapshot 测试的完成结论。
+Status: partial — A complete（2026-08-30）；B complete（2026-08-30）；C 由 R 替代；R complete（2026-08-31）。历史 A/B 完成记录保留。NM1.5 未开始。
 
 ### 10.1 A：原地修改和局部恢复
 
@@ -467,6 +477,8 @@ Suite totals:
 
 ### 10.3 C：共享 pipeline 使用权
 
+Status: implemented in working tree, acceptance incomplete — 2026-08-30 审查的失败与修复安排见第 10.5 节；不沿用 snapshot 验收结论。
+
 工作：
 
 1. cache hit 返回同一图片已有 document/executor；cache miss 走同一创建/读取入口，不建立后台专用加载链。
@@ -476,12 +488,14 @@ Suite totals:
 4. thumbnail、analysis 和 export 都使用普通 pipeline 句柄；迁移调用方后删除 snapshot 专用 API。
 5. `SetForceCPUOutput`、decode/resize、frame sink 等共享 executor 配置只在 scheduler 锁内发生。
    使用既有请求参数保存/恢复机制，不另加一份编辑状态快照。
+   这是 C 的迁移起点；R 必须改为 task/request 值直接传给执行入口，不再保留产品 DAG 的可变任务模式。
 6. 任务使用取得 render lock 时的 document，渲染期间不允许写入。
    缩略图不保证与编辑器每帧同步；analysis/export 的单次输出必须来自同一次连贯读取，
    不宣称冻结了排队时刻的参数。NM1 不新增按任意历史 HEAD 导出的能力。
-7. 沿用现有缩略图失效/取消机制。若磁盘结果按提交标签缓存，不能把排队时旧标签贴到执行时新像素上；
-   预览值也不能冒充已提交结果写入该缓存。必要时只不写这次磁盘缓存，仍交付实际渲染结果。
-   这是现有缓存写入的正确性要求，不新增 hash/token/修订号，也不恢复冻结 document。
+7. 缩略图磁盘写回资格、标签及失效机制已从本阶段移至
+   [独立 Issue #113](https://github.com/zidage/AlcedoStudio/issues/113)。方向是由 disk cache service
+   拥有机制，而非 scheduler 结果回调回读 live 状态；具体接口后续讨论，不在 C/R 内继续扩展该策略。
+   原有请求失效/取消机制仍须保留；不把独立 Issue 当成已解决，也不把它列为 NM1.5 前置条件。
 8. 所有完成回调只终结一次；避免 callback 在 render lock 内释放资源时重复取锁。
 
 主调用链：
@@ -506,7 +520,7 @@ Thumbnail / Analysis / Export
 | `CanceledAndFailedTaskReleasesPipelineUse` | 取消/配置异常/Apply 异常各自终结一次，释放 pin、恢复请求状态 |
 | `BackgroundReleaseDoesNotSaveOrClearEditorState` | 无 DB 写入，不清 dirty；编辑器仍持有时缓存不被整体释放 |
 | `DocumentMutationWaitsForSharedRender` | 通过屏障控制读写顺序，观察到完整旧值或新值，无半更新；不用 sleep 猜时序 |
-| `QueuedRenderDoesNotStorePixelsUnderStaleCommitLabel` | 排队后编辑不会造成错误缓存标签；预览不污染已提交磁盘结果 |
+| `QueuedRenderDoesNotStorePixelsUnderStaleCommitLabel` | 移交独立 Issue；旧测试未通过，不计入 C/R 完成证明或退出门槛 |
 
 ### 10.4 修改范围
 
@@ -522,9 +536,293 @@ Thumbnail / Analysis / Export
 以上路径中缩写的 `src/...` 均相对于 `alcedo_studio/`。
 优先删除旧分支并复用现有函数；文件变大时按已有职责拆分，不用新服务层包住旧复杂度。
 
+### 10.5 NM1.4R — 任务请求与后台工作区修复
+
+Date: 2026-08-30
+
+Revised: 2026-08-31 — 后台沿用 arena 接口按实际请求分配，用完释放；不引入通用两阶段分配机制。
+
+Status: complete — 2026-08-31 实施完成；入口为当时 C 未提交工作区；出口在 NM1.5 之前。完成记录见本节末。
+
+#### 背景与取舍
+
+1. **共享模型仍是目标。** 保留每图一个 live document/executor、普通 guard/pin、后台释放不保存。
+   不恢复 PipelineSnapshot、后台专用加载链或独立参数副本。
+2. **缓存是纹理/中间结果缓存。** 不是 OperatorModel 参数表，也不是缩略图磁盘缓存。
+   旧 DAG 曾忽略 task 的 cache 开关，后台因此污染或清空编辑器缓存；2026-08-23 GPU DAG 方案
+   G7R.H 用独立 one-shot workspace 隔离。B 延续该实现。隔离效果必须保留，但两套长期 device
+   与 Capture/Restore 状态不是产品要求，不应由测试固定为唯一实现。
+3. **当前请求传递绕行共享状态。** task 类型先调用 SetEnableCache，Apply 再读 executor 成员
+   翻译成 RenderCachePolicy；后台还复制/恢复 decode、ROI、host output、JSON 请求参数和 sink。
+   同图 render lock 已串行使用 executor，不能继续叠加模式 flag 和全局 double-check 锁来维护这些状态。
+4. **后台优先降低资源占用。** 缩略图追求吞吐，导出保留完整质量，但两者都不以毫秒级响应为首要目标。
+   它们在同一既有线程池中可同时处理多张图片。省几次分配的收益不能优先于削减各任务的大块预留。
+   用户明确不做全局显存预算、预留账本或根据预算动态调整并行 task 数；不另建调度系统。
+5. **分配时机必须分清。** 当前 Develop 在开始前按 source.host_extent 预留 scratch：普通估算
+   像素数 × 16 字节，Neural 估算像素数 × 24 字节 + 64 MiB，后续使用历史容量加余量；
+   arena 按需增长还采用 16 MiB 最小 slab / 64 MiB 粒度。Develop 完成后已经同步释放 scratch，
+   不能误写成一直保留至整帧结束。最终缩略图尺寸小也不证明上游 RAW 开发输入同样小。
+   各 pass 的中间图按需分配，但 Bypass 的写入表仍持有多张图到任务末尾；Grade 的局部租约
+   结束也不等于 texture pool 已释放底层显存。因此只去掉初始 Reserve 不能完成占用修复。
+   TransientBufferArena 的 Reset/RewindToMark 与 TransientBufferScope 退出也只回退位置，
+   不释放底层 slab；仅改成精确大小的 slab，仍会保留阶段高水位。后台必须同时去掉预留和空闲块保留。
+   禁止的是按整图像素数猜测总工作区；算子按具体 buffer/tensor 的形状、元素大小和对齐计算
+   实际申请量仍然必要，不属于经验估算。显存释放必须晚于 GPU 最后一次使用，不是申请后立即释放。
+6. **不增加通用两阶段分配。** 当前许多算子的显式 scratch 大小在相关 kernel 提交前已知，
+   但 Develop 内分配与执行交错，Allocate 返回的地址会立即用于 GpuMat、workspace 绑定和提交。
+   统一登记请求后回填指针需要改造调用方；总申请量也不等于同时存活峰值。把不同寿命的 buffer
+   合成一块，会延迟归还已用完的部分；为解决它再引入寿命规划与地址复用不属于 R。
+   允许单个算子局部合并已知同时使用、同时释放的请求，不把它扩展成全管线预分配或通用规划器。
+7. **导出 recipe 目前不完整。** ExportRecipe 有 codec/resize/metadata/是否嵌 ICC，
+   缺实际输出 encoding space、EOTF 和 peak luminance。ExportService 渲染返回后回读 live DRT
+   再决定编码/ICC，是数据边界错误。应在构造每张图片的完整 recipe 时确定，而非结果回调补齐。
+8. **证据不能混用。** 审查聚焦测试共 57 项：54 PASS、2 pin 断言 FAIL、1 标签测试 90s TIMEOUT；
+   两项失败独立重跑 2/2 PASS。结果 callback 先唤醒测试、on_complete 后释放 pin，测试直接读
+   非原子计数，不能据此声称永久泄漏。旧并行缓存测试使用两个 32×32 合成输入，只证明结束后
+   释放和隔离，未证明多张 RAW 的峰值占用。标签测试移交独立 Issue，其超时不算 R 的生产故障。
+
+#### 必须实施的修复
+
+- [x] **请求直接传入。** 使用既有 task/RenderRequest 承载 cache policy、decode、ROI、resize、
+  输出目的地及必要的导出输出配置。Apply/Render 直接消费请求值；产品 DAG 不再通过
+  SetEnableCache、OneShotRenderParamsSnapshot 或 JSON 请求状态回填来切换工作模式。
+  request 是本次运行输入，不是 document 副本。不新增含义重叠的 one-shot/low-memory/release flags。
+- [x] **后台 scratch 不预留。** 沿用现有 arena 分配接口，为后台请求提供按块申请的行为。
+  首轮也不按整图像素数或经验系数估算总工作区，不使用历史高水位、安全余量、最小大 slab 或
+  16/64 MiB 增长规则。每次仅分配具体请求所需大小及必要对齐/后端分配粒度，不提前申请后续操作
+  的空间。该行为由本次 task 请求选择，不修改 pipeline 共享状态，不新增含义重叠的模式 flag。
+  保留共享算法与 kernel，不复制后台管线，不增加通用的请求登记、延迟指针回填或内存布局规划器。
+- [x] **后台 scratch 用完释放。** arena 只管理这些分配的所有权，不保留空闲块作为下一操作或
+  下一任务的容量。调用方按块或明确同寿命的作用域标明最后使用；GPU 依赖满足后释放底层分配，
+  不能仅 Reset/Rewind 后留着 slab，也不能统一拖到 Develop 或任务末尾。嵌套作用域不得释放
+  外层仍使用的内存；任务成功、部分分配失败、执行失败和取消均须安全清理。
+  不靠频繁设备级同步把多任务 GPU 工作实质串行化。可在后端使用原生 stream 顺序分配/释放，
+  但不自建模拟异步分配系统；若使用原生内存池，须明确空闲内存的归还策略和同步边界，不能将
+  arena 的 used bytes 归零等同于物理显存已归还，也不逐任务修改全局共享池策略。
+- [x] **缩短中间图与临时纹理生命周期。** Bypass 不读写编辑器结果缓存；中间图在最后消费者
+  结束后释放或安全复用，不为统一末尾清理而长期持有。ping-pong 仅在操作确实需要时获取；
+  保留 final mix、mask、邻域算子还会读取的输入，不能机械地把所有处理压成两个 buffer。
+  GPU 完成/依赖顺序必须先满足，再释放或改写；CPU 已提交 kernel 不等于 GPU 已用完。
+- [x] **分开运行对象和大块资源生命周期。** 允许复用必要的 device/stream/已编译程序，
+  不以其地址稳定为验收目标；后台任务结束后不留下该任务的大块 texture/transient/neural 工作区。
+  不能把完整 device/workspace 常驻每图作为缓存开关实现，也不能破坏编辑器仍有效的结果缓存。
+- [x] **删除无预算作用的附加锁。** 本轮 GpuDeviceAllocationMutex 不能当成全局显存管理器；
+  删除仅以阻止总预算超用为理由加入的进程递归锁及重复创建检查。保留后端原本必要的资源注册、
+  命令提交同步和同图 render lock；若个别驱动操作确有额外串行要求，须提供具体证据并局部处理。
+  不增加全局 bytes 预留、预算准入或动态并发控制。不保证任意多张超大图绝不会 OOM；真实分配
+  失败要清理并报告，不能降 decode/算法/后端，也不能靠串行整个 GPU 渲染代替本修复。
+- [x] **修复最后使用权与重新获取竞争。** Release 降到零后等待 render lock，期间允许新请求
+  repin；清理时必须重新确认并以一致顺序完成。不得持 cache lock 等 render lock。
+  Load 的 reinitialize 不能让后续 cache hit 把尚未准备完的对象当作就绪对象使用。
+  并发 cache miss 既要返回同一 live 身份，也要检查创建/读取次数，不仅比较最终返回地址。
+- [x] **完成事件与结果交付明确分开。** 正常、prepare/configure/Apply 失败、取消均只终结一次，
+  使用权在真正完成时释放且不保存；外部完成在 render lock 外执行。测试等完成屏障后再在正确
+  同步下检查 pin/cache，不使用无界轮询或 sleep。覆盖无编辑器 pin 与另有使用者的两类情况。
+- [x] **每图导出 recipe 构造完整。** app/service 在任务入队前完成输出配置解析与校验；
+  沿用图片 DRT 时，在该图片 recipe 构造边界按统一访问锁读取一次；显式导出目标则使用其设置。
+  批量导出逐图解析，不把第一张图的输出配置用于全部图片。渲染与编码/ICC 使用同一份配置；
+  encoder 不回读 document，也不能仅改变 ICC 标签而仍按另一套配置渲染像素。
+  请求中的输出配置不通过临时修改共享 DRT 再恢复来应用；与 thumbnail 并发也不能改变其输出。
+  不嵌入 ICC 仅影响标签写入，不能使 recipe 缺少决定实际像素编码的配置。
+- [x] **必要清理。** 删除无生产调用方的 HasUsablePipelineGraph 及其自证式断言；恢复两个
+  app 大测试文件原有行尾，消除整文件 diff。只收敛本阶段职责，不启动全库拆分、NM2 多 Grade
+  执行或 NM4 history 重构。新接口注释明确请求寿命、锁、GPU 完成与错误清理要求。
+
+#### 独立 Issue 与明确非目标
+
+[缩略图/analysis 磁盘写回 Issue #113](https://github.com/zidage/AlcedoStudio/issues/113)负责讨论
+写回资格、提交标签、失效、dirty/preview 镜像字段去留及服务接口。目标责任方是 disk cache service，
+不是 scheduler callback；这里只记录方向，不冻结具体 API。
+R 不实施该策略、不删除其现有保护后宣称已修复，也不以其未完成阻塞 NM1.5。若请求 API 迁移
+必须适配现有 callback，只做必要接线，保持问题记录。磁盘策略测试须单独列出，不能隐藏失败、
+改为全局禁写缓存或默默跳过后报告全 suite 通过。
+
+R 不做全局预算/并发数机制或通用两阶段分配规划、不降低导出质量或缩略图既有 decode 设置、不增加任意历史 HEAD
+导出、不模拟编辑器与后台同时修改 document、不新增持久化 schema。NM1.5 的 I/O 工作保持原范围。
+
+#### 主要调用链与所有权
+
+```text
+Thumbnail / Analysis request，或 app 构造的每图完整 ExportRecipe
+  -> 普通 pipeline 使用权 + 本次不可变运行请求
+  -> 既有 scheduler/thread pool
+  -> 同图 render lock -> Apply(document, request)
+  -> cache-enabled: 保留编辑器结果复用
+     bypass: 每操作按实际请求申请 scratch，不预留；只持有当前仍被消费的中间图和必要 ping-pong
+             -> 各资源最后使用的 GPU 依赖满足 -> 释放已用完资源，不保留空闲 scratch 块
+  -> 最终 GPU 完成边界 -> 确认本任务临时资源已释放 -> unlock
+  -> 交付图像；export 编码使用同一 recipe；thumbnail 磁盘策略留独立 Issue
+  -> completion -> release use（无保存；与 repin 协调）
+
+配置/分配/执行失败或取消
+  -> 停止继续提交 -> 等待仍在用资源的 GPU 工作或按后端失败规则处置
+  -> 清本任务资源，保留编辑器已成功结果 -> 解锁
+  -> 真实错误/取消终结一次 -> release use；不降低质量或替换实现
+```
+
+document/Model 仍由 live pipeline 拥有；请求由 task 拥有；运行资源由现有 renderer/workspace
+拥有，后台结果租约按实际消费者寿命结束；LRU/pin 仍由 PipelineMgmtService 管理。
+导出输出配置属于每图 recipe；磁盘写回策略不进入 runtime。不得引入一个同时拥有这些状态的
+新 Context/Manager，也不能仅移动同一大类的方法到其他 cpp 来声称完成职责拆分。
+
+#### 修改范围与测试入口
+
+以下 `src/`、`tests/` 相对于 `alcedo_studio/`；按实际调用链改动，不要求每个文件都修改。
+
+| 范围 | 主要文件/模块 | 现有测试入口 |
+| --- | --- | --- |
+| task 请求与共享执行 | `src/include/renderer/pipeline_task.hpp`、`src/renderer/pipeline_scheduler.cpp`、`src/include/edit/geometry/render_request.hpp`、`src/include/edit/pipeline/pipeline_cpu.hpp`、`src/edit/pipeline/pipeline_cpu.cpp` | PipelineFrameSinkTest、PipelineDocumentRenderTest、scheduler 测试 |
+| scratch/中间图寿命 | `src/include/gpu/{transient_buffer_arena.hpp,transient_buffer_scope.hpp}`、`src/include/edit/runtime/{renderer.hpp,detail/renderer.inl.hpp,plan_executor.hpp,basic_render_workspace.hpp,graph_image_cache.hpp,texture_pool.hpp,develop_transient.hpp}`、三后端相关 pass | arena/workspace、result-cache、真实 RAW 测试；查实际 CTest 注册名 |
+| 附加锁清理 | `src/include/gpu/gpu_device_allocation.hpp`、CUDA/OpenCL backend 及 renderer 创建处 | 后端分配/失败清理与并行测试 |
+| 使用权 | `src/include/app/pipeline_service.hpp`、`src/app/pipeline_service.cpp` | PipelineSharedUseTest、pipeline service 测试 |
+| 完整导出配置 | `src/include/io/image/export_recipe.hpp`、`src/io/image/export_recipe.cpp`、`src/include/io/image/export_color_profile_config.hpp`、export service、`src/ui/alcedo_main/album_backend/import_export.cpp` 与 image writer 的必要接线 | ExportRecipeTest、ExportServiceTest、像素/ICC 测试 |
+| 小范围清理 | pipeline document 中未用探测 API、对应断言、app 测试行尾 | default graph 回归、diff 检查 |
+
+#### 验收要求
+
+测试名表示具体行为，可合并为参数化测试；不按行数机械增加文件或通用观测框架。
+
+| 测试/证据 | 必须观察到的行为 |
+| --- | --- |
+| `TaskRenderOptionsDoNotPersistInExecutor` | editor/thumbnail/export 交替及失败后，请求设置不残留；实际 ROI/decode/输出目的地和像素符合各自请求，无 JSON 保存恢复依赖 |
+| `BackgroundScratchAllocatesOnlyRequestedAlignedBytes` | 可控分配后端证明首轮和重复请求均无像素估算/历史高水位 Reserve、无安全余量或固定 16/64 MiB 超额增长；只在实际请求时申请对应大小及必要对齐/后端粒度 |
+| `BackgroundScratchReleasesStorageAfterLastUse` | arena 仍存活时，观察最后一次 GPU 使用完成后底层释放，且发生在后续独立操作分配前；不是只看 bump/used bytes 归零。嵌套作用域保持外层分配有效；无空闲块留待下一操作或任务 |
+| `BackgroundIntermediateImagesReleaseAfterLastConsumer` | 有确定消费者顺序的图证明最后消费者后释放/复用；mix/mask/邻域还需的输入未被覆盖，像素与参考相同 |
+| `BackgroundTaskFailureReleasesTemporaryGpuResources` | 正常、部分分配失败、执行失败和取消均无残余本任务大块资源，无编辑器缓存损失；不是只检查函数不抛异常 |
+| `BackgroundRendersKeepEditorResultCacheReusable` | editor 建缓存→后台成功/失败→editor 再渲染仍命中相同有效结果，输出正确；不要求独立 device 地址 |
+| `ParallelBackgroundRendersPreservePixelsAndReleaseWorkspaces` | 至少两图在既有线程池并发；缩略图与完整质量导出均正确；观察 GPU 工作重叠，不能只证明 CPU task 同时存在。记录执行中 texture/scratch 总峰值及结束后残余，不只看末尾为零 |
+| 资源占用对照 | 相同 RAW、算子、decode/输出设置、后端与固定并发数，对照修复前后峰值；在确定存在超额预留/过长持有的 fixture 上断言下降。区分仍在使用的 bytes、分配器保留的 bytes 与设备实际占用，注明统计范围；记录各释放边界及真实 RAW 数值、耗时。不能以逻辑释放代替物理占用证据，不以 Debug GPU 速度改产品策略 |
+| `PipelineReacquirePreventsStaleLastUseCleanup` | 屏障固定降到零→等待清理→repin，仍在使用的 session cache/sink 不被过期清理破坏 |
+| `ConcurrentPipelineAcquirePublishesOneReadyLiveInstance` | 并发 miss/重新初始化只发布一份可用 live 对象，观察构造/读取次数和就绪顺序，而非只比较最终指针 |
+| `BackgroundCompletionSignalsAfterPipelineUseRelease` | 测试等待明确的使用权释放完成事件；成功/失败/取消各终结一次，其他 pin 不受影响，无后台保存 |
+| `ExportRecipeContainsResolvedOutputColorBeforeScheduling` | 每图 recipe 在排队前具有有效 space/EOTF/亮度；缺失或不合法配置在渲染前明确失败 |
+| `ExportPixelsAndIccUseTheSameRecipeColorConfiguration` | 已知色块/数值参考证明实际像素符合 recipe，写出的 ICC 与之相符；OMIT 时只有 ICC 缺省，像素编码不变 |
+| `ConcurrentThumbnailAndExportDoNotChangeDocumentOutputSettings` | 同图请求正确串行，不同图可并行；导出设置只作用本次请求，thumbnail 与 document DRT 未被改写 |
+
+复跑 C 的共享使用权、取消/失败、document 只读与真实 RAW 测试；修复两个 pin 断言的完成同步。
+磁盘写回标签用例按独立 Issue 单列未解决，不以其通过作为 R 门槛，也不计为 R 新完成证据。
+公共模板改动必须检查 CUDA/OpenCL/Metal；本机不可运行的后端明确记录验证缺口，不能冒充已通过。
+
+**退出条件：** 上述 R 清单及其聚焦行为有执行证据；无请求状态回填，后台 scratch 无首轮像素估算、
+历史高水位或增长余量预留，用完释放且不保留空闲块；无后台残留中间结果。真实并行资源峰值、
+分配器保留量和质量对照已记录；使用权竞争、完成同步及导出 recipe
+修复通过。只允许把独立磁盘写回 Issue 列为本轮之外的已知待办，其他关键缺口不能以“后续整理”跳过。
+完成时在本节追加日期、成功/失败链、准确命令、通过/失败/跳过计数与平台限制，更新第 14/16 节，
+再进入 NM1.5。历史 B 的 device 复用测试可改为行为断言，不沿用其旧实现约束。
+
+##### Phase NM1.4R completion record (2026-08-31)
+
+**Status:** complete — 产品 scheduler 把 `PipelineApplyRequest` 直接交给 `Apply`；后台 Bypass 使用 ExactRelease arena（按请求对齐字节分配、最后使用后释放、不保留空闲 slab）；中间写入图在最后消费者后 `ReleaseWrite`；已删除 `GpuDeviceAllocationMutex`；pin 降到 0 后不持 cache lock 等 render lock，就绪发布与 `WaitUntilPinCount` 分开；每图 `ExportRecipe.output_color_` 在入队前解析，像素与 ICC 读同一份配置；`HasUsablePipelineGraph` 已删除。未开始 NM1.5。Issue #113 磁盘写回不在本轮门槛内。
+
+**Primary success call chain:**
+
+```text
+Thumbnail / Analysis / Export
+  -> PipelineMgmtService::LoadPipeline (pin + live_ready_)
+  -> PipelineTask::MakeApplyRequest (cache/decode/ROI/sink/output_color)
+  -> 同图 render lock -> CPUPipelineExecutor::Apply(input, request)
+  -> UseSessionCache: 编辑器结果缓存可继续命中
+     BypassSessionCache: ExactRelease 按块 Allocate；PlanExecutor 最后消费者 ReleaseWrite
+             -> GPU 最后使用后释放 scratch slab；one-shot workspace 任务结束 used=0
+  -> export 编码/ICC 只用 recipe；不 ReplaceParams 共享 DRT
+  -> on_complete 在 render lock 外 -> ReleasePipelineUse（不保存）
+```
+
+**Primary failure call chain:**
+
+```text
+prepare / configure / Apply 失败或取消
+  -> 停止继续提交 -> 等待仍在用的 GPU 工作
+  -> 清本任务 one-shot/ExactRelease 资源，保留编辑器已成功结果
+  -> 真实错误/取消只终结一次 -> ReleasePipelineUse；不降 decode/算法/后端
+EnqueueExportTask 缺少 resolved output_color_
+  -> 入队前抛错，不渲染
+OpenDRT 不支持的 overlay（例如 Rec2020 + Gamma 2.2）
+  -> 报告真实 DRT 错误；测试改用已支持的 P3 D65 + Gamma 2.2
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `TaskRenderOptionsDoNotPersistInExecutor` | `PipelineSharedUseTest` | PASS |
+| `BackgroundScratchAllocatesOnlyRequestedAlignedBytes` | `GpuDagCudaWorkspaceTest` | PASS |
+| `BackgroundScratchReleasesStorageAfterLastUse` | `GpuDagCudaWorkspaceTest` | PASS |
+| `BackgroundIntermediateImagesReleaseAfterLastConsumer` | `GpuDagCudaWorkspaceTest` | PASS |
+| `BackgroundTaskFailureReleasesTemporaryGpuResources` | `PipelineSharedUseTest` | PASS |
+| `BackgroundRendersKeepEditorResultCacheReusable` | `PipelineSharedUseTest` | PASS |
+| `ParallelBackgroundRendersPreservePixelsAndReleaseWorkspaces` | `PipelineSharedUseTest` | PASS；allocator 峰值 1440000768 B（约 1373 MiB，两张 `mfzoty.dng`）；任务后 one-shot residual 0 |
+| ExactRelease 占用对照 | `GPU_POOL` 日志 / 并行测试 | Bypass `transient=366.2/366.2 MiB`（used==capacity，非 16/64 MiB 最小 slab）；session 路径仍见 `transient release 16.0 MiB`。本执行未采集修复前同 fixture 数值基线 |
+| `PipelineReacquirePreventsStaleLastUseCleanup` | `PipelineSharedUseTest` | PASS |
+| `ConcurrentPipelineAcquirePublishesOneReadyLiveInstance` | `PipelineSharedUseTest` | PASS |
+| `BackgroundCompletionSignalsAfterPipelineUseRelease` | `PipelineSharedUseTest` | PASS；等待 `done_fut` 后再 `WaitUntilPinCount`，无 yield/sleep 轮询 |
+| `ExportRecipeContainsResolvedOutputColorBeforeScheduling` | `ExportServiceTest` | PASS |
+| `ExportPixelsAndIccUseTheSameRecipeColorConfiguration` | `ExportServiceTest` | PASS；Rec709 vs P3 D65 Gamma 2.2 像素 INF>1；OMIT 与 P3 像素 INF≤1；ICC 字节与 resolver 一致 / OMIT 无 ICC。像素用 OIIO 解码（本机 OpenCV `imread` 读带 ICC 的 JPEG 为空） |
+| `ConcurrentThumbnailAndExportDoNotChangeDocumentOutputSettings` | `PipelineSharedUseTest` | PASS；overlay 为 P3 D65 + Gamma 2.2 |
+
+复跑：
+
+| Suite / filter | Result |
+| --- | --- |
+| `PipelineSharedUseTest` 排除 #113 两例 | **14/14 PASS**（48.7 s） |
+| `PipelineFrameSinkTest` | **34/34 PASS** |
+| `PipelineDocumentRenderTest` | **10/10 PASS** |
+| `ExportRecipeTest` | **18/18 PASS** |
+| `GpuDagModelGraphTest` | **47/47 PASS** |
+| `GpuDagCudaWorkspaceTest` `*BackgroundScratch*:*BackgroundIntermediate*` | **3/3 PASS** |
+| Thumbnail GPU-DAG / analysis / cancel 7 例 | **7/7 PASS**（import 补齐 `PipelineMgmtService` 后；先前缺相机矩阵走 OpenCL 失败） |
+| `ExportServiceTests.ExportPixelsAndIccUseTheSameRecipeColorConfiguration` | **PASS**（11.2 s） |
+
+未作为 R 门槛、未计入通过：
+
+- `QueuedRenderDoesNotStorePixelsUnderStaleCommitLabel`
+- `ThumbnailDiskCacheWriteAllowedRejectsStalePreviewAndDirtyLabels`
+
+Commands（仓库根目录，`win_debug`，CUDA 12.8，`HAVE_CUDA`+`HAVE_OPENCL`）：
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target PipelineSharedUseTest ExportServiceTest PipelineFrameSinkTest PipelineDocumentRenderTest GpuDagCudaWorkspaceTest ExportRecipeTest GpuDagModelGraphTest ThumbnailServiceTest
+build\debug\alcedo_studio\tests\app\PipelineSharedUseTest_runtime\PipelineSharedUseTest.exe --gtest_filter=-PipelineSharedUseTest.QueuedRenderDoesNotStorePixelsUnderStaleCommitLabel:PipelineSharedUseTest.ThumbnailDiskCacheWriteAllowedRejectsStalePreviewAndDirtyLabels
+build\debug\alcedo_studio\tests\app\ExportServiceTest_runtime\ExportServiceTest.exe --gtest_filter=ExportServiceTests.ExportPixelsAndIccUseTheSameRecipeColorConfiguration
+build\debug\alcedo_studio\tests\edit\PipelineFrameSinkTest_runtime\PipelineFrameSinkTest.exe
+build\debug\alcedo_studio\tests\edit\PipelineDocumentRenderTest_runtime\PipelineDocumentRenderTest.exe
+build\debug\alcedo_studio\tests\edit\GpuDagCudaWorkspaceTest_runtime\GpuDagCudaWorkspaceTest.exe --gtest_filter=*BackgroundScratch*:*BackgroundIntermediate*
+build\debug\alcedo_studio\tests\app\ExportRecipeTest_runtime\ExportRecipeTest.exe
+build\debug\alcedo_studio\tests\edit\GpuDagModelGraphTest_runtime\GpuDagModelGraphTest.exe
+build\debug\alcedo_studio\tests\app\ThumbnailServiceTest_runtime\ThumbnailServiceTest.exe --gtest_filter=ThumbnailServiceTests.ThumbnailRenderUsesGpuDagDocumentWithoutStageApplyOnto:ThumbnailServiceTests.AnalysisRenditionUsesLiveDocument:ThumbnailServiceTests.AnalysisRenditionRendersWithoutSavePipelineOnLiveGuard:ThumbnailServiceTests.CancelPendingReturnsNull:ThumbnailServiceTests.CancelPendingDrainsAllResolutions:ThumbnailServiceTests.ReleaseThumbnailTriggersCancel:ThumbnailServiceTests.CancelWhileRenderInProgress
+```
+
+日志：`build/tmp/nm14r/tests.log`。
+
+**Checklist / exit condition:** 第 10.5 节十条修复与具名测试均有本次执行证据。磁盘写回两例仍属 Issue #113，未勾成通过。未进入 NM1.5。
+
+**LOC note（grill-code-review）：**
+
+| 文件 | 总 LOC | 备注 |
+| --- | ---: | --- |
+| `tests/app/pipeline_shared_use_test.cpp` | 1064 | 新文件；pin/占用/导出 overlay/共享 live。#113 磁盘标签仍留在同文件，不在本轮拆分 |
+| `src/app/pipeline_service.cpp` | 1181 | pin/ready/`WaitUntilPinCount` 加在既有 cache 服务上；R 不拆 god class |
+| `src/renderer/pipeline_scheduler.cpp` | ~670 | `MakeApplyRequest` / 产品 `Apply(request)`；`SetExecutorRenderParams` 仅留给旧测试 |
+| `src/include/gpu/transient_buffer_arena.hpp` | 448 | ExactRelease vs SessionPacked |
+| `src/include/edit/pipeline/pipeline_apply_request.hpp` | 37 | 新请求类型 |
+| `src/include/gpu/transient_allocation_policy.hpp` | 25 | 新策略枚举 |
+| `tests/app/export_service_test.cpp` | ~608 | 像素/ICC；OIIO 读 JPEG |
+| `tests/app/thumbnail_service_test.cpp` | ~2866 | 既有大文件；本轮只改 import 接线与少量 GPU-DAG 断言 |
+| `tests/edit/pipeline/pipeline_frame_sink_test.cpp` | ~1087 | 重置后 merged-stage 指针可能堆复用；断言改为经过 null identity |
+
+**Residual gaps:**
+
+- `LoadPipeline` 仍 `RemirrorGpuDagDocument`，属 NM1.5。
+- `SetEnableCache` / `CaptureOneShotRenderParams` 仍存在，供旧 FrameSink 测试；产品 scheduler 不靠它们切换 Bypass。
+- 本机产品路径为 CUDA。OpenCL DRT overlay 已编译；Metal overlay 已改同源但未在本机运行。OpenCL `ExecuteOpenClCameraColor: missing camera matrices` 出现在未把 `PipelineMgmtService` 交给 import 的旧测试夹具，补齐后 7/7 PASS，不视为后端降级。
+- ExactRelease 帧内 texture pool 仍可达数百 MiB（真实 RAW 纹理）；证据是 transient used==capacity、任务后 residual 0，以及 arena 单测禁止 16/64 MiB 预留。
+- 并行占用观察线程读取 renderer 内部，无 render lock（仅测试）。
+- 无修复前同 fixture 峰值数字对照；不能把 Debug CUDA 速度当成产品 decode 策略依据。
+- Issue #113 磁盘写回未解决。
+
 ## 11. NM1.5 — 保存读取与阶段验收
 
-Status: not started。
+Status: not started — 前置条件为 NM1.4R 完成；独立缩略图磁盘写回 Issue 不作为前置条件。
 
 ### 11.1 工作
 
@@ -591,7 +889,7 @@ ReconnectColorGrade(PipelineDocument& document, node_id, predecessor, successor)
 
 ## 13. 验证方式与证据
 
-以下为 NM1 全阶段验证要求；NM1.4 A 的已执行命令、结果和范围见第 10.1 节，B 见第 10.2 节；C 与 NM1.5 仍须独立验收。
+以下为 NM1 全阶段验证要求；NM1.4 A 的已执行命令、结果和范围见第 10.1 节，B 见第 10.2 节；C/R 与 NM1.5 仍须独立验收，磁盘写回策略单列独立 Issue。
 
 Windows 构建遵循 `alcedo-msvc-cmake` 技能，从仓库根目录运行：
 
@@ -613,19 +911,21 @@ ctest --test-dir build/debug -R "GpuDagModelGraphTest|PipelineMapperTest|Thumbna
 
 ## 14. NM1 退出条件
 
-- [ ] 同一图片只有一个 live document/executor；后台任务复用普通使用句柄。
+- [x] 同一图片只有一个 live document/executor；后台任务复用普通使用句柄。
 - [x] preview/settled/参数 Undo/Redo 不深拷贝整图；图命令只保留局部恢复数据（NM1.4 A）。
 - [ ] document 读写、渲染和序列化遵守统一互斥，完成/取消/异常没有锁重入或使用权泄漏。
 - [ ] Add/Remove/Reconnect/Rename/Enabled 保留；非法操作恢复节点、边、值和已支持的 history 状态。
 - [x] Default 工厂自带 1.5 EV/1.3 saturation；Clean 工厂无视觉变化且无四项后处理（既有证据，集成时复测）。
 - [x] 完整 target、输入序列锁定、未知字段/Mask 拒绝及同会话参数 Undo/Redo 在简化后重新通过（NM1.4 A）。
-- [ ] 编辑器、缩略图、analysis、export 从同一 document 得到正确 DAG 像素；单次参数不污染后续任务。
-- [ ] 后台完成不保存、不清 dirty；最后一次使用结束前不淘汰对象，编辑器在用的缓存不被整体释放。
+- [x] 编辑器、缩略图、analysis、export 从同一 document 得到正确 DAG 像素；单次参数不污染后续任务。
+- [x] NM1.4R 完成：请求直接传入；后台 scratch 不预留、不保留空闲块，中间图按需分配和及时释放；真实并发资源峰值与底层释放有证据，不增加预算驱动的调度或通用两阶段分配机制。
+- [x] 每图 export recipe 在排队前包含完整输出配置；渲染与编码/ICC 使用同一配置，不回读或临时改写共享 DRT。
+- [x] 后台完成不保存、不清 dirty；最后一次使用结束前不淘汰对象，编辑器在用的缓存不被整体释放。
 - [ ] 产品 Apply/Load/Save 不再使用 stage 镜像或 stage 作为参数源；旧类型可留作非产品代码。
 - [ ] 新图导入和 document 保存读取完整；存储失败保留未保存状态，坏图读取真实失败。
 - [ ] NM1 未引入完整 typed history、跨进程节点重放、旧项目迁移或额外 root/document 副本。
 - [ ] 不开放依赖 NM2/NM4/NM5/NM6 的生产入口；不宣称节点 history/recovery 或多 Grade GPU 已完成。
-- [ ] 第 10/11 节行为有执行证据；第 16 节追加本版实施结果，NM1.4/NM1.5 才能改为 complete。
+- [ ] 第 10/11 节本阶段范围内行为有执行证据；第 16 节追加本版实施结果，NM1.4/R/NM1.5 才能改为 complete。独立磁盘写回 Issue 明确列为未完成，不虚报已解决。
 
 ## 15. 交给后续 Phase 的边界
 
@@ -637,6 +937,7 @@ ctest --test-dir build/debug -R "GpuDagModelGraphTest|PipelineMapperTest|Thumbna
   以 history 为准重放，checkpoint hash 只用于跳过不必要重放；不保留旧项目兼容读取和 stage 提交迁移。
 - **NM5/NM6：** 在模型、真实多节点渲染和 history 完成后接 UI；不把 QML 对象当作模型或复制存储。
 - **Stage 类型删除：** 后续删除仍未被产品使用的旧类型及测试 importer，不为保留它们增加新镜像。
+- **缩略图磁盘写回：** [独立 Issue #113](https://github.com/zidage/AlcedoStudio/issues/113)继续讨论 disk cache service 的机制与回调职责；从 C/R 验收范围移出，不是 NM1.5 的前置条件。
 - **NML：** 已取消，不创建旧项目升级阶段。
 
 ## 16. 既有证据与本版状态
@@ -676,3 +977,16 @@ ctest --test-dir build/debug -R "GpuDagModelGraphTest|PipelineMapperTest|Thumbna
 NM1.4 A 实施结果（2026-08-30）：**complete**，本版验收 121/121 PASS，成功链、失败链、测试和缺口见第 10.1 节完成记录。
 
 NM1.4 B 实施结果（2026-08-30）：**complete** — 产品 Apply 只读绑定 document；BypassSessionCache 复用 one-shot device 并释放 workspace；并行独立 renderer 的 one-shot 分配通过。证据见第 10.2 节完成记录。NM1.4 C、NM1.5 的状态未提前提升。
+
+NM1.4 C 审查与修复安排（2026-08-30）：**documentation only；R not started**。审查 57 项中
+54 PASS、2 pin 断言 FAIL、1 磁盘标签测试 TIMEOUT；两项 pin 失败独立重跑通过。原始证据位于
+`build/tmp/nm14c-review/tests.log`、`recheck-tests.log`、`review.md`。本次仅新增第 10.5 节修复要求
+并移交磁盘写回 Issue，没有修改生产代码或补跑实现测试，不把首轮失败改写为全部通过。
+
+NM1.4R 分配要求修订（2026-08-31）：明确后台不执行首轮像素估算、历史高水位或增长余量预留；
+arena 按实际请求分配，在最后使用完成后释放底层资源，不保留空闲 scratch 块。不引入通用两阶段
+分配或延迟指针回填机制。该修订已由同日实施兑现，见第 10.5 节完成记录。
+
+NM1.4R 实施结果（2026-08-31）：**complete** — 请求直接传入、ExactRelease 后台 scratch、
+中间图最后消费者释放、pin/完成同步、完整 export recipe。聚焦具名测试与复跑均 PASS；
+#113 磁盘标签两例未作为门槛。证据与缺口见第 10.5 节完成记录。NM1.5 未开始。

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm1_pipeline_document_editing_plan.md
@@ -2,9 +2,9 @@
 
 Date: 2026-08-29
 
-Status: in progress — NM1.1 complete; NM1.2–NM1.5 not started.
+Status: in progress — NM1.1–NM1.2 complete; NM1.3–NM1.5 not started.
 
-Branch: `feature/pipeline_document_migration`
+Branch: `feature/pipeline-document-editing`
 
 Base: `origin/main` at NM0 merge (`d5a96267`, QuickQanava pin already on main).
 
@@ -198,7 +198,7 @@ NM1.1 主链 validation 与图命令（含完整删除）
   -> NM1.5 产品写入权威与 Save/Apply 停止用 stage 覆盖新文档
 ```
 
-同一分支 `feature/pipeline_document_migration` 上按序落地。可以按 `NM1.1+NM1.2`、`NM1.3`、`NM1.4`、`NM1.5` 拆 PR；不要把 NM2–NM8 塞进本分支。
+同一分支 `feature/pipeline-document-editing` 上按序落地。可以按 `NM1.1+NM1.2`、`NM1.3`、`NM1.4`、`NM1.5` 拆 PR；不要把 NM2–NM8 塞进本分支。
 
 ---
 
@@ -404,6 +404,56 @@ UI or test tries to build a Clean node by patching Default
 | `DefaultPipelineDocumentBakesOnePointFiveEvAndSaturationOnePointThree` | 不经 importer，Default Grade 即为 1.5 / 1.3 |
 | `MakeCleanColorGradeUsesIdentityParamsAndOmitsPostAdjustments` | 0 EV、sat 1.0、无四项后处理 |
 | `AddCleanColorGradeDoesNotCopyDefaultExposureOrSaturation` | 新节点不是 +1.5 / 1.3 |
+
+##### Phase NM1.2 completion record (2026-08-30)
+
+**Status:** complete — Default document factory bakes +1.5 EV / saturation 1.3; Clean node factory is identity without the four post adjustments.
+
+**Primary success call chain:**
+
+```text
+CreateDefaultPipelineDocument
+  -> ColorGradeNodeModel::MakeDefault (catalog identity, 17 adjustments)
+  -> ApplyDefaultPipelineLook (exposure_ev 1.5, saturation 1.3)
+  -> Validate + ValidateImageBackbone empty
+```
+
+```text
+AddCleanColorGrade
+  -> CreateCleanColorGradeNode / ColorGradeNodeModel::MakeClean
+  -> insert + reconnect candidate backbone
+```
+
+**Primary failure call chain:**
+
+```text
+UI or test tries to build a Clean node by patching Default
+  -> not an API
+  -> MakeClean is a separate type list (13 adjustments); patched Default JSON still differs
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `DefaultPipelineDocumentBakesOnePointFiveEvAndSaturationOnePointThree` | `GpuDagModelGraphTest` | PASS |
+| `MakeCleanColorGradeUsesIdentityParamsAndOmitsPostAdjustments` | `GpuDagModelGraphTest` | PASS |
+| `AddCleanColorGradeDoesNotCopyDefaultExposureOrSaturation` | `GpuDagModelGraphTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagModelGraphTest
+ctest --test-dir build/debug -R GpuDagModelGraphTest --output-on-failure
+```
+
+Suite totals: `GpuDagModelGraphTest` 46/46 PASS.
+
+**Checklist / exit condition:** NM1.2 Default vs Clean factories, baked product look without remirror, and AddClean using MakeClean are done. NM1 overall items for typed targets, thumbnail DAG, and product Save/Apply remain for NM1.3–NM1.5.
+
+**LOC note (grill-code-review):** largest changed files — `pipeline_graph_commands.cpp` 318, `pipeline_graph_command_test.cpp` 255, `color_grade_node_model.cpp` 216, `legacy_import_test.cpp` 209, `pipeline_document.cpp` 176, `default_pipeline_test.cpp` 155. All under 1000 LOC. Clean vs Default lists are separate factories; product look is applied only in `CreateDefaultPipelineDocument`.
+
+**Remaining gaps:** typed `EditorParameterTarget` and history live document writes (NM1.3); thumbnail/snapshot DAG (NM1.4); product Apply/Save still remirror from stages (NM1.5). `pipeline_defaults::kCleanBaseline*` remains for the CPU compat layer. Default Color Grade still includes Clarity/Sharpen/Halation/Film Grain until NM2.
 
 ---
 
@@ -640,7 +690,7 @@ cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target Thu
 - [ ] 双向 mirror 仅作为旧项目 / 旧 payload 兼容层存在，且有测试锁住「不得覆盖新图结构」
 - [ ] Thumbnail / analysis / 同 snapshot 像素路径 DAG 渲染，不经 stage ApplyOnto
 - [x] Add / Remove（含 primary）/ Reconnect 原子、失败回滚、canonical JSON 可逆
-- [ ] Default 三节点工厂自带 `+1.5 EV` / saturation `1.3`；Clean 为 identity 且无四项后处理
+- [x] Default 三节点工厂自带 `+1.5 EV` / saturation `1.3`；Clean 为 identity 且无四项后处理
 - [ ] `EditorParameterTarget` 锁定；Mask target 拒绝
 - [ ] History live Undo 恢复文档值（payload schema 仍可是旧的）
 - [ ] 生产 UI 仍无新增节点入口
@@ -659,6 +709,7 @@ cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target Thu
 ## 16. Completion records
 
 NM1.1 (2026-08-29): complete — recorded under §7.
+NM1.2 (2026-08-30): complete — recorded under §8.
 
 后续子 Phase 完成后按同一模板追加。模板：
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-29
 
-Status: NM0 complete；NM1–NM8 planned。
+Status: NM0 complete；NM1 in progress；NML 与 NM2–NM8 planned。
 
 本方案承接 [GPU DAG 编辑管线重构 Phase 计划](gpu_dag_pipeline_rebuild_phase_plan.md)。前一份
 计划建立了 `PipelineDocument`、`PipelineGraph`、GPU execution plan、三后端管线、MaskStore
@@ -10,7 +10,7 @@ Status: NM0 complete；NM1–NM8 planned。
 调整面板、多蒙版绘制、编辑历史和 Version 工作流。
 
 本文件定义背景、产品语义、目标架构、跨模块边界、一级 Phase 顺序、主要调用链、风险和
-最终验收范围。它固定 `NM0` 到 `NM8` 的阶段门槛，但不预先写每个阶段内部的详细执行步骤。
+最终验收范围。它固定 `NM0` 到 `NM8` 以及兼容升级 Phase `NML` 的阶段门槛，但不预先写每个阶段内部的详细执行步骤。
 开始某个一级 Phase 前，再根据当时的代码状态创建对应执行方案；该文件继续拆成
 `NMx.1`、`NMx.2` 等具体子 Phase，并决定实际 PR/branch 粒度。执行方案可以调整内部拆分，
 但不得无说明地越过本文的一级依赖或改变已经锁定的产品语义。
@@ -1126,7 +1126,8 @@ Adjustment Transfer Paste
 | Phase | Status | 未来执行方案 | 阶段结果 |
 | --- | --- | --- | --- |
 | NM0 — QuickQanava Integration Baseline | complete | [node_mask_editor/phase_nm0_quickqanava_integration_plan.md](node_mask_editor/phase_nm0_quickqanava_integration_plan.md) | 固定依赖、构建和 package 路径，证明官方组件可被 production QML 使用 |
-| NM1 — PipelineDocument Editing Foundation | planned | `node_mask_editor/phase_nm1_pipeline_document_editing_plan.md` | 删除双写来源，建立 graph 不变量、Clean node 和 typed mutation |
+| NM1 — PipelineDocument Editing Foundation | in progress | [node_mask_editor/phase_nm1_pipeline_document_editing_plan.md](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md) | PipelineDocument 成为新编辑写入权威；图命令含完整删除；thumbnail DAG；stage 仅作兼容镜像 |
+| NML — Legacy Stage Compatibility and Default DAG Upgrade | planned | `node_mask_editor/phase_nml_legacy_stage_dag_upgrade_plan.md` | 旧 stage 存储可审计地升级为默认三节点 DAG；stage 表仍可作读取兼容层 |
 | NM2 — Multi-Grade Runtime and Ownership | planned | `node_mask_editor/phase_nm2_multi_grade_runtime_plan.md` | compiler 和三后端真正执行多 Color Grade，并落实参数所有权 |
 | NM3 — Multi-Mask Model and Runtime | planned | `node_mask_editor/phase_nm3_multi_mask_runtime_plan.md` | 每节点多 Mask、Union、Range 字段和不可变 raster asset 完整可用 |
 | NM4 — History, Version, Recovery, and Paste | planned | `node_mask_editor/phase_nm4_history_version_paste_plan.md` | typed history、每 Version 一 DAG、recovery 和 Paste-only 完成切换 |
@@ -1234,16 +1235,34 @@ macOS debug linked `libQuickQanava.a` (Homebrew Qt 6.9.2, clang 21.1.1).
 
 ### 21.2 Phase NM1 — PipelineDocument Editing Foundation
 
+执行方案：[Phase NM1 PipelineDocument editing foundation](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md)。
+
 **为什么排在 UI 前：** 当前 legacy stage 和 `PipelineDocument` 仍然都可能影响编辑状态。
 如果先做 Nodes panel，QuickQanava 会成为第三个状态来源。
 
-**阶段边界：** 让 `PipelineDocument` 成为唯一可写编辑状态；增加候选文档 mutation、完整
-graph validation、原子 Add/Remove/Reconnect、stable IDs、Clean Color Grade 创建入口、typed
-parameter target 和失败回滚。调整面板可以暂时继续展示现有产品 UI，但所有写入必须经过新
-app service API。
+**阶段边界：** 让 `PipelineDocument` 成为新编辑、history live mutation 和 thumbnail 像素的
+写入/渲染权威；增加候选文档 mutation、完整 graph validation、原子 Add/Remove/Reconnect
+（含删除 Default / `grade.primary`）、stable IDs、Clean Color Grade 创建入口、typed
+parameter target 和失败回滚。`CPUPipelineExecutor` stage 表作为旧项目和旧 history payload
+的兼容镜像保留。调整面板可以暂时继续展示现有产品 UI，但所有新写入必须经过新
+app service API。Thumbnail 必须 DAG 渲染，不得先转到 stage 再出图。
 
-**退出条件：** legacy stage 不再反向覆盖新文档；无效 mutation 不改变 document/history
-head；默认三节点和 Clean node 行为有 model tests；UI 还未开放新增节点入口。
+**退出条件：** 新文档编辑不被 live stages 覆盖；无效 mutation 不改变 document/history
+head；默认三节点和 Clean node 行为有 model tests；thumbnail/analysis 走 DAG；UI 还未开放
+新增节点入口。旧 stage 项目的持久升级不在本 Phase 完成。
+
+### 21.2a Phase NML — Legacy Stage Compatibility and Default DAG Upgrade
+
+**为什么单独成一级 Phase：** NM1 必须立刻停止把 stage 当作新编辑和 thumbnail 的源，但旧项目
+仍要能打开。把「一次性、可审计地把旧 stage 存储升级成默认三节点 DAG」塞进 NM1 会把兼容
+读取和数据升级缠在一起。History payload 的 typed 重构仍在 NM4。
+
+**阶段边界：** 保留 stage 表作为读取兼容层；提供明确的升级路径，把旧 stage JSON / adapter
+写成当前默认三节点 `PipelineDocument` 并持久化；升级失败返回真实错误，不恢复 legacy 编辑
+路径，也不静默丢弃可读取的旧数据。开始本 Phase 时再写执行方案。
+
+**退出条件：** 旧项目可以升级到默认三节点 DAG；升级后的 root/checkpoint 以文档为准；未能升级
+的数据仍可按 NM1 的兼容打开规则失败或只读打开，行为有测试。
 
 ### 21.3 Phase NM2 — Multi-Grade Runtime and Parameter Ownership
 
@@ -1346,6 +1365,7 @@ service 路径；更新本文 completion record。
 ```text
 NM0 QuickQanava baseline
   -> NM1 PipelineDocument editing foundation
+  -> NML Legacy stage compatibility and default DAG upgrade
   -> NM2 Multi-grade runtime and ownership
   -> NM3 Multi-mask model and runtime
   -> NM4 History, Version, recovery, and Paste
@@ -1354,6 +1374,9 @@ NM0 QuickQanava baseline
   -> NM7 Viewer mask authoring
   -> NM8 Product qualification and cutover
 ```
+
+NML 插在 NM1 与 NM2 之间，是因为多 Grade runtime 假定存储里已经是可执行的 DAG 文档。NM1
+期间旧项目仍靠 importer 和双向镜像打开，不把持久升级提前做完。
 
 上一个 Phase 的退出条件是下一个 Phase 的输入。可以在前一个 Phase 接近完成时做只读审计或
 准备下一份执行方案，但不能提前向 production 暴露依赖尚未完成的操作。若实施证据证明必须
@@ -1515,7 +1538,9 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 
 症状：node panel 修改新 document，adjustment panel 仍修改 legacy stage，下一帧或保存时覆盖。
 
-处理：N1 先完成 PipelineDocument 单一写入来源；N5/N6 production 接入以此为前置条件。
+处理：NM1 让新编辑、history live 和 thumbnail 以 `PipelineDocument` 为权威；stage 只保留为旧
+项目兼容镜像，且不得覆盖新图结构。旧存储的持久升级由 NML 完成。N5/N6 production 接入以
+NM1 写入权威为前置条件。
 
 ### 25.2 多 Grade 只在 compiler 表面循环
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
@@ -4,6 +4,16 @@ Date: 2026-08-29
 
 Status: NM0 complete；NM1 in progress；NM2–NM8 planned。NML cancelled (2026-08-30).
 
+2026-08-30 简化修订：每张图片只有一个 live document，领域函数原地修改，后台任务共用
+executor；不以整图 candidate 或独立 snapshot executor 实现原子性。History 仍是已提交状态
+的恢复依据，完整 typed history、节点 recovery 与项目格式切换仍在 NM4。
+NM1.4 C 已有未提交的共享 executor 实现，但验收未通过；新增 NM1.4R 修复作为 NM1.5 的前置阶段。
+R 处理任务请求、后台工作区占用、使用权与完整导出 recipe，不增加全局显存预算驱动的并发调度。
+2026-08-31 补充：后台 scratch 不做首轮像素估算或历史容量预留，按实际请求申请，用完释放，
+不保留空闲块；不增加通用两阶段分配或延迟指针回填机制。
+[缩略图磁盘写回 Issue #113](https://github.com/zidage/AlcedoStudio/issues/113)单独跟踪，后续讨论由
+disk cache service 拥有写回/失效机制；不在 R 中实施，也不作为 NM1.5 的前置条件。
+
 本方案承接 [GPU DAG 编辑管线重构 Phase 计划](gpu_dag_pipeline_rebuild_phase_plan.md)。前一份
 计划建立了 `PipelineDocument`、`PipelineGraph`、GPU execution plan、三后端管线、MaskStore
 和默认三节点文档；本方案负责把这些底层能力提升为可被用户直接操作的节点编辑、节点感知
@@ -13,7 +23,8 @@ Status: NM0 complete；NM1 in progress；NM2–NM8 planned。NML cancelled (2026
 最终验收范围。它固定 `NM0` 到 `NM8` 的阶段门槛，但不预先写每个阶段内部的详细执行步骤。
 一级 Phase `NML`（旧 stage 存储升级到默认 DAG）于 2026-08-30 取消。产品不打开 DAG document
 之前的 stage-only 项目，也不迁移旧 mini-git commit。后续 Phase 删除 CPU stage 表，不做旧
-项目升级。详细措辞见 [NM1 执行方案第 3.1 节](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md)。
+项目升级。最终格式发布时通过项目 metadata 版本统一拒绝旧项目，不设计 v2/stage 迁移。
+详细边界见 [NM1 执行方案](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md)第 3、10、11 节。
 开始某个一级 Phase 前，再根据当时的代码状态创建对应执行方案；该文件继续拆成
 `NMx.1`、`NMx.2` 等具体子 Phase，并决定实际 PR/branch 粒度。执行方案可以调整内部拆分，
 但不得无说明地越过本文的一级依赖或改变已经锁定的产品语义。
@@ -75,13 +86,22 @@ DRT and Post Processing
 
 ```text
 PipelineDocument
-  = 当前图片、当前 Version、当前 working head 的唯一可写编辑状态
+  = 当前图片的唯一可写内存编辑状态，允许包含尚未提交的 preview
 
-GPU runtime / execution plan / QML projection / history projection
+GPU runtime / execution plan / QML parameter projection
   = PipelineDocument 的派生状态
+
+History
+  = 唯一 Version/HEAD；已提交编辑的记录和恢复依据
+
+Pipeline checkpoint
+  = 已保存 document + 对应的 commit hash 标签；只用于快速读取
 ```
 
-旧 stage adapter 不得继续接收 UI 写入后再反向覆盖新图。
+PipelineMgmtService 管理同一图片的使用权和存活期；editor、thumbnail、analysis、export
+可以共用 document/executor，单次请求参数由 scheduler 在 render lock 内安装和恢复。
+旧 stage adapter 不得继续接收 UI 写入后再反向覆盖新图；后台释放不隐式保存编辑。
+NM4 才完成 history 对新图的持久化和重放，不能为填阶段空缺在 NM1 新建一套历史模型。
 
 ### 2.2 PipelineGraph 只有添加和连接
 
@@ -200,7 +220,7 @@ Mask 的唯一组合语义是 Union。
 - 节点和蒙版 edit history；
 - 每个 Version 对应一份 DAG；
 - Paste 创建新 Version；
-- 当前格式数据升级、存储恢复、重开和跨后端验证。
+- 新项目格式切换、存储恢复、重开和跨后端验证；不迁移旧项目。
 
 ### 4.2 本方案不包含
 
@@ -273,7 +293,7 @@ Develop -> ColorGrade[0] -> ... -> ColorGrade[n] -> DRT/Post
 7. 该路径必须经过全部 Color Grade 并最终到达 DRT/Post；
 8. scene-image 端口不允许 fan-out 或 fan-in；
 9. Mask 不作为可自由连接的顶层 graph node；
-10. 图结构修改必须先在候选文档上完成全部验证，再替换 live document；
+10. 图结构修改在同一访问互斥范围内完成，预查条件并保留受影响节点/边以便局部恢复，不复制整份文档；
 11. 失败的修改不能留下部分 edge、history commit 或半更新的 UI projection。
 
 这个限制不是退回串行 stage。NodeId、edge、拓扑 hash、编译顺序、Version 文档仍然是图数据；
@@ -331,7 +351,7 @@ SetColorGradeEnabled(node_id, enabled)
 | DRT method / output transform | 否 | 否 | 是 | 否 |
 | Crop / rotation / image geometry | 否 | 否 | 否 | 是 |
 
-DRT/Post endpoint 可以继续保留现有序列化 type ID，以降低当前文档升级成本，但其 model 和
+DRT/Post endpoint 可以继续保留现有序列化 type ID，但其 model 和
 execution plan 必须实际拥有后处理参数。中间 Color Grade 的 adjustment catalog 不得创建
 Clarity、Sharpen、Halation 或 Film Grain 实例。
 
@@ -351,7 +371,8 @@ auto CreateCleanColorGradeNode(NodeId id) -> std::unique_ptr<ColorGradeNodeModel
 - 创建 Develop、Default Color Grade、DRT/Post；
 - Default Color Grade 使用当前产品基线，包括 Exposure `+1.5 EV` 和 Saturation `+30`
   对应的新模型数值；
-- 为图片 root 记录当时的完整默认文档，后续代码默认值变化不能重写已存在 root。
+- 导入时加入图片固有参数；NM4 保证初始状态在项目格式内可稳定重建，
+  后续默认值变化不能改变既有历史重放。NM1 不为此新增持久化 root document。
 
 `CreateCleanColorGradeNode()`：
 
@@ -640,18 +661,20 @@ Mask 列表 UI 重排和 QuickQanava layout 不属于照片 mutation。
 
 ### 11.3 原子执行
 
-Graph 和 Mask 结构修改使用 prepared operation：
+原子性表示外部看不到半次修改，输入或结构失败能够恢复；不要求整图复制或多对象发布协议。
 
-1. clone 当前 `PipelineDocument`；
-2. 对候选文档应用 typed mutation；
-3. 验证 graph、参数所有权、MaskId 唯一性和 asset 引用；
-4. 为当前 backend 准备或验证新的 static execution plan；
-5. 构造 forward/inverse history payload；
-6. 只有全部准备成功后，原子发布 document、working head 和 projection revision；
-7. 提交 Quality render；
-8. 任一步失败都保留旧 document、旧 history tip 和最后一帧。
+1. 解析输入，通过 Model 规范化值，检查目标、参数所有权、连接与 asset 引用；
+2. 预先准备必要的局部参数、节点或资源，保留受影响的 before 数据；
+3. 在统一的 live pipeline 访问互斥范围内原地应用领域函数；
+4. 结构变化验证 graph/Mask 不变量，失败只恢复受影响对象；普通参数修改不做整图拓扑验证；
+5. settled 按 WAL 顺序记录同一份修改并完成 history/live 更新，成功后通知 projection 和提交渲染；
+6. preview 不写 WAL、不移动 HEAD，取消恢复输入开始时的局部 before。
 
-不允许通过捕获异常后继续使用旧 stage 或较弱管线路径来隐藏失败。
+完整结构 forward/inverse、WAL 节点重放与 Version/Paste 属于 NM4。NM1 只保留已完成的
+同会话参数 history 接线，不借此新增持久化桥接或 candidate 服务。
+失败恢复不重建无关 OperatorModel，不通过整图 JSON 重演模型行为。
+GPU 执行失败返回真实错误并保留最后一帧；已经记录成功的编辑不会因此被隐式撤销。
+不允许通过捕获异常后继续使用旧 stage、其他 backend 或较低质量来隐藏失败。
 
 ---
 
@@ -758,23 +781,28 @@ busy state 或 QSG overlay 更新而全量刷新。
 
 ## 14. Version 和 Paste
 
-### 14.1 每个 Version 对应一份 DAG
+### 14.1 每个 Version 可以重建自己的 DAG
 
 Version 仍然是 named ref，history 仍然拥有唯一 HEAD。语义改为：
 
 ```text
 image root
-  = 导入元数据解析完成后的不可变默认 PipelineDocument
+  = 确定的初始默认状态 + 图片固有参数，是重放起点
 
 Version head
-  = 从 root 沿 first-parent commits 重放后得到的 PipelineDocument
+  = 历史提交位置；从初始状态沿 first-parent commits 应用得到该 Version 的 document
 
 serialized_pipeline_state
-  = 与 materialized head/chain 匹配的 PipelineDocument checkpoint
+  = document + 已落实的 commit hash 标签，用于跳过不必要的重放
 ```
 
-新建默认 Version 指向当前三节点 root。新建 Version at root 也恢复三节点 DAG，而不是复制当前
-working graph。
+每个 Version 对应一份逻辑结果，不表示每个 Version 常驻一份可写 document。切换时仍然只操作
+该图片的一个 live document。初始状态清除先前用户编辑，但保留图片固有参数；Default 与 Clean
+Grade 的区别不变。新建默认 Version 指向初始三节点状态。
+
+NM4 负责稳定初始状态、typed payload 和实际 checkpoint 标签的存储，先接入有效 WAL 再比较
+history HEAD 与 checkpoint 的 commit hash；相符就加载，不符就重放。Pipeline 标签不自行移动 HEAD，
+也不是从 history 实时读一个 getter 来声称 Model 已经应用成功。不要求额外的逐参数 chain 比较。
 
 ### 14.2 Pipeline DAG merge 取消
 
@@ -783,10 +811,8 @@ Adjustment Transfer 产品层只保留 Paste：
 - UI 删除 Merge 入口、冲突对话框和 merge-specific 状态；
 - service 不再创建新的 two-parent pipeline merge commit；
 - 不定义 NodeId 匹配、edge 冲突、Mask 冲突或两个 DAG 的自动合并；
-- history 存储如果已经包含旧 two-parent merge commit，默认保留读取和 first-parent replay
-  能力，避免现有项目无法打开；
-- 是否在下一次项目格式升级中彻底转换旧 merge commit，必须在数据迁移测试后单独决定，不能
-  静默丢弃。
+- 新项目格式不读取或转换旧项目内的 merge commit；旧项目在打开入口明确拒绝，
+  不能为了兼容旧提交保留 stage 编辑路径。
 
 取消新的 merge 产品操作不等于把 history commit graph 改成线性数组。Version 分支和共享
 祖先仍然保留。
@@ -795,15 +821,15 @@ Adjustment Transfer 产品层只保留 Paste：
 
 Paste 是“把一份可转移 PipelineDocument 写成目标图片的新 Version”，不是把它与当前图合并：
 
-1. 读取目标图片不可变 root；
+1. 取得目标图片的初始状态定义和图片固有参数；
 2. 保留目标 Develop endpoint 及其 RAW metadata/camera profile/lens identity；
 3. 从 transfer package 导入 Color Grade 主链、参数、Mask 和 DRT/Post 可转移参数；
-4. 按目标 root 重新映射 NodeId、AdjustmentInstanceId 和 MaskId；
+4. 按目标图片重新映射 NodeId、AdjustmentInstanceId 和 MaskId；
 5. 复制或复用内容寻址 MaskAsset；
 6. 验证目标 image backbone 和参数所有权；
 7. 创建一个新的 named Version；
 8. 将该 Version 设为 active；
-9. 进行一次原子的 history/pipeline/storage publication；
+9. 在唯一 live document 上完成局部操作，使用 WAL/history 正常记录和保存，不建立第二份候选编辑模型；
 10. 请求 Quality render。
 
 Document geometry 默认不随 Paste 转移，避免把源图片比例和 crop 直接套到目标图片；如果产品
@@ -845,7 +871,7 @@ connectorCreateDefaultEdge = false
 connectorRequestEdgeCreation
   -> EditorNodeController validate
   -> typed reconnect mutation
-  -> PipelineDocument publish
+  -> apply command on live PipelineDocument
   -> graph projection revision
 ```
 
@@ -964,7 +990,7 @@ version_id / working head generation
 NodeId
 MaskId
 Mask source kind
-before snapshot
+before parameters of the edited mask
 provisional params or stroke
 dirty rectangle
 ```
@@ -986,14 +1012,14 @@ select Color Grade
 
 - image switch、Version checkout、Undo/Redo、node deletion 前必须完成或取消 authoring；
 - stale session generation 的异步 render/result 不得更新新图片 overlay；
-- Escape 恢复 before snapshot；
+- Escape 恢复被编辑 Mask 的 before 参数；
 - Delete 删除 selected Mask，但不能删除错误节点中同 index 的 Mask；
 - viewer pan/zoom 与 Mask authoring 使用明确 mode/focus 路由，不能同时解释同一个 pointer input；
 - keyboard 用户可以选择 Mask、移动控制点、调整数值并退出模式。
 
 ---
 
-## 19. 序列化与数据升级
+## 19. 序列化与项目格式切换
 
 新 PipelineDocument schema 至少保存：
 
@@ -1019,17 +1045,13 @@ select Color Grade
 - render request；
 - panel active page。
 
-由于当前 format v2 使用单 `grade.primary` 和顶层 MaskNode，新模型需要提升 document format。
-提供一个明确、单向的当前 v2 -> 新格式转换：
+NM4 在节点、Mask 和 history 数据就绪后统一切换 document/history/project metadata 格式。
+新版本只创建和读取新项目；旧项目在打开入口返回 unsupported-format error，不转换当前 v2
+或 stage 项目，不重算旧提交。
 
-- `grade.primary` 成为 Default Color Grade；
-- 当前唯一 mask edge 转成该 grade 的第一个 Mask；
-- Clarity/Sharpen/Halation/Film Grain 从 primary grade 移到 DRT/Post；
-- 保留节点参数和 MaskAssetKey；
-- 无法满足新不变量的数据返回明确升级错误；
-- 旧 stage JSON 仍按 GPU DAG 计划返回 unsupported-format error，不恢复 legacy 编辑路径。
-
-转换必须有 golden JSON、round-trip、错误注入和真实项目 reopen 测试。
+NM1 使用当前开发图格式完成模型和 document 保存读取；NM2/NM3 修改节点字段与所有权，
+不因此要求 NM1 先实现最终项目版本。NM4 才证明新格式的 golden JSON、round-trip、
+错误处理、history recovery 与真实项目 reopen。合法性校验留在读取边界，不在渲染调用方逐层分流。
 
 ---
 
@@ -1040,15 +1062,12 @@ select Color Grade
 ```text
 NodeEditorPanel / QuickQanava action
   -> EditorNodeController::AddCleanColorGrade
-  -> EditorPipelineCommandService::Prepare
-  -> Clone PipelineDocument
+  -> validate command inputs and acquire live pipeline access
   -> CreateCleanColorGradeNode
-  -> Insert node + reconnect candidate backbone
+  -> Insert node + reconnect live backbone (keep affected edges for rollback)
   -> Validate graph and ownership
-  -> Compile/validate static plan
-  -> Build PipelineEditBatch
-  -> append journal + move active Version head
-  -> publish PipelineDocument + graph/context/history revisions
+  -> record PipelineEditBatch with WAL/history ordering (NM4)
+  -> finish local change and notify graph/context/history projections
   -> submit GraphTopologyChanged Quality render
 ```
 
@@ -1099,10 +1118,9 @@ pointer samples
 ```text
 Version selected
   -> finish/cancel provisional input
-  -> reconstruct PipelineDocument from root + first-parent commits
+  -> reset the same live document to initial state and apply first-parent commits
   -> validate graph/assets
-  -> prepare runtime execution plan
-  -> atomically publish active Version + document
+  -> finish WAL/history head move; failure restores prior state through existing operations
   -> replace node/context/history projections
   -> VersionDocumentChanged Quality render
 ```
@@ -1111,12 +1129,12 @@ Version selected
 
 ```text
 Adjustment Transfer Paste
-  -> read target root PipelineDocument
+  -> read target initial state and image metadata
   -> import transferable grade chain + DRT/Post params + Mask assets
   -> remap IDs
-  -> validate and prepare runtime
+  -> validate local changes and apply to the same live document
   -> create and activate new Version
-  -> atomic storage publication
+  -> finish WAL/history operation and use normal persistence
   -> PastedPipelineDocument Quality render
 ```
 
@@ -1133,7 +1151,7 @@ Adjustment Transfer Paste
 | Phase | Status | 未来执行方案 | 阶段结果 |
 | --- | --- | --- | --- |
 | NM0 — QuickQanava Integration Baseline | complete | [node_mask_editor/phase_nm0_quickqanava_integration_plan.md](node_mask_editor/phase_nm0_quickqanava_integration_plan.md) | 固定依赖、构建和 package 路径，证明官方组件可被 production QML 使用 |
-| NM1 — PipelineDocument Editing Foundation | in progress | [node_mask_editor/phase_nm1_pipeline_document_editing_plan.md](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md) | PipelineDocument 成为新编辑写入权威；图命令含完整删除；thumbnail DAG；无 stage 产品镜像；无图存储拒绝打开 |
+| NM1 — PipelineDocument Editing Foundation | in progress; C acceptance incomplete; R before NM1.5 | [node_mask_editor/phase_nm1_pipeline_document_editing_plan.md](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md) | 单 live document；共享 executor；R 修复任务请求、后台资源占用、使用权与导出 recipe；随后统一 document I/O |
 | NML — Legacy Stage Compatibility and Default DAG Upgrade | cancelled 2026-08-30 | — | 不升级、不打开 DAG document 之前的 stage-only 项目；不迁移 mini-git commit |
 | NM2 — Multi-Grade Runtime and Ownership | planned | `node_mask_editor/phase_nm2_multi_grade_runtime_plan.md` | compiler 和三后端真正执行多 Color Grade，并落实参数所有权 |
 | NM3 — Multi-Mask Model and Runtime | planned | `node_mask_editor/phase_nm3_multi_mask_runtime_plan.md` | 每节点多 Mask、Union、Range 字段和不可变 raster asset 完整可用 |
@@ -1247,17 +1265,31 @@ macOS debug linked `libQuickQanava.a` (Homebrew Qt 6.9.2, clang 21.1.1).
 **为什么排在 UI 前：** 当前 legacy stage 和 `PipelineDocument` 仍然都可能影响编辑状态。
 如果先做 Nodes panel，QuickQanava 会成为第三个状态来源。
 
-**阶段边界：** 让 `PipelineDocument` 成为新编辑、history live mutation 和 thumbnail 像素的
-写入/渲染权威；增加候选文档 mutation、完整 graph validation、原子 Add/Remove/Reconnect
-（含删除 Default / `grade.primary`）、stable IDs、Clean Color Grade 创建入口、typed
-parameter target 和失败回滚。产品不保留 CPU stage 表作为旧项目兼容镜像。进程内 stage 表
-可以暂时留在代码中，直到后续 Phase 删除。NM 执行期间不要求现有 adjustment UI 继续可用；
-每个 patch 必须带完整 typed target。Thumbnail 必须 DAG 渲染，不得先转到 stage 再出图。无可用
-图的存储拒绝打开。
+**阶段边界：** 一个 live `PipelineDocument` 作为内存编辑对象，领域函数原地修改参数与结构；
+保留完整 Add/Remove/Reconnect（含删除 Default / `grade.primary`）、stable IDs、Default/Clean、
+完整 target、输入锁定与局部失败恢复。后台任务共用该图片的 document/executor，
+获取/释放与保存分离；产品 Load/Apply/Save 无 stage 镜像。旧 stage 类型可留到后续删除。
+JSON 是存储格式，不是反复复制和发布的编辑模型。
 
-**退出条件：** 新文档编辑不被 live stages 覆盖；无效 mutation 不改变 document/history
-head；默认三节点和 Clean node 行为有 model tests；thumbnail/analysis 走 DAG；UI 还未开放
-新增节点入口。产品不打开 DAG document 之前的项目。
+NM1.4 先修正 NM1.1/NM1.3 的整图复制和访问锁，再移除产品 Apply 覆盖并迁移后台任务；
+**NM1.4R 必须先于 NM1.5 完成**：任务配置直接作为请求输入；后台 scratch 沿用 arena 接口，
+只按实际请求申请，不做首轮像素估算、历史高水位或增长余量预留；GPU 最后使用完成后释放底层
+分配，不以 Reset/Rewind 代替释放，不保留空闲块。不增加通用两阶段分配或延迟指针回填机制；
+中间图/ping-pong 按真实消费者寿命释放或安全复用；修复 release/repin 与完成同步；
+每图导出 recipe 在入队前确定实际输出色彩配置，渲染和编码/ICC 共用，不在渲染后回读 live DRT。
+用户明确不做全局显存预算、预留账本或基于预算动态调整 task 数；保留既有并行线程池、算法和质量。
+编辑器修改不与后台刷新/导出同时发生，但 thumbnail 与 export 可以并发；不为任意并发编辑增加冻结图。
+[缩略图/analysis 磁盘写回 Issue #113](https://github.com/zidage/AlcedoStudio/issues/113)留独立 Issue 讨论，
+目标由 disk cache service 管理，不在 scheduler callback 推测 live 编辑状态；不纳入 R 退出条件。
+NM1.5 随后完成保存读取和本阶段范围内的全阶段验收。完整 typed history、节点 recovery、Version/Paste 与项目
+格式切换仍由 NM4 完成，不为 NM1 的阶段空缺新增持久化记录或影子图。
+
+**退出条件：** 同图共享对象和请求参数不残留有测试；后台资源生命周期及真实 GPU 并发峰值有证据，
+区分仍在使用的内存、分配器保留量和设备实际占用，不能只证明逻辑释放或 CPU task 并发；
+导出 recipe 的输出配置与像素/ICC 一致；参数编辑不重建整图；无效修改恢复局部数据；
+Default/Clean、完整 target 与同会话已有参数 Undo/Redo 通过；thumbnail/analysis/export 使用 DAG；
+document 保存读取不丢节点和参数，后台释放不保存或清 dirty。坏图明确失败。
+NM1 不宣称完整节点 history/reopen 或多 Grade GPU 执行完成，不开放 Nodes 或缺少 target 的 UI 写入。
 
 ### 21.2a Phase NML — 已取消（2026-08-30）
 
@@ -1266,9 +1298,9 @@ head；默认三节点和 Clean node 行为有 model tests；thumbnail/analysis 
 
 替代规则：
 
-- 存储含有可用 format v2 图：打开。文档是编辑状态。
-- 存储只有 stage JSON 或 stage adapter、没有可用图：不要打开。返回真实错误。不要 import
-  成默认三节点图。不要改写 mini-git commit。
+- NM1 开发中的 document 读取只接受当前有效图，坏图真实失败，不从 stage/default 替代。
+- NM4 统一发布新项目 metadata/document/history 格式，旧项目在入口拒绝。
+  不以“旧项目碰巧含 v2 图”为理由继续打开，不 import、不改写 mini-git commit。
 - 后续 Phase 删除 CPU stage 表。该 Phase 不是旧项目升级。
 
 不要创建 `phase_nml_legacy_stage_dag_upgrade_plan.md`。
@@ -1306,9 +1338,10 @@ immutable asset Undo 前置能力都有测试；尚不开放 viewer 绘制 UI。
 Version、journal、recovery 和 reopen 语义，不能把持久性留到 UI 之后补做。
 
 **阶段边界：** 普通 stage/operator payload 切换为 typed `PipelineEditBatch`；结构操作保存完整
-forward/inverse 数据；root、Version head 和 serialized checkpoint 都使用新
-`PipelineDocument`；完成 format v2 升级；Adjustment Transfer 删除新的 merge 创建路径，只
-保留创建新 Version 的 Paste；旧可达 merge commit 继续可读。
+forward/inverse 数据；替换 NM1.3 的同会话参数记录，完成初始状态、history HEAD 和 document
+checkpoint 的保存及重放。统一提升项目 metadata/document/history 格式，只支持新项目，不迁移旧提交。
+Adjustment Transfer 删除新的 merge 创建路径，只保留创建新 Version 的 Paste。
+继续通过 NM1 的领域函数操作同一个 live document，不恢复 candidate/snapshot 发布模型。
 
 **退出条件：** Add/Delete/Reconnect/Mask asset replacement 能在无 production UI 的 service
 integration tests 中 Undo/Redo、branch、checkout、recover 和 reopen；Paste 保留目标 Develop
@@ -1452,7 +1485,7 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - 多 Mask Union 与 CPU reference 一致；
 - zero masks、all-disabled masks、one/many enabled masks 的边界行为；
 - MaskStore 同内容复用 key，不同内容不能覆盖旧 key；
-- v2 -> 新格式转换和 JSON round-trip。
+- 当前受支持格式的 JSON round-trip；旧项目 metadata 在入口被拒绝。
 
 ### 23.2 Runtime/backend tests
 
@@ -1474,8 +1507,8 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - Paste 创建新 Version，保留目标 Develop metadata；
 - Paste remap 后无 ID 冲突，Mask asset 可读取；
 - 不再创建新的 merge commit；
-- 旧可达 merge commit 仍可读取和 first-parent replay；
-- journal/recovery/reopen 后 working head、chain hash、document hash 一致。
+- 旧项目拒绝打开，不迁移旧 stage/merge 提交；
+- journal/recovery/reopen 后 checkpoint 的 commit 标签与 history HEAD 对应，document 等于该提交链的重放结果。
 
 ### 23.4 QML/UI tests
 
@@ -1546,9 +1579,11 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 
 症状：node panel 修改新 document，adjustment panel 仍修改 legacy stage，下一帧或保存时覆盖。
 
-处理：NM1 让新编辑、history live 和 thumbnail 以 `PipelineDocument` 为权威。产品不保留
-stage 镜像。NM1.5 从产品 Apply/Save 移除 stage 覆盖文档。无图存储拒绝打开。N5/N6
-production 接入以 NM1 写入权威为前置条件。后续 Phase 删除 CPU stage 表。
+处理：NM1 让新编辑和全部渲染使用同一个 live `PipelineDocument`，history 仍决定已提交状态。
+NM1.4 删除整图复制和产品 Apply 的 stage 覆盖，再复用后台 executor；NM1.4R 收敛请求与后台
+资源生命周期、修复使用权和导出 recipe，完成后 NM1.5 才实施无镜像保存读取。
+坏图真实失败，项目格式统一切换留在 NM4。NM5/NM6 接入以前必须完成这些基础及 NM4 history。
+后续删除未被产品使用的 CPU stage 类型。
 
 ### 25.2 多 Grade 只在 compiler 表面循环
 
@@ -1579,7 +1614,8 @@ production 接入以 NM1 写入权威为前置条件。后续 Phase 删除 CPU s
 
 ### 25.7 Paste 误复制源 RAW 状态
 
-处理：始终从目标 root 建文档并保留目标 Develop；transfer package 显式列出可转移内容。
+处理：在目标 live document 上应用目标图片的初始状态并保留目标 Develop；
+transfer package 显式列出可转移内容。
 
 ### 25.8 UI panel 太窄
 
@@ -1606,7 +1642,7 @@ production 接入以 NM1 写入权威为前置条件。后续 Phase 删除 CPU s
 - [ ] Adjustment Transfer 只创建 Paste Version，不再创建新的 pipeline merge commit。
 - [ ] Mask raster asset 不可变，stroke Undo/Redo 不依赖被覆盖文件。
 - [ ] CUDA、OpenCL、Metal 不使用 CPU 或其他 backend 替代路径。
-- [ ] 无可用图的 stage-only 存储拒绝打开；产品路径不使用 stage 镜像。
+- [ ] 旧项目 metadata 在打开入口拒绝；当前格式坏图真实失败；产品路径不使用 stage 镜像。
 - [ ] Windows/macOS package 可加载 QuickQanava QML module 和全部新 panel。
 - [ ] 真实 RAW E2E、reopen、Version、Paste、性能和资源证据全部记录在最终资格验证记录中。
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-29
 
-Status: NM0 complete；NM1 in progress；NML 与 NM2–NM8 planned。
+Status: NM0 complete；NM1 in progress；NM2–NM8 planned。NML cancelled (2026-08-30).
 
 本方案承接 [GPU DAG 编辑管线重构 Phase 计划](gpu_dag_pipeline_rebuild_phase_plan.md)。前一份
 计划建立了 `PipelineDocument`、`PipelineGraph`、GPU execution plan、三后端管线、MaskStore
@@ -10,7 +10,10 @@ Status: NM0 complete；NM1 in progress；NML 与 NM2–NM8 planned。
 调整面板、多蒙版绘制、编辑历史和 Version 工作流。
 
 本文件定义背景、产品语义、目标架构、跨模块边界、一级 Phase 顺序、主要调用链、风险和
-最终验收范围。它固定 `NM0` 到 `NM8` 以及兼容升级 Phase `NML` 的阶段门槛，但不预先写每个阶段内部的详细执行步骤。
+最终验收范围。它固定 `NM0` 到 `NM8` 的阶段门槛，但不预先写每个阶段内部的详细执行步骤。
+一级 Phase `NML`（旧 stage 存储升级到默认 DAG）于 2026-08-30 取消。产品不打开 DAG document
+之前的 stage-only 项目，也不迁移旧 mini-git commit。后续 Phase 删除 CPU stage 表，不做旧
+项目升级。详细措辞见 [NM1 执行方案第 3.1 节](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md)。
 开始某个一级 Phase 前，再根据当时的代码状态创建对应执行方案；该文件继续拆成
 `NMx.1`、`NMx.2` 等具体子 Phase，并决定实际 PR/branch 粒度。执行方案可以调整内部拆分，
 但不得无说明地越过本文的一级依赖或改变已经锁定的产品语义。
@@ -209,7 +212,9 @@ Mask 的唯一组合语义是 Union。
 - AI segmentation mask；
 - 在节点编辑器中显示内部 GPU pass；
 - detached HEAD；
-- 新的管线 merge 操作。
+- 新的管线 merge 操作；
+- 打开或升级 DAG document 之前的 stage-only 项目；
+- 把旧 mini-git commit 从 stage 身份迁移成 DAG mutation。
 
 ---
 
@@ -605,8 +610,10 @@ EditorParameterTarget
   field_key
 ```
 
-每次输入序列开始时锁定 target。即使用户在拖动期间通过快捷键或其他 UI 改变 selected node，
-当前序列也必须继续写入开始时的 NodeId/MaskId，或者明确取消；不能把后半段值写到另一个节点。
+每个 patch 必须携带完整 `EditorParameterTarget`。缺少 `owner_kind`、`node_id` 或 Color Grade
+的 `adjustment_instance_id` 时拒绝写入；不根据 field catalog 或选中节点填入缺省 target。
+输入序列的第一个合法 patch 锁定 target；同一序列的后续完整 patch 复用该锁定。详见 NM1
+执行方案第 3.1 节。
 
 ### 11.2 Mutation 分类
 
@@ -1126,8 +1133,8 @@ Adjustment Transfer Paste
 | Phase | Status | 未来执行方案 | 阶段结果 |
 | --- | --- | --- | --- |
 | NM0 — QuickQanava Integration Baseline | complete | [node_mask_editor/phase_nm0_quickqanava_integration_plan.md](node_mask_editor/phase_nm0_quickqanava_integration_plan.md) | 固定依赖、构建和 package 路径，证明官方组件可被 production QML 使用 |
-| NM1 — PipelineDocument Editing Foundation | in progress | [node_mask_editor/phase_nm1_pipeline_document_editing_plan.md](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md) | PipelineDocument 成为新编辑写入权威；图命令含完整删除；thumbnail DAG；stage 仅作兼容镜像 |
-| NML — Legacy Stage Compatibility and Default DAG Upgrade | planned | `node_mask_editor/phase_nml_legacy_stage_dag_upgrade_plan.md` | 旧 stage 存储可审计地升级为默认三节点 DAG；stage 表仍可作读取兼容层 |
+| NM1 — PipelineDocument Editing Foundation | in progress | [node_mask_editor/phase_nm1_pipeline_document_editing_plan.md](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md) | PipelineDocument 成为新编辑写入权威；图命令含完整删除；thumbnail DAG；无 stage 产品镜像；无图存储拒绝打开 |
+| NML — Legacy Stage Compatibility and Default DAG Upgrade | cancelled 2026-08-30 | — | 不升级、不打开 DAG document 之前的 stage-only 项目；不迁移 mini-git commit |
 | NM2 — Multi-Grade Runtime and Ownership | planned | `node_mask_editor/phase_nm2_multi_grade_runtime_plan.md` | compiler 和三后端真正执行多 Color Grade，并落实参数所有权 |
 | NM3 — Multi-Mask Model and Runtime | planned | `node_mask_editor/phase_nm3_multi_mask_runtime_plan.md` | 每节点多 Mask、Union、Range 字段和不可变 raster asset 完整可用 |
 | NM4 — History, Version, Recovery, and Paste | planned | `node_mask_editor/phase_nm4_history_version_paste_plan.md` | typed history、每 Version 一 DAG、recovery 和 Paste-only 完成切换 |
@@ -1243,26 +1250,28 @@ macOS debug linked `libQuickQanava.a` (Homebrew Qt 6.9.2, clang 21.1.1).
 **阶段边界：** 让 `PipelineDocument` 成为新编辑、history live mutation 和 thumbnail 像素的
 写入/渲染权威；增加候选文档 mutation、完整 graph validation、原子 Add/Remove/Reconnect
 （含删除 Default / `grade.primary`）、stable IDs、Clean Color Grade 创建入口、typed
-parameter target 和失败回滚。`CPUPipelineExecutor` stage 表作为旧项目和旧 history payload
-的兼容镜像保留。调整面板可以暂时继续展示现有产品 UI，但所有新写入必须经过新
-app service API。Thumbnail 必须 DAG 渲染，不得先转到 stage 再出图。
+parameter target 和失败回滚。产品不保留 CPU stage 表作为旧项目兼容镜像。进程内 stage 表
+可以暂时留在代码中，直到后续 Phase 删除。NM 执行期间不要求现有 adjustment UI 继续可用；
+每个 patch 必须带完整 typed target。Thumbnail 必须 DAG 渲染，不得先转到 stage 再出图。无可用
+图的存储拒绝打开。
 
 **退出条件：** 新文档编辑不被 live stages 覆盖；无效 mutation 不改变 document/history
 head；默认三节点和 Clean node 行为有 model tests；thumbnail/analysis 走 DAG；UI 还未开放
-新增节点入口。旧 stage 项目的持久升级不在本 Phase 完成。
+新增节点入口。产品不打开 DAG document 之前的项目。
 
-### 21.2a Phase NML — Legacy Stage Compatibility and Default DAG Upgrade
+### 21.2a Phase NML — 已取消（2026-08-30）
 
-**为什么单独成一级 Phase：** NM1 必须立刻停止把 stage 当作新编辑和 thumbnail 的源，但旧项目
-仍要能打开。把「一次性、可审计地把旧 stage 存储升级成默认三节点 DAG」塞进 NM1 会把兼容
-读取和数据升级缠在一起。History payload 的 typed 重构仍在 NM4。
+后续 Phase 将删除 CPU stage 表。产品 stage 镜像会变成随后删除的额外工作。把旧 stage
+项目升级为默认 DAG 会改写参数和 mini-git commit。工作量大。本产品不保留这些旧项目。
 
-**阶段边界：** 保留 stage 表作为读取兼容层；提供明确的升级路径，把旧 stage JSON / adapter
-写成当前默认三节点 `PipelineDocument` 并持久化；升级失败返回真实错误，不恢复 legacy 编辑
-路径，也不静默丢弃可读取的旧数据。开始本 Phase 时再写执行方案。
+替代规则：
 
-**退出条件：** 旧项目可以升级到默认三节点 DAG；升级后的 root/checkpoint 以文档为准；未能升级
-的数据仍可按 NM1 的兼容打开规则失败或只读打开，行为有测试。
+- 存储含有可用 format v2 图：打开。文档是编辑状态。
+- 存储只有 stage JSON 或 stage adapter、没有可用图：不要打开。返回真实错误。不要 import
+  成默认三节点图。不要改写 mini-git commit。
+- 后续 Phase 删除 CPU stage 表。该 Phase 不是旧项目升级。
+
+不要创建 `phase_nml_legacy_stage_dag_upgrade_plan.md`。
 
 ### 21.3 Phase NM2 — Multi-Grade Runtime and Parameter Ownership
 
@@ -1365,7 +1374,6 @@ service 路径；更新本文 completion record。
 ```text
 NM0 QuickQanava baseline
   -> NM1 PipelineDocument editing foundation
-  -> NML Legacy stage compatibility and default DAG upgrade
   -> NM2 Multi-grade runtime and ownership
   -> NM3 Multi-mask model and runtime
   -> NM4 History, Version, recovery, and Paste
@@ -1375,8 +1383,8 @@ NM0 QuickQanava baseline
   -> NM8 Product qualification and cutover
 ```
 
-NML 插在 NM1 与 NM2 之间，是因为多 Grade runtime 假定存储里已经是可执行的 DAG 文档。NM1
-期间旧项目仍靠 importer 和双向镜像打开，不把持久升级提前做完。
+NML 已取消。NM2 假定已打开的项目带有可用 DAG 文档。没有图的项目不会进入 NM2。后续
+Phase 删除 CPU stage 表。该删除不是旧项目升级。
 
 上一个 Phase 的退出条件是下一个 Phase 的输入。可以在前一个 Phase 接近完成时做只读审计或
 准备下一份执行方案，但不能提前向 production 暴露依赖尚未完成的操作。若实施证据证明必须
@@ -1538,9 +1546,9 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 
 症状：node panel 修改新 document，adjustment panel 仍修改 legacy stage，下一帧或保存时覆盖。
 
-处理：NM1 让新编辑、history live 和 thumbnail 以 `PipelineDocument` 为权威；stage 只保留为旧
-项目兼容镜像，且不得覆盖新图结构。旧存储的持久升级由 NML 完成。N5/N6 production 接入以
-NM1 写入权威为前置条件。
+处理：NM1 让新编辑、history live 和 thumbnail 以 `PipelineDocument` 为权威。产品不保留
+stage 镜像。NM1.5 从产品 Apply/Save 移除 stage 覆盖文档。无图存储拒绝打开。N5/N6
+production 接入以 NM1 写入权威为前置条件。后续 Phase 删除 CPU stage 表。
 
 ### 25.2 多 Grade 只在 compiler 表面循环
 
@@ -1598,6 +1606,7 @@ NM1 写入权威为前置条件。
 - [ ] Adjustment Transfer 只创建 Paste Version，不再创建新的 pipeline merge commit。
 - [ ] Mask raster asset 不可变，stroke Undo/Redo 不依赖被覆盖文件。
 - [ ] CUDA、OpenCL、Metal 不使用 CPU 或其他 backend 替代路径。
+- [ ] 无可用图的 stage-only 存储拒绝打开；产品路径不使用 stage 镜像。
 - [ ] Windows/macOS package 可加载 QuickQanava QML module 和全部新 panel。
 - [ ] 真实 RAW E2E、reopen、Version、Paste、性能和资源证据全部记录在最终资格验证记录中。
 


### PR DESCRIPTION
## Summary

Completes the Node Mask pipeline-document editing phase from NM1.1 through NM1.5.

- Keeps one live `PipelineDocument` and shared executor per image.
- Completes in-place graph editing, document-driven product rendering, shared background use, and explicit lifecycle release.
- Makes format-version-2 document JSON the product save/load source.
- Removes product-stage mirroring from load, save, import, mapper, duplicate, and editor-release boundaries.
- Adds document validation, dirty/WAL preservation on failure, unsettled-preview rejection, and document round-trip/import coverage.
- Updates the NM roadmap with completion status, call chains, test evidence, and residual scope.

## Verification

Built from the repository root with Windows/MSVC debug tooling:

```text
cmd /c scripts\msvc_env.cmd --build build\debug --target PipelineMapperTest ImportPipelineDocumentTest SleeveServiceTest PipelineSharedUseTest EditorSessionPipelinePortTest alcedo_main --parallel 4
```

Executed results:

- `PipelineMapperTest`: 30/30 passed; 2 explicitly disabled.
- NM1.5 document save/read/import acceptance: 6/6 passed.
- `PipelineSharedUseTest`: 16/16 passed.
- `SleeveServiceTest`: 24/24 passed.
- `AdjustmentTransferServiceTest`: 7/7 passed.
- `EditorSessionPipelinePortTest`: 2/2 passed.
- `alcedo_main`: compiled and linked successfully.
- NM1.5 touched files pass `git diff --check`.

## Scope boundaries

- Thumbnail and analysis disk writeback policy remains tracked separately in Issue #113 and is not part of this phase.
- Verification was run on Windows/MSVC with CUDA/OpenCL available; Metal was not run on this host.
- Legacy stage APIs, the legacy importer, and serialized history checkpoints remain for non-NM1.5 compatibility paths; product document load/apply/save does not use them as the document source.
- The pre-existing line-ending-only change in `alcedo_studio/src/edit/CMakeLists.txt` was intentionally left out of the commit.
