### PR TITLE
refactor(ui): isolate Nodes Qan mutation ownership

### DIFF
--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
@@ -8,12 +8,13 @@
 #include <QObject>
 #include <QPointF>
 #include <QPointer>
-#include <QQuickItem>
 #include <QQmlComponent>
 #include <QQmlEngine>
+#include <QQuickItem>
 #include <QString>
 #include <QUrl>
 #include <QVariantList>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -22,9 +23,11 @@
 #include <unordered_map>
 #include <vector>
 
+#include "app/editor_node_graph_draft.hpp"
 #include "app/editor_node_graph_projection.hpp"
 #include "edit/graph/graph_ids.hpp"
 #include "qanGraph.h"
+#include "ui/alcedo_main/album_backend/qan_delegate_library.hpp"
 
 namespace qan {
 class Edge;
@@ -69,8 +72,8 @@ class AlcedoQanGraph : public QObject {
                  NOTIFY DelegatesChanged)
   Q_PROPERTY(QUrl portDelegateUrl READ port_delegate_url WRITE set_port_delegate_url NOTIFY
                  DelegatesChanged)
-  Q_PROPERTY(QUrl portDockDelegateUrl READ port_dock_delegate_url WRITE
-                 set_port_dock_delegate_url NOTIFY DelegatesChanged)
+  Q_PROPERTY(QUrl portDockDelegateUrl READ port_dock_delegate_url WRITE set_port_dock_delegate_url
+                 NOTIFY DelegatesChanged)
   Q_PROPERTY(QUrl edgeDelegateUrl READ edge_delegate_url WRITE set_edge_delegate_url NOTIFY
                  DelegatesChanged)
 
@@ -146,6 +149,21 @@ class AlcedoQanGraph : public QObject {
       -> AlcedoQanGraphApplyResult;
 
   /**
+   * @brief Apply one admitted draft mutation to the live Qan projection.
+   *
+   * The operation is atomic from the adapter's perspective. Only completed
+   * visual steps are reversed when a later step fails. The adapter never
+   * changes the product draft, history, or render state; the controller owns
+   * the one corresponding draft reversal.
+   *
+   * @pre GUI thread, a bound graph, and a complete current projection.
+   * @return Failure contains the original Qan error and any visual-reversal
+   *         error encountered while restoring the prior projection.
+   */
+  [[nodiscard]] auto ApplyMutation(const alcedo::EditorNodeGraphDraftMutation& mutation)
+      -> AlcedoQanGraphApplyResult;
+
+  /**
    * @brief Insert one projected node and its ports without replacing the graph.
    * @return Failure restores no other primitives. The new node is removed on error.
    */
@@ -168,7 +186,7 @@ class AlcedoQanGraph : public QObject {
   /**
    * @brief Recolor every mapped edge to the permanent AppTheme stroke.
    */
-  void PromoteCandidatePresentation();
+  void               PromoteCandidatePresentation();
   /**
    * @brief Record committed snapshot revisions without replacing Qan primitives.
    *
@@ -209,17 +227,17 @@ class AlcedoQanGraph : public QObject {
    * identity the adapter exposes; a raw Qan selected-node list is not a
    * product selection source.
    */
-  [[nodiscard]] auto LiveNodeId(const qan::Node* node) const -> std::optional<NodeId>;
+  [[nodiscard]] auto  LiveNodeId(const qan::Node* node) const -> std::optional<NodeId>;
 
   /**
    * @return Copied node-card values for @p node_id, or nullptr when unmapped.
    */
-  [[nodiscard]] auto NodeProjection(const NodeId& node_id) const -> const EditorNodeProjection*;
+  [[nodiscard]] auto  NodeProjection(const NodeId& node_id) const -> const EditorNodeProjection*;
 
-  [[nodiscard]] auto session_generation() const -> std::uint64_t;
-  [[nodiscard]] auto projection_revision() const -> std::uint64_t;
-  [[nodiscard]] auto topology_revision() const -> std::uint64_t;
-  [[nodiscard]] auto has_projection() const -> bool;
+  [[nodiscard]] auto  session_generation() const -> std::uint64_t;
+  [[nodiscard]] auto  projection_revision() const -> std::uint64_t;
+  [[nodiscard]] auto  topology_revision() const -> std::uint64_t;
+  [[nodiscard]] auto  has_projection() const -> bool;
 
   /**
    * @brief Apply the one-node product selection to live Qan visuals.
@@ -227,21 +245,21 @@ class AlcedoQanGraph : public QObject {
    * Clears the Qan selected-node list, then selects at most one mapped node.
    * A Qan selected-node list is never treated as a product selection source.
    */
-  void ApplyProductSelection(const std::optional<NodeId>& node_id);
+  void                ApplyProductSelection(const std::optional<NodeId>& node_id);
 
   /**
    * @brief Move a live node item. No-op for unknown or stale NodeIds.
    */
-  void SetNodeItemPosition(const NodeId& node_id, QPointF position);
-  [[nodiscard]] auto NodeItemPosition(const NodeId& node_id) const -> std::optional<QPointF>;
+  void                SetNodeItemPosition(const NodeId& node_id, QPointF position);
+  [[nodiscard]] auto  NodeItemPosition(const NodeId& node_id) const -> std::optional<QPointF>;
 
   /**
    * @brief Set Color Grade Mask-drawer open state on the live delegate.
    *
    * Endpoints ignore the call. Missing NodeIds are no-ops.
    */
-  void SetDrawerOpen(const NodeId& node_id, bool open);
-  [[nodiscard]] auto DrawerOpen(const NodeId& node_id) const -> bool;
+  void                SetDrawerOpen(const NodeId& node_id, bool open);
+  [[nodiscard]] auto  DrawerOpen(const NodeId& node_id) const -> bool;
 
   Q_INVOKABLE QString liveNodeId(QObject* node) const;
   Q_INVOKABLE void    setNodePosition(const QString& node_id, qreal x, qreal y);
@@ -290,6 +308,45 @@ class AlcedoQanGraph : public QObject {
   [[nodiscard]] virtual auto InsertQanNode(qan::Graph& graph, const EditorNodeProjection& node)
       -> qan::Node*;
 
+  /**
+   * @brief Insert one visual port through the pinned QuickQanava graph.
+   *
+   * Tests may override this operation to return nullptr. Production forwards
+   * to qan::Graph::insertPort and does not substitute another delegate.
+   */
+  [[nodiscard]] virtual auto InsertQanPort(qan::Graph& graph, qan::Node& node, bool is_input,
+                                           const QString& port_id) -> qan::PortItem*;
+
+  /**
+   * @brief Insert one visual edge through the pinned QuickQanava graph.
+   */
+  [[nodiscard]] virtual auto InsertQanEdge(qan::Graph& graph, qan::Node& source,
+                                           qan::Node& destination, QQmlComponent* component)
+      -> qan::Edge*;
+
+  /**
+   * @brief Bind an edge to its source and destination ports.
+   * @return false when the visual binding operation was not completed.
+   */
+  [[nodiscard]] virtual auto BindQanEdge(qan::Graph& graph, qan::Edge& edge, qan::PortItem& source,
+                                         qan::PortItem& destination) -> bool;
+
+  /**
+   * @brief Remove one visual edge. Tests may reject the operation.
+   */
+  [[nodiscard]] virtual auto RemoveQanEdge(qan::Graph& graph, qan::Edge& edge) -> bool;
+
+  /**
+   * @brief Remove one visual port. Tests may reject the operation.
+   */
+  [[nodiscard]] virtual auto RemoveQanPort(qan::Graph& graph, qan::Node& node, qan::PortItem& port)
+      -> bool;
+
+  /**
+   * @brief Remove one visual node. Tests may reject the operation.
+   */
+  [[nodiscard]] virtual auto RemoveQanNode(qan::Graph& graph, qan::Node& node) -> bool;
+
  private:
   struct EdgeKey {
     NodeId      source_node_id;
@@ -327,14 +384,14 @@ class AlcedoQanGraph : public QObject {
     std::uint64_t session_generation = 0;
   };
 
-  void               ClearIdentityMaps();
-  void               ClearDrawerConnections();
-  void               BindDrawerSignals();
-  void               BindDrawerSignal(QQuickItem* item, const NodeId& node_id);
-  void               ConfigureGraphPolicy();
-  void               ConfigureConnector();
-  void               ApplyConnectablePolicy();
-  void               OnGraphDestroyed();
+  void ClearIdentityMaps();
+  void ClearDrawerConnections();
+  void BindDrawerSignals();
+  void BindDrawerSignal(QQuickItem* item, const NodeId& node_id);
+  void ConfigureGraphPolicy();
+  void ConfigureConnector();
+  void ApplyConnectablePolicy();
+  void OnGraphDestroyed();
   void OnConnectorRequestEdgeCreation(qan::Node* src, QObject* dst, qan::PortItem* src_port,
                                       qan::PortItem* dst_port);
 
@@ -342,10 +399,38 @@ class AlcedoQanGraph : public QObject {
   void OnDrawerOpenChanged();
 
  private:
-  void               DestroyMappedPrimitives();
-  void               DestroyPrimitives(const std::vector<QPointer<qan::Edge>>& edges,
-                                       const std::vector<QPointer<qan::Node>>& nodes);
-  void               AttachLiveVisuals();
+  void DestroyMappedPrimitives();
+  void AttachLiveVisuals();
+
+  struct NodeVisualState {
+    EditorNodeProjection projection;
+    std::size_t          applied_index = 0;
+    QPointF              position;
+    bool                 has_position = false;
+    bool                 drawer_open  = true;
+  };
+
+  struct PortVisualSpec {
+    PortId port_id;
+    bool   is_input = false;
+  };
+
+  [[nodiscard]] auto InsertNodeVisual(const EditorNodeProjection& node,
+                                      std::uint64_t               session_generation,
+                                      const NodeVisualState* restore_state = nullptr) -> QString;
+  [[nodiscard]] auto RemoveNodeVisual(const NodeId&    node_id,
+                                      NodeVisualState* removed_state = nullptr) -> QString;
+  [[nodiscard]] auto RestoreNodePorts(const NodeId& node_id, qan::Node& node,
+                                      const std::vector<PortVisualSpec>& ports) -> QString;
+  [[nodiscard]] auto InsertEdgeVisual(const EditorNodeEdgeProjection& edge, bool candidate)
+      -> QString;
+  [[nodiscard]] auto RemoveEdgeVisual(const EditorNodeEdgeProjection& edge,
+                                      bool require_present = true) -> QString;
+  [[nodiscard]] auto RemoveCreatedEdge(qan::Edge& edge) -> QString;
+  void               DetachEdgeFromPorts(qan::Edge& edge);
+  void               RestoreEdgeToPorts(qan::Edge& edge);
+  void               EraseAppliedNode(const NodeId& node_id);
+  void               EraseAppliedEdge(const EditorNodeEdgeProjection& edge);
 
   [[nodiscard]] auto RejectIfStale(const EditorNodeGraphSnapshot& snapshot) const -> QString;
   [[nodiscard]] auto ValidateSnapshot(const EditorNodeGraphSnapshot& snapshot) const -> QString;
@@ -360,17 +445,7 @@ class AlcedoQanGraph : public QObject {
   [[nodiscard]] auto InsertEdge(const EditorNodeEdgeProjection& edge) -> QString;
   void               ApplyNodePresentation(qan::Node& qan_node, const EditorNodeProjection& node);
   void               ApplyEdgePresentation(qan::Edge& qan_edge, bool candidate);
-  [[nodiscard]] auto EnsureDelegates() -> QString;
-  struct LoadedComponent {
-    std::unique_ptr<QQmlComponent> component;
-    QString                        error;
-  };
-  [[nodiscard]] auto        LoadComponent(const QUrl& url, const QString& role) -> LoadedComponent;
-  void                      DropCachedDelegates();
-  [[nodiscard]] auto        InstallPortDelegate() -> QString;
-  [[nodiscard]] auto        InstallPortDockDelegate() -> QString;
-  void                      InstallInvisibleSelectionDelegate();
-  [[nodiscard]] auto        ComponentFor(EditorNodeKind kind) const -> QQmlComponent*;
+  [[nodiscard]] auto ComponentFor(EditorNodeKind kind) const -> QQmlComponent*;
 
   [[nodiscard]] static auto MakeEdgeKey(const EditorNodeEdgeProjection& edge) -> EdgeKey;
   [[nodiscard]] static auto ToQString(std::string_view text) -> QString;
@@ -381,26 +456,15 @@ class AlcedoQanGraph : public QObject {
       -> QVariantList;
 
   QPointer<qan::Graph>                              graph_;
-  QUrl                                              color_grade_delegate_url_;
-  QUrl                                              endpoint_delegate_url_;
-  QUrl                                              port_delegate_url_;
-  QUrl                                              port_dock_delegate_url_;
-  QUrl                                              edge_delegate_url_;
-  QPointer<QQmlEngine>                              delegate_engine_;
-  QPointer<qan::Graph>                              port_delegate_graph_;
-  QPointer<qan::Graph>                              port_dock_delegate_graph_;
-  std::unique_ptr<QQmlComponent>                    color_grade_component_;
-  std::unique_ptr<QQmlComponent>                    endpoint_component_;
-  std::unique_ptr<QQmlComponent>                    edge_component_;
-  bool                                              has_projection_      = false;
-  bool                                              rebuild_in_progress_ = false;
+  QanDelegateLibrary                                delegate_library_;
+  bool                                              has_projection_         = false;
+  bool                                              rebuild_in_progress_    = false;
   int                                               topology_replace_count_ = 0;
   std::map<EdgeKey, bool>                           edge_candidate_;
   EditorNodeGraphSnapshot                           applied_;
   std::map<NodeId, QPointer<qan::Node>>             node_by_id_;
   std::map<EdgeKey, QPointer<qan::Edge>>            edge_by_key_;
   std::map<NodeId, NodePorts>                       ports_by_node_;
-  std::map<NodeId, EditorNodeProjection>            node_projections_;
   std::unordered_map<const qan::Node*, ReverseNode> node_from_qan_;
   std::vector<QMetaObject::Connection>              drawer_connections_;
   NodeId                                            product_selected_node_id_;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -60,8 +60,8 @@ class EditorNodeController : public QObject {
   Q_PROPERTY(bool canReconnectSelectedColorGrade READ can_reconnect_selected_color_grade NOTIFY
                  ActionAvailabilityChanged)
   Q_PROPERTY(bool incompleteDraft READ incomplete_draft NOTIFY DraftStateChanged)
-  Q_PROPERTY(QString incompleteDraftInstruction READ incomplete_draft_instruction NOTIFY
-                 DraftStateChanged)
+  Q_PROPERTY(
+      QString incompleteDraftInstruction READ incomplete_draft_instruction NOTIFY DraftStateChanged)
   Q_PROPERTY(QString selectedNodeName READ selected_node_name NOTIFY SelectionChanged)
   Q_PROPERTY(QObject* graphAdapter READ graph_adapter_object WRITE set_graph_adapter NOTIFY
                  GraphAdapterChanged)
@@ -105,7 +105,7 @@ class EditorNodeController : public QObject {
    * No-op with a cleared snapshot when the session has no document. A build
    * error keeps the previous snapshot.
    */
-  Q_INVOKABLE bool   refreshFromSession();
+  Q_INVOKABLE bool refreshFromSession();
 
   /**
    * @brief Project the active graph onto an AlcedoQanGraph adapter.
@@ -119,7 +119,7 @@ class EditorNodeController : public QObject {
    *        missing snapshot.
    * @return false when ApplySnapshot fails; lastError holds the adapter error.
    */
-  Q_INVOKABLE bool   applyToGraph(QObject* adapter);
+  Q_INVOKABLE bool applyToGraph(QObject* adapter);
 
   /**
    * @brief Select one product node.
@@ -127,42 +127,42 @@ class EditorNodeController : public QObject {
    * Unknown or empty ids fail closed and leave the current selection unchanged.
    * @param node_id Product NodeId string.
    */
-  Q_INVOKABLE void   selectNode(const QString& node_id);
-  Q_INVOKABLE void   selectPreviousBackboneNode();
-  Q_INVOKABLE void   selectNextBackboneNode();
-  Q_INVOKABLE void   selectDevelop();
-  Q_INVOKABLE void   selectDrt();
+  Q_INVOKABLE void selectNode(const QString& node_id);
+  Q_INVOKABLE void selectPreviousBackboneNode();
+  Q_INVOKABLE void selectNextBackboneNode();
+  Q_INVOKABLE void selectDevelop();
+  Q_INVOKABLE void selectDrt();
   /**
    * @brief Add one disconnected clean Color Grade below the main node DAG.
    *
    * Does not write PipelineDocument or history while the draft is incomplete.
    */
-  Q_INVOKABLE bool   addCleanColorGrade();
+  Q_INVOKABLE bool addCleanColorGrade();
   /**
    * @brief Rename one Color Grade without changing its stable NodeId.
    * @return false for endpoints, blank names, stale generations, or history failure.
    */
-  Q_INVOKABLE bool   renameColorGrade(const QString& node_id, const QString& display_name);
+  Q_INVOKABLE bool renameColorGrade(const QString& node_id, const QString& display_name);
   /**
    * @brief Remove one Color Grade from the draft. Does not bridge neighbors.
    */
-  Q_INVOKABLE bool   deleteColorGrade(const QString& node_id);
+  Q_INVOKABLE bool deleteColorGrade(const QString& node_id);
   /**
    * @brief Exclusive-port connect from @p source output to @p destination input.
    */
-  Q_INVOKABLE bool   requestConnect(const QString& source_node_id,
-                                    const QString& destination_node_id);
-  Q_INVOKABLE bool   requestConnect(const QString& source_node_id,
-                                    const QString& destination_node_id, quint64 request_generation);
+  Q_INVOKABLE bool requestConnect(const QString& source_node_id,
+                                  const QString& destination_node_id);
+  Q_INVOKABLE bool requestConnect(const QString& source_node_id, const QString& destination_node_id,
+                                  quint64 request_generation);
   /**
    * @brief Resolve a visual-connector drop as exclusive-port Connect.
    *
    * Output-to-output drops are rejected. Any supported Color Grade or Develop
    * output may start a connection.
    */
-  Q_INVOKABLE bool   requestConnectorMove(const QString& source_node_id,
-                                          const QString& destination_node_id,
-                                          bool           destination_is_output);
+  Q_INVOKABLE bool requestConnectorMove(const QString& source_node_id,
+                                        const QString& destination_node_id,
+                                        bool           destination_is_output);
 
   [[nodiscard]] auto selected_node_id() const -> NodeId { return selected_node_id_; }
   [[nodiscard]] auto selected_node_id_string() const -> QString;
@@ -255,8 +255,8 @@ class EditorNodeController : public QObject {
   [[nodiscard]] auto CurrentDraftIdentity() const -> alcedo::EditorNodeGraphDraftIdentity;
   [[nodiscard]] auto EnsureDraft() -> bool;
   void               DiscardDraft();
-  [[nodiscard]] auto ApplyMutationToGraph(const alcedo::EditorNodeGraphDraftMutation& mutation)
-      -> bool;
+  [[nodiscard]] auto ApplyDraftMutationToAdapter(
+      const alcedo::EditorNodeGraphDraftMutation& mutation) -> bool;
   [[nodiscard]] auto MaybeSubmitDraft() -> bool;
   [[nodiscard]] auto TopologyChanged(const EditorNodeGraphSnapshot& snapshot) const -> bool;
   [[nodiscard]] auto BoundSessionGeneration() const -> std::optional<std::uint64_t>;
@@ -283,34 +283,34 @@ class EditorNodeController : public QObject {
   void               AdoptCommittedDocument(const PipelineDocument& document);
   [[nodiscard]] auto HasActiveGraph() const -> bool;
 
-  QPointer<EditorSessionController> session_;
-  QPointer<AlcedoQanGraph>          graph_adapter_;
-  QPointer<EditorNodeLayoutStore>   layout_store_;
-  QMetaObject::Connection           state_connection_;
-  QMetaObject::Connection           history_connection_;
-  QMetaObject::Connection           availability_connection_;
-  QMetaObject::Connection           graph_adapter_connection_;
-  EditorNodeGraphSnapshot           snapshot_{};
-  bool                              has_snapshot_ = false;
-  NodeId                            selected_node_id_;
-  NodeId                            selection_restore_node_id_;
-  bool                              command_active_          = false;
-  bool                              projection_apply_queued_ = false;
-  quint64                           session_generation_      = 0;
-  quint64                           projection_revision_     = 0;
-  quint64                           topology_revision_       = 0;
-  quint64                           element_id_              = 0;
-  quint64                           image_id_                = 0;
-  QString                           version_id_;
-  QString                           last_error_;
-  std::unique_ptr<alcedo::EditorNodeGraphDraft> draft_;
+  QPointer<EditorSessionController>                   session_;
+  QPointer<AlcedoQanGraph>                            graph_adapter_;
+  QPointer<EditorNodeLayoutStore>                     layout_store_;
+  QMetaObject::Connection                             state_connection_;
+  QMetaObject::Connection                             history_connection_;
+  QMetaObject::Connection                             availability_connection_;
+  QMetaObject::Connection                             graph_adapter_connection_;
+  EditorNodeGraphSnapshot                             snapshot_{};
+  bool                                                has_snapshot_ = false;
+  NodeId                                              selected_node_id_;
+  NodeId                                              selection_restore_node_id_;
+  bool                                                command_active_          = false;
+  bool                                                projection_apply_queued_ = false;
+  quint64                                             session_generation_      = 0;
+  quint64                                             projection_revision_     = 0;
+  quint64                                             topology_revision_       = 0;
+  quint64                                             element_id_              = 0;
+  quint64                                             image_id_                = 0;
+  QString                                             version_id_;
+  QString                                             last_error_;
+  std::unique_ptr<alcedo::EditorNodeGraphDraft>       draft_;
   std::optional<alcedo::EditorNodeGraphDraftIdentity> submitted_identity_;
-  EditorNodeLayoutKey                   last_layout_key_{};
-  quint64                           adapter_attach_generation_          = 0;
-  quint64                           pending_apply_attach_generation_    = 0;
-  int                               queued_projection_apply_count_      = 0;
-  int                               completed_projection_apply_count_   = 0;
-  int                               skipped_stale_projection_apply_count_ = 0;
+  EditorNodeLayoutKey                                 last_layout_key_{};
+  quint64                                             adapter_attach_generation_            = 0;
+  quint64                                             pending_apply_attach_generation_      = 0;
+  int                                                 queued_projection_apply_count_        = 0;
+  int                                                 completed_projection_apply_count_     = 0;
+  int                                                 skipped_stale_projection_apply_count_ = 0;
 };
 
 void RegisterEditorNodeQmlTypes();

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/qan_delegate_library.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/qan_delegate_library.hpp
@@ -1,0 +1,109 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <QPointer>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QUrl>
+#include <memory>
+
+#include "app/editor_node_graph_projection.hpp"
+#include "qanGraph.h"
+
+namespace alcedo::ui {
+
+/**
+ * @brief Owns the QML delegates used by one Alcedo QuickQanava adapter.
+ *
+ * The library owns delegate URLs and components that are tied to a
+ * QQmlEngine. QuickQanava owns components installed on a qan::Graph, so the
+ * library retains only per-graph installation markers for those components.
+ * It has no controller, adapter, or shared application context ownership.
+ *
+ * Threading: GUI thread only. @c EnsureLoaded must run on the thread that owns
+ * the supplied engine and graph. Pointer lifetime: the engine and graph must
+ * outlive the call; the library clears markers when either changes or when
+ * Reset is called. Failure returns the actual delegate-load or installation
+ * error and never selects an upstream visual delegate as a substitute.
+ */
+class QanDelegateLibrary final {
+ public:
+  QanDelegateLibrary()                                     = default;
+  ~QanDelegateLibrary()                                    = default;
+
+  QanDelegateLibrary(const QanDelegateLibrary&)            = delete;
+  QanDelegateLibrary& operator=(const QanDelegateLibrary&) = delete;
+  QanDelegateLibrary(QanDelegateLibrary&&)                 = delete;
+  QanDelegateLibrary& operator=(QanDelegateLibrary&&)      = delete;
+
+  /**
+   * @brief Configure all delegate URLs and discard cached components on change.
+   */
+  void Configure(QUrl color_grade_delegate_url, QUrl endpoint_delegate_url, QUrl port_delegate_url,
+                 QUrl port_dock_delegate_url, QUrl edge_delegate_url);
+
+  /**
+   * @brief Load delegates for @p engine and install graph-owned delegates.
+   * @return Empty on success, or the exact load/installation failure.
+   */
+  [[nodiscard]] auto EnsureLoaded(QQmlEngine& engine, qan::Graph& graph) -> QString;
+
+  /**
+   * @brief Return the cached node delegate for @p kind.
+   * @return A cached component, or nullptr before a successful EnsureLoaded.
+   */
+  [[nodiscard]] auto ComponentFor(EditorNodeKind kind) const -> QQmlComponent*;
+
+  /**
+   * @brief Return the cached edge delegate after a successful EnsureLoaded.
+   */
+  [[nodiscard]] auto EdgeComponent() const -> QQmlComponent* { return edge_component_.get(); }
+
+  /**
+   * @brief Drop engine-owned components and all graph-installation markers.
+   *
+   * Components already transferred to a graph remain owned by that graph.
+   */
+  void               Reset();
+
+  [[nodiscard]] auto ColorGradeDelegateUrl() const -> const QUrl& {
+    return color_grade_delegate_url_;
+  }
+  [[nodiscard]] auto EndpointDelegateUrl() const -> const QUrl& { return endpoint_delegate_url_; }
+  [[nodiscard]] auto PortDelegateUrl() const -> const QUrl& { return port_delegate_url_; }
+  [[nodiscard]] auto PortDockDelegateUrl() const -> const QUrl& { return port_dock_delegate_url_; }
+  [[nodiscard]] auto EdgeDelegateUrl() const -> const QUrl& { return edge_delegate_url_; }
+
+ private:
+  struct LoadedComponent {
+    std::unique_ptr<QQmlComponent> component;
+    QString                        error;
+  };
+
+  [[nodiscard]] auto LoadComponent(QQmlEngine& engine, const QUrl& url, const QString& role)
+      -> LoadedComponent;
+  [[nodiscard]] auto InstallPortDelegate(QQmlEngine& engine, qan::Graph& graph) -> QString;
+  [[nodiscard]] auto InstallPortDockDelegate(QQmlEngine& engine, qan::Graph& graph) -> QString;
+  [[nodiscard]] auto InstallInvisibleSelectionDelegate(QQmlEngine& engine, qan::Graph& graph)
+      -> QString;
+  void                           ResetGraphInstallations();
+
+  QUrl                           color_grade_delegate_url_;
+  QUrl                           endpoint_delegate_url_;
+  QUrl                           port_delegate_url_;
+  QUrl                           port_dock_delegate_url_;
+  QUrl                           edge_delegate_url_;
+
+  QPointer<QQmlEngine>           engine_;
+  QPointer<qan::Graph>           port_delegate_graph_;
+  QPointer<qan::Graph>           port_dock_delegate_graph_;
+  QPointer<qan::Graph>           selection_delegate_graph_;
+  std::unique_ptr<QQmlComponent> color_grade_component_;
+  std::unique_ptr<QQmlComponent> endpoint_component_;
+  std::unique_ptr<QQmlComponent> edge_component_;
+};
+
+}  // namespace alcedo::ui

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -249,6 +249,8 @@ target_compile_definitions(AppTheme PRIVATE
 add_library(AlcedoQanGraph STATIC
     "${ALCEDO_UI_SHELL_ROOT}/album_backend/alcedo_qan_graph.cpp"
     "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp"
+    "${ALCEDO_UI_SHELL_ROOT}/album_backend/qan_delegate_library.cpp"
+    "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/album_backend/qan_delegate_library.hpp"
 )
 target_include_directories(AlcedoQanGraph
     PUBLIC

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
@@ -15,6 +15,7 @@
 #include <QVariantMap>
 #include <algorithm>
 #include <cstddef>
+#include <iterator>
 #include <optional>
 #include <string>
 
@@ -72,7 +73,7 @@ AlcedoQanGraph::~AlcedoQanGraph() {
   rebuild_in_progress_ = true;
   ClearDrawerConnections();
   ClearIdentityMaps();
-  DropCachedDelegates();
+  delegate_library_.Reset();
 }
 
 void AlcedoQanGraph::set_graph(qan::Graph* graph) {
@@ -86,7 +87,7 @@ void AlcedoQanGraph::set_graph(qan::Graph* graph) {
   ClearIdentityMaps();
   has_projection_ = false;
   applied_        = {};
-  DropCachedDelegates();
+  delegate_library_.Reset();
   rebuild_in_progress_ = false;
   graph_               = graph;
   if (!graph_.isNull()) {
@@ -97,59 +98,74 @@ void AlcedoQanGraph::set_graph(qan::Graph* graph) {
 }
 
 void AlcedoQanGraph::set_color_grade_delegate_url(const QUrl& url) {
-  if (color_grade_delegate_url_ == url) {
+  if (delegate_library_.ColorGradeDelegateUrl() == url) {
     return;
   }
-  color_grade_delegate_url_ = url;
-  DropCachedDelegates();
+  delegate_library_.Configure(
+      url, delegate_library_.EndpointDelegateUrl(), delegate_library_.PortDelegateUrl(),
+      delegate_library_.PortDockDelegateUrl(), delegate_library_.EdgeDelegateUrl());
   emit DelegatesChanged();
 }
 
-auto AlcedoQanGraph::color_grade_delegate_url() const -> QUrl { return color_grade_delegate_url_; }
+auto AlcedoQanGraph::color_grade_delegate_url() const -> QUrl {
+  return delegate_library_.ColorGradeDelegateUrl();
+}
 
 void AlcedoQanGraph::set_endpoint_delegate_url(const QUrl& url) {
-  if (endpoint_delegate_url_ == url) {
+  if (delegate_library_.EndpointDelegateUrl() == url) {
     return;
   }
-  endpoint_delegate_url_ = url;
-  DropCachedDelegates();
+  delegate_library_.Configure(
+      delegate_library_.ColorGradeDelegateUrl(), url, delegate_library_.PortDelegateUrl(),
+      delegate_library_.PortDockDelegateUrl(), delegate_library_.EdgeDelegateUrl());
   emit DelegatesChanged();
 }
 
-auto AlcedoQanGraph::endpoint_delegate_url() const -> QUrl { return endpoint_delegate_url_; }
+auto AlcedoQanGraph::endpoint_delegate_url() const -> QUrl {
+  return delegate_library_.EndpointDelegateUrl();
+}
 
 void AlcedoQanGraph::set_port_delegate_url(const QUrl& url) {
-  if (port_delegate_url_ == url) {
+  if (delegate_library_.PortDelegateUrl() == url) {
     return;
   }
-  port_delegate_url_ = url;
-  DropCachedDelegates();
+  delegate_library_.Configure(
+      delegate_library_.ColorGradeDelegateUrl(), delegate_library_.EndpointDelegateUrl(), url,
+      delegate_library_.PortDockDelegateUrl(), delegate_library_.EdgeDelegateUrl());
   emit DelegatesChanged();
 }
 
-auto AlcedoQanGraph::port_delegate_url() const -> QUrl { return port_delegate_url_; }
+auto AlcedoQanGraph::port_delegate_url() const -> QUrl {
+  return delegate_library_.PortDelegateUrl();
+}
 
 void AlcedoQanGraph::set_port_dock_delegate_url(const QUrl& url) {
-  if (port_dock_delegate_url_ == url) {
+  if (delegate_library_.PortDockDelegateUrl() == url) {
     return;
   }
-  port_dock_delegate_url_ = url;
-  DropCachedDelegates();
+  delegate_library_.Configure(
+      delegate_library_.ColorGradeDelegateUrl(), delegate_library_.EndpointDelegateUrl(),
+      delegate_library_.PortDelegateUrl(), url, delegate_library_.EdgeDelegateUrl());
   emit DelegatesChanged();
 }
 
-auto AlcedoQanGraph::port_dock_delegate_url() const -> QUrl { return port_dock_delegate_url_; }
+auto AlcedoQanGraph::port_dock_delegate_url() const -> QUrl {
+  return delegate_library_.PortDockDelegateUrl();
+}
 
 void AlcedoQanGraph::set_edge_delegate_url(const QUrl& url) {
-  if (edge_delegate_url_ == url) {
+  if (delegate_library_.EdgeDelegateUrl() == url) {
     return;
   }
-  edge_delegate_url_ = url;
-  DropCachedDelegates();
+  delegate_library_.Configure(
+      delegate_library_.ColorGradeDelegateUrl(), delegate_library_.EndpointDelegateUrl(),
+      delegate_library_.PortDelegateUrl(), delegate_library_.PortDockDelegateUrl(), url);
   emit DelegatesChanged();
 }
 
-auto AlcedoQanGraph::edge_delegate_url() const -> QUrl { return edge_delegate_url_; }
+auto AlcedoQanGraph::edge_delegate_url() const -> QUrl {
+  return delegate_library_.EdgeDelegateUrl();
+}
 
 auto AlcedoQanGraph::graph() const -> qan::Graph* { return graph_.data(); }
 
@@ -236,11 +252,12 @@ auto AlcedoQanGraph::LiveNodeId(const qan::Node* node) const -> std::optional<No
 }
 
 auto AlcedoQanGraph::NodeProjection(const NodeId& node_id) const -> const EditorNodeProjection* {
-  const auto it = node_projections_.find(node_id);
-  if (it == node_projections_.end()) {
+  const auto it = std::find_if(applied_.nodes.begin(), applied_.nodes.end(),
+                               [&](const auto& node) { return node.node_id == node_id; });
+  if (it == applied_.nodes.end()) {
     return nullptr;
   }
-  return &it->second;
+  return &*it;
 }
 
 auto AlcedoQanGraph::session_generation() const -> std::uint64_t {
@@ -266,13 +283,45 @@ auto AlcedoQanGraph::InsertQanNode(qan::Graph& graph, const EditorNodeProjection
   return graph.insertNode(component);
 }
 
+auto AlcedoQanGraph::InsertQanPort(qan::Graph& graph, qan::Node& node, bool is_input,
+                                   const QString& port_id) -> qan::PortItem* {
+  const auto dock = is_input ? qan::NodeItem::Dock::Top : qan::NodeItem::Dock::Bottom;
+  const auto type = is_input ? qan::PortItem::Type::In : qan::PortItem::Type::Out;
+  return graph.insertPort(&node, dock, type, QString(), port_id);
+}
+
+auto AlcedoQanGraph::InsertQanEdge(qan::Graph& graph, qan::Node& source, qan::Node& destination,
+                                   QQmlComponent* component) -> qan::Edge* {
+  return graph.insertEdge(&source, &destination, component);
+}
+
+auto AlcedoQanGraph::BindQanEdge(qan::Graph& graph, qan::Edge& edge, qan::PortItem& source,
+                                 qan::PortItem& destination) -> bool {
+  graph.bindEdge(&edge, &source, &destination);
+  return true;
+}
+
+auto AlcedoQanGraph::RemoveQanEdge(qan::Graph& graph, qan::Edge& edge) -> bool {
+  return graph.removeEdge(&edge, true);
+}
+
+auto AlcedoQanGraph::RemoveQanPort(qan::Graph& graph, qan::Node& node, qan::PortItem& port)
+    -> bool {
+  graph.removePort(&node, &port);
+  return true;
+}
+
+auto AlcedoQanGraph::RemoveQanNode(qan::Graph& graph, qan::Node& node) -> bool {
+  HideDetachedVisual(node.getItem());
+  return graph.removeNode(&node, true);
+}
+
 void AlcedoQanGraph::ClearIdentityMaps() {
   ClearDrawerConnections();
   node_by_id_.clear();
   edge_by_key_.clear();
   edge_candidate_.clear();
   ports_by_node_.clear();
-  node_projections_.clear();
   node_from_qan_.clear();
 }
 
@@ -281,42 +330,32 @@ void AlcedoQanGraph::OnGraphDestroyed() {
   ClearIdentityMaps();
   has_projection_ = false;
   applied_        = {};
-  DropCachedDelegates();
+  delegate_library_.Reset();
   graph_.clear();
   rebuild_in_progress_ = false;
   emit GraphChanged();
 }
 
 void AlcedoQanGraph::DestroyMappedPrimitives() {
-  std::vector<QPointer<qan::Edge>> edges;
+  std::vector<EditorNodeEdgeProjection> edges;
   edges.reserve(edge_by_key_.size());
   for (const auto& [key, edge] : edge_by_key_) {
-    edges.push_back(edge);
-  }
-  std::vector<QPointer<qan::Node>> nodes;
-  nodes.reserve(node_by_id_.size());
-  for (const auto& [id, node] : node_by_id_) {
-    nodes.push_back(node);
-  }
-  DestroyPrimitives(edges, nodes);
-}
-
-void AlcedoQanGraph::DestroyPrimitives(const std::vector<QPointer<qan::Edge>>& edges,
-                                       const std::vector<QPointer<qan::Node>>& nodes) {
-  if (graph_.isNull()) {
-    return;
+    Q_UNUSED(edge);
+    edges.push_back(EditorNodeEdgeProjection{key.source_node_id, key.source_port_id,
+                                             key.destination_node_id, key.destination_port_id});
   }
   for (const auto& edge : edges) {
-    if (!edge.isNull()) {
-      HideDetachedVisual(edge->getItem());
-      graph_->removeEdge(edge.data(), true);
-    }
+    (void)RemoveEdgeVisual(edge);
   }
-  for (const auto& node : nodes) {
-    if (!node.isNull()) {
-      HideDetachedVisual(node->getItem());
-      graph_->removeNode(node.data(), true);
-    }
+
+  std::vector<NodeId> nodes;
+  nodes.reserve(node_by_id_.size());
+  for (const auto& [id, node] : node_by_id_) {
+    Q_UNUSED(node);
+    nodes.push_back(id);
+  }
+  for (const auto& node_id : nodes) {
+    (void)RemoveNodeVisual(node_id);
   }
 }
 
@@ -433,7 +472,6 @@ auto AlcedoQanGraph::ApplyRoles(const EditorNodeGraphSnapshot& snapshot)
       return result;
     }
     ApplyNodePresentation(*qan_node, node);
-    node_projections_[node.node_id] = node;
   }
   applied_        = snapshot;
   has_projection_ = true;
@@ -489,31 +527,18 @@ auto AlcedoQanGraph::InsertTopology(const EditorNodeGraphSnapshot& snapshot) -> 
   if (graph_.isNull()) {
     return QStringLiteral("AlcedoQanGraph has no Qan graph");
   }
-  const auto delegate_error = EnsureDelegates();
+  auto* engine = qmlEngine(graph_.data());
+  if (engine == nullptr) {
+    return QStringLiteral("Qan graph has no QML engine");
+  }
+  const auto delegate_error = delegate_library_.EnsureLoaded(*engine, *graph_);
   if (!delegate_error.isEmpty()) {
     return delegate_error;
   }
   for (const auto& node : snapshot.nodes) {
-    auto* qan_node = InsertQanNode(*graph_, node);
-    if (qan_node == nullptr) {
-      if (ComponentFor(node.node_kind) == nullptr) {
-        return node.node_kind == EditorNodeKind::ColorGrade
-                   ? QStringLiteral("Alcedo color-grade node delegate is not set")
-                   : QStringLiteral("Alcedo endpoint node delegate is not set");
-      }
-      return QStringLiteral("Qan node creation failed");
-    }
-    if (qan_node->getItem() == nullptr) {
-      graph_->removeNode(qan_node, true);
-      return QStringLiteral("Qan node is missing a visual item");
-    }
-    ApplyNodePresentation(*qan_node, node);
-    node_by_id_[node.node_id]       = qan_node;
-    node_projections_[node.node_id] = node;
-    node_from_qan_[qan_node]        = ReverseNode{node.node_id, snapshot.session_generation};
-    const auto port_error           = InsertNodePorts(*qan_node, node);
-    if (!port_error.isEmpty()) {
-      return port_error;
+    const auto error = InsertNodeVisual(node, snapshot.session_generation);
+    if (!error.isEmpty()) {
+      return error;
     }
   }
   for (const auto& edge : snapshot.edges) {
@@ -523,6 +548,58 @@ auto AlcedoQanGraph::InsertTopology(const EditorNodeGraphSnapshot& snapshot) -> 
     }
   }
   AttachLiveVisuals();
+  return {};
+}
+
+auto AlcedoQanGraph::InsertNodeVisual(const EditorNodeProjection& node,
+                                      std::uint64_t               session_generation,
+                                      const NodeVisualState*      restore_state) -> QString {
+  if (graph_.isNull()) {
+    return QStringLiteral("AlcedoQanGraph has no Qan graph");
+  }
+  if (NodeFor(node.node_id) != nullptr) {
+    return QStringLiteral("Qan node already exists");
+  }
+
+  auto* qan_node = InsertQanNode(*graph_, node);
+  if (qan_node == nullptr) {
+    if (ComponentFor(node.node_kind) == nullptr) {
+      return node.node_kind == EditorNodeKind::ColorGrade
+                 ? QStringLiteral("Alcedo color-grade node delegate is not set")
+                 : QStringLiteral("Alcedo endpoint node delegate is not set");
+    }
+    return QStringLiteral("Qan node creation failed");
+  }
+  if (qan_node->getItem() == nullptr) {
+    QString error = QStringLiteral("Qan node is missing a visual item");
+    if (!RemoveQanNode(*graph_, *qan_node)) {
+      error += QStringLiteral("; reversing the incomplete Qan node failed");
+    }
+    return error;
+  }
+
+  ApplyNodePresentation(*qan_node, node);
+  node_by_id_[node.node_id]    = qan_node;
+  node_from_qan_[qan_node]     = ReverseNode{node.node_id, session_generation};
+  ports_by_node_[node.node_id] = {};
+  const auto port_error        = InsertNodePorts(*qan_node, node);
+  if (!port_error.isEmpty()) {
+    const auto cleanup_error = RemoveNodeVisual(node.node_id);
+    if (!cleanup_error.isEmpty()) {
+      return port_error + QStringLiteral("; reversing the incomplete Qan node failed: ") +
+             cleanup_error;
+    }
+    return port_error;
+  }
+
+  if (restore_state != nullptr && qan_node->getItem() != nullptr) {
+    if (restore_state->has_position) {
+      qan_node->getItem()->setPosition(restore_state->position);
+    }
+    if (qan_node->getItem()->property("drawerOpen").isValid()) {
+      qan_node->getItem()->setProperty("drawerOpen", restore_state->drawer_open);
+    }
+  }
   return {};
 }
 
@@ -547,9 +624,7 @@ auto AlcedoQanGraph::InsertPort(qan::Node& qan_node, const NodeId& node_id, cons
   if (graph_.isNull()) {
     return nullptr;
   }
-  const auto dock = is_input ? qan::NodeItem::Dock::Top : qan::NodeItem::Dock::Bottom;
-  const auto type = is_input ? qan::PortItem::Type::In : qan::PortItem::Type::Out;
-  auto* port = graph_->insertPort(&qan_node, dock, type, QString(), QanPortId(is_input, port_id));
+  auto* port = InsertQanPort(*graph_, qan_node, is_input, QanPortId(is_input, port_id));
   if (port == nullptr) {
     return nullptr;
   }
@@ -563,6 +638,20 @@ auto AlcedoQanGraph::InsertPort(qan::Node& qan_node, const NodeId& node_id, cons
 }
 
 auto AlcedoQanGraph::InsertEdge(const EditorNodeEdgeProjection& edge) -> QString {
+  return InsertEdgeVisual(edge, false);
+}
+
+auto AlcedoQanGraph::InsertEdgeVisual(const EditorNodeEdgeProjection& edge, bool candidate)
+    -> QString {
+  if (graph_.isNull()) {
+    return QStringLiteral("AlcedoQanGraph has no Qan graph");
+  }
+  if (EdgeFor(edge) != nullptr) {
+    return QStringLiteral("Qan edge already exists");
+  }
+  if (delegate_library_.EdgeComponent() == nullptr) {
+    return QStringLiteral("Alcedo edge delegate is not loaded");
+  }
   auto* source = NodeFor(edge.source_node_id);
   auto* dest   = NodeFor(edge.destination_node_id);
   auto* out    = OutputPortFor(edge.source_node_id, edge.source_port_id);
@@ -576,24 +665,35 @@ auto AlcedoQanGraph::InsertEdge(const EditorNodeEdgeProjection& edge) -> QString
   if (in == nullptr) {
     return QStringLiteral("Qan destination port is missing");
   }
-  auto* qan_edge = graph_->insertEdge(source, dest, edge_component_.get());
-  if (qan_edge == nullptr || qan_edge->getItem() == nullptr) {
+  auto* qan_edge = InsertQanEdge(*graph_, *source, *dest, delegate_library_.EdgeComponent());
+  if (qan_edge == nullptr) {
     return QStringLiteral("Qan edge creation failed");
+  }
+  auto cleanup_created_edge = [&](const QString& error) {
+    const auto cleanup_error = RemoveCreatedEdge(*qan_edge);
+    if (cleanup_error.isEmpty()) {
+      return error;
+    }
+    return error + QStringLiteral("; reversing the incomplete Qan edge failed: ") + cleanup_error;
+  };
+  if (qan_edge->getItem() == nullptr) {
+    return cleanup_created_edge(QStringLiteral("Qan edge is missing a visual item"));
   }
   if (auto* item = qan_edge->getItem()) {
     item->setSrcShape(qan::EdgeStyle::ArrowShape::None);
     item->setDstShape(qan::EdgeStyle::ArrowShape::None);
   }
-  graph_->bindEdge(qan_edge, out, in);
+  if (!BindQanEdge(*graph_, *qan_edge, *out, *in)) {
+    return cleanup_created_edge(QStringLiteral("Qan edge binding failed"));
+  }
   if (qan_edge->getItem()->getSourceItem() != out ||
       qan_edge->getItem()->getDestinationItem() != in) {
-    graph_->removeEdge(qan_edge, true);
-    return QStringLiteral("Qan edge did not bind to the requested ports");
+    return cleanup_created_edge(QStringLiteral("Qan edge did not bind to the requested ports"));
   }
   const auto key    = MakeEdgeKey(edge);
   edge_by_key_[key] = qan_edge;
-  ApplyEdgePresentation(*qan_edge, false);
-  edge_candidate_[key] = false;
+  ApplyEdgePresentation(*qan_edge, candidate);
+  edge_candidate_[key] = candidate;
   return {};
 }
 
@@ -608,29 +708,22 @@ auto AlcedoQanGraph::InsertProjectedNode(const EditorNodeProjection& node)
     result.error = QStringLiteral("Qan node already exists");
     return result;
   }
-  const auto delegate_error = EnsureDelegates();
+  auto* engine = qmlEngine(graph_.data());
+  if (engine == nullptr) {
+    result.error = QStringLiteral("Qan graph has no QML engine");
+    return result;
+  }
+  const auto delegate_error = delegate_library_.EnsureLoaded(*engine, *graph_);
   if (!delegate_error.isEmpty()) {
     result.error = delegate_error;
     return result;
   }
-  auto* qan_node = InsertQanNode(*graph_, node);
-  if (qan_node == nullptr || qan_node->getItem() == nullptr) {
-    if (qan_node != nullptr) {
-      graph_->removeNode(qan_node, true);
-    }
-    result.error = QStringLiteral("Qan node creation failed");
+  const auto error = InsertNodeVisual(node, applied_.session_generation);
+  if (!error.isEmpty()) {
+    result.error = error;
     return result;
   }
-  ApplyNodePresentation(*qan_node, node);
-  node_by_id_[node.node_id]       = qan_node;
-  node_projections_[node.node_id] = node;
-  node_from_qan_[qan_node]        = ReverseNode{node.node_id, applied_.session_generation};
-  const auto port_error           = InsertNodePorts(*qan_node, node);
-  if (!port_error.isEmpty()) {
-    (void)RemoveProjectedNode(node.node_id);
-    result.error = port_error;
-    return result;
-  }
+  auto* qan_node = NodeFor(node.node_id);
   BindDrawerSignal(qan_node->getItem(), node.node_id);
   applied_.nodes.push_back(node);
   AttachLiveVisuals();
@@ -645,31 +738,77 @@ auto AlcedoQanGraph::RemoveProjectedNode(const NodeId& node_id) -> AlcedoQanGrap
     result.error = QStringLiteral("AlcedoQanGraph has no Qan graph");
     return result;
   }
-  std::vector<EdgeKey> incident;
+  if (NodeFor(node_id) == nullptr) {
+    result.succeeded = true;
+    return result;
+  }
+  struct RemovedEdge {
+    EditorNodeEdgeProjection edge;
+    bool                     candidate = false;
+  };
+  auto append_reversal_error = [](QString* all_errors, const QString& error) {
+    if (error.isEmpty()) {
+      return;
+    }
+    if (!all_errors->isEmpty()) {
+      *all_errors += QStringLiteral("; ");
+    }
+    *all_errors += error;
+  };
+  std::vector<RemovedEdge> incident;
   for (const auto& [key, edge] : edge_by_key_) {
     if (key.source_node_id == node_id || key.destination_node_id == node_id) {
-      incident.push_back(key);
+      incident.push_back(
+          RemovedEdge{{key.source_node_id, key.source_port_id, key.destination_node_id,
+                       key.destination_port_id},
+                      edge_candidate_.contains(key) ? edge_candidate_.at(key) : false});
     }
   }
-  for (const auto& key : incident) {
-    EditorNodeEdgeProjection edge{key.source_node_id, key.source_port_id, key.destination_node_id,
-                                  key.destination_port_id};
-    (void)RemoveProjectedEdge(edge);
+  std::vector<RemovedEdge> removed_edges;
+  for (const auto& item : incident) {
+    const auto error = RemoveEdgeVisual(item.edge);
+    if (!error.isEmpty()) {
+      QString reversal_error;
+      for (auto it = removed_edges.rbegin(); it != removed_edges.rend(); ++it) {
+        append_reversal_error(&reversal_error, InsertEdgeVisual(it->edge, it->candidate));
+      }
+      result.error = error;
+      if (!reversal_error.isEmpty()) {
+        result.error += QStringLiteral("; visual reversal failed: ") + reversal_error;
+      }
+      result.succeeded = false;
+      return result;
+    }
+    removed_edges.push_back(item);
   }
-  auto* qan_node = NodeFor(node_id);
-  if (qan_node != nullptr) {
-    node_from_qan_.erase(qan_node);
-    HideDetachedVisual(qan_node->getItem());
-    graph_->removeNode(qan_node, true);
-    FlushDeferredDeletes();
+  const bool selection_removed = product_selected_node_id_ == node_id;
+  const auto node_error        = RemoveNodeVisual(node_id);
+  if (!node_error.isEmpty()) {
+    QString reversal_error;
+    for (auto it = removed_edges.rbegin(); it != removed_edges.rend(); ++it) {
+      const auto error = InsertEdgeVisual(it->edge, it->candidate);
+      if (!error.isEmpty()) {
+        reversal_error += (reversal_error.isEmpty() ? QString() : QStringLiteral("; ")) + error;
+      }
+    }
+    result.error = node_error;
+    if (!reversal_error.isEmpty()) {
+      result.error += QStringLiteral("; visual reversal failed: ") + reversal_error;
+    }
+    result.succeeded = false;
+    return result;
   }
-  node_by_id_.erase(node_id);
-  node_projections_.erase(node_id);
-  ports_by_node_.erase(node_id);
-  applied_.nodes.erase(std::remove_if(applied_.nodes.begin(), applied_.nodes.end(),
-                                      [&](const auto& node) { return node.node_id == node_id; }),
-                       applied_.nodes.end());
-  ApplyConnectablePolicy();
+  for (const auto& item : removed_edges) {
+    EraseAppliedEdge(item.edge);
+  }
+  EraseAppliedNode(node_id);
+  ClearDrawerConnections();
+  BindDrawerSignals();
+  if (selection_removed) {
+    ApplyProductSelection(std::nullopt);
+  } else {
+    ApplyConnectablePolicy();
+  }
   result.succeeded = true;
   return result;
 }
@@ -687,7 +826,7 @@ auto AlcedoQanGraph::InsertProjectedEdge(const EditorNodeEdgeProjection& edge, b
     result.succeeded                   = true;
     return result;
   }
-  const auto error = InsertEdge(edge);
+  const auto error = InsertEdgeVisual(edge, candidate);
   if (!error.isEmpty()) {
     result.error = error;
     return result;
@@ -710,26 +849,367 @@ auto AlcedoQanGraph::RemoveProjectedEdge(const EditorNodeEdgeProjection& edge)
     result.error = QStringLiteral("AlcedoQanGraph has no Qan graph");
     return result;
   }
-  const auto key = MakeEdgeKey(edge);
-  auto       it  = edge_by_key_.find(key);
-  if (it != edge_by_key_.end() && !it->second.isNull()) {
-    if (auto* item = it->second->getItem()) {
-      if (auto* src = qobject_cast<qan::PortItem*>(item->getSourceItem())) {
-        src->getOutEdgeItems().removeAll(item);
+  if (EdgeFor(edge) == nullptr) {
+    result.succeeded = true;
+    return result;
+  }
+  const auto error = RemoveEdgeVisual(edge);
+  if (!error.isEmpty()) {
+    result.error = error;
+    return result;
+  }
+  EraseAppliedEdge(edge);
+  result.succeeded = true;
+  return result;
+}
+
+auto AlcedoQanGraph::RestoreNodePorts(const NodeId& node_id, qan::Node& node,
+                                      const std::vector<PortVisualSpec>& ports) -> QString {
+  QString error;
+  for (const auto& spec : ports) {
+    const auto& node_ports = ports_by_node_[node_id];
+    const auto& map        = spec.is_input ? node_ports.inputs : node_ports.outputs;
+    const auto  found      = map.find(spec.port_id);
+    if (found != map.end() && !found->second.isNull()) {
+      continue;
+    }
+    if (InsertPort(node, node_id, spec.port_id, spec.is_input) == nullptr) {
+      if (!error.isEmpty()) {
+        error += QStringLiteral("; ");
       }
-      if (auto* dst = qobject_cast<qan::PortItem*>(item->getDestinationItem())) {
-        dst->getInEdgeItems().removeAll(item);
+      error += QStringLiteral("Qan port restoration failed");
+    }
+  }
+  return error;
+}
+
+auto AlcedoQanGraph::RemoveNodeVisual(const NodeId& node_id, NodeVisualState* removed_state)
+    -> QString {
+  const auto found = node_by_id_.find(node_id);
+  if (found == node_by_id_.end() || found->second.isNull()) {
+    return QStringLiteral("Qan node is missing");
+  }
+  auto* const                 qan_node = found->second.data();
+  const auto                  ports_it = ports_by_node_.find(node_id);
+  std::vector<PortVisualSpec> ports;
+  if (ports_it != ports_by_node_.end()) {
+    ports.reserve(ports_it->second.inputs.size() + ports_it->second.outputs.size());
+    for (const auto& [port_id, port] : ports_it->second.inputs) {
+      if (!port.isNull()) {
+        ports.push_back(PortVisualSpec{port_id, true});
       }
     }
-    HideDetachedVisual(it->second->getItem());
-    graph_->removeEdge(it->second.data(), true);
-    FlushDeferredDeletes();
+    for (const auto& [port_id, port] : ports_it->second.outputs) {
+      if (!port.isNull()) {
+        ports.push_back(PortVisualSpec{port_id, false});
+      }
+    }
   }
-  edge_by_key_.erase(key);
+
+  if (removed_state != nullptr) {
+    const auto* projection = NodeProjection(node_id);
+    if (projection != nullptr) {
+      removed_state->projection = *projection;
+    }
+    const auto applied_node =
+        std::find_if(applied_.nodes.begin(), applied_.nodes.end(),
+                     [&](const auto& item) { return item.node_id == node_id; });
+    if (applied_node != applied_.nodes.end()) {
+      removed_state->applied_index =
+          static_cast<std::size_t>(std::distance(applied_.nodes.begin(), applied_node));
+    }
+    if (qan_node->getItem() != nullptr) {
+      removed_state->position     = qan_node->getItem()->position();
+      removed_state->has_position = true;
+      const auto drawer           = qan_node->getItem()->property("drawerOpen");
+      if (drawer.isValid()) {
+        removed_state->drawer_open = drawer.toBool();
+      }
+    }
+  }
+
+  auto restore_ports = [&]() {
+    const auto restore_error = RestoreNodePorts(node_id, *qan_node, ports);
+    AttachLiveVisuals();
+    return restore_error;
+  };
+
+  for (const auto& spec : ports) {
+    auto&      node_ports = ports_by_node_[node_id];
+    auto&      map        = spec.is_input ? node_ports.inputs : node_ports.outputs;
+    const auto found_port = map.find(spec.port_id);
+    if (found_port == map.end() || found_port->second.isNull()) {
+      continue;
+    }
+    if (!RemoveQanPort(*graph_, *qan_node, *found_port->second)) {
+      QString    error         = QStringLiteral("Qan port removal failed");
+      const auto restore_error = restore_ports();
+      if (!restore_error.isEmpty()) {
+        error += QStringLiteral("; restoring ports failed: ") + restore_error;
+      }
+      return error;
+    }
+    map.erase(found_port);
+  }
+
+  const auto* raw_node = qan_node;
+  if (!RemoveQanNode(*graph_, *qan_node)) {
+    QString    error         = QStringLiteral("Qan node removal failed");
+    const auto restore_error = restore_ports();
+    if (!restore_error.isEmpty()) {
+      error += QStringLiteral("; restoring ports failed: ") + restore_error;
+    }
+    AttachLiveVisuals();
+    return error;
+  }
+  node_from_qan_.erase(raw_node);
+  node_by_id_.erase(node_id);
+  ports_by_node_.erase(node_id);
+  FlushDeferredDeletes();
+  return {};
+}
+
+void AlcedoQanGraph::DetachEdgeFromPorts(qan::Edge& edge) {
+  auto* item = edge.getItem();
+  if (item == nullptr) {
+    return;
+  }
+  if (auto* source = qobject_cast<qan::PortItem*>(item->getSourceItem())) {
+    source->getOutEdgeItems().removeAll(item);
+  }
+  if (auto* destination = qobject_cast<qan::PortItem*>(item->getDestinationItem())) {
+    destination->getInEdgeItems().removeAll(item);
+  }
+}
+
+void AlcedoQanGraph::RestoreEdgeToPorts(qan::Edge& edge) {
+  auto* item = edge.getItem();
+  if (item == nullptr) {
+    return;
+  }
+  if (auto* source = qobject_cast<qan::PortItem*>(item->getSourceItem())) {
+    source->addOutEdgeItem(*item);
+  }
+  if (auto* destination = qobject_cast<qan::PortItem*>(item->getDestinationItem())) {
+    destination->addInEdgeItem(*item);
+  }
+}
+
+auto AlcedoQanGraph::RemoveCreatedEdge(qan::Edge& edge) -> QString {
+  if (graph_.isNull()) {
+    return QStringLiteral("AlcedoQanGraph has no Qan graph");
+  }
+  DetachEdgeFromPorts(edge);
+  HideDetachedVisual(edge.getItem());
+  if (!RemoveQanEdge(*graph_, edge)) {
+    RestoreEdgeToPorts(edge);
+    return QStringLiteral("Qan edge removal failed");
+  }
+  FlushDeferredDeletes();
+  return {};
+}
+
+auto AlcedoQanGraph::RemoveEdgeVisual(const EditorNodeEdgeProjection& edge, bool require_present)
+    -> QString {
+  const auto key = MakeEdgeKey(edge);
+  const auto it  = edge_by_key_.find(key);
+  if (it == edge_by_key_.end()) {
+    return require_present ? QStringLiteral("Qan edge is missing") : QString();
+  }
+  if (it->second.isNull()) {
+    return QStringLiteral("Qan edge is missing");
+  }
+  auto* const qan_edge = it->second.data();
+  DetachEdgeFromPorts(*qan_edge);
+  HideDetachedVisual(qan_edge->getItem());
+  if (!RemoveQanEdge(*graph_, *qan_edge)) {
+    RestoreEdgeToPorts(*qan_edge);
+    return QStringLiteral("Qan edge removal failed");
+  }
+  edge_by_key_.erase(it);
   edge_candidate_.erase(key);
+  FlushDeferredDeletes();
+  return {};
+}
+
+void AlcedoQanGraph::EraseAppliedNode(const NodeId& node_id) {
+  applied_.nodes.erase(std::remove_if(applied_.nodes.begin(), applied_.nodes.end(),
+                                      [&](const auto& node) { return node.node_id == node_id; }),
+                       applied_.nodes.end());
+}
+
+void AlcedoQanGraph::EraseAppliedEdge(const EditorNodeEdgeProjection& edge) {
+  const auto key = MakeEdgeKey(edge);
   applied_.edges.erase(std::remove_if(applied_.edges.begin(), applied_.edges.end(),
                                       [&](const auto& item) { return MakeEdgeKey(item) == key; }),
                        applied_.edges.end());
+}
+
+auto AlcedoQanGraph::ApplyMutation(const alcedo::EditorNodeGraphDraftMutation& mutation)
+    -> AlcedoQanGraphApplyResult {
+  AlcedoQanGraphApplyResult result;
+  if (!mutation.succeeded) {
+    result.error = QString::fromStdString(mutation.error);
+    return result;
+  }
+  if (mutation.no_op) {
+    result.succeeded = true;
+    return result;
+  }
+  if (graph_.isNull() || !has_projection_) {
+    result.error = QStringLiteral("AlcedoQanGraph has no complete projection");
+    return result;
+  }
+
+  struct RemovedEdgeState {
+    EditorNodeEdgeProjection edge;
+    bool                     candidate = false;
+  };
+  std::vector<NodeVisualState>  removed_nodes;
+  std::vector<RemovedEdgeState> removed_edges;
+  removed_nodes.reserve(mutation.removed_node_ids.size());
+  removed_edges.reserve(mutation.removed_edges.size());
+
+  for (const auto& node_id : mutation.removed_node_ids) {
+    const auto* projection = NodeProjection(node_id);
+    if (projection == nullptr || NodeFor(node_id) == nullptr) {
+      result.error = QStringLiteral("Qan mutation references a missing node");
+      return result;
+    }
+    NodeVisualState state;
+    state.projection = *projection;
+    const auto applied_node =
+        std::find_if(applied_.nodes.begin(), applied_.nodes.end(),
+                     [&](const auto& item) { return item.node_id == node_id; });
+    if (applied_node != applied_.nodes.end()) {
+      state.applied_index =
+          static_cast<std::size_t>(std::distance(applied_.nodes.begin(), applied_node));
+    }
+    if (auto* node = NodeFor(node_id); node != nullptr && node->getItem() != nullptr) {
+      state.position     = node->getItem()->position();
+      state.has_position = true;
+      const auto drawer  = node->getItem()->property("drawerOpen");
+      if (drawer.isValid()) {
+        state.drawer_open = drawer.toBool();
+      }
+    }
+    removed_nodes.push_back(std::move(state));
+  }
+  for (const auto& edge : mutation.removed_edges) {
+    if (EdgeFor(edge) == nullptr) {
+      result.error = QStringLiteral("Qan mutation references a missing edge");
+      return result;
+    }
+    const auto key = MakeEdgeKey(edge);
+    const auto it  = edge_candidate_.find(key);
+    removed_edges.push_back(RemovedEdgeState{edge, it != edge_candidate_.end() && it->second});
+  }
+  for (const auto& node : mutation.inserted_nodes) {
+    if (NodeFor(node.node_id) != nullptr) {
+      result.error = QStringLiteral("Qan mutation inserts an existing node");
+      return result;
+    }
+  }
+  for (const auto& edge : mutation.inserted_edges) {
+    if (EdgeFor(edge) != nullptr) {
+      result.error = QStringLiteral("Qan mutation inserts an existing edge");
+      return result;
+    }
+  }
+
+  const NodeId                          prior_selection = product_selected_node_id_;
+  std::vector<RemovedEdgeState>         completed_removed_edges;
+  std::vector<NodeVisualState>          completed_removed_nodes;
+  std::vector<NodeId>                   completed_inserted_nodes;
+  std::vector<EditorNodeEdgeProjection> completed_inserted_edges;
+
+  auto append_reversal_error = [](QString* all_errors, const QString& error) {
+    if (error.isEmpty()) {
+      return;
+    }
+    if (!all_errors->isEmpty()) {
+      *all_errors += QStringLiteral("; ");
+    }
+    *all_errors += error;
+  };
+  auto apply_prior_selection = [&]() {
+    if (prior_selection.Empty() || NodeFor(prior_selection) == nullptr) {
+      ApplyProductSelection(std::nullopt);
+      return;
+    }
+    ApplyProductSelection(prior_selection);
+  };
+  auto fail = [&](QString original_error) {
+    QString reversal_errors;
+    for (auto it = completed_inserted_edges.rbegin(); it != completed_inserted_edges.rend(); ++it) {
+      append_reversal_error(&reversal_errors, RemoveEdgeVisual(*it));
+    }
+    for (auto it = completed_inserted_nodes.rbegin(); it != completed_inserted_nodes.rend(); ++it) {
+      append_reversal_error(&reversal_errors, RemoveNodeVisual(*it));
+    }
+    for (auto it = completed_removed_nodes.rbegin(); it != completed_removed_nodes.rend(); ++it) {
+      append_reversal_error(&reversal_errors,
+                            InsertNodeVisual(it->projection, applied_.session_generation, &*it));
+    }
+    for (auto it = completed_removed_edges.rbegin(); it != completed_removed_edges.rend(); ++it) {
+      append_reversal_error(&reversal_errors, InsertEdgeVisual(it->edge, it->candidate));
+    }
+    ClearDrawerConnections();
+    BindDrawerSignals();
+    AttachLiveVisuals();
+    apply_prior_selection();
+    result.error = std::move(original_error);
+    if (!reversal_errors.isEmpty()) {
+      result.error += QStringLiteral("; visual reversal failed: ") + reversal_errors;
+    }
+    result.succeeded = false;
+    return result;
+  };
+
+  for (const auto& edge : removed_edges) {
+    const auto error = RemoveEdgeVisual(edge.edge);
+    if (!error.isEmpty()) {
+      return fail(error);
+    }
+    completed_removed_edges.push_back(edge);
+  }
+  for (const auto& state : removed_nodes) {
+    const auto error = RemoveNodeVisual(state.projection.node_id);
+    if (!error.isEmpty()) {
+      return fail(error);
+    }
+    completed_removed_nodes.push_back(state);
+  }
+  for (const auto& node : mutation.inserted_nodes) {
+    const auto error = InsertNodeVisual(node, applied_.session_generation);
+    if (!error.isEmpty()) {
+      return fail(error);
+    }
+    completed_inserted_nodes.push_back(node.node_id);
+  }
+  for (const auto& edge : mutation.inserted_edges) {
+    const auto error = InsertEdgeVisual(edge, true);
+    if (!error.isEmpty()) {
+      return fail(error);
+    }
+    completed_inserted_edges.push_back(edge);
+  }
+
+  for (const auto& edge : mutation.removed_edges) {
+    EraseAppliedEdge(edge);
+  }
+  for (const auto& node_id : mutation.removed_node_ids) {
+    EraseAppliedNode(node_id);
+  }
+  for (const auto& node : mutation.inserted_nodes) {
+    applied_.nodes.push_back(node);
+    BindDrawerSignal(NodeFor(node.node_id)->getItem(), node.node_id);
+  }
+  for (const auto& edge : mutation.inserted_edges) {
+    applied_.edges.push_back(edge);
+  }
+  AttachLiveVisuals();
+  apply_prior_selection();
   result.succeeded = true;
   return result;
 }
@@ -774,7 +1254,6 @@ auto AlcedoQanGraph::PromoteCommittedSnapshot(const EditorNodeGraphSnapshot& sna
   for (const auto& node : snapshot.nodes) {
     auto* qan_node = NodeFor(node.node_id);
     ApplyNodePresentation(*qan_node, node);
-    node_projections_[node.node_id] = node;
   }
   PromoteCandidatePresentation();
   applied_         = snapshot;
@@ -822,141 +1301,8 @@ void AlcedoQanGraph::ApplyNodePresentation(qan::Node& qan_node, const EditorNode
   item->setProperty("masks", MasksToVariant(node.masks));
 }
 
-auto AlcedoQanGraph::EnsureDelegates() -> QString {
-  if (graph_.isNull()) {
-    return QStringLiteral("AlcedoQanGraph has no Qan graph");
-  }
-  auto* engine = qmlEngine(graph_.data());
-  if (engine == nullptr) {
-    return QStringLiteral("Qan graph has no QML engine");
-  }
-  if (delegate_engine_.data() != engine) {
-    DropCachedDelegates();
-    delegate_engine_ = engine;
-  }
-  if (!color_grade_component_) {
-    auto loaded = LoadComponent(color_grade_delegate_url_,
-                                QStringLiteral("Alcedo color-grade node delegate"));
-    if (!loaded.component) {
-      return loaded.error;
-    }
-    color_grade_component_ = std::move(loaded.component);
-  }
-  if (!endpoint_component_) {
-    auto loaded =
-        LoadComponent(endpoint_delegate_url_, QStringLiteral("Alcedo endpoint node delegate"));
-    if (!loaded.component) {
-      return loaded.error;
-    }
-    endpoint_component_ = std::move(loaded.component);
-  }
-  if (!edge_component_) {
-    auto loaded = LoadComponent(edge_delegate_url_, QStringLiteral("Alcedo edge delegate"));
-    if (!loaded.component) {
-      return loaded.error;
-    }
-    edge_component_ = std::move(loaded.component);
-  }
-  const auto port_error = InstallPortDelegate();
-  if (!port_error.isEmpty()) {
-    return port_error;
-  }
-  return InstallPortDockDelegate();
-}
-
-auto AlcedoQanGraph::LoadComponent(const QUrl& url, const QString& role) -> LoadedComponent {
-  LoadedComponent loaded;
-  if (url.isEmpty()) {
-    loaded.error = role + QStringLiteral(" URL is empty");
-    return loaded;
-  }
-  if (graph_.isNull()) {
-    loaded.error = QStringLiteral("AlcedoQanGraph has no Qan graph");
-    return loaded;
-  }
-  auto* engine = qmlEngine(graph_.data());
-  if (engine == nullptr) {
-    loaded.error = QStringLiteral("Qan graph has no QML engine");
-    return loaded;
-  }
-  auto component = std::make_unique<QQmlComponent>(engine, url, QQmlComponent::PreferSynchronous);
-  if (component->isError() || !component->isReady()) {
-    loaded.error = role + QStringLiteral(" failed to load");
-    if (!component->errorString().isEmpty()) {
-      loaded.error += QStringLiteral(": ") + component->errorString().trimmed();
-    }
-    return loaded;
-  }
-  loaded.component = std::move(component);
-  return loaded;
-}
-
-void AlcedoQanGraph::DropCachedDelegates() {
-  color_grade_component_.reset();
-  endpoint_component_.reset();
-  edge_component_.reset();
-  delegate_engine_.clear();
-  port_delegate_graph_.clear();
-  port_dock_delegate_graph_.clear();
-}
-
-auto AlcedoQanGraph::InstallPortDelegate() -> QString {
-  if (graph_.isNull()) {
-    return QStringLiteral("AlcedoQanGraph has no Qan graph");
-  }
-  if (port_delegate_graph_.data() == graph_.data()) {
-    return {};
-  }
-  auto loaded = LoadComponent(port_delegate_url_, QStringLiteral("Alcedo port delegate"));
-  if (!loaded.component) {
-    return loaded.error;
-  }
-  graph_->setProperty("portDelegate", QVariant::fromValue(loaded.component.release()));
-  port_delegate_graph_ = graph_;
-  return {};
-}
-
-auto AlcedoQanGraph::InstallPortDockDelegate() -> QString {
-  if (graph_.isNull()) {
-    return QStringLiteral("AlcedoQanGraph has no Qan graph");
-  }
-  if (port_dock_delegate_graph_.data() == graph_.data()) {
-    return {};
-  }
-  auto loaded = LoadComponent(port_dock_delegate_url_, QStringLiteral("Alcedo port dock delegate"));
-  if (!loaded.component) {
-    return loaded.error;
-  }
-  graph_->setProperty("horizontalDockDelegate", QVariant::fromValue(loaded.component.release()));
-  port_dock_delegate_graph_ = graph_;
-  return {};
-}
-
-void AlcedoQanGraph::InstallInvisibleSelectionDelegate() {
-  if (graph_.isNull()) {
-    return;
-  }
-  auto* engine = qmlEngine(graph_.data());
-  if (engine == nullptr) {
-    return;
-  }
-  // Node delegates paint their own selection outline; the QuickQanava
-  // selection item must exist (qan::NodeItem expects one) but render nothing.
-  auto component = std::make_unique<QQmlComponent>(engine);
-  component->setData(QByteArrayLiteral("import QtQuick\nItem {}\n"), QUrl());
-  if (!component->isReady()) {
-    qWarning() << "AlcedoQanGraph: failed to create invisible selection delegate:"
-               << component->errorString();
-    return;
-  }
-  graph_->setProperty("selectionDelegate", QVariant::fromValue(component.release()));
-}
-
 auto AlcedoQanGraph::ComponentFor(EditorNodeKind kind) const -> QQmlComponent* {
-  if (kind == EditorNodeKind::ColorGrade) {
-    return color_grade_component_.get();
-  }
-  return endpoint_component_.get();
+  return delegate_library_.ComponentFor(kind);
 }
 
 auto AlcedoQanGraph::NodeKindKey(EditorNodeKind kind) -> QString {
@@ -1001,7 +1347,6 @@ void AlcedoQanGraph::ConfigureGraphPolicy() {
     return;
   }
   graph_->setMultipleSelectionEnabled(false);
-  InstallInvisibleSelectionDelegate();
   graph_->setConnectorCreateDefaultEdge(false);
   graph_->setConnectorEnabled(true);
   connect(graph_.data(), &qan::Graph::connectorChanged, this, &AlcedoQanGraph::ConfigureConnector,

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -369,11 +369,10 @@ bool EditorNodeController::applyToGraph(QObject* adapter) {
     SetLastError(tr("The node graph has no snapshot"));
     return false;
   }
-  EditorNodeGraphSnapshot view;
+  EditorNodeGraphSnapshot        view;
   const EditorNodeGraphSnapshot* projected = &snapshot_;
   if (draft_ != nullptr) {
-    view      = draft_->CurrentSnapshot(session_generation_, projection_revision_,
-                                        topology_revision_);
+    view = draft_->CurrentSnapshot(session_generation_, projection_revision_, topology_revision_);
     projected = &view;
   } else if (!has_snapshot_) {
     SetLastError(tr("The node graph has no snapshot"));
@@ -484,11 +483,10 @@ void EditorNodeController::ApplyBoundGraph() {
   ++completed_projection_apply_count_;
   auto* layout = layout_store_.data();
   if (layout != nullptr) {
-    layout->EnsureDefaultPositions(draft_ == nullptr
-                                       ? snapshot_
-                                       : draft_->CurrentSnapshot(session_generation_,
-                                                                 projection_revision_,
-                                                                 topology_revision_));
+    layout->EnsureDefaultPositions(draft_ == nullptr ? snapshot_
+                                                     : draft_->CurrentSnapshot(session_generation_,
+                                                                               projection_revision_,
+                                                                               topology_revision_));
     for (const auto& node : ActiveNodes()) {
       const auto id = NodeIdToQString(node.node_id);
       if (layout->hasNodePosition(id)) {
@@ -508,10 +506,7 @@ void EditorNodeController::QueueProjectionApply() {
     return;
   }
   projection_apply_queued_ = true;
-  QMetaObject::invokeMethod(
-      this,
-      [this] { ApplyBoundGraphIfCurrent(); },
-      Qt::QueuedConnection);
+  QMetaObject::invokeMethod(this, [this] { ApplyBoundGraphIfCurrent(); }, Qt::QueuedConnection);
 }
 
 void EditorNodeController::ApplyBoundGraphIfCurrent() {
@@ -659,7 +654,7 @@ bool EditorNodeController::addCleanColorGrade() {
     SetLastError(QString::fromStdString(mutation.error));
     return false;
   }
-  if (!ApplyMutationToGraph(mutation)) {
+  if (!ApplyDraftMutationToAdapter(mutation)) {
     return false;
   }
   if (layout_store_ != nullptr) {
@@ -726,7 +721,7 @@ bool EditorNodeController::deleteColorGrade(const QString& node_id) {
     SetLastError(QString::fromStdString(mutation.error));
     return false;
   }
-  if (!ApplyMutationToGraph(mutation)) {
+  if (!ApplyDraftMutationToAdapter(mutation)) {
     return false;
   }
   emit DraftStateChanged();
@@ -783,7 +778,7 @@ bool EditorNodeController::requestConnect(const QString& source_node_id,
     SetLastError({});
     return true;
   }
-  if (!ApplyMutationToGraph(mutation)) {
+  if (!ApplyDraftMutationToAdapter(mutation)) {
     return false;
   }
   emit DraftStateChanged();
@@ -865,75 +860,30 @@ void EditorNodeController::DiscardDraft() {
 }
 
 void EditorNodeController::AdoptCommittedDocument(const PipelineDocument& document) {
-  auto built = EditorNodeGraphProjection::Build(document, session_generation_, 0, 0);
-  topology_revision_            = topology_revision_ + 1;
-  projection_revision_          = projection_revision_ + 1;
-  built.session_generation      = session_generation_;
-  built.topology_revision       = topology_revision_;
-  built.projection_revision     = projection_revision_;
-  snapshot_                     = std::move(built);
-  has_snapshot_                 = true;
+  auto built                = EditorNodeGraphProjection::Build(document, session_generation_, 0, 0);
+  topology_revision_        = topology_revision_ + 1;
+  projection_revision_      = projection_revision_ + 1;
+  built.session_generation  = session_generation_;
+  built.topology_revision   = topology_revision_;
+  built.projection_revision = projection_revision_;
+  snapshot_                 = std::move(built);
+  has_snapshot_             = true;
 }
 
-auto EditorNodeController::ApplyMutationToGraph(const alcedo::EditorNodeGraphDraftMutation& mutation)
-    -> bool {
+auto EditorNodeController::ApplyDraftMutationToAdapter(
+    const alcedo::EditorNodeGraphDraftMutation& mutation) -> bool {
   if (graph_adapter_ == nullptr || graph_adapter_->graph() == nullptr) {
     return true;
   }
-  std::vector<EditorNodeProjection>     applied_nodes;
-  std::vector<EditorNodeEdgeProjection> applied_edges;
-  auto fail = [&](const QString& error) {
-    SetLastError(error);
-    if (draft_ != nullptr) {
-      draft_->RestoreLastMutation();
-    }
-    for (auto it = applied_edges.rbegin(); it != applied_edges.rend(); ++it) {
-      (void)graph_adapter_->RemoveProjectedEdge(*it);
-    }
-    for (auto it = applied_nodes.rbegin(); it != applied_nodes.rend(); ++it) {
-      (void)graph_adapter_->RemoveProjectedNode(it->node_id);
-    }
-    if (draft_ != nullptr) {
-      for (const auto& node_id : mutation.removed_node_ids) {
-        const auto* node = draft_->FindNode(node_id);
-        if (node != nullptr) {
-          (void)graph_adapter_->InsertProjectedNode(*node);
-        }
-      }
-      for (const auto& edge : mutation.removed_edges) {
-        (void)graph_adapter_->InsertProjectedEdge(edge, true);
-      }
-    }
-    return false;
-  };
-  for (const auto& edge : mutation.removed_edges) {
-    const auto result = graph_adapter_->RemoveProjectedEdge(edge);
-    if (!result.succeeded) {
-      return fail(result.error);
-    }
+  const auto result = graph_adapter_->ApplyMutation(mutation);
+  if (result.succeeded) {
+    return true;
   }
-  for (const auto& node_id : mutation.removed_node_ids) {
-    const auto result = graph_adapter_->RemoveProjectedNode(node_id);
-    if (!result.succeeded) {
-      return fail(result.error);
-    }
+  if (draft_ != nullptr) {
+    draft_->RestoreLastMutation();
   }
-  for (const auto& node : mutation.inserted_nodes) {
-    const auto result = graph_adapter_->InsertProjectedNode(node);
-    if (!result.succeeded) {
-      return fail(result.error);
-    }
-    applied_nodes.push_back(node);
-  }
-  for (const auto& edge : mutation.inserted_edges) {
-    const auto result = graph_adapter_->InsertProjectedEdge(edge, true);
-    if (!result.succeeded) {
-      return fail(result.error);
-    }
-    applied_edges.push_back(edge);
-  }
-  graph_adapter_->ApplyProductSelection(selected_node_id_);
-  return true;
+  SetLastError(result.error);
+  return false;
 }
 
 auto EditorNodeController::MaybeSubmitDraft() -> bool {
@@ -952,9 +902,9 @@ auto EditorNodeController::MaybeSubmitDraft() -> bool {
     emit ActionAvailabilityChanged();
     return true;
   }
-  auto change                  = draft_->MakeChange();
-  submitted_identity_          = CurrentDraftIdentity();
-  const auto result            = session_->SubmitNodeGraphTopologyEdit(change);
+  auto change         = draft_->MakeChange();
+  submitted_identity_ = CurrentDraftIdentity();
+  const auto result   = session_->SubmitNodeGraphTopologyEdit(change);
   if (alcedo::EditorSessionResultIsFailure(result.kind)) {
     submitted_identity_.reset();
     SetLastError(QString::fromStdString(result.message));

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/qan_delegate_library.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/qan_delegate_library.cpp
@@ -1,0 +1,178 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "ui/alcedo_main/album_backend/qan_delegate_library.hpp"
+
+#include <QByteArray>
+#include <QVariant>
+#include <utility>
+
+#include "qanGraph.h"
+
+namespace alcedo::ui {
+
+void QanDelegateLibrary::Configure(QUrl color_grade_delegate_url, QUrl endpoint_delegate_url,
+                                   QUrl port_delegate_url, QUrl port_dock_delegate_url,
+                                   QUrl edge_delegate_url) {
+  if (color_grade_delegate_url_ == color_grade_delegate_url &&
+      endpoint_delegate_url_ == endpoint_delegate_url && port_delegate_url_ == port_delegate_url &&
+      port_dock_delegate_url_ == port_dock_delegate_url &&
+      edge_delegate_url_ == edge_delegate_url) {
+    return;
+  }
+  color_grade_delegate_url_ = std::move(color_grade_delegate_url);
+  endpoint_delegate_url_    = std::move(endpoint_delegate_url);
+  port_delegate_url_        = std::move(port_delegate_url);
+  port_dock_delegate_url_   = std::move(port_dock_delegate_url);
+  edge_delegate_url_        = std::move(edge_delegate_url);
+  Reset();
+}
+
+auto QanDelegateLibrary::EnsureLoaded(QQmlEngine& engine, qan::Graph& graph) -> QString {
+  if (engine_.data() != &engine) {
+    Reset();
+    engine_ = &engine;
+  }
+  if (port_delegate_graph_.data() != &graph) {
+    port_delegate_graph_.clear();
+  }
+  if (port_dock_delegate_graph_.data() != &graph) {
+    port_dock_delegate_graph_.clear();
+  }
+  if (selection_delegate_graph_.data() != &graph) {
+    selection_delegate_graph_.clear();
+  }
+
+  if (!color_grade_component_) {
+    auto loaded = LoadComponent(engine, color_grade_delegate_url_,
+                                QStringLiteral("Alcedo color-grade node delegate"));
+    if (!loaded.component) {
+      return loaded.error;
+    }
+    color_grade_component_ = std::move(loaded.component);
+  }
+  if (!endpoint_component_) {
+    auto loaded = LoadComponent(engine, endpoint_delegate_url_,
+                                QStringLiteral("Alcedo endpoint node delegate"));
+    if (!loaded.component) {
+      return loaded.error;
+    }
+    endpoint_component_ = std::move(loaded.component);
+  }
+  if (!edge_component_) {
+    auto loaded = LoadComponent(engine, edge_delegate_url_, QStringLiteral("Alcedo edge delegate"));
+    if (!loaded.component) {
+      return loaded.error;
+    }
+    edge_component_ = std::move(loaded.component);
+  }
+
+  auto error = InstallPortDelegate(engine, graph);
+  if (!error.isEmpty()) {
+    return error;
+  }
+  error = InstallPortDockDelegate(engine, graph);
+  if (!error.isEmpty()) {
+    return error;
+  }
+  return InstallInvisibleSelectionDelegate(engine, graph);
+}
+
+auto QanDelegateLibrary::ComponentFor(EditorNodeKind kind) const -> QQmlComponent* {
+  return kind == EditorNodeKind::ColorGrade ? color_grade_component_.get()
+                                            : endpoint_component_.get();
+}
+
+void QanDelegateLibrary::Reset() {
+  color_grade_component_.reset();
+  endpoint_component_.reset();
+  edge_component_.reset();
+  engine_.clear();
+  ResetGraphInstallations();
+}
+
+void QanDelegateLibrary::ResetGraphInstallations() {
+  port_delegate_graph_.clear();
+  port_dock_delegate_graph_.clear();
+  selection_delegate_graph_.clear();
+}
+
+auto QanDelegateLibrary::LoadComponent(QQmlEngine& engine, const QUrl& url, const QString& role)
+    -> LoadedComponent {
+  LoadedComponent loaded;
+  if (url.isEmpty()) {
+    loaded.error = role + QStringLiteral(" URL is empty");
+    return loaded;
+  }
+  auto component = std::make_unique<QQmlComponent>(&engine, url, QQmlComponent::PreferSynchronous);
+  if (component->isError() || !component->isReady()) {
+    loaded.error = role + QStringLiteral(" failed to load");
+    if (!component->errorString().isEmpty()) {
+      loaded.error += QStringLiteral(": ") + component->errorString().trimmed();
+    }
+    return loaded;
+  }
+  loaded.component = std::move(component);
+  return loaded;
+}
+
+auto QanDelegateLibrary::InstallPortDelegate(QQmlEngine& engine, qan::Graph& graph) -> QString {
+  if (port_delegate_graph_.data() == &graph) {
+    return {};
+  }
+  auto loaded = LoadComponent(engine, port_delegate_url_, QStringLiteral("Alcedo port delegate"));
+  if (!loaded.component) {
+    return loaded.error;
+  }
+  auto* component = loaded.component.get();
+  if (!graph.setProperty("portDelegate", QVariant::fromValue(component))) {
+    return QStringLiteral("Alcedo port delegate installation failed");
+  }
+  loaded.component.release();
+  port_delegate_graph_ = &graph;
+  return {};
+}
+
+auto QanDelegateLibrary::InstallPortDockDelegate(QQmlEngine& engine, qan::Graph& graph) -> QString {
+  if (port_dock_delegate_graph_.data() == &graph) {
+    return {};
+  }
+  auto loaded =
+      LoadComponent(engine, port_dock_delegate_url_, QStringLiteral("Alcedo port dock delegate"));
+  if (!loaded.component) {
+    return loaded.error;
+  }
+  auto* component = loaded.component.get();
+  if (!graph.setProperty("horizontalDockDelegate", QVariant::fromValue(component))) {
+    return QStringLiteral("Alcedo port dock delegate installation failed");
+  }
+  loaded.component.release();
+  port_dock_delegate_graph_ = &graph;
+  return {};
+}
+
+auto QanDelegateLibrary::InstallInvisibleSelectionDelegate(QQmlEngine& engine, qan::Graph& graph)
+    -> QString {
+  if (selection_delegate_graph_.data() == &graph) {
+    return {};
+  }
+  auto component = std::make_unique<QQmlComponent>(&engine);
+  component->setData(QByteArrayLiteral("import QtQuick\nItem {}\n"), QUrl());
+  if (component->isError() || !component->isReady()) {
+    QString error = QStringLiteral("Alcedo selection delegate failed to load");
+    if (!component->errorString().isEmpty()) {
+      error += QStringLiteral(": ") + component->errorString().trimmed();
+    }
+    return error;
+  }
+  auto* raw_component = component.get();
+  if (!graph.setProperty("selectionDelegate", QVariant::fromValue(raw_component))) {
+    return QStringLiteral("Alcedo selection delegate installation failed");
+  }
+  component.release();
+  selection_delegate_graph_ = &graph;
+  return {};
+}
+
+}  // namespace alcedo::ui

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -772,6 +772,7 @@ target_link_libraries(AlcedoQanGraphTest
         AlcedoQanGraph
         QuickQanava
         QuickQanavaplugin
+        EditorNodeGraphDraft
         GTest::gtest
         Qt6::Core
         Qt6::Gui
@@ -791,6 +792,41 @@ alcedo_ui_gtest_discover_tests(AlcedoQanGraphTest
     TEST_PREFIX "AlcedoQanGraphTest."
     PROPERTIES LABELS "quickqanava;editor_nodes")
 alcedo_register_test_target(AlcedoQanGraphTest ui)
+
+# Delegate cache ownership and engine/graph recreation without the node controller.
+add_executable(QanDelegateLibraryTest
+    ${ALCEDO_TEST_ROOT}/ui/qan_delegate_library_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
+)
+target_include_directories(QanDelegateLibraryTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR}
+    PRIVATE ${ALCEDO_TEST_ROOT}/ui
+)
+target_link_libraries(QanDelegateLibraryTest
+    PRIVATE
+        AlcedoQanGraph
+        QuickQanava
+        QuickQanavaplugin
+        GTest::gtest
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Test
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::QuickEffects
+        Qt6::Svg
+        Qt6::Widgets
+)
+target_compile_definitions(QanDelegateLibraryTest
+    PRIVATE ALCEDO_TEST_SRC_DIR="${ALCEDO_SRC_DIR}"
+)
+set_target_properties(QanDelegateLibraryTest PROPERTIES AUTOMOC ON)
+alcedo_ui_gtest_discover_tests(QanDelegateLibraryTest
+    TEST_PREFIX "QanDelegateLibraryTest."
+    PROPERTIES LABELS "quickqanava;editor_nodes")
+alcedo_register_test_target(QanDelegateLibraryTest ui)
 
 # Alcedo node/endpoint/Mask-drawer delegates: VI bans, drawer fold, ports, icons.
 add_executable(EditorNodeDelegateQmlTest

--- a/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
+++ b/alcedo_studio/tests/ui/alcedo_qan_graph_test.cpp
@@ -25,6 +25,7 @@
 #include <QStringList>
 #include <QUrl>
 #include <QuickQanava>
+#include <array>
 #include <cmath>
 #include <filesystem>
 #include <functional>
@@ -196,6 +197,103 @@ class FailAfterInsertsGraph final : public alcedo::ui::AlcedoQanGraph {
   std::optional<int> remaining_success_;
 };
 
+enum class QanOperation : std::size_t {
+  InsertNode = 0,
+  InsertPort,
+  InsertEdge,
+  BindEdge,
+  RemoveEdge,
+  RemovePort,
+  RemoveNode,
+};
+
+class FailureInjectingQanGraph final : public alcedo::ui::AlcedoQanGraph {
+ public:
+  void FailOnNext(QanOperation operation) { FailOnCall(operation, 1); }
+
+  void FailOnCall(QanOperation operation, int call_number) {
+    failure_calls_.fill(std::nullopt);
+    failure_calls_[static_cast<std::size_t>(operation)] = call_number;
+    operation_calls_.fill(0);
+  }
+
+  void FailOnCalls(QanOperation first_operation, int first_call, QanOperation second_operation,
+                   int second_call) {
+    failure_calls_.fill(std::nullopt);
+    failure_calls_[static_cast<std::size_t>(first_operation)]  = first_call;
+    failure_calls_[static_cast<std::size_t>(second_operation)] = second_call;
+    operation_calls_.fill(0);
+  }
+
+ protected:
+  auto InsertQanNode(qan::Graph& graph, const alcedo::EditorNodeProjection& node)
+      -> qan::Node* override {
+    if (ShouldFail(QanOperation::InsertNode)) {
+      return nullptr;
+    }
+    return AlcedoQanGraph::InsertQanNode(graph, node);
+  }
+
+  auto InsertQanPort(qan::Graph& graph, qan::Node& node, bool is_input, const QString& port_id)
+      -> qan::PortItem* override {
+    if (ShouldFail(QanOperation::InsertPort)) {
+      return nullptr;
+    }
+    return AlcedoQanGraph::InsertQanPort(graph, node, is_input, port_id);
+  }
+
+  auto InsertQanEdge(qan::Graph& graph, qan::Node& source, qan::Node& destination,
+                     QQmlComponent* component) -> qan::Edge* override {
+    if (ShouldFail(QanOperation::InsertEdge)) {
+      return nullptr;
+    }
+    return AlcedoQanGraph::InsertQanEdge(graph, source, destination, component);
+  }
+
+  auto BindQanEdge(qan::Graph& graph, qan::Edge& edge, qan::PortItem& source,
+                   qan::PortItem& destination) -> bool override {
+    if (ShouldFail(QanOperation::BindEdge)) {
+      return false;
+    }
+    return AlcedoQanGraph::BindQanEdge(graph, edge, source, destination);
+  }
+
+  auto RemoveQanEdge(qan::Graph& graph, qan::Edge& edge) -> bool override {
+    if (ShouldFail(QanOperation::RemoveEdge)) {
+      return false;
+    }
+    return AlcedoQanGraph::RemoveQanEdge(graph, edge);
+  }
+
+  auto RemoveQanPort(qan::Graph& graph, qan::Node& node, qan::PortItem& port) -> bool override {
+    if (ShouldFail(QanOperation::RemovePort)) {
+      return false;
+    }
+    return AlcedoQanGraph::RemoveQanPort(graph, node, port);
+  }
+
+  auto RemoveQanNode(qan::Graph& graph, qan::Node& node) -> bool override {
+    if (ShouldFail(QanOperation::RemoveNode)) {
+      return false;
+    }
+    return AlcedoQanGraph::RemoveQanNode(graph, node);
+  }
+
+ private:
+  [[nodiscard]] auto ShouldFail(QanOperation operation) -> bool {
+    const auto index = static_cast<std::size_t>(operation);
+    ++operation_calls_[index];
+    if (!failure_calls_[index].has_value() || operation_calls_[index] != *failure_calls_[index]) {
+      return false;
+    }
+    failure_calls_[index].reset();
+    return true;
+  }
+
+  std::array<std::optional<int>, 7> failure_calls_{};
+  std::array<int, 7>                operation_calls_{};
+};
+
 }  // namespace
 
 namespace alcedo {
@@ -238,6 +336,54 @@ auto ExpectLiveBackbone(const ui::AlcedoQanGraph& adapter, const EditorNodeGraph
     EXPECT_EQ(qan_edge->getItem()->getSourceItem(), source_port);
     EXPECT_EQ(qan_edge->getItem()->getDestinationItem(), dest_port);
     EXPECT_TRUE(qan_edge->getLabel().isEmpty());
+  }
+}
+
+auto MakeAddedColorGradeMutation() -> EditorNodeGraphDraftMutation {
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, {});
+  return draft.AddColorGrade(NodeId{"grade.extra"});
+}
+
+auto MakeEdgeMutation(const EditorNodeEdgeProjection& first_removed,
+                      const EditorNodeEdgeProjection& second_removed)
+    -> EditorNodeGraphDraftMutation {
+  EditorNodeGraphDraftMutation mutation;
+  mutation.succeeded = true;
+  mutation.removed_edges.push_back(first_removed);
+  mutation.removed_edges.push_back(second_removed);
+  mutation.inserted_edges.push_back(EditorNodeEdgeProjection{
+      NodeId{"develop"}, PortId{"image"}, NodeId{"grade.extra.a"}, PortId{"image"}});
+  mutation.inserted_edges.push_back(EditorNodeEdgeProjection{
+      NodeId{"grade.extra.a"}, PortId{"image"}, NodeId{"grade.extra.b"}, PortId{"image"}});
+  return mutation;
+}
+
+auto MakeExtraNode(const char* node_id) -> EditorNodeProjection {
+  EditorNodeProjection node;
+  node.node_id      = NodeId{node_id};
+  node.node_kind    = EditorNodeKind::ColorGrade;
+  node.display_name = "Detached Color Grade";
+  return node;
+}
+
+void ExpectSelectedNode(const qan::Graph& graph, const qan::Node* expected) {
+  const auto& selected = graph.getSelectedNodes();
+  ASSERT_EQ(selected.size(), 1u);
+  EXPECT_EQ(selected.at(0).data(), expected);
+}
+
+void ExpectMappedEdges(const ui::AlcedoQanGraph&                    adapter,
+                       const std::vector<EditorNodeEdgeProjection>& edges) {
+  ASSERT_EQ(adapter.graph()->get_edge_count(), static_cast<int>(edges.size()));
+  for (const auto& edge : edges) {
+    auto* qan_edge = adapter.EdgeFor(edge);
+    ASSERT_NE(qan_edge, nullptr);
+    ASSERT_NE(qan_edge->getItem(), nullptr);
+    EXPECT_EQ(qan_edge->getItem()->getSourceItem(),
+              adapter.OutputPortFor(edge.source_node_id, edge.source_port_id));
+    EXPECT_EQ(qan_edge->getItem()->getDestinationItem(),
+              adapter.InputPortFor(edge.destination_node_id, edge.destination_port_id));
   }
 }
 
@@ -311,8 +457,7 @@ TEST_F(AlcedoQanGraph, InstallsFlushPortDockAndInvisibleSelectionDelegate) {
   EXPECT_TRUE(dock_component->url().toString().endsWith(QStringLiteral("EditorNodePortDock.qml")))
       << dock_component->url().toString().toStdString();
 
-  const auto* selection_component =
-      graph->property("selectionDelegate").value<QQmlComponent*>();
+  const auto* selection_component = graph->property("selectionDelegate").value<QQmlComponent*>();
   ASSERT_NE(selection_component, nullptr);
   EXPECT_TRUE(selection_component->url().isEmpty())
       << "selection delegate must be the inline invisible Item, not "
@@ -395,9 +540,9 @@ TEST_F(AlcedoQanGraph, RemovingAColorGradeReplacesQanPrimitivesAndHidesTheRemove
   const auto first = EditorNodeGraphProjection::Build(document, 9, 1, 1);
   ASSERT_TRUE(adapter.ApplySnapshot(first).succeeded) << "initial apply";
 
-  QPointer<qan::Node>      removed_node = adapter.NodeFor(NodeId{"grade.primary"});
+  QPointer<qan::Node> removed_node = adapter.NodeFor(NodeId{"grade.primary"});
   ASSERT_FALSE(removed_node.isNull());
-  QPointer<QQuickItem>     removed_item = removed_node->getItem();
+  QPointer<QQuickItem> removed_item = removed_node->getItem();
   ASSERT_FALSE(removed_item.isNull());
   EXPECT_TRUE(removed_item->isVisible());
 
@@ -495,6 +640,283 @@ TEST_F(AlcedoQanGraph, AdapterInsertFailureRestoresThePriorCompleteQanProjection
   EXPECT_EQ(adapter.projection_revision(), 7u);
   ExpectLiveBackbone(adapter, prior);
   EXPECT_EQ(adapter.NodeFor(NodeId{"grade.second"}), nullptr);
+}
+
+TEST_F(AlcedoQanGraph, FailedNodeInsertionPreservesUnrelatedIdentitySelectionAndLayout) {
+  FailureInjectingQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 20, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+
+  auto* develop = adapter.NodeFor(NodeId{"develop"});
+  auto* primary = adapter.NodeFor(NodeId{"grade.primary"});
+  auto* drt     = adapter.NodeFor(NodeId{"drt"});
+  ASSERT_NE(develop, nullptr);
+  ASSERT_NE(primary, nullptr);
+  ASSERT_NE(drt, nullptr);
+  QPointer<qan::Edge> first_edge = adapter.EdgeFor(prior.edges.front());
+  QPointer<qan::Edge> last_edge  = adapter.EdgeFor(prior.edges.back());
+  adapter.SetNodeItemPosition(NodeId{"grade.primary"}, QPointF(131, 247));
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  adapter.FailOnNext(QanOperation::InsertNode);
+  const auto result = adapter.ApplyMutation(MakeAddedColorGradeMutation());
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("Qan node creation failed")), -1);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.extra"}), nullptr);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"develop"}), develop);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"drt"}), drt);
+  EXPECT_EQ(adapter.EdgeFor(prior.edges.front()), first_edge.data());
+  EXPECT_EQ(adapter.EdgeFor(prior.edges.back()), last_edge.data());
+  ExpectMappedEdges(adapter, prior.edges);
+  ASSERT_TRUE(adapter.NodeItemPosition(NodeId{"grade.primary"}).has_value());
+  EXPECT_EQ(adapter.NodeItemPosition(NodeId{"grade.primary"}).value(), QPointF(131, 247));
+  EXPECT_FALSE(adapter.DrawerOpen(NodeId{"grade.primary"}));
+  ExpectSelectedNode(*harness_->Graph(), primary);
+}
+
+TEST_F(AlcedoQanGraph, FailedPortInsertionRemovesThePartialNodeAndRestoresSelection) {
+  FailureInjectingQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 21, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+
+  auto* primary = adapter.NodeFor(NodeId{"grade.primary"});
+  ASSERT_NE(primary, nullptr);
+  QPointer<qan::Edge> first_edge = adapter.EdgeFor(prior.edges.front());
+  adapter.SetNodeItemPosition(NodeId{"grade.primary"}, QPointF(163, 281));
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  adapter.FailOnNext(QanOperation::InsertPort);
+  const auto result = adapter.ApplyMutation(MakeAddedColorGradeMutation());
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("Qan port insertion failed")), -1);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.extra"}), nullptr);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(adapter.EdgeFor(prior.edges.front()), first_edge.data());
+  EXPECT_EQ(harness_->Graph()->getNodeCount(), 3);
+  ExpectMappedEdges(adapter, prior.edges);
+  ASSERT_TRUE(adapter.NodeItemPosition(NodeId{"grade.primary"}).has_value());
+  EXPECT_EQ(adapter.NodeItemPosition(NodeId{"grade.primary"}).value(), QPointF(163, 281));
+  EXPECT_FALSE(adapter.DrawerOpen(NodeId{"grade.primary"}));
+  ExpectSelectedNode(*harness_->Graph(), primary);
+}
+
+TEST_F(AlcedoQanGraph, FailedEdgeInsertionRestoresRemovedEdgesAndPreservesNodeIdentity) {
+  FailureInjectingQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 22, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+  ASSERT_TRUE(adapter.InsertProjectedNode(MakeExtraNode("grade.extra.a")).succeeded);
+  ASSERT_TRUE(adapter.InsertProjectedNode(MakeExtraNode("grade.extra.b")).succeeded);
+
+  auto* develop = adapter.NodeFor(NodeId{"develop"});
+  auto* primary = adapter.NodeFor(NodeId{"grade.primary"});
+  auto* drt     = adapter.NodeFor(NodeId{"drt"});
+  auto* extra_a = adapter.NodeFor(NodeId{"grade.extra.a"});
+  auto* extra_b = adapter.NodeFor(NodeId{"grade.extra.b"});
+  ASSERT_NE(develop, nullptr);
+  ASSERT_NE(primary, nullptr);
+  ASSERT_NE(drt, nullptr);
+  ASSERT_NE(extra_a, nullptr);
+  ASSERT_NE(extra_b, nullptr);
+  adapter.SetNodeItemPosition(NodeId{"grade.primary"}, QPointF(191, 313));
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  auto mutation = MakeEdgeMutation(prior.edges.front(), prior.edges.back());
+  adapter.FailOnNext(QanOperation::InsertEdge);
+  const auto result = adapter.ApplyMutation(mutation);
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("Qan edge creation failed")), -1);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"develop"}), develop);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"drt"}), drt);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.extra.a"}), extra_a);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.extra.b"}), extra_b);
+  EXPECT_EQ(adapter.EdgeFor(mutation.inserted_edges.front()), nullptr);
+  EXPECT_EQ(adapter.EdgeFor(mutation.inserted_edges.back()), nullptr);
+  ExpectMappedEdges(adapter, prior.edges);
+  ASSERT_TRUE(adapter.NodeItemPosition(NodeId{"grade.primary"}).has_value());
+  EXPECT_EQ(adapter.NodeItemPosition(NodeId{"grade.primary"}).value(), QPointF(191, 313));
+  EXPECT_FALSE(adapter.DrawerOpen(NodeId{"grade.primary"}));
+  ExpectSelectedNode(*harness_->Graph(), primary);
+}
+
+TEST_F(AlcedoQanGraph, FailedEdgeBindingRemovesTheIncompleteEdgeAndRestoresTopology) {
+  FailureInjectingQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 23, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+  ASSERT_TRUE(adapter.InsertProjectedNode(MakeExtraNode("grade.extra.a")).succeeded);
+  ASSERT_TRUE(adapter.InsertProjectedNode(MakeExtraNode("grade.extra.b")).succeeded);
+
+  auto* primary = adapter.NodeFor(NodeId{"grade.primary"});
+  ASSERT_NE(primary, nullptr);
+  adapter.SetNodeItemPosition(NodeId{"grade.primary"}, QPointF(223, 349));
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  auto mutation = MakeEdgeMutation(prior.edges.front(), prior.edges.back());
+  adapter.FailOnNext(QanOperation::BindEdge);
+  const auto result = adapter.ApplyMutation(mutation);
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("Qan edge binding failed")), -1);
+  EXPECT_EQ(adapter.EdgeFor(mutation.inserted_edges.front()), nullptr);
+  EXPECT_EQ(adapter.EdgeFor(mutation.inserted_edges.back()), nullptr);
+  ExpectMappedEdges(adapter, prior.edges);
+  ASSERT_TRUE(adapter.NodeItemPosition(NodeId{"grade.primary"}).has_value());
+  EXPECT_EQ(adapter.NodeItemPosition(NodeId{"grade.primary"}).value(), QPointF(223, 349));
+  EXPECT_FALSE(adapter.DrawerOpen(NodeId{"grade.primary"}));
+  ExpectSelectedNode(*harness_->Graph(), primary);
+}
+
+TEST_F(AlcedoQanGraph, FailedEdgeRemovalRestoresPortListsAndPreservesVisualIdentity) {
+  FailureInjectingQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 24, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+
+  auto* primary = adapter.NodeFor(NodeId{"grade.primary"});
+  auto* first   = adapter.EdgeFor(prior.edges.front());
+  ASSERT_NE(primary, nullptr);
+  ASSERT_NE(first, nullptr);
+  adapter.SetNodeItemPosition(NodeId{"grade.primary"}, QPointF(251, 383));
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  adapter.FailOnNext(QanOperation::RemoveEdge);
+  const auto result = adapter.RemoveProjectedEdge(prior.edges.front());
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("Qan edge removal failed")), -1);
+  EXPECT_EQ(adapter.EdgeFor(prior.edges.front()), first);
+  ExpectMappedEdges(adapter, prior.edges);
+  ASSERT_TRUE(adapter.NodeItemPosition(NodeId{"grade.primary"}).has_value());
+  EXPECT_EQ(adapter.NodeItemPosition(NodeId{"grade.primary"}).value(), QPointF(251, 383));
+  EXPECT_FALSE(adapter.DrawerOpen(NodeId{"grade.primary"}));
+  ExpectSelectedNode(*harness_->Graph(), primary);
+}
+
+TEST_F(AlcedoQanGraph, FailedPortRemovalRestoresTheNodeWithoutChangingOtherIdentities) {
+  FailureInjectingQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 25, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+  ASSERT_TRUE(adapter.InsertProjectedNode(MakeExtraNode("grade.extra")).succeeded);
+
+  auto* primary = adapter.NodeFor(NodeId{"grade.primary"});
+  auto* extra   = adapter.NodeFor(NodeId{"grade.extra"});
+  ASSERT_NE(primary, nullptr);
+  ASSERT_NE(extra, nullptr);
+  adapter.SetNodeItemPosition(NodeId{"grade.primary"}, QPointF(277, 419));
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  adapter.FailOnNext(QanOperation::RemovePort);
+  const auto result = adapter.RemoveProjectedNode(NodeId{"grade.extra"});
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("Qan port removal failed")), -1);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.extra"}), extra);
+  EXPECT_NE(adapter.InputPortFor(NodeId{"grade.extra"}, kImagePort()), nullptr);
+  EXPECT_NE(adapter.OutputPortFor(NodeId{"grade.extra"}, kImagePort()), nullptr);
+  ExpectMappedEdges(adapter, prior.edges);
+  ASSERT_TRUE(adapter.NodeItemPosition(NodeId{"grade.primary"}).has_value());
+  EXPECT_EQ(adapter.NodeItemPosition(NodeId{"grade.primary"}).value(), QPointF(277, 419));
+  EXPECT_FALSE(adapter.DrawerOpen(NodeId{"grade.primary"}));
+  ExpectSelectedNode(*harness_->Graph(), primary);
+}
+
+TEST_F(AlcedoQanGraph, FailedNodeRemovalRestoresItsPortsAndKeepsTheProjectionUsable) {
+  FailureInjectingQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 26, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+  ASSERT_TRUE(adapter.InsertProjectedNode(MakeExtraNode("grade.extra")).succeeded);
+
+  auto* primary = adapter.NodeFor(NodeId{"grade.primary"});
+  auto* extra   = adapter.NodeFor(NodeId{"grade.extra"});
+  ASSERT_NE(primary, nullptr);
+  ASSERT_NE(extra, nullptr);
+  adapter.SetNodeItemPosition(NodeId{"grade.primary"}, QPointF(299, 457));
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  adapter.FailOnNext(QanOperation::RemoveNode);
+  const auto result = adapter.RemoveProjectedNode(NodeId{"grade.extra"});
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("Qan node removal failed")), -1);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.extra"}), extra);
+  EXPECT_NE(adapter.InputPortFor(NodeId{"grade.extra"}, kImagePort()), nullptr);
+  EXPECT_NE(adapter.OutputPortFor(NodeId{"grade.extra"}, kImagePort()), nullptr);
+  ExpectMappedEdges(adapter, prior.edges);
+  ASSERT_TRUE(adapter.NodeItemPosition(NodeId{"grade.primary"}).has_value());
+  EXPECT_EQ(adapter.NodeItemPosition(NodeId{"grade.primary"}).value(), QPointF(299, 457));
+  EXPECT_FALSE(adapter.DrawerOpen(NodeId{"grade.primary"}));
+  ExpectSelectedNode(*harness_->Graph(), primary);
+}
+
+TEST_F(AlcedoQanGraph, VisualReversalFailureReportsBothTheOriginalAndReversalErrors) {
+  FailureInjectingQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 27, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+  ASSERT_TRUE(adapter.InsertProjectedNode(MakeExtraNode("grade.extra.a")).succeeded);
+  ASSERT_TRUE(adapter.InsertProjectedNode(MakeExtraNode("grade.extra.b")).succeeded);
+
+  auto* primary = adapter.NodeFor(NodeId{"grade.primary"});
+  ASSERT_NE(primary, nullptr);
+  adapter.SetNodeItemPosition(NodeId{"grade.primary"}, QPointF(317, 491));
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  const auto mutation = MakeEdgeMutation(prior.edges.front(), prior.edges.back());
+  adapter.FailOnCalls(QanOperation::InsertEdge, 2, QanOperation::RemoveEdge, 3);
+  const auto result = adapter.ApplyMutation(mutation);
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("Qan edge creation failed")), -1);
+  EXPECT_NE(result.error.indexOf(QStringLiteral("visual reversal failed")), -1);
+  EXPECT_NE(adapter.EdgeFor(mutation.inserted_edges.front()), nullptr);
+  EXPECT_EQ(adapter.EdgeFor(mutation.inserted_edges.back()), nullptr);
+  EXPECT_EQ(adapter.NodeFor(NodeId{"grade.primary"}), primary);
+  ASSERT_TRUE(adapter.NodeItemPosition(NodeId{"grade.primary"}).has_value());
+  EXPECT_EQ(adapter.NodeItemPosition(NodeId{"grade.primary"}).value(), QPointF(317, 491));
+  EXPECT_FALSE(adapter.DrawerOpen(NodeId{"grade.primary"}));
+  ExpectSelectedNode(*harness_->Graph(), primary);
+}
+
+TEST_F(AlcedoQanGraph, FailedVisualMutationLeavesTheProductDocumentUntouched) {
+  PipelineDocument document = CreateDefaultPipelineDocument();
+  auto             draft    = EditorNodeGraphDraft::FromDocument(document, {});
+  const auto       mutation = draft.AddColorGrade(NodeId{"grade.extra"});
+  ASSERT_TRUE(mutation.succeeded);
+  ASSERT_NE(draft.FindNode(NodeId{"grade.extra"}), nullptr);
+  ASSERT_EQ(document.Graph().FindNode(NodeId{"grade.extra"}), nullptr);
+
+  FailureInjectingQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto prior = EditorNodeGraphProjection::Build(document, 28, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(prior).succeeded) << "initial apply";
+  adapter.FailOnNext(QanOperation::InsertNode);
+  const auto result = adapter.ApplyMutation(mutation);
+
+  EXPECT_FALSE(result.succeeded);
+  EXPECT_EQ(document.Graph().FindNode(NodeId{"grade.extra"}), nullptr);
+  EXPECT_EQ(document.NextColorGradeNameNumber(), 2u);
+  EXPECT_NE(draft.FindNode(NodeId{"grade.extra"}), nullptr);
+  draft.RestoreLastMutation();
+  EXPECT_EQ(draft.Nodes(), prior.nodes);
+  EXPECT_EQ(draft.Edges(), prior.edges);
 }
 
 TEST_F(AlcedoQanGraph, GraphDestructionClearsIdentityMaps) {
@@ -643,9 +1065,9 @@ TEST_F(AlcedoQanGraph, IncrementalInsertAndRemovePreserveUnaffectedIdentities) {
 
   EditorNodeEdgeProjection edge{NodeId{"develop"}, PortId{"image"}, NodeId{"grade.extra"},
                                 PortId{"image"}};
-  ASSERT_TRUE(adapter.RemoveProjectedEdge(EditorNodeEdgeProjection{
-                                              NodeId{"develop"}, PortId{"image"},
-                                              NodeId{"grade.primary"}, PortId{"image"}})
+  ASSERT_TRUE(adapter
+                  .RemoveProjectedEdge(EditorNodeEdgeProjection{
+                      NodeId{"develop"}, PortId{"image"}, NodeId{"grade.primary"}, PortId{"image"}})
                   .succeeded);
   EXPECT_NE(adapter.OutputPortFor(NodeId{"develop"}, PortId{"image"}), nullptr);
   EXPECT_NE(adapter.InputPortFor(NodeId{"grade.extra"}, PortId{"image"}), nullptr);

--- a/alcedo_studio/tests/ui/qan_delegate_library_test.cpp
+++ b/alcedo_studio/tests/ui/qan_delegate_library_test.cpp
@@ -1,0 +1,143 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "ui/alcedo_main/album_backend/qan_delegate_library.hpp"
+
+#include <gtest/gtest.h>
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QQuickStyle>
+#include <QQuickWindow>
+#include <QUrl>
+#include <QuickQanava>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+
+#include "qanGraph.h"
+
+Q_IMPORT_QML_PLUGIN(QuickQanavaPlugin)
+
+namespace {
+
+constexpr char kHarnessQml[] = R"qml(
+import QtQuick
+import QtQuick.Controls
+import QuickQanava 2.0 as Qan
+
+ApplicationWindow {
+    width: 320
+    height: 240
+    visible: true
+
+    Qan.GraphView {
+        anchors.fill: parent
+        navigable: false
+
+        graph: Qan.Graph {
+            objectName: "delegateGraph"
+        }
+    }
+}
+)qml";
+
+auto           QmlDirectory() -> QString {
+  return QString::fromStdString(
+      (std::filesystem::path(ALCEDO_TEST_SRC_DIR) / "ui" / "alcedo_main" / "qml").string());
+}
+
+auto QmlFileUrl(const char* file_name) -> QUrl {
+  return QUrl::fromLocalFile(QmlDirectory() + QLatin1Char('/') + QLatin1String(file_name));
+}
+
+void SetBasicStyle() {
+  static std::once_flag style_once;
+  std::call_once(style_once, [] { QQuickStyle::setStyle(QStringLiteral("Basic")); });
+}
+
+class QanHarness final {
+ public:
+  QanHarness() {
+    SetBasicStyle();
+    engine_.addImportPath(QStringLiteral("qrc:/"));
+    engine_.addImportPath(QmlDirectory());
+    QuickQanava::initialize(&engine_);
+    engine_.loadData(QByteArray{kHarnessQml},
+                     QUrl(QStringLiteral("file:///QanDelegateHarness.qml")));
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
+    if (!engine_.rootObjects().isEmpty()) {
+      window_ = qobject_cast<QQuickWindow*>(engine_.rootObjects().constFirst());
+    }
+  }
+
+  [[nodiscard]] auto graph() const -> qan::Graph* {
+    return window_ == nullptr ? nullptr : window_->findChild<qan::Graph*>("delegateGraph");
+  }
+
+ private:
+  QQmlApplicationEngine engine_;
+  QQuickWindow*         window_ = nullptr;
+};
+
+void Configure(alcedo::ui::QanDelegateLibrary& library) {
+  library.Configure(QmlFileUrl("EditorNodeDelegate.qml"),
+                    QmlFileUrl("EditorEndpointNodeDelegate.qml"),
+                    QmlFileUrl("EditorNodePortDelegate.qml"), QmlFileUrl("EditorNodePortDock.qml"),
+                    QmlFileUrl("EditorNodeEdgeDelegate.qml"));
+}
+
+}  // namespace
+
+namespace alcedo::ui {
+
+TEST(QanDelegateLibraryTest, LoadsAllDelegatesAndInstallsGraphOwnedComponentsWithoutController) {
+  QanHarness harness;
+  ASSERT_NE(harness.graph(), nullptr);
+  auto* engine = qmlEngine(harness.graph());
+  ASSERT_NE(engine, nullptr);
+
+  QanDelegateLibrary library;
+  Configure(library);
+  EXPECT_TRUE(library.EnsureLoaded(*engine, *harness.graph()).isEmpty());
+  EXPECT_NE(library.ComponentFor(EditorNodeKind::ColorGrade), nullptr);
+  EXPECT_NE(library.ComponentFor(EditorNodeKind::Develop), nullptr);
+  EXPECT_NE(library.EdgeComponent(), nullptr);
+  EXPECT_NE(harness.graph()->property("portDelegate").value<QQmlComponent*>(), nullptr);
+  EXPECT_NE(harness.graph()->property("horizontalDockDelegate").value<QQmlComponent*>(), nullptr);
+  EXPECT_NE(harness.graph()->property("selectionDelegate").value<QQmlComponent*>(), nullptr);
+}
+
+TEST(QanDelegateLibraryTest, ResetDropsEngineCacheAndReloadsForARecreatedEngine) {
+  QanHarness first;
+  QanHarness second;
+  ASSERT_NE(first.graph(), nullptr);
+  ASSERT_NE(second.graph(), nullptr);
+  auto* first_engine  = qmlEngine(first.graph());
+  auto* second_engine = qmlEngine(second.graph());
+  ASSERT_NE(first_engine, nullptr);
+  ASSERT_NE(second_engine, nullptr);
+  ASSERT_NE(first_engine, second_engine);
+
+  QanDelegateLibrary library;
+  Configure(library);
+  ASSERT_TRUE(library.EnsureLoaded(*first_engine, *first.graph()).isEmpty());
+  auto* first_component = library.ComponentFor(EditorNodeKind::ColorGrade);
+  ASSERT_NE(first_component, nullptr);
+
+  library.Reset();
+  EXPECT_EQ(library.ComponentFor(EditorNodeKind::ColorGrade), nullptr);
+  EXPECT_EQ(library.EdgeComponent(), nullptr);
+
+  EXPECT_TRUE(library.EnsureLoaded(*second_engine, *second.graph()).isEmpty());
+  EXPECT_NE(library.ComponentFor(EditorNodeKind::ColorGrade), nullptr);
+  EXPECT_NE(library.ComponentFor(EditorNodeKind::ColorGrade), first_component);
+  EXPECT_NE(second.graph()->property("portDelegate").value<QQmlComponent*>(), nullptr);
+  EXPECT_NE(second.graph()->property("selectionDelegate").value<QQmlComponent*>(), nullptr);
+}
+
+}  // namespace alcedo::ui

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: NM5.1–NM5.7R implementation recorded; NM5.8a–NM5.8b complete 2026-09-04; NM5.8c–NM5.8g pending
+Status: NM5.1–NM5.7R implementation recorded; NM5.8a–NM5.8c complete 2026-09-04; NM5.8d–NM5.8g pending
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -3105,6 +3105,101 @@ constructing `EditorNodeController`; require unload/recreate with a different en
 production QML panel tests after registering all new files. Physical `.cpp` splitting alone does
 not complete this stage.
 
+##### NM5.8c completion record (2026-09-04)
+
+**Status:** complete — delegate ownership is isolated, full replacement and incremental visual
+operations share the same primitive helpers, and draft mutation reversal is adapter-owned.
+
+**Primary success call chains:**
+
+```text
+AlcedoQanGraph::InsertTopology / InsertProjectedNode
+  -> qmlEngine(bound graph)
+  -> QanDelegateLibrary::EnsureLoaded(engine, graph)
+  -> LoadComponent for node and edge delegates
+  -> install graph-owned port, dock, and invisible-selection components
+  -> InsertNodeVisual / InsertEdgeVisual
+  -> register NodeId/Qan and edge/port maps, presentation, and drawer signals
+
+EditorNodeController::ApplyDraftMutationToAdapter
+  -> AlcedoQanGraph::ApplyMutation
+  -> prevalidate mapped removals and insertions
+  -> RemoveEdgeVisual / RemoveNodeVisual for completed removals
+  -> InsertNodeVisual / InsertEdgeVisual for completed insertions
+  -> update the applied projection only after every visual step succeeds
+  -> preserve selection and layout, then return success
+```
+
+**Primary failure call chain:**
+
+```text
+Injected node/port/edge insertion, binding, or removal failure
+  -> return the actual Qan operation error
+  -> reverse only the completed visual operations in reverse order
+  -> restore QuickQanava port lists before an exclusive edge can be rebound
+  -> restore edge candidate state, drawer connections, selection, and layout
+  -> append every visual-reversal error to the original error
+  -> controller calls EditorNodeGraphDraft::RestoreLastMutation once
+  -> controller exposes the adapter error without submitting a product change
+```
+
+**What was proven (executed tests):**
+
+| Required behavior | Target / binary | Result |
+| --- | --- | --- |
+| Node, port, edge insertion and edge-binding failure preserve unrelated identities, edges, selection, and layout | `AlcedoQanGraphTest` | PASS |
+| Edge, port, and node removal failure restores the mapped projection | `AlcedoQanGraphTest` | PASS |
+| Visual reversal failure returns both the original and reversal errors | `AlcedoQanGraphTest` | PASS |
+| Failed visual mutation leaves `PipelineDocument` unchanged | `AlcedoQanGraphTest` | PASS |
+| Delegate loading and graph-owned installation without `EditorNodeController` | `QanDelegateLibraryTest` | PASS |
+| Reset followed by loading through a different `QQmlEngine` | `QanDelegateLibraryTest` | PASS |
+| Draft add/delete/connect behavior and no product command for an incomplete draft | `EditorNodeSelectionLayoutTest` | PASS |
+| Registered Nodes-page QML behavior after the adapter change | `EditorNodesPanelQmlTest` | PASS |
+
+**Commands and totals:**
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target AlcedoQanGraphTest QanDelegateLibraryTest EditorNodesPanelQmlTest EditorNodeSelectionLayoutTest
+build/debug/alcedo_studio/tests/ui/AlcedoQanGraphTest_runtime/AlcedoQanGraphTest.exe --gtest_color=no
+build/debug/alcedo_studio/tests/ui/QanDelegateLibraryTest_runtime/QanDelegateLibraryTest.exe --gtest_color=no
+build/debug/alcedo_studio/tests/ui/EditorNodesPanelQmlTest_runtime/EditorNodesPanelQmlTest.exe --gtest_color=no
+build/debug/alcedo_studio/tests/ui/EditorNodeSelectionLayoutTest_runtime/EditorNodeSelectionLayoutTest.exe --gtest_color=no
+```
+
+The MSVC build completed successfully. `AlcedoQanGraphTest` ran 25/25, `QanDelegateLibraryTest`
+ran 2/2, `EditorNodesPanelQmlTest` ran 22/22, and `EditorNodeSelectionLayoutTest` ran 34/34.
+The build and runtime logs were kept under `build/tmp/`. The runtime suites still print existing
+Qt/QuickQanava QML warnings about native-style customization, unmatched `Connections` handlers,
+and undefined dock properties; they did not affect pass/fail results and remain outside this
+stage's scope.
+
+**Checklist / exit condition:**
+
+- [x] `QanDelegateLibrary` owns delegate URLs, engine identity, cached components, and graph
+      installation markers; it has no controller or adapter parent and no shared context.
+- [x] Full replacement and incremental operations use shared node/edge creation, presentation,
+      registration, and cleanup helpers.
+- [x] Qan reversal tracks only completed visual operations and reports reversal errors.
+- [x] The adapter retains reverse Qan-pointer-to-`NodeId` maps and no redundant node projection
+      map; `applied_` is the authoritative node-card value store.
+- [x] The controller has one adapter mutation call and one draft reversal on adapter failure.
+- [x] Production and focused test CMake source lists register every new file.
+- [x] Failure injection covers every requested primitive boundary and a failing visual reversal.
+- [x] Delegate tests use separate engines and do not construct `EditorNodeController`.
+
+**LOC / diff note:** The working-tree diff is 1,275 insertions and 456 deletions across tracked
+files, plus 430 lines in the three new files (`qan_delegate_library.hpp` 109,
+`qan_delegate_library.cpp` 178, and `qan_delegate_library_test.cpp` 143). The adapter source is
+1,598 lines (1,159 before this stage) and its header is 473 lines (368 before); the delegate
+library is split into the new 109-line header and 178-line source. The controller source is 988
+lines (957 before), below the plan's approximate split threshold after Qan rollback moved out.
+
+**Residual gaps:** NM5.8d still owns obsolete command-entry cleanup. NM5.8e still owns persistent
+topology Undo/Redo, WAL recovery, reopen, checkout, and long-lived Loader evidence. NM5.8f still
+owns keyboard, accessibility, localization, large-font, and visual-state qualification. NM5.8g
+still owns fresh install/package, notices, available macOS, and final regression evidence. NM8
+retains real-RAW and three-backend qualification.
+
 #### 16.3.4 NM5.8d — Remove unused command entry points; preserve stored history
 
 **Files:** `editor_session_controller.{hpp,cpp}`, `editor_node_controller.{hpp,cpp}`,
@@ -3242,7 +3337,7 @@ checks here.
 | --- | --- | --- |
 | NM5.8a | Complete 2026-09-04 | One update route; queued teardown and layout restore |
 | NM5.8b | Complete 2026-09-04 | Bounded reversal/copy work; exact draft values and counters |
-| NM5.8c | Pending | Delegate ownership; primitive failure and reversal matrix |
+| NM5.8c | Complete 2026-09-04 | Delegate ownership; primitive failure and reversal matrix |
 | NM5.8d | Pending | Caller deletion audit; retained typed replay/paste |
 | NM5.8e | Pending | Persistent topology history; lifecycle and failure recovery |
 | NM5.8f | Pending | Keyboard, screen reader, localization, visual matrix |


### PR DESCRIPTION
## Summary
- Extract `QanDelegateLibrary` so delegate URLs, cached components, engine identity, and graph-owned installation are managed independently of `EditorNodeController`.
- Move incremental Qan visual mutation and reversal into `AlcedoQanGraph::ApplyMutation`, with shared node/edge creation and cleanup helpers used by full replacement and incremental updates.
- Add failure injection coverage for node, port, edge, binding, removal, and visual-reversal failures while preserving unrelated QObject identity, topology, selection, layout, drawer state, and error reporting.
- Keep product draft restoration in the controller as one bounded reversal after an adapter failure; failed visual changes do not submit a product-document update.
- Record NM5.8c completion in the Nodes panel plan.

## Relationship to #127

This branch starts from `main` after #127 was merged. #127 contains the NM5.8a/b apply-path and draft-reversal work; this PR contains the follow-up NM5.8c Qan ownership and failure-reversal work.

## Test plan

- [x] `AlcedoQanGraphTest` — 25/25, including injected insertion, binding, removal, reversal, identity, topology, selection, layout, and product-document assertions
- [x] `QanDelegateLibraryTest` — 2/2, including standalone graph installation and loading through separate `QQmlEngine` instances
- [x] `EditorNodesPanelQmlTest` — 22/22
- [x] `EditorNodeSelectionLayoutTest` — 34/34
- [x] Windows/MSVC focused build through `scripts\\msvc_env.cmd`