### PR TITLE
fix(editor): avoid redundant node projections on workspace switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,21 +4,17 @@ This file provides guidance to AI agents (Kimi, Claude, Codex, etc.) when workin
 
 ## Project Overview
 
-**Alcedo Studio** is a RAW photo editor and digital asset management (DAM) system written in C++20. It features CUDA-accelerated (Windows) and Metal-accelerated (macOS) image processing, a DuckDB-backed asset management system ("Sleeve"), and a Qt 6 UI combining QML (album browser) and Qt Widgets (editor).
+**Alcedo Studio** is a RAW photo editor and digital asset management (DAM) system written in C++20. It features CUDA-accelerated (Windows) and Metal-accelerated (macOS) image processing and a DuckDB-backed asset management system ("Sleeve"). The entire UI uses Qt 6 QML / Qt Quick, including the album browser, editor workspace, adjustment panels, and dialogs, with C++ backends and rendering integration.
 
-## Agent Execution Posture
+## Execution and Product Rules
+
+### Complete the requested capability
 
 Agents working in this repository must be decisive and implementation-driven. Do not respond to product or engineering direction with passive staged deferrals such as "first avoid this", "later maybe add this", "medium term", "long term", or similar framing that delays the requested capability after the user has made the product goal clear.
 
-## Branch naming
-
-Branch names must describe the feature, fix, refactor, or other engineering purpose of the work.
-Do not include `codex` in a branch name. Use a functional name such as
-`fix/neighbor-operator-ping-pong` or `feature/opencl-program-cache`.
-
 When the user names a concrete integration or capability, treat it as the target and work out the implementation path, constraints, tests, and risks directly. If there are real blockers, state them as concrete engineering facts and propose the closest viable implementation, not a soft retreat to a weaker product.
 
-## No fallback unless the user explicitly allows it
+### No fallback without explicit authorization
 
 Do **not** add, restore, or "temporarily" use any fallback, degraded path, silent substitute, or weaker stand-in unless the user has **explicitly** allowed that specific fallback in this conversation (or in an existing, already-landed product rule they pointed at).
 
@@ -32,7 +28,121 @@ This includes, and is not limited to:
 
 If the requested path cannot be implemented, **fail with the real error** and state the engineering blocker. Do not ship a weaker product and call it a fix. Performance of a CUDA **debug** build is not a reason to change product decode or quality policy.
 
-## Temporary files and local workspace
+## Code Style and Data Updates
+
+These rules apply to all project-authored code, including tests and tooling. They are project-wide
+requirements and do not depend on a task-specific skill being activated.
+
+### Language, formatting, and member names
+
+- Use C++20 and the repository's clang-format configuration (Google style, 100-column limit).
+- Follow the repository's clang-tidy rules. Private members use a trailing `_`; public and
+  protected members do not.
+- Name types, functions, variables, and tests after the data they represent or the operation they
+  perform. Apply the terminology rules below to identifiers as well as prose.
+
+### Update existing data through its owner
+
+**Do not create snapshots, mirror structs, or temporary copies of existing data structures just
+to read, pass, or update their state.** Renaming a copy to `State`, `Context`, or `Payload` does not
+make it acceptable. The rule concerns duplicated state, not the spelling of `snapshot`.
+
+Use this order when implementing a read or update:
+
+1. Identify the existing data structure and the service or component that owns it.
+2. Read through the owner's API or a const reference/view with a valid lifetime and appropriate
+   synchronization. Do not expose mutable internals or retain references beyond their safe lifetime.
+3. Apply changes through a focused operation on that owner. Pass the fields or change description
+   needed for the operation instead of copying the entire object, editing the copy, and writing it back.
+4. Validate inputs before mutation and preserve the owner's invariants. Publish notifications only
+   after the complete update is visible.
+
+An **atomic operation** here means one logically indivisible update: observers cannot see partial
+state, and concurrent changes cannot be silently overwritten. Use the existing transaction, lock,
+or owning-thread mechanism as appropriate. This does not require `std::atomic` for every field and
+does not authorize unsynchronized in-place writes. Keep failure behavior explicit; a failed update
+must not leave partially applied state.
+
+### Necessary copies and snapshots
+
+A snapshot is allowed only when a concrete requirement needs independent state, such as a
+consistent point-in-time package export. Before introducing one:
+
+- Explain why an owner operation, scoped read, or minimal change description cannot satisfy the
+  requirement. Convenience, avoiding an API change, or a generic claim of thread safety is insufficient.
+- Document the purpose, captured fields, owner, lifetime, and consistency mechanism at the defining
+  type or creation site. Copy only the data the requirement needs.
+- Define whether the captured state is immutable or independently editable, and how it is released.
+  Do not write an old copy back over live state without explicit conflict handling.
+- Reuse an existing representation that meets the requirement rather than adding another parallel
+  representation. An existing snapshot API is not permission to introduce more snapshots.
+
+Ordinary scalar/value parameters and results are not prohibited. Review copies that duplicate an
+existing object's state, especially whole objects, containers, and image buffers. Required algorithm
+output buffers are not snapshots merely because they use separate storage.
+
+## Naming and Terminology
+
+### Scope and exceptions
+
+The table below defines the scope of each restriction. Matching is case-insensitive and includes
+compound identifiers and derived forms where applicable. Use names that state the actual operation,
+artifact, comparison, or guarantee; replacing one vague label with another does not satisfy the rule.
+
+Exact external API/framework/model identifiers are allowed where interoperability requires their
+spelling. Keep that spelling at the integration site; do not propagate it into Alcedo-owned names or
+surrounding prose. These rules may quote prohibited terms to define or explain the prohibition.
+
+### Prohibited terms and concrete replacements
+
+| Term | Scope | Required wording or behavior |
+| --- | --- | --- |
+| `hydration`, `hydrate`, and derived forms | Project-authored identifiers, tests, comments, documentation, plans, and user-facing text | Name the operation: read, load, populate, restore, or apply. |
+| `gesture` and derived forms | Project-authored identifiers, tests, comments, documentation, plans, and user-facing text | Name the actual input: drag, pinch, input sequence, pointer release, or settled edit. |
+| `golden` | Project-authored identifiers, test/target names, filenames, comments, documentation, plans, and user-facing text | State what is stored or verified: expected pixel values, serialized output, a reference image comparison with a stated tolerance, or a specific rendering result. |
+| `smoke` | Test names, targets, files, and documentation | State the behavior and expected result. A name that only means "something ran" is insufficient. |
+| `contract`, `contracts` | Everything under `docs/roadmap/`, including prose, headings, link labels, and filenames | Name the exact artifact or guarantee: interface, API, schema, protocol, invariant, behavior specification, acceptance criterion, compatibility requirement, or performance target. |
+| `seed` used as a verb for a non-random operation | Project-authored code identifiers, tests, and comments | Use populate, insert, initialize, restore, copy, or apply. Conventional inputs to random-number generators, cryptographic primitives, and deterministic fuzz runs remain allowed. |
+
+### Test and reference-data names
+
+Every test must state the behavior, regression, invariant, or property it verifies. Unit,
+integration, regression, property, and benchmark are useful categories, but each still needs an
+explicit assertion goal.
+
+Examples of concrete names:
+
+- `NeuralEngineDemosaicsRealBayerRawPatchToValidRgb`
+- `LoadFailureReportsErrorAndKeepsCacheCold`
+- `RenderedPixelsMatchReferenceWithinTolerance`
+- `SerializedEditHistoryMatchesExpectedJson`
+
+For stored expected results, name the actual contents and purpose, such as
+`expected_edit_history.json` or `exposure_plus_one_expected_pixels.exr`. A file comparison alone
+does not explain the behavior being checked: the test must identify the output, comparison rule,
+and tolerance where relevant. Do not mechanically replace `golden` with `baseline` or `reference`
+without making those details clear.
+
+### Checks before completing relevant edits
+
+- Search first-party source, tests, docs, and plans for prohibited project-wide terminology. Review
+  matches against the scope and external-identifier exception above.
+- Replace prohibited names in touched code and update their callers, test registrations, and links
+  together. When touching a non-conventional `seed` verb, rename it in the same change.
+- For roadmap edits, search the entire `docs/roadmap/` tree, including filenames. Rename violating
+  linked files and update their references.
+- Review added copies and snapshot types against the data-update rules above; verify that each
+  exception has a concrete need and a defined consistency mechanism.
+
+## Workspace and Branches
+
+### Branch names
+
+Branch names must describe the feature, fix, refactor, or other engineering purpose of the work.
+Do not include `codex` in a branch name. Use a functional name such as
+`fix/neighbor-operator-ping-pong` or `feature/opencl-program-cache`.
+
+### Temporary files and local state
 
 Do **not** create temporary directories or ad-hoc dump files at the repository root
 (for example `/tmp`, `tmp/`, root-level `*.log`, harness dumps, one-off scripts, or
@@ -105,35 +215,7 @@ ctest --test-dir build/debug --output-on-failure
 ./build/debug/tests/test_exposure_op
 ```
 
-**Test naming ban — no "smoke" tests.** Do not name tests, targets, files, or
-docs with `smoke` / `Smoke` / `SMOKE` (e.g. `*SmokeTest`, `FooSmokeOnBar`).
-Every test must state a concrete purpose: what behavior, contract, regression,
-or property it verifies (examples: `NeuralEngineDemosaicsRealBayerRawPatchToValidRgb`,
-`LoadFailureFallsBackToLegacyAndKeepsCacheCold`). Vague names that only mean
-"something ran" are not allowed. Prefer: unit / integration / regression /
-property / golden / benchmark, each with an explicit assertion goal.
-
-**Roadmap terminology ban.** Files under `docs/roadmap/` must not use `contract`,
-`contracts`, or casing variants in prose, headings, link labels, or filenames. Name the exact
-artifact or guarantee instead: interface, API, schema, protocol, invariant, behavior specification,
-acceptance criterion, compatibility requirement, or performance target. Before completing roadmap
-edits, search the entire roadmap tree and rename any linked file that violates this rule.
-
-**Project terminology ban.** Project-authored code identifiers, tests, comments, documentation,
-plans, and user-facing text must not use `hydration`, `hydrate`, `gesture`, or casing/derived
-variants. These words hide the concrete operation being performed. Use exact terms such as read,
-load, populate, apply, drag, pinch, input sequence, pointer release, or settled edit. External
-framework identifiers that require an exact spelling, such as Qt types, enum values, signals, or
-QML properties, are the only exception. Keep the exception at the call site and do not repeat the
-external wording in Alcedo-owned API names or surrounding prose. Before completing relevant edits,
-search first-party source, tests, docs, and plans for violations.
-
-**`Seed` verb ban in code.** Project-authored code identifiers, tests, and comments must not use
-`Seed` / `seed` as a verb for populate, insert, initialize, restore, copy, or apply operations. Name
-the concrete operation instead. Conventional seed usage remains allowed when it means an input to
-a random-number generator, cryptographic primitive, deterministic fuzz run, or an exact external
-API/model identifier. When touching code that contains a non-conventional `Seed` verb, replace it
-with the precise operation name in the same change.
+Test names and reference-data files must follow **Naming and Terminology** above.
 
 WebGPU RAW tests must heap-allocate `LibRaw` raw processors (for example with
 `std::make_unique<LibRaw>()`). Do not stack-allocate `LibRaw` in WebGPU-related tests; Dawn +
@@ -165,10 +247,11 @@ These façade services are the **only** API surface the UI layer may call. They 
 - **Storage**: DuckDB ORM layer with mappers and controllers (`storage/`)
 
 ### Layer 5 — UI (`ui/`)
-- **AlbumBackendLib**: Reusable QML/C++ backend module for the album browser
-- **EditViewer**: Real-time editor viewport using Qt RHI (D3D11 / Metal / OpenGL fallback)
-- **editor_dialog**: Editor UI panels (tone, color, geometry, versioning, scope/histogram)
-- **alcedo_main**: Application entry point (QML + C++ shell)
+
+- **alcedo_main**: Application entry point and unified QML / Qt Quick shell
+- **alcedo_main/qml/**: Album browser, editor workspace, adjustment panels, version/history views, scopes, and dialogs
+- **alcedo_main/album_backend/**: C++ models and controllers exposed to QML for library and editor operations
+- **editor_rhi/**: `EditorViewportItem` and rendering integration for the Qt Quick editor viewport
 
 ## Key Technical Notes
 
@@ -176,8 +259,7 @@ These façade services are the **only** API surface the UI layer may call. They 
 - **Submodules** (`third_party/lensfun`, `third_party/libultrahdr`, `third_party/QuickQanava`) must be initialized before configuring: `git submodule update --init --recursive` for lensfun/libultrahdr, and `git submodule update --init alcedo_studio/src/third_party/QuickQanava` (no nested checkout).
 - **Windows packages** are resolved via vcpkg; macOS via Homebrew.
 - **CUDA** requires Toolkit 12.8 and compute capability ≥ 6.0. CUDA files have their own compile database entry.
-- **C++ standard**: C++20 with AVX/AVX2 SIMD flags.
-- **Naming convention** (clang-tidy enforced): private members use a trailing `_` suffix; public/protected members do not.
+- **SIMD**: The C++ build uses AVX/AVX2 SIMD flags.
 - **32-bit float pipeline**: All internal image processing operates in 32-bit float; output rendering uses ACES 2.0 with optional CUBE LUT.
 
 ## Skills

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -507,6 +507,17 @@ auto EditorSessionService::history_snapshot() -> EditorHistorySnapshot {
   return snapshot;
 }
 
+auto EditorSessionService::active_version_id() const -> version_ref_id_t {
+  if (!dependencies_.history || !lifecycle_.has_history_guard()) return {};
+  std::string      error;
+  version_ref_id_t version_id;
+  if (!dependencies_.history->ReadActiveVersionId(lifecycle_.history_guard(), &version_id,
+                                                   &error)) {
+    return {};
+  }
+  return version_id;
+}
+
 auto EditorSessionService::pipeline_document() const -> const PipelineDocument* {
   if (!dependencies_.pipeline || !lifecycle_.has_image()) {
     return nullptr;

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -157,6 +157,17 @@ class IEditorHistoryPort {
     return false;
   }
 
+  /// Read only the active Version identity. This avoids constructing the
+  /// Versions/commits projection when a consumer only needs a layout key or
+  /// stale-session check.
+  virtual auto ReadActiveVersionId(const EditorHistoryGuardHandle& /*guard*/,
+                                   version_ref_id_t* /*version_id*/, std::string* error) -> bool {
+    if (error != nullptr) {
+      *error = "Active Version identity is not supported by this history port";
+    }
+    return false;
+  }
+
   /// Read named Version refs and the active Version's first-parent commit path.
   /// Journal frames are an internal recovery mechanism and are never returned
   /// as user-facing rows.

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -81,6 +81,8 @@ class IEditorSessionBackend {
   /// across backend change notifications to emit one dedicated history signal
   /// instead of refreshing on every renderer event.
   [[nodiscard]] virtual auto history_revision() const -> std::uint64_t { return 0; }
+  /// Lightweight active Version identity for session/layout comparisons.
+  [[nodiscard]] virtual auto active_version_id() const -> version_ref_id_t { return {}; }
   [[nodiscard]] virtual auto history_snapshot() -> EditorHistorySnapshot { return {}; }
   /// Live PipelineDocument for the Nodes-page projection. Null when the backend
   /// has no loaded image document. Default fakes return nullptr.
@@ -373,6 +375,7 @@ class EditorSessionService final : public IEditorSessionBackend {
   [[nodiscard]] auto history_revision() const -> std::uint64_t override {
     return history_revision_.load(std::memory_order_acquire);
   }
+  [[nodiscard]] auto active_version_id() const -> version_ref_id_t override;
   [[nodiscard]] auto history_snapshot() -> EditorHistorySnapshot override;
   [[nodiscard]] auto pipeline_document() const -> const PipelineDocument* override;
   [[nodiscard]] auto presentation_sink_id() const -> PresentationSinkId {

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_projection.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_projection.hpp
@@ -22,6 +22,10 @@ class EditorHistoryProjection {
  public:
   explicit EditorHistoryProjection(EditorHistoryState& state);
 
+  /// Read the active Version identity without walking refs or commits.
+  auto ReadActiveVersionId(const alcedo::EditorHistoryGuardHandle& guard,
+                           alcedo::version_ref_id_t* version_id, std::string* error) -> bool;
+
   /// Project the named refs and active first-parent path for the QML model.
   auto ReadHistorySnapshot(const alcedo::EditorHistoryGuardHandle& guard,
                            alcedo::EditorHistorySnapshot* snapshot, std::string* error) -> bool;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -238,7 +238,8 @@ class EditorNodeController : public QObject {
 
  private:
   void               DisconnectSession();
-  void               OnSessionChanged();
+  void               OnSessionStateChanged();
+  void               OnSessionHistoryChanged();
   void               ClearSnapshot();
   void               SetLastError(QString error);
   void               RestoreSelectionAfterSnapshot();
@@ -278,6 +279,7 @@ class EditorNodeController : public QObject {
   void               PersistSavedSelection();
   void               ApplyLiveSelectionToAdapter();
   [[nodiscard]] auto SessionMatchesSubmittedIdentity() const -> bool;
+  [[nodiscard]] auto SessionLocationChanged() const -> bool;
   [[nodiscard]] auto SessionIdentityChanged() const -> bool;
   [[nodiscard]] auto AdapterShowsCurrentCommittedProjection() const -> bool;
   void               AdoptCommittedDocument(const PipelineDocument& document);
@@ -297,11 +299,15 @@ class EditorNodeController : public QObject {
   bool                                                command_active_          = false;
   bool                                                projection_apply_queued_ = false;
   quint64                                             session_generation_      = 0;
+  quint64                                             observed_history_revision_ = 0;
   quint64                                             projection_revision_     = 0;
   quint64                                             topology_revision_       = 0;
   quint64                                             element_id_              = 0;
   quint64                                             image_id_                = 0;
   QString                                             version_id_;
+  quint64                                             snapshot_element_id_ = 0;
+  quint64                                             snapshot_image_id_   = 0;
+  QString                                             snapshot_version_id_;
   QString                                             last_error_;
   std::unique_ptr<alcedo::EditorNodeGraphDraft>       draft_;
   std::optional<alcedo::EditorNodeGraphDraftIdentity> submitted_identity_;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -151,6 +151,8 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   [[nodiscard]] QString active_adjustment_panel() const { return active_adjustment_panel_; }
   [[nodiscard]] QString editor_tool_panel_page() const { return editor_tool_panel_page_; }
   [[nodiscard]] qulonglong session_generation() const;
+  [[nodiscard]] qulonglong history_revision() const;
+  [[nodiscard]] QString    active_version_id() const;
   [[nodiscard]] auto       pipeline_document() const -> const alcedo::PipelineDocument*;
   // Phase 6C-7: load panel state from the backend adjustment snapshot.
   [[nodiscard]] auto    adjustment_snapshot() const -> QVariantMap;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
@@ -102,6 +102,9 @@ class EditorSessionHistoryPort final : public alcedo::IEditorHistoryPort {
       -> bool override;
   auto CheckoutVersion(const alcedo::EditorHistoryGuardHandle& guard,
                        const alcedo::Hash128& version_id, std::string* error) -> bool override;
+  auto ReadActiveVersionId(const alcedo::EditorHistoryGuardHandle& guard,
+                           alcedo::version_ref_id_t* version_id,
+                           std::string* error) -> bool override;
   auto ReadHistorySnapshot(const alcedo::EditorHistoryGuardHandle& guard,
                            alcedo::EditorHistorySnapshot* snapshot, std::string* error)
       -> bool override;

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_projection.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_projection.cpp
@@ -14,6 +14,26 @@ namespace alcedo::ui {
 
 EditorHistoryProjection::EditorHistoryProjection(EditorHistoryState& state) : state_(state) {}
 
+auto EditorHistoryProjection::ReadActiveVersionId(
+    const alcedo::EditorHistoryGuardHandle& guard, alcedo::version_ref_id_t* version_id,
+    std::string* error) -> bool {
+  if (version_id == nullptr) {
+    if (error != nullptr) *error = "Active Version identity output is null";
+    return false;
+  }
+  auto state = state_.PeekWorkingState(guard.element_id);
+  if (!state) {
+    *version_id = {};
+    return true;
+  }
+  if (!state->pipeline_guard || !state->pipeline_guard->commit_graph_) {
+    if (error != nullptr) *error = "Editor history graph is unavailable";
+    return false;
+  }
+  *version_id = state->pipeline_guard->commit_graph_->GetActiveVersionId();
+  return true;
+}
+
 auto EditorHistoryProjection::ReadHistorySnapshot(
     const alcedo::EditorHistoryGuardHandle& guard, alcedo::EditorHistorySnapshot* snapshot,
     std::string* error) -> bool {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -42,6 +42,11 @@ auto SameTopology(const EditorNodeGraphSnapshot& lhs, const EditorNodeGraphSnaps
   return true;
 }
 
+auto SameProjectionContent(const EditorNodeGraphSnapshot& lhs,
+                           const EditorNodeGraphSnapshot& rhs) -> bool {
+  return lhs.nodes == rhs.nodes && lhs.edges == rhs.edges;
+}
+
 }  // namespace
 
 EditorNodeController::EditorNodeController(QObject* parent) : QObject(parent) {}
@@ -83,15 +88,21 @@ void EditorNodeController::set_editor_session(QObject* session) {
   session_ = typed;
   if (session_ != nullptr) {
     state_connection_   = connect(session_.data(), &EditorSessionController::StateChanged, this,
-                                  &EditorNodeController::OnSessionChanged);
+                                  &EditorNodeController::OnSessionStateChanged);
     history_connection_ = connect(session_.data(), &EditorSessionController::HistoryChanged, this,
-                                  &EditorNodeController::OnSessionChanged);
+                                  &EditorNodeController::OnSessionHistoryChanged);
     availability_connection_ =
         connect(session_.data(), &EditorSessionController::ActionAvailabilityChanged, this,
                 &EditorNodeController::ActionAvailabilityChanged);
   }
   emit EditorSessionChanged();
-  OnSessionChanged();
+  submitted_identity_.reset();
+  DiscardDraft();
+  if (session_ != nullptr) {
+    refreshFromSession();
+  } else {
+    ClearSnapshot();
+  }
 }
 
 void EditorNodeController::SetLayoutIdentity(quint64 element_id, quint64 image_id,
@@ -134,6 +145,9 @@ void EditorNodeController::ClearSnapshot() {
   session_generation_        = BoundSessionGeneration().value_or(0);
   projection_revision_       = 0;
   topology_revision_         = 0;
+  snapshot_element_id_       = 0;
+  snapshot_image_id_         = 0;
+  snapshot_version_id_.clear();
   emit SnapshotChanged();
   emit SelectionChanged();
   emit ActionAvailabilityChanged();
@@ -314,6 +328,13 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
     SetLastError(tr("The graph snapshot has no nodes"));
     return false;
   }
+  if (has_snapshot_ && snapshot.session_generation == session_generation_ &&
+      element_id_ == snapshot_element_id_ && image_id_ == snapshot_image_id_ &&
+      version_id_ == snapshot_version_id_ &&
+      SameProjectionContent(snapshot, snapshot_)) {
+    SetLastError({});
+    return true;
+  }
 
   const bool generation_changed =
       !has_snapshot_ || snapshot.session_generation != session_generation_;
@@ -333,6 +354,9 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
   snapshot.projection_revision = projection_revision_;
   snapshot_                    = std::move(snapshot);
   has_snapshot_                = true;
+  snapshot_element_id_         = element_id_;
+  snapshot_image_id_           = image_id_;
+  snapshot_version_id_         = version_id_;
   SyncLayoutKey();
   RestoreSelectionAfterSnapshot();
   SetLastError({});
@@ -530,7 +554,8 @@ bool EditorNodeController::refreshFromSession() {
   }
   element_id_ = session_->element_id();
   image_id_   = session_->image_id();
-  version_id_ = QString::fromStdString(session_->history_snapshot().active_version_id.ToString());
+  version_id_ = session_->active_version_id();
+  observed_history_revision_ = session_->history_revision();
   SyncLayoutKey();
   const auto* document = session_->pipeline_document();
   if (document == nullptr) {
@@ -549,22 +574,47 @@ auto EditorNodeController::SessionMatchesSubmittedIdentity() const -> bool {
   const auto& submitted = *submitted_identity_;
   return submitted.element_id == static_cast<std::uint64_t>(session_->element_id()) &&
          submitted.image_id == static_cast<std::uint64_t>(session_->image_id()) &&
-         submitted.version_id == session_->history_snapshot().active_version_id.ToString() &&
+         QString::fromStdString(submitted.version_id) == session_->active_version_id() &&
          submitted.session_generation == static_cast<std::uint64_t>(session_->session_generation());
 }
 
 [[nodiscard]] auto EditorNodeController::SessionIdentityChanged() const -> bool {
+  return SessionLocationChanged() ||
+         (session_ != nullptr && session_->active_version_id() != version_id_);
+}
+
+[[nodiscard]] auto EditorNodeController::SessionLocationChanged() const -> bool {
   if (session_ == nullptr) {
     return false;
   }
   return static_cast<quint64>(session_->element_id()) != element_id_ ||
          static_cast<quint64>(session_->image_id()) != image_id_ ||
-         QString::fromStdString(session_->history_snapshot().active_version_id.ToString()) !=
-             version_id_ ||
          static_cast<quint64>(session_->session_generation()) != session_generation_;
 }
 
-void EditorNodeController::OnSessionChanged() {
+void EditorNodeController::OnSessionStateChanged() {
+  if (session_ == nullptr) {
+    submitted_identity_.reset();
+    DiscardDraft();
+    ClearSnapshot();
+    return;
+  }
+  if (SessionLocationChanged()) {
+    submitted_identity_.reset();
+    DiscardDraft();
+    refreshFromSession();
+  }
+}
+
+void EditorNodeController::OnSessionHistoryChanged() {
+  if (session_ == nullptr) {
+    return;
+  }
+  const auto history_revision = session_->history_revision();
+  if (history_revision == observed_history_revision_) {
+    return;
+  }
+  observed_history_revision_ = history_revision;
   if (SessionIdentityChanged()) {
     submitted_identity_.reset();
     DiscardDraft();
@@ -698,7 +748,6 @@ bool EditorNodeController::renameColorGrade(const QString& node_id, const QStrin
   }
   refreshFromSession();
   selectNode(node_id);
-  QueueProjectionApply();
   return true;
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -1299,6 +1299,16 @@ auto EditorSessionController::NormalizeToolPanelPage(const QString& page) -> QSt
 
 auto EditorSessionController::session_generation() const -> qulonglong { return SessionEpoch(); }
 
+auto EditorSessionController::history_revision() const -> qulonglong {
+  return session_backend_ ? session_backend_->history_revision() : 0;
+}
+
+auto EditorSessionController::active_version_id() const -> QString {
+  return session_backend_
+             ? QString::fromStdString(session_backend_->active_version_id().ToString())
+             : QString{};
+}
+
 auto EditorSessionController::pipeline_document() const -> const alcedo::PipelineDocument* {
   return session_backend_ ? session_backend_->pipeline_document() : nullptr;
 }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
@@ -194,6 +194,12 @@ auto EditorSessionHistoryPort::CheckoutVersion(const alcedo::EditorHistoryGuardH
   return mutation_->CheckoutVersion(guard, version_id, error);
 }
 
+auto EditorSessionHistoryPort::ReadActiveVersionId(
+    const alcedo::EditorHistoryGuardHandle& guard, alcedo::version_ref_id_t* version_id,
+    std::string* error) -> bool {
+  return projection_->ReadActiveVersionId(guard, version_id, error);
+}
+
 auto EditorSessionHistoryPort::ReadHistorySnapshot(const alcedo::EditorHistoryGuardHandle& guard,
                                                    alcedo::EditorHistorySnapshot* snapshot,
                                                    std::string* error) -> bool {

--- a/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
+++ b/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
@@ -222,6 +222,17 @@ class EditorSessionHistoryPortTest : public ::testing::Test {
   EditorSessionHistoryPort                   history_;
 };
 
+TEST_F(EditorSessionHistoryPortTest, ActiveVersionIdentityReadReturnsOnlyTheCheckedOutRef) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  alcedo::version_ref_id_t active_version_id;
+
+  ASSERT_TRUE(history_.ReadActiveVersionId(handle, &active_version_id, &error)) << error;
+
+  EXPECT_EQ(active_version_id, guard_->commit_graph_->GetActiveVersionId());
+}
+
 TEST(EditorHistoryPureReducerTest, ReplaysHeadWithoutConstructingRenderExecutor) {
   auto graph = alcedo::CommitGraph::CreateEmpty(43);
   auto root_snapshot = MakeEmptyCompleteAdjustmentSnapshot();

--- a/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
+++ b/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
@@ -364,6 +364,9 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
 
   [[nodiscard]] auto history_snapshot() -> EditorHistorySnapshot override { return snapshot_; }
   [[nodiscard]] auto history_revision() const -> std::uint64_t override { return history_revision_; }
+  [[nodiscard]] auto active_version_id() const -> version_ref_id_t override {
+    return snapshot_.active_version_id;
+  }
   [[nodiscard]] auto pipeline_document() const -> const PipelineDocument* override {
     return document_.get();
   }

--- a/alcedo_studio/tests/ui/editor_node_controller_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_controller_test.cpp
@@ -61,6 +61,17 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto pipeline_document() const -> const PipelineDocument* override {
     return &document_;
   }
+  [[nodiscard]] auto history_revision() const -> std::uint64_t override {
+    return history_revision_;
+  }
+  [[nodiscard]] auto active_version_id() const -> alcedo::version_ref_id_t override {
+    ++active_version_read_count_;
+    return {};
+  }
+  [[nodiscard]] auto history_snapshot() -> alcedo::EditorHistorySnapshot override {
+    ++history_snapshot_read_count_;
+    return {};
+  }
   [[nodiscard]] auto active_image_load_request() const -> alcedo::ImageLoadRequestId override {
     return request_;
   }
@@ -155,6 +166,11 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
     identity_.image_id = image_id;
     NotifyChange();
   }
+  void PublishStateChange() { NotifyChange(); }
+  void PublishHistoryChange() {
+    ++history_revision_;
+    NotifyChange();
+  }
   auto Document() -> PipelineDocument& { return document_; }
   void SetFailCommands(bool fail) { fail_commands_ = fail; }
   void PublishAvailability(alcedo::EditorActionAvailability availability) {
@@ -169,6 +185,12 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto rename_count() const -> int { return rename_count_; }
   [[nodiscard]] auto reconnect_count() const -> int { return reconnect_count_; }
   [[nodiscard]] auto edit_node_graph_count() const -> int { return edit_node_graph_count_; }
+  [[nodiscard]] auto active_version_read_count() const -> int {
+    return active_version_read_count_;
+  }
+  [[nodiscard]] auto history_snapshot_read_count() const -> int {
+    return history_snapshot_read_count_;
+  }
   [[nodiscard]] auto last_reconnect_node() const -> NodeId { return last_reconnect_node_; }
   [[nodiscard]] auto last_reconnect_predecessor() const -> NodeId {
     return last_reconnect_predecessor_;
@@ -204,6 +226,9 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   int                                               rename_count_  = 0;
   int                                               reconnect_count_ = 0;
   int                                               edit_node_graph_count_ = 0;
+  std::uint64_t                                     history_revision_ = 0;
+  mutable int                                       active_version_read_count_ = 0;
+  int                                               history_snapshot_read_count_ = 0;
   alcedo::NodeGraphTopologyChange                   last_topology_change_{};
   NodeId                                            last_reconnect_node_;
   NodeId                                            last_reconnect_predecessor_;
@@ -523,16 +548,72 @@ TEST(EditorNodeController, OrdinaryDraftEditsDoNotCopyIntoTheCommittedSnapshot) 
   EXPECT_EQ(controller.completed_projection_apply_count(), applies_before);
 }
 
-TEST(EditorNodeController, OneCommittedRevisionCoalescesQueuedProjectionApplies) {
+TEST(EditorNodeController, IdenticalCommittedProjectionDoesNotPublishOrQueueAnotherApply) {
   EditorNodeController controller;
   ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 1));
   const auto queued_after_first = controller.queued_projection_apply_count();
+  const auto revision_after_first = controller.projection_revision();
   EXPECT_GE(queued_after_first, 1);
   ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 1));
-  EXPECT_EQ(controller.queued_projection_apply_count(), queued_after_first + 1);
+  EXPECT_EQ(controller.queued_projection_apply_count(), queued_after_first);
+  EXPECT_EQ(controller.projection_revision(), revision_after_first);
   QCoreApplication::processEvents();
   EXPECT_EQ(controller.completed_projection_apply_count(), 0);
   EXPECT_GE(controller.skipped_stale_projection_apply_count(), 1);
+}
+
+TEST(EditorNodeController, RepeatedSessionStateChangesDoNotReadHistoryOrRepublishNodes) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(81);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  const auto revision = controller.projection_revision();
+  const auto queued   = controller.queued_projection_apply_count();
+  const auto active_version_reads = backend.active_version_read_count();
+
+  for (int index = 0; index < 20; ++index) {
+    backend.PublishStateChange();
+  }
+
+  EXPECT_EQ(backend.history_snapshot_read_count(), 0);
+  EXPECT_EQ(backend.active_version_read_count(), active_version_reads);
+  EXPECT_EQ(controller.projection_revision(), revision);
+  EXPECT_EQ(controller.queued_projection_apply_count(), queued);
+}
+
+TEST(EditorNodeController, UnchangedHistoryProjectionDoesNotPublishOrQueueAnotherApply) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(82);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  const auto revision = controller.projection_revision();
+  const auto queued   = controller.queued_projection_apply_count();
+
+  backend.PublishHistoryChange();
+
+  EXPECT_EQ(backend.history_snapshot_read_count(), 0);
+  EXPECT_EQ(controller.projection_revision(), revision);
+  EXPECT_EQ(controller.queued_projection_apply_count(), queued);
+}
+
+TEST(EditorNodeController, ChangedHistoryProjectionPublishesExactlyOneApply) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(83);
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  const auto revision = controller.projection_revision();
+  const auto queued   = controller.queued_projection_apply_count();
+  ASSERT_TRUE(alcedo::RenameColorGrade(backend.Document(), NodeId{"grade.primary"}, "Updated")
+                  .empty());
+
+  backend.PublishHistoryChange();
+
+  EXPECT_EQ(backend.history_snapshot_read_count(), 0);
+  EXPECT_EQ(controller.projection_revision(), revision + 1);
+  EXPECT_EQ(controller.queued_projection_apply_count(), queued + 1);
 }
 
 TEST(EditorNodeController, QueuedProjectionApplyIgnoresStaleAdapterAfterDetach) {

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -536,8 +536,8 @@ TEST_F(EditorNodesPanelQmlTest, CloseWithQueuedApplyThenReopenRestoresOnce) {
   QTRY_VERIFY_WITH_TIMEOUT(nodes->has_snapshot(), 2000);
   const auto queued_before = nodes->queued_projection_apply_count();
   ASSERT_NE(backend_.pipeline_document(), nullptr);
-  ASSERT_TRUE(nodes->PublishDocument(*backend_.pipeline_document(),
-                                     static_cast<std::uint64_t>(nodes->session_generation())));
+  const auto result = backend_.RenameColorGrade(NodeId{"grade.primary"}, "Queued update");
+  ASSERT_FALSE(alcedo::EditorSessionResultIsFailure(result.kind));
   EXPECT_GT(nodes->queued_projection_apply_count(), queued_before);
 
   controller_.set_editor_tool_panel_page(QString());

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2921,7 +2921,33 @@ replacements; identity retention alone cannot detect duplicate role/layout work.
 ##### NM5.8a completion record (2026-09-04)
 
 **Status:** complete — one attach/apply route, live selection on the controller, layout-key restore,
-queued apply lifetime, image/Version identity not swallowed by submit echo
+queued apply lifetime, image/Version identity not swallowed by submit echo; workspace-switch
+projection regression corrected 2026-09-04
+
+**Workspace-switch regression correction:** NM5.8a initially connected both `StateChanged` and
+`HistoryChanged` to the same refresh route. Each identity check called `history_snapshot()`, which
+walks Version refs and the active first-parent commit path and formats every commit row on the GUI
+thread. Ordinary workspace/session notifications could therefore perform multiple full history
+projections, rebuild an unchanged Nodes value snapshot, and queue another Qan apply.
+
+The corrected route keeps the immutable Nodes snapshot only as the published boundary:
+
+```text
+StateChanged
+  -> compare element/image/session generation only
+  -> unchanged: no history read, no Nodes projection, no Qan work
+
+HistoryChanged
+  -> compare monotonic history revision
+  -> read active Version identity through ReadActiveVersionId (no ref/commit walk)
+  -> build a candidate Nodes projection only when the history revision changed
+  -> nodes/edges unchanged: keep the current projection revision and do not queue Qan
+  -> nodes/edges changed: publish once and queue one apply
+```
+
+`history_snapshot()` remains the History/Versions model API; it is no longer used as a session
+identity lookup by `EditorNodeController`. Repeated render, presentation, and workspace state
+notifications do not enter history projection or node publication.
 
 **Primary success call chain:**
 
@@ -2969,16 +2995,21 @@ session image/Version/generation differs from the cached Nodes identity
 | `CloseWithQueuedApplyThenReopenRestoresOnce` | `EditorNodesPanelQmlTest` | PASS |
 | `ReopenRestoresPositionsViewZoomSelectionAndDrawerState` | `EditorNodesPanelQmlTest` | PASS |
 | `TwoVersionsKeepSeparateLayoutValues` | `EditorNodesPanelQmlTest` | PASS |
-| `OneCommittedRevisionCoalescesQueuedProjectionApplies` | `EditorNodeSelectionLayoutTest` | PASS |
+| `IdenticalCommittedProjectionDoesNotPublishOrQueueAnotherApply` | `EditorNodeSelectionLayoutTest` | PASS |
+| `RepeatedSessionStateChangesDoNotReadHistoryOrRepublishNodes` | `EditorNodeSelectionLayoutTest` | PASS |
+| `UnchangedHistoryProjectionDoesNotPublishOrQueueAnotherApply` | `EditorNodeSelectionLayoutTest` | PASS |
+| `ChangedHistoryProjectionPublishesExactlyOneApply` | `EditorNodeSelectionLayoutTest` | PASS |
 | `QueuedProjectionApplyIgnoresStaleAdapterAfterDetach` | `EditorNodeSelectionLayoutTest` | PASS |
 | `LayoutKeyActivatesBeforeSavedSelectionRestore` | `EditorNodeSelectionLayoutTest` | PASS |
 | `SavedLayoutSelectionDoesNotOverrideLiveSelectionOnTheSameKey` | `EditorNodeSelectionLayoutTest` | PASS |
 | `OrdinaryDraftEditsDoNotCopyIntoTheCommittedSnapshot` | `EditorNodeSelectionLayoutTest` | PASS |
 | `ImageSwitchAfterSubmitRefreshesTheCommittedProjection` | `EditorNodeSelectionLayoutTest` | PASS |
 | `TwoVersionsKeepSeparatePositionsAndDrawerState` | `EditorNodeSelectionLayoutTest` | PASS |
+| `ActiveVersionIdentityReadReturnsOnlyTheCheckedOutRef` | `EditorSessionHistoryPortTest` | PASS |
 
-Commands: `cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorNodeGraphDraftTest EditorNodeGraphProjectionTest EditorNodeSelectionLayoutTest EditorNodesPanelQmlTest` then the four test executables under `build/debug/alcedo_studio/tests/`.
-Suite totals: `EditorNodesPanelQmlTest` 22/22; `EditorNodeSelectionLayoutTest` 34/34.
+Regression commands: `cmd /c scripts\msvc_env.cmd --build build\debug --target EditorNodeSelectionLayoutTest EditorNodesPanelQmlTest EditorSessionHistoryPortTest --parallel 4`, then the three generated test executables.
+Suite totals after the correction: `EditorNodesPanelQmlTest` 22/22;
+`EditorNodeSelectionLayoutTest` 37/37; `EditorSessionHistoryPortTest` 73/73.
 
 **Checklist / exit condition:** 16.3.1 acceptance items covered by the tests above.
 


### PR DESCRIPTION
## Summary
- Stop EditorNodeController from reading a full EditorHistorySnapshot during session identity checks.
- Split StateChanged and HistoryChanged handling so ordinary workspace, renderer, presentation, and task-detail notifications do not enter history or Nodes projection work.
- Add a lightweight active Version identity read that does not walk Version refs, commits, or formatted history rows.
- Keep the current Nodes projection revision and skip Qan apply when nodes and edges are unchanged, while preserving image, Version, and session layout restoration.
- Remove the duplicate Qan apply request from the Color Grade rename path.

## Regression
This is a post-merge follow-up to #128. The regression originated in the Nodes page update path introduced before NM5.8a and was amplified when StateChanged and HistoryChanged were routed through the same refresh handler. Workspace switching could run multiple full history projections on the GUI thread and then publish an unchanged Nodes snapshot.

## Snapshot boundary
EditorHistorySnapshot remains the History/Versions model input. EditorNodeGraphSnapshot remains the immutable PipelineDocument-to-QML boundary, but it is now published only when Nodes-visible content or image/Version/session identity changes.

## Test plan
- [x] EditorNodeSelectionLayoutTest — 37/37
- [x] EditorNodesPanelQmlTest — 22/22
- [x] EditorSessionHistoryPortTest — 73/73
- [x] 132/132 focused tests pass
- [x] git diff --check

## Roadmap
The NM5.8a completion record now documents the regression, corrected call chains, snapshot responsibilities, and test evidence.