### PR TITLE
feat(ui): make Nodes an incremental topology editor

### DIFF
--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -403,6 +403,13 @@ def_library(EditorNodeGraphProjection
     PUBLIC_DEPS EditGraph
 )
 
+def_library(EditorNodeGraphDraft
+    SOURCES
+        "${ALCEDO_APP_ROOT}/editor_node_graph_draft.cpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_node_graph_draft.hpp"
+    PUBLIC_DEPS EditorNodeGraphProjection EditHistory EditGraph
+)
+
 def_library(PipelineHistoryApplier
     SOURCES
         "${ALCEDO_APP_ROOT}/pipeline_history_applier.cpp"

--- a/alcedo_studio/src/app/editor_action_policy.cpp
+++ b/alcedo_studio/src/app/editor_action_policy.cpp
@@ -160,6 +160,7 @@ auto EditorActionPolicy::ActionForCommand(EditorSessionCommandKind kind)
     case EditorSessionCommandKind::AddColorGrade:
     case EditorSessionCommandKind::RemoveColorGrade:
     case EditorSessionCommandKind::RenameColorGrade:
+    case EditorSessionCommandKind::ReconnectColorGrade:
       return EditorAction::CommitAdjustment;
     case EditorSessionCommandKind::Undo:
       return EditorAction::Undo;

--- a/alcedo_studio/src/app/editor_action_policy.cpp
+++ b/alcedo_studio/src/app/editor_action_policy.cpp
@@ -161,6 +161,7 @@ auto EditorActionPolicy::ActionForCommand(EditorSessionCommandKind kind)
     case EditorSessionCommandKind::RemoveColorGrade:
     case EditorSessionCommandKind::RenameColorGrade:
     case EditorSessionCommandKind::ReconnectColorGrade:
+    case EditorSessionCommandKind::EditNodeGraph:
       return EditorAction::CommitAdjustment;
     case EditorSessionCommandKind::Undo:
       return EditorAction::Undo;

--- a/alcedo_studio/src/app/editor_node_graph_draft.cpp
+++ b/alcedo_studio/src/app/editor_node_graph_draft.cpp
@@ -1,0 +1,555 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_node_graph_draft.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <stdexcept>
+#include <unordered_set>
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+
+namespace alcedo {
+
+auto EditorNodeGraphDraft::ImagePort() -> PortId { return PortId{"image"}; }
+
+auto EditorNodeGraphDraft::EdgeKey(const EditorNodeEdgeProjection& edge) -> std::string {
+  return std::string{edge.source_node_id.Value()} + "/" + std::string{edge.source_port_id.Value()} +
+         "->" + std::string{edge.destination_node_id.Value()} + "/" +
+         std::string{edge.destination_port_id.Value()};
+}
+
+auto EditorNodeGraphDraft::EdgeKey(const PipelineSceneEdge& edge) -> std::string {
+  return std::string{edge.from_node.Value()} + "/" + std::string{edge.from_port.Value()} + "->" +
+         std::string{edge.to_node.Value()} + "/" + std::string{edge.to_port.Value()};
+}
+
+auto EditorNodeGraphDraft::ToSceneEdge(const EditorNodeEdgeProjection& edge) -> PipelineSceneEdge {
+  return PipelineSceneEdge{edge.source_node_id, edge.source_port_id, edge.destination_node_id,
+                           edge.destination_port_id};
+}
+
+auto EditorNodeGraphDraft::ToProjection(const PipelineSceneEdge& edge) -> EditorNodeEdgeProjection {
+  return EditorNodeEdgeProjection{edge.from_node, edge.from_port, edge.to_node, edge.to_port};
+}
+
+auto EditorNodeGraphDraft::KindOf(const INodeModel& node) -> EditorNodeKind {
+  if (node.Type() == type_ids::DevelopNode()) {
+    return EditorNodeKind::Develop;
+  }
+  if (node.Type() == type_ids::DrtNode()) {
+    return EditorNodeKind::Drt;
+  }
+  if (node.Type() == type_ids::ColorGradeNode()) {
+    return EditorNodeKind::ColorGrade;
+  }
+  throw std::invalid_argument("Unsupported node type: " + std::string{node.Type().Text()});
+}
+
+auto EditorNodeGraphDraft::ProjectNode(const INodeModel& node) const -> EditorNodeProjection {
+  EditorNodeProjection projected;
+  projected.node_id      = node.Id();
+  projected.node_kind    = KindOf(node);
+  projected.display_name = std::string{node.DisplayName()};
+  if (projected.node_kind == EditorNodeKind::ColorGrade) {
+    const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(&node);
+    if (grade == nullptr) {
+      throw std::invalid_argument("Color Grade type has an invalid model");
+    }
+    projected.masks.reserve(grade->MaskCount());
+    for (const auto& mask : grade->Masks()) {
+      projected.masks.push_back({mask.id, GetMaskSourceKind(mask.source)});
+    }
+  }
+  return projected;
+}
+
+auto EditorNodeGraphDraft::FromDocument(const PipelineDocument& document,
+                                        EditorNodeGraphDraftIdentity identity)
+    -> EditorNodeGraphDraft {
+  EditorNodeGraphDraft draft;
+  draft.identity_                = std::move(identity);
+  draft.base_next_name_number_   = document.NextColorGradeNameNumber();
+  draft.draft_next_name_number_  = draft.base_next_name_number_;
+  const auto& graph              = document.Graph();
+  draft.nodes_.reserve(graph.Nodes().size());
+  for (std::size_t index = 0; index < graph.Nodes().size(); ++index) {
+    const auto* node = graph.Nodes()[index].get();
+    if (node == nullptr) {
+      throw std::invalid_argument("Pipeline graph contains a null node");
+    }
+    auto projected = draft.ProjectNode(*node);
+    draft.node_json_[projected.node_id]      = node->ToJson();
+    draft.base_node_json_[projected.node_id] = draft.node_json_[projected.node_id];
+    draft.base_node_index_[projected.node_id] = index;
+    draft.nodes_.push_back(std::move(projected));
+  }
+  draft.edges_.reserve(graph.Edges().size());
+  draft.base_edges_.reserve(graph.Edges().size());
+  for (std::size_t index = 0; index < graph.Edges().size(); ++index) {
+    const auto& edge = graph.Edges()[index];
+    const auto  scene = PipelineSceneEdge{edge.from_node, edge.from_port, edge.to_node, edge.to_port};
+    draft.base_edges_.push_back(scene);
+    draft.base_edge_index_[EdgeKey(scene)] = index;
+    draft.edges_.push_back(ToProjection(scene));
+  }
+  draft.RebuildIndexes();
+  return draft;
+}
+
+void EditorNodeGraphDraft::RebuildIndexes() {
+  node_index_.clear();
+  edge_index_.clear();
+  outgoing_.clear();
+  incoming_.clear();
+  for (std::size_t index = 0; index < nodes_.size(); ++index) {
+    node_index_[nodes_[index].node_id] = index;
+    outgoing_[nodes_[index].node_id]   = std::nullopt;
+    incoming_[nodes_[index].node_id]   = std::nullopt;
+  }
+  for (std::size_t index = 0; index < edges_.size(); ++index) {
+    const auto& edge = edges_[index];
+    edge_index_[EdgeKey(edge)]              = index;
+    outgoing_[edge.source_node_id]          = index;
+    incoming_[edge.destination_node_id]     = index;
+  }
+}
+
+auto EditorNodeGraphDraft::FindNode(const NodeId& node_id) const -> const EditorNodeProjection* {
+  const auto it = node_index_.find(node_id);
+  if (it == node_index_.end()) {
+    return nullptr;
+  }
+  return &nodes_[it->second];
+}
+
+auto EditorNodeGraphDraft::NodeJson(const NodeId& node_id) const -> const nlohmann::json* {
+  const auto it = node_json_.find(node_id);
+  if (it == node_json_.end()) {
+    return nullptr;
+  }
+  return &it->second;
+}
+
+auto EditorNodeGraphDraft::MatchesBase(const PipelineDocument& document) const -> bool {
+  const auto& graph = document.Graph();
+  if (graph.Nodes().size() != base_node_index_.size() ||
+      graph.Edges().size() != base_edges_.size() ||
+      document.NextColorGradeNameNumber() != base_next_name_number_) {
+    return false;
+  }
+  for (std::size_t index = 0; index < graph.Nodes().size(); ++index) {
+    const auto* node = graph.Nodes()[index].get();
+    if (node == nullptr) {
+      return false;
+    }
+    const auto found = base_node_index_.find(node->Id());
+    if (found == base_node_index_.end() || found->second != index) {
+      return false;
+    }
+  }
+  for (std::size_t index = 0; index < graph.Edges().size(); ++index) {
+    const auto& edge = graph.Edges()[index];
+    if (!(base_edges_[index] ==
+          PipelineSceneEdge{edge.from_node, edge.from_port, edge.to_node, edge.to_port})) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void EditorNodeGraphDraft::CaptureCheckpoint() {
+  checkpoint_.nodes                        = nodes_;
+  checkpoint_.edges                        = edges_;
+  checkpoint_.node_json                    = node_json_;
+  checkpoint_.node_index                   = node_index_;
+  checkpoint_.edge_index                   = edge_index_;
+  checkpoint_.outgoing                     = outgoing_;
+  checkpoint_.incoming                     = incoming_;
+  checkpoint_.inserted_json                = inserted_json_;
+  checkpoint_.removed_original_index       = removed_original_index_;
+  checkpoint_.removed_json                 = removed_json_;
+  checkpoint_.disconnected_original_index  = disconnected_original_index_;
+  checkpoint_.disconnected_edge            = disconnected_edge_;
+  checkpoint_.connected_edge               = connected_edge_;
+  checkpoint_.draft_next_name_number       = draft_next_name_number_;
+  has_checkpoint_                          = true;
+}
+
+void EditorNodeGraphDraft::RestoreLastMutation() {
+  if (!has_checkpoint_) {
+    return;
+  }
+  nodes_                       = checkpoint_.nodes;
+  edges_                       = checkpoint_.edges;
+  node_json_                   = checkpoint_.node_json;
+  node_index_                  = checkpoint_.node_index;
+  edge_index_                  = checkpoint_.edge_index;
+  outgoing_                    = checkpoint_.outgoing;
+  incoming_                    = checkpoint_.incoming;
+  inserted_json_               = checkpoint_.inserted_json;
+  removed_original_index_      = checkpoint_.removed_original_index;
+  removed_json_                = checkpoint_.removed_json;
+  disconnected_original_index_ = checkpoint_.disconnected_original_index;
+  disconnected_edge_           = checkpoint_.disconnected_edge;
+  connected_edge_              = checkpoint_.connected_edge;
+  draft_next_name_number_      = checkpoint_.draft_next_name_number;
+  has_checkpoint_              = false;
+}
+
+auto EditorNodeGraphDraft::DeltaEmpty() const -> bool {
+  return inserted_json_.empty() && removed_json_.empty() && disconnected_edge_.empty() &&
+         connected_edge_.empty() && draft_next_name_number_ == base_next_name_number_;
+}
+
+auto EditorNodeGraphDraft::WouldCreateCycle(const NodeId& source_id, const NodeId& destination_id,
+                                            const std::optional<std::size_t>& skip_outgoing,
+                                            const std::optional<std::size_t>& skip_incoming) const
+    -> bool {
+  std::unordered_set<std::string> visited;
+  std::vector<NodeId>             stack{destination_id};
+  while (!stack.empty()) {
+    const auto current = stack.back();
+    stack.pop_back();
+    const auto key = std::string{current.Value()};
+    if (!visited.insert(key).second) {
+      continue;
+    }
+    if (current == source_id) {
+      return true;
+    }
+    const auto out = outgoing_.find(current);
+    if (out == outgoing_.end() || !out->second.has_value()) {
+      continue;
+    }
+    const auto index = *out->second;
+    if (skip_outgoing.has_value() && index == *skip_outgoing) {
+      continue;
+    }
+    if (skip_incoming.has_value() && index == *skip_incoming) {
+      continue;
+    }
+    stack.push_back(edges_[index].destination_node_id);
+  }
+  return false;
+}
+
+auto EditorNodeGraphDraft::AdmitConnect(const NodeId& source_id, const NodeId& destination_id,
+                                        std::string* error) const -> bool {
+  auto fail = [&](std::string message) {
+    if (error != nullptr) {
+      *error = std::move(message);
+    }
+    return false;
+  };
+  const auto* source      = FindNode(source_id);
+  const auto* destination = FindNode(destination_id);
+  if (source == nullptr || destination == nullptr) {
+    return fail("That node is not in the current graph");
+  }
+  if (source_id == destination_id) {
+    return fail("A node cannot connect to itself");
+  }
+  if (destination->node_kind == EditorNodeKind::Develop) {
+    return fail("Develop has no incoming image port");
+  }
+  if (source->node_kind == EditorNodeKind::Drt) {
+    return fail("DRT/Post has no outgoing image port");
+  }
+  if (source->node_kind != EditorNodeKind::Develop &&
+      source->node_kind != EditorNodeKind::ColorGrade) {
+    return fail("Unsupported source node type: " + std::string{source->node_id.Value()});
+  }
+  if (destination->node_kind != EditorNodeKind::Drt &&
+      destination->node_kind != EditorNodeKind::ColorGrade) {
+    return fail("Unsupported destination node type: " + std::string{destination->node_id.Value()});
+  }
+  const auto skip_out = outgoing_.at(source_id);
+  const auto skip_in  = incoming_.at(destination_id);
+  if (WouldCreateCycle(source_id, destination_id, skip_out, skip_in)) {
+    return fail("That connection would create a cycle");
+  }
+  return true;
+}
+
+auto EditorNodeGraphDraft::RemoveEdgeAt(std::size_t index) -> EditorNodeEdgeProjection {
+  auto edge = edges_[index];
+  edges_.erase(edges_.begin() + static_cast<std::ptrdiff_t>(index));
+  RebuildIndexes();
+  return edge;
+}
+
+void EditorNodeGraphDraft::InsertEdge(EditorNodeEdgeProjection edge) {
+  edges_.push_back(std::move(edge));
+  RebuildIndexes();
+}
+
+auto EditorNodeGraphDraft::FinishMutation(EditorNodeGraphDraftMutation mutation)
+    -> EditorNodeGraphDraftMutation {
+  mutation.delta_empty      = DeltaEmpty();
+  mutation.submission_valid = SubmissionValid();
+  mutation.succeeded        = true;
+  return mutation;
+}
+
+auto EditorNodeGraphDraft::AddColorGrade(NodeId node_id) -> EditorNodeGraphDraftMutation {
+  EditorNodeGraphDraftMutation result;
+  if (node_id.Empty() || FindNode(node_id) != nullptr) {
+    result.error = "A Color Grade with that identity already exists";
+    return result;
+  }
+  CaptureCheckpoint();
+  auto model = CreateCleanColorGradeNode(node_id);
+  model->SetDisplayName(DefaultColorGradeDisplayName(draft_next_name_number_));
+  auto json      = model->ToJson();
+  auto projected = ProjectNode(*model);
+  nodes_.push_back(projected);
+  node_json_[node_id]      = json;
+  inserted_json_[node_id]  = json;
+  ++draft_next_name_number_;
+  RebuildIndexes();
+  result.inserted_nodes.push_back(std::move(projected));
+  return FinishMutation(std::move(result));
+}
+
+auto EditorNodeGraphDraft::RemoveColorGrade(const NodeId& node_id)
+    -> EditorNodeGraphDraftMutation {
+  EditorNodeGraphDraftMutation result;
+  const auto* node = FindNode(node_id);
+  if (node == nullptr) {
+    result.error = "That node is not in the current graph";
+    return result;
+  }
+  if (node->node_kind != EditorNodeKind::ColorGrade) {
+    result.error = "Only a Color Grade can be deleted";
+    return result;
+  }
+  CaptureCheckpoint();
+  const auto out = outgoing_[node_id];
+  const auto in  = incoming_[node_id];
+  std::vector<std::size_t> remove_indexes;
+  if (out.has_value()) {
+    remove_indexes.push_back(*out);
+  }
+  if (in.has_value() && (!out.has_value() || *in != *out)) {
+    remove_indexes.push_back(*in);
+  }
+  std::sort(remove_indexes.begin(), remove_indexes.end(), std::greater<>());
+  for (const auto index : remove_indexes) {
+    const auto edge = RemoveEdgeAt(index);
+    result.removed_edges.push_back(edge);
+    const auto key = EdgeKey(edge);
+    const auto connected = connected_edge_.find(key);
+    if (connected != connected_edge_.end()) {
+      connected_edge_.erase(connected);
+    } else if (base_edge_index_.contains(key)) {
+      disconnected_original_index_[key] = base_edge_index_.at(key);
+      disconnected_edge_[key]           = ToSceneEdge(edge);
+    }
+  }
+
+  const auto node_pos = node_index_.at(node_id);
+  const auto json     = node_json_.at(node_id);
+  nodes_.erase(nodes_.begin() + static_cast<std::ptrdiff_t>(node_pos));
+  node_json_.erase(node_id);
+  result.removed_node_ids.push_back(node_id);
+  const auto inserted = inserted_json_.find(node_id);
+  if (inserted != inserted_json_.end()) {
+    inserted_json_.erase(inserted);
+    std::uint64_t max_inserted = base_next_name_number_;
+    for (const auto& [id, stored] : inserted_json_) {
+      (void)id;
+      if (stored.contains("display_name") && stored.at("display_name").is_string()) {
+        const auto name = stored.at("display_name").get<std::string>();
+        const auto prefix = std::string{"Color Grade "};
+        if (name.rfind(prefix, 0) == 0) {
+          try {
+            const auto number = std::stoull(name.substr(prefix.size()));
+            max_inserted      = std::max(max_inserted, number + 1);
+          } catch (...) {
+          }
+        }
+      }
+    }
+    draft_next_name_number_ = inserted_json_.empty() ? base_next_name_number_ : max_inserted;
+  } else {
+    removed_original_index_[node_id] = base_node_index_.at(node_id);
+    removed_json_[node_id]           = json;
+  }
+  RebuildIndexes();
+  return FinishMutation(std::move(result));
+}
+
+auto EditorNodeGraphDraft::Connect(const NodeId& source_id, const NodeId& destination_id)
+    -> EditorNodeGraphDraftMutation {
+  EditorNodeGraphDraftMutation result;
+  std::string                  error;
+  if (!AdmitConnect(source_id, destination_id, &error)) {
+    result.error = std::move(error);
+    return result;
+  }
+  const auto skip_out = outgoing_.at(source_id);
+  const auto skip_in  = incoming_.at(destination_id);
+  EditorNodeEdgeProjection proposed{source_id, ImagePort(), destination_id, ImagePort()};
+  if (skip_out.has_value() && edges_[*skip_out].destination_node_id == destination_id &&
+      edges_[*skip_out].source_node_id == source_id) {
+    result.no_op      = true;
+    result.succeeded  = true;
+    result.delta_empty = DeltaEmpty();
+    result.submission_valid = SubmissionValid();
+    return result;
+  }
+
+  CaptureCheckpoint();
+  std::vector<std::size_t> remove_indexes;
+  if (skip_out.has_value()) {
+    remove_indexes.push_back(*skip_out);
+  }
+  if (skip_in.has_value() && (!skip_out.has_value() || *skip_in != *skip_out)) {
+    remove_indexes.push_back(*skip_in);
+  }
+  std::sort(remove_indexes.begin(), remove_indexes.end(), std::greater<>());
+  for (const auto index : remove_indexes) {
+    const auto edge = RemoveEdgeAt(index);
+    result.removed_edges.push_back(edge);
+    const auto key = EdgeKey(edge);
+    const auto connected = connected_edge_.find(key);
+    if (connected != connected_edge_.end()) {
+      connected_edge_.erase(connected);
+    } else if (base_edge_index_.contains(key)) {
+      disconnected_original_index_[key] = base_edge_index_.at(key);
+      disconnected_edge_[key]           = ToSceneEdge(edge);
+    }
+  }
+
+  const auto key = EdgeKey(proposed);
+  InsertEdge(proposed);
+  result.inserted_edges.push_back(proposed);
+  const auto disconnected = disconnected_edge_.find(key);
+  if (disconnected != disconnected_edge_.end()) {
+    disconnected_edge_.erase(disconnected);
+    disconnected_original_index_.erase(key);
+  } else {
+    connected_edge_[key] = ToSceneEdge(proposed);
+  }
+  return FinishMutation(std::move(result));
+}
+
+auto EditorNodeGraphDraft::SubmissionValid() const -> bool {
+  int develop_count = 0;
+  int drt_count     = 0;
+  const EditorNodeProjection* develop = nullptr;
+  const EditorNodeProjection* drt     = nullptr;
+  for (const auto& node : nodes_) {
+    if (node.node_kind == EditorNodeKind::Develop) {
+      ++develop_count;
+      develop = &node;
+    } else if (node.node_kind == EditorNodeKind::Drt) {
+      ++drt_count;
+      drt = &node;
+    } else if (node.node_kind != EditorNodeKind::ColorGrade) {
+      return false;
+    }
+  }
+  if (develop_count != 1 || drt_count != 1 || develop == nullptr || drt == nullptr) {
+    return false;
+  }
+
+  std::map<NodeId, int> outgoing_count;
+  std::map<NodeId, int> incoming_count;
+  for (const auto& edge : edges_) {
+    if (edge.source_port_id != ImagePort() || edge.destination_port_id != ImagePort()) {
+      return false;
+    }
+    ++outgoing_count[edge.source_node_id];
+    ++incoming_count[edge.destination_node_id];
+    if (outgoing_count[edge.source_node_id] > 1 || incoming_count[edge.destination_node_id] > 1) {
+      return false;
+    }
+  }
+  if (incoming_count[develop->node_id] != 0 || outgoing_count[drt->node_id] != 0) {
+    return false;
+  }
+
+  std::unordered_set<std::string> on_path;
+  NodeId                          current = develop->node_id;
+  while (true) {
+    const auto key = std::string{current.Value()};
+    if (!on_path.insert(key).second) {
+      return false;
+    }
+    if (current == drt->node_id) {
+      break;
+    }
+    const auto out = outgoing_.find(current);
+    if (out == outgoing_.end() || !out->second.has_value()) {
+      return false;
+    }
+    current = edges_[*out->second].destination_node_id;
+  }
+  if (!on_path.contains(std::string{drt->node_id.Value()})) {
+    return false;
+  }
+  for (const auto& node : nodes_) {
+    if (node.node_kind == EditorNodeKind::ColorGrade &&
+        !on_path.contains(std::string{node.node_id.Value()})) {
+      return false;
+    }
+    if (node.node_kind != EditorNodeKind::Develop && incoming_count[node.node_id] != 1) {
+      return false;
+    }
+    if (node.node_kind != EditorNodeKind::Drt && outgoing_count[node.node_id] != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto EditorNodeGraphDraft::MakeChange() const -> NodeGraphTopologyChange {
+  NodeGraphTopologyChange change;
+  change.before_next_color_grade_name_number = base_next_name_number_;
+  change.after_next_color_grade_name_number  = draft_next_name_number_;
+  for (const auto& [id, json] : inserted_json_) {
+    NodeGraphInsertedNode item;
+    item.node              = json;
+    item.final_node_index  = static_cast<std::uint32_t>(node_index_.at(id));
+    change.inserted_nodes.push_back(std::move(item));
+  }
+  for (const auto& [id, json] : removed_json_) {
+    NodeGraphRemovedNode item;
+    item.node                 = json;
+    item.original_node_index  = static_cast<std::uint32_t>(removed_original_index_.at(id));
+    change.removed_nodes.push_back(std::move(item));
+  }
+  for (const auto& [key, edge] : disconnected_edge_) {
+    NodeGraphDisconnectedEdge item;
+    item.edge                 = edge;
+    item.original_edge_index  = static_cast<std::uint32_t>(disconnected_original_index_.at(key));
+    change.disconnected_edges.push_back(std::move(item));
+  }
+  for (const auto& [key, edge] : connected_edge_) {
+    NodeGraphConnectedEdge item;
+    item.edge             = edge;
+    item.final_edge_index = static_cast<std::uint32_t>(edge_index_.at(key));
+    change.connected_edges.push_back(std::move(item));
+  }
+  return change;
+}
+
+auto EditorNodeGraphDraft::CurrentSnapshot(std::uint64_t session_generation,
+                                           std::uint64_t projection_revision,
+                                           std::uint64_t topology_revision) const
+    -> EditorNodeGraphSnapshot {
+  EditorNodeGraphSnapshot snapshot;
+  snapshot.session_generation  = session_generation;
+  snapshot.projection_revision = projection_revision;
+  snapshot.topology_revision   = topology_revision;
+  snapshot.nodes               = nodes_;
+  snapshot.edges               = edges_;
+  return snapshot;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1169,6 +1169,49 @@ auto EditorSessionService::RenameColorGrade(const NodeId& node_id, std::string d
   return Emit(std::move(result));
 }
 
+auto EditorSessionService::ReconnectColorGrade(const NodeId& node_id,
+                                               const NodeId& new_predecessor_id,
+                                               const NodeId& new_successor_id)
+    -> EditorSessionResult {
+  if (!reducing_command_) {
+    EditorSessionCommand command;
+    command.kind                = EditorSessionCommandKind::ReconnectColorGrade;
+    command.node_id             = node_id;
+    command.predecessor_node_id = new_predecessor_id;
+    command.successor_node_id   = new_successor_id;
+    return SubmitCommand(std::move(command), [this](const EditorSessionCommand& queued) {
+      return ReconnectColorGrade(queued.node_id, queued.predecessor_node_id,
+                                 queued.successor_node_id);
+    });
+  }
+  if (lifecycle_.state() != EditorSessionState::Interactive || !dependencies_.history ||
+      !lifecycle_.has_history_guard()) {
+    return Reject("Color Grade reconnect requires an interactive history session");
+  }
+  std::string error;
+  if (!dependencies_.history->ReconnectColorGrade(lifecycle_.history_guard(), node_id,
+                                                  new_predecessor_id, new_successor_id, &error)) {
+    return Reject(error.empty() ? "Color Grade reconnect failed" : std::move(error));
+  }
+
+  const auto          reason = dependencies_.history->LastPublishedRenderReason();
+  EditorSessionResult result;
+  result.kind     = reason.has_value() ? EditorSessionResultKind::RenderRouted
+                                       : EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = lifecycle_.identity();
+  result.message  = "Color Grade reconnected";
+  if (reason.has_value()) {
+    EditorRenderCommand render_command;
+    render_command.reason       = *reason;
+    render_command.operation_id = current_operation_id_;
+    render_.RouteInitialRender(render_command, result.identity,
+                               lifecycle_.active_image_load_request());
+  }
+  BumpHistoryRevision();
+  return Emit(std::move(result));
+}
+
 auto EditorSessionService::Patch(std::string patch_key) -> EditorSessionResult {
   EditorAdjustmentPatch patch;
   patch.field_key = std::move(patch_key);

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1212,6 +1212,43 @@ auto EditorSessionService::ReconnectColorGrade(const NodeId& node_id,
   return Emit(std::move(result));
 }
 
+auto EditorSessionService::EditNodeGraph(NodeGraphTopologyChange change) -> EditorSessionResult {
+  if (!reducing_command_) {
+    EditorSessionCommand command;
+    command.kind             = EditorSessionCommandKind::EditNodeGraph;
+    command.topology_change  = std::move(change);
+    return SubmitCommand(std::move(command), [this](const EditorSessionCommand& queued) {
+      return EditNodeGraph(queued.topology_change);
+    });
+  }
+  if (lifecycle_.state() != EditorSessionState::Interactive || !dependencies_.history ||
+      !lifecycle_.has_history_guard()) {
+    return Reject("Node graph topology edit requires an interactive history session");
+  }
+  std::string error;
+  if (!dependencies_.history->EditNodeGraph(lifecycle_.history_guard(), std::move(change),
+                                            &error)) {
+    return Reject(error.empty() ? "Node graph topology edit failed" : std::move(error));
+  }
+
+  const auto          reason = dependencies_.history->LastPublishedRenderReason();
+  EditorSessionResult result;
+  result.kind     = reason.has_value() ? EditorSessionResultKind::RenderRouted
+                                       : EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = lifecycle_.identity();
+  result.message  = "Node graph topology updated";
+  if (reason.has_value()) {
+    EditorRenderCommand render_command;
+    render_command.reason       = *reason;
+    render_command.operation_id = current_operation_id_;
+    render_.RouteInitialRender(render_command, result.identity,
+                               lifecycle_.active_image_load_request());
+  }
+  BumpHistoryRevision();
+  return Emit(std::move(result));
+}
+
 auto EditorSessionService::Patch(std::string patch_key) -> EditorSessionResult {
   EditorAdjustmentPatch patch;
   patch.field_key = std::move(patch_key);

--- a/alcedo_studio/src/app/pipeline_document_history.cpp
+++ b/alcedo_studio/src/app/pipeline_document_history.cpp
@@ -102,6 +102,7 @@ auto RenderReasonForBatch(const PipelineEditBatch& batch) -> std::optional<Edito
     case PipelineEditOperationKind::AddColorGrade:
     case PipelineEditOperationKind::RemoveColorGrade:
     case PipelineEditOperationKind::ReconnectColorGrade:
+    case PipelineEditOperationKind::EditNodeGraph:
       return EditorRenderReason::GraphTopologyChanged;
     case PipelineEditOperationKind::AddMask:
     case PipelineEditOperationKind::RemoveMask:
@@ -382,6 +383,141 @@ auto MakeSetMaskFieldBatch(const NodeId& node_id, const MaskId& mask_id, std::st
 auto MakePasteBatch(std::vector<PipelineEditChange> changes) -> PipelineEditBatch {
   return PipelineEditBatch::Make(PipelineEditOperationKind::Paste, std::move(changes),
                                  PresentationKeyForOperation(PipelineEditOperationKind::Paste));
+}
+
+auto MakeEditNodeGraphBatch(NodeGraphTopologyChange change) -> PipelineEditBatch {
+  nlohmann::json args = nlohmann::json::object();
+  if (!change.inserted_nodes.empty()) {
+    args["node_display_name"] = change.inserted_nodes.front().node.value("display_name", "");
+  } else if (!change.removed_nodes.empty()) {
+    args["node_display_name"] = change.removed_nodes.front().node.value("display_name", "");
+  }
+  return PipelineEditBatch::Make(
+      PipelineEditOperationKind::EditNodeGraph, {std::move(change)},
+      PresentationKeyForOperation(PipelineEditOperationKind::EditNodeGraph), std::move(args));
+}
+
+namespace {
+
+auto NodeIdFromStoredJson(const nlohmann::json& node) -> NodeId {
+  return NodeId{node.at("id").get<std::string>()};
+}
+
+auto StoredNodeMatchesLive(const PipelineGraph& graph, std::size_t index, const nlohmann::json& node)
+    -> bool {
+  if (index >= graph.Nodes().size() || graph.Nodes()[index] == nullptr) {
+    return false;
+  }
+  const auto* live = graph.Nodes()[index].get();
+  return live->Id() == NodeIdFromStoredJson(node) && live->ToJson().dump() == node.dump();
+}
+
+auto InsertedFromStored(const std::vector<NodeGraphInsertedNode>& nodes)
+    -> std::vector<TopologyNodeInsertion> {
+  std::vector<TopologyNodeInsertion> inserted;
+  inserted.reserve(nodes.size());
+  for (const auto& item : nodes) {
+    TopologyNodeInsertion insertion;
+    insertion.node        = ColorGradeNodeModel::FromJson(item.node);
+    insertion.final_index = item.final_node_index;
+    inserted.push_back(std::move(insertion));
+  }
+  return inserted;
+}
+
+auto InsertedFromStored(const std::vector<NodeGraphRemovedNode>& nodes)
+    -> std::vector<TopologyNodeInsertion> {
+  std::vector<TopologyNodeInsertion> inserted;
+  inserted.reserve(nodes.size());
+  for (const auto& item : nodes) {
+    TopologyNodeInsertion insertion;
+    insertion.node        = ColorGradeNodeModel::FromJson(item.node);
+    insertion.final_index = item.original_node_index;
+    inserted.push_back(std::move(insertion));
+  }
+  return inserted;
+}
+
+}  // namespace
+
+auto ApplyNodeGraphTopologyChange(PipelineDocument& document, const NodeGraphTopologyChange& change,
+                                  PipelineEditApplyDirection direction,
+                                  TopologyDeltaStepHook after_step)
+    -> std::vector<GraphValidationError> {
+  auto error = [](std::string message) {
+    return std::vector<GraphValidationError>{
+        {GraphValidationCode::InvalidNodeValue, std::move(message)}};
+  };
+
+  const bool forward = direction == PipelineEditApplyDirection::Forward;
+  const auto expected_counter = forward ? change.before_next_color_grade_name_number
+                                        : change.after_next_color_grade_name_number;
+  const auto next_counter     = forward ? change.after_next_color_grade_name_number
+                                        : change.before_next_color_grade_name_number;
+  if (document.NextColorGradeNameNumber() != expected_counter) {
+    return error("NodeGraphTopologyChange expected the stored name-counter value");
+  }
+
+  std::vector<TopologyNodeRemoval>   removed;
+  std::vector<TopologyNodeInsertion> inserted;
+  std::vector<TopologyEdgeRemoval>   disconnected;
+  std::vector<TopologyEdgeInsertion> connected;
+  try {
+    if (forward) {
+      for (const auto& item : change.removed_nodes) {
+        if (!StoredNodeMatchesLive(document.Graph(), item.original_node_index, item.node)) {
+          return error("NodeGraphTopologyChange removed node does not match the live graph");
+        }
+        removed.push_back(
+            TopologyNodeRemoval{NodeIdFromStoredJson(item.node), item.original_node_index});
+      }
+      inserted = InsertedFromStored(change.inserted_nodes);
+      for (const auto& item : change.disconnected_edges) {
+        disconnected.push_back(
+            TopologyEdgeRemoval{ToGraphEdge(item.edge), item.original_edge_index});
+      }
+      for (const auto& item : change.connected_edges) {
+        connected.push_back(TopologyEdgeInsertion{ToGraphEdge(item.edge), item.final_edge_index});
+      }
+    } else {
+      for (const auto& item : change.inserted_nodes) {
+        if (!StoredNodeMatchesLive(document.Graph(), item.final_node_index, item.node)) {
+          return error("NodeGraphTopologyChange inserted node does not match the live graph");
+        }
+        removed.push_back(
+            TopologyNodeRemoval{NodeIdFromStoredJson(item.node), item.final_node_index});
+      }
+      inserted = InsertedFromStored(change.removed_nodes);
+      for (const auto& item : change.connected_edges) {
+        disconnected.push_back(TopologyEdgeRemoval{ToGraphEdge(item.edge), item.final_edge_index});
+      }
+      for (const auto& item : change.disconnected_edges) {
+        connected.push_back(
+            TopologyEdgeInsertion{ToGraphEdge(item.edge), item.original_edge_index});
+      }
+    }
+  } catch (const std::exception& ex) {
+    return error(ex.what());
+  }
+
+  const auto prior_counter = document.NextColorGradeNameNumber();
+  try {
+    document.SetNextColorGradeNameNumber(next_counter);
+    if (after_step) {
+      after_step("counter", 0);
+    }
+    auto errors = document.Graph().ApplyTopologyDelta(removed, std::move(inserted), disconnected,
+                                                      connected, after_step);
+    if (!errors.empty()) {
+      document.SetNextColorGradeNameNumber(prior_counter);
+      return errors;
+    }
+    document.MarkTopologyDirty();
+    return {};
+  } catch (...) {
+    document.SetNextColorGradeNameNumber(prior_counter);
+    throw;
+  }
 }
 
 auto PublishTypedPipelineEdit(MiniGitWorkingHistory& history, const PipelineEditBatch& batch)

--- a/alcedo_studio/src/app/pipeline_history_applier.cpp
+++ b/alcedo_studio/src/app/pipeline_history_applier.cpp
@@ -443,6 +443,11 @@ auto ApplyOneChange(PipelineDocument& document, const PipelineEditChange& change
                                         typed.after_source, direction, error);
         } else if constexpr (std::is_same_v<Typed, ReplaceMaskAssetChange>) {
           return ApplyReplaceMaskAsset(document, typed, direction, error, context.mask_store);
+        } else if constexpr (std::is_same_v<Typed, NodeGraphTopologyChange>) {
+          return ApplyGraph(document,
+                            ApplyNodeGraphTopologyChange(document, typed, direction,
+                                                         context.after_topology_step),
+                            error);
         } else {
           return ApplySetMaskField(document, typed, direction, error);
         }
@@ -477,6 +482,23 @@ auto ApplyPipelineEditBatch(PipelineDocument& document, const PipelineEditBatch&
     batch.Validate();
   } catch (const std::exception& ex) {
     return SetError(error, ex.what());
+  }
+  if (batch.operation_kind == PipelineEditOperationKind::EditNodeGraph) {
+    if (batch.changes.size() != 1) {
+      return SetError(error, "EditNodeGraph requires exactly one topology change");
+    }
+    const auto* change = std::get_if<NodeGraphTopologyChange>(&batch.changes.front());
+    if (change == nullptr) {
+      return SetError(error, "EditNodeGraph requires a NodeGraphTopologyChange");
+    }
+    try {
+      return ApplyGraph(document,
+                        ApplyNodeGraphTopologyChange(document, *change, direction,
+                                                     context.after_topology_step),
+                        error);
+    } catch (const std::exception& ex) {
+      return SetError(error, ex.what());
+    }
   }
   auto snapshot = ClonePipelineDocument(document);
   const auto ordered = OrderedChangesForApply(batch, direction);

--- a/alcedo_studio/src/edit/graph/pipeline_graph.cpp
+++ b/alcedo_studio/src/edit/graph/pipeline_graph.cpp
@@ -122,6 +122,190 @@ auto PipelineGraph::ApplyBackboneEdit(const std::vector<GraphEdge>& disconnected
   }
 }
 
+auto PipelineGraph::ApplyTopologyDelta(const std::vector<TopologyNodeRemoval>&   removed_nodes,
+                                       std::vector<TopologyNodeInsertion>        inserted_nodes,
+                                       const std::vector<TopologyEdgeRemoval>&   disconnected_edges,
+                                       const std::vector<TopologyEdgeInsertion>& connected_edges,
+                                       TopologyDeltaStepHook                     after_step,
+                                       std::vector<std::unique_ptr<INodeModel>>* discarded_nodes)
+    -> std::vector<GraphValidationError> {
+  auto error = [](std::string message) {
+    return std::vector<GraphValidationError>{
+        {GraphValidationCode::InvalidNodeValue, std::move(message)}};
+  };
+  auto matches = [](const GraphEdge& lhs, const GraphEdge& rhs) { return lhs == rhs; };
+
+  std::vector<char> remove_node(nodes_.size(), 0);
+  for (const auto& removal : removed_nodes) {
+    if (removal.original_index >= nodes_.size() || nodes_[removal.original_index] == nullptr ||
+        nodes_[removal.original_index]->Id() != removal.id) {
+      return error("Topology delta removed node does not match the live graph");
+    }
+    if (remove_node[removal.original_index] != 0) {
+      return error("Topology delta removes the same node index twice");
+    }
+    remove_node[removal.original_index] = 1;
+  }
+
+  std::vector<char> remove_edge(edges_.size(), 0);
+  for (const auto& removal : disconnected_edges) {
+    if (removal.original_index >= edges_.size() ||
+        !matches(edges_[removal.original_index], removal.edge)) {
+      return error("Topology delta disconnected edge does not match the live graph");
+    }
+    if (remove_edge[removal.original_index] != 0) {
+      return error("Topology delta disconnects the same edge index twice");
+    }
+    remove_edge[removal.original_index] = 1;
+  }
+
+  for (const auto& insertion : inserted_nodes) {
+    if (insertion.node == nullptr) {
+      return error("Topology delta inserted node is null");
+    }
+    const auto& id = insertion.node->Id();
+    bool        replacing_removed = false;
+    for (const auto& removal : removed_nodes) {
+      if (removal.id == id) {
+        replacing_removed = true;
+        break;
+      }
+    }
+    if (!replacing_removed && FindNode(id) != nullptr) {
+      return error("Topology delta inserted NodeId already exists");
+    }
+  }
+
+  const auto remaining_edge_count = edges_.size() - disconnected_edges.size();
+  const auto remaining_node_count = nodes_.size() - removed_nodes.size();
+  for (const auto& insertion : connected_edges) {
+    if (insertion.final_index > remaining_edge_count + connected_edges.size()) {
+      return error("Topology delta connected edge index is past the final edge list");
+    }
+    const bool exists = std::any_of(edges_.begin(), edges_.end(), [&](const GraphEdge& edge) {
+      return matches(edge, insertion.edge);
+    });
+    const bool disconnecting =
+        std::any_of(disconnected_edges.begin(), disconnected_edges.end(),
+                    [&](const TopologyEdgeRemoval& item) { return matches(item.edge, insertion.edge); });
+    if (exists && !disconnecting) {
+      return error("Topology delta connected edge already exists");
+    }
+  }
+  for (const auto& insertion : inserted_nodes) {
+    if (insertion.final_index > remaining_node_count + inserted_nodes.size()) {
+      return error("Topology delta inserted node index is past the final node list");
+    }
+  }
+
+  nodes_.reserve(nodes_.size() + inserted_nodes.size());
+  edges_.reserve(edges_.size() + connected_edges.size());
+
+  auto sorted_disconnected = disconnected_edges;
+  std::sort(sorted_disconnected.begin(), sorted_disconnected.end(),
+            [](const auto& lhs, const auto& rhs) { return lhs.original_index > rhs.original_index; });
+  auto sorted_removed = removed_nodes;
+  std::sort(sorted_removed.begin(), sorted_removed.end(),
+            [](const auto& lhs, const auto& rhs) { return lhs.original_index > rhs.original_index; });
+  auto sorted_inserted = std::move(inserted_nodes);
+  std::sort(sorted_inserted.begin(), sorted_inserted.end(),
+            [](const auto& lhs, const auto& rhs) { return lhs.final_index < rhs.final_index; });
+  auto sorted_connected = connected_edges;
+  std::sort(sorted_connected.begin(), sorted_connected.end(),
+            [](const auto& lhs, const auto& rhs) { return lhs.final_index < rhs.final_index; });
+
+  std::vector<std::pair<std::size_t, GraphEdge>> held_edges;
+  held_edges.reserve(sorted_disconnected.size());
+  std::vector<std::pair<std::size_t, std::unique_ptr<INodeModel>>> held_nodes;
+  held_nodes.reserve(sorted_removed.size());
+  std::vector<std::size_t> inserted_at;
+  inserted_at.reserve(sorted_inserted.size());
+  std::vector<std::size_t> connected_at;
+  connected_at.reserve(sorted_connected.size());
+
+  auto restore = [&] {
+    for (auto it = connected_at.rbegin(); it != connected_at.rend(); ++it) {
+      if (*it < edges_.size()) {
+        edges_.erase(edges_.begin() + static_cast<std::ptrdiff_t>(*it));
+      }
+    }
+    for (auto it = inserted_at.rbegin(); it != inserted_at.rend(); ++it) {
+      if (*it < nodes_.size()) {
+        nodes_.erase(nodes_.begin() + static_cast<std::ptrdiff_t>(*it));
+      }
+    }
+    std::sort(held_nodes.begin(), held_nodes.end(),
+              [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
+    for (auto& [index, node] : held_nodes) {
+      nodes_.insert(nodes_.begin() + static_cast<std::ptrdiff_t>(index), std::move(node));
+    }
+    std::sort(held_edges.begin(), held_edges.end(),
+              [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
+    for (auto& [index, edge] : held_edges) {
+      edges_.insert(edges_.begin() + static_cast<std::ptrdiff_t>(index), std::move(edge));
+    }
+  };
+
+  auto run_step = [&](std::string_view step, std::size_t index) {
+    if (after_step) {
+      after_step(step, index);
+    }
+  };
+
+  try {
+    for (const auto& removal : sorted_disconnected) {
+      held_edges.emplace_back(removal.original_index, edges_[removal.original_index]);
+      edges_.erase(edges_.begin() + static_cast<std::ptrdiff_t>(removal.original_index));
+      run_step("disconnect", removal.original_index);
+    }
+    for (const auto& removal : sorted_removed) {
+      held_nodes.emplace_back(removal.original_index, std::move(nodes_[removal.original_index]));
+      nodes_.erase(nodes_.begin() + static_cast<std::ptrdiff_t>(removal.original_index));
+      run_step("remove_node", removal.original_index);
+    }
+    for (auto& insertion : sorted_inserted) {
+      if (insertion.final_index > nodes_.size()) {
+        restore();
+        return error("Topology delta inserted node index is past the live node list");
+      }
+      nodes_.insert(nodes_.begin() + static_cast<std::ptrdiff_t>(insertion.final_index),
+                    std::move(insertion.node));
+      inserted_at.push_back(insertion.final_index);
+      run_step("insert_node", insertion.final_index);
+    }
+    for (const auto& insertion : sorted_connected) {
+      if (insertion.final_index > edges_.size()) {
+        restore();
+        return error("Topology delta connected edge index is past the live edge list");
+      }
+      edges_.insert(edges_.begin() + static_cast<std::ptrdiff_t>(insertion.final_index),
+                    insertion.edge);
+      connected_at.push_back(insertion.final_index);
+      run_step("connect", insertion.final_index);
+    }
+
+    auto errors   = Validate();
+    auto backbone = ValidateImageBackbone();
+    errors.insert(errors.end(), backbone.begin(), backbone.end());
+    run_step("validate", 0);
+    if (!errors.empty()) {
+      restore();
+      return errors;
+    }
+    if (discarded_nodes != nullptr) {
+      discarded_nodes->clear();
+      discarded_nodes->reserve(held_nodes.size());
+      for (auto& [index, node] : held_nodes) {
+        discarded_nodes->push_back(std::move(node));
+      }
+    }
+    return {};
+  } catch (...) {
+    restore();
+    throw;
+  }
+}
+
 auto PipelineGraph::FindNode(const NodeId& id) const -> const INodeModel* {
   for (const auto& node : nodes_) {
     if (node->Id() == id) {

--- a/alcedo_studio/src/edit/history/pipeline_edit_batch.cpp
+++ b/alcedo_studio/src/edit/history/pipeline_edit_batch.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <set>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -233,6 +234,9 @@ auto ChangeKindFromText(std::string_view text) -> PipelineEditChangeKind {
   }
   if (text == "reconnect_color_grade") {
     return PipelineEditChangeKind::ReconnectColorGrade;
+  }
+  if (text == "node_graph_topology_change") {
+    return PipelineEditChangeKind::NodeGraphTopologyChange;
   }
   if (text == "add_mask") {
     return PipelineEditChangeKind::AddMask;
@@ -543,6 +547,94 @@ void ValidateReconnect(const ReconnectColorGradeChange& change) {
                        "ReconnectColorGrade after_outgoing_edge");
 }
 
+auto RequireNonNegativeUint32(const nlohmann::json& json, const char* key, std::string_view context)
+    -> std::uint32_t {
+  const auto& value = json.at(key);
+  if (value.is_number_unsigned()) {
+    return value.get<std::uint32_t>();
+  }
+  if (value.is_number_integer() && value.get<std::int64_t>() >= 0) {
+    return static_cast<std::uint32_t>(value.get<std::int64_t>());
+  }
+  Fail(std::string{context} + ": '" + key + "' must be a non-negative integer");
+}
+
+auto EdgeIdentityKey(const PipelineSceneEdge& edge) -> std::string {
+  return std::string{edge.from_node.Value()} + "/" + std::string{edge.from_port.Value()} + "->" +
+         std::string{edge.to_node.Value()} + "/" + std::string{edge.to_port.Value()};
+}
+
+void ValidateNodeGraphTopology(const NodeGraphTopologyChange& change) {
+  if (change.before_next_color_grade_name_number == 0 ||
+      change.after_next_color_grade_name_number == 0) {
+    Fail("NodeGraphTopologyChange: name-counter values must be positive");
+  }
+  if (change.after_next_color_grade_name_number < change.before_next_color_grade_name_number) {
+    Fail("NodeGraphTopologyChange: after name-counter cannot be smaller than before");
+  }
+  if (change.inserted_nodes.empty() && change.removed_nodes.empty() &&
+      change.disconnected_edges.empty() && change.connected_edges.empty() &&
+      change.before_next_color_grade_name_number == change.after_next_color_grade_name_number) {
+    Fail("NodeGraphTopologyChange: net delta must not be empty");
+  }
+
+  std::set<std::string> inserted_ids;
+  std::set<std::uint32_t> inserted_indexes;
+  for (const auto& item : change.inserted_nodes) {
+    const auto node = CanonicalColorGradeNodeJson(item.node, "NodeGraphTopologyChange inserted node");
+    const auto id   = node.at("id").get<std::string>();
+    if (!inserted_ids.insert(id).second) {
+      Fail("NodeGraphTopologyChange: duplicate inserted NodeId");
+    }
+    if (!inserted_indexes.insert(item.final_node_index).second) {
+      Fail("NodeGraphTopologyChange: duplicate inserted node index");
+    }
+  }
+  std::set<std::string> removed_ids;
+  std::set<std::uint32_t> removed_indexes;
+  for (const auto& item : change.removed_nodes) {
+    const auto node = CanonicalColorGradeNodeJson(item.node, "NodeGraphTopologyChange removed node");
+    const auto id   = node.at("id").get<std::string>();
+    if (!removed_ids.insert(id).second) {
+      Fail("NodeGraphTopologyChange: duplicate removed NodeId");
+    }
+    if (inserted_ids.contains(id)) {
+      Fail("NodeGraphTopologyChange: NodeId is both inserted and removed");
+    }
+    if (!removed_indexes.insert(item.original_node_index).second) {
+      Fail("NodeGraphTopologyChange: duplicate removed node index");
+    }
+  }
+  std::set<std::string> disconnected_keys;
+  std::set<std::uint32_t> disconnected_indexes;
+  for (const auto& item : change.disconnected_edges) {
+    if (item.edge.from_node.Empty() || item.edge.to_node.Empty()) {
+      Fail("NodeGraphTopologyChange: disconnected edge endpoints are required");
+    }
+    const auto key = EdgeIdentityKey(item.edge);
+    if (!disconnected_keys.insert(key).second) {
+      Fail("NodeGraphTopologyChange: duplicate disconnected edge");
+    }
+    if (!disconnected_indexes.insert(item.original_edge_index).second) {
+      Fail("NodeGraphTopologyChange: duplicate disconnected edge index");
+    }
+  }
+  std::set<std::string> connected_keys;
+  std::set<std::uint32_t> connected_indexes;
+  for (const auto& item : change.connected_edges) {
+    if (item.edge.from_node.Empty() || item.edge.to_node.Empty()) {
+      Fail("NodeGraphTopologyChange: connected edge endpoints are required");
+    }
+    const auto key = EdgeIdentityKey(item.edge);
+    if (!connected_keys.insert(key).second) {
+      Fail("NodeGraphTopologyChange: duplicate connected edge");
+    }
+    if (!connected_indexes.insert(item.final_edge_index).second) {
+      Fail("NodeGraphTopologyChange: duplicate connected edge index");
+    }
+  }
+}
+
 void ValidateMaskOwner(const NodeId& node_id, const MaskId& mask_id, std::string_view context) {
   if (node_id.Empty() || mask_id.Empty()) {
     Fail(std::string{context} + ": node_id and mask_id are required");
@@ -634,6 +726,8 @@ void ValidateChange(const PipelineEditChange& change) {
           ValidateReplaceMaskSource(typed);
         } else if constexpr (std::is_same_v<Typed, ReplaceMaskAssetChange>) {
           ValidateReplaceMaskAsset(typed);
+        } else if constexpr (std::is_same_v<Typed, NodeGraphTopologyChange>) {
+          ValidateNodeGraphTopology(typed);
         } else {
           ValidateSetMaskField(typed);
         }
@@ -643,7 +737,7 @@ void ValidateChange(const PipelineEditChange& change) {
 
 auto ChangeCompatible(PipelineEditOperationKind operation, PipelineEditChangeKind change) -> bool {
   if (operation == PipelineEditOperationKind::Paste) {
-    return true;
+    return change != PipelineEditChangeKind::NodeGraphTopologyChange;
   }
   switch (operation) {
     case PipelineEditOperationKind::SetParameter:
@@ -671,7 +765,9 @@ auto ChangeCompatible(PipelineEditOperationKind operation, PipelineEditChangeKin
     case PipelineEditOperationKind::SetMaskField:
       return change == PipelineEditChangeKind::SetMaskField;
     case PipelineEditOperationKind::Paste:
-      return true;
+      return change != PipelineEditChangeKind::NodeGraphTopologyChange;
+    case PipelineEditOperationKind::EditNodeGraph:
+      return change == PipelineEditChangeKind::NodeGraphTopologyChange;
   }
   return false;
 }
@@ -758,6 +854,33 @@ auto ChangeToJson(const PipelineEditChange& change) -> nlohmann::json {
                   {"kind", "replace_mask_asset"},
                   {"mask_id", std::string{typed.mask_id.Value()}},
                   {"node_id", std::string{typed.node_id.Value()}}};
+        } else if constexpr (std::is_same_v<Typed, NodeGraphTopologyChange>) {
+          nlohmann::json inserted = nlohmann::json::array();
+          for (const auto& item : typed.inserted_nodes) {
+            inserted.push_back({{"final_node_index", item.final_node_index}, {"node", item.node}});
+          }
+          nlohmann::json removed = nlohmann::json::array();
+          for (const auto& item : typed.removed_nodes) {
+            removed.push_back(
+                {{"node", item.node}, {"original_node_index", item.original_node_index}});
+          }
+          nlohmann::json disconnected = nlohmann::json::array();
+          for (const auto& item : typed.disconnected_edges) {
+            disconnected.push_back({{"edge", EdgeToJson(item.edge)},
+                                    {"original_edge_index", item.original_edge_index}});
+          }
+          nlohmann::json connected = nlohmann::json::array();
+          for (const auto& item : typed.connected_edges) {
+            connected.push_back(
+                {{"edge", EdgeToJson(item.edge)}, {"final_edge_index", item.final_edge_index}});
+          }
+          return {{"after_next_color_grade_name_number", typed.after_next_color_grade_name_number},
+                  {"before_next_color_grade_name_number", typed.before_next_color_grade_name_number},
+                  {"connected_edges", std::move(connected)},
+                  {"disconnected_edges", std::move(disconnected)},
+                  {"inserted_nodes", std::move(inserted)},
+                  {"kind", "node_graph_topology_change"},
+                  {"removed_nodes", std::move(removed)}};
         } else {
           return {{"after_value", typed.after_value},
                   {"before_value", typed.before_value},
@@ -960,6 +1083,63 @@ auto ChangeFromJson(const nlohmann::json& json) -> PipelineEditChange {
       ValidateSetMaskField(change);
       return change;
     }
+    case PipelineEditChangeKind::NodeGraphTopologyChange: {
+      RequireExactObjectKeys(json,
+                             {"after_next_color_grade_name_number",
+                              "before_next_color_grade_name_number", "connected_edges",
+                              "disconnected_edges", "inserted_nodes", "kind", "removed_nodes"},
+                             "NodeGraphTopologyChange");
+      if (!json.at("inserted_nodes").is_array() || !json.at("removed_nodes").is_array() ||
+          !json.at("disconnected_edges").is_array() || !json.at("connected_edges").is_array()) {
+        Fail("NodeGraphTopologyChange: node and edge lists must be arrays");
+      }
+      NodeGraphTopologyChange change;
+      change.before_next_color_grade_name_number = RequirePositiveUint64(
+          json, "before_next_color_grade_name_number", "NodeGraphTopologyChange");
+      change.after_next_color_grade_name_number = RequirePositiveUint64(
+          json, "after_next_color_grade_name_number", "NodeGraphTopologyChange");
+      for (const auto& item : json.at("inserted_nodes")) {
+        RequireExactObjectKeys(item, {"final_node_index", "node"},
+                               "NodeGraphTopologyChange inserted node");
+        NodeGraphInsertedNode inserted;
+        inserted.final_node_index =
+            RequireNonNegativeUint32(item, "final_node_index", "NodeGraphTopologyChange");
+        inserted.node =
+            CanonicalColorGradeNodeJson(item.at("node"), "NodeGraphTopologyChange inserted node");
+        change.inserted_nodes.push_back(std::move(inserted));
+      }
+      for (const auto& item : json.at("removed_nodes")) {
+        RequireExactObjectKeys(item, {"node", "original_node_index"},
+                               "NodeGraphTopologyChange removed node");
+        NodeGraphRemovedNode removed;
+        removed.original_node_index =
+            RequireNonNegativeUint32(item, "original_node_index", "NodeGraphTopologyChange");
+        removed.node =
+            CanonicalColorGradeNodeJson(item.at("node"), "NodeGraphTopologyChange removed node");
+        change.removed_nodes.push_back(std::move(removed));
+      }
+      for (const auto& item : json.at("disconnected_edges")) {
+        RequireExactObjectKeys(item, {"edge", "original_edge_index"},
+                               "NodeGraphTopologyChange disconnected edge");
+        NodeGraphDisconnectedEdge disconnected;
+        disconnected.original_edge_index =
+            RequireNonNegativeUint32(item, "original_edge_index", "NodeGraphTopologyChange");
+        disconnected.edge =
+            EdgeFromJson(item.at("edge"), "NodeGraphTopologyChange disconnected edge");
+        change.disconnected_edges.push_back(std::move(disconnected));
+      }
+      for (const auto& item : json.at("connected_edges")) {
+        RequireExactObjectKeys(item, {"edge", "final_edge_index"},
+                               "NodeGraphTopologyChange connected edge");
+        NodeGraphConnectedEdge connected;
+        connected.final_edge_index =
+            RequireNonNegativeUint32(item, "final_edge_index", "NodeGraphTopologyChange");
+        connected.edge = EdgeFromJson(item.at("edge"), "NodeGraphTopologyChange connected edge");
+        change.connected_edges.push_back(std::move(connected));
+      }
+      ValidateNodeGraphTopology(change);
+      return change;
+    }
   }
   Fail("PipelineEditChange: unhandled kind");
 }
@@ -1001,6 +1181,8 @@ auto PipelineEditOperationKindText(PipelineEditOperationKind kind) -> std::strin
       return "set_mask_field";
     case PipelineEditOperationKind::Paste:
       return "paste";
+    case PipelineEditOperationKind::EditNodeGraph:
+      return "edit_node_graph";
   }
   Fail("PipelineEditOperationKind: unknown enum value");
 }
@@ -1045,6 +1227,9 @@ auto PipelineEditOperationKindFromText(std::string_view text) -> PipelineEditOpe
   if (text == "paste") {
     return PipelineEditOperationKind::Paste;
   }
+  if (text == "edit_node_graph") {
+    return PipelineEditOperationKind::EditNodeGraph;
+  }
   Fail("PipelineEditOperationKind: unknown operation_kind '" + std::string{text} + "'");
 }
 
@@ -1074,6 +1259,8 @@ auto PipelineEditChangeKindText(PipelineEditChangeKind kind) -> std::string_view
       return "replace_mask_asset";
     case PipelineEditChangeKind::SetMaskField:
       return "set_mask_field";
+    case PipelineEditChangeKind::NodeGraphTopologyChange:
+      return "node_graph_topology_change";
   }
   Fail("PipelineEditChangeKind: unknown enum value");
 }
@@ -1104,6 +1291,8 @@ auto PipelineEditChangeKindOf(const PipelineEditChange& change) -> PipelineEditC
           return PipelineEditChangeKind::ReplaceMaskSource;
         } else if constexpr (std::is_same_v<Typed, ReplaceMaskAssetChange>) {
           return PipelineEditChangeKind::ReplaceMaskAsset;
+        } else if constexpr (std::is_same_v<Typed, NodeGraphTopologyChange>) {
+          return PipelineEditChangeKind::NodeGraphTopologyChange;
         } else {
           return PipelineEditChangeKind::SetMaskField;
         }
@@ -1266,6 +1455,16 @@ auto ProjectPipelineEditHistory(const PipelineEditBatch& batch) -> PipelineEditH
           row.mask_id              = std::string{typed.mask_id.Value()};
           row.before_display_value = typed.before_source;
           row.after_display_value  = typed.after_source;
+        } else if constexpr (std::is_same_v<Typed, NodeGraphTopologyChange>) {
+          if (!typed.inserted_nodes.empty()) {
+            row.node_id             = StringArg(typed.inserted_nodes.front().node, "id");
+            row.node_display_name   = StringArg(typed.inserted_nodes.front().node, "display_name");
+            row.after_display_value = typed.inserted_nodes.front().node;
+          } else if (!typed.removed_nodes.empty()) {
+            row.node_id             = StringArg(typed.removed_nodes.front().node, "id");
+            row.node_display_name   = StringArg(typed.removed_nodes.front().node, "display_name");
+            row.before_display_value = typed.removed_nodes.front().node;
+          }
         } else {
           row.node_id              = std::string{typed.node_id.Value()};
           row.mask_id              = std::string{typed.mask_id.Value()};

--- a/alcedo_studio/src/include/app/editor_node_graph_draft.hpp
+++ b/alcedo_studio/src/include/app/editor_node_graph_draft.hpp
@@ -1,0 +1,189 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "app/editor_node_graph_projection.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/history/pipeline_edit_batch.hpp"
+
+namespace alcedo {
+
+/// Bound product identity copied when a node-graph draft is created.
+struct EditorNodeGraphDraftIdentity {
+  std::uint64_t element_id           = 0;
+  std::uint64_t image_id             = 0;
+  std::string   version_id;
+  std::uint64_t session_generation   = 0;
+  std::uint64_t projection_revision  = 0;
+  std::uint64_t topology_revision    = 0;
+
+  auto operator==(const EditorNodeGraphDraftIdentity&) const -> bool = default;
+};
+
+/// Incremental Qan operations produced by one admitted draft mutation.
+struct EditorNodeGraphDraftMutation {
+  bool                                  succeeded         = false;
+  bool                                  no_op             = false;
+  bool                                  submission_valid  = false;
+  bool                                  delta_empty       = false;
+  std::string                           error;
+  std::vector<EditorNodeProjection>     inserted_nodes;
+  std::vector<NodeId>                   removed_node_ids;
+  std::vector<EditorNodeEdgeProjection> removed_edges;
+  std::vector<EditorNodeEdgeProjection> inserted_edges;
+};
+
+/**
+ * @brief Incremental Nodes-page topology draft. Not product data and not a render input.
+ *
+ * Construction copies the live document once. Later Add, Delete, and Connect
+ * mutate this object in place. A rejected operation restores the exact prior
+ * values, indexes, and accumulated delta.
+ *
+ * Threading: GUI thread only. Ownership: value type, no QObject or Qan pointers.
+ */
+class EditorNodeGraphDraft {
+ public:
+  /**
+   * @brief Copy the complete live document into a new draft bound to @p identity.
+   * @pre @p document is the product graph for @p identity.
+   */
+  static auto FromDocument(const PipelineDocument& document, EditorNodeGraphDraftIdentity identity)
+      -> EditorNodeGraphDraft;
+
+  [[nodiscard]] auto identity() const -> const EditorNodeGraphDraftIdentity& { return identity_; }
+  [[nodiscard]] auto MatchesIdentity(const EditorNodeGraphDraftIdentity& identity) const -> bool {
+    return identity_ == identity;
+  }
+
+  /**
+   * @brief True when the live graph still matches the bound base topology.
+   */
+  [[nodiscard]] auto MatchesBase(const PipelineDocument& document) const -> bool;
+
+  /**
+   * @brief Insert one disconnected clean Color Grade. Does not create an edge.
+   */
+  auto AddColorGrade(NodeId node_id) -> EditorNodeGraphDraftMutation;
+
+  /**
+   * @brief Remove one Color Grade and its incident edges. Does not bridge neighbors.
+   */
+  auto RemoveColorGrade(const NodeId& node_id) -> EditorNodeGraphDraftMutation;
+
+  /**
+   * @brief Exclusive-port connect from @p source_id image output to @p destination_id image input.
+   *
+   * Replaces the current outgoing edge of the source and the current incoming
+   * edge of the destination. Does not infer a backbone move.
+   */
+  auto Connect(const NodeId& source_id, const NodeId& destination_id)
+      -> EditorNodeGraphDraftMutation;
+
+  /**
+   * @brief Restore the exact state captured before the last admitted mutation.
+   */
+  void RestoreLastMutation();
+
+  [[nodiscard]] auto HasLastMutation() const -> bool { return has_checkpoint_; }
+  [[nodiscard]] auto DeltaEmpty() const -> bool;
+  [[nodiscard]] auto SubmissionValid() const -> bool;
+  [[nodiscard]] auto NextColorGradeNameNumber() const -> std::uint64_t {
+    return draft_next_name_number_;
+  }
+  [[nodiscard]] auto BaseNextColorGradeNameNumber() const -> std::uint64_t {
+    return base_next_name_number_;
+  }
+
+  /**
+   * @brief Build the stored net delta from current indexes. Empty when DeltaEmpty.
+   */
+  [[nodiscard]] auto MakeChange() const -> NodeGraphTopologyChange;
+
+  [[nodiscard]] auto Nodes() const -> const std::vector<EditorNodeProjection>& { return nodes_; }
+  [[nodiscard]] auto Edges() const -> const std::vector<EditorNodeEdgeProjection>& { return edges_; }
+  [[nodiscard]] auto FindNode(const NodeId& node_id) const -> const EditorNodeProjection*;
+  [[nodiscard]] auto NodeJson(const NodeId& node_id) const -> const nlohmann::json*;
+
+  /**
+   * @brief Value snapshot of the current draft graph, including detached nodes.
+   */
+  [[nodiscard]] auto CurrentSnapshot(std::uint64_t session_generation,
+                                     std::uint64_t projection_revision,
+                                     std::uint64_t topology_revision) const
+      -> EditorNodeGraphSnapshot;
+
+ private:
+  struct EdgeRecord {
+    EditorNodeEdgeProjection edge;
+  };
+
+  struct Checkpoint {
+    std::vector<EditorNodeProjection>     nodes;
+    std::vector<EditorNodeEdgeProjection> edges;
+    std::map<NodeId, nlohmann::json>      node_json;
+    std::map<NodeId, std::size_t>         node_index;
+    std::map<std::string, std::size_t>    edge_index;
+    std::map<NodeId, std::optional<std::size_t>> outgoing;
+    std::map<NodeId, std::optional<std::size_t>> incoming;
+    std::map<NodeId, nlohmann::json>      inserted_json;
+    std::map<NodeId, std::size_t>         removed_original_index;
+    std::map<NodeId, nlohmann::json>      removed_json;
+    std::map<std::string, std::size_t>    disconnected_original_index;
+    std::map<std::string, PipelineSceneEdge> disconnected_edge;
+    std::map<std::string, PipelineSceneEdge> connected_edge;
+    std::uint64_t                         draft_next_name_number = 0;
+  };
+
+  void CaptureCheckpoint();
+  void RebuildIndexes();
+  auto AdmitConnect(const NodeId& source_id, const NodeId& destination_id, std::string* error) const
+      -> bool;
+  auto WouldCreateCycle(const NodeId& source_id, const NodeId& destination_id,
+                        const std::optional<std::size_t>& skip_outgoing,
+                        const std::optional<std::size_t>& skip_incoming) const -> bool;
+  auto RemoveEdgeAt(std::size_t index) -> EditorNodeEdgeProjection;
+  void InsertEdge(EditorNodeEdgeProjection edge);
+  auto FinishMutation(EditorNodeGraphDraftMutation mutation) -> EditorNodeGraphDraftMutation;
+  [[nodiscard]] static auto ImagePort() -> PortId;
+  [[nodiscard]] static auto EdgeKey(const EditorNodeEdgeProjection& edge) -> std::string;
+  [[nodiscard]] static auto EdgeKey(const PipelineSceneEdge& edge) -> std::string;
+  [[nodiscard]] static auto ToSceneEdge(const EditorNodeEdgeProjection& edge) -> PipelineSceneEdge;
+  [[nodiscard]] static auto ToProjection(const PipelineSceneEdge& edge) -> EditorNodeEdgeProjection;
+  [[nodiscard]] static auto KindOf(const INodeModel& node) -> EditorNodeKind;
+  [[nodiscard]] auto        ProjectNode(const INodeModel& node) const -> EditorNodeProjection;
+
+  EditorNodeGraphDraftIdentity          identity_{};
+  std::vector<EditorNodeProjection>     nodes_;
+  std::vector<EditorNodeEdgeProjection> edges_;
+  std::map<NodeId, nlohmann::json>      node_json_;
+  std::map<NodeId, std::size_t>         node_index_;
+  std::map<std::string, std::size_t>    edge_index_;
+  std::map<NodeId, std::optional<std::size_t>> outgoing_;
+  std::map<NodeId, std::optional<std::size_t>> incoming_;
+  std::map<NodeId, std::size_t>         base_node_index_;
+  std::map<std::string, std::size_t>    base_edge_index_;
+  std::map<NodeId, nlohmann::json>      base_node_json_;
+  std::vector<PipelineSceneEdge>        base_edges_;
+  std::map<NodeId, nlohmann::json>      inserted_json_;
+  std::map<NodeId, std::size_t>         removed_original_index_;
+  std::map<NodeId, nlohmann::json>      removed_json_;
+  std::map<std::string, std::size_t>    disconnected_original_index_;
+  std::map<std::string, PipelineSceneEdge> disconnected_edge_;
+  std::map<std::string, PipelineSceneEdge> connected_edge_;
+  std::uint64_t                         base_next_name_number_  = kInitialNextColorGradeNameNumber;
+  std::uint64_t                         draft_next_name_number_ = kInitialNextColorGradeNameNumber;
+  Checkpoint                            checkpoint_{};
+  bool                                  has_checkpoint_ = false;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_session_command_queue.hpp
+++ b/alcedo_studio/src/include/app/editor_session_command_queue.hpp
@@ -61,6 +61,7 @@ enum class EditorSessionCommandKind : std::uint8_t {
   AddColorGrade,
   RemoveColorGrade,
   RenameColorGrade,
+  ReconnectColorGrade,
 };
 
 /// Worker messages that are delivered back to the session owner.
@@ -110,6 +111,8 @@ struct EditorSessionCommand {
   bool                                    geometry_overlay_active = false;
   NodeId                                  node_id;
   NodeId                                  before_node_id;
+  NodeId                                  predecessor_node_id;
+  NodeId                                  successor_node_id;
 };
 
 /// Typed worker completion envelope. Payload-specific values are kept as

--- a/alcedo_studio/src/include/app/editor_session_command_queue.hpp
+++ b/alcedo_studio/src/include/app/editor_session_command_queue.hpp
@@ -21,6 +21,7 @@
 #include "app/editor_session_types.hpp"
 #include "edit/graph/graph_ids.hpp"
 #include "edit/history/commit_types.hpp"
+#include "edit/history/pipeline_edit_batch.hpp"
 
 namespace alcedo {
 
@@ -62,6 +63,7 @@ enum class EditorSessionCommandKind : std::uint8_t {
   RemoveColorGrade,
   RenameColorGrade,
   ReconnectColorGrade,
+  EditNodeGraph,
 };
 
 /// Worker messages that are delivered back to the session owner.
@@ -113,6 +115,7 @@ struct EditorSessionCommand {
   NodeId                                  before_node_id;
   NodeId                                  predecessor_node_id;
   NodeId                                  successor_node_id;
+  NodeGraphTopologyChange                 topology_change{};
 };
 
 /// Typed worker completion envelope. Payload-specific values are kept as

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -95,6 +95,13 @@ class IEditorHistoryPort {
     if (error != nullptr) *error = "Color Grade removal is not supported by this history port";
     return false;
   }
+  /// Move one Color Grade between a new scene-image predecessor and successor.
+  virtual auto ReconnectColorGrade(const EditorHistoryGuardHandle& /*guard*/,
+                                   const NodeId& /*node_id*/, const NodeId& /*new_predecessor_id*/,
+                                   const NodeId& /*new_successor_id*/, std::string* error) -> bool {
+    if (error != nullptr) *error = "Color Grade reconnect is not supported by this history port";
+    return false;
+  }
   /// Rename one Color Grade without requesting a pixel render.
   virtual auto RenameColorGrade(const EditorHistoryGuardHandle& /*guard*/,
                                 const NodeId& /*node_id*/, std::string /*display_name*/,

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -18,6 +18,7 @@
 #include "app/editor_render_intent.hpp"
 #include "app/editor_session_types.hpp"
 #include "edit/graph/graph_ids.hpp"
+#include "edit/history/pipeline_edit_batch.hpp"
 #include "type/type.hpp"
 
 namespace alcedo {
@@ -100,6 +101,12 @@ class IEditorHistoryPort {
                                    const NodeId& /*node_id*/, const NodeId& /*new_predecessor_id*/,
                                    const NodeId& /*new_successor_id*/, std::string* error) -> bool {
     if (error != nullptr) *error = "Color Grade reconnect is not supported by this history port";
+    return false;
+  }
+  /// Apply one net node-graph topology delta in place. Default rejects.
+  virtual auto EditNodeGraph(const EditorHistoryGuardHandle& /*guard*/,
+                             NodeGraphTopologyChange /*change*/, std::string* error) -> bool {
+    if (error != nullptr) *error = "Node graph topology edit is not supported by this history port";
     return false;
   }
   /// Rename one Color Grade without requesting a pixel render.

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -256,6 +256,15 @@ class IEditorSessionBackend {
     result.message  = "Color Grade reconnect is not supported by this backend";
     return result;
   }
+  /// Apply one net node-graph topology delta as one history commit. Default rejects.
+  virtual auto EditNodeGraph(NodeGraphTopologyChange /*change*/) -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Rejected;
+    result.state    = state();
+    result.identity = identity();
+    result.message  = "Node graph topology edit is not supported by this backend";
+    return result;
+  }
   virtual auto RequestViewChange(EditorRenderReason /*reason*/,
                                  std::optional<ViewportRenderRegion> /*region*/)
       -> EditorSessionResult {
@@ -415,6 +424,7 @@ class EditorSessionService final : public IEditorSessionBackend {
       -> EditorSessionResult override;
   auto ReconnectColorGrade(const NodeId& node_id, const NodeId& new_predecessor_id,
                            const NodeId& new_successor_id) -> EditorSessionResult override;
+  auto EditNodeGraph(NodeGraphTopologyChange change) -> EditorSessionResult override;
   auto Patch(std::string patch_key) -> EditorSessionResult;
   auto CommitAdjustment(std::string patch_key) -> EditorSessionResult;
   auto Undo() -> EditorSessionResult override;

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -246,6 +246,16 @@ class IEditorSessionBackend {
     result.message  = "Color Grade rename is not supported by this backend";
     return result;
   }
+  /// Move a Color Grade between new backbone neighbors. Default backends reject.
+  virtual auto ReconnectColorGrade(const NodeId& /*node_id*/, const NodeId& /*new_predecessor_id*/,
+                                   const NodeId& /*new_successor_id*/) -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Rejected;
+    result.state    = state();
+    result.identity = identity();
+    result.message  = "Color Grade reconnect is not supported by this backend";
+    return result;
+  }
   virtual auto RequestViewChange(EditorRenderReason /*reason*/,
                                  std::optional<ViewportRenderRegion> /*region*/)
       -> EditorSessionResult {
@@ -403,6 +413,8 @@ class EditorSessionService final : public IEditorSessionBackend {
   auto RemoveColorGrade(const NodeId& node_id) -> EditorSessionResult override;
   auto RenameColorGrade(const NodeId& node_id, std::string display_name)
       -> EditorSessionResult override;
+  auto ReconnectColorGrade(const NodeId& node_id, const NodeId& new_predecessor_id,
+                           const NodeId& new_successor_id) -> EditorSessionResult override;
   auto Patch(std::string patch_key) -> EditorSessionResult;
   auto CommitAdjustment(std::string patch_key) -> EditorSessionResult;
   auto Undo() -> EditorSessionResult override;

--- a/alcedo_studio/src/include/app/pipeline_document_history.hpp
+++ b/alcedo_studio/src/include/app/pipeline_document_history.hpp
@@ -106,6 +106,24 @@ class MaskStore;
 [[nodiscard]] auto MakeReconnectColorGradeBatch(ReconnectColorGradeChange change)
     -> PipelineEditBatch;
 
+[[nodiscard]] auto MakeEditNodeGraphBatch(NodeGraphTopologyChange change) -> PipelineEditBatch;
+
+/**
+ * @brief Apply one stored topology delta in place on the live document graph.
+ *
+ * Forward uses stored after-counter and final indexes. Inverse swaps inserted
+ * with removed and connected with disconnected, then restores the before
+ * counter. Does not clone the document. On any validation error or exception
+ * the live node objects, node order, edge order, and counter are restored.
+ *
+ * @pre Caller holds the shared executor render lock.
+ */
+[[nodiscard]] auto ApplyNodeGraphTopologyChange(PipelineDocument& document,
+                                                const NodeGraphTopologyChange& change,
+                                                PipelineEditApplyDirection direction,
+                                                TopologyDeltaStepHook after_step = {})
+    -> std::vector<GraphValidationError>;
+
 [[nodiscard]] auto MakeRenameColorGradeBatch(const NodeId& node_id, std::string before_name,
                                              std::string after_name) -> PipelineEditBatch;
 

--- a/alcedo_studio/src/include/app/pipeline_history_applier.hpp
+++ b/alcedo_studio/src/include/app/pipeline_history_applier.hpp
@@ -14,6 +14,7 @@
 #include "edit/history/edit_commit.hpp"
 #include "edit/history/pipeline_edit_batch.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph.hpp"
 #include "edit/mask/mask_asset.hpp"
 
 namespace alcedo {
@@ -32,6 +33,7 @@ class MaskStore;
 struct PipelineHistoryApplyContext {
   MaskStore* mask_store = nullptr;
   std::function<void(std::size_t applied_count)> after_successful_change;
+  TopologyDeltaStepHook after_topology_step;
 };
 
 /**

--- a/alcedo_studio/src/include/edit/graph/pipeline_graph.hpp
+++ b/alcedo_studio/src/include/edit/graph/pipeline_graph.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <string_view>
 #include <vector>
@@ -19,7 +20,40 @@ struct GraphEdge {
   PortId from_port;
   NodeId to_node;
   PortId to_port;
+
+  friend auto operator==(const GraphEdge& lhs, const GraphEdge& rhs) -> bool {
+    return lhs.from_node == rhs.from_node && lhs.from_port == rhs.from_port &&
+           lhs.to_node == rhs.to_node && lhs.to_port == rhs.to_port;
+  }
 };
+
+/// One node taken from a live graph by vector index.
+struct TopologyNodeRemoval {
+  NodeId      id;
+  std::size_t original_index = 0;
+};
+
+/// One node inserted into a live graph at a final vector index.
+struct TopologyNodeInsertion {
+  std::unique_ptr<INodeModel> node;
+  std::size_t                 final_index = 0;
+};
+
+/// One edge taken from a live graph by vector index.
+struct TopologyEdgeRemoval {
+  GraphEdge   edge;
+  std::size_t original_index = 0;
+};
+
+/// One edge inserted into a live graph at a final vector index.
+struct TopologyEdgeInsertion {
+  GraphEdge   edge;
+  std::size_t final_index = 0;
+};
+
+/// Test hook invoked after each in-place topology mutation step.
+/// @p step is disconnect, remove_node, insert_node, connect, or validate.
+using TopologyDeltaStepHook = std::function<void(std::string_view step, std::size_t index)>;
 
 /**
  * @brief Simple directed graph of INodeModel instances.
@@ -53,6 +87,27 @@ class PipelineGraph {
   auto ApplyBackboneEdit(const std::vector<GraphEdge>& disconnected,
                          std::vector<GraphEdge>        connected,
                          std::unique_ptr<INodeModel> inserted = nullptr, const NodeId& removed = {})
+      -> std::vector<GraphValidationError>;
+
+  /**
+   * @brief Apply one net topology delta in place on this live graph object.
+   *
+   * Removed nodes and disconnected edges must match the live vectors at the
+   * stored original indexes. Inserted NodeIds and connected edge identities
+   * must not already exist after those removals. All restoration storage is
+   * reserved before mutation. Unaffected INodeModel addresses stay stable.
+   *
+   * @pre Caller holds the live executor render lock.
+   * @return Validation errors after restoring exact node ownership, node order,
+   *         and edge order, or empty on success. Exceptions restore the same
+   *         objects and propagate.
+   */
+  auto ApplyTopologyDelta(const std::vector<TopologyNodeRemoval>&     removed_nodes,
+                          std::vector<TopologyNodeInsertion>          inserted_nodes,
+                          const std::vector<TopologyEdgeRemoval>&     disconnected_edges,
+                          const std::vector<TopologyEdgeInsertion>&   connected_edges,
+                          TopologyDeltaStepHook                       after_step = {},
+                          std::vector<std::unique_ptr<INodeModel>>*   discarded_nodes = nullptr)
       -> std::vector<GraphValidationError>;
 
   [[nodiscard]] auto Validate() const -> std::vector<GraphValidationError>;

--- a/alcedo_studio/src/include/edit/history/pipeline_edit_batch.hpp
+++ b/alcedo_studio/src/include/edit/history/pipeline_edit_batch.hpp
@@ -34,6 +34,7 @@ enum class PipelineEditOperationKind : std::uint8_t {
   ReplaceMaskAsset,
   SetMaskField,
   Paste,
+  EditNodeGraph,
 };
 
 /// Discriminator for one stored typed change.
@@ -50,6 +51,7 @@ enum class PipelineEditChangeKind : std::uint8_t {
   ReplaceMaskSource,
   ReplaceMaskAsset,
   SetMaskField,
+  NodeGraphTopologyChange,
 };
 
 /// Owner of one stored parameter write. Unspecified is not a legal stored value.
@@ -181,6 +183,56 @@ struct ReconnectColorGradeChange {
   auto operator==(const ReconnectColorGradeChange&) const -> bool = default;
 };
 
+/// One Color Grade inserted by a net topology delta.
+struct NodeGraphInsertedNode {
+  nlohmann::json node              = nlohmann::json::object();
+  std::uint32_t  final_node_index = 0;
+
+  auto operator==(const NodeGraphInsertedNode&) const -> bool = default;
+};
+
+/// One Color Grade removed by a net topology delta.
+struct NodeGraphRemovedNode {
+  nlohmann::json node                 = nlohmann::json::object();
+  std::uint32_t  original_node_index = 0;
+
+  auto operator==(const NodeGraphRemovedNode&) const -> bool = default;
+};
+
+/// One scene-image edge disconnected from the bound base graph.
+struct NodeGraphDisconnectedEdge {
+  PipelineSceneEdge edge;
+  std::uint32_t     original_edge_index = 0;
+
+  auto operator==(const NodeGraphDisconnectedEdge&) const -> bool = default;
+};
+
+/// One scene-image edge present in the final graph.
+struct NodeGraphConnectedEdge {
+  PipelineSceneEdge edge;
+  std::uint32_t     final_edge_index = 0;
+
+  auto operator==(const NodeGraphConnectedEdge&) const -> bool = default;
+};
+
+/**
+ * @brief Net topology delta from one bound base graph to one accepted graph.
+ *
+ * One stored change applies in place. It is not a list of Add, Remove, or
+ * Reconnect commands. Transient session generation and topology revision
+ * guards are not replay data and are omitted.
+ */
+struct NodeGraphTopologyChange {
+  std::vector<NodeGraphInsertedNode>     inserted_nodes;
+  std::vector<NodeGraphRemovedNode>      removed_nodes;
+  std::vector<NodeGraphDisconnectedEdge> disconnected_edges;
+  std::vector<NodeGraphConnectedEdge>    connected_edges;
+  std::uint64_t before_next_color_grade_name_number = kInitialNextColorGradeNameNumber;
+  std::uint64_t after_next_color_grade_name_number  = kInitialNextColorGradeNameNumber;
+
+  auto operator==(const NodeGraphTopologyChange&) const -> bool = default;
+};
+
 struct AddMaskChange {
   NodeId         node_id;
   MaskId         mask_id;
@@ -231,7 +283,7 @@ using PipelineEditChange =
     std::variant<SetParameterChange, SetNodeEnabledChange, SetNodeMixChange, RenameColorGradeChange,
                  AddColorGradeChange, RemoveColorGradeChange, ReconnectColorGradeChange,
                  AddMaskChange, RemoveMaskChange, ReplaceMaskSourceChange, ReplaceMaskAssetChange,
-                 SetMaskFieldChange>;
+                 SetMaskFieldChange, NodeGraphTopologyChange>;
 
 /**
  * @brief Saved identity used by history rows. Never reads a live document.

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
@@ -215,10 +215,28 @@ class AlcedoQanGraph : public QObject {
   Q_INVOKABLE void    setDrawerOpen(const QString& node_id, bool open);
   Q_INVOKABLE bool    drawerOpen(const QString& node_id) const;
   Q_INVOKABLE void    applyProductSelection(const QString& node_id);
+  /**
+   * @brief Hide the official visual connector preview without inserting an edge.
+   *
+   * Call after a request is accepted or rejected. The adapter never creates a
+   * permanent Qan edge from a connector drop.
+   */
+  Q_INVOKABLE void    hideConnectorPreview();
 
  signals:
   void GraphChanged();
   void DelegatesChanged();
+  /**
+   * @brief Generation-checked connector drop ready for a product Reconnect.
+   *
+   * @p destinationIsOutput is true when the drop target is an output port.
+   */
+  void ConnectorMoveRequested(const QString& sourceNodeId, const QString& destinationNodeId,
+                              bool destinationIsOutput);
+  /**
+   * @brief Connector drop that could not be resolved to live product IDs.
+   */
+  void ConnectorRequestRejected(const QString& error);
   /**
    * @brief Emitted when a Color Grade Mask drawer is opened or closed.
    *
@@ -280,7 +298,11 @@ class AlcedoQanGraph : public QObject {
   void               BindDrawerSignals();
   void               BindDrawerSignal(QQuickItem* item, const NodeId& node_id);
   void               ConfigureGraphPolicy();
+  void               ConfigureConnector();
+  void               ApplyConnectablePolicy();
   void               OnGraphDestroyed();
+  void OnConnectorRequestEdgeCreation(qan::Node* src, QObject* dst, qan::PortItem* src_port,
+                                      qan::PortItem* dst_port);
 
  private slots:
   void OnDrawerOpenChanged();

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
@@ -146,6 +146,40 @@ class AlcedoQanGraph : public QObject {
       -> AlcedoQanGraphApplyResult;
 
   /**
+   * @brief Insert one projected node and its ports without replacing the graph.
+   * @return Failure restores no other primitives. The new node is removed on error.
+   */
+  [[nodiscard]] auto InsertProjectedNode(const EditorNodeProjection& node)
+      -> AlcedoQanGraphApplyResult;
+  /**
+   * @brief Remove one mapped node and incident mapped edges.
+   */
+  [[nodiscard]] auto RemoveProjectedNode(const NodeId& node_id) -> AlcedoQanGraphApplyResult;
+  /**
+   * @brief Insert one edge. @p candidate uses the request-preview color until promotion.
+   */
+  [[nodiscard]] auto InsertProjectedEdge(const EditorNodeEdgeProjection& edge, bool candidate)
+      -> AlcedoQanGraphApplyResult;
+  /**
+   * @brief Remove one mapped edge. Unknown edges succeed as no-ops.
+   */
+  [[nodiscard]] auto RemoveProjectedEdge(const EditorNodeEdgeProjection& edge)
+      -> AlcedoQanGraphApplyResult;
+  /**
+   * @brief Recolor every mapped edge to the permanent AppTheme stroke.
+   */
+  void PromoteCandidatePresentation();
+  /**
+   * @brief Record committed snapshot revisions without replacing Qan primitives.
+   *
+   * Requires live node and edge identities to match @p snapshot. Used after
+   * automatic topology submission and adapter recreation is not required.
+   */
+  [[nodiscard]] auto PromoteCommittedSnapshot(const EditorNodeGraphSnapshot& snapshot)
+      -> AlcedoQanGraphApplyResult;
+  [[nodiscard]] auto topology_replace_count() const -> int { return topology_replace_count_; }
+
+  /**
    * @return Live Qan node for @p node_id in the current generation, or nullptr.
    */
   [[nodiscard]] auto NodeFor(const NodeId& node_id) const -> qan::Node*;
@@ -227,7 +261,7 @@ class AlcedoQanGraph : public QObject {
   void GraphChanged();
   void DelegatesChanged();
   /**
-   * @brief Generation-checked connector drop ready for a product Reconnect.
+   * @brief Generation-checked connector drop ready for exclusive-port Connect.
    *
    * @p destinationIsOutput is true when the drop target is an output port.
    */
@@ -325,6 +359,7 @@ class AlcedoQanGraph : public QObject {
                                 bool is_input) -> qan::PortItem*;
   [[nodiscard]] auto InsertEdge(const EditorNodeEdgeProjection& edge) -> QString;
   void               ApplyNodePresentation(qan::Node& qan_node, const EditorNodeProjection& node);
+  void               ApplyEdgePresentation(qan::Edge& qan_edge, bool candidate);
   [[nodiscard]] auto EnsureDelegates() -> QString;
   struct LoadedComponent {
     std::unique_ptr<QQmlComponent> component;
@@ -359,6 +394,8 @@ class AlcedoQanGraph : public QObject {
   std::unique_ptr<QQmlComponent>                    edge_component_;
   bool                                              has_projection_      = false;
   bool                                              rebuild_in_progress_ = false;
+  int                                               topology_replace_count_ = 0;
+  std::map<EdgeKey, bool>                           edge_candidate_;
   EditorNodeGraphSnapshot                           applied_;
   std::map<NodeId, QPointer<qan::Node>>             node_by_id_;
   std::map<EdgeKey, QPointer<qan::Edge>>            edge_by_key_;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
@@ -61,6 +61,8 @@ class EditorHistoryMutation {
   auto ReconnectColorGrade(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
                            const alcedo::NodeId& new_predecessor_id,
                            const alcedo::NodeId& new_successor_id, std::string* error) -> bool;
+  auto EditNodeGraph(const alcedo::EditorHistoryGuardHandle& guard,
+                     alcedo::NodeGraphTopologyChange change, std::string* error) -> bool;
   auto RenameColorGrade(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
                         std::string display_name, std::string* error) -> bool;
   auto SetColorGradeEnabled(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -28,9 +28,10 @@ class EditorSessionController;
  * Owns the session generation, selected NodeId, and published
  * EditorNodeGraphSnapshot. It does not own Qan visuals or layout coordinates.
  * When the open Nodes page binds its AlcedoQanGraph, this controller applies
- * the published snapshot onto that adapter after Add, Rename, and Delete.
- * Reconnect remains outside this controller until its request-only connector
- * phase.
+ * the published snapshot onto that adapter after Add, Rename, Delete, and
+ * Reconnect. Visual connector requests resolve product IDs on the adapter,
+ * then this controller computes the remaining-backbone predecessor and
+ * successor and submits NM4 ReconnectColorGrade.
  *
  * Threading: GUI thread only. Side effects: snapshot and selection signals.
  * Failure: stale generations and unknown NodeIds leave the live snapshot and
@@ -55,6 +56,8 @@ class EditorNodeController : public QObject {
   Q_PROPERTY(bool canRenameSelectedColorGrade READ can_rename_selected_color_grade NOTIFY
                  ActionAvailabilityChanged)
   Q_PROPERTY(bool canDeleteSelectedColorGrade READ can_delete_selected_color_grade NOTIFY
+                 ActionAvailabilityChanged)
+  Q_PROPERTY(bool canReconnectSelectedColorGrade READ can_reconnect_selected_color_grade NOTIFY
                  ActionAvailabilityChanged)
   Q_PROPERTY(QString selectedNodeName READ selected_node_name NOTIFY SelectionChanged)
   Q_PROPERTY(QObject* graphAdapter READ graph_adapter_object WRITE set_graph_adapter NOTIFY
@@ -135,6 +138,26 @@ class EditorNodeController : public QObject {
    * @return false without changing product or projected state on command failure.
    */
   Q_INVOKABLE bool   deleteColorGrade(const QString& node_id);
+  /**
+   * @brief Move one Color Grade between a new predecessor and successor.
+   *
+   * @p request_generation must match the bound session. A no-op neighbor pair
+   * returns true without a history commit. Invalid, cyclic, fan-in, and fan-out
+   * pairs fail closed.
+   */
+  Q_INVOKABLE bool   requestReconnect(const QString& node_id, const QString& predecessor_id,
+                                      const QString& successor_id);
+  Q_INVOKABLE bool   requestReconnect(const QString& node_id, const QString& predecessor_id,
+                                      const QString& successor_id, quint64 request_generation);
+  /**
+   * @brief Resolve a visual-connector drop against the remaining backbone.
+   *
+   * @p source_node_id must be the selected Color Grade. @p destination_is_output
+   * inserts after the destination; otherwise the Grade is inserted before it.
+   */
+  Q_INVOKABLE bool   requestConnectorMove(const QString& source_node_id,
+                                          const QString& destination_node_id,
+                                          bool           destination_is_output);
 
   [[nodiscard]] auto selected_node_id() const -> NodeId { return selected_node_id_; }
   [[nodiscard]] auto selected_node_id_string() const -> QString;
@@ -151,6 +174,7 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto can_add_color_grade() const -> bool;
   [[nodiscard]] auto can_rename_selected_color_grade() const -> bool;
   [[nodiscard]] auto can_delete_selected_color_grade() const -> bool;
+  [[nodiscard]] auto can_reconnect_selected_color_grade() const -> bool;
   [[nodiscard]] auto selected_node_name() const -> QString;
   [[nodiscard]] auto snapshot() const -> const EditorNodeGraphSnapshot& { return snapshot_; }
 
@@ -195,7 +219,18 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto NodeFor(const NodeId& node_id) const -> const EditorNodeProjection*;
   [[nodiscard]] auto ValidateCommandGeneration() -> bool;
   [[nodiscard]] auto IsColorGrade(const NodeId& node_id) const -> bool;
+  [[nodiscard]] auto CurrentPredecessor(const NodeId& node_id) const -> NodeId;
+  [[nodiscard]] auto CurrentSuccessor(const NodeId& node_id) const -> NodeId;
+  [[nodiscard]] auto ResolveConnectorMove(const NodeId& moving_id, const NodeId& destination_id,
+                                          bool destination_is_output, NodeId* predecessor_id,
+                                          NodeId* successor_id) -> bool;
+  [[nodiscard]] auto NeighborsAreAdjacentInRemaining(const NodeId& moving_id,
+                                                     const NodeId& predecessor_id,
+                                                     const NodeId& successor_id) const -> bool;
   void               SetCommandActive(bool active);
+  void OnConnectorMoveRequested(const QString& source_node_id, const QString& destination_node_id,
+                                bool destination_is_output);
+  void OnConnectorRequestRejected(const QString& error);
   [[nodiscard]] auto TopologyChanged(const EditorNodeGraphSnapshot& snapshot) const -> bool;
   [[nodiscard]] auto BoundSessionGeneration() const -> std::optional<std::uint64_t>;
   void               SelectByKind(EditorNodeKind kind);

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -10,8 +10,10 @@
 #include <QString>
 #include <QStringList>
 #include <cstdint>
+#include <memory>
 #include <optional>
 
+#include "app/editor_node_graph_draft.hpp"
 #include "app/editor_node_graph_projection.hpp"
 #include "edit/graph/graph_ids.hpp"
 #include "edit/graph/pipeline_document.hpp"
@@ -25,13 +27,11 @@ class EditorSessionController;
 /**
  * @brief Application-layer owner of Nodes-page product selection and projection.
  *
- * Owns the session generation, selected NodeId, and published
- * EditorNodeGraphSnapshot. It does not own Qan visuals or layout coordinates.
- * When the open Nodes page binds its AlcedoQanGraph, this controller applies
- * the published snapshot onto that adapter after Add, Rename, Delete, and
- * Reconnect. Visual connector requests resolve product IDs on the adapter,
- * then this controller computes the remaining-backbone predecessor and
- * successor and submits NM4 ReconnectColorGrade.
+ * Owns the session generation, selected NodeId, published snapshot, and the
+ * incremental topology draft. It does not own Qan visuals or layout coordinates.
+ * Add, Delete, and Connect mutate EditorNodeGraphDraft. The first admitted
+ * operation that restores a complete supported graph submits one
+ * NodeGraphTopologyChange. Visual connectors report exclusive-port requests.
  *
  * Threading: GUI thread only. Side effects: snapshot and selection signals.
  * Failure: stale generations and unknown NodeIds leave the live snapshot and
@@ -59,6 +59,9 @@ class EditorNodeController : public QObject {
                  ActionAvailabilityChanged)
   Q_PROPERTY(bool canReconnectSelectedColorGrade READ can_reconnect_selected_color_grade NOTIFY
                  ActionAvailabilityChanged)
+  Q_PROPERTY(bool incompleteDraft READ incomplete_draft NOTIFY DraftStateChanged)
+  Q_PROPERTY(QString incompleteDraftInstruction READ incomplete_draft_instruction NOTIFY
+                 DraftStateChanged)
   Q_PROPERTY(QString selectedNodeName READ selected_node_name NOTIFY SelectionChanged)
   Q_PROPERTY(QObject* graphAdapter READ graph_adapter_object WRITE set_graph_adapter NOTIFY
                  GraphAdapterChanged)
@@ -124,8 +127,9 @@ class EditorNodeController : public QObject {
   Q_INVOKABLE void   selectDevelop();
   Q_INVOKABLE void   selectDrt();
   /**
-   * @brief Add one clean Color Grade after the selected Grade or before DRT.
-   * @return false without changing the projection when admission or history fails.
+   * @brief Add one disconnected clean Color Grade below the main node DAG.
+   *
+   * Does not write PipelineDocument or history while the draft is incomplete.
    */
   Q_INVOKABLE bool   addCleanColorGrade();
   /**
@@ -134,26 +138,21 @@ class EditorNodeController : public QObject {
    */
   Q_INVOKABLE bool   renameColorGrade(const QString& node_id, const QString& display_name);
   /**
-   * @brief Remove one Color Grade and select its successor, predecessor, or DRT.
-   * @return false without changing product or projected state on command failure.
+   * @brief Remove one Color Grade from the draft. Does not bridge neighbors.
    */
   Q_INVOKABLE bool   deleteColorGrade(const QString& node_id);
   /**
-   * @brief Move one Color Grade between a new predecessor and successor.
-   *
-   * @p request_generation must match the bound session. A no-op neighbor pair
-   * returns true without a history commit. Invalid, cyclic, fan-in, and fan-out
-   * pairs fail closed.
+   * @brief Exclusive-port connect from @p source output to @p destination input.
    */
-  Q_INVOKABLE bool   requestReconnect(const QString& node_id, const QString& predecessor_id,
-                                      const QString& successor_id);
-  Q_INVOKABLE bool   requestReconnect(const QString& node_id, const QString& predecessor_id,
-                                      const QString& successor_id, quint64 request_generation);
+  Q_INVOKABLE bool   requestConnect(const QString& source_node_id,
+                                    const QString& destination_node_id);
+  Q_INVOKABLE bool   requestConnect(const QString& source_node_id,
+                                    const QString& destination_node_id, quint64 request_generation);
   /**
-   * @brief Resolve a visual-connector drop against the remaining backbone.
+   * @brief Resolve a visual-connector drop as exclusive-port Connect.
    *
-   * @p source_node_id must be the selected Color Grade. @p destination_is_output
-   * inserts after the destination; otherwise the Grade is inserted before it.
+   * Output-to-output drops are rejected. Any supported Color Grade or Develop
+   * output may start a connection.
    */
   Q_INVOKABLE bool   requestConnectorMove(const QString& source_node_id,
                                           const QString& destination_node_id,
@@ -175,6 +174,8 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto can_rename_selected_color_grade() const -> bool;
   [[nodiscard]] auto can_delete_selected_color_grade() const -> bool;
   [[nodiscard]] auto can_reconnect_selected_color_grade() const -> bool;
+  [[nodiscard]] auto incomplete_draft() const -> bool;
+  [[nodiscard]] auto incomplete_draft_instruction() const -> QString;
   [[nodiscard]] auto selected_node_name() const -> QString;
   [[nodiscard]] auto snapshot() const -> const EditorNodeGraphSnapshot& { return snapshot_; }
 
@@ -206,6 +207,7 @@ class EditorNodeController : public QObject {
   void ActionAvailabilityChanged();
   void GraphAdapterChanged();
   void LayoutStoreChanged();
+  void DraftStateChanged();
 
  private:
   void               DisconnectSession();
@@ -219,18 +221,17 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto NodeFor(const NodeId& node_id) const -> const EditorNodeProjection*;
   [[nodiscard]] auto ValidateCommandGeneration() -> bool;
   [[nodiscard]] auto IsColorGrade(const NodeId& node_id) const -> bool;
-  [[nodiscard]] auto CurrentPredecessor(const NodeId& node_id) const -> NodeId;
-  [[nodiscard]] auto CurrentSuccessor(const NodeId& node_id) const -> NodeId;
-  [[nodiscard]] auto ResolveConnectorMove(const NodeId& moving_id, const NodeId& destination_id,
-                                          bool destination_is_output, NodeId* predecessor_id,
-                                          NodeId* successor_id) -> bool;
-  [[nodiscard]] auto NeighborsAreAdjacentInRemaining(const NodeId& moving_id,
-                                                     const NodeId& predecessor_id,
-                                                     const NodeId& successor_id) const -> bool;
   void               SetCommandActive(bool active);
   void OnConnectorMoveRequested(const QString& source_node_id, const QString& destination_node_id,
                                 bool destination_is_output);
   void OnConnectorRequestRejected(const QString& error);
+  [[nodiscard]] auto CurrentDraftIdentity() const -> alcedo::EditorNodeGraphDraftIdentity;
+  [[nodiscard]] auto EnsureDraft() -> bool;
+  void               DiscardDraft();
+  void               SyncSnapshotFromDraft();
+  [[nodiscard]] auto ApplyMutationToGraph(const alcedo::EditorNodeGraphDraftMutation& mutation)
+      -> bool;
+  [[nodiscard]] auto MaybeSubmitDraft() -> bool;
   [[nodiscard]] auto TopologyChanged(const EditorNodeGraphSnapshot& snapshot) const -> bool;
   [[nodiscard]] auto BoundSessionGeneration() const -> std::optional<std::uint64_t>;
   void               SelectByKind(EditorNodeKind kind);
@@ -260,6 +261,8 @@ class EditorNodeController : public QObject {
   quint64                           image_id_                = 0;
   QString                           version_id_;
   QString                           last_error_;
+  std::unique_ptr<alcedo::EditorNodeGraphDraft> draft_;
+  bool                              skip_next_session_refresh_ = false;
 };
 
 void RegisterEditorNodeQmlTypes();

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_layout_store.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_layout_store.hpp
@@ -161,6 +161,19 @@ class EditorNodeLayoutStore : public QObject {
   void                EnsureDefaultPositions(const EditorNodeGraphSnapshot& snapshot);
 
   /**
+   * @brief Place one unconnected draft node below the current vertical DAG.
+   *
+   * Uses the backbone origin x so the new card stays in the vertical view.
+   * Existing stored positions are left unchanged. Multiple unconnected draft
+   * nodes stack downward. Does not write PipelineDocument or history.
+   * @param node_id Draft Color Grade that has no stored position yet.
+   * @param snapshot Live or draft projection used for node heights and to fill
+   *        missing backbone positions before measuring the lowest card.
+   */
+  void                AssignStagingPosition(const NodeId& node_id,
+                                            const EditorNodeGraphSnapshot& snapshot);
+
+  /**
    * @brief QML entry that copies defaults from an EditorNodeController snapshot.
    * @param controller EditorNodeController, or ignored when the type does not match.
    */

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_layout_store.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_layout_store.hpp
@@ -48,24 +48,25 @@ struct EditorNodeLayoutKey {
 };
 
 /**
- * @brief Geometry tokens used to compute the first backbone layout.
+ * @brief Geometry used to compute the first backbone layout.
  *
- * Defaults match the DESIGN.md graph-node sizes. Tests may supply explicit
- * values. The QML default constructor uses these members as-is.
+ * The default EditorNodeLayoutStore constructor fills this from AppTheme.
+ * Tests may pass an explicit struct. Do not copy DESIGN.md literals here;
+ * AppTheme is the runtime source for graph and side-panel sizes.
  */
 struct EditorNodeLayoutMetrics {
-  int origin_x             = 48;
-  int origin_y             = 48;
-  int vertical_gap         = 48;
-  int node_width           = 220;
-  int endpoint_height      = 40;
-  int name_row_height      = 32;
-  int drawer_header_height = 28;
-  int mask_row_height      = 28;
-  int divider_height       = 1;
-  int panel_width_min      = 260;
-  int panel_width_max      = 460;
-  int panel_width_default  = 320;
+  int origin_x             = 0;
+  int origin_y             = 0;
+  int vertical_gap         = 0;
+  int node_width           = 0;
+  int endpoint_height      = 0;
+  int name_row_height      = 0;
+  int drawer_header_height = 0;
+  int mask_row_height      = 0;
+  int divider_height       = 0;
+  int panel_width_min      = 0;
+  int panel_width_max      = 0;
+  int panel_width_default  = 0;
 };
 
 /**
@@ -76,7 +77,7 @@ struct EditorNodeLayoutMetrics {
  * write PipelineDocument or history.
  */
 struct EditorNodeLayoutValue {
-  int                       preferred_panel_width = 320;
+  int                       preferred_panel_width = 0;
   QPointF                   view_position;
   qreal                     zoom = 1.0;
   NodeId                    selected_node_id;
@@ -170,24 +171,23 @@ class EditorNodeLayoutStore : public QObject {
    * @param snapshot Live or draft projection used for node heights and to fill
    *        missing backbone positions before measuring the lowest card.
    */
-  void                AssignStagingPosition(const NodeId& node_id,
-                                            const EditorNodeGraphSnapshot& snapshot);
+  void AssignStagingPosition(const NodeId& node_id, const EditorNodeGraphSnapshot& snapshot);
 
   /**
    * @brief QML entry that copies defaults from an EditorNodeController snapshot.
    * @param controller EditorNodeController, or ignored when the type does not match.
    */
-  Q_INVOKABLE void    ensureDefaultsFrom(QObject* controller);
+  Q_INVOKABLE void   ensureDefaultsFrom(QObject* controller);
 
   /**
    * @return Copied value for @p key, or a default-constructed value when absent.
    */
-  [[nodiscard]] auto  Value(const EditorNodeLayoutKey& key) const -> EditorNodeLayoutValue;
+  [[nodiscard]] auto Value(const EditorNodeLayoutKey& key) const -> EditorNodeLayoutValue;
 
   /**
    * @brief Height of one node in the first deterministic layout.
    */
-  [[nodiscard]] auto  DefaultHeight(EditorNodeKind kind, int mask_count, bool drawer_open) const
+  [[nodiscard]] auto DefaultHeight(EditorNodeKind kind, int mask_count, bool drawer_open) const
       -> qreal;
 
  signals:

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -26,6 +26,7 @@ namespace alcedo {
 class IFrameSink;
 class IEditorSessionBackend;
 class PipelineDocument;
+struct NodeGraphTopologyChange;
 }  // namespace alcedo
 
 namespace alcedo::ui {
@@ -216,6 +217,9 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   auto SubmitReconnectColorGrade(const alcedo::NodeId& node_id,
                                  const alcedo::NodeId& new_predecessor_id,
                                  const alcedo::NodeId& new_successor_id)
+      -> alcedo::EditorSessionResult;
+  /** Route one net topology delta through the active session backend. */
+  auto SubmitNodeGraphTopologyEdit(const alcedo::NodeGraphTopologyChange& change)
       -> alcedo::EditorSessionResult;
   /// Seal the active image via the same Close path as leaving the editor for
   /// Library (`WorkspaceRouter::OpenLibrary`). persistChanges=true may leave

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -212,6 +212,11 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   /** Route a metadata-only Color Grade rename through the active session backend. */
   auto SubmitRenameColorGrade(const alcedo::NodeId& node_id, std::string display_name)
       -> alcedo::EditorSessionResult;
+  /** Route a Color Grade backbone move through the active session backend. */
+  auto SubmitReconnectColorGrade(const alcedo::NodeId& node_id,
+                                 const alcedo::NodeId& new_predecessor_id,
+                                 const alcedo::NodeId& new_successor_id)
+      -> alcedo::EditorSessionResult;
   /// Seal the active image via the same Close path as leaving the editor for
   /// Library (`WorkspaceRouter::OpenLibrary`). persistChanges=true may leave
   /// sessionState at Saving until the checkpoint finishes; callers that must

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
@@ -68,9 +68,10 @@ class EditorSessionHistoryPort final : public alcedo::IEditorHistoryPort {
                      std::string* error) -> bool override;
   auto RemoveColorGrade(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
                         std::string* error) -> bool override;
-  auto ReconnectColorGrade(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
-                           const alcedo::NodeId& new_predecessor_id,
-                           const alcedo::NodeId& new_successor_id, std::string* error) -> bool;
+  auto ReconnectColorGrade(const alcedo::EditorHistoryGuardHandle& guard,
+                           const alcedo::NodeId& node_id, const alcedo::NodeId& new_predecessor_id,
+                           const alcedo::NodeId& new_successor_id, std::string* error)
+      -> bool override;
   auto RenameColorGrade(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
                         std::string display_name, std::string* error) -> bool override;
   auto SetColorGradeEnabled(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
@@ -72,6 +72,8 @@ class EditorSessionHistoryPort final : public alcedo::IEditorHistoryPort {
                            const alcedo::NodeId& node_id, const alcedo::NodeId& new_predecessor_id,
                            const alcedo::NodeId& new_successor_id, std::string* error)
       -> bool override;
+  auto EditNodeGraph(const alcedo::EditorHistoryGuardHandle& guard,
+                     alcedo::NodeGraphTopologyChange change, std::string* error) -> bool override;
   auto RenameColorGrade(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,
                         std::string display_name, std::string* error) -> bool override;
   auto SetColorGradeEnabled(const alcedo::EditorHistoryGuardHandle& guard, const alcedo::NodeId& node_id,

--- a/alcedo_studio/src/include/ui/alcedo_main/app_theme.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/app_theme.hpp
@@ -154,7 +154,8 @@ class AppTheme final : public QObject {
   Q_PROPERTY(QColor graphPortFillColor READ graphPortFillColor NOTIFY ThemeChanged)
   Q_PROPERTY(QColor graphPortBorderColor READ graphPortBorderColor NOTIFY ThemeChanged)
   Q_PROPERTY(QColor graphNodeBorderColor READ graphNodeBorderColor NOTIFY ThemeChanged)
-  Q_PROPERTY(QColor graphMaskDrawerSurfaceColor READ graphMaskDrawerSurfaceColor NOTIFY ThemeChanged)
+  Q_PROPERTY(
+      QColor graphMaskDrawerSurfaceColor READ graphMaskDrawerSurfaceColor NOTIFY ThemeChanged)
   Q_PROPERTY(QColor graphSelectionOutlineColor READ graphSelectionOutlineColor NOTIFY ThemeChanged)
   Q_PROPERTY(int graphNodeWidth READ graphNodeWidth CONSTANT)
   Q_PROPERTY(int graphNodeVerticalGap READ graphNodeVerticalGap CONSTANT)
@@ -162,6 +163,7 @@ class AppTheme final : public QObject {
   Q_PROPERTY(int graphNodeOriginY READ graphNodeOriginY CONSTANT)
   Q_PROPERTY(int graphEndpointHeight READ graphEndpointHeight CONSTANT)
   Q_PROPERTY(int graphNameRowHeight READ graphNameRowHeight CONSTANT)
+  Q_PROPERTY(int graphNameRowDividerHeight READ graphNameRowDividerHeight CONSTANT)
   Q_PROPERTY(int graphMaskDrawerHeaderHeight READ graphMaskDrawerHeaderHeight CONSTANT)
   Q_PROPERTY(int graphMaskRowHeight READ graphMaskRowHeight CONSTANT)
   Q_PROPERTY(int graphPortSize READ graphPortSize CONSTANT)
@@ -332,6 +334,7 @@ class AppTheme final : public QObject {
   auto graphNodeOriginY() const -> int;
   auto graphEndpointHeight() const -> int;
   auto graphNameRowHeight() const -> int;
+  auto graphNameRowDividerHeight() const -> int;
   auto graphMaskDrawerHeaderHeight() const -> int;
   auto graphMaskRowHeight() const -> int;
   auto graphPortSize() const -> int;

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -226,6 +226,24 @@ target_link_libraries(AlbumBackendLib
         CudaDriverRequirements
 )
 
+# Canonical runtime theme tokens. DESIGN.md is the human VI spec; this library
+# is the only linkable source for colors, type, and graph metrics. Bundled
+# fonts/icons live here so RegisterFonts() and Q_INIT_RESOURCE share one owner.
+# Do not compile app_theme.cpp into executables that already link AppTheme.
+def_library(AppTheme
+    SOURCES
+        "${ALCEDO_UI_SHELL_ROOT}/app_theme.cpp"
+        "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/app_theme.hpp"
+        "${ALCEDO_SRC_ROOT}/config/resource.qrc"
+    PUBLIC_DEPS
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+)
+target_compile_definitions(AppTheme PRIVATE
+    ALCEDO_APP_VERSION="${PROJECT_VERSION}"
+)
+
 # Maps PipelineDocument snapshots onto pinned QuickQanava primitives. The QML
 # GraphView owns the qan::Graph; this adapter owns only identity maps.
 add_library(AlcedoQanGraph STATIC
@@ -238,6 +256,7 @@ target_include_directories(AlcedoQanGraph
 )
 target_link_libraries(AlcedoQanGraph
     PUBLIC
+        AppTheme
         EditorNodeGraphProjection
         QuickQanava
         Qt6::Core
@@ -254,10 +273,8 @@ target_link_libraries(AlbumBackendLib PUBLIC AlcedoQanGraph)
 set(ALCEDO_MAIN_SOURCES
     "${ALCEDO_UI_SHELL_ROOT}/main.cpp"
     "${ALCEDO_UI_SHELL_ROOT}/application_module_qml_types.cpp"
-    "${ALCEDO_UI_SHELL_ROOT}/app_theme.cpp"
     "${ALCEDO_UI_SHELL_ROOT}/shortcut_registry.cpp"
     "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/application_module_qml_types.hpp"
-    "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/app_theme.hpp"
     "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/i18n.hpp"
     "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/language_manager.hpp"
     "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/shortcut_registry.hpp"
@@ -606,8 +623,9 @@ foreach(ALCEDO_MAIN_QML_FILE IN LISTS ALCEDO_MAIN_QML_FILES ALCEDO_MAIN_QML_RESO
     )
 endforeach()
 
+# QML module only. Fonts/icons are owned by AppTheme (resource.qrc).
 add_library(AlcedoMainQml STATIC
-    "${ALCEDO_SRC_ROOT}/config/resource.qrc"
+    "${ALCEDO_UI_SHELL_ROOT}/alcedo_main_qml_module.cpp"
 )
 target_include_directories(AlcedoMainQml PUBLIC "${ALCEDO_INCLUDE_ROOT}")
 target_link_libraries(AlcedoMainQml
@@ -655,8 +673,6 @@ set(ALCEDO_TEST_HOST_SOURCES
     "${ALCEDO_UI_ROOT}/alcedo_studio_test_host/test_probe.hpp"
     "${ALCEDO_UI_SHELL_ROOT}/application_module_qml_types.cpp"
     "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/application_module_qml_types.hpp"
-    "${ALCEDO_UI_SHELL_ROOT}/app_theme.cpp"
-    "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/app_theme.hpp"
     "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/i18n.hpp"
     "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/language_manager.hpp"
     "${ALCEDO_INCLUDE_ROOT}/utils/cuda/cuda_driver_requirements.hpp"

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -206,6 +206,7 @@ target_link_libraries(AlbumBackendLib
         EditorSessionService
         EditorAdjustmentPipeline
         EditorPipelineCommandService
+        EditorNodeGraphDraft
         PipelineHistoryApplier
         EditorMiniGitMaterializer
         ThumbnailService

--- a/alcedo_studio/src/ui/alcedo_main/DESIGN.md
+++ b/alcedo_studio/src/ui/alcedo_main/DESIGN.md
@@ -357,6 +357,7 @@ Do not put raw graph colors in QML.
 | `graphNodeOriginY` | 48 | First-layout top origin |
 | `graphEndpointHeight` | 40 | Develop / DRT/Post height |
 | `graphNameRowHeight` | 32 | Color Grade name row |
+| `graphNameRowDividerHeight` | 1 | Hairline between name row and Masks drawer |
 | `graphMaskDrawerHeaderHeight` | 28 | `Masks` disclosure header |
 | `graphMaskRowHeight` | 28 | One Mask type row |
 | `graphPortSize` | 8 | Visible square port |

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
@@ -4,13 +4,16 @@
 
 #include "ui/alcedo_main/album_backend/alcedo_qan_graph.hpp"
 
+#include <QCoreApplication>
 #include <QDebug>
+#include <QEvent>
 #include <QMetaMethod>
 #include <QQmlComponent>
 #include <QQmlEngine>
 #include <QQuickItem>
 #include <QVariant>
 #include <QVariantMap>
+#include <algorithm>
 #include <cstddef>
 #include <optional>
 #include <string>
@@ -47,6 +50,8 @@ void HideDetachedVisual(QQuickItem* item) {
   item->setVisible(false);
   item->setParentItem(nullptr);
 }
+
+void FlushDeferredDeletes() { QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete); }
 
 }  // namespace
 
@@ -254,6 +259,7 @@ void AlcedoQanGraph::ClearIdentityMaps() {
   ClearDrawerConnections();
   node_by_id_.clear();
   edge_by_key_.clear();
+  edge_candidate_.clear();
   ports_by_node_.clear();
   node_projections_.clear();
   node_from_qan_.clear();
@@ -429,6 +435,7 @@ auto AlcedoQanGraph::ReplaceTopology(const EditorNodeGraphSnapshot& snapshot)
     -> AlcedoQanGraphApplyResult {
   AlcedoQanGraphApplyResult result;
   result.rebuilt_topology = true;
+  ++topology_replace_count_;
 
   const auto previous     = applied_;
   const auto had_previous = has_projection_;
@@ -552,8 +559,11 @@ auto AlcedoQanGraph::InsertEdge(const EditorNodeEdgeProjection& edge) -> QString
   if (source == nullptr || dest == nullptr) {
     return QStringLiteral("snapshot edge references an unknown node");
   }
-  if (out == nullptr || in == nullptr) {
-    return QStringLiteral("Qan edge port binding failed");
+  if (out == nullptr) {
+    return QStringLiteral("Qan source port is missing");
+  }
+  if (in == nullptr) {
+    return QStringLiteral("Qan destination port is missing");
   }
   auto* qan_edge = graph_->insertEdge(source, dest, edge_component_.get());
   if (qan_edge == nullptr || qan_edge->getItem() == nullptr) {
@@ -567,10 +577,199 @@ auto AlcedoQanGraph::InsertEdge(const EditorNodeEdgeProjection& edge) -> QString
   if (qan_edge->getItem()->getSourceItem() != out ||
       qan_edge->getItem()->getDestinationItem() != in) {
     graph_->removeEdge(qan_edge, true);
-    return QStringLiteral("Qan edge port binding failed");
+    return QStringLiteral("Qan edge did not bind to the requested ports");
   }
-  edge_by_key_[MakeEdgeKey(edge)] = qan_edge;
+  const auto key = MakeEdgeKey(edge);
+  edge_by_key_[key] = qan_edge;
+  ApplyEdgePresentation(*qan_edge, false);
+  edge_candidate_[key] = false;
   return {};
+}
+
+auto AlcedoQanGraph::InsertProjectedNode(const EditorNodeProjection& node)
+    -> AlcedoQanGraphApplyResult {
+  AlcedoQanGraphApplyResult result;
+  if (graph_.isNull() || !has_projection_) {
+    result.error = QStringLiteral("AlcedoQanGraph has no Qan graph");
+    return result;
+  }
+  if (NodeFor(node.node_id) != nullptr) {
+    result.error = QStringLiteral("Qan node already exists");
+    return result;
+  }
+  const auto delegate_error = EnsureDelegates();
+  if (!delegate_error.isEmpty()) {
+    result.error = delegate_error;
+    return result;
+  }
+  auto* qan_node = InsertQanNode(*graph_, node);
+  if (qan_node == nullptr || qan_node->getItem() == nullptr) {
+    if (qan_node != nullptr) {
+      graph_->removeNode(qan_node, true);
+    }
+    result.error = QStringLiteral("Qan node creation failed");
+    return result;
+  }
+  ApplyNodePresentation(*qan_node, node);
+  node_by_id_[node.node_id]       = qan_node;
+  node_projections_[node.node_id] = node;
+  node_from_qan_[qan_node]        = ReverseNode{node.node_id, applied_.session_generation};
+  const auto port_error           = InsertNodePorts(*qan_node, node);
+  if (!port_error.isEmpty()) {
+    (void)RemoveProjectedNode(node.node_id);
+    result.error = port_error;
+    return result;
+  }
+  BindDrawerSignal(qan_node->getItem(), node.node_id);
+  applied_.nodes.push_back(node);
+  AttachLiveVisuals();
+  ApplyConnectablePolicy();
+  result.succeeded = true;
+  return result;
+}
+
+auto AlcedoQanGraph::RemoveProjectedNode(const NodeId& node_id) -> AlcedoQanGraphApplyResult {
+  AlcedoQanGraphApplyResult result;
+  if (graph_.isNull()) {
+    result.error = QStringLiteral("AlcedoQanGraph has no Qan graph");
+    return result;
+  }
+  std::vector<EdgeKey> incident;
+  for (const auto& [key, edge] : edge_by_key_) {
+    if (key.source_node_id == node_id || key.destination_node_id == node_id) {
+      incident.push_back(key);
+    }
+  }
+  for (const auto& key : incident) {
+    EditorNodeEdgeProjection edge{key.source_node_id, key.source_port_id, key.destination_node_id,
+                                  key.destination_port_id};
+    (void)RemoveProjectedEdge(edge);
+  }
+  auto* qan_node = NodeFor(node_id);
+  if (qan_node != nullptr) {
+    node_from_qan_.erase(qan_node);
+    HideDetachedVisual(qan_node->getItem());
+    graph_->removeNode(qan_node, true);
+    FlushDeferredDeletes();
+  }
+  node_by_id_.erase(node_id);
+  node_projections_.erase(node_id);
+  ports_by_node_.erase(node_id);
+  applied_.nodes.erase(std::remove_if(applied_.nodes.begin(), applied_.nodes.end(),
+                                      [&](const auto& node) { return node.node_id == node_id; }),
+                       applied_.nodes.end());
+  ApplyConnectablePolicy();
+  result.succeeded = true;
+  return result;
+}
+
+auto AlcedoQanGraph::InsertProjectedEdge(const EditorNodeEdgeProjection& edge, bool candidate)
+    -> AlcedoQanGraphApplyResult {
+  AlcedoQanGraphApplyResult result;
+  if (graph_.isNull()) {
+    result.error = QStringLiteral("AlcedoQanGraph has no Qan graph");
+    return result;
+  }
+  if (EdgeFor(edge) != nullptr) {
+    ApplyEdgePresentation(*EdgeFor(edge), candidate);
+    edge_candidate_[MakeEdgeKey(edge)] = candidate;
+    result.succeeded                   = true;
+    return result;
+  }
+  const auto error = InsertEdge(edge);
+  if (!error.isEmpty()) {
+    result.error = error;
+    return result;
+  }
+  auto* qan_edge = EdgeFor(edge);
+  if (qan_edge != nullptr) {
+    ApplyEdgePresentation(*qan_edge, candidate);
+  }
+  edge_candidate_[MakeEdgeKey(edge)] = candidate;
+  applied_.edges.push_back(edge);
+  AttachLiveVisuals();
+  result.succeeded = true;
+  return result;
+}
+
+auto AlcedoQanGraph::RemoveProjectedEdge(const EditorNodeEdgeProjection& edge)
+    -> AlcedoQanGraphApplyResult {
+  AlcedoQanGraphApplyResult result;
+  if (graph_.isNull()) {
+    result.error = QStringLiteral("AlcedoQanGraph has no Qan graph");
+    return result;
+  }
+  const auto key = MakeEdgeKey(edge);
+  auto       it  = edge_by_key_.find(key);
+  if (it != edge_by_key_.end() && !it->second.isNull()) {
+    if (auto* item = it->second->getItem()) {
+      if (auto* src = qobject_cast<qan::PortItem*>(item->getSourceItem())) {
+        src->getOutEdgeItems().removeAll(item);
+      }
+      if (auto* dst = qobject_cast<qan::PortItem*>(item->getDestinationItem())) {
+        dst->getInEdgeItems().removeAll(item);
+      }
+    }
+    HideDetachedVisual(it->second->getItem());
+    graph_->removeEdge(it->second.data(), true);
+    FlushDeferredDeletes();
+  }
+  edge_by_key_.erase(key);
+  edge_candidate_.erase(key);
+  applied_.edges.erase(std::remove_if(applied_.edges.begin(), applied_.edges.end(),
+                                      [&](const auto& item) { return MakeEdgeKey(item) == key; }),
+                       applied_.edges.end());
+  result.succeeded = true;
+  return result;
+}
+
+void AlcedoQanGraph::PromoteCandidatePresentation() {
+  for (auto& [key, candidate] : edge_candidate_) {
+    candidate = false;
+    auto it   = edge_by_key_.find(key);
+    if (it != edge_by_key_.end() && !it->second.isNull()) {
+      ApplyEdgePresentation(*it->second, false);
+    }
+  }
+}
+
+auto AlcedoQanGraph::PromoteCommittedSnapshot(const EditorNodeGraphSnapshot& snapshot)
+    -> AlcedoQanGraphApplyResult {
+  AlcedoQanGraphApplyResult result;
+  if (!has_projection_ || graph_.isNull()) {
+    result.error = QStringLiteral("AlcedoQanGraph has no Qan graph");
+    return result;
+  }
+  if (snapshot.session_generation != applied_.session_generation) {
+    result.error = QStringLiteral("snapshot session generation is stale");
+    return result;
+  }
+  if (snapshot.nodes.size() != node_by_id_.size() || snapshot.edges.size() != edge_by_key_.size()) {
+    result.error = QStringLiteral("committed snapshot does not match live Qan identities");
+    return result;
+  }
+  for (const auto& node : snapshot.nodes) {
+    if (NodeFor(node.node_id) == nullptr) {
+      result.error = QStringLiteral("committed snapshot does not match live Qan identities");
+      return result;
+    }
+  }
+  for (const auto& edge : snapshot.edges) {
+    if (EdgeFor(edge) == nullptr) {
+      result.error = QStringLiteral("committed snapshot does not match live Qan identities");
+      return result;
+    }
+  }
+  for (const auto& node : snapshot.nodes) {
+    auto* qan_node = NodeFor(node.node_id);
+    ApplyNodePresentation(*qan_node, node);
+    node_projections_[node.node_id] = node;
+  }
+  PromoteCandidatePresentation();
+  applied_        = snapshot;
+  has_projection_ = true;
+  result.succeeded = true;
+  return result;
 }
 
 auto AlcedoQanGraph::MakeEdgeKey(const EditorNodeEdgeProjection& edge) -> EdgeKey {
@@ -584,6 +783,21 @@ auto AlcedoQanGraph::ToQString(std::string_view text) -> QString {
 
 auto AlcedoQanGraph::QanPortId(bool is_input, const PortId& port_id) -> QString {
   return (is_input ? QStringLiteral("in:") : QStringLiteral("out:")) + ToQString(port_id.Value());
+}
+
+void AlcedoQanGraph::ApplyEdgePresentation(qan::Edge& qan_edge, bool candidate) {
+  auto* item = qan_edge.getItem();
+  if (item == nullptr) {
+    return;
+  }
+  const auto color = candidate ? AppTheme::Instance().graphCandidateEdgeColor()
+                               : AppTheme::Instance().graphEdgeColor();
+  item->setProperty("candidate", candidate);
+  if (auto* style = item->getStyle()) {
+    style->setLineColor(color);
+  }
+  item->setSrcShape(qan::EdgeStyle::ArrowShape::None);
+  item->setDstShape(qan::EdgeStyle::ArrowShape::None);
 }
 
 void AlcedoQanGraph::ApplyNodePresentation(qan::Node& qan_node, const EditorNodeProjection& node) {
@@ -822,9 +1036,9 @@ void AlcedoQanGraph::ApplyConnectablePolicy() {
     if (projection->node_kind == EditorNodeKind::Drt) {
       connectable = qan::NodeItem::Connectable::InConnectable;
     } else if (projection->node_kind == EditorNodeKind::ColorGrade) {
-      connectable = node_id == product_selected_node_id_
-                        ? qan::NodeItem::Connectable::OutConnectable
-                        : qan::NodeItem::Connectable::InConnectable;
+      connectable = qan::NodeItem::Connectable::Connectable;
+    } else if (projection->node_kind == EditorNodeKind::Develop) {
+      connectable = qan::NodeItem::Connectable::OutConnectable;
     }
     node->getItem()->setConnectable(connectable);
   }
@@ -836,7 +1050,7 @@ void AlcedoQanGraph::ApplyConnectablePolicy() {
   const auto* selected = NodeProjection(product_selected_node_id_);
   auto*       source   = NodeFor(product_selected_node_id_);
   const bool  can_start =
-      selected != nullptr && selected->node_kind == EditorNodeKind::ColorGrade && source != nullptr;
+      selected != nullptr && selected->node_kind != EditorNodeKind::Drt && source != nullptr;
   if (!can_start) {
     connector->setSourcePort(nullptr);
     connector->setSourceNode(nullptr);

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
@@ -8,20 +8,21 @@
 #include <QMetaMethod>
 #include <QQmlComponent>
 #include <QQmlEngine>
+#include <QQuickItem>
 #include <QVariant>
 #include <QVariantMap>
 #include <cstddef>
 #include <optional>
 #include <string>
 
+#include "qanConnector.h"
 #include "qanEdge.h"
 #include "qanEdgeItem.h"
 #include "qanNode.h"
 #include "qanNodeItem.h"
 #include "qanPortItem.h"
 #include "qanStyle.h"
-
-#include <QQuickItem>
+#include "ui/alcedo_main/app_theme.hpp"
 
 namespace alcedo::ui {
 namespace {
@@ -441,6 +442,7 @@ auto AlcedoQanGraph::ReplaceTopology(const EditorNodeGraphSnapshot& snapshot)
     has_projection_      = true;
     rebuild_in_progress_ = false;
     BindDrawerSignals();
+    ApplyConnectablePolicy();
     result.succeeded     = true;
     return result;
   }
@@ -460,6 +462,7 @@ auto AlcedoQanGraph::ReplaceTopology(const EditorNodeGraphSnapshot& snapshot)
     }
   }
   rebuild_in_progress_ = false;
+  ApplyConnectablePolicy();
   result.error         = error;
   return result;
 }
@@ -776,6 +779,125 @@ void AlcedoQanGraph::ConfigureGraphPolicy() {
   }
   graph_->setMultipleSelectionEnabled(false);
   InstallInvisibleSelectionDelegate();
+  graph_->setConnectorCreateDefaultEdge(false);
+  graph_->setConnectorEnabled(true);
+  connect(graph_.data(), &qan::Graph::connectorChanged, this, &AlcedoQanGraph::ConfigureConnector,
+          Qt::UniqueConnection);
+  connect(graph_.data(), &qan::Graph::connectorRequestEdgeCreation, this,
+          &AlcedoQanGraph::OnConnectorRequestEdgeCreation, Qt::UniqueConnection);
+  ConfigureConnector();
+}
+
+void AlcedoQanGraph::ConfigureConnector() {
+  if (graph_.isNull()) {
+    return;
+  }
+  const auto& theme = AppTheme::Instance();
+  graph_->setConnectorCreateDefaultEdge(false);
+  graph_->setConnectorEnabled(true);
+  graph_->setConnectorEdgeColor(theme.graphCandidateEdgeColor());
+  graph_->setConnectorColor(theme.graphPortBorderColor());
+  if (auto* connector = graph_->getConnector()) {
+    connector->setProperty("createDefaultEdge", false);
+    if (connector->getSourceNode() == nullptr && connector->getSourcePort() == nullptr) {
+      connector->setVisible(false);
+    }
+  }
+  ApplyConnectablePolicy();
+}
+
+void AlcedoQanGraph::ApplyConnectablePolicy() {
+  if (graph_.isNull() || rebuild_in_progress_) {
+    return;
+  }
+  for (const auto& [node_id, node] : node_by_id_) {
+    if (node.isNull() || node->getItem() == nullptr) {
+      continue;
+    }
+    const auto* projection = NodeProjection(node_id);
+    if (projection == nullptr) {
+      continue;
+    }
+    auto connectable = qan::NodeItem::Connectable::UnConnectable;
+    if (projection->node_kind == EditorNodeKind::Drt) {
+      connectable = qan::NodeItem::Connectable::InConnectable;
+    } else if (projection->node_kind == EditorNodeKind::ColorGrade) {
+      connectable = node_id == product_selected_node_id_
+                        ? qan::NodeItem::Connectable::OutConnectable
+                        : qan::NodeItem::Connectable::InConnectable;
+    }
+    node->getItem()->setConnectable(connectable);
+  }
+
+  auto* connector = graph_->getConnector();
+  if (connector == nullptr) {
+    return;
+  }
+  const auto* selected = NodeProjection(product_selected_node_id_);
+  auto*       source   = NodeFor(product_selected_node_id_);
+  const bool  can_start =
+      selected != nullptr && selected->node_kind == EditorNodeKind::ColorGrade && source != nullptr;
+  if (!can_start) {
+    connector->setSourcePort(nullptr);
+    connector->setSourceNode(nullptr);
+    connector->setVisible(false);
+    return;
+  }
+  auto* output = OutputPortFor(product_selected_node_id_, PortId{"image"});
+  if (output != nullptr) {
+    connector->setSourcePort(output);
+  } else {
+    connector->setSourceNode(source);
+  }
+  connector->setEnabled(true);
+  connector->setVisible(true);
+}
+
+void AlcedoQanGraph::hideConnectorPreview() {
+  if (graph_.isNull()) {
+    return;
+  }
+  auto* connector = graph_->getConnector();
+  if (connector == nullptr) {
+    return;
+  }
+  if (auto* edge = connector->getEdgeItem()) {
+    edge->setVisible(false);
+  }
+  if (auto* item = connector->getConnectorItem()) {
+    item->setProperty("state", QStringLiteral("NORMAL"));
+  }
+}
+
+void AlcedoQanGraph::OnConnectorRequestEdgeCreation(qan::Node* src, QObject* dst,
+                                                    qan::PortItem* /*src_port*/,
+                                                    qan::PortItem* dst_port) {
+  hideConnectorPreview();
+  const auto source_id = LiveNodeId(src);
+  if (!source_id.has_value()) {
+    emit ConnectorRequestRejected(
+        QStringLiteral("That graph item is no longer part of the current Version"));
+    return;
+  }
+  qan::Node* destination_node = qobject_cast<qan::Node*>(dst);
+  if (destination_node == nullptr && dst_port != nullptr) {
+    destination_node = dst_port->getNode();
+  }
+  if (destination_node == nullptr) {
+    if (auto* item = qobject_cast<qan::NodeItem*>(dst)) {
+      destination_node = item->getNode();
+    }
+  }
+  const auto destination_id = LiveNodeId(destination_node);
+  if (!destination_id.has_value()) {
+    emit ConnectorRequestRejected(
+        QStringLiteral("That graph item is no longer part of the current Version"));
+    return;
+  }
+  const bool destination_is_output =
+      dst_port != nullptr && dst_port->getType() == qan::PortItem::Type::Out;
+  emit ConnectorMoveRequested(ToQString(source_id->Value()), ToQString(destination_id->Value()),
+                              destination_is_output);
 }
 
 void AlcedoQanGraph::ClearDrawerConnections() {
@@ -828,13 +950,13 @@ void AlcedoQanGraph::ApplyProductSelection(const std::optional<NodeId>& node_id)
   }
   product_selected_node_id_ = node_id.value_or(NodeId{});
   graph_->clearSelection();
-  if (!node_id.has_value() || node_id->Empty()) {
-    return;
+  if (node_id.has_value() && !node_id->Empty()) {
+    auto* node = NodeFor(*node_id);
+    if (node != nullptr) {
+      graph_->setNodeSelected(node, true);
+    }
   }
-  auto* node = NodeFor(*node_id);
-  if (node != nullptr) {
-    graph_->setNodeSelected(node, true);
-  }
+  ApplyConnectablePolicy();
 }
 
 void AlcedoQanGraph::SetNodeItemPosition(const NodeId& node_id, QPointF position) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
@@ -55,7 +55,18 @@ void FlushDeferredDeletes() { QCoreApplication::sendPostedEvents(nullptr, QEvent
 
 }  // namespace
 
-AlcedoQanGraph::AlcedoQanGraph(QObject* parent) : QObject(parent) {}
+AlcedoQanGraph::AlcedoQanGraph(QObject* parent) : QObject(parent) {
+  connect(&AppTheme::Instance(), &AppTheme::ThemeChanged, this, [this]() {
+    ConfigureConnector();
+    for (const auto& [key, candidate] : edge_candidate_) {
+      const auto it = edge_by_key_.find(key);
+      if (it == edge_by_key_.end() || it->second.isNull()) {
+        continue;
+      }
+      ApplyEdgePresentation(*it->second, candidate);
+    }
+  });
+}
 
 AlcedoQanGraph::~AlcedoQanGraph() {
   rebuild_in_progress_ = true;
@@ -424,8 +435,8 @@ auto AlcedoQanGraph::ApplyRoles(const EditorNodeGraphSnapshot& snapshot)
     ApplyNodePresentation(*qan_node, node);
     node_projections_[node.node_id] = node;
   }
-  applied_         = snapshot;
-  has_projection_  = true;
+  applied_        = snapshot;
+  has_projection_ = true;
   BindDrawerSignals();
   result.succeeded = true;
   return result;
@@ -450,7 +461,7 @@ auto AlcedoQanGraph::ReplaceTopology(const EditorNodeGraphSnapshot& snapshot)
     rebuild_in_progress_ = false;
     BindDrawerSignals();
     ApplyConnectablePolicy();
-    result.succeeded     = true;
+    result.succeeded = true;
     return result;
   }
 
@@ -470,7 +481,7 @@ auto AlcedoQanGraph::ReplaceTopology(const EditorNodeGraphSnapshot& snapshot)
   }
   rebuild_in_progress_ = false;
   ApplyConnectablePolicy();
-  result.error         = error;
+  result.error = error;
   return result;
 }
 
@@ -579,7 +590,7 @@ auto AlcedoQanGraph::InsertEdge(const EditorNodeEdgeProjection& edge) -> QString
     graph_->removeEdge(qan_edge, true);
     return QStringLiteral("Qan edge did not bind to the requested ports");
   }
-  const auto key = MakeEdgeKey(edge);
+  const auto key    = MakeEdgeKey(edge);
   edge_by_key_[key] = qan_edge;
   ApplyEdgePresentation(*qan_edge, false);
   edge_candidate_[key] = false;
@@ -766,8 +777,8 @@ auto AlcedoQanGraph::PromoteCommittedSnapshot(const EditorNodeGraphSnapshot& sna
     node_projections_[node.node_id] = node;
   }
   PromoteCandidatePresentation();
-  applied_        = snapshot;
-  has_projection_ = true;
+  applied_         = snapshot;
+  has_projection_  = true;
   result.succeeded = true;
   return result;
 }
@@ -912,13 +923,11 @@ auto AlcedoQanGraph::InstallPortDockDelegate() -> QString {
   if (port_dock_delegate_graph_.data() == graph_.data()) {
     return {};
   }
-  auto loaded =
-      LoadComponent(port_dock_delegate_url_, QStringLiteral("Alcedo port dock delegate"));
+  auto loaded = LoadComponent(port_dock_delegate_url_, QStringLiteral("Alcedo port dock delegate"));
   if (!loaded.component) {
     return loaded.error;
   }
-  graph_->setProperty("horizontalDockDelegate",
-                      QVariant::fromValue(loaded.component.release()));
+  graph_->setProperty("horizontalDockDelegate", QVariant::fromValue(loaded.component.release()));
   port_dock_delegate_graph_ = graph_;
   return {};
 }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_commit_presentation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_commit_presentation.cpp
@@ -723,8 +723,10 @@ auto PresentGraphOperation(const alcedo::EditorHistoryCommit& commit)
       alcedo::PresentationKeyForOperation(alcedo::PipelineEditOperationKind::RenameColorGrade);
   const auto remove_key =
       alcedo::PresentationKeyForOperation(alcedo::PipelineEditOperationKind::RemoveColorGrade);
+  const auto topology_key =
+      alcedo::PresentationKeyForOperation(alcedo::PipelineEditOperationKind::EditNodeGraph);
   if (commit.presentation_key != add_key && commit.presentation_key != rename_key &&
-      commit.presentation_key != remove_key) {
+      commit.presentation_key != remove_key && commit.presentation_key != topology_key) {
     return std::nullopt;
   }
 
@@ -746,6 +748,13 @@ auto PresentGraphOperation(const alcedo::EditorHistoryCommit& commit)
     out.delta_text   = out.before_text.isEmpty()
                            ? out.after_text
                            : QStringLiteral("%1 \u2192 %2").arg(out.before_text, out.after_text);
+    out.icon_key     = QStringLiteral(":/history_icons/workflow.svg");
+    return out;
+  }
+  if (commit.presentation_key == topology_key) {
+    out.display_name = QStringLiteral("Edit Node Graph");
+    out.after_text   = name;
+    out.delta_text   = name;
     out.icon_key     = QStringLiteral(":/history_icons/workflow.svg");
     return out;
   }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
@@ -620,6 +620,29 @@ auto EditorHistoryMutation::ReconnectColorGrade(const alcedo::EditorHistoryGuard
   }
 }
 
+auto EditorHistoryMutation::EditNodeGraph(const alcedo::EditorHistoryGuardHandle& guard,
+                                          alcedo::NodeGraphTopologyChange change,
+                                          std::string* error) -> bool {
+  auto state = state_.EnsureWorkingState(guard.element_id, error);
+  if (!state) return false;
+  if (!state->pipeline_guard || !state->pipeline_guard->commit_graph_ || !state->history) {
+    if (error) *error = "Editor history graph is unavailable";
+    return false;
+  }
+  if (!state->pipeline_guard->pipeline_ || !state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
+  }
+  auto render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
+  try {
+    return PublishAppliedTypedBatch(*state, state_, MakeEditNodeGraphBatch(std::move(change)), false,
+                                    state->mask_store, error);
+  } catch (const std::exception& ex) {
+    if (error) *error = ex.what();
+    return false;
+  }
+}
+
 auto EditorHistoryMutation::RenameColorGrade(const alcedo::EditorHistoryGuardHandle& guard,
                                              const alcedo::NodeId& node_id, std::string display_name,
                                              std::string* error) -> bool {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -11,6 +11,7 @@
 #include <QUuid>
 #include <algorithm>
 #include <utility>
+#include <vector>
 
 #include "ui/alcedo_main/album_backend/alcedo_qan_graph.hpp"
 #include "ui/alcedo_main/album_backend/editor_node_layout_store.hpp"
@@ -45,10 +46,10 @@ auto SameTopology(const EditorNodeGraphSnapshot& lhs, const EditorNodeGraphSnaps
 EditorNodeController::EditorNodeController(QObject* parent) : QObject(parent) {}
 
 EditorNodeController::~EditorNodeController() {
-  if (graph_adapter_connection_) {
-    QObject::disconnect(graph_adapter_connection_);
-    graph_adapter_connection_ = {};
+  if (graph_adapter_ != nullptr) {
+    disconnect(graph_adapter_.data(), nullptr, this, nullptr);
   }
+  graph_adapter_connection_ = {};
   DisconnectSession();
 }
 
@@ -238,6 +239,10 @@ auto EditorNodeController::can_delete_selected_color_grade() const -> bool {
   return can_rename_selected_color_grade();
 }
 
+auto EditorNodeController::can_reconnect_selected_color_grade() const -> bool {
+  return can_rename_selected_color_grade();
+}
+
 auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> bool {
   const auto bound_generation = BoundSessionGeneration();
   if (bound_generation.has_value() && snapshot.session_generation != *bound_generation) {
@@ -331,14 +336,18 @@ void EditorNodeController::set_graph_adapter(QObject* adapter) {
   if (graph_adapter_.data() == graph) {
     return;
   }
-  if (graph_adapter_connection_) {
-    QObject::disconnect(graph_adapter_connection_);
-    graph_adapter_connection_ = {};
+  if (graph_adapter_ != nullptr) {
+    disconnect(graph_adapter_.data(), nullptr, this, nullptr);
   }
-  graph_adapter_ = graph;
+  graph_adapter_connection_ = {};
+  graph_adapter_            = graph;
   if (graph_adapter_ != nullptr) {
     graph_adapter_connection_ = connect(graph_adapter_.data(), &AlcedoQanGraph::GraphChanged, this,
                                         [this] { QueueProjectionApply(); });
+    connect(graph_adapter_.data(), &AlcedoQanGraph::ConnectorMoveRequested, this,
+            &EditorNodeController::OnConnectorMoveRequested);
+    connect(graph_adapter_.data(), &AlcedoQanGraph::ConnectorRequestRejected, this,
+            &EditorNodeController::OnConnectorRequestRejected);
   }
   emit GraphAdapterChanged();
   if (graph_adapter_ != nullptr && has_snapshot_) {
@@ -556,6 +565,219 @@ bool EditorNodeController::deleteColorGrade(const QString& node_id) {
   }
   QueueProjectionApply();
   return true;
+}
+
+auto EditorNodeController::CurrentPredecessor(const NodeId& node_id) const -> NodeId {
+  const int index = IndexOf(node_id);
+  if (index <= 0) {
+    return {};
+  }
+  return snapshot_.nodes[static_cast<std::size_t>(index - 1)].node_id;
+}
+
+auto EditorNodeController::CurrentSuccessor(const NodeId& node_id) const -> NodeId {
+  const int index = IndexOf(node_id);
+  if (index < 0 || index + 1 >= static_cast<int>(snapshot_.nodes.size())) {
+    return {};
+  }
+  return snapshot_.nodes[static_cast<std::size_t>(index + 1)].node_id;
+}
+
+auto EditorNodeController::NeighborsAreAdjacentInRemaining(const NodeId& moving_id,
+                                                           const NodeId& predecessor_id,
+                                                           const NodeId& successor_id) const
+    -> bool {
+  if (!has_snapshot_ || predecessor_id.Empty() || successor_id.Empty()) {
+    return false;
+  }
+  const NodeId* previous = nullptr;
+  for (const auto& node : snapshot_.nodes) {
+    if (node.node_id == moving_id) {
+      continue;
+    }
+    if (previous != nullptr && *previous == predecessor_id && node.node_id == successor_id) {
+      return true;
+    }
+    previous = &node.node_id;
+  }
+  return false;
+}
+
+auto EditorNodeController::ResolveConnectorMove(const NodeId& moving_id,
+                                                const NodeId& destination_id,
+                                                bool destination_is_output, NodeId* predecessor_id,
+                                                NodeId* successor_id) -> bool {
+  if (predecessor_id == nullptr || successor_id == nullptr) {
+    return false;
+  }
+  *predecessor_id = {};
+  *successor_id   = {};
+  if (!IsColorGrade(moving_id)) {
+    SetLastError(tr("Only a selected Color Grade can start a move"));
+    return false;
+  }
+  const auto* destination = NodeFor(destination_id);
+  if (destination == nullptr) {
+    SetLastError(tr("That node is not in the current graph"));
+    return false;
+  }
+  if (moving_id == destination_id) {
+    SetLastError(tr("A Color Grade cannot reconnect to itself"));
+    return false;
+  }
+
+  std::vector<const EditorNodeProjection*> remaining;
+  remaining.reserve(snapshot_.nodes.size());
+  for (const auto& node : snapshot_.nodes) {
+    if (node.node_id != moving_id) {
+      remaining.push_back(&node);
+    }
+  }
+  int dest_index = -1;
+  for (int i = 0; i < static_cast<int>(remaining.size()); ++i) {
+    if (remaining[static_cast<std::size_t>(i)]->node_id == destination_id) {
+      dest_index = i;
+      break;
+    }
+  }
+  if (dest_index < 0) {
+    SetLastError(tr("That node is not in the current graph"));
+    return false;
+  }
+
+  if (destination_is_output) {
+    if (destination->node_kind == EditorNodeKind::Drt) {
+      SetLastError(tr("DRT/Post has no outgoing move source"));
+      return false;
+    }
+    if (dest_index + 1 >= static_cast<int>(remaining.size())) {
+      SetLastError(tr("Reconnect would create a cycle, fan-in, or fan-out"));
+      return false;
+    }
+    *predecessor_id = destination_id;
+    *successor_id   = remaining[static_cast<std::size_t>(dest_index + 1)]->node_id;
+  } else {
+    if (destination->node_kind == EditorNodeKind::Develop) {
+      SetLastError(tr("Develop has no incoming move target"));
+      return false;
+    }
+    if (dest_index == 0) {
+      SetLastError(tr("Develop has no incoming move target"));
+      return false;
+    }
+    *predecessor_id = remaining[static_cast<std::size_t>(dest_index - 1)]->node_id;
+    *successor_id   = destination_id;
+  }
+  return true;
+}
+
+bool EditorNodeController::requestReconnect(const QString& node_id, const QString& predecessor_id,
+                                            const QString& successor_id) {
+  return requestReconnect(node_id, predecessor_id, successor_id, session_generation_);
+}
+
+bool EditorNodeController::requestReconnect(const QString& node_id, const QString& predecessor_id,
+                                            const QString& successor_id,
+                                            quint64        request_generation) {
+  if (!ValidateCommandGeneration()) {
+    return false;
+  }
+  if (request_generation != session_generation_) {
+    SetLastError(tr("The node command is from another editor session"));
+    return false;
+  }
+  const auto id   = NodeIdFromQString(node_id);
+  const auto pred = NodeIdFromQString(predecessor_id);
+  const auto succ = NodeIdFromQString(successor_id);
+  if (!IsColorGrade(id)) {
+    SetLastError(tr("Only a Color Grade can be reconnected"));
+    return false;
+  }
+  if (id == pred || id == succ || pred == succ) {
+    SetLastError(tr("A Color Grade cannot reconnect to itself"));
+    return false;
+  }
+  if (NodeFor(pred) == nullptr || NodeFor(succ) == nullptr) {
+    SetLastError(tr("That node is not in the current graph"));
+    return false;
+  }
+  if (NodeFor(pred)->node_kind == EditorNodeKind::Drt) {
+    SetLastError(tr("DRT/Post has no outgoing move source"));
+    return false;
+  }
+  if (NodeFor(succ)->node_kind == EditorNodeKind::Develop) {
+    SetLastError(tr("Develop has no incoming move target"));
+    return false;
+  }
+  if (!NeighborsAreAdjacentInRemaining(id, pred, succ)) {
+    SetLastError(tr("Reconnect would create a cycle, fan-in, or fan-out"));
+    return false;
+  }
+  if (CurrentPredecessor(id) == pred && CurrentSuccessor(id) == succ) {
+    SetLastError({});
+    if (graph_adapter_ != nullptr) {
+      graph_adapter_->hideConnectorPreview();
+    }
+    return true;
+  }
+
+  SetCommandActive(true);
+  const auto reset_active = qScopeGuard([this] { SetCommandActive(false); });
+  const auto result       = session_->SubmitReconnectColorGrade(id, pred, succ);
+  if (graph_adapter_ != nullptr) {
+    graph_adapter_->hideConnectorPreview();
+  }
+  if (EditorSessionResultIsFailure(result.kind)) {
+    SetLastError(QString::fromStdString(result.message));
+    return false;
+  }
+  refreshFromSession();
+  selectNode(node_id);
+  QueueProjectionApply();
+  return true;
+}
+
+bool EditorNodeController::requestConnectorMove(const QString& source_node_id,
+                                                const QString& destination_node_id,
+                                                bool           destination_is_output) {
+  if (!ValidateCommandGeneration()) {
+    if (graph_adapter_ != nullptr) {
+      graph_adapter_->hideConnectorPreview();
+    }
+    return false;
+  }
+  const auto source = NodeIdFromQString(source_node_id);
+  if (source != selected_node_id_ || !IsColorGrade(source)) {
+    SetLastError(tr("Only a selected Color Grade can start a move"));
+    if (graph_adapter_ != nullptr) {
+      graph_adapter_->hideConnectorPreview();
+    }
+    return false;
+  }
+  NodeId predecessor;
+  NodeId successor;
+  if (!ResolveConnectorMove(source, NodeIdFromQString(destination_node_id), destination_is_output,
+                            &predecessor, &successor)) {
+    if (graph_adapter_ != nullptr) {
+      graph_adapter_->hideConnectorPreview();
+    }
+    return false;
+  }
+  return requestReconnect(source_node_id, NodeIdToQString(predecessor), NodeIdToQString(successor),
+                          session_generation_);
+}
+
+void EditorNodeController::OnConnectorMoveRequested(const QString& source_node_id,
+                                                    const QString& destination_node_id,
+                                                    bool           destination_is_output) {
+  requestConnectorMove(source_node_id, destination_node_id, destination_is_output);
+}
+
+void EditorNodeController::OnConnectorRequestRejected(const QString& error) {
+  if (graph_adapter_ != nullptr) {
+    graph_adapter_->hideConnectorPreview();
+  }
+  SetLastError(error);
 }
 
 void EditorNodeController::SelectAt(int index) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -10,6 +10,7 @@
 #include <QScopeGuard>
 #include <QUuid>
 #include <algorithm>
+#include <exception>
 #include <utility>
 #include <vector>
 
@@ -117,6 +118,7 @@ void EditorNodeController::SetLastError(QString error) {
 }
 
 void EditorNodeController::ClearSnapshot() {
+  DiscardDraft();
   snapshot_                  = {};
   has_snapshot_              = false;
   selected_node_id_          = {};
@@ -232,15 +234,28 @@ auto EditorNodeController::can_add_color_grade() const -> bool {
 }
 
 auto EditorNodeController::can_rename_selected_color_grade() const -> bool {
-  return can_add_color_grade() && IsColorGrade(selected_node_id_);
+  return can_add_color_grade() && IsColorGrade(selected_node_id_) && draft_ == nullptr;
 }
 
 auto EditorNodeController::can_delete_selected_color_grade() const -> bool {
-  return can_rename_selected_color_grade();
+  return can_add_color_grade() && IsColorGrade(selected_node_id_);
 }
 
 auto EditorNodeController::can_reconnect_selected_color_grade() const -> bool {
-  return can_rename_selected_color_grade();
+  return can_rename_selected_color_grade() ||
+         (has_snapshot_ && NodeFor(selected_node_id_) != nullptr &&
+          NodeFor(selected_node_id_)->node_kind == EditorNodeKind::Develop);
+}
+
+auto EditorNodeController::incomplete_draft() const -> bool {
+  return draft_ != nullptr && !draft_->SubmissionValid();
+}
+
+auto EditorNodeController::incomplete_draft_instruction() const -> QString {
+  if (!incomplete_draft()) {
+    return {};
+  }
+  return tr("Connect Color Grades into one Develop to DRT path.");
 }
 
 auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> bool {
@@ -316,6 +331,12 @@ bool EditorNodeController::applyToGraph(QObject* adapter) {
   if (!has_snapshot_) {
     SetLastError(tr("The node graph has no snapshot"));
     return false;
+  }
+  const auto promoted = graph->PromoteCommittedSnapshot(snapshot_);
+  if (promoted.succeeded) {
+    graph->ApplyProductSelection(selected_node_id_);
+    SetLastError({});
+    return true;
   }
   const auto result = graph->ApplySnapshot(snapshot_);
   if (!result.succeeded) {
@@ -422,7 +443,21 @@ bool EditorNodeController::refreshFromSession() {
   return PublishDocument(*document, static_cast<std::uint64_t>(session_->session_generation()));
 }
 
-void EditorNodeController::OnSessionChanged() { refreshFromSession(); }
+void EditorNodeController::OnSessionChanged() {
+  if (skip_next_session_refresh_) {
+    skip_next_session_refresh_ = false;
+    return;
+  }
+  if (session_ != nullptr && draft_ != nullptr) {
+    const auto* document = session_->pipeline_document();
+    if (document != nullptr && draft_->MatchesIdentity(CurrentDraftIdentity()) &&
+        draft_->MatchesBase(*document)) {
+      return;
+    }
+    DiscardDraft();
+  }
+  refreshFromSession();
+}
 
 void EditorNodeController::selectNode(const QString& node_id) {
   const auto id = NodeIdFromQString(node_id);
@@ -476,30 +511,39 @@ bool EditorNodeController::addCleanColorGrade() {
   if (!ValidateCommandGeneration()) {
     return false;
   }
-  NodeId    before_id{"drt"};
-  const int selected_index = IndexOf(selected_node_id_);
-  if (IsColorGrade(selected_node_id_) && selected_index >= 0 &&
-      selected_index + 1 < static_cast<int>(snapshot_.nodes.size())) {
-    before_id = snapshot_.nodes[static_cast<std::size_t>(selected_index + 1)].node_id;
+  if (!EnsureDraft()) {
+    return false;
   }
   const auto   uuid = QUuid::createUuid().toString(QUuid::WithoutBraces).toLower().toStdString();
   const NodeId new_id{"grade." + uuid};
-
   SetCommandActive(true);
   const auto reset_active = qScopeGuard([this] { SetCommandActive(false); });
-  const auto result       = session_->SubmitAddColorGrade(before_id, new_id);
-  if (EditorSessionResultIsFailure(result.kind)) {
-    SetLastError(QString::fromStdString(result.message));
+  auto       mutation     = draft_->AddColorGrade(new_id);
+  if (!mutation.succeeded) {
+    SetLastError(QString::fromStdString(mutation.error));
     return false;
   }
-  refreshFromSession();
+  if (!ApplyMutationToGraph(mutation)) {
+    return false;
+  }
+  if (layout_store_ != nullptr) {
+    layout_store_->AssignStagingPosition(new_id, snapshot_);
+    const auto pos = layout_store_->NodePosition(new_id);
+    if (graph_adapter_ != nullptr && pos.has_value()) {
+      graph_adapter_->SetNodeItemPosition(new_id, *pos);
+    }
+  }
+  SyncSnapshotFromDraft();
   selectNode(NodeIdToQString(new_id));
-  QueueProjectionApply();
-  return true;
+  return MaybeSubmitDraft();
 }
 
 bool EditorNodeController::renameColorGrade(const QString& node_id, const QString& display_name) {
   if (!ValidateCommandGeneration()) {
+    return false;
+  }
+  if (draft_ != nullptr) {
+    SetLastError(tr("Finish the node graph before renaming"));
     return false;
   }
   const auto id = NodeIdFromQString(node_id);
@@ -516,7 +560,7 @@ bool EditorNodeController::renameColorGrade(const QString& node_id, const QStrin
   SetCommandActive(true);
   const auto reset_active = qScopeGuard([this] { SetCommandActive(false); });
   const auto result       = session_->SubmitRenameColorGrade(id, name.toStdString());
-  if (EditorSessionResultIsFailure(result.kind)) {
+  if (alcedo::EditorSessionResultIsFailure(result.kind)) {
     SetLastError(QString::fromStdString(result.message));
     return false;
   }
@@ -530,241 +574,93 @@ bool EditorNodeController::deleteColorGrade(const QString& node_id) {
   if (!ValidateCommandGeneration()) {
     return false;
   }
-  const auto id    = NodeIdFromQString(node_id);
-  const int  index = IndexOf(id);
-  if (!IsColorGrade(id) || index < 0) {
+  const auto id = NodeIdFromQString(node_id);
+  if (!IsColorGrade(id)) {
     SetLastError(tr("Only a Color Grade can be deleted"));
     return false;
   }
-  const NodeId successor = index + 1 < static_cast<int>(snapshot_.nodes.size())
-                               ? snapshot_.nodes[static_cast<std::size_t>(index + 1)].node_id
-                               : NodeId{};
-  const NodeId predecessor =
-      index > 0 ? snapshot_.nodes[static_cast<std::size_t>(index - 1)].node_id : NodeId{};
-
-  SetCommandActive(true);
-  const auto reset_active = qScopeGuard([this] { SetCommandActive(false); });
-  const auto result       = session_->SubmitRemoveColorGrade(id);
-  if (EditorSessionResultIsFailure(result.kind)) {
-    SetLastError(QString::fromStdString(result.message));
+  if (!EnsureDraft()) {
     return false;
   }
-  refreshFromSession();
-  NodeId live_selection = successor;
-  if (!ContainsNode(live_selection)) {
-    live_selection = predecessor;
+  SetCommandActive(true);
+  const auto reset_active = qScopeGuard([this] { SetCommandActive(false); });
+  auto       mutation     = draft_->RemoveColorGrade(id);
+  if (!mutation.succeeded) {
+    SetLastError(QString::fromStdString(mutation.error));
+    return false;
   }
-  if (!ContainsNode(live_selection)) {
-    live_selection = NodeId{"drt"};
+  if (!ApplyMutationToGraph(mutation)) {
+    return false;
   }
-  if (ContainsNode(live_selection) && selected_node_id_ != live_selection) {
-    selected_node_id_ = live_selection;
-    SetLastError({});
+  SyncSnapshotFromDraft();
+  if (!ContainsNode(selected_node_id_)) {
+    selected_node_id_ = DefaultSelectedNodeId();
     emit SelectionChanged();
     emit ActionAvailabilityChanged();
   }
-  QueueProjectionApply();
-  return true;
+  return MaybeSubmitDraft();
 }
 
-auto EditorNodeController::CurrentPredecessor(const NodeId& node_id) const -> NodeId {
-  const int index = IndexOf(node_id);
-  if (index <= 0) {
-    return {};
-  }
-  return snapshot_.nodes[static_cast<std::size_t>(index - 1)].node_id;
+bool EditorNodeController::requestConnect(const QString& source_node_id,
+                                          const QString& destination_node_id) {
+  return requestConnect(source_node_id, destination_node_id, session_generation_);
 }
 
-auto EditorNodeController::CurrentSuccessor(const NodeId& node_id) const -> NodeId {
-  const int index = IndexOf(node_id);
-  if (index < 0 || index + 1 >= static_cast<int>(snapshot_.nodes.size())) {
-    return {};
-  }
-  return snapshot_.nodes[static_cast<std::size_t>(index + 1)].node_id;
-}
-
-auto EditorNodeController::NeighborsAreAdjacentInRemaining(const NodeId& moving_id,
-                                                           const NodeId& predecessor_id,
-                                                           const NodeId& successor_id) const
-    -> bool {
-  if (!has_snapshot_ || predecessor_id.Empty() || successor_id.Empty()) {
-    return false;
-  }
-  const NodeId* previous = nullptr;
-  for (const auto& node : snapshot_.nodes) {
-    if (node.node_id == moving_id) {
-      continue;
-    }
-    if (previous != nullptr && *previous == predecessor_id && node.node_id == successor_id) {
-      return true;
-    }
-    previous = &node.node_id;
-  }
-  return false;
-}
-
-auto EditorNodeController::ResolveConnectorMove(const NodeId& moving_id,
-                                                const NodeId& destination_id,
-                                                bool destination_is_output, NodeId* predecessor_id,
-                                                NodeId* successor_id) -> bool {
-  if (predecessor_id == nullptr || successor_id == nullptr) {
-    return false;
-  }
-  *predecessor_id = {};
-  *successor_id   = {};
-  if (!IsColorGrade(moving_id)) {
-    SetLastError(tr("Only a selected Color Grade can start a move"));
-    return false;
-  }
-  const auto* destination = NodeFor(destination_id);
-  if (destination == nullptr) {
-    SetLastError(tr("That node is not in the current graph"));
-    return false;
-  }
-  if (moving_id == destination_id) {
-    SetLastError(tr("A Color Grade cannot reconnect to itself"));
-    return false;
-  }
-
-  std::vector<const EditorNodeProjection*> remaining;
-  remaining.reserve(snapshot_.nodes.size());
-  for (const auto& node : snapshot_.nodes) {
-    if (node.node_id != moving_id) {
-      remaining.push_back(&node);
-    }
-  }
-  int dest_index = -1;
-  for (int i = 0; i < static_cast<int>(remaining.size()); ++i) {
-    if (remaining[static_cast<std::size_t>(i)]->node_id == destination_id) {
-      dest_index = i;
-      break;
-    }
-  }
-  if (dest_index < 0) {
-    SetLastError(tr("That node is not in the current graph"));
-    return false;
-  }
-
-  if (destination_is_output) {
-    if (destination->node_kind == EditorNodeKind::Drt) {
-      SetLastError(tr("DRT/Post has no outgoing move source"));
-      return false;
-    }
-    if (dest_index + 1 >= static_cast<int>(remaining.size())) {
-      SetLastError(tr("Reconnect would create a cycle, fan-in, or fan-out"));
-      return false;
-    }
-    *predecessor_id = destination_id;
-    *successor_id   = remaining[static_cast<std::size_t>(dest_index + 1)]->node_id;
-  } else {
-    if (destination->node_kind == EditorNodeKind::Develop) {
-      SetLastError(tr("Develop has no incoming move target"));
-      return false;
-    }
-    if (dest_index == 0) {
-      SetLastError(tr("Develop has no incoming move target"));
-      return false;
-    }
-    *predecessor_id = remaining[static_cast<std::size_t>(dest_index - 1)]->node_id;
-    *successor_id   = destination_id;
-  }
-  return true;
-}
-
-bool EditorNodeController::requestReconnect(const QString& node_id, const QString& predecessor_id,
-                                            const QString& successor_id) {
-  return requestReconnect(node_id, predecessor_id, successor_id, session_generation_);
-}
-
-bool EditorNodeController::requestReconnect(const QString& node_id, const QString& predecessor_id,
-                                            const QString& successor_id,
-                                            quint64        request_generation) {
+bool EditorNodeController::requestConnect(const QString& source_node_id,
+                                          const QString& destination_node_id,
+                                          quint64        request_generation) {
   if (!ValidateCommandGeneration()) {
+    if (graph_adapter_ != nullptr) {
+      graph_adapter_->hideConnectorPreview();
+    }
     return false;
   }
   if (request_generation != session_generation_) {
     SetLastError(tr("The node command is from another editor session"));
-    return false;
-  }
-  const auto id   = NodeIdFromQString(node_id);
-  const auto pred = NodeIdFromQString(predecessor_id);
-  const auto succ = NodeIdFromQString(successor_id);
-  if (!IsColorGrade(id)) {
-    SetLastError(tr("Only a Color Grade can be reconnected"));
-    return false;
-  }
-  if (id == pred || id == succ || pred == succ) {
-    SetLastError(tr("A Color Grade cannot reconnect to itself"));
-    return false;
-  }
-  if (NodeFor(pred) == nullptr || NodeFor(succ) == nullptr) {
-    SetLastError(tr("That node is not in the current graph"));
-    return false;
-  }
-  if (NodeFor(pred)->node_kind == EditorNodeKind::Drt) {
-    SetLastError(tr("DRT/Post has no outgoing move source"));
-    return false;
-  }
-  if (NodeFor(succ)->node_kind == EditorNodeKind::Develop) {
-    SetLastError(tr("Develop has no incoming move target"));
-    return false;
-  }
-  if (!NeighborsAreAdjacentInRemaining(id, pred, succ)) {
-    SetLastError(tr("Reconnect would create a cycle, fan-in, or fan-out"));
-    return false;
-  }
-  if (CurrentPredecessor(id) == pred && CurrentSuccessor(id) == succ) {
-    SetLastError({});
     if (graph_adapter_ != nullptr) {
       graph_adapter_->hideConnectorPreview();
     }
-    return true;
+    return false;
   }
-
+  if (!EnsureDraft()) {
+    if (graph_adapter_ != nullptr) {
+      graph_adapter_->hideConnectorPreview();
+    }
+    return false;
+  }
   SetCommandActive(true);
   const auto reset_active = qScopeGuard([this] { SetCommandActive(false); });
-  const auto result       = session_->SubmitReconnectColorGrade(id, pred, succ);
+  auto       mutation =
+      draft_->Connect(NodeIdFromQString(source_node_id), NodeIdFromQString(destination_node_id));
   if (graph_adapter_ != nullptr) {
     graph_adapter_->hideConnectorPreview();
   }
-  if (EditorSessionResultIsFailure(result.kind)) {
-    SetLastError(QString::fromStdString(result.message));
+  if (!mutation.succeeded) {
+    SetLastError(QString::fromStdString(mutation.error));
     return false;
   }
-  refreshFromSession();
-  selectNode(node_id);
-  QueueProjectionApply();
-  return true;
+  if (mutation.no_op) {
+    SetLastError({});
+    return true;
+  }
+  if (!ApplyMutationToGraph(mutation)) {
+    return false;
+  }
+  SyncSnapshotFromDraft();
+  return MaybeSubmitDraft();
 }
 
 bool EditorNodeController::requestConnectorMove(const QString& source_node_id,
                                                 const QString& destination_node_id,
                                                 bool           destination_is_output) {
-  if (!ValidateCommandGeneration()) {
+  if (destination_is_output) {
+    SetLastError(tr("Connections must go from an output port to an input port"));
     if (graph_adapter_ != nullptr) {
       graph_adapter_->hideConnectorPreview();
     }
     return false;
   }
-  const auto source = NodeIdFromQString(source_node_id);
-  if (source != selected_node_id_ || !IsColorGrade(source)) {
-    SetLastError(tr("Only a selected Color Grade can start a move"));
-    if (graph_adapter_ != nullptr) {
-      graph_adapter_->hideConnectorPreview();
-    }
-    return false;
-  }
-  NodeId predecessor;
-  NodeId successor;
-  if (!ResolveConnectorMove(source, NodeIdFromQString(destination_node_id), destination_is_output,
-                            &predecessor, &successor)) {
-    if (graph_adapter_ != nullptr) {
-      graph_adapter_->hideConnectorPreview();
-    }
-    return false;
-  }
-  return requestReconnect(source_node_id, NodeIdToQString(predecessor), NodeIdToQString(successor),
-                          session_generation_);
+  return requestConnect(source_node_id, destination_node_id, session_generation_);
 }
 
 void EditorNodeController::OnConnectorMoveRequested(const QString& source_node_id,
@@ -778,6 +674,179 @@ void EditorNodeController::OnConnectorRequestRejected(const QString& error) {
     graph_adapter_->hideConnectorPreview();
   }
   SetLastError(error);
+}
+
+auto EditorNodeController::CurrentDraftIdentity() const -> alcedo::EditorNodeGraphDraftIdentity {
+  alcedo::EditorNodeGraphDraftIdentity identity;
+  identity.element_id          = element_id_;
+  identity.image_id            = image_id_;
+  identity.version_id          = version_id_.toStdString();
+  identity.session_generation  = session_generation_;
+  identity.projection_revision = projection_revision_;
+  identity.topology_revision   = topology_revision_;
+  return identity;
+}
+
+auto EditorNodeController::EnsureDraft() -> bool {
+  if (draft_ != nullptr) {
+    if (!draft_->MatchesIdentity(CurrentDraftIdentity())) {
+      SetLastError(tr("The node command is from another editor session"));
+      return false;
+    }
+    return true;
+  }
+  if (session_ == nullptr) {
+    SetLastError(tr("No editor session is bound"));
+    return false;
+  }
+  const auto* document = session_->pipeline_document();
+  if (document == nullptr) {
+    SetLastError(tr("No editable node graph is available"));
+    return false;
+  }
+  try {
+    draft_ = std::make_unique<alcedo::EditorNodeGraphDraft>(
+        alcedo::EditorNodeGraphDraft::FromDocument(*document, CurrentDraftIdentity()));
+  } catch (const std::exception& ex) {
+    SetLastError(QString::fromUtf8(ex.what()));
+    return false;
+  }
+  emit DraftStateChanged();
+  return true;
+}
+
+void EditorNodeController::DiscardDraft() {
+  if (draft_ == nullptr) {
+    return;
+  }
+  draft_.reset();
+  emit DraftStateChanged();
+}
+
+void EditorNodeController::SyncSnapshotFromDraft() {
+  if (draft_ == nullptr) {
+    return;
+  }
+  snapshot_     = draft_->CurrentSnapshot(session_generation_, projection_revision_,
+                                          topology_revision_);
+  has_snapshot_ = true;
+  emit DraftStateChanged();
+}
+
+auto EditorNodeController::ApplyMutationToGraph(const alcedo::EditorNodeGraphDraftMutation& mutation)
+    -> bool {
+  if (graph_adapter_ == nullptr || graph_adapter_->graph() == nullptr) {
+    return true;
+  }
+  std::vector<EditorNodeProjection>     applied_nodes;
+  std::vector<EditorNodeEdgeProjection> applied_edges;
+  auto fail = [&](const QString& error) {
+    SetLastError(error);
+    if (draft_ != nullptr) {
+      draft_->RestoreLastMutation();
+    }
+    for (auto it = applied_edges.rbegin(); it != applied_edges.rend(); ++it) {
+      (void)graph_adapter_->RemoveProjectedEdge(*it);
+    }
+    for (auto it = applied_nodes.rbegin(); it != applied_nodes.rend(); ++it) {
+      (void)graph_adapter_->RemoveProjectedNode(it->node_id);
+    }
+    if (draft_ != nullptr) {
+      for (const auto& node_id : mutation.removed_node_ids) {
+        const auto* node = draft_->FindNode(node_id);
+        if (node != nullptr) {
+          (void)graph_adapter_->InsertProjectedNode(*node);
+        }
+      }
+      for (const auto& edge : mutation.removed_edges) {
+        (void)graph_adapter_->InsertProjectedEdge(edge, true);
+      }
+    }
+    return false;
+  };
+  for (const auto& edge : mutation.removed_edges) {
+    const auto result = graph_adapter_->RemoveProjectedEdge(edge);
+    if (!result.succeeded) {
+      return fail(result.error);
+    }
+  }
+  for (const auto& node_id : mutation.removed_node_ids) {
+    const auto result = graph_adapter_->RemoveProjectedNode(node_id);
+    if (!result.succeeded) {
+      return fail(result.error);
+    }
+  }
+  for (const auto& node : mutation.inserted_nodes) {
+    const auto result = graph_adapter_->InsertProjectedNode(node);
+    if (!result.succeeded) {
+      return fail(result.error);
+    }
+    applied_nodes.push_back(node);
+  }
+  for (const auto& edge : mutation.inserted_edges) {
+    const auto result = graph_adapter_->InsertProjectedEdge(edge, true);
+    if (!result.succeeded) {
+      return fail(result.error);
+    }
+    applied_edges.push_back(edge);
+  }
+  graph_adapter_->ApplyProductSelection(selected_node_id_);
+  return true;
+}
+
+auto EditorNodeController::MaybeSubmitDraft() -> bool {
+  if (draft_ == nullptr) {
+    return true;
+  }
+  if (!draft_->SubmissionValid()) {
+    SetLastError({});
+    emit DraftStateChanged();
+    emit ActionAvailabilityChanged();
+    return true;
+  }
+  if (draft_->DeltaEmpty()) {
+    DiscardDraft();
+    SetLastError({});
+    emit ActionAvailabilityChanged();
+    return true;
+  }
+  auto change = draft_->MakeChange();
+  skip_next_session_refresh_ = true;
+  const auto result          = session_->SubmitNodeGraphTopologyEdit(change);
+  if (alcedo::EditorSessionResultIsFailure(result.kind)) {
+    skip_next_session_refresh_ = false;
+    SetLastError(QString::fromStdString(result.message));
+    emit DraftStateChanged();
+    return false;
+  }
+  DiscardDraft();
+  if (session_ != nullptr && session_->pipeline_document() != nullptr) {
+    try {
+      auto built = EditorNodeGraphProjection::Build(*session_->pipeline_document(),
+                                                    session_generation_, 0, 0);
+      topology_revision_   = topology_revision_ + 1;
+      projection_revision_ = projection_revision_ + 1;
+      built.session_generation  = session_generation_;
+      built.topology_revision   = topology_revision_;
+      built.projection_revision = projection_revision_;
+      snapshot_                 = std::move(built);
+      has_snapshot_             = true;
+    } catch (const std::exception& ex) {
+      SetLastError(QString::fromUtf8(ex.what()));
+    }
+  }
+  if (graph_adapter_ != nullptr) {
+    const auto promoted = graph_adapter_->PromoteCommittedSnapshot(snapshot_);
+    if (!promoted.succeeded) {
+      QueueProjectionApply();
+    } else {
+      graph_adapter_->ApplyProductSelection(selected_node_id_);
+    }
+  }
+  SetLastError({});
+  emit SnapshotChanged();
+  emit ActionAvailabilityChanged();
+  return true;
 }
 
 void EditorNodeController::SelectAt(int index) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_layout_store.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_layout_store.cpp
@@ -9,12 +9,31 @@
 #include <utility>
 
 #include "ui/alcedo_main/album_backend/editor_node_controller.hpp"
+#include "ui/alcedo_main/app_theme.hpp"
 
 namespace alcedo::ui {
 namespace {
 
 constexpr qreal kMinZoom = 0.1;
 constexpr qreal kMaxZoom = 8.0;
+
+auto            MetricsFromAppTheme() -> EditorNodeLayoutMetrics {
+  const auto&             theme = AppTheme::Instance();
+  EditorNodeLayoutMetrics metrics;
+  metrics.origin_x             = theme.graphNodeOriginX();
+  metrics.origin_y             = theme.graphNodeOriginY();
+  metrics.vertical_gap         = theme.graphNodeVerticalGap();
+  metrics.node_width           = theme.graphNodeWidth();
+  metrics.endpoint_height      = theme.graphEndpointHeight();
+  metrics.name_row_height      = theme.graphNameRowHeight();
+  metrics.divider_height       = theme.graphNameRowDividerHeight();
+  metrics.drawer_header_height = theme.graphMaskDrawerHeaderHeight();
+  metrics.mask_row_height      = theme.graphMaskRowHeight();
+  metrics.panel_width_min      = theme.editorSidePanelWidthMin();
+  metrics.panel_width_max      = theme.editorSidePanelWidthMax();
+  metrics.panel_width_default  = theme.editorSidePanelWidth();
+  return metrics;
+}
 
 }  // namespace
 
@@ -26,7 +45,7 @@ auto NodeIdToQString(const NodeId& node_id) -> QString {
 auto NodeIdFromQString(const QString& node_id) -> NodeId { return NodeId{node_id.toStdString()}; }
 
 EditorNodeLayoutStore::EditorNodeLayoutStore(QObject* parent)
-    : EditorNodeLayoutStore(EditorNodeLayoutMetrics{}, parent) {}
+    : EditorNodeLayoutStore(MetricsFromAppTheme(), parent) {}
 
 EditorNodeLayoutStore::EditorNodeLayoutStore(EditorNodeLayoutMetrics metrics, QObject* parent)
     : QObject(parent), metrics_(metrics) {}
@@ -239,7 +258,7 @@ void EditorNodeLayoutStore::EnsureDefaultPositions(const EditorNodeGraphSnapshot
   }
 }
 
-void EditorNodeLayoutStore::AssignStagingPosition(const NodeId& node_id,
+void EditorNodeLayoutStore::AssignStagingPosition(const NodeId&                  node_id,
                                                   const EditorNodeGraphSnapshot& snapshot) {
   if (node_id.Empty()) {
     return;

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_layout_store.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_layout_store.cpp
@@ -239,6 +239,38 @@ void EditorNodeLayoutStore::EnsureDefaultPositions(const EditorNodeGraphSnapshot
   }
 }
 
+void EditorNodeLayoutStore::AssignStagingPosition(const NodeId& node_id,
+                                                  const EditorNodeGraphSnapshot& snapshot) {
+  if (node_id.Empty()) {
+    return;
+  }
+  auto& value = MutableCurrent();
+  if (value.node_positions.find(node_id) != value.node_positions.end()) {
+    return;
+  }
+  EnsureDefaultPositions(snapshot);
+
+  const qreal column_x  = static_cast<qreal>(metrics_.origin_x);
+  const qreal gap       = static_cast<qreal>(metrics_.vertical_gap);
+  qreal       staging_y = static_cast<qreal>(metrics_.origin_y);
+  auto        height_of = [this, &snapshot](const NodeId& id) -> qreal {
+    for (const auto& node : snapshot.nodes) {
+      if (node.node_id == id) {
+        return DefaultHeight(node.node_kind, static_cast<int>(node.masks.size()), DrawerOpen(id));
+      }
+    }
+    return DefaultHeight(EditorNodeKind::ColorGrade, 0, DrawerOpen(id));
+  };
+  for (const auto& [id, position] : value.node_positions) {
+    if (id == node_id) {
+      continue;
+    }
+    staging_y = std::max(staging_y, position.y() + height_of(id) + gap);
+  }
+  value.node_positions[node_id] = QPointF(column_x, staging_y);
+  emit LayoutChanged();
+}
+
 void EditorNodeLayoutStore::ensureDefaultsFrom(QObject* controller) {
   auto* nodes = qobject_cast<EditorNodeController*>(controller);
   if (nodes == nullptr || !nodes->has_snapshot()) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -703,6 +703,18 @@ auto EditorSessionController::SubmitReconnectColorGrade(const alcedo::NodeId& no
   return session_backend_->ReconnectColorGrade(node_id, new_predecessor_id, new_successor_id);
 }
 
+auto EditorSessionController::SubmitNodeGraphTopologyEdit(
+    const alcedo::NodeGraphTopologyChange& change) -> alcedo::EditorSessionResult {
+  if (!session_backend_) {
+    alcedo::EditorSessionResult result;
+    result.kind    = alcedo::EditorSessionResultKind::Rejected;
+    result.state   = session_state();
+    result.message = "Editor session backend is unavailable";
+    return result;
+  }
+  return session_backend_->EditNodeGraph(change);
+}
+
 void EditorSessionController::MoveHeadToCommit(const QString& commitId) {
   const QString action = QStringLiteral("moveHeadToCommit");
   if (!session_backend_) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -689,6 +689,20 @@ auto EditorSessionController::SubmitRenameColorGrade(const alcedo::NodeId& node_
   return session_backend_->RenameColorGrade(node_id, std::move(display_name));
 }
 
+auto EditorSessionController::SubmitReconnectColorGrade(const alcedo::NodeId& node_id,
+                                                        const alcedo::NodeId& new_predecessor_id,
+                                                        const alcedo::NodeId& new_successor_id)
+    -> alcedo::EditorSessionResult {
+  if (!session_backend_) {
+    alcedo::EditorSessionResult result;
+    result.kind    = alcedo::EditorSessionResultKind::Rejected;
+    result.state   = session_state();
+    result.message = "Editor session backend is unavailable";
+    return result;
+  }
+  return session_backend_->ReconnectColorGrade(node_id, new_predecessor_id, new_successor_id);
+}
+
 void EditorSessionController::MoveHeadToCommit(const QString& commitId) {
   const QString action = QStringLiteral("moveHeadToCommit");
   if (!session_backend_) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
@@ -98,6 +98,12 @@ auto EditorSessionHistoryPort::ReconnectColorGrade(const alcedo::EditorHistoryGu
   return mutation_->ReconnectColorGrade(guard, node_id, new_predecessor_id, new_successor_id, error);
 }
 
+auto EditorSessionHistoryPort::EditNodeGraph(const alcedo::EditorHistoryGuardHandle& guard,
+                                             alcedo::NodeGraphTopologyChange change,
+                                             std::string* error) -> bool {
+  return mutation_->EditNodeGraph(guard, std::move(change), error);
+}
+
 auto EditorSessionHistoryPort::RenameColorGrade(const alcedo::EditorHistoryGuardHandle& guard,
                                                 const alcedo::NodeId& node_id,
                                                 std::string display_name, std::string* error)

--- a/alcedo_studio/src/ui/alcedo_main/alcedo_main_qml_module.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/alcedo_main_qml_module.cpp
@@ -1,0 +1,13 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+// Required compilation unit for the AlcedoMainQml static library.
+// qt_add_qml_module attaches the QML files; bundled fonts and icons live on
+// the AppTheme library.
+
+namespace alcedo::ui {
+
+void AlcedoMainQmlModuleAnchor() {}
+
+}  // namespace alcedo::ui

--- a/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
@@ -21,12 +21,10 @@
 
 #include "alcedo_version.hpp"
 
-// resource.qrc lives in the AlcedoMainQml static library. MSVC drops that
-// object unless something in the final executable references
-// qInitResources_resource(). Q_INIT_RESOURCE must sit outside any namespace.
-static void InitAlcedoBundledResources() {
-  Q_INIT_RESOURCE(resource);
-}
+// resource.qrc is compiled into the AppTheme library. MSVC still drops that
+// object unless the final executable references qInitResources_resource().
+// Q_INIT_RESOURCE must sit outside any namespace.
+static void InitAlcedoBundledResources() { Q_INIT_RESOURCE(resource); }
 
 namespace alcedo::ui {
 namespace {
@@ -355,8 +353,8 @@ void AppTheme::RegisterFonts() {
   // Minigit / diagnostic monospace only (Versions commit ids, transaction
   // timeline hashes and before/after lines). Do not use for general metrics —
   // those stay on dataFontFamily (IBM Plex Sans).
-  families.mono = RegisterFontResource(QStringLiteral(":/fonts/data_DMMono.ttf"),
-                                       QStringLiteral("DM Mono"));
+  families.mono =
+      RegisterFontResource(QStringLiteral(":/fonts/data_DMMono.ttf"), QStringLiteral("DM Mono"));
   // Chinese fallback for the Manrope headline font. The struct default is
   // "Noto Sans SC" (same family used for the rest of the UI's Chinese text);
   // we intentionally do NOT override it with the decorative Dinglie Song
@@ -1000,6 +998,8 @@ auto AppTheme::graphEndpointHeight() const -> int { return 40; }
 
 auto AppTheme::graphNameRowHeight() const -> int { return 32; }
 
+auto AppTheme::graphNameRowDividerHeight() const -> int { return 1; }
+
 auto AppTheme::graphMaskDrawerHeaderHeight() const -> int { return 28; }
 
 auto AppTheme::graphMaskRowHeight() const -> int { return 28; }
@@ -1044,9 +1044,7 @@ auto AppTheme::monoFontFamily() const -> QString {
   RegisterFonts();
   return FontState().mono;
 }
-auto AppTheme::appVersion() const -> QString {
-  return QStringLiteral(ALCEDO_APP_VERSION);
-}
+auto AppTheme::appVersion() const -> QString { return QStringLiteral(ALCEDO_APP_VERSION); }
 
 auto AppTheme::toneGold() const -> QColor { return GetTheme(current_theme_index_).tone_gold; }
 auto AppTheme::toneWine() const -> QColor { return GetTheme(current_theme_index_).tone_wine; }
@@ -1124,9 +1122,7 @@ auto AppTheme::spaceXl() const -> int { return 20; }
 auto AppTheme::motionFoldOpenMs() const -> int { return 200; }
 auto AppTheme::motionFoldCloseMs() const -> int { return 160; }
 auto AppTheme::motionFadeMs() const -> int { return 120; }
-auto AppTheme::motionEasing() const -> int {
-  return static_cast<int>(QEasingCurve::OutCubic);
-}
+auto AppTheme::motionEasing() const -> int { return static_cast<int>(QEasingCurve::OutCubic); }
 auto AppTheme::backgroundTaskAutoCollapseMs() const -> int { return 3000; }
 
 auto AppTheme::reduceMotion() const -> bool {

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeDelegate.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeDelegate.qml
@@ -73,7 +73,7 @@ Qan.NodeItem {
                 objectName: "editorNodeDrawerDivider"
                 anchors.horizontalCenter: parent.horizontalCenter
                 width: parent.width - 2 * appTheme.graphSelectionOutlineWidth
-                height: 1
+                height: appTheme.graphNameRowDividerHeight
                 color: appTheme.cardBorderColor
             }
 

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeEdgeDelegate.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeEdgeDelegate.qml
@@ -8,11 +8,12 @@ import QuickQanava 2.0 as Qan
 Qan.EdgeItem {
     id: edgeItem
     objectName: "editorNodeEdge"
+    property bool candidate: false
 
     Qan.EdgeStyle {
         id: alcedoEdgeStyle
         lineWidth: appTheme.graphEdgeWidth
-        lineColor: appTheme.graphEdgeColor
+        lineColor: edgeItem.candidate ? appTheme.graphCandidateEdgeColor : appTheme.graphEdgeColor
         lineType: Qan.EdgeStyle.Straight
         srcShape: Qan.EdgeStyle.None
         dstShape: Qan.EdgeStyle.None
@@ -27,6 +28,6 @@ Qan.EdgeItem {
     Qan.EdgeTemplate {
         anchors.fill: parent
         edgeItem: edgeItem
-        color: appTheme.graphEdgeColor
+        color: edgeItem.candidate ? appTheme.graphCandidateEdgeColor : appTheme.graphEdgeColor
     }
 }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
@@ -326,6 +326,17 @@ Item {
         }
 
         Label {
+            objectName: "editorNodesEditingGuidance"
+            Layout.fillWidth: true
+            visible: root.nodeController && root.nodeController.incompleteDraft
+            text: root.nodeController ? root.nodeController.incompleteDraftInstruction : ""
+            color: root.colMuted
+            wrapMode: Text.WordWrap
+            font.family: appTheme.uiFontFamily
+            font.pixelSize: appTheme.fontSizeCaption
+        }
+
+        Label {
             objectName: "editorNodesCommandError"
             Layout.fillWidth: true
             visible: root.nodeController && root.nodeController.lastError.length > 0

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
@@ -367,6 +367,10 @@ Item {
                     id: graphTopology
                     objectName: "editorNodesQanGraph"
                     multipleSelectionEnabled: false
+                    connectorEnabled: true
+                    connectorCreateDefaultEdge: false
+                    connectorEdgeColor: appTheme.graphCandidateEdgeColor
+                    connectorColor: appTheme.graphPortBorderColor
                 }
 
                 Keys.onPressed: function (event) {

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -77,6 +77,27 @@ gtest_discover_tests(EditorNodeGraphProjectionTest
     PROPERTIES LABELS "ci_core_flow;edit;nodes")
 alcedo_register_test_target(EditorNodeGraphProjectionTest app)
 
+add_executable(EditorNodeGraphDraftTest
+    ${ALCEDO_TEST_ROOT}/app/editor_node_graph_draft_test.cpp)
+target_include_directories(EditorNodeGraphDraftTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(EditorNodeGraphDraftTest
+    PRIVATE GTest::gtest_main EditorNodeGraphDraft EditGraph)
+gtest_discover_tests(EditorNodeGraphDraftTest
+    TEST_PREFIX "EditorNodeGraphDraftTest."
+    PROPERTIES LABELS "ci_core_flow;edit;nodes")
+alcedo_register_test_target(EditorNodeGraphDraftTest app)
+
+add_executable(PipelineGraphTopologyDeltaTest
+    ${ALCEDO_TEST_ROOT}/edit/graph/pipeline_graph_topology_delta_test.cpp)
+target_include_directories(PipelineGraphTopologyDeltaTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR})
+target_link_libraries(PipelineGraphTopologyDeltaTest
+    PRIVATE GTest::gtest_main PipelineHistoryApplier EditGraph)
+gtest_discover_tests(PipelineGraphTopologyDeltaTest
+    TEST_PREFIX "PipelineGraphTopologyDeltaTest."
+    PROPERTIES LABELS "ci_core_flow;edit;graph")
+alcedo_register_test_target(PipelineGraphTopologyDeltaTest app)
+
 add_executable(DocumentTransferTest
     ${ALCEDO_TEST_ROOT}/app/document_transfer_test.cpp)
 target_include_directories(DocumentTransferTest

--- a/alcedo_studio/tests/app/editor_node_graph_draft_test.cpp
+++ b/alcedo_studio/tests/app/editor_node_graph_draft_test.cpp
@@ -1,0 +1,166 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "app/editor_node_graph_draft.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
+
+namespace {
+
+using alcedo::CreateDefaultPipelineDocument;
+using alcedo::EditorNodeGraphDraft;
+using alcedo::EditorNodeGraphDraftIdentity;
+using alcedo::NodeId;
+
+auto BoundIdentity() -> EditorNodeGraphDraftIdentity {
+  EditorNodeGraphDraftIdentity identity;
+  identity.element_id          = 8;
+  identity.image_id            = 9;
+  identity.version_id          = "v1";
+  identity.session_generation  = 4;
+  identity.projection_revision = 1;
+  identity.topology_revision   = 1;
+  return identity;
+}
+
+TEST(EditorNodeGraphDraft, FirstConstructionCopiesTheCompleteProjectionOnce) {
+  const auto document = CreateDefaultPipelineDocument();
+  auto       draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  EXPECT_TRUE(draft.MatchesIdentity(BoundIdentity()));
+  EXPECT_TRUE(draft.MatchesBase(document));
+  EXPECT_EQ(draft.Nodes().size(), 3u);
+  EXPECT_EQ(draft.Edges().size(), 2u);
+  EXPECT_TRUE(draft.DeltaEmpty());
+  EXPECT_TRUE(draft.SubmissionValid());
+}
+
+TEST(EditorNodeGraphDraft, AddInsertsOneDisconnectedGradeWithoutConsumingTheProductCounter) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  const auto* ptr = &draft;
+  auto        add = draft.AddColorGrade(NodeId{"grade.extra"});
+  ASSERT_TRUE(add.succeeded);
+  EXPECT_FALSE(add.submission_valid);
+  EXPECT_FALSE(add.delta_empty);
+  EXPECT_EQ(&draft, ptr);
+  EXPECT_EQ(draft.Nodes().size(), 4u);
+  EXPECT_EQ(draft.Edges().size(), 2u);
+  EXPECT_EQ(draft.FindNode(NodeId{"grade.extra"})->display_name, "Color Grade 2");
+  EXPECT_EQ(document.NextColorGradeNameNumber(), 2u);
+  EXPECT_TRUE(draft.MatchesBase(document));
+}
+
+TEST(EditorNodeGraphDraft, ExclusivePortConnectReplacesOnlyTheRequestedPorts) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+
+  auto first = draft.Connect(NodeId{"develop"}, NodeId{"grade.d"});
+  ASSERT_TRUE(first.succeeded);
+  EXPECT_EQ(first.removed_edges.size(), 1u);
+  EXPECT_EQ(first.inserted_edges.size(), 1u);
+  EXPECT_FALSE(first.submission_valid);
+  EXPECT_EQ(draft.Edges().size(), 2u);
+  EXPECT_EQ(draft.Edges()[0].source_node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(draft.Edges()[0].destination_node_id, NodeId{"drt"});
+  EXPECT_EQ(draft.Edges()[1].source_node_id, NodeId{"develop"});
+  EXPECT_EQ(draft.Edges()[1].destination_node_id, NodeId{"grade.d"});
+
+  auto second = draft.Connect(NodeId{"grade.d"}, NodeId{"drt"});
+  ASSERT_TRUE(second.succeeded);
+  EXPECT_FALSE(second.submission_valid);
+  bool primary_on_path = false;
+  for (const auto& edge : draft.Edges()) {
+    if (edge.source_node_id == NodeId{"grade.primary"} ||
+        edge.destination_node_id == NodeId{"grade.primary"}) {
+      primary_on_path = true;
+    }
+  }
+  EXPECT_FALSE(primary_on_path);
+}
+
+TEST(EditorNodeGraphDraft, ReconnectingTheDetachedGradeMakesTheDraftSubmittable) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  ASSERT_TRUE(draft.Connect(NodeId{"develop"}, NodeId{"grade.d"}).succeeded);
+  ASSERT_TRUE(draft.Connect(NodeId{"grade.d"}, NodeId{"drt"}).succeeded);
+  ASSERT_FALSE(draft.SubmissionValid());
+
+  auto reconnect = draft.Connect(NodeId{"grade.d"}, NodeId{"grade.primary"});
+  ASSERT_TRUE(reconnect.succeeded);
+  auto finish = draft.Connect(NodeId{"grade.primary"}, NodeId{"drt"});
+  ASSERT_TRUE(finish.succeeded);
+  EXPECT_TRUE(finish.submission_valid);
+  EXPECT_FALSE(finish.delta_empty);
+  const auto change = draft.MakeChange();
+  EXPECT_EQ(change.inserted_nodes.size(), 1u);
+  EXPECT_TRUE(change.removed_nodes.empty());
+}
+
+TEST(EditorNodeGraphDraft, DeletingTheDetachedGradeMakesThePathValid) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  ASSERT_TRUE(draft.Connect(NodeId{"develop"}, NodeId{"grade.d"}).succeeded);
+  ASSERT_TRUE(draft.Connect(NodeId{"grade.d"}, NodeId{"drt"}).succeeded);
+  ASSERT_FALSE(draft.SubmissionValid());
+  auto remove = draft.RemoveColorGrade(NodeId{"grade.primary"});
+  ASSERT_TRUE(remove.succeeded);
+  EXPECT_TRUE(remove.submission_valid);
+  EXPECT_EQ(draft.FindNode(NodeId{"grade.primary"}), nullptr);
+}
+
+TEST(EditorNodeGraphDraft, ReturningToTheBaseEmptiesTheDelta) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  auto remove = draft.RemoveColorGrade(NodeId{"grade.d"});
+  ASSERT_TRUE(remove.succeeded);
+  EXPECT_TRUE(remove.delta_empty);
+  EXPECT_TRUE(draft.DeltaEmpty());
+  EXPECT_TRUE(draft.SubmissionValid());
+  EXPECT_EQ(draft.NextColorGradeNameNumber(), 2u);
+}
+
+TEST(EditorNodeGraphDraft, UnsupportedConnectLeavesValuesIndexesAndDeltaUnchanged) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  const auto before_nodes = draft.Nodes();
+  const auto before_edges = draft.Edges();
+  const auto before_delta = draft.DeltaEmpty();
+
+  auto self = draft.Connect(NodeId{"grade.d"}, NodeId{"grade.d"});
+  EXPECT_FALSE(self.succeeded);
+  EXPECT_EQ(self.error, "A node cannot connect to itself");
+
+  auto into_develop = draft.Connect(NodeId{"grade.d"}, NodeId{"develop"});
+  EXPECT_FALSE(into_develop.succeeded);
+  EXPECT_EQ(into_develop.error, "Develop has no incoming image port");
+
+  auto from_drt = draft.Connect(NodeId{"drt"}, NodeId{"grade.d"});
+  EXPECT_FALSE(from_drt.succeeded);
+  EXPECT_EQ(from_drt.error, "DRT/Post has no outgoing image port");
+
+  EXPECT_EQ(draft.Nodes().size(), before_nodes.size());
+  EXPECT_EQ(draft.Edges().size(), before_edges.size());
+  EXPECT_EQ(draft.DeltaEmpty(), before_delta);
+}
+
+TEST(EditorNodeGraphDraft, RestoreLastMutationReversesAnAdmittedConnect) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  ASSERT_TRUE(draft.Connect(NodeId{"develop"}, NodeId{"grade.d"}).succeeded);
+  EXPECT_TRUE(draft.HasLastMutation());
+  draft.RestoreLastMutation();
+  EXPECT_EQ(draft.Edges().size(), 2u);
+  EXPECT_EQ(draft.Edges()[0].source_node_id, NodeId{"develop"});
+  EXPECT_EQ(draft.Edges()[0].destination_node_id, NodeId{"grade.primary"});
+}
+
+}  // namespace

--- a/alcedo_studio/tests/app/editor_session_action_policy_cq3_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_action_policy_cq3_test.cpp
@@ -145,6 +145,8 @@ TEST(EditorSessionNodeCommandPolicy,
             EditorAction::CommitAdjustment);
   EXPECT_EQ(EditorActionPolicy::ActionForCommand(EditorSessionCommandKind::ReconnectColorGrade),
             EditorAction::CommitAdjustment);
+  EXPECT_EQ(EditorActionPolicy::ActionForCommand(EditorSessionCommandKind::EditNodeGraph),
+            EditorAction::CommitAdjustment);
 }
 
 TEST_F(EditorSessionActionPolicyCq3Test,

--- a/alcedo_studio/tests/app/editor_session_action_policy_cq3_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_action_policy_cq3_test.cpp
@@ -136,12 +136,14 @@ TEST_F(EditorSessionActionPolicyCq3Test,
 }
 
 TEST(EditorSessionNodeCommandPolicy,
-     AddRenameAndRemoveUseTheSameAdmissionDecisionAsSettledAdjustments) {
+     AddRenameRemoveAndReconnectUseTheSameAdmissionDecisionAsSettledAdjustments) {
   EXPECT_EQ(EditorActionPolicy::ActionForCommand(EditorSessionCommandKind::AddColorGrade),
             EditorAction::CommitAdjustment);
   EXPECT_EQ(EditorActionPolicy::ActionForCommand(EditorSessionCommandKind::RenameColorGrade),
             EditorAction::CommitAdjustment);
   EXPECT_EQ(EditorActionPolicy::ActionForCommand(EditorSessionCommandKind::RemoveColorGrade),
+            EditorAction::CommitAdjustment);
+  EXPECT_EQ(EditorActionPolicy::ActionForCommand(EditorSessionCommandKind::ReconnectColorGrade),
             EditorAction::CommitAdjustment);
 }
 

--- a/alcedo_studio/tests/app/editor_session_node_command_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_node_command_test.cpp
@@ -114,6 +114,32 @@ TEST_F(EditorSessionNodeCommandTest, DeleteCreatesOneHistoryChangeAndRoutesTopol
 }
 
 TEST_F(EditorSessionNodeCommandTest,
+       EditNodeGraphCreatesOneHistoryChangeAndRoutesTopologyQualityRender) {
+  const auto renders_before  = scheduler_->requests.size();
+  const auto revision_before = service_->history_revision();
+  NodeGraphTopologyChange change;
+  change.before_next_color_grade_name_number = 2;
+  change.after_next_color_grade_name_number  = 2;
+  NodeGraphDisconnectedEdge disconnected;
+  disconnected.edge                = PipelineSceneEdge{NodeId{"grade.primary"}, PortId{"image"},
+                                                       NodeId{"drt"}, PortId{"image"}};
+  disconnected.original_edge_index = 1;
+  change.disconnected_edges.push_back(disconnected);
+  NodeGraphConnectedEdge connected;
+  connected.edge             = PipelineSceneEdge{NodeId{"grade.primary"}, PortId{"image"},
+                                                 NodeId{"drt"}, PortId{"image"}};
+  connected.final_edge_index = 1;
+  change.connected_edges.push_back(connected);
+  const auto result = service_->EditNodeGraph(change);
+
+  EXPECT_EQ(result.kind, EditorSessionResultKind::RenderRouted);
+  EXPECT_EQ(history_->edit_node_graph_count, 1);
+  EXPECT_EQ(service_->history_revision(), revision_before + 1);
+  ASSERT_EQ(scheduler_->requests.size(), renders_before + 1);
+  EXPECT_EQ(scheduler_->requests.back().intent.reason, EditorRenderReason::GraphTopologyChanged);
+}
+
+TEST_F(EditorSessionNodeCommandTest,
        ReconnectCreatesOneHistoryChangeAndRoutesTopologyQualityRender) {
   const auto renders_before  = scheduler_->requests.size();
   const auto revision_before = service_->history_revision();

--- a/alcedo_studio/tests/app/editor_session_node_command_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_node_command_test.cpp
@@ -114,6 +114,23 @@ TEST_F(EditorSessionNodeCommandTest, DeleteCreatesOneHistoryChangeAndRoutesTopol
 }
 
 TEST_F(EditorSessionNodeCommandTest,
+       ReconnectCreatesOneHistoryChangeAndRoutesTopologyQualityRender) {
+  const auto renders_before  = scheduler_->requests.size();
+  const auto revision_before = service_->history_revision();
+  const auto result =
+      service_->ReconnectColorGrade(NodeId{"grade.primary"}, NodeId{"develop"}, NodeId{"drt"});
+
+  EXPECT_EQ(result.kind, EditorSessionResultKind::RenderRouted);
+  EXPECT_EQ(history_->reconnect_grade_count, 1);
+  EXPECT_EQ(history_->last_node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(history_->last_predecessor_id, NodeId{"develop"});
+  EXPECT_EQ(history_->last_successor_id, NodeId{"drt"});
+  EXPECT_EQ(service_->history_revision(), revision_before + 1);
+  ASSERT_EQ(scheduler_->requests.size(), renders_before + 1);
+  EXPECT_EQ(scheduler_->requests.back().intent.reason, EditorRenderReason::GraphTopologyChanged);
+}
+
+TEST_F(EditorSessionNodeCommandTest,
        JournalFailurePublishesExactErrorWithoutHistoryOrRenderChange) {
   history_->fail_node_command = true;
   const auto renders_before   = scheduler_->requests.size();

--- a/alcedo_studio/tests/edit/graph/pipeline_graph_topology_delta_test.cpp
+++ b/alcedo_studio/tests/edit/graph/pipeline_graph_topology_delta_test.cpp
@@ -1,0 +1,232 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "app/pipeline_document_history.hpp"
+#include "app/pipeline_history_applier.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
+
+namespace {
+
+using alcedo::ApplyNodeGraphTopologyChange;
+using alcedo::ApplyPipelineEditBatch;
+using alcedo::ColorGradeNodeModel;
+using alcedo::CreateCleanColorGradeNode;
+using alcedo::CreateDefaultPipelineDocument;
+using alcedo::GraphEdge;
+using alcedo::MakeEditNodeGraphBatch;
+using alcedo::NodeGraphConnectedEdge;
+using alcedo::NodeGraphDisconnectedEdge;
+using alcedo::NodeGraphInsertedNode;
+using alcedo::NodeGraphRemovedNode;
+using alcedo::NodeGraphTopologyChange;
+using alcedo::NodeId;
+using alcedo::PipelineDocument;
+using alcedo::PipelineEditApplyDirection;
+using alcedo::PipelineSceneEdge;
+using alcedo::PortId;
+using alcedo::TopologyEdgeInsertion;
+using alcedo::TopologyEdgeRemoval;
+using alcedo::TopologyNodeInsertion;
+using alcedo::TopologyNodeRemoval;
+
+auto Image() -> PortId { return PortId{"image"}; }
+
+auto Scene(const NodeId& from, const NodeId& to) -> PipelineSceneEdge {
+  return PipelineSceneEdge{from, Image(), to, Image()};
+}
+
+auto NodeIndex(const PipelineDocument& document, const NodeId& id) -> std::size_t {
+  for (std::size_t index = 0; index < document.Graph().Nodes().size(); ++index) {
+    if (document.Graph().Nodes()[index]->Id() == id) {
+      return index;
+    }
+  }
+  ADD_FAILURE() << "missing node " << id.Value();
+  return 0;
+}
+
+auto EdgeIndex(const PipelineDocument& document, const NodeId& from, const NodeId& to)
+    -> std::size_t {
+  const auto& edges = document.Graph().Edges();
+  for (std::size_t index = 0; index < edges.size(); ++index) {
+    if (edges[index].from_node == from && edges[index].to_node == to) {
+      return index;
+    }
+  }
+  ADD_FAILURE() << "missing edge";
+  return 0;
+}
+
+auto InsertGradeChange(const PipelineDocument& document, NodeId id) -> NodeGraphTopologyChange {
+  auto       node = CreateCleanColorGradeNode(id);
+  node->SetDisplayName("Color Grade 2");
+  NodeGraphTopologyChange change;
+  change.before_next_color_grade_name_number = document.NextColorGradeNameNumber();
+  change.after_next_color_grade_name_number  = change.before_next_color_grade_name_number + 1;
+  NodeGraphInsertedNode inserted;
+  inserted.node             = node->ToJson();
+  inserted.final_node_index = static_cast<std::uint32_t>(document.Graph().NodeCount());
+  change.inserted_nodes.push_back(std::move(inserted));
+  return change;
+}
+
+TEST(PipelineGraphTopologyDelta, ForwardInsertKeepsUnaffectedNodeAddresses) {
+  auto        document = CreateDefaultPipelineDocument();
+  const auto* develop  = document.Graph().FindNode(NodeId{"develop"});
+  const auto* primary  = document.Graph().FindNode(NodeId{"grade.primary"});
+  const auto* drt      = document.Graph().FindNode(NodeId{"drt"});
+  ASSERT_NE(develop, nullptr);
+  ASSERT_NE(primary, nullptr);
+  ASSERT_NE(drt, nullptr);
+
+  auto change = InsertGradeChange(document, NodeId{"grade.extra"});
+  // Incomplete graph: extra node with no edges. ApplyTopologyDelta validates the
+  // complete graph, so connect Develop->primary->extra->DRT in one delta.
+  change.disconnected_edges.push_back(
+      NodeGraphDisconnectedEdge{Scene(NodeId{"grade.primary"}, NodeId{"drt"}),
+                                static_cast<std::uint32_t>(EdgeIndex(
+                                    document, NodeId{"grade.primary"}, NodeId{"drt"}))});
+  change.connected_edges.push_back(NodeGraphConnectedEdge{
+      Scene(NodeId{"grade.primary"}, NodeId{"grade.extra"}), 1});
+  change.connected_edges.push_back(
+      NodeGraphConnectedEdge{Scene(NodeId{"grade.extra"}, NodeId{"drt"}), 2});
+
+  EXPECT_TRUE(ApplyNodeGraphTopologyChange(document, change, PipelineEditApplyDirection::Forward)
+                  .empty());
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"develop"}), develop);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"drt"}), drt);
+  EXPECT_NE(document.Graph().FindNode(NodeId{"grade.extra"}), nullptr);
+  EXPECT_EQ(document.NextColorGradeNameNumber(), 3u);
+}
+
+TEST(PipelineGraphTopologyDelta, InverseRestoresNodeOrderEdgesCounterAndObjectIdentity) {
+  auto        document = CreateDefaultPipelineDocument();
+  const auto* develop  = document.Graph().FindNode(NodeId{"develop"});
+  const auto* primary  = document.Graph().FindNode(NodeId{"grade.primary"});
+  const auto* drt      = document.Graph().FindNode(NodeId{"drt"});
+  auto        change   = InsertGradeChange(document, NodeId{"grade.extra"});
+  change.disconnected_edges.push_back(
+      NodeGraphDisconnectedEdge{Scene(NodeId{"grade.primary"}, NodeId{"drt"}),
+                                static_cast<std::uint32_t>(EdgeIndex(
+                                    document, NodeId{"grade.primary"}, NodeId{"drt"}))});
+  change.connected_edges.push_back(
+      NodeGraphConnectedEdge{Scene(NodeId{"grade.primary"}, NodeId{"grade.extra"}), 1});
+  change.connected_edges.push_back(
+      NodeGraphConnectedEdge{Scene(NodeId{"grade.extra"}, NodeId{"drt"}), 2});
+  ASSERT_TRUE(ApplyNodeGraphTopologyChange(document, change, PipelineEditApplyDirection::Forward)
+                  .empty());
+
+  EXPECT_TRUE(ApplyNodeGraphTopologyChange(document, change, PipelineEditApplyDirection::Inverse)
+                  .empty());
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"develop"}), develop);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"drt"}), drt);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.extra"}), nullptr);
+  EXPECT_EQ(document.Graph().NodeCount(), 3u);
+  EXPECT_EQ(document.Graph().Edges().size(), 2u);
+  EXPECT_EQ(document.NextColorGradeNameNumber(), 2u);
+  EXPECT_EQ(NodeIndex(document, NodeId{"develop"}), 0u);
+  EXPECT_EQ(NodeIndex(document, NodeId{"grade.primary"}), 1u);
+  EXPECT_EQ(NodeIndex(document, NodeId{"drt"}), 2u);
+}
+
+TEST(PipelineGraphTopologyDelta, ValidationFailureRestoresLiveGraphAndCounter) {
+  auto document = CreateDefaultPipelineDocument();
+  const auto* primary = document.Graph().FindNode(NodeId{"grade.primary"});
+  auto        change  = InsertGradeChange(document, NodeId{"grade.extra"});
+  // Insert the node without connecting it: backbone validation must fail.
+  const auto before_json = document.ToJson().dump();
+  const auto errors =
+      ApplyNodeGraphTopologyChange(document, change, PipelineEditApplyDirection::Forward);
+  EXPECT_FALSE(errors.empty());
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.extra"}), nullptr);
+  EXPECT_EQ(document.NextColorGradeNameNumber(), 2u);
+  EXPECT_EQ(document.ToJson().dump(), before_json);
+}
+
+TEST(PipelineGraphTopologyDelta, FailureAfterEachStepRestoresExactState) {
+  auto make_change = [](const PipelineDocument& document) {
+    auto change = InsertGradeChange(document, NodeId{"grade.extra"});
+    change.disconnected_edges.push_back(
+        NodeGraphDisconnectedEdge{Scene(NodeId{"grade.primary"}, NodeId{"drt"}),
+                                  static_cast<std::uint32_t>(EdgeIndex(
+                                      document, NodeId{"grade.primary"}, NodeId{"drt"}))});
+    change.connected_edges.push_back(
+        NodeGraphConnectedEdge{Scene(NodeId{"grade.primary"}, NodeId{"grade.extra"}), 1});
+    change.connected_edges.push_back(
+        NodeGraphConnectedEdge{Scene(NodeId{"grade.extra"}, NodeId{"drt"}), 2});
+    return change;
+  };
+  const std::vector<std::string> steps = {"counter", "disconnect", "insert_node", "connect",
+                                          "validate"};
+  for (const auto& fail_step : steps) {
+    auto              document = CreateDefaultPipelineDocument();
+    const auto*       develop  = document.Graph().FindNode(NodeId{"develop"});
+    const auto*       primary  = document.Graph().FindNode(NodeId{"grade.primary"});
+    const auto*       drt      = document.Graph().FindNode(NodeId{"drt"});
+    const auto        before   = document.ToJson().dump();
+    const auto        change   = make_change(document);
+    try {
+      (void)ApplyNodeGraphTopologyChange(
+          document, change, PipelineEditApplyDirection::Forward,
+          [&](std::string_view step, std::size_t) {
+            if (step == fail_step) {
+              throw std::runtime_error("injected " + std::string{step});
+            }
+          });
+      FAIL() << "expected injected failure at " << fail_step;
+    } catch (const std::runtime_error& ex) {
+      EXPECT_EQ(std::string{ex.what()}, "injected " + fail_step);
+    }
+    EXPECT_EQ(document.Graph().FindNode(NodeId{"develop"}), develop) << fail_step;
+    EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.primary"}), primary) << fail_step;
+    EXPECT_EQ(document.Graph().FindNode(NodeId{"drt"}), drt) << fail_step;
+    EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.extra"}), nullptr) << fail_step;
+    EXPECT_EQ(document.NextColorGradeNameNumber(), 2u) << fail_step;
+    EXPECT_EQ(document.ToJson().dump(), before) << fail_step;
+  }
+}
+
+TEST(PipelineGraphTopologyDelta, TypedBatchApplyDoesNotCloneTheLiveGraph) {
+  auto        document = CreateDefaultPipelineDocument();
+  const auto* develop  = document.Graph().FindNode(NodeId{"develop"});
+  const auto* primary  = document.Graph().FindNode(NodeId{"grade.primary"});
+  const auto* drt      = document.Graph().FindNode(NodeId{"drt"});
+  auto        change   = InsertGradeChange(document, NodeId{"grade.extra"});
+  change.disconnected_edges.push_back(
+      NodeGraphDisconnectedEdge{Scene(NodeId{"grade.primary"}, NodeId{"drt"}),
+                                static_cast<std::uint32_t>(EdgeIndex(
+                                    document, NodeId{"grade.primary"}, NodeId{"drt"}))});
+  change.connected_edges.push_back(
+      NodeGraphConnectedEdge{Scene(NodeId{"grade.primary"}, NodeId{"grade.extra"}), 1});
+  change.connected_edges.push_back(
+      NodeGraphConnectedEdge{Scene(NodeId{"grade.extra"}, NodeId{"drt"}), 2});
+  std::string error;
+  ASSERT_TRUE(ApplyPipelineEditBatch(document, MakeEditNodeGraphBatch(change),
+                                     PipelineEditApplyDirection::Forward, &error))
+      << error;
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"develop"}), develop);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"drt"}), drt);
+  ASSERT_TRUE(ApplyPipelineEditBatch(document, MakeEditNodeGraphBatch(change),
+                                     PipelineEditApplyDirection::Inverse, &error))
+      << error;
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"develop"}), develop);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"drt"}), drt);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.extra"}), nullptr);
+}
+
+}  // namespace

--- a/alcedo_studio/tests/edit/history/pipeline_edit_batch_test.cpp
+++ b/alcedo_studio/tests/edit/history/pipeline_edit_batch_test.cpp
@@ -342,6 +342,20 @@ TEST(PipelineEditBatch, RoundTripForEveryChangeVariant) {
   ExpectRoundTrip(MakeRemoveGradeBatch());
   ExpectRoundTrip(MakeReconnectBatch());
 
+  NodeGraphTopologyChange topology;
+  topology.before_next_color_grade_name_number = 2;
+  topology.after_next_color_grade_name_number  = 3;
+  NodeGraphDisconnectedEdge disconnected;
+  disconnected.edge                = MakeSceneEdge("grade.look", "drt");
+  disconnected.original_edge_index = 1;
+  topology.disconnected_edges.push_back(disconnected);
+  NodeGraphConnectedEdge connected_edge;
+  connected_edge.edge             = MakeSceneEdge("grade.look", "grade.extra");
+  connected_edge.final_edge_index = 1;
+  topology.connected_edges.push_back(connected_edge);
+  ExpectRoundTrip(PipelineEditBatch::Make(PipelineEditOperationKind::EditNodeGraph, {topology},
+                                          "history.operation.edit_node_graph"));
+
   AddMaskChange add_mask;
   add_mask.node_id       = NodeId{"grade.look"};
   add_mask.mask_id       = MaskId{"mask.radial"};

--- a/alcedo_studio/tests/support/editor_session_test_ports.hpp
+++ b/alcedo_studio/tests/support/editor_session_test_ports.hpp
@@ -93,8 +93,11 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
   int                            add_grade_count    = 0;
   int                            remove_grade_count = 0;
   int                            rename_grade_count = 0;
+  int                                             reconnect_grade_count = 0;
   NodeId                         last_node_id;
   NodeId                         last_before_node_id;
+  NodeId                                          last_predecessor_id;
+  NodeId                                          last_successor_id;
   std::string                    last_grade_name;
   std::optional<EditorRenderReason> last_render_reason = EditorRenderReason::UndoRedo;
   std::shared_ptr<const EditorMiniGitSaveCapture> next_capture = MakeOpaqueSaveCapture();
@@ -166,6 +169,21 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
     last_node_id       = node_id;
     last_grade_name    = std::move(display_name);
     last_render_reason = std::nullopt;
+    if (fail_node_command) {
+      if (error != nullptr) *error = "mini-Git journal append failed";
+      return false;
+    }
+    return true;
+  }
+
+  auto ReconnectColorGrade(const EditorHistoryGuardHandle&, const NodeId& node_id,
+                           const NodeId& new_predecessor_id, const NodeId& new_successor_id,
+                           std::string* error) -> bool override {
+    ++reconnect_grade_count;
+    last_node_id        = node_id;
+    last_predecessor_id = new_predecessor_id;
+    last_successor_id   = new_successor_id;
+    last_render_reason  = EditorRenderReason::GraphTopologyChanged;
     if (fail_node_command) {
       if (error != nullptr) *error = "mini-Git journal append failed";
       return false;

--- a/alcedo_studio/tests/support/editor_session_test_ports.hpp
+++ b/alcedo_studio/tests/support/editor_session_test_ports.hpp
@@ -94,6 +94,8 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
   int                            remove_grade_count = 0;
   int                            rename_grade_count = 0;
   int                                             reconnect_grade_count = 0;
+  int                            edit_node_graph_count = 0;
+  NodeGraphTopologyChange        last_topology_change{};
   NodeId                         last_node_id;
   NodeId                         last_before_node_id;
   NodeId                                          last_predecessor_id;
@@ -184,6 +186,18 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
     last_predecessor_id = new_predecessor_id;
     last_successor_id   = new_successor_id;
     last_render_reason  = EditorRenderReason::GraphTopologyChanged;
+    if (fail_node_command) {
+      if (error != nullptr) *error = "mini-Git journal append failed";
+      return false;
+    }
+    return true;
+  }
+
+  auto EditNodeGraph(const EditorHistoryGuardHandle&, NodeGraphTopologyChange change,
+                     std::string* error) -> bool override {
+    ++edit_node_graph_count;
+    last_topology_change = std::move(change);
+    last_render_reason   = EditorRenderReason::GraphTopologyChanged;
     if (fail_node_command) {
       if (error != nullptr) *error = "mini-Git journal append failed";
       return false;

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -125,8 +125,6 @@ add_executable(UiFuzzAutomationTest
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
     ${ALCEDO_SRC_DIR}/ui/alcedo_main/application_module_qml_types.cpp
     ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/application_module_qml_types.hpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
     ${ALCEDO_SRC_DIR}/ui/alcedo_studio_test_host/probe_json.cpp
     ${ALCEDO_SRC_DIR}/ui/alcedo_studio_test_host/probe_json.hpp
     ${ALCEDO_SRC_DIR}/ui/alcedo_studio_test_host/probe_item_tree.cpp
@@ -427,9 +425,6 @@ endif()
 add_executable(GlobalSearchDialogQmlTest
     ${ALCEDO_TEST_ROOT}/ui/global_search_dialog_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(GlobalSearchDialogQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -457,9 +452,6 @@ alcedo_register_test_target(GlobalSearchDialogQmlTest ui)
 add_executable(MainQmlWorkflowTest
     ${ALCEDO_TEST_ROOT}/ui/main_qml_workflow_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(MainQmlWorkflowTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -490,9 +482,6 @@ add_executable(EditorCheckpointQmlIntegrationTest
     ${ALCEDO_TEST_ROOT}/ui/editor_checkpoint_qml_integration_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/main_qml_test_fixture.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorCheckpointQmlIntegrationTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -523,9 +512,6 @@ add_executable(WorkspaceShellTest
     ${ALCEDO_TEST_ROOT}/ui/workspace_shell_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/main_qml_test_fixture.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(WorkspaceShellTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -558,9 +544,6 @@ alcedo_link_quickqanava_qml(WorkspaceShellTest)
 add_executable(EditorFilmstripQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_filmstrip_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/editor_filmstrip_qml_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorFilmstripQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -615,9 +598,6 @@ alcedo_register_test_target(EditorAdjustmentModelTest ui)
 add_executable(EditorAdjustmentControlQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_adjustment_control_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorAdjustmentControlQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -647,9 +627,6 @@ set(ALCEDO_HISTORY_VERSIONS_RAIL_QML_HARNESS
     ${ALCEDO_TEST_ROOT}/ui/editor_history_versions_rail_qml_harness.cpp
     ${ALCEDO_TEST_ROOT}/ui/editor_history_versions_rail_qml_harness.hpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 
 add_executable(EditorVersionsPanelQmlTest
@@ -784,9 +761,6 @@ alcedo_register_test_target(QuickQanavaProductionIntegrationTest ui)
 add_executable(AlcedoQanGraphTest
     ${ALCEDO_TEST_ROOT}/ui/alcedo_qan_graph_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(AlcedoQanGraphTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -822,9 +796,6 @@ alcedo_register_test_target(AlcedoQanGraphTest ui)
 add_executable(EditorNodeDelegateQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_node_delegate_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorNodeDelegateQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -861,9 +832,6 @@ add_executable(EditorNodeSelectionLayoutTest
     ${ALCEDO_TEST_ROOT}/ui/editor_node_layout_store_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/editor_node_controller_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorNodeSelectionLayoutTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -953,9 +921,6 @@ alcedo_register_test_target(EditorScopeControllerTest ui)
 add_executable(EditorAdjustmentSnapshotQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_adjustment_snapshot_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorAdjustmentSnapshotQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -986,9 +951,6 @@ alcedo_register_test_target(EditorAdjustmentSnapshotQmlTest ui)
 add_executable(EditorDisplayTransformSnapshotQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_display_transform_snapshot_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorDisplayTransformSnapshotQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1039,9 +1001,6 @@ alcedo_register_test_target(EditorGeometryMathTest ui)
 add_executable(EditorGeometryPanelQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_geometry_panel_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorGeometryPanelQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1073,9 +1032,6 @@ alcedo_register_test_target(EditorGeometryPanelQmlTest ui)
 add_executable(EditorRawDecodePanelQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_raw_decode_panel_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorRawDecodePanelQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1130,9 +1086,6 @@ add_executable(EditorAdjustmentTransferRealProjectE2eTest
     ${ALCEDO_TEST_ROOT}/ui/editor_adjustment_transfer_real_project_e2e_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/main_qml_test_fixture.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorAdjustmentTransferRealProjectE2eTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1165,9 +1118,6 @@ alcedo_link_quickqanava_qml(EditorAdjustmentTransferRealProjectE2eTest)
 add_executable(EditorWorkspaceNavigationQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_workspace_navigation_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorWorkspaceNavigationQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1175,6 +1125,7 @@ target_include_directories(EditorWorkspaceNavigationQmlTest
 )
 target_link_libraries(EditorWorkspaceNavigationQmlTest
     PRIVATE
+        AppTheme
         GTest::gtest
         Qt6::Core
         Qt6::Test
@@ -1196,9 +1147,6 @@ alcedo_register_test_target(EditorWorkspaceNavigationQmlTest ui)
 add_executable(EditorAdjustmentTransferActionsQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_adjustment_transfer_actions_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorAdjustmentTransferActionsQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1206,6 +1154,7 @@ target_include_directories(EditorAdjustmentTransferActionsQmlTest
 )
 target_link_libraries(EditorAdjustmentTransferActionsQmlTest
     PRIVATE
+        AppTheme
         GTest::gtest
         Qt6::Core
         Qt6::Test
@@ -1229,9 +1178,6 @@ alcedo_register_test_target(EditorAdjustmentTransferActionsQmlTest ui)
 add_executable(AdjustmentTransferDialogQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_adjustment_transfer_dialog_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(AdjustmentTransferDialogQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1239,6 +1185,7 @@ target_include_directories(AdjustmentTransferDialogQmlTest
 )
 target_link_libraries(AdjustmentTransferDialogQmlTest
     PRIVATE
+        AppTheme
         GTest::gtest
         Qt6::Core
         Qt6::Test
@@ -1346,9 +1293,6 @@ alcedo_register_test_target(EditorCdlTrackballGeometryTest ui)
 add_executable(EditorLutPanelQmlTest
     ${ALCEDO_TEST_ROOT}/ui/editor_lut_panel_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorLutPanelQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1356,6 +1300,7 @@ target_include_directories(EditorLutPanelQmlTest
 )
 target_link_libraries(EditorLutPanelQmlTest
     PRIVATE
+        AppTheme
         GTest::gtest
         Qt6::Core
         Qt6::Test
@@ -1379,9 +1324,6 @@ alcedo_register_test_target(EditorLutPanelQmlTest ui)
 add_executable(ExportNamingEditorQmlTest
     ${ALCEDO_TEST_ROOT}/ui/export_naming_editor_qml_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(ExportNamingEditorQmlTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1389,6 +1331,7 @@ target_include_directories(ExportNamingEditorQmlTest
 )
 target_link_libraries(ExportNamingEditorQmlTest
     PRIVATE
+        AppTheme
         GTest::gtest
         Qt6::Core
         Qt6::Test
@@ -1411,9 +1354,6 @@ alcedo_register_test_target(ExportNamingEditorQmlTest ui)
 add_executable(EditorLookPanelInteractionTest
     ${ALCEDO_TEST_ROOT}/ui/editor_look_panel_interaction_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorLookPanelInteractionTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1446,9 +1386,6 @@ alcedo_register_test_target(EditorLookPanelInteractionTest ui)
 # EditorSessionHistoryPort + pipeline guard + contended render worker.
 add_executable(EditorMultiSliderQuickTest
     ${ALCEDO_TEST_ROOT}/ui/editor_multi_slider_quicktest.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorMultiSliderQuickTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1489,9 +1426,6 @@ alcedo_register_test_target(EditorMultiSliderQuickTest ui)
 
 add_executable(EditorRealRawGpuE2eTest
     ${ALCEDO_TEST_ROOT}/ui/editor_real_raw_gpu_e2e_test.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorRealRawGpuE2eTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}
@@ -1568,9 +1502,6 @@ add_executable(EditorCheckpointNavigationTest
     ${ALCEDO_TEST_ROOT}/integration/editor_checkpoint_navigation_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/main_qml_test_fixture.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
-    ${ALCEDO_SRC_DIR}/ui/alcedo_main/app_theme.cpp
-    ${ALCEDO_SRC_DIR}/include/ui/alcedo_main/app_theme.hpp
-    ${ALCEDO_SRC_DIR}/config/resource.qrc
 )
 target_include_directories(EditorCheckpointNavigationTest
     PUBLIC ${ALCEDO_INCLUDE_DIR}

--- a/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
+++ b/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
@@ -14,13 +14,14 @@
 #include <QObject>
 #include <QPointer>
 #include <QQmlApplicationEngine>
-#include <QQuickItem>
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlError>
 #include <QQmlExtensionPlugin>
+#include <QQuickItem>
 #include <QQuickStyle>
 #include <QQuickWindow>
+#include <QSignalSpy>
 #include <QStringList>
 #include <QUrl>
 #include <QuickQanava>
@@ -37,6 +38,7 @@
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/graph/pipeline_graph_commands.hpp"
 #include "edit/mask/mask_model.hpp"
+#include "qanConnector.h"
 #include "qanEdge.h"
 #include "qanEdgeItem.h"
 #include "qanGraph.h"
@@ -510,6 +512,108 @@ TEST_F(AlcedoQanGraph, GraphDestructionClearsIdentityMaps) {
   EXPECT_FALSE(adapter.has_projection());
   EXPECT_EQ(adapter.NodeFor(NodeId{"develop"}), nullptr);
   EXPECT_EQ(adapter.LiveNodeId(old_node.data()), std::nullopt);
+}
+
+TEST_F(AlcedoQanGraph, EnablesRequestOnlyConnectorWithThemeColorsAndRoleConnectable) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.second"}).empty());
+  const auto snapshot = EditorNodeGraphProjection::Build(document, 4, 2, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded) << "initial apply";
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  auto* graph = harness_->Graph();
+  ASSERT_NE(graph, nullptr);
+  ASSERT_TRUE(WaitFor([&] { return graph->getConnector() != nullptr; }));
+  EXPECT_TRUE(graph->getConnectorEnabled());
+  EXPECT_FALSE(graph->getConnectorCreateDefaultEdge());
+  EXPECT_EQ(graph->getConnectorEdgeColor(),
+            alcedo::ui::AppTheme::Instance().graphCandidateEdgeColor());
+  EXPECT_EQ(graph->getConnectorColor(), alcedo::ui::AppTheme::Instance().graphPortBorderColor());
+  EXPECT_EQ(adapter.NodeFor(NodeId{"develop"})->getItem()->getConnectable(),
+            qan::NodeItem::Connectable::UnConnectable);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"drt"})->getItem()->getConnectable(),
+            qan::NodeItem::Connectable::InConnectable);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"})->getItem()->getConnectable(),
+            qan::NodeItem::Connectable::OutConnectable);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.second"})->getItem()->getConnectable(),
+            qan::NodeItem::Connectable::InConnectable);
+  ASSERT_NE(graph->getConnector()->getSourcePort(), nullptr);
+  EXPECT_EQ(graph->getConnector()->getSourcePort(),
+            adapter.OutputPortFor(NodeId{"grade.primary"}, kImagePort()));
+}
+
+TEST_F(AlcedoQanGraph, ConnectorDropResolvesLiveIdsWithoutInsertingAPermanentEdge) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.second"}).empty());
+  const auto snapshot = EditorNodeGraphProjection::Build(document, 5, 2, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded) << "initial apply";
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+  auto* graph = harness_->Graph();
+  ASSERT_TRUE(WaitFor([&] { return graph->getConnector() != nullptr; }));
+  const auto edges_before = graph->get_edge_count();
+
+  QSignalSpy moved(&adapter, &ui::AlcedoQanGraph::ConnectorMoveRequested);
+  QSignalSpy rejected(&adapter, &ui::AlcedoQanGraph::ConnectorRequestRejected);
+  auto*      dest_item = adapter.NodeFor(NodeId{"drt"})->getItem();
+  ASSERT_NE(dest_item, nullptr);
+  ASSERT_TRUE(QMetaObject::invokeMethod(graph->getConnector(), "connectorReleased",
+                                        Qt::DirectConnection, Q_ARG(QQuickItem*, dest_item)));
+  ASSERT_EQ(moved.count(), 1);
+  EXPECT_EQ(rejected.count(), 0);
+  const auto args = moved.takeFirst();
+  EXPECT_EQ(args.at(0).toString(), QStringLiteral("grade.primary"));
+  EXPECT_EQ(args.at(1).toString(), QStringLiteral("drt"));
+  EXPECT_FALSE(args.at(2).toBool());
+  EXPECT_EQ(graph->get_edge_count(), edges_before);
+}
+
+TEST_F(AlcedoQanGraph, ConnectorDropOnUnknownPrimitiveRejectsWithoutCreatingAnEdge) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 6, 2, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded) << "initial apply";
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+  auto* graph = harness_->Graph();
+  ASSERT_TRUE(WaitFor([&] { return graph->getConnector() != nullptr; }));
+  auto* stray = graph->insertNode();
+  ASSERT_NE(stray, nullptr);
+  ASSERT_NE(stray->getItem(), nullptr);
+  const auto edges_before = graph->get_edge_count();
+
+  QSignalSpy rejected(&adapter, &ui::AlcedoQanGraph::ConnectorRequestRejected);
+  QSignalSpy moved(&adapter, &ui::AlcedoQanGraph::ConnectorMoveRequested);
+  ASSERT_TRUE(QMetaObject::invokeMethod(graph->getConnector(), "connectorReleased",
+                                        Qt::DirectConnection,
+                                        Q_ARG(QQuickItem*, stray->getItem())));
+  ASSERT_EQ(rejected.count(), 1);
+  EXPECT_EQ(moved.count(), 0);
+  EXPECT_EQ(rejected.takeFirst().at(0).toString(),
+            QStringLiteral("That graph item is no longer part of the current Version"));
+  EXPECT_EQ(graph->get_edge_count(), edges_before);
+}
+
+TEST_F(AlcedoQanGraph, DrawerFoldKeepsPortIdentityForReconnect) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 7, 2, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded) << "initial apply";
+  auto* output = adapter.OutputPortFor(NodeId{"grade.primary"}, kImagePort());
+  auto* input  = adapter.InputPortFor(NodeId{"grade.primary"}, kImagePort());
+  ASSERT_NE(output, nullptr);
+  ASSERT_NE(input, nullptr);
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  ASSERT_TRUE(WaitFor([&] {
+    auto* item = adapter.NodeFor(NodeId{"grade.primary"})->getItem();
+    return item != nullptr && !item->property("drawerOpen").toBool();
+  }));
+  EXPECT_EQ(adapter.OutputPortFor(NodeId{"grade.primary"}, kImagePort()), output);
+  EXPECT_EQ(adapter.InputPortFor(NodeId{"grade.primary"}, kImagePort()), input);
+  EXPECT_EQ(output->getId(), QStringLiteral("out:image"));
+  EXPECT_EQ(input->getId(), QStringLiteral("in:image"));
 }
 
 TEST_F(AlcedoQanGraph, ApplySnapshotFailsWhenColorGradeDelegateUrlIsEmpty) {

--- a/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
+++ b/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
@@ -532,13 +532,13 @@ TEST_F(AlcedoQanGraph, EnablesRequestOnlyConnectorWithThemeColorsAndRoleConnecta
             alcedo::ui::AppTheme::Instance().graphCandidateEdgeColor());
   EXPECT_EQ(graph->getConnectorColor(), alcedo::ui::AppTheme::Instance().graphPortBorderColor());
   EXPECT_EQ(adapter.NodeFor(NodeId{"develop"})->getItem()->getConnectable(),
-            qan::NodeItem::Connectable::UnConnectable);
+            qan::NodeItem::Connectable::OutConnectable);
   EXPECT_EQ(adapter.NodeFor(NodeId{"drt"})->getItem()->getConnectable(),
             qan::NodeItem::Connectable::InConnectable);
   EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"})->getItem()->getConnectable(),
-            qan::NodeItem::Connectable::OutConnectable);
+            qan::NodeItem::Connectable::Connectable);
   EXPECT_EQ(adapter.NodeFor(NodeId{"grade.second"})->getItem()->getConnectable(),
-            qan::NodeItem::Connectable::InConnectable);
+            qan::NodeItem::Connectable::Connectable);
   ASSERT_NE(graph->getConnector()->getSourcePort(), nullptr);
   EXPECT_EQ(graph->getConnector()->getSourcePort(),
             adapter.OutputPortFor(NodeId{"grade.primary"}, kImagePort()));
@@ -614,6 +614,47 @@ TEST_F(AlcedoQanGraph, DrawerFoldKeepsPortIdentityForReconnect) {
   EXPECT_EQ(adapter.InputPortFor(NodeId{"grade.primary"}, kImagePort()), input);
   EXPECT_EQ(output->getId(), QStringLiteral("out:image"));
   EXPECT_EQ(input->getId(), QStringLiteral("in:image"));
+}
+
+TEST_F(AlcedoQanGraph, IncrementalInsertAndRemovePreserveUnaffectedIdentities) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 8, 2, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded);
+  const auto replace_count = adapter.topology_replace_count();
+  auto*      develop       = adapter.NodeFor(NodeId{"develop"});
+  auto*      primary       = adapter.NodeFor(NodeId{"grade.primary"});
+  auto*      drt           = adapter.NodeFor(NodeId{"drt"});
+  ASSERT_NE(develop, nullptr);
+  ASSERT_NE(primary, nullptr);
+  ASSERT_NE(drt, nullptr);
+
+  EditorNodeProjection extra;
+  extra.node_id      = NodeId{"grade.extra"};
+  extra.node_kind    = EditorNodeKind::ColorGrade;
+  extra.display_name = "Color Grade 2";
+  ASSERT_TRUE(adapter.InsertProjectedNode(extra).succeeded);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"develop"}), develop);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"drt"}), drt);
+  EXPECT_NE(adapter.NodeFor(NodeId{"grade.extra"}), nullptr);
+  EXPECT_NE(adapter.InputPortFor(NodeId{"grade.extra"}, PortId{"image"}), nullptr);
+  EXPECT_NE(adapter.OutputPortFor(NodeId{"grade.extra"}, PortId{"image"}), nullptr);
+
+  EditorNodeEdgeProjection edge{NodeId{"develop"}, PortId{"image"}, NodeId{"grade.extra"},
+                                PortId{"image"}};
+  ASSERT_TRUE(adapter.RemoveProjectedEdge(EditorNodeEdgeProjection{
+                                              NodeId{"develop"}, PortId{"image"},
+                                              NodeId{"grade.primary"}, PortId{"image"}})
+                  .succeeded);
+  EXPECT_NE(adapter.OutputPortFor(NodeId{"develop"}, PortId{"image"}), nullptr);
+  EXPECT_NE(adapter.InputPortFor(NodeId{"grade.extra"}, PortId{"image"}), nullptr);
+  const auto edge_result = adapter.InsertProjectedEdge(edge, true);
+  ASSERT_TRUE(edge_result.succeeded) << edge_result.error.toStdString();
+  EXPECT_EQ(adapter.topology_replace_count(), replace_count);
+  ASSERT_TRUE(adapter.RemoveProjectedNode(NodeId{"grade.extra"}).succeeded);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.extra"}), nullptr);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"develop"}), develop);
 }
 
 TEST_F(AlcedoQanGraph, ApplySnapshotFailsWhenColorGradeDelegateUrlIsEmpty) {

--- a/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
+++ b/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
@@ -295,6 +295,20 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
     return Accepted("Color Grade renamed");
   }
 
+  auto ReconnectColorGrade(const NodeId& node_id, const NodeId& new_predecessor_id,
+                           const NodeId& new_successor_id) -> EditorSessionResult override {
+    if (fail_node_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors =
+        alcedo::ReconnectColorGrade(*document_, node_id, new_predecessor_id, new_successor_id);
+    if (!errors.empty()) return Rejected(errors.front().message.c_str());
+    last_reconnected_node_id_      = node_id;
+    last_reconnect_predecessor_id_ = new_predecessor_id;
+    last_reconnect_successor_id_   = new_successor_id;
+    ++reconnect_grade_count_;
+    NotifyHistoryChange();
+    return Accepted("Color Grade reconnected");
+  }
+
   auto Close(bool) -> EditorSessionResult override {
     state_     = EditorSessionState::NoImage;
     has_image_ = false;
@@ -366,9 +380,19 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto add_grade_count() const -> int { return add_grade_count_; }
   [[nodiscard]] auto remove_grade_count() const -> int { return remove_grade_count_; }
   [[nodiscard]] auto rename_grade_count() const -> int { return rename_grade_count_; }
+  [[nodiscard]] auto reconnect_grade_count() const -> int { return reconnect_grade_count_; }
   [[nodiscard]] auto last_added_node_id() const -> NodeId { return last_added_node_id_; }
   [[nodiscard]] auto last_removed_node_id() const -> NodeId { return last_removed_node_id_; }
   [[nodiscard]] auto last_renamed_node_id() const -> NodeId { return last_renamed_node_id_; }
+  [[nodiscard]] auto last_reconnected_node_id() const -> NodeId {
+    return last_reconnected_node_id_;
+  }
+  [[nodiscard]] auto last_reconnect_predecessor_id() const -> NodeId {
+    return last_reconnect_predecessor_id_;
+  }
+  [[nodiscard]] auto last_reconnect_successor_id() const -> NodeId {
+    return last_reconnect_successor_id_;
+  }
 
   void SetRecovery(bool pending, std::string error = {}) {
     recovery_pending_ = pending;
@@ -443,9 +467,13 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
   int                   add_grade_count_       = 0;
   int                   remove_grade_count_    = 0;
   int                   rename_grade_count_    = 0;
+  int                   reconnect_grade_count_ = 0;
   NodeId                last_added_node_id_;
   NodeId                last_removed_node_id_;
   NodeId                last_renamed_node_id_;
+  NodeId                last_reconnected_node_id_;
+  NodeId                last_reconnect_predecessor_id_;
+  NodeId                last_reconnect_successor_id_;
 };
 
 class RecordingInteractionPolicy final : public QObject {

--- a/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
+++ b/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
@@ -31,6 +31,7 @@
 
 #include "app/editor_render_intent.hpp"
 #include "app/editor_session_service.hpp"
+#include "app/pipeline_document_history.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/graph/pipeline_graph_commands.hpp"
 #include "type/hash_type.hpp"
@@ -309,6 +310,19 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
     return Accepted("Color Grade reconnected");
   }
 
+  auto EditNodeGraph(NodeGraphTopologyChange change) -> EditorSessionResult override {
+    if (fail_node_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors = ApplyNodeGraphTopologyChange(*document_, change,
+                                                     PipelineEditApplyDirection::Forward);
+    if (!errors.empty()) return Rejected(errors.front().message.c_str());
+    last_topology_change_ = std::move(change);
+    ++edit_node_graph_count_;
+    NotifyHistoryChange();
+    EditorSessionResult result = Accepted("Node graph topology updated");
+    result.kind                = EditorSessionResultKind::RenderRouted;
+    return result;
+  }
+
   auto Close(bool) -> EditorSessionResult override {
     state_     = EditorSessionState::NoImage;
     has_image_ = false;
@@ -381,6 +395,10 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto remove_grade_count() const -> int { return remove_grade_count_; }
   [[nodiscard]] auto rename_grade_count() const -> int { return rename_grade_count_; }
   [[nodiscard]] auto reconnect_grade_count() const -> int { return reconnect_grade_count_; }
+  [[nodiscard]] auto edit_node_graph_count() const -> int { return edit_node_graph_count_; }
+  [[nodiscard]] auto last_topology_change() const -> const NodeGraphTopologyChange& {
+    return last_topology_change_;
+  }
   [[nodiscard]] auto last_added_node_id() const -> NodeId { return last_added_node_id_; }
   [[nodiscard]] auto last_removed_node_id() const -> NodeId { return last_removed_node_id_; }
   [[nodiscard]] auto last_renamed_node_id() const -> NodeId { return last_renamed_node_id_; }
@@ -468,6 +486,8 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
   int                   remove_grade_count_    = 0;
   int                   rename_grade_count_    = 0;
   int                   reconnect_grade_count_ = 0;
+  int                   edit_node_graph_count_ = 0;
+  NodeGraphTopologyChange last_topology_change_{};
   NodeId                last_added_node_id_;
   NodeId                last_removed_node_id_;
   NodeId                last_renamed_node_id_;

--- a/alcedo_studio/tests/ui/editor_node_controller_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_controller_test.cpp
@@ -14,6 +14,7 @@
 #include "app/editor_node_graph_projection.hpp"
 #include "app/editor_session_request_ids.hpp"
 #include "app/editor_session_service.hpp"
+#include "app/pipeline_document_history.hpp"
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/graph/pipeline_graph_commands.hpp"
@@ -35,6 +36,7 @@ using alcedo::PipelineDocument;
 using alcedo::ui::EditorNodeController;
 using alcedo::ui::EditorNodeLayoutStore;
 using alcedo::ui::EditorSessionController;
+using alcedo::ui::NodeIdToQString;
 
 class DocumentSessionBackend final : public IEditorSessionBackend {
  public:
@@ -122,6 +124,18 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
     NotifyChange();
     return Accepted("Color Grade reconnected");
   }
+  auto EditNodeGraph(alcedo::NodeGraphTopologyChange change) -> EditorSessionResult override {
+    ++edit_node_graph_count_;
+    last_topology_change_ = change;
+    if (fail_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors = alcedo::ApplyNodeGraphTopologyChange(
+        document_, change, alcedo::PipelineEditApplyDirection::Forward);
+    if (!errors.empty()) return Rejected(errors.front().message);
+    NotifyChange();
+    auto result = Accepted("Node graph topology updated");
+    result.kind = alcedo::EditorSessionResultKind::RenderRouted;
+    return result;
+  }
 
   void SetGeneration(std::uint64_t value) { request_.value = value; }
   auto Document() -> PipelineDocument& { return document_; }
@@ -137,6 +151,7 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto remove_count() const -> int { return remove_count_; }
   [[nodiscard]] auto rename_count() const -> int { return rename_count_; }
   [[nodiscard]] auto reconnect_count() const -> int { return reconnect_count_; }
+  [[nodiscard]] auto edit_node_graph_count() const -> int { return edit_node_graph_count_; }
   [[nodiscard]] auto last_reconnect_node() const -> NodeId { return last_reconnect_node_; }
   [[nodiscard]] auto last_reconnect_predecessor() const -> NodeId {
     return last_reconnect_predecessor_;
@@ -171,6 +186,8 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   int                                               remove_count_  = 0;
   int                                               rename_count_  = 0;
   int                                               reconnect_count_ = 0;
+  int                                               edit_node_graph_count_ = 0;
+  alcedo::NodeGraphTopologyChange                   last_topology_change_{};
   NodeId                                            last_reconnect_node_;
   NodeId                                            last_reconnect_predecessor_;
   NodeId                                            last_reconnect_successor_;
@@ -236,7 +253,7 @@ TEST(EditorNodeController, StaleGenerationSnapshotIsRejected) {
   EXPECT_FALSE(controller.last_error().isEmpty());
 }
 
-TEST(EditorNodeController, AddCreatesCleanGradeAfterSelectedGradeAndConsumesOneName) {
+TEST(EditorNodeController, AddCreatesDisconnectedDraftGradeWithoutAProductCommand) {
   DocumentSessionBackend backend;
   backend.SetGeneration(15);
   EditorSessionController session(&backend);
@@ -245,15 +262,34 @@ TEST(EditorNodeController, AddCreatesCleanGradeAfterSelectedGradeAndConsumesOneN
   controller.selectNode(QStringLiteral("grade.primary"));
 
   ASSERT_TRUE(controller.addCleanColorGrade());
-  EXPECT_EQ(backend.add_count(), 1);
-  EXPECT_EQ(backend.Document().NextColorGradeNameNumber(), 3u);
-  const auto& ids = controller.backbone_node_ids();
-  ASSERT_EQ(ids.size(), 4);
-  EXPECT_EQ(ids[0], QStringLiteral("develop"));
-  EXPECT_EQ(ids[1], QStringLiteral("grade.primary"));
-  EXPECT_EQ(ids[2], controller.selected_node_id_string());
-  EXPECT_EQ(ids[3], QStringLiteral("drt"));
+  EXPECT_EQ(backend.add_count(), 0);
+  EXPECT_EQ(backend.edit_node_graph_count(), 0);
+  EXPECT_EQ(backend.Document().NextColorGradeNameNumber(), 2u);
+  EXPECT_TRUE(controller.incomplete_draft());
+  EXPECT_EQ(controller.backbone_node_ids().size(), 4);
   EXPECT_EQ(controller.selected_node_name(), QStringLiteral("Color Grade 2"));
+  EXPECT_EQ(controller.snapshot().edges.size(), 2u);
+}
+
+TEST(EditorNodeController, AddPlacesTheDisconnectedGradeBelowTheBackbone) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(15);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  EditorNodeLayoutStore   store;
+  controller.set_editor_session(&session);
+  controller.set_layout_store(&store);
+  store.EnsureDefaultPositions(controller.snapshot());
+
+  const auto drt_before = store.NodePosition(NodeId{"drt"});
+  ASSERT_TRUE(drt_before.has_value());
+  ASSERT_TRUE(controller.addCleanColorGrade());
+
+  const auto staged = store.NodePosition(controller.selected_node_id());
+  ASSERT_TRUE(staged.has_value());
+  EXPECT_DOUBLE_EQ(staged->x(), drt_before->x());
+  EXPECT_GT(staged->y(), drt_before->y());
+  EXPECT_EQ(store.NodePosition(NodeId{"drt"}), drt_before);
 }
 
 TEST(EditorNodeController, RenameChangesLabelWithoutChangingSelectionIdentity) {
@@ -269,44 +305,21 @@ TEST(EditorNodeController, RenameChangesLabelWithoutChangingSelectionIdentity) {
   EXPECT_EQ(controller.selected_node_name(), QStringLiteral("Sky"));
 }
 
-TEST(EditorNodeController, DeleteSelectsSuccessorThenUndoProjectionRestoresDeletedSelection) {
+TEST(EditorNodeController, DeleteOfADraftGradeDoesNotSubmitWhileThePathIsBroken) {
   DocumentSessionBackend backend;
   backend.SetGeneration(17);
   ASSERT_TRUE(
       alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
-  auto* primary = dynamic_cast<alcedo::ColorGradeNodeModel*>(
-      backend.Document().Graph().FindNode(NodeId{"grade.primary"}));
-  ASSERT_NE(primary, nullptr);
-  primary->AddMask(alcedo::grade_mask_test::MakeRadialMask(alcedo::MaskId{"mask.radial"}), 0);
   EditorSessionController session(&backend);
   EditorNodeController    controller;
   controller.set_editor_session(&session);
   controller.selectNode(QStringLiteral("grade.primary"));
-  const auto primary_masks = [&controller] {
-    for (const auto& node : controller.snapshot().nodes) {
-      if (node.node_id == NodeId{"grade.primary"}) {
-        return node.masks;
-      }
-    }
-    return std::vector<alcedo::EditorNodeMaskProjection>{};
-  };
-  ASSERT_EQ(primary_masks().size(), 1u);
 
   ASSERT_TRUE(controller.deleteColorGrade(QStringLiteral("grade.primary")));
-  EXPECT_EQ(backend.remove_count(), 1);
-  EXPECT_EQ(controller.selected_node_id(), NodeId{"grade.extra"});
-
-  auto undo_document = CreateDefaultPipelineDocument();
-  ASSERT_TRUE(
-      alcedo::AddCleanColorGrade(undo_document, NodeId{"drt"}, NodeId{"grade.extra"}).empty());
-  auto* restored = dynamic_cast<alcedo::ColorGradeNodeModel*>(
-      undo_document.Graph().FindNode(NodeId{"grade.primary"}));
-  ASSERT_NE(restored, nullptr);
-  restored->AddMask(alcedo::grade_mask_test::MakeRadialMask(alcedo::MaskId{"mask.radial"}), 0);
-  ASSERT_TRUE(controller.PublishDocument(undo_document, 17));
-  EXPECT_EQ(controller.selected_node_id(), NodeId{"grade.primary"});
-  ASSERT_EQ(primary_masks().size(), 1u);
-  EXPECT_EQ(primary_masks().front().mask_id, alcedo::MaskId{"mask.radial"});
+  EXPECT_EQ(backend.remove_count(), 0);
+  EXPECT_EQ(backend.edit_node_graph_count(), 0);
+  EXPECT_TRUE(controller.incomplete_draft());
+  EXPECT_EQ(controller.snapshot().nodes.size(), 3u);
 }
 
 TEST(EditorNodeController, EndpointsAndStaleGenerationRejectCommandsBeforeBackendMutation) {
@@ -337,13 +350,12 @@ TEST(EditorNodeController, BackendFailurePreservesDocumentCounterProjectionAndSe
   const auto before_ids      = controller.backbone_node_ids();
   const auto before_counter  = backend.Document().NextColorGradeNameNumber();
   const auto before_selected = controller.selected_node_id();
-  backend.SetFailCommands(true);
 
-  EXPECT_FALSE(controller.addCleanColorGrade());
-  EXPECT_EQ(controller.backbone_node_ids(), before_ids);
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  EXPECT_EQ(controller.backbone_node_ids().size(), before_ids.size() + 1);
   EXPECT_EQ(backend.Document().NextColorGradeNameNumber(), before_counter);
-  EXPECT_EQ(controller.selected_node_id(), before_selected);
-  EXPECT_EQ(controller.last_error(), QStringLiteral("mini-Git journal append failed"));
+  EXPECT_NE(controller.selected_node_id(), before_selected);
+  EXPECT_EQ(backend.edit_node_graph_count(), 0);
 }
 
 TEST(EditorNodeController, MissingNodeAfterRefreshSelectsRemainingColorGrade) {
@@ -377,155 +389,102 @@ TEST(EditorNodeController, BlockedEditAvailabilityDisablesAddWithoutSnapshotChan
   EXPECT_EQ(backend.add_count(), 0);
 }
 
-TEST(EditorNodeController, ActiveCommandRejectsNestedAddBeforeBackendMutation) {
+TEST(EditorNodeController, ActiveCommandRejectsNestedAddBeforeDraftMutation) {
   DocumentSessionBackend backend;
   backend.SetGeneration(22);
   EditorSessionController session(&backend);
   EditorNodeController    controller;
   controller.set_editor_session(&session);
-  bool nested_accepted = true;
-  backend.SetBeforeAdd([&] { nested_accepted = controller.addCleanColorGrade(); });
 
   ASSERT_TRUE(controller.addCleanColorGrade());
-  EXPECT_FALSE(nested_accepted);
-  EXPECT_EQ(backend.add_count(), 1);
   EXPECT_EQ(controller.backbone_node_ids().size(), 4);
+  EXPECT_EQ(backend.edit_node_graph_count(), 0);
 }
 
-TEST(EditorNodeController, ConnectorMovePlacesGradeBetweenRemainingNeighbors) {
+TEST(EditorNodeController, ExclusivePortConnectLeavesDetachedGradesWithoutSubmitting) {
   DocumentSessionBackend backend;
-  ASSERT_TRUE(
-      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
   backend.SetGeneration(30);
   EditorSessionController session(&backend);
   EditorNodeController    controller;
   controller.set_editor_session(&session);
-  controller.selectNode(QStringLiteral("grade.primary"));
-  ASSERT_TRUE(controller.can_reconnect_selected_color_grade());
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  const auto extra = controller.selected_node_id();
 
-  ASSERT_TRUE(controller.requestConnectorMove(QStringLiteral("grade.primary"),
-                                              QStringLiteral("drt"), false));
-  EXPECT_EQ(backend.reconnect_count(), 1);
-  EXPECT_EQ(backend.last_reconnect_node(), NodeId{"grade.primary"});
-  EXPECT_EQ(backend.last_reconnect_predecessor(), NodeId{"grade.extra"});
-  EXPECT_EQ(backend.last_reconnect_successor(), NodeId{"drt"});
-  const auto ids = controller.backbone_node_ids();
-  ASSERT_EQ(ids.size(), 4);
-  EXPECT_EQ(ids[0], QStringLiteral("develop"));
-  EXPECT_EQ(ids[1], QStringLiteral("grade.extra"));
-  EXPECT_EQ(ids[2], QStringLiteral("grade.primary"));
-  EXPECT_EQ(ids[3], QStringLiteral("drt"));
-  EXPECT_EQ(controller.selected_node_id(), NodeId{"grade.primary"});
+  ASSERT_TRUE(controller.requestConnect(QStringLiteral("develop"), NodeIdToQString(extra)));
+  EXPECT_EQ(backend.edit_node_graph_count(), 0);
+  EXPECT_TRUE(controller.incomplete_draft());
+  ASSERT_TRUE(controller.requestConnect(NodeIdToQString(extra), QStringLiteral("drt")));
+  EXPECT_EQ(backend.edit_node_graph_count(), 0);
+  EXPECT_TRUE(controller.incomplete_draft());
 }
 
-TEST(EditorNodeController, NoOpConnectorMoveCreatesNoHistoryCommit) {
+TEST(EditorNodeController, CompletingThePathSubmitsOneTopologyChange) {
   DocumentSessionBackend backend;
-  ASSERT_TRUE(
-      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
   backend.SetGeneration(31);
   EditorSessionController session(&backend);
   EditorNodeController    controller;
   controller.set_editor_session(&session);
-  controller.selectNode(QStringLiteral("grade.primary"));
-  const auto before = controller.backbone_node_ids();
-
-  EXPECT_TRUE(controller.requestConnectorMove(QStringLiteral("grade.primary"),
-                                              QStringLiteral("grade.extra"), false));
-  EXPECT_EQ(backend.reconnect_count(), 0);
-  EXPECT_EQ(controller.backbone_node_ids(), before);
-  EXPECT_TRUE(controller.last_error().isEmpty());
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  const auto extra = controller.selected_node_id();
+  ASSERT_TRUE(controller.requestConnect(QStringLiteral("develop"), NodeIdToQString(extra)));
+  ASSERT_TRUE(controller.requestConnect(NodeIdToQString(extra), QStringLiteral("grade.primary")));
+  ASSERT_TRUE(controller.requestConnect(QStringLiteral("grade.primary"), QStringLiteral("drt")));
+  EXPECT_EQ(backend.edit_node_graph_count(), 1);
+  EXPECT_FALSE(controller.incomplete_draft());
+  EXPECT_EQ(backend.Document().Graph().FindNode(extra) != nullptr, true);
+  EXPECT_EQ(backend.Document().NextColorGradeNameNumber(), 3u);
 }
 
-TEST(EditorNodeController, DevelopAndDrtRejectIncomingAndOutgoingMoveTargets) {
+TEST(EditorNodeController, DevelopAndDrtRejectUnsupportedPortRoles) {
   DocumentSessionBackend backend;
-  ASSERT_TRUE(
-      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
   backend.SetGeneration(32);
   EditorSessionController session(&backend);
   EditorNodeController    controller;
   controller.set_editor_session(&session);
-  controller.selectNode(QStringLiteral("grade.primary"));
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  const auto extra = controller.selected_node_id_string();
 
-  EXPECT_FALSE(controller.requestConnectorMove(QStringLiteral("grade.primary"),
-                                               QStringLiteral("develop"), false));
-  EXPECT_EQ(controller.last_error(), QStringLiteral("Develop has no incoming move target"));
-  EXPECT_FALSE(
-      controller.requestConnectorMove(QStringLiteral("grade.extra"), QStringLiteral("drt"), true));
+  EXPECT_FALSE(controller.requestConnect(extra, QStringLiteral("develop")));
+  EXPECT_EQ(controller.last_error(), QStringLiteral("Develop has no incoming image port"));
+  EXPECT_FALSE(controller.requestConnectorMove(extra, QStringLiteral("drt"), true));
   EXPECT_EQ(controller.last_error(),
-            QStringLiteral("Only a selected Color Grade can start a move"));
-  controller.selectNode(QStringLiteral("grade.extra"));
-  EXPECT_FALSE(
-      controller.requestConnectorMove(QStringLiteral("grade.extra"), QStringLiteral("drt"), true));
-  EXPECT_EQ(controller.last_error(), QStringLiteral("DRT/Post has no outgoing move source"));
-  EXPECT_EQ(backend.reconnect_count(), 0);
+            QStringLiteral("Connections must go from an output port to an input port"));
+  EXPECT_FALSE(controller.requestConnect(QStringLiteral("drt"), extra));
+  EXPECT_EQ(controller.last_error(), QStringLiteral("DRT/Post has no outgoing image port"));
+  EXPECT_EQ(backend.edit_node_graph_count(), 0);
 }
 
-TEST(EditorNodeController, CycleAndFanOutReconnectsFailWithoutDocumentChange) {
+TEST(EditorNodeController, SelfConnectAndStaleGenerationLeaveTheDraftUnchanged) {
   DocumentSessionBackend backend;
-  ASSERT_TRUE(
-      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
-  backend.SetGeneration(33);
-  EditorSessionController session(&backend);
-  EditorNodeController    controller;
-  controller.set_editor_session(&session);
-  const auto before = controller.backbone_node_ids();
-
-  EXPECT_FALSE(controller.requestReconnect(QStringLiteral("grade.primary"),
-                                           QStringLiteral("grade.primary"), QStringLiteral("drt")));
-  EXPECT_EQ(controller.last_error(), QStringLiteral("A Color Grade cannot reconnect to itself"));
-  EXPECT_FALSE(controller.requestReconnect(QStringLiteral("grade.primary"),
-                                           QStringLiteral("develop"), QStringLiteral("drt")));
-  EXPECT_EQ(controller.last_error(),
-            QStringLiteral("Reconnect would create a cycle, fan-in, or fan-out"));
-  EXPECT_EQ(backend.reconnect_count(), 0);
-  EXPECT_EQ(controller.backbone_node_ids(), before);
-}
-
-TEST(EditorNodeController, StaleGenerationAndBackendFailureLeaveReconnectUnchanged) {
-  DocumentSessionBackend backend;
-  ASSERT_TRUE(
-      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
   backend.SetGeneration(34);
   EditorSessionController session(&backend);
   EditorNodeController    controller;
   controller.set_editor_session(&session);
-  controller.selectNode(QStringLiteral("grade.primary"));
-  const auto before = controller.backbone_node_ids();
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  const auto extra = controller.selected_node_id_string();
+  const auto before = controller.snapshot().edges.size();
 
-  EXPECT_FALSE(controller.requestReconnect(
-      QStringLiteral("grade.primary"), QStringLiteral("grade.extra"), QStringLiteral("drt"), 1));
+  EXPECT_FALSE(controller.requestConnect(extra, extra));
+  EXPECT_EQ(controller.last_error(), QStringLiteral("A node cannot connect to itself"));
+  EXPECT_FALSE(controller.requestConnect(QStringLiteral("develop"), extra, 1));
   EXPECT_EQ(controller.last_error(),
             QStringLiteral("The node command is from another editor session"));
-  EXPECT_EQ(backend.reconnect_count(), 0);
-
-  backend.SetFailCommands(true);
-  EXPECT_FALSE(controller.requestReconnect(QStringLiteral("grade.primary"),
-                                           QStringLiteral("grade.extra"), QStringLiteral("drt")));
-  EXPECT_EQ(backend.reconnect_count(), 1);
-  EXPECT_EQ(controller.backbone_node_ids(), before);
-  EXPECT_EQ(controller.last_error(), QStringLiteral("mini-Git journal append failed"));
+  EXPECT_EQ(controller.snapshot().edges.size(), before);
+  EXPECT_EQ(backend.edit_node_graph_count(), 0);
 }
 
-TEST(EditorNodeController, UndoProjectionRestoresReconnectOrderAndSelection) {
+TEST(EditorNodeController, ReturningADraftToTheBaseExitsEditingWithoutACommit) {
   DocumentSessionBackend backend;
-  ASSERT_TRUE(
-      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
   backend.SetGeneration(35);
   EditorSessionController session(&backend);
   EditorNodeController    controller;
   controller.set_editor_session(&session);
-  controller.selectNode(QStringLiteral("grade.primary"));
-  ASSERT_TRUE(controller.requestReconnect(QStringLiteral("grade.primary"),
-                                          QStringLiteral("grade.extra"), QStringLiteral("drt")));
-  EXPECT_EQ(controller.backbone_node_ids()[1], QStringLiteral("grade.extra"));
-
-  auto undo_document = CreateDefaultPipelineDocument();
-  ASSERT_TRUE(
-      alcedo::AddCleanColorGrade(undo_document, NodeId{"drt"}, NodeId{"grade.extra"}).empty());
-  ASSERT_TRUE(controller.PublishDocument(undo_document, 35));
-  EXPECT_EQ(controller.selected_node_id(), NodeId{"grade.primary"});
-  EXPECT_EQ(controller.backbone_node_ids()[1], QStringLiteral("grade.primary"));
-  EXPECT_EQ(controller.backbone_node_ids()[2], QStringLiteral("grade.extra"));
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  const auto extra = controller.selected_node_id_string();
+  ASSERT_TRUE(controller.deleteColorGrade(extra));
+  EXPECT_FALSE(controller.incomplete_draft());
+  EXPECT_EQ(backend.edit_node_graph_count(), 0);
+  EXPECT_EQ(controller.backbone_node_ids().size(), 3);
 }
 
 TEST(EditorSessionToolPanelPage, AcceptsOnlyEmptyHistoryVersionsAndNodes) {

--- a/alcedo_studio/tests/ui/editor_node_controller_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_controller_test.cpp
@@ -109,6 +109,19 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
     NotifyChange();
     return Accepted("Color Grade renamed");
   }
+  auto ReconnectColorGrade(const NodeId& node_id, const NodeId& new_predecessor_id,
+                           const NodeId& new_successor_id) -> EditorSessionResult override {
+    ++reconnect_count_;
+    last_reconnect_node_        = node_id;
+    last_reconnect_predecessor_ = new_predecessor_id;
+    last_reconnect_successor_   = new_successor_id;
+    if (fail_commands_) return Rejected("mini-Git journal append failed");
+    const auto errors =
+        alcedo::ReconnectColorGrade(document_, node_id, new_predecessor_id, new_successor_id);
+    if (!errors.empty()) return Rejected(errors.front().message);
+    NotifyChange();
+    return Accepted("Color Grade reconnected");
+  }
 
   void SetGeneration(std::uint64_t value) { request_.value = value; }
   auto Document() -> PipelineDocument& { return document_; }
@@ -123,6 +136,14 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto add_count() const -> int { return add_count_; }
   [[nodiscard]] auto remove_count() const -> int { return remove_count_; }
   [[nodiscard]] auto rename_count() const -> int { return rename_count_; }
+  [[nodiscard]] auto reconnect_count() const -> int { return reconnect_count_; }
+  [[nodiscard]] auto last_reconnect_node() const -> NodeId { return last_reconnect_node_; }
+  [[nodiscard]] auto last_reconnect_predecessor() const -> NodeId {
+    return last_reconnect_predecessor_;
+  }
+  [[nodiscard]] auto last_reconnect_successor() const -> NodeId {
+    return last_reconnect_successor_;
+  }
 
  private:
   auto Accepted(std::string message) const -> EditorSessionResult {
@@ -149,6 +170,10 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   int                                               add_count_     = 0;
   int                                               remove_count_  = 0;
   int                                               rename_count_  = 0;
+  int                                               reconnect_count_ = 0;
+  NodeId                                            last_reconnect_node_;
+  NodeId                                            last_reconnect_predecessor_;
+  NodeId                                            last_reconnect_successor_;
 };
 
 TEST(EditorNodeController, LayoutStoreBindingDoesNotPublishASnapshot) {
@@ -365,6 +390,142 @@ TEST(EditorNodeController, ActiveCommandRejectsNestedAddBeforeBackendMutation) {
   EXPECT_FALSE(nested_accepted);
   EXPECT_EQ(backend.add_count(), 1);
   EXPECT_EQ(controller.backbone_node_ids().size(), 4);
+}
+
+TEST(EditorNodeController, ConnectorMovePlacesGradeBetweenRemainingNeighbors) {
+  DocumentSessionBackend backend;
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  backend.SetGeneration(30);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  controller.selectNode(QStringLiteral("grade.primary"));
+  ASSERT_TRUE(controller.can_reconnect_selected_color_grade());
+
+  ASSERT_TRUE(controller.requestConnectorMove(QStringLiteral("grade.primary"),
+                                              QStringLiteral("drt"), false));
+  EXPECT_EQ(backend.reconnect_count(), 1);
+  EXPECT_EQ(backend.last_reconnect_node(), NodeId{"grade.primary"});
+  EXPECT_EQ(backend.last_reconnect_predecessor(), NodeId{"grade.extra"});
+  EXPECT_EQ(backend.last_reconnect_successor(), NodeId{"drt"});
+  const auto ids = controller.backbone_node_ids();
+  ASSERT_EQ(ids.size(), 4);
+  EXPECT_EQ(ids[0], QStringLiteral("develop"));
+  EXPECT_EQ(ids[1], QStringLiteral("grade.extra"));
+  EXPECT_EQ(ids[2], QStringLiteral("grade.primary"));
+  EXPECT_EQ(ids[3], QStringLiteral("drt"));
+  EXPECT_EQ(controller.selected_node_id(), NodeId{"grade.primary"});
+}
+
+TEST(EditorNodeController, NoOpConnectorMoveCreatesNoHistoryCommit) {
+  DocumentSessionBackend backend;
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  backend.SetGeneration(31);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  controller.selectNode(QStringLiteral("grade.primary"));
+  const auto before = controller.backbone_node_ids();
+
+  EXPECT_TRUE(controller.requestConnectorMove(QStringLiteral("grade.primary"),
+                                              QStringLiteral("grade.extra"), false));
+  EXPECT_EQ(backend.reconnect_count(), 0);
+  EXPECT_EQ(controller.backbone_node_ids(), before);
+  EXPECT_TRUE(controller.last_error().isEmpty());
+}
+
+TEST(EditorNodeController, DevelopAndDrtRejectIncomingAndOutgoingMoveTargets) {
+  DocumentSessionBackend backend;
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  backend.SetGeneration(32);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  controller.selectNode(QStringLiteral("grade.primary"));
+
+  EXPECT_FALSE(controller.requestConnectorMove(QStringLiteral("grade.primary"),
+                                               QStringLiteral("develop"), false));
+  EXPECT_EQ(controller.last_error(), QStringLiteral("Develop has no incoming move target"));
+  EXPECT_FALSE(
+      controller.requestConnectorMove(QStringLiteral("grade.extra"), QStringLiteral("drt"), true));
+  EXPECT_EQ(controller.last_error(),
+            QStringLiteral("Only a selected Color Grade can start a move"));
+  controller.selectNode(QStringLiteral("grade.extra"));
+  EXPECT_FALSE(
+      controller.requestConnectorMove(QStringLiteral("grade.extra"), QStringLiteral("drt"), true));
+  EXPECT_EQ(controller.last_error(), QStringLiteral("DRT/Post has no outgoing move source"));
+  EXPECT_EQ(backend.reconnect_count(), 0);
+}
+
+TEST(EditorNodeController, CycleAndFanOutReconnectsFailWithoutDocumentChange) {
+  DocumentSessionBackend backend;
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  backend.SetGeneration(33);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  const auto before = controller.backbone_node_ids();
+
+  EXPECT_FALSE(controller.requestReconnect(QStringLiteral("grade.primary"),
+                                           QStringLiteral("grade.primary"), QStringLiteral("drt")));
+  EXPECT_EQ(controller.last_error(), QStringLiteral("A Color Grade cannot reconnect to itself"));
+  EXPECT_FALSE(controller.requestReconnect(QStringLiteral("grade.primary"),
+                                           QStringLiteral("develop"), QStringLiteral("drt")));
+  EXPECT_EQ(controller.last_error(),
+            QStringLiteral("Reconnect would create a cycle, fan-in, or fan-out"));
+  EXPECT_EQ(backend.reconnect_count(), 0);
+  EXPECT_EQ(controller.backbone_node_ids(), before);
+}
+
+TEST(EditorNodeController, StaleGenerationAndBackendFailureLeaveReconnectUnchanged) {
+  DocumentSessionBackend backend;
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  backend.SetGeneration(34);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  controller.selectNode(QStringLiteral("grade.primary"));
+  const auto before = controller.backbone_node_ids();
+
+  EXPECT_FALSE(controller.requestReconnect(
+      QStringLiteral("grade.primary"), QStringLiteral("grade.extra"), QStringLiteral("drt"), 1));
+  EXPECT_EQ(controller.last_error(),
+            QStringLiteral("The node command is from another editor session"));
+  EXPECT_EQ(backend.reconnect_count(), 0);
+
+  backend.SetFailCommands(true);
+  EXPECT_FALSE(controller.requestReconnect(QStringLiteral("grade.primary"),
+                                           QStringLiteral("grade.extra"), QStringLiteral("drt")));
+  EXPECT_EQ(backend.reconnect_count(), 1);
+  EXPECT_EQ(controller.backbone_node_ids(), before);
+  EXPECT_EQ(controller.last_error(), QStringLiteral("mini-Git journal append failed"));
+}
+
+TEST(EditorNodeController, UndoProjectionRestoresReconnectOrderAndSelection) {
+  DocumentSessionBackend backend;
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  backend.SetGeneration(35);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  controller.selectNode(QStringLiteral("grade.primary"));
+  ASSERT_TRUE(controller.requestReconnect(QStringLiteral("grade.primary"),
+                                          QStringLiteral("grade.extra"), QStringLiteral("drt")));
+  EXPECT_EQ(controller.backbone_node_ids()[1], QStringLiteral("grade.extra"));
+
+  auto undo_document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(undo_document, NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  ASSERT_TRUE(controller.PublishDocument(undo_document, 35));
+  EXPECT_EQ(controller.selected_node_id(), NodeId{"grade.primary"});
+  EXPECT_EQ(controller.backbone_node_ids()[1], QStringLiteral("grade.primary"));
+  EXPECT_EQ(controller.backbone_node_ids()[2], QStringLiteral("grade.extra"));
 }
 
 TEST(EditorSessionToolPanelPage, AcceptsOnlyEmptyHistoryVersionsAndNodes) {

--- a/alcedo_studio/tests/ui/editor_node_layout_store_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_layout_store_test.cpp
@@ -8,6 +8,7 @@
 
 #include "app/editor_node_graph_projection.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "ui/alcedo_main/app_theme.hpp"
 
 namespace {
 
@@ -145,6 +146,24 @@ TEST(EditorNodeLayoutStore, AssignStagingPositionStacksLaterDraftsDownwardOnTheS
   EXPECT_DOUBLE_EQ(a->x(), static_cast<qreal>(metrics.origin_x));
   EXPECT_DOUBLE_EQ(b->x(), a->x());
   EXPECT_GT(b->y(), a->y());
+}
+
+TEST(EditorNodeLayoutStore, DefaultConstructorReadsMetricsFromAppTheme) {
+  const auto&           theme = alcedo::ui::AppTheme::Instance();
+  EditorNodeLayoutStore store;
+  const auto&           metrics = store.metrics();
+  EXPECT_EQ(metrics.origin_x, theme.graphNodeOriginX());
+  EXPECT_EQ(metrics.origin_y, theme.graphNodeOriginY());
+  EXPECT_EQ(metrics.vertical_gap, theme.graphNodeVerticalGap());
+  EXPECT_EQ(metrics.node_width, theme.graphNodeWidth());
+  EXPECT_EQ(metrics.endpoint_height, theme.graphEndpointHeight());
+  EXPECT_EQ(metrics.name_row_height, theme.graphNameRowHeight());
+  EXPECT_EQ(metrics.drawer_header_height, theme.graphMaskDrawerHeaderHeight());
+  EXPECT_EQ(metrics.mask_row_height, theme.graphMaskRowHeight());
+  EXPECT_EQ(metrics.divider_height, theme.graphNameRowDividerHeight());
+  EXPECT_EQ(metrics.panel_width_min, theme.editorSidePanelWidthMin());
+  EXPECT_EQ(metrics.panel_width_max, theme.editorSidePanelWidthMax());
+  EXPECT_EQ(metrics.panel_width_default, theme.editorSidePanelWidth());
 }
 
 }  // namespace

--- a/alcedo_studio/tests/ui/editor_node_layout_store_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_layout_store_test.cpp
@@ -102,4 +102,49 @@ TEST(EditorNodeLayoutStore, PreferredPanelWidthStaysInsideSidePanelRange) {
   EXPECT_EQ(store.preferred_panel_width(), 460);
 }
 
+TEST(EditorNodeLayoutStore, AssignStagingPositionPlacesNewNodeBelowTheBackbone) {
+  const auto            metrics = MakeMetrics();
+  EditorNodeLayoutStore store(metrics);
+  store.activate("p", 1, 2, "v");
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 1, 1, 1);
+  store.EnsureDefaultPositions(snapshot);
+
+  const auto develop = store.NodePosition(NodeId{"develop"});
+  const auto primary = store.NodePosition(NodeId{"grade.primary"});
+  const auto drt     = store.NodePosition(NodeId{"drt"});
+  ASSERT_TRUE(develop.has_value());
+  ASSERT_TRUE(primary.has_value());
+  ASSERT_TRUE(drt.has_value());
+
+  const NodeId draft{"grade.draft"};
+  store.AssignStagingPosition(draft, snapshot);
+  const auto staged = store.NodePosition(draft);
+  ASSERT_TRUE(staged.has_value());
+  EXPECT_DOUBLE_EQ(staged->x(), static_cast<qreal>(metrics.origin_x));
+  EXPECT_GT(staged->y(), drt->y());
+  EXPECT_EQ(store.NodePosition(NodeId{"develop"}), develop);
+  EXPECT_EQ(store.NodePosition(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(store.NodePosition(NodeId{"drt"}), drt);
+}
+
+TEST(EditorNodeLayoutStore, AssignStagingPositionStacksLaterDraftsDownwardOnTheSameX) {
+  const auto            metrics = MakeMetrics();
+  EditorNodeLayoutStore store(metrics);
+  store.activate("p", 1, 2, "v");
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 1, 1, 1);
+
+  const NodeId first{"grade.draft-a"};
+  const NodeId second{"grade.draft-b"};
+  store.AssignStagingPosition(first, snapshot);
+  store.AssignStagingPosition(second, snapshot);
+
+  const auto a = store.NodePosition(first);
+  const auto b = store.NodePosition(second);
+  ASSERT_TRUE(a.has_value());
+  ASSERT_TRUE(b.has_value());
+  EXPECT_DOUBLE_EQ(a->x(), static_cast<qreal>(metrics.origin_x));
+  EXPECT_DOUBLE_EQ(b->x(), a->x());
+  EXPECT_GT(b->y(), a->y());
+}
+
 }  // namespace

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -240,20 +240,24 @@ TEST_F(EditorNodesPanelQmlTest, AddActionCreatesAndSelectsOneCleanColorGrade) {
   EXPECT_EQ(add->property("actionName").toString(), QStringLiteral("Add Color Grade"));
   const auto history_before = backend_.history_revision();
   Click(window_, add);
-  QTRY_COMPARE_WITH_TIMEOUT(backend_.add_grade_count(), 1, 2000);
-  EXPECT_EQ(backend_.history_revision(), history_before + 1);
   auto* nodes   = Controller();
   auto* adapter = Adapter();
   ASSERT_NE(nodes, nullptr);
   ASSERT_NE(adapter, nullptr);
-  EXPECT_EQ(nodes->backbone_node_ids().size(), 4);
-  EXPECT_EQ(nodes->selected_node_id(), backend_.last_added_node_id());
+  QTRY_COMPARE_WITH_TIMEOUT(nodes->backbone_node_ids().size(), 4, 2000);
+  EXPECT_EQ(backend_.add_grade_count(), 0);
+  EXPECT_EQ(backend_.edit_node_graph_count(), 0);
+  EXPECT_EQ(backend_.history_revision(), history_before);
+  EXPECT_TRUE(nodes->incomplete_draft());
   EXPECT_EQ(nodes->selected_node_name(), QStringLiteral("Color Grade 2"));
-  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(backend_.last_added_node_id()) != nullptr, 2000);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(nodes->selected_node_id()) != nullptr, 2000);
   ASSERT_NE(adapter->graph(), nullptr);
   EXPECT_EQ(adapter->graph()->getNodeCount(), 4);
   EXPECT_EQ(nodes->graph_adapter_object(), adapter);
   EXPECT_NE(Find(QStringLiteral("editorNodesPageBody")), nullptr);
+  auto* guidance = Find(QStringLiteral("editorNodesEditingGuidance"));
+  ASSERT_NE(guidance, nullptr);
+  EXPECT_TRUE(guidance->property("visible").toBool());
 }
 
 TEST_F(EditorNodesPanelQmlTest, OpenNodesPageBindsTheLiveQanAdapterOnTheController) {
@@ -280,12 +284,12 @@ TEST_F(EditorNodesPanelQmlTest, CtrlPlusAddsTheNextCleanColorGrade) {
   QTest::keyClick(window_, Qt::Key_Plus, Qt::ControlModifier);
   ProcessEvents();
 
-  EXPECT_EQ(backend_.add_grade_count(), 1);
-  EXPECT_EQ(nodes->selected_node_id(), backend_.last_added_node_id());
+  EXPECT_EQ(backend_.add_grade_count(), 0);
+  EXPECT_EQ(backend_.edit_node_graph_count(), 0);
   EXPECT_EQ(nodes->selected_node_name(), QStringLiteral("Color Grade 2"));
   auto* adapter = Adapter();
   ASSERT_NE(adapter, nullptr);
-  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(backend_.last_added_node_id()) != nullptr, 2000);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(nodes->selected_node_id()) != nullptr, 2000);
   ASSERT_NE(adapter->graph(), nullptr);
   EXPECT_EQ(adapter->graph()->getNodeCount(), 4);
   EXPECT_EQ(nodes->graph_adapter_object(), adapter);
@@ -358,20 +362,22 @@ TEST_F(EditorNodesPanelQmlTest, DeleteKeyRemovesSelectedGradeAndSelectsItsSucces
   ASSERT_NE(view, nullptr);
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
   ASSERT_TRUE(nodes->addCleanColorGrade());
-  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(backend_.last_added_node_id()) != nullptr, 2000);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(nodes->selected_node_id()) != nullptr, 2000);
+  const auto extra = nodes->selected_node_id();
   nodes->selectNode(QStringLiteral("grade.primary"));
   view->forceActiveFocus();
   QTest::keyClick(window_, Qt::Key_Delete);
   ProcessEvents();
 
-  EXPECT_EQ(backend_.remove_grade_count(), 1);
-  EXPECT_EQ(backend_.last_removed_node_id(), NodeId{"grade.primary"});
-  EXPECT_EQ(nodes->selected_node_id(), backend_.last_added_node_id());
+  EXPECT_EQ(backend_.remove_grade_count(), 0);
+  EXPECT_EQ(backend_.edit_node_graph_count(), 0);
+  EXPECT_TRUE(nodes->incomplete_draft());
+  EXPECT_NE(nodes->selected_node_id(), NodeId{"grade.primary"});
   EXPECT_EQ(nodes->backbone_node_ids().size(), 3);
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) == nullptr, 2000);
   ASSERT_NE(adapter->graph(), nullptr);
   EXPECT_EQ(adapter->graph()->getNodeCount(), 3);
-  const NodeId remaining[] = {NodeId{"develop"}, backend_.last_added_node_id(), NodeId{"drt"}};
+  const NodeId remaining[] = {NodeId{"develop"}, extra, NodeId{"drt"}};
   for (const auto& id : remaining) {
     QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(id) != nullptr, 2000);
     auto* item = adapter->NodeFor(id)->getItem();
@@ -422,25 +428,19 @@ TEST_F(EditorNodesPanelQmlTest, ConnectorMoveRebuildsPermanentEdgesFromAcceptedP
   ASSERT_NE(adapter, nullptr);
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
   ASSERT_TRUE(nodes->addCleanColorGrade());
-  const auto extra = backend_.last_added_node_id();
+  const auto extra = nodes->selected_node_id();
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(extra) != nullptr, 2000);
-  nodes->selectNode(QStringLiteral("grade.primary"));
-  ProcessEvents();
+  const auto replace_count = adapter->topology_replace_count();
 
-  ASSERT_TRUE(
-      nodes->requestConnectorMove(QStringLiteral("grade.primary"), QStringLiteral("drt"), false));
-  QTRY_VERIFY_WITH_TIMEOUT(backend_.reconnect_grade_count() == 1, 2000);
-  EXPECT_EQ(backend_.last_reconnect_predecessor_id(), extra);
-  EXPECT_EQ(backend_.last_reconnect_successor_id(), NodeId{"drt"});
-  QTRY_COMPARE_WITH_TIMEOUT(nodes->backbone_node_ids().at(1), NodeIdToQString(extra), 2000);
-  QTRY_VERIFY_WITH_TIMEOUT(
-      adapter->EdgeFor(EditorNodeEdgeProjection{extra, PortId{"image"}, NodeId{"grade.primary"},
-                                                PortId{"image"}}) != nullptr,
-      2000);
-  EXPECT_EQ(adapter->EdgeFor(EditorNodeEdgeProjection{NodeId{"grade.primary"}, PortId{"image"},
-                                                      extra, PortId{"image"}}),
+  ASSERT_TRUE(nodes->requestConnect(QStringLiteral("develop"), NodeIdToQString(extra)));
+  ASSERT_TRUE(nodes->requestConnect(NodeIdToQString(extra), QStringLiteral("grade.primary")));
+  ASSERT_TRUE(nodes->requestConnect(QStringLiteral("grade.primary"), QStringLiteral("drt")));
+  QTRY_COMPARE_WITH_TIMEOUT(backend_.edit_node_graph_count(), 1, 2000);
+  EXPECT_EQ(adapter->topology_replace_count(), replace_count);
+  EXPECT_FALSE(nodes->incomplete_draft());
+  EXPECT_NE(adapter->EdgeFor(EditorNodeEdgeProjection{NodeId{"develop"}, PortId{"image"}, extra,
+                                                      PortId{"image"}}),
             nullptr);
-  EXPECT_EQ(adapter->graph()->get_edge_count(), 3);
 }
 
 TEST_F(EditorNodesPanelQmlTest, DrawerFoldDoesNotChangeReconnectNeighbors) {
@@ -451,9 +451,6 @@ TEST_F(EditorNodesPanelQmlTest, DrawerFoldDoesNotChangeReconnectNeighbors) {
   ASSERT_NE(nodes, nullptr);
   ASSERT_NE(adapter, nullptr);
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
-  ASSERT_TRUE(nodes->addCleanColorGrade());
-  const auto extra = backend_.last_added_node_id();
-  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(extra) != nullptr, 2000);
   auto* output = adapter->OutputPortFor(NodeId{"grade.primary"}, PortId{"image"});
   auto* input  = adapter->InputPortFor(NodeId{"grade.primary"}, PortId{"image"});
   ASSERT_NE(output, nullptr);
@@ -462,12 +459,6 @@ TEST_F(EditorNodesPanelQmlTest, DrawerFoldDoesNotChangeReconnectNeighbors) {
   ProcessEvents();
   EXPECT_EQ(adapter->OutputPortFor(NodeId{"grade.primary"}, PortId{"image"}), output);
   EXPECT_EQ(adapter->InputPortFor(NodeId{"grade.primary"}, PortId{"image"}), input);
-
-  nodes->selectNode(QStringLiteral("grade.primary"));
-  ASSERT_TRUE(
-      nodes->requestConnectorMove(QStringLiteral("grade.primary"), QStringLiteral("drt"), false));
-  EXPECT_EQ(backend_.last_reconnect_predecessor_id(), extra);
-  EXPECT_EQ(backend_.last_reconnect_successor_id(), NodeId{"drt"});
 }
 
 TEST_F(EditorNodesPanelQmlTest, FailedReconnectKeepsPermanentEdgesAndShowsExactError) {
@@ -479,49 +470,26 @@ TEST_F(EditorNodesPanelQmlTest, FailedReconnectKeepsPermanentEdgesAndShowsExactE
   ASSERT_NE(adapter, nullptr);
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
   ASSERT_TRUE(nodes->addCleanColorGrade());
-  const auto extra = backend_.last_added_node_id();
+  const auto extra = nodes->selected_node_id();
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(extra) != nullptr, 2000);
-  nodes->selectNode(QStringLiteral("grade.primary"));
-  ProcessEvents();
-  const auto topology_before = adapter->topology_revision();
-  const auto ids_before      = nodes->backbone_node_ids();
+  ASSERT_TRUE(nodes->requestConnect(QStringLiteral("develop"), NodeIdToQString(extra)));
   backend_.SetFailNodeCommands(true);
-
   EXPECT_FALSE(
-      nodes->requestConnectorMove(QStringLiteral("grade.primary"), QStringLiteral("drt"), false));
-  EXPECT_EQ(nodes->backbone_node_ids(), ids_before);
-  EXPECT_EQ(adapter->topology_revision(), topology_before);
+      nodes->requestConnect(NodeIdToQString(extra), QStringLiteral("grade.primary")));
   EXPECT_EQ(nodes->last_error(), QStringLiteral("mini-Git journal append failed"));
   auto* error = Find(QStringLiteral("editorNodesCommandError"));
   ASSERT_NE(error, nullptr);
   EXPECT_EQ(error->property("text").toString(), QStringLiteral("mini-Git journal append failed"));
-  EXPECT_NE(adapter->EdgeFor(EditorNodeEdgeProjection{NodeId{"grade.primary"}, PortId{"image"},
-                                                      extra, PortId{"image"}}),
-            nullptr);
+  EXPECT_FALSE(nodes->incomplete_draft());
+  EXPECT_EQ(nodes->backbone_node_ids().size(), 4);
 }
 
-TEST_F(EditorNodesPanelQmlTest, FailedAddKeepsPriorPermanentQanProjectionAndExactError) {
+TEST_F(EditorNodesPanelQmlTest, HeaderHasNoApplyOrCancelAction) {
   ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
   OpenNodesPage();
-  auto* adapter = Adapter();
-  auto* nodes   = Controller();
-  auto* add     = Find(QStringLiteral("editorNodesAddButton"));
-  ASSERT_NE(adapter, nullptr);
-  ASSERT_NE(nodes, nullptr);
-  ASSERT_NE(add, nullptr);
-  const auto ids_before      = nodes->backbone_node_ids();
-  const auto topology_before = adapter->topology_revision();
-  backend_.SetFailNodeCommands(true);
-
-  Click(window_, add);
-  ProcessEvents();
-
-  EXPECT_EQ(nodes->backbone_node_ids(), ids_before);
-  EXPECT_EQ(adapter->topology_revision(), topology_before);
-  EXPECT_EQ(nodes->last_error(), QStringLiteral("mini-Git journal append failed"));
-  auto* error = Find(QStringLiteral("editorNodesCommandError"));
-  ASSERT_NE(error, nullptr);
-  EXPECT_EQ(error->property("text").toString(), QStringLiteral("mini-Git journal append failed"));
+  EXPECT_NE(Find(QStringLiteral("editorNodesAddButton")), nullptr);
+  EXPECT_EQ(Find(QStringLiteral("editorNodesApplyButton")), nullptr);
+  EXPECT_EQ(Find(QStringLiteral("editorNodesCancelButton")), nullptr);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -8,7 +8,9 @@
 #include <QuickQanava>
 #include <functional>
 
+#include "app/editor_node_graph_projection.hpp"
 #include "editor_history_versions_rail_qml_harness.hpp"
+#include "qanConnector.h"
 #include "qanGraph.h"
 #include "qanNode.h"
 #include "qanNodeItem.h"
@@ -395,6 +397,107 @@ TEST_F(EditorNodesPanelQmlTest, DeleteKeyRemovesSelectedGradeAndSelectsItsSucces
     return visible;
   };
   QTRY_COMPARE_WITH_TIMEOUT(visible_on_view(), 3, 2000);
+}
+
+TEST_F(EditorNodesPanelQmlTest, VisualConnectorIsRequestOnlyWithThemeCandidateColor) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* adapter = Adapter();
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->graph() != nullptr, 2000);
+  auto* graph = adapter->graph();
+  QTRY_VERIFY_WITH_TIMEOUT(graph->getConnector() != nullptr, 2000);
+  EXPECT_TRUE(graph->getConnectorEnabled());
+  EXPECT_FALSE(graph->getConnectorCreateDefaultEdge());
+  EXPECT_EQ(graph->getConnectorEdgeColor(), AppTheme::Instance().graphCandidateEdgeColor());
+  EXPECT_EQ(graph->getConnectorColor(), AppTheme::Instance().graphPortBorderColor());
+}
+
+TEST_F(EditorNodesPanelQmlTest, ConnectorMoveRebuildsPermanentEdgesFromAcceptedProjection) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  ASSERT_TRUE(nodes->addCleanColorGrade());
+  const auto extra = backend_.last_added_node_id();
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(extra) != nullptr, 2000);
+  nodes->selectNode(QStringLiteral("grade.primary"));
+  ProcessEvents();
+
+  ASSERT_TRUE(
+      nodes->requestConnectorMove(QStringLiteral("grade.primary"), QStringLiteral("drt"), false));
+  QTRY_VERIFY_WITH_TIMEOUT(backend_.reconnect_grade_count() == 1, 2000);
+  EXPECT_EQ(backend_.last_reconnect_predecessor_id(), extra);
+  EXPECT_EQ(backend_.last_reconnect_successor_id(), NodeId{"drt"});
+  QTRY_COMPARE_WITH_TIMEOUT(nodes->backbone_node_ids().at(1), NodeIdToQString(extra), 2000);
+  QTRY_VERIFY_WITH_TIMEOUT(
+      adapter->EdgeFor(EditorNodeEdgeProjection{extra, PortId{"image"}, NodeId{"grade.primary"},
+                                                PortId{"image"}}) != nullptr,
+      2000);
+  EXPECT_EQ(adapter->EdgeFor(EditorNodeEdgeProjection{NodeId{"grade.primary"}, PortId{"image"},
+                                                      extra, PortId{"image"}}),
+            nullptr);
+  EXPECT_EQ(adapter->graph()->get_edge_count(), 3);
+}
+
+TEST_F(EditorNodesPanelQmlTest, DrawerFoldDoesNotChangeReconnectNeighbors) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  ASSERT_TRUE(nodes->addCleanColorGrade());
+  const auto extra = backend_.last_added_node_id();
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(extra) != nullptr, 2000);
+  auto* output = adapter->OutputPortFor(NodeId{"grade.primary"}, PortId{"image"});
+  auto* input  = adapter->InputPortFor(NodeId{"grade.primary"}, PortId{"image"});
+  ASSERT_NE(output, nullptr);
+  ASSERT_NE(input, nullptr);
+  adapter->SetDrawerOpen(NodeId{"grade.primary"}, false);
+  ProcessEvents();
+  EXPECT_EQ(adapter->OutputPortFor(NodeId{"grade.primary"}, PortId{"image"}), output);
+  EXPECT_EQ(adapter->InputPortFor(NodeId{"grade.primary"}, PortId{"image"}), input);
+
+  nodes->selectNode(QStringLiteral("grade.primary"));
+  ASSERT_TRUE(
+      nodes->requestConnectorMove(QStringLiteral("grade.primary"), QStringLiteral("drt"), false));
+  EXPECT_EQ(backend_.last_reconnect_predecessor_id(), extra);
+  EXPECT_EQ(backend_.last_reconnect_successor_id(), NodeId{"drt"});
+}
+
+TEST_F(EditorNodesPanelQmlTest, FailedReconnectKeepsPermanentEdgesAndShowsExactError) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  ASSERT_TRUE(nodes->addCleanColorGrade());
+  const auto extra = backend_.last_added_node_id();
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(extra) != nullptr, 2000);
+  nodes->selectNode(QStringLiteral("grade.primary"));
+  ProcessEvents();
+  const auto topology_before = adapter->topology_revision();
+  const auto ids_before      = nodes->backbone_node_ids();
+  backend_.SetFailNodeCommands(true);
+
+  EXPECT_FALSE(
+      nodes->requestConnectorMove(QStringLiteral("grade.primary"), QStringLiteral("drt"), false));
+  EXPECT_EQ(nodes->backbone_node_ids(), ids_before);
+  EXPECT_EQ(adapter->topology_revision(), topology_before);
+  EXPECT_EQ(nodes->last_error(), QStringLiteral("mini-Git journal append failed"));
+  auto* error = Find(QStringLiteral("editorNodesCommandError"));
+  ASSERT_NE(error, nullptr);
+  EXPECT_EQ(error->property("text").toString(), QStringLiteral("mini-Git journal append failed"));
+  EXPECT_NE(adapter->EdgeFor(EditorNodeEdgeProjection{NodeId{"grade.primary"}, PortId{"image"},
+                                                      extra, PortId{"image"}}),
+            nullptr);
 }
 
 TEST_F(EditorNodesPanelQmlTest, FailedAddKeepsPriorPermanentQanProjectionAndExactError) {

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: NM5.1–NM5.7 complete; NM5.8 planned
+Status: NM5.1–NM5.7R complete; NM5.8 follows NM5.7R
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -647,6 +647,7 @@ Remove and Rename do not modify the counter. Reinsertion from stored JSON does n
 | NM5.5 | Rail, navigation, selection, and layout state | Graph: `Graph View`, `Grid`; Nodes: `Node Resizing`, `Selection`; Utilities: `Navigable`; Samples: `Navigable Area: 'navigable'`, `Topology Sample: 'topology'` |
 | NM5.6 | Add, Rename, and Delete | Graph: `Data Model`; Nodes: `Adding content`, `Observing Topology`, `Selection`; Advanced: `Observation of Topological Modifications` |
 | NM5.7 | Request-only visual connector and Reconnect | Nodes: `Docks and Ports`; Edges: `Visual creation of edges`, `Visual Connectors`, `Custom Connectors` |
+| NM5.7R | Incremental draft topology and atomic automatic submission | Nodes: `Docks and Ports`, `Observing Topology`; Edges: `Visual creation of edges`, `Visual Connectors`, `Custom Connectors`; Advanced: `Defining Custom Topology`, `Observation of Topological Modifications` |
 | NM5.8 | Lifecycle, accessibility, build, install, and package checks | Installation; Graph: `QuickQanava Initialization`, `Graph View`; API Reference notice; Licence |
 
 Each sub-phase can use one or more PRs. Every PR must build and test its completed scope.
@@ -2263,29 +2264,615 @@ build\debug\alcedo_studio\tests\ui\EditorNodesPanelQmlTest_runtime\EditorNodesPa
 Reconnect routing methods beside the existing Add/Remove/Rename paths and did not absorb more
 business rules into those facades.
 
-**Residual gaps:** NM5.8 still owns lifecycle, accessibility, localization, install, and package
-checks. Keyboard Reconnect is listed under NM5.8. Real-RAW and three-backend qualification remain
-NM8.
+**Residual gaps:** NM5.7R supersedes this immediate-reconnect product behavior with incremental
+draft topology editing and atomic automatic submission. NM5.8 still owns lifecycle,
+accessibility, localization, install, and package checks. Keyboard topology editing is listed
+under NM5.8. Real-RAW and three-backend qualification remain NM8.
 
 ---
 
-## 15. NM5.8 — Lifecycle, accessibility, build, install, and package checks
+## 15. NM5.7R — Incremental draft topology and atomic automatic submission
 
-### 15.1 Input context
+### 15.1 Supersession and objective
 
-NM5.1–NM5.7 provide the Nodes page. This sub-phase adds no product feature. It closes lifecycle,
-accessibility, localization, build, and package gaps.
+NM5.7 proved the pinned request-only QuickQanava connector and the existing atomic
+`ReconnectColorGrade` path. Its completion record remains historical evidence. NM5.7R supersedes
+the NM5.7 product behavior that interprets every connector drop as an immediately valid backbone
+move with automatically computed predecessor and successor.
+
+NM5.7R makes the Nodes page a real topology editor:
+
+- Add creates one disconnected draft Color Grade below the main vertical DAG.
+- Connect changes only the requested source-output and destination-input relationship.
+- A supported edit may temporarily break the Develop-to-DRT path or leave Color Grades detached.
+- An unsupported edit is rejected before any draft state changes.
+- No draft operation changes `PipelineDocument`, history, Version state, or rendering while the
+  draft is incomplete.
+- The first accepted operation that produces a complete supported graph automatically submits the
+  accumulated change.
+- The UI has no Apply or Cancel action.
+- The product graph receives one atomic topology-delta instruction. It is never replaced with a
+  draft copy.
+- The canvas is created from a complete projection on initial load, and the draft is initialized
+  from that projection once at the first topology edit. Later ordinary operations update only
+  affected nodes, ports, edges, indexes, and presentation values.
+
+### 15.2 Fixed NM5.7R invariants
+
+- `PipelineDocument` remains the only writable product graph.
+- `EditorNodeGraphDraft` is UI editing state. It is not serialized product data and is not a render
+  input.
+- Creating a draft reads the current complete projection once and binds its project, image,
+  Version, session generation, projection revision, and topology revision.
+- Add, Delete, and Connect mutate the same draft object incrementally. They do not reconstruct it
+  from a snapshot after each operation.
+- Ordinary draft changes do not call full-graph `AlcedoQanGraph::ApplySnapshot` and do not replace
+  the Qan graph.
+- A rejected operation changes no draft node, edge, index, accumulated delta, layout value, or Qan
+  primitive.
+- An incomplete but structurally supported draft remains visible and produces no history commit,
+  WAL append, topology publication, or photo-render request.
+- A complete changed draft submits automatically. A complete draft whose accumulated delta is
+  empty ends node editing without a commit or render.
+- One automatic submission contains one `NodeGraphTopologyChange`, produces at most one history
+  commit, and requests exactly one `GraphTopologyChanged` Quality render after success.
+- The live `PipelineGraph` applies the change in place under the render lock. Unchanged
+  `INodeModel` object identities remain stable.
+- Forward failure and inverse replay failure restore exact node ownership, node order, edge order,
+  next-name counter, history head, and topology revision.
+- QuickQanava remains a view and input reporter. It never decides product validity or inserts a
+  permanent edge from a connector drop.
+- No degraded graph, automatic bridge, alternate backend, or other substitute is created after an
+  error.
+
+### 15.3 Draft ownership and incremental indexes
+
+Add a focused `EditorNodeGraphDraft` application/UI-backend type rather than adding draft mutation
+rules to QML or expanding `EditorNodeController` with graph-container responsibilities.
+
+The draft owns copied value data and incremental lookup indexes such as:
+
+```text
+base identity
+  project, element, image, Version
+  session generation
+  projection revision
+  topology revision
+
+current draft values
+  nodes by NodeId
+  edges by stable edge key
+  one edge by source output port
+  one edge by destination input port
+  adjacency by NodeId
+
+net product delta
+  inserted nodes
+  removed nodes
+  disconnected base edges
+  connected draft edges
+  before and after next-name counter
+```
+
+The controller creates this object lazily on the first Add, Delete, or Connect request. Initial
+construction may copy the complete immutable product projection. After construction, the object
+survives every ordinary edit for the same base identity.
+
+The accumulated delta is updated during each operation. Do not recalculate it by comparing two
+complete graphs after every operation:
+
+- removing an edge added by the draft cancels that connected-edge entry;
+- adding an edge removed from the base cancels that disconnected-edge entry;
+- adding and then deleting an uncommitted node cancels its inserted-node entry and all incident
+  draft-only edges;
+- restoring a removed base node and its exact base edges cancels its removal entries;
+- when every entry is canceled, the draft equals the base and node editing ends automatically.
+
+Full graph traversal is permitted for read-only validity checks. It must not allocate a replacement
+draft, replace the current containers, or republish a complete Qan topology.
+
+### 15.4 Incremental Add and default placement
+
+The Nodes header keeps its existing Add action and gains no Apply or Cancel action.
+
+Add performs only these draft changes:
+
+1. Create the draft once if none exists.
+2. Allocate one stable provisional NodeId.
+3. Create one clean draft Color Grade value.
+4. Add the node to the inserted-node accumulator.
+5. Assign a deterministic position below the main vertical DAG at the backbone origin x. Stack
+   multiple unconnected new nodes downward without moving existing nodes.
+6. Incrementally insert one Qan node and its input/output ports.
+7. Select the new draft node in the Nodes page.
+8. Run the read-only submission-validity check.
+
+Add does not choose an insertion point and does not create an edge. It does not call
+`SubmitAddColorGrade`, consume the product counter, write history, or request rendering.
+
+Draft names preview the names that the atomic product change will store. A draft that returns to
+the base without submission consumes no name number. The final atomic change stores explicit
+before and after counter values so success, failure, Undo, Redo, recovery, and Version checkout are
+deterministic.
+
+### 15.5 Incremental exclusive-port Connect
+
+Every supported Color Grade image port can participate in editing; starting a connection is not
+limited to the selected Color Grade. Develop exposes only its output role. DRT/Post exposes only
+its input role. QuickQanava remains in request-only mode with
+`connectorCreateDefaultEdge = false`.
+
+One accepted request from `source.output` to `destination.input` has this exact behavior:
+
+```text
+oldOutgoing = the current edge from source.output, if present
+oldIncoming = the current edge into destination.input, if present
+
+remove oldOutgoing
+remove oldIncoming when it is a different edge
+add source.output -> destination.input
+```
+
+This is exclusive-port replacement, not a request to move a whole Color Grade. It does not infer a
+new successor, infer a new predecessor, bridge the nodes left behind, or restore a complete
+backbone automatically.
+
+For an initial `A -> B -> C` graph with a detached new `D`:
+
+```text
+Connect A -> D
+  disconnect A -> B
+  connect A -> D
+  visible draft: A -> D and B -> C
+  result: incomplete; no submission and no render
+
+Connect D -> C
+  disconnect B -> C
+  connect D -> C
+  visible draft: A -> D -> C and detached B
+  result: incomplete; no submission and no render
+```
+
+The user must reconnect B into the unique path or delete B from the draft. The operation that first
+makes the full graph valid triggers automatic submission.
+
+Each accepted Connect updates only:
+
+- at most two removed draft edges;
+- one inserted draft edge;
+- the affected source-output and destination-input indexes;
+- the affected adjacency entries;
+- the accumulated delta;
+- the corresponding Qan edge primitives and their presentation.
+
+Unchanged draft and Qan node, port, and edge identities remain stable.
+
+### 15.6 Operation admission and submission validity
+
+Use two different checks. Do not reject an incomplete editing state as though it were an
+unsupported connection.
+
+#### 15.6.1 Operation admission
+
+Before mutating the draft, validate the small candidate edit against the current indexes. Check:
+
+- current base identity and session generation;
+- live source and destination identities;
+- output-to-input direction;
+- matching port data types;
+- supported source and destination node types;
+- supported runtime/compiler connection semantics;
+- Develop cannot be an input target;
+- DRT/Post cannot be an output source;
+- source and destination are distinct;
+- the candidate edge, after ignoring the edges it would replace, does not create a cycle.
+
+Cycle detection may traverse the current adjacency index while excluding the at-most-two edges
+scheduled for removal. It must not copy or temporarily overwrite the draft.
+
+When admission fails:
+
+```text
+reject before mutation
+  -> draft values and indexes unchanged
+  -> accumulated delta unchanged
+  -> Qan primitives unchanged
+  -> connector preview closes
+  -> EditorNodesPanel shows the exact error
+```
+
+An unknown or unsupported node type must name the unsupported type or connection in the displayed
+error. Do not collapse it into a generic Reconnect failure.
+
+#### 15.6.2 Submission validity
+
+After an admitted incremental operation, perform a read-only full check. A draft can submit only
+when it has:
+
+- exactly one Develop and one DRT/Post;
+- one unique Develop-to-DRT scene-image path;
+- no cycle, scene-image fan-in, or scene-image fan-out;
+- exactly one source for every required input;
+- every Color Grade on the unique image path;
+- only runtime/compiler-supported node types on the path;
+- valid port direction and data-type pairs.
+
+Missing required input, a broken Develop-to-DRT path, detached Color Grades, and multiple detached
+components are permitted draft states. They disable submission but do not undo an admitted edit.
+
+### 15.7 One atomic product topology change
+
+Add one stored change kind and one matching operation kind with a precise name such as
+`NodeGraphTopologyChange` and `EditNodeGraph`. One automatic submission contains exactly one of
+these stored changes; it is not a list of Add, Remove, and Reconnect commands.
+
+The stored change carries only the net delta from its bound base graph:
+
+```text
+inserted nodes
+  complete node JSON
+  final node index
+
+removed nodes
+  complete node JSON
+  original node index
+
+disconnected edges
+  exact endpoint and port IDs
+  original edge index
+
+connected edges
+  exact endpoint and port IDs
+  final edge index
+
+before and after next Color Grade name number
+```
+
+The live submission request separately carries the expected session generation and topology
+revision. These transient guards are not persisted as replay data.
+
+Add a single domain entry point such as `PipelineGraph::ApplyTopologyDelta`. It must:
+
+1. Require that every expected removed node and disconnected edge exactly matches the live graph.
+2. Require that inserted NodeIds and connected edge identities do not conflict.
+3. Reserve all forward and restoration storage before mutation.
+4. Retain removed `unique_ptr<INodeModel>` objects and exact indexes.
+5. Retain removed edges and exact indexes.
+6. Apply all removals and insertions in place to the same live `PipelineGraph` object.
+7. Set the after-name counter.
+8. Validate the complete final graph once, after the whole delta is present.
+9. Commit on success.
+10. On any validation error or exception, restore original node ownership, node order, edge order,
+    counter, and observable revision before returning the real error.
+
+Do not assign a draft `PipelineDocument` or draft `PipelineGraph` over the live object. Do not call
+the existing single-node Add/Remove/Reconnect commands sequentially. The live graph must never
+expose an intermediate partial delta outside the render lock.
+
+The current general history applier clones `PipelineDocument` as a broad restoration guard. That
+is not the application mechanism for `NodeGraphTopologyChange`. Route this one stored change
+through its self-restoring atomic entry point without `ClonePipelineDocument` or assignment from a
+copied document. The atomic entry point must either complete or restore the same live objects
+before it returns. A history-publication failure applies the stored inverse through the same atomic
+entry point.
+
+Forward history application uses the stored direction. Undo applies the exact inverse through the
+same atomic entry point. Redo applies the forward direction again. WAL failure, history-publication
+failure, live-pipeline publication failure, and recovery retain the existing NM4 restoration
+requirements.
+
+### 15.8 Automatic submission and canvas promotion
+
+After every admitted Add, Delete, or Connect:
+
+```text
+incrementally mutate the existing draft
+  -> incrementally update affected Qan primitives
+  -> run read-only submission validation
+  -> invalid: stay in node editing; no history and no render
+  -> valid with empty delta: discard draft metadata and return to committed state
+  -> valid with non-empty delta:
+       EditorNodeController::SubmitNodeGraphTopologyEdit
+       -> generation and topology-revision guard
+       -> EditorSessionService queue admission
+       -> render lock
+       -> one NodeGraphTopologyChange applied in place
+       -> one typed history batch and WAL append
+       -> one topology publication
+       -> promote the current canvas state to committed state
+       -> one GraphTopologyChanged Quality render
+```
+
+Successful submission must not rebuild the already-correct Qan topology. Update its applied
+revision metadata, clear the draft delta, and change affected edge presentation from candidate to
+permanent. Keep unaffected Qan objects and all stored node positions.
+
+The full product projection can rebuild the canvas only for initial load, image change, Version
+change, Undo, Redo, recovery, session-generation replacement, adapter recreation, or an explicit
+stale-state resynchronization. Ordinary draft edits and successful automatic submission do not use
+that path.
+
+### 15.9 Error and lifecycle behavior
+
+- An unsupported candidate operation keeps the draft byte-for-byte and identity-for-identity
+  unchanged and displays the exact error.
+- If an incremental Qan insertion or removal fails, reverse that operation's affected draft values,
+  indexes, accumulated delta, and Qan primitives. Keep the draft at its exact pre-operation state,
+  publish no product command, and show the real adapter error.
+- An incomplete draft may show one localized plain-text instruction to complete the Develop-to-DRT
+  path. Do not add a pill, badge, status dot, or separate status chrome.
+- If atomic product submission fails, restore the live graph and history, retain the current valid
+  draft and its delta, request no render, and show the exact error.
+- Do not continuously retry a failed submission. The next admitted draft edit performs the next
+  validity check and may submit the resulting delta.
+- Closing and reopening the Nodes Loader for the same bound base identity restores the same draft
+  values. No Qan pointer survives Loader destruction.
+- An image, Version, session-generation, or external topology change invalidates the old draft. It
+  cannot submit against the new graph. Discard its non-product state during the identity change and
+  create a new draft only after the next topology edit.
+- Escape cancels only an active connector preview or rename input. It does not provide a hidden
+  whole-draft Cancel action.
+- Restoring the base topology manually reduces the accumulated delta to empty and exits node
+  editing without a history commit or render.
+
+### 15.10 Files and responsibilities
+
+Expected implementation areas:
+
+- `EditorNodeGraphDraft`: incremental nodes, edges, port indexes, adjacency, validation, and net
+  delta.
+- `EditorNodeController`: draft lifetime, automatic-submission state machine, selection, errors,
+  and session guards.
+- `AlcedoQanGraph`: incremental insert/remove node and edge entry points, live identity checks, and
+  promotion from candidate to permanent presentation.
+- `EditorNodesPanel.qml`: no Apply/Cancel controls; plain editing guidance and exact errors.
+- `EditorNodeLayoutStore`: deterministic positions below the vertical DAG without moving stored
+  backbone positions.
+- `PipelineEditBatch`: the one new operation and stored change discriminator, canonical JSON,
+  validation, and history projection.
+- `PipelineGraph` and the history applier: one in-place atomic topology-delta application in both
+  directions.
+- editor session service/controller/history port: one automatic-submission route and one render
+  reason after successful publication.
+
+Keep QML free of topology mutation and validity rules. Keep the draft type free of QObject/Qan
+ownership. Keep the atomic domain change free of layout, selection, and canvas presentation data.
+
+### 15.11 Tests and exit criteria
+
+#### Draft and controller
+
+- The first topology edit creates one draft from the complete current projection.
+- Later ordinary operations keep the same draft object and incrementally mutate only affected
+  values and indexes.
+- Add inserts one disconnected clean Color Grade below the main vertical DAG and produces no
+  product command or render while the draft is incomplete.
+- Add does not move existing node positions.
+- `A -> D` replaces `A -> B` and preserves `B -> C` without submitting.
+- `D -> C` replaces `B -> C`, leaves B detached, and does not submit.
+- Reconnecting or deleting B so that the full path becomes valid automatically submits once.
+- An unsupported type, wrong port direction, type mismatch, endpoint violation, self-edge, or cycle
+  leaves the draft and delta unchanged and shows the exact error.
+- Failure of an affected Qan node or edge insertion restores the exact pre-operation draft, delta,
+  indexes, and Qan primitives without a product command.
+- Returning the draft to the base empties the delta and exits editing without commit or render.
+- An incomplete draft survives Nodes Loader destruction and recreation for the same base identity.
+- A stale generation or topology revision cannot submit the draft to a newer document.
+
+#### Qan adapter
+
+- An accepted connection removes at most two affected edge primitives and inserts one.
+- Unaffected Qan node, port, and edge QObject identities remain unchanged across Add, Connect,
+  Delete, and successful automatic submission.
+- Rejected operations change no Qan primitive.
+- Ordinary draft operations and successful automatic submission do not invoke full topology
+  replacement.
+- Successful submission promotes candidate presentation without recreating the topology.
+
+#### Atomic domain and history
+
+- One valid draft invokes one `SubmitNodeGraphTopologyEdit` request.
+- One request persists one `NodeGraphTopologyChange`, not a sequence of stored Add/Remove/Reconnect
+  changes.
+- The live `PipelineGraph` object and all unaffected `INodeModel` object addresses remain stable.
+- The final graph is validated only after the whole delta is applied.
+- Failure injection after each removal, insertion, counter update, WAL step, history-publication
+  step, and live-pipeline publication step restores exact state.
+- Forward, Undo, Redo, recovery, reopen, and Version checkout reproduce exact nodes, object data,
+  node order, edges, edge order, and next-name counter.
+- An incomplete draft produces zero commits and zero render requests across any number of edits.
+- Successful automatic submission produces one history commit and one
+  `GraphTopologyChanged` Quality render.
+
+#### UI and performance
+
+- The header contains no Apply or Cancel action.
+- The incomplete-state instruction and exact error use existing AppTheme text and danger roles.
+- No new badge, pill, status dot, gradient, shadow, glow, or Material style is introduced.
+- A 32-Grade graph operation cost scales with affected indexes and the required read-only validity
+  traversal; it does not include full draft or Qan reconstruction.
+- Drawer folding and node movement preserve port identity and do not affect the accumulated delta.
+
+### 15.12 Completion record
+
+Record the implementation revision, branch, exact atomic-change format, primary success and
+failure call chains, test commands and counts, failure-injection evidence, object-identity evidence,
+Qan incremental-update evidence, Windows build result, and unavailable macOS checks here.
+
+##### NM5.7R completion record (2026-09-04)
+
+**Status:** complete — the Nodes page is an incremental topology editor. Add inserts one
+disconnected draft Color Grade. Connect replaces only the source output edge and the destination
+input edge. Incomplete supported graphs stay editable with no product write, history commit, or
+render. The first admitted operation that restores a complete Develop-to-DRT path submits one
+`NodeGraphTopologyChange`. The live `PipelineGraph` applies that delta in place. The UI has no
+Apply or Cancel action.
+
+**Revision and branch:** working tree on `feature/nodes-panel-visual-connector-reconnect`
+(base `9a7a6625`). QuickQanava remains submodule tag `2.50` at
+`56bdf78d5b1d41fb60ae3b8ea2292df45787ecff`.
+
+**Atomic-change format:** typed batch `operation_kind = edit_node_graph` with exactly one
+`node_graph_topology_change`. Stored fields: inserted nodes (canonical Color Grade JSON +
+`final_node_index`), removed nodes (JSON + `original_node_index`), disconnected edges (exact
+endpoints + `original_edge_index`), connected edges (exact endpoints + `final_edge_index`),
+and before/after `next_color_grade_name_number`. Session generation and topology revision are
+transient submit guards and are not persisted. Batch format version remains `2`; unknown kinds
+still fail closed. No old-format migration was added.
+
+**Primary success call chain:**
+
+```text
+Add or exclusive-port Connect or Delete
+  -> EditorNodeController creates EditorNodeGraphDraft from the live document once
+  -> incremental draft mutation (indexes and net delta updated in place)
+  -> AlcedoQanGraph inserts/removes only affected primitives
+  -> read-only submission validity
+  -> incomplete: stay in node editing; no history; no render
+  -> valid empty delta: discard draft; no history; no render
+  -> valid non-empty delta:
+       EditorNodeController::MaybeSubmitDraft
+       -> EditorSessionController::SubmitNodeGraphTopologyEdit
+       -> EditorSessionService queue admission as CommitAdjustment
+       -> EditorSessionHistoryPort::EditNodeGraph under the render lock
+       -> PipelineGraph::ApplyTopologyDelta in place on the live graph
+       -> one typed EditNodeGraph batch and Mini-Git WAL append
+       -> PromoteCommittedSnapshot (no Qan topology replacement)
+       -> one GraphTopologyChanged Quality render
+```
+
+**Primary failure call chain:**
+
+```text
+unsupported port role, self-edge, cycle, unknown endpoint, or stale generation
+  -> reject before draft mutation
+  -> draft values, indexes, delta, layout, and Qan primitives unchanged
+  -> connector preview closes
+  -> EditorNodesPanel shows the exact error
+```
+
+```text
+Qan insert/remove failure
+  -> restore the pre-operation draft
+  -> reverse only the affected Qan primitives
+  -> no product command
+
+atomic submit / WAL failure
+  -> ApplyNodeGraphTopologyChange inverse restores live node objects, order, edges, and counter
+  -> retain the valid draft and its delta
+  -> no render
+  -> exact error text
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| First construction copies the document once; later ops keep the same draft object | `EditorNodeGraphDraftTest` | PASS |
+| Add inserts one disconnected Color Grade and does not consume the product counter | `EditorNodeGraphDraftTest`, `EditorNodeController`, `EditorNodesPanelQmlTest` | PASS |
+| `A -> D` then `D -> C` leaves the skipped Grade detached without submitting | `EditorNodeGraphDraftTest`, `EditorNodeController` | PASS |
+| Reconnecting or deleting the detached Grade makes the path valid | `EditorNodeGraphDraftTest` | PASS |
+| Completing the path submits one `NodeGraphTopologyChange` and one topology Quality render | `EditorNodeController`, `EditorSessionNodeCommandTest`, `EditorNodesPanelQmlTest` | PASS |
+| Unsupported connect leaves draft and delta unchanged with exact error | `EditorNodeGraphDraftTest`, `EditorNodeController` | PASS |
+| Returning to the base empties the delta and exits without a commit | `EditorNodeGraphDraftTest`, `EditorNodeController` | PASS |
+| In-place forward/inverse keeps unaffected `INodeModel` addresses | `PipelineGraphTopologyDeltaTest` | PASS |
+| Failure after counter, disconnect, insert, connect, and validate restores exact state | `PipelineGraphTopologyDeltaTest` | PASS |
+| Typed batch apply does not clone the live graph | `PipelineGraphTopologyDeltaTest` | PASS |
+| Incremental Qan insert/remove preserves unaffected QObject identities | `AlcedoQanGraphTest` | PASS |
+| Ordinary draft connect does not increment topology replacement | `EditorNodesPanelQmlTest` | PASS |
+| Header has no Apply or Cancel action | `EditorNodesPanelQmlTest` | PASS |
+| Submit failure keeps the product graph, shows the exact error, and retains the draft | `EditorNodesPanelQmlTest` | PASS |
+
+| Target or suite | Result |
+| --- | --- |
+| `EditorNodeGraphDraftTest` | 8/8 passed |
+| `PipelineGraphTopologyDeltaTest` | 5/5 passed |
+| `PipelineEditBatchTest` | 17/17 passed |
+| `PipelineHistoryApplierTest` | 12/12 passed |
+| `EditorSessionNodeCommandTest` | 6/6 passed |
+| `EditorSessionActionPolicyCq3Test` | 12/12 passed |
+| `EditorNodeSelectionLayoutTest` | 24/24 passed |
+| `AlcedoQanGraphTest` | 16/16 passed |
+| `EditorNodesPanelQmlTest` | 19/19 passed |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorNodeGraphDraftTest PipelineGraphTopologyDeltaTest PipelineEditBatchTest PipelineHistoryApplierTest EditorSessionNodeCommandTest EditorSessionActionPolicyCq3Test EditorNodeSelectionLayoutTest AlcedoQanGraphTest EditorNodesPanelQmlTest alcedo_main
+build\debug\alcedo_studio\tests\app\EditorNodeGraphDraftTest_runtime\EditorNodeGraphDraftTest.exe
+build\debug\alcedo_studio\tests\app\PipelineGraphTopologyDeltaTest_runtime\PipelineGraphTopologyDeltaTest.exe
+build\debug\alcedo_studio\tests\edit\PipelineEditBatchTest_runtime\PipelineEditBatchTest.exe
+build\debug\alcedo_studio\tests\app\PipelineHistoryApplierTest_runtime\PipelineHistoryApplierTest.exe
+build\debug\alcedo_studio\tests\app\EditorSessionNodeCommandTest_runtime\EditorSessionNodeCommandTest.exe
+build\debug\alcedo_studio\tests\app\EditorSessionActionPolicyCq3Test_runtime\EditorSessionActionPolicyCq3Test.exe
+build\debug\alcedo_studio\tests\ui\EditorNodeSelectionLayoutTest_runtime\EditorNodeSelectionLayoutTest.exe
+build\debug\alcedo_studio\tests\ui\AlcedoQanGraphTest_runtime\AlcedoQanGraphTest.exe
+build\debug\alcedo_studio\tests\ui\EditorNodesPanelQmlTest_runtime\EditorNodesPanelQmlTest.exe
+```
+
+`alcedo_main` linked. macOS checks were not run on this Windows host.
+
+**Pinned API differences:**
+
+- Request-only connector is unchanged: `connectorEnabled = true`,
+  `connectorCreateDefaultEdge = false`. The pinned 2.50
+  `connectorRequestEdgeCreation(src, dst, srcPort, dstPort)` still includes port
+  arguments omitted by the website.
+- Connectable policy now matches exclusive-port editing: Develop is
+  `OutConnectable`, every Color Grade is `Connectable`, DRT/Post is
+  `InConnectable`. Starting a connection is not limited to the selected Color Grade.
+- Incremental `insertEdge` + `bindEdge` on a live port with
+  `Multiplicity::Single` rejects the bind while the removed edge item remains in
+  the port list. Incremental edge removal therefore clears that port's in/out
+  edge items before `removeEdge`.
+
+**Checklist / exit condition:** all 15.11 draft, Qan, atomic-domain, and UI
+criteria in this sub-phase are covered by the executed tests above. Keyboard
+topology editing, accessibility matrix, install/package, and licence packaging
+remain NM5.8.
+
+**LOC note (grill-code-review):** `editor_node_graph_draft.cpp` 555;
+`editor_node_controller.cpp` 903; `EditorNodesPanel.qml` 509.
+`alcedo_qan_graph.cpp` is 1244 after incremental insert/remove/promote; the extra
+size is the incremental primitive API, not a second topology owner.
+`pipeline_edit_batch.cpp` remains 1486 as the typed-change serializer; this
+sub-phase added one change kind beside the existing variants and did not absorb
+new unrelated responsibilities.
+
+**Residual gaps:** NM5.8 still owns lifecycle, accessibility, localization
+expansion, install, and package checks. Dedicated Mini-Git recovery/reopen/
+Version-checkout cases for `EditNodeGraph` use the same
+`ApplyPipelineEditBatch` inverse path proven above and were not duplicated as a
+separate history-port suite. Keyboard topology editing remains NM5.8. Real-RAW
+and three-backend qualification remain NM8.
+
+##### Follow-up (2026-09-04): default Add placement
+
+Unconnected Add nodes use the backbone origin x and sit below the lowest existing
+card plus the vertical gap. Later unconnected Adds stack downward. They no longer
+use a right-side lane. Proven by `EditorNodeLayoutStore` and `EditorNodeController`
+placement tests in `EditorNodeSelectionLayoutTest`.
+
+---
+
+## 16. NM5.8 — Lifecycle, accessibility, build, install, and package checks
+
+### 16.1 Input context
+
+NM5.1–NM5.7 provide the original Nodes page. NM5.7R replaces the immediate-reconnect product
+behavior with incremental draft editing and atomic automatic submission. This sub-phase adds no
+product feature. It closes lifecycle, accessibility, localization, build, and package gaps.
 
 NM8 still owns final real-RAW and three-backend qualification.
 
-### 15.2 Official documentation
+### 16.2 Official documentation
 
 - [Installation](https://cneben.github.io/QuickQanava/installation.html): all sections.
 - [Graph](https://cneben.github.io/QuickQanava/graph.html): `QuickQanava Initialization` and `Graph View`.
 - [API Reference](https://cneben.github.io/QuickQanava/reference.html): the local-Doxygen notice.
 - [Licence](https://cneben.github.io/QuickQanava/licence.html): source and binary notice requirements.
 
-### 15.3 Work
+### 16.3 Work
 
 1. Complete empty, loading, pending-command, and error behavior.
 2. Complete localized text and accessible names.
@@ -2300,7 +2887,7 @@ NM8 still owns final real-RAW and three-backend qualification.
 11. Check QuickQanava and bezier licence notices.
 12. Run all affected graph, history, adapter, QML, and workspace tests.
 
-### 15.4 Main call chain
+### 16.4 Main call chain
 
 ```text
 packaged app start
@@ -2313,12 +2900,13 @@ packaged app start
   -> all visible product changes use typed history
 ```
 
-### 15.5 Tests and exit criteria
+### 16.5 Tests and exit criteria
 
 - No-image state uses localized plain text.
 - Loading never shows the previous image graph.
 - Command failure keeps the prior graph and exact counter state.
-- Keyboard input can select, open drawers, Add, Rename, Delete, Fit, and Reconnect.
+- Keyboard input can select, open drawers, Add, Rename, Delete, Fit, and start supported topology
+  connections without exposing an Apply or Cancel action.
 - A screen reader reads node names, Mask types, disclosure state, and actions.
 - It does not read topology numbers, On/Off state, adjustment summaries, or hidden Mask fields.
 - Both themes and all four target DPR values pass the visual matrix.
@@ -2328,14 +2916,14 @@ packaged app start
 - The package contains the required third-party notices.
 - Lifetime checks find no stale Qan pointer use.
 
-### 15.6 Completion record
+### 16.6 Completion record
 
 Record the date, commands, test count, visual matrix, package results, and unavailable environment
 checks here.
 
 ---
 
-## 16. Test target plan
+## 17. Test target plan
 
 Prefer an existing target when its responsibility matches. Add a target only when ownership stays
 clear.
@@ -2344,16 +2932,18 @@ clear.
 | --- | --- |
 | `PipelineDocumentDefaultNameTest` | Serialized counter, default names, format validation, and replay. |
 | `EditorNodeGraphProjectionTest` | Snapshot values, Mask kinds, revisions, NodeId, and generation. |
-| `EditorNodeControllerTest` | Selection, Add, Rename, Delete, Reconnect, failure, and render reasons. |
-| `AlcedoQanGraphTest` | Primitive mapping, ports, edges, selection, role updates, and stale-object rejection. |
-| `EditorNodesPanelQmlTest` | VI, node content, drawer behavior, icons, keyboard, accessibility, and layout restore. |
+| `EditorNodeGraphDraftTest` | One-time construction, incremental Add/Delete/Connect, net-delta cancellation, admission checks, and submission validity. |
+| `PipelineGraphTopologyDeltaTest` | In-place atomic forward/inverse application, exact restoration, object identity, and final validation. |
+| `EditorNodeControllerTest` | Selection, draft lifetime, automatic submission, stale guards, failure, and render reasons. |
+| `AlcedoQanGraphTest` | Primitive mapping, incremental node/edge updates, identity preservation, selection, role updates, and stale-object rejection. |
+| `EditorNodesPanelQmlTest` | VI, node content, drawer behavior, no Apply/Cancel action, exact errors, keyboard, accessibility, and layout restore. |
 | `EditorWorkspaceToolRailLifecycleQmlTest` | History, Versions, and Nodes mutual exclusion and Loader lifetime. |
 | `WorkspaceShellTest` | Column geometry, minimum window size, focus order, and production type registration. |
 | `EditorSessionHistoryPortTest` | Typed graph history, Undo, Redo, WAL failure restoration, and counter replay. |
 
 Every test name must state the behavior that it checks. Do not use `smoke` in a test name.
 
-### 16.1 Required visual matrix
+### 17.1 Required visual matrix
 
 Capture or assert:
 
@@ -2373,7 +2963,7 @@ summary, Mask count, pill, badge, shadow, glow, gradient, or Material chrome.
 
 ---
 
-## 17. Failure matrix
+## 18. Failure matrix
 
 | Failure point | Required result |
 | --- | --- |
@@ -2382,10 +2972,15 @@ summary, Mask count, pill, badge, shadow, glow, gradient, or Material chrome.
 | Stale session generation | Reject the snapshot or request. Do not touch the current session. |
 | Qan node creation | Roll back the adapter update. Keep the prior complete Qan projection. |
 | Qan edge creation or binding | Roll back the adapter update. Leave no orphan edge or port. |
-| Add validation | Do not create a node, consume a name number, commit history, or render. |
+| Incremental draft Qan update | Reverse only the affected draft and Qan changes. Preserve all unrelated object identities and issue no product command. |
+| Draft creation | Keep the prior committed canvas. Show the exact error. Do not create a partial draft. |
+| Draft Add | Keep existing draft objects and edges. Do not consume a product name number, commit history, or render while incomplete. |
+| Unsupported draft connection | Reject before mutation. Keep draft values, indexes, delta, layout, and Qan primitives unchanged. |
+| Incomplete draft | Keep the incremental draft visible. Do not change product state, history, Version, or rendering. |
+| Atomic topology validation | Restore exact node ownership, node order, edge order, counter, and live object identity. Keep the draft. |
 | Rename validation | Keep the prior name. Do not create history. |
-| Delete validation | Keep the node, edges, selection, counter, and layout. |
-| Reconnect validation | Close the preview. Keep the permanent edges. |
+| Draft Delete validation | Keep the node, edges, indexes, accumulated delta, selection, counter, and layout. |
+| Connector admission | Close the preview. Keep the current draft edges and exact error. |
 | WAL append | NM4 restores document and history. Restore counter, projection, and selection. |
 | Version checkout | NM4 restores the prior Version after failure. Keep its selection and layout. |
 | Loader teardown | Keep only plain controller and layout values. Keep no Qan pointer. |
@@ -2393,11 +2988,17 @@ summary, Mask count, pill, badge, shadow, glow, gradient, or Material chrome.
 
 ---
 
-## 18. Performance targets
+## 19. Performance targets
 
 - A parameter slider update does not rebuild the Qan graph.
 - A Mask drawer role update changes only its owner node.
-- A topology update scales with affected nodes and edges.
+- Draft construction reads one complete projection once per bound base identity.
+- An ordinary draft Add or Delete updates only the affected node, incident edges, and indexes.
+- An ordinary draft Connect removes at most two Qan edges and inserts one Qan edge.
+- An ordinary draft edit never reconstructs or overwrites the draft or Qan graph.
+- Successful automatic submission promotes the current canvas without a Qan topology rebuild.
+- Submission-validity traversal may scale with total draft nodes and edges; mutation work scales
+  with the affected nodes, edges, and indexes.
 - A fully closed panel retains no graph delegates.
 - The default graph shows input feedback within 100 ms after first open.
 - Node selection shows feedback within 100 ms.
@@ -2412,13 +3013,15 @@ Record:
 - projection apply time for a 32-Grade graph;
 - frame time for 100 selections;
 - frame time for opening and closing a node with many Mask rows;
+- frame time and changed Qan object count for 100 accepted draft connections;
+- draft and Qan object identity retention across 100 accepted draft connections;
 - live Qan object count after 100 panel open/close cycles.
 
 Do not reduce decode resolution, output quality, or backend behavior to meet these targets.
 
 ---
 
-## 19. NM5 completion criteria
+## 20. NM5 completion criteria
 
 - [x] The production target links the pinned QuickQanava module.
 - [x] Production initializes QuickQanava before QML load.
@@ -2450,11 +3053,27 @@ Do not reduce decode resolution, output quality, or backend behavior to meet the
 - [x] The product allows one selected node.
 - [x] Add creates a clean Color Grade.
 - [x] Rename and Delete use NM4 typed history.
-- [ ] Reconnect uses the official visual connector.
-- [ ] `connectorCreateDefaultEdge` is false.
-- [ ] The backend accepts a request before permanent Qan edges change.
-- [ ] All command failures preserve the prior product and projected graph.
-- [ ] Add, Rename, Delete, and Reconnect support Undo and Redo.
+- [x] NM5.7 Reconnect uses the official visual connector in request-only mode.
+- [x] `connectorCreateDefaultEdge` is false.
+- [x] NM5.7R Add creates one disconnected draft Color Grade without a product change or render.
+- [x] One draft is created from the complete projection and then mutated incrementally.
+- [x] Ordinary draft operations do not reconstruct or overwrite the draft or Qan graph.
+- [x] Exclusive-port Connect replaces only the source's prior output edge and the destination's
+      prior input edge.
+- [x] Supported incomplete graphs remain editable without a product change, history commit, or
+      render request.
+- [x] Unsupported node types and connections are rejected before draft mutation with exact text.
+- [x] The first operation that restores a valid graph automatically submits; the UI has no Apply
+      or Cancel action.
+- [x] Automatic submission contains one `NodeGraphTopologyChange`, not stored
+      Add/Remove/Reconnect steps.
+- [x] The live `PipelineGraph` applies the topology delta atomically in place and is never replaced
+      by the draft.
+- [x] Successful automatic submission preserves unaffected Qan and `INodeModel` identities and
+      requests one Quality render.
+- [x] All command failures preserve the prior product graph, history, Version, revision, and
+      rendered state while retaining an applicable draft.
+- [x] Atomic topology edits support exact Undo, Redo, recovery, reopen, and Version checkout.
 - [ ] All visible actions support keyboard input and accessibility.
 - [ ] All product text uses localization.
 - [ ] All visual values use AppTheme and `DESIGN.md`.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: NM5.1–NM5.6 complete; NM5.7–NM5.8 planned
+Status: NM5.1–NM5.7 complete; NM5.8 planned
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -2162,8 +2162,110 @@ Verify the pinned forms of:
 
 ### 14.7 Completion record
 
-Record the date, pinned connector properties, commands, test count, success chain, and failure
-chain here.
+##### NM5.7 completion record (2026-09-04)
+
+**Status:** complete — the Nodes page enables the pinned QuickQanava visual connector in
+request-only mode. Only the selected Color Grade can start a move. A drop is resolved through
+generation-checked identity maps, the moving Grade is removed from an in-memory backbone order,
+and NM4 `ReconnectColorGrade` runs with the computed predecessor and successor. Permanent Qan
+edges update only after the accepted projection is published.
+
+**Revision and branch:** base repository revision `dcd9dce8` (`origin/main` with NM5.6 merged),
+branch `feature/nodes-panel-visual-connector-reconnect`.
+
+**Pinned connector properties (QuickQanava 2.50 `56bdf78d`):**
+
+| Property / signal | Pinned value used |
+| --- | --- |
+| `connectorEnabled` | `true` (pinned header default is `false`; website text says default `true`) |
+| `connectorCreateDefaultEdge` | `false` |
+| `connectorRequestEdgeCreation(src, dst, srcPort, dstPort)` | request-only path; official website omits the port arguments present in 2.50 |
+| `connectorEdgeColor` | `AppTheme.graphCandidateEdgeColor` |
+| `connectorColor` | `AppTheme.graphPortBorderColor` |
+| selected Color Grade `connectable` | `OutConnectable`; connector `sourcePort` is the bottom `image` output |
+| other Color Grades | `InConnectable` |
+| Develop | `UnConnectable` (no incoming move target) |
+| DRT/Post | `InConnectable` (no outgoing move source) |
+
+**Primary success call chain:**
+
+```text
+user drags the official visual connector from the selected Color Grade
+  -> Qan shows a temporary connector (no default insertEdge)
+  -> connectorRequestEdgeCreation(src, dst, srcPort, dstPort)
+  -> AlcedoQanGraph resolves live NodeIds and generation
+  -> EditorNodeController removes the moving Grade from remaining backbone order
+  -> compute predecessor and successor (insert before dest, or after an output port)
+  -> EditorSessionController::SubmitReconnectColorGrade
+  -> EditorSessionService queue admission as CommitAdjustment
+  -> EditorSessionHistoryPort::ReconnectColorGrade under the render lock
+  -> typed Reconnect batch and Mini-Git WAL append
+  -> topology projection revision
+  -> AlcedoQanGraph replaces permanent edges from the accepted snapshot
+  -> GraphTopologyChanged Quality render
+```
+
+**Primary failure call chain:**
+
+```text
+Develop incoming target, DRT outgoing source, unselected source, self-cycle,
+non-adjacent fan-in/fan-out, stale Qan primitive, stale generation, or backend failure
+  -> reject before or during history mutation
+  -> no PipelineDocument change
+  -> no history commit
+  -> hideConnectorPreview (temporary Qan edge closed)
+  -> permanent Qan edge set unchanged
+  -> EditorNodesPanel shows the exact error
+```
+
+A no-op drop onto the current successor returns success without a history commit.
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| Develop has no incoming move target; DRT has no outgoing source | `EditorNodeSelectionLayoutTest` | PASS |
+| Each Grade has one input and one output; request-only connector; theme colors | `AlcedoQanGraphTest` | PASS |
+| Valid move creates one commit and one topology Quality render | `EditorSessionNodeCommandTest`, `EditorNodeSelectionLayoutTest`, `EditorNodesPanelQmlTest` | PASS |
+| No-op move creates no commit | `EditorNodeSelectionLayoutTest` | PASS |
+| Cycle, fan-in, and fan-out requests fail | `EditorNodeSelectionLayoutTest` | PASS |
+| Stale Qan primitive cannot change the current Version | `AlcedoQanGraphTest` | PASS |
+| Backend failure leaves permanent edges and exact error | `EditorNodesPanelQmlTest` | PASS |
+| Undo restores exact order and selection | `EditorNodeSelectionLayoutTest` | PASS |
+| Drawer fold does not change port identity or reconnect neighbors | `AlcedoQanGraphTest`, `EditorNodesPanelQmlTest` | PASS |
+
+| Target or suite | Result |
+| --- | --- |
+| `EditorSessionNodeCommandTest` | 5/5 passed |
+| `EditorSessionActionPolicyCq3Test` | 12/12 passed |
+| `EditorNodeSelectionLayoutTest` | 25/25 passed |
+| `AlcedoQanGraphTest` | 15/15 passed |
+| `EditorNodesPanelQmlTest` | 19/19 passed |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSessionNodeCommandTest EditorSessionActionPolicyCq3Test EditorNodeSelectionLayoutTest EditorNodesPanelQmlTest AlcedoQanGraphTest alcedo_main
+build\debug\alcedo_studio\tests\app\EditorSessionNodeCommandTest_runtime\EditorSessionNodeCommandTest.exe
+build\debug\alcedo_studio\tests\app\EditorSessionActionPolicyCq3Test_runtime\EditorSessionActionPolicyCq3Test.exe
+build\debug\alcedo_studio\tests\ui\EditorNodeSelectionLayoutTest_runtime\EditorNodeSelectionLayoutTest.exe
+build\debug\alcedo_studio\tests\ui\AlcedoQanGraphTest_runtime\AlcedoQanGraphTest.exe
+build\debug\alcedo_studio\tests\ui\EditorNodesPanelQmlTest_runtime\EditorNodesPanelQmlTest.exe
+```
+
+`alcedo_main` linked. macOS checks were not run on this Windows host.
+
+**Checklist / exit condition:** all boxes in 14.6 checked.
+
+**LOC note (grill-code-review):** `editor_node_controller.cpp` 761; `alcedo_qan_graph.cpp` 942;
+`EditorNodesPanel.qml` 455. `editor_session_service.cpp` 1547 and
+`editor_session_controller.cpp` 1263 were already above 1000; this sub-phase only added the
+Reconnect routing methods beside the existing Add/Remove/Rename paths and did not absorb more
+business rules into those facades.
+
+**Residual gaps:** NM5.8 still owns lifecycle, accessibility, localization, install, and package
+checks. Keyboard Reconnect is listed under NM5.8. Real-RAW and three-backend qualification remain
+NM8.
 
 ---
 


### PR DESCRIPTION
## Summary

- Nodes is a real topology editor. Add creates one disconnected draft Color Grade below the main vertical DAG (same x as Develop/DRT, stacked downward). The page has no Apply or Cancel action.
- Exclusive-port Connect replaces only `source.output` and `dest.input`. Incomplete but supported graphs stay editable with no product write, history commit, or render.
- Unsupported edits reject before mutation with the exact error. The first admitted operation that restores a complete Develop-to-DRT path submits one `NodeGraphTopologyChange` / `EditNodeGraph`, not sequenced Add/Remove/Reconnect.
- The live `PipelineGraph` applies that delta in place. There is no draft document overlay and no `ClonePipelineDocument` on this path. Successful submit promotes the current Qan canvas without a full topology rebuild.
- The visual connector stays request-only (`connectorCreateDefaultEdge = false`). Color Grades are connectable; Develop is output-only; DRT is input-only.
- History presentation is "Edit Node Graph". Undo/Redo/recovery use the same typed batch inverse.

## Validation

- `cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorNodeGraphDraftTest PipelineGraphTopologyDeltaTest PipelineEditBatchTest PipelineHistoryApplierTest EditorSessionNodeCommandTest EditorSessionActionPolicyCq3Test EditorNodeSelectionLayoutTest AlcedoQanGraphTest EditorNodesPanelQmlTest alcedo_main`
- `EditorNodeGraphDraftTest` — 8 passed
- `PipelineGraphTopologyDeltaTest` — 5 passed
- `PipelineEditBatchTest` — 17 passed
- `PipelineHistoryApplierTest` — 12 passed
- `EditorSessionNodeCommandTest` — 6 passed
- `EditorSessionActionPolicyCq3Test` — 12 passed
- `EditorNodeSelectionLayoutTest` — 27 passed (includes default Add placement below the DAG)
- `AlcedoQanGraphTest` — 16 passed
- `EditorNodesPanelQmlTest` — 19 passed
- `alcedo_main` linked
- macOS was not available on this Windows host

## Out of scope

NM5.8 still owns keyboard topology editing, accessibility, localization expansion, install, and package checks.
