### PR TITLE
refactor(ui): NM5.8a/b one apply path and bounded draft reversal

### DIFF
--- a/alcedo_studio/src/app/editor_node_graph_draft.cpp
+++ b/alcedo_studio/src/app/editor_node_graph_draft.cpp
@@ -5,14 +5,39 @@
 #include "app/editor_node_graph_draft.hpp"
 
 #include <algorithm>
-#include <functional>
 #include <stdexcept>
+#include <type_traits>
 #include <unordered_set>
+#include <utility>
 
 #include "edit/graph/color_grade_node_model.hpp"
-#include "edit/operators/models/builtin_type_ids.hpp"
 
 namespace alcedo {
+namespace {
+
+auto MaxInsertedNameNumber(const std::map<NodeId, nlohmann::json>& inserted,
+                           std::uint64_t                           base_number) -> std::uint64_t {
+  std::uint64_t max_inserted = base_number;
+  const auto    prefix       = std::string{"Color Grade "};
+  for (const auto& [id, stored] : inserted) {
+    (void)id;
+    if (!stored.contains("display_name") || !stored.at("display_name").is_string()) {
+      continue;
+    }
+    const auto name = stored.at("display_name").get<std::string>();
+    if (name.rfind(prefix, 0) != 0) {
+      continue;
+    }
+    try {
+      const auto number = std::stoull(name.substr(prefix.size()));
+      max_inserted      = std::max(max_inserted, number + 1);
+    } catch (...) {
+    }
+  }
+  return max_inserted;
+}
+
+}  // namespace
 
 auto EditorNodeGraphDraft::ImagePort() -> PortId { return PortId{"image"}; }
 
@@ -36,85 +61,88 @@ auto EditorNodeGraphDraft::ToProjection(const PipelineSceneEdge& edge) -> Editor
   return EditorNodeEdgeProjection{edge.from_node, edge.from_port, edge.to_node, edge.to_port};
 }
 
-auto EditorNodeGraphDraft::KindOf(const INodeModel& node) -> EditorNodeKind {
-  if (node.Type() == type_ids::DevelopNode()) {
-    return EditorNodeKind::Develop;
+template <class Map, class Key>
+void EditorNodeGraphDraft::Remember(
+    std::map<Key, std::optional<typename Map::mapped_type>>* prior, const Map& current,
+    const Key& key) {
+  if (prior->contains(key)) {
+    return;
   }
-  if (node.Type() == type_ids::DrtNode()) {
-    return EditorNodeKind::Drt;
+  const auto it = current.find(key);
+  if (it == current.end()) {
+    prior->emplace(key, std::nullopt);
+    return;
   }
-  if (node.Type() == type_ids::ColorGradeNode()) {
-    return EditorNodeKind::ColorGrade;
+  prior->emplace(key, it->second);
+  if constexpr (std::is_same_v<typename Map::mapped_type, nlohmann::json>) {
+    ++work_stats_.json_entry_copies;
   }
-  throw std::invalid_argument("Unsupported node type: " + std::string{node.Type().Text()});
 }
 
-auto EditorNodeGraphDraft::ProjectNode(const INodeModel& node) const -> EditorNodeProjection {
-  EditorNodeProjection projected;
-  projected.node_id      = node.Id();
-  projected.node_kind    = KindOf(node);
-  projected.display_name = std::string{node.DisplayName()};
-  if (projected.node_kind == EditorNodeKind::ColorGrade) {
-    const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(&node);
-    if (grade == nullptr) {
-      throw std::invalid_argument("Color Grade type has an invalid model");
-    }
-    projected.masks.reserve(grade->MaskCount());
-    for (const auto& mask : grade->Masks()) {
-      projected.masks.push_back({mask.id, GetMaskSourceKind(mask.source)});
+template <class Map, class Key>
+void EditorNodeGraphDraft::RestoreMap(
+    Map* current, const std::map<Key, std::optional<typename Map::mapped_type>>& prior) {
+  for (const auto& [key, value] : prior) {
+    if (!value.has_value()) {
+      current->erase(key);
+    } else {
+      (*current)[key] = *value;
     }
   }
-  return projected;
 }
 
 auto EditorNodeGraphDraft::FromDocument(const PipelineDocument& document,
                                         EditorNodeGraphDraftIdentity identity)
     -> EditorNodeGraphDraft {
   EditorNodeGraphDraft draft;
-  draft.identity_                = std::move(identity);
-  draft.base_next_name_number_   = document.NextColorGradeNameNumber();
-  draft.draft_next_name_number_  = draft.base_next_name_number_;
-  const auto& graph              = document.Graph();
+  draft.identity_               = std::move(identity);
+  draft.base_next_name_number_  = document.NextColorGradeNameNumber();
+  draft.draft_next_name_number_ = draft.base_next_name_number_;
+  const auto& graph             = document.Graph();
   draft.nodes_.reserve(graph.Nodes().size());
   for (std::size_t index = 0; index < graph.Nodes().size(); ++index) {
     const auto* node = graph.Nodes()[index].get();
     if (node == nullptr) {
       throw std::invalid_argument("Pipeline graph contains a null node");
     }
-    auto projected = draft.ProjectNode(*node);
-    draft.node_json_[projected.node_id]      = node->ToJson();
-    draft.base_node_json_[projected.node_id] = draft.node_json_[projected.node_id];
+    auto projected = EditorNodeGraphProjection::ProjectNode(*node);
+    auto json      = node->ToJson();
+    draft.node_json_[projected.node_id]      = json;
+    draft.base_node_json_[projected.node_id] = std::move(json);
     draft.base_node_index_[projected.node_id] = index;
     draft.nodes_.push_back(std::move(projected));
   }
   draft.edges_.reserve(graph.Edges().size());
   draft.base_edges_.reserve(graph.Edges().size());
   for (std::size_t index = 0; index < graph.Edges().size(); ++index) {
-    const auto& edge = graph.Edges()[index];
+    const auto& edge  = graph.Edges()[index];
     const auto  scene = PipelineSceneEdge{edge.from_node, edge.from_port, edge.to_node, edge.to_port};
     draft.base_edges_.push_back(scene);
     draft.base_edge_index_[EdgeKey(scene)] = index;
     draft.edges_.push_back(ToProjection(scene));
   }
   draft.RebuildIndexes();
+  draft.submission_valid_ = draft.ComputeSubmissionValid();
   return draft;
 }
 
 void EditorNodeGraphDraft::RebuildIndexes() {
+  ++work_stats_.complete_index_rebuilds;
   node_index_.clear();
-  edge_index_.clear();
   outgoing_.clear();
   incoming_.clear();
   for (std::size_t index = 0; index < nodes_.size(); ++index) {
-    node_index_[nodes_[index].node_id] = index;
-    outgoing_[nodes_[index].node_id]   = std::nullopt;
-    incoming_[nodes_[index].node_id]   = std::nullopt;
+    const auto& id         = nodes_[index].node_id;
+    node_index_[id]        = index;
+    outgoing_[id]          = std::nullopt;
+    incoming_[id]          = std::nullopt;
+    work_stats_.index_entry_updates += 3;
   }
-  for (std::size_t index = 0; index < edges_.size(); ++index) {
-    const auto& edge = edges_[index];
-    edge_index_[EdgeKey(edge)]              = index;
-    outgoing_[edge.source_node_id]          = index;
-    incoming_[edge.destination_node_id]     = index;
+  for (const auto& edge : edges_) {
+    const auto key                 = EdgeKey(edge);
+    outgoing_[edge.source_node_id] = key;
+    incoming_[edge.destination_node_id] = key;
+    work_stats_.index_entry_updates += 2;
   }
 }
 
@@ -132,6 +160,25 @@ auto EditorNodeGraphDraft::NodeJson(const NodeId& node_id) const -> const nlohma
     return nullptr;
   }
   return &it->second;
+}
+
+auto EditorNodeGraphDraft::FindEdgeIndex(const std::string& key) const
+    -> std::optional<std::size_t> {
+  for (std::size_t index = 0; index < edges_.size(); ++index) {
+    if (EdgeKey(edges_[index]) == key) {
+      return index;
+    }
+  }
+  return std::nullopt;
+}
+
+auto EditorNodeGraphDraft::FindEdgeByKey(const std::string& key) const
+    -> const EditorNodeEdgeProjection* {
+  const auto index = FindEdgeIndex(key);
+  if (!index.has_value()) {
+    return nullptr;
+  }
+  return &edges_[*index];
 }
 
 auto EditorNodeGraphDraft::MatchesBase(const PipelineDocument& document) const -> bool {
@@ -161,53 +208,158 @@ auto EditorNodeGraphDraft::MatchesBase(const PipelineDocument& document) const -
   return true;
 }
 
-void EditorNodeGraphDraft::CaptureCheckpoint() {
-  checkpoint_.nodes                        = nodes_;
-  checkpoint_.edges                        = edges_;
-  checkpoint_.node_json                    = node_json_;
-  checkpoint_.node_index                   = node_index_;
-  checkpoint_.edge_index                   = edge_index_;
-  checkpoint_.outgoing                     = outgoing_;
-  checkpoint_.incoming                     = incoming_;
-  checkpoint_.inserted_json                = inserted_json_;
-  checkpoint_.removed_original_index       = removed_original_index_;
-  checkpoint_.removed_json                 = removed_json_;
-  checkpoint_.disconnected_original_index  = disconnected_original_index_;
-  checkpoint_.disconnected_edge            = disconnected_edge_;
-  checkpoint_.connected_edge               = connected_edge_;
-  checkpoint_.draft_next_name_number       = draft_next_name_number_;
-  has_checkpoint_                          = true;
+void EditorNodeGraphDraft::BeginReversal() {
+  reversal_                        = {};
+  reversal_.valid                  = true;
+  reversal_.prior_next_name_number = draft_next_name_number_;
+  reversal_.prior_submission_valid = submission_valid_;
+}
+
+void EditorNodeGraphDraft::InsertNodeAt(std::size_t index, EditorNodeProjection node) {
+  const auto id = node.node_id;
+  nodes_.insert(nodes_.begin() + static_cast<std::ptrdiff_t>(index), std::move(node));
+  ++work_stats_.node_entry_copies;
+  for (auto& [nid, idx] : node_index_) {
+    if (idx >= index) {
+      ++idx;
+      ++work_stats_.index_entry_updates;
+    }
+  }
+  node_index_[id] = index;
+  outgoing_[id]   = std::nullopt;
+  incoming_[id]   = std::nullopt;
+  work_stats_.index_entry_updates += 3;
+}
+
+void EditorNodeGraphDraft::EraseNodeAt(std::size_t index) {
+  const auto id = nodes_[index].node_id;
+  nodes_.erase(nodes_.begin() + static_cast<std::ptrdiff_t>(index));
+  node_index_.erase(id);
+  outgoing_.erase(id);
+  incoming_.erase(id);
+  for (auto& [nid, idx] : node_index_) {
+    if (idx > index) {
+      --idx;
+      ++work_stats_.index_entry_updates;
+    }
+  }
+}
+
+void EditorNodeGraphDraft::InsertEdge(EditorNodeEdgeProjection edge) {
+  InsertEdgeAt(edges_.size(), std::move(edge));
+}
+
+void EditorNodeGraphDraft::InsertEdgeAt(std::size_t index, EditorNodeEdgeProjection edge) {
+  const auto key = EdgeKey(edge);
+  outgoing_[edge.source_node_id]        = key;
+  incoming_[edge.destination_node_id]   = key;
+  work_stats_.index_entry_updates += 2;
+  ++work_stats_.edge_entry_copies;
+  edges_.insert(edges_.begin() + static_cast<std::ptrdiff_t>(index), std::move(edge));
+}
+
+auto EditorNodeGraphDraft::RemoveEdgeByKey(const std::string& key) -> EditorNodeEdgeProjection {
+  const auto index = FindEdgeIndex(key);
+  if (!index.has_value()) {
+    throw std::logic_error("Draft edge key is missing: " + key);
+  }
+  auto edge = edges_[*index];
+  outgoing_[edge.source_node_id]      = std::nullopt;
+  incoming_[edge.destination_node_id] = std::nullopt;
+  work_stats_.index_entry_updates += 2;
+  ++work_stats_.edge_entry_copies;
+  edges_.erase(edges_.begin() + static_cast<std::ptrdiff_t>(*index));
+  return edge;
+}
+
+void EditorNodeGraphDraft::DisconnectDraftKeys(const std::vector<std::string>& keys,
+                                               EditorNodeGraphDraftMutation*   mutation) {
+  struct Pending {
+    std::string key;
+    std::size_t index = 0;
+  };
+  std::vector<Pending> pending;
+  pending.reserve(keys.size());
+  for (const auto& key : keys) {
+    const auto index = FindEdgeIndex(key);
+    if (!index.has_value()) {
+      continue;
+    }
+    pending.push_back(Pending{key, *index});
+  }
+  std::sort(pending.begin(), pending.end(),
+            [](const Pending& lhs, const Pending& rhs) { return lhs.index > rhs.index; });
+  for (const auto& item : pending) {
+    auto edge = RemoveEdgeByKey(item.key);
+    if (mutation != nullptr) {
+      mutation->removed_edges.push_back(edge);
+    }
+    reversal_.removed_edge_indexes.push_back(item.index);
+    reversal_.removed_edges.push_back(edge);
+    Remember(&reversal_.prior_connected, connected_edge_, item.key);
+    Remember(&reversal_.prior_disconnected, disconnected_, item.key);
+    const auto connected = connected_edge_.find(item.key);
+    if (connected != connected_edge_.end()) {
+      connected_edge_.erase(connected);
+    } else if (base_edge_index_.contains(item.key)) {
+      disconnected_[item.key] =
+          DisconnectedEdgeDelta{base_edge_index_.at(item.key), ToSceneEdge(edge)};
+    }
+  }
 }
 
 void EditorNodeGraphDraft::RestoreLastMutation() {
-  if (!has_checkpoint_) {
+  if (!reversal_.valid) {
     return;
   }
-  nodes_                       = checkpoint_.nodes;
-  edges_                       = checkpoint_.edges;
-  node_json_                   = checkpoint_.node_json;
-  node_index_                  = checkpoint_.node_index;
-  edge_index_                  = checkpoint_.edge_index;
-  outgoing_                    = checkpoint_.outgoing;
-  incoming_                    = checkpoint_.incoming;
-  inserted_json_               = checkpoint_.inserted_json;
-  removed_original_index_      = checkpoint_.removed_original_index;
-  removed_json_                = checkpoint_.removed_json;
-  disconnected_original_index_ = checkpoint_.disconnected_original_index;
-  disconnected_edge_           = checkpoint_.disconnected_edge;
-  connected_edge_              = checkpoint_.connected_edge;
-  draft_next_name_number_      = checkpoint_.draft_next_name_number;
-  has_checkpoint_              = false;
+  for (auto it = reversal_.added_edge_keys.rbegin(); it != reversal_.added_edge_keys.rend(); ++it) {
+    (void)RemoveEdgeByKey(*it);
+  }
+  for (auto it = reversal_.added_node_ids.rbegin(); it != reversal_.added_node_ids.rend(); ++it) {
+    const auto index = node_index_.at(*it);
+    EraseNodeAt(index);
+  }
+
+  std::vector<std::size_t> node_order(reversal_.removed_node_indexes.size());
+  for (std::size_t i = 0; i < node_order.size(); ++i) {
+    node_order[i] = i;
+  }
+  std::sort(node_order.begin(), node_order.end(), [&](std::size_t lhs, std::size_t rhs) {
+    return reversal_.removed_node_indexes[lhs] < reversal_.removed_node_indexes[rhs];
+  });
+  for (const auto i : node_order) {
+    InsertNodeAt(reversal_.removed_node_indexes[i], reversal_.removed_nodes[i]);
+  }
+
+  std::vector<std::size_t> edge_order(reversal_.removed_edge_indexes.size());
+  for (std::size_t i = 0; i < edge_order.size(); ++i) {
+    edge_order[i] = i;
+  }
+  std::sort(edge_order.begin(), edge_order.end(), [&](std::size_t lhs, std::size_t rhs) {
+    return reversal_.removed_edge_indexes[lhs] < reversal_.removed_edge_indexes[rhs];
+  });
+  for (const auto i : edge_order) {
+    InsertEdgeAt(reversal_.removed_edge_indexes[i], reversal_.removed_edges[i]);
+  }
+
+  RestoreMap(&node_json_, reversal_.prior_node_json);
+  RestoreMap(&inserted_json_, reversal_.prior_inserted_json);
+  RestoreMap(&removed_, reversal_.prior_removed);
+  RestoreMap(&disconnected_, reversal_.prior_disconnected);
+  RestoreMap(&connected_edge_, reversal_.prior_connected);
+  draft_next_name_number_ = reversal_.prior_next_name_number;
+  submission_valid_       = reversal_.prior_submission_valid;
+  reversal_               = {};
 }
 
 auto EditorNodeGraphDraft::DeltaEmpty() const -> bool {
-  return inserted_json_.empty() && removed_json_.empty() && disconnected_edge_.empty() &&
+  return inserted_json_.empty() && removed_.empty() && disconnected_.empty() &&
          connected_edge_.empty() && draft_next_name_number_ == base_next_name_number_;
 }
 
 auto EditorNodeGraphDraft::WouldCreateCycle(const NodeId& source_id, const NodeId& destination_id,
-                                            const std::optional<std::size_t>& skip_outgoing,
-                                            const std::optional<std::size_t>& skip_incoming) const
+                                            const std::optional<std::string>& skip_outgoing,
+                                            const std::optional<std::string>& skip_incoming) const
     -> bool {
   std::unordered_set<std::string> visited;
   std::vector<NodeId>             stack{destination_id};
@@ -225,14 +377,18 @@ auto EditorNodeGraphDraft::WouldCreateCycle(const NodeId& source_id, const NodeI
     if (out == outgoing_.end() || !out->second.has_value()) {
       continue;
     }
-    const auto index = *out->second;
-    if (skip_outgoing.has_value() && index == *skip_outgoing) {
+    const auto& edge_key = *out->second;
+    if (skip_outgoing.has_value() && edge_key == *skip_outgoing) {
       continue;
     }
-    if (skip_incoming.has_value() && index == *skip_incoming) {
+    if (skip_incoming.has_value() && edge_key == *skip_incoming) {
       continue;
     }
-    stack.push_back(edges_[index].destination_node_id);
+    const auto* edge = FindEdgeByKey(edge_key);
+    if (edge == nullptr) {
+      continue;
+    }
+    stack.push_back(edge->destination_node_id);
   }
   return false;
 }
@@ -265,7 +421,8 @@ auto EditorNodeGraphDraft::AdmitConnect(const NodeId& source_id, const NodeId& d
   }
   if (destination->node_kind != EditorNodeKind::Drt &&
       destination->node_kind != EditorNodeKind::ColorGrade) {
-    return fail("Unsupported destination node type: " + std::string{destination->node_id.Value()});
+    return fail("Unsupported destination node type: " +
+                std::string{destination->node_id.Value()});
   }
   const auto skip_out = outgoing_.at(source_id);
   const auto skip_in  = incoming_.at(destination_id);
@@ -275,22 +432,11 @@ auto EditorNodeGraphDraft::AdmitConnect(const NodeId& source_id, const NodeId& d
   return true;
 }
 
-auto EditorNodeGraphDraft::RemoveEdgeAt(std::size_t index) -> EditorNodeEdgeProjection {
-  auto edge = edges_[index];
-  edges_.erase(edges_.begin() + static_cast<std::ptrdiff_t>(index));
-  RebuildIndexes();
-  return edge;
-}
-
-void EditorNodeGraphDraft::InsertEdge(EditorNodeEdgeProjection edge) {
-  edges_.push_back(std::move(edge));
-  RebuildIndexes();
-}
-
 auto EditorNodeGraphDraft::FinishMutation(EditorNodeGraphDraftMutation mutation)
     -> EditorNodeGraphDraftMutation {
   mutation.delta_empty      = DeltaEmpty();
-  mutation.submission_valid = SubmissionValid();
+  mutation.submission_valid = ComputeSubmissionValid();
+  submission_valid_         = mutation.submission_valid;
   mutation.succeeded        = true;
   return mutation;
 }
@@ -301,16 +447,19 @@ auto EditorNodeGraphDraft::AddColorGrade(NodeId node_id) -> EditorNodeGraphDraft
     result.error = "A Color Grade with that identity already exists";
     return result;
   }
-  CaptureCheckpoint();
+  BeginReversal();
   auto model = CreateCleanColorGradeNode(node_id);
   model->SetDisplayName(DefaultColorGradeDisplayName(draft_next_name_number_));
   auto json      = model->ToJson();
-  auto projected = ProjectNode(*model);
-  nodes_.push_back(projected);
-  node_json_[node_id]      = json;
-  inserted_json_[node_id]  = json;
+  auto projected = EditorNodeGraphProjection::ProjectNode(*model);
+  Remember(&reversal_.prior_node_json, node_json_, node_id);
+  Remember(&reversal_.prior_inserted_json, inserted_json_, node_id);
+  reversal_.added_node_ids.push_back(node_id);
+  InsertNodeAt(nodes_.size(), projected);
+  node_json_[node_id]     = json;
+  inserted_json_[node_id] = json;
+  work_stats_.json_entry_copies += 2;
   ++draft_next_name_number_;
-  RebuildIndexes();
   result.inserted_nodes.push_back(std::move(projected));
   return FinishMutation(std::move(result));
 }
@@ -318,7 +467,7 @@ auto EditorNodeGraphDraft::AddColorGrade(NodeId node_id) -> EditorNodeGraphDraft
 auto EditorNodeGraphDraft::RemoveColorGrade(const NodeId& node_id)
     -> EditorNodeGraphDraftMutation {
   EditorNodeGraphDraftMutation result;
-  const auto* node = FindNode(node_id);
+  const auto*                  node = FindNode(node_id);
   if (node == nullptr) {
     result.error = "That node is not in the current graph";
     return result;
@@ -327,59 +476,38 @@ auto EditorNodeGraphDraft::RemoveColorGrade(const NodeId& node_id)
     result.error = "Only a Color Grade can be deleted";
     return result;
   }
-  CaptureCheckpoint();
-  const auto out = outgoing_[node_id];
-  const auto in  = incoming_[node_id];
-  std::vector<std::size_t> remove_indexes;
+  BeginReversal();
+  const auto out = outgoing_.at(node_id);
+  const auto in  = incoming_.at(node_id);
+  std::vector<std::string> remove_keys;
   if (out.has_value()) {
-    remove_indexes.push_back(*out);
+    remove_keys.push_back(*out);
   }
   if (in.has_value() && (!out.has_value() || *in != *out)) {
-    remove_indexes.push_back(*in);
+    remove_keys.push_back(*in);
   }
-  std::sort(remove_indexes.begin(), remove_indexes.end(), std::greater<>());
-  for (const auto index : remove_indexes) {
-    const auto edge = RemoveEdgeAt(index);
-    result.removed_edges.push_back(edge);
-    const auto key = EdgeKey(edge);
-    const auto connected = connected_edge_.find(key);
-    if (connected != connected_edge_.end()) {
-      connected_edge_.erase(connected);
-    } else if (base_edge_index_.contains(key)) {
-      disconnected_original_index_[key] = base_edge_index_.at(key);
-      disconnected_edge_[key]           = ToSceneEdge(edge);
-    }
-  }
+  DisconnectDraftKeys(remove_keys, &result);
 
   const auto node_pos = node_index_.at(node_id);
   const auto json     = node_json_.at(node_id);
-  nodes_.erase(nodes_.begin() + static_cast<std::ptrdiff_t>(node_pos));
+  reversal_.removed_node_indexes.push_back(node_pos);
+  reversal_.removed_nodes.push_back(*node);
+  Remember(&reversal_.prior_node_json, node_json_, node_id);
+  Remember(&reversal_.prior_inserted_json, inserted_json_, node_id);
+  Remember(&reversal_.prior_removed, removed_, node_id);
+  EraseNodeAt(node_pos);
   node_json_.erase(node_id);
   result.removed_node_ids.push_back(node_id);
   const auto inserted = inserted_json_.find(node_id);
   if (inserted != inserted_json_.end()) {
     inserted_json_.erase(inserted);
-    std::uint64_t max_inserted = base_next_name_number_;
-    for (const auto& [id, stored] : inserted_json_) {
-      (void)id;
-      if (stored.contains("display_name") && stored.at("display_name").is_string()) {
-        const auto name = stored.at("display_name").get<std::string>();
-        const auto prefix = std::string{"Color Grade "};
-        if (name.rfind(prefix, 0) == 0) {
-          try {
-            const auto number = std::stoull(name.substr(prefix.size()));
-            max_inserted      = std::max(max_inserted, number + 1);
-          } catch (...) {
-          }
-        }
-      }
-    }
-    draft_next_name_number_ = inserted_json_.empty() ? base_next_name_number_ : max_inserted;
+    draft_next_name_number_ =
+        inserted_json_.empty() ? base_next_name_number_
+                               : MaxInsertedNameNumber(inserted_json_, base_next_name_number_);
   } else {
-    removed_original_index_[node_id] = base_node_index_.at(node_id);
-    removed_json_[node_id]           = json;
+    removed_[node_id] = RemovedNodeDelta{base_node_index_.at(node_id), json};
+    ++work_stats_.json_entry_copies;
   }
-  RebuildIndexes();
   return FinishMutation(std::move(result));
 }
 
@@ -394,55 +522,49 @@ auto EditorNodeGraphDraft::Connect(const NodeId& source_id, const NodeId& destin
   const auto skip_out = outgoing_.at(source_id);
   const auto skip_in  = incoming_.at(destination_id);
   EditorNodeEdgeProjection proposed{source_id, ImagePort(), destination_id, ImagePort()};
-  if (skip_out.has_value() && edges_[*skip_out].destination_node_id == destination_id &&
-      edges_[*skip_out].source_node_id == source_id) {
-    result.no_op      = true;
-    result.succeeded  = true;
-    result.delta_empty = DeltaEmpty();
-    result.submission_valid = SubmissionValid();
-    return result;
-  }
-
-  CaptureCheckpoint();
-  std::vector<std::size_t> remove_indexes;
   if (skip_out.has_value()) {
-    remove_indexes.push_back(*skip_out);
-  }
-  if (skip_in.has_value() && (!skip_out.has_value() || *skip_in != *skip_out)) {
-    remove_indexes.push_back(*skip_in);
-  }
-  std::sort(remove_indexes.begin(), remove_indexes.end(), std::greater<>());
-  for (const auto index : remove_indexes) {
-    const auto edge = RemoveEdgeAt(index);
-    result.removed_edges.push_back(edge);
-    const auto key = EdgeKey(edge);
-    const auto connected = connected_edge_.find(key);
-    if (connected != connected_edge_.end()) {
-      connected_edge_.erase(connected);
-    } else if (base_edge_index_.contains(key)) {
-      disconnected_original_index_[key] = base_edge_index_.at(key);
-      disconnected_edge_[key]           = ToSceneEdge(edge);
+    const auto* current = FindEdgeByKey(*skip_out);
+    if (current != nullptr && current->destination_node_id == destination_id &&
+        current->source_node_id == source_id) {
+      result.no_op            = true;
+      result.succeeded        = true;
+      result.delta_empty      = DeltaEmpty();
+      result.submission_valid = submission_valid_;
+      return result;
     }
   }
 
+  BeginReversal();
+  std::vector<std::string> remove_keys;
+  if (skip_out.has_value()) {
+    remove_keys.push_back(*skip_out);
+  }
+  if (skip_in.has_value() && (!skip_out.has_value() || *skip_in != *skip_out)) {
+    remove_keys.push_back(*skip_in);
+  }
+  DisconnectDraftKeys(remove_keys, &result);
+
   const auto key = EdgeKey(proposed);
+  Remember(&reversal_.prior_connected, connected_edge_, key);
+  Remember(&reversal_.prior_disconnected, disconnected_, key);
   InsertEdge(proposed);
+  reversal_.added_edge_keys.push_back(key);
   result.inserted_edges.push_back(proposed);
-  const auto disconnected = disconnected_edge_.find(key);
-  if (disconnected != disconnected_edge_.end()) {
-    disconnected_edge_.erase(disconnected);
-    disconnected_original_index_.erase(key);
+  const auto disconnected = disconnected_.find(key);
+  if (disconnected != disconnected_.end()) {
+    disconnected_.erase(disconnected);
   } else {
     connected_edge_[key] = ToSceneEdge(proposed);
   }
   return FinishMutation(std::move(result));
 }
 
-auto EditorNodeGraphDraft::SubmissionValid() const -> bool {
-  int develop_count = 0;
-  int drt_count     = 0;
-  const EditorNodeProjection* develop = nullptr;
-  const EditorNodeProjection* drt     = nullptr;
+auto EditorNodeGraphDraft::ComputeSubmissionValid() -> bool {
+  ++work_stats_.validity_traversals;
+  int                             develop_count = 0;
+  int                             drt_count     = 0;
+  const EditorNodeProjection*     develop       = nullptr;
+  const EditorNodeProjection*     drt           = nullptr;
   for (const auto& node : nodes_) {
     if (node.node_kind == EditorNodeKind::Develop) {
       ++develop_count;
@@ -488,7 +610,11 @@ auto EditorNodeGraphDraft::SubmissionValid() const -> bool {
     if (out == outgoing_.end() || !out->second.has_value()) {
       return false;
     }
-    current = edges_[*out->second].destination_node_id;
+    const auto* edge = FindEdgeByKey(*out->second);
+    if (edge == nullptr) {
+      return false;
+    }
+    current = edge->destination_node_id;
   }
   if (!on_path.contains(std::string{drt->node_id.Value()})) {
     return false;
@@ -512,28 +638,36 @@ auto EditorNodeGraphDraft::MakeChange() const -> NodeGraphTopologyChange {
   NodeGraphTopologyChange change;
   change.before_next_color_grade_name_number = base_next_name_number_;
   change.after_next_color_grade_name_number  = draft_next_name_number_;
+  std::map<NodeId, std::uint32_t> node_order;
+  for (std::size_t index = 0; index < nodes_.size(); ++index) {
+    node_order[nodes_[index].node_id] = static_cast<std::uint32_t>(index);
+  }
+  std::map<std::string, std::uint32_t> edge_order;
+  for (std::size_t index = 0; index < edges_.size(); ++index) {
+    edge_order[EdgeKey(edges_[index])] = static_cast<std::uint32_t>(index);
+  }
   for (const auto& [id, json] : inserted_json_) {
     NodeGraphInsertedNode item;
-    item.node              = json;
-    item.final_node_index  = static_cast<std::uint32_t>(node_index_.at(id));
+    item.node             = json;
+    item.final_node_index = node_order.at(id);
     change.inserted_nodes.push_back(std::move(item));
   }
-  for (const auto& [id, json] : removed_json_) {
+  for (const auto& [id, record] : removed_) {
     NodeGraphRemovedNode item;
-    item.node                 = json;
-    item.original_node_index  = static_cast<std::uint32_t>(removed_original_index_.at(id));
+    item.node                = record.json;
+    item.original_node_index = static_cast<std::uint32_t>(record.original_index);
     change.removed_nodes.push_back(std::move(item));
   }
-  for (const auto& [key, edge] : disconnected_edge_) {
+  for (const auto& [key, record] : disconnected_) {
     NodeGraphDisconnectedEdge item;
-    item.edge                 = edge;
-    item.original_edge_index  = static_cast<std::uint32_t>(disconnected_original_index_.at(key));
+    item.edge                = record.edge;
+    item.original_edge_index = static_cast<std::uint32_t>(record.original_index);
     change.disconnected_edges.push_back(std::move(item));
   }
   for (const auto& [key, edge] : connected_edge_) {
     NodeGraphConnectedEdge item;
     item.edge             = edge;
-    item.final_edge_index = static_cast<std::uint32_t>(edge_index_.at(key));
+    item.final_edge_index = edge_order.at(key);
     change.connected_edges.push_back(std::move(item));
   }
   return change;

--- a/alcedo_studio/src/app/editor_node_graph_projection.cpp
+++ b/alcedo_studio/src/app/editor_node_graph_projection.cpp
@@ -15,7 +15,13 @@
 namespace alcedo {
 namespace {
 
-auto NodeKindOf(const INodeModel& node) -> EditorNodeKind {
+auto ContainsNode(const std::vector<NodeId>& ids, const NodeId& id) -> bool {
+  return std::find(ids.begin(), ids.end(), id) != ids.end();
+}
+
+}  // namespace
+
+auto EditorNodeGraphProjection::KindOf(const INodeModel& node) -> EditorNodeKind {
   if (node.Type() == type_ids::DevelopNode()) {
     return EditorNodeKind::Develop;
   }
@@ -25,14 +31,28 @@ auto NodeKindOf(const INodeModel& node) -> EditorNodeKind {
   if (node.Type() == type_ids::DrtNode()) {
     return EditorNodeKind::Drt;
   }
-  throw std::invalid_argument("EditorNodeGraphProjection encountered an unsupported node type");
+  throw std::invalid_argument("Unsupported Nodes-page node type: " +
+                              std::string{node.Type().Text()});
 }
 
-auto ContainsNode(const std::vector<NodeId>& ids, const NodeId& id) -> bool {
-  return std::find(ids.begin(), ids.end(), id) != ids.end();
+auto EditorNodeGraphProjection::ProjectNode(const INodeModel& node) -> EditorNodeProjection {
+  EditorNodeProjection projected;
+  projected.node_id      = node.Id();
+  projected.node_kind    = KindOf(node);
+  projected.display_name = std::string{node.DisplayName()};
+  if (projected.node_kind != EditorNodeKind::ColorGrade) {
+    return projected;
+  }
+  const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(&node);
+  if (grade == nullptr) {
+    throw std::invalid_argument("Color Grade type has an invalid model");
+  }
+  projected.masks.reserve(grade->MaskCount());
+  for (const auto& mask : grade->Masks()) {
+    projected.masks.push_back({mask.id, GetMaskSourceKind(mask.source)});
+  }
+  return projected;
 }
-
-}  // namespace
 
 auto EditorNodeGraphProjection::Build(const PipelineDocument& document,
                                       std::uint64_t           session_generation,
@@ -56,23 +76,7 @@ auto EditorNodeGraphProjection::Build(const PipelineDocument& document,
           "EditorNodeGraphProjection image backbone contains an unknown node");
     }
 
-    EditorNodeProjection projected;
-    projected.node_id      = node->Id();
-    projected.node_kind    = NodeKindOf(*node);
-    projected.display_name = std::string{node->DisplayName()};
-
-    if (projected.node_kind == EditorNodeKind::ColorGrade) {
-      const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(node);
-      if (grade == nullptr) {
-        throw std::invalid_argument(
-            "EditorNodeGraphProjection Color Grade type has an invalid model");
-      }
-      projected.masks.reserve(grade->MaskCount());
-      for (const auto& mask : grade->Masks()) {
-        projected.masks.push_back({mask.id, GetMaskSourceKind(mask.source)});
-      }
-    }
-    snapshot.nodes.push_back(std::move(projected));
+    snapshot.nodes.push_back(ProjectNode(*node));
   }
 
   snapshot.edges.reserve(document.Graph().Edges().size());

--- a/alcedo_studio/src/include/app/editor_node_graph_draft.hpp
+++ b/alcedo_studio/src/include/app/editor_node_graph_draft.hpp
@@ -19,22 +19,22 @@ namespace alcedo {
 
 /// Bound product identity copied when a node-graph draft is created.
 struct EditorNodeGraphDraftIdentity {
-  std::uint64_t element_id           = 0;
-  std::uint64_t image_id             = 0;
+  std::uint64_t element_id          = 0;
+  std::uint64_t image_id            = 0;
   std::string   version_id;
-  std::uint64_t session_generation   = 0;
-  std::uint64_t projection_revision  = 0;
-  std::uint64_t topology_revision    = 0;
+  std::uint64_t session_generation  = 0;
+  std::uint64_t projection_revision = 0;
+  std::uint64_t topology_revision   = 0;
 
   auto operator==(const EditorNodeGraphDraftIdentity&) const -> bool = default;
 };
 
 /// Incremental Qan operations produced by one admitted draft mutation.
 struct EditorNodeGraphDraftMutation {
-  bool                                  succeeded         = false;
-  bool                                  no_op             = false;
-  bool                                  submission_valid  = false;
-  bool                                  delta_empty       = false;
+  bool                                  succeeded        = false;
+  bool                                  no_op            = false;
+  bool                                  submission_valid = false;
+  bool                                  delta_empty      = false;
   std::string                           error;
   std::vector<EditorNodeProjection>     inserted_nodes;
   std::vector<NodeId>                   removed_node_ids;
@@ -43,11 +43,29 @@ struct EditorNodeGraphDraftMutation {
 };
 
 /**
+ * @brief Copy and index work recorded by one draft object.
+ *
+ * Tests reset these counters after construction. Validity traversal is counted
+ * separately from mutation copies. A whole-draft checkpoint copies every node,
+ * edge, JSON map, index, and net-delta map in one step.
+ */
+struct EditorNodeGraphDraftWorkStats {
+  int complete_state_copies   = 0;
+  int complete_index_rebuilds = 0;
+  int node_entry_copies       = 0;
+  int edge_entry_copies       = 0;
+  int json_entry_copies       = 0;
+  int index_entry_updates     = 0;
+  int validity_traversals     = 0;
+};
+
+/**
  * @brief Incremental Nodes-page topology draft. Not product data and not a render input.
  *
  * Construction copies the live document once. Later Add, Delete, and Connect
- * mutate this object in place. A rejected operation restores the exact prior
- * values, indexes, and accumulated delta.
+ * mutate this object in place. A rejected operation leaves values, indexes,
+ * cached submission validity, and the accumulated delta unchanged. An admitted
+ * operation stores a bounded reversal record of affected entries only.
  *
  * Threading: GUI thread only. Ownership: value type, no QObject or Qan pointers.
  */
@@ -91,21 +109,33 @@ class EditorNodeGraphDraft {
 
   /**
    * @brief Restore the exact state captured before the last admitted mutation.
+   *
+   * No-op when HasLastMutation is false. After restore there is no further
+   * reversal until another mutation is admitted.
    */
   void RestoreLastMutation();
 
-  [[nodiscard]] auto HasLastMutation() const -> bool { return has_checkpoint_; }
+  [[nodiscard]] auto HasLastMutation() const -> bool { return reversal_.valid; }
   [[nodiscard]] auto DeltaEmpty() const -> bool;
-  [[nodiscard]] auto SubmissionValid() const -> bool;
+  /**
+   * @brief Cached result of the last admitted mutation or construction.
+   *
+   * Does not walk the graph. Invalid requests leave this value unchanged.
+   */
+  [[nodiscard]] auto SubmissionValid() const -> bool { return submission_valid_; }
   [[nodiscard]] auto NextColorGradeNameNumber() const -> std::uint64_t {
     return draft_next_name_number_;
   }
   [[nodiscard]] auto BaseNextColorGradeNameNumber() const -> std::uint64_t {
     return base_next_name_number_;
   }
+  [[nodiscard]] auto work_stats() const -> EditorNodeGraphDraftWorkStats { return work_stats_; }
+  void               ResetWorkStats() { work_stats_ = {}; }
 
   /**
    * @brief Build the stored net delta from current indexes. Empty when DeltaEmpty.
+   *
+   * Materializes ordered serialized node and edge indexes with a full traversal.
    */
   [[nodiscard]] auto MakeChange() const -> NodeGraphTopologyChange;
 
@@ -116,6 +146,9 @@ class EditorNodeGraphDraft {
 
   /**
    * @brief Value snapshot of the current draft graph, including detached nodes.
+   *
+   * Copies the live node and edge vectors. Call only at an explicit projection
+   * boundary such as page recreation.
    */
   [[nodiscard]] auto CurrentSnapshot(std::uint64_t session_generation,
                                      std::uint64_t projection_revision,
@@ -123,67 +156,87 @@ class EditorNodeGraphDraft {
       -> EditorNodeGraphSnapshot;
 
  private:
-  struct EdgeRecord {
-    EditorNodeEdgeProjection edge;
+  struct RemovedNodeDelta {
+    std::size_t    original_index = 0;
+    nlohmann::json json;
   };
 
-  struct Checkpoint {
-    std::vector<EditorNodeProjection>     nodes;
-    std::vector<EditorNodeEdgeProjection> edges;
-    std::map<NodeId, nlohmann::json>      node_json;
-    std::map<NodeId, std::size_t>         node_index;
-    std::map<std::string, std::size_t>    edge_index;
-    std::map<NodeId, std::optional<std::size_t>> outgoing;
-    std::map<NodeId, std::optional<std::size_t>> incoming;
-    std::map<NodeId, nlohmann::json>      inserted_json;
-    std::map<NodeId, std::size_t>         removed_original_index;
-    std::map<NodeId, nlohmann::json>      removed_json;
-    std::map<std::string, std::size_t>    disconnected_original_index;
-    std::map<std::string, PipelineSceneEdge> disconnected_edge;
-    std::map<std::string, PipelineSceneEdge> connected_edge;
-    std::uint64_t                         draft_next_name_number = 0;
+  struct DisconnectedEdgeDelta {
+    std::size_t        original_index = 0;
+    PipelineSceneEdge  edge;
   };
 
-  void CaptureCheckpoint();
+  struct ReversalRecord {
+    bool            valid = false;
+    std::uint64_t   prior_next_name_number = 0;
+    bool            prior_submission_valid = false;
+
+    std::vector<NodeId>                   added_node_ids;
+    std::vector<std::string>              added_edge_keys;
+    std::vector<std::size_t>              removed_node_indexes;
+    std::vector<EditorNodeProjection>     removed_nodes;
+    std::vector<std::size_t>              removed_edge_indexes;
+    std::vector<EditorNodeEdgeProjection> removed_edges;
+
+    std::map<NodeId, std::optional<nlohmann::json>>      prior_node_json;
+    std::map<NodeId, std::optional<nlohmann::json>>      prior_inserted_json;
+    std::map<NodeId, std::optional<RemovedNodeDelta>>    prior_removed;
+    std::map<std::string, std::optional<DisconnectedEdgeDelta>> prior_disconnected;
+    std::map<std::string, std::optional<PipelineSceneEdge>>    prior_connected;
+  };
+
+  void BeginReversal();
   void RebuildIndexes();
   auto AdmitConnect(const NodeId& source_id, const NodeId& destination_id, std::string* error) const
       -> bool;
   auto WouldCreateCycle(const NodeId& source_id, const NodeId& destination_id,
-                        const std::optional<std::size_t>& skip_outgoing,
-                        const std::optional<std::size_t>& skip_incoming) const -> bool;
-  auto RemoveEdgeAt(std::size_t index) -> EditorNodeEdgeProjection;
+                        const std::optional<std::string>& skip_outgoing,
+                        const std::optional<std::string>& skip_incoming) const -> bool;
+  auto RemoveEdgeByKey(const std::string& key) -> EditorNodeEdgeProjection;
   void InsertEdge(EditorNodeEdgeProjection edge);
+  void InsertEdgeAt(std::size_t index, EditorNodeEdgeProjection edge);
+  void InsertNodeAt(std::size_t index, EditorNodeProjection node);
+  void EraseNodeAt(std::size_t index);
+  void DisconnectDraftKeys(const std::vector<std::string>& keys,
+                           EditorNodeGraphDraftMutation*   mutation);
   auto FinishMutation(EditorNodeGraphDraftMutation mutation) -> EditorNodeGraphDraftMutation;
+  [[nodiscard]] auto ComputeSubmissionValid() -> bool;
+  [[nodiscard]] auto FindEdgeByKey(const std::string& key) const -> const EditorNodeEdgeProjection*;
+  [[nodiscard]] auto FindEdgeIndex(const std::string& key) const -> std::optional<std::size_t>;
+
+  template <class Map, class Key>
+  void Remember(std::map<Key, std::optional<typename Map::mapped_type>>* prior, const Map& current,
+                const Key& key);
+  template <class Map, class Key>
+  static void RestoreMap(Map* current,
+                         const std::map<Key, std::optional<typename Map::mapped_type>>& prior);
+
   [[nodiscard]] static auto ImagePort() -> PortId;
   [[nodiscard]] static auto EdgeKey(const EditorNodeEdgeProjection& edge) -> std::string;
   [[nodiscard]] static auto EdgeKey(const PipelineSceneEdge& edge) -> std::string;
   [[nodiscard]] static auto ToSceneEdge(const EditorNodeEdgeProjection& edge) -> PipelineSceneEdge;
   [[nodiscard]] static auto ToProjection(const PipelineSceneEdge& edge) -> EditorNodeEdgeProjection;
-  [[nodiscard]] static auto KindOf(const INodeModel& node) -> EditorNodeKind;
-  [[nodiscard]] auto        ProjectNode(const INodeModel& node) const -> EditorNodeProjection;
 
   EditorNodeGraphDraftIdentity          identity_{};
   std::vector<EditorNodeProjection>     nodes_;
   std::vector<EditorNodeEdgeProjection> edges_;
   std::map<NodeId, nlohmann::json>      node_json_;
   std::map<NodeId, std::size_t>         node_index_;
-  std::map<std::string, std::size_t>    edge_index_;
-  std::map<NodeId, std::optional<std::size_t>> outgoing_;
-  std::map<NodeId, std::optional<std::size_t>> incoming_;
+  std::map<NodeId, std::optional<std::string>> outgoing_;
+  std::map<NodeId, std::optional<std::string>> incoming_;
   std::map<NodeId, std::size_t>         base_node_index_;
   std::map<std::string, std::size_t>    base_edge_index_;
   std::map<NodeId, nlohmann::json>      base_node_json_;
   std::vector<PipelineSceneEdge>        base_edges_;
   std::map<NodeId, nlohmann::json>      inserted_json_;
-  std::map<NodeId, std::size_t>         removed_original_index_;
-  std::map<NodeId, nlohmann::json>      removed_json_;
-  std::map<std::string, std::size_t>    disconnected_original_index_;
-  std::map<std::string, PipelineSceneEdge> disconnected_edge_;
-  std::map<std::string, PipelineSceneEdge> connected_edge_;
+  std::map<NodeId, RemovedNodeDelta>    removed_;
+  std::map<std::string, DisconnectedEdgeDelta> disconnected_;
+  std::map<std::string, PipelineSceneEdge>     connected_edge_;
   std::uint64_t                         base_next_name_number_  = kInitialNextColorGradeNameNumber;
   std::uint64_t                         draft_next_name_number_ = kInitialNextColorGradeNameNumber;
-  Checkpoint                            checkpoint_{};
-  bool                                  has_checkpoint_ = false;
+  bool                                  submission_valid_       = false;
+  ReversalRecord                        reversal_{};
+  EditorNodeGraphDraftWorkStats         work_stats_{};
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_node_graph_projection.hpp
+++ b/alcedo_studio/src/include/app/editor_node_graph_projection.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "edit/graph/graph_ids.hpp"
+#include "edit/graph/i_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/mask/mask_model.hpp"
 
@@ -83,6 +84,24 @@ struct EditorNodeGraphSnapshot {
  */
 class EditorNodeGraphProjection {
  public:
+  /**
+   * @brief Map a live node model to Develop, Color Grade, or DRT/Post.
+   * @throws std::invalid_argument when @p node is not a supported Nodes-page type.
+   */
+  [[nodiscard]] static auto KindOf(const INodeModel& node) -> EditorNodeKind;
+
+  /**
+   * @brief Copy node identity, kind, display name, and Mask rows in stored order.
+   *
+   * Mask rows keep document display order. Parameter values, enabled state, mix,
+   * and Mask presentation metadata are omitted. Detached Color Grades are valid
+   * inputs; callers choose backbone-only or full-graph traversal.
+   *
+   * @throws std::invalid_argument when @p node is an unsupported type or a Color
+   *         Grade whose model cannot be read.
+   */
+  [[nodiscard]] static auto ProjectNode(const INodeModel& node) -> EditorNodeProjection;
+
   /**
    * @param document Valid PipelineDocument whose image backbone is projected.
    * @param session_generation Session value copied into the snapshot.

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -17,11 +17,11 @@
 #include "app/editor_node_graph_projection.hpp"
 #include "edit/graph/graph_ids.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "ui/alcedo_main/album_backend/editor_node_layout_store.hpp"
 
 namespace alcedo::ui {
 
 class AlcedoQanGraph;
-class EditorNodeLayoutStore;
 class EditorSessionController;
 
 /**
@@ -108,9 +108,15 @@ class EditorNodeController : public QObject {
   Q_INVOKABLE bool   refreshFromSession();
 
   /**
-   * @brief Project the current snapshot onto an AlcedoQanGraph adapter.
+   * @brief Project the active graph onto an AlcedoQanGraph adapter.
+   *
+   * Uses the committed snapshot, or materializes a draft snapshot at this
+   * explicit projection boundary (page recreation). Does not apply selection;
+   * ApplyBoundGraph applies layout and live selection after a successful
+   * projection.
+   *
    * @param adapter AlcedoQanGraph instance. Rejects null, wrong types, and a
-   *        missing snapshot. On success, applies the one-node product selection.
+   *        missing snapshot.
    * @return false when ApplySnapshot fails; lastError holds the adapter error.
    */
   Q_INVOKABLE bool   applyToGraph(QObject* adapter);
@@ -178,6 +184,27 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto incomplete_draft_instruction() const -> QString;
   [[nodiscard]] auto selected_node_name() const -> QString;
   [[nodiscard]] auto snapshot() const -> const EditorNodeGraphSnapshot& { return snapshot_; }
+  /**
+   * @brief Nodes and edges currently shown on the page.
+   *
+   * Reads the incremental draft while it exists; otherwise the committed
+   * snapshot. Does not copy the draft into snapshot_.
+   */
+  [[nodiscard]] auto ActiveNodes() const -> const std::vector<EditorNodeProjection>&;
+  [[nodiscard]] auto ActiveEdges() const -> const std::vector<EditorNodeEdgeProjection>&;
+  /// Queued ApplyBoundGraph requests, including coalesced repeats.
+  [[nodiscard]] auto queued_projection_apply_count() const -> int {
+    return queued_projection_apply_count_;
+  }
+  /// Successful adapter projection applies. Duplicate applies of the same
+  /// committed revision are not counted.
+  [[nodiscard]] auto completed_projection_apply_count() const -> int {
+    return completed_projection_apply_count_;
+  }
+  /// Queued applies dropped because the adapter, generation, or attach identity was stale.
+  [[nodiscard]] auto skipped_stale_projection_apply_count() const -> int {
+    return skipped_stale_projection_apply_count_;
+  }
 
   /**
    * @brief Bind the live Qan adapter owned by the open Nodes page.
@@ -228,7 +255,6 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto CurrentDraftIdentity() const -> alcedo::EditorNodeGraphDraftIdentity;
   [[nodiscard]] auto EnsureDraft() -> bool;
   void               DiscardDraft();
-  void               SyncSnapshotFromDraft();
   [[nodiscard]] auto ApplyMutationToGraph(const alcedo::EditorNodeGraphDraftMutation& mutation)
       -> bool;
   [[nodiscard]] auto MaybeSubmitDraft() -> bool;
@@ -236,10 +262,26 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto BoundSessionGeneration() const -> std::optional<std::uint64_t>;
   void               SelectByKind(EditorNodeKind kind);
   void               SelectAt(int index);
+  /**
+   * @brief Apply the committed or draft projection, then layout and live selection.
+   *
+   * Activates the layout key before reading stored positions and drawers. QML
+   * restores GraphView zoom and pan. Ordinary draft edits must not call this;
+   * they use incremental adapter mutation.
+   */
   void               ApplyBoundGraph();
   /// Apply the bound Qan adapter after the current GUI event so Add/Delete are
   /// not nested inside a GraphView key or menu handler.
   void               QueueProjectionApply();
+  void               ApplyBoundGraphIfCurrent();
+  void               SyncLayoutKey();
+  void               PersistSavedSelection();
+  void               ApplyLiveSelectionToAdapter();
+  [[nodiscard]] auto SessionMatchesSubmittedIdentity() const -> bool;
+  [[nodiscard]] auto SessionIdentityChanged() const -> bool;
+  [[nodiscard]] auto AdapterShowsCurrentCommittedProjection() const -> bool;
+  void               AdoptCommittedDocument(const PipelineDocument& document);
+  [[nodiscard]] auto HasActiveGraph() const -> bool;
 
   QPointer<EditorSessionController> session_;
   QPointer<AlcedoQanGraph>          graph_adapter_;
@@ -262,7 +304,13 @@ class EditorNodeController : public QObject {
   QString                           version_id_;
   QString                           last_error_;
   std::unique_ptr<alcedo::EditorNodeGraphDraft> draft_;
-  bool                              skip_next_session_refresh_ = false;
+  std::optional<alcedo::EditorNodeGraphDraftIdentity> submitted_identity_;
+  EditorNodeLayoutKey                   last_layout_key_{};
+  quint64                           adapter_attach_generation_          = 0;
+  quint64                           pending_apply_attach_generation_    = 0;
+  int                               queued_projection_apply_count_      = 0;
+  int                               completed_projection_apply_count_   = 0;
+  int                               skipped_stale_projection_apply_count_ = 0;
 };
 
 void RegisterEditorNodeQmlTypes();

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -96,9 +96,17 @@ void EditorNodeController::set_editor_session(QObject* session) {
 
 void EditorNodeController::SetLayoutIdentity(quint64 element_id, quint64 image_id,
                                              QString version_id) {
+  const bool identity_changed =
+      element_id_ != element_id || image_id_ != image_id || version_id_ != version_id;
   element_id_ = element_id;
   image_id_   = image_id;
   version_id_ = std::move(version_id);
+  if (identity_changed) {
+    SyncLayoutKey();
+    if (has_snapshot_) {
+      RestoreSelectionAfterSnapshot();
+    }
+  }
   emit SnapshotChanged();
 }
 
@@ -131,41 +139,52 @@ void EditorNodeController::ClearSnapshot() {
   emit ActionAvailabilityChanged();
 }
 
+auto EditorNodeController::HasActiveGraph() const -> bool {
+  return draft_ != nullptr || has_snapshot_;
+}
+
+auto EditorNodeController::ActiveNodes() const -> const std::vector<EditorNodeProjection>& {
+  if (draft_ != nullptr) {
+    return draft_->Nodes();
+  }
+  return snapshot_.nodes;
+}
+
+auto EditorNodeController::ActiveEdges() const -> const std::vector<EditorNodeEdgeProjection>& {
+  if (draft_ != nullptr) {
+    return draft_->Edges();
+  }
+  return snapshot_.edges;
+}
+
 auto EditorNodeController::ContainsNode(const NodeId& node_id) const -> bool {
-  if (!has_snapshot_ || node_id.Empty()) {
-    return false;
-  }
-  for (const auto& node : snapshot_.nodes) {
-    if (node.node_id == node_id) {
-      return true;
-    }
-  }
-  return false;
+  return NodeFor(node_id) != nullptr;
 }
 
 auto EditorNodeController::DefaultSelectedNodeId() const -> NodeId {
-  if (!has_snapshot_) {
+  if (!HasActiveGraph()) {
     return {};
   }
-  for (const auto& node : snapshot_.nodes) {
+  for (const auto& node : ActiveNodes()) {
     if (node.node_kind == EditorNodeKind::ColorGrade) {
       return node.node_id;
     }
   }
-  for (const auto& node : snapshot_.nodes) {
+  for (const auto& node : ActiveNodes()) {
     if (node.node_kind == EditorNodeKind::Drt) {
       return node.node_id;
     }
   }
-  return snapshot_.nodes.front().node_id;
+  return ActiveNodes().empty() ? NodeId{} : ActiveNodes().front().node_id;
 }
 
 auto EditorNodeController::IndexOf(const NodeId& node_id) const -> int {
-  if (!has_snapshot_) {
+  if (!HasActiveGraph()) {
     return -1;
   }
-  for (int i = 0; i < static_cast<int>(snapshot_.nodes.size()); ++i) {
-    if (snapshot_.nodes[static_cast<std::size_t>(i)].node_id == node_id) {
+  const auto& nodes = ActiveNodes();
+  for (int i = 0; i < static_cast<int>(nodes.size()); ++i) {
+    if (nodes[static_cast<std::size_t>(i)].node_id == node_id) {
       return i;
     }
   }
@@ -173,8 +192,11 @@ auto EditorNodeController::IndexOf(const NodeId& node_id) const -> int {
 }
 
 auto EditorNodeController::NodeFor(const NodeId& node_id) const -> const EditorNodeProjection* {
-  if (!has_snapshot_) {
+  if (node_id.Empty() || !HasActiveGraph()) {
     return nullptr;
+  }
+  if (draft_ != nullptr) {
+    return draft_->FindNode(node_id);
   }
   const auto it = std::find_if(snapshot_.nodes.begin(), snapshot_.nodes.end(),
                                [&](const auto& node) { return node.node_id == node_id; });
@@ -194,6 +216,19 @@ auto EditorNodeController::TopologyChanged(const EditorNodeGraphSnapshot& snapsh
 }
 
 void EditorNodeController::RestoreSelectionAfterSnapshot() {
+  if (layout_store_ != nullptr) {
+    const auto key         = layout_store_->current_key();
+    const bool key_changed = key != last_layout_key_;
+    last_layout_key_       = key;
+    if (key_changed) {
+      const auto stored = layout_store_->selected_node_id();
+      if (ContainsNode(stored)) {
+        selected_node_id_          = stored;
+        selection_restore_node_id_ = {};
+        return;
+      }
+    }
+  }
   if (ContainsNode(selection_restore_node_id_)) {
     selected_node_id_          = selection_restore_node_id_;
     selection_restore_node_id_ = {};
@@ -214,11 +249,12 @@ auto EditorNodeController::selected_node_id_string() const -> QString {
 
 auto EditorNodeController::backbone_node_ids() const -> QStringList {
   QStringList ids;
-  if (!has_snapshot_) {
+  if (!HasActiveGraph()) {
     return ids;
   }
-  ids.reserve(static_cast<qsizetype>(snapshot_.nodes.size()));
-  for (const auto& node : snapshot_.nodes) {
+  const auto& nodes = ActiveNodes();
+  ids.reserve(static_cast<qsizetype>(nodes.size()));
+  for (const auto& node : nodes) {
     ids.push_back(NodeIdToQString(node.node_id));
   }
   return ids;
@@ -297,6 +333,7 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
   snapshot.projection_revision = projection_revision_;
   snapshot_                    = std::move(snapshot);
   has_snapshot_                = true;
+  SyncLayoutKey();
   RestoreSelectionAfterSnapshot();
   SetLastError({});
   emit SnapshotChanged();
@@ -328,22 +365,30 @@ bool EditorNodeController::applyToGraph(QObject* adapter) {
     SetLastError(tr("The graph adapter is missing"));
     return false;
   }
-  if (!has_snapshot_) {
+  if (!HasActiveGraph()) {
     SetLastError(tr("The node graph has no snapshot"));
     return false;
   }
-  const auto promoted = graph->PromoteCommittedSnapshot(snapshot_);
+  EditorNodeGraphSnapshot view;
+  const EditorNodeGraphSnapshot* projected = &snapshot_;
+  if (draft_ != nullptr) {
+    view      = draft_->CurrentSnapshot(session_generation_, projection_revision_,
+                                        topology_revision_);
+    projected = &view;
+  } else if (!has_snapshot_) {
+    SetLastError(tr("The node graph has no snapshot"));
+    return false;
+  }
+  const auto promoted = graph->PromoteCommittedSnapshot(*projected);
   if (promoted.succeeded) {
-    graph->ApplyProductSelection(selected_node_id_);
     SetLastError({});
     return true;
   }
-  const auto result = graph->ApplySnapshot(snapshot_);
+  const auto result = graph->ApplySnapshot(*projected);
   if (!result.succeeded) {
     SetLastError(result.error);
     return false;
   }
-  graph->ApplyProductSelection(selected_node_id_);
   SetLastError({});
   return true;
 }
@@ -362,6 +407,7 @@ void EditorNodeController::set_graph_adapter(QObject* adapter) {
   }
   graph_adapter_connection_ = {};
   graph_adapter_            = graph;
+  ++adapter_attach_generation_;
   if (graph_adapter_ != nullptr) {
     graph_adapter_connection_ = connect(graph_adapter_.data(), &AlcedoQanGraph::GraphChanged, this,
                                         [this] { QueueProjectionApply(); });
@@ -371,7 +417,7 @@ void EditorNodeController::set_graph_adapter(QObject* adapter) {
             &EditorNodeController::OnConnectorRequestRejected);
   }
   emit GraphAdapterChanged();
-  if (graph_adapter_ != nullptr && has_snapshot_) {
+  if (graph_adapter_ != nullptr && HasActiveGraph() && graph_adapter_->graph() != nullptr) {
     ApplyBoundGraph();
   }
 }
@@ -385,43 +431,100 @@ void EditorNodeController::set_layout_store(QObject* store) {
   }
   layout_store_ = layout;
   emit LayoutStoreChanged();
+  SyncLayoutKey();
+}
+
+void EditorNodeController::SyncLayoutKey() {
+  if (layout_store_ == nullptr) {
+    return;
+  }
+  layout_store_->activate(QString(), element_id_, image_id_, version_id_);
+}
+
+void EditorNodeController::PersistSavedSelection() {
+  if (layout_store_ == nullptr) {
+    return;
+  }
+  layout_store_->set_selected_node_id(selected_node_id_);
+}
+
+void EditorNodeController::ApplyLiveSelectionToAdapter() {
+  if (graph_adapter_ == nullptr) {
+    return;
+  }
+  graph_adapter_->ApplyProductSelection(selected_node_id_);
+}
+
+auto EditorNodeController::AdapterShowsCurrentCommittedProjection() const -> bool {
+  if (draft_ != nullptr || graph_adapter_.isNull() || !graph_adapter_->has_projection()) {
+    return false;
+  }
+  return graph_adapter_->session_generation() == session_generation_ &&
+         graph_adapter_->topology_revision() == topology_revision_ &&
+         graph_adapter_->projection_revision() == projection_revision_;
 }
 
 void EditorNodeController::ApplyBoundGraph() {
-  if (graph_adapter_.isNull() || !has_snapshot_ || graph_adapter_->graph() == nullptr) {
+  if (graph_adapter_.isNull() || graph_adapter_->graph() == nullptr || !HasActiveGraph()) {
+    return;
+  }
+  const auto bound = BoundSessionGeneration();
+  if (bound.has_value() && session_generation_ != *bound) {
+    ++skipped_stale_projection_apply_count_;
+    return;
+  }
+  SyncLayoutKey();
+  if (AdapterShowsCurrentCommittedProjection()) {
+    ApplyLiveSelectionToAdapter();
     return;
   }
   if (!applyToGraph(graph_adapter_.data())) {
     return;
   }
+  ++completed_projection_apply_count_;
   auto* layout = layout_store_.data();
-  if (layout == nullptr) {
-    return;
-  }
-  layout->ensureDefaultsFrom(this);
-  for (const auto& node : snapshot_.nodes) {
-    const auto id = NodeIdToQString(node.node_id);
-    if (layout->hasNodePosition(id)) {
-      const auto pos = layout->nodePosition(id);
-      graph_adapter_->setNodePosition(id, pos.x(), pos.y());
+  if (layout != nullptr) {
+    layout->EnsureDefaultPositions(draft_ == nullptr
+                                       ? snapshot_
+                                       : draft_->CurrentSnapshot(session_generation_,
+                                                                 projection_revision_,
+                                                                 topology_revision_));
+    for (const auto& node : ActiveNodes()) {
+      const auto id = NodeIdToQString(node.node_id);
+      if (layout->hasNodePosition(id)) {
+        const auto pos = layout->nodePosition(id);
+        graph_adapter_->setNodePosition(id, pos.x(), pos.y());
+      }
+      graph_adapter_->setDrawerOpen(id, layout->drawerOpen(id));
     }
-    graph_adapter_->setDrawerOpen(id, layout->drawerOpen(id));
   }
-  graph_adapter_->applyProductSelection(selected_node_id_string());
+  ApplyLiveSelectionToAdapter();
 }
 
 void EditorNodeController::QueueProjectionApply() {
+  ++queued_projection_apply_count_;
+  pending_apply_attach_generation_ = adapter_attach_generation_;
   if (projection_apply_queued_) {
     return;
   }
   projection_apply_queued_ = true;
   QMetaObject::invokeMethod(
       this,
-      [this] {
-        projection_apply_queued_ = false;
-        ApplyBoundGraph();
-      },
+      [this] { ApplyBoundGraphIfCurrent(); },
       Qt::QueuedConnection);
+}
+
+void EditorNodeController::ApplyBoundGraphIfCurrent() {
+  projection_apply_queued_ = false;
+  if (graph_adapter_.isNull() || graph_adapter_->graph() == nullptr) {
+    ++skipped_stale_projection_apply_count_;
+    return;
+  }
+  if (adapter_attach_generation_ != pending_apply_attach_generation_) {
+    ++skipped_stale_projection_apply_count_;
+    return;
+  }
+  ApplyBoundGraph();
 }
 
 bool EditorNodeController::refreshFromSession() {
@@ -433,6 +536,7 @@ bool EditorNodeController::refreshFromSession() {
   element_id_ = session_->element_id();
   image_id_   = session_->image_id();
   version_id_ = QString::fromStdString(session_->history_snapshot().active_version_id.ToString());
+  SyncLayoutKey();
   const auto* document = session_->pipeline_document();
   if (document == nullptr) {
     ClearSnapshot();
@@ -443,11 +547,39 @@ bool EditorNodeController::refreshFromSession() {
   return PublishDocument(*document, static_cast<std::uint64_t>(session_->session_generation()));
 }
 
+auto EditorNodeController::SessionMatchesSubmittedIdentity() const -> bool {
+  if (!submitted_identity_.has_value() || session_ == nullptr) {
+    return false;
+  }
+  const auto& submitted = *submitted_identity_;
+  return submitted.element_id == static_cast<std::uint64_t>(session_->element_id()) &&
+         submitted.image_id == static_cast<std::uint64_t>(session_->image_id()) &&
+         submitted.version_id == session_->history_snapshot().active_version_id.ToString() &&
+         submitted.session_generation == static_cast<std::uint64_t>(session_->session_generation());
+}
+
+[[nodiscard]] auto EditorNodeController::SessionIdentityChanged() const -> bool {
+  if (session_ == nullptr) {
+    return false;
+  }
+  return static_cast<quint64>(session_->element_id()) != element_id_ ||
+         static_cast<quint64>(session_->image_id()) != image_id_ ||
+         QString::fromStdString(session_->history_snapshot().active_version_id.ToString()) !=
+             version_id_ ||
+         static_cast<quint64>(session_->session_generation()) != session_generation_;
+}
+
 void EditorNodeController::OnSessionChanged() {
-  if (skip_next_session_refresh_) {
-    skip_next_session_refresh_ = false;
+  if (SessionIdentityChanged()) {
+    submitted_identity_.reset();
+    DiscardDraft();
+    refreshFromSession();
     return;
   }
+  if (submitted_identity_.has_value() && SessionMatchesSubmittedIdentity()) {
+    return;
+  }
+  submitted_identity_.reset();
   if (session_ != nullptr && draft_ != nullptr) {
     const auto* document = session_->pipeline_document();
     if (document != nullptr && draft_->MatchesIdentity(CurrentDraftIdentity()) &&
@@ -468,11 +600,15 @@ void EditorNodeController::selectNode(const QString& node_id) {
   if (selected_node_id_ == id) {
     selection_restore_node_id_ = {};
     SetLastError({});
+    PersistSavedSelection();
+    ApplyLiveSelectionToAdapter();
     return;
   }
   selected_node_id_          = id;
   selection_restore_node_id_ = {};
   SetLastError({});
+  PersistSavedSelection();
+  ApplyLiveSelectionToAdapter();
   emit SelectionChanged();
   emit ActionAvailabilityChanged();
 }
@@ -533,7 +669,8 @@ bool EditorNodeController::addCleanColorGrade() {
       graph_adapter_->SetNodeItemPosition(new_id, *pos);
     }
   }
-  SyncSnapshotFromDraft();
+  emit DraftStateChanged();
+  emit ActionAvailabilityChanged();
   selectNode(NodeIdToQString(new_id));
   return MaybeSubmitDraft();
 }
@@ -592,9 +729,12 @@ bool EditorNodeController::deleteColorGrade(const QString& node_id) {
   if (!ApplyMutationToGraph(mutation)) {
     return false;
   }
-  SyncSnapshotFromDraft();
+  emit DraftStateChanged();
+  emit ActionAvailabilityChanged();
   if (!ContainsNode(selected_node_id_)) {
     selected_node_id_ = DefaultSelectedNodeId();
+    PersistSavedSelection();
+    ApplyLiveSelectionToAdapter();
     emit SelectionChanged();
     emit ActionAvailabilityChanged();
   }
@@ -646,7 +786,8 @@ bool EditorNodeController::requestConnect(const QString& source_node_id,
   if (!ApplyMutationToGraph(mutation)) {
     return false;
   }
-  SyncSnapshotFromDraft();
+  emit DraftStateChanged();
+  emit ActionAvailabilityChanged();
   return MaybeSubmitDraft();
 }
 
@@ -723,14 +864,15 @@ void EditorNodeController::DiscardDraft() {
   emit DraftStateChanged();
 }
 
-void EditorNodeController::SyncSnapshotFromDraft() {
-  if (draft_ == nullptr) {
-    return;
-  }
-  snapshot_     = draft_->CurrentSnapshot(session_generation_, projection_revision_,
-                                          topology_revision_);
-  has_snapshot_ = true;
-  emit DraftStateChanged();
+void EditorNodeController::AdoptCommittedDocument(const PipelineDocument& document) {
+  auto built = EditorNodeGraphProjection::Build(document, session_generation_, 0, 0);
+  topology_revision_            = topology_revision_ + 1;
+  projection_revision_          = projection_revision_ + 1;
+  built.session_generation      = session_generation_;
+  built.topology_revision       = topology_revision_;
+  built.projection_revision     = projection_revision_;
+  snapshot_                     = std::move(built);
+  has_snapshot_                 = true;
 }
 
 auto EditorNodeController::ApplyMutationToGraph(const alcedo::EditorNodeGraphDraftMutation& mutation)
@@ -810,11 +952,11 @@ auto EditorNodeController::MaybeSubmitDraft() -> bool {
     emit ActionAvailabilityChanged();
     return true;
   }
-  auto change = draft_->MakeChange();
-  skip_next_session_refresh_ = true;
-  const auto result          = session_->SubmitNodeGraphTopologyEdit(change);
+  auto change                  = draft_->MakeChange();
+  submitted_identity_          = CurrentDraftIdentity();
+  const auto result            = session_->SubmitNodeGraphTopologyEdit(change);
   if (alcedo::EditorSessionResultIsFailure(result.kind)) {
-    skip_next_session_refresh_ = false;
+    submitted_identity_.reset();
     SetLastError(QString::fromStdString(result.message));
     emit DraftStateChanged();
     return false;
@@ -822,15 +964,7 @@ auto EditorNodeController::MaybeSubmitDraft() -> bool {
   DiscardDraft();
   if (session_ != nullptr && session_->pipeline_document() != nullptr) {
     try {
-      auto built = EditorNodeGraphProjection::Build(*session_->pipeline_document(),
-                                                    session_generation_, 0, 0);
-      topology_revision_   = topology_revision_ + 1;
-      projection_revision_ = projection_revision_ + 1;
-      built.session_generation  = session_generation_;
-      built.topology_revision   = topology_revision_;
-      built.projection_revision = projection_revision_;
-      snapshot_                 = std::move(built);
-      has_snapshot_             = true;
+      AdoptCommittedDocument(*session_->pipeline_document());
     } catch (const std::exception& ex) {
       SetLastError(QString::fromUtf8(ex.what()));
     }
@@ -840,9 +974,10 @@ auto EditorNodeController::MaybeSubmitDraft() -> bool {
     if (!promoted.succeeded) {
       QueueProjectionApply();
     } else {
-      graph_adapter_->ApplyProductSelection(selected_node_id_);
+      ApplyLiveSelectionToAdapter();
     }
   }
+  submitted_identity_.reset();
   SetLastError({});
   emit SnapshotChanged();
   emit ActionAvailabilityChanged();
@@ -850,10 +985,10 @@ auto EditorNodeController::MaybeSubmitDraft() -> bool {
 }
 
 void EditorNodeController::SelectAt(int index) {
-  if (!has_snapshot_ || index < 0 || index >= static_cast<int>(snapshot_.nodes.size())) {
+  if (!HasActiveGraph() || index < 0 || index >= static_cast<int>(ActiveNodes().size())) {
     return;
   }
-  selectNode(NodeIdToQString(snapshot_.nodes[static_cast<std::size_t>(index)].node_id));
+  selectNode(NodeIdToQString(ActiveNodes()[static_cast<std::size_t>(index)].node_id));
 }
 
 void EditorNodeController::selectPreviousBackboneNode() {
@@ -867,10 +1002,10 @@ void EditorNodeController::selectPreviousBackboneNode() {
 
 void EditorNodeController::selectNextBackboneNode() {
   const int index = IndexOf(selected_node_id_);
-  if (!has_snapshot_) {
+  if (!HasActiveGraph()) {
     return;
   }
-  const int last = static_cast<int>(snapshot_.nodes.size()) - 1;
+  const int last = static_cast<int>(ActiveNodes().size()) - 1;
   if (index < 0) {
     SelectAt(last);
     return;
@@ -879,10 +1014,10 @@ void EditorNodeController::selectNextBackboneNode() {
 }
 
 void EditorNodeController::SelectByKind(EditorNodeKind kind) {
-  if (!has_snapshot_) {
+  if (!HasActiveGraph()) {
     return;
   }
-  for (const auto& node : snapshot_.nodes) {
+  for (const auto& node : ActiveNodes()) {
     if (node.node_kind == kind) {
       selectNode(NodeIdToQString(node.node_id));
       return;

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
@@ -34,8 +34,6 @@ Item {
                 + String(root.nodeController.versionId)
     }
 
-    onLayoutIdentityKeyChanged: activateLayoutKey()
-
     function addColorGrade() {
         if (!root.nodeController || !root.nodeController.canAddColorGrade) {
             return
@@ -108,61 +106,28 @@ Item {
         }
     }
 
-    function applyLayout() {
-        if (!root.nodeController || !root.nodeLayoutStore || !qanAdapter) {
+    function restoreGraphView() {
+        if (!graphView || !root.nodeLayoutStore) {
             return
         }
-        root.nodeLayoutStore.ensureDefaultsFrom(root.nodeController)
-        const ids = root.nodeController.backboneNodeIds
-        for (var i = 0; i < ids.length; ++i) {
-            const id = ids[i]
-            if (root.nodeLayoutStore.hasNodePosition(id)) {
-                const pos = root.nodeLayoutStore.nodePosition(id)
-                qanAdapter.setNodePosition(id, pos.x, pos.y)
-            }
-            qanAdapter.setDrawerOpen(id, root.nodeLayoutStore.drawerOpen(id))
-        }
-        if (graphView) {
-            graphView.zoom = root.nodeLayoutStore.zoom
-            if (graphView.containerItem) {
-                graphView.containerItem.x = root.nodeLayoutStore.viewPosition.x
-                graphView.containerItem.y = root.nodeLayoutStore.viewPosition.y
-            }
-        }
-        qanAdapter.applyProductSelection(root.nodeController.selectedNodeId)
-    }
-
-    function bindControllerAdapter() {
-        if (!root.nodeController) {
-            return
-        }
-        if (qanAdapter && qanAdapter.graph) {
-            root.nodeController.graphAdapter = qanAdapter
+        graphView.zoom = root.nodeLayoutStore.zoom
+        if (graphView.containerItem) {
+            graphView.containerItem.x = root.nodeLayoutStore.viewPosition.x
+            graphView.containerItem.y = root.nodeLayoutStore.viewPosition.y
         }
     }
 
-    function clearControllerAdapter() {
+    function attachAdapter() {
+        if (!root.nodeController || !qanAdapter) {
+            return
+        }
+        root.nodeController.graphAdapter = qanAdapter
+    }
+
+    function detachAdapter() {
         if (root.nodeController) {
             root.nodeController.graphAdapter = null
         }
-    }
-
-    Binding {
-        target: root.nodeController
-        property: "graphAdapter"
-        value: (qanAdapter && qanAdapter.graph) ? qanAdapter : null
-        when: root.nodeController !== null && root.nodeController !== undefined
-    }
-
-    function bindGraph() {
-        bindControllerAdapter()
-        if (!root.nodeController || !qanAdapter || !qanAdapter.graph) {
-            return
-        }
-        if (!root.nodeController.applyToGraph(qanAdapter)) {
-            return
-        }
-        applyLayout()
     }
 
     function fitGraph() {
@@ -173,35 +138,18 @@ Item {
         captureView()
     }
 
-    function activateLayoutKey() {
-        if (!root.nodeLayoutStore || !root.nodeController) {
-            return
-        }
-        root.nodeLayoutStore.activate("", root.nodeController.elementId,
-                                      root.nodeController.imageId,
-                                      root.nodeController.versionId)
-        const stored = root.nodeLayoutStore.selectedNodeId
-        if (stored && stored.length > 0) {
-            root.nodeController.selectNode(stored)
-        }
-    }
+    onLayoutIdentityKeyChanged: restoreGraphView()
 
     Connections {
         target: root.nodeController
-        function onSnapshotChanged() {
-            Qt.callLater(function () { root.bindGraph() })
-        }
         function onSelectionChanged() {
-            if (qanAdapter) {
-                qanAdapter.applyProductSelection(root.nodeController.selectedNodeId)
-            }
-            if (root.nodeLayoutStore) {
-                root.nodeLayoutStore.selectedNodeId = root.nodeController.selectedNodeId
-            }
             if (root.renameVisible
                     && root.renameNodeId !== root.nodeController.selectedNodeId) {
                 root.cancelRename()
             }
+        }
+        function onSnapshotChanged() {
+            root.restoreGraphView()
         }
     }
 
@@ -213,15 +161,13 @@ Item {
             }
         }
         function onGraphChanged() {
-            root.bindControllerAdapter()
-            Qt.callLater(function () { root.bindGraph() })
+            root.attachAdapter()
         }
     }
 
     Component.onCompleted: {
-        activateLayoutKey()
-        bindControllerAdapter()
-        bindGraph()
+        attachAdapter()
+        restoreGraphView()
         if (graphView.originCross) {
             graphView.originCross.visible = false
         }
@@ -231,7 +177,7 @@ Item {
 
     Component.onDestruction: {
         captureView()
-        clearControllerAdapter()
+        detachAdapter()
     }
 
     ColumnLayout {

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -81,7 +81,7 @@ add_executable(EditorNodeGraphDraftTest
     ${ALCEDO_TEST_ROOT}/app/editor_node_graph_draft_test.cpp)
 target_include_directories(EditorNodeGraphDraftTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(EditorNodeGraphDraftTest
-    PRIVATE GTest::gtest_main EditorNodeGraphDraft EditGraph)
+    PRIVATE GTest::gtest_main EditorNodeGraphDraft EditGraph PipelineHistoryApplier)
 gtest_discover_tests(EditorNodeGraphDraftTest
     TEST_PREFIX "EditorNodeGraphDraftTest."
     PROPERTIES LABELS "ci_core_flow;edit;nodes")

--- a/alcedo_studio/tests/app/editor_node_graph_draft_test.cpp
+++ b/alcedo_studio/tests/app/editor_node_graph_draft_test.cpp
@@ -4,16 +4,31 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "app/editor_node_graph_draft.hpp"
+#include "app/pipeline_document_history.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/graph_validation.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/graph/pipeline_graph_commands.hpp"
+#include "edit/mask/mask_model.hpp"
 
 namespace {
 
+using alcedo::AddCleanColorGrade;
+using alcedo::ApplyNodeGraphTopologyChange;
+using alcedo::ClonePipelineDocument;
+using alcedo::ColorGradeNodeModel;
 using alcedo::CreateDefaultPipelineDocument;
 using alcedo::EditorNodeGraphDraft;
 using alcedo::EditorNodeGraphDraftIdentity;
+using alcedo::MaskId;
+using alcedo::MaskModel;
 using alcedo::NodeId;
+using alcedo::PipelineDocument;
+using alcedo::PipelineEditApplyDirection;
+using alcedo::RadialMaskSource;
 
 auto BoundIdentity() -> EditorNodeGraphDraftIdentity {
   EditorNodeGraphDraftIdentity identity;
@@ -24,6 +39,42 @@ auto BoundIdentity() -> EditorNodeGraphDraftIdentity {
   identity.projection_revision = 1;
   identity.topology_revision   = 1;
   return identity;
+}
+
+auto MakeMask(const std::string& id, float center) -> MaskModel {
+  MaskModel mask;
+  mask.id           = MaskId{id};
+  mask.display_name = "Mask";
+  RadialMaskSource radial;
+  radial.center_x = center;
+  mask.source     = std::move(radial);
+  return mask;
+}
+
+auto DocumentWithGrades(int grade_count, int masks_per_grade) -> PipelineDocument {
+  auto document = CreateDefaultPipelineDocument();
+  auto fill     = [&](ColorGradeNodeModel* grade, const std::string& prefix) {
+    if (grade == nullptr) {
+      return;
+    }
+    for (int mask = 0; mask < masks_per_grade; ++mask) {
+      grade->AddMask(MakeMask(prefix + "." + std::to_string(mask), 0.1f * static_cast<float>(mask)),
+                     static_cast<std::size_t>(mask));
+    }
+  };
+  fill(document.PrimaryGrade(), "mask.primary");
+  for (int extra = 0; extra < grade_count - 1; ++extra) {
+    const auto id = NodeId{"grade.g" + std::to_string(extra)};
+    EXPECT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, id).empty());
+    fill(dynamic_cast<ColorGradeNodeModel*>(document.Graph().FindNode(id)),
+         "mask.g" + std::to_string(extra));
+  }
+  return document;
+}
+
+void ExpectNoWholeDraftCopy(const EditorNodeGraphDraft& draft) {
+  EXPECT_EQ(draft.work_stats().complete_state_copies, 0);
+  EXPECT_EQ(draft.work_stats().complete_index_rebuilds, 0);
 }
 
 TEST(EditorNodeGraphDraft, FirstConstructionCopiesTheCompleteProjectionOnce) {
@@ -161,6 +212,130 @@ TEST(EditorNodeGraphDraft, RestoreLastMutationReversesAnAdmittedConnect) {
   EXPECT_EQ(draft.Edges().size(), 2u);
   EXPECT_EQ(draft.Edges()[0].source_node_id, NodeId{"develop"});
   EXPECT_EQ(draft.Edges()[0].destination_node_id, NodeId{"grade.primary"});
+}
+
+TEST(EditorNodeGraphDraft, AddDeleteConnectReversalRestoresExactCounterOrderAndJson) {
+  auto  document = CreateDefaultPipelineDocument();
+  auto* grade    = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  grade->AddMask(MakeMask("mask.keep", 0.4f), 0);
+  auto       draft       = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  const auto json_before = *draft.NodeJson(NodeId{"grade.primary"});
+  const auto nodes_before = draft.Nodes();
+  const auto edges_before = draft.Edges();
+  const auto counter      = draft.NextColorGradeNameNumber();
+  draft.ResetWorkStats();
+
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  ExpectNoWholeDraftCopy(draft);
+  draft.RestoreLastMutation();
+  EXPECT_EQ(draft.FindNode(NodeId{"grade.d"}), nullptr);
+  EXPECT_EQ(draft.NextColorGradeNameNumber(), counter);
+  EXPECT_EQ(draft.Nodes(), nodes_before);
+  EXPECT_EQ(draft.Edges(), edges_before);
+
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  ASSERT_TRUE(draft.Connect(NodeId{"develop"}, NodeId{"grade.d"}).succeeded);
+  draft.RestoreLastMutation();
+  EXPECT_EQ(draft.Edges()[0].source_node_id, NodeId{"develop"});
+  EXPECT_EQ(draft.Edges()[0].destination_node_id, NodeId{"grade.primary"});
+  EXPECT_NE(draft.FindNode(NodeId{"grade.d"}), nullptr);
+
+  ASSERT_TRUE(draft.Connect(NodeId{"develop"}, NodeId{"grade.d"}).succeeded);
+  ASSERT_TRUE(draft.RemoveColorGrade(NodeId{"grade.primary"}).succeeded);
+  EXPECT_EQ(draft.FindNode(NodeId{"grade.primary"}), nullptr);
+  draft.RestoreLastMutation();
+  EXPECT_NE(draft.FindNode(NodeId{"grade.primary"}), nullptr);
+  EXPECT_EQ(*draft.NodeJson(NodeId{"grade.primary"}), json_before);
+  EXPECT_EQ(draft.FindNode(NodeId{"grade.d"})->display_name, "Color Grade 2");
+  ExpectNoWholeDraftCopy(draft);
+}
+
+TEST(EditorNodeGraphDraft, NetCancellationRestoresBaseWithoutWholeDraftCopy) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  draft.ResetWorkStats();
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  auto remove = draft.RemoveColorGrade(NodeId{"grade.d"});
+  ASSERT_TRUE(remove.succeeded);
+  EXPECT_TRUE(remove.delta_empty);
+  EXPECT_TRUE(draft.DeltaEmpty());
+  EXPECT_TRUE(draft.SubmissionValid());
+  EXPECT_EQ(draft.Nodes().size(), 3u);
+  ExpectNoWholeDraftCopy(draft);
+}
+
+TEST(EditorNodeGraphDraft, MultipleDetachedGradesKeepIndependentNodesAndEdges) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  draft.ResetWorkStats();
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.a"}).succeeded);
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.b"}).succeeded);
+  EXPECT_EQ(draft.Nodes().size(), 5u);
+  EXPECT_EQ(draft.Edges().size(), 2u);
+  EXPECT_NE(draft.FindNode(NodeId{"grade.a"}), nullptr);
+  EXPECT_NE(draft.FindNode(NodeId{"grade.b"}), nullptr);
+  EXPECT_EQ(draft.FindNode(NodeId{"grade.a"})->display_name, "Color Grade 2");
+  EXPECT_EQ(draft.FindNode(NodeId{"grade.b"})->display_name, "Color Grade 3");
+  draft.RestoreLastMutation();
+  EXPECT_EQ(draft.FindNode(NodeId{"grade.b"}), nullptr);
+  EXPECT_NE(draft.FindNode(NodeId{"grade.a"}), nullptr);
+  EXPECT_EQ(draft.Edges().size(), 2u);
+  ExpectNoWholeDraftCopy(draft);
+}
+
+TEST(EditorNodeGraphDraft, RejectedConnectRetainsCachedSubmissionValidity) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  draft.ResetWorkStats();
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  EXPECT_FALSE(draft.SubmissionValid());
+  const auto traversals = draft.work_stats().validity_traversals;
+  EXPECT_GE(traversals, 1);
+  auto self = draft.Connect(NodeId{"grade.d"}, NodeId{"grade.d"});
+  EXPECT_FALSE(self.succeeded);
+  EXPECT_EQ(draft.work_stats().validity_traversals, traversals);
+  EXPECT_FALSE(draft.SubmissionValid());
+}
+
+TEST(EditorNodeGraphDraft, SerializedDraftChangeMatchesInPlaceForwardAndInverse) {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.d"}).succeeded);
+  ASSERT_TRUE(draft.Connect(NodeId{"develop"}, NodeId{"grade.d"}).succeeded);
+  ASSERT_TRUE(draft.Connect(NodeId{"grade.d"}, NodeId{"grade.primary"}).succeeded);
+  ASSERT_TRUE(draft.Connect(NodeId{"grade.primary"}, NodeId{"drt"}).succeeded);
+  ASSERT_TRUE(draft.SubmissionValid());
+  const auto change      = draft.MakeChange();
+  const auto before_json = document.ToJson().dump();
+  auto       forward     = ClonePipelineDocument(document);
+  ASSERT_TRUE(ApplyNodeGraphTopologyChange(forward, change, PipelineEditApplyDirection::Forward)
+                  .empty());
+  EXPECT_NE(forward.Graph().FindNode(NodeId{"grade.d"}), nullptr);
+  ASSERT_TRUE(ApplyNodeGraphTopologyChange(forward, change, PipelineEditApplyDirection::Inverse)
+                  .empty());
+  EXPECT_EQ(forward.ToJson().dump(), before_json);
+  EXPECT_EQ(forward.NextColorGradeNameNumber(), document.NextColorGradeNameNumber());
+}
+
+TEST(EditorNodeGraphDraft, ThirtyTwoGradeGraphRepeatedConnectStaysBounded) {
+  auto document = DocumentWithGrades(32, 8);
+  EXPECT_EQ(document.Graph().NodeCount(), 34u);
+  auto draft = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  EXPECT_TRUE(draft.SubmissionValid());
+  draft.ResetWorkStats();
+  ASSERT_TRUE(draft.AddColorGrade(NodeId{"grade.extra"}).succeeded);
+  const NodeId develop{"develop"};
+  const NodeId extra{"grade.extra"};
+  const NodeId primary{"grade.primary"};
+  for (int step = 0; step < 50; ++step) {
+    ASSERT_TRUE(draft.Connect(develop, extra).succeeded) << step;
+    ASSERT_TRUE(draft.Connect(develop, primary).succeeded) << step;
+  }
+  ExpectNoWholeDraftCopy(draft);
+  EXPECT_EQ(draft.work_stats().validity_traversals, 101);
+  EXPECT_LT(draft.work_stats().node_entry_copies, 8);
+  EXPECT_LT(draft.work_stats().edge_entry_copies, 400);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/app/editor_node_graph_projection_test.cpp
+++ b/alcedo_studio/tests/app/editor_node_graph_projection_test.cpp
@@ -106,6 +106,25 @@ TEST(EditorNodeGraphProjection, TopologyChangeAppearsInNodeAndRevisionValues) {
   EXPECT_EQ(snapshot.edges.size(), 3u);
 }
 
+TEST(EditorNodeGraphProjection, ProjectNodeCopiesStoredMaskOrderForDetachedGrades) {
+  const auto  document = CreateDefaultPipelineDocument();
+  const auto* primary  = document.PrimaryGrade();
+  ASSERT_NE(primary, nullptr);
+  const auto  from_build = EditorNodeGraphProjection::Build(document, 1, 1, 1).nodes[1];
+  const auto  from_node  = EditorNodeGraphProjection::ProjectNode(*primary);
+  EXPECT_EQ(from_node, from_build);
+
+  auto extra = CreateCleanColorGradeNode(NodeId{"grade.detached"});
+  extra->AddMask(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}), 0);
+  extra->AddMask(MakeMask(MaskId{"mask.brush"}, BrushMaskSource{}), 1);
+  const auto projected = EditorNodeGraphProjection::ProjectNode(*extra);
+  EXPECT_EQ(projected.node_id, NodeId{"grade.detached"});
+  EXPECT_EQ(projected.node_kind, EditorNodeKind::ColorGrade);
+  ASSERT_EQ(projected.masks.size(), 2u);
+  EXPECT_EQ(projected.masks[0].mask_id, MaskId{"mask.radial"});
+  EXPECT_EQ(projected.masks[1].mask_id, MaskId{"mask.brush"});
+}
+
 TEST(EditorNodeGraphProjection, InvalidBackboneIsRejected) {
   EXPECT_THROW(EditorNodeGraphProjection::Build(PipelineDocument{}, 1, 1, 1),
                std::invalid_argument);

--- a/alcedo_studio/tests/ui/editor_node_controller_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_controller_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <QCoreApplication>
 #include <algorithm>
 #include <functional>
 #include <vector>
@@ -74,8 +75,20 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
 
   void SetPresentationSinkId(alcedo::PresentationSinkId) override {}
   void SetPresentationSize(int, int) override {}
-  auto Open(sl_element_id_t, image_id_t) -> EditorSessionResult override { return {}; }
-  auto Switch(sl_element_id_t, image_id_t) -> EditorSessionResult override { return {}; }
+  auto Open(sl_element_id_t element_id, image_id_t image_id) -> EditorSessionResult override {
+    identity_.element_id = element_id;
+    identity_.image_id   = image_id;
+    ++request_.value;
+    NotifyChange();
+    return Accepted("opened");
+  }
+  auto Switch(sl_element_id_t element_id, image_id_t image_id) -> EditorSessionResult override {
+    identity_.element_id = element_id;
+    identity_.image_id   = image_id;
+    ++request_.value;
+    NotifyChange();
+    return Accepted("switched");
+  }
   auto Close(bool) -> EditorSessionResult override { return {}; }
   auto Shutdown() -> EditorSessionResult override { return {}; }
   auto Discard() -> EditorSessionResult override { return {}; }
@@ -138,6 +151,10 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   }
 
   void SetGeneration(std::uint64_t value) { request_.value = value; }
+  void SetImageId(image_id_t image_id) {
+    identity_.image_id = image_id;
+    NotifyChange();
+  }
   auto Document() -> PipelineDocument& { return document_; }
   void SetFailCommands(bool fail) { fail_commands_ = fail; }
   void PublishAvailability(alcedo::EditorActionAvailability availability) {
@@ -268,7 +285,7 @@ TEST(EditorNodeController, AddCreatesDisconnectedDraftGradeWithoutAProductComman
   EXPECT_TRUE(controller.incomplete_draft());
   EXPECT_EQ(controller.backbone_node_ids().size(), 4);
   EXPECT_EQ(controller.selected_node_name(), QStringLiteral("Color Grade 2"));
-  EXPECT_EQ(controller.snapshot().edges.size(), 2u);
+  EXPECT_EQ(controller.ActiveEdges().size(), 2u);
 }
 
 TEST(EditorNodeController, AddPlacesTheDisconnectedGradeBelowTheBackbone) {
@@ -319,7 +336,7 @@ TEST(EditorNodeController, DeleteOfADraftGradeDoesNotSubmitWhileThePathIsBroken)
   EXPECT_EQ(backend.remove_count(), 0);
   EXPECT_EQ(backend.edit_node_graph_count(), 0);
   EXPECT_TRUE(controller.incomplete_draft());
-  EXPECT_EQ(controller.snapshot().nodes.size(), 3u);
+  EXPECT_EQ(controller.ActiveNodes().size(), 3u);
 }
 
 TEST(EditorNodeController, EndpointsAndStaleGenerationRejectCommandsBeforeBackendMutation) {
@@ -433,6 +450,8 @@ TEST(EditorNodeController, CompletingThePathSubmitsOneTopologyChange) {
   EXPECT_FALSE(controller.incomplete_draft());
   EXPECT_EQ(backend.Document().Graph().FindNode(extra) != nullptr, true);
   EXPECT_EQ(backend.Document().NextColorGradeNameNumber(), 3u);
+  EXPECT_EQ(controller.snapshot().nodes.size(), 4u);
+  EXPECT_EQ(controller.ActiveNodes().size(), 4u);
 }
 
 TEST(EditorNodeController, DevelopAndDrtRejectUnsupportedPortRoles) {
@@ -462,14 +481,14 @@ TEST(EditorNodeController, SelfConnectAndStaleGenerationLeaveTheDraftUnchanged) 
   controller.set_editor_session(&session);
   ASSERT_TRUE(controller.addCleanColorGrade());
   const auto extra = controller.selected_node_id_string();
-  const auto before = controller.snapshot().edges.size();
+  const auto before = controller.ActiveEdges().size();
 
   EXPECT_FALSE(controller.requestConnect(extra, extra));
   EXPECT_EQ(controller.last_error(), QStringLiteral("A node cannot connect to itself"));
   EXPECT_FALSE(controller.requestConnect(QStringLiteral("develop"), extra, 1));
   EXPECT_EQ(controller.last_error(),
             QStringLiteral("The node command is from another editor session"));
-  EXPECT_EQ(controller.snapshot().edges.size(), before);
+  EXPECT_EQ(controller.ActiveEdges().size(), before);
   EXPECT_EQ(backend.edit_node_graph_count(), 0);
 }
 
@@ -485,6 +504,104 @@ TEST(EditorNodeController, ReturningADraftToTheBaseExitsEditingWithoutACommit) {
   EXPECT_FALSE(controller.incomplete_draft());
   EXPECT_EQ(backend.edit_node_graph_count(), 0);
   EXPECT_EQ(controller.backbone_node_ids().size(), 3);
+}
+
+TEST(EditorNodeController, OrdinaryDraftEditsDoNotCopyIntoTheCommittedSnapshot) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(36);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  const auto committed_nodes = controller.snapshot().nodes.size();
+  const auto committed_edges = controller.snapshot().edges.size();
+  const auto applies_before  = controller.completed_projection_apply_count();
+
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  EXPECT_EQ(controller.snapshot().nodes.size(), committed_nodes);
+  EXPECT_EQ(controller.snapshot().edges.size(), committed_edges);
+  EXPECT_EQ(controller.ActiveNodes().size(), committed_nodes + 1);
+  EXPECT_EQ(controller.completed_projection_apply_count(), applies_before);
+}
+
+TEST(EditorNodeController, OneCommittedRevisionCoalescesQueuedProjectionApplies) {
+  EditorNodeController controller;
+  ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 1));
+  const auto queued_after_first = controller.queued_projection_apply_count();
+  EXPECT_GE(queued_after_first, 1);
+  ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 1));
+  EXPECT_EQ(controller.queued_projection_apply_count(), queued_after_first + 1);
+  QCoreApplication::processEvents();
+  EXPECT_EQ(controller.completed_projection_apply_count(), 0);
+  EXPECT_GE(controller.skipped_stale_projection_apply_count(), 1);
+}
+
+TEST(EditorNodeController, QueuedProjectionApplyIgnoresStaleAdapterAfterDetach) {
+  EditorNodeController controller;
+  ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 2));
+  controller.set_graph_adapter(nullptr);
+  QCoreApplication::processEvents();
+  EXPECT_EQ(controller.completed_projection_apply_count(), 0);
+  EXPECT_GE(controller.skipped_stale_projection_apply_count(), 1);
+}
+
+TEST(EditorNodeController, LayoutKeyActivatesBeforeSavedSelectionRestore) {
+  EditorNodeLayoutStore store;
+  EditorNodeController  controller;
+  controller.set_layout_store(&store);
+  controller.SetLayoutIdentity(1, 2, QStringLiteral("version-a"));
+  ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 3));
+  controller.selectNode(QStringLiteral("develop"));
+  store.SetNodePosition(NodeId{"grade.primary"}, QPointF(11, 22));
+  EXPECT_EQ(store.selected_node_id(), NodeId{"develop"});
+
+  controller.SetLayoutIdentity(1, 2, QStringLiteral("version-b"));
+  EXPECT_EQ(store.current_key().version_id, QStringLiteral("version-b"));
+  EXPECT_TRUE(store.selected_node_id().Empty());
+  EXPECT_FALSE(store.hasNodePosition(QStringLiteral("grade.primary")));
+
+  controller.SetLayoutIdentity(1, 2, QStringLiteral("version-a"));
+  ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 3));
+  EXPECT_EQ(store.current_key().version_id, QStringLiteral("version-a"));
+  EXPECT_EQ(controller.selected_node_id(), NodeId{"develop"});
+  EXPECT_EQ(store.NodePosition(NodeId{"grade.primary"}), QPointF(11, 22));
+}
+
+TEST(EditorNodeController, SavedLayoutSelectionDoesNotOverrideLiveSelectionOnTheSameKey) {
+  EditorNodeLayoutStore store;
+  EditorNodeController  controller;
+  controller.set_layout_store(&store);
+  controller.SetLayoutIdentity(4, 5, QStringLiteral("v"));
+  ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 4));
+  controller.selectNode(QStringLiteral("develop"));
+  store.set_selected_node_id(NodeId{"grade.primary"});
+  ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 4));
+  EXPECT_EQ(controller.selected_node_id(), NodeId{"develop"});
+}
+
+TEST(EditorNodeController, ImageSwitchAfterSubmitRefreshesTheCommittedProjection) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(37);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  EXPECT_EQ(controller.image_id(), 9u);
+  backend.SetImageId(50);
+  EXPECT_EQ(session.image_id(), 50u);
+  EXPECT_EQ(controller.image_id(), 50u);
+
+  backend.SetImageId(9);
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  const auto extra = controller.selected_node_id();
+  ASSERT_TRUE(controller.requestConnect(QStringLiteral("develop"), NodeIdToQString(extra)));
+  ASSERT_TRUE(controller.requestConnect(NodeIdToQString(extra), QStringLiteral("grade.primary")));
+  ASSERT_TRUE(controller.requestConnect(QStringLiteral("grade.primary"), QStringLiteral("drt")));
+  EXPECT_FALSE(controller.incomplete_draft());
+  EXPECT_EQ(controller.image_id(), 9u);
+
+  backend.SetImageId(99);
+  EXPECT_EQ(session.image_id(), 99u);
+  EXPECT_EQ(controller.image_id(), 99u);
+  EXPECT_EQ(controller.snapshot().nodes.size(), 4u);
 }
 
 TEST(EditorSessionToolPanelPage, AcceptsOnlyEmptyHistoryVersionsAndNodes) {

--- a/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
@@ -477,9 +477,9 @@ TEST_F(EditorNodeDelegateQml, EdgeEndpointsStayGluedToPortsThroughFirstOpenBurst
   const auto snapshot = EditorNodeGraphProjection::Build(document, 1, 1, 1);
   ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded);
 
-  // First-open burst: EditorNodesPanel.bindGraph applies the stored layout in
-  // the same event turn as the snapshot insert, before any polish pass has
-  // anchored the port docks to the node edges.
+  // First-open burst: EditorNodeController applies stored layout in the same
+  // event turn as the snapshot insert, before any polish pass has anchored the
+  // port docks to the node edges.
   adapter.SetNodeItemPosition(NodeId{"develop"}, QPointF(48, 48));
   adapter.SetNodeItemPosition(NodeId{"grade.primary"}, QPointF(48, 136));
   adapter.SetNodeItemPosition(NodeId{"drt"}, QPointF(48, 329));

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -492,5 +492,68 @@ TEST_F(EditorNodesPanelQmlTest, HeaderHasNoApplyOrCancelAction) {
   EXPECT_EQ(Find(QStringLiteral("editorNodesCancelButton")), nullptr);
 }
 
+TEST_F(EditorNodesPanelQmlTest, OpenPageAppliesCommittedProjectionOnce) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  QTRY_VERIFY_WITH_TIMEOUT(Adapter() != nullptr, 2000);
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->has_projection(), 2000);
+  ProcessEvents();
+  EXPECT_EQ(nodes->completed_projection_apply_count(), 1);
+  EXPECT_EQ(adapter->topology_replace_count(), 1);
+  EXPECT_EQ(nodes->selected_node_id(), NodeId{"grade.primary"});
+}
+
+TEST_F(EditorNodesPanelQmlTest, OrdinaryDraftEditsDoNotReplaceQanTopology) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  QTRY_VERIFY_WITH_TIMEOUT(Adapter() != nullptr, 2000);
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  ProcessEvents();
+  const auto applies   = nodes->completed_projection_apply_count();
+  const auto replaces  = adapter->topology_replace_count();
+  ASSERT_TRUE(nodes->addCleanColorGrade());
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(nodes->selected_node_id()) != nullptr, 2000);
+  EXPECT_EQ(nodes->completed_projection_apply_count(), applies);
+  EXPECT_EQ(adapter->topology_replace_count(), replaces);
+  EXPECT_EQ(nodes->snapshot().nodes.size(), 3u);
+  EXPECT_EQ(nodes->ActiveNodes().size(), 4u);
+}
+
+TEST_F(EditorNodesPanelQmlTest, CloseWithQueuedApplyThenReopenRestoresOnce) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  QTRY_VERIFY_WITH_TIMEOUT(Adapter() != nullptr, 2000);
+  auto* nodes = Controller();
+  ASSERT_NE(nodes, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(nodes->has_snapshot(), 2000);
+  const auto queued_before = nodes->queued_projection_apply_count();
+  ASSERT_NE(backend_.pipeline_document(), nullptr);
+  ASSERT_TRUE(nodes->PublishDocument(*backend_.pipeline_document(),
+                                     static_cast<std::uint64_t>(nodes->session_generation())));
+  EXPECT_GT(nodes->queued_projection_apply_count(), queued_before);
+
+  controller_.set_editor_tool_panel_page(QString());
+  ProcessEvents();
+  QTRY_VERIFY_WITH_TIMEOUT(Find(QStringLiteral("editorNodesPageBody")) == nullptr, 2000);
+  OpenNodesPage();
+  QTRY_VERIFY_WITH_TIMEOUT(Adapter() != nullptr, 2000);
+  nodes         = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->has_projection(), 2000);
+  ProcessEvents();
+  EXPECT_EQ(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, true);
+  EXPECT_EQ(nodes->graph_adapter_object(), adapter);
+}
+
 }  // namespace
 }  // namespace alcedo::ui::test

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/node_panel_simplification_review.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/node_panel_simplification_review.md
@@ -1,0 +1,234 @@
+# Nodes panel implementation and simplification review
+
+Date: 2026-09-04. Source baseline: `2bedebdd`; working tree was clean before this review.
+
+Scope: NM5 production panel, controller, draft, projection, adapter, and their NM1–NM4 document,
+session-command, history, paste, compiler, and Mask boundaries. This is a source-structure review
+plus targeted execution evidence, not renewed numerical qualification of every GPU backend.
+Implementation work is specified in [NM5.8a–NM5.8g](phase_nm5_nodes_panel_plan.md#16-nm58--code-simplification-and-final-nodes-page-checks).
+
+## Findings
+
+### R1 — P1: draft editing still performs whole-graph copying and index work
+
+**Style/maintainability; performance mechanism established by source, latency not measured.**
+`app/editor_node_graph_draft.cpp:173` copies nodes, edges, node JSON, every working index, and net
+delta maps into `Checkpoint` for each admitted mutation. `RemoveEdgeAt` and `InsertEdge` at lines
+275–285 each call `RebuildIndexes`; a connection replacing two edges can rebuild three times.
+`editor_node_controller.cpp:722` then obtains a complete value snapshot from the draft.
+`FinishMutation`, `MaybeSubmitDraft`, and `incomplete_draft` also repeat submission-validity work.
+
+This is the highest-value simplification because the machinery duplicates state and work while
+Section 19 promises mutation work proportional to affected entries. Keep a bounded reversal record,
+stable edge indexing, one active read view, and one computed validity result (NM5.8b). Full validation
+traversal is still allowed. Avoid replacing these structures with another whole-graph context.
+
+**Coverage gap:** `FirstConstructionCopiesTheCompleteProjectionOnce` asserts sizes, identity, and
+validity; it counts no copies. `AddInsertsOneDisconnectedGradeWithoutConsumingTheProductCounter`
+compares `&draft`, which remains equal even if every member is copied. Add operation/copy counters
+and payload-heavy 32-Grade repeated-edit tests; object identity alone does not prove this target.
+
+### R2 — P2: QML and controller duplicate projection, layout, and selection application
+
+**Style/maintainability.** `EditorNodesPanel.qml:110` restores every node position/drawer and applies
+selection, duplicating `EditorNodeController::ApplyBoundGraph` at line 387. The panel combines a
+`Binding` at line 152 with imperative adapter assignment, `bindGraph`, completion handling, and
+queued callbacks from both snapshot and graph signals. The controller independently queues apply
+from `PublishSnapshot` and `GraphChanged`. Successful application applies selection more than once.
+
+Consolidate attachment and projection scheduling in the controller, retain layout values in the
+layout store, and leave GraphView navigation/focus in QML (NM5.8a). Existing reopen/layout tests
+passed, but do not count duplicate apply calls. Add those assertions before deleting update paths.
+Do not add a wrapper component merely to move the duplicate logic into another QML file.
+
+### R3 — P2: Qan creation, reversal, delegate caching, and publication have mixed ownership
+
+**Style/maintainability.** `alcedo_qan_graph.cpp` is 1253 lines. `InsertTopology:488` and
+`InsertProjectedNode:600` repeat node creation/presentation/map/port work, while the controller's
+`ApplyMutationToGraph:732` performs Qan rollback. The adapter owns delegate loading/installation,
+primitive lifetime, identity maps, presentation, selection, and connector translation.
+
+Put visual mutation/reversal behind one adapter API and share primitive creation; extract only the
+cohesive delegate-library responsibility with its engine, URL, component, and installation state
+(NM5.8c). A full replacement still needs a different lifecycle from an incremental edit.
+The reverse-pointer map is necessary generation validation, not redundant product data.
+
+**Coverage gap:** test each partial visual mutation and reversal failure. Existing domain
+`FailureAfterEachStepRestoresExactState` covers product graph steps, not every Qan operation.
+Source inspection alone does not establish a user-visible rollback failure.
+
+### R4 — P2: unused interactive entry candidates coexist with required historical types
+
+**Style/maintainability.** Repository search found production declarations/definitions only for
+`EditorSessionController::SubmitAddColorGrade:654`, `SubmitRemoveColorGrade:667`, and
+`SubmitReconnectColorGrade:692`; the current node controller uses draft topology submission.
+`canReconnectSelectedColorGrade` has no QML consumer and describes the earlier selection policy.
+
+Audit and delete unused upper-layer entry points. Follow each service/queue/port/mutation caller
+before deleting the rest. `EditorSessionService:1058–1266` repeats publication/render/revision code
+across five node commands; keep a small shared completion helper for retained commands (NM5.8d).
+
+Do **not** delete the old typed payloads: `document_transfer.cpp:357–374` still creates Remove/Add
+changes, `pipeline_history_applier.cpp` replays them, and Mask reachability inspects their stored
+nodes. Serialized history and active paste producers are concrete retained uses. Rename also has
+different render semantics from topology edits and remains a separate command.
+
+### R5 — P2: projection policy is implemented twice
+
+**Style/maintainability.** `EditorNodeGraphDraft::KindOf/ProjectNode:37–70` and
+`EditorNodeGraphProjection::Build:37–92` both map model types, names, and ordered Mask rows.
+Share the node-to-value conversion in the projection module (NM5.8b). Do not merge their graph
+traversals: committed projection uses a valid backbone; draft projection includes detached nodes.
+Keep NM3 stored Mask display order distinct from the compiler's deterministic MaskId ordering.
+
+### R6 — P2: topology history completion exceeds the dedicated test evidence
+
+**Coverage gap.** The NM5.7R record acknowledges no separate recovery/reopen/checkout cases for
+`EditNodeGraph`, but Section 20 checked off all of them. `EditorSessionNodeCommandTest` uses
+`ControllableEditorHistoryPort`; its topology test counts calls/revision/render requests rather
+than persisting and replaying a real change. Controller and panel fixtures apply real domain deltas
+through replacement session backends. `PipelineHistoryApplierTest` contains general replay tests,
+not the full new topology publication/reopen sequence.
+
+The existing persistent suites in `tests/edit/history/editor_session_history_port_test.cpp`,
+`editor_version_checkout_test.cpp`, `editor_document_history_test.cpp`, and
+`editor_history_materializer_test.cpp` also have no direct `EditNodeGraph`/`NodeGraphTopology`
+case. Add the new scenario in a focused history source instead of enlarging the history-port file.
+
+Keep the passing unit tests and add the production-history matrix in NM5.8e. The plan checkbox is
+now open with its exact evidence requirement. Also inject post-commit projection failure and
+promotion failure around `MaybeSubmitDraft:797`; its separate publication/error path deserves
+execution evidence before consolidation. No runtime failure is claimed from reading that path.
+
+## Retained NM1–NM4 responsibilities
+
+- **NM1:** `PipelineDocument` remains writable product state. Current-panel read projection and
+  render-lock restoration remain needed; they cannot be deleted merely because Nodes now has a
+  separate visual projection. `PipelineMgmtService::CheckoutVersion:1002` owns storage replay and
+  restoration, which needs a broader state inventory before any independent service split.
+- **NM2:** `graph_compiler.cpp:306` compiles a Grade with explicit NodeId/input/output and
+  adjustment ownership. Separate compiled runtime values and UI snapshots serve different readers.
+  No evidence from this review justifies merging native backend implementations or removing the
+  graph compiler's ownership checks. GPU kernels were not numerically requalified this round.
+- **NM3:** `CompileGradeOwnedMaskStack:257` generates Mask execution inputs/Union; the Nodes
+  projection emits stored display rows. Sharing these two ordering policies would change behavior.
+  MaskStore lifetime, raster requests, and persistent-asset reachability remain distinct duties.
+- **NM4:** typed changes, inverse replay, immutable roots, WAL publication, and paste are retained.
+  This review inspected current callers instead of treating older roadmap residual notes as proof
+  that already-removed migration code still exists. Broader pipeline-service decomposition is not
+  a prerequisite for the bounded Nodes cleanup.
+
+## State ownership after simplification
+
+| Owner | Mutable state and responsibility |
+| --- | --- |
+| `EditorNodeController` | Session/adapter/layout handles and connections; committed snapshot and revisions; image/Version identity; live selection and restoration candidate; command/error state; one queued update; ownership of the draft and submission completion matching |
+| `EditorNodeGraphDraft` | Base identity/order/values; editable nodes/edges/counter; lookup and adjacency indexes; net delta; bounded operation reversal; cached validity |
+| `EditorNodeLayoutStore` | Per-key positions, view, zoom, drawer values, and saved selection used only for restoration |
+| `EditorNodesPanel` | Rename text/id/focus, GraphView lifetime/navigation, and local menu interaction |
+| `AlcedoQanGraph` | Graph handle; applied values/revisions; node/edge/port/reverse maps; candidate flags; drawer connections; applied selection; replacement state/counters; local visual reversal |
+| `QanDelegateLibrary` | Delegate URLs, engine handle, cached components, and graph-specific installation handles |
+| `EditorSessionService` | Existing queue/lifecycle/operation state; typed command routing and success publication; no new generic mutable command context |
+
+The extracted delegate library must be independently constructible and tested. Public module APIs
+need Doxygen describing thread affinity, pointer lifetime, mutation/reversal, and failure behavior.
+The current QML update helpers and draft index/checkpoint helpers lack comparable explanations;
+document the retained operations rather than adding comments to obsolete duplicates.
+
+## Test evidence and acceptance matrix
+
+Executed on Windows against **existing** `build/debug` runtime binaries. No configure/build was
+performed, so these results do not establish that every binary was built from `2bedebdd`.
+All nine binaries exited 0: **116 tests passed, no reported failures or skips**.
+
+| Target | Passed | What its inspected assertions support |
+| --- | ---: | --- |
+| `EditorNodeGraphDraftTest` | 8 | Draft topology, cancellation, invalid connect, reversal; not bounded copy work |
+| `EditorNodeGraphProjectionTest` | 6 | Projected values, identity, ordered Mask rows |
+| `PipelineGraphTopologyDeltaTest` | 5 | In-place forward/inverse and injected domain-step restoration |
+| `PipelineEditBatchTest` | 17 | Typed payload validation/serialization and history values |
+| `PipelineHistoryApplierTest` | 12 | Apply/inverse, general replay, locking, and asset checks |
+| `EditorSessionNodeCommandTest` | 6 | Command routing/revision/render assertions with fake history |
+| `EditorNodeSelectionLayoutTest` | 27 | Controller selection/draft behavior and layout values |
+| `AlcedoQanGraphTest` | 16 | Adapter projection, incremental primitives, identity/lifetime checks |
+| `EditorNodesPanelQmlTest` | 19 | Real QML panel with test backend, draft actions, layout, and errors |
+
+Reproduction commands (run from repository root):
+
+```powershell
+& build/debug/alcedo_studio/tests/app/EditorNodeGraphDraftTest_runtime/EditorNodeGraphDraftTest.exe
+& build/debug/alcedo_studio/tests/app/EditorNodeGraphProjectionTest_runtime/EditorNodeGraphProjectionTest.exe
+& build/debug/alcedo_studio/tests/app/PipelineGraphTopologyDeltaTest_runtime/PipelineGraphTopologyDeltaTest.exe
+& build/debug/alcedo_studio/tests/edit/PipelineEditBatchTest_runtime/PipelineEditBatchTest.exe
+& build/debug/alcedo_studio/tests/app/PipelineHistoryApplierTest_runtime/PipelineHistoryApplierTest.exe
+& build/debug/alcedo_studio/tests/app/EditorSessionNodeCommandTest_runtime/EditorSessionNodeCommandTest.exe
+& build/debug/alcedo_studio/tests/ui/EditorNodeSelectionLayoutTest_runtime/EditorNodeSelectionLayoutTest.exe
+& build/debug/alcedo_studio/tests/ui/AlcedoQanGraphTest_runtime/AlcedoQanGraphTest.exe
+& build/debug/alcedo_studio/tests/ui/EditorNodesPanelQmlTest_runtime/EditorNodesPanelQmlTest.exe
+```
+
+Per-target execution output is in untracked `build/tmp/nm5-review/<target>.log`.
+No observed test failure was found. Persistent new-topology history, copy/work bounds, full visual
+matrix, native screen reader, fresh build, installed package, macOS, and real-RAW remain outside
+the demonstrated result. Do not infer them from passing unit or QML-fixture tests.
+
+## Source size and split decisions
+
+All source/test files below have **0 added / 0 removed lines in this review**. Only this report and
+the phase plan were edited. Counts include blank lines; large files require responsibility review,
+not automatic file chopping.
+
+The phase plan was already 3088 lines, mostly prior sub-phase requirements and completion records.
+This review retains those records and splits the new work by responsibility inside Section 16;
+the separate review report keeps the evidence discussion out of the execution steps. A later
+documentation-only extraction can move completed records with stable links, but is not a code
+simplification deliverable.
+
+| File | LOC | Decision |
+| --- | ---: | --- |
+| `EditorNodesPanel.qml` | 509 | Delete duplicate update work before considering component extraction |
+| `editor_node_controller.cpp` | 903 | Move visual reversal to adapter; keep command/projection facade focused |
+| `alcedo_qan_graph.cpp` | 1253 | Extract delegate library with its state; consolidate primitive helpers |
+| `editor_node_graph_draft.cpp` | 555 | Simplify reversal/index state in place |
+| `editor_node_graph_projection.cpp` | 93 | Own reusable node projection |
+| `editor_session_service.cpp` | 1679 | Remove obsolete entry candidates and duplicate completion tail; no general rewrite |
+| `editor_history_mutation.cpp` | 1055 | Remove only verified-unused node entry methods; retain typed publication owner |
+| `pipeline_service.cpp` | 1355 | Separate future load/replay/persistence work needs complete guard/cache/lock inventory |
+| `pipeline_edit_batch.cpp` | 1486 | Codec has many variants; a future graph-change codec may own stateless read/write APIs; preserve format now |
+| `pipeline_graph_commands.cpp` | 311 | Retain domain operations still used by history/paste |
+| `pipeline_history_applier.cpp` | 629 | Retain inverse/replay boundary and add focused topology-history evidence |
+| `graph_compiler.cpp` | 497 | Retain runtime compilation boundary |
+| `editor_nodes_panel_qml_test.cpp` | 496 | Correct stale names and add lifecycle/apply-count assertions |
+| `editor_node_controller_test.cpp` | 504 | Keep controller fixture focused; do not embed persistent storage here |
+| `alcedo_qan_graph_test.cpp` | 672 | Extract delegate tests with delegate owner |
+| `editor_history_versions_rail_qml_harness.hpp` | 754 | Do not grow into storage/runtime fixture; add focused history fixture |
+
+## Main call chains to preserve
+
+```text
+Add/Delete/Connect in QML or Qan connector
+  -> EditorNodeController admission
+  -> EditorNodeGraphDraft mutation + validity
+  -> AlcedoQanGraph incremental visual mutation
+  -> incomplete: retain draft, no history/render
+  -> complete: SubmitNodeGraphTopologyEdit -> EditorSessionService::EditNodeGraph
+     -> EditorSessionHistoryPort -> EditorHistoryMutation
+     -> typed batch + in-place product delta + WAL/head publication
+     -> one topology Quality render + committed projection promotion
+
+Rename -> controller -> session Rename -> typed name change
+  -> publication -> node role update, no photo render
+
+Version checkout/recovery/reopen -> persistent root + typed replay
+  -> live document under existing lock/restoration boundary
+  -> session notification -> committed projection + layout-key restore
+
+Qan mutation failure -> reverse completed visual steps + reverse draft operation
+  -> exact error; no product submission
+WAL/publication failure -> product inverse restoration
+  -> retain applicable draft + exact error; no topology render
+```
+
+NM5.8 stages must record source/test deletions, retained compatibility callers, total/diff LOC,
+registration, and executed evidence. Do not count relocation of one class's methods as reduced
+ownership or claim all previous NM phases have been requalified by this review.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: NM5.1–NM5.7R complete; NM5.8 follows NM5.7R
+Status: NM5.1–NM5.7R implementation recorded; NM5.8a–NM5.8b complete 2026-09-04; NM5.8c–NM5.8g pending
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -2855,13 +2855,21 @@ placement tests in `EditorNodeSelectionLayoutTest`.
 
 ---
 
-## 16. NM5.8 — Lifecycle, accessibility, build, install, and package checks
+## 16. NM5.8 — Code simplification and final Nodes-page checks
 
 ### 16.1 Input context
 
 NM5.1–NM5.7 provide the original Nodes page. NM5.7R replaces the immediate-reconnect product
-behavior with incremental draft editing and atomic automatic submission. This sub-phase adds no
-product feature. It closes lifecycle, accessibility, localization, build, and package gaps.
+behavior with incremental draft editing and atomic automatic submission. The
+[2026-09-04 implementation review](node_panel_simplification_review.md) found duplicated
+QML/controller update paths, whole-draft rollback copies, repeated index construction, and obsolete
+command entry candidates. NM5.8 now removes that maintenance cost before closing lifecycle,
+accessibility, localization, build, and package gaps. Existing product behavior remains required.
+
+Earlier completion records are historical execution records. A passing object-address assertion
+does not prove bounded copying, and direct inverse application does not prove product reopen or
+Version checkout. The evidence gaps below remain open even where NM5.7R previously marked them
+complete.
 
 NM8 still owns final real-RAW and three-backend qualification.
 
@@ -2873,6 +2881,315 @@ NM8 still owns final real-RAW and three-backend qualification.
 - [Licence](https://cneben.github.io/QuickQanava/licence.html): source and binary notice requirements.
 
 ### 16.3 Work
+
+Execute NM5.8a through NM5.8g in order. Each stage must leave a usable, tested Nodes page.
+Use responsibility boundaries for commits; approximately 500 changed lines is a review target,
+not a reason to leave half a state transition in another commit. Do not introduce generic command
+frameworks, a second product graph, a second selection owner, or a new rendering backend path.
+
+#### 16.3.1 NM5.8a — One projection, selection, and layout update path
+
+**Files:** `EditorNodesPanel.qml`, `editor_node_controller.{hpp,cpp}`,
+`editor_node_layout_store.{hpp,cpp}`, `editor_node_controller_test.cpp`,
+`editor_node_layout_store_test.cpp`, and `editor_nodes_panel_qml_test.cpp`.
+Existing files live under the source/test directories listed in the review.
+
+- Keep committed projection identity, revisions, selection, command availability, and the queued
+  projection update in `EditorNodeController`. Keep per-image/Version positions, zoom, view,
+  saved selection, and drawer values in `EditorNodeLayoutStore`; saved selection is restoration
+  data, not a second live selection source.
+- Keep GraphView navigation and rename focus/text in QML. The controller owns applying node
+  positions, drawers, and live selection to the adapter. QML restores only GraphView zoom/view.
+- Replace the combination of `Binding`, `bindControllerAdapter`, `bindGraph`, `GraphChanged`,
+  `SnapshotChanged`, and completion-time rebinding with one attach/detach route. Remove the QML
+  node traversal duplicated by `ApplyBoundGraph`; preserve layout-key activation before restore.
+- Consolidate committed revision publication used by `PublishSnapshot` and `MaybeSubmitDraft`.
+  Keep draft changes on the incremental route. Do not turn each mutation into `ApplySnapshot`.
+- Audit `ContainsNode`, `IndexOf`, and `NodeFor` for one lookup implementation. Do not introduce
+  another index unless a measured use requires it.
+- Give deferred updates an explicit lifetime/identity check. Replace the unqualified
+  `skip_next_session_refresh_` suppression with completion matching if event-order tests show
+  it is needed; do not suppress unrelated image/Version notifications.
+
+**Acceptance:** extend `EditorNodeSelectionLayoutTest` and `EditorNodesPanelQmlTest` to assert one
+logical projection apply per committed revision, no replacement for ordinary draft edits, one
+live selection, layout-key ordering, and close/reopen with an update already queued. Existing
+`ReopenRestoresPositionsViewZoomSelectionAndDrawerState` and
+`TwoVersionsKeepSeparateLayoutValues` remain required. Count apply requests as well as topology
+replacements; identity retention alone cannot detect duplicate role/layout work.
+
+##### NM5.8a completion record (2026-09-04)
+
+**Status:** complete — one attach/apply route, live selection on the controller, layout-key restore,
+queued apply lifetime, image/Version identity not swallowed by submit echo
+
+**Primary success call chain:**
+
+```text
+Nodes Loader creates EditorNodesPanel
+  -> attachAdapter / set_graph_adapter
+  -> ApplyBoundGraph (immediate if the Qan graph exists, else queued on GraphChanged)
+  -> SyncLayoutKey then applyToGraph
+  -> EnsureDefaultPositions, node positions, drawers, ApplyProductSelection
+  -> QML restoreGraphView (zoom and pan only)
+```
+
+Ordinary draft edits stay on the incremental route:
+
+```text
+addCleanColorGrade / deleteColorGrade / requestConnect
+  -> EditorNodeGraphDraft mutation
+  -> ApplyMutationToGraph (insert/remove projected primitives)
+  -> ActiveNodes/ActiveEdges read the draft
+  -> snapshot_ stays the last committed projection
+```
+
+**Primary failure call chain:**
+
+```text
+PublishSnapshot queues ApplyBoundGraph, then the page unloads
+  -> set_graph_adapter(null) increments attach generation
+  -> ApplyBoundGraphIfCurrent sees a stale generation or null adapter
+  -> skipped_stale_projection_apply_count, no ApplySnapshot
+```
+
+```text
+session image/Version/generation differs from the cached Nodes identity
+  -> SessionIdentityChanged
+  -> discard draft, refreshFromSession
+  -> submitted-echo skip does not apply
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `OpenPageAppliesCommittedProjectionOnce` | `EditorNodesPanelQmlTest` | PASS |
+| `OrdinaryDraftEditsDoNotReplaceQanTopology` | `EditorNodesPanelQmlTest` | PASS |
+| `CloseWithQueuedApplyThenReopenRestoresOnce` | `EditorNodesPanelQmlTest` | PASS |
+| `ReopenRestoresPositionsViewZoomSelectionAndDrawerState` | `EditorNodesPanelQmlTest` | PASS |
+| `TwoVersionsKeepSeparateLayoutValues` | `EditorNodesPanelQmlTest` | PASS |
+| `OneCommittedRevisionCoalescesQueuedProjectionApplies` | `EditorNodeSelectionLayoutTest` | PASS |
+| `QueuedProjectionApplyIgnoresStaleAdapterAfterDetach` | `EditorNodeSelectionLayoutTest` | PASS |
+| `LayoutKeyActivatesBeforeSavedSelectionRestore` | `EditorNodeSelectionLayoutTest` | PASS |
+| `SavedLayoutSelectionDoesNotOverrideLiveSelectionOnTheSameKey` | `EditorNodeSelectionLayoutTest` | PASS |
+| `OrdinaryDraftEditsDoNotCopyIntoTheCommittedSnapshot` | `EditorNodeSelectionLayoutTest` | PASS |
+| `ImageSwitchAfterSubmitRefreshesTheCommittedProjection` | `EditorNodeSelectionLayoutTest` | PASS |
+| `TwoVersionsKeepSeparatePositionsAndDrawerState` | `EditorNodeSelectionLayoutTest` | PASS |
+
+Commands: `cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorNodeGraphDraftTest EditorNodeGraphProjectionTest EditorNodeSelectionLayoutTest EditorNodesPanelQmlTest` then the four test executables under `build/debug/alcedo_studio/tests/`.
+Suite totals: `EditorNodesPanelQmlTest` 22/22; `EditorNodeSelectionLayoutTest` 34/34.
+
+**Checklist / exit condition:** 16.3.1 acceptance items covered by the tests above.
+
+**LOC note (grill-code-review):** `editor_node_controller.cpp` 957 lines (under the ~1000-line split threshold; NM5.8c moves Qan mutation reversal out of this file). `EditorNodesPanel.qml` 414 lines. Layout store sources were not split; the controller now activates the layout key and applies positions, drawers, and live selection.
+
+**Residual gaps:** `EditorNodeLayoutStore::ensureDefaultsFrom` still reads committed `snapshot()` and has no QML caller. NM5.8c still owns adapter `ApplyMutation` and delegate-library extraction. Keyboard, persistent history, and package checks remain NM5.8e–g. NM8 retains real-RAW and three-backend qualification.
+
+#### 16.3.2 NM5.8b — Bounded draft rollback and one node projection implementation
+
+**Files:** `app/editor_node_graph_draft.cpp`, `include/app/editor_node_graph_draft.hpp`,
+`app/editor_node_graph_projection.cpp`, `include/app/editor_node_graph_projection.hpp`,
+`editor_node_controller.{hpp,cpp}`, `editor_node_graph_draft_test.cpp`, and
+`editor_node_graph_projection_test.cpp`.
+
+- Keep `EditorNodeGraphDraft` as the sole owner of draft topology, base identity, default-name
+  counter, indexes, net delta, and last-operation reversal data. Preserve the immutable base data
+  needed to serialize removed nodes and restore original ordering.
+- Replace `Checkpoint` copies of all nodes, edges, JSON, indexes, and accumulated deltas with an
+  operation reversal record containing only affected entries and prior counter/order values.
+  First land reversal with existing storage; then simplify indexing in a separate coherent commit.
+- Replace per-edge `RebuildIndexes` calls with affected-entry updates. Prefer stable edge keys or
+  stable storage so removing an edge does not renumber every adjacency entry. Materialize ordered
+  serialized indexes at `MakeChange`, where full traversal is acceptable.
+- Remove unused `EdgeRecord` and unused conversion/accessor surfaces after a repository caller
+  scan. Consolidate paired key/value maps only where both have identical ownership and lifetime.
+- Share node-kind/name/Mask-row projection through `EditorNodeGraphProjection::ProjectNode`.
+  Keep committed backbone traversal and draft traversal distinct: detached nodes are legitimate
+  draft content, and Mask display order must remain the stored order.
+- Stop copying `CurrentSnapshot` into controller `snapshot_` after each draft operation. The
+  controller exposes the active read view from the draft or committed snapshot; materialize a
+  complete value snapshot only at an explicit projection boundary such as page recreation.
+- Compute submission validity once per admitted mutation and expose the result. QML availability
+  reads must not repeat graph traversals; invalid requests must retain the prior cached result.
+
+**Acceptance:** `EditorNodeGraphDraftTest` must cover Add/Delete/Connect reversal, net cancellation,
+multiple detached nodes, exact counter/order/JSON restoration, and a 32-Grade graph with large
+Mask payloads over 100 connections. Add deterministic work/copy instrumentation that asserts no
+whole-draft checkpoint or per-edge complete index rebuild. Record validity traversal separately;
+it may visit the whole graph. Compare serialized forward/inverse results with
+`PipelineGraphTopologyDeltaTest`. Do not claim this stage complete based on `&draft` equality.
+
+##### NM5.8b completion record (2026-09-04)
+
+**Status:** complete — bounded last-mutation reversal, stable edge keys, shared `ProjectNode`/`KindOf`,
+cached submission validity, no per-edit copy into controller `snapshot_`
+
+**Primary success call chain:**
+
+```text
+EditorNodeGraphDraft::FromDocument
+  -> ProjectNode for every live node (including detached Color Grades)
+  -> RebuildIndexes once
+  -> ComputeSubmissionValid once
+AddColorGrade / RemoveColorGrade / Connect
+  -> BeginReversal of affected entries and prior counter/validity
+  -> InsertNodeAt / EraseNodeAt / InsertEdgeAt / RemoveEdgeByKey / DisconnectDraftKeys
+  -> FinishMutation ComputeSubmissionValid once
+RestoreLastMutation
+  -> reverse added/removed nodes and edges, restore JSON/delta maps and counters
+MakeChange
+  -> materialize ordered serialized indexes
+  -> ApplyNodeGraphTopologyChange Forward then Inverse restores document JSON and name counter
+```
+
+**Primary failure call chain:**
+
+```text
+Connect rejected (self-connect, cycle, unknown node, unsupported port)
+  -> AdmitConnect fails before BeginReversal
+  -> indexes, delta, and cached SubmissionValid unchanged
+  -> validity_traversals does not increase
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `AddDeleteConnectReversalRestoresExactCounterOrderAndJson` | `EditorNodeGraphDraftTest` | PASS |
+| `NetCancellationRestoresBaseWithoutWholeDraftCopy` | `EditorNodeGraphDraftTest` | PASS |
+| `MultipleDetachedGradesKeepIndependentNodesAndEdges` | `EditorNodeGraphDraftTest` | PASS |
+| `RejectedConnectRetainsCachedSubmissionValidity` | `EditorNodeGraphDraftTest` | PASS |
+| `SerializedDraftChangeMatchesInPlaceForwardAndInverse` | `EditorNodeGraphDraftTest` | PASS |
+| `ThirtyTwoGradeGraphRepeatedConnectStaysBounded` | `EditorNodeGraphDraftTest` | PASS |
+| `ProjectNodeCopiesStoredMaskOrderForDetachedGrades` | `EditorNodeGraphProjectionTest` | PASS |
+| `OrdinaryDraftEditsDoNotCopyIntoTheCommittedSnapshot` | `EditorNodeSelectionLayoutTest` | PASS |
+
+Commands: same MSVC debug build as NM5.8a, then `EditorNodeGraphDraftTest.exe` and `EditorNodeGraphProjectionTest.exe`.
+Suite totals: `EditorNodeGraphDraftTest` 14/14; `EditorNodeGraphProjectionTest` 7/7. Work stats assert `complete_state_copies == 0` and `complete_index_rebuilds == 0` after construction; 32-Grade × 8 Masks × 100 connects recorded `validity_traversals == 101`.
+
+**Checklist / exit condition:** 16.3.2 acceptance items covered. Forward/inverse comparison uses `ApplyNodeGraphTopologyChange` (the same in-place applier as `PipelineGraphTopologyDeltaTest`), not `&draft` equality.
+
+**LOC note (grill-code-review):** `editor_node_graph_draft.cpp` 642 lines; header 213. `editor_node_graph_projection.cpp` 82 lines; header 110.
+
+**Residual gaps:** NM5.8c still owns Qan primitive reversal. Persistent Undo/Redo/WAL/reopen/checkout evidence remains NM5.8e. NM8 retains real-RAW and three-backend qualification.
+
+#### 16.3.3 NM5.8c — Qan primitive ownership and atomic visual mutation
+
+**Files:** `alcedo_qan_graph.{hpp,cpp}`, new
+`qan_delegate_library.{hpp,cpp}` in the matching `album_backend` source/include directories,
+`editor_node_controller.cpp`, `alcedo_qan_graph_test.cpp`, focused
+`qan_delegate_library_test.cpp`, and the production/UI-test CMake source lists.
+
+- Extract `QanDelegateLibrary` with `Configure`, `EnsureLoaded`, `ComponentFor`, and `Reset` APIs.
+  It owns delegate URLs, engine identity, cached components, and per-graph delegate-install state.
+  Move `EnsureDelegates`, `LoadComponent`, `DropCachedDelegates`, and delegate installation with
+  that state. It receives explicit engine/graph arguments and never a controller/adapter parent
+  pointer, shared mutable context, or friend access.
+- `AlcedoQanGraph` retains graph lifetime, NodeId/Qan maps, ports, candidate edges, applied
+  projection, drawer connections, and applied selection. Full replacement and incremental insert
+  must share primitive creation, presentation, registration, and cleanup helpers. Preserve pinned
+  QuickQanava port-list cleanup needed before rebinding an exclusive port.
+- Move Qan-operation reversal out of `EditorNodeController::ApplyMutationToGraph` into an adapter
+  `ApplyMutation` API. Track only successfully completed visual changes. On failure return the
+  original error plus any reversal error; the controller reverses the draft once.
+- Remove redundant stored node-projection copies where one authoritative value plus lookup is
+  sufficient. Keep reverse pointer-to-NodeId maps: they enforce generation/lifetime safety.
+- Preserve separate full replacement and incremental mutation operations. They have different
+  lifetime guarantees and must not be collapsed into a rebuild on every edit.
+
+**Acceptance:** `AlcedoQanGraphTest` injects failure at each node/port/edge insertion, removal, and
+binding step, and during visual reversal. Assert unrelated QObject identities, exact edges,
+selection/layout, error visibility, and no product submission. Test `QanDelegateLibrary` without
+constructing `EditorNodeController`; require unload/recreate with a different engine. Re-run the
+production QML panel tests after registering all new files. Physical `.cpp` splitting alone does
+not complete this stage.
+
+#### 16.3.4 NM5.8d — Remove unused command entry points; preserve stored history
+
+**Files:** `editor_session_controller.{hpp,cpp}`, `editor_node_controller.{hpp,cpp}`,
+`app/editor_session_service.cpp`, `include/app/editor_session_service.hpp`,
+`include/app/editor_session_ports.hpp`, `include/app/editor_session_command_queue.hpp`,
+`app/editor_action_policy.cpp`, `editor_session_history_port.{hpp,cpp}`,
+`editor_history_mutation.{hpp,cpp}`, and their existing command/history tests.
+
+- Inventory callers of `SubmitAddColorGrade`, `SubmitRemoveColorGrade`, and
+  `SubmitReconnectColorGrade`; the review found only declarations/definitions in production.
+  Delete unused controller wrappers and the unused `canReconnectSelectedColorGrade` surface.
+  Audit service, queue, port, and mutation methods independently before removing the corresponding
+  obsolete interactive entry chain. Existing tests must move to the supported path or the actual
+  retained domain API; do not keep a production entry point solely for an old test.
+- Keep `RenameColorGrade` and `EditNodeGraph` as distinct commands. Consolidate their common
+  success publication/render-reason/revision tail in a small service helper. The service retains
+  queue admission and lifecycle policy; the helper owns no new state.
+- Preserve Add/Remove/Reconnect typed payload parsing, serialization, inverse replay, presentation,
+  and Mask reachability where stored data requires them. `document_transfer.cpp` still constructs
+  Add/Remove changes. Preserve its producers and the supporting domain operations.
+- Do not change stored kind strings, hashes, format versions, name-counter semantics, or paste
+  behavior as a cleanup side effect. Do not remove current-panel projection of document values
+  from NM1/NM4; NM6 must still receive a working adjustment panel.
+- Limit this stage to node command ownership. The oversized session/pipeline/history files do not
+  justify a general service rewrite. Any wider split needs its own state inventory and acceptance.
+
+**Acceptance:** run `EditorSessionNodeCommandTest`, action-policy tests, `PipelineEditBatchTest`,
+`PipelineHistoryApplierTest`, document-transfer tests, and Mask reachability tests. Prove that one
+topology command publishes one batch/revision/Quality render, Rename publishes no photo render,
+and old payloads still replay with exact names/counters and pasted Mask assets. Record a final
+production caller scan for every removed public symbol.
+
+#### 16.3.5 NM5.8e — Real history and lifecycle evidence
+
+**Files:** `editor_nodes_panel_qml_test.cpp`, `editor_node_controller_test.cpp`,
+`editor_session_node_command_test.cpp`, new `tests/edit/history/editor_node_topology_history_test.cpp`,
+`pipeline_history_applier_test.cpp`, `tests/edit/history/editor_version_checkout_test.cpp`, and
+their focused fixtures. Register the new persistent-history source in the matching history test
+target. Reuse the storage setup patterns in `editor_session_history_port_test.cpp` without growing
+that oversized file or the shared 754-line rail harness with unrelated storage and GPU setup.
+
+- Submit a real `NodeGraphTopologyChange` through the production history port and temporary
+  storage, then Undo, Redo, recover the WAL, reopen, and checkout a second Version.
+- Assert document serialization, node/edge order, counters, head/Version, Mask asset values,
+  projection identity, and render reason/count. Direct domain inverse tests and fake-history call
+  counters remain useful unit evidence but do not satisfy this acceptance.
+- Inject WAL failure, post-commit projection failure, and projection-promotion failure. Require
+  exact errors; no success result may silently erase a projection error. Assert product commit
+  state separately from visual state when the failure occurs after publication.
+- Exercise queued refresh after image switch, same-image Version switch, incomplete draft during
+  parameter/Mask-role changes, panel replacement, and 100 Loader open/close cycles. Record live
+  Qan object counts and prove no stale callback mutates the next page/session.
+- Correct test names that still describe immediate reconnect/rebuild or bridge-on-delete when
+  their assertions now exercise draft editing. Keep assertions on the actual user-visible result.
+
+**Acceptance:** all new persistent-history tests run from registered targets. Fill the matrix in
+Sections 17–19 with executable evidence, including recovery failure and subsequent usable state.
+Only then mark exact topology Undo/Redo/recovery/reopen/checkout complete in Section 20.
+
+#### 16.3.6 NM5.8f — Keyboard, accessibility, localization, and visual states
+
+Complete the original empty/loading/pending/error states, keyboard connection flow, drawer focus,
+accessible names, localization, 30–40 percent text expansion, large system fonts, and the full
+Section 17.1 visual matrix. Use the Alcedo QML skills before implementation. Keep domain validation
+in the domain; translate structured known errors once at the application presentation boundary
+while preserving exact technical details for unknown failures.
+
+**Acceptance:** `EditorNodesPanelQmlTest`, delegate tests, rail lifecycle tests, and
+`WorkspaceShellTest` cover every visible action and all existing VI restrictions. Record real
+screen-reader checks separately from QML property assertions. No new Apply/Cancel UI is allowed.
+
+#### 16.3.7 NM5.8g — Build, install, package, and final regression
+
+Complete the original Windows/MSVC and available macOS builds, install/package QML import checks,
+and QuickQanava/bezier notices. Run the affected graph, history, adapter, QML, workspace, and
+NM1–NM4 regression targets after the cleanup. Native runtime tests remain required if runtime
+source changes; this split does not authorize backend algorithm or quality changes.
+
+**Acceptance:** record exact configure/build/test/install/package commands, target registration,
+test counts, installed-app startup, licence contents, visual matrix, and unavailable environments.
+Run the Section 19 performance checks on the resulting production path. Fresh build evidence is
+required; the review's existing-binary reruns are only a baseline. NM8 retains real-RAW and final
+three-backend qualification.
+
+**Original acceptance checklist, retained across NM5.8a–NM5.8g:**
 
 1. Complete empty, loading, pending-command, and error behavior.
 2. Complete localized text and accessible names.
@@ -2920,6 +3237,16 @@ packaged app start
 
 Record the date, commands, test count, visual matrix, package results, and unavailable environment
 checks here.
+
+| Stage | Status | Required evidence |
+| --- | --- | --- |
+| NM5.8a | Complete 2026-09-04 | One update route; queued teardown and layout restore |
+| NM5.8b | Complete 2026-09-04 | Bounded reversal/copy work; exact draft values and counters |
+| NM5.8c | Pending | Delegate ownership; primitive failure and reversal matrix |
+| NM5.8d | Pending | Caller deletion audit; retained typed replay/paste |
+| NM5.8e | Pending | Persistent topology history; lifecycle and failure recovery |
+| NM5.8f | Pending | Keyboard, screen reader, localization, visual matrix |
+| NM5.8g | Pending | Fresh builds, regression, installed packages, notices |
 
 ---
 
@@ -3073,7 +3400,8 @@ Do not reduce decode resolution, output quality, or backend behavior to meet the
       requests one Quality render.
 - [x] All command failures preserve the prior product graph, history, Version, revision, and
       rendered state while retaining an applicable draft.
-- [x] Atomic topology edits support exact Undo, Redo, recovery, reopen, and Version checkout.
+- [ ] Atomic topology edits have dedicated production-history evidence for exact Undo, Redo,
+      recovery, reopen, and Version checkout (NM5.8e; direct inverse tests already pass).
 - [ ] All visible actions support keyboard input and accessibility.
 - [ ] All product text uses localization.
 - [ ] All visual values use AppTheme and `DESIGN.md`.


### PR DESCRIPTION
## Summary
- Give the Nodes page one attach/apply route: the controller owns committed projection, live selection, layout-key restore, and queued `ApplyBoundGraph`; QML only attaches the adapter and restores GraphView zoom/pan.
- Replace whole-draft checkpoint copies with a bounded last-mutation reversal, stable edge keys, shared `ProjectNode`/`KindOf`, and cached submission validity so ordinary draft edits do not rebuild Qan topology or copy into `snapshot_`.
- Record NM5.8a/b completion in the Nodes panel plan. NM5.8c–g (Qan mutation ownership, unused command cleanup, persistent history, a11y, package) remain open.

## Test plan
- [x] `EditorNodeGraphDraftTest` 14/14 (reversal, net cancel, 32-Grade bounded connects, forward/inverse `ApplyNodeGraphTopologyChange`)
- [x] `EditorNodeGraphProjectionTest` 7/7 (including detached-grade Mask order)
- [x] `EditorNodeSelectionLayoutTest` 34/34 (one queued apply, stale detach, layout-key restore, image switch after submit)
- [x] `EditorNodesPanelQmlTest` 22/22 (open applies once, ordinary drafts do not replace topology, close/reopen with a queued apply, existing restore tests)
- [ ] Re-run the same four targets after review comments if the apply/draft path changes

Made with [Cursor](https://cursor.com)