### PR TITLE
feat(ui): integrate QuickQanava production foundation

### DIFF
--- a/alcedo_studio/src/third_party/cmake/AlcedoQuickQanava.cmake
+++ b/alcedo_studio/src/third_party/cmake/AlcedoQuickQanava.cmake
@@ -157,12 +157,19 @@ foreach(_rel IN LISTS _alcedo_quickqanava_qml)
     list(APPEND _alcedo_quickqanava_qml_abs "${_abs}")
 endforeach()
 
+# The pinned QML sources use both unversioned imports and the documented 2.0
+# public import. Keep the source files visible to both import forms without
+# changing the pinned checkout.
+set_source_files_properties(${_alcedo_quickqanava_qml_abs}
+    PROPERTIES QT_QML_SOURCE_VERSIONS "2.0;1.0")
+
 set(_alcedo_quickqanava_binary_dir "${CMAKE_BINARY_DIR}/third_party/QuickQanava")
 file(MAKE_DIRECTORY "${_alcedo_quickqanava_binary_dir}")
 
 qt_add_qml_module(QuickQanava
     STATIC
     URI QuickQanava
+    VERSION 2.0
     SOURCES ${_alcedo_quickqanava_sources}
     QML_FILES ${_alcedo_quickqanava_qml_abs}
     RESOURCE_PREFIX /

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -442,6 +442,8 @@ target_link_libraries(alcedo_main
         AlbumBackendLib
         AppDiagnostics
         UiLocalization
+        QuickQanava
+        QuickQanavaplugin
         Qt6::Quick
         Qt6::Qml
         Qt6::QuickControls2

--- a/alcedo_studio/src/ui/alcedo_main/main.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/main.cpp
@@ -11,6 +11,7 @@
 #include <QIcon>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QQmlExtensionPlugin>
 #include <qqml.h>
 #include <QQuickStyle>
 #include <QQuickWindow>
@@ -19,6 +20,8 @@
 #include <QSettings>
 #include <QString>
 #include <QtGlobal>
+
+#include <QuickQanava>
 
 #include <exiv2/error.hpp>
 #include <optional>
@@ -37,6 +40,8 @@
 #include "edit/operators/operator_registeration.hpp"
 #include "utils/diagnostics/app_logging.hpp"
 #include "utils/clock/time_provider.hpp"
+
+Q_IMPORT_QML_PLUGIN(QuickQanavaPlugin)
 
 #ifdef Q_OS_WIN
 #include "windows_frameless_window.hpp"
@@ -255,6 +260,7 @@ int main(int argc, char* argv[]) {
 
   QQmlApplicationEngine engine;
   engine.addImportPath("qrc:/");
+  QuickQanava::initialize(&engine);
   language_manager.AttachEngine(&engine);
   app_modules.AttachQmlEngine(&engine);
   engine.rootContext()->setContextProperty("appModules", &app_modules);

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -733,6 +733,36 @@ alcedo_ui_gtest_discover_tests(EditorHistoryVersionsRailLifecycleQmlTest
     PROPERTIES LABELS "workspace_qml;editor_history;editor_versions")
 alcedo_register_test_target(EditorHistoryVersionsRailLifecycleQmlTest ui)
 
+# QuickQanava production integration: static-module initialization, a
+# Loader-owned graph, and repeated graph object teardown/recreation.
+add_executable(QuickQanavaProductionIntegrationTest
+    ${ALCEDO_TEST_ROOT}/ui/quickqanava_production_integration_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
+)
+target_include_directories(QuickQanavaProductionIntegrationTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR}
+    PRIVATE ${ALCEDO_TEST_ROOT}/ui
+)
+target_link_libraries(QuickQanavaProductionIntegrationTest
+    PRIVATE
+        QuickQanava
+        QuickQanavaplugin
+        GTest::gtest
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Test
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::QuickEffects
+        Qt6::Widgets
+)
+alcedo_ui_gtest_discover_tests(QuickQanavaProductionIntegrationTest
+    TEST_PREFIX "QuickQanavaProductionIntegrationTest."
+    PROPERTIES LABELS "quickqanava;workspace_qml")
+alcedo_register_test_target(QuickQanavaProductionIntegrationTest ui)
+
 # Phase 7B: final-display identity stamping, stale-output rejection, and
 # hidden/resume analyzer lifecycle.
 add_executable(EditorScopeControllerTest

--- a/alcedo_studio/tests/ui/quickqanava_production_integration_test.cpp
+++ b/alcedo_studio/tests/ui/quickqanava_production_integration_test.cpp
@@ -1,0 +1,237 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDeadlineTimer>
+#include <QEvent>
+#include <QEventLoop>
+#include <QPointer>
+#include <QQmlApplicationEngine>
+#include <QQmlError>
+#include <QQmlExtensionPlugin>
+#include <QQuickStyle>
+#include <QQuickWindow>
+#include <QStringList>
+#include <QUrl>
+#include <QVariant>
+#include <QuickQanava>
+#include <functional>
+#include <mutex>
+
+Q_IMPORT_QML_PLUGIN(QuickQanavaPlugin)
+
+namespace {
+
+constexpr char kGraphHarnessQml[]  = R"qml(
+import QtQuick
+import QtQuick.Controls
+import QuickQanava 2.0 as Qan
+
+ApplicationWindow {
+    id: root
+    objectName: "quickQanavaHarness"
+    width: 640
+    height: 480
+    visible: true
+
+    Component {
+        id: graphViewComponent
+
+        Qan.GraphView {
+            id: graphView
+            objectName: "qanGraphView"
+            anchors.fill: parent
+            navigable: false
+            property var graphNode: graphTopology.insertedNode
+
+            graph: Qan.Graph {
+                id: graphTopology
+                objectName: "qanGraph"
+                property var insertedNode: null
+
+                Component.onCompleted: {
+                    var node = graphTopology.insertNode()
+                    if (!node) {
+                        console.error("QuickQanava graph node creation failed")
+                        return
+                    }
+                    node.label = "Read-only proof node"
+                    graphTopology.insertedNode = node
+                }
+            }
+        }
+    }
+
+    Loader {
+        id: graphLoader
+        objectName: "graphLoader"
+        anchors.fill: parent
+        active: true
+        asynchronous: false
+        sourceComponent: graphViewComponent
+    }
+
+    property var graphViewObject: graphLoader.item
+    property var graphObject: graphViewObject ? graphViewObject.graph : null
+    property var graphNodeObject: graphViewObject ? graphViewObject.graphNode : null
+    property int graphNodeCount: graphObject ? graphObject.getNodeCount() : 0
+    property string graphNodeLabel: graphNodeObject ? graphNodeObject.label : ""
+}
+)qml";
+
+constexpr char kMissingModuleQml[] = R"qml(
+import QtQuick
+import QuickQanavaUnavailable 1.0
+
+Item {}
+)qml";
+
+void           SetBasicStyle() {
+  static std::once_flag style_once;
+  std::call_once(style_once, [] { QQuickStyle::setStyle(QStringLiteral("Basic")); });
+}
+
+bool WaitFor(const std::function<bool()>& predicate, int timeout_ms = 1000) {
+  QDeadlineTimer deadline{timeout_ms};
+  while (!predicate() && !deadline.hasExpired()) {
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+  }
+  return predicate();
+}
+
+QObject* ObjectProperty(QObject* object, const char* property_name) {
+  if (object == nullptr) {
+    return nullptr;
+  }
+  return object->property(property_name).value<QObject*>();
+}
+
+class QuickQanavaHarness final {
+ public:
+  QuickQanavaHarness() {
+    QObject::connect(&engine_, &QQmlApplicationEngine::warnings, &engine_,
+                     [this](const QList<QQmlError>& errors) {
+                       for (const auto& error : errors) {
+                         warnings_.append(error.toString());
+                       }
+                     });
+
+    SetBasicStyle();
+    engine_.addImportPath(QStringLiteral("qrc:/"));
+    QuickQanava::initialize(&engine_);
+    engine_.loadData(QByteArray{kGraphHarnessQml},
+                     QUrl(QStringLiteral("file:///QuickQanavaHarness.qml")));
+
+    if (!engine_.rootObjects().isEmpty()) {
+      window_ = qobject_cast<QQuickWindow*>(engine_.rootObjects().constFirst());
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
+  }
+
+  QQuickWindow*      window() const { return window_; }
+  const QStringList& warnings() const { return warnings_; }
+
+ private:
+  QQmlApplicationEngine engine_;
+  QQuickWindow*         window_ = nullptr;
+  QStringList           warnings_;
+};
+
+std::string WarningText(const QStringList& warnings) {
+  return warnings.join(QLatin1Char('\n')).toStdString();
+}
+
+}  // namespace
+
+TEST(QuickQanavaProductionIntegrationTest, BasicStyleLoadsOneReadOnlyGraphNode) {
+  QuickQanavaHarness harness;
+
+  ASSERT_NE(harness.window(), nullptr) << WarningText(harness.warnings());
+  ASSERT_TRUE(harness.warnings().isEmpty()) << WarningText(harness.warnings());
+  EXPECT_EQ(QQuickStyle::name(), QStringLiteral("Basic"));
+
+  QObject* graph_view = harness.window()->findChild<QObject*>("qanGraphView");
+  QObject* graph      = harness.window()->findChild<QObject*>("qanGraph");
+  QObject* node       = ObjectProperty(harness.window(), "graphNodeObject");
+
+  ASSERT_NE(graph_view, nullptr);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_NE(node, nullptr);
+  EXPECT_EQ(ObjectProperty(graph_view, "graph"), graph);
+  EXPECT_EQ(harness.window()->property("graphObject").value<QObject*>(), graph);
+  EXPECT_EQ(harness.window()->property("graphNodeCount").toInt(), 1);
+  EXPECT_EQ(harness.window()->property("graphNodeLabel").toString(),
+            QStringLiteral("Read-only proof node"));
+  EXPECT_NE(ObjectProperty(node, "item"), nullptr);
+}
+
+TEST(QuickQanavaProductionIntegrationTest, LoaderRecreatesGraphViewAndTopologyWithoutStaleObjects) {
+  QuickQanavaHarness harness;
+
+  ASSERT_NE(harness.window(), nullptr) << WarningText(harness.warnings());
+  ASSERT_TRUE(harness.warnings().isEmpty()) << WarningText(harness.warnings());
+
+  QObject* loader = harness.window()->findChild<QObject*>("graphLoader");
+  ASSERT_NE(loader, nullptr);
+
+  constexpr int kRebuildCount = 5;
+  for (int rebuild = 0; rebuild < kRebuildCount; ++rebuild) {
+    QPointer<QObject> old_graph_view{harness.window()->findChild<QObject*>("qanGraphView")};
+    QPointer<QObject> old_graph{harness.window()->findChild<QObject*>("qanGraph")};
+    ASSERT_FALSE(old_graph_view.isNull());
+    ASSERT_FALSE(old_graph.isNull());
+
+    ASSERT_TRUE(loader->setProperty("active", false));
+    const auto graph_cleared = [&harness]() {
+      return harness.window()->findChild<QObject*>("qanGraphView") == nullptr &&
+             harness.window()->findChild<QObject*>("qanGraph") == nullptr &&
+             ObjectProperty(harness.window(), "graphViewObject") == nullptr &&
+             ObjectProperty(harness.window(), "graphObject") == nullptr &&
+             ObjectProperty(harness.window(), "graphNodeObject") == nullptr;
+    };
+    ASSERT_TRUE(WaitFor(graph_cleared));
+    EXPECT_TRUE(old_graph_view.isNull());
+    EXPECT_TRUE(old_graph.isNull());
+    EXPECT_EQ(harness.window()->property("graphNodeCount").toInt(), 0);
+    EXPECT_TRUE(harness.window()->property("graphNodeLabel").toString().isEmpty());
+
+    ASSERT_TRUE(loader->setProperty("active", true));
+    ASSERT_TRUE(WaitFor([&harness]() {
+      return harness.window()->findChild<QObject*>("qanGraphView") != nullptr &&
+             harness.window()->findChild<QObject*>("qanGraph") != nullptr &&
+             ObjectProperty(harness.window(), "graphNodeObject") != nullptr &&
+             harness.window()->property("graphNodeCount").toInt() == 1;
+    }));
+    EXPECT_EQ(harness.window()->property("graphNodeLabel").toString(),
+              QStringLiteral("Read-only proof node"));
+  }
+
+  EXPECT_TRUE(harness.warnings().isEmpty()) << WarningText(harness.warnings());
+}
+
+TEST(QuickQanavaProductionIntegrationTest,
+     MissingQuickQanavaImportReturnsQmlErrorWithoutRootObject) {
+  SetBasicStyle();
+  QQmlApplicationEngine engine;
+  QStringList           warnings;
+  QObject::connect(&engine, &QQmlApplicationEngine::warnings, &engine,
+                   [&warnings](const QList<QQmlError>& errors) {
+                     for (const auto& error : errors) {
+                       warnings.append(error.toString());
+                     }
+                   });
+
+  engine.loadData(QByteArray{kMissingModuleQml},
+                  QUrl(QStringLiteral("file:///MissingQuickQanavaImport.qml")));
+
+  EXPECT_TRUE(engine.rootObjects().isEmpty());
+  ASSERT_FALSE(warnings.isEmpty());
+  const QString error_text = warnings.join(QLatin1Char('\n'));
+  EXPECT_NE(error_text.indexOf(QStringLiteral("QuickQanavaUnavailable")), -1);
+  EXPECT_NE(error_text.indexOf(QStringLiteral("not installed")), -1);
+}

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: planned
+Status: NM5.1 complete; NM5.2–NM5.8 planned
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -707,6 +707,89 @@ alcedo_main startup
 
 Record the date, revision, exact initialization signature, commands, test count, and upstream
 differences here after implementation.
+
+##### NM5.1 completion record (2026-09-03)
+
+**Status:** complete — production `alcedo_main` links the pinned QuickQanava static module and
+initializes it before the Alcedo QML module loads. The production-style harness proves a
+Loader-owned `Qan.GraphView`/`Qan.Graph` with one visual node, repeated Loader teardown and
+recreation, and the real missing-module error path.
+
+**Revision:** base repository revision `9ba15d40`, branch
+`feature/nodes-panel-foundation`; QuickQanava remains submodule tag `2.50` at
+`56bdf78d5b1d41fb60ae3b8ea2292df45787ecff`. The pinned checkout has no source changes.
+
+**Primary success call chains:**
+
+```text
+alcedo_main startup
+  -> QQuickStyle::setStyle("Basic")
+  -> QQmlApplicationEngine with qrc:/ import path
+  -> QuickQanava::initialize(QQmlEngine* engine) with &engine
+  -> engine.loadFromModule("Alcedo.Main", "Main")
+```
+
+```text
+QuickQanavaProductionIntegrationTest
+  -> Basic style and qrc:/ import path
+  -> QuickQanava::initialize(&engine)
+  -> Loader sourceComponent creates Qan.GraphView
+  -> Qan.Graph binds to GraphView.graph
+  -> Component.onCompleted calls graph.insertNode()
+  -> node label and visual item are observed
+  -> Loader active=false/true destroys and recreates the graph five times
+```
+
+**Tests and evidence:**
+
+| Evidence | Result |
+| --- | --- |
+| `alcedo_main` links `QuickQanava` and `QuickQanavaplugin` | PASS |
+| Basic style remains selected before engine creation | PASS |
+| One `Qan.Graph` and one `Qan.Node` load through the Loader | PASS |
+| `Qan.GraphView.graph` binds to the Loader-owned graph and the node has an item | PASS |
+| Five Loader teardown/recreation cycles leave no stale graph objects | PASS |
+| Missing QuickQanava import reports the actual QML error and creates no root object | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target QuickQanavaProductionIntegrationTest alcedo_main --parallel 4
+build/debug/alcedo_studio/tests/ui/QuickQanavaProductionIntegrationTest_runtime/QuickQanavaProductionIntegrationTest.exe --gtest_color=no
+```
+
+The direct test run passed all 3 tests. A filtered CTest run could not reach this target because
+the UI directory's existing PRE_TEST discovery first launches
+`SharedToneCurveTest_runtime/SharedToneCurveTest.exe`, which exits with `0xc0000139` for the
+pre-existing lensfun runtime entry-point mismatch. The new binary was therefore run directly;
+its own runtime directory contains the expected offscreen Qt plugins and all three tests pass.
+
+**Pinned API differences:**
+
+- The website Graph snippet shows a no-argument `QuickQanava::initialize()` form, but the pinned
+  2.50 header exposes only `static void initialize(QQmlEngine* engine)`. Production and the
+  harness use the pinned `QuickQanava::initialize(&engine)` signature.
+- Website external-project examples add a source-directory import path. Alcedo embeds the static
+  module and adds `qrc:/` before initialization, which is the path used by the pinned
+  `QuickQanava` component factories.
+- The pinned QML sources use unversioned `import QuickQanava as Qan`, while the public harness
+  uses the documented `import QuickQanava 2.0 as Qan`. Qt 6.9.3 therefore needs the Alcedo-owned
+  QML module wrapper to publish the pinned QML files at both 2.0 and 1.0 while keeping the
+  module's public version at 2.0. This keeps the submodule checkout unchanged and allows both
+  the documented entry point and the pinned nested imports to resolve.
+
+**Checklist / exit condition:** all NM5.1 work and exit conditions are checked. No production
+PipelineDocument or Qan projection was added in this setup phase.
+
+**LOC note (grill-code-review):** 237-line integration harness; 30-line test registration;
+7-line QML module-version compatibility setup; 8 production link/initialization lines. The
+QuickQanava submodule source remains unchanged.
+
+**Residual gaps:** NM5.2–NM5.8 still own the immutable Alcedo projection, node delegate, Nodes
+rail page, selection/navigation state, graph commands, visual connector, and final lifecycle/build
+qualification. macOS checks were not run on this Windows host. The unrelated CTest discovery
+runtime mismatch remains outside NM5.1.
 
 ---
 
@@ -1413,9 +1496,9 @@ Do not reduce decode resolution, output quality, or backend behavior to meet the
 
 ## 19. NM5 completion criteria
 
-- [ ] The production target links the pinned QuickQanava module.
-- [ ] Production initializes QuickQanava before QML load.
-- [ ] Production remains on Qt Quick Controls Basic.
+- [x] The production target links the pinned QuickQanava module.
+- [x] Production initializes QuickQanava before QML load.
+- [x] Production remains on Qt Quick Controls Basic.
 - [ ] Nodes is a page in the shared editor tool rail.
 - [ ] History, Versions, and Nodes share one page state and Loader.
 - [ ] `PipelineDocument` remains the only product graph.


### PR DESCRIPTION
## Summary

- Link the pinned QuickQanava static module and plugin into `alcedo_main`.
- Initialize QuickQanava after the `qrc:/` import path is available and before loading Alcedo QML, while retaining the Qt Quick Controls `Basic` style.
- Publish the pinned QML sources for the documented `2.0` import and the pinned unversioned nested imports without changing the QuickQanava submodule.
- Add a Loader-owned Qan graph integration harness that creates one node, verifies the visual item and graph binding, repeats teardown/recreation five times, and checks the real missing-module error path.
- Mark NM5.1 complete in the roadmap with the primary call chains and pinned API differences.

## Validation

- `cmd /c scripts\msvc_env.cmd --preset win_debug`
- `cmd /c scripts\msvc_env.cmd --build --preset win_debug --target QuickQanavaProductionIntegrationTest alcedo_main --parallel 4`
- `QuickQanavaProductionIntegrationTest.exe --gtest_color=no` — 3 tests passed.
- `git diff --check` — passed.
- New integration test passes `clang-format --dry-run --Werror`.

## Known limitation

The filtered CTest run is blocked before this target by the existing UI `PRE_TEST` discovery, which launches `SharedToneCurveTest_runtime/SharedToneCurveTest.exe` and hits the pre-existing lensfun runtime entry-point mismatch (`0xc0000139`). The new test binary was run directly and passed all three tests. macOS validation was not available on this Windows host.