### PR TITLE
feat(ui): map Nodes projection onto QuickQanava primitives

### DIFF
--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
@@ -1,0 +1,211 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "app/editor_node_graph_projection.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "qanGraph.h"
+
+namespace qan {
+class Edge;
+class Node;
+class PortItem;
+}  // namespace qan
+
+namespace alcedo::ui {
+
+/**
+ * @brief Result of applying an immutable node-graph snapshot to a Qan graph.
+ *
+ * @p succeeded is true only when the live Qan primitives match @p snapshot.
+ * Topology rebuilds that fail restore the prior complete projection before
+ * returning. The adapter never mutates PipelineDocument.
+ */
+struct AlcedoQanGraphApplyResult {
+  bool    succeeded        = false;
+  bool    rebuilt_topology = false;
+  QString error;
+};
+
+/**
+ * @brief Maps an EditorNodeGraphSnapshot onto documented QuickQanava primitives.
+ *
+ * Ownership: this object does not own the Qan graph. The QML Loader / GraphView
+ * owns @c qan::Graph. Identity maps hold QPointer values and are cleared before
+ * any mapped primitive is destroyed. A Qan node pointer is never a NodeId.
+ *
+ * Threading: GUI thread only. ApplySnapshot and identity queries must run on
+ * the thread that owns the Qan graph.
+ *
+ * Side effects: insert, remove, port bind, and label updates on the bound Qan
+ * graph. No history commit, no photo render, and no domain graph mutation.
+ */
+class AlcedoQanGraph : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(qan::Graph* graph READ graph WRITE set_graph NOTIFY GraphChanged)
+
+ public:
+  explicit AlcedoQanGraph(QObject* parent = nullptr);
+  ~AlcedoQanGraph() override;
+
+  /**
+   * @brief Bind the Qan graph that receives projected primitives.
+   * @param graph Loader-owned graph, or nullptr to drop identity maps. The
+   *        previous graph is not cleared; only adapter maps are dropped.
+   */
+  void               set_graph(qan::Graph* graph);
+  [[nodiscard]] auto graph() const -> qan::Graph*;
+
+  /**
+   * @brief Project @p snapshot onto the bound Qan graph.
+   *
+   * Same session and topology revision with matching node/edge identities
+   * updates labels and Mask roles in place. A generation or topology change
+   * replaces every primitive. A stale generation, topology, or projection
+   * revision is rejected without mutation.
+   *
+   * @pre GUI thread. @c graph() is a completed Qan graph with port delegates.
+   * @return Success with @c rebuilt_topology set when primitives were replaced.
+   *         On Qan insert/bind failure, the prior complete projection is
+   *         restored when one existed.
+   */
+  [[nodiscard]] auto ApplySnapshot(const EditorNodeGraphSnapshot& snapshot)
+      -> AlcedoQanGraphApplyResult;
+
+  /**
+   * @return Live Qan node for @p node_id in the current generation, or nullptr.
+   */
+  [[nodiscard]] auto NodeFor(const NodeId& node_id) const -> qan::Node*;
+
+  /**
+   * @return Live Qan edge for the projected backbone identity, or nullptr.
+   */
+  [[nodiscard]] auto EdgeFor(const EditorNodeEdgeProjection& edge) const -> qan::Edge*;
+
+  /**
+   * @return Top input port for @p node_id and @p port_id, or nullptr.
+   */
+  [[nodiscard]] auto InputPortFor(const NodeId& node_id, const PortId& port_id) const
+      -> qan::PortItem*;
+
+  /**
+   * @return Bottom output port for @p node_id and @p port_id, or nullptr.
+   */
+  [[nodiscard]] auto OutputPortFor(const NodeId& node_id, const PortId& port_id) const
+      -> qan::PortItem*;
+
+  /**
+   * @brief Resolve a Qan node to a product NodeId.
+   *
+   * Rejects nullptr, destroyed primitives, unknown pointers, and primitives
+   * recorded under another session generation. This is the only selection
+   * identity the adapter exposes; a raw Qan selected-node list is not a
+   * product selection source.
+   */
+  [[nodiscard]] auto LiveNodeId(const qan::Node* node) const -> std::optional<NodeId>;
+
+  /**
+   * @return Copied node-card values for @p node_id, or nullptr when unmapped.
+   */
+  [[nodiscard]] auto NodeProjection(const NodeId& node_id) const -> const EditorNodeProjection*;
+
+  [[nodiscard]] auto session_generation() const -> std::uint64_t;
+  [[nodiscard]] auto projection_revision() const -> std::uint64_t;
+  [[nodiscard]] auto topology_revision() const -> std::uint64_t;
+  [[nodiscard]] auto has_projection() const -> bool;
+
+ signals:
+  void GraphChanged();
+
+ protected:
+  /**
+   * @brief Documented @c qan::Graph::insertNode() entry used during rebuilds.
+   *
+   * Tests may override this to inject a nullptr result. Production always
+   * forwards to the bound graph.
+   */
+  [[nodiscard]] virtual auto InsertQanNode(qan::Graph& graph) -> qan::Node*;
+
+ private:
+  struct EdgeKey {
+    NodeId      source_node_id;
+    PortId      source_port_id;
+    NodeId      destination_node_id;
+    PortId      destination_port_id;
+
+    friend auto operator<(const EdgeKey& lhs, const EdgeKey& rhs) -> bool {
+      if (lhs.source_node_id != rhs.source_node_id) {
+        return lhs.source_node_id < rhs.source_node_id;
+      }
+      if (lhs.source_port_id != rhs.source_port_id) {
+        return lhs.source_port_id < rhs.source_port_id;
+      }
+      if (lhs.destination_node_id != rhs.destination_node_id) {
+        return lhs.destination_node_id < rhs.destination_node_id;
+      }
+      return lhs.destination_port_id < rhs.destination_port_id;
+    }
+
+    friend auto operator==(const EdgeKey& lhs, const EdgeKey& rhs) -> bool {
+      return lhs.source_node_id == rhs.source_node_id && lhs.source_port_id == rhs.source_port_id &&
+             lhs.destination_node_id == rhs.destination_node_id &&
+             lhs.destination_port_id == rhs.destination_port_id;
+    }
+  };
+
+  struct NodePorts {
+    std::map<PortId, QPointer<qan::PortItem>> inputs;
+    std::map<PortId, QPointer<qan::PortItem>> outputs;
+  };
+
+  struct ReverseNode {
+    NodeId        node_id;
+    std::uint64_t session_generation = 0;
+  };
+
+  void               ClearIdentityMaps();
+  void               OnGraphDestroyed();
+  void               DestroyMappedPrimitives();
+  void               DestroyPrimitives(const std::vector<QPointer<qan::Edge>>& edges,
+                                       const std::vector<QPointer<qan::Node>>& nodes);
+
+  [[nodiscard]] auto RejectIfStale(const EditorNodeGraphSnapshot& snapshot) const -> QString;
+  [[nodiscard]] auto ValidateSnapshot(const EditorNodeGraphSnapshot& snapshot) const -> QString;
+  [[nodiscard]] auto CanUpdateRoles(const EditorNodeGraphSnapshot& snapshot) const -> bool;
+  auto ApplyRoles(const EditorNodeGraphSnapshot& snapshot) -> AlcedoQanGraphApplyResult;
+  auto ReplaceTopology(const EditorNodeGraphSnapshot& snapshot) -> AlcedoQanGraphApplyResult;
+  [[nodiscard]] auto InsertTopology(const EditorNodeGraphSnapshot& snapshot) -> QString;
+  [[nodiscard]] auto InsertNodePorts(qan::Node& qan_node, const EditorNodeProjection& node)
+      -> QString;
+  [[nodiscard]] auto InsertPort(qan::Node& qan_node, const NodeId& node_id, const PortId& port_id,
+                                bool is_input) -> qan::PortItem*;
+  [[nodiscard]] auto InsertEdge(const EditorNodeEdgeProjection& edge) -> QString;
+
+  [[nodiscard]] static auto MakeEdgeKey(const EditorNodeEdgeProjection& edge) -> EdgeKey;
+  [[nodiscard]] static auto ToQString(std::string_view text) -> QString;
+  [[nodiscard]] static auto QanPortId(bool is_input, const PortId& port_id) -> QString;
+
+  QPointer<qan::Graph>      graph_;
+  bool                      has_projection_      = false;
+  bool                      rebuild_in_progress_ = false;
+  EditorNodeGraphSnapshot   applied_;
+  std::map<NodeId, QPointer<qan::Node>>             node_by_id_;
+  std::map<EdgeKey, QPointer<qan::Edge>>            edge_by_key_;
+  std::map<NodeId, NodePorts>                       ports_by_node_;
+  std::map<NodeId, EditorNodeProjection>            node_projections_;
+  std::unordered_map<const qan::Node*, ReverseNode> node_from_qan_;
+};
+
+}  // namespace alcedo::ui

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -221,9 +221,30 @@ target_link_libraries(AlbumBackendLib
         CudaDriverRequirements
 )
 
+# Maps PipelineDocument snapshots onto pinned QuickQanava primitives. The QML
+# GraphView owns the qan::Graph; this adapter owns only identity maps.
+add_library(AlcedoQanGraph STATIC
+    "${ALCEDO_UI_SHELL_ROOT}/album_backend/alcedo_qan_graph.cpp"
+    "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp"
+)
+target_include_directories(AlcedoQanGraph
+    PUBLIC
+        "${ALCEDO_INCLUDE_ROOT}"
+)
+target_link_libraries(AlcedoQanGraph
+    PUBLIC
+        EditorNodeGraphProjection
+        QuickQanava
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+)
+
 # The editor shell is QML-only. Widgets remains private to the album backend for
 # the native project and Nikon recovery file dialogs.
 target_link_libraries(AlbumBackendLib PRIVATE Qt6::Widgets)
+target_link_libraries(AlbumBackendLib PUBLIC AlcedoQanGraph)
 
 set(ALCEDO_MAIN_SOURCES
     "${ALCEDO_UI_SHELL_ROOT}/main.cpp"

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
@@ -1,0 +1,449 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "ui/alcedo_main/album_backend/alcedo_qan_graph.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "qanEdge.h"
+#include "qanEdgeItem.h"
+#include "qanNode.h"
+#include "qanNodeItem.h"
+#include "qanPortItem.h"
+
+namespace alcedo::ui {
+namespace {
+
+auto ContainsNodeId(const std::vector<EditorNodeProjection>& nodes, const NodeId& id) -> bool {
+  for (const auto& node : nodes) {
+    if (node.node_id == id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+AlcedoQanGraph::AlcedoQanGraph(QObject* parent) : QObject(parent) {}
+
+AlcedoQanGraph::~AlcedoQanGraph() {
+  rebuild_in_progress_ = true;
+  ClearIdentityMaps();
+}
+
+void AlcedoQanGraph::set_graph(qan::Graph* graph) {
+  if (graph_.data() == graph) {
+    return;
+  }
+  if (!graph_.isNull()) {
+    disconnect(graph_.data(), nullptr, this, nullptr);
+  }
+  rebuild_in_progress_ = true;
+  ClearIdentityMaps();
+  has_projection_      = false;
+  applied_             = {};
+  rebuild_in_progress_ = false;
+  graph_               = graph;
+  if (!graph_.isNull()) {
+    connect(graph_.data(), &QObject::destroyed, this, &AlcedoQanGraph::OnGraphDestroyed);
+  }
+  emit GraphChanged();
+}
+
+auto AlcedoQanGraph::graph() const -> qan::Graph* { return graph_.data(); }
+
+auto AlcedoQanGraph::ApplySnapshot(const EditorNodeGraphSnapshot& snapshot)
+    -> AlcedoQanGraphApplyResult {
+  AlcedoQanGraphApplyResult result;
+  if (graph_.isNull()) {
+    result.error = QStringLiteral("AlcedoQanGraph has no Qan graph");
+    return result;
+  }
+  const auto stale = RejectIfStale(snapshot);
+  if (!stale.isEmpty()) {
+    result.error = stale;
+    return result;
+  }
+  const auto invalid = ValidateSnapshot(snapshot);
+  if (!invalid.isEmpty()) {
+    result.error = invalid;
+    return result;
+  }
+  if (CanUpdateRoles(snapshot)) {
+    return ApplyRoles(snapshot);
+  }
+  return ReplaceTopology(snapshot);
+}
+
+auto AlcedoQanGraph::NodeFor(const NodeId& node_id) const -> qan::Node* {
+  const auto it = node_by_id_.find(node_id);
+  if (it == node_by_id_.end()) {
+    return nullptr;
+  }
+  return it->second.data();
+}
+
+auto AlcedoQanGraph::EdgeFor(const EditorNodeEdgeProjection& edge) const -> qan::Edge* {
+  const auto it = edge_by_key_.find(MakeEdgeKey(edge));
+  if (it == edge_by_key_.end()) {
+    return nullptr;
+  }
+  return it->second.data();
+}
+
+auto AlcedoQanGraph::InputPortFor(const NodeId& node_id, const PortId& port_id) const
+    -> qan::PortItem* {
+  const auto node = ports_by_node_.find(node_id);
+  if (node == ports_by_node_.end()) {
+    return nullptr;
+  }
+  const auto port = node->second.inputs.find(port_id);
+  if (port == node->second.inputs.end()) {
+    return nullptr;
+  }
+  return port->second.data();
+}
+
+auto AlcedoQanGraph::OutputPortFor(const NodeId& node_id, const PortId& port_id) const
+    -> qan::PortItem* {
+  const auto node = ports_by_node_.find(node_id);
+  if (node == ports_by_node_.end()) {
+    return nullptr;
+  }
+  const auto port = node->second.outputs.find(port_id);
+  if (port == node->second.outputs.end()) {
+    return nullptr;
+  }
+  return port->second.data();
+}
+
+auto AlcedoQanGraph::LiveNodeId(const qan::Node* node) const -> std::optional<NodeId> {
+  if (rebuild_in_progress_ || node == nullptr) {
+    return std::nullopt;
+  }
+  const auto it = node_from_qan_.find(node);
+  if (it == node_from_qan_.end()) {
+    return std::nullopt;
+  }
+  if (!has_projection_ || it->second.session_generation != applied_.session_generation) {
+    return std::nullopt;
+  }
+  if (NodeFor(it->second.node_id) != node) {
+    return std::nullopt;
+  }
+  return it->second.node_id;
+}
+
+auto AlcedoQanGraph::NodeProjection(const NodeId& node_id) const -> const EditorNodeProjection* {
+  const auto it = node_projections_.find(node_id);
+  if (it == node_projections_.end()) {
+    return nullptr;
+  }
+  return &it->second;
+}
+
+auto AlcedoQanGraph::session_generation() const -> std::uint64_t {
+  return has_projection_ ? applied_.session_generation : 0;
+}
+
+auto AlcedoQanGraph::projection_revision() const -> std::uint64_t {
+  return has_projection_ ? applied_.projection_revision : 0;
+}
+
+auto AlcedoQanGraph::topology_revision() const -> std::uint64_t {
+  return has_projection_ ? applied_.topology_revision : 0;
+}
+
+auto AlcedoQanGraph::has_projection() const -> bool { return has_projection_; }
+
+auto AlcedoQanGraph::InsertQanNode(qan::Graph& graph) -> qan::Node* { return graph.insertNode(); }
+
+void AlcedoQanGraph::ClearIdentityMaps() {
+  node_by_id_.clear();
+  edge_by_key_.clear();
+  ports_by_node_.clear();
+  node_projections_.clear();
+  node_from_qan_.clear();
+}
+
+void AlcedoQanGraph::OnGraphDestroyed() {
+  rebuild_in_progress_ = true;
+  ClearIdentityMaps();
+  has_projection_ = false;
+  applied_        = {};
+  graph_.clear();
+  rebuild_in_progress_ = false;
+  emit GraphChanged();
+}
+
+void AlcedoQanGraph::DestroyMappedPrimitives() {
+  std::vector<QPointer<qan::Edge>> edges;
+  edges.reserve(edge_by_key_.size());
+  for (const auto& [key, edge] : edge_by_key_) {
+    edges.push_back(edge);
+  }
+  std::vector<QPointer<qan::Node>> nodes;
+  nodes.reserve(node_by_id_.size());
+  for (const auto& [id, node] : node_by_id_) {
+    nodes.push_back(node);
+  }
+  DestroyPrimitives(edges, nodes);
+}
+
+void AlcedoQanGraph::DestroyPrimitives(const std::vector<QPointer<qan::Edge>>& edges,
+                                       const std::vector<QPointer<qan::Node>>& nodes) {
+  if (graph_.isNull()) {
+    return;
+  }
+  for (const auto& edge : edges) {
+    if (!edge.isNull()) {
+      graph_->removeEdge(edge.data(), true);
+    }
+  }
+  for (const auto& node : nodes) {
+    if (!node.isNull()) {
+      graph_->removeNode(node.data(), true);
+    }
+  }
+}
+
+auto AlcedoQanGraph::RejectIfStale(const EditorNodeGraphSnapshot& snapshot) const -> QString {
+  if (!has_projection_) {
+    return {};
+  }
+  if (snapshot.session_generation < applied_.session_generation) {
+    return QStringLiteral("snapshot session generation is stale");
+  }
+  if (snapshot.session_generation != applied_.session_generation) {
+    return {};
+  }
+  if (snapshot.topology_revision < applied_.topology_revision) {
+    return QStringLiteral("snapshot topology revision is stale");
+  }
+  if (snapshot.topology_revision == applied_.topology_revision &&
+      snapshot.projection_revision < applied_.projection_revision) {
+    return QStringLiteral("snapshot projection revision is stale");
+  }
+  return {};
+}
+
+auto AlcedoQanGraph::ValidateSnapshot(const EditorNodeGraphSnapshot& snapshot) const -> QString {
+  if (snapshot.nodes.empty()) {
+    return QStringLiteral("snapshot has no nodes");
+  }
+  for (std::size_t i = 0; i < snapshot.nodes.size(); ++i) {
+    if (snapshot.nodes[i].node_id.Empty()) {
+      return QStringLiteral("snapshot contains an empty NodeId");
+    }
+    for (std::size_t j = i + 1; j < snapshot.nodes.size(); ++j) {
+      if (snapshot.nodes[i].node_id == snapshot.nodes[j].node_id) {
+        return QStringLiteral("snapshot contains a duplicate NodeId");
+      }
+    }
+  }
+  for (const auto& edge : snapshot.edges) {
+    if (!ContainsNodeId(snapshot.nodes, edge.source_node_id) ||
+        !ContainsNodeId(snapshot.nodes, edge.destination_node_id)) {
+      return QStringLiteral("snapshot edge references an unknown node");
+    }
+  }
+  return {};
+}
+
+auto AlcedoQanGraph::CanUpdateRoles(const EditorNodeGraphSnapshot& snapshot) const -> bool {
+  if (!has_projection_ || graph_.isNull()) {
+    return false;
+  }
+  if (snapshot.session_generation != applied_.session_generation ||
+      snapshot.topology_revision != applied_.topology_revision) {
+    return false;
+  }
+  if (snapshot.nodes.size() != applied_.nodes.size() ||
+      snapshot.edges.size() != applied_.edges.size()) {
+    return false;
+  }
+  for (std::size_t i = 0; i < snapshot.nodes.size(); ++i) {
+    if (snapshot.nodes[i].node_id != applied_.nodes[i].node_id ||
+        snapshot.nodes[i].node_kind != applied_.nodes[i].node_kind) {
+      return false;
+    }
+    if (NodeFor(snapshot.nodes[i].node_id) == nullptr) {
+      return false;
+    }
+  }
+  for (std::size_t i = 0; i < snapshot.edges.size(); ++i) {
+    if (MakeEdgeKey(snapshot.edges[i]) != MakeEdgeKey(applied_.edges[i])) {
+      return false;
+    }
+    if (EdgeFor(snapshot.edges[i]) == nullptr) {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto AlcedoQanGraph::ApplyRoles(const EditorNodeGraphSnapshot& snapshot)
+    -> AlcedoQanGraphApplyResult {
+  AlcedoQanGraphApplyResult result;
+  for (const auto& node : snapshot.nodes) {
+    auto* qan_node = NodeFor(node.node_id);
+    if (qan_node == nullptr) {
+      result.error = QStringLiteral("Qan node is missing a visual item");
+      return result;
+    }
+    qan_node->setLabel(ToQString(node.display_name));
+    node_projections_[node.node_id] = node;
+  }
+  applied_         = snapshot;
+  has_projection_  = true;
+  result.succeeded = true;
+  return result;
+}
+
+auto AlcedoQanGraph::ReplaceTopology(const EditorNodeGraphSnapshot& snapshot)
+    -> AlcedoQanGraphApplyResult {
+  AlcedoQanGraphApplyResult result;
+  result.rebuilt_topology = true;
+
+  const auto previous     = applied_;
+  const auto had_previous = has_projection_;
+  rebuild_in_progress_    = true;
+  DestroyMappedPrimitives();
+  ClearIdentityMaps();
+
+  auto error = InsertTopology(snapshot);
+  if (error.isEmpty()) {
+    applied_             = snapshot;
+    has_projection_      = true;
+    rebuild_in_progress_ = false;
+    result.succeeded     = true;
+    return result;
+  }
+
+  DestroyMappedPrimitives();
+  ClearIdentityMaps();
+  has_projection_ = false;
+  applied_        = {};
+  if (had_previous) {
+    const auto restore_error = InsertTopology(previous);
+    if (restore_error.isEmpty()) {
+      applied_        = previous;
+      has_projection_ = true;
+    } else {
+      error += QStringLiteral("; restoring the prior Qan projection failed: ") + restore_error;
+    }
+  }
+  rebuild_in_progress_ = false;
+  result.error         = error;
+  return result;
+}
+
+auto AlcedoQanGraph::InsertTopology(const EditorNodeGraphSnapshot& snapshot) -> QString {
+  if (graph_.isNull()) {
+    return QStringLiteral("AlcedoQanGraph has no Qan graph");
+  }
+  for (const auto& node : snapshot.nodes) {
+    auto* qan_node = InsertQanNode(*graph_);
+    if (qan_node == nullptr) {
+      return QStringLiteral("Qan node creation failed");
+    }
+    if (qan_node->getItem() == nullptr) {
+      graph_->removeNode(qan_node, true);
+      return QStringLiteral("Qan node is missing a visual item");
+    }
+    qan_node->setLabel(ToQString(node.display_name));
+    node_by_id_[node.node_id]       = qan_node;
+    node_projections_[node.node_id] = node;
+    node_from_qan_[qan_node]        = ReverseNode{node.node_id, snapshot.session_generation};
+    const auto port_error           = InsertNodePorts(*qan_node, node);
+    if (!port_error.isEmpty()) {
+      return port_error;
+    }
+  }
+  for (const auto& edge : snapshot.edges) {
+    const auto edge_error = InsertEdge(edge);
+    if (!edge_error.isEmpty()) {
+      return edge_error;
+    }
+  }
+  return {};
+}
+
+auto AlcedoQanGraph::InsertNodePorts(qan::Node& qan_node, const EditorNodeProjection& node)
+    -> QString {
+  const PortId image{"image"};
+  if (node.node_kind != EditorNodeKind::Develop) {
+    if (InsertPort(qan_node, node.node_id, image, true) == nullptr) {
+      return QStringLiteral("Qan port insertion failed");
+    }
+  }
+  if (node.node_kind != EditorNodeKind::Drt) {
+    if (InsertPort(qan_node, node.node_id, image, false) == nullptr) {
+      return QStringLiteral("Qan port insertion failed");
+    }
+  }
+  return {};
+}
+
+auto AlcedoQanGraph::InsertPort(qan::Node& qan_node, const NodeId& node_id, const PortId& port_id,
+                                bool is_input) -> qan::PortItem* {
+  if (graph_.isNull()) {
+    return nullptr;
+  }
+  const auto dock = is_input ? qan::NodeItem::Dock::Top : qan::NodeItem::Dock::Bottom;
+  const auto type = is_input ? qan::PortItem::Type::In : qan::PortItem::Type::Out;
+  auto* port = graph_->insertPort(&qan_node, dock, type, QString(), QanPortId(is_input, port_id));
+  if (port == nullptr) {
+    return nullptr;
+  }
+  port->setMultiplicity(qan::PortItem::Multiplicity::Single);
+  if (is_input) {
+    ports_by_node_[node_id].inputs[port_id] = port;
+  } else {
+    ports_by_node_[node_id].outputs[port_id] = port;
+  }
+  return port;
+}
+
+auto AlcedoQanGraph::InsertEdge(const EditorNodeEdgeProjection& edge) -> QString {
+  auto* source = NodeFor(edge.source_node_id);
+  auto* dest   = NodeFor(edge.destination_node_id);
+  auto* out    = OutputPortFor(edge.source_node_id, edge.source_port_id);
+  auto* in     = InputPortFor(edge.destination_node_id, edge.destination_port_id);
+  if (source == nullptr || dest == nullptr) {
+    return QStringLiteral("snapshot edge references an unknown node");
+  }
+  if (out == nullptr || in == nullptr) {
+    return QStringLiteral("Qan edge port binding failed");
+  }
+  auto* qan_edge = graph_->insertEdge(source, dest);
+  if (qan_edge == nullptr || qan_edge->getItem() == nullptr) {
+    return QStringLiteral("Qan edge creation failed");
+  }
+  graph_->bindEdge(qan_edge, out, in);
+  if (qan_edge->getItem()->getSourceItem() != out ||
+      qan_edge->getItem()->getDestinationItem() != in) {
+    graph_->removeEdge(qan_edge, true);
+    return QStringLiteral("Qan edge port binding failed");
+  }
+  edge_by_key_[MakeEdgeKey(edge)] = qan_edge;
+  return {};
+}
+
+auto AlcedoQanGraph::MakeEdgeKey(const EditorNodeEdgeProjection& edge) -> EdgeKey {
+  return EdgeKey{edge.source_node_id, edge.source_port_id, edge.destination_node_id,
+                 edge.destination_port_id};
+}
+
+auto AlcedoQanGraph::ToQString(std::string_view text) -> QString {
+  return QString::fromUtf8(text.data(), static_cast<qsizetype>(text.size()));
+}
+
+auto AlcedoQanGraph::QanPortId(bool is_input, const PortId& port_id) -> QString {
+  return (is_input ? QStringLiteral("in:") : QStringLiteral("out:")) + ToQString(port_id.Value());
+}
+
+}  // namespace alcedo::ui

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -764,6 +764,36 @@ alcedo_ui_gtest_discover_tests(QuickQanavaProductionIntegrationTest
     PROPERTIES LABELS "quickqanava;workspace_qml")
 alcedo_register_test_target(QuickQanavaProductionIntegrationTest ui)
 
+# Read-only Qan adapter: NodeId maps, ports, role updates, generation replacement.
+add_executable(AlcedoQanGraphTest
+    ${ALCEDO_TEST_ROOT}/ui/alcedo_qan_graph_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
+)
+target_include_directories(AlcedoQanGraphTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR}
+    PRIVATE ${ALCEDO_TEST_ROOT}/ui
+)
+target_link_libraries(AlcedoQanGraphTest
+    PRIVATE
+        AlcedoQanGraph
+        QuickQanava
+        QuickQanavaplugin
+        GTest::gtest
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Test
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::QuickEffects
+        Qt6::Widgets
+)
+alcedo_ui_gtest_discover_tests(AlcedoQanGraphTest
+    TEST_PREFIX "AlcedoQanGraphTest."
+    PROPERTIES LABELS "quickqanava;editor_nodes")
+alcedo_register_test_target(AlcedoQanGraphTest ui)
+
 # Phase 7B: final-display identity stamping, stale-output rejection, and
 # hidden/resume analyzer lifecycle.
 add_executable(EditorScopeControllerTest

--- a/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
+++ b/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
@@ -1,0 +1,422 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "ui/alcedo_main/album_backend/alcedo_qan_graph.hpp"
+
+#include <gtest/gtest.h>
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDeadlineTimer>
+#include <QEvent>
+#include <QEventLoop>
+#include <QObject>
+#include <QPointer>
+#include <QQmlApplicationEngine>
+#include <QQmlError>
+#include <QQmlExtensionPlugin>
+#include <QQuickStyle>
+#include <QQuickWindow>
+#include <QStringList>
+#include <QUrl>
+#include <QuickQanava>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "app/editor_node_graph_projection.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "qanEdge.h"
+#include "qanEdgeItem.h"
+#include "qanGraph.h"
+#include "qanNode.h"
+#include "qanNodeItem.h"
+#include "qanPortItem.h"
+
+Q_IMPORT_QML_PLUGIN(QuickQanavaPlugin)
+
+namespace {
+
+constexpr char kGraphHarnessQml[] = R"qml(
+import QtQuick
+import QtQuick.Controls
+import QuickQanava 2.0 as Qan
+
+ApplicationWindow {
+    id: root
+    objectName: "alcedoQanHarness"
+    width: 640
+    height: 480
+    visible: true
+
+    Component {
+        id: graphViewComponent
+
+        Qan.GraphView {
+            id: graphView
+            objectName: "qanGraphView"
+            anchors.fill: parent
+            navigable: false
+
+            graph: Qan.Graph {
+                id: graphTopology
+                objectName: "qanGraph"
+            }
+        }
+    }
+
+    Loader {
+        id: graphLoader
+        objectName: "graphLoader"
+        anchors.fill: parent
+        active: true
+        asynchronous: false
+        sourceComponent: graphViewComponent
+    }
+}
+)qml";
+
+void           SetBasicStyle() {
+  static std::once_flag style_once;
+  std::call_once(style_once, [] { QQuickStyle::setStyle(QStringLiteral("Basic")); });
+}
+
+bool WaitFor(const std::function<bool()>& predicate, int timeout_ms = 1000) {
+  QDeadlineTimer deadline{timeout_ms};
+  while (!predicate() && !deadline.hasExpired()) {
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+  }
+  return predicate();
+}
+
+class QanHarness final {
+ public:
+  QanHarness() {
+    QObject::connect(&engine_, &QQmlApplicationEngine::warnings, &engine_,
+                     [this](const QList<QQmlError>& errors) {
+                       for (const auto& error : errors) {
+                         warnings_.append(error.toString());
+                       }
+                     });
+
+    SetBasicStyle();
+    engine_.addImportPath(QStringLiteral("qrc:/"));
+    QuickQanava::initialize(&engine_);
+    engine_.loadData(QByteArray{kGraphHarnessQml},
+                     QUrl(QStringLiteral("file:///AlcedoQanGraphHarness.qml")));
+
+    if (!engine_.rootObjects().isEmpty()) {
+      window_ = qobject_cast<QQuickWindow*>(engine_.rootObjects().constFirst());
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
+  }
+
+  [[nodiscard]] auto window() const -> QQuickWindow* { return window_; }
+  [[nodiscard]] auto warnings() const -> const QStringList& { return warnings_; }
+  [[nodiscard]] auto Graph() const -> qan::Graph* {
+    return window_ == nullptr ? nullptr : window_->findChild<qan::Graph*>("qanGraph");
+  }
+  [[nodiscard]] auto Loader() const -> QObject* {
+    return window_ == nullptr ? nullptr : window_->findChild<QObject*>("graphLoader");
+  }
+
+ private:
+  QQmlApplicationEngine engine_;
+  QQuickWindow*         window_ = nullptr;
+  QStringList           warnings_;
+};
+
+auto WarningText(const QStringList& warnings) -> std::string {
+  return warnings.join(QLatin1Char('\n')).toStdString();
+}
+
+auto MakeMask(alcedo::MaskId id, alcedo::MaskSource source) -> alcedo::MaskModel {
+  alcedo::MaskModel mask;
+  mask.id           = std::move(id);
+  mask.display_name = "Mask";
+  mask.source       = std::move(source);
+  return mask;
+}
+
+class FailAfterInsertsGraph final : public alcedo::ui::AlcedoQanGraph {
+ public:
+  void FailAfterSuccessfulInserts(int count) { remaining_success_ = count; }
+
+ protected:
+  auto InsertQanNode(qan::Graph& graph) -> qan::Node* override {
+    if (remaining_success_.has_value()) {
+      if (*remaining_success_ == 0) {
+        remaining_success_.reset();
+        return nullptr;
+      }
+      --*remaining_success_;
+    }
+    return AlcedoQanGraph::InsertQanNode(graph);
+  }
+
+ private:
+  std::optional<int> remaining_success_;
+};
+
+}  // namespace
+
+namespace alcedo {
+
+constexpr auto kImagePort = [] { return PortId{"image"}; };
+
+auto ExpectLiveBackbone(const ui::AlcedoQanGraph& adapter, const EditorNodeGraphSnapshot& snapshot)
+    -> void {
+  ASSERT_EQ(adapter.graph() == nullptr ? 0 : adapter.graph()->getNodeCount(),
+            static_cast<int>(snapshot.nodes.size()));
+  for (const auto& node : snapshot.nodes) {
+    auto* qan_node = adapter.NodeFor(node.node_id);
+    ASSERT_NE(qan_node, nullptr) << std::string{node.node_id.Value()};
+    EXPECT_EQ(adapter.LiveNodeId(qan_node), node.node_id);
+    EXPECT_EQ(qan_node->getLabel(),
+              QString::fromUtf8(node.display_name.data(),
+                                static_cast<qsizetype>(node.display_name.size())));
+    EXPECT_NE(qan_node->getLabel().toStdString(), std::string{node.node_id.Value()});
+    EXPECT_NE(qan_node->getItem(), nullptr);
+  }
+
+  const PortId image = kImagePort();
+  EXPECT_EQ(adapter.InputPortFor(NodeId{"develop"}, image), nullptr);
+  EXPECT_NE(adapter.OutputPortFor(NodeId{"develop"}, image), nullptr);
+  EXPECT_EQ(adapter.OutputPortFor(NodeId{"drt"}, image), nullptr);
+  EXPECT_NE(adapter.InputPortFor(NodeId{"drt"}, image), nullptr);
+
+  for (const auto& edge : snapshot.edges) {
+    auto* qan_edge = adapter.EdgeFor(edge);
+    ASSERT_NE(qan_edge, nullptr);
+    ASSERT_NE(qan_edge->getItem(), nullptr);
+    auto* source_port = adapter.OutputPortFor(edge.source_node_id, edge.source_port_id);
+    auto* dest_port   = adapter.InputPortFor(edge.destination_node_id, edge.destination_port_id);
+    ASSERT_NE(source_port, nullptr);
+    ASSERT_NE(dest_port, nullptr);
+    EXPECT_EQ(source_port->getDockType(), qan::NodeItem::Dock::Bottom);
+    EXPECT_EQ(source_port->getType(), qan::PortItem::Type::Out);
+    EXPECT_EQ(dest_port->getDockType(), qan::NodeItem::Dock::Top);
+    EXPECT_EQ(dest_port->getType(), qan::PortItem::Type::In);
+    EXPECT_EQ(qan_edge->getItem()->getSourceItem(), source_port);
+    EXPECT_EQ(qan_edge->getItem()->getDestinationItem(), dest_port);
+    EXPECT_TRUE(qan_edge->getLabel().isEmpty());
+  }
+}
+
+class AlcedoQanGraph : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    harness_ = std::make_unique<QanHarness>();
+    ASSERT_NE(harness_->window(), nullptr) << WarningText(harness_->warnings());
+    ASSERT_TRUE(harness_->warnings().isEmpty()) << WarningText(harness_->warnings());
+  }
+
+  static void TearDownTestSuite() { harness_.reset(); }
+
+  void        SetUp() override {
+    ASSERT_NE(harness_, nullptr);
+    auto* loader = harness_->Loader();
+    ASSERT_NE(loader, nullptr);
+    ASSERT_TRUE(loader->setProperty("active", false));
+    ASSERT_TRUE(WaitFor([] { return harness_->Graph() == nullptr; }));
+    ASSERT_TRUE(loader->setProperty("active", true));
+    ASSERT_TRUE(WaitFor([] { return harness_->Graph() != nullptr; }));
+  }
+
+  static std::unique_ptr<QanHarness> harness_;
+};
+
+std::unique_ptr<QanHarness> AlcedoQanGraph::harness_;
+
+TEST_F(AlcedoQanGraph, MapsEachProjectedNodeIdToOneLiveQanNodeInTheCurrentGeneration) {
+  ui::AlcedoQanGraph adapter;
+  adapter.set_graph(harness_->Graph());
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 4, 2, 1);
+  const auto result   = adapter.ApplySnapshot(snapshot);
+
+  ASSERT_TRUE(result.succeeded) << result.error.toStdString();
+  EXPECT_TRUE(result.rebuilt_topology);
+  EXPECT_EQ(adapter.session_generation(), 4u);
+  ExpectLiveBackbone(adapter, snapshot);
+  EXPECT_EQ(adapter.LiveNodeId(nullptr), std::nullopt);
+}
+
+TEST_F(AlcedoQanGraph, BindsEachBackboneEdgeToTheMatchingTopAndBottomPorts) {
+  ui::AlcedoQanGraph adapter;
+  adapter.set_graph(harness_->Graph());
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.second"}).empty());
+  const auto snapshot = EditorNodeGraphProjection::Build(document, 1, 3, 2);
+  const auto result   = adapter.ApplySnapshot(snapshot);
+
+  ASSERT_TRUE(result.succeeded) << result.error.toStdString();
+  ASSERT_EQ(snapshot.edges.size(), 3u);
+  ExpectLiveBackbone(adapter, snapshot);
+  EXPECT_EQ(adapter.OutputPortFor(NodeId{"grade.primary"}, PortId{"image"})->getId(),
+            QStringLiteral("out:image"));
+  EXPECT_EQ(adapter.InputPortFor(NodeId{"grade.second"}, PortId{"image"})->getId(),
+            QStringLiteral("in:image"));
+}
+
+TEST_F(AlcedoQanGraph, RenameUpdatesOneNodeLabelWithoutReplacingQanPrimitives) {
+  ui::AlcedoQanGraph adapter;
+  adapter.set_graph(harness_->Graph());
+  auto       document = CreateDefaultPipelineDocument();
+  const auto before   = EditorNodeGraphProjection::Build(document, 6, 10, 4);
+  ASSERT_TRUE(adapter.ApplySnapshot(before).succeeded) << "initial apply";
+
+  QPointer<qan::Node> grade = adapter.NodeFor(NodeId{"grade.primary"});
+  QPointer<qan::Edge> first = adapter.EdgeFor(before.edges.front());
+  QPointer<qan::Edge> last  = adapter.EdgeFor(before.edges.back());
+  ASSERT_FALSE(grade.isNull());
+
+  ASSERT_TRUE(RenameColorGrade(document, NodeId{"grade.primary"}, "Look A").empty());
+  const auto after  = EditorNodeGraphProjection::Build(document, 6, 11, 4);
+  const auto result = adapter.ApplySnapshot(after);
+
+  ASSERT_TRUE(result.succeeded) << result.error.toStdString();
+  EXPECT_FALSE(result.rebuilt_topology);
+  EXPECT_EQ(grade.data(), adapter.NodeFor(NodeId{"grade.primary"}));
+  EXPECT_EQ(first.data(), adapter.EdgeFor(after.edges.front()));
+  EXPECT_EQ(last.data(), adapter.EdgeFor(after.edges.back()));
+  EXPECT_EQ(grade->getLabel(), QStringLiteral("Look A"));
+  EXPECT_EQ(adapter.NodeProjection(NodeId{"grade.primary"})->display_name, "Look A");
+  EXPECT_EQ(harness_->Graph()->getNodeCount(), 3);
+}
+
+TEST_F(AlcedoQanGraph, MaskKindChangeUpdatesOneNodeWithoutReplacingEdges) {
+  ui::AlcedoQanGraph adapter;
+  adapter.set_graph(harness_->Graph());
+  auto  document = CreateDefaultPipelineDocument();
+  auto* grade    = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  grade->AddMask(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}), 0);
+
+  const auto before = EditorNodeGraphProjection::Build(document, 2, 5, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(before).succeeded) << "initial apply";
+  QPointer<qan::Node> grade_node = adapter.NodeFor(NodeId{"grade.primary"});
+  QPointer<qan::Edge> incoming   = adapter.EdgeFor(before.edges.front());
+  QPointer<qan::Edge> outgoing   = adapter.EdgeFor(before.edges.back());
+
+  grade->ReplaceMaskSource(MaskId{"mask.radial"}, BrushMaskSource{});
+  const auto after  = EditorNodeGraphProjection::Build(document, 2, 6, 1);
+  const auto result = adapter.ApplySnapshot(after);
+
+  ASSERT_TRUE(result.succeeded) << result.error.toStdString();
+  EXPECT_FALSE(result.rebuilt_topology);
+  EXPECT_EQ(grade_node.data(), adapter.NodeFor(NodeId{"grade.primary"}));
+  EXPECT_EQ(incoming.data(), adapter.EdgeFor(after.edges.front()));
+  EXPECT_EQ(outgoing.data(), adapter.EdgeFor(after.edges.back()));
+  ASSERT_NE(adapter.NodeProjection(NodeId{"grade.primary"}), nullptr);
+  ASSERT_EQ(adapter.NodeProjection(NodeId{"grade.primary"})->masks.size(), 1u);
+  EXPECT_EQ(adapter.NodeProjection(NodeId{"grade.primary"})->masks.front().source_kind,
+            MaskSourceKind::Brush);
+  EXPECT_EQ(harness_->Graph()->getNodeCount(), 3);
+}
+
+TEST_F(AlcedoQanGraph, VersionReplacementRemovesOldPrimitivesAndReverseMapEntries) {
+  ui::AlcedoQanGraph adapter;
+  adapter.set_graph(harness_->Graph());
+  const auto first = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 8, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(first).succeeded) << "initial apply";
+
+  QPointer<qan::Node> old_develop = adapter.NodeFor(NodeId{"develop"});
+  QPointer<qan::Node> old_grade   = adapter.NodeFor(NodeId{"grade.primary"});
+  QPointer<qan::Edge> old_edge    = adapter.EdgeFor(first.edges.front());
+  ASSERT_FALSE(old_develop.isNull());
+  bool maps_cleared_before_destroy = false;
+  QObject::connect(old_develop.data(), &QObject::destroyed, &adapter, [&]() {
+    maps_cleared_before_destroy = !adapter.LiveNodeId(old_develop.data()).has_value();
+  });
+
+  auto next_document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(next_document, NodeId{"drt"}, NodeId{"grade.second"}).empty());
+  const auto second = EditorNodeGraphProjection::Build(next_document, 8, 4, 2);
+  const auto result = adapter.ApplySnapshot(second);
+
+  ASSERT_TRUE(result.succeeded) << result.error.toStdString();
+  EXPECT_TRUE(result.rebuilt_topology);
+  EXPECT_TRUE(maps_cleared_before_destroy);
+  EXPECT_TRUE(old_develop.isNull());
+  EXPECT_TRUE(old_grade.isNull());
+  EXPECT_TRUE(old_edge.isNull());
+  EXPECT_EQ(adapter.LiveNodeId(old_develop.data()), std::nullopt);
+  ExpectLiveBackbone(adapter, second);
+  EXPECT_NE(adapter.NodeFor(NodeId{"develop"}), old_develop.data());
+}
+
+TEST_F(AlcedoQanGraph, StalePrimitiveCannotSelectOrEditTheNewDocument) {
+  ui::AlcedoQanGraph adapter;
+  adapter.set_graph(harness_->Graph());
+  const auto current = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 12, 3, 2);
+  ASSERT_TRUE(adapter.ApplySnapshot(current).succeeded) << "initial apply";
+  QPointer<qan::Node> live_grade = adapter.NodeFor(NodeId{"grade.primary"});
+  ASSERT_FALSE(live_grade.isNull());
+
+  const auto stale = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 11, 9, 9);
+  const auto stale_result = adapter.ApplySnapshot(stale);
+  EXPECT_FALSE(stale_result.succeeded);
+  EXPECT_EQ(stale_result.error, QStringLiteral("snapshot session generation is stale"));
+  EXPECT_EQ(adapter.session_generation(), 12u);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"}), live_grade.data());
+  EXPECT_EQ(adapter.LiveNodeId(live_grade.data()), NodeId{"grade.primary"});
+  EXPECT_EQ(harness_->Graph()->getNodeCount(), 3);
+
+  auto next_document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(RenameColorGrade(next_document, NodeId{"grade.primary"}, "Version B").empty());
+  const auto next = EditorNodeGraphProjection::Build(next_document, 13, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(next).succeeded) << "generation replacement";
+  EXPECT_TRUE(live_grade.isNull());
+  EXPECT_EQ(adapter.LiveNodeId(live_grade.data()), std::nullopt);
+  ASSERT_NE(adapter.NodeFor(NodeId{"grade.primary"}), nullptr);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"})->getLabel(), QStringLiteral("Version B"));
+}
+
+TEST_F(AlcedoQanGraph, AdapterInsertFailureRestoresThePriorCompleteQanProjection) {
+  FailAfterInsertsGraph adapter;
+  adapter.set_graph(harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 3, 7, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+  ExpectLiveBackbone(adapter, prior);
+
+  auto next_document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(next_document, NodeId{"drt"}, NodeId{"grade.second"}).empty());
+  const auto next = EditorNodeGraphProjection::Build(next_document, 3, 8, 2);
+  adapter.FailAfterSuccessfulInserts(1);
+  const auto result = adapter.ApplySnapshot(next);
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_TRUE(result.rebuilt_topology);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("Qan node creation failed")), -1);
+  EXPECT_EQ(adapter.session_generation(), 3u);
+  EXPECT_EQ(adapter.topology_revision(), 1u);
+  EXPECT_EQ(adapter.projection_revision(), 7u);
+  ExpectLiveBackbone(adapter, prior);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.second"}), nullptr);
+}
+
+TEST_F(AlcedoQanGraph, GraphDestructionClearsIdentityMaps) {
+  ui::AlcedoQanGraph adapter;
+  adapter.set_graph(harness_->Graph());
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 1, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded) << "initial apply";
+  QPointer<qan::Graph> old_graph = harness_->Graph();
+  QPointer<qan::Node>  old_node  = adapter.NodeFor(NodeId{"develop"});
+
+  ASSERT_TRUE(harness_->Loader()->setProperty("active", false));
+  ASSERT_TRUE(WaitFor([&]() { return old_graph.isNull() && harness_->Graph() == nullptr; }));
+  EXPECT_TRUE(old_node.isNull());
+  EXPECT_EQ(adapter.graph(), nullptr);
+  EXPECT_FALSE(adapter.has_projection());
+  EXPECT_EQ(adapter.NodeFor(NodeId{"develop"}), nullptr);
+  EXPECT_EQ(adapter.LiveNodeId(old_node.data()), std::nullopt);
+}
+
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: NM5.1–NM5.2 complete; NM5.3–NM5.8 planned
+Status: NM5.1–NM5.3 complete; NM5.4–NM5.8 planned
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -1068,6 +1068,122 @@ Verify exact pinned names for:
 
 Record the date, pinned API signatures, commands, test count, success chain, and failure chain here.
 
+##### NM5.3 completion record (2026-09-03)
+
+**Status:** complete — `AlcedoQanGraph` maps an immutable `EditorNodeGraphSnapshot` onto
+documented QuickQanava primitives. Each projected node, backbone edge, and real top/bottom
+port is created through pinned `insertNode` / `insertEdge` / `insertPort` / `bindEdge` calls.
+NodeId and edge identity live only in adapter maps, not in Qan labels. Rename and Mask
+source-kind updates keep the live Qan objects. Version or generation replacement clears
+reverse maps before destroying primitives. A stale snapshot or Qan pointer cannot select or
+edit the live document. A failed Qan insert restores the prior complete projection. This
+sub-phase does not expose Add, Rename, Delete, or Reconnect product commands, and QML does
+not construct the adapter yet.
+
+**Revision:** base repository revision `2829e926` (`NM5.2`), branch
+`feature/nodes-panel-qan-adapter`. QuickQanava remains submodule tag `2.50` at
+`56bdf78d5b1d41fb60ae3b8ea2292df45787ecff`.
+
+**Pinned API signatures used:**
+
+```text
+qan::Graph::insertNode(QQmlComponent* = nullptr, qan::NodeStyle* = nullptr)
+qan::Graph::removeNode(qan::Node* node, bool force = false)
+qan::Graph::insertEdge(qan::Node* source, qan::Node* destination, QQmlComponent* = nullptr)
+qan::Graph::removeEdge(qan::Edge* edge, bool force = false)
+qan::Graph::insertPort(qan::Node* node, qan::NodeItem::Dock dock,
+                       qan::PortItem::Type portType = InOut, QString label = "", QString id = "")
+qan::Graph::bindEdge(qan::Edge* edge, qan::PortItem* outPort, qan::PortItem* inPort)
+qan::Node::setLabel(const QString&)
+qan::Node::getItem()
+qan::NodeItem::findPort(const QString& portId)
+qan::EdgeItem::getSourceItem() / getDestinationItem()
+QObject::destroyed
+```
+
+**Primary success call chain:**
+
+```text
+EditorNodeGraphProjection::Build
+  -> EditorNodeGraphSnapshot
+  -> AlcedoQanGraph::ApplySnapshot
+  -> same generation + topology revision: setLabel and Mask roles in place
+  -> generation or topology change: clear identity maps
+  -> qan::Graph::removeEdge / removeNode(force)
+  -> qan::Graph::insertNode / insertPort / insertEdge / bindEdge
+  -> NodeId <-> QPointer<qan::Node> and edge-identity maps
+  -> GraphView-owned qan::Graph
+```
+
+**Primary failure call chain:**
+
+```text
+stale session/topology/projection revision
+  -> reject ApplySnapshot
+  -> live Qan primitives, maps, and revisions unchanged
+```
+
+```text
+Qan insertNode / insertPort / insertEdge / bindEdge failure
+  -> rebuild_in_progress rejects LiveNodeId
+  -> destroy partial primitives
+  -> rebuild the prior snapshot
+  -> return the real Qan error; no substitute graph
+```
+
+**Pinned API differences:**
+
+- The `insertPort` comment refers to `qan::NodeItem::getPort()`. Pinned 2.50 exposes
+  `findPort(const QString& portId)` instead. The adapter stores QPointer ports keyed by
+  product PortId and uses empty Qan port labels with `in:` / `out:` identity strings.
+- `qan::Node::delegate()` and `qan::Edge::delegate()` cache a process-lifetime
+  `QQmlComponent` on the first `QQmlEngine`. A second engine cannot create visual items
+  through C++ `insertNode()`. Adapter tests share one engine and recreate the Loader-owned
+  graph. Production already uses one engine.
+- The class comment says visual connectors default to enabled. Pinned 2.50 sets
+  `_connectorEnabled = false`. This sub-phase leaves that default; later work enables
+  request-only mode.
+- Website `QuickQanava::initialize()` remains `initialize(QQmlEngine*)` as recorded in NM5.1.
+
+**Tests and evidence:**
+
+| Required criterion | Test | Result |
+| --- | --- | --- |
+| NodeId maps to one live Qan node | `MapsEachProjectedNodeIdToOneLiveQanNodeInTheCurrentGeneration` | PASS |
+| Backbone edges bind to top/bottom ports | `BindsEachBackboneEdgeToTheMatchingTopAndBottomPorts` | PASS |
+| Rename updates one label without replacing the graph | `RenameUpdatesOneNodeLabelWithoutReplacingQanPrimitives` | PASS |
+| Mask kind change updates one node without replacing edges | `MaskKindChangeUpdatesOneNodeWithoutReplacingEdges` | PASS |
+| Version replacement removes old primitives and reverse maps | `VersionReplacementRemovesOldPrimitivesAndReverseMapEntries` | PASS |
+| Stale primitive cannot select or edit | `StalePrimitiveCannotSelectOrEditTheNewDocument` | PASS |
+| Adapter failure restores the prior projection | `AdapterInsertFailureRestoresThePriorCompleteQanProjection` | PASS |
+| Loader destruction clears identity maps | `GraphDestructionClearsIdentityMaps` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target AlcedoQanGraphTest --parallel 4
+build/debug/alcedo_studio/tests/ui/AlcedoQanGraphTest_runtime/AlcedoQanGraphTest.exe --gtest_color=no
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --target AlbumBackendLib --parallel 4
+```
+
+Suite totals: **8/8 passed** on the direct runtime binary. `AlbumBackendLib` links
+`AlcedoQanGraph`. QML type registration was not added because QML does not construct the
+adapter in this sub-phase.
+
+**Checklist / exit condition:** all NM5.3 work and exit conditions are checked. No node
+delegate, Mask drawer, Nodes rail page, or graph command was added.
+
+**LOC note (grill-code-review):** 212-line adapter header, 450-line adapter source, 421-line
+focused test file, plus CMake wiring in `alcedo_main/CMakeLists.txt` and `tests/ui/CMakeLists.txt`.
+No changed file exceeds the 1000-line review threshold.
+
+**Residual gaps:** NM5.4–NM5.8 still own the Alcedo node delegate, Mask drawer, Nodes rail
+page, layout/selection store, Add/Rename/Delete, visual connector, accessibility, and
+package checks. macOS checks were not run on this Windows host. The unrelated CTest
+discovery runtime mismatch remains outside this sub-phase; the adapter binary was run
+directly.
+
 ---
 
 ## 11. NM5.4 — Alcedo node delegate and Mask drawer
@@ -1626,7 +1742,7 @@ Do not reduce decode resolution, output quality, or backend behavior to meet the
 - [ ] The page contains no unapproved pill, badge, or status dot.
 - [ ] The page contains no `xx · xx` compound label or equivalent substitute.
 - [x] Projection uses stable NodeId, MaskId, revisions, and session generation.
-- [ ] No Qan pointer survives a generation replacement.
+- [x] No Qan pointer survives a generation replacement.
 - [x] Parameter edits do not rebuild the graph.
 - [x] Version checkout publishes the correct projection.
 - [ ] The initial layout is vertical and deterministic.


### PR DESCRIPTION
## Summary

- Add `AlcedoQanGraph`, a read-only adapter that maps an immutable `EditorNodeGraphSnapshot` onto pinned QuickQanava nodes, ports, and edges.
- Keep NodeId and edge identity in adapter maps; Qan labels stay display names only.
- Apply rename and Mask source-kind updates in place; replace primitives only on session or topology generation change.
- Reject stale snapshots, clear reverse maps before destroying primitives, and restore the prior complete projection if a Qan insert fails.
- Mark NM5.3 complete in the roadmap.

## Validation

- `cmd /c scripts\msvc_env.cmd --preset win_debug`
- `cmd /c scripts\msvc_env.cmd --build --preset win_debug --target AlcedoQanGraphTest --parallel 4`
- `AlcedoQanGraphTest.exe --gtest_color=no` — 8 tests passed.
- `cmd /c scripts\msvc_env.cmd --build --preset win_debug --target AlbumBackendLib --parallel 4`
- `git diff --check` — passed.
- New C++ source files pass `clang-format --dry-run --Werror`.

## Known limitation

The selected CTest listing is blocked before this target by the existing UI `PRE_TEST` discovery, which launches `SharedToneCurveTest_runtime/SharedToneCurveTest.exe` and hits the pre-existing lensfun runtime entry-point mismatch (`0xc0000139`). The new test binary was run directly and passed all eight tests. macOS validation was not available on this Windows host. NM5.4–NM5.8 remain outside this PR scope.