### PR TITLE
feat(ui): add Nodes panel Color Grade add, rename, and delete

### DIFF
--- a/alcedo_studio/src/app/editor_action_policy.cpp
+++ b/alcedo_studio/src/app/editor_action_policy.cpp
@@ -157,6 +157,9 @@ auto EditorActionPolicy::ActionForCommand(EditorSessionCommandKind kind)
     case EditorSessionCommandKind::PreviewAdjustment:
       return EditorAction::PreviewAdjustment;
     case EditorSessionCommandKind::CommitAdjustment:
+    case EditorSessionCommandKind::AddColorGrade:
+    case EditorSessionCommandKind::RemoveColorGrade:
+    case EditorSessionCommandKind::RenameColorGrade:
       return EditorAction::CommitAdjustment;
     case EditorSessionCommandKind::Undo:
       return EditorAction::Undo;

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1055,6 +1055,120 @@ auto EditorSessionService::CommitAdjustment(EditorAdjustmentPatch patch) -> Edit
   return Emit(std::move(result));
 }
 
+auto EditorSessionService::AddColorGrade(const NodeId& before_node_id, const NodeId& new_id)
+    -> EditorSessionResult {
+  if (!reducing_command_) {
+    EditorSessionCommand command;
+    command.kind           = EditorSessionCommandKind::AddColorGrade;
+    command.before_node_id = before_node_id;
+    command.node_id        = new_id;
+    return SubmitCommand(std::move(command), [this](const EditorSessionCommand& queued) {
+      return AddColorGrade(queued.before_node_id, queued.node_id);
+    });
+  }
+  if (lifecycle_.state() != EditorSessionState::Interactive || !dependencies_.history ||
+      !lifecycle_.has_history_guard()) {
+    return Reject("Color Grade creation requires an interactive history session");
+  }
+  std::string error;
+  if (!dependencies_.history->AddColorGrade(lifecycle_.history_guard(), before_node_id, new_id,
+                                            &error)) {
+    return Reject(error.empty() ? "Color Grade creation failed" : std::move(error));
+  }
+
+  const auto          reason = dependencies_.history->LastPublishedRenderReason();
+  EditorSessionResult result;
+  result.kind     = reason.has_value() ? EditorSessionResultKind::RenderRouted
+                                       : EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = lifecycle_.identity();
+  result.message  = "Color Grade created";
+  if (reason.has_value()) {
+    EditorRenderCommand render_command;
+    render_command.reason       = *reason;
+    render_command.operation_id = current_operation_id_;
+    render_.RouteInitialRender(render_command, result.identity,
+                               lifecycle_.active_image_load_request());
+  }
+  BumpHistoryRevision();
+  return Emit(std::move(result));
+}
+
+auto EditorSessionService::RemoveColorGrade(const NodeId& node_id) -> EditorSessionResult {
+  if (!reducing_command_) {
+    EditorSessionCommand command;
+    command.kind    = EditorSessionCommandKind::RemoveColorGrade;
+    command.node_id = node_id;
+    return SubmitCommand(std::move(command), [this](const EditorSessionCommand& queued) {
+      return RemoveColorGrade(queued.node_id);
+    });
+  }
+  if (lifecycle_.state() != EditorSessionState::Interactive || !dependencies_.history ||
+      !lifecycle_.has_history_guard()) {
+    return Reject("Color Grade removal requires an interactive history session");
+  }
+  std::string error;
+  if (!dependencies_.history->RemoveColorGrade(lifecycle_.history_guard(), node_id, &error)) {
+    return Reject(error.empty() ? "Color Grade removal failed" : std::move(error));
+  }
+
+  const auto          reason = dependencies_.history->LastPublishedRenderReason();
+  EditorSessionResult result;
+  result.kind     = reason.has_value() ? EditorSessionResultKind::RenderRouted
+                                       : EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = lifecycle_.identity();
+  result.message  = "Color Grade removed";
+  if (reason.has_value()) {
+    EditorRenderCommand render_command;
+    render_command.reason       = *reason;
+    render_command.operation_id = current_operation_id_;
+    render_.RouteInitialRender(render_command, result.identity,
+                               lifecycle_.active_image_load_request());
+  }
+  BumpHistoryRevision();
+  return Emit(std::move(result));
+}
+
+auto EditorSessionService::RenameColorGrade(const NodeId& node_id, std::string display_name)
+    -> EditorSessionResult {
+  if (!reducing_command_) {
+    EditorSessionCommand command;
+    command.kind    = EditorSessionCommandKind::RenameColorGrade;
+    command.node_id = node_id;
+    command.text    = std::move(display_name);
+    return SubmitCommand(std::move(command), [this](const EditorSessionCommand& queued) {
+      return RenameColorGrade(queued.node_id, queued.text);
+    });
+  }
+  if (lifecycle_.state() != EditorSessionState::Interactive || !dependencies_.history ||
+      !lifecycle_.has_history_guard()) {
+    return Reject("Color Grade rename requires an interactive history session");
+  }
+  std::string error;
+  if (!dependencies_.history->RenameColorGrade(lifecycle_.history_guard(), node_id,
+                                               std::move(display_name), &error)) {
+    return Reject(error.empty() ? "Color Grade rename failed" : std::move(error));
+  }
+
+  const auto          reason = dependencies_.history->LastPublishedRenderReason();
+  EditorSessionResult result;
+  result.kind     = reason.has_value() ? EditorSessionResultKind::RenderRouted
+                                       : EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = lifecycle_.identity();
+  result.message  = "Color Grade renamed";
+  if (reason.has_value()) {
+    EditorRenderCommand render_command;
+    render_command.reason       = *reason;
+    render_command.operation_id = current_operation_id_;
+    render_.RouteInitialRender(render_command, result.identity,
+                               lifecycle_.active_image_load_request());
+  }
+  BumpHistoryRevision();
+  return Emit(std::move(result));
+}
+
 auto EditorSessionService::Patch(std::string patch_key) -> EditorSessionResult {
   EditorAdjustmentPatch patch;
   patch.field_key = std::move(patch_key);

--- a/alcedo_studio/src/include/app/editor_session_command_queue.hpp
+++ b/alcedo_studio/src/include/app/editor_session_command_queue.hpp
@@ -19,6 +19,7 @@
 #include "app/editor_session_render_controller.hpp"
 #include "app/editor_session_request_ids.hpp"
 #include "app/editor_session_types.hpp"
+#include "edit/graph/graph_ids.hpp"
 #include "edit/history/commit_types.hpp"
 
 namespace alcedo {
@@ -57,6 +58,9 @@ enum class EditorSessionCommandKind : std::uint8_t {
   SetPresentationTarget,
   SetPresentationSize,
   SetGeometryOverlay,
+  AddColorGrade,
+  RemoveColorGrade,
+  RenameColorGrade,
 };
 
 /// Worker messages that are delivered back to the session owner.
@@ -104,6 +108,8 @@ struct EditorSessionCommand {
   int                                     presentation_width   = 0;
   int                                     presentation_height  = 0;
   bool                                    geometry_overlay_active = false;
+  NodeId                                  node_id;
+  NodeId                                  before_node_id;
 };
 
 /// Typed worker completion envelope. Payload-specific values are kept as

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -17,6 +17,7 @@
 #include "app/editor_history_types.hpp"
 #include "app/editor_render_intent.hpp"
 #include "app/editor_session_types.hpp"
+#include "edit/graph/graph_ids.hpp"
 #include "type/type.hpp"
 
 namespace alcedo {
@@ -80,6 +81,26 @@ class IEditorHistoryPort {
                                 const EditorAdjustmentPatch& /*patch*/, std::string* /*error*/)
       -> bool {
     return true;
+  }
+  /// Add one clean Color Grade immediately before @p before_node_id.
+  virtual auto AddColorGrade(const EditorHistoryGuardHandle& /*guard*/,
+                             const NodeId& /*before_node_id*/, const NodeId& /*new_id*/,
+                             std::string* error) -> bool {
+    if (error != nullptr) *error = "Color Grade creation is not supported by this history port";
+    return false;
+  }
+  /// Remove one Color Grade and bridge its scene-image predecessor and successor.
+  virtual auto RemoveColorGrade(const EditorHistoryGuardHandle& /*guard*/,
+                                const NodeId& /*node_id*/, std::string* error) -> bool {
+    if (error != nullptr) *error = "Color Grade removal is not supported by this history port";
+    return false;
+  }
+  /// Rename one Color Grade without requesting a pixel render.
+  virtual auto RenameColorGrade(const EditorHistoryGuardHandle& /*guard*/,
+                                const NodeId& /*node_id*/, std::string /*display_name*/,
+                                std::string* error) -> bool {
+    if (error != nullptr) *error = "Color Grade rename is not supported by this history port";
+    return false;
   }
   virtual auto Undo(const EditorHistoryGuardHandle& guard, std::string* error) -> bool = 0;
   virtual auto Redo(const EditorHistoryGuardHandle& guard, std::string* error) -> bool = 0;

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -217,6 +217,35 @@ class IEditorSessionBackend {
     result.message = "Adjustment commit not supported by this backend";
     return result;
   }
+  /// Add a clean Color Grade through typed history. Default backends reject.
+  virtual auto AddColorGrade(const NodeId& /*before_node_id*/, const NodeId& /*new_id*/)
+      -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Rejected;
+    result.state    = state();
+    result.identity = identity();
+    result.message  = "Color Grade creation is not supported by this backend";
+    return result;
+  }
+  /// Remove a Color Grade and bridge its backbone neighbors. Default backends reject.
+  virtual auto RemoveColorGrade(const NodeId& /*node_id*/) -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Rejected;
+    result.state    = state();
+    result.identity = identity();
+    result.message  = "Color Grade removal is not supported by this backend";
+    return result;
+  }
+  /// Rename a Color Grade as a metadata-only history change. Default backends reject.
+  virtual auto RenameColorGrade(const NodeId& /*node_id*/, std::string /*display_name*/)
+      -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Rejected;
+    result.state    = state();
+    result.identity = identity();
+    result.message  = "Color Grade rename is not supported by this backend";
+    return result;
+  }
   virtual auto RequestViewChange(EditorRenderReason /*reason*/,
                                  std::optional<ViewportRenderRegion> /*region*/)
       -> EditorSessionResult {
@@ -369,10 +398,15 @@ class EditorSessionService final : public IEditorSessionBackend {
   [[nodiscard]] auto has_unmaterialized_changes() -> bool override;
   auto               Patch(EditorAdjustmentPatch patch) -> EditorSessionResult override;
   auto               CommitAdjustment(EditorAdjustmentPatch patch) -> EditorSessionResult override;
-  auto               Patch(std::string patch_key) -> EditorSessionResult;
-  auto               CommitAdjustment(std::string patch_key) -> EditorSessionResult;
-  auto               Undo() -> EditorSessionResult override;
-  auto               Redo() -> EditorSessionResult override;
+  auto               AddColorGrade(const NodeId& before_node_id, const NodeId& new_id)
+      -> EditorSessionResult override;
+  auto RemoveColorGrade(const NodeId& node_id) -> EditorSessionResult override;
+  auto RenameColorGrade(const NodeId& node_id, std::string display_name)
+      -> EditorSessionResult override;
+  auto Patch(std::string patch_key) -> EditorSessionResult;
+  auto CommitAdjustment(std::string patch_key) -> EditorSessionResult;
+  auto Undo() -> EditorSessionResult override;
+  auto Redo() -> EditorSessionResult override;
   auto MoveHeadToCommit(const commit_hash_t& commit_id) -> EditorSessionResult override;
   auto Discard() -> EditorSessionResult override;
   auto Shutdown() -> EditorSessionResult override;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
@@ -289,6 +289,7 @@ class AlcedoQanGraph : public QObject {
   void               DestroyMappedPrimitives();
   void               DestroyPrimitives(const std::vector<QPointer<qan::Edge>>& edges,
                                        const std::vector<QPointer<qan::Node>>& nodes);
+  void               AttachLiveVisuals();
 
   [[nodiscard]] auto RejectIfStale(const EditorNodeGraphSnapshot& snapshot) const -> QString;
   [[nodiscard]] auto ValidateSnapshot(const EditorNodeGraphSnapshot& snapshot) const -> QString;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_commit_presentation.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_commit_presentation.hpp
@@ -10,6 +10,10 @@
 
 #include "edit/history/commit_types.hpp"
 
+namespace alcedo {
+struct EditorHistoryCommit;
+}
+
 namespace alcedo::ui {
 
 /// User-facing presentation of one history commit row. Produced by a pure
@@ -30,15 +34,29 @@ struct EditorHistoryCommitPresentation {
   QString icon_key;
 };
 
-/// Pure payload-to-display conversion for one editor history commit. Maps the
-/// stable field key and the committed before/after JSON to
-/// user-facing text and an operator glyph key. Typed pipeline batches carry
-/// presentation_key and saved identity on EditorHistoryCommit.
+/// Present an adjustment-field commit from its stored field key and JSON.
+///
+/// Prefer @ref PresentEditorHistoryCommit(const alcedo::EditorHistoryCommit&)
+/// when the row came from a typed pipeline batch so localization keys and
+/// saved node names are used.
 auto PresentEditorHistoryCommit(const std::string& field_key,
                                 const std::string& before_value_json,
                                 const std::string& after_value_json,
                                 bool               before_enabled,
                                 bool               after_enabled)
+    -> EditorHistoryCommitPresentation;
+
+/**
+ * @brief Present one published history row, including typed graph operations.
+ *
+ * @param commit Immutable history projection row. Graph Add/Rename/Delete rows
+ *        use @c presentation_key and saved @c node_display_name. Adjustment
+ *        rows still use @c field_key and before/after JSON.
+ * @return Display strings and glyph key. Never throws; unknown keys fall back
+ *         to the adjustment formatter.
+ * @note Pure and synchronous. Does not read live selection or the document.
+ */
+auto PresentEditorHistoryCommit(const alcedo::EditorHistoryCommit& commit)
     -> EditorHistoryCommitPresentation;
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -18,6 +18,8 @@
 
 namespace alcedo::ui {
 
+class AlcedoQanGraph;
+class EditorNodeLayoutStore;
 class EditorSessionController;
 
 /**
@@ -25,7 +27,10 @@ class EditorSessionController;
  *
  * Owns the session generation, selected NodeId, and published
  * EditorNodeGraphSnapshot. It does not own Qan visuals or layout coordinates.
- * Graph mutations (Add, Rename, Delete, Reconnect) are not exposed here.
+ * When the open Nodes page binds its AlcedoQanGraph, this controller applies
+ * the published snapshot onto that adapter after Add, Rename, and Delete.
+ * Reconnect remains outside this controller until its request-only connector
+ * phase.
  *
  * Threading: GUI thread only. Side effects: snapshot and selection signals.
  * Failure: stale generations and unknown NodeIds leave the live snapshot and
@@ -38,7 +43,6 @@ class EditorNodeController : public QObject {
   Q_PROPERTY(
       QString selectedNodeId READ selected_node_id_string WRITE selectNode NOTIFY SelectionChanged)
   Q_PROPERTY(QStringList backboneNodeIds READ backbone_node_ids NOTIFY SnapshotChanged)
-  Q_PROPERTY(quint64 sessionGeneration READ session_generation NOTIFY SnapshotChanged)
   Q_PROPERTY(quint64 projectionRevision READ projection_revision NOTIFY SnapshotChanged)
   Q_PROPERTY(quint64 topologyRevision READ topology_revision NOTIFY SnapshotChanged)
   Q_PROPERTY(quint64 elementId READ element_id NOTIFY SnapshotChanged)
@@ -46,7 +50,17 @@ class EditorNodeController : public QObject {
   Q_PROPERTY(QString versionId READ version_id NOTIFY SnapshotChanged)
   Q_PROPERTY(QString lastError READ last_error NOTIFY lastErrorChanged)
   Q_PROPERTY(bool hasSnapshot READ has_snapshot NOTIFY SnapshotChanged)
-  Q_PROPERTY(bool canAddColorGrade READ can_add_color_grade NOTIFY SnapshotChanged)
+  Q_PROPERTY(bool commandActive READ command_active NOTIFY CommandStateChanged)
+  Q_PROPERTY(bool canAddColorGrade READ can_add_color_grade NOTIFY ActionAvailabilityChanged)
+  Q_PROPERTY(bool canRenameSelectedColorGrade READ can_rename_selected_color_grade NOTIFY
+                 ActionAvailabilityChanged)
+  Q_PROPERTY(bool canDeleteSelectedColorGrade READ can_delete_selected_color_grade NOTIFY
+                 ActionAvailabilityChanged)
+  Q_PROPERTY(QString selectedNodeName READ selected_node_name NOTIFY SelectionChanged)
+  Q_PROPERTY(QObject* graphAdapter READ graph_adapter_object WRITE set_graph_adapter NOTIFY
+                 GraphAdapterChanged)
+  Q_PROPERTY(QObject* layoutStore READ layout_store_object WRITE set_layout_store NOTIFY
+                 LayoutStoreChanged)
 
  public:
   explicit EditorNodeController(QObject* parent = nullptr);
@@ -106,6 +120,21 @@ class EditorNodeController : public QObject {
   Q_INVOKABLE void   selectNextBackboneNode();
   Q_INVOKABLE void   selectDevelop();
   Q_INVOKABLE void   selectDrt();
+  /**
+   * @brief Add one clean Color Grade after the selected Grade or before DRT.
+   * @return false without changing the projection when admission or history fails.
+   */
+  Q_INVOKABLE bool   addCleanColorGrade();
+  /**
+   * @brief Rename one Color Grade without changing its stable NodeId.
+   * @return false for endpoints, blank names, stale generations, or history failure.
+   */
+  Q_INVOKABLE bool   renameColorGrade(const QString& node_id, const QString& display_name);
+  /**
+   * @brief Remove one Color Grade and select its successor, predecessor, or DRT.
+   * @return false without changing product or projected state on command failure.
+   */
+  Q_INVOKABLE bool   deleteColorGrade(const QString& node_id);
 
   [[nodiscard]] auto selected_node_id() const -> NodeId { return selected_node_id_; }
   [[nodiscard]] auto selected_node_id_string() const -> QString;
@@ -118,8 +147,26 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto version_id() const -> QString { return version_id_; }
   [[nodiscard]] auto last_error() const -> QString { return last_error_; }
   [[nodiscard]] auto has_snapshot() const -> bool { return has_snapshot_; }
-  [[nodiscard]] auto can_add_color_grade() const -> bool { return false; }
+  [[nodiscard]] auto command_active() const -> bool { return command_active_; }
+  [[nodiscard]] auto can_add_color_grade() const -> bool;
+  [[nodiscard]] auto can_rename_selected_color_grade() const -> bool;
+  [[nodiscard]] auto can_delete_selected_color_grade() const -> bool;
+  [[nodiscard]] auto selected_node_name() const -> QString;
   [[nodiscard]] auto snapshot() const -> const EditorNodeGraphSnapshot& { return snapshot_; }
+
+  /**
+   * @brief Bind the live Qan adapter owned by the open Nodes page.
+   *
+   * Null while the page is unloaded. When set and a snapshot exists, the
+   * adapter is applied immediately so Add/Delete do not wait on QML Connections.
+   */
+  [[nodiscard]] auto graph_adapter_object() const -> QObject*;
+  void               set_graph_adapter(QObject* adapter);
+  /**
+   * @brief Bind the layout store used to place nodes after a Qan apply.
+   */
+  [[nodiscard]] auto layout_store_object() const -> QObject*;
+  void               set_layout_store(QObject* store);
 
   /**
    * @brief Set image/Version identity used by layout keys when no session is bound.
@@ -131,6 +178,10 @@ class EditorNodeController : public QObject {
   void SnapshotChanged();
   void SelectionChanged();
   void lastErrorChanged();
+  void CommandStateChanged();
+  void ActionAvailabilityChanged();
+  void GraphAdapterChanged();
+  void LayoutStoreChanged();
 
  private:
   void               DisconnectSession();
@@ -141,22 +192,37 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto ContainsNode(const NodeId& node_id) const -> bool;
   [[nodiscard]] auto DefaultSelectedNodeId() const -> NodeId;
   [[nodiscard]] auto IndexOf(const NodeId& node_id) const -> int;
+  [[nodiscard]] auto NodeFor(const NodeId& node_id) const -> const EditorNodeProjection*;
+  [[nodiscard]] auto ValidateCommandGeneration() -> bool;
+  [[nodiscard]] auto IsColorGrade(const NodeId& node_id) const -> bool;
+  void               SetCommandActive(bool active);
   [[nodiscard]] auto TopologyChanged(const EditorNodeGraphSnapshot& snapshot) const -> bool;
   [[nodiscard]] auto BoundSessionGeneration() const -> std::optional<std::uint64_t>;
   void               SelectByKind(EditorNodeKind kind);
   void               SelectAt(int index);
+  void               ApplyBoundGraph();
+  /// Apply the bound Qan adapter after the current GUI event so Add/Delete are
+  /// not nested inside a GraphView key or menu handler.
+  void               QueueProjectionApply();
 
   QPointer<EditorSessionController> session_;
+  QPointer<AlcedoQanGraph>          graph_adapter_;
+  QPointer<EditorNodeLayoutStore>   layout_store_;
   QMetaObject::Connection           state_connection_;
   QMetaObject::Connection           history_connection_;
+  QMetaObject::Connection           availability_connection_;
+  QMetaObject::Connection           graph_adapter_connection_;
   EditorNodeGraphSnapshot           snapshot_{};
   bool                              has_snapshot_ = false;
   NodeId                            selected_node_id_;
-  quint64                           session_generation_  = 0;
-  quint64                           projection_revision_ = 0;
-  quint64                           topology_revision_   = 0;
-  quint64                           element_id_          = 0;
-  quint64                           image_id_            = 0;
+  NodeId                            selection_restore_node_id_;
+  bool                              command_active_          = false;
+  bool                              projection_apply_queued_ = false;
+  quint64                           session_generation_      = 0;
+  quint64                           projection_revision_     = 0;
+  quint64                           topology_revision_       = 0;
+  quint64                           element_id_              = 0;
+  quint64                           image_id_                = 0;
   QString                           version_id_;
   QString                           last_error_;
 };

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -16,6 +16,7 @@
 #include "app/adjustment_transfer_types.hpp"
 #include "app/editor_history_types.hpp"
 #include "app/editor_session_types.hpp"
+#include "edit/graph/graph_ids.hpp"
 #include "ui/alcedo_main/album_backend/editor_action_availability_model.hpp"
 #include "ui/alcedo_main/album_backend/editor_adjustment_submitter.hpp"
 #include "ui/alcedo_main/album_backend/editor_history_operation_publisher.hpp"
@@ -202,6 +203,15 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   Q_INVOKABLE void   MoveHeadToCommit(const QString& commitId);
   Q_INVOKABLE void   Close();
   Q_INVOKABLE void   Shutdown();
+
+  /** Route a clean Color Grade creation through the active session backend. */
+  auto SubmitAddColorGrade(const alcedo::NodeId& before_node_id, const alcedo::NodeId& new_id)
+      -> alcedo::EditorSessionResult;
+  /** Route an atomic Color Grade removal through the active session backend. */
+  auto SubmitRemoveColorGrade(const alcedo::NodeId& node_id) -> alcedo::EditorSessionResult;
+  /** Route a metadata-only Color Grade rename through the active session backend. */
+  auto SubmitRenameColorGrade(const alcedo::NodeId& node_id, std::string display_name)
+      -> alcedo::EditorSessionResult;
   /// Seal the active image via the same Close path as leaving the editor for
   /// Library (`WorkspaceRouter::OpenLibrary`). persistChanges=true may leave
   /// sessionState at Saving until the checkpoint finishes; callers that must

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
@@ -65,14 +65,14 @@ class EditorSessionHistoryPort final : public alcedo::IEditorHistoryPort {
                                alcedo::PipelineEditBatch batch, std::string* error) -> bool;
   auto AddColorGrade(const alcedo::EditorHistoryGuardHandle& guard,
                      const alcedo::NodeId& before_node_id, const alcedo::NodeId& new_id,
-                     std::string* error) -> bool;
+                     std::string* error) -> bool override;
   auto RemoveColorGrade(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
-                        std::string* error) -> bool;
+                        std::string* error) -> bool override;
   auto ReconnectColorGrade(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
                            const alcedo::NodeId& new_predecessor_id,
                            const alcedo::NodeId& new_successor_id, std::string* error) -> bool;
   auto RenameColorGrade(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
-                        std::string display_name, std::string* error) -> bool;
+                        std::string display_name, std::string* error) -> bool override;
   auto SetColorGradeEnabled(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
                             bool enabled, std::string* error) -> bool;
   auto SetColorGradeMix(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
@@ -21,6 +21,8 @@
 #include "qanPortItem.h"
 #include "qanStyle.h"
 
+#include <QQuickItem>
+
 namespace alcedo::ui {
 namespace {
 
@@ -31,6 +33,18 @@ auto ContainsNodeId(const std::vector<EditorNodeProjection>& nodes, const NodeId
     }
   }
   return false;
+}
+
+/// QuickQanava parents NodeItem/EdgeItem to the view container and destroys
+/// them with deleteLater. Hide and unparent immediately so a topology rebuild
+/// cannot leave the previous cards on screen while the photo has already
+/// moved on.
+void HideDetachedVisual(QQuickItem* item) {
+  if (item == nullptr) {
+    return;
+  }
+  item->setVisible(false);
+  item->setParentItem(nullptr);
 }
 
 }  // namespace
@@ -276,12 +290,42 @@ void AlcedoQanGraph::DestroyPrimitives(const std::vector<QPointer<qan::Edge>>& e
   }
   for (const auto& edge : edges) {
     if (!edge.isNull()) {
+      HideDetachedVisual(edge->getItem());
       graph_->removeEdge(edge.data(), true);
     }
   }
   for (const auto& node : nodes) {
     if (!node.isNull()) {
+      HideDetachedVisual(node->getItem());
       graph_->removeNode(node.data(), true);
+    }
+  }
+}
+
+void AlcedoQanGraph::AttachLiveVisuals() {
+  if (graph_.isNull()) {
+    return;
+  }
+  auto* container = graph_->getContainerItem();
+  auto  attach    = [container](QQuickItem* item) {
+    if (item == nullptr) {
+      return;
+    }
+    item->setVisible(true);
+    if (container != nullptr && item->parentItem() != container) {
+      item->setParentItem(container);
+    }
+  };
+  for (const auto& [id, node] : node_by_id_) {
+    Q_UNUSED(id);
+    if (!node.isNull()) {
+      attach(node->getItem());
+    }
+  }
+  for (const auto& [key, edge] : edge_by_key_) {
+    Q_UNUSED(key);
+    if (!edge.isNull()) {
+      attach(edge->getItem());
     }
   }
 }
@@ -457,6 +501,7 @@ auto AlcedoQanGraph::InsertTopology(const EditorNodeGraphSnapshot& snapshot) -> 
       return edge_error;
     }
   }
+  AttachLiveVisuals();
   return {};
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_commit_presentation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_commit_presentation.cpp
@@ -15,7 +15,10 @@
 #include <utility>
 
 #include "app/editor_adjustment_pipeline.hpp"
+#include "app/editor_history_types.hpp"
+#include "app/pipeline_document_history.hpp"
 #include "edit/operators/op_base.hpp"
+#include "json.hpp"
 
 namespace alcedo::ui {
 namespace {
@@ -694,12 +697,92 @@ auto BuildSummary(OperatorType op, const nlohmann::json& after, const nlohmann::
   return {};
 }
 
+auto DisplayTextFromStoredJson(const std::string& json_text, const std::string& fallback)
+    -> QString {
+  if (!json_text.empty()) {
+    try {
+      const auto parsed = nlohmann::json::parse(json_text);
+      if (parsed.is_string()) {
+        return QString::fromStdString(parsed.get<std::string>());
+      }
+      if (parsed.is_object() && parsed.contains("display_name") &&
+          parsed.at("display_name").is_string()) {
+        return QString::fromStdString(parsed.at("display_name").get<std::string>());
+      }
+    } catch (...) {
+    }
+  }
+  return QString::fromStdString(fallback);
+}
+
+auto PresentGraphOperation(const alcedo::EditorHistoryCommit& commit)
+    -> std::optional<EditorHistoryCommitPresentation> {
+  const auto add_key =
+      alcedo::PresentationKeyForOperation(alcedo::PipelineEditOperationKind::AddColorGrade);
+  const auto rename_key =
+      alcedo::PresentationKeyForOperation(alcedo::PipelineEditOperationKind::RenameColorGrade);
+  const auto remove_key =
+      alcedo::PresentationKeyForOperation(alcedo::PipelineEditOperationKind::RemoveColorGrade);
+  if (commit.presentation_key != add_key && commit.presentation_key != rename_key &&
+      commit.presentation_key != remove_key) {
+    return std::nullopt;
+  }
+
+  EditorHistoryCommitPresentation out;
+  const QString name = DisplayTextFromStoredJson(commit.after_value_json, commit.node_display_name);
+  if (commit.presentation_key == add_key) {
+    out.display_name = QStringLiteral("Add Color Grade");
+    out.after_text   = name;
+    out.delta_text   = name;
+    out.icon_key     = QStringLiteral(":/history_icons/git-commit-horizontal.svg");
+    return out;
+  }
+  if (commit.presentation_key == rename_key) {
+    const QString before =
+        DisplayTextFromStoredJson(commit.before_value_json, commit.node_display_name);
+    out.display_name = QStringLiteral("Rename Color Grade");
+    out.before_text  = before;
+    out.after_text   = name.isEmpty() ? QString::fromStdString(commit.node_display_name) : name;
+    out.delta_text   = out.before_text.isEmpty()
+                           ? out.after_text
+                           : QStringLiteral("%1 \u2192 %2").arg(out.before_text, out.after_text);
+    out.icon_key     = QStringLiteral(":/history_icons/workflow.svg");
+    return out;
+  }
+  out.display_name = QStringLiteral("Delete Color Grade");
+  out.after_text   = name.isEmpty() ? QString::fromStdString(commit.node_display_name) : name;
+  out.delta_text   = out.after_text;
+  out.icon_key     = QStringLiteral(":/history_icons/square-split-horizontal.svg");
+  return out;
+}
+
 }  // namespace
 
 auto PresentEditorHistoryCommit(const std::string& field_key, const std::string& before_value_json,
                                 const std::string& after_value_json, bool before_enabled,
                                 bool after_enabled)
     -> EditorHistoryCommitPresentation {
+  alcedo::EditorHistoryCommit commit;
+  commit.field_key         = field_key;
+  commit.before_value_json = before_value_json;
+  commit.after_value_json  = after_value_json;
+  commit.before_enabled    = before_enabled;
+  commit.after_enabled     = after_enabled;
+  return PresentEditorHistoryCommit(commit);
+}
+
+auto PresentEditorHistoryCommit(const alcedo::EditorHistoryCommit& commit)
+    -> EditorHistoryCommitPresentation {
+  if (const auto graph = PresentGraphOperation(commit)) {
+    return *graph;
+  }
+
+  const auto& field_key         = commit.field_key;
+  const auto& before_value_json = commit.before_value_json;
+  const auto& after_value_json  = commit.after_value_json;
+  const bool  before_enabled    = commit.before_enabled;
+  const bool  after_enabled     = commit.after_enabled;
+
   EditorHistoryCommitPresentation out;
   const auto         spec = alcedo::ResolveEditorAdjustmentField(field_key);
   const OperatorType op   = spec.has_value() ? spec->operator_type : OperatorType::UNKNOWN;

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_models.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_models.cpp
@@ -212,9 +212,7 @@ auto EditorHistoryModel::PresentationFor(const alcedo::EditorHistoryCommit& comm
       it != presentation_cache_.end()) {
     return it->second;
   }
-  auto pres = PresentEditorHistoryCommit(
-      commit.field_key, commit.before_value_json, commit.after_value_json,
-      commit.before_enabled, commit.after_enabled);
+  auto pres = PresentEditorHistoryCommit(commit);
   presentation_cache_.emplace(commit.commit_hash, pres);
   return pres;
 }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -6,6 +6,9 @@
 
 #include <qqml.h>
 
+#include <QMetaObject>
+#include <QScopeGuard>
+#include <QUuid>
 #include <algorithm>
 #include <utility>
 
@@ -41,7 +44,13 @@ auto SameTopology(const EditorNodeGraphSnapshot& lhs, const EditorNodeGraphSnaps
 
 EditorNodeController::EditorNodeController(QObject* parent) : QObject(parent) {}
 
-EditorNodeController::~EditorNodeController() { DisconnectSession(); }
+EditorNodeController::~EditorNodeController() {
+  if (graph_adapter_connection_) {
+    QObject::disconnect(graph_adapter_connection_);
+    graph_adapter_connection_ = {};
+  }
+  DisconnectSession();
+}
 
 auto EditorNodeController::editor_session_object() const -> QObject* { return session_.data(); }
 
@@ -55,6 +64,10 @@ void EditorNodeController::DisconnectSession() {
   if (history_connection_) {
     QObject::disconnect(history_connection_);
     history_connection_ = {};
+  }
+  if (availability_connection_) {
+    QObject::disconnect(availability_connection_);
+    availability_connection_ = {};
   }
   session_.clear();
 }
@@ -71,6 +84,9 @@ void EditorNodeController::set_editor_session(QObject* session) {
                                   &EditorNodeController::OnSessionChanged);
     history_connection_ = connect(session_.data(), &EditorSessionController::HistoryChanged, this,
                                   &EditorNodeController::OnSessionChanged);
+    availability_connection_ =
+        connect(session_.data(), &EditorSessionController::ActionAvailabilityChanged, this,
+                &EditorNodeController::ActionAvailabilityChanged);
   }
   emit EditorSessionChanged();
   OnSessionChanged();
@@ -100,14 +116,16 @@ void EditorNodeController::SetLastError(QString error) {
 }
 
 void EditorNodeController::ClearSnapshot() {
-  snapshot_            = {};
-  has_snapshot_        = false;
-  selected_node_id_    = {};
-  session_generation_  = BoundSessionGeneration().value_or(0);
-  projection_revision_ = 0;
-  topology_revision_   = 0;
+  snapshot_                  = {};
+  has_snapshot_              = false;
+  selected_node_id_          = {};
+  selection_restore_node_id_ = {};
+  session_generation_        = BoundSessionGeneration().value_or(0);
+  projection_revision_       = 0;
+  topology_revision_         = 0;
   emit SnapshotChanged();
   emit SelectionChanged();
+  emit ActionAvailabilityChanged();
 }
 
 auto EditorNodeController::ContainsNode(const NodeId& node_id) const -> bool {
@@ -131,6 +149,11 @@ auto EditorNodeController::DefaultSelectedNodeId() const -> NodeId {
       return node.node_id;
     }
   }
+  for (const auto& node : snapshot_.nodes) {
+    if (node.node_kind == EditorNodeKind::Drt) {
+      return node.node_id;
+    }
+  }
   return snapshot_.nodes.front().node_id;
 }
 
@@ -146,6 +169,20 @@ auto EditorNodeController::IndexOf(const NodeId& node_id) const -> int {
   return -1;
 }
 
+auto EditorNodeController::NodeFor(const NodeId& node_id) const -> const EditorNodeProjection* {
+  if (!has_snapshot_) {
+    return nullptr;
+  }
+  const auto it = std::find_if(snapshot_.nodes.begin(), snapshot_.nodes.end(),
+                               [&](const auto& node) { return node.node_id == node_id; });
+  return it == snapshot_.nodes.end() ? nullptr : &*it;
+}
+
+auto EditorNodeController::IsColorGrade(const NodeId& node_id) const -> bool {
+  const auto* node = NodeFor(node_id);
+  return node != nullptr && node->node_kind == EditorNodeKind::ColorGrade;
+}
+
 auto EditorNodeController::TopologyChanged(const EditorNodeGraphSnapshot& snapshot) const -> bool {
   if (!has_snapshot_) {
     return true;
@@ -154,8 +191,16 @@ auto EditorNodeController::TopologyChanged(const EditorNodeGraphSnapshot& snapsh
 }
 
 void EditorNodeController::RestoreSelectionAfterSnapshot() {
+  if (ContainsNode(selection_restore_node_id_)) {
+    selected_node_id_          = selection_restore_node_id_;
+    selection_restore_node_id_ = {};
+    return;
+  }
   if (ContainsNode(selected_node_id_)) {
     return;
+  }
+  if (!selected_node_id_.Empty()) {
+    selection_restore_node_id_ = selected_node_id_;
   }
   selected_node_id_ = DefaultSelectedNodeId();
 }
@@ -174,6 +219,23 @@ auto EditorNodeController::backbone_node_ids() const -> QStringList {
     ids.push_back(NodeIdToQString(node.node_id));
   }
   return ids;
+}
+
+auto EditorNodeController::selected_node_name() const -> QString {
+  const auto* node = NodeFor(selected_node_id_);
+  return node == nullptr ? QString{} : QString::fromStdString(node->display_name);
+}
+
+auto EditorNodeController::can_add_color_grade() const -> bool {
+  return has_snapshot_ && session_ != nullptr && session_->can_edit() && !command_active_;
+}
+
+auto EditorNodeController::can_rename_selected_color_grade() const -> bool {
+  return can_add_color_grade() && IsColorGrade(selected_node_id_);
+}
+
+auto EditorNodeController::can_delete_selected_color_grade() const -> bool {
+  return can_rename_selected_color_grade();
 }
 
 auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> bool {
@@ -200,8 +262,9 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
   const bool generation_changed =
       !has_snapshot_ || snapshot.session_generation != session_generation_;
   if (generation_changed) {
-    session_generation_  = snapshot.session_generation;
-    topology_revision_   = snapshot.topology_revision == 0 ? 1 : snapshot.topology_revision;
+    selection_restore_node_id_ = {};
+    session_generation_        = snapshot.session_generation;
+    topology_revision_         = snapshot.topology_revision == 0 ? 1 : snapshot.topology_revision;
     projection_revision_ = snapshot.projection_revision == 0 ? 1 : snapshot.projection_revision;
   } else if (TopologyChanged(snapshot)) {
     topology_revision_   = std::max(topology_revision_ + 1, snapshot.topology_revision);
@@ -218,6 +281,8 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
   SetLastError({});
   emit SnapshotChanged();
   emit SelectionChanged();
+  emit ActionAvailabilityChanged();
+  QueueProjectionApply();
   return true;
 }
 
@@ -257,6 +322,78 @@ bool EditorNodeController::applyToGraph(QObject* adapter) {
   return true;
 }
 
+auto EditorNodeController::graph_adapter_object() const -> QObject* {
+  return graph_adapter_.data();
+}
+
+void EditorNodeController::set_graph_adapter(QObject* adapter) {
+  auto* graph = qobject_cast<AlcedoQanGraph*>(adapter);
+  if (graph_adapter_.data() == graph) {
+    return;
+  }
+  if (graph_adapter_connection_) {
+    QObject::disconnect(graph_adapter_connection_);
+    graph_adapter_connection_ = {};
+  }
+  graph_adapter_ = graph;
+  if (graph_adapter_ != nullptr) {
+    graph_adapter_connection_ = connect(graph_adapter_.data(), &AlcedoQanGraph::GraphChanged, this,
+                                        [this] { QueueProjectionApply(); });
+  }
+  emit GraphAdapterChanged();
+  if (graph_adapter_ != nullptr && has_snapshot_) {
+    ApplyBoundGraph();
+  }
+}
+
+auto EditorNodeController::layout_store_object() const -> QObject* { return layout_store_.data(); }
+
+void EditorNodeController::set_layout_store(QObject* store) {
+  auto* layout = qobject_cast<EditorNodeLayoutStore*>(store);
+  if (layout_store_.data() == layout) {
+    return;
+  }
+  layout_store_ = layout;
+  emit LayoutStoreChanged();
+}
+
+void EditorNodeController::ApplyBoundGraph() {
+  if (graph_adapter_.isNull() || !has_snapshot_ || graph_adapter_->graph() == nullptr) {
+    return;
+  }
+  if (!applyToGraph(graph_adapter_.data())) {
+    return;
+  }
+  auto* layout = layout_store_.data();
+  if (layout == nullptr) {
+    return;
+  }
+  layout->ensureDefaultsFrom(this);
+  for (const auto& node : snapshot_.nodes) {
+    const auto id = NodeIdToQString(node.node_id);
+    if (layout->hasNodePosition(id)) {
+      const auto pos = layout->nodePosition(id);
+      graph_adapter_->setNodePosition(id, pos.x(), pos.y());
+    }
+    graph_adapter_->setDrawerOpen(id, layout->drawerOpen(id));
+  }
+  graph_adapter_->applyProductSelection(selected_node_id_string());
+}
+
+void EditorNodeController::QueueProjectionApply() {
+  if (projection_apply_queued_) {
+    return;
+  }
+  projection_apply_queued_ = true;
+  QMetaObject::invokeMethod(
+      this,
+      [this] {
+        projection_apply_queued_ = false;
+        ApplyBoundGraph();
+      },
+      Qt::QueuedConnection);
+}
+
 bool EditorNodeController::refreshFromSession() {
   if (session_ == nullptr) {
     ClearSnapshot();
@@ -285,12 +422,140 @@ void EditorNodeController::selectNode(const QString& node_id) {
     return;
   }
   if (selected_node_id_ == id) {
+    selection_restore_node_id_ = {};
     SetLastError({});
     return;
   }
-  selected_node_id_ = id;
+  selected_node_id_          = id;
+  selection_restore_node_id_ = {};
   SetLastError({});
   emit SelectionChanged();
+  emit ActionAvailabilityChanged();
+}
+
+void EditorNodeController::SetCommandActive(bool active) {
+  if (command_active_ == active) {
+    return;
+  }
+  command_active_ = active;
+  emit CommandStateChanged();
+  emit ActionAvailabilityChanged();
+}
+
+auto EditorNodeController::ValidateCommandGeneration() -> bool {
+  if (command_active_) {
+    SetLastError(tr("Another node command is active"));
+    return false;
+  }
+  if (session_ == nullptr || !has_snapshot_) {
+    SetLastError(tr("No editable node graph is available"));
+    return false;
+  }
+  const auto bound_generation = BoundSessionGeneration();
+  if (!bound_generation.has_value() || session_generation_ != *bound_generation) {
+    SetLastError(tr("The node command is from another editor session"));
+    return false;
+  }
+  if (!session_->can_edit()) {
+    SetLastError(tr("The node graph is not editable in the current session state"));
+    return false;
+  }
+  return true;
+}
+
+bool EditorNodeController::addCleanColorGrade() {
+  if (!ValidateCommandGeneration()) {
+    return false;
+  }
+  NodeId    before_id{"drt"};
+  const int selected_index = IndexOf(selected_node_id_);
+  if (IsColorGrade(selected_node_id_) && selected_index >= 0 &&
+      selected_index + 1 < static_cast<int>(snapshot_.nodes.size())) {
+    before_id = snapshot_.nodes[static_cast<std::size_t>(selected_index + 1)].node_id;
+  }
+  const auto   uuid = QUuid::createUuid().toString(QUuid::WithoutBraces).toLower().toStdString();
+  const NodeId new_id{"grade." + uuid};
+
+  SetCommandActive(true);
+  const auto reset_active = qScopeGuard([this] { SetCommandActive(false); });
+  const auto result       = session_->SubmitAddColorGrade(before_id, new_id);
+  if (EditorSessionResultIsFailure(result.kind)) {
+    SetLastError(QString::fromStdString(result.message));
+    return false;
+  }
+  refreshFromSession();
+  selectNode(NodeIdToQString(new_id));
+  QueueProjectionApply();
+  return true;
+}
+
+bool EditorNodeController::renameColorGrade(const QString& node_id, const QString& display_name) {
+  if (!ValidateCommandGeneration()) {
+    return false;
+  }
+  const auto id = NodeIdFromQString(node_id);
+  if (!IsColorGrade(id)) {
+    SetLastError(tr("Only a Color Grade can be renamed"));
+    return false;
+  }
+  const auto name = display_name.trimmed();
+  if (name.isEmpty()) {
+    SetLastError(tr("Color Grade name cannot be empty"));
+    return false;
+  }
+
+  SetCommandActive(true);
+  const auto reset_active = qScopeGuard([this] { SetCommandActive(false); });
+  const auto result       = session_->SubmitRenameColorGrade(id, name.toStdString());
+  if (EditorSessionResultIsFailure(result.kind)) {
+    SetLastError(QString::fromStdString(result.message));
+    return false;
+  }
+  refreshFromSession();
+  selectNode(node_id);
+  QueueProjectionApply();
+  return true;
+}
+
+bool EditorNodeController::deleteColorGrade(const QString& node_id) {
+  if (!ValidateCommandGeneration()) {
+    return false;
+  }
+  const auto id    = NodeIdFromQString(node_id);
+  const int  index = IndexOf(id);
+  if (!IsColorGrade(id) || index < 0) {
+    SetLastError(tr("Only a Color Grade can be deleted"));
+    return false;
+  }
+  const NodeId successor = index + 1 < static_cast<int>(snapshot_.nodes.size())
+                               ? snapshot_.nodes[static_cast<std::size_t>(index + 1)].node_id
+                               : NodeId{};
+  const NodeId predecessor =
+      index > 0 ? snapshot_.nodes[static_cast<std::size_t>(index - 1)].node_id : NodeId{};
+
+  SetCommandActive(true);
+  const auto reset_active = qScopeGuard([this] { SetCommandActive(false); });
+  const auto result       = session_->SubmitRemoveColorGrade(id);
+  if (EditorSessionResultIsFailure(result.kind)) {
+    SetLastError(QString::fromStdString(result.message));
+    return false;
+  }
+  refreshFromSession();
+  NodeId live_selection = successor;
+  if (!ContainsNode(live_selection)) {
+    live_selection = predecessor;
+  }
+  if (!ContainsNode(live_selection)) {
+    live_selection = NodeId{"drt"};
+  }
+  if (ContainsNode(live_selection) && selected_node_id_ != live_selection) {
+    selected_node_id_ = live_selection;
+    SetLastError({});
+    emit SelectionChanged();
+    emit ActionAvailabilityChanged();
+  }
+  QueueProjectionApply();
+  return true;
 }
 
 void EditorNodeController::SelectAt(int index) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -651,6 +651,44 @@ void EditorSessionController::Redo() {
   PublishHistoryInvokableReturn(action, result);
 }
 
+auto EditorSessionController::SubmitAddColorGrade(const alcedo::NodeId& before_node_id,
+                                                  const alcedo::NodeId& new_id)
+    -> alcedo::EditorSessionResult {
+  if (!session_backend_) {
+    alcedo::EditorSessionResult result;
+    result.kind    = alcedo::EditorSessionResultKind::Rejected;
+    result.state   = session_state();
+    result.message = "Editor session backend is unavailable";
+    return result;
+  }
+  return session_backend_->AddColorGrade(before_node_id, new_id);
+}
+
+auto EditorSessionController::SubmitRemoveColorGrade(const alcedo::NodeId& node_id)
+    -> alcedo::EditorSessionResult {
+  if (!session_backend_) {
+    alcedo::EditorSessionResult result;
+    result.kind    = alcedo::EditorSessionResultKind::Rejected;
+    result.state   = session_state();
+    result.message = "Editor session backend is unavailable";
+    return result;
+  }
+  return session_backend_->RemoveColorGrade(node_id);
+}
+
+auto EditorSessionController::SubmitRenameColorGrade(const alcedo::NodeId& node_id,
+                                                     std::string           display_name)
+    -> alcedo::EditorSessionResult {
+  if (!session_backend_) {
+    alcedo::EditorSessionResult result;
+    result.kind    = alcedo::EditorSessionResultKind::Rejected;
+    result.state   = session_state();
+    result.message = "Editor session backend is unavailable";
+    return result;
+  }
+  return session_backend_->RenameColorGrade(node_id, std::move(display_name));
+}
+
 void EditorSessionController::MoveHeadToCommit(const QString& commitId) {
   const QString action = QStringLiteral("moveHeadToCommit");
   if (!session_backend_) {

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
@@ -7,7 +7,7 @@ import Alcedo.Main 1.0
 
 // Nodes page: header plus a navigable QuickQanava canvas. Product selection
 // lives on EditorNodeController. Positions, zoom, view, and Mask drawers live
-// on EditorNodeLayoutStore. This page does not mutate PipelineDocument.
+// on EditorNodeLayoutStore. Product changes route through EditorNodeController.
 Item {
     id: root
     objectName: "editorNodesPageBody"
@@ -17,7 +17,9 @@ Item {
     property var nodeController: null
     property var nodeLayoutStore: null
 
-    property string statusMessage: ""
+    property bool renameVisible: false
+    property string renameNodeId: ""
+    property string renameOriginalName: ""
 
     readonly property color colText: theme ? theme.colText : appTheme.textColor
     readonly property color colMuted: theme ? theme.colTextMuted : appTheme.textMutedColor
@@ -33,6 +35,67 @@ Item {
     }
 
     onLayoutIdentityKeyChanged: activateLayoutKey()
+
+    function addColorGrade() {
+        if (!root.nodeController || !root.nodeController.canAddColorGrade) {
+            return
+        }
+        root.nodeController.addCleanColorGrade()
+    }
+
+    function beginRename() {
+        if (!root.nodeController
+                || !root.nodeController.canRenameSelectedColorGrade) {
+            return
+        }
+        root.renameNodeId = root.nodeController.selectedNodeId
+        root.renameOriginalName = root.nodeController.selectedNodeName
+        renameField.text = root.renameOriginalName
+        root.renameVisible = true
+        Qt.callLater(function () {
+            if (root.renameVisible) {
+                renameField.forceActiveFocus()
+                renameField.selectAll()
+            }
+        })
+    }
+
+    function cancelRename() {
+        root.renameVisible = false
+        root.renameNodeId = ""
+        root.renameOriginalName = ""
+        renameField.text = ""
+        graphView.forceActiveFocus()
+    }
+
+    function commitRename() {
+        if (!root.renameVisible || !root.nodeController) {
+            return
+        }
+        const name = renameField.text.trim()
+        if (name.length === 0) {
+            return
+        }
+        if (name === root.renameOriginalName) {
+            cancelRename()
+            return
+        }
+        if (root.nodeController.renameColorGrade(root.renameNodeId, name)) {
+            cancelRename()
+        }
+    }
+
+    function deleteSelectedColorGrade() {
+        if (!root.nodeController
+                || !root.nodeController.canDeleteSelectedColorGrade) {
+            return
+        }
+        if (root.renameVisible) {
+            cancelRename()
+        }
+        root.nodeController.deleteColorGrade(root.nodeController.selectedNodeId)
+        graphView.forceActiveFocus()
+    }
 
     function captureView() {
         if (!graphView || !root.nodeLayoutStore) {
@@ -69,7 +132,30 @@ Item {
         qanAdapter.applyProductSelection(root.nodeController.selectedNodeId)
     }
 
+    function bindControllerAdapter() {
+        if (!root.nodeController) {
+            return
+        }
+        if (qanAdapter && qanAdapter.graph) {
+            root.nodeController.graphAdapter = qanAdapter
+        }
+    }
+
+    function clearControllerAdapter() {
+        if (root.nodeController) {
+            root.nodeController.graphAdapter = null
+        }
+    }
+
+    Binding {
+        target: root.nodeController
+        property: "graphAdapter"
+        value: (qanAdapter && qanAdapter.graph) ? qanAdapter : null
+        when: root.nodeController !== null && root.nodeController !== undefined
+    }
+
     function bindGraph() {
+        bindControllerAdapter()
         if (!root.nodeController || !qanAdapter || !qanAdapter.graph) {
             return
         }
@@ -103,7 +189,7 @@ Item {
     Connections {
         target: root.nodeController
         function onSnapshotChanged() {
-            bindGraph()
+            Qt.callLater(function () { root.bindGraph() })
         }
         function onSelectionChanged() {
             if (qanAdapter) {
@@ -111,6 +197,10 @@ Item {
             }
             if (root.nodeLayoutStore) {
                 root.nodeLayoutStore.selectedNodeId = root.nodeController.selectedNodeId
+            }
+            if (root.renameVisible
+                    && root.renameNodeId !== root.nodeController.selectedNodeId) {
+                root.cancelRename()
             }
         }
     }
@@ -123,12 +213,14 @@ Item {
             }
         }
         function onGraphChanged() {
-            bindGraph()
+            root.bindControllerAdapter()
+            Qt.callLater(function () { root.bindGraph() })
         }
     }
 
     Component.onCompleted: {
         activateLayoutKey()
+        bindControllerAdapter()
         bindGraph()
         if (graphView.originCross) {
             graphView.originCross.visible = false
@@ -137,7 +229,10 @@ Item {
         graphView.hScrollBar.policy = ScrollBar.AlwaysOff
     }
 
-    Component.onDestruction: captureView()
+    Component.onDestruction: {
+        captureView()
+        clearControllerAdapter()
+    }
 
     ColumnLayout {
         anchors.fill: parent
@@ -172,7 +267,73 @@ Item {
                 fillSelected: appTheme.buttonSelectedFillColor
                 focusRingColor: root.colText
                 actionName: qsTr("Add Color Grade")
+                onClicked: root.addColorGrade()
             }
+        }
+
+        RowLayout {
+            objectName: "editorNodeRenameRow"
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.renameVisible ? appTheme.iconButtonHitSizeCompact : 0
+            spacing: appTheme.spaceSm
+            visible: root.renameVisible
+
+            TextField {
+                id: renameField
+                objectName: "editorNodeRenameField"
+                Layout.fillWidth: true
+                Layout.preferredHeight: appTheme.iconButtonHitSizeCompact
+                enabled: root.renameVisible && root.nodeController
+                         && !root.nodeController.commandActive
+                color: root.colText
+                font.family: appTheme.uiFontFamily
+                font.pixelSize: appTheme.fontSizeBody
+                placeholderText: qsTr("Color Grade name")
+                selectByMouse: true
+                leftPadding: appTheme.spaceSm
+                rightPadding: appTheme.spaceSm
+                Accessible.name: qsTr("Rename Color Grade")
+                background: Rectangle {
+                    radius: appTheme.controlRadiusSmall
+                    color: appTheme.bgBaseColor
+                    border.width: 1
+                    border.color: renameField.activeFocus ? root.colText : root.colCardBorder
+                }
+                onAccepted: root.commitRename()
+                Keys.onEscapePressed: function (event) {
+                    root.cancelRename()
+                    event.accepted = true
+                }
+            }
+
+            IconActionButton {
+                objectName: "editorNodeRenameAcceptButton"
+                compact: true
+                enabled: root.renameVisible && root.nodeController
+                         && !root.nodeController.commandActive
+                         && renameField.text.trim().length > 0
+                iconSrc: "qrc:/panel_icons/edit.svg"
+                iconColorDefault: root.colText
+                iconColorMuted: root.colMuted
+                fillIdle: root.colCardSurface
+                fillHover: appTheme.buttonHoveredFillColor
+                fillPressed: appTheme.buttonPressedFillColor
+                fillSelected: appTheme.buttonSelectedFillColor
+                focusRingColor: root.colText
+                actionName: qsTr("Accept Rename")
+                onClicked: root.commitRename()
+            }
+        }
+
+        Label {
+            objectName: "editorNodesCommandError"
+            Layout.fillWidth: true
+            visible: root.nodeController && root.nodeController.lastError.length > 0
+            text: root.nodeController ? root.nodeController.lastError : ""
+            color: appTheme.dangerColor
+            wrapMode: Text.WordWrap
+            font.family: appTheme.uiFontFamily
+            font.pixelSize: appTheme.fontSizeCaption
         }
 
         Rectangle {
@@ -212,7 +373,17 @@ Item {
                     if (!root.nodeController) {
                         return
                     }
-                    if (event.key === Qt.Key_Up) {
+                    if (event.key === Qt.Key_F2) {
+                        root.beginRename()
+                        event.accepted = true
+                    } else if (event.key === Qt.Key_Delete) {
+                        root.deleteSelectedColorGrade()
+                        event.accepted = true
+                    } else if ((event.key === Qt.Key_Plus || event.key === Qt.Key_Equal)
+                               && (event.modifiers & Qt.ControlModifier)) {
+                        root.addColorGrade()
+                        event.accepted = true
+                    } else if (event.key === Qt.Key_Up) {
                         root.nodeController.selectPreviousBackboneNode()
                         event.accepted = true
                     } else if (event.key === Qt.Key_Down) {
@@ -243,6 +414,19 @@ Item {
                     if (id.length > 0) {
                         root.nodeController.selectNode(id)
                     }
+                }
+                onNodeRightClicked: function (node, position) {
+                    if (!root.nodeController || !qanAdapter || !node || !node.item) {
+                        return
+                    }
+                    const id = qanAdapter.liveNodeId(node)
+                    if (id.length === 0) {
+                        return
+                    }
+                    root.nodeController.selectNode(id)
+                    const menuPosition = node.item.mapToItem(canvasHost,
+                                                              position.x, position.y)
+                    nodeMenu.openAt(menuPosition.x, menuPosition.y)
                 }
                 onRightClicked: function () {
                     canvasMenu.popup()
@@ -282,6 +466,27 @@ Item {
                     objectName: "editorNodesFitMenuItem"
                     text: qsTr("Fit")
                     onTriggered: root.fitGraph()
+                }
+            }
+
+            AppContextMenu {
+                id: nodeMenu
+                objectName: "editorNodesNodeMenu"
+
+                AppMenuItem {
+                    objectName: "editorNodesRenameMenuItem"
+                    text: qsTr("Rename Color Grade")
+                    enabled: root.nodeController
+                             ? root.nodeController.canRenameSelectedColorGrade : false
+                    onTriggered: root.beginRename()
+                }
+
+                AppMenuItem {
+                    objectName: "editorNodesDeleteMenuItem"
+                    text: qsTr("Delete Color Grade")
+                    enabled: root.nodeController
+                             ? root.nodeController.canDeleteSelectedColorGrade : false
+                    onTriggered: root.deleteSelectedColorGrade()
                 }
             }
         }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspaceRail.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspaceRail.qml
@@ -102,13 +102,14 @@ Item {
         editorSession: root.editorSession
     }
 
+    EditorNodeLayoutStore {
+        id: nodesLayoutStore
+    }
+
     EditorNodeController {
         id: nodesController
         editorSession: root.editorSession
-    }
-
-    EditorNodeLayoutStore {
-        id: nodesLayoutStore
+        layoutStore: nodesLayoutStore
     }
 
     function driveFoldProgress(value) {

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -344,6 +344,17 @@ gtest_discover_tests(EditorSessionCommandQueueBaselineTest
     PROPERTIES LABELS "editor_session")
 alcedo_register_test_target(EditorSessionCommandQueueBaselineTest app)
 
+add_executable(EditorSessionNodeCommandTest
+    ${ALCEDO_TEST_ROOT}/app/editor_session_node_command_test.cpp)
+target_include_directories(EditorSessionNodeCommandTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR})
+target_link_libraries(EditorSessionNodeCommandTest
+    EditorSessionService xxHash JSON ${ALCEDO_TEST_OPENCV_MIN_DEPS} GTest::gtest_main)
+gtest_discover_tests(EditorSessionNodeCommandTest
+    TEST_PREFIX "EditorSessionNodeCommandTest."
+    PROPERTIES LABELS "editor_session;quickqanava")
+alcedo_register_test_target(EditorSessionNodeCommandTest app)
+
 # CQ3: action-admission policy, operation leases, scoped request-id correlation.
 add_executable(EditorSessionActionPolicyCq3Test
     ${ALCEDO_TEST_ROOT}/app/editor_session_action_policy_cq3_test.cpp)

--- a/alcedo_studio/tests/app/editor_session_action_policy_cq3_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_action_policy_cq3_test.cpp
@@ -135,6 +135,16 @@ TEST_F(EditorSessionActionPolicyCq3Test,
   EXPECT_TRUE(published.For(EditorAction::ApplyPaste).allowed);
 }
 
+TEST(EditorSessionNodeCommandPolicy,
+     AddRenameAndRemoveUseTheSameAdmissionDecisionAsSettledAdjustments) {
+  EXPECT_EQ(EditorActionPolicy::ActionForCommand(EditorSessionCommandKind::AddColorGrade),
+            EditorAction::CommitAdjustment);
+  EXPECT_EQ(EditorActionPolicy::ActionForCommand(EditorSessionCommandKind::RenameColorGrade),
+            EditorAction::CommitAdjustment);
+  EXPECT_EQ(EditorActionPolicy::ActionForCommand(EditorSessionCommandKind::RemoveColorGrade),
+            EditorAction::CommitAdjustment);
+}
+
 TEST_F(EditorSessionActionPolicyCq3Test,
        AcceptedOperationLeaseBlocksAndCompletionRestoresExactlyItsDeclaredActions) {
   openInteractive();

--- a/alcedo_studio/tests/app/editor_session_node_command_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_node_command_test.cpp
@@ -1,0 +1,130 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "app/editor_render_coordinator.hpp"
+#include "app/editor_session_bootstrap.hpp"
+#include "app/editor_session_service.hpp"
+#include "support/editor_session_command_queue_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+class RecordingNodeCommandScheduler final : public IEditorPipelineSchedulerPort {
+ public:
+  auto Schedule(const EditorRenderRequest& request, EditorPipelineScheduleCompletion = {})
+      -> std::uint64_t override {
+    requests.push_back(request);
+    return ++next_job;
+  }
+  void                             Cancel(std::uint64_t) override {}
+  void                             WaitForSessionIdle(std::uint64_t) override {}
+
+  std::vector<EditorRenderRequest> requests;
+  std::uint64_t                    next_job = 0;
+};
+
+class EditorSessionNodeCommandTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    history_          = std::make_shared<test::ControllableEditorHistoryPort>();
+    pipeline_         = std::make_shared<test::FakeEditorPipelinePort>();
+    tasks_            = std::make_shared<test::FakeEditorTaskPort>();
+    journal_          = std::make_shared<test::OrderRecordingJournalPort>();
+    scheduler_        = std::make_shared<RecordingNodeCommandScheduler>();
+    checkpoint_store_ = std::make_shared<test::FakeEditorCheckpointStore>();
+    thumbnails_       = std::make_shared<test::FakeEditorThumbnailPort>();
+    runtime_          = EditorSessionRuntime::CreateWithPorts(pipeline_, history_, tasks_, journal_,
+                                                              scheduler_, checkpoint_store_, thumbnails_);
+    service_          = runtime_->service.get();
+    service_->SetPresentationSinkId(1);
+    service_->SetPresentationSize(640, 480);
+    OpenInteractive();
+  }
+
+  void OpenInteractive() {
+    (void)service_->Open(10, 20);
+    service_->DrainCommandQueueForTests();
+    const auto first = service_->first_frame_request_id();
+    ASSERT_NE(first, 0u);
+    runtime_->coordinator->NotifySchedulerCompleted(first, true);
+    service_->DrainCommandQueueForTests();
+    const auto quality = runtime_->coordinator->last_scheduled_request_id();
+    if (quality != first) {
+      runtime_->coordinator->NotifySchedulerCompleted(quality, true);
+      service_->DrainCommandQueueForTests();
+    }
+    ASSERT_EQ(service_->state(), EditorSessionState::Interactive);
+  }
+
+  std::shared_ptr<test::ControllableEditorHistoryPort> history_;
+  std::shared_ptr<test::FakeEditorPipelinePort>        pipeline_;
+  std::shared_ptr<test::FakeEditorTaskPort>            tasks_;
+  std::shared_ptr<test::OrderRecordingJournalPort>     journal_;
+  std::shared_ptr<RecordingNodeCommandScheduler>       scheduler_;
+  std::shared_ptr<test::FakeEditorCheckpointStore>     checkpoint_store_;
+  std::shared_ptr<test::FakeEditorThumbnailPort>       thumbnails_;
+  std::unique_ptr<EditorSessionRuntime>                runtime_;
+  EditorSessionService*                                service_ = nullptr;
+};
+
+TEST_F(EditorSessionNodeCommandTest, AddCreatesOneHistoryChangeAndRoutesTopologyQualityRender) {
+  const auto renders_before  = scheduler_->requests.size();
+  const auto revision_before = service_->history_revision();
+  const auto result          = service_->AddColorGrade(NodeId{"drt"}, NodeId{"grade.extra"});
+
+  EXPECT_EQ(result.kind, EditorSessionResultKind::RenderRouted);
+  EXPECT_EQ(history_->add_grade_count, 1);
+  EXPECT_EQ(history_->last_before_node_id, NodeId{"drt"});
+  EXPECT_EQ(history_->last_node_id, NodeId{"grade.extra"});
+  EXPECT_EQ(service_->history_revision(), revision_before + 1);
+  ASSERT_EQ(scheduler_->requests.size(), renders_before + 1);
+  EXPECT_EQ(scheduler_->requests.back().intent.reason, EditorRenderReason::GraphTopologyChanged);
+}
+
+TEST_F(EditorSessionNodeCommandTest, RenameCreatesOneHistoryChangeWithoutRender) {
+  const auto renders_before  = scheduler_->requests.size();
+  const auto revision_before = service_->history_revision();
+  const auto result          = service_->RenameColorGrade(NodeId{"grade.primary"}, "Sky");
+
+  EXPECT_EQ(result.kind, EditorSessionResultKind::Accepted);
+  EXPECT_EQ(history_->rename_grade_count, 1);
+  EXPECT_EQ(history_->last_node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(history_->last_grade_name, "Sky");
+  EXPECT_EQ(service_->history_revision(), revision_before + 1);
+  EXPECT_EQ(scheduler_->requests.size(), renders_before);
+}
+
+TEST_F(EditorSessionNodeCommandTest, DeleteCreatesOneHistoryChangeAndRoutesTopologyQualityRender) {
+  const auto renders_before  = scheduler_->requests.size();
+  const auto revision_before = service_->history_revision();
+  const auto result          = service_->RemoveColorGrade(NodeId{"grade.primary"});
+
+  EXPECT_EQ(result.kind, EditorSessionResultKind::RenderRouted);
+  EXPECT_EQ(history_->remove_grade_count, 1);
+  EXPECT_EQ(history_->last_node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(service_->history_revision(), revision_before + 1);
+  ASSERT_EQ(scheduler_->requests.size(), renders_before + 1);
+  EXPECT_EQ(scheduler_->requests.back().intent.reason, EditorRenderReason::GraphTopologyChanged);
+}
+
+TEST_F(EditorSessionNodeCommandTest,
+       JournalFailurePublishesExactErrorWithoutHistoryOrRenderChange) {
+  history_->fail_node_command = true;
+  const auto renders_before   = scheduler_->requests.size();
+  const auto revision_before  = service_->history_revision();
+  const auto result           = service_->AddColorGrade(NodeId{"drt"}, NodeId{"grade.extra"});
+
+  EXPECT_EQ(result.kind, EditorSessionResultKind::Rejected);
+  EXPECT_EQ(result.message, "mini-Git journal append failed");
+  EXPECT_EQ(service_->history_revision(), revision_before);
+  EXPECT_EQ(scheduler_->requests.size(), renders_before);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/history/editor_document_history_test.cpp
+++ b/alcedo_studio/tests/edit/history/editor_document_history_test.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "app/editor_pipeline_command_service.hpp"
+#include "app/editor_history_types.hpp"
 #include "app/pipeline_document_history.hpp"
 #include "app/pipeline_service.hpp"
 #include "edit/graph/color_grade_node_model.hpp"
@@ -28,6 +29,7 @@
 #include "edit/operators/operator_registeration.hpp"
 #include "grade_owned_mask_support.hpp"
 #include "support/editor_parameter_target_test.hpp"
+#include "ui/alcedo_main/album_backend/editor_history_commit_presentation.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_history_port.hpp"
 
 namespace alcedo::ui {
@@ -530,6 +532,64 @@ TEST_F(EditorDocumentHistoryTest, RenameCreatesHistoryWithoutRenderIntent) {
   ASSERT_NE(grade, nullptr);
   EXPECT_EQ(grade->DisplayName(), "Look A");
   EXPECT_FALSE(history_.LastPublishedRenderReason().has_value());
+}
+
+TEST_F(EditorDocumentHistoryTest, AddRenameAndDeleteSnapshotsPresentTypedHistoryTitles) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  ASSERT_TRUE(history_.AddColorGrade(handle, alcedo::NodeId{"drt"}, alcedo::NodeId{"grade.extra"},
+                                     &error))
+      << error;
+  alcedo::EditorHistorySnapshot added;
+  ASSERT_TRUE(history_.ReadHistorySnapshot(handle, &added, &error)) << error;
+  ASSERT_FALSE(added.commits.empty());
+  const auto add_pres = PresentEditorHistoryCommit(added.commits.front());
+  EXPECT_EQ(added.commits.front().presentation_key, "history.operation.add_color_grade");
+  EXPECT_EQ(add_pres.display_name.toStdString(), "Add Color Grade");
+  EXPECT_EQ(add_pres.after_text.toStdString(), "Color Grade 2");
+
+  ASSERT_TRUE(history_.RenameColorGrade(handle, alcedo::NodeId{"grade.extra"}, "Sky", &error))
+      << error;
+  alcedo::EditorHistorySnapshot renamed;
+  ASSERT_TRUE(history_.ReadHistorySnapshot(handle, &renamed, &error)) << error;
+  ASSERT_FALSE(renamed.commits.empty());
+  const auto rename_pres = PresentEditorHistoryCommit(renamed.commits.front());
+  EXPECT_EQ(renamed.commits.front().presentation_key, "history.operation.rename_color_grade");
+  EXPECT_EQ(rename_pres.display_name.toStdString(), "Rename Color Grade");
+  EXPECT_EQ(rename_pres.after_text.toStdString(), "Sky");
+
+  ASSERT_TRUE(history_.RemoveColorGrade(handle, alcedo::NodeId{"grade.extra"}, &error)) << error;
+  alcedo::EditorHistorySnapshot removed;
+  ASSERT_TRUE(history_.ReadHistorySnapshot(handle, &removed, &error)) << error;
+  ASSERT_FALSE(removed.commits.empty());
+  const auto remove_pres = PresentEditorHistoryCommit(removed.commits.front());
+  EXPECT_EQ(removed.commits.front().presentation_key, "history.operation.remove_color_grade");
+  EXPECT_EQ(remove_pres.display_name.toStdString(), "Delete Color Grade");
+  EXPECT_EQ(remove_pres.delta_text.toStdString(), "Sky");
+}
+
+TEST_F(EditorDocumentHistoryTest,
+       AddJournalFailureRestoresDocumentHeadCounterAndPublishedRenderReason) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  const auto before_document = alcedo::CanonicalPipelineDocumentJson(*guard_->document_);
+  const auto before_head     = guard_->working_head_commit_hash();
+  const auto before_count    = guard_->commit_graph_->CommitCount();
+  const auto before_counter  = guard_->document_->NextColorGradeNameNumber();
+  const auto before_reason   = history_.LastPublishedRenderReason();
+  ASSERT_TRUE(std::filesystem::create_directory(journal_path_));
+
+  EXPECT_FALSE(history_.AddColorGrade(handle, alcedo::NodeId{"drt"}, alcedo::NodeId{"grade.failed"},
+                                      &error));
+  EXPECT_EQ(error, "mini-Git journal file could not be opened for append");
+  EXPECT_EQ(alcedo::CanonicalPipelineDocumentJson(*guard_->document_), before_document);
+  EXPECT_EQ(guard_->working_head_commit_hash(), before_head);
+  EXPECT_EQ(guard_->commit_graph_->CommitCount(), before_count);
+  EXPECT_EQ(guard_->document_->NextColorGradeNameNumber(), before_counter);
+  EXPECT_EQ(guard_->document_->Graph().FindNode(alcedo::NodeId{"grade.failed"}), nullptr);
+  EXPECT_EQ(history_.LastPublishedRenderReason(), before_reason);
 }
 
 TEST_F(EditorDocumentHistoryTest, MaskAddRemoveUndoRestoresValueAndDisplayIndex) {

--- a/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
+++ b/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
@@ -34,6 +34,8 @@
 #include "edit/pipeline/pipeline_cpu.hpp"
 #include "storage/store/edit_history/commit_graph_store.hpp"
 #include "support/document_transfer_test_support.hpp"
+#include "app/pipeline_document_history.hpp"
+#include "app/editor_history_types.hpp"
 #include "ui/alcedo_main/album_backend/editor_history_commit_presentation.hpp"
 #include "ui/alcedo_main/album_backend/editor_history_shared_helpers.hpp"
 #include "utils/clock/time_provider.hpp"
@@ -985,6 +987,51 @@ TEST(EditorHistoryCommitPresentationTest, FormatsNumericBooleanPathEnumAndCompou
                                          R"({"crop_rotate":{"angle_degrees":12.0}})", true, true);
   EXPECT_EQ(crop.display_name.toStdString(), "Crop / Rotate");
   EXPECT_EQ(crop.after_text.toStdString(), "+12\u00b0");
+}
+
+TEST(EditorHistoryCommitPresentationTest, TypedGraphOperationsUseSavedNamesAndKeepAdjustmentRows) {
+  using alcedo::EditorHistoryCommit;
+  using alcedo::PipelineEditOperationKind;
+  using alcedo::PresentationKeyForOperation;
+
+  EditorHistoryCommit add;
+  add.presentation_key  = PresentationKeyForOperation(PipelineEditOperationKind::AddColorGrade);
+  add.node_display_name = "Color Grade 2";
+  add.after_value_json  = R"({"display_name":"Color Grade 2"})";
+  const auto add_pres   = PresentEditorHistoryCommit(add);
+  EXPECT_EQ(add_pres.display_name.toStdString(), "Add Color Grade");
+  EXPECT_EQ(add_pres.after_text.toStdString(), "Color Grade 2");
+  EXPECT_EQ(add_pres.delta_text.toStdString(), "Color Grade 2");
+
+  EditorHistoryCommit rename;
+  rename.presentation_key  = PresentationKeyForOperation(PipelineEditOperationKind::RenameColorGrade);
+  rename.node_display_name = "Sky";
+  rename.before_value_json = R"("Color Grade 1")";
+  rename.after_value_json  = R"("Sky")";
+  const auto rename_pres   = PresentEditorHistoryCommit(rename);
+  EXPECT_EQ(rename_pres.display_name.toStdString(), "Rename Color Grade");
+  EXPECT_EQ(rename_pres.before_text.toStdString(), "Color Grade 1");
+  EXPECT_EQ(rename_pres.after_text.toStdString(), "Sky");
+  EXPECT_EQ(rename_pres.delta_text.toStdString(), "Color Grade 1 \u2192 Sky");
+
+  EditorHistoryCommit remove;
+  remove.presentation_key  = PresentationKeyForOperation(PipelineEditOperationKind::RemoveColorGrade);
+  remove.node_display_name = "Color Grade 2";
+  remove.after_value_json  = R"({"display_name":"Color Grade 2"})";
+  const auto remove_pres   = PresentEditorHistoryCommit(remove);
+  EXPECT_EQ(remove_pres.display_name.toStdString(), "Delete Color Grade");
+  EXPECT_EQ(remove_pres.delta_text.toStdString(), "Color Grade 2");
+
+  EditorHistoryCommit exposure;
+  exposure.field_key         = "exposure";
+  exposure.presentation_key  = PresentationKeyForOperation(PipelineEditOperationKind::SetParameter);
+  exposure.before_value_json = R"({"exposure":0.0})";
+  exposure.after_value_json  = R"({"exposure":0.35})";
+  exposure.before_enabled    = true;
+  exposure.after_enabled     = true;
+  const auto exposure_pres   = PresentEditorHistoryCommit(exposure);
+  EXPECT_EQ(exposure_pres.display_name.toStdString(), "Exposure");
+  EXPECT_EQ(exposure_pres.after_text.toStdString(), "+0.35");
 }
 
 // ---------------------------------------------------------------------------

--- a/alcedo_studio/tests/support/editor_session_test_ports.hpp
+++ b/alcedo_studio/tests/support/editor_session_test_ports.hpp
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -88,6 +89,14 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
   EditorRenderAdjustmentSnapshot current_snapshot{};
   EditorAdjustmentPatch          last_captured_patch{};
   EditorAdjustmentPatch          last_committed_patch{};
+  bool                           fail_node_command  = false;
+  int                            add_grade_count    = 0;
+  int                            remove_grade_count = 0;
+  int                            rename_grade_count = 0;
+  NodeId                         last_node_id;
+  NodeId                         last_before_node_id;
+  std::string                    last_grade_name;
+  std::optional<EditorRenderReason> last_render_reason = EditorRenderReason::UndoRedo;
   std::shared_ptr<const EditorMiniGitSaveCapture> next_capture = MakeOpaqueSaveCapture();
 
   auto Acquire(sl_element_id_t element_id, std::string* error)
@@ -124,6 +133,49 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
       return false;
     }
     return true;
+  }
+
+  auto AddColorGrade(const EditorHistoryGuardHandle&, const NodeId& before_node_id,
+                     const NodeId& new_id, std::string* error) -> bool override {
+    ++add_grade_count;
+    last_before_node_id = before_node_id;
+    last_node_id        = new_id;
+    last_render_reason  = EditorRenderReason::GraphTopologyChanged;
+    if (fail_node_command) {
+      if (error != nullptr) *error = "mini-Git journal append failed";
+      return false;
+    }
+    return true;
+  }
+
+  auto RemoveColorGrade(const EditorHistoryGuardHandle&, const NodeId& node_id, std::string* error)
+      -> bool override {
+    ++remove_grade_count;
+    last_node_id       = node_id;
+    last_render_reason = EditorRenderReason::GraphTopologyChanged;
+    if (fail_node_command) {
+      if (error != nullptr) *error = "mini-Git journal append failed";
+      return false;
+    }
+    return true;
+  }
+
+  auto RenameColorGrade(const EditorHistoryGuardHandle&, const NodeId& node_id,
+                        std::string display_name, std::string* error) -> bool override {
+    ++rename_grade_count;
+    last_node_id       = node_id;
+    last_grade_name    = std::move(display_name);
+    last_render_reason = std::nullopt;
+    if (fail_node_command) {
+      if (error != nullptr) *error = "mini-Git journal append failed";
+      return false;
+    }
+    return true;
+  }
+
+  [[nodiscard]] auto LastPublishedRenderReason() const
+      -> std::optional<EditorRenderReason> override {
+    return last_render_reason;
   }
 
   auto Undo(const EditorHistoryGuardHandle&, std::string* error) -> bool override {

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -869,6 +869,7 @@ target_include_directories(EditorNodeSelectionLayoutTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
     PRIVATE ${ALCEDO_TEST_DIR}
     PRIVATE ${ALCEDO_TEST_ROOT}/ui
+    PRIVATE ${ALCEDO_TEST_ROOT}/edit/graph
 )
 target_link_libraries(EditorNodeSelectionLayoutTest
     PRIVATE

--- a/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
+++ b/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
@@ -14,6 +14,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QQmlApplicationEngine>
+#include <QQuickItem>
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlError>
@@ -382,6 +383,35 @@ TEST_F(AlcedoQanGraph, MaskKindChangeUpdatesOneNodeWithoutReplacingEdges) {
   EXPECT_EQ(adapter.NodeProjection(NodeId{"grade.primary"})->masks.front().source_kind,
             MaskSourceKind::Brush);
   EXPECT_EQ(harness_->Graph()->getNodeCount(), 3);
+}
+
+TEST_F(AlcedoQanGraph, RemovingAColorGradeReplacesQanPrimitivesAndHidesTheRemovedCard) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  const auto first = EditorNodeGraphProjection::Build(document, 9, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(first).succeeded) << "initial apply";
+
+  QPointer<qan::Node>      removed_node = adapter.NodeFor(NodeId{"grade.primary"});
+  ASSERT_FALSE(removed_node.isNull());
+  QPointer<QQuickItem>     removed_item = removed_node->getItem();
+  ASSERT_FALSE(removed_item.isNull());
+  EXPECT_TRUE(removed_item->isVisible());
+
+  ASSERT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
+  const auto second = EditorNodeGraphProjection::Build(document, 9, 2, 2);
+  const auto result = adapter.ApplySnapshot(second);
+
+  ASSERT_TRUE(result.succeeded) << result.error.toStdString();
+  EXPECT_TRUE(result.rebuilt_topology);
+  EXPECT_TRUE(removed_node.isNull());
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"}), nullptr);
+  if (!removed_item.isNull()) {
+    EXPECT_FALSE(removed_item->isVisible());
+    EXPECT_EQ(removed_item->parentItem(), nullptr);
+  }
+  ExpectLiveBackbone(adapter, second);
 }
 
 TEST_F(AlcedoQanGraph, VersionReplacementRemovesOldPrimitivesAndReverseMapEntries) {

--- a/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
+++ b/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
@@ -32,6 +32,7 @@
 #include "app/editor_render_intent.hpp"
 #include "app/editor_session_service.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
 #include "type/hash_type.hpp"
 #include "ui/alcedo_main/album_backend/editor_history_models.hpp"
 #include "ui/alcedo_main/album_backend/editor_node_controller.hpp"
@@ -113,6 +114,10 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
     };
     allow(alcedo::EditorAction::Undo, snapshot_.can_undo);
     allow(alcedo::EditorAction::Redo, snapshot_.can_redo);
+    allow(alcedo::EditorAction::PreviewAdjustment,
+          state_ == EditorSessionState::Interactive && has_image_);
+    allow(alcedo::EditorAction::CommitAdjustment,
+          state_ == EditorSessionState::Interactive && has_image_);
     allow(alcedo::EditorAction::MoveHead, true);
     allow(alcedo::EditorAction::ApplyPaste, true);
     allow(alcedo::EditorAction::RetrySave, recovery_pending_);
@@ -258,6 +263,38 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
     return Accepted("View changed");
   }
 
+  auto AddColorGrade(const NodeId& before_node_id, const NodeId& new_id)
+      -> EditorSessionResult override {
+    if (fail_node_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors = AddCleanColorGrade(*document_, before_node_id, new_id);
+    if (!errors.empty()) return Rejected(errors.front().message.c_str());
+    last_added_node_id_ = new_id;
+    ++add_grade_count_;
+    NotifyHistoryChange();
+    return Accepted("Color Grade created");
+  }
+
+  auto RemoveColorGrade(const NodeId& node_id) -> EditorSessionResult override {
+    if (fail_node_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors = RemoveColorGradeAndBridge(*document_, node_id);
+    if (!errors.empty()) return Rejected(errors.front().message.c_str());
+    last_removed_node_id_ = node_id;
+    ++remove_grade_count_;
+    NotifyHistoryChange();
+    return Accepted("Color Grade removed");
+  }
+
+  auto RenameColorGrade(const NodeId& node_id, std::string display_name)
+      -> EditorSessionResult override {
+    if (fail_node_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors = alcedo::RenameColorGrade(*document_, node_id, std::move(display_name));
+    if (!errors.empty()) return Rejected(errors.front().message.c_str());
+    last_renamed_node_id_ = node_id;
+    ++rename_grade_count_;
+    NotifyHistoryChange();
+    return Accepted("Color Grade renamed");
+  }
+
   auto Close(bool) -> EditorSessionResult override {
     state_     = EditorSessionState::NoImage;
     has_image_ = false;
@@ -326,6 +363,12 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto blocked_rename_count() const -> int { return blocked_rename_count_; }
   [[nodiscard]] auto patch_count() const -> int { return patch_count_; }
   [[nodiscard]] auto view_change_count() const -> int { return view_change_count_; }
+  [[nodiscard]] auto add_grade_count() const -> int { return add_grade_count_; }
+  [[nodiscard]] auto remove_grade_count() const -> int { return remove_grade_count_; }
+  [[nodiscard]] auto rename_grade_count() const -> int { return rename_grade_count_; }
+  [[nodiscard]] auto last_added_node_id() const -> NodeId { return last_added_node_id_; }
+  [[nodiscard]] auto last_removed_node_id() const -> NodeId { return last_removed_node_id_; }
+  [[nodiscard]] auto last_renamed_node_id() const -> NodeId { return last_renamed_node_id_; }
 
   void SetRecovery(bool pending, std::string error = {}) {
     recovery_pending_ = pending;
@@ -334,6 +377,7 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
   }
 
   void SetBlockVersionOps(bool block) { block_version_ops_ = block; }
+  void SetFailNodeCommands(bool fail) { fail_node_commands_ = fail; }
 
  private:
   auto Accepted(const char* message) const -> EditorSessionResult {
@@ -391,10 +435,17 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
   int                   discard_count_         = 0;
   int                   cancel_recovery_count_ = 0;
   bool                  block_version_ops_     = false;
+  bool                  fail_node_commands_    = false;
   int                   blocked_create_count_  = 0;
   int                   blocked_rename_count_  = 0;
   int                   patch_count_           = 0;
   int                   view_change_count_     = 0;
+  int                   add_grade_count_       = 0;
+  int                   remove_grade_count_    = 0;
+  int                   rename_grade_count_    = 0;
+  NodeId                last_added_node_id_;
+  NodeId                last_removed_node_id_;
+  NodeId                last_renamed_node_id_;
 };
 
 class RecordingInteractionPolicy final : public QObject {

--- a/alcedo_studio/tests/ui/editor_node_controller_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_controller_test.cpp
@@ -7,12 +7,19 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <functional>
+#include <vector>
 
+#include "app/editor_action_policy.hpp"
 #include "app/editor_node_graph_projection.hpp"
 #include "app/editor_session_request_ids.hpp"
 #include "app/editor_session_service.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
+#include "grade_owned_mask_support.hpp"
 #include "type/type.hpp"
+#include "ui/alcedo_main/album_backend/editor_node_layout_store.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_controller.hpp"
 
 namespace {
@@ -26,6 +33,7 @@ using alcedo::IEditorSessionBackend;
 using alcedo::NodeId;
 using alcedo::PipelineDocument;
 using alcedo::ui::EditorNodeController;
+using alcedo::ui::EditorNodeLayoutStore;
 using alcedo::ui::EditorSessionController;
 
 class DocumentSessionBackend final : public IEditorSessionBackend {
@@ -34,6 +42,10 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
     identity_.element_id = 8;
     identity_.image_id   = 9;
     document_            = CreateDefaultPipelineDocument();
+    availability_.decisions[static_cast<std::size_t>(alcedo::EditorAction::PreviewAdjustment)]
+        .allowed = true;
+    availability_.decisions[static_cast<std::size_t>(alcedo::EditorAction::CommitAdjustment)]
+        .allowed = true;
   }
 
   [[nodiscard]] auto state() const -> EditorSessionState override {
@@ -49,6 +61,14 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto active_image_load_request() const -> alcedo::ImageLoadRequestId override {
     return request_;
   }
+  [[nodiscard]] auto action_availability() const -> alcedo::EditorActionAvailability override {
+    return availability_;
+  }
+
+  void SetActionAvailabilityObserver(
+      IEditorSessionBackend::ActionAvailabilityObserver observer) override {
+    availability_observer_ = std::move(observer);
+  }
 
   void SetPresentationSinkId(alcedo::PresentationSinkId) override {}
   void SetPresentationSize(int, int) override {}
@@ -60,14 +80,87 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   auto Undo() -> EditorSessionResult override { return {}; }
   auto Redo() -> EditorSessionResult override { return {}; }
 
+  auto AddColorGrade(const NodeId& before_node_id, const NodeId& new_id)
+      -> EditorSessionResult override {
+    if (before_add_) {
+      before_add_();
+    }
+    ++add_count_;
+    if (fail_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors = alcedo::AddCleanColorGrade(document_, before_node_id, new_id);
+    if (!errors.empty()) return Rejected(errors.front().message);
+    NotifyChange();
+    return Accepted("Color Grade created");
+  }
+  auto RemoveColorGrade(const NodeId& node_id) -> EditorSessionResult override {
+    ++remove_count_;
+    if (fail_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors = alcedo::RemoveColorGradeAndBridge(document_, node_id);
+    if (!errors.empty()) return Rejected(errors.front().message);
+    NotifyChange();
+    return Accepted("Color Grade removed");
+  }
+  auto RenameColorGrade(const NodeId& node_id, std::string display_name)
+      -> EditorSessionResult override {
+    ++rename_count_;
+    if (fail_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors = alcedo::RenameColorGrade(document_, node_id, std::move(display_name));
+    if (!errors.empty()) return Rejected(errors.front().message);
+    NotifyChange();
+    return Accepted("Color Grade renamed");
+  }
+
   void SetGeneration(std::uint64_t value) { request_.value = value; }
   auto Document() -> PipelineDocument& { return document_; }
+  void SetFailCommands(bool fail) { fail_commands_ = fail; }
+  void PublishAvailability(alcedo::EditorActionAvailability availability) {
+    availability_ = std::move(availability);
+    if (availability_observer_) {
+      availability_observer_(availability_);
+    }
+  }
+  void SetBeforeAdd(std::function<void()> before_add) { before_add_ = std::move(before_add); }
+  [[nodiscard]] auto add_count() const -> int { return add_count_; }
+  [[nodiscard]] auto remove_count() const -> int { return remove_count_; }
+  [[nodiscard]] auto rename_count() const -> int { return rename_count_; }
 
  private:
-  EditorSessionIdentity      identity_{};
-  PipelineDocument           document_;
-  alcedo::ImageLoadRequestId request_{};
+  auto Accepted(std::string message) const -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind     = alcedo::EditorSessionResultKind::Accepted;
+    result.state    = EditorSessionState::Interactive;
+    result.identity = identity_;
+    result.message  = std::move(message);
+    return result;
+  }
+  auto Rejected(std::string message) const -> EditorSessionResult {
+    auto result = Accepted(std::move(message));
+    result.kind = alcedo::EditorSessionResultKind::Rejected;
+    return result;
+  }
+
+  EditorSessionIdentity                             identity_{};
+  PipelineDocument                                  document_;
+  alcedo::ImageLoadRequestId                        request_{};
+  alcedo::EditorActionAvailability                  availability_{};
+  IEditorSessionBackend::ActionAvailabilityObserver availability_observer_;
+  std::function<void()>                             before_add_;
+  bool                                              fail_commands_ = false;
+  int                                               add_count_     = 0;
+  int                                               remove_count_  = 0;
+  int                                               rename_count_  = 0;
 };
+
+TEST(EditorNodeController, LayoutStoreBindingDoesNotPublishASnapshot) {
+  EditorNodeController  controller;
+  EditorNodeLayoutStore store;
+  EXPECT_EQ(controller.layout_store_object(), nullptr);
+  controller.set_layout_store(&store);
+  EXPECT_EQ(controller.layout_store_object(), &store);
+  EXPECT_FALSE(controller.has_snapshot());
+  controller.set_layout_store(nullptr);
+  EXPECT_EQ(controller.layout_store_object(), nullptr);
+}
 
 TEST(EditorNodeController, PublishDocumentSelectsPrimaryColorGrade) {
   EditorNodeController controller;
@@ -118,6 +211,116 @@ TEST(EditorNodeController, StaleGenerationSnapshotIsRejected) {
   EXPECT_FALSE(controller.last_error().isEmpty());
 }
 
+TEST(EditorNodeController, AddCreatesCleanGradeAfterSelectedGradeAndConsumesOneName) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(15);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  controller.selectNode(QStringLiteral("grade.primary"));
+
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  EXPECT_EQ(backend.add_count(), 1);
+  EXPECT_EQ(backend.Document().NextColorGradeNameNumber(), 3u);
+  const auto& ids = controller.backbone_node_ids();
+  ASSERT_EQ(ids.size(), 4);
+  EXPECT_EQ(ids[0], QStringLiteral("develop"));
+  EXPECT_EQ(ids[1], QStringLiteral("grade.primary"));
+  EXPECT_EQ(ids[2], controller.selected_node_id_string());
+  EXPECT_EQ(ids[3], QStringLiteral("drt"));
+  EXPECT_EQ(controller.selected_node_name(), QStringLiteral("Color Grade 2"));
+}
+
+TEST(EditorNodeController, RenameChangesLabelWithoutChangingSelectionIdentity) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(16);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+
+  ASSERT_TRUE(controller.renameColorGrade(QStringLiteral("grade.primary"), QStringLiteral("Sky")));
+  EXPECT_EQ(backend.rename_count(), 1);
+  EXPECT_EQ(controller.selected_node_id(), NodeId{"grade.primary"});
+  EXPECT_EQ(controller.selected_node_name(), QStringLiteral("Sky"));
+}
+
+TEST(EditorNodeController, DeleteSelectsSuccessorThenUndoProjectionRestoresDeletedSelection) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(17);
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  auto* primary = dynamic_cast<alcedo::ColorGradeNodeModel*>(
+      backend.Document().Graph().FindNode(NodeId{"grade.primary"}));
+  ASSERT_NE(primary, nullptr);
+  primary->AddMask(alcedo::grade_mask_test::MakeRadialMask(alcedo::MaskId{"mask.radial"}), 0);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  controller.selectNode(QStringLiteral("grade.primary"));
+  const auto primary_masks = [&controller] {
+    for (const auto& node : controller.snapshot().nodes) {
+      if (node.node_id == NodeId{"grade.primary"}) {
+        return node.masks;
+      }
+    }
+    return std::vector<alcedo::EditorNodeMaskProjection>{};
+  };
+  ASSERT_EQ(primary_masks().size(), 1u);
+
+  ASSERT_TRUE(controller.deleteColorGrade(QStringLiteral("grade.primary")));
+  EXPECT_EQ(backend.remove_count(), 1);
+  EXPECT_EQ(controller.selected_node_id(), NodeId{"grade.extra"});
+
+  auto undo_document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(undo_document, NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  auto* restored = dynamic_cast<alcedo::ColorGradeNodeModel*>(
+      undo_document.Graph().FindNode(NodeId{"grade.primary"}));
+  ASSERT_NE(restored, nullptr);
+  restored->AddMask(alcedo::grade_mask_test::MakeRadialMask(alcedo::MaskId{"mask.radial"}), 0);
+  ASSERT_TRUE(controller.PublishDocument(undo_document, 17));
+  EXPECT_EQ(controller.selected_node_id(), NodeId{"grade.primary"});
+  ASSERT_EQ(primary_masks().size(), 1u);
+  EXPECT_EQ(primary_masks().front().mask_id, alcedo::MaskId{"mask.radial"});
+}
+
+TEST(EditorNodeController, EndpointsAndStaleGenerationRejectCommandsBeforeBackendMutation) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(18);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+
+  EXPECT_FALSE(controller.renameColorGrade(QStringLiteral("develop"), QStringLiteral("Raw")));
+  EXPECT_FALSE(controller.deleteColorGrade(QStringLiteral("drt")));
+  EXPECT_FALSE(
+      controller.renameColorGrade(QStringLiteral("grade.missing"), QStringLiteral("Missing")));
+  EXPECT_FALSE(controller.deleteColorGrade(QStringLiteral("grade.missing")));
+  backend.SetGeneration(19);
+  EXPECT_FALSE(controller.addCleanColorGrade());
+  EXPECT_EQ(backend.add_count(), 0);
+  EXPECT_EQ(backend.remove_count(), 0);
+  EXPECT_EQ(backend.rename_count(), 0);
+}
+
+TEST(EditorNodeController, BackendFailurePreservesDocumentCounterProjectionAndSelection) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(19);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  const auto before_ids      = controller.backbone_node_ids();
+  const auto before_counter  = backend.Document().NextColorGradeNameNumber();
+  const auto before_selected = controller.selected_node_id();
+  backend.SetFailCommands(true);
+
+  EXPECT_FALSE(controller.addCleanColorGrade());
+  EXPECT_EQ(controller.backbone_node_ids(), before_ids);
+  EXPECT_EQ(backend.Document().NextColorGradeNameNumber(), before_counter);
+  EXPECT_EQ(controller.selected_node_id(), before_selected);
+  EXPECT_EQ(controller.last_error(), QStringLiteral("mini-Git journal append failed"));
+}
+
 TEST(EditorNodeController, MissingNodeAfterRefreshSelectsRemainingColorGrade) {
   EditorNodeController controller;
   auto                 document = CreateDefaultPipelineDocument();
@@ -131,6 +334,37 @@ TEST(EditorNodeController, MissingNodeAfterRefreshSelectsRemainingColorGrade) {
   ASSERT_TRUE(controller.PublishSnapshot(std::move(next)));
   EXPECT_NE(controller.selected_node_id(), NodeId{"grade.primary"});
   EXPECT_FALSE(controller.selected_node_id().Empty());
+}
+
+TEST(EditorNodeController, BlockedEditAvailabilityDisablesAddWithoutSnapshotChange) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(21);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  ASSERT_TRUE(controller.can_add_color_grade());
+
+  alcedo::EditorActionAvailability blocked;
+  backend.PublishAvailability(blocked);
+  EXPECT_FALSE(session.can_edit());
+  EXPECT_FALSE(controller.can_add_color_grade());
+  EXPECT_FALSE(controller.addCleanColorGrade());
+  EXPECT_EQ(backend.add_count(), 0);
+}
+
+TEST(EditorNodeController, ActiveCommandRejectsNestedAddBeforeBackendMutation) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(22);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  bool nested_accepted = true;
+  backend.SetBeforeAdd([&] { nested_accepted = controller.addCleanColorGrade(); });
+
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  EXPECT_FALSE(nested_accepted);
+  EXPECT_EQ(backend.add_count(), 1);
+  EXPECT_EQ(controller.backbone_node_ids().size(), 4);
 }
 
 TEST(EditorSessionToolPanelPage, AcceptsOnlyEmptyHistoryVersionsAndNodes) {

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -6,6 +6,7 @@
 #include <QPointF>
 #include <QQuickItem>
 #include <QuickQanava>
+#include <functional>
 
 #include "editor_history_versions_rail_qml_harness.hpp"
 #include "qanGraph.h"
@@ -227,17 +228,197 @@ TEST_F(EditorNodesPanelQmlTest, ReduceMotionMakesRelatedFoldsImmediate) {
   EXPECT_NEAR(drawer->property("foldProgress").toReal(), 0.0, 0.001);
 }
 
-TEST_F(EditorNodesPanelQmlTest, AddActionDoesNotMutateTheGraph) {
+TEST_F(EditorNodesPanelQmlTest, AddActionCreatesAndSelectsOneCleanColorGrade) {
   ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
   OpenNodesPage();
   QTRY_VERIFY_WITH_TIMEOUT(Find(QStringLiteral("editorNodesAddButton")) != nullptr, 2000);
   auto* add = Find(QStringLiteral("editorNodesAddButton"));
   ASSERT_NE(add, nullptr);
-  EXPECT_FALSE(add->property("enabled").toBool());
+  EXPECT_TRUE(add->property("enabled").toBool());
   EXPECT_EQ(add->property("actionName").toString(), QStringLiteral("Add Color Grade"));
   const auto history_before = backend_.history_revision();
   Click(window_, add);
-  EXPECT_EQ(backend_.history_revision(), history_before);
+  QTRY_COMPARE_WITH_TIMEOUT(backend_.add_grade_count(), 1, 2000);
+  EXPECT_EQ(backend_.history_revision(), history_before + 1);
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  EXPECT_EQ(nodes->backbone_node_ids().size(), 4);
+  EXPECT_EQ(nodes->selected_node_id(), backend_.last_added_node_id());
+  EXPECT_EQ(nodes->selected_node_name(), QStringLiteral("Color Grade 2"));
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(backend_.last_added_node_id()) != nullptr, 2000);
+  ASSERT_NE(adapter->graph(), nullptr);
+  EXPECT_EQ(adapter->graph()->getNodeCount(), 4);
+  EXPECT_EQ(nodes->graph_adapter_object(), adapter);
+  EXPECT_NE(Find(QStringLiteral("editorNodesPageBody")), nullptr);
+}
+
+TEST_F(EditorNodesPanelQmlTest, OpenNodesPageBindsTheLiveQanAdapterOnTheController) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  QTRY_VERIFY_WITH_TIMEOUT(Adapter() != nullptr, 2000);
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(nodes->graph_adapter_object() == adapter, 2000);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+}
+
+TEST_F(EditorNodesPanelQmlTest, CtrlPlusAddsTheNextCleanColorGrade) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* view  = Find(QStringLiteral("editorNodesGraphView"));
+  auto* nodes = Controller();
+  ASSERT_NE(view, nullptr);
+  ASSERT_NE(nodes, nullptr);
+  view->forceActiveFocus();
+
+  QTest::keyClick(window_, Qt::Key_Plus, Qt::ControlModifier);
+  ProcessEvents();
+
+  EXPECT_EQ(backend_.add_grade_count(), 1);
+  EXPECT_EQ(nodes->selected_node_id(), backend_.last_added_node_id());
+  EXPECT_EQ(nodes->selected_node_name(), QStringLiteral("Color Grade 2"));
+  auto* adapter = Adapter();
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(backend_.last_added_node_id()) != nullptr, 2000);
+  ASSERT_NE(adapter->graph(), nullptr);
+  EXPECT_EQ(adapter->graph()->getNodeCount(), 4);
+  EXPECT_EQ(nodes->graph_adapter_object(), adapter);
+}
+
+TEST_F(EditorNodesPanelQmlTest, F2RenamesSelectedColorGradeAndKeepsItsIdentity) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* view  = Find(QStringLiteral("editorNodesGraphView"));
+  auto* nodes = Controller();
+  ASSERT_NE(view, nullptr);
+  ASSERT_NE(nodes, nullptr);
+  view->forceActiveFocus();
+  QTest::keyClick(window_, Qt::Key_F2);
+  ProcessEvents();
+
+  auto* field = Find(QStringLiteral("editorNodeRenameField"));
+  ASSERT_NE(field, nullptr);
+  EXPECT_TRUE(field->isVisible());
+  field->setProperty("text", QStringLiteral("Sky"));
+  field->forceActiveFocus();
+  QTest::keyClick(window_, Qt::Key_Return);
+  ProcessEvents();
+
+  EXPECT_EQ(backend_.rename_grade_count(), 1);
+  EXPECT_EQ(backend_.last_renamed_node_id(), NodeId{"grade.primary"});
+  EXPECT_EQ(nodes->selected_node_id(), NodeId{"grade.primary"});
+  EXPECT_EQ(nodes->selected_node_name(), QStringLiteral("Sky"));
+}
+
+TEST_F(EditorNodesPanelQmlTest, NodeContextMenuOffersRenameAndDeleteOnlyForColorGrades) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* adapter = Adapter();
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  auto* grade_item = adapter->NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(grade_item, nullptr);
+  QTest::mouseClick(window_, Qt::RightButton, Qt::NoModifier,
+                    grade_item->mapToScene(QPointF(8, 8)).toPoint());
+  ProcessEvents();
+
+  auto* menu = window_->findChild<QObject*>(QStringLiteral("editorNodesNodeMenu"));
+  ASSERT_NE(menu, nullptr);
+  EXPECT_TRUE(menu->property("visible").toBool());
+  auto* rename = Find(QStringLiteral("editorNodesRenameMenuItem"));
+  auto* remove = Find(QStringLiteral("editorNodesDeleteMenuItem"));
+  ASSERT_NE(rename, nullptr);
+  ASSERT_NE(remove, nullptr);
+  EXPECT_TRUE(rename->property("enabled").toBool());
+  EXPECT_TRUE(remove->property("enabled").toBool());
+  EXPECT_EQ(Find(QStringLiteral("editorNodesEnableMenuItem")), nullptr);
+
+  auto* nodes = Controller();
+  ASSERT_NE(nodes, nullptr);
+  nodes->selectDevelop();
+  ProcessEvents();
+  EXPECT_FALSE(rename->property("enabled").toBool());
+  EXPECT_FALSE(remove->property("enabled").toBool());
+}
+
+TEST_F(EditorNodesPanelQmlTest, DeleteKeyRemovesSelectedGradeAndSelectsItsSuccessor) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  auto* view    = Find(QStringLiteral("editorNodesGraphView"));
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  ASSERT_NE(view, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  ASSERT_TRUE(nodes->addCleanColorGrade());
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(backend_.last_added_node_id()) != nullptr, 2000);
+  nodes->selectNode(QStringLiteral("grade.primary"));
+  view->forceActiveFocus();
+  QTest::keyClick(window_, Qt::Key_Delete);
+  ProcessEvents();
+
+  EXPECT_EQ(backend_.remove_grade_count(), 1);
+  EXPECT_EQ(backend_.last_removed_node_id(), NodeId{"grade.primary"});
+  EXPECT_EQ(nodes->selected_node_id(), backend_.last_added_node_id());
+  EXPECT_EQ(nodes->backbone_node_ids().size(), 3);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) == nullptr, 2000);
+  ASSERT_NE(adapter->graph(), nullptr);
+  EXPECT_EQ(adapter->graph()->getNodeCount(), 3);
+  const NodeId remaining[] = {NodeId{"develop"}, backend_.last_added_node_id(), NodeId{"drt"}};
+  for (const auto& id : remaining) {
+    QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(id) != nullptr, 2000);
+    auto* item = adapter->NodeFor(id)->getItem();
+    ASSERT_NE(item, nullptr);
+    EXPECT_TRUE(item->isVisible());
+    EXPECT_NE(item->parentItem(), nullptr);
+  }
+  const auto visible_on_view = [view]() {
+    int                              visible = 0;
+    std::function<void(QQuickItem*)> walk    = [&](QQuickItem* item) {
+      if (item == nullptr) {
+        return;
+      }
+      if (item->objectName() == QLatin1String("qan::NodeItem") && item->isVisible()) {
+        ++visible;
+      }
+      const auto children = item->childItems();
+      for (auto* child : children) {
+        walk(child);
+      }
+    };
+    walk(view);
+    return visible;
+  };
+  QTRY_COMPARE_WITH_TIMEOUT(visible_on_view(), 3, 2000);
+}
+
+TEST_F(EditorNodesPanelQmlTest, FailedAddKeepsPriorPermanentQanProjectionAndExactError) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* adapter = Adapter();
+  auto* nodes   = Controller();
+  auto* add     = Find(QStringLiteral("editorNodesAddButton"));
+  ASSERT_NE(adapter, nullptr);
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(add, nullptr);
+  const auto ids_before      = nodes->backbone_node_ids();
+  const auto topology_before = adapter->topology_revision();
+  backend_.SetFailNodeCommands(true);
+
+  Click(window_, add);
+  ProcessEvents();
+
+  EXPECT_EQ(nodes->backbone_node_ids(), ids_before);
+  EXPECT_EQ(adapter->topology_revision(), topology_before);
+  EXPECT_EQ(nodes->last_error(), QStringLiteral("mini-Git journal append failed"));
+  auto* error = Find(QStringLiteral("editorNodesCommandError"));
+  ASSERT_NE(error, nullptr);
+  EXPECT_EQ(error->property("text").toString(), QStringLiteral("mini-Git journal append failed"));
 }
 
 }  // namespace

--- a/alcedo_studio/tests/ui/editor_session_controller_phase5a_test.cpp
+++ b/alcedo_studio/tests/ui/editor_session_controller_phase5a_test.cpp
@@ -19,11 +19,14 @@
 #include <fstream>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "app/editor_session_bootstrap.hpp"
 #include "app/editor_session_service.hpp"
 #include "app/editor_session_types.hpp"
+#include "app/pipeline_document_history.hpp"
+#include "type/hash_type.hpp"
 #include "ui/alcedo_main/album_backend/editor_history_models.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_controller.hpp"
 #include "ui/alcedo_main/album_backend/workspace_router.hpp"
@@ -1357,5 +1360,30 @@ TEST(EditorSessionControllerPhase5ATest, InvalidVersionOrCommitIdPublishesReject
   EXPECT_EQ(controller.last_history_result().value("action").toString(),
             QStringLiteral("moveHeadToCommit"));
 }
+
+TEST(EditorSessionControllerPhase5ATest, HistoryModelPresentsTypedAddColorGradeTitleAndName) {
+  FakeSessionBackend backend;
+  backend.state_    = EditorSessionState::Interactive;
+  backend.identity_ = {42, 84};
+
+  alcedo::EditorHistoryCommit add;
+  add.commit_hash       = alcedo::Hash128(1, 0);
+  add.presentation_key  = alcedo::PresentationKeyForOperation(
+      alcedo::PipelineEditOperationKind::AddColorGrade);
+  add.node_display_name = "Color Grade 2";
+  add.after_value_json  = R"({"display_name":"Color Grade 2"})";
+  add.position          = alcedo::EditorHistoryTimelinePosition::Current;
+  backend.history_projection_.commits.push_back(std::move(add));
+
+  EditorSessionController controller(&backend);
+  EditorHistoryModel      model;
+  model.setEditorSession(&controller);
+  ASSERT_EQ(model.count(), 1);
+  EXPECT_EQ(model.data(model.index(0), EditorHistoryModel::DisplayNameRole).toString(),
+            QStringLiteral("Add Color Grade"));
+  EXPECT_EQ(model.data(model.index(0), EditorHistoryModel::DeltaTextRole).toString(),
+            QStringLiteral("Color Grade 2"));
+}
+
 }  // namespace
 }  // namespace alcedo::ui

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: NM5.1–NM5.5 complete; NM5.6–NM5.8 planned
+Status: NM5.1–NM5.6 complete; NM5.7–NM5.8 planned
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -1817,6 +1817,260 @@ Rename is metadata-only. It creates history but does not start a photo render.
 
 Record the date, commands, test count, success chain, failure chain, and render reasons here.
 
+##### NM5.6 completion record (2026-09-04)
+
+**Status:** complete — the Nodes header and `Ctrl++` add a clean Color Grade after the selected
+Grade or before DRT. F2 and the node context menu rename the selected Grade in place. Delete and
+the node context menu remove the selected Grade and select its successor, predecessor, or DRT.
+The UI exposes no Enable or Disable action and adds no persistent card actions. All three commands
+use the session queue and NM4 typed history; Qan receives only the accepted document projection.
+
+**Revision and branch:** base repository revision `2dd00168`, branch
+`feature/nodes-panel-add-rename-delete`.
+
+**Primary success call chains:**
+
+```text
+header Add or Ctrl++
+  -> EditorNodeController::addCleanColorGrade
+  -> verify the bound session, internal generation fence, and edit availability
+  -> create grade.<QUuid> and resolve the next before_node_id
+  -> EditorSessionController::SubmitAddColorGrade
+  -> EditorSessionService queue admission as CommitAdjustment
+  -> EditorSessionHistoryPort::AddColorGrade under the render lock
+  -> typed Add batch and Mini-Git WAL append
+  -> history publication and EditorNodeGraphProjection refresh
+  -> AlcedoQanGraph applies the accepted topology
+  -> select the new stable NodeId
+  -> GraphTopologyChanged Quality render
+```
+
+```text
+F2 or node-menu Rename
+  -> EditorNodeController::renameColorGrade
+  -> reject endpoints, missing ids, blank names, stale sessions, and blocked edits
+  -> EditorSessionController::SubmitRenameColorGrade
+  -> EditorSessionService queue admission as CommitAdjustment
+  -> EditorSessionHistoryPort::RenameColorGrade
+  -> typed Rename batch and Mini-Git WAL append
+  -> metadata projection refresh with the same NodeId and selection
+  -> no render reason and no photo render
+```
+
+```text
+Delete key or node-menu Delete
+  -> EditorNodeController::deleteColorGrade
+  -> verify a live Color Grade and remember successor plus predecessor
+  -> EditorSessionController::SubmitRemoveColorGrade
+  -> EditorSessionService queue admission as CommitAdjustment
+  -> EditorSessionHistoryPort::RemoveColorGrade
+  -> typed Remove batch bridges the exact backbone neighbors and appends the WAL record
+  -> accepted topology projection replaces the permanent Qan topology
+  -> select successor, predecessor, or DRT; retain the removed NodeId for Undo selection restore
+  -> GraphTopologyChanged Quality render
+```
+
+**Failure chain:**
+
+```text
+invalid endpoint, missing NodeId, stale internal generation, blocked action, or active command
+  -> reject before history mutation
+
+domain validation or Mini-Git WAL append failure
+  -> NM4 restores document, head, default-name counter, and published render reason
+  -> EditorSessionService returns the exact error without routing a render
+  -> EditorNodeController keeps selection and the accepted projection
+  -> AlcedoQanGraph creates no temporary permanent node or edge
+  -> EditorNodesPanel shows the exact error
+```
+
+**Render reasons:** successful Add and Delete publish `GraphTopologyChanged`, which routes one
+Quality render. Rename publishes no render reason and routes no photo render. Failed commands do
+not change the prior published render reason and route no render.
+
+**Tests and evidence:**
+
+| Target or suite | Result |
+| --- | --- |
+| `EditorSessionNodeCommandTest` | 4/4 passed: queue/service routing, one history change, Add/Delete topology render, Rename no-render, and exact failure publication. |
+| `EditorSessionActionPolicyCq3Test` | 12/12 passed: the new command kinds use settled-edit admission, and public QML/API generation tokens remain absent. |
+| `EditorNodeSelectionLayoutTest` | 16/16 passed: stable Add placement/name, Rename identity, Delete fallback, Undo selection restore, endpoint/missing-id/stale-session rejection, and failure preservation. |
+| `EditorNodesPanelQmlTest` | 14/14 passed: header Add, `Ctrl++`, F2, Delete, the shared right-click menu, no Enable action, exact error text, and unchanged permanent Qan projection on failure. |
+| `AlcedoQanGraphTest` | 10/10 passed: live identity mapping, role-only Rename, topology replacement, stale-pointer rejection, and adapter rollback. |
+| Filtered `EditorSessionHistoryPortTest` and `EditorDocumentHistoryTest` | 51/51 passed: real typed Add/Rename/Delete Undo/Redo, exact edges and Mask content, render intent, and real WAL-open failure restoration. |
+| **Focused direct runtime execution** | **107/107 passed across six binaries.** |
+| `ctest --test-dir build/debug -L quickqanava --output-on-failure` | **41/41 passed.** |
+
+Build and test commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSessionActionPolicyCq3Test EditorSessionNodeCommandTest EditorNodeSelectionLayoutTest EditorNodesPanelQmlTest EditorSessionHistoryPortTest AlcedoQanGraphTest alcedo_main
+ctest --test-dir build/debug -L quickqanava --output-on-failure
+```
+
+The six focused binaries were also run directly from their generated `_runtime` directories. The
+production `alcedo_main` target and the QML cache compilation completed successfully. The wrapper
+printed its existing `vswhere.exe` lookup warning but found the configured MSVC environment and
+completed each build.
+
+**Pinned API differences:** the online Nodes documentation describes graph-level selection and
+node-event observation but does not give the QML callback parameter list used here. The pinned
+2.50 `qanGraphView.h` exposes `nodeRightClicked(qan::Node*, QPointF)`. The Nodes page therefore
+handles pinned `onNodeRightClicked(node, position)`, resolves the `qan::Node*` through
+`AlcedoQanGraph::liveNodeId`, and opens the shared menu only for a current mapped node. No pinned
+source was changed.
+
+**LOC note (grill-code-review):** the implementation adds 631 production lines and 554 test lines,
+including the new 131-line focused service test. The largest touched production files were already
+large orchestration files; the focused additions remain in their existing queue, controller, and
+history responsibilities. `EditorNodeController` is 519 lines and `EditorNodesPanel.qml` is 467
+lines after this phase. No new file exceeds the review threshold.
+
+**Review result:** grill-code-review found no remaining high-confidence correctness, ownership,
+performance, naming, fixture-fidelity, or maintainability blocker. Its verification pass caught
+and closed queue-admission mapping, public generation-token exposure, duplicate projection refresh,
+right-click coordinate routing, and formatter-churn issues before completion.
+
+**Residual gaps:** NM5.7 still owns the request-only visual connector and Reconnect UI. NM5.8 still
+owns final accessibility/localization/theme audits plus Windows install/package and available-macOS
+qualification. Those later checks are not claimed here.
+
+##### NM5.6 completion record (2026-09-04, history presentation and session availability)
+
+**Status:** complete — typed Add/Rename/Delete history rows show saved Color Grade names instead of
+the generic adjustment “Edit” title, and Nodes Add/Rename/Delete disable when session
+`can_edit` flips through `ActionAvailabilityChanged` without a snapshot change. Nested Add while a
+command is already active is rejected before a second backend mutation. Undo of Delete restores the
+removed Grade’s Mask drawer content on the node projection.
+
+This record covers the residual of 13.5 (`history presentation`, `session action availability`) and
+the 13.6 Mask-restore and command-active criteria. The earlier 2026-09-04 record still covers the
+header/`Ctrl++`/F2/Delete command path.
+
+**Revision and branch:** base repository revision `2dd00168`, branch
+`feature/nodes-panel-add-rename-delete`.
+
+**Primary success call chain:**
+
+```text
+typed Add / Rename / Delete commit
+  -> ProjectPipelineEditHistory
+  -> EditorHistoryCommit.presentation_key + node_display_name
+  -> PresentEditorHistoryCommit(commit)
+  -> EditorHistoryModel displayName / deltaText
+```
+
+```text
+header Add / Ctrl++ / F2 rename / Delete
+  -> EditorNodeController
+  -> EditorSessionController::Submit*
+  -> EditorSessionService queue (CommitAdjustment admission)
+  -> EditorSessionHistoryPort typed batch + WAL
+  -> projection / AlcedoQanGraph after accept
+  -> Add/Delete: GraphTopologyChanged Quality render; Rename: no render
+```
+
+**Availability call chain:**
+
+```text
+session ActionAvailabilityChanged (observer, no StateChanged)
+  -> EditorNodeController::ActionAvailabilityChanged
+  -> QML re-reads canAddColorGrade / canRenameColorGrade / canDeleteColorGrade
+```
+
+**Primary failure call chain:**
+
+```text
+blocked can_edit / command_active_ / WAL append failure
+  -> reject before mutation, or restore document / counter / projection / selection
+  -> exact error
+  -> no temporary permanent Qan node
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `TypedGraphOperationsUseSavedNamesAndKeepAdjustmentRows` | `EditorSessionHistoryPortTest` | PASS |
+| `AddRenameAndDeleteSnapshotsPresentTypedHistoryTitles` | `EditorSessionHistoryPortTest` (`EditorDocumentHistoryTest`) | PASS |
+| `HistoryModelPresentsTypedAddColorGradeTitleAndName` | `EditorSessionControllerPhase5ATest` | PASS |
+| `BlockedEditAvailabilityDisablesAddWithoutSnapshotChange` | `EditorNodeSelectionLayoutTest` | PASS |
+| `ActiveCommandRejectsNestedAddBeforeBackendMutation` | `EditorNodeSelectionLayoutTest` | PASS |
+| `DeleteSelectsSuccessorThenUndoProjectionRestoresDeletedSelection` (Mask restore) | `EditorNodeSelectionLayoutTest` | PASS |
+| Add/Rename/Delete queue, render, exact WAL error | `EditorSessionNodeCommandTest` | PASS 4/4 |
+| Settled-edit admission for graph command kinds | `EditorSessionActionPolicyCq3Test` | PASS 12/12 |
+| Header Add, `Ctrl++`, F2, Delete, context menu, failure Qan | `EditorNodesPanelQmlTest` | PASS 14/14 |
+| Role-only Rename, topology replacement, adapter rollback | `AlcedoQanGraphTest` | PASS 10/10 |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSessionHistoryPortTest EditorNodeSelectionLayoutTest EditorSessionControllerPhase5ATest EditorNodesPanelQmlTest EditorSessionNodeCommandTest EditorSessionActionPolicyCq3Test AlcedoQanGraphTest
+```
+
+Ninja reported no outstanding work for those targets (they were already built in this tree). The
+seven binaries were then run directly from their `_runtime` directories. Suite totals:
+**174/174 passed** (72 + 18 + 44 + 4 + 12 + 14 + 10). Logs:
+`build/tmp/nm5.6-residual/<binary>.log`. `ctest -L quickqanava` was not re-run in this residual
+pass; the labeled Qan binaries above were executed directly instead.
+
+**Checklist / exit condition:** 13.3 items 1–11 and 13.6 remain satisfied, including History titles
+for typed graph operations, session action availability without a snapshot change, nested-command
+rejection, and Undo restoring Mask drawer content on the node projection.
+
+**LOC note (grill-code-review):** residual production is the commit-object
+`PresentEditorHistoryCommit` overload (~80 lines in
+`editor_history_commit_presentation.cpp`) plus `EditorHistoryModel::PresentationFor` using that
+overload and `EditorNodeController` forwarding `ActionAvailabilityChanged`. Residual tests add the
+six named cases above. `editor_history_commit_presentation.cpp` is 788 lines;
+`editor_node_controller.cpp` is 473 lines. No new file exceeds the review split threshold.
+
+**Remaining gaps:** NM5.7 still owns the request-only visual connector and Reconnect UI. NM5.8 still
+owns final accessibility/localization/theme audits plus Windows install/package and available-macOS
+qualification.
+
+##### NM5.6 completion record (2026-09-04, live Qan apply on the open Nodes page)
+
+**Status:** complete — Add, Rename, and Delete apply the published snapshot onto the bound
+`AlcedoQanGraph` from `EditorNodeController` while the Nodes page stays open. The page binds
+`graphAdapter` for the life of the Loader and clears it on destroy. Topology rebuilds re-parent
+and show live node and edge items on the GraphView container, so the user does not close and
+reopen the panel to see the accepted backbone.
+
+**Revision and branch:** base repository revision `2dd00168`, branch
+`feature/nodes-panel-add-rename-delete`.
+
+**Primary success call chain:**
+
+```text
+Add / Rename / Delete
+  -> EditorSessionService typed history accept
+  -> EditorNodeController::refreshFromSession / PublishSnapshot
+  -> QueueProjectionApply
+  -> ApplyBoundGraph
+  -> AlcedoQanGraph::ApplySnapshot
+  -> AttachLiveVisuals on the GraphView container
+```
+
+**What was proven (executed tests):**
+
+| Target or suite | Result |
+| --- | --- |
+| `EditorNodeSelectionLayoutTest` | 19/19 passed, including live adapter/layout binding and Undo selection restore. |
+| `EditorNodesPanelQmlTest` | 15/15 passed, including open-page adapter bind, live Add Qan identity, and Delete successor cards remaining visible on the GraphView. |
+| `AlcedoQanGraphTest` | 11/11 passed, including topology replacement and hidden removed cards. |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorNodeSelectionLayoutTest EditorNodesPanelQmlTest AlcedoQanGraphTest alcedo_main
+```
+
+The three binaries were run directly from their `_runtime` directories after the live-apply
+change. `alcedo_main` linked with the updated QML cache. macOS checks were not run on this
+Windows host. NM5.7–NM5.8 remain outside this sub-phase.
+
 ---
 
 ## 14. NM5.7 — Request-only visual connector and Reconnect
@@ -2092,8 +2346,8 @@ Do not reduce decode resolution, output quality, or backend behavior to meet the
 - [x] The initial layout is vertical and deterministic.
 - [x] Node positions, view, zoom, selection, and drawer state are local UI state.
 - [x] The product allows one selected node.
-- [ ] Add creates a clean Color Grade.
-- [ ] Rename and Delete use NM4 typed history.
+- [x] Add creates a clean Color Grade.
+- [x] Rename and Delete use NM4 typed history.
 - [ ] Reconnect uses the official visual connector.
 - [ ] `connectorCreateDefaultEdge` is false.
 - [ ] The backend accepts a request before permanent Qan edges change.


### PR DESCRIPTION
## Summary

- Add session-queue Color Grade Add, Rename, and Delete through NM4 typed history. Add and Delete route one `GraphTopologyChanged` Quality render; Rename is metadata-only and does not start a photo render.
- Wire the Nodes header, `Ctrl++`, F2, Delete, and the shared node context menu to `EditorNodeController`. Develop and DRT reject Rename and Delete. There is no Enable or Disable action.
- Show saved Color Grade names on typed history rows, and disable Add/Rename/Delete when session `can_edit` flips without a snapshot change.
- Bind the open `AlcedoQanGraph` as `graphAdapter` so the live canvas updates without closing the Nodes page. Topology rebuilds re-parent and show cards on the GraphView container.
- Mark NM5.6 complete in the roadmap.

## Validation

- `cmd /c scripts\msvc_env.cmd --preset win_debug`
- `cmd /c scripts\msvc_env.cmd --build --preset win_debug --target EditorSessionActionPolicyCq3Test EditorSessionNodeCommandTest EditorNodeSelectionLayoutTest EditorNodesPanelQmlTest EditorSessionHistoryPortTest EditorSessionControllerPhase5ATest AlcedoQanGraphTest alcedo_main --parallel 4`
- `EditorSessionNodeCommandTest.exe --gtest_color=no` — 4 tests passed.
- `EditorSessionActionPolicyCq3Test.exe --gtest_color=no` — 12 tests passed.
- `EditorSessionHistoryPortTest.exe --gtest_color=no` — 72 tests passed.
- `EditorSessionControllerPhase5ATest.exe --gtest_color=no` — 44 tests passed.
- `EditorNodeSelectionLayoutTest.exe --gtest_color=no` — 19 tests passed.
- `EditorNodesPanelQmlTest.exe --gtest_color=no` — 15 tests passed.
- `AlcedoQanGraphTest.exe --gtest_color=no` — 11 tests passed.
- Direct execution of all 7 generated `_runtime` test binaries — 177 tests passed.
- `git diff --check` — passed.
- New C++ source files pass `clang-format --dry-run --Werror`.

## Known limitation

The selected CTest listing is blocked before these targets by the existing UI `PRE_TEST` discovery, which launches `SharedToneCurveTest_runtime/SharedToneCurveTest.exe` and hits the pre-existing lensfun runtime entry-point mismatch (`0xc0000139`). The new and focused test binaries were run directly and passed 177 tests. macOS validation was not available on this Windows host. NM5.7–NM5.8 remain outside this PR scope.
