### PR TITLE
fix(windows): load submodule lensfun instead of vcpkg at runtime

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,6 +11,9 @@
       "description": "Windows: Build with debug info",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/debug",
+      "environment": {
+        "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-overlays"
+      },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
@@ -24,6 +27,9 @@
       "description": "Windows: Build release",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/release",
+      "environment": {
+        "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-overlays"
+      },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
@@ -39,6 +45,9 @@
       "description": "Windows: Build release test executables",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/release-test",
+      "environment": {
+        "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-overlays"
+      },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",

--- a/alcedo_studio/src/cmake/AlcedoTargetHelpers.cmake
+++ b/alcedo_studio/src/cmake/AlcedoTargetHelpers.cmake
@@ -65,11 +65,20 @@ function(alcedo_copy_linked_runtime_dlls target_name)
   endif()
 
   set(_alcedo_runtime_search_dirs "$<TARGET_FILE_DIR:${target_name}>")
-  if(DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
-    list(APPEND _alcedo_runtime_search_dirs
-      "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/$<$<CONFIG:Debug>:debug/>bin"
-    )
+  # Submodule lensfun and first-party product DLLs must win over vcpkg/installed.
+  # vcpkg lensfun 0.3.4 exports C++ names only; Operators imports the C lf_* API
+  # from alcedo_studio/src/third_party/lensfun. Searching vcpkg first yields
+  # STATUS_ENTRYPOINT_NOT_FOUND (0xC0000139).
+  if(TARGET puerhlab_lensfun)
+    list(APPEND _alcedo_runtime_search_dirs "$<TARGET_FILE_DIR:puerhlab_lensfun>")
   endif()
+  list(APPEND _alcedo_runtime_search_dirs
+    "${CMAKE_BINARY_DIR}/alcedo_studio/src/decoders"
+    "${CMAKE_BINARY_DIR}/alcedo_studio/src/edit"
+    "${CMAKE_BINARY_DIR}/alcedo_studio/src/image"
+    "${CMAKE_BINARY_DIR}/alcedo_studio/src/opencl"
+    "${CMAKE_BINARY_DIR}/alcedo_studio/src/utils"
+  )
   if(DEFINED CUDAToolkit_BIN_DIR AND NOT "${CUDAToolkit_BIN_DIR}" STREQUAL "")
     list(APPEND _alcedo_runtime_search_dirs "${CUDAToolkit_BIN_DIR}")
   endif()
@@ -77,8 +86,10 @@ function(alcedo_copy_linked_runtime_dlls target_name)
     "${CMAKE_SOURCE_DIR}/alcedo_studio/third_party/libduckdb-windows"
     "${CMAKE_SOURCE_DIR}/alcedo_studio/third_party/exiv2_x64-windows/bin"
   )
-  if(TARGET alcedo_lensfun)
-    list(APPEND _alcedo_runtime_search_dirs "$<TARGET_FILE_DIR:alcedo_lensfun>")
+  if(DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+    list(APPEND _alcedo_runtime_search_dirs
+      "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/$<$<CONFIG:Debug>:debug/>bin"
+    )
   endif()
   if(TARGET Qt6::Core)
     list(APPEND _alcedo_runtime_search_dirs "$<TARGET_FILE_DIR:Qt6::Core>")

--- a/alcedo_studio/src/decoders/CMakeLists.txt
+++ b/alcedo_studio/src/decoders/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 
 def_cuda_library(Operators
     SOURCES ${OPERATORS_SRCS}
-    PUBLIC_DEPS ImageBuffer JSON OpenColorIO::OpenColorIO hwy::hwy lensfun::lensfun
+    PUBLIC_DEPS ImageBuffer JSON OpenColorIO::OpenColorIO hwy::hwy puerhlab_lensfun
     # Image provides RawColorContextToJson/FromJson used by RawDecodeOp durable params.
     PRIVATE_DEPS ${ALCEDO_OPENCV_IMAGE_DEPS} RawProcessor Image EditGraph
 )
@@ -157,6 +157,14 @@ if(DEFINED ALCEDO_LENSFUN_INCLUDE_DIR AND NOT "${ALCEDO_LENSFUN_INCLUDE_DIR}" ST
 endif()
 if(TARGET puerhlab_lensfun_build)
     add_dependencies(Operators puerhlab_lensfun_build)
+endif()
+if(WIN32 AND TARGET puerhlab_lensfun)
+    add_custom_command(TARGET Operators POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE:puerhlab_lensfun>"
+            "$<TARGET_FILE_DIR:Operators>/lensfun.dll"
+        COMMENT "Alcedo: install submodule lensfun.dll next to Operators"
+        VERBATIM)
 endif()
 
 # --- Accelerator Backend Selection ---

--- a/alcedo_studio/src/third_party/CMakeLists.txt
+++ b/alcedo_studio/src/third_party/CMakeLists.txt
@@ -266,12 +266,21 @@ if(WIN32)
 endif()
 add_dependencies(puerhlab_lensfun puerhlab_lensfun_build)
 
+# Product code links the bundled submodule. A package-manager lensfun target
+# (vcpkg 0.3.4 exports C++ names only) must not win this name.
+if(TARGET lensfun::lensfun)
+    get_target_property(_alcedo_lensfun_alias lensfun::lensfun ALIASED_TARGET)
+    if(NOT _alcedo_lensfun_alias STREQUAL "puerhlab_lensfun")
+        message(FATAL_ERROR
+            "lensfun::lensfun is already defined and is not the bundled submodule. "
+            "Remove the vcpkg lensfun package (`vcpkg remove lensfun`) and reconfigure. "
+            "Alcedo builds Lensfun from alcedo_studio/src/third_party/lensfun.")
+    endif()
+else()
+    add_library(lensfun::lensfun ALIAS puerhlab_lensfun)
+endif()
 if(NOT TARGET alcedo_lensfun)
     add_library(alcedo_lensfun ALIAS puerhlab_lensfun)
-endif()
-
-if(NOT TARGET lensfun::lensfun)
-    add_library(lensfun::lensfun ALIAS puerhlab_lensfun)
 endif()
 
 set(PUERHLAB_LENSFUN_INCLUDE_DIR "${PUERHLAB_LENSFUN_INSTALL_DIR}/include" CACHE INTERNAL

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -866,10 +866,10 @@ add_custom_command(TARGET alcedo_main POST_BUILD
     VERBATIM
 )
 
-if(WIN32 AND TARGET alcedo_lensfun)
+if(WIN32 AND TARGET puerhlab_lensfun)
     add_custom_command(TARGET alcedo_main POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "$<TARGET_FILE:alcedo_lensfun>"
+            "$<TARGET_FILE:puerhlab_lensfun>"
             "$<TARGET_FILE_DIR:alcedo_main>/lensfun.dll"
         VERBATIM
     )

--- a/alcedo_studio/tests/cmake/AlcedoTestRegistration.cmake
+++ b/alcedo_studio/tests/cmake/AlcedoTestRegistration.cmake
@@ -74,7 +74,8 @@ endfunction()
 #      appended after vcpkg applocal.
 #   4. Per-target ${name}_runtime/ output dir so parallel Ninja builds cannot
 #      re-applocal a sibling EXE's shared folder.
-#   5. Force-copy third_party lensfun + vendored duckdb (never leave vcpkg's).
+#   5. Force-copy submodule lensfun.dll after applocal. Never leave a
+#      package-manager lensfun.dll next to a test EXE.
 #
 # Domain CMakeLists must NOT hand-roll lensfun/duckdb POST_BUILD copies.
 
@@ -111,8 +112,8 @@ function(alcedo_copy_windows_test_runtime_dlls target_name)
   alcedo_copy_linked_runtime_dlls(${target_name})
 
   set(_lensfun_dll "")
-  if(TARGET alcedo_lensfun)
-    set(_lensfun_dll "$<TARGET_FILE:alcedo_lensfun>")
+  if(TARGET puerhlab_lensfun)
+    set(_lensfun_dll "$<TARGET_FILE:puerhlab_lensfun>")
   elseif(EXISTS "${CMAKE_BINARY_DIR}/third_party/lensfun/install/bin/lensfun.dll")
     set(_lensfun_dll "${CMAKE_BINARY_DIR}/third_party/lensfun/install/bin/lensfun.dll")
   endif()
@@ -122,7 +123,7 @@ function(alcedo_copy_windows_test_runtime_dlls target_name)
       COMMAND ${CMAKE_COMMAND} -E copy
               "${_lensfun_dll}"
               "$<TARGET_FILE_DIR:${target_name}>/lensfun.dll"
-      COMMENT "Alcedo: overwrite vcpkg applocal lensfun.dll with third_party for ${target_name}"
+      COMMENT "Alcedo: install submodule lensfun.dll next to ${target_name}"
       VERBATIM)
   else()
     message(WARNING

--- a/docs/lensfun_build/lensfun_local_build.md
+++ b/docs/lensfun_build/lensfun_local_build.md
@@ -28,6 +28,8 @@ If `glib` is not installed there yet, install it first:
 .\vcpkg\vcpkg.exe install glib:x64-windows
 ```
 
+Do not install the vcpkg `lensfun` port. Alcedo builds Lensfun from `alcedo_studio/src/third_party/lensfun`. The vcpkg overlay at `vcpkg-overlays/lensfun` keeps that port from installing a competing `lensfun.dll`.
+
 If you want to use a non-vcpkg GLib2 package, pass `ALCEDO_LENSFUN_GLIB2_BASE_DIR` explicitly when configuring Alcedo Studio.
 
 ## Example Top-Level Configure

--- a/docs/lensfun_build/lensfun_local_build.zh-CN.md
+++ b/docs/lensfun_build/lensfun_local_build.zh-CN.md
@@ -28,6 +28,8 @@ git submodule update --init --recursive alcedo/src/third_party/lensfun
 .\vcpkg\vcpkg.exe install glib:x64-windows
 ```
 
+不要安装 vcpkg 的 `lensfun` 端口。Alcedo 从 `alcedo_studio/src/third_party/lensfun` 构建 Lensfun。`vcpkg-overlays/lensfun` 会阻止该端口再安装一份互相冲突的 `lensfun.dll`。
+
 如果你想改用非 vcpkg 的 GLib2 包，请在配置 Alcedo Studio 时显式传入 `ALCEDO_LENSFUN_GLIB2_BASE_DIR`。
 
 ## 顶层配置示例

--- a/scripts/cmake/copy_linked_runtime_dlls.cmake
+++ b/scripts/cmake/copy_linked_runtime_dlls.cmake
@@ -3,17 +3,137 @@ if(NOT DEFINED ALCEDO_RUNTIME_DEST OR "${ALCEDO_RUNTIME_DEST}" STREQUAL "")
 endif()
 
 file(MAKE_DIRECTORY "${ALCEDO_RUNTIME_DEST}")
+cmake_path(NORMAL_PATH ALCEDO_RUNTIME_DEST OUTPUT_VARIABLE _alcedo_runtime_dest_normalized)
+
+# vcpkg lensfun 0.3.4 exports C++ names only. Operators imports the C lf_* API
+# from the bundled submodule. Never copy a package-manager lensfun.dll.
+function(alcedo_runtime_is_package_lensfun dll_path out_var)
+  get_filename_component(_alcedo_dll_name "${dll_path}" NAME)
+  if(NOT _alcedo_dll_name STREQUAL "lensfun.dll")
+    set(${out_var} FALSE PARENT_SCOPE)
+    return()
+  endif()
+  cmake_path(NORMAL_PATH dll_path OUTPUT_VARIABLE _alcedo_dll_normalized)
+  if(_alcedo_dll_normalized MATCHES "[/\\\\]vcpkg[/\\\\](installed|packages|buildtrees)[/\\\\]")
+    set(${out_var} TRUE PARENT_SCOPE)
+  else()
+    set(${out_var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(alcedo_runtime_is_submodule_lensfun dll_path out_var)
+  get_filename_component(_alcedo_dll_name "${dll_path}" NAME)
+  if(NOT _alcedo_dll_name STREQUAL "lensfun.dll")
+    set(${out_var} FALSE PARENT_SCOPE)
+    return()
+  endif()
+  cmake_path(NORMAL_PATH dll_path OUTPUT_VARIABLE _alcedo_dll_normalized)
+  if(_alcedo_dll_normalized MATCHES "third_party[/\\\\]lensfun[/\\\\]install[/\\\\]")
+    set(${out_var} TRUE PARENT_SCOPE)
+  else()
+    set(${out_var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(alcedo_runtime_copy_dll source_path dest_dir)
+  alcedo_runtime_is_package_lensfun("${source_path}" _alcedo_skip_package_lensfun)
+  if(_alcedo_skip_package_lensfun)
+    return()
+  endif()
+  get_filename_component(_alcedo_dll_name "${source_path}" NAME)
+  if(_alcedo_dll_name STREQUAL "lensfun.dll")
+    alcedo_runtime_is_submodule_lensfun("${source_path}" _alcedo_is_submodule_lensfun)
+    if(NOT _alcedo_is_submodule_lensfun)
+      return()
+    endif()
+  endif()
+  file(COPY_FILE
+    "${source_path}"
+    "${dest_dir}/${_alcedo_dll_name}"
+    ONLY_IF_DIFFERENT
+  )
+endfunction()
+
+function(alcedo_runtime_install_submodule_lensfun dest_dir)
+  alcedo_runtime_find_build_root("${dest_dir}" _alcedo_build_root)
+  if("${_alcedo_build_root}" STREQUAL "")
+    return()
+  endif()
+  set(_alcedo_submodule_lensfun
+    "${_alcedo_build_root}/third_party/lensfun/install/bin/lensfun.dll")
+  if(EXISTS "${_alcedo_submodule_lensfun}")
+    alcedo_runtime_copy_dll("${_alcedo_submodule_lensfun}" "${dest_dir}")
+  endif()
+endfunction()
+
+function(alcedo_runtime_find_build_root start_dir out_var)
+  set(_alcedo_build_probe "${start_dir}")
+  foreach(_alcedo_i RANGE 0 8)
+    if(EXISTS "${_alcedo_build_probe}/CMakeCache.txt")
+      set(${out_var} "${_alcedo_build_probe}" PARENT_SCOPE)
+      return()
+    endif()
+    get_filename_component(_alcedo_build_probe "${_alcedo_build_probe}" DIRECTORY)
+  endforeach()
+  set(${out_var} "" PARENT_SCOPE)
+endfunction()
+
+function(alcedo_runtime_find_first_party_dll build_root dll_name out_var)
+  # leftover lensfun.dll copies sit next to Operators in src/decoders. That file
+  # is not a first-party product; the bundled submodule lives under
+  # third_party/lensfun/install.
+  if(dll_name STREQUAL "lensfun.dll")
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+  foreach(_alcedo_product_dir IN ITEMS decoders edit image opencl utils)
+    set(_alcedo_candidate "${build_root}/alcedo_studio/src/${_alcedo_product_dir}/${dll_name}")
+    if(EXISTS "${_alcedo_candidate}")
+      set(${out_var} "${_alcedo_candidate}" PARENT_SCOPE)
+      return()
+    endif()
+  endforeach()
+  set(${out_var} "" PARENT_SCOPE)
+endfunction()
+
+function(alcedo_runtime_source_is_dest_local source_path dest_dir out_var)
+  cmake_path(NORMAL_PATH source_path OUTPUT_VARIABLE _alcedo_source_normalized)
+  cmake_path(NORMAL_PATH dest_dir OUTPUT_VARIABLE _alcedo_dest_normalized)
+  cmake_path(IS_PREFIX _alcedo_dest_normalized _alcedo_source_normalized NORMALIZE _alcedo_is_local)
+  set(${out_var} "${_alcedo_is_local}" PARENT_SCOPE)
+endfunction()
+
+# GET_RUNTIME_DEPENDENCIES still searches the executable directory even when
+# that directory is omitted from DIRECTORIES. A leftover first-party DLL there
+# (RawProcessorOp, Operators, ...) is then copied onto itself with
+# ONLY_IF_DIFFERENT, leaving STATUS_ENTRYPOINT_NOT_FOUND (0xC0000139).
+function(alcedo_runtime_refresh_first_party_dlls dest_dir)
+  alcedo_runtime_find_build_root("${dest_dir}" _alcedo_build_root)
+  if("${_alcedo_build_root}" STREQUAL "")
+    return()
+  endif()
+  foreach(_alcedo_product_dir IN ITEMS decoders edit image opencl utils)
+    file(GLOB _alcedo_product_dlls
+      LIST_DIRECTORIES false
+      "${_alcedo_build_root}/alcedo_studio/src/${_alcedo_product_dir}/*.dll"
+    )
+    foreach(_alcedo_product_dll IN LISTS _alcedo_product_dlls)
+      get_filename_component(_alcedo_dll_name "${_alcedo_product_dll}" NAME)
+      if(_alcedo_dll_name STREQUAL "lensfun.dll")
+        continue()
+      endif()
+      if(EXISTS "${dest_dir}/${_alcedo_dll_name}")
+        alcedo_runtime_copy_dll("${_alcedo_product_dll}" "${dest_dir}")
+      endif()
+    endforeach()
+  endforeach()
+endfunction()
 
 if(DEFINED ALCEDO_RUNTIME_DLLS AND NOT "${ALCEDO_RUNTIME_DLLS}" STREQUAL "")
   string(REPLACE "," ";" _alcedo_runtime_dlls "${ALCEDO_RUNTIME_DLLS}")
   foreach(_alcedo_runtime_dll IN LISTS _alcedo_runtime_dlls)
     if(EXISTS "${_alcedo_runtime_dll}")
-      get_filename_component(_alcedo_runtime_dll_name "${_alcedo_runtime_dll}" NAME)
-      file(COPY_FILE
-        "${_alcedo_runtime_dll}"
-        "${ALCEDO_RUNTIME_DEST}/${_alcedo_runtime_dll_name}"
-        ONLY_IF_DIFFERENT
-      )
+      alcedo_runtime_copy_dll("${_alcedo_runtime_dll}" "${ALCEDO_RUNTIME_DEST}")
     else()
       message(FATAL_ERROR "Linked runtime DLL does not exist: ${_alcedo_runtime_dll}")
     endif()
@@ -25,7 +145,6 @@ if(DEFINED ALCEDO_RUNTIME_EXECUTABLE AND EXISTS "${ALCEDO_RUNTIME_EXECUTABLE}")
   # The executable directory already contains files copied by applocal. Passing it back to
   # GET_RUNTIME_DEPENDENCIES together with the package bin directory makes identical DLL names
   # appear as conflicting candidates on CMake 4.x.
-  cmake_path(NORMAL_PATH ALCEDO_RUNTIME_DEST OUTPUT_VARIABLE _alcedo_runtime_dest_normalized)
   set(_alcedo_filtered_runtime_search_dirs "")
   foreach(_alcedo_runtime_search_dir IN LISTS _alcedo_runtime_search_dirs)
     cmake_path(NORMAL_PATH _alcedo_runtime_search_dir OUTPUT_VARIABLE _alcedo_runtime_search_dir_normalized)
@@ -52,29 +171,23 @@ if(DEFINED ALCEDO_RUNTIME_EXECUTABLE AND EXISTS "${ALCEDO_RUNTIME_EXECUTABLE}")
   )
 
   foreach(_alcedo_runtime_dll IN LISTS _alcedo_resolved_runtime_dlls)
-    get_filename_component(_alcedo_runtime_dll_name "${_alcedo_runtime_dll}" NAME)
-    file(COPY_FILE
+    alcedo_runtime_source_is_dest_local(
       "${_alcedo_runtime_dll}"
-      "${ALCEDO_RUNTIME_DEST}/${_alcedo_runtime_dll_name}"
-      ONLY_IF_DIFFERENT
+      "${ALCEDO_RUNTIME_DEST}"
+      _alcedo_resolved_is_local
     )
+    if(_alcedo_resolved_is_local)
+      continue()
+    endif()
+    alcedo_runtime_copy_dll("${_alcedo_runtime_dll}" "${ALCEDO_RUNTIME_DEST}")
   endforeach()
 
   if(_alcedo_unresolved_runtime_dlls)
     # Thin unit tests may import first-party CUDA product DLLs without those
-    # output dirs being in DIRECTORIES (adding them can conflict on opencl.dll).
-    # Resolve only the remaining names under the build tree, then re-check.
+    # output dirs being in DIRECTORIES. Resolve remaining names from product
+    # output directories, never leftover copies under tests/ or ui/.
     get_filename_component(_alcedo_exe_dir "${ALCEDO_RUNTIME_EXECUTABLE}" DIRECTORY)
-    # Climb toward the CMake build root: .../tests/<domain>/<name>_runtime -> build root
-    set(_alcedo_build_probe "${_alcedo_exe_dir}")
-    set(_alcedo_build_root "")
-    foreach(_alcedo_i RANGE 0 8)
-      if(EXISTS "${_alcedo_build_probe}/CMakeCache.txt")
-        set(_alcedo_build_root "${_alcedo_build_probe}")
-        break()
-      endif()
-      get_filename_component(_alcedo_build_probe "${_alcedo_build_probe}" DIRECTORY)
-    endforeach()
+    alcedo_runtime_find_build_root("${_alcedo_exe_dir}" _alcedo_build_root)
 
     set(_alcedo_still_unresolved "")
     set(_alcedo_resolved_any FALSE)
@@ -82,20 +195,14 @@ if(DEFINED ALCEDO_RUNTIME_EXECUTABLE AND EXISTS "${ALCEDO_RUNTIME_EXECUTABLE}")
       get_filename_component(_alcedo_missing_name "${_alcedo_missing}" NAME)
       set(_alcedo_found "")
       if(NOT "${_alcedo_build_root}" STREQUAL "")
-        file(GLOB_RECURSE _alcedo_candidates
-          LIST_DIRECTORIES false
-          "${_alcedo_build_root}/alcedo_studio/src/*/${_alcedo_missing_name}"
+        alcedo_runtime_find_first_party_dll(
+          "${_alcedo_build_root}"
+          "${_alcedo_missing_name}"
+          _alcedo_found
         )
-        if(_alcedo_candidates)
-          list(GET _alcedo_candidates 0 _alcedo_found)
-        endif()
       endif()
       if(NOT "${_alcedo_found}" STREQUAL "" AND EXISTS "${_alcedo_found}")
-        file(COPY_FILE
-          "${_alcedo_found}"
-          "${ALCEDO_RUNTIME_DEST}/${_alcedo_missing_name}"
-          ONLY_IF_DIFFERENT
-        )
+        alcedo_runtime_copy_dll("${_alcedo_found}" "${ALCEDO_RUNTIME_DEST}")
         set(_alcedo_resolved_any TRUE)
       else()
         list(APPEND _alcedo_still_unresolved "${_alcedo_missing}")
@@ -107,19 +214,13 @@ if(DEFINED ALCEDO_RUNTIME_EXECUTABLE AND EXISTS "${ALCEDO_RUNTIME_EXECUTABLE}")
     if(_alcedo_resolved_any AND NOT "${_alcedo_build_root}" STREQUAL "")
       foreach(_alcedo_extra IN ITEMS CudaUtils.dll)
         if(NOT EXISTS "${ALCEDO_RUNTIME_DEST}/${_alcedo_extra}")
-          file(GLOB_RECURSE _alcedo_extra_candidates
-            LIST_DIRECTORIES false
-            "${_alcedo_build_root}/alcedo_studio/src/*/${_alcedo_extra}"
+          alcedo_runtime_find_first_party_dll(
+            "${_alcedo_build_root}"
+            "${_alcedo_extra}"
+            _alcedo_extra_found
           )
-          if(_alcedo_extra_candidates)
-            list(GET _alcedo_extra_candidates 0 _alcedo_extra_found)
-            if(EXISTS "${_alcedo_extra_found}")
-              file(COPY_FILE
-                "${_alcedo_extra_found}"
-                "${ALCEDO_RUNTIME_DEST}/${_alcedo_extra}"
-                ONLY_IF_DIFFERENT
-              )
-            endif()
+          if(NOT "${_alcedo_extra_found}" STREQUAL "" AND EXISTS "${_alcedo_extra_found}")
+            alcedo_runtime_copy_dll("${_alcedo_extra_found}" "${ALCEDO_RUNTIME_DEST}")
           endif()
         endif()
       endforeach()
@@ -131,3 +232,6 @@ if(DEFINED ALCEDO_RUNTIME_EXECUTABLE AND EXISTS "${ALCEDO_RUNTIME_EXECUTABLE}")
     endif()
   endif()
 endif()
+
+alcedo_runtime_refresh_first_party_dlls("${ALCEDO_RUNTIME_DEST}")
+alcedo_runtime_install_submodule_lensfun("${ALCEDO_RUNTIME_DEST}")

--- a/vcpkg-overlays/lensfun/portfile.cmake
+++ b/vcpkg-overlays/lensfun/portfile.cmake
@@ -1,0 +1,7 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright"
+  "Alcedo Studio builds Lensfun from alcedo_studio/src/third_party/lensfun.\n")
+message(STATUS
+  "vcpkg port lensfun is disabled; Alcedo uses the lensfun git submodule.")

--- a/vcpkg-overlays/lensfun/vcpkg.json
+++ b/vcpkg-overlays/lensfun/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "lensfun",
+  "version": "0.3.99",
+  "description": "Disabled. Alcedo Studio builds Lensfun from alcedo_studio/src/third_party/lensfun.",
+  "homepage": "https://lensfun.github.io/"
+}


### PR DESCRIPTION
## Summary

- Link Operators, tests, and `alcedo_main` to the bundled `puerhlab_lensfun` submodule (`alcedo_studio/src/third_party/lensfun`). Reject a package-manager `lensfun::lensfun` target at configure time.
- Copy only the submodule `lensfun.dll` next to Windows EXEs. Skip vcpkg `installed` / `packages` / `buildtrees` copies, and overwrite leftover `src/decoders/lensfun.dll` with the submodule ABI.
- Refresh first-party product DLLs (including `RawProcessorOp.dll`) from `src/decoders` and related output dirs so CTest PRE_TEST no longer loads a stale CUDA copy and dies with `0xC0000139`.
- Add an empty vcpkg overlay port so `vcpkg install lensfun` cannot plant a competing DLL. GLib may still come from vcpkg to *build* the submodule.

## Validation

- `cmd /c scripts\msvc_env.cmd --preset win_debug`
- `cmd /c scripts\msvc_env.cmd --build --preset win_debug --target SharedToneCurveTest --parallel 4`
- `SharedToneCurveTest` — 5/5 passed via the EXE and via `ctest -R SharedToneCurveTest`.
- `ctest --test-dir build/debug -N` — 2298 tests listed, exit 0. Previously PRE_TEST aborted on `SharedToneCurveTest` / `ToneMappingFacadeTest` with `0xC0000139`.
- Runtime `lensfun.dll` SHA256 matches `build/debug/third_party/lensfun/install/bin/lensfun.dll` (1.2 MB C `lf_*` ABI), not vcpkg 0.3.4.

## Known limitation

macOS validation was not available on this Windows host. Rebuilding existing `*_runtime` trees is still required for leftover DLLs from older POST_BUILD copies; a fresh debug configure/build copies the submodule and product DLLs automatically.

Made with [Cursor](https://cursor.com)