### PR TITLE
feat(editor): finish NM5.8e persistent topology history

### DIFF
--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -42,8 +42,8 @@ auto SameTopology(const EditorNodeGraphSnapshot& lhs, const EditorNodeGraphSnaps
   return true;
 }
 
-auto SameProjectionContent(const EditorNodeGraphSnapshot& lhs,
-                           const EditorNodeGraphSnapshot& rhs) -> bool {
+auto SameProjectionContent(const EditorNodeGraphSnapshot& lhs, const EditorNodeGraphSnapshot& rhs)
+    -> bool {
   return lhs.nodes == rhs.nodes && lhs.edges == rhs.edges;
 }
 
@@ -324,8 +324,7 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
   }
   if (has_snapshot_ && snapshot.session_generation == session_generation_ &&
       element_id_ == snapshot_element_id_ && image_id_ == snapshot_image_id_ &&
-      version_id_ == snapshot_version_id_ &&
-      SameProjectionContent(snapshot, snapshot_)) {
+      version_id_ == snapshot_version_id_ && SameProjectionContent(snapshot, snapshot_)) {
     SetLastError({});
     return true;
   }
@@ -546,9 +545,9 @@ bool EditorNodeController::refreshFromSession() {
     SetLastError(tr("No editor session is bound"));
     return false;
   }
-  element_id_ = session_->element_id();
-  image_id_   = session_->image_id();
-  version_id_ = session_->active_version_id();
+  element_id_                = session_->element_id();
+  image_id_                  = session_->image_id();
+  version_id_                = session_->active_version_id();
   observed_history_revision_ = session_->history_revision();
   SyncLayoutKey();
   const auto* document = session_->pipeline_document();
@@ -955,23 +954,31 @@ auto EditorNodeController::MaybeSubmitDraft() -> bool {
     return false;
   }
   DiscardDraft();
+  QString projection_error;
   if (session_ != nullptr && session_->pipeline_document() != nullptr) {
     try {
       AdoptCommittedDocument(*session_->pipeline_document());
     } catch (const std::exception& ex) {
-      SetLastError(QString::fromUtf8(ex.what()));
+      projection_error = QString::fromUtf8(ex.what());
+      SetLastError(projection_error);
     }
   }
   if (graph_adapter_ != nullptr) {
     const auto promoted = graph_adapter_->PromoteCommittedSnapshot(snapshot_);
     if (!promoted.succeeded) {
+      if (!promoted.error.isEmpty()) {
+        projection_error = promoted.error;
+        SetLastError(projection_error);
+      }
       QueueProjectionApply();
     } else {
       ApplyLiveSelectionToAdapter();
     }
   }
   submitted_identity_.reset();
-  SetLastError({});
+  if (projection_error.isEmpty()) {
+    SetLastError({});
+  }
   emit SnapshotChanged();
   emit ActionAvailabilityChanged();
   return true;

--- a/alcedo_studio/tests/edit/history/editor_node_topology_history_test.cpp
+++ b/alcedo_studio/tests/edit/history/editor_node_topology_history_test.cpp
@@ -1,0 +1,457 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "app/editor_mini_git_materializer.hpp"
+#include "app/editor_node_graph_draft.hpp"
+#include "app/editor_node_graph_projection.hpp"
+#include "app/editor_pipeline_command_service.hpp"
+#include "app/pipeline_document_history.hpp"
+#include "app/pipeline_history_applier.hpp"
+#include "app/pipeline_service.hpp"
+#include "app/project_service.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/history/commit_graph.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "edit/mask/mask_store.hpp"
+#include "edit/operators/operator_registeration.hpp"
+#include "edit/pipeline/pipeline_cpu.hpp"
+#include "grade_owned_mask_support.hpp"
+#include "storage/store/edit_history/commit_graph_store.hpp"
+#include "ui/alcedo_main/album_backend/editor_session_history_port.hpp"
+
+namespace alcedo::ui {
+namespace {
+
+constexpr sl_element_id_t kElementId = 946;
+
+struct ProjectPaths {
+  std::filesystem::path root;
+  std::filesystem::path database;
+  std::filesystem::path metadata;
+  std::filesystem::path journal;
+  std::filesystem::path mask_root;
+};
+
+auto MakeProjectPaths() -> ProjectPaths {
+  const auto stamp =
+      std::to_string(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+  ProjectPaths paths;
+  paths.root      = std::filesystem::path{"build/tmp"} / ("node_topology_history_" + stamp);
+  paths.database  = paths.root / "project.db";
+  paths.metadata  = paths.root / "project.json";
+  paths.journal   = paths.root / "editor.wal";
+  paths.mask_root = paths.root / "masks";
+  std::filesystem::create_directories(paths.root);
+  return paths;
+}
+
+class TemporaryProject final {
+ public:
+  TemporaryProject() : paths_(MakeProjectPaths()) {}
+  ~TemporaryProject() {
+    std::error_code error;
+    std::filesystem::remove_all(paths_.root, error);
+  }
+
+  TemporaryProject(const TemporaryProject&)             = delete;
+  TemporaryProject&  operator=(const TemporaryProject&) = delete;
+
+  [[nodiscard]] auto paths() const -> const ProjectPaths& { return paths_; }
+
+ private:
+  ProjectPaths paths_;
+};
+
+class PersistentEditor final {
+ public:
+  PersistentEditor(const ProjectPaths& paths, ProjectOpenMode mode, sl_element_id_t element_id)
+      : paths_(paths),
+        project_(paths.database, paths.metadata, mode),
+        pipeline_service_(std::make_shared<PipelineMgmtService>(project_.GetStorage())),
+        pipeline_(std::make_shared<EditorSessionPipelinePort>()),
+        element_id_(element_id) {}
+
+  auto Open(std::string* error) -> bool {
+    try {
+      guard_ = pipeline_service_->LoadEditorPipeline(element_id_);
+      if (guard_ == nullptr) {
+        if (error != nullptr) {
+          *error = "PipelineMgmtService returned no editor guard";
+        }
+        return false;
+      }
+      pipeline_->SetServices(
+          EditorSessionPipelineMappers{[service = pipeline_service_]() { return service; },
+                                       [guard = guard_](sl_element_id_t) { return guard; }});
+      history_.SetServices(EditorSessionHistoryPort::Services{
+          [journal = paths_.journal](sl_element_id_t) { return journal; }});
+      history_.SetPipelinePort(pipeline_);
+      handle_ = history_.Acquire(element_id_, error);
+      return handle_.valid;
+    } catch (const std::exception& exception) {
+      if (error != nullptr) {
+        *error = exception.what();
+      }
+      return false;
+    }
+  }
+
+  void ReleaseHistory() {
+    if (!handle_.valid) {
+      return;
+    }
+    history_.Release(handle_);
+    handle_ = {};
+  }
+
+  void SavePipelineAndMetadata() {
+    ReleaseHistory();
+    pipeline_service_->SavePipeline(guard_);
+    project_.SaveProject(paths_.metadata);
+  }
+
+  void SaveMetadataOnly() {
+    ReleaseHistory();
+    project_.SaveProject(paths_.metadata);
+  }
+
+  auto MaterializeCheckpoint(std::string* error) -> bool {
+    const auto capture = history_.CaptureSaveCheckpoint(handle_, error);
+    if (!capture || !capture->last_journal_sequence.has_value()) {
+      return false;
+    }
+    {
+      auto             db_guard = project_.GetStorage()->GetDatabase().GetConnectionGuard();
+      auto             db_lock  = db_guard.Lock();
+      CommitGraphStore graph_service(db_guard.conn_);
+      graph_service.Materialize(capture->materialization);
+    }
+    if (!history_.DiscardMaterializedJournalThrough(handle_, *capture->last_journal_sequence,
+                                                    error)) {
+      return false;
+    }
+    return history_.SyncMaterializedStateAfterCheckpoint(handle_, error);
+  }
+
+  [[nodiscard]] auto guard() const -> const std::shared_ptr<PipelineGuard>& { return guard_; }
+  [[nodiscard]] auto guard() -> std::shared_ptr<PipelineGuard>& { return guard_; }
+  [[nodiscard]] auto history() -> EditorSessionHistoryPort& { return history_; }
+  [[nodiscard]] auto handle() const -> const EditorHistoryGuardHandle& { return handle_; }
+
+ private:
+  ProjectPaths                               paths_;
+  ProjectService                             project_;
+  std::shared_ptr<PipelineMgmtService>       pipeline_service_;
+  std::shared_ptr<PipelineGuard>             guard_;
+  std::shared_ptr<EditorSessionPipelinePort> pipeline_;
+  EditorSessionHistoryPort                   history_;
+  EditorHistoryGuardHandle                   handle_{};
+  sl_element_id_t                            element_id_ = 0;
+};
+
+struct TopologyEditExpectation {
+  NodeGraphTopologyChange        change;
+  std::vector<NodeId>            node_ids;
+  std::vector<PipelineSceneEdge> edges;
+};
+
+auto BuildTopologyEdit(const PipelineDocument& document) -> TopologyEditExpectation {
+  auto       draft   = EditorNodeGraphDraft::FromDocument(document, {});
+  const auto require = [](const EditorNodeGraphDraftMutation& mutation, const char* operation) {
+    if (!mutation.succeeded) {
+      throw std::runtime_error(std::string{operation} + ": " + mutation.error);
+    }
+  };
+
+  const NodeId extra{"grade.topology"};
+  require(draft.AddColorGrade(extra), "add color grade");
+  require(draft.Connect(NodeId{"develop"}, extra), "connect develop");
+  require(draft.Connect(extra, NodeId{"grade.primary"}), "connect primary input");
+  require(draft.Connect(NodeId{"grade.primary"}, NodeId{"drt"}), "connect drt");
+  if (!draft.SubmissionValid()) {
+    throw std::runtime_error("topology draft is not a complete Develop-to-DRT path");
+  }
+
+  TopologyEditExpectation expected;
+  expected.change = draft.MakeChange();
+  expected.node_ids.reserve(draft.Nodes().size());
+  for (const auto& node : draft.Nodes()) {
+    expected.node_ids.push_back(node.node_id);
+  }
+  expected.edges.reserve(draft.Edges().size());
+  for (const auto& edge : draft.Edges()) {
+    expected.edges.push_back(PipelineSceneEdge{edge.source_node_id, edge.source_port_id,
+                                               edge.destination_node_id, edge.destination_port_id});
+  }
+  return expected;
+}
+
+auto GraphNodeIds(const PipelineDocument& document) -> std::vector<NodeId> {
+  std::vector<NodeId> ids;
+  ids.reserve(document.Graph().Nodes().size());
+  for (const auto& node : document.Graph().Nodes()) {
+    ids.push_back(node->Id());
+  }
+  return ids;
+}
+
+auto GraphEdges(const PipelineDocument& document) -> std::vector<PipelineSceneEdge> {
+  std::vector<PipelineSceneEdge> edges;
+  edges.reserve(document.Graph().Edges().size());
+  for (const auto& edge : document.Graph().Edges()) {
+    edges.push_back(PipelineSceneEdge{edge.from_node, edge.from_port, edge.to_node, edge.to_port});
+  }
+  return edges;
+}
+
+void ExpectGraphOrder(const PipelineDocument& document, const std::vector<NodeId>& node_ids,
+                      const std::vector<PipelineSceneEdge>& edges) {
+  ASSERT_EQ(GraphNodeIds(document), node_ids);
+  EXPECT_EQ(GraphEdges(document), edges);
+}
+
+auto MaskJson(const PipelineDocument& document, const MaskId& mask_id) -> nlohmann::json {
+  const auto* grade = document.Graph().FindNode(NodeId{"grade.primary"});
+  const auto* model = dynamic_cast<const ColorGradeNodeModel*>(grade);
+  if (model == nullptr) {
+    throw std::runtime_error("primary Color Grade is missing");
+  }
+  const auto* mask = model->FindMask(mask_id);
+  if (mask == nullptr) {
+    throw std::runtime_error("expected persistent Mask is missing");
+  }
+  return MaskModelToJson(*mask);
+}
+
+auto MakeMemoryGuard(sl_element_id_t element_id) -> std::shared_ptr<PipelineGuard> {
+  auto guard           = std::make_shared<PipelineGuard>();
+  guard->id_           = element_id;
+  guard->pipeline_     = std::make_shared<CPUPipelineExecutor>();
+  guard->document_     = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  guard->commit_graph_ = std::make_shared<CommitGraph>(CommitGraph::CreateEmpty(element_id));
+  guard->root_id_      = guard->commit_graph_->GetRootId();
+  guard->root_document_ =
+      std::make_shared<PipelineDocument>(ClonePipelineDocument(*guard->document_));
+  return guard;
+}
+
+TEST(NodeGraphTopologyHistory, ProductionPortPersistsExactTopologyThroughRecoveryAndCheckout) {
+  RegisterAllOperators();
+  TemporaryProject               temporary;
+  const auto&                    paths = temporary.paths();
+  std::string                    error;
+  version_ref_id_t               default_version{};
+  version_ref_id_t               second_version{};
+  head_commit_hash_t             topology_head;
+  head_commit_hash_t             masked_head;
+  std::string                    before_topology_hash;
+  std::string                    after_topology_hash;
+  std::string                    after_mask_hash;
+  std::vector<NodeId>            initial_nodes;
+  std::vector<PipelineSceneEdge> initial_edges;
+  std::vector<NodeId>            topology_nodes;
+  std::vector<PipelineSceneEdge> topology_edges;
+  nlohmann::json                 expected_mask;
+  MaskAssetKey                   saved_asset_key;
+
+  {
+    PersistentEditor editor(paths, ProjectOpenMode::kCreateNew, kElementId);
+    ASSERT_TRUE(editor.Open(&error)) << error;
+    auto& guard          = *editor.guard();
+    default_version      = guard.commit_graph_->GetActiveVersionId();
+    initial_nodes        = GraphNodeIds(*guard.document_);
+    initial_edges        = GraphEdges(*guard.document_);
+
+    before_topology_hash = CanonicalPipelineDocumentJson(*guard.document_);
+    const auto topology  = BuildTopologyEdit(*guard.document_);
+    topology_nodes       = topology.node_ids;
+    topology_edges       = topology.edges;
+    ASSERT_TRUE(editor.history().EditNodeGraph(editor.handle(), topology.change, &error)) << error;
+    after_topology_hash = CanonicalPipelineDocumentJson(*guard.document_);
+    topology_head       = guard.working_head_commit_hash();
+
+    EXPECT_EQ(guard.commit_graph_->GetActiveVersionId(), default_version);
+    EXPECT_EQ(guard.document_->NextColorGradeNameNumber(), 3u);
+    ExpectGraphOrder(*guard.document_, topology_nodes, topology_edges);
+    ASSERT_TRUE(editor.history().LastPublishedRenderReason().has_value());
+    EXPECT_EQ(*editor.history().LastPublishedRenderReason(),
+              EditorRenderReason::GraphTopologyChanged);
+
+    EditorHistorySnapshot snapshot;
+    ASSERT_TRUE(editor.history().ReadHistorySnapshot(editor.handle(), &snapshot, &error)) << error;
+    ASSERT_FALSE(snapshot.commits.empty());
+    EXPECT_EQ(snapshot.active_version_id, default_version);
+    EXPECT_EQ(snapshot.active_head, topology_head);
+    const auto topology_commit =
+        std::find_if(snapshot.commits.begin(), snapshot.commits.end(),
+                     [](const auto& commit) { return commit.operation_kind == "edit_node_graph"; });
+    ASSERT_NE(topology_commit, snapshot.commits.end());
+    EXPECT_EQ(topology_commit->commit_hash, topology_head.value());
+    EXPECT_TRUE(snapshot.can_undo);
+    EXPECT_FALSE(snapshot.can_redo);
+
+    ASSERT_TRUE(editor.history().Undo(editor.handle(), &error)) << error;
+    EXPECT_EQ(CanonicalPipelineDocumentJson(*guard.document_), before_topology_hash);
+    EXPECT_EQ(guard.document_->NextColorGradeNameNumber(), 2u);
+    ExpectGraphOrder(*guard.document_, initial_nodes, initial_edges);
+    ASSERT_TRUE(editor.history().LastPublishedRenderReason().has_value());
+    EXPECT_EQ(*editor.history().LastPublishedRenderReason(), EditorRenderReason::UndoRedo);
+
+    ASSERT_TRUE(editor.history().Redo(editor.handle(), &error)) << error;
+    EXPECT_EQ(CanonicalPipelineDocumentJson(*guard.document_), after_topology_hash);
+    EXPECT_EQ(guard.document_->NextColorGradeNameNumber(), 3u);
+    ExpectGraphOrder(*guard.document_, topology_nodes, topology_edges);
+    ASSERT_TRUE(editor.history().LastPublishedRenderReason().has_value());
+    EXPECT_EQ(*editor.history().LastPublishedRenderReason(), EditorRenderReason::UndoRedo);
+
+    editor.SaveMetadataOnly();
+  }
+
+  {
+    PersistentEditor editor(paths, ProjectOpenMode::kLoadExisting, kElementId);
+    ASSERT_TRUE(editor.Open(&error)) << error;
+    const auto& guard = *editor.guard();
+    EXPECT_EQ(guard.commit_graph_->GetActiveVersionId(), default_version);
+    EXPECT_EQ(guard.commit_graph_->GetAllVersionRefs().size(), 1u);
+    EXPECT_EQ(guard.working_head_commit_hash(), topology_head);
+    EXPECT_EQ(CanonicalPipelineDocumentJson(*guard.document_), after_topology_hash);
+    EXPECT_EQ(guard.document_->NextColorGradeNameNumber(), 3u);
+    ExpectGraphOrder(*guard.document_, topology_nodes, topology_edges);
+
+    EditorHistorySnapshot snapshot;
+    ASSERT_TRUE(editor.history().ReadHistorySnapshot(editor.handle(), &snapshot, &error)) << error;
+    EXPECT_EQ(snapshot.active_version_id, default_version);
+    EXPECT_EQ(snapshot.active_head, topology_head);
+    ASSERT_FALSE(snapshot.commits.empty());
+    EXPECT_TRUE(
+        std::any_of(snapshot.commits.begin(), snapshot.commits.end(),
+                    [](const auto& commit) { return commit.operation_kind == "edit_node_graph"; }));
+
+    ASSERT_TRUE(editor.history().CreateRootVersionAndCheckout(editor.handle(), "Clean",
+                                                              &second_version, &error))
+        << error;
+    EXPECT_NE(second_version, default_version);
+    EXPECT_EQ(guard.commit_graph_->GetActiveVersionId(), second_version);
+    EXPECT_FALSE(guard.working_head_commit_hash().has_value());
+    ExpectGraphOrder(*guard.document_, initial_nodes, initial_edges);
+
+    ASSERT_TRUE(editor.history().CheckoutVersion(editor.handle(), default_version, &error))
+        << error;
+    EXPECT_EQ(guard.commit_graph_->GetActiveVersionId(), default_version);
+    EXPECT_EQ(guard.working_head_commit_hash(), topology_head);
+    EXPECT_EQ(CanonicalPipelineDocumentJson(*guard.document_), after_topology_hash);
+    ExpectGraphOrder(*guard.document_, topology_nodes, topology_edges);
+    ASSERT_TRUE(editor.history().LastPublishedRenderReason().has_value());
+    EXPECT_EQ(*editor.history().LastPublishedRenderReason(),
+              EditorRenderReason::VersionDocumentChanged);
+
+    MaskStore           store(paths.mask_root);
+    MaskAssetDescriptor descriptor;
+    descriptor.extent           = {4, 4};
+    descriptor.reference_bounds = {0.0f, 0.0f, 1.0f, 1.0f};
+    saved_asset_key             = store.Put(descriptor, std::vector<std::uint8_t>(16, 19));
+    const auto mask =
+        grade_mask_test::MakeBrushMask(MaskId{"mask.topology"}, saved_asset_key, descriptor);
+    expected_mask = MaskModelToJson(mask);
+    ASSERT_TRUE(editor.history().AddMask(editor.handle(), NodeId{"grade.primary"}, mask, 0, &error))
+        << error;
+    ASSERT_TRUE(editor.history().ReplaceMaskAsset(editor.handle(), NodeId{"grade.primary"},
+                                                  MaskId{"mask.topology"},
+                                                  expected_mask.at("source"), store, &error))
+        << error;
+    EXPECT_EQ(MaskJson(*guard.document_, MaskId{"mask.topology"}), expected_mask);
+    after_mask_hash = CanonicalPipelineDocumentJson(*guard.document_);
+    masked_head     = guard.working_head_commit_hash();
+    ASSERT_TRUE(editor.MaterializeCheckpoint(&error)) << error;
+    editor.SavePipelineAndMetadata();
+  }
+
+  {
+    PersistentEditor editor(paths, ProjectOpenMode::kLoadExisting, kElementId);
+    ASSERT_TRUE(editor.Open(&error)) << error;
+    const auto& guard = *editor.guard();
+    EXPECT_EQ(guard.commit_graph_->GetActiveVersionId(), default_version);
+    EXPECT_EQ(guard.working_head_commit_hash(), masked_head);
+    EXPECT_EQ(CanonicalPipelineDocumentJson(*guard.document_), after_mask_hash);
+    EXPECT_EQ(guard.commit_graph_->GetAllVersionRefs().size(), 2u);
+    ExpectGraphOrder(*guard.document_, topology_nodes, topology_edges);
+    EXPECT_EQ(MaskJson(*guard.document_, MaskId{"mask.topology"}), expected_mask);
+    EXPECT_TRUE(std::filesystem::exists(MaskStore(paths.mask_root).PathFor(saved_asset_key)));
+
+    EditorHistorySnapshot snapshot;
+    ASSERT_TRUE(editor.history().ReadHistorySnapshot(editor.handle(), &snapshot, &error)) << error;
+    EXPECT_EQ(snapshot.active_version_id, default_version);
+    EXPECT_EQ(snapshot.active_head, masked_head);
+    ASSERT_FALSE(snapshot.commits.empty());
+    EXPECT_TRUE(
+        std::any_of(snapshot.commits.begin(), snapshot.commits.end(),
+                    [](const auto& commit) { return commit.operation_kind == "edit_node_graph"; }));
+
+    ASSERT_TRUE(editor.history().CheckoutVersion(editor.handle(), second_version, &error)) << error;
+    EXPECT_EQ(guard.commit_graph_->GetActiveVersionId(), second_version);
+    EXPECT_FALSE(guard.working_head_commit_hash().has_value());
+    ExpectGraphOrder(*guard.document_, initial_nodes, initial_edges);
+    EXPECT_EQ(guard.document_->NextColorGradeNameNumber(), 2u);
+    EXPECT_TRUE(CollectPersistentMaskAssetKeys(*guard.document_).empty());
+    ASSERT_TRUE(editor.history().LastPublishedRenderReason().has_value());
+    EXPECT_EQ(*editor.history().LastPublishedRenderReason(),
+              EditorRenderReason::VersionDocumentChanged);
+  }
+}
+
+TEST(NodeGraphTopologyHistory, JournalFailureRestoresTopologyDocumentHeadAndRenderState) {
+  RegisterAllOperators();
+  TemporaryProject temporary;
+  const auto&      paths    = temporary.paths();
+
+  auto             guard    = MakeMemoryGuard(kElementId + 1);
+  auto             pipeline = std::make_shared<EditorSessionPipelinePort>();
+  pipeline->SetServices(
+      EditorSessionPipelineMappers{{}, [guard](sl_element_id_t) { return guard; }});
+  EditorSessionHistoryPort history;
+  history.SetServices(
+      EditorSessionHistoryPort::Services{[path = paths.journal](sl_element_id_t) { return path; }});
+  history.SetPipelinePort(pipeline);
+
+  std::string error;
+  const auto  handle = history.Acquire(kElementId + 1, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  ASSERT_TRUE(std::filesystem::create_directory(paths.journal));
+  const auto prior_hash         = CanonicalPipelineDocumentJson(*guard->document_);
+  const auto prior_head         = guard->working_head_commit_hash();
+  const auto prior_commit_count = guard->commit_graph_->CommitCount();
+  const auto prior_reason       = history.LastPublishedRenderReason();
+  const auto prior_counter      = guard->document_->NextColorGradeNameNumber();
+
+  const auto topology           = BuildTopologyEdit(*guard->document_);
+  error.clear();
+  EXPECT_FALSE(history.EditNodeGraph(handle, topology.change, &error));
+  EXPECT_EQ(error, "mini-Git journal file could not be opened for append");
+  EXPECT_EQ(CanonicalPipelineDocumentJson(*guard->document_), prior_hash);
+  EXPECT_EQ(guard->working_head_commit_hash(), prior_head);
+  EXPECT_EQ(guard->commit_graph_->CommitCount(), prior_commit_count);
+  EXPECT_EQ(guard->document_->NextColorGradeNameNumber(), prior_counter);
+  EXPECT_EQ(history.LastPublishedRenderReason(), prior_reason);
+  const std::vector<NodeId> expected_initial_ids = {NodeId{"develop"}, NodeId{"grade.primary"},
+                                                    NodeId{"drt"}};
+  EXPECT_EQ(GraphNodeIds(*guard->document_), expected_initial_ids);
+  history.Release(handle);
+}
+
+}  // namespace
+}  // namespace alcedo::ui

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -183,6 +183,7 @@ add_executable(EditorSessionHistoryPortTest
     ${ALCEDO_TEST_ROOT}/edit/history/editor_session_history_port_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/history/editor_document_history_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/history/editor_version_checkout_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/history/editor_node_topology_history_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/history/editor_document_paste_test.cpp
     ${CMAKE_SOURCE_DIR}/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
     ${CMAKE_SOURCE_DIR}/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_state_detail.cpp
@@ -198,6 +199,7 @@ target_include_directories(EditorSessionHistoryPortTest
   PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR} ${ALCEDO_TEST_ROOT}/edit/graph)
 target_link_libraries(EditorSessionHistoryPortTest
   AdjustmentTransferService
+  EditorNodeGraphDraft
   EditorNodeGraphProjection
   EditorAdjustmentPipeline
   EditorPipelineCommandService

--- a/alcedo_studio/tests/ui/editor_node_controller_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_controller_test.cpp
@@ -20,6 +20,7 @@
 #include "edit/graph/pipeline_graph_commands.hpp"
 #include "grade_owned_mask_support.hpp"
 #include "type/type.hpp"
+#include "ui/alcedo_main/album_backend/alcedo_qan_graph.hpp"
 #include "ui/alcedo_main/album_backend/editor_node_layout_store.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_controller.hpp"
 
@@ -147,9 +148,7 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   }
   [[nodiscard]] auto rename_count() const -> int { return rename_count_; }
   [[nodiscard]] auto edit_node_graph_count() const -> int { return edit_node_graph_count_; }
-  [[nodiscard]] auto active_version_read_count() const -> int {
-    return active_version_read_count_;
-  }
+  [[nodiscard]] auto active_version_read_count() const -> int { return active_version_read_count_; }
   [[nodiscard]] auto history_snapshot_read_count() const -> int {
     return history_snapshot_read_count_;
   }
@@ -174,11 +173,11 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   alcedo::ImageLoadRequestId                        request_{};
   alcedo::EditorActionAvailability                  availability_{};
   IEditorSessionBackend::ActionAvailabilityObserver availability_observer_;
-  bool                                              fail_commands_ = false;
-  int                                               rename_count_  = 0;
-  int                                               edit_node_graph_count_ = 0;
-  std::uint64_t                                     history_revision_ = 0;
-  mutable int                                       active_version_read_count_ = 0;
+  bool                                              fail_commands_               = false;
+  int                                               rename_count_                = 0;
+  int                                               edit_node_graph_count_       = 0;
+  std::uint64_t                                     history_revision_            = 0;
+  mutable int                                       active_version_read_count_   = 0;
   int                                               history_snapshot_read_count_ = 0;
   alcedo::NodeGraphTopologyChange                   last_topology_change_{};
 };
@@ -424,6 +423,31 @@ TEST(EditorNodeController, CompletingThePathSubmitsOneTopologyChange) {
   EXPECT_EQ(controller.ActiveNodes().size(), 4u);
 }
 
+TEST(EditorNodeController, ProductTopologyCommitKeepsProjectionFailureVisible) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(33);
+  EditorSessionController    session(&backend);
+  EditorNodeController       controller;
+  alcedo::ui::AlcedoQanGraph adapter;
+  controller.set_editor_session(&session);
+  controller.set_graph_adapter(&adapter);
+
+  ASSERT_TRUE(controller.addCleanColorGrade());
+  const auto extra = controller.selected_node_id();
+  ASSERT_TRUE(controller.requestConnect(QStringLiteral("develop"), NodeIdToQString(extra)));
+  ASSERT_TRUE(controller.requestConnect(NodeIdToQString(extra), QStringLiteral("grade.primary")));
+
+  EXPECT_EQ(backend.edit_node_graph_count(), 1);
+  EXPECT_NE(backend.Document().Graph().FindNode(extra), nullptr);
+  EXPECT_EQ(controller.snapshot().nodes.size(), 4u);
+  EXPECT_FALSE(adapter.has_projection());
+  EXPECT_EQ(controller.last_error(), QStringLiteral("AlcedoQanGraph has no Qan graph"));
+
+  QCoreApplication::processEvents();
+  EXPECT_EQ(controller.last_error(), QStringLiteral("AlcedoQanGraph has no Qan graph"));
+  EXPECT_EQ(controller.snapshot().nodes.size(), 4u);
+}
+
 TEST(EditorNodeController, DevelopAndDrtRejectUnsupportedPortRoles) {
   DocumentSessionBackend backend;
   backend.SetGeneration(32);
@@ -450,7 +474,7 @@ TEST(EditorNodeController, SelfConnectAndStaleGenerationLeaveTheDraftUnchanged) 
   EditorNodeController    controller;
   controller.set_editor_session(&session);
   ASSERT_TRUE(controller.addCleanColorGrade());
-  const auto extra = controller.selected_node_id_string();
+  const auto extra  = controller.selected_node_id_string();
   const auto before = controller.ActiveEdges().size();
 
   EXPECT_FALSE(controller.requestConnect(extra, extra));
@@ -496,7 +520,7 @@ TEST(EditorNodeController, OrdinaryDraftEditsDoNotCopyIntoTheCommittedSnapshot) 
 TEST(EditorNodeController, IdenticalCommittedProjectionDoesNotPublishOrQueueAnotherApply) {
   EditorNodeController controller;
   ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 1));
-  const auto queued_after_first = controller.queued_projection_apply_count();
+  const auto queued_after_first   = controller.queued_projection_apply_count();
   const auto revision_after_first = controller.projection_revision();
   EXPECT_GE(queued_after_first, 1);
   ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 1));
@@ -513,8 +537,8 @@ TEST(EditorNodeController, RepeatedSessionStateChangesDoNotReadHistoryOrRepublis
   EditorSessionController session(&backend);
   EditorNodeController    controller;
   controller.set_editor_session(&session);
-  const auto revision = controller.projection_revision();
-  const auto queued   = controller.queued_projection_apply_count();
+  const auto revision             = controller.projection_revision();
+  const auto queued               = controller.queued_projection_apply_count();
   const auto active_version_reads = backend.active_version_read_count();
 
   for (int index = 0; index < 20; ++index) {
@@ -551,8 +575,8 @@ TEST(EditorNodeController, ChangedHistoryProjectionPublishesExactlyOneApply) {
   controller.set_editor_session(&session);
   const auto revision = controller.projection_revision();
   const auto queued   = controller.queued_projection_apply_count();
-  ASSERT_TRUE(alcedo::RenameColorGrade(backend.Document(), NodeId{"grade.primary"}, "Updated")
-                  .empty());
+  ASSERT_TRUE(
+      alcedo::RenameColorGrade(backend.Document(), NodeId{"grade.primary"}, "Updated").empty());
 
   backend.PublishHistoryChange();
 

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -42,6 +42,19 @@ class EditorNodesPanelQmlTest : public RailQmlFixture {
   auto Adapter() -> AlcedoQanGraph* {
     return window_ == nullptr ? nullptr : window_->findChild<AlcedoQanGraph*>();
   }
+
+  auto LiveQanNodeItemCount() const -> int {
+    if (window_ == nullptr) {
+      return 0;
+    }
+    int count = 0;
+    for (auto* object : window_->findChildren<QObject*>()) {
+      if (object->objectName() == QLatin1String("qan::NodeItem")) {
+        ++count;
+      }
+    }
+    return count;
+  }
 };
 
 TEST_F(EditorNodesPanelQmlTest, HistoryVersionsAndNodesAreMutuallyExclusive) {
@@ -87,6 +100,30 @@ TEST_F(EditorNodesPanelQmlTest, FullCloseDestroysGraphDelegates) {
   EXPECT_EQ(Find(QStringLiteral("qan::NodeItem")), nullptr);
   EXPECT_EQ(Find(QStringLiteral("editorNodesQanGraph")), nullptr);
   EXPECT_GE(rail->property("panelBodyDestroyCount").toInt(), destroys_before + 1);
+}
+
+TEST_F(EditorNodesPanelQmlTest,
+       RepeatedNodesPageOpenAndCloseCyclesReleaseQanItemsAndIgnoreStaleRefreshes) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+
+  for (int cycle = 0; cycle < 100; ++cycle) {
+    OpenNodesPage();
+    QTRY_COMPARE_WITH_TIMEOUT(LiveQanNodeItemCount(), 3, 2000);
+
+    const QString display_name = QStringLiteral("Cycle %1").arg(cycle);
+    const auto    result =
+        backend_.RenameColorGrade(NodeId{"grade.primary"}, display_name.toStdString());
+    ASSERT_FALSE(alcedo::EditorSessionResultIsFailure(result.kind));
+    controller_.set_editor_tool_panel_page(QString());
+    ProcessEvents();
+    QTRY_COMPARE_WITH_TIMEOUT(LiveQanNodeItemCount(), 0, 2000);
+
+    OpenNodesPage();
+    QTRY_COMPARE_WITH_TIMEOUT(LiveQanNodeItemCount(), 3, 2000);
+    auto* nodes = Controller();
+    ASSERT_NE(nodes, nullptr);
+    QTRY_COMPARE_WITH_TIMEOUT(nodes->selected_node_name(), display_name, 2000);
+  }
 }
 
 TEST_F(EditorNodesPanelQmlTest, ReopenRestoresPositionsViewZoomSelectionAndDrawerState) {
@@ -416,7 +453,7 @@ TEST_F(EditorNodesPanelQmlTest, VisualConnectorIsRequestOnlyWithThemeCandidateCo
   EXPECT_EQ(graph->getConnectorColor(), AppTheme::Instance().graphPortBorderColor());
 }
 
-TEST_F(EditorNodesPanelQmlTest, ConnectorMoveRebuildsPermanentEdgesFromAcceptedProjection) {
+TEST_F(EditorNodesPanelQmlTest, ConnectorMovePromotesPermanentEdgesFromAcceptedProjection) {
   ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
   OpenNodesPage();
   auto* nodes   = Controller();
@@ -471,8 +508,7 @@ TEST_F(EditorNodesPanelQmlTest, FailedReconnectKeepsPermanentEdgesAndShowsExactE
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(extra) != nullptr, 2000);
   ASSERT_TRUE(nodes->requestConnect(QStringLiteral("develop"), NodeIdToQString(extra)));
   backend_.SetFailNodeCommands(true);
-  EXPECT_FALSE(
-      nodes->requestConnect(NodeIdToQString(extra), QStringLiteral("grade.primary")));
+  EXPECT_FALSE(nodes->requestConnect(NodeIdToQString(extra), QStringLiteral("grade.primary")));
   EXPECT_EQ(nodes->last_error(), QStringLiteral("mini-Git journal append failed"));
   auto* error = Find(QStringLiteral("editorNodesCommandError"));
   ASSERT_NE(error, nullptr);
@@ -514,8 +550,8 @@ TEST_F(EditorNodesPanelQmlTest, OrdinaryDraftEditsDoNotReplaceQanTopology) {
   ASSERT_NE(adapter, nullptr);
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
   ProcessEvents();
-  const auto applies   = nodes->completed_projection_apply_count();
-  const auto replaces  = adapter->topology_replace_count();
+  const auto applies  = nodes->completed_projection_apply_count();
+  const auto replaces = adapter->topology_replace_count();
   ASSERT_TRUE(nodes->addCleanColorGrade());
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(nodes->selected_node_id()) != nullptr, 2000);
   EXPECT_EQ(nodes->completed_projection_apply_count(), applies);

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: NM5.1–NM5.7R implementation recorded; NM5.8a–NM5.8d complete 2026-09-04; NM5.8e–NM5.8g pending
+Status: NM5.1–NM5.7R implementation recorded; NM5.8a–NM5.8e complete 2026-09-05; NM5.8f–NM5.8g pending
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -3399,11 +3399,9 @@ dock properties did not affect pass/fail.
 threshold; this stage only deleted unused command entries and added a small success helper, as
 the plan required. No general service rewrite.
 
-**Residual gaps:** NM5.8e still owns persistent topology Undo/Redo, WAL recovery, reopen,
-checkout, and long-lived Loader evidence for `NodeGraphTopologyChange` submitted through the
-production history port. NM5.8f still owns keyboard, accessibility, localization, large-font,
-and visual-state qualification. NM5.8g still owns fresh install/package, notices, available
-macOS, and final regression evidence. NM8 retains real-RAW and three-backend qualification.
+**Residual gaps:** NM5.8f still owns keyboard, accessibility, localization, large-font, and
+visual-state qualification. NM5.8g still owns fresh install/package, notices, available macOS,
+and final regression evidence. NM8 retains real-RAW and three-backend qualification.
 
 #### 16.3.5 NM5.8e — Real history and lifecycle evidence
 
@@ -3512,9 +3510,76 @@ checks here.
 | NM5.8b | Complete 2026-09-04 | Bounded reversal/copy work; exact draft values and counters |
 | NM5.8c | Complete 2026-09-04 | Delegate ownership; primitive failure and reversal matrix |
 | NM5.8d | Complete 2026-09-04 | Caller deletion audit; retained typed replay/paste |
-| NM5.8e | Pending | Persistent topology history; lifecycle and failure recovery |
+| NM5.8e | Complete 2026-09-05 | Persistent topology history; lifecycle and failure recovery |
 | NM5.8f | Pending | Keyboard, screen reader, localization, visual matrix |
 | NM5.8g | Pending | Fresh builds, regression, installed packages, notices |
+
+#### NM5.8e completion — 2026-09-05
+
+**Status:** Complete. The exact topology history path and the long-lived Nodes Loader path now
+have production evidence. The new persistent-history source is registered in
+`alcedo_studio/tests/ui/CMakeLists.txt` under `EditorSessionHistoryPortTest`.
+
+**Implementation and primary call chains:**
+
+- `EditorNodeController::MaybeSubmitDraft` → `EditorSessionController::SubmitNodeGraphTopologyEdit`
+  → `EditorSessionHistoryPort::EditNodeGraph` → `EditorHistoryMutation::EditNodeGraph` → typed
+  Mini-Git publication and `ApplyHistoryCommitToLivePipeline`. A successful product commit now
+  retains a projection-promotion error instead of clearing it after queuing the refresh.
+- `EditorNodeGraphDraft::FromDocument` → `MakeChange` → the production history port → temporary
+  DuckDB project storage. The persistent test asserts exact serialized documents, ordered nodes and
+  edges, the Color Grade counter, active Version/head, Brush Mask values, and render reasons across
+  Undo, Redo, WAL recovery, reopen, and checkout of a root Version.
+- `EditorNodesPanel.qml` Loader → `AlcedoQanGraph` → `qan::NodeItem` ownership. The lifecycle test
+  queues a rename before each teardown, reopens the page, checks the new selection, and observes
+  three live Qan node items while open and zero after close for 100 cycles.
+
+**Executable evidence:**
+
+- `cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSessionHistoryPortTest`
+  completed successfully. The focused `NodeGraphTopologyHistory.*` run passed 2/2, including the
+  exact WAL append failure and the complete production persistence path.
+- Runtime commands used the wrapper-built executables with `--gtest_color=no`: the complete
+  `EditorSessionHistoryPortTest`, `PipelineHistoryApplierTest`, `EditorSessionNodeCommandTest`,
+  `EditorNodeSelectionLayoutTest`, and `EditorNodesPanelQmlTest` binaries, plus focused filters
+  `NodeGraphTopologyHistory.*`,
+  `EditorNodeController.ProductTopologyCommitKeepsProjectionFailureVisible`, and
+  `EditorNodesPanelQmlTest.RepeatedNodesPageOpenAndCloseCyclesReleaseQanItemsAndIgnoreStaleRefreshes`.
+- The complete `EditorSessionHistoryPortTest` binary passed 75/75. This includes the new topology
+  source, existing typed-history coverage, `EditorVersionCheckoutTest`, and storage reopen cases.
+- `PipelineHistoryApplierTest` passed 12/12; `EditorSessionNodeCommandTest` passed 3/3;
+  `EditorNodeSelectionLayoutTest` passed 38/38; and `EditorNodesPanelQmlTest` passed 23/23.
+- `EditorNodeController.ProductTopologyCommitKeepsProjectionFailureVisible` passed with the exact
+  `AlcedoQanGraph has no Qan graph` error still visible after event processing, while the product
+  document contains the committed topology.
+- `EditorNodesPanelQmlTest.RepeatedNodesPageOpenAndCloseCyclesReleaseQanItemsAndIgnoreStaleRefreshes`
+  passed all 100 open/close cycles. Each cycle asserted three live `qan::NodeItem` objects while
+  open, zero after teardown, and the newly queued display name after reopening.
+
+**Failure and state evidence:**
+
+- `NodeGraphTopologyHistory.JournalFailureRestoresTopologyDocumentHeadAndRenderState` asserted the
+  exact `mini-Git journal file could not be opened for append` error, unchanged document hash,
+  history head, commit count, counter, and published render reason.
+- The production topology test asserted the product document and history head separately from the
+  visual projection after publication. Undo and Redo both restored the exact ordered topology and
+  emitted `UndoRedo`; checkout emitted `VersionDocumentChanged`.
+- The QML run also passed queued-refresh teardown and reconnect-failure cases, including the exact
+  `mini-Git journal append failed` presentation.
+
+**Scope totals and pinned APIs:**
+
+- Four existing implementation/test files and one new 457-line persistent-history fixture changed,
+  plus the history-target registration; tracked edits add 97 lines and remove 28 lines, excluding
+  the new file from the Git numstat output.
+- No QuickQanava revision or API change, no new Qt control style, and no CMake preset/toolchain
+  change. The new test uses the existing `AlcedoQanGraph::PromoteCommittedSnapshot` result and
+  existing Loader object lifetime; no new parallel product graph or selection source was added.
+- The visual matrix, install/package checks, third-party notices, and macOS environment were not
+  claimed for NM5.8e; they remain explicit NM5.8f/NM5.8g work. No package or macOS result was
+  substituted for the executable evidence above.
+- NM5.8f and NM5.8g remain pending for keyboard/accessibility/localization/visual qualification,
+  fresh install/package checks, notices, available macOS evidence, and final regression coverage.
 
 ---
 
@@ -3536,7 +3601,15 @@ clear.
 | `WorkspaceShellTest` | Column geometry, minimum window size, focus order, and production type registration. |
 | `EditorSessionHistoryPortTest` | Typed graph history, Undo, Redo, WAL failure restoration, and counter replay. |
 
-Every test name must state the behavior that it checks. Do not use `smoke` in a test name.
+**NM5.8e registered-target evidence (2026-09-05):** `editor_node_topology_history_test.cpp` is
+compiled into `EditorSessionHistoryPortTest`, alongside `editor_version_checkout_test.cpp` and
+the existing history sources. The wrapper-built runtime passed 75/75 history tests. The related
+registered runtimes passed `PipelineHistoryApplierTest` 12/12, `EditorSessionNodeCommandTest`
+3/3, `EditorNodeSelectionLayoutTest` 38/38, and `EditorNodesPanelQmlTest` 23/23. The focused
+topology filter passed 2/2 and the focused 100-cycle Loader test passed 1/1.
+
+Every test name must state the behavior that it checks. Do not use a generic run-only label in a
+test name.
 
 ### 17.1 Required visual matrix
 
@@ -3581,6 +3654,12 @@ summary, Mask count, pill, badge, shadow, glow, gradient, or Material chrome.
 | Loader teardown | Keep only plain controller and layout values. Keep no Qan pointer. |
 | Package QML module load | Fail package acceptance. Do not release a build with a hidden Nodes page. |
 
+**NM5.8e executable failure evidence:** the production WAL append test preserved the document,
+head, commit count, counter, and render reason after the exact append-open error. The controller
+test preserved the committed product topology while keeping the exact Qan projection-promotion
+error visible. The full Nodes runtime passed the queued-refresh teardown, failed reconnect, and
+100-cycle Loader tests; every stale rename was observed only by the page that reopened it.
+
 ---
 
 ## 19. Performance targets
@@ -3611,6 +3690,12 @@ Record:
 - frame time and changed Qan object count for 100 accepted draft connections;
 - draft and Qan object identity retention across 100 accepted draft connections;
 - live Qan object count after 100 panel open/close cycles.
+
+**NM5.8e measured lifecycle result (2026-09-05):**
+`RepeatedNodesPageOpenAndCloseCyclesReleaseQanItemsAndIgnoreStaleRefreshes` recorded 3 live
+`qan::NodeItem` objects after each Nodes open and 0 after each close for 100 cycles. It also
+asserted the queued display name after reopening each page. This is executable object-count and
+stale-callback evidence; it does not claim the remaining frame-time or package targets.
 
 Do not reduce decode resolution, output quality, or backend behavior to meet these targets.
 
@@ -3668,7 +3753,7 @@ Do not reduce decode resolution, output quality, or backend behavior to meet the
       requests one Quality render.
 - [x] All command failures preserve the prior product graph, history, Version, revision, and
       rendered state while retaining an applicable draft.
-- [ ] Atomic topology edits have dedicated production-history evidence for exact Undo, Redo,
+- [x] Atomic topology edits have dedicated production-history evidence for exact Undo, Redo,
       recovery, reopen, and Version checkout (NM5.8e; direct inverse tests already pass).
 - [ ] All visible actions support keyboard input and accessibility.
 - [ ] All product text uses localization.


### PR DESCRIPTION
## Summary

- Complete NM5.8e persistent `NodeGraphTopologyChange` coverage through the production history port and temporary storage.
- Verify exact topology serialization, node and edge order, counters, document head, Version checkout, recovery, reopen, Undo, and Redo behavior.
- Preserve projection and promotion errors after a successful product commit instead of clearing the real failure.
- Add a 100-cycle Nodes Loader lifecycle test that checks live Qan item counts and ignores stale refresh callbacks.
- Record implementation call chains and executable evidence in the NM5 Nodes panel roadmap.

## Verification

- `EditorSessionHistoryPortTest`: 75/75 passed.
- `NodeGraphTopologyHistory.*`: 2/2 passed.
- `PipelineHistoryApplierTest`: 12/12 passed.
- `EditorSessionNodeCommandTest`: 3/3 passed.
- `EditorNodeSelectionLayoutTest`: 38/38 passed.
- `EditorNodesPanelQmlTest`: 23/23 passed.
- Projection-error regression: 1/1 passed.
- 100-cycle Nodes Loader lifecycle test: 1/1 passed.
- `clang-format --dry-run --Werror` and `git diff --check` passed.

## Scope

NM5.8f and NM5.8g remain separate follow-up work. This change does not claim package or macOS qualification. The WAL recovery fixture uses a mask-free WAL suffix because the current recovery entry point does not accept a `MaskStore`; Mask values are still verified in the production session and after persisted reopen.
