### PR TITLE
docs: define NM5 node editor UI and implementation plan

### DIFF
--- a/.agents/skills/alcedo-qml-ui/SKILL.md
+++ b/.agents/skills/alcedo-qml-ui/SKILL.md
@@ -18,7 +18,7 @@ marketing UI skills when touching `alcedo_studio/src/ui/alcedo_main/`.
 
 ## Before any visual or panel change
 
-1. Read **`alcedo_studio/src/ui/alcedo_main/DESIGN.md`** (VI contract).
+1. Read **`alcedo_studio/src/ui/alcedo_main/DESIGN.md`** (VI specification).
 2. Map every color, radius, space, type size, and icon size to an **`appTheme`**
    token or a listed shared component.
 3. If a new value is required, add it to **`AppTheme`** (`app_theme.hpp` /
@@ -57,6 +57,40 @@ QQuickStyle::setStyle("Basic");
   Material ripples and minimum paddings
 
 Tests may load Material for isolation harnesses; production QML must not.
+
+---
+
+## Hard ban: compound labels with centered-dot separators
+
+Alcedo-owned UI copy must not join independent names, values, counts, modes, or
+states into an `xx · xx` string. This rule applies to panel titles, node chrome,
+metadata, badges, toolbars, list rows, and status text.
+
+**Forbidden examples:** `On · 2 masks`, `RAW · Active`, `Tone Curve · Enabled`.
+
+Give each item a separate visual role instead. Use a dedicated label, value,
+icon with an accessible name, column, or row. Use spacing, alignment, or a
+structural divider when the relationship needs visual grouping. Do not evade
+this rule by replacing the centered dot with a bullet, slash, vertical bar, or
+dash inside the same compound label.
+
+## Hard ban: unrequested pills and badges
+
+Do not add a new pill, badge, chip, tag, lozenge, or similar rounded text
+container unless the user explicitly requests that element for the current UI.
+Do not infer permission from a reference image, an existing component, or the
+type of data. Use plain text, an icon, a standard action, or layout structure by
+default. Do not copy an existing approved pill or badge into a new surface
+without an explicit user request.
+
+## Hard ban: unrequested status dots
+
+Do not add a new status dot, presence dot, activity dot, notification dot, or
+other colored circular indicator unless the user explicitly requests it for the
+current UI. Do not infer permission from a reference image, an existing
+component, or a semantic color token. Do not use a dot for decorative balance.
+Existing approved indicators can remain in an unchanged surface. Do not copy
+them into a new or changed surface without an explicit user request.
 
 ---
 

--- a/alcedo_studio/src/ui/alcedo_main/DESIGN.md
+++ b/alcedo_studio/src/ui/alcedo_main/DESIGN.md
@@ -61,6 +61,41 @@ Version and transaction **titles**, times, and section chrome stay on
 
 ---
 
+## UI copy composition
+
+### Hard ban: `xx · xx` labels
+
+Do not join independent names, values, counts, modes, or states with a centered
+dot in Alcedo-owned UI copy. This ban applies to panel titles, node chrome,
+metadata, badges, toolbars, list rows, and status text.
+
+Forbidden examples include `On · 2 masks`, `RAW · Active`, and
+`Tone Curve · Enabled`. Give each item a separate visual role: a dedicated
+label, value, icon with an accessible name, column, or row. Use spacing,
+alignment, or a structural divider when the relationship needs visual grouping.
+Do not reproduce the same compound-label pattern with a bullet, slash, vertical
+bar, or dash.
+
+### Hard ban: unrequested pills and badges
+
+Do not add a new pill, badge, chip, tag, lozenge, or similar rounded text
+container unless the user explicitly requests that element for the current UI.
+A reference image, an existing component, or a data type does not give this
+permission. Use plain text, an icon, a standard action, or layout structure by
+default. Do not copy an existing approved pill or badge into a new surface
+without an explicit user request.
+
+### Hard ban: unrequested status dots
+
+Do not add a new status dot, presence dot, activity dot, notification dot, or
+other colored circular indicator unless the user explicitly requests it for the
+current UI. A reference image, an existing component, or a semantic color token
+does not give this permission. Do not use a dot for decorative balance.
+Existing approved indicators can remain in an unchanged surface. Do not copy
+them into a new or changed surface without an explicit user request.
+
+---
+
 ## Color and surface hierarchy
 
 Semantic colors follow the active theme (`currentThemeIndex` 0 Alcedo / 1 Classic)
@@ -273,6 +308,117 @@ QPainter-backed waveform density image.
 
 ---
 
+## Nodes panel and graph nodes
+
+The Nodes page is the third expandable page in `EditorWorkspaceRail`. It shares
+the rail shell, width limits, fold motion, and Loader lifetime with History and
+Versions. Only one tool page can be open.
+
+### Nodes rail icon
+
+Use `panel_icons/nodes.svg` for the Nodes toggle. The icon uses the approved
+Tabler `stack-2` paths:
+
+```svg
+<path d="M12 4l-8 4l8 4l8 -4l-8 -4" />
+<path d="M4 12l8 4l8 -4" />
+<path d="M4 16l8 4l8 -4" />
+```
+
+Normalize the asset to the shared 24×24 viewBox and white source stroke. Keep
+the user-approved 2 px stroke width. Tint it with `ColorImage`. Do not add a count, badge, or status
+dot to this icon.
+
+### Graph canvas
+
+The graph uses a vertical Develop-to-DRT/Post backbone. The canvas uses a deep
+AppTheme surface and a quiet official QuickQanava `Qan.LineGrid`. Do not add a
+nested card, minimap, gradient, shadow, glow, or glass effect.
+
+Use AppTheme roles for the canvas, grid, edge, port, candidate edge, and node
+selection. Add each missing role to `AppTheme` and this file in the same change.
+Do not put raw graph colors in QML.
+
+### Color Grade node content
+
+A Color Grade node shows only:
+
+1. Its display name.
+2. A `Masks` drawer header.
+3. Its Mask source types when the drawer is open.
+
+Do not show a topology number. The default name can contain a creation number,
+such as `Color Grade 3`. Topology changes do not change this name.
+
+Do not show node-kind text, a status dot, On/Off content, an adjustment summary,
+a Mask count, or a persistent action row. Do not add a pill or badge. Do not use
+an `xx · xx` compound label or an equivalent separator pattern.
+
+The node uses `cardSurfaceColor` with a 1 px `cardBorderColor` outline. Selection
+keeps the same surface and uses a high-contrast outline around the full node.
+Selection does not change the node size. It does not add a label, status dot,
+glow, or large blue fill.
+
+Develop and DRT/Post use compact endpoint delegates. They show their fixed names
+and real ports. They do not show a Mask drawer. Do not add a `Locked` badge.
+
+### Mask drawer
+
+Each Color Grade Mask drawer starts open. The user can open or close it from the
+full `Masks` header row. A disclosure chevron shows the fold direction. It is
+not a status indicator.
+
+The header stays visible when the drawer is closed. It does not show a Mask
+count. The body clips during the fold and uses `motionFoldOpenMs`,
+`motionFoldCloseMs`, and `motionEasing`. `reduceMotion` sets the duration to
+zero.
+
+The open state is UI layout state. A drawer change does not modify the pipeline,
+create history, or start photo rendering. An empty open drawer has no Mask rows.
+
+Each Mask row is flat. It shows only the approved source-type icon and localized
+type name. Do not show the Mask name, opacity, enabled value, invert value,
+ranges, identity, selection, or actions.
+
+| Model kind | UI label | Icon |
+| --- | --- | --- |
+| `MaskSourceKind::LinearGradient` | `Gradient` | `mask_icons/gradient.svg` |
+| `MaskSourceKind::Radial` | `Radial` | `mask_icons/radial.svg` |
+| `MaskSourceKind::Brush` | `Brush` | `mask_icons/brush.svg` |
+
+Use these approved paths:
+
+```svg
+<!-- Gradient: Tabler wash-dry -->
+<path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12" />
+
+<!-- Radial: Tabler wash-dryclean -->
+<path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+
+<!-- Brush: Tabler brush -->
+<path d="M3 21v-4a4 4 0 1 1 4 4h-4" />
+<path d="M21 3a16 16 0 0 0 -12.8 10.2" />
+<path d="M21 3a16 16 0 0 1 -10.2 12.8" />
+<path d="M10.6 9a9 9 0 0 1 4.4 4.4" />
+```
+
+Normalize all three files to the shared 24×24 viewBox and white source stroke.
+Keep the user-approved 2 px stroke width. Use one optical size and one source
+size for the group. The Radial circle is an approved type icon. Do not reuse it
+as a status dot.
+
+### Ports and variable height
+
+Use one small square input port at the top and one small square output port at
+the bottom of a Color Grade. The visible square has a larger input area. A port
+is a connection control, not a status dot.
+
+The output port follows the bottom of the node when the Mask drawer changes
+height. Bound edges must update to the new port position. The user cannot resize
+the node directly.
+
+---
+
 ## Icon and action geometry
 
 Three independent sizes — never inherit only the SVG viewBox:
@@ -304,7 +450,8 @@ geometry tests (token equality + optional grab fixtures).
 on a 24×24 viewBox. At the compact 18 px optical size this resolves to roughly
 1.125 logical pixels before antialiasing, keeping dense navigation crisp rather
 than visually bold. Do not mix the upstream Tabler 2 px default with locally
-normalized icons in the same navigation group.
+normalized icons in the same navigation group. The user-approved Nodes rail
+icon and Gradient, Radial, and Brush Mask icons are documented 2 px exceptions.
 
 **Every SVG action must:**
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -1,0 +1,1462 @@
+# Phase NM5 — QuickQanava Nodes Panel
+
+Date: 2026-09-02
+
+Status: planned
+
+Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
+
+Parent plan: [Node-aware Pipeline Editing and Mask Authoring](../node_mask_editor_master_plan.md),
+Sections 15–18 and 21.6.
+
+---
+
+## 1. Objective
+
+NM5 adds the production Nodes page to the editor tool rail. The page uses the pinned
+QuickQanava module. It shows the image backbone of the current `PipelineDocument`.
+
+NM5 lets the user:
+
+- open and close the Nodes page;
+- select one pipeline node;
+- add a clean Color Grade;
+- rename a Color Grade;
+- delete a Color Grade;
+- move a Color Grade to another valid backbone position;
+- move and zoom the graph view;
+- move nodes for local layout;
+- open and close each Color Grade Mask drawer.
+
+The node card shows the node name and the Mask stack. It does not show adjustment names.
+Each Mask row shows only the Mask source type.
+
+All pipeline changes use the NM4 typed-history path. All graph validation stays in Alcedo.
+QuickQanava displays the projection and reports user input. It never owns product data.
+
+### 1.1 Scope exclusions
+
+NM5 does not:
+
+- add node Enable or Disable actions;
+- show On, Off, Active, or Inactive state in a node;
+- show topology numbers;
+- show adjustment summaries;
+- show Mask counts;
+- edit, add, remove, rename, or reorder Masks;
+- add Mask authoring to the viewer;
+- change right-side adjustment ownership;
+- add arbitrary branches, groups, or compositors;
+- use QuickQanava groups;
+- implement a second graph canvas;
+- replace QuickQanava navigation, selection, ports, edges, or visual connectors;
+- add a minimap.
+
+The domain can retain existing enabled fields for stored data and execution. NM5 does not expose
+those fields in the Nodes UI.
+
+### 1.2 Product boundary after NM5
+
+NM5 provides the complete Nodes page and its real edit paths. NM6 consumes the selected NodeId
+for right-side adjustment routing. NM7 adds Mask selection and Mask authoring. NM8 performs the
+final cross-platform qualification.
+
+---
+
+## 2. Required repository context
+
+Read the current source before each sub-phase. A file name is not evidence that an interface is
+still unchanged.
+
+| Source | Required information |
+| --- | --- |
+| [Master plan](../node_mask_editor_master_plan.md) | Read Sections 3, 5, 6, 11–18, 20, 21, and 23–26. They define identity, writes, history, UI, tests, and failure behavior. |
+| [NM0 plan](phase_nm0_quickqanava_integration_plan.md) | Read the pinned revision, static module setup, licence work, and incomplete production checks. |
+| [NM1 plan](phase_nm1_pipeline_document_editing_plan.md) | Read the single live document rule, render lock, failure restoration, and render reasons. |
+| [NM2 plan](phase_nm2_multi_grade_runtime_plan.md) | Read backbone order, NodeId identity, and multi-Grade execution. |
+| [NM3 plan](phase_nm3_multi_mask_runtime_plan.md) | Read the ordered display list of Masks and `MaskSourceKind`. |
+| [NM4 plan](phase_nm4_history_version_paste_plan.md) | Read typed graph changes, Undo, Redo, checkout, recovery, and WAL failure behavior. |
+| [QML VI](../../../../../alcedo_studio/src/ui/alcedo_main/DESIGN.md) | Read Basic style, AppTheme, copy bans, icon rules, panel geometry, focus, fold motion, and Loader lifetime. |
+| [EditorWorkspace.qml](../../../../../alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml) | Read the current editor columns and the 360 logical-pixel viewer floor. |
+| [EditorWorkspaceRail.qml](../../../../../alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspaceRail.qml) | Read the current History and Versions pages, fold progress, Loader, and rail actions. |
+| [EditorSessionController](../../../../../alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp) | Read session identity, page state, action availability, and generation signals. |
+| [EditorSessionHistoryPort](../../../../../alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp) | Read the NM4 Add, Remove, Reconnect, and Rename entry points. Do not expose `SetColorGradeEnabled` in NM5. |
+| [PipelineDocument](../../../../../alcedo_studio/src/include/edit/graph/pipeline_document.hpp) | Read serialization, graph ownership, and the default document factory. |
+| [ColorGradeNodeModel](../../../../../alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp) | Read display name, Masks, and input/output ports. |
+| [MaskModel](../../../../../alcedo_studio/src/include/edit/mask/mask_model.hpp) | Read `Brush`, `Radial`, and `LinearGradient` source kinds. |
+
+### 2.1 Fixed product invariants
+
+- `PipelineDocument` is the only writable product graph.
+- QuickQanava objects are projection objects.
+- A `qan::Node*` is never a NodeId.
+- A Qan object does not survive a projection generation change.
+- QML calls application-layer controllers only.
+- QML never modifies the product graph directly.
+- A graph command uses the NM4 typed batch, WAL, history head, and render path.
+- A UI-only change does not create a history commit.
+- A UI-only change does not start a photo render.
+- A failed graph command leaves the document, history, projection, and permanent Qan graph unchanged.
+- A stale session or generation cannot change the current image.
+- The product graph has one Develop-to-DRT scene-image backbone.
+- Develop and DRT/Post cannot be removed or renamed.
+- The Nodes UI has one selected node.
+
+---
+
+## 3. QuickQanava official-source rule
+
+QuickQanava is a specialized third-party library. Do not infer its interface from a generic node
+editor or another graph library.
+
+The pinned checkout is tag `2.50`, commit
+`56bdf78d5b1d41fb60ae3b8ea2292df45787ecff`.
+
+The website can describe a newer revision. The pinned checkout defines the buildable interface.
+If the website and checkout differ, record the difference in the sub-phase completion record.
+Do not move to another upstream revision during NM5.
+
+### 3.1 Official documentation index
+
+| Official page | Required sections | NM5 use |
+| --- | --- | --- |
+| [QuickQanava](https://cneben.github.io/QuickQanava/index.html) | `Introduction` | Confirms the directed-graph, QML-delegate, drag, resize, and visual-topology scope. |
+| [Installation](https://cneben.github.io/QuickQanava/installation.html) | `QuickQanava Quick Start`, `Using from external projects with CMake`, `Dependencies` | Defines the static-library and CMake integration path. |
+| [Graph](https://cneben.github.io/QuickQanava/graph.html) | `Data Model`, `QuickQanava Initialization`, `Graph View`, `Grid` | Defines topology/view separation, initialization, navigation, and official grid support. |
+| [Nodes/Groups](https://cneben.github.io/QuickQanava/nodes.html) | `Adding content`, `Docks and Ports`, `Node Resizing`, `Observing Topology`, `Selection`, `Defining Custom Nodes` | Defines nodes, visual items, port binding, size changes, selection, and custom delegates. |
+| [Edges](https://cneben.github.io/QuickQanava/edges.html) | `Creating Edges`, `Visual creation of edges`, `Visual Connectors`, `Custom Connectors` | Defines edge insertion and the request-only connector mode. |
+| [Styles](https://cneben.github.io/QuickQanava/styles.html) | `Defining Styles`, `Node Style`, `Material Styling` | Defines style properties. Alcedo does not copy the Material appearance. |
+| [Utilities](https://cneben.github.io/QuickQanava/utilities.html) | `Navigable` | Points to the navigation interface. Verify exact methods in the pinned header. |
+| [Advanced use (C++)](https://cneben.github.io/QuickQanava/advanced.html) | `Using from C++`, `Defining Custom Topology`, `Insertion of non Visual Content`, `Observation of Topological Modifications` | Defines C++ access, factories, and topology observation. |
+| [Samples](https://cneben.github.io/QuickQanava/samples.html) | `Custom Nodes: 'custom'`, `Navigable Area: 'navigable'`, `Topology Sample: 'topology'` | Confirms official usage patterns. Sample appearance is not Alcedo VI. |
+| [API Reference](https://cneben.github.io/QuickQanava/reference.html) | `API Reference` | States that the detailed online reference is unavailable. Generate local Doxygen or read pinned headers. |
+| [Licence](https://cneben.github.io/QuickQanava/licence.html) | `Licence` | Defines source and binary redistribution notices. |
+
+### 3.2 Required pinned headers
+
+Check these files before using an exact C++ or QML property name:
+
+- `alcedo_studio/src/third_party/QuickQanava/src/qanGraph.h`
+- `alcedo_studio/src/third_party/QuickQanava/src/qanGraph.hpp`
+- `alcedo_studio/src/third_party/QuickQanava/src/qanGraphView.h`
+- `alcedo_studio/src/third_party/QuickQanava/src/qanNavigable.h`
+- `alcedo_studio/src/third_party/QuickQanava/src/qanNode.h`
+- `alcedo_studio/src/third_party/QuickQanava/src/qanNodeItem.h`
+- `alcedo_studio/src/third_party/QuickQanava/src/qanPortItem.h`
+- `alcedo_studio/src/third_party/QuickQanava/src/qanEdge.h`
+- `alcedo_studio/src/third_party/QuickQanava/src/qanEdgeItem.h`
+- `alcedo_studio/src/third_party/QuickQanava/src/qanStyle.h`
+
+Generate local Doxygen from the pinned checkout when the headers do not give enough context.
+Save generated output under `build/tmp/nm5_quickqanava_docs/`. Do not add it to the repository.
+
+### 3.3 Confirmed framework boundaries
+
+The official documentation confirms these boundaries:
+
+- `Qan.GraphView.graph` binds a graph to a view.
+- `qan::Graph` or `Qan.Graph` modifies QuickQanava topology.
+- A topology primitive has a visual item through `item` or `getItem()`.
+- `Qan.GraphView` supplies mouse navigation when navigation is enabled.
+- `Qan.LineGrid` is the supported documented grid. The website marks PointGrid as deprecated. The
+  pinned 2.50 source has removed PointGrid. NM5 uses only `Qan.LineGrid`.
+- `insertPort()` creates ports.
+- `bindEdgeSource()` and `bindEdgeDestination()` bind an edge to ports.
+- custom QML delegates define node content;
+- rectangular node bounds update after width or height changes;
+- selection uses graph policy and selected-node state;
+- `connectorCreateDefaultEdge = false` prevents the default connector from inserting an edge;
+- `connectorRequestEdgeCreation(src, dst)` reports a request when default insertion is disabled.
+
+The official documentation does not make `PipelineDocument` a QuickQanava object. It does not
+define Alcedo history, Version behavior, naming, Mask semantics, or render scheduling.
+
+---
+
+## 4. Current source baseline
+
+### 4.1 Existing capability
+
+- NM0 adds the QuickQanava submodule and builds its static module.
+- NM0 records the BSD-3-Clause licence and the bezier dependency notice.
+- NM0 does not link QuickQanava into the production `alcedo_main` path.
+- NM4 provides typed Add, Remove, Reconnect, Rename, and replay behavior.
+- `PipelineDocument` serializes the graph and all Color Grade Masks.
+- `ColorGradeNodeModel::Masks()` keeps Mask display order.
+- `GetMaskSourceKind()` returns `Brush`, `Radial`, or `LinearGradient`.
+- `EditorWorkspaceRail.qml` supports History and Versions.
+- The rail destroys a loaded page after the close fold reaches zero.
+- The rail stores list offsets outside page Loaders.
+- `DESIGN.md` defines Basic style, AppTheme use, icon geometry, panel size, and fold motion.
+
+### 4.2 Missing capability
+
+- The production executable does not initialize QuickQanava.
+- The production QML module does not contain a Nodes page.
+- No application projection maps `PipelineDocument` into Qan primitives.
+- No controller owns selected NodeId for the Nodes page.
+- No UI store owns graph position, view position, zoom, or drawer state.
+- No default Color Grade naming counter exists in `PipelineDocument`.
+- The default node name is currently `Color Grade`, without a number.
+- No approved Alcedo node delegate exists.
+- No Mask type icon resources exist for the node drawer.
+- The current rail page property is named for History only.
+
+### 4.3 Existing APIs that NM5 must not expose
+
+The current domain and history layers include `SetColorGradeEnabled`. NM5 does not remove this
+stored behavior. NM5 also does not expose it in QML, the node menu, keyboard input, node content,
+screen-reader text, or tests of visible actions.
+
+---
+
+## 5. Approved Nodes UI
+
+### 5.1 Workspace position
+
+Nodes is the third expandable page in `EditorWorkspaceRail`. History, Versions, and Nodes use one
+page key and one Loader. Only one page can be open.
+
+```text
+Top toolbar
+
+┌────────┬─────────────────────────┬───────────────────┐
+│ Rail   │ Viewer                  │ Adjustment stack  │
+│        │                         │                   │
+│ Hist   │                         │ Selected node     │
+│ Vers   │                         │ context in NM6    │
+│ Nodes  │                         │                   │
+│ Tasks  │                         │                   │
+├────────┴─────────────────────────┴───────────────────┤
+│ Filmstrip under the viewer column                   │
+└─────────────────────────────────────────────────────┘
+```
+
+Nodes replaces only the left expandable body. It does not cover the viewer. It does not create a
+floating window.
+
+### 5.2 Rail icon
+
+Use the user-approved Tabler `stack-2` path for the Nodes toggle:
+
+```svg
+<path d="M12 4l-8 4l8 4l8 -4l-8 -4" />
+<path d="M4 12l8 4l8 -4" />
+<path d="M4 16l8 4l8 -4" />
+```
+
+Store the normalized asset as `alcedo_studio/src/config/panel_icons/nodes.svg`.
+
+The asset must use:
+
+- `viewBox="0 0 24 24"`;
+- `fill="none"`;
+- `stroke="white"`;
+- `stroke-width="2"`;
+- round line caps and joins.
+
+Add the asset to `alcedo_studio/src/config/resource.qrc`. Use `IconActionButton` and AppTheme tint.
+Use `Nodes` for the tooltip and accessible name. Do not add a count or status marker to the icon.
+
+### 5.3 Page structure
+
+The page has two visible layers:
+
+1. A compact header.
+2. The graph canvas.
+
+The header shows `Nodes` and one Add action. It does not show a node count, Version summary, Fit
+label, status text, pill, badge, or status dot. The Add action uses `IconActionButton`.
+
+Fit remains available through `Ctrl+0` and the canvas context menu. This keeps the header simple.
+
+The canvas uses a deep AppTheme surface and a quiet official `Qan.LineGrid`. It has no nested card,
+gradient, shadow, glow, glass effect, or minimap.
+
+### 5.4 Graph direction
+
+The default graph is vertical:
+
+```text
+Develop
+   ↓
+Color Grade 1
+   ↓
+Color Grade 2
+   ↓
+DRT/Post
+```
+
+Develop is at the top. DRT/Post is at the bottom. Color Grades follow execution order.
+
+The first view of a Version uses deterministic positions. Do not depend on an undocumented
+upstream layout algorithm. QuickQanava supplies display and navigation, not product ordering.
+
+Users can move nodes. Users can move and zoom the view. These changes are local UI state.
+
+### 5.5 Default Color Grade names
+
+Do not show a topology number. A node name can contain a creation number.
+
+The default names are:
+
+```text
+Color Grade 1
+Color Grade 2
+Color Grade 3
+```
+
+`Color Grade 1` is the primary Grade in a new default document. The document starts its next-name
+counter at `2`.
+
+The counter has these rules:
+
+- a successful Add operation consumes one value;
+- a failed Add operation does not consume a value;
+- Rename does not change the counter;
+- Remove does not decrease the counter;
+- Reconnect does not change the counter;
+- node movement does not change the counter;
+- existing node names do not change when topology order changes;
+- each serialized document stores its next counter value;
+- Undo, Redo, recovery, reopen, and Version checkout restore deterministic document state.
+
+The counter is product metadata. It is not Qan state and not local layout state.
+
+Update `PipelineDocument` serialization with an explicit field such as
+`next_color_grade_name_number`. Bump the document format when required by the current NM4 format
+rules. Do not migrate an unsupported older project format.
+
+The Add typed change must preserve enough before and after data for exact replay. Reinserting a
+stored node during Undo or Redo must not claim another default name.
+
+### 5.6 Ordinary Color Grade node
+
+An ordinary node contains:
+
+1. The node display name.
+2. A Mask drawer header.
+3. The Mask rows when the drawer is open.
+
+It does not contain:
+
+- a topology number;
+- node-kind text;
+- a status dot;
+- On or Off text;
+- an Enable or Disable action;
+- an adjustment name or adjustment summary;
+- a Mask count;
+- a rename, delete, or other persistent action row;
+- a pill, badge, chip, tag, or lozenge;
+- an `xx · xx` compound label.
+
+Rename and Delete stay available through the shared context menu and keyboard input. The card does
+not reserve space for these actions.
+
+### 5.7 Mask drawer
+
+Each Color Grade has one Mask drawer below the name row. The drawer is open by default. The user can
+close or open it from its `Masks` header row.
+
+Open state:
+
+```text
+             ■
+   ┌────────────────────┐
+   │ Color Grade 4      │
+   ├────────────────────┤
+   │ Masks            ▾ │
+   ├────────────────────┤
+   │ [icon] Gradient    │
+   │ [icon] Radial      │
+   │ [icon] Brush       │
+   └────────────────────┘
+             ■
+```
+
+Closed state:
+
+```text
+             ■
+   ┌────────────────────┐
+   │ Color Grade 4      │
+   ├────────────────────┤
+   │ Masks            ▸ │
+   └────────────────────┘
+             ■
+```
+
+The drawer follows these rules:
+
+- the `Masks` header stays visible in both states;
+- the header does not show a count;
+- the header uses a disclosure chevron, not a state dot;
+- the full header row is operable;
+- the open or closed state is local UI layout state;
+- a drawer change does not modify `PipelineDocument`;
+- a drawer change does not create history;
+- a drawer change does not start photo rendering;
+- the body clips during fold motion;
+- `motionFoldOpenMs`, `motionFoldCloseMs`, and `motionEasing` control the fold;
+- `reduceMotion` sets the duration to zero;
+- the output port follows the bottom of the current delegate height;
+- bound edges update after the delegate height changes.
+
+Store drawer state outside the Loader. Key it by project, image, Version, and NodeId. A new key
+starts open. Undo can restore a removed NodeId and recover its prior drawer state.
+
+An open empty drawer has no Mask rows.
+
+### 5.8 Mask rows
+
+Mask rows are read-only in NM5. Their order equals `ColorGradeNodeModel::Masks()` display order.
+
+Each row shows only:
+
+- the approved source-type icon;
+- the localized type name.
+
+The mapping is:
+
+| Model kind | UI label | Asset |
+| --- | --- | --- |
+| `MaskSourceKind::LinearGradient` | `Gradient` | `qrc:/mask_icons/gradient.svg` |
+| `MaskSourceKind::Radial` | `Radial` | `qrc:/mask_icons/radial.svg` |
+| `MaskSourceKind::Brush` | `Brush` | `qrc:/mask_icons/brush.svg` |
+
+Do not show the Mask display name, opacity, enabled value, invert value, ranges, MaskId, timestamp,
+selection, or actions. Do not add a hover action or row menu in NM5.
+
+Keep MaskId in the application projection. NM7 needs stable identity. Do not expose the ID as UI
+text.
+
+### 5.9 Approved Mask SVG paths
+
+Gradient uses the user-approved Tabler `wash-dry` path:
+
+```svg
+<path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12" />
+```
+
+Radial uses the user-approved Tabler `wash-dryclean` path:
+
+```svg
+<path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+```
+
+Brush uses the user-approved Tabler `brush` paths:
+
+```svg
+<path d="M3 21v-4a4 4 0 1 1 4 4h-4" />
+<path d="M21 3a16 16 0 0 0 -12.8 10.2" />
+<path d="M21 3a16 16 0 0 1 -10.2 12.8" />
+<path d="M10.6 9a9 9 0 0 1 4.4 4.4" />
+```
+
+Store these assets under `alcedo_studio/src/config/mask_icons/`. Add them to `resource.qrc`.
+
+All three assets use the same 24×24 viewBox, white source stroke, and user-approved 2 px stroke as
+the Nodes icon. Use AppTheme tint at runtime. Do not change one icon's optical size to compensate
+for its path complexity.
+
+The Radial circle is an approved type icon. It is not a status dot. Do not reuse it as one.
+
+### 5.10 Endpoints
+
+Develop and DRT/Post use compact endpoint delegates. They show their fixed names and real ports.
+They do not show the Mask drawer.
+
+Do not add a `Locked` badge or a status dot. Use action availability, tooltip text, and accessible
+text to explain why Rename or Delete is unavailable.
+
+### 5.11 Selection
+
+The product allows one selected node. Selection does not change node size.
+
+Use the shared surface and a high-contrast outline. Do not add a selected-state label, pill, badge,
+status dot, glow, or large blue fill. The selection outline contains the full open drawer.
+
+QuickQanava selection is a view of `EditorNodeController.selectedNodeId`. The controller owns the
+product selection. A Qan selected-node list cannot become a second selection source.
+
+### 5.12 Ports and edges
+
+Each Color Grade has one top input port and one bottom output port. Develop has no scene-image input.
+DRT/Post has no scene-image output.
+
+Use a small square as the visible port. Give it a larger hit area. A port is a connection control,
+not a status dot.
+
+Use a thin edge with an AppTheme role. Do not use flow animation, glow, or decorative arrows.
+
+The permanent edge set always comes from the accepted Alcedo projection. A visual connector is only
+a request preview until the backend accepts it.
+
+### 5.13 Copy and decoration bans
+
+The Nodes page must follow the global VI rules:
+
+- no `xx · xx` compound labels;
+- no equivalent compound label with a bullet, slash, vertical bar, or dash;
+- no new pill, badge, chip, tag, or lozenge without an explicit user request;
+- no new status dot without an explicit user request;
+- no shadow, glow, gradient, or glass effect;
+- no Material import or Material control appearance;
+- no raw visual literals when an AppTheme role is required.
+
+---
+
+## 6. Ownership and interfaces
+
+### 6.1 Projection
+
+Add an immutable application projection. Use value types across the UI boundary.
+
+The projection needs at least:
+
+```text
+EditorNodeGraphSnapshot
+  session_generation
+  projection_revision
+  topology_revision
+  nodes[]
+  edges[]
+
+EditorNodeProjection
+  node_id
+  node_kind
+  display_name
+  masks[]
+
+EditorNodeMaskProjection
+  mask_id
+  source_kind
+
+EditorNodeEdgeProjection
+  source_node_id
+  source_port_id
+  destination_node_id
+  destination_port_id
+```
+
+Do not project adjustments, enabled values, mix, Mask opacity, or Mask display names into node-card
+roles. Those values do not appear in the NM5 node delegate.
+
+Projection update rules:
+
+- a parameter edit does not rebuild the graph;
+- a Mask source-kind change updates the owning Grade drawer;
+- a Mask Add, Remove, or display-order change updates the owning Grade drawer;
+- a Rename updates one node label;
+- a topology revision adds, removes, or reconnects Qan primitives;
+- a Version checkout replaces the snapshot;
+- a generation change rejects older snapshots and Qan callbacks.
+
+### 6.2 Controller
+
+`EditorNodeController` owns:
+
+- the current session handle and generation;
+- `selectedNodeId`;
+- graph command availability;
+- Add, Rename, Delete, and Reconnect requests;
+- projection revision publication;
+- exact localized failure text;
+- selection restoration after graph changes.
+
+It does not own Qan visuals or layout coordinates.
+
+Suggested QML-facing actions:
+
+```text
+addColorGrade()
+renameColorGrade(nodeId, displayName)
+removeColorGrade(nodeId)
+requestReconnect(nodeId, predecessorId, successorId, requestGeneration)
+selectNode(nodeId)
+```
+
+Do not add `setNodeEnabled()` or an equivalent QML action.
+
+### 6.3 Qan adapter
+
+`AlcedoQanGraph` maps projection values to Qan primitives. Keep maps in both directions:
+
+```text
+NodeId -> QPointer<qan::Node>
+qan::Node* -> NodeId plus projection generation
+edge identity -> QPointer<qan::Edge>
+```
+
+Clear all reverse maps before a full projection replacement. Reject a callback when its primitive
+or generation is stale.
+
+The adapter can insert and remove Qan primitives after an accepted projection update. It cannot
+call Alcedo domain mutation functions directly.
+
+### 6.4 Layout store
+
+`EditorNodeLayoutStore` owns only local UI values:
+
+```text
+LayoutKey
+  project identity
+  image identity
+  Version identity
+
+LayoutValue
+  preferred panel width
+  view position
+  zoom
+  selected NodeId
+  node positions by NodeId
+  Mask drawer open state by NodeId
+```
+
+The store does not keep `QObject*`, `qan::Node*`, or QML item pointers. It does not write
+`PipelineDocument` or history.
+
+### 6.5 Default-name counter
+
+Add the next-name counter to `PipelineDocument`. The graph command consumes the counter only after
+all Add validation succeeds.
+
+The typed Add payload must make forward and inverse replay exact. Use explicit before and after
+counter values if the current whole-node payload does not make counter replay exact.
+
+The default document factory sets:
+
+```text
+primary Grade display name = Color Grade 1
+next Color Grade name number = 2
+```
+
+Remove and Rename do not modify the counter. Reinsertion from stored JSON does not allocate a name.
+
+---
+
+## 7. Sub-phase map
+
+| Sub-phase | Result | Required official sections |
+| --- | --- | --- |
+| NM5.1 | Production link, initialization, and read-only proof | Installation: `QuickQanava Quick Start`, `Using from external projects with CMake`; Graph: `QuickQanava Initialization`, `Graph View` |
+| NM5.2 | Default-name counter and immutable projection | Graph: `Data Model`; Nodes: `Adding content`, `Observing Topology`; Advanced: `Using from C++`, `Defining Custom Topology` |
+| NM5.3 | Qan adapter, ports, and read-only topology | Nodes: `Adding content`, `Docks and Ports`, `Observing Topology`; Edges: `Creating Edges`; Advanced: `Defining Custom Topology` |
+| NM5.4 | Alcedo node delegate and Mask drawer | Nodes: `Docks and Ports`, `Node Resizing`, `Selection`, `Defining Custom Nodes`; Styles: `Defining Styles`, `Node Style`; Samples: `Custom Nodes: 'custom'` |
+| NM5.5 | Rail, navigation, selection, and layout state | Graph: `Graph View`, `Grid`; Nodes: `Node Resizing`, `Selection`; Utilities: `Navigable`; Samples: `Navigable Area: 'navigable'`, `Topology Sample: 'topology'` |
+| NM5.6 | Add, Rename, and Delete | Graph: `Data Model`; Nodes: `Adding content`, `Observing Topology`, `Selection`; Advanced: `Observation of Topological Modifications` |
+| NM5.7 | Request-only visual connector and Reconnect | Nodes: `Docks and Ports`; Edges: `Visual creation of edges`, `Visual Connectors`, `Custom Connectors` |
+| NM5.8 | Lifecycle, accessibility, build, install, and package checks | Installation; Graph: `QuickQanava Initialization`, `Graph View`; API Reference notice; Licence |
+
+Each sub-phase can use one or more PRs. Every PR must build and test its completed scope.
+
+---
+
+## 8. NM5.1 — Production link, initialization, and read-only proof
+
+### 8.1 Input context
+
+NM0 builds the pinned static QuickQanava module. It does not prove that the production engine can
+load a Qan graph. This sub-phase proves that path before product projection work starts.
+
+### 8.2 Official documentation
+
+- [Installation](https://cneben.github.io/QuickQanava/installation.html): `QuickQanava Quick Start` and `Using from external projects with CMake`.
+- [Graph](https://cneben.github.io/QuickQanava/graph.html): `QuickQanava Initialization` and `Graph View`.
+- [Advanced use (C++)](https://cneben.github.io/QuickQanava/advanced.html): `Using from C++`.
+
+### 8.3 Work
+
+1. Link the production owner target to the pinned QuickQanava target.
+2. Call the pinned initialization function before the production engine loads QML.
+3. Keep `QQuickStyle::setStyle("Basic")`.
+4. Add a Loader-owned, read-only Qan graph proof to a test harness.
+5. Create the graph and one node only through documented Qan entry points.
+6. Destroy and recreate the Loader repeatedly.
+7. Record all differences between website examples and the pinned interface.
+
+### 8.4 Main call chain
+
+```text
+alcedo_main startup
+  -> set Qt Quick Controls Basic style
+  -> initialize pinned QuickQanava module
+  -> load Alcedo QML engine
+  -> harness Loader creates Qan.GraphView
+  -> Qan.Graph binds to GraphView.graph
+```
+
+### 8.5 Files
+
+- `alcedo_studio/src/ui/alcedo_main/CMakeLists.txt`
+- `alcedo_studio/src/ui/alcedo_main/main.cpp`
+- an NM5 integration harness under `alcedo_studio/tests/ui/`
+- `alcedo_studio/tests/ui/CMakeLists.txt`
+
+### 8.6 Tests and exit criteria
+
+- The production target links the pinned module.
+- Initialization occurs before QML load.
+- The production style remains Basic.
+- The harness loads and destroys the Qan objects without warnings or stale access.
+- A missing Qan import fails with the real QML error.
+- The test does not replace a failed graph with a placeholder implementation.
+
+### 8.7 Completion record
+
+Record the date, revision, exact initialization signature, commands, test count, and upstream
+differences here after implementation.
+
+---
+
+## 9. NM5.2 — Default-name counter and immutable projection
+
+### 9.1 Input context
+
+NM4 can rebuild the full document at any history head. `PipelineDocument` does not yet store a
+default-name counter. The UI also has no immutable graph snapshot.
+
+This sub-phase changes product data and application projection. It does not create production Qan
+primitives.
+
+### 9.2 Official documentation
+
+- [Graph](https://cneben.github.io/QuickQanava/graph.html): `Data Model`.
+- [Nodes/Groups](https://cneben.github.io/QuickQanava/nodes.html): `Adding content` and `Observing Topology`.
+- [Advanced use (C++)](https://cneben.github.io/QuickQanava/advanced.html): `Using from C++` and `Defining Custom Topology`.
+
+These sections explain Qan topology and visual primitives. They do not define Alcedo naming or
+history. Alcedo owns both.
+
+### 9.3 Work
+
+1. Add the serialized next-name counter to `PipelineDocument`.
+2. Set the primary default name to `Color Grade 1`.
+3. Set the new-document counter to `2`.
+4. Make a successful Add consume one number.
+5. Keep the counter unchanged after Add failure, Rename, Remove, or Reconnect.
+6. Extend typed Add replay with exact counter state.
+7. Update format validation and fixtures.
+8. Add immutable node, Mask, edge, revision, and generation projection values.
+9. Project MaskId and source kind in display order.
+10. Omit adjustment and enabled roles from the node projection.
+
+### 9.4 Main call chains
+
+Read path:
+
+```text
+history head or Version checkout
+  -> current PipelineDocument under the read boundary
+  -> EditorNodeGraphProjection
+  -> immutable EditorNodeGraphSnapshot
+  -> UI-thread publication with session generation
+```
+
+Default-name path:
+
+```text
+Add command validation
+  -> read next_color_grade_name_number
+  -> create a local Color Grade change with "Color Grade N" and next value N + 1
+  -> validate the complete local graph change
+  -> capture node JSON and exact before/after counter values
+  -> accept both node and counter changes, or restore both on failure
+```
+
+### 9.5 Files and interfaces
+
+Plan to modify:
+
+- `pipeline_document.hpp/.cpp`
+- `color_grade_node_model.cpp`
+- `pipeline_graph_commands.hpp/.cpp`
+- `pipeline_edit_batch.hpp/.cpp`
+- `pipeline_document_history.hpp/.cpp`
+- NM4 graph/history tests and stored fixtures
+
+Plan to add:
+
+- `editor_node_graph_projection.hpp/.cpp`
+- projection tests
+
+### 9.6 Tests and exit criteria
+
+- A default document contains `Color Grade 1` and counter value `2`.
+- Two successful Adds create `Color Grade 2` and `Color Grade 3`.
+- Rename does not change the next value.
+- Remove does not reuse a consumed value in the same document state.
+- Reconnect does not change names or counter state.
+- Add failure does not consume a value.
+- Undo and Redo restore exact node names and counter values.
+- Recovery and reopen restore exact node names and counter values.
+- Version checkout publishes the matching projection.
+- Mask projection order equals model display order.
+- A parameter edit does not publish a topology rebuild.
+- A stale generation snapshot is rejected.
+
+### 9.7 Completion record
+
+Record the date, format revision, schema field, commands, test count, success chain, and failure
+chain here after implementation.
+
+---
+
+## 10. NM5.3 — Qan adapter, ports, and read-only topology
+
+### 10.1 Input context
+
+NM5.2 provides immutable values with stable IDs and explicit revisions. QuickQanava still cannot
+become a product data source.
+
+This sub-phase maps a snapshot into Qan primitives. It does not expose product graph commands.
+
+### 10.2 Official documentation
+
+- [Graph](https://cneben.github.io/QuickQanava/graph.html): `Data Model` and `Graph View`.
+- [Nodes/Groups](https://cneben.github.io/QuickQanava/nodes.html): `Adding content`, `Docks and Ports`, and `Observing Topology`.
+- [Edges](https://cneben.github.io/QuickQanava/edges.html): `Creating Edges`.
+- [Advanced use (C++)](https://cneben.github.io/QuickQanava/advanced.html): `Defining Custom Topology`.
+
+### 10.3 Work
+
+1. Add the thin `AlcedoQanGraph` adapter.
+2. Create one Qan primitive for each projected pipeline node.
+3. Create one Qan edge for each projected backbone edge.
+4. Create and bind the real top and bottom ports.
+5. Keep NodeId and edge identity maps outside QML text labels.
+6. Apply role-only updates without rebuilding topology.
+7. Replace all primitives after Version or generation replacement.
+8. Reject callbacks from an older generation.
+9. Clear reverse maps before object destruction.
+
+### 10.4 Main call chain
+
+```text
+EditorNodeGraphSnapshot
+  -> AlcedoQanGraph compares revisions
+  -> documented Qan insert/remove calls
+  -> documented port insertion and binding
+  -> Qan graph bound to GraphView
+```
+
+### 10.5 Files and interfaces
+
+Plan to add:
+
+- `alcedo_qan_graph.hpp/.cpp`
+- adapter tests
+
+Plan to modify:
+
+- `AlbumBackendLib` sources and links
+- QML type registration if QML constructs the adapter
+- `alcedo_main/CMakeLists.txt`
+
+Verify exact pinned names for:
+
+- node and edge insertion/removal;
+- port insertion;
+- edge source and destination binding;
+- primitive visual-item access;
+- node selected state;
+- object-destruction signals.
+
+### 10.6 Tests and exit criteria
+
+- NodeId maps to one live Qan node in the current generation.
+- Each backbone edge binds to the correct ports.
+- A Rename updates one label without replacing the graph.
+- A Mask kind change updates one node without replacing edges.
+- A Version replacement removes every old primitive and reverse-map entry.
+- A stale primitive cannot select or edit the new document.
+- Adapter failure restores the prior complete Qan projection.
+
+### 10.7 Completion record
+
+Record the date, pinned API signatures, commands, test count, success chain, and failure chain here.
+
+---
+
+## 11. NM5.4 — Alcedo node delegate and Mask drawer
+
+### 11.1 Input context
+
+NM5.3 provides a read-only Qan graph. Default QuickQanava delegates do not follow Alcedo VI. The
+approved node uses a variable-height Mask drawer.
+
+This sub-phase changes display only. It does not expose graph commands.
+
+### 11.2 Official documentation
+
+- [Nodes/Groups](https://cneben.github.io/QuickQanava/nodes.html): `Docks and Ports`, `Node Resizing`, `Selection`, and `Defining Custom Nodes`.
+- [Styles](https://cneben.github.io/QuickQanava/styles.html): `Defining Styles` and `Node Style`.
+- [Samples](https://cneben.github.io/QuickQanava/samples.html): `Custom Nodes: 'custom'`.
+- [Advanced use (C++)](https://cneben.github.io/QuickQanava/advanced.html): `Defining Custom Topology`.
+
+The upstream Material section identifies style binding points only. Do not import Material.
+
+### 11.3 Work
+
+1. Add the Color Grade delegate with name row and Mask drawer.
+2. Add compact Develop and DRT/Post delegates.
+3. Keep Qan node resize disabled for user input.
+4. Let the delegate height follow its drawer content.
+5. Verify automatic rectangular bound updates after height changes.
+6. Keep the output port at the current node bottom.
+7. Add Gradient, Radial, and Brush type rows.
+8. Add the four approved SVG resources.
+9. Add required graph AppTheme roles and document them in `DESIGN.md`.
+10. Use a shared disclosure control and existing fold motion.
+11. Apply all copy and decoration bans from Section 5.13.
+
+### 11.4 Main call chain
+
+```text
+projected node and Mask kinds
+  -> Qan primitive uses Alcedo custom delegate
+  -> node name row
+  -> default-open Mask drawer
+  -> icon and localized type row for each Mask
+  -> delegate height changes
+  -> Qan rectangular bounds and bound edges update
+```
+
+### 11.5 Files
+
+Plan to add:
+
+- `qml/EditorNodeDelegate.qml`
+- `qml/EditorEndpointNodeDelegate.qml`
+- `qml/EditorNodeMaskDrawer.qml`
+- `qml/EditorNodeMaskTypeRow.qml`
+- `qml/EditorNodePortDelegate.qml`
+- `qml/EditorNodeEdgeDelegate.qml` only if the pinned extension point requires it
+- `config/panel_icons/nodes.svg`
+- `config/mask_icons/gradient.svg`
+- `config/mask_icons/radial.svg`
+- `config/mask_icons/brush.svg`
+
+Plan to modify:
+
+- `config/resource.qrc`
+- `app_theme.hpp/.cpp`
+- `DESIGN.md`
+- `alcedo_main/CMakeLists.txt`
+
+### 11.6 Tests and exit criteria
+
+- The node has no topology number.
+- The node has no status dot.
+- The node has no On or Off text.
+- The node has no adjustment summary.
+- The node has no Mask count.
+- The node has no pill or badge.
+- Each Mask row shows only approved type icon and type label.
+- Mask row order equals model display order.
+- The drawer starts open for a new layout key.
+- The user can close and reopen the drawer.
+- The output port and edges follow both heights.
+- Drawer input does not create history or rendering.
+- Production QML has no Material import.
+- Node effects, shadow, glow, and gradient stay disabled.
+- Both themes and DPR 1.0, 1.25, 1.5, and 2.0 keep icons clear.
+
+### 11.7 Completion record
+
+Record the date, screenshots, token additions, pinned delegate API, commands, and test count here.
+
+---
+
+## 12. NM5.5 — Rail, navigation, selection, and layout state
+
+### 12.1 Input context
+
+NM5.4 provides the read-only production visual. The rail still supports only History and Versions.
+The rail destroys its page Loader after a complete close.
+
+This sub-phase enables selection and UI layout. It does not expose graph mutations.
+
+### 12.2 Official documentation
+
+- [Graph](https://cneben.github.io/QuickQanava/graph.html): `Graph View` and `Grid`.
+- [Nodes/Groups](https://cneben.github.io/QuickQanava/nodes.html): `Node Resizing` and `Selection`.
+- [Utilities](https://cneben.github.io/QuickQanava/utilities.html): `Navigable`.
+- [Samples](https://cneben.github.io/QuickQanava/samples.html): `Navigable Area: 'navigable'` and `Topology Sample: 'topology'`.
+
+### 12.3 Work
+
+1. Rename `historyPanelPage` to a neutral tool-page property.
+2. Accept only `""`, `history`, `versions`, and `nodes`.
+3. Migrate object names and tests to neutral rail names.
+4. Add the approved Nodes rail action.
+5. Add `EditorNodesPanel.qml`.
+6. Reuse the current rail fold and Loader.
+7. Destroy graph delegates after a complete close.
+8. Keep plain layout values outside the Loader.
+9. Use the existing side-panel width range.
+10. Preserve the 360 logical-pixel viewer floor.
+11. Configure one selected node.
+12. Make `EditorNodeController.selectedNodeId` authoritative.
+13. Add backbone keyboard navigation.
+14. Add `Ctrl+0` Fit behavior after pinned-header verification.
+15. Save node positions, view position, zoom, selection, and drawer state.
+16. Restore per-Version layout and selection.
+
+### 12.4 Main call chains
+
+Open:
+
+```text
+Nodes rail action
+  -> tool page becomes nodes
+  -> existing fold opens the body
+  -> Loader creates EditorNodesPanel
+  -> GraphView binds AlcedoQanGraph
+  -> layout store applies positions, view, zoom, drawer state, and selection
+```
+
+Close:
+
+```text
+Nodes rail action or another tool page
+  -> capture plain layout values
+  -> fold closes
+  -> Loader destroys GraphView at progress zero
+  -> controller and layout store keep no Qan pointers
+```
+
+Select:
+
+```text
+documented Qan node click
+  -> adapter resolves NodeId and generation
+  -> EditorNodeController.selectNode
+  -> selectedNodeId changes
+  -> adapter applies the one-node visual selection
+```
+
+### 12.5 Keyboard and accessibility
+
+| Input | Result |
+| --- | --- |
+| `Tab`, `Shift+Tab` | Move through the header, canvas, and operable drawer headers. |
+| `Up`, `Down` | Select the previous or next backbone node. |
+| `Home`, `End` | Select Develop or DRT/Post. |
+| `Enter`, `Space` on drawer header | Open or close the current drawer. |
+| `F2` | Rename a selected Color Grade after NM5.6. |
+| `Delete` | Delete a selected Color Grade after NM5.6. |
+| `Ctrl++` | Add a Color Grade after NM5.6. |
+| `Ctrl+0` | Fit the graph. |
+| `Escape` | Cancel rename or a connector request. Otherwise return focus to the canvas. |
+
+Every action needs localized tooltip text and `Accessible.name`. Every focus target needs a visible
+focus treatment. A screen reader must read the node name and Mask type rows. It must not announce
+hidden enabled or adjustment data.
+
+### 12.6 Files
+
+Plan to add:
+
+- `qml/EditorNodesPanel.qml`
+- `editor_node_controller.hpp/.cpp`
+- `editor_node_layout_store.hpp/.cpp`
+
+Plan to modify:
+
+- `EditorWorkspaceRail.qml`
+- `EditorWorkspace.qml`
+- `EditorSessionController`
+- QML type registration
+- `alcedo_main/CMakeLists.txt`
+- rail and workspace tests
+
+### 12.7 Tests and exit criteria
+
+- Only the four allowed page keys are accepted.
+- History, Versions, and Nodes are mutually exclusive.
+- A full close leaves no graph delegates.
+- Reopen restores positions, view, zoom, selection, and drawer state.
+- Two Versions keep separate layout values.
+- Undo restoration of a NodeId can recover its prior position and drawer state.
+- Ctrl-click cannot create a second product selection.
+- Graph movement and drawer folds do not start photo rendering.
+- `reduceMotion` makes all related folds immediate.
+- The viewer stays at least 360 logical pixels wide at 960×640.
+
+### 12.8 Completion record
+
+Record the date, pinned navigation API, commands, test count, success chain, and failure chain here.
+
+---
+
+## 13. NM5.6 — Add, Rename, and Delete
+
+### 13.1 Input context
+
+NM5.5 provides stable selection and lifecycle behavior. NM4 provides real typed graph history. NM5.2
+provides the naming counter. This sub-phase connects only Add, Rename, and Delete.
+
+Reconnect remains in NM5.7. Enable and Disable are not NM5 actions.
+
+### 13.2 Official documentation
+
+- [Graph](https://cneben.github.io/QuickQanava/graph.html): `Data Model`.
+- [Nodes/Groups](https://cneben.github.io/QuickQanava/nodes.html): `Adding content`, `Observing Topology`, and `Selection`.
+- [Advanced use (C++)](https://cneben.github.io/QuickQanava/advanced.html): `Observation of Topological Modifications`.
+
+These sections apply only to Qan projection updates. Alcedo commands own the product change.
+
+### 13.3 Work
+
+1. Connect the header Add action to `EditorNodeController`.
+2. Generate a stable NodeId in the application layer.
+3. Insert before DRT/Post, or after the selected Grade through the existing `before_node_id` rule.
+4. Claim the next default name inside the accepted domain change.
+5. Connect F2 and the node context menu to typed Rename.
+6. Connect Delete and the context menu to typed Remove.
+7. Do not put persistent action buttons on the node card.
+8. Disable conflicting commands while a command is active.
+9. Apply Qan changes only after a successful projection update.
+10. Restore selection after deletion by successor, predecessor, then DRT/Post.
+11. Publish exact errors without creating a substitute graph.
+
+### 13.4 Main call chain
+
+```text
+Add, Rename, or Delete UI request
+  -> EditorNodeController validates session, generation, and NodeId
+  -> EditorSessionHistoryPort command
+  -> domain change under the render lock
+  -> typed batch and WAL
+  -> history head publication
+  -> node or topology projection revision
+  -> AlcedoQanGraph update
+  -> Quality render only when pixels or topology changed
+```
+
+Rename is metadata-only. It creates history but does not start a photo render.
+
+### 13.5 Files
+
+- `editor_node_controller.hpp/.cpp`
+- `EditorNodesPanel.qml`
+- `EditorNodeDelegate.qml`
+- `EditorSessionHistoryPort`
+- default-name counter and typed Add files from NM5.2
+- session action availability
+- history presentation
+
+### 13.6 Tests and exit criteria
+
+- Add creates one clean Grade with the next default name.
+- Add creates one commit and one required Quality render.
+- Rename creates one metadata commit and no render.
+- Delete bridges the correct predecessor and successor.
+- Delete creates one commit and one required Quality render.
+- Develop and DRT/Post reject Rename and Delete.
+- No visible Enable or Disable action exists.
+- Invalid NodeId and stale generation requests fail.
+- WAL failure restores document, history, counter, projection, and selection.
+- A failed command creates no temporary permanent Qan node.
+- Undo and Redo restore names, topology, Mask drawer content, and selection.
+
+### 13.7 Completion record
+
+Record the date, commands, test count, success chain, failure chain, and render reasons here.
+
+---
+
+## 14. NM5.7 — Request-only visual connector and Reconnect
+
+### 14.1 Input context
+
+NM5.6 connects all planned graph commands except Reconnect. The product graph still permits one
+backbone. A visual connector can report a request, but it cannot create product topology.
+
+### 14.2 Official documentation
+
+- [Nodes/Groups](https://cneben.github.io/QuickQanava/nodes.html): `Docks and Ports`.
+- [Edges](https://cneben.github.io/QuickQanava/edges.html): `Visual creation of edges`, `Visual Connectors`, and `Custom Connectors`.
+- [Samples](https://cneben.github.io/QuickQanava/samples.html): the feature matrix entry for visual connectors.
+
+The official Edges page requires `connectorCreateDefaultEdge = false` for request-only behavior.
+It then reports `connectorRequestEdgeCreation(src, dst)`.
+
+### 14.3 Work
+
+1. Enable the documented visual connector.
+2. Set `connectorCreateDefaultEdge` to false.
+3. Let only a selected Color Grade start a move request.
+4. Keep Develop and DRT/Post fixed in the backbone.
+5. Resolve Qan source and target through generation-checked identity maps.
+6. Remove the moving Grade from an in-memory order calculation only.
+7. Resolve the target position in the remaining backbone.
+8. Compute the new predecessor and successor.
+9. Call NM4 `ReconnectColorGrade` through the controller.
+10. Update permanent Qan edges only after projection publication.
+11. Remove the preview and show exact error text after failure.
+
+### 14.4 Main call chain
+
+```text
+user drags the official visual connector
+  -> Qan shows a temporary connector
+  -> connectorRequestEdgeCreation(src, dst)
+  -> adapter resolves IDs and generation
+  -> controller computes predecessor and successor
+  -> EditorSessionHistoryPort::ReconnectColorGrade
+  -> domain validation and typed history
+  -> topology projection revision
+  -> permanent Qan edge update
+```
+
+Failure path:
+
+```text
+invalid, stale, cyclic, fan-in, or fan-out request
+  -> controller rejects the request
+  -> no PipelineDocument change
+  -> no history commit
+  -> no permanent Qan edge
+  -> temporary connector closes
+  -> localized error text
+```
+
+### 14.5 Files and pinned interfaces
+
+- `AlcedoQanGraph`
+- `EditorNodeController`
+- `EditorNodePortDelegate.qml`
+- `EditorNodeEdgeDelegate.qml`, if required
+- `EditorNodesPanel.qml`
+- `EditorSessionHistoryPort::ReconnectColorGrade`
+
+Verify the pinned forms of:
+
+- port insertion and binding;
+- `connectorEnabled`;
+- `connectorCreateDefaultEdge`;
+- `connectorRequestEdgeCreation`;
+- connector source configuration;
+- node connectable state.
+
+### 14.6 Tests and exit criteria
+
+- Develop has no incoming move target.
+- DRT/Post has no outgoing move source.
+- Each Grade has one input and one output.
+- A valid move creates one commit.
+- A no-op move creates no commit.
+- Cycle, fan-in, and fan-out requests fail.
+- A stale Qan primitive cannot change the current Version.
+- Backend failure leaves the permanent edge set unchanged.
+- Undo and Redo restore the exact order.
+- Drawer height does not change port identity or reconnect results.
+
+### 14.7 Completion record
+
+Record the date, pinned connector properties, commands, test count, success chain, and failure
+chain here.
+
+---
+
+## 15. NM5.8 — Lifecycle, accessibility, build, install, and package checks
+
+### 15.1 Input context
+
+NM5.1–NM5.7 provide the Nodes page. This sub-phase adds no product feature. It closes lifecycle,
+accessibility, localization, build, and package gaps.
+
+NM8 still owns final real-RAW and three-backend qualification.
+
+### 15.2 Official documentation
+
+- [Installation](https://cneben.github.io/QuickQanava/installation.html): all sections.
+- [Graph](https://cneben.github.io/QuickQanava/graph.html): `QuickQanava Initialization` and `Graph View`.
+- [API Reference](https://cneben.github.io/QuickQanava/reference.html): the local-Doxygen notice.
+- [Licence](https://cneben.github.io/QuickQanava/licence.html): source and binary notice requirements.
+
+### 15.3 Work
+
+1. Complete empty, loading, pending-command, and error behavior.
+2. Complete localized text and accessible names.
+3. Check 30–40 percent text expansion.
+4. Check large system font sizes.
+5. Repeat Loader destruction and recreation.
+6. Check image switch, Version checkout, Undo, Redo, and recovery.
+7. Check every UI ban with property assertions or screenshots.
+8. Build on Windows with the repository MSVC wrapper.
+9. Build on macOS when the environment is available.
+10. Check install and package QML imports.
+11. Check QuickQanava and bezier licence notices.
+12. Run all affected graph, history, adapter, QML, and workspace tests.
+
+### 15.4 Main call chain
+
+```text
+packaged app start
+  -> Basic style
+  -> pinned QuickQanava initialization
+  -> static QML module is available
+  -> editor opens
+  -> Nodes Loader creates GraphView
+  -> current Version projection appears
+  -> all visible product changes use typed history
+```
+
+### 15.5 Tests and exit criteria
+
+- No-image state uses localized plain text.
+- Loading never shows the previous image graph.
+- Command failure keeps the prior graph and exact counter state.
+- Keyboard input can select, open drawers, Add, Rename, Delete, Fit, and Reconnect.
+- A screen reader reads node names, Mask types, disclosure state, and actions.
+- It does not read topology numbers, On/Off state, adjustment summaries, or hidden Mask fields.
+- Both themes and all four target DPR values pass the visual matrix.
+- The production QML tree contains no unapproved pill, badge, or status dot.
+- The Windows package loads QuickQanava.
+- The macOS package loads QuickQanava when that environment is available.
+- The package contains the required third-party notices.
+- Lifetime checks find no stale Qan pointer use.
+
+### 15.6 Completion record
+
+Record the date, commands, test count, visual matrix, package results, and unavailable environment
+checks here.
+
+---
+
+## 16. Test target plan
+
+Prefer an existing target when its responsibility matches. Add a target only when ownership stays
+clear.
+
+| Target | Responsibility |
+| --- | --- |
+| `PipelineDocumentDefaultNameTest` | Serialized counter, default names, format validation, and replay. |
+| `EditorNodeGraphProjectionTest` | Snapshot values, Mask kinds, revisions, NodeId, and generation. |
+| `EditorNodeControllerTest` | Selection, Add, Rename, Delete, Reconnect, failure, and render reasons. |
+| `AlcedoQanGraphTest` | Primitive mapping, ports, edges, selection, role updates, and stale-object rejection. |
+| `EditorNodesPanelQmlTest` | VI, node content, drawer behavior, icons, keyboard, accessibility, and layout restore. |
+| `EditorWorkspaceToolRailLifecycleQmlTest` | History, Versions, and Nodes mutual exclusion and Loader lifetime. |
+| `WorkspaceShellTest` | Column geometry, minimum window size, focus order, and production type registration. |
+| `EditorSessionHistoryPortTest` | Typed graph history, Undo, Redo, WAL failure restoration, and counter replay. |
+
+Every test name must state the behavior that it checks. Do not use `smoke` in a test name.
+
+### 16.1 Required visual matrix
+
+Capture or assert:
+
+- empty and populated Mask drawers;
+- open and closed Mask drawers;
+- selected and unselected nodes;
+- Develop, Color Grade, and DRT/Post delegates;
+- long translated node names;
+- 0, 1, and many Masks;
+- both Alcedo themes;
+- DPR 1.0, 1.25, 1.5, and 2.0;
+- reduced motion;
+- minimum 960×640 window geometry.
+
+The matrix must show that the page has no topology number, status dot, On/Off content, adjustment
+summary, Mask count, pill, badge, shadow, glow, gradient, or Material chrome.
+
+---
+
+## 17. Failure matrix
+
+| Failure point | Required result |
+| --- | --- |
+| QuickQanava import | App or test startup fails with the real QML error. Do not continue with a substitute canvas. |
+| Projection read | Keep the prior graph. Show the exact error. Do not create a default replacement graph. |
+| Stale session generation | Reject the snapshot or request. Do not touch the current session. |
+| Qan node creation | Roll back the adapter update. Keep the prior complete Qan projection. |
+| Qan edge creation or binding | Roll back the adapter update. Leave no orphan edge or port. |
+| Add validation | Do not create a node, consume a name number, commit history, or render. |
+| Rename validation | Keep the prior name. Do not create history. |
+| Delete validation | Keep the node, edges, selection, counter, and layout. |
+| Reconnect validation | Close the preview. Keep the permanent edges. |
+| WAL append | NM4 restores document and history. Restore counter, projection, and selection. |
+| Version checkout | NM4 restores the prior Version after failure. Keep its selection and layout. |
+| Loader teardown | Keep only plain controller and layout values. Keep no Qan pointer. |
+| Package QML module load | Fail package acceptance. Do not release a build with a hidden Nodes page. |
+
+---
+
+## 18. Performance targets
+
+- A parameter slider update does not rebuild the Qan graph.
+- A Mask drawer role update changes only its owner node.
+- A topology update scales with affected nodes and edges.
+- A fully closed panel retains no graph delegates.
+- The default graph shows input feedback within 100 ms after first open.
+- Node selection shows feedback within 100 ms.
+- Add, Delete, and Reconnect show pending feedback within 100 ms.
+- Graph navigation, node movement, and drawer folds do not start photo rendering.
+- Layout storage does not block the GUI thread.
+
+Record:
+
+- first Nodes Loader time;
+- delegate count for the default graph and a 32-Grade graph;
+- projection apply time for a 32-Grade graph;
+- frame time for 100 selections;
+- frame time for opening and closing a node with many Mask rows;
+- live Qan object count after 100 panel open/close cycles.
+
+Do not reduce decode resolution, output quality, or backend behavior to meet these targets.
+
+---
+
+## 19. NM5 completion criteria
+
+- [ ] The production target links the pinned QuickQanava module.
+- [ ] Production initializes QuickQanava before QML load.
+- [ ] Production remains on Qt Quick Controls Basic.
+- [ ] Nodes is a page in the shared editor tool rail.
+- [ ] History, Versions, and Nodes share one page state and Loader.
+- [ ] `PipelineDocument` remains the only product graph.
+- [ ] The document stores the next default Color Grade name number.
+- [ ] A new document names its primary Grade `Color Grade 1`.
+- [ ] Add uses increasing default names and exact typed-history replay.
+- [ ] Nodes show no topology numbers.
+- [ ] Nodes show no status dots.
+- [ ] Nodes show no On/Off state or action.
+- [ ] Nodes show no adjustment summary.
+- [ ] Each Color Grade shows a default-open Mask drawer.
+- [ ] The user can close and reopen each drawer.
+- [ ] Drawer state is local UI state and creates no history or render.
+- [ ] Mask rows show only the approved type icon and type label.
+- [ ] The Nodes rail uses the approved `stack-2` path.
+- [ ] Gradient, Radial, and Brush use the approved paths.
+- [ ] The page contains no unapproved pill, badge, or status dot.
+- [ ] The page contains no `xx · xx` compound label or equivalent substitute.
+- [ ] Projection uses stable NodeId, MaskId, revisions, and session generation.
+- [ ] No Qan pointer survives a generation replacement.
+- [ ] Parameter edits do not rebuild the graph.
+- [ ] Version checkout publishes the correct projection.
+- [ ] The initial layout is vertical and deterministic.
+- [ ] Node positions, view, zoom, selection, and drawer state are local UI state.
+- [ ] The product allows one selected node.
+- [ ] Add creates a clean Color Grade.
+- [ ] Rename and Delete use NM4 typed history.
+- [ ] Reconnect uses the official visual connector.
+- [ ] `connectorCreateDefaultEdge` is false.
+- [ ] The backend accepts a request before permanent Qan edges change.
+- [ ] All command failures preserve the prior product and projected graph.
+- [ ] Add, Rename, Delete, and Reconnect support Undo and Redo.
+- [ ] All visible actions support keyboard input and accessibility.
+- [ ] All product text uses localization.
+- [ ] All visual values use AppTheme and `DESIGN.md`.
+- [ ] Node delegates use no shadow, glow, gradient, or Material style.
+- [ ] Reduced-motion behavior passes.
+- [ ] The viewer keeps its 360 logical-pixel floor at 960×640.
+- [ ] Windows build, install, and package checks pass.
+- [ ] macOS build, install, and package checks pass when the environment is available.
+- [ ] Required third-party notices are in the package.
+- [ ] Every sub-phase completion record lists pinned API differences.
+
+NM6 must use NM5 `selectedNodeId`. NM6 must not create another node selection source.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
@@ -1,8 +1,9 @@
-# Node-aware Pipeline Editing and Mask Authoring 总体方案
+# Node-aware Pipeline Editing and Mask Authoring Master Plan
 
 Date: 2026-08-29
 
-Status: NM0, NM2, and NM3 complete；NM1 in progress；NM4–NM8 planned。NML cancelled (2026-08-30).
+Status: NM0, NM2, NM3, and NM4 complete; NM1 in progress; NM5-NM8 planned. NML was
+cancelled on 2026-08-30.
 
 2026-08-30 简化修订：每张图片只有一个 live document，领域函数原地修改，后台任务共用
 executor；不以整图 candidate 或独立 snapshot executor 实现原子性。History 仍是已提交状态
@@ -13,6 +14,9 @@ R 处理任务请求、后台工作区占用、使用权与完整导出 recipe�
 不保留空闲块；不增加通用两阶段分配或延迟指针回填机制。
 [缩略图磁盘写回 Issue #113](https://github.com/zidage/AlcedoStudio/issues/113)单独跟踪，后续讨论由
 disk cache service 拥有写回/失效机制；不在 R 中实施，也不作为 NM1.5 的前置条件。
+2026-09-02 UI revision: NM4 is complete. The approved node-editor UI, VI mapping,
+QuickQanava boundary, and official documentation sources for NM5-NM8 are fixed before NM5 starts.
+See the [NM5 execution plan](node_mask_editor/phase_nm5_nodes_panel_plan.md) for its sub-phases.
 
 本方案承接 [GPU DAG 编辑管线重构 Phase 计划](gpu_dag_pipeline_rebuild_phase_plan.md)。前一份
 计划建立了 `PipelineDocument`、`PipelineGraph`、GPU execution plan、三后端管线、MaskStore
@@ -36,8 +40,17 @@ disk cache service 拥有写回/失效机制；不在 R 中实施，也不作为
 - [Editor Single Live Pipeline + WAL + Checkpoint](../ui/editor_single_live_pipeline_wal_checkpoint_plan.md)
 - [Phase 7A History/Versions Recovery and Editor Performance Plan](../ui/phase_7a_history_versions_repair_and_ui_refactor_plan.md)
 - [QuickQanava repository](https://github.com/cneben/QuickQanava)
+- [QuickQanava documentation home](https://cneben.github.io/QuickQanava/index.html)
+- [QuickQanava installation documentation](https://cneben.github.io/QuickQanava/installation.html)
 - [QuickQanava graph documentation](https://cneben.github.io/QuickQanava/graph.html)
+- [QuickQanava nodes and groups documentation](https://cneben.github.io/QuickQanava/nodes.html)
+- [QuickQanava edges documentation](https://cneben.github.io/QuickQanava/edges.html)
+- [QuickQanava styles documentation](https://cneben.github.io/QuickQanava/styles.html)
+- [QuickQanava utilities documentation](https://cneben.github.io/QuickQanava/utilities.html)
 - [QuickQanava custom topology documentation](https://cneben.github.io/QuickQanava/advanced.html)
+- [QuickQanava samples documentation](https://cneben.github.io/QuickQanava/samples.html)
+- [QuickQanava API reference notice](https://cneben.github.io/QuickQanava/reference.html)
+- [QuickQanava licence](https://cneben.github.io/QuickQanava/licence.html)
 
 ---
 
@@ -762,13 +775,13 @@ render。这样 Version checkout 可以恢复当时的节点名称，历史描�
 history row 从 typed payload 派生可本地化描述，例如：
 
 ```text
-Exposure · Warm Face: +0.30 → +0.55
-Added Color Grade · Sky
-Removed Color Grade · Background
-Reconnected Color Grade · Skin after Base Grade
-Added Radial Mask · Warm Face
-Brush stroke · Warm Face / Mask 2
-Feather · Warm Face / Radial 1: 24 px → 48 px
+Exposure for Warm Face: +0.30 → +0.55
+Added Color Grade: Sky
+Removed Color Grade: Background
+Reconnected Color Grade: Skin after Base Grade
+Added Radial Mask: Warm Face
+Brush stroke for Warm Face / Mask 2
+Feather for Warm Face / Radial 1: 24 px → 48 px
 ```
 
 不要把已本地化字符串写入 commit payload。payload 保存稳定 ID、operation kind 和数值；QML
@@ -839,18 +852,43 @@ Paste 失败时不得创建空 Version、部分 Mask asset 引用或移动 activ
 
 ---
 
-## 15. QuickQanava 集成边界
+## 15. QuickQanava integration boundary
 
-### 15.1 依赖策略
+All QuickQanava decisions must cite the official documentation. Do not infer behavior from another
+node editor.
 
-- 使用上游 QuickQanava，不实现自有 graph canvas、edge router、port hit testing、selection、
-  pan 或 zoom 组件；
-- 固定经过验证的 tag/commit，不在 configure 时跟随浮动分支；
-- 优先作为仓库 submodule/vendor source 接入，构建不依赖在线 FetchContent；
-- 记录 BSD-3-Clause license 和第三方 notices；
-- 验证 Qt 6.9.3、C++20 主工程、Windows/MSVC 和 macOS/Clang；
-- 验证静态/动态 QML module 的 import path、资源、install 和 package；
-- production QML 继续使用 Qt Quick Controls Basic，不因上游示例改成 Material。
+The online API Reference no longer contains class details. Its page directs users to generate
+Doxygen from the upstream source. Alcedo pins tag `2.50`, commit
+`56bdf78d5b1d41fb60ae3b8ea2292df45787ecff`. The pinned headers define the exact buildable API.
+
+| Design question | Official section | Fixed decision |
+| --- | --- | --- |
+| Library scope | [QuickQanava `Introduction`](https://cneben.github.io/QuickQanava/index.html) | Use the official directed-graph view, QML delegates, drag, navigation, and visual topology input. |
+| CMake and static library | [Installation](https://cneben.github.io/QuickQanava/installation.html) | Use the pinned submodule and CMake. Configuration does not fetch a moving revision. |
+| Product data and visuals | [Graph `Data Model`](https://cneben.github.io/QuickQanava/graph.html) | `PipelineDocument` owns product data. The Qan graph is a projection. |
+| Engine integration | [Graph `QuickQanava Initialization`](https://cneben.github.io/QuickQanava/graph.html) | Initialize before QML load. Production stays on Basic style. |
+| View navigation | [Graph `Graph View`](https://cneben.github.io/QuickQanava/graph.html), [Utilities `Navigable`](https://cneben.github.io/QuickQanava/utilities.html) | Use documented pan and zoom. Verify center and fit methods in the pinned header. |
+| Grid | [Graph `Grid`](https://cneben.github.io/QuickQanava/graph.html) | Use `Qan.LineGrid`. Do not add snap-to-grid. |
+| Nodes and ports | [Nodes/Groups `Adding content`, `Docks and Ports`](https://cneben.github.io/QuickQanava/nodes.html) | Use official node, port, and edge-to-port APIs. |
+| Variable node height | [Nodes/Groups `Node Resizing`, `Defining Custom Nodes`](https://cneben.github.io/QuickQanava/nodes.html) | Use a rectangular custom delegate. Verify bounds and edges after a Mask drawer fold. |
+| Single selection | [Nodes/Groups `Selection`](https://cneben.github.io/QuickQanava/nodes.html) | Use official selection. The Alcedo controller owns the selected NodeId. |
+| Custom appearance | [Nodes/Groups `Defining Custom Nodes`](https://cneben.github.io/QuickQanava/nodes.html), [Advanced `Defining Custom Topology`](https://cneben.github.io/QuickQanava/advanced.html) | Use an Alcedo QML delegate and a thin C++ adapter. |
+| Reconnect request | [Edges `Visual Connectors`](https://cneben.github.io/QuickQanava/edges.html) | Set `connectorCreateDefaultEdge = false`. Send the request to the Alcedo service. |
+| Style | [Styles `Node Style`, `Material Styling`](https://cneben.github.io/QuickQanava/styles.html) | Use style extension points only. Do not copy Material appearance. Disable effects and gradient fill. |
+| Samples | [Samples](https://cneben.github.io/QuickQanava/samples.html) | Use custom, navigable, topology, and connector examples only to confirm official usage. |
+| API signatures | [API Reference](https://cneben.github.io/QuickQanava/reference.html) | Check pinned `src/*.h` files and local Doxygen. Record differences in each completion record. |
+| Distribution | [Licence](https://cneben.github.io/QuickQanava/licence.html) | Keep the required notices in source and binary distributions. |
+
+### 15.1 Dependency policy
+
+- Use upstream QuickQanava. Do not implement a second graph canvas, edge router, port hit test,
+  selection system, or navigation system.
+- Keep the verified tag and commit. Do not follow a moving branch during configuration.
+- Build from the repository submodule. Do not add an online FetchContent dependency.
+- Keep BSD-3-Clause and third-party notices.
+- Verify Qt 6.9.3, C++20, Windows/MSVC, and macOS/Clang.
+- Verify QML import paths, resources, install output, and packages.
+- Keep Qt Quick Controls Basic in production.
 
 ### 15.2 Adapter
 
@@ -858,40 +896,43 @@ Paste 失败时不得创建空 Version、部分 Mask asset 引用或移动 activ
 PipelineDocument
   -> EditorNodeGraphProjection
   -> AlcedoQanGraph adapter
-  -> QuickQanava GraphView / node / port / edge delegates
+  -> QuickQanava GraphView, node, port, and edge delegates
 ```
 
-允许为 QuickQanava extension point 编写薄的 Alcedo delegate，以显示节点标题、状态、端口和
-VI token；不允许重新实现节点拖动、edge 绘制、connector 或 graph navigation。
+The adapter can use documented QuickQanava extension points. It can show node names, Mask source
+types, ports, edges, and AppTheme roles. It cannot reimplement node movement, edge drawing, visual
+connectors, selection, or graph navigation.
 
-建议关闭 QuickQanava 默认的直接建边行为：
+Disable default edge insertion:
 
 ```text
 connectorCreateDefaultEdge = false
 connectorRequestEdgeCreation
-  -> EditorNodeController validate
-  -> typed reconnect mutation
-  -> apply command on live PipelineDocument
+  -> EditorNodeController validation
+  -> typed Reconnect mutation
+  -> live PipelineDocument change
   -> graph projection revision
 ```
 
-视觉 connector 在 backend 成功前只表示候选连接。失败时恢复原图并显示精确原因。
+The visual connector remains temporary until the backend succeeds. Failure restores the prior
+permanent graph and reports the exact reason.
 
-### 15.3 Projection 更新
+### 15.3 Projection updates
 
-- 参数 slider 变化不重建 graph projection；
-- node name/enabled/mask count 只更新对应 node roles；
-- graph topology revision 才添加/删除 node 和 edge projection；
-- Version checkout 替换整份 projection，但保留同 Version layout state；
-- Qan object lifetime 不能成为 NodeId lifetime；
-- QML 不保存裸 C++ model 指针跨异步操作。
+- A parameter slider change does not rebuild the graph projection.
+- A Rename updates one node label.
+- A Mask Add, Remove, reorder, or source-kind change updates only the owner node drawer.
+- A topology revision adds, removes, or reconnects projected nodes and edges.
+- A Version checkout replaces the projection and restores that Version's local layout state.
+- Qan object lifetime never defines NodeId lifetime.
+- QML does not keep a raw C++ model pointer across asynchronous work.
 
 ---
 
-## 16. Nodes 面板
+## 16. Nodes panel
 
-Nodes 作为左侧 `EditorWorkspaceRail` 的第三个可展开页面，与 History、Versions 同属一个视觉
-和生命周期体系：
+Nodes is the third expandable page in `EditorWorkspaceRail`. It shares visual rules and Loader
+lifetime with History and Versions.
 
 ```text
 Rail
@@ -901,33 +942,262 @@ Rail
   Background Tasks
 ```
 
-需要把当前 `historyPanelPage` 概念改成中性的 rail page state，例如
-`editorToolPanelPage`。合法值至少为 `""`、`history`、`versions`、`nodes`。
+### 16.1 Design inputs
 
-布局规则：
+| Item | Fixed value |
+| --- | --- |
+| Platforms | Windows and macOS desktop |
+| Window | 1200×760 logical pixels by default; 960×640 minimum |
+| DPR | 1.0, 1.25, 1.5, and 2.0 |
+| Style | Qt Quick Controls Basic |
+| VI | `AppTheme` and `DESIGN.md` |
+| Primary content | Center photo viewer |
+| Secondary content | Selected node and right adjustment stack |
+| Tertiary content | Graph layout and navigation |
+| Input | Mouse, trackpad, and keyboard |
+| Text | `qsTr()` with 30–40 percent expansion allowance |
 
-- 使用 `cardSurfaceColor`、`cardBorderColor`、`panelRadius` 和现有 fold motion；
-- 默认宽度 `editorSidePanelWidth`；
-- 如果 320 px 对 node graph 不够，允许在现有 `editorSidePanelWidthMin/Max` 范围内由用户调整，
-  不能为 Nodes 建立并行宽度体系；
-- panel fully closed 时卸载 graph delegates，layout state 存在 rail/controller；
-- reduced motion 时立即到达终态；
-- 节点/端口/删除/添加必须支持键盘操作和可见 focus；
-- tooltip、Accessible.name 和错误信息必须可本地化；
-- 不依靠 hover 才显示唯一操作入口。
+Use the existing dense-editor typography. Do not add another type scale.
 
-第一版主链默认纵向排列，Develop 在上、DRT/Post 在下。节点位置是用户可调的 UI layout，
-按 `(project, image, version, NodeId)` 保存，不进入 Version DAG 或 edit history。
+### 16.2 Workspace relationship
 
-Endpoint node 显示锁定/不可删除状态。Color Grade 显示 enabled、Mask 数量和当前选择。添加按钮
-创建 Clean Color Grade，并插入到当前 Color Grade 后或 DRT/Post 前；具体规则必须在 UI 和
-keyboard action 中一致。
+```text
+Top toolbar
+
+┌────────┬─────────────────────────┬───────────────────┐
+│ Rail   │ Viewer                  │ Adjustment stack  │
+│ 48 px  │                         │ 320 px preferred  │
+│        │                         │                   │
+│ Hist   │                         │ Selected node     │
+│ Vers   │                         │ context           │
+│ Nodes  │                         │                   │
+│ Tasks  │                         │                   │
+├────────┴─────────────────────────┴───────────────────┤
+│ Filmstrip under the viewer column                   │
+└─────────────────────────────────────────────────────┘
+```
+
+Nodes replaces only the left expandable body. It does not cover the viewer or create a floating
+window. History, Versions, and Nodes cannot be open together.
+
+Rename `historyPanelPage` to a neutral property such as `editorToolPanelPage`. Accept only `""`,
+`history`, `versions`, and `nodes`.
+
+### 16.3 Page and rail action
+
+The page has a compact header and a graph canvas. The header shows `Nodes` and one Add action.
+Fit remains available through `Ctrl+0` and the canvas context menu.
+
+Use the approved Tabler `stack-2` paths for `panel_icons/nodes.svg`:
+
+```svg
+<path d="M12 4l-8 4l8 4l8 -4l-8 -4" />
+<path d="M4 12l8 4l8 -4" />
+<path d="M4 16l8 4l8 -4" />
+```
+
+Normalize the source to a 24×24 viewBox and white stroke. Keep the user-approved 2 px stroke. Use
+`IconActionButton` and AppTheme tint. Do not add a count, pill, badge, or status dot.
+
+### 16.4 Direction and local layout
+
+The first layout is vertical. Develop is at the top. DRT/Post is at the bottom. Color Grades follow
+execution order.
+
+Generate deterministic first positions from backbone order. Do not depend on an undocumented
+QuickQanava layout. Do not add snap-to-grid or a minimap.
+
+Users can move nodes, move the view, and zoom. Store these values by project, image, Version, and
+NodeId. Also store selected NodeId and each Color Grade drawer state.
+
+These values are local UI state. They do not enter `PipelineDocument`, history, or photo rendering.
+Keep removed NodeId layout values so Undo can restore them.
+
+### 16.5 Default names
+
+Node names do not show topology position. New Color Grades use a serialized creation counter:
+
+```text
+Color Grade 1
+Color Grade 2
+Color Grade 3
+```
+
+The default document names the primary Grade `Color Grade 1` and stores next value `2`. A successful
+Add consumes one value. Add failure does not. Rename, Remove, Reconnect, and node movement do not
+change the counter. A topology reorder never changes an existing name.
+
+The counter is document metadata. Typed Add history must replay the exact counter transition.
+Reinsertion of stored node JSON does not allocate another name.
+
+### 16.6 Node and Mask drawer
+
+A Color Grade node shows only its display name and Mask stack. It does not show a topology number,
+node kind, status dot, On/Off state, adjustment summary, Mask count, or persistent action row.
+
+The Mask stack is a drawer below the name. The drawer starts open. Its `Masks` header stays visible
+when closed. The full header row opens or closes the drawer. A disclosure chevron shows direction.
+
+Each row shows only the approved source-type icon and localized type label:
+
+| Model kind | UI label | Icon |
+| --- | --- | --- |
+| `MaskSourceKind::LinearGradient` | `Gradient` | `mask_icons/gradient.svg` |
+| `MaskSourceKind::Radial` | `Radial` | `mask_icons/radial.svg` |
+| `MaskSourceKind::Brush` | `Brush` | `mask_icons/brush.svg` |
+
+Do not show Mask name, opacity, enabled state, invert state, ranges, identity, selection, or actions.
+An empty open drawer has no Mask rows.
+
+Drawer state is local UI layout state. A fold creates no history and no render. The output port and
+bound edge follow the current node height.
+
+Develop and DRT/Post use compact fixed-name delegates. They do not show Mask drawers. Do not add a
+`Locked` badge or status dot.
+
+### 16.7 Approved Mask paths
+
+Gradient uses Tabler `wash-dry`:
+
+```svg
+<path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12" />
+```
+
+Radial uses Tabler `wash-dryclean`:
+
+```svg
+<path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+```
+
+Brush uses Tabler `brush`:
+
+```svg
+<path d="M3 21v-4a4 4 0 1 1 4 4h-4" />
+<path d="M21 3a16 16 0 0 0 -12.8 10.2" />
+<path d="M21 3a16 16 0 0 1 -10.2 12.8" />
+<path d="M10.6 9a9 9 0 0 1 4.4 4.4" />
+```
+
+Normalize all three files to the shared 24×24 viewBox and white stroke. Keep the user-approved
+2 px stroke. The Radial circle is an approved type icon. Do not reuse it as a status dot.
+
+### 16.8 VI mapping
+
+| Element | Rule |
+| --- | --- |
+| Rail and panel shell | `cardSurfaceColor`, `cardBorderColor`, `panelRadius`, and existing fold motion |
+| Graph canvas | Deep AppTheme surface |
+| Grid | Official `Qan.LineGrid` with an AppTheme graph role |
+| Color Grade node | `cardSurfaceColor` plus 1 px `cardBorderColor` |
+| Selected node | Same fill with a high-contrast outline around the full drawer |
+| Port | Small solid square with a larger input area |
+| Edge | Thin line with an AppTheme graph role |
+| Candidate edge | Separate AppTheme role; temporary until validation succeeds |
+| Error | `dangerColor` plus text; never color alone |
+
+Add missing graph roles to AppTheme and `DESIGN.md` in one change. QML does not contain raw graph
+colors, spacing, radii, or durations.
+
+Set `NodeStyle.effectEnabled` to false. Use solid fill. Do not use shadow, glow, gradient, glass,
+Material appearance, unrequested pills or badges, unrequested status dots, or `xx · xx` labels.
+
+### 16.9 Selection, keyboard, and accessibility
+
+The product allows one selected node. `EditorNodeController.selectedNodeId` is authoritative.
+QuickQanava selection mirrors it.
+
+After Version checkout, restore that Version's recent selected NodeId. If it is absent, select the
+first Color Grade. If no Grade exists, select DRT/Post.
+
+| Input | Result |
+| --- | --- |
+| `Tab`, `Shift+Tab` | Move through the header, canvas, and drawer headers. |
+| `Up`, `Down` | Select the previous or next backbone node. |
+| `Home`, `End` | Select Develop or DRT/Post. |
+| `Enter`, `Space` on `Masks` | Open or close the drawer. |
+| `F2` | Rename a selected Color Grade. |
+| `Escape` | Cancel Rename or Reconnect. Otherwise return focus to the canvas. |
+| `Delete` | Delete a selected Color Grade. |
+| `Ctrl++` | Add a clean Color Grade. |
+| `Ctrl+0` | Fit the graph through a pinned, documented navigation API. |
+
+Delete is undoable and needs no confirmation dialog. Endpoints reject Delete. All actions use
+localized text, accessible names, and visible keyboard focus.
+
+### 16.10 Size and Loader lifetime
+
+Use `editorSidePanelWidth` as the preferred width. History, Versions, and Nodes share one stored
+tool-panel width. Clamp it to `editorSidePanelWidthMin/Max`.
+
+The workspace computes an effective width after it reserves the 360 logical-pixel viewer floor and
+the right-panel minimum. The viewer keeps that floor at 960×640.
+
+After a complete close, the Loader destroys GraphView delegates. The controller and layout store
+retain plain values only. They retain no `qan::Node*`.
+
+Use the existing rail fold. `reduceMotion` makes it immediate.
+
+### 16.11 Structure command rule
+
+QML calls `EditorNodeController` only. QML does not modify product topology.
+
+```text
+QML action
+  -> EditorNodeController session and generation check
+  -> NM4 EditorSessionHistoryPort command
+  -> domain validation under the render lock
+  -> typed batch, WAL, and history head
+  -> projection publication
+  -> AlcedoQanGraph update
+  -> required render intent
+```
+
+Do not update permanent Qan topology before service success. Failure keeps the prior projection and
+shows the exact error.
+
+NM5 does not expose `SetColorGradeEnabled` or any equivalent On/Off action. The existing stored
+field can remain for data compatibility and execution.
+
+### 16.12 Reconnect rule
+
+Each Color Grade has one top input port and one bottom output port. Develop has no incoming scene
+port. DRT/Post has no outgoing scene port.
+
+Use the official visual connector. Set `connectorCreateDefaultEdge` to false. The connector shows a
+temporary request only.
+
+Only a selected Color Grade can start a move. Resolve the target against the backbone after the
+moving Grade is removed from an in-memory order calculation.
+
+```text
+connectorRequestEdgeCreation
+  -> resolve NodeId, target, and generation
+  -> remove the moving Grade from temporary order
+  -> compute new predecessor and successor
+  -> validate one complete backbone move
+  -> NM4 ReconnectColorGrade
+  -> topology projection revision
+  -> permanent Qan edge update
+```
+
+An invalid or stale request changes no document, creates no history, and leaves no permanent edge.
+
+### 16.13 Detailed execution plan
+
+See [Phase NM5 — QuickQanava Nodes Panel](node_mask_editor/phase_nm5_nodes_panel_plan.md) for the
+sub-phases, files, interfaces, call chains, tests, and required official sections.
 
 ---
 
 ## 17. Node-aware Adjustment Stack
 
-引入 `EditorAdjustmentContext`，至少发布：
+NM6 has a narrow QuickQanava dependency. It uses the official
+[Graph `Data Model`](https://cneben.github.io/QuickQanava/graph.html) section and the
+[Nodes/Groups `Selection`](https://cneben.github.io/QuickQanava/nodes.html) section. These
+sections define the boundary between topology, visual items, and node selection. NM6 does not
+store adjustment state in QuickQanava.
+
+Add `EditorAdjustmentContext`. It publishes at least these fields:
 
 ```text
 selected_node_id
@@ -939,38 +1209,101 @@ adjustment_snapshot
 context_revision
 ```
 
-右侧 `EditorAdjustmentStack.qml` 不再假设一个全局参数表，而是按 context 显示可用 panel：
+`EditorAdjustmentStack.qml` must use this context. It must not assume one global parameter set.
+It shows only the panels that the selected node supports.
 
-| 选中对象 | 可用 panel |
+| Selected object | Available panels |
 | --- | --- |
-| Develop | RAW Decode、Develop-owned controls、Geometry |
-| Color Grade | Tone、Look、LUT、Masks、Geometry |
-| DRT/Post | DRT/Display、Clarity、Sharpen、Halation、Film Grain、Geometry |
+| Develop | RAW Decode, Develop-owned controls, Geometry |
+| Color Grade | Tone, Look, LUT, Masks, Geometry |
+| DRT/Post | DRT/Display, Clarity, Sharpen, Halation, Film Grain, Geometry |
 
-Geometry 是 Document/global 参数，所以在三个 context 都可以访问；它不因节点选择而创建三份
-实例。
+Geometry is a document-level parameter group. All three contexts can open it. Node selection does
+not create three Geometry instances.
 
-每个 panel 的 `loadFromSnapshot()` 改为读取当前 context 的 snapshot。Panel 初次构建、
-session rebind、Version checkout、node selection 和 Undo/Redo 后都要加载正确值，但 load-only
-路径不能提交 history 或 render。
+### 17.1 Right-panel wayfinding
 
-当用户切换节点时：
+The adjustment stack has one fixed context header below the scope area and above the adjustment
+navigation.
 
-1. 结束或取消当前 provisional input sequence；
-2. 更新 selected NodeId；
-3. 发布新的 context snapshot；
-4. adjustment stack 选择该节点支持的首选 panel，或保留仍然合法的 panel；
-5. 只更新 UI，不触发照片渲染。
+The header shows:
 
-删除 selected Color Grade 后，选择其后继 Color Grade；若没有则选择前驱；再没有则选择
-DRT/Post。Version checkout 后优先恢复该 Version 的最近选择，找不到时选择 Default/第一个
-Color Grade。
+- the current node display name;
+- the node kind on a separate plain-text line;
+- the selected Mask name when the Masks panel has a valid Mask selection.
+
+The header uses a flat layout and a bottom divider. It does not use a new panel surface. It does not
+use a pill, badge, chip, tag, or status dot. It does not join values with a decorative separator.
+The node display name uses `fontSizeTitle` and `fontWeightStrong`. The node kind and Mask name use
+caption tokens.
+
+The header identifies the owner of the visible parameters. It does not store a second selection.
+It does not show or change a Color Grade On/Off value.
+
+### 17.2 Panel routing
+
+The existing adjustment navigation keeps its monochrome segmented VI. It shows only the panels
+that the selected node supports. It does not present an unsupported panel as editable content.
+
+When the selected node changes, routing uses these rules:
+
+1. Keep Geometry when Geometry is still valid.
+2. Keep the current panel when the new node supports it.
+3. Select RAW by default for Develop.
+4. Select Tone by default for Color Grade.
+5. Select Display by default for DRT/Post.
+
+The panel key, `StackLayout` index, and navigation order must use one mapping. Do not keep separate
+hard-coded orders.
+
+Each panel `loadFromSnapshot()` operation reads the current context snapshot. It loads the correct
+values after initial construction, session rebind, Version checkout, node selection, and Undo/Redo.
+A load-only path does not submit history or request a render.
+
+When the user selects a different node:
+
+1. Settle or cancel the current provisional input sequence.
+2. Update the selected `NodeId`.
+3. Publish a new context snapshot.
+4. Select the preferred supported panel, or keep the current panel when it is still valid.
+5. Update the UI without a photo render.
+
+After deletion of the selected Color Grade, select its successor. If there is no successor, select
+its predecessor. If neither exists, select DRT/Post. After Version checkout, restore the last valid
+selection for that Version. If no stored selection is valid, select the Default or first Color
+Grade node.
+
+### 17.3 Selection ownership
+
+`EditorNodeController.selectedNodeId` from NM5 is the only node selection. NM6 does not add a
+second selected-node property. A click in the right panel does not implicitly select another Color
+Grade.
+
+A node-selection change is a UI-state change. It does not submit history. It does not request a
+photo render.
+
+A parameter target contains the full `NodeId` and `AdjustmentInstanceId`. A Color Grade panel does
+not use an implicit `grade.primary` target.
+
+### 17.4 Size and text
+
+The adjustment stack continues to use `editorSidePanelWidthMin` and
+`editorSidePanelWidthMax`. The context header and navigation do not increase the minimum panel
+width. User-visible text uses `qsTr()`. The header elides a long name and exposes the full name to
+assistive technology. A large system font does not cover the navigation or the first panel
+control.
 
 ---
 
-## 18. Mask authoring 状态机
+## 18. Mask authoring state machine
 
-建议由 `EditorMaskAuthoringController` 统一管理，而不是把状态分散到 QML handlers：
+QuickQanava does not draw the Mask overlay. NM7 uses the official
+[Graph `Data Model`](https://cneben.github.io/QuickQanava/graph.html) section and the
+[Nodes/Groups `Selection`](https://cneben.github.io/QuickQanava/nodes.html) section only to keep the
+owner Color Grade selected. The Alcedo viewer architecture continues to own viewer input, QSG
+overlays, and Mask pixels.
+
+`EditorMaskAuthoringController` owns the state. Do not distribute this state across QML handlers.
 
 ```text
 Inactive
@@ -982,7 +1315,7 @@ Settling
 Failed
 ```
 
-状态至少锁定：
+The state captures at least:
 
 ```text
 session_generation
@@ -995,7 +1328,7 @@ provisional params or stroke
 dirty rectangle
 ```
 
-创建流程：
+Creation uses this call chain:
 
 ```text
 select Color Grade
@@ -1008,65 +1341,139 @@ select Color Grade
   -> settle to one history commit and Quality render
 ```
 
-需要明确以下抢占行为：
+Use these interruption rules:
 
-- image switch、Version checkout、Undo/Redo、node deletion 前必须完成或取消 authoring；
-- stale session generation 的异步 render/result 不得更新新图片 overlay；
-- Escape 恢复被编辑 Mask 的 before 参数；
-- Delete 删除 selected Mask，但不能删除错误节点中同 index 的 Mask；
-- viewer pan/zoom 与 Mask authoring 使用明确 mode/focus 路由，不能同时解释同一个 pointer input；
-- keyboard 用户可以选择 Mask、移动控制点、调整数值并退出模式。
+- Settle or cancel authoring before image switch, Version checkout, Undo/Redo, or node deletion.
+- Reject an asynchronous render result from a stale session generation.
+- Escape restores the before parameters of the edited Mask.
+- Delete removes the selected Mask by `NodeId` and `MaskId`. It does not use a row index as identity.
+- Viewer pan/zoom and Mask authoring use an explicit mode and focus route. They do not interpret the
+  same pointer input.
+- A keyboard user can select a Mask, move a control point, change a value, and leave the mode.
+
+### 18.1 Masks panel
+
+Masks is a right-side panel for the Color Grade context. Its controls do not become QuickQanava
+graph content.
+
+The panel has this structure:
+
+1. A header shows `Masks`.
+2. Three fixed actions create Brush, Radial, or Linear Gradient Masks.
+3. A list shows the Masks that the selected Color Grade owns.
+4. The selected row exposes only supported Mask controls, including opacity, rename, and delete.
+5. A range area shows only fields that the product implements.
+
+The Mask list uses the existing recessed list well. A selected row uses
+`editorListSelectedFillColor` and `editorListSelectedInkColor`. A Mask type uses the approved icon
+and text label from Section 16 and `DESIGN.md`. Color is not the only selection cue. The panel does
+not add a pill, badge, chip, tag, or status dot unless a later product requirement explicitly asks
+for one.
+
+After Mask add, delete, or reorder, update the owning node's Mask drawer rows. Update row identity,
+order, type, and label only. Do not add a Mask count. Do not rebuild the full graph.
+
+### 18.2 Viewer authoring bar
+
+In authoring mode, the viewer shows a compact authoring bar. It shows the source kind, selected
+Mask name, Done, and Cancel. Each value has its own text element. Do not join values with a
+decorative separator.
+
+The bar uses `cardSurfaceColor`, `cardBorderColor`, and `panelRadius`. Done and Cancel use existing
+shared action components. Escape is equivalent to Cancel. Enter is equivalent to Done when the
+current source can settle.
+
+The authoring bar does not cover a primary control point. It does not change the viewer coordinate
+space.
+
+### 18.3 QSG overlay VI
+
+The QSG overlay uses Mask semantic roles from `AppTheme`. Add these roles if the implementation
+needs them:
+
+- `maskOverlayControlColor`
+- `maskOverlayControlOutlineColor`
+- `maskOverlayCoverageColor`
+- `maskOverlayInactiveColor`
+
+Control points use a two-layer, high-contrast stroke. The coverage preview uses a visible alpha and
+an outline. Selection, invalid input, and disabled input also use shape or text. Color is not the
+only cue. A small point that only reports status is not permitted.
+
+During adjustment input, hide the overlay as specified in Section 10.4. After authoring ends,
+restore the overlay from controller state.
+
+### 18.4 Cross-panel input ownership
+
+After Mask authoring starts:
+
+- Nodes keeps the current Color Grade selected.
+- Graph structure actions are temporarily unavailable.
+- Node layout input is temporarily unavailable.
+- The right Masks panel stays visible.
+- The viewer receives Mask input.
+- History and Version checkout obey the settle-or-cancel rules.
+
+After authoring ends, graph input becomes available. Reject input and render results from an old
+session generation.
 
 ---
 
-## 19. 序列化与项目格式切换
+## 19. Serialization and project-format cutover
 
-新 PipelineDocument schema 至少保存：
+The new `PipelineDocument` schema stores at least:
 
-- document geometry；
-- Develop model；
-- 有序 Color Grade nodes；
-- scene-image edges；
-- 每个 Color Grade 的 adjustment 列表、enabled、mix；
-- 每个 Color Grade 的 masks；
-- MaskId、source、enabled、opacity；
-- `color_range` 和 `luminance_range` 的直接字段；
-- raster `MaskAssetKey` 和 descriptor；
-- DRT/Post 参数和后处理参数。
+- document geometry;
+- the Develop model;
+- ordered Color Grade nodes;
+- scene-image edges;
+- the next default Color Grade name number;
+- each Color Grade adjustment list, enabled value, and mix value;
+- each Color Grade Mask list;
+- each `MaskId`, source, enabled value, and opacity;
+- direct `color_range` and `luminance_range` fields;
+- each raster `MaskAssetKey` and descriptor;
+- DRT/Post and post-processing parameters.
 
-不保存：
+It does not store:
 
-- QuickQanava object；
-- graph selection、hover、focus；
-- graph pan/zoom；
-- QSG vertices/material instances；
-- provisional stroke；
-- dirty bits、GPU handles、cache state；
-- render request；
-- panel active page。
+- a QuickQanava object;
+- graph selection, hover, or focus;
+- graph pan or zoom;
+- QSG vertices or material instances;
+- a provisional stroke;
+- dirty bits, GPU handles, or cache state;
+- a render request;
+- the active panel page.
 
-NM4 在节点、Mask 和 history 数据就绪后统一切换 document/history/project metadata 格式。
-新版本只创建和读取新项目；旧项目在打开入口返回 unsupported-format error，不转换当前 v2
-或 stage 项目，不重算旧提交。
+NM4 changes the document, history, and project-metadata formats after node, Mask, and history data
+are ready. The new release creates and reads only the new project format. The project-open boundary
+returns an unsupported-format error for an old project. It does not convert the current v2 or stage
+project and does not recalculate an old commit.
 
-NM1 使用当前开发图格式完成模型和 document 保存读取；NM2/NM3 修改节点字段与所有权，
-不因此要求 NM1 先实现最终项目版本。NM4 才证明新格式的 golden JSON、round-trip、
-错误处理、history recovery 与真实项目 reopen。合法性校验留在读取边界，不在渲染调用方逐层分流。
+NM1 uses the development graph format to complete model and document I/O. NM2 and NM3 change node
+fields and ownership. These changes do not require NM1 to publish the final project format. NM4
+proves golden JSON, round-trip behavior, error handling, history recovery, and real-project reopen
+for the new format. Validate data at the read boundary. Do not distribute format checks across
+render callers.
 
 ---
 
-## 20. 主要调用链
+## 20. Primary call chains
 
-### 20.1 新建 Color Grade
+### 20.1 Add a Color Grade
 
 ```text
 NodeEditorPanel / QuickQanava action
   -> EditorNodeController::AddCleanColorGrade
   -> validate command inputs and acquire live pipeline access
-  -> CreateCleanColorGradeNode
+  -> read next_color_grade_name_number
+  -> form the default display name
+  -> CreateCleanColorGradeNode with that name
   -> Insert node + reconnect live backbone (keep affected edges for rollback)
   -> Validate graph and ownership
-  -> record PipelineEditBatch with WAL/history ordering (NM4)
+  -> record PipelineEditBatch with exact before/after counter values and NM4 WAL/history ordering
+  -> advance the serialized counter only as part of the accepted change
   -> finish local change and notify graph/context/history projections
   -> submit GraphTopologyChanged Quality render
 ```
@@ -1083,7 +1490,7 @@ AdjustmentSlider
   -> settled: one typed edit commit + Quality render
 ```
 
-### 20.3 Radial Mask 编辑
+### 20.3 Edit a Radial Mask
 
 ```text
 Masks panel selects Radial
@@ -1140,26 +1547,27 @@ Adjustment Transfer Paste
 
 ---
 
-## 21. 一级 Phase 总表
+## 21. Phase summary
 
-本总体方案锁定以下一级 Phase。它们是架构和产品能力的顺序，不等同于一个 PR；每个 Phase
-将来都有自己的执行方案，执行方案内部再拆具体子 Phase 和可评审 PR。
+This master plan fixes the following top-level phase order. The order describes architecture and
+product dependencies. It does not require one pull request for each phase. Each execution plan can
+split its phase into reviewable sub-phases and pull requests.
 
-本次只预留文件路径，不创建空的执行方案。开始对应 Phase 时创建文件，并把表中的代码路径
-改成 Markdown 链接。
+Create an execution-plan file when its phase starts. Do not create an empty plan. Replace a reserved
+path with a Markdown link when the file exists.
 
-| Phase | Status | 未来执行方案 | 阶段结果 |
+| Phase | Status | Execution plan | Result |
 | --- | --- | --- | --- |
-| NM0 — QuickQanava Integration Baseline | complete | [node_mask_editor/phase_nm0_quickqanava_integration_plan.md](node_mask_editor/phase_nm0_quickqanava_integration_plan.md) | 固定依赖、构建和 package 路径，证明官方组件可被 production QML 使用 |
-| NM1 — PipelineDocument Editing Foundation | in progress; C acceptance incomplete; R before NM1.5 | [node_mask_editor/phase_nm1_pipeline_document_editing_plan.md](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md) | 单 live document；共享 executor；R 修复任务请求、后台资源占用、使用权与导出 recipe；随后统一 document I/O |
-| NML — Legacy Stage Compatibility and Default DAG Upgrade | cancelled 2026-08-30 | — | 不升级、不打开 DAG document 之前的 stage-only 项目；不迁移 mini-git commit |
-| NM2 — Multi-Grade Runtime and Ownership | complete | [node_mask_editor/phase_nm2_multi_grade_runtime_plan.md](node_mask_editor/phase_nm2_multi_grade_runtime_plan.md) | compiler 和三后端真正执行多 Color Grade，并落实参数所有权 |
-| NM3 — Multi-Mask Model and Runtime | complete | [node_mask_editor/phase_nm3_multi_mask_runtime_plan.md](node_mask_editor/phase_nm3_multi_mask_runtime_plan.md) | 每节点多 Mask、Union、Range 字段和不可变 raster asset 完整可用 |
-| NM4 — History, Version, Recovery, and Paste | planned | [node_mask_editor/phase_nm4_history_version_paste_plan.md](node_mask_editor/phase_nm4_history_version_paste_plan.md) | typed history、每 Version 一 DAG、recovery 和 Paste-only 完成切换 |
-| NM5 — QuickQanava Nodes Panel | planned | `node_mask_editor/phase_nm5_nodes_panel_plan.md` | 左侧 Nodes 面板连接真实 command/history/render 路径 |
-| NM6 — Node-aware Adjustment Stack | planned | `node_mask_editor/phase_nm6_node_aware_adjustments_plan.md` | 右侧参数面板按 Develop/Color Grade/DRT/Post context 工作 |
-| NM7 — Viewer Mask Authoring | planned | `node_mask_editor/phase_nm7_viewer_mask_authoring_plan.md` | Brush/Radial/Linear、QSG overlay、Interactive/Quality 和 history 完整连通 |
-| NM8 — Product Qualification and Cutover | planned | `node_mask_editor/phase_nm8_product_qualification_plan.md` | 三后端、真实 RAW、reopen、Version/Paste、性能和 package 验收完成 |
+| NM0 — QuickQanava Integration Baseline | complete | [node_mask_editor/phase_nm0_quickqanava_integration_plan.md](node_mask_editor/phase_nm0_quickqanava_integration_plan.md) | Pin the dependency and establish the build, package, and production-QML paths. |
+| NM1 — PipelineDocument Editing Foundation | in progress; C acceptance incomplete; R before NM1.5 | [node_mask_editor/phase_nm1_pipeline_document_editing_plan.md](node_mask_editor/phase_nm1_pipeline_document_editing_plan.md) | Use one live document and one shared executor. Correct task requests, background resource use, access ownership, export recipes, and document I/O. |
+| NML — Legacy Stage Compatibility and Default DAG Upgrade | cancelled 2026-08-30 | — | Do not upgrade or open stage-only projects from before the DAG document. Do not migrate mini-git commits. |
+| NM2 — Multi-Grade Runtime and Ownership | complete | [node_mask_editor/phase_nm2_multi_grade_runtime_plan.md](node_mask_editor/phase_nm2_multi_grade_runtime_plan.md) | Execute multiple Color Grade nodes in all three backends and apply parameter ownership. |
+| NM3 — Multi-Mask Model and Runtime | complete | [node_mask_editor/phase_nm3_multi_mask_runtime_plan.md](node_mask_editor/phase_nm3_multi_mask_runtime_plan.md) | Support multiple Masks per node, Union, range fields, and immutable raster assets. |
+| NM4 — History, Version, Recovery, and Paste | complete | [node_mask_editor/phase_nm4_history_version_paste_plan.md](node_mask_editor/phase_nm4_history_version_paste_plan.md) | Complete typed history, one DAG per Version, recovery, and Paste-only transfer. |
+| NM5 — QuickQanava Nodes Panel | planned | [node_mask_editor/phase_nm5_nodes_panel_plan.md](node_mask_editor/phase_nm5_nodes_panel_plan.md) | Connect the left Nodes panel to the real command, history, and render paths. |
+| NM6 — Node-aware Adjustment Stack | planned | `node_mask_editor/phase_nm6_node_aware_adjustments_plan.md` | Make the right adjustment panel use Develop, Color Grade, and DRT/Post context. |
+| NM7 — Viewer Mask Authoring | planned | `node_mask_editor/phase_nm7_viewer_mask_authoring_plan.md` | Connect Brush, Radial, and Linear Gradient authoring to QSG overlays, Interactive and Quality rendering, and history. |
+| NM8 — Product Qualification and Cutover | planned | `node_mask_editor/phase_nm8_product_qualification_plan.md` | Qualify all three backends, real RAW files, reopen, Version, Paste, performance, and package behavior. |
 
 ### 21.1 Phase NM0 — QuickQanava Integration Baseline
 
@@ -1366,54 +1774,120 @@ metadata，失败不创建部分 Version。
 
 ### 21.6 Phase NM5 — QuickQanava Nodes Panel
 
-**为什么此时才开放：** 到这里 node mutation 已经有真实多节点 backend 和完整 history/
-Version 行为，Nodes panel 不会暴露半完成产品操作。
+Execution plan: [Phase NM5 — QuickQanava Nodes Panel](node_mask_editor/phase_nm5_nodes_panel_plan.md).
 
-**阶段边界：** 在 `EditorWorkspaceRail` 增加 Nodes 页面；建立 `EditorNodeGraphProjection`、
-Alcedo Qan adapter、node selection、Clean node 添加、删除、重新连接、rename 和 layout state；
-所有 connector 请求先经 app service；只使用 QuickQanava 的 graph interaction primitives。
+**Reason for this position:** Node changes now use the real multi-node backends and the complete
+history and Version paths. The Nodes panel does not expose an incomplete product operation.
 
-**退出条件：** Nodes panel 的所有可见命令都走 NM1–NM4 路径；失败不留下视觉 edge；panel
-Loader、Basic style、AppTheme、keyboard、accessibility、reduced motion 和 package 测试通过。
+**Scope:** Add the Nodes page to `EditorWorkspaceRail`. Add `EditorNodeGraphProjection`, the Alcedo
+Qan adapter, node selection, the serialized default-name counter, Clean Color Grade add, delete,
+reconnect, rename, and layout state. Add the default-open Mask drawer to each Color Grade node.
+Each Mask row shows only the approved type icon and type label. Route each connector request through
+the application service. Use QuickQanava only for graph interaction and visual topology.
+
+The node body does not show topology numbers, status dots, Color Grade On/Off content, adjustment
+summaries, Mask counts, persistent action rows, pills, badges, chips, or tags. The page toggle uses
+the approved stack icon. Gradient, Radial, and Brush rows use the approved icons in `DESIGN.md`.
+
+**Exit criteria:** Every visible Nodes command uses the NM1-NM4 paths. A failed request leaves no
+visual edge. The panel Loader, Basic style, AppTheme mapping, keyboard access, assistive-technology
+metadata, reduced-motion behavior, and package load pass their tests.
+
+**Required official QuickQanava documentation:**
+
+- [Installation](https://cneben.github.io/QuickQanava/installation.html): production CMake and the
+  static module.
+- [Graph](https://cneben.github.io/QuickQanava/graph.html): data and visual separation,
+  initialization, `GraphView`, navigation, and `LineGrid`.
+- [Nodes/Groups](https://cneben.github.io/QuickQanava/nodes.html): nodes, ports, selection, resize,
+  and custom delegates.
+- [Edges](https://cneben.github.io/QuickQanava/edges.html): edges and visual connector requests.
+- [Styles](https://cneben.github.io/QuickQanava/styles.html): style properties. Do not import the
+  upstream Material example into Alcedo production QML.
+- [Advanced use](https://cneben.github.io/QuickQanava/advanced.html): the C++ graph and custom
+  topology adapter.
+- [Samples](https://cneben.github.io/QuickQanava/samples.html): `custom`, `navigable`, `topology`,
+  and connector examples.
+- [API Reference](https://cneben.github.io/QuickQanava/reference.html): local Doxygen and pinned
+  checkout header verification, as directed by the page.
+- [Licence](https://cneben.github.io/QuickQanava/licence.html): package notice.
 
 ### 21.7 Phase NM6 — Node-aware Adjustment Stack
 
-**为什么排在 Nodes panel 后：** adjustment context 需要稳定的 selected NodeId、node kind、
-删除后选择规则和 Version checkout selection 恢复。先改右侧 panel 会继续依赖隐式 primary
-grade。
+**Reason for this position:** Adjustment context needs a stable selected `NodeId`, node kind,
+post-delete selection rule, and Version-checkout selection restore. An earlier change to the right
+panel would continue to depend on an implicit primary Color Grade.
 
-**阶段边界：** 引入 `EditorAdjustmentContext`；Develop、Color Grade 和 DRT/Post 显示各自合法
-panels；Geometry 保持 document/global；每个 panel 的 `loadFromSnapshot()` 读取当前 context；
-统一 slider API 锁定 NodeId/AdjustmentInstanceId；切换节点只更新 UI，不渲染。
+**Scope:** Add `EditorAdjustmentContext`. Show only the valid panels for Develop, Color Grade, and
+DRT/Post. Keep Geometry at document scope. Make each panel `loadFromSnapshot()` read the current
+context. Make the shared slider interface capture `NodeId` and `AdjustmentInstanceId`. A node
+selection change updates the UI and does not request a photo render. The context header does not
+show a Color Grade On/Off value, pill, badge, chip, tag, status dot, or decorative separator label.
 
-**退出条件：** 三类 node context、selection restore、panel re-entry、Version checkout、
-load-only、provisional/settled 和 history target 测试通过；Color Grade context 中不存在
-RAW Decode 或 DRT/Post 专属控件。
+**Exit criteria:** Tests pass for all three node contexts, selection restore, panel re-entry,
+Version checkout, load-only paths, provisional and settled input, and full history targets. A Color
+Grade context does not contain RAW Decode or DRT/Post-only controls.
+
+**Required official QuickQanava documentation:**
+
+- [Graph `Data Model`](https://cneben.github.io/QuickQanava/graph.html): Qan visual topology does not
+  own adjustment state.
+- [Nodes/Groups `Selection`](https://cneben.github.io/QuickQanava/nodes.html): the selected node from
+  NM5 is an NM6 context input.
+- [Advanced `Observation of Topological Modifications`](https://cneben.github.io/QuickQanava/advanced.html):
+  use topology observations only to refresh the visual selection. They do not replace the
+  application snapshot signal.
 
 ### 21.8 Phase NM7 — Viewer Mask Authoring
 
-**为什么最后接入交互：** viewer authoring 同时依赖 selected node context、多 Mask runtime、
-immutable MaskStore、typed history 和 Interactive/Quality render。任何一项缺失都会产生无法
-恢复或无法正确预览的编辑。
+**Reason for this position:** Viewer authoring needs the selected-node context, multi-Mask runtime,
+immutable `MaskStore`, typed history, and Interactive and Quality rendering. A missing dependency
+would produce an edit that cannot restore or preview correctly.
 
-**阶段边界：** Masks panel 的 style action、Brush/Radial/Linear 创建、viewer input routing、
-ReferenceSpace mapping、QSG mask editing overlay、临时 raster dirty rectangle、settled asset、
-Escape 取消、模式抢占和 stale session fencing 完整接入。调色参数输入期间隐藏 overlay。
+**Scope:** Add the Masks panel actions, Brush, Radial, and Linear Gradient creation, viewer input
+routing, `ReferenceSpace` mapping, QSG Mask-editing overlay, provisional raster dirty rectangle,
+settled asset, Escape cancellation, mode interruption, and stale-session fencing. Hide the overlay
+during adjustment input. Use the approved Mask type icons. Do not add an unrequested pill, badge,
+chip, tag, or status dot.
 
-**退出条件：** 三种 Mask 都能在真实 viewer 中编辑；QSG 与 evaluator 参数一致；pointer
-release 一次 commit；settled 后 Quality；Escape 无 commit；image/Version 切换不接受旧结果。
+**Exit criteria:** Users can edit all three Mask types in the real viewer. QSG and evaluator
+parameters agree. Pointer release creates one commit. A settled edit requests Quality. Escape does
+not create a commit. Image and Version changes reject old results.
+
+**Required official QuickQanava documentation:**
+
+- [Graph `Data Model`](https://cneben.github.io/QuickQanava/graph.html): a Mask stays in the Alcedo
+  model. It does not enter Qan topology.
+- [Nodes/Groups `Selection`](https://cneben.github.io/QuickQanava/nodes.html): keep the owner Color
+  Grade selected during authoring.
+
+QuickQanava does not own viewer input, the QSG overlay, or Mask coverage. NM7 does not infer these
+features from QuickQanava examples.
 
 ### 21.9 Phase NM8 — Product Qualification and Cutover
 
-**为什么独立：** 单元和组件测试不能证明 QuickQanava package、真实 RAW、多 backend、history
-recovery、Mask asset 和最终帧在同一产品路径中一致。
+**Reason for a separate phase:** Unit and component tests cannot prove that the packaged
+QuickQanava module, real RAW input, all backends, history recovery, Mask assets, and final frame use
+one correct product path.
 
-**阶段边界：** 执行第 23 节全部测试和真实 RAW E2E；记录 Windows/CUDA、OpenCL、macOS/Metal、
-package、reopen、Version、Paste、性能、内存和 cache 证据；删除在前面 Phase 明确替代的旧 UI/
-service 路径；更新本文 completion record。
+**Scope:** Run all tests in Section 23 and the real-RAW end-to-end cases. Record evidence for
+Windows/CUDA, OpenCL, macOS/Metal, package load, reopen, Version, Paste, performance, memory, and
+cache behavior. Remove old UI and service paths that an earlier phase explicitly replaced. Update
+this document with the completion record.
 
-**退出条件：** 第 26 节全局完成条件全部满足；不存在 legacy stage 回写、单 primary grade 产品
-分支、可变 raster key、新 merge UI 或其他 backend/CPU 替代路径。
+**Exit criteria:** All global completion criteria in Section 26 pass. There is no legacy-stage
+write-back, single-primary-Color-Grade product branch, mutable raster key, new merge UI, or substitute
+backend or CPU path.
+
+**Required official QuickQanava documentation:**
+
+- [Installation](https://cneben.github.io/QuickQanava/installation.html): verify Windows and macOS
+  build, install, and package paths.
+- [Graph `QuickQanava Initialization`](https://cneben.github.io/QuickQanava/graph.html): verify the
+  engine load order in the packaged application.
+- [API Reference](https://cneben.github.io/QuickQanava/reference.html): verify the pinned-checkout
+  API against local Doxygen output.
+- [Licence](https://cneben.github.io/QuickQanava/licence.html): verify the final binary notice.
 
 ---
 
@@ -1583,7 +2057,7 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - 多 Color Grade 结果缓存按 NodeId + input content + node params/mask content 分层；
 - node deletion/reconnect 允许淘汰不可达 node cache，但必须遵守 GPU submission lease；
 - panel close 后没有残留 Qan delegates 或 QML connection 泄漏；
-- N8 必须记录同一真实 RAW、同一 viewport、同一 backend 的单节点基线和多节点/多 Mask 数据。
+- NM8 必须记录同一真实 RAW、同一 viewport、同一 backend 的单节点基线和多节点/多 Mask 数据。
 
 在 N8 之前由现有产品 baseline 确定具体毫秒和内存预算；不能用降低 decode 分辨率、质量或
 切换 backend 的方式达标。


### PR DESCRIPTION
## Summary

- define the approved Alcedo Studio Nodes panel and graph-node visual language
- add the complete English NM5 execution plan with eight implementation sub-phases
- define the persistent default Color Grade naming counter
- document the QuickQanava integration boundary and the official sections required by each sub-phase
- add UI-wide bans for centered-dot compound labels, unrequested pills or badges, and unrequested status dots

## Approximate design

```text
┌──────┬──────────────────────┬──────────────────────────┬──────────────────┐
│ Rail │ Nodes                │ Viewer                   │ Adjustments      │
│      │                      │                          │                  │
│ Hist │       Develop        │                          │ Selected node    │
│ Vers │          ■           │                          │ context          │
│ Node │          │           │                          │                  │
│ Task │  ┌────────────────┐  │                          │                  │
│      │  │ Color Grade 1  │  │                          │                  │
│      │  ├────────────────┤  │                          │                  │
│      │  │ Masks        ▾ │  │                          │                  │
│      │  ├────────────────┤  │                          │                  │
│      │  │ [icon] Gradient│  │                          │                  │
│      │  │ [icon] Radial  │  │                          │                  │
│      │  │ [icon] Brush   │  │                          │                  │
│      │  └────────────────┘  │                          │                  │
│      │          ■           │                          │                  │
│      │          │           │                          │                  │
│      │       DRT/Post       │                          │                  │
├──────┴──────────────────────┴──────────────────────────┴──────────────────┤
│ Filmstrip under the viewer                                               │
└───────────────────────────────────────────────────────────────────────────┘
```

The symbols above are approximate. Production assets use the approved Tabler SVG paths. The small
squares at the node boundary are connection ports, not status indicators.

Expanded and collapsed Color Grade states:

```text
Expanded                         Collapsed

         ■                                ■
┌────────────────────┐           ┌────────────────────┐
│ Color Grade 4      │           │ Color Grade 4      │
├────────────────────┤           ├────────────────────┤
│ Masks            ▾ │           │ Masks            ▸ │
├────────────────────┤           └────────────────────┘
│ [icon] Gradient    │                    ■
│ [icon] Radial      │
│ [icon] Brush       │
└────────────────────┘
         ■
```

## Fixed UI decisions

- Nodes is the third expandable page in `EditorWorkspaceRail`.
- The graph uses a vertical Develop-to-DRT/Post backbone.
- New nodes use persistent creation names such as `Color Grade 1` and `Color Grade 2`.
- Topology changes do not rename existing nodes.
- A Color Grade node shows only its display name and Mask drawer.
- The Mask drawer starts open and can be closed manually.
- Each Mask row shows only its approved type icon and `Gradient`, `Radial`, or `Brush` label.
- The node shows no topology number, node kind, status dot, On/Off state, adjustment summary, Mask
  count, persistent action row, pill, badge, chip, or tag.
- Develop and DRT/Post use compact endpoint delegates.
- Permanent topology changes occur only after the Alcedo command and typed-history path succeeds.

## NM5 sub-phases

1. Production link, initialization, and read-only proof.
2. Default-name counter and immutable projection.
3. Qan adapter, ports, and read-only topology.
4. Alcedo node delegate and Mask drawer.
5. Rail, navigation, selection, and layout state.
6. Add, Rename, and Delete.
7. Request-only visual connector and Reconnect.
8. Lifecycle, accessibility, build, install, and package checks.

Each sub-phase identifies the exact QuickQanava documentation sections, required repository
context, interfaces, files, call chains, tests, exit criteria, and completion-record fields.

## QuickQanava basis

The plan uses only the pinned QuickQanava 2.50 checkout and its documented extension points:

- Installation and static module integration
- Graph data model, initialization, `GraphView`, and `Qan.LineGrid`
- nodes, ports, resizing, selection, and custom delegates
- request-only visual connectors and edge creation
- style extension points without Material production styling
- pinned headers and local Doxygen for exact API signatures
- source and binary licence notices

The website marks PointGrid as deprecated. The pinned 2.50 source has removed it. NM5 therefore
uses only `Qan.LineGrid`.

## Validation

- `git diff --check`
- local Markdown link resolution
- balanced Markdown code fences
- English-only NM5 execution plan
- pinned-source verification for the planned QuickQanava ports, edge binding, connector, selection,
  grid, and resizing interfaces
- roadmap terminology checks

This PR changes documentation and the shared QML UI skill only. It does not implement NM5 runtime
or QML production code.
