### PR TITLE
feat(editor): finish NM5.8g Nodes package notices and regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -833,6 +833,39 @@ function(alcedo_install_metal_runtime_libs destination)
     install(FILES ${ALCEDO_METAL_RUNTIME_LIBS} DESTINATION "${destination}")
 endfunction()
 
+# Ship Alcedo LICENSE/NOTICE plus gathered third-party texts, including the
+# QuickQanava BSD-3-Clause and vendored bezier MIT notices required for binary
+# redistribution. @p destination is next to the Windows executable or inside
+# the macOS bundle Resources directory so THIRD_PARTY_NOTICE.txt relative paths
+# to third_party_licenses/ remain valid.
+function(alcedo_install_legal_notices destination)
+    set(_alcedo_notice_root "${CMAKE_SOURCE_DIR}")
+    set(_alcedo_required_notices
+        "${_alcedo_notice_root}/LICENSE"
+        "${_alcedo_notice_root}/NOTICE"
+        "${_alcedo_notice_root}/THIRD_PARTY_NOTICE.txt"
+        "${_alcedo_notice_root}/third_party_licenses/QuickQanava-licence.txt"
+        "${_alcedo_notice_root}/third_party_licenses/QuickQanava-bezier-LICENSE.txt"
+    )
+    foreach(_alcedo_notice IN LISTS _alcedo_required_notices)
+        if(NOT EXISTS "${_alcedo_notice}")
+            message(FATAL_ERROR
+                "[alcedo] Required legal notice is missing: ${_alcedo_notice}")
+        endif()
+    endforeach()
+    install(FILES
+        "${_alcedo_notice_root}/LICENSE"
+        "${_alcedo_notice_root}/NOTICE"
+        "${_alcedo_notice_root}/THIRD_PARTY_NOTICE.txt"
+        DESTINATION "${destination}"
+    )
+    install(DIRECTORY "${_alcedo_notice_root}/third_party_licenses/"
+        DESTINATION "${destination}/third_party_licenses"
+        FILES_MATCHING
+            PATTERN "*"
+    )
+endfunction()
+
 add_subdirectory(${CMAKE_SOURCE_DIR}/alcedo_studio/src/third_party)
 if(DEFINED ALCEDO_LENSFUN_LIBRARY_DIR AND NOT "${ALCEDO_LENSFUN_LIBRARY_DIR}" STREQUAL "")
     list(APPEND CMAKE_BUILD_RPATH "${ALCEDO_LENSFUN_LIBRARY_DIR}")
@@ -879,6 +912,7 @@ if(TARGET ${ALCEDO_MAIN_BIN})
         install(DIRECTORY "${_config_dir}/icc/" DESTINATION "${_bundle_macos_dest}/config/icc")
         install(DIRECTORY "${_config_dir}/lens_calib/" DESTINATION "${_bundle_macos_dest}/config/lens_calib")
         install(DIRECTORY "${_config_dir}/nikon_lens/" DESTINATION "${_bundle_macos_dest}/config/nikon_lens")
+        alcedo_install_legal_notices("${_bundle_resources_dest}")
         alcedo_install_demosaicnet_models("${_config_dir}" "${_bundle_macos_dest}")
         alcedo_install_packaged_luts("${_config_dir}" "${_bundle_macos_dest}/LUTs")
         if(ALCEDO_OPENCL_ENABLED)
@@ -996,6 +1030,7 @@ if(TARGET ${ALCEDO_MAIN_BIN})
         install(DIRECTORY "${_config_dir}/icc/" DESTINATION "${CMAKE_INSTALL_BINDIR}/config/icc")
         install(DIRECTORY "${_config_dir}/lens_calib/" DESTINATION "${CMAKE_INSTALL_BINDIR}/config/lens_calib")
         install(DIRECTORY "${_config_dir}/nikon_lens/" DESTINATION "${CMAKE_INSTALL_BINDIR}/config/nikon_lens")
+        alcedo_install_legal_notices("${CMAKE_INSTALL_BINDIR}")
         alcedo_install_demosaicnet_models("${_config_dir}" "${CMAKE_INSTALL_BINDIR}")
 
         alcedo_install_packaged_luts("${_config_dir}" "${CMAKE_INSTALL_BINDIR}/LUTs")

--- a/alcedo_studio/src/include/ui/edit_viewer/color_manager.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/color_manager.hpp
@@ -10,6 +10,14 @@ namespace alcedo {
 
 class ColorManager {
  public:
+  /// Apply @p config to the CAMetalLayer owned by an AppKit window or view.
+  /// @param native_view_or_window NSWindow or NSView pointer. Null, Qt dummy
+  ///        `winId()` values, and other non-AppKit objects return false and
+  ///        leave display state unchanged.
+  /// @param config Viewer output color space and transfer. SDR values clear HDR
+  ///        EDR metadata on the layer.
+  /// @return true when a CAMetalLayer received the color space.
+  /// @thread The AppKit/GUI thread that owns the native object.
   static auto ApplyWindowColorSpace(void* native_view_or_window,
                                     const ViewerDisplayConfig& config) -> bool;
 };

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -1017,3 +1017,14 @@ if(APPLE AND ALCEDO_MACOS_BUNDLE AND
         VERBATIM
     )
 endif()
+
+add_test(NAME ProductionBinaryLoadsQuickQanavaModule
+    COMMAND alcedo_main --verify-qml-imports
+)
+set_tests_properties(ProductionBinaryLoadsQuickQanavaModule PROPERTIES
+    PASS_REGULAR_EXPRESSION "qml.imports.ok=QuickQanava"
+    FAIL_REGULAR_EXPRESSION "module .*QuickQanava"
+    WORKING_DIRECTORY "$<TARGET_FILE_DIR:alcedo_main>"
+    LABELS "quickqanava;package"
+    TIMEOUT 60
+)

--- a/alcedo_studio/src/ui/alcedo_main/main.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/main.cpp
@@ -9,8 +9,12 @@
 #include <QFontDatabase>
 #include <QGuiApplication>
 #include <QIcon>
+#include <QObject>
 #include <QQmlApplicationEngine>
+#include <QQmlComponent>
 #include <QQmlContext>
+#include <QQmlEngine>
+#include <QQmlError>
 #include <QQmlExtensionPlugin>
 #include <qqml.h>
 #include <QQuickStyle>
@@ -24,6 +28,8 @@
 #include <QuickQanava>
 
 #include <exiv2/error.hpp>
+#include <cstdio>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -57,6 +63,15 @@ constexpr auto kAcceleratorBackendSettingsKey = "gpu/acceleratorBackend";
 // writes after QApplication exists. Do not rely on QSettings{} alone before QApp.
 constexpr auto kSettingsOrganization = "Alcedo";
 constexpr auto kSettingsApplication  = "Alcedo";
+
+[[nodiscard]] auto HasFlag(int argc, char** argv, std::string_view flag) -> bool {
+  for (int i = 1; i < argc; ++i) {
+    if (std::string_view(argv[i] ? argv[i] : "") == flag) {
+      return true;
+    }
+  }
+  return false;
+}
 
 auto FindArgValue(int argc, char** argv, std::string_view option_name)
     -> std::optional<std::string_view> {
@@ -124,6 +139,45 @@ auto ToAcceleratorPreference(alcedo::editor_rhi::EditorBackend backend)
   return alcedo::AcceleratorBackendPreference::CPU;
 }
 
+constexpr char kQuickQanavaImportProbeQml[] = R"qml(
+import QtQuick
+import QuickQanava 2.0 as Qan
+Item { objectName: "quickQanavaImportProbe" }
+)qml";
+
+/**
+ * @brief Load the pinned QuickQanava module and exit without opening the app.
+ *
+ * Used by install/package verification. Does not initialize an editor backend,
+ * create a window, or start a photo render. Failure prints the real QML error
+ * and returns a non-zero status; there is no substitute canvas.
+ *
+ * @pre A QApplication exists. QuickQanava is linked and the QML plugin is
+ *      imported. @p engine has `qrc:/` on its import path.
+ * @return 0 when the probe object is created; 1 when the import or create fails.
+ */
+auto VerifyQuickQanavaQmlImport(QQmlEngine& engine) -> int {
+  QuickQanava::initialize(&engine);
+  QQmlComponent component(&engine);
+  component.setData(QByteArray(kQuickQanavaImportProbeQml),
+                    QUrl(QStringLiteral("qrc:/QuickQanavaImportProbe.qml")));
+  if (component.isError()) {
+    const auto errors = component.errors();
+    for (const auto& error : errors) {
+      std::fprintf(stderr, "%s\n", qPrintable(error.toString()));
+    }
+    return 1;
+  }
+  std::unique_ptr<QObject> probe{component.create()};
+  if (probe == nullptr || probe->objectName() != QLatin1String("quickQanavaImportProbe")) {
+    std::fprintf(stderr, "QuickQanava import probe failed to create an Item\n");
+    return 1;
+  }
+  std::fprintf(stdout, "qml.imports.ok=QuickQanava\n");
+  std::fflush(stdout);
+  return 0;
+}
+
 }  // namespace
 
 int main(int argc, char* argv[]) {
@@ -140,6 +194,14 @@ int main(int argc, char* argv[]) {
   QCoreApplication::setOrganizationDomain(QStringLiteral("alcedo.app"));
   QCoreApplication::setApplicationName(QStringLiteral("Alcedo"));
   QCoreApplication::setApplicationVersion(QStringLiteral(ALCEDO_APP_VERSION));
+
+  if (HasFlag(argc, argv, "--verify-qml-imports")) {
+    QApplication app(argc, argv);
+    QQuickStyle::setStyle("Basic");
+    QQmlEngine engine;
+    engine.addImportPath("qrc:/");
+    return VerifyQuickQanavaQmlImport(engine);
+  }
 
   // Priority matches the old manual override model:
   //   1) --editor-backend (debug/force, same as before)

--- a/alcedo_studio/src/ui/edit_viewer/color_manager.mm
+++ b/alcedo_studio/src/ui/edit_viewer/color_manager.mm
@@ -15,6 +15,7 @@
 #include <QString>
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 namespace alcedo {
 namespace {
@@ -190,7 +191,10 @@ auto ResolveEDRMetadata(const ViewerDisplayConfig& config) -> CAEDRMetadata* {
 
 auto ColorManager::ApplyWindowColorSpace(void*                      native_view_or_window,
                                          const ViewerDisplayConfig& config) -> bool {
-  if (!native_view_or_window) {
+  const auto native_address = reinterpret_cast<std::uintptr_t>(native_view_or_window);
+  // Qt offscreen `QWindow::winId()` can be a non-zero dummy such as 1. Sending
+  // -isKindOfClass: to that pointer is a SIGSEGV, not a clean ObjC miss.
+  if (native_address < 4096u) {
     return false;
   }
 

--- a/alcedo_studio/tests/CMakeLists.txt
+++ b/alcedo_studio/tests/CMakeLists.txt
@@ -84,3 +84,12 @@ add_subdirectory(app)
 # alcedo_register_test_target). Do not hand-roll POST_BUILD DLL copies in domain
 # manifests — that opt-in pattern is why 0xC0000139 kept returning for new tests.
 
+
+add_test(NAME PackagedNoticeSourcesContainQuickQanavaAndBezierClauses
+    COMMAND ${CMAKE_COMMAND}
+        -DALCEDO_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_SOURCE_DIR}/scripts/cmake/check_quickqanava_legal_notices.cmake
+)
+set_tests_properties(PackagedNoticeSourcesContainQuickQanavaAndBezierClauses PROPERTIES
+    LABELS "quickqanava;legal_notices"
+)

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -762,6 +762,7 @@ alcedo_register_test_target(QuickQanavaProductionIntegrationTest ui)
 # Read-only Qan adapter: NodeId maps, ports, role updates, generation replacement.
 add_executable(AlcedoQanGraphTest
     ${ALCEDO_TEST_ROOT}/ui/alcedo_qan_graph_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/alcedo_qan_graph_performance_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
 )
 target_include_directories(AlcedoQanGraphTest

--- a/alcedo_studio/tests/ui/alcedo_qan_graph_performance_test.cpp
+++ b/alcedo_studio/tests/ui/alcedo_qan_graph_performance_test.cpp
@@ -1,0 +1,406 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "ui/alcedo_main/album_backend/alcedo_qan_graph.hpp"
+
+#include <gtest/gtest.h>
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDeadlineTimer>
+#include <QElapsedTimer>
+#include <QEvent>
+#include <QEventLoop>
+#include <QObject>
+#include <QPointer>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QQmlError>
+#include <QQuickStyle>
+#include <QQuickWindow>
+#include <QStringList>
+#include <QUrl>
+#include <QuickQanava>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "app/editor_node_graph_draft.hpp"
+#include "app/editor_node_graph_projection.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "qanEdge.h"
+#include "qanEdgeItem.h"
+#include "qanGraph.h"
+#include "qanNode.h"
+#include "qanNodeItem.h"
+#include "ui/alcedo_main/app_theme.hpp"
+
+#include <algorithm>
+
+namespace {
+
+constexpr char kGraphHarnessQml[] = R"qml(
+import QtQuick
+import QtQuick.Controls
+import QuickQanava 2.0 as Qan
+
+ApplicationWindow {
+    id: root
+    objectName: "alcedoQanPerformanceHarness"
+    width: 960
+    height: 640
+    visible: true
+
+    Component {
+        id: graphViewComponent
+
+        Qan.GraphView {
+            id: graphView
+            objectName: "qanGraphView"
+            anchors.fill: parent
+            navigable: false
+
+            graph: Qan.Graph {
+                id: graphTopology
+                objectName: "qanGraph"
+            }
+        }
+    }
+
+    Loader {
+        id: graphLoader
+        objectName: "graphLoader"
+        anchors.fill: parent
+        active: true
+        asynchronous: false
+        sourceComponent: graphViewComponent
+    }
+}
+)qml";
+
+auto SrcQmlDir() -> QString {
+  return QString::fromStdString(
+      (std::filesystem::path(ALCEDO_TEST_SRC_DIR) / "ui" / "alcedo_main" / "qml").string());
+}
+
+auto QmlFileUrl(const char* file_name) -> QUrl {
+  return QUrl::fromLocalFile(SrcQmlDir() + QLatin1Char('/') + QLatin1String(file_name));
+}
+
+void SetBasicStyle() {
+  static std::once_flag style_once;
+  std::call_once(style_once, [] { QQuickStyle::setStyle(QStringLiteral("Basic")); });
+}
+
+bool WaitFor(const std::function<bool()>& predicate, int timeout_ms = 2000) {
+  QDeadlineTimer deadline{timeout_ms};
+  while (!predicate() && !deadline.hasExpired()) {
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+  }
+  return predicate();
+}
+
+class QanHarness final {
+ public:
+  QanHarness() {
+    QObject::connect(&engine_, &QQmlApplicationEngine::warnings, &engine_,
+                     [this](const QList<QQmlError>& errors) {
+                       for (const auto& error : errors) {
+                         warnings_.append(error.toString());
+                       }
+                     });
+
+    SetBasicStyle();
+    alcedo::ui::AppTheme::Instance().setReduceMotion(true);
+    engine_.addImportPath(QStringLiteral("qrc:/"));
+    engine_.addImportPath(SrcQmlDir());
+    engine_.rootContext()->setContextProperty(QStringLiteral("appTheme"),
+                                              &alcedo::ui::AppTheme::Instance());
+    QuickQanava::initialize(&engine_);
+    engine_.loadData(QByteArray{kGraphHarnessQml},
+                     QUrl(QStringLiteral("file:///AlcedoQanGraphPerformanceHarness.qml")));
+
+    if (!engine_.rootObjects().isEmpty()) {
+      window_ = qobject_cast<QQuickWindow*>(engine_.rootObjects().constFirst());
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
+  }
+
+  [[nodiscard]] auto window() const -> QQuickWindow* { return window_; }
+  [[nodiscard]] auto warnings() const -> const QStringList& { return warnings_; }
+  [[nodiscard]] auto Graph() const -> qan::Graph* {
+    return window_ == nullptr ? nullptr : window_->findChild<qan::Graph*>("qanGraph");
+  }
+  [[nodiscard]] auto Loader() const -> QObject* {
+    return window_ == nullptr ? nullptr : window_->findChild<QObject*>("graphLoader");
+  }
+
+ private:
+  QQmlApplicationEngine engine_;
+  QQuickWindow*         window_ = nullptr;
+  QStringList           warnings_;
+};
+
+auto WarningText(const QStringList& warnings) -> std::string {
+  return warnings.join(QLatin1Char('\n')).toStdString();
+}
+
+void AttachAlcedoDelegates(alcedo::ui::AlcedoQanGraph& adapter, qan::Graph* graph) {
+  adapter.set_color_grade_delegate_url(QmlFileUrl("EditorNodeDelegate.qml"));
+  adapter.set_endpoint_delegate_url(QmlFileUrl("EditorEndpointNodeDelegate.qml"));
+  adapter.set_port_delegate_url(QmlFileUrl("EditorNodePortDelegate.qml"));
+  adapter.set_port_dock_delegate_url(QmlFileUrl("EditorNodePortDock.qml"));
+  adapter.set_edge_delegate_url(QmlFileUrl("EditorNodeEdgeDelegate.qml"));
+  adapter.set_graph(graph);
+}
+
+auto MakeMask(const std::string& id, float center) -> alcedo::MaskModel {
+  alcedo::MaskModel mask;
+  mask.id           = alcedo::MaskId{id};
+  mask.display_name = "Mask";
+  alcedo::RadialMaskSource radial;
+  radial.center_x = center;
+  mask.source     = std::move(radial);
+  return mask;
+}
+
+auto DocumentWithGrades(int grade_count, int masks_per_grade) -> alcedo::PipelineDocument {
+  auto document = alcedo::CreateDefaultPipelineDocument();
+  auto fill     = [&](alcedo::ColorGradeNodeModel* grade, const std::string& prefix) {
+    if (grade == nullptr) {
+      return;
+    }
+    for (int mask = 0; mask < masks_per_grade; ++mask) {
+      grade->AddMask(MakeMask(prefix + "." + std::to_string(mask), 0.1f * static_cast<float>(mask)),
+                     static_cast<std::size_t>(mask));
+    }
+  };
+  fill(document.PrimaryGrade(), "mask.primary");
+  for (int extra = 0; extra < grade_count - 1; ++extra) {
+    const auto id = alcedo::NodeId{"grade.g" + std::to_string(extra)};
+    EXPECT_TRUE(alcedo::AddCleanColorGrade(document, alcedo::NodeId{"drt"}, id).empty());
+    fill(dynamic_cast<alcedo::ColorGradeNodeModel*>(document.Graph().FindNode(id)),
+         "mask.g" + std::to_string(extra));
+  }
+  return document;
+}
+
+auto BoundIdentity() -> alcedo::EditorNodeGraphDraftIdentity {
+  alcedo::EditorNodeGraphDraftIdentity identity;
+  identity.element_id          = 8;
+  identity.image_id            = 9;
+  identity.version_id          = "v1";
+  identity.session_generation  = 4;
+  identity.projection_revision = 1;
+  identity.topology_revision   = 1;
+  return identity;
+}
+
+auto LiveNodeDelegateCount(const alcedo::ui::AlcedoQanGraph&        adapter,
+                           const alcedo::EditorNodeGraphSnapshot& snapshot) -> int {
+  int count = 0;
+  for (const auto& node : snapshot.nodes) {
+    auto* qan_node = adapter.NodeFor(node.node_id);
+    if (qan_node != nullptr && qan_node->getItem() != nullptr) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+auto LiveEdgeDelegateCount(const alcedo::ui::AlcedoQanGraph&        adapter,
+                           const alcedo::EditorNodeGraphSnapshot& snapshot) -> int {
+  int count = 0;
+  for (const auto& edge : snapshot.edges) {
+    auto* qan_edge = adapter.EdgeFor(edge);
+    if (qan_edge != nullptr && qan_edge->getItem() != nullptr) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+}  // namespace
+
+namespace alcedo {
+
+class AlcedoQanGraphPerformance : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    harness_ = std::make_unique<QanHarness>();
+    ASSERT_NE(harness_->window(), nullptr) << WarningText(harness_->warnings());
+    ASSERT_TRUE(harness_->warnings().isEmpty()) << WarningText(harness_->warnings());
+  }
+
+  static void TearDownTestSuite() { harness_.reset(); }
+
+  void        SetUp() override {
+    ASSERT_NE(harness_, nullptr);
+    auto* loader = harness_->Loader();
+    ASSERT_NE(loader, nullptr);
+    ASSERT_TRUE(loader->setProperty("active", false));
+    ASSERT_TRUE(WaitFor([] { return harness_->Graph() == nullptr; }));
+    ASSERT_TRUE(loader->setProperty("active", true));
+    ASSERT_TRUE(WaitFor([] { return harness_->Graph() != nullptr; }));
+  }
+
+  static std::unique_ptr<QanHarness> harness_;
+};
+
+std::unique_ptr<QanHarness> AlcedoQanGraphPerformance::harness_;
+
+TEST_F(AlcedoQanGraphPerformance, DefaultGraphApplyCreatesThreeNodeDelegatesAndTwoEdges) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  QElapsedTimer timer;
+  timer.start();
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 1, 1, 1);
+  const auto result   = adapter.ApplySnapshot(snapshot);
+  ASSERT_TRUE(result.succeeded) << result.error.toStdString();
+  ASSERT_TRUE(WaitFor([&] { return LiveNodeDelegateCount(adapter, snapshot) == 3; }));
+  const auto apply_ms = static_cast<int>(timer.elapsed());
+  RecordProperty("default_graph_apply_ms", apply_ms);
+  RecordProperty("default_graph_node_delegates", LiveNodeDelegateCount(adapter, snapshot));
+  RecordProperty("default_graph_edge_delegates", LiveEdgeDelegateCount(adapter, snapshot));
+
+  EXPECT_TRUE(result.rebuilt_topology);
+  EXPECT_EQ(adapter.graph()->getNodeCount(), 3);
+  EXPECT_EQ(adapter.graph()->get_edge_count(), 2);
+  EXPECT_EQ(LiveNodeDelegateCount(adapter, snapshot), 3);
+  EXPECT_EQ(LiveEdgeDelegateCount(adapter, snapshot), 2);
+}
+
+TEST_F(AlcedoQanGraphPerformance, ThirtyTwoGradeGraphApplyRecordsDelegateCountsAndApplyTime) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  auto document = DocumentWithGrades(32, 8);
+  EXPECT_EQ(document.Graph().NodeCount(), 34u);
+  const auto snapshot = EditorNodeGraphProjection::Build(document, 2, 1, 1);
+  QElapsedTimer timer;
+  timer.start();
+  const auto result = adapter.ApplySnapshot(snapshot);
+  ASSERT_TRUE(result.succeeded) << result.error.toStdString();
+  ASSERT_TRUE(WaitFor([&] { return LiveNodeDelegateCount(adapter, snapshot) == 34; }, 15000));
+  const auto apply_ms = static_cast<int>(timer.elapsed());
+  RecordProperty("thirty_two_grade_apply_ms", apply_ms);
+  RecordProperty("thirty_two_grade_node_delegates", LiveNodeDelegateCount(adapter, snapshot));
+  RecordProperty("thirty_two_grade_edge_delegates", LiveEdgeDelegateCount(adapter, snapshot));
+
+  EXPECT_TRUE(result.rebuilt_topology);
+  EXPECT_EQ(adapter.graph()->getNodeCount(), 34);
+  EXPECT_EQ(adapter.graph()->get_edge_count(), 33);
+  EXPECT_EQ(LiveNodeDelegateCount(adapter, snapshot), 34);
+  EXPECT_EQ(LiveEdgeDelegateCount(adapter, snapshot), 33);
+}
+
+TEST_F(AlcedoQanGraphPerformance, OneHundredSelectionsStayWithinOneHundredMillisecondsEach) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 3, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded);
+  ASSERT_TRUE(WaitFor([&] { return adapter.NodeFor(NodeId{"grade.primary"}) != nullptr; }));
+  const NodeId ids[] = {NodeId{"develop"}, NodeId{"grade.primary"}, NodeId{"drt"}};
+  QElapsedTimer total;
+  total.start();
+  qint64 max_ms = 0;
+  for (int step = 0; step < 100; ++step) {
+    QElapsedTimer step_timer;
+    step_timer.start();
+    adapter.ApplyProductSelection(ids[step % 3]);
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
+    max_ms = std::max(max_ms, step_timer.elapsed());
+  }
+  RecordProperty("one_hundred_selection_total_ms", static_cast<int>(total.elapsed()));
+  RecordProperty("one_hundred_selection_max_ms", static_cast<int>(max_ms));
+  EXPECT_EQ(adapter.topology_replace_count(), 1);
+  EXPECT_LT(max_ms, 100);
+}
+
+TEST_F(AlcedoQanGraphPerformance, OpeningAndClosingAManyMaskNodeKeepsOwnerIdentity) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  auto document = DocumentWithGrades(1, 16);
+  const auto snapshot = EditorNodeGraphProjection::Build(document, 4, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded);
+  ASSERT_TRUE(WaitFor([&] { return adapter.NodeFor(NodeId{"grade.primary"}) != nullptr; }));
+  QPointer<qan::Node> grade = adapter.NodeFor(NodeId{"grade.primary"});
+  QElapsedTimer timer;
+  timer.start();
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  ASSERT_TRUE(WaitFor([&] {
+    auto* node = adapter.NodeFor(NodeId{"grade.primary"});
+    auto* item = node == nullptr ? nullptr : node->getItem();
+    return item != nullptr && !item->property("drawerOpen").toBool();
+  }));
+  adapter.SetDrawerOpen(NodeId{"grade.primary"}, true);
+  ASSERT_TRUE(WaitFor([&] {
+    auto* node = adapter.NodeFor(NodeId{"grade.primary"});
+    auto* item = node == nullptr ? nullptr : node->getItem();
+    return item != nullptr && item->property("drawerOpen").toBool();
+  }));
+  const auto fold_ms = static_cast<int>(timer.elapsed());
+  RecordProperty("many_mask_drawer_fold_ms", fold_ms);
+  EXPECT_EQ(grade.data(), adapter.NodeFor(NodeId{"grade.primary"}));
+  EXPECT_EQ(adapter.topology_replace_count(), 1);
+  EXPECT_LT(fold_ms, 100);
+}
+
+TEST_F(AlcedoQanGraphPerformance, OneHundredAcceptedDraftConnectsRetainQanIdentities) {
+  ui::AlcedoQanGraph adapter;
+  AttachAlcedoDelegates(adapter, harness_->Graph());
+  auto document = CreateDefaultPipelineDocument();
+  auto draft    = EditorNodeGraphDraft::FromDocument(document, BoundIdentity());
+  const auto snapshot = EditorNodeGraphProjection::Build(document, 4, 1, 1);
+  ASSERT_TRUE(adapter.ApplySnapshot(snapshot).succeeded);
+  ASSERT_TRUE(WaitFor([&] { return adapter.NodeFor(NodeId{"grade.primary"}) != nullptr; }));
+  QPointer<qan::Node> develop = adapter.NodeFor(NodeId{"develop"});
+  QPointer<qan::Node> primary = adapter.NodeFor(NodeId{"grade.primary"});
+  QPointer<qan::Node> drt     = adapter.NodeFor(NodeId{"drt"});
+  const auto replace_count    = adapter.topology_replace_count();
+  auto       add              = draft.AddColorGrade(NodeId{"grade.extra"});
+  ASSERT_TRUE(add.succeeded) << add.error;
+  const auto add_visual = adapter.ApplyMutation(add);
+  ASSERT_TRUE(add_visual.succeeded) << add_visual.error.toStdString();
+  ASSERT_TRUE(WaitFor([&] { return adapter.NodeFor(NodeId{"grade.extra"}) != nullptr; }));
+
+  int         changed_edges = 0;
+  QElapsedTimer timer;
+  timer.start();
+  const NodeId develop_id{"develop"};
+  const NodeId extra_id{"grade.extra"};
+  const NodeId primary_id{"grade.primary"};
+  for (int step = 0; step < 50; ++step) {
+    auto first = draft.Connect(develop_id, extra_id);
+    ASSERT_TRUE(first.succeeded) << first.error;
+    changed_edges += static_cast<int>(first.removed_edges.size() + first.inserted_edges.size());
+    EXPECT_LE(first.removed_edges.size(), 2u);
+    EXPECT_LE(first.inserted_edges.size(), 1u);
+    const auto first_visual = adapter.ApplyMutation(first);
+    ASSERT_TRUE(first_visual.succeeded) << first_visual.error.toStdString();
+    auto second = draft.Connect(develop_id, primary_id);
+    ASSERT_TRUE(second.succeeded) << second.error;
+    EXPECT_LE(second.removed_edges.size(), 2u);
+    EXPECT_LE(second.inserted_edges.size(), 1u);
+    changed_edges += static_cast<int>(second.removed_edges.size() + second.inserted_edges.size());
+    const auto second_visual = adapter.ApplyMutation(second);
+    ASSERT_TRUE(second_visual.succeeded) << second_visual.error.toStdString();
+  }
+  const auto connect_ms = static_cast<int>(timer.elapsed());
+  RecordProperty("one_hundred_draft_connect_ms", connect_ms);
+  RecordProperty("one_hundred_draft_connect_changed_edges", changed_edges);
+  EXPECT_EQ(adapter.topology_replace_count(), replace_count);
+  EXPECT_EQ(develop.data(), adapter.NodeFor(NodeId{"develop"}));
+  EXPECT_EQ(primary.data(), adapter.NodeFor(NodeId{"grade.primary"}));
+  EXPECT_EQ(drt.data(), adapter.NodeFor(NodeId{"drt"}));
+  EXPECT_FALSE(develop.isNull());
+  EXPECT_NE(adapter.NodeFor(NodeId{"grade.extra"}), nullptr);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -3,6 +3,7 @@
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
 #include <QAccessible>
+#include <QElapsedTimer>
 #include <QMetaObject>
 #include <QPointF>
 #include <QQmlContext>
@@ -978,6 +979,40 @@ TEST_F(EditorNodesPanelQmlTest, FortyPercentTextExpansionKeepsTitleWrappingInsid
   EXPECT_TRUE(add->isVisible());
   QCoreApplication::removeTranslator(&expander);
   engine_.retranslate();
+}
+
+TEST_F(EditorNodesPanelQmlTest, FirstNodesLoaderShowsDefaultGraphDelegates) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  QElapsedTimer timer;
+  timer.start();
+  OpenNodesPage();
+  QTRY_COMPARE_WITH_TIMEOUT(LiveQanNodeItemCount(), 3, 2000);
+  const auto loader_ms = static_cast<int>(timer.elapsed());
+  RecordProperty("first_nodes_loader_ms", loader_ms);
+  auto* view = Find(QStringLiteral("editorNodesGraphView"));
+  ASSERT_NE(view, nullptr);
+  EXPECT_TRUE(view->isVisible());
+  EXPECT_LT(loader_ms, 100);
+}
+
+TEST_F(EditorNodesPanelQmlTest, AddColorGradeShowsPendingWithoutReplacingQanTopology) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  const auto replace_count = adapter->topology_replace_count();
+  QElapsedTimer timer;
+  timer.start();
+  ASSERT_TRUE(nodes->addCleanColorGrade());
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(nodes->selected_node_id()) != nullptr, 2000);
+  const auto add_ms = static_cast<int>(timer.elapsed());
+  RecordProperty("add_color_grade_feedback_ms", add_ms);
+  EXPECT_EQ(adapter->topology_replace_count(), replace_count);
+  EXPECT_TRUE(nodes->incomplete_draft());
+  EXPECT_LT(add_ms, 100);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/ui/editor_window_color_management_test.mm
+++ b/alcedo_studio/tests/ui/editor_window_color_management_test.mm
@@ -53,6 +53,12 @@ TEST(EditorWindowColorManagementTest, PqAndHlgApplyEdrMetadataThenSdrClearsIt) {
   }
 }
 
+TEST(EditorWindowColorManagementTest, DummyPlatformWinIdReturnsFalseWithoutCrashing) {
+  EXPECT_FALSE(ColorManager::ApplyWindowColorSpace(nullptr, ViewerDisplayConfig{}));
+  EXPECT_FALSE(
+      ColorManager::ApplyWindowColorSpace(reinterpret_cast<void*>(1), ViewerDisplayConfig{}));
+}
+
 TEST(EditorWindowColorManagementTest, FindsMetalLayerBelowTheUnifiedContentView) {
   @autoreleasepool {
     NSView* root        = [[NSView alloc] initWithFrame:NSMakeRect(0.0, 0.0, 320.0, 180.0)];

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: NM5.1–NM5.7R implementation recorded; NM5.8a–NM5.8f complete 2026-09-05; NM5.8g pending
+Status: NM5.1–NM5.7R implementation recorded; NM5.8a–NM5.8g complete 2026-09-05
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -3544,6 +3544,85 @@ three-backend qualification.
 11. Check QuickQanava and bezier licence notices.
 12. Run all affected graph, history, adapter, QML, and workspace tests.
 
+##### Phase NM5.8g completion record (2026-09-05)
+
+**Status:** complete — Windows MSVC configure/build, graph/history/adapter/QML/workspace regression, install-tree and NSIS package QuickQanava import, and QuickQanava BSD-3-Clause plus bezier MIT notices. macOS package checks were not run on this host.
+
+**Primary success call chain:**
+
+```text
+packaged/installed alcedo_main --verify-qml-imports
+  -> QQuickStyle Basic
+  -> QQmlEngine import path qrc:/
+  -> QuickQanava::initialize
+  -> import QuickQanava 2.0 as Qan
+  -> probe Item objectName quickQanavaImportProbe
+  -> stdout qml.imports.ok=QuickQanava
+```
+
+```text
+cmake --install (absolute CMAKE_INSTALL_PREFIX)
+  -> alcedo_install_legal_notices(bin)
+  -> LICENSE, NOTICE, THIRD_PARTY_NOTICE.txt, third_party_licenses/
+  -> verify_windows_install_tree.ps1 asserts BSD-3-Clause binary clause and bezier MIT text
+  -> installed alcedo_main --verify-qml-imports
+```
+
+**Primary failure call chain:**
+
+```text
+missing or broken QuickQanava QML import
+  -> QQmlComponent prints the real QML error
+  -> non-zero process status
+  -> ProductionBinaryLoadsQuickQanavaModule / install-tree verify fail
+  -> no substitute canvas
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| Debug `alcedo_main --verify-qml-imports` | `ProductionBinaryLoadsQuickQanavaModule` | PASS |
+| Source-tree QuickQanava/bezier notice text | `PackagedNoticeSourcesContainQuickQanavaAndBezierClauses` | PASS |
+| Default graph 3 node / 2 edge delegates | `AlcedoQanGraphPerformance.DefaultGraphApplyCreatesThreeNodeDelegatesAndTwoEdges` | PASS (apply 97 ms) |
+| 32-Grade graph 34 node / 33 edge delegates | `AlcedoQanGraphPerformance.ThirtyTwoGradeGraphApplyRecordsDelegateCountsAndApplyTime` | PASS (apply 918 ms) |
+| 100 selections each under 100 ms | `AlcedoQanGraphPerformance.OneHundredSelectionsStayWithinOneHundredMillisecondsEach` | PASS (max 54 ms) |
+| Many-Mask drawer fold keeps owner identity | `AlcedoQanGraphPerformance.OpeningAndClosingAManyMaskNodeKeepsOwnerIdentity` | PASS (4 ms) |
+| 100 accepted draft Connects keep Qan identities | `AlcedoQanGraphPerformance.OneHundredAcceptedDraftConnectsRetainQanIdentities` | PASS (415 ms, 200 edge mutations) |
+| First Nodes Loader under 100 ms | `EditorNodesPanelQmlTest.FirstNodesLoaderShowsDefaultGraphDelegates` | PASS (`EXPECT_LT(loader_ms, 100)`) |
+| Add pending without Qan topology replace | `EditorNodesPanelQmlTest.AddColorGradeShowsPendingWithoutReplacingQanTopology` | PASS (25 ms) |
+| 100 open/close Qan lifetime | `EditorNodesPanelQmlTest.RepeatedNodesPageOpenAndCloseCyclesReleaseQanItemsAndIgnoreStaleRefreshes` | PASS |
+| Installed-app QuickQanava import | `build/install/bin/alcedo_main.exe --verify-qml-imports` | PASS (`qml.imports.ok=QuickQanava`) |
+| CPack staging QuickQanava import | `_CPack_Packages/.../bin/alcedo_main.exe --verify-qml-imports` | PASS |
+| Windows NSIS package | `AlcedoStudio-0.2.9-Windows-AMD64.exe` | generated (136.94 MB) |
+
+Commands:
+
+- `cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/misc/Qt/6.9.3/msvc2022_64/lib/cmake"`
+- `cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target alcedo_main AlcedoQanGraphTest EditorNodesPanelQmlTest EditorNodeDelegateQmlTest EditorHistoryVersionsRailLifecycleQmlTest WorkspaceShellTest EditorNodeSelectionLayoutTest EditorNodeGraphDraftTest EditorNodeGraphProjectionTest EditorSessionHistoryPortTest EditorSessionNodeCommandTest PipelineHistoryApplierTest PipelineEditBatchTest PipelineGraphTopologyDeltaTest PipelineDocumentDefaultNameTest QuickQanavaProductionIntegrationTest QanDelegateLibraryTest`
+- `ctest --test-dir build/debug --output-on-failure --no-tests=error -R "AlcedoQanGraphTest|EditorNodesPanelQmlTest|EditorNodeDelegateQmlTest|EditorHistoryVersionsRailLifecycleQmlTest|EditorNodeSelectionLayoutTest|EditorNodeGraphDraftTest|EditorNodeGraphProjectionTest|EditorSessionHistoryPortTest|EditorSessionNodeCommandTest|PipelineHistoryApplierTest|PipelineEditBatchTest|PipelineGraphTopologyDeltaTest|PipelineDocumentDefaultNameTest|QuickQanavaProductionIntegrationTest|QanDelegateLibraryTest|ProductionBinaryLoadsQuickQanavaModule|PackagedNoticeSourcesContainQuickQanavaAndBezierClauses|WorkspaceShellTests.NodesPage"`
+- `cmd /c scripts\msvc_env.cmd --preset win_release -DCMAKE_PREFIX_PATH="D:/misc/Qt/6.9.3/msvc2022_64/lib/cmake"`
+- `cmd /c scripts\msvc_env.cmd --build --preset win_release --parallel 4 --target alcedo_main`
+- `cmd /c scripts\msvc_env.cmd --install build/release`
+- `powershell -ExecutionPolicy Bypass -File scripts/verify_windows_install_tree.ps1 -InstallDir build/install`
+- `cpack --config build/release/CPackConfig.cmake -B build/tmp/nm5-8g/package`
+
+Suite totals: first debug filter **275/277** in 224.35 s (two new delegate-count waits used `findChildren<qan::NodeItem*>`, which does not see QML-created items). After counting live `getItem()` delegates, those two cases passed **2/2**. Combined affected set **277/277**.
+
+Per-binary after the fix: `AlcedoQanGraphTest` 31/31, `EditorNodesPanelQmlTest` 33/33, `EditorNodeDelegateQmlTest` 19/19, `EditorHistoryVersionsRailLifecycleQmlTest` 6/6, `WorkspaceShellTest` NodesPage 2/2, `EditorNodeSelectionLayoutTest` 40/40 (includes `editor_node_controller_test.cpp`), `EditorNodeGraphDraftTest` 14/14, `EditorNodeGraphProjectionTest` 7/7, `EditorSessionHistoryPortTest` 75/75, `EditorSessionNodeCommandTest` 3/3, `PipelineHistoryApplierTest` 12/12, `PipelineEditBatchTest` 17/17, `PipelineGraphTopologyDeltaTest` 5/5, `PipelineDocumentDefaultNameTest` 6/6, `QuickQanavaProductionIntegrationTest` 3/3, `QanDelegateLibraryTest` 2/2, `ProductionBinaryLoadsQuickQanavaModule` 1/1, `PackagedNoticeSourcesContainQuickQanavaAndBezierClauses` 1/1.
+
+The plan name `EditorWorkspaceToolRailLifecycleQmlTest` is the existing `EditorHistoryVersionsRailLifecycleQmlTest` binary.
+
+**Section 19 recorded production-path timings** (debug MSVC, gtest `RecordProperty` in `build/tmp/nm5-8g/qan_perf.xml`): default apply 97 ms with 3/2 delegates; 32-Grade apply 918 ms with 34/33 delegates; 100 selections max 54 ms; many-Mask drawer fold 4 ms; 100 draft Connects 415 ms with 200 changed Qan edges and retained Develop/primary/DRT identities. First Nodes Loader asserted under 100 ms on a fresh process; Add pending feedback 25 ms without incrementing `topology_replace_count`. Decode resolution, output quality, and backend were not changed.
+
+**Checklist / exit condition:** original items 1–7 remain covered by the re-run QML/workspace/history binaries and the NM5.8f visual-matrix record. Item 8 passed (Windows wrapper configure/build). Item 9 is open: this host is Windows, so no macOS configure/build/install/package was executed. Items 10–12 passed (install + CPack staging `--verify-qml-imports`, notice files in `bin/` and the NSIS staging tree, affected regression filter).
+
+**LOC note (grill-code-review):** tracked edits +235 lines across 8 files. New `alcedo_qan_graph_performance_test.cpp` is 407 lines; `check_quickqanava_legal_notices.cmake` is 50 lines. `editor_nodes_panel_qml_test.cpp` is 1019 lines after two timing tests; those tests stay on the existing Nodes Loader fixture rather than a second binary. `main.cpp` is 377 lines.
+
+**Pinned API differences:** production CLI `--verify-qml-imports` (Basic style, no editor backend, no window, no render). CMake `alcedo_install_legal_notices(destination)` installs `LICENSE` / `NOTICE` / `THIRD_PARTY_NOTICE.txt` / `third_party_licenses/` next to the Windows executable and into macOS `Contents/Resources`. CTest names `ProductionBinaryLoadsQuickQanavaModule` and `PackagedNoticeSourcesContainQuickQanavaAndBezierClauses`. Verify scripts assert `Redistributions in binary form must reproduce` and bezier `MIT License`. No QuickQanava submodule pin or Qt style change.
+
+**Remaining gaps:** macOS configure/build/install/package was not run (Windows environment). Native screen-reader narration remains the NM5.8f residual. A full editor window from the NSIS-installed Program Files tree was not opened; package acceptance used `--verify-qml-imports` on the cmake install tree and the CPack staging tree. `cmake --install build/release --prefix build/install` (relative prefix) failed Qt `qt.conf` absolute-path checking; the working install used the preset absolute `CMAKE_INSTALL_PREFIX`. NM8 still owns real-RAW and three-backend qualification.
+
 ### 16.4 Main call chain
 
 ```text
@@ -3586,7 +3665,7 @@ checks here.
 | NM5.8d | Complete 2026-09-04 | Caller deletion audit; retained typed replay/paste |
 | NM5.8e | Complete 2026-09-05 | Persistent topology history; lifecycle and failure recovery |
 | NM5.8f | Complete 2026-09-05 | Keyboard, QML accessibility, localization, visual matrix |
-| NM5.8g | Pending | Fresh builds, regression, installed packages, notices |
+| NM5.8g | Complete 2026-09-05 | Fresh Windows builds, regression, install/package, notices |
 
 #### NM5.8e completion — 2026-09-05
 
@@ -3669,6 +3748,13 @@ under section 16.3.6 in this document.
   `AlcedoQanGraphTest` 26/26, `EditorNodeGraphDraftTest` 14/14.
 - Native NVDA/Narrator/VoiceOver was not run. Install, package, notices, and macOS remain
   NM5.8g. No package or macOS result is substituted here.
+
+#### NM5.8g completion — 2026-09-05
+
+**Status:** Complete. Fresh Windows/MSVC configure and build, the affected graph/history/adapter/QML/workspace regression filter, install-tree and NSIS package QuickQanava import, and QuickQanava/bezier notices now have executable evidence. The full call chains, test table, Section 19 timings, LOC note, and residuals are under section 16.3.7 in this document.
+
+- Wrapper debug configure/build succeeded. The affected `ctest` filter is **277/277** after fixing QML delegate counting. Wrapper release configure/build of `alcedo_main`, `cmake --install build/release`, `scripts/verify_windows_install_tree.ps1`, and `cpack` NSIS all passed. Installed and CPack-staging `alcedo_main --verify-qml-imports` both printed `qml.imports.ok=QuickQanava`.
+- macOS was not available on this Windows host. No macOS package result is substituted here. No QuickQanava submodule or Qt style change.
 
 ---
 
@@ -3850,9 +3936,9 @@ Do not reduce decode resolution, output quality, or backend behavior to meet the
 - [x] Node delegates use no shadow, glow, gradient, or Material style.
 - [x] Reduced-motion behavior passes.
 - [x] The viewer keeps its 360 logical-pixel floor at 960×640.
-- [ ] Windows build, install, and package checks pass.
+- [x] Windows build, install, and package checks pass.
 - [ ] macOS build, install, and package checks pass when the environment is available.
-- [ ] Required third-party notices are in the package.
-- [ ] Every sub-phase completion record lists pinned API differences.
+- [x] Required third-party notices are in the package.
+- [x] Every sub-phase completion record lists pinned API differences.
 
 NM6 must use NM5 `selectedNodeId`. NM6 must not create another node selection source.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm5_nodes_panel_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02
 
-Status: NM5.1–NM5.7R implementation recorded; NM5.8a–NM5.8g complete 2026-09-05
+Status: NM5.1–NM5.7R implementation recorded; NM5.8a–NM5.8g complete 2026-09-05, including macOS package evidence
 
 Prerequisites: NM4 is complete. NM1.4R and NM1.5 behavior remains required.
 
@@ -3623,6 +3623,90 @@ The plan name `EditorWorkspaceToolRailLifecycleQmlTest` is the existing `EditorH
 
 **Remaining gaps:** macOS configure/build/install/package was not run (Windows environment). Native screen-reader narration remains the NM5.8f residual. A full editor window from the NSIS-installed Program Files tree was not opened; package acceptance used `--verify-qml-imports` on the cmake install tree and the CPack staging tree. `cmake --install build/release --prefix build/install` (relative prefix) failed Qt `qt.conf` absolute-path checking; the working install used the preset absolute `CMAKE_INSTALL_PREFIX`. NM8 still owns real-RAW and three-backend qualification.
 
+##### Phase NM5.8g macOS completion record (2026-09-05)
+
+**Status:** complete — macOS debug-test configure/build, affected graph/history/adapter/QML/workspace regression, release install/package QuickQanava import, and QuickQanava BSD-3-Clause plus bezier MIT notices in `Contents/Resources`.
+
+**Primary success call chain:**
+
+```text
+packaged/installed AlcedoStudio.app --verify-qml-imports
+  -> QQuickStyle Basic
+  -> QQmlEngine import path qrc:/
+  -> QuickQanava::initialize
+  -> import QuickQanava 2.0 as Qan
+  -> probe Item objectName quickQanavaImportProbe
+  -> stdout qml.imports.ok=QuickQanava
+```
+
+```text
+cmake --build build/macos-release --target install
+  -> qt_generate_deploy_qml_app_script / macdeployqt
+  -> alcedo_install_legal_notices(Contents/Resources)
+  -> scripts/verify_macos_install_tree.sh
+  -> LICENSE, NOTICE, THIRD_PARTY_NOTICE.txt, third_party_licenses/
+  -> installed AlcedoStudio --verify-qml-imports
+  -> cpack DragNDrop + ZIP staging trees pass the same verify
+```
+
+**Primary failure call chain:**
+
+```text
+missing or broken QuickQanava QML import, or dummy Qt winId color-space apply
+  -> QQmlComponent prints the real QML error, or ColorManager returns false
+  -> non-zero process status / SIGSEGV avoided for winId 1
+  -> ProductionBinaryLoadsQuickQanavaModule / verify_macos_install_tree.sh fail
+  -> no substitute canvas
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| Debug `alcedo_main --verify-qml-imports` | `ProductionBinaryLoadsQuickQanavaModule` | PASS |
+| Source-tree QuickQanava/bezier notice text | `PackagedNoticeSourcesContainQuickQanavaAndBezierClauses` | PASS |
+| Dummy `QWindow::winId()` is not an NSWindow | `EditorWindowColorManagementTest.DummyPlatformWinIdReturnsFalseWithoutCrashing` | PASS |
+| Default graph 3 node / 2 edge delegates | `AlcedoQanGraphPerformance.DefaultGraphApplyCreatesThreeNodeDelegatesAndTwoEdges` | PASS (apply 260 ms) |
+| 32-Grade graph 34 node / 33 edge delegates | `AlcedoQanGraphPerformance.ThirtyTwoGradeGraphApplyRecordsDelegateCountsAndApplyTime` | PASS (apply 91 ms) |
+| 100 selections each under 100 ms | `AlcedoQanGraphPerformance.OneHundredSelectionsStayWithinOneHundredMillisecondsEach` | PASS (max 7 ms) |
+| Many-Mask drawer fold keeps owner identity | `AlcedoQanGraphPerformance.OpeningAndClosingAManyMaskNodeKeepsOwnerIdentity` | PASS (0 ms recorded) |
+| 100 accepted draft Connects keep Qan identities | `AlcedoQanGraphPerformance.OneHundredAcceptedDraftConnectsRetainQanIdentities` | PASS (17 ms, 200 edge mutations) |
+| First Nodes Loader under 100 ms | `EditorNodesPanelQmlTest.FirstNodesLoaderShowsDefaultGraphDelegates` | PASS (`EXPECT_LT(loader_ms, 100)`) |
+| Add pending without Qan topology replace | `EditorNodesPanelQmlTest.AddColorGradeShowsPendingWithoutReplacingQanTopology` | PASS (4 ms) |
+| Nodes page 360 px floor at 960×640 | `WorkspaceShellTests.NodesPageKeepsViewerAtLeast360LogicalPixelsAt960x640` | PASS |
+| Empty Nodes chrome accessible names | `WorkspaceShellTests.NodesPageEmptyChromeExposesAccessibleNamesAndTabStops` | PASS |
+| Installed-app QuickQanava import | `build/install/AlcedoStudio.app/.../AlcedoStudio --verify-qml-imports` | PASS (`qml.imports.ok=QuickQanava`) |
+| CPack DragNDrop staging QuickQanava import | `_CPack_Packages/Darwin/DragNDrop/.../AlcedoStudio.app` | PASS |
+| CPack ZIP staging QuickQanava import | `_CPack_Packages/Darwin/ZIP/.../AlcedoStudio.app` | PASS |
+| macOS packages | `AlcedoStudio-0.2.9-Darwin-arm64.dmg` (193 MB), `.zip` (212 MB) | generated |
+
+Commands:
+
+- `cmake --preset macos_debug_tests -DALCEDO_GENERATE_QMLTYPES=ON`
+- `cmake --build build/macos-debug-tests --parallel 8 --target alcedo_main AlcedoQanGraphTest EditorNodesPanelQmlTest EditorNodeDelegateQmlTest EditorHistoryVersionsRailLifecycleQmlTest WorkspaceShellTest EditorNodeSelectionLayoutTest EditorNodeGraphDraftTest EditorNodeGraphProjectionTest EditorSessionHistoryPortTest EditorSessionNodeCommandTest PipelineHistoryApplierTest PipelineEditBatchTest PipelineGraphTopologyDeltaTest PipelineDocumentDefaultNameTest QuickQanavaProductionIntegrationTest QanDelegateLibraryTest EditorWindowColorManagementTest`
+- `ctest --test-dir build/macos-debug-tests --output-on-failure --no-tests=error --output-junit build/tmp/nm5-8g-macos/ctest.xml -R "AlcedoQanGraphTest|EditorNodesPanelQmlTest|EditorNodeDelegateQmlTest|EditorHistoryVersionsRailLifecycleQmlTest|EditorNodeSelectionLayoutTest|EditorNodeGraphDraftTest|EditorNodeGraphProjectionTest|EditorSessionHistoryPortTest|EditorSessionNodeCommandTest|PipelineHistoryApplierTest|PipelineEditBatchTest|PipelineGraphTopologyDeltaTest|PipelineDocumentDefaultNameTest|QuickQanavaProductionIntegrationTest|QanDelegateLibraryTest|ProductionBinaryLoadsQuickQanavaModule|PackagedNoticeSourcesContainQuickQanavaAndBezierClauses|WorkspaceShellTests.NodesPage"`
+- `./scripts/package_macos.sh --channel beta --jobs 8 --package-out-dir build/tmp/nm5-8g-macos/package`
+- `scripts/verify_macos_install_tree.sh --install-dir build/install --bundle-name AlcedoStudio` (clean Qt env; see below)
+- `cpack --config build/macos-release/CPackConfig.cmake -B build/tmp/nm5-8g-macos/package`
+
+Suite totals: affected CTest filter **277/277** in 122.76 s after the color-space guard. Additional `EditorWindowColorManagementTest` **3/3**.
+
+Per-binary: `AlcedoQanGraphTest` 31/31, `EditorNodesPanelQmlTest` 33/33, `EditorNodeDelegateQmlTest` 19/19, `EditorHistoryVersionsRailLifecycleQmlTest` 6/6, `WorkspaceShellTest` NodesPage 2/2, `EditorNodeSelectionLayoutTest` 40/40, `EditorNodeGraphDraftTest` 14/14, `EditorNodeGraphProjectionTest` 7/7, `EditorSessionHistoryPortTest` 75/75, `EditorSessionNodeCommandTest` 3/3, `PipelineHistoryApplierTest` 12/12, `PipelineEditBatchTest` 17/17, `PipelineGraphTopologyDeltaTest` 5/5, `PipelineDocumentDefaultNameTest` 6/6, `QuickQanavaProductionIntegrationTest` 3/3, `QanDelegateLibraryTest` 2/2, `ProductionBinaryLoadsQuickQanavaModule` 1/1, `PackagedNoticeSourcesContainQuickQanavaAndBezierClauses` 1/1.
+
+**Section 19 recorded production-path timings** (macOS arm64 debug Homebrew Qt 6.9.2, gtest `RecordProperty` in `build/tmp/nm5-8g-macos/qan_perf.xml`): default apply 260 ms with 3/2 delegates; 32-Grade apply 91 ms with 34/33 delegates; 100 selections max 7 ms; many-Mask drawer fold 0 ms recorded; 100 draft Connects 17 ms with 200 changed Qan edges. First Nodes Loader asserted under 100 ms; Add pending feedback 4 ms. Decode resolution, output quality, and backend were not changed.
+
+**Checklist / exit condition:** original items 1–8 and 10–12 remain covered by the Windows record plus this macOS re-run. Item 9 passed: macOS debug-test configure/build, `macos_release` install (macdeployqt), `verify_macos_install_tree.sh` on the cmake install tree and both CPack staging apps, DragNDrop DMG and ZIP packages.
+
+**LOC note (grill-code-review):** macOS verification required a 19-line color-space guard: `color_manager.mm` 254 lines, `color_manager.hpp` 25 lines, `editor_window_color_management_test.mm` 82 lines. No file exceeded the ~1000-line split threshold.
+
+**Pinned API differences:** same `--verify-qml-imports` CLI and `alcedo_install_legal_notices` destination as Windows, installed into macOS `Contents/Resources`. `macos_debug_tests` keeps `ALCEDO_GENERATE_QMLTYPES=OFF` in the preset; this run overrode `-DALCEDO_GENERATE_QMLTYPES=ON` so `qml_register_types_Alcedo_Main` is generated. Official Qt 6.9.3 (`ALCEDO_QT_PREFIX=/Users/zidage/Qt/6.9.3/macos`) for the package; Homebrew Qt 6.9.2 for debug tests. No QuickQanava submodule pin or Qt style change.
+
+**Observed macOS defect and fix:** opening the Nodes page in `WorkspaceShellTest` (offscreen QPA) attached `EditorViewportItem` and passed Qt dummy `winId()` `1` into `ColorManager::ApplyWindowColorSpace`. `-isKindOfClass:` on that pointer was `EXC_BAD_ACCESS`. The function now returns false for native addresses below 4096 without sending ObjC messages. Isolated `EditorNodesPanelQmlTest` already passed before the guard.
+
+**Packaging note:** the first `package_macos.sh` verify aborted because `QT_QPA_PLATFORM=offscreen` and `QT_PLUGIN_PATH=/opt/homebrew/share/qt/plugins` leaked from the debug CTest process into the bundled Qt 6.9.3 app. Re-running `verify_macos_install_tree.sh` and CPack with those variables unset passed. macdeployqt itself completed; it was not re-run for the install tree.
+
+**Residual gaps:** Native VoiceOver was not executed. A full editor window was not opened from the mounted DMG; package acceptance used `--verify-qml-imports` on the cmake install tree and both CPack staging apps. `macos_debug_tests` still defaults `ALCEDO_GENERATE_QMLTYPES=OFF`. NM8 still owns real-RAW and three-backend qualification.
+
 ### 16.4 Main call chain
 
 ```text
@@ -3665,7 +3749,7 @@ checks here.
 | NM5.8d | Complete 2026-09-04 | Caller deletion audit; retained typed replay/paste |
 | NM5.8e | Complete 2026-09-05 | Persistent topology history; lifecycle and failure recovery |
 | NM5.8f | Complete 2026-09-05 | Keyboard, QML accessibility, localization, visual matrix |
-| NM5.8g | Complete 2026-09-05 | Fresh Windows builds, regression, install/package, notices |
+| NM5.8g | Complete 2026-09-05 | Fresh Windows and macOS builds, regression, install/package, notices |
 
 #### NM5.8e completion — 2026-09-05
 
@@ -3755,6 +3839,14 @@ under section 16.3.6 in this document.
 
 - Wrapper debug configure/build succeeded. The affected `ctest` filter is **277/277** after fixing QML delegate counting. Wrapper release configure/build of `alcedo_main`, `cmake --install build/release`, `scripts/verify_windows_install_tree.ps1`, and `cpack` NSIS all passed. Installed and CPack-staging `alcedo_main --verify-qml-imports` both printed `qml.imports.ok=QuickQanava`.
 - macOS was not available on this Windows host. No macOS package result is substituted here. No QuickQanava submodule or Qt style change.
+
+#### NM5.8g macOS completion — 2026-09-05
+
+**Status:** Complete. macOS `macos_debug_tests` configure/build, the same 277-test affected filter, `macos_release` install with macdeployqt, install-tree and CPack DragNDrop/ZIP QuickQanava import, and QuickQanava/bezier notices in `Contents/Resources` now have executable evidence. Call chains, test table, Section 19 timings, and residuals are under the 2026-09-05 macOS record in section 16.3.7.
+
+- `cmake --preset macos_debug_tests -DALCEDO_GENERATE_QMLTYPES=ON` and the affected debug targets built. The CTest filter is **277/277**. `EditorWindowColorManagementTest` is **3/3** after rejecting dummy `winId()` `1`.
+- `./scripts/package_macos.sh --channel beta` configured `macos_release` with Qt 6.9.3, built install (macdeployqt), then CPack produced `AlcedoStudio-0.2.9-Darwin-arm64.dmg` and `.zip`. `scripts/verify_macos_install_tree.sh` passed on `build/install/AlcedoStudio.app` and both CPack staging apps. Installed `AlcedoStudio --verify-qml-imports` printed `qml.imports.ok=QuickQanava`.
+- Opening Nodes in `WorkspaceShellTest` on offscreen QPA previously SIGSEGV'd in `ColorManager::ApplyWindowColorSpace`. That path now returns false for non-AppKit dummy handles. No QuickQanava submodule or Qt style change.
 
 ---
 
@@ -3937,7 +4029,7 @@ Do not reduce decode resolution, output quality, or backend behavior to meet the
 - [x] Reduced-motion behavior passes.
 - [x] The viewer keeps its 360 logical-pixel floor at 960×640.
 - [x] Windows build, install, and package checks pass.
-- [ ] macOS build, install, and package checks pass when the environment is available.
+- [x] macOS build, install, and package checks pass when the environment is available.
 - [x] Required third-party notices are in the package.
 - [x] Every sub-phase completion record lists pinned API differences.
 

--- a/scripts/cmake/check_quickqanava_legal_notices.cmake
+++ b/scripts/cmake/check_quickqanava_legal_notices.cmake
@@ -1,0 +1,50 @@
+# Assert source-tree legal notices contain the QuickQanava BSD-3-Clause binary
+# redistribution clause and the vendored bezier MIT text. Invoke with:
+#   cmake -DALCEDO_SOURCE_DIR=<repo> -P scripts/cmake/check_quickqanava_legal_notices.cmake
+
+if(NOT ALCEDO_SOURCE_DIR)
+  get_filename_component(ALCEDO_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+endif()
+
+function(alcedo_assert_file_contains path needle)
+  if(NOT EXISTS "${path}")
+    message(FATAL_ERROR "Required legal notice is missing: ${path}")
+  endif()
+  file(READ "${path}" _text)
+  string(FIND "${_text}" "${needle}" _found)
+  if(_found EQUAL -1)
+    message(FATAL_ERROR
+      "Legal notice ${path} does not contain required text: ${needle}")
+  endif()
+endfunction()
+
+alcedo_assert_file_contains(
+  "${ALCEDO_SOURCE_DIR}/third_party_licenses/QuickQanava-licence.txt"
+  "Redistributions in binary form must reproduce")
+alcedo_assert_file_contains(
+  "${ALCEDO_SOURCE_DIR}/third_party_licenses/QuickQanava-licence.txt"
+  "Benoit AUTHEMAN")
+alcedo_assert_file_contains(
+  "${ALCEDO_SOURCE_DIR}/third_party_licenses/QuickQanava-bezier-LICENSE.txt"
+  "MIT License")
+alcedo_assert_file_contains(
+  "${ALCEDO_SOURCE_DIR}/third_party_licenses/QuickQanava-bezier-LICENSE.txt"
+  "Permission is hereby granted")
+alcedo_assert_file_contains(
+  "${ALCEDO_SOURCE_DIR}/THIRD_PARTY_NOTICE.txt"
+  "QuickQanava")
+alcedo_assert_file_contains(
+  "${ALCEDO_SOURCE_DIR}/THIRD_PARTY_NOTICE.txt"
+  "bezier")
+alcedo_assert_file_contains(
+  "${ALCEDO_SOURCE_DIR}/NOTICE"
+  "QuickQanava")
+alcedo_assert_file_contains(
+  "${ALCEDO_SOURCE_DIR}/LICENSE"
+  "GNU GENERAL PUBLIC LICENSE")
+alcedo_assert_file_contains(
+  "${ALCEDO_SOURCE_DIR}/LICENSE"
+  "Version 3")
+
+message(STATUS
+  "QuickQanava BSD-3-Clause and bezier MIT notice texts are present.")

--- a/scripts/verify_macos_install_tree.sh
+++ b/scripts/verify_macos_install_tree.sh
@@ -246,4 +246,39 @@ if [[ "${#missing_deps[@]}" -gt 0 ]]; then
   exit 1
 fi
 
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+  assert_file "$path"
+  if ! grep -F -q -- "$needle" "$path"; then
+    fail "required notice text is missing from $path: $needle"
+  fi
+}
+
+assert_file "${resources_dir}/LICENSE"
+assert_file "${resources_dir}/NOTICE"
+assert_file "${resources_dir}/THIRD_PARTY_NOTICE.txt"
+assert_dir "${resources_dir}/third_party_licenses"
+assert_file_contains "${resources_dir}/NOTICE" "QuickQanava"
+assert_file_contains "${resources_dir}/THIRD_PARTY_NOTICE.txt" "QuickQanava"
+assert_file_contains "${resources_dir}/THIRD_PARTY_NOTICE.txt" "bezier"
+assert_file_contains \
+  "${resources_dir}/third_party_licenses/QuickQanava-licence.txt" \
+  "Redistributions in binary form must reproduce"
+assert_file_contains \
+  "${resources_dir}/third_party_licenses/QuickQanava-bezier-LICENSE.txt" \
+  "MIT License"
+assert_file_contains \
+  "${resources_dir}/third_party_licenses/QuickQanava-bezier-LICENSE.txt" \
+  "Permission is hereby granted"
+
+qml_probe_out="$(mktemp "${TMPDIR:-/tmp}/alcedo_qml_import.XXXXXX")"
+if ! "$main_exe" --verify-qml-imports >"$qml_probe_out" 2>&1; then
+  fail "installed app --verify-qml-imports failed: $(cat "$qml_probe_out")"
+fi
+if ! grep -F -q "qml.imports.ok=QuickQanava" "$qml_probe_out"; then
+  fail "installed app did not report a QuickQanava QML import: $(cat "$qml_probe_out")"
+fi
+rm -f "$qml_probe_out"
+
 echo "[alcedo] macOS install tree verification passed: $app_dir"

--- a/scripts/verify_windows_install_tree.ps1
+++ b/scripts/verify_windows_install_tree.ps1
@@ -135,4 +135,51 @@ if ($LASTEXITCODE -ne 0) {
     throw "Windows EXE PE icon does not match the committed ICO."
 }
 
+function Assert-FileContains {
+    param(
+        [string]$Path,
+        [string]$Needle
+    )
+    Assert-File $Path
+    $text = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+    if ($null -eq $text -or $text.IndexOf($Needle) -lt 0) {
+        throw "Required notice text '$Needle' is missing from: $Path"
+    }
+}
+
+$noticeDir = Join-Path $binDir 'third_party_licenses'
+Assert-File (Join-Path $binDir 'LICENSE')
+Assert-File (Join-Path $binDir 'NOTICE')
+Assert-File (Join-Path $binDir 'THIRD_PARTY_NOTICE.txt')
+Assert-Directory $noticeDir
+Assert-FileContains -Path (Join-Path $binDir 'NOTICE') -Needle 'QuickQanava'
+Assert-FileContains -Path (Join-Path $binDir 'THIRD_PARTY_NOTICE.txt') -Needle 'QuickQanava'
+Assert-FileContains -Path (Join-Path $binDir 'THIRD_PARTY_NOTICE.txt') -Needle 'bezier'
+Assert-FileContains `
+    -Path (Join-Path $noticeDir 'QuickQanava-licence.txt') `
+    -Needle 'Redistributions in binary form must reproduce'
+Assert-FileContains `
+    -Path (Join-Path $noticeDir 'QuickQanava-bezier-LICENSE.txt') `
+    -Needle 'MIT License'
+Assert-FileContains `
+    -Path (Join-Path $noticeDir 'QuickQanava-bezier-LICENSE.txt') `
+    -Needle 'Permission is hereby granted'
+
+$mainExe = Join-Path $binDir 'alcedo_main.exe'
+$qmlStdoutPath = Join-Path $installRoot 'qml_import_probe_stdout.txt'
+$qmlStderrPath = Join-Path $installRoot 'qml_import_probe_stderr.txt'
+$qmlProbe = Start-Process -FilePath $mainExe -ArgumentList '--verify-qml-imports' `
+    -WorkingDirectory $binDir -Wait -PassThru -NoNewWindow `
+    -RedirectStandardOutput $qmlStdoutPath `
+    -RedirectStandardError $qmlStderrPath
+$qmlStdout = Get-Content -LiteralPath $qmlStdoutPath -Raw -ErrorAction SilentlyContinue
+$qmlStderr = Get-Content -LiteralPath $qmlStderrPath -Raw -ErrorAction SilentlyContinue
+$qmlOutput = "$qmlStdout`n$qmlStderr"
+if ($qmlProbe.ExitCode -ne 0) {
+    throw "Installed alcedo_main.exe --verify-qml-imports exited $($qmlProbe.ExitCode): $qmlOutput"
+}
+if ($qmlOutput -notmatch 'qml\.imports\.ok=QuickQanava') {
+    throw "Installed alcedo_main.exe did not report a QuickQanava QML import: $qmlOutput"
+}
+
 Write-Host "[alcedo] Windows install tree verification passed: $binDir" -ForegroundColor Green


### PR DESCRIPTION
## Summary

- Complete NM5.8g Windows install, NSIS package, QuickQanava QML import, and third-party notice coverage for the Nodes page.
- Install `LICENSE`, `NOTICE`, `THIRD_PARTY_NOTICE.txt`, and `third_party_licenses/` next to the Windows executable and into macOS `Contents/Resources`.
- Add `alcedo_main --verify-qml-imports` so package verification loads the pinned QuickQanava module with Basic style and fails on the real QML error.
- Record Section 19 Nodes graph timings on the production adapter and Loader path, and write the NM5.8g completion record into the Nodes panel roadmap.

## Verification

- Affected debug `ctest` filter: 277/277 passed (`AlcedoQanGraphTest` 31/31, `EditorNodesPanelQmlTest` 33/33, `EditorNodeDelegateQmlTest` 19/19, `EditorHistoryVersionsRailLifecycleQmlTest` 6/6, `WorkspaceShellTest` NodesPage 2/2, `EditorNodeSelectionLayoutTest` 40/40, `EditorNodeGraphDraftTest` 14/14, `EditorNodeGraphProjectionTest` 7/7, `EditorSessionHistoryPortTest` 75/75, `EditorSessionNodeCommandTest` 3/3, `PipelineHistoryApplierTest` 12/12, `PipelineEditBatchTest` 17/17, `PipelineGraphTopologyDeltaTest` 5/5, `PipelineDocumentDefaultNameTest` 6/6, `QuickQanavaProductionIntegrationTest` 3/3, `QanDelegateLibraryTest` 2/2, `ProductionBinaryLoadsQuickQanavaModule` 1/1, `PackagedNoticeSourcesContainQuickQanavaAndBezierClauses` 1/1).
- Section 19 timings: default apply 97 ms (3/2 delegates); 32-Grade apply 918 ms (34/33); 100 selections max 54 ms; many-Mask drawer fold 4 ms; 100 draft Connects 415 ms with retained Qan identities; first Nodes Loader under 100 ms; Add pending 25 ms.
- Windows/MSVC configure and build through `scripts\msvc_env.cmd` (`win_debug` and `win_release`).
- `cmake --install build/release` and `scripts/verify_windows_install_tree.ps1` passed, including installed `alcedo_main --verify-qml-imports`.
- `cpack` NSIS package generated; CPack staging `alcedo_main --verify-qml-imports` printed `qml.imports.ok=QuickQanava`.

## Scope

macOS configure, build, install, and package were not run on this Windows host. Native NVDA/Narrator/VoiceOver remains the NM5.8f residual. A full editor window from a Program Files install was not opened; package acceptance uses `--verify-qml-imports`. No QuickQanava submodule or Qt style change. NM8 still owns real-RAW and three-backend qualification.

Made with [Cursor](https://cursor.com)