### PR TITLE
feat(editor): queue typed adjustment input (NM6.1–NM6.2)

### DIFF
--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -424,12 +424,21 @@ def_library(PipelineHistoryApplier
 
 target_link_libraries(PipelineMgmtService PRIVATE PipelineHistoryApplier EditorAdjustmentPipeline)
 
+def_library(EditorPendingInput
+    SOURCES
+        "${ALCEDO_APP_ROOT}/editor_pending_input.cpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_pending_input.hpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_adjustment_types.hpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_session_types.hpp"
+)
+
 def_library(EditorSessionService
     SOURCES
         "${ALCEDO_APP_ROOT}/editor_session_service.cpp"
         "${ALCEDO_APP_ROOT}/editor_render_coordinator.cpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_session_types.hpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_adjustment_types.hpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_pending_input.hpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_render_intent.hpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_session_ports.hpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_session_service.hpp"
@@ -438,7 +447,7 @@ def_library(EditorSessionService
         "${ALCEDO_INCLUDE_ROOT}/edit/frame_presentation_types.hpp"
     # The session facade is application-only; no Widgets dependency belongs
     # on this target or on its public link interface.
-    PRIVATE_DEPS xxHash JSON ${ALCEDO_OPENCV_CORE_DEPS} AppDiagnostics
+    PRIVATE_DEPS EditorPendingInput xxHash JSON ${ALCEDO_OPENCV_CORE_DEPS} AppDiagnostics
                  EditHistory EditorMiniGitMaterializer EditorSaveCheckpointService EditorSessionLifecycle
                  EditorSessionNavigationController EditorSessionRenderController
                  EditorSessionEditController EditorSessionCommandQueue EditorActionPolicy

--- a/alcedo_studio/src/app/editor_pending_input.cpp
+++ b/alcedo_studio/src/app/editor_pending_input.cpp
@@ -1,0 +1,188 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_pending_input.hpp"
+
+namespace alcedo {
+namespace {
+
+[[nodiscard]] auto RejectAdmit(std::string error) -> EditorPendingInputAdmitResult {
+  EditorPendingInputAdmitResult result;
+  result.error = std::move(error);
+  return result;
+}
+
+[[nodiscard]] auto AcceptAdmit(std::uint64_t sequence_id) -> EditorPendingInputAdmitResult {
+  EditorPendingInputAdmitResult result;
+  result.accepted    = true;
+  result.sequence_id = sequence_id;
+  return result;
+}
+
+[[nodiscard]] auto SameSessionImage(const EditorSessionIdentity& left,
+                                    const EditorSessionIdentity& right) -> bool {
+  return left.element_id == right.element_id && left.image_id == right.image_id;
+}
+
+/// Node / instance / owner identity only. Field keys are not part of sequence
+/// targeting; parameter values are never compared.
+[[nodiscard]] auto SameWriteTargetIdentity(const EditorParameterTarget& left,
+                                           const EditorParameterTarget& right) -> bool {
+  return left.owner_kind == right.owner_kind && left.node_id == right.node_id &&
+         left.adjustment_instance_id == right.adjustment_instance_id && left.mask_id == right.mask_id;
+}
+
+[[nodiscard]] auto SequenceTargetFrom(const EditorParameterTarget& target)
+    -> EditorParameterTarget {
+  EditorParameterTarget captured = target;
+  captured.field_key.clear();
+  return captured;
+}
+
+[[nodiscard]] auto HasCompleteWriteIdentity(const EditorParameterTarget& target) -> bool {
+  return target.owner_kind != EditorParameterOwnerKind::Unspecified;
+}
+
+}  // namespace
+
+auto EditorPendingInputQueue::AdmitFieldChange(EditorSessionIdentity          identity,
+                                               const EditorAdjustmentPatch&   patch)
+    -> EditorPendingInputAdmitResult {
+  std::scoped_lock lock(mutex_);
+  return AdmitFieldChangeLocked(identity, patch);
+}
+
+auto EditorPendingInputQueue::AdmitBoundary(EditorSessionIdentity          identity,
+                                            EditorPendingInputBoundaryKind kind)
+    -> EditorPendingInputAdmitResult {
+  std::scoped_lock lock(mutex_);
+  return AdmitBoundaryLocked(identity, kind);
+}
+
+auto EditorPendingInputQueue::Peek() const -> EditorPendingInputView {
+  std::scoped_lock lock(mutex_);
+  return PeekLocked();
+}
+
+auto EditorPendingInputQueue::empty() const -> bool {
+  std::scoped_lock lock(mutex_);
+  return sealed_.empty() && !open_.has_value();
+}
+
+auto EditorPendingInputQueue::AdmitFieldChangeLocked(EditorSessionIdentity        identity,
+                                                     const EditorAdjustmentPatch& patch)
+    -> EditorPendingInputAdmitResult {
+  if (patch.field_key.empty()) {
+    return RejectAdmit("Adjustment input requires a field key");
+  }
+  if (!patch.target.field_key.empty() && patch.target.field_key != patch.field_key) {
+    return RejectAdmit("Editor parameter target field_key must match the patch field_key");
+  }
+  if (identity.element_id == 0 || identity.image_id == 0) {
+    return RejectAdmit("Adjustment input requires session image identity");
+  }
+
+  if (open_.has_value()) {
+    if (!SameSessionImage(open_->identity, identity)) {
+      return RejectAdmit("Queued adjustment input belongs to a different image");
+    }
+    if (HasCompleteWriteIdentity(open_->captured_target) &&
+        HasCompleteWriteIdentity(patch.target) &&
+        !SameWriteTargetIdentity(open_->captured_target, patch.target)) {
+      return RejectAdmit(
+          "Queued adjustment input cannot retarget a different node in the same sequence");
+    }
+  } else {
+    StartSequenceLocked(identity, patch.target);
+  }
+
+  if (!HasCompleteWriteIdentity(open_->captured_target) &&
+      HasCompleteWriteIdentity(patch.target)) {
+    open_->captured_target = SequenceTargetFrom(patch.target);
+  }
+
+  EditorPendingFieldChange change;
+  change.identity    = identity;
+  change.target      = patch.target;
+  change.target.field_key = patch.field_key;
+  if (HasCompleteWriteIdentity(open_->captured_target)) {
+    change.target.owner_kind             = open_->captured_target.owner_kind;
+    change.target.node_id                = open_->captured_target.node_id;
+    change.target.adjustment_instance_id = open_->captured_target.adjustment_instance_id;
+    change.target.mask_id                = open_->captured_target.mask_id;
+  }
+  change.params_json = patch.params_json;
+  change.enabled     = patch.enabled;
+
+  const auto existing = open_field_index_.find(patch.field_key);
+  if (existing != open_field_index_.end()) {
+    open_->fields[existing->second] = std::move(change);
+  } else {
+    open_field_index_.emplace(patch.field_key, open_->fields.size());
+    open_->fields.push_back(std::move(change));
+  }
+
+  const auto sequence_id = open_->sequence_id;
+  if (patch.settled) {
+    SealOpenLocked(EditorPendingInputBoundaryKind::Release);
+  }
+  return AcceptAdmit(sequence_id);
+}
+
+auto EditorPendingInputQueue::AdmitBoundaryLocked(EditorSessionIdentity          identity,
+                                                  EditorPendingInputBoundaryKind kind)
+    -> EditorPendingInputAdmitResult {
+  if (kind == EditorPendingInputBoundaryKind::None) {
+    return RejectAdmit("Pending input boundary requires Release, Cancel, or NodeSwitch");
+  }
+  if (identity.element_id == 0 || identity.image_id == 0) {
+    return RejectAdmit("Adjustment input requires session image identity");
+  }
+  if (open_.has_value() && !SameSessionImage(open_->identity, identity)) {
+    return RejectAdmit("Queued adjustment input belongs to a different image");
+  }
+  if (!open_.has_value()) {
+    StartSequenceLocked(identity, EditorParameterTarget{});
+  }
+  const auto sequence_id = open_->sequence_id;
+  if (kind == EditorPendingInputBoundaryKind::Cancel) {
+    open_->fields.clear();
+    open_field_index_.clear();
+  }
+  SealOpenLocked(kind);
+  return AcceptAdmit(sequence_id);
+}
+
+auto EditorPendingInputQueue::StartSequenceLocked(EditorSessionIdentity        identity,
+                                                  const EditorParameterTarget& target)
+    -> EditorPendingSequence& {
+  EditorPendingSequence sequence;
+  sequence.sequence_id     = next_sequence_id_++;
+  sequence.identity        = identity;
+  sequence.captured_target = SequenceTargetFrom(target);
+  open_                    = std::move(sequence);
+  open_field_index_.clear();
+  return *open_;
+}
+
+void EditorPendingInputQueue::SealOpenLocked(EditorPendingInputBoundaryKind kind) {
+  if (!open_.has_value()) {
+    return;
+  }
+  open_->seal = kind;
+  sealed_.push_back(std::move(*open_));
+  open_.reset();
+  open_field_index_.clear();
+}
+
+auto EditorPendingInputQueue::PeekLocked() const -> EditorPendingInputView {
+  EditorPendingInputView view;
+  view.sequences = sealed_;
+  if (open_.has_value()) {
+    view.sequences.push_back(*open_);
+  }
+  return view;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -5,6 +5,7 @@
 #include "app/editor_session_service.hpp"
 
 #include <algorithm>
+#include <mutex>
 #include <utility>
 
 #include "app/editor_action_policy.hpp"
@@ -1064,6 +1065,54 @@ auto EditorSessionService::CommitAdjustment(EditorAdjustmentPatch patch) -> Edit
   result.message  = outcome.message;
   BumpHistoryRevision();
   return Emit(std::move(result));
+}
+
+auto EditorSessionService::EnqueueAdjustmentInput(EditorAdjustmentPatch patch)
+    -> EditorSessionResult {
+  if (lifecycle_.state() != EditorSessionState::Interactive) {
+    return Reject("Queued adjustment input requires an interactive session");
+  }
+  if (!lifecycle_.has_image()) {
+    return Reject("Queued adjustment input requires an open image");
+  }
+  const auto identity = lifecycle_.identity();
+  const auto admitted = pending_input_.AdmitFieldChange(identity, patch);
+  if (!admitted.accepted) {
+    return Reject(admitted.error.empty() ? "Queued adjustment input was rejected"
+                                         : admitted.error);
+  }
+  EditorSessionResult result;
+  result.kind     = EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = identity;
+  result.message  = "Adjustment input queued";
+  return result;
+}
+
+auto EditorSessionService::EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind kind)
+    -> EditorSessionResult {
+  if (lifecycle_.state() != EditorSessionState::Interactive) {
+    return Reject("Queued adjustment input requires an interactive session");
+  }
+  if (!lifecycle_.has_image()) {
+    return Reject("Queued adjustment input requires an open image");
+  }
+  const auto identity = lifecycle_.identity();
+  const auto admitted = pending_input_.AdmitBoundary(identity, kind);
+  if (!admitted.accepted) {
+    return Reject(admitted.error.empty() ? "Queued adjustment boundary was rejected"
+                                         : admitted.error);
+  }
+  EditorSessionResult result;
+  result.kind     = EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = identity;
+  result.message  = "Adjustment input boundary queued";
+  return result;
+}
+
+auto EditorSessionService::PeekPendingInput() const -> EditorPendingInputView {
+  return pending_input_.Peek();
 }
 
 auto EditorSessionService::PublishTypedNodeHistorySuccess(std::string message)

--- a/alcedo_studio/src/include/app/editor_pending_input.hpp
+++ b/alcedo_studio/src/include/app/editor_pending_input.hpp
@@ -1,0 +1,174 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "app/editor_adjustment_types.hpp"
+#include "app/editor_session_types.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Ordered boundary that seals one pending input sequence.
+ *
+ * These are not copies of live parameter state. They mark when a sequence
+ * stops accepting further field replacements.
+ */
+enum class EditorPendingInputBoundaryKind : std::uint8_t {
+  None = 0,
+  Release,
+  Cancel,
+  NodeSwitch,
+};
+
+/**
+ * @brief One field write waiting for the session owner to apply.
+ *
+ * @p params_json is the caller's write payload for this field only. It is not
+ * a copy of the live operator, node, or document parameter collection.
+ */
+struct EditorPendingFieldChange {
+  EditorSessionIdentity identity{};
+  EditorParameterTarget target{};
+  std::string           params_json;
+  bool                  enabled = true;
+};
+
+/**
+ * @brief One input sequence: coalesced field writes plus an optional seal.
+ *
+ * @p captured_target stores NodeId / AdjustmentInstanceId / owner identity
+ * taken at sequence start. Its @c field_key is empty. It does not store
+ * parameter values.
+ */
+struct EditorPendingSequence {
+  std::uint64_t                  sequence_id = 0;
+  EditorSessionIdentity          identity{};
+  EditorParameterTarget          captured_target{};
+  std::vector<EditorPendingFieldChange> fields;
+  EditorPendingInputBoundaryKind seal = EditorPendingInputBoundaryKind::None;
+};
+
+/**
+ * @brief Inspectable copy of queued change descriptions.
+ *
+ * This is the pending-input queue's own contents, not a mirror of
+ * PipelineDocument or an EditorRenderAdjustmentSnapshot.
+ */
+struct EditorPendingInputView {
+  std::vector<EditorPendingSequence> sequences;
+};
+
+/**
+ * @brief Result of admitting one field write or boundary.
+ *
+ * @p accepted means queued for later owner processing, not history-committed
+ * and not applied to the live document.
+ */
+struct EditorPendingInputAdmitResult {
+  bool          accepted    = false;
+  std::string   error;
+  std::uint64_t sequence_id = 0;
+};
+
+/**
+ * @brief Bounded pending-input queue for typed adjustment writes.
+ *
+ * Absolute assignments to the same sequence, target identity, and field keep
+ * only the newest write payload. Distinct fields merge. Release, cancel, and
+ * node-switch seals are retained in order and start a new sequence.
+ *
+ * The GUI may admit work without reading live parameters or taking the render
+ * lock. Application, history before-values, and rendering are owner consume
+ * operations and do not run here.
+ *
+ * @thread_safety All public methods are serialized by an internal mutex.
+ */
+class EditorPendingInputQueue {
+ public:
+  EditorPendingInputQueue() = default;
+
+  /**
+   * @brief Queue one absolute field write.
+   *
+   * @pre @p identity identifies the session/image that produced the write.
+   * @pre @p patch.field_key is non-empty. @p patch.params_json is the field
+   *      write payload, not a live parameter-body copy.
+   * @param identity Session/image ids captured at enqueue. Not a document copy.
+   * @param patch Field key, write payload, optional target ids, and whether
+   *        this write also releases the sequence.
+   * @return Accepted with the sequence id, or rejected with @p error. Never
+   *         mutates live document or history.
+   */
+  auto AdmitFieldChange(EditorSessionIdentity identity, const EditorAdjustmentPatch& patch)
+      -> EditorPendingInputAdmitResult;
+
+  /**
+   * @brief Queue a sequence seal without a new field write.
+   *
+   * @param identity Session/image ids for the boundary.
+   * @param kind Release, Cancel, or NodeSwitch. None is rejected.
+   * @return Accepted with the sealed sequence id, or rejected.
+   *
+   * Cancel discards unapplied field writes of the open sequence and still
+   * records the Cancel seal so the boundary is not dropped.
+   */
+  auto AdmitBoundary(EditorSessionIdentity identity, EditorPendingInputBoundaryKind kind)
+      -> EditorPendingInputAdmitResult;
+
+  /**
+   * @brief Copy queued sequences for tests and owner inspection.
+   *
+   * @return Sealed sequences in admit order, then the open sequence if any.
+   */
+  [[nodiscard]] auto Peek() const -> EditorPendingInputView;
+
+  /// True when no sealed or open sequences remain.
+  [[nodiscard]] auto empty() const -> bool;
+
+ private:
+  auto AdmitFieldChangeLocked(EditorSessionIdentity identity, const EditorAdjustmentPatch& patch)
+      -> EditorPendingInputAdmitResult;
+  auto AdmitBoundaryLocked(EditorSessionIdentity identity, EditorPendingInputBoundaryKind kind)
+      -> EditorPendingInputAdmitResult;
+  auto StartSequenceLocked(EditorSessionIdentity identity, const EditorParameterTarget& target)
+      -> EditorPendingSequence&;
+  void SealOpenLocked(EditorPendingInputBoundaryKind kind);
+  [[nodiscard]] auto PeekLocked() const -> EditorPendingInputView;
+
+  mutable std::mutex                                 mutex_;
+  std::uint64_t                                      next_sequence_id_ = 1;
+  std::optional<EditorPendingSequence>               open_;
+  std::vector<EditorPendingSequence>                 sealed_;
+  std::unordered_map<std::string, std::size_t>       open_field_index_;
+};
+
+/**
+ * @brief Find the newest queued write for @p field_key.
+ *
+ * Searches from the last sequence so an open sequence wins over an earlier
+ * sealed one.
+ */
+[[nodiscard]] inline auto FindPendingField(const EditorPendingInputView& view,
+                                           std::string_view              field_key)
+    -> const EditorPendingFieldChange* {
+  for (auto sequence = view.sequences.rbegin(); sequence != view.sequences.rend(); ++sequence) {
+    for (const auto& field : sequence->fields) {
+      if (field.target.field_key == field_key) {
+        return &field;
+      }
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -14,6 +14,7 @@
 
 #include "app/adjustment_transfer_types.hpp"
 #include "app/editor_action_policy.hpp"
+#include "app/editor_pending_input.hpp"
 #include "app/editor_session_request_ids.hpp"
 #include "app/editor_render_intent.hpp"
 #include "app/editor_save_checkpoint_service.hpp"
@@ -219,6 +220,44 @@ class IEditorSessionBackend {
     result.message = "Adjustment commit not supported by this backend";
     return result;
   }
+  /**
+   * @brief Admit one typed field write into the pending-input queue.
+   *
+   * Acceptance means queued for later owner processing. It does not apply the
+   * write to the live document, capture history before-values, or commit.
+   * The queued payload is the caller's field write, not a copy of live
+   * operator/node/document parameters.
+   * Accepted writes are not appended to the session result log; inspect the
+   * pending-input queue instead. Default backends reject so fakes must opt in.
+   */
+  virtual auto EnqueueAdjustmentInput(EditorAdjustmentPatch /*patch*/) -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind    = EditorSessionResultKind::Rejected;
+    result.state   = state();
+    result.identity = identity();
+    result.message = "Queued adjustment input is not supported by this backend";
+    return result;
+  }
+  /**
+   * @brief Admit a Release, Cancel, or NodeSwitch seal on the open sequence.
+   *
+   * Does not apply or restore live parameters. Default backends reject.
+   */
+  virtual auto EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind /*kind*/)
+      -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Rejected;
+    result.state    = state();
+    result.identity = identity();
+    result.message  = "Queued adjustment input is not supported by this backend";
+    return result;
+  }
+  /**
+   * @brief Inspect queued change descriptions. Empty when the backend has none.
+   *
+   * The view is the pending-input queue itself, not a live parameter-body copy.
+   */
+  [[nodiscard]] virtual auto PeekPendingInput() const -> EditorPendingInputView { return {}; }
   /// Rename a Color Grade as a metadata-only history change. Default backends reject.
   virtual auto RenameColorGrade(const NodeId& /*node_id*/, std::string /*display_name*/)
       -> EditorSessionResult {
@@ -391,6 +430,10 @@ class EditorSessionService final : public IEditorSessionBackend {
   [[nodiscard]] auto has_unmaterialized_changes() -> bool override;
   auto               Patch(EditorAdjustmentPatch patch) -> EditorSessionResult override;
   auto               CommitAdjustment(EditorAdjustmentPatch patch) -> EditorSessionResult override;
+  auto EnqueueAdjustmentInput(EditorAdjustmentPatch patch) -> EditorSessionResult override;
+  auto EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind kind)
+      -> EditorSessionResult override;
+  [[nodiscard]] auto PeekPendingInput() const -> EditorPendingInputView override;
   auto RenameColorGrade(const NodeId& node_id, std::string display_name)
       -> EditorSessionResult override;
   auto EditNodeGraph(NodeGraphTopologyChange change) -> EditorSessionResult override;
@@ -498,6 +541,7 @@ class EditorSessionService final : public IEditorSessionBackend {
   EditorSessionRenderController           render_;
   EditorSessionEditController             edit_;
   EditorSessionNavigationController       navigation_;
+  EditorPendingInputQueue                 pending_input_;
   bool                                    reducing_command_     = false;
   std::uint64_t                           current_operation_id_ = 0;
   std::size_t                             publication_depth_    = 0;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_adjustment_models.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_adjustment_models.hpp
@@ -15,13 +15,12 @@ class QTimer;
 
 namespace alcedo::ui {
 
-/// Phase 6A typed adjustment models. Focused QObjects carrying value/range/enum/
-/// toggle state, defaults, validation, and pointer-drag state. The models submit
-/// one `EditorAdjustmentPatch` at a time through the
-/// `IEditorAdjustmentSubmitter` seam; they never touch the pipeline scheduler,
-/// the render coordinator, or the journal. One `settled=true` submit per
-/// completed pointer drag is required. Interactive previews while dragging use
-/// `settled=false` and are coalesced by the Phase 5D coordinator.
+/// Typed adjustment models. Focused QObjects carrying value/range/enum/
+/// toggle state, defaults, validation, and pointer-drag state. The models
+/// enqueue one field write at a time through the `IEditorAdjustmentSubmitter`
+/// seam; they never touch the pipeline scheduler, the render coordinator, or
+/// the journal. One `settled=true` enqueue per completed pointer drag seals
+/// that sequence. Interactive previews while dragging use `settled=false`.
 ///
 /// `fieldKey` is the stable history identifier; `label` is the display name the
 /// panel shows. The history layer derives the human-readable row label from
@@ -77,10 +76,11 @@ class EditorAdjustmentModelBase : public QObject {
   /// otherwise return `defaultJson`.
   [[nodiscard]] auto resolveParams(const QJSValue& arg, const QString& defaultJson) const
       -> QString;
-  /// Submit one patch through the seam. Defensive: no-op (returns false) when
-  /// there is no submitter or the session cannot accept patches (canEdit()
-  /// false). `settled=false` requests an interactive preview; `settled=true`
-  /// finalizes one committed transaction.
+  /// Enqueue one field write through the seam. Defensive: no-op (returns false)
+  /// when there is no submitter or the session cannot accept input
+  /// (`canEdit()` false). `settled=false` continues the sequence;
+  /// `settled=true` seals it with Release. True means accepted for processing,
+  /// not live-applied or history-committed.
   auto submitNow(const QString& paramsJson, bool settled) -> bool;
   [[nodiscard]] auto submitterHandle() const -> IEditorAdjustmentSubmitter* {
     return submitter_;
@@ -191,9 +191,9 @@ class EditorAdjustmentValueModel : public EditorAdjustmentModelBase {
   bool valid_ = true;
   QString errorMessage_;
   bool dragActive_ = false;
-  /// True when updateDrag changed the value during the current gesture. A
+  /// True when updateDrag changed the value during the current pointer drag. A
   /// press+release without movement (including half of a double-click) must not
-  /// emit a settled commit; double-click reset owns that path instead.
+  /// emit a settled seal; double-click reset owns that path instead.
   bool dragMoved_ = false;
 };
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_adjustment_submitter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_adjustment_submitter.hpp
@@ -8,23 +8,21 @@
 
 namespace alcedo::ui {
 
-/// Narrow QML-facing seam used by the Phase 6A typed adjustment models to
-/// submit one adjustment patch at a time. `EditorSessionController` implements
+/// Narrow QML-facing seam used by typed adjustment models to enqueue one
+/// adjustment field write at a time. `EditorSessionController` implements
 /// this; tests inject a fake. The models never touch the pipeline scheduler,
 /// the render coordinator, or the journal — they only call this seam, which
-/// forwards to `EditorSessionService::Patch` (interactive) or `CommitAdjustment`
-/// (settled). One `settled=true` call per completed pointer drag or stabilized
-/// keyboard/wheel input sequence is required.
+/// forwards to `IEditorSessionBackend::EnqueueAdjustmentInput`. True means the
+/// write was accepted for later owner processing, not that live parameters or
+/// history were updated. One `settled=true` call per completed pointer drag or
+/// stabilized keyboard/wheel input sequence seals that sequence with Release.
 class IEditorAdjustmentSubmitter {
  public:
   virtual ~IEditorAdjustmentSubmitter() = default;
 
-  /// Submit one adjustment patch. `settled=false` requests an interactive
-  /// preview; `settled=true` finalizes the value as one committed transaction
-  /// (full-quality render). Returns false when the session cannot accept
-  /// patches right now (no image, or not in the Interactive state). Callers
-  /// must check `canEdit()` first and must drop the call silently when this
-  /// returns false.
+  /// Enqueue one adjustment field write. `settled=false` continues the current
+  /// input sequence; `settled=true` also seals it with Release. Returns false
+  /// when the session cannot accept input (no image, or not Interactive).
   virtual auto submitPatch(QString fieldKey, QString paramsJson, bool settled) -> bool = 0;
 
   /// True when the session has an image and is in the Interactive state, i.e.

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -15,6 +15,7 @@
 
 #include "app/adjustment_transfer_types.hpp"
 #include "app/editor_history_types.hpp"
+#include "app/editor_pending_input.hpp"
 #include "app/editor_session_types.hpp"
 #include "edit/graph/graph_ids.hpp"
 #include "ui/alcedo_main/album_backend/editor_action_availability_model.hpp"
@@ -181,12 +182,14 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   [[nodiscard]] bool can_edit() const;
   [[nodiscard]] bool can_discard_current_commit() const;
 
-  // Phase 6A: IEditorAdjustmentSubmitter. The typed adjustment models call
-  // submitPatch to route one patch through the session service (interactive
-  // preview when settled=false, one committed transaction when settled=true).
-  // The same method is the QML-visible entry (Q_INVOKABLE) and the interface
-  // override; both forward to the same backend call.
+  // IEditorAdjustmentSubmitter. Typed adjustment models call submitPatch to
+  // enqueue one field write (and a Release seal when settled=true). True means
+  // the session accepted the write for later owner processing, not that live
+  // parameters or history were updated.
   Q_INVOKABLE bool   submitPatch(QString fieldKey, QString paramsJson, bool settled) override;
+  /// Queue a node-switch seal so later writes start a new sequence. Old
+  /// sequence ids keep their captured target. No live mutation.
+  Q_INVOKABLE bool   enqueueNodeSwitchBoundary();
   [[nodiscard]] auto canEdit() const -> bool override { return can_edit(); }
 
   Q_INVOKABLE void   Open(uint elementId = 0, uint imageId = 0);
@@ -329,8 +332,8 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   // Phase 6C-7: cached adjustment snapshot for QML panel loading.
   mutable QVariantMap             adjustment_snapshot_;
   /// When true, OnBackendChanged still refreshes the cached snapshot map but
-  /// does not emit AdjustmentSnapshotChanged. Used for interactive submitPatch
-  /// so pointer moves do not re-enter QML loadFromSnapshot on every tick.
+  /// does not emit AdjustmentSnapshotChanged. Kept so a later owner completion
+  /// can suppress panel reload while a pointer drag is still on the stack.
   bool                            suppress_snapshot_publish_ = false;
   // Phase 7A R2: last history revision observed from the backend. OnBackendChanged
   // emits HistoryChanged only when the backend's history_revision advances, so

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -1146,10 +1146,10 @@ bool EditorSessionController::submitPatch(QString fieldKey, QString paramsJson, 
   }
   // QQuickRhiItem::synchronize only runs after the item is marked dirty. Do
   // this on the GUI thread while handling the pointer move, before the worker
-  // can block waiting for a recyclable direct-present slot. Unsettled patches
+  // can block waiting for a recyclable direct-present slot. Unsettled writes
   // also arm a vsync-sampled consume so a Ready frame does not wait for the
-  // next pointer event or a missed requestUpdate. The worker's NotifyFrameReady
-  // update remains the completion-side wakeup when the loop is not armed.
+  // next pointer event or a missed requestUpdate. Enqueue does not apply live
+  // parameters; present wakeups stay presentation-only.
   if (viewport) {
     if (settled) {
       viewport->endInteractivePresentLoop();
@@ -1158,23 +1158,26 @@ bool EditorSessionController::submitPatch(QString fieldKey, QString paramsJson, 
     }
     viewport->prepareForAdjustmentFrame();
   }
-  alcedo::EditorAdjustmentPatch patch;
-  patch.field_key              = fieldKey.toStdString();
-  patch.params_json            = paramsJson.toStdString();
-  patch.settled                = settled;
-  // Typed models already own the live value during a pointer drag. Echoing the
-  // full adjustment snapshot into QML on every interactive patch forces
-  // loadFromSnapshot across Tone+Look while the mouse handler is still on the
-  // stack. Rapid handoff (finish slider A → drag slider B) multiplies that with
-  // history capture/commit under the pipeline render lock and freezes the GUI.
-  const bool previous_suppress = suppress_snapshot_publish_;
-  if (!settled) {
-    suppress_snapshot_publish_ = true;
+  if (session_backend_ == nullptr) {
+    return false;
   }
-  const auto result =
-      settled ? session_backend_->CommitAdjustment(patch) : session_backend_->Patch(patch);
-  suppress_snapshot_publish_ = previous_suppress;
-  return result.kind != alcedo::EditorSessionResultKind::Rejected;
+  alcedo::EditorAdjustmentPatch patch;
+  patch.field_key   = fieldKey.toStdString();
+  patch.params_json = paramsJson.toStdString();
+  patch.settled     = settled;
+  const auto result = session_backend_->EnqueueAdjustmentInput(std::move(patch));
+  return result.kind != alcedo::EditorSessionResultKind::Rejected &&
+         result.kind != alcedo::EditorSessionResultKind::Failed;
+}
+
+bool EditorSessionController::enqueueNodeSwitchBoundary() {
+  if (session_backend_ == nullptr || !can_edit()) {
+    return false;
+  }
+  const auto result = session_backend_->EnqueuePendingInputBoundary(
+      alcedo::EditorPendingInputBoundaryKind::NodeSwitch);
+  return result.kind != alcedo::EditorSessionResultKind::Rejected &&
+         result.kind != alcedo::EditorSessionResultKind::Failed;
 }
 
 void EditorSessionController::set_filmstrip_collapsed(bool collapsed) {

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -234,7 +234,7 @@ alcedo_register_test_target(EditHistoryMgmtServiceTest app ci_core)
 # EditorSessionCommandQueue is linked explicitly because the service's public
 # header exposes the queue types while linking the queue library privately.
 add_executable(EditorRenderCoordinatorTest ${ALCEDO_TEST_ROOT}/app/editor_render_coordinator_test.cpp)
-target_include_directories(EditorRenderCoordinatorTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_include_directories(EditorRenderCoordinatorTest PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR})
 target_link_libraries(EditorRenderCoordinatorTest
   EditorSessionService EditorSessionCommandQueue GTest::gtest_main)
 gtest_discover_tests(EditorRenderCoordinatorTest TEST_PREFIX "EditorRenderCoordinatorTest."

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -342,6 +342,25 @@ alcedo_register_test_target(EditorSessionEditControllerTest app ci_core)
 # EditorSessionService facade routing tests. Limited to
 # routing and externally visible result ordering; component behavior belongs in
 # the five module test targets above.
+add_executable(EditorPendingInputTest ${ALCEDO_TEST_ROOT}/app/editor_pending_input_test.cpp)
+target_include_directories(EditorPendingInputTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(EditorPendingInputTest PRIVATE EditorPendingInput GTest::gtest_main)
+gtest_discover_tests(EditorPendingInputTest TEST_PREFIX "EditorPendingInputTest."
+    PROPERTIES LABELS "ci_core_flow;editor_session")
+alcedo_register_test_target(EditorPendingInputTest app ci_core)
+
+add_executable(EditorPendingInputSessionTest
+    ${ALCEDO_TEST_ROOT}/app/editor_pending_input_session_test.cpp)
+target_include_directories(EditorPendingInputSessionTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR})
+target_link_libraries(EditorPendingInputSessionTest
+    PRIVATE EditorSessionService EditorSessionCommandQueue xxHash JSON
+            ${ALCEDO_TEST_OPENCV_MIN_DEPS} GTest::gtest_main)
+gtest_discover_tests(EditorPendingInputSessionTest
+    TEST_PREFIX "EditorPendingInputSessionTest."
+    PROPERTIES LABELS "ci_core_flow;editor_session")
+alcedo_register_test_target(EditorPendingInputSessionTest app ci_core)
+
 add_executable(EditorSessionServiceFacadeTest ${ALCEDO_TEST_ROOT}/app/editor_session_service_facade_test.cpp)
 target_include_directories(EditorSessionServiceFacadeTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(EditorSessionServiceFacadeTest

--- a/alcedo_studio/tests/app/editor_pending_input_session_test.cpp
+++ b/alcedo_studio/tests/app/editor_pending_input_session_test.cpp
@@ -1,0 +1,142 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_pending_input.hpp"
+#include "app/editor_render_coordinator.hpp"
+#include "app/editor_session_bootstrap.hpp"
+#include "app/editor_session_service.hpp"
+#include "support/editor_session_command_queue_test_support.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace alcedo {
+namespace {
+
+class RecordingScheduler final : public IEditorPipelineSchedulerPort {
+ public:
+  auto Schedule(const EditorRenderRequest&, EditorPipelineScheduleCompletion = {})
+      -> std::uint64_t override {
+    return ++next_job_;
+  }
+  void Cancel(std::uint64_t) override {}
+  void WaitForSessionIdle(std::uint64_t) override {}
+
+ private:
+  std::uint64_t next_job_ = 0;
+};
+
+class EditorPendingInputSessionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    history_          = std::make_shared<test::FakeEditorHistoryPort>();
+    pipeline_         = std::make_shared<test::FakeEditorPipelinePort>();
+    tasks_            = std::make_shared<test::FakeEditorTaskPort>();
+    journal_          = std::make_shared<test::FakeEditorJournalPort>();
+    scheduler_        = std::make_shared<RecordingScheduler>();
+    checkpoint_store_ = std::make_shared<test::FakeEditorCheckpointStore>();
+    runtime_          = EditorSessionRuntime::CreateWithPorts(
+        pipeline_, history_, tasks_, journal_, scheduler_, checkpoint_store_);
+    service_ = runtime_->service.get();
+    service_->SetPresentationSinkId(1);
+    service_->SetPresentationSize(640, 480);
+  }
+
+  void OpenInteractive() {
+    (void)service_->Open(10, 20);
+    service_->DrainCommandQueueForTests();
+    const auto rid = service_->first_frame_request_id();
+    if (rid != 0) {
+      runtime_->coordinator->NotifySchedulerCompleted(rid, true);
+      service_->DrainCommandQueueForTests();
+      const auto quality_rid = runtime_->coordinator->last_scheduled_request_id();
+      if (quality_rid != rid) {
+        runtime_->coordinator->NotifySchedulerCompleted(quality_rid, true);
+        service_->DrainCommandQueueForTests();
+      }
+    }
+    ASSERT_EQ(service_->state(), EditorSessionState::Interactive);
+  }
+
+  std::shared_ptr<test::FakeEditorHistoryPort>      history_;
+  std::shared_ptr<test::FakeEditorPipelinePort>     pipeline_;
+  std::shared_ptr<test::FakeEditorTaskPort>         tasks_;
+  std::shared_ptr<test::FakeEditorJournalPort>      journal_;
+  std::shared_ptr<RecordingScheduler>               scheduler_;
+  std::shared_ptr<test::FakeEditorCheckpointStore>  checkpoint_store_;
+  std::unique_ptr<EditorSessionRuntime>             runtime_;
+  EditorSessionService*                             service_ = nullptr;
+};
+
+TEST_F(EditorPendingInputSessionTest, EnqueueDoesNotCaptureHistoryOrApplyLivePatch) {
+  OpenInteractive();
+  const int captures_before = history_->capture_count;
+  const int commits_before  = history_->commit_count;
+
+  EditorAdjustmentPatch preview;
+  preview.field_key   = "exposure";
+  preview.params_json = R"({"value":0.25})";
+  preview.settled     = false;
+  const auto queued   = service_->EnqueueAdjustmentInput(preview);
+  EXPECT_EQ(queued.kind, EditorSessionResultKind::Accepted);
+
+  EditorAdjustmentPatch settled = preview;
+  settled.params_json           = R"({"value":0.40})";
+  settled.settled               = true;
+  const auto released           = service_->EnqueueAdjustmentInput(settled);
+  EXPECT_EQ(released.kind, EditorSessionResultKind::Accepted);
+
+  EXPECT_EQ(history_->capture_count, captures_before);
+  EXPECT_EQ(history_->commit_count, commits_before);
+  EXPECT_TRUE(history_->current_snapshot.params_json.empty());
+  EXPECT_TRUE(history_->current_snapshot.patches.empty());
+
+  const auto pending = service_->PeekPendingInput();
+  ASSERT_EQ(pending.sequences.size(), 1u);
+  EXPECT_EQ(pending.sequences.front().seal, EditorPendingInputBoundaryKind::Release);
+  const auto* exposure = FindPendingField(pending, "exposure");
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_EQ(exposure->params_json, R"({"value":0.40})");
+  EXPECT_EQ(exposure->identity.element_id, static_cast<sl_element_id_t>(10));
+  EXPECT_EQ(exposure->identity.image_id, static_cast<image_id_t>(20));
+}
+
+TEST_F(EditorPendingInputSessionTest, EnqueueRejectedWhenSessionIsNotInteractive) {
+  EditorAdjustmentPatch patch;
+  patch.field_key   = "exposure";
+  patch.params_json = R"({"value":0.25})";
+  const auto rejected = service_->EnqueueAdjustmentInput(patch);
+  EXPECT_EQ(rejected.kind, EditorSessionResultKind::Rejected);
+  EXPECT_TRUE(service_->PeekPendingInput().sequences.empty());
+}
+
+TEST_F(EditorPendingInputSessionTest, NodeSwitchBoundaryKeepsOriginalSequenceTarget) {
+  OpenInteractive();
+  const int captures_before = history_->capture_count;
+  EditorAdjustmentPatch first;
+  first.field_key   = "exposure";
+  first.params_json = R"({"value":0.1})";
+  first.target.owner_kind             = EditorParameterOwnerKind::ColorGrade;
+  first.target.node_id                = NodeId{"grade.a"};
+  first.target.adjustment_instance_id = AdjustmentInstanceId{"tone"};
+  first.target.field_key              = "exposure";
+  ASSERT_EQ(service_->EnqueueAdjustmentInput(first).kind, EditorSessionResultKind::Accepted);
+  ASSERT_EQ(service_->EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind::NodeSwitch).kind,
+            EditorSessionResultKind::Accepted);
+
+  EditorAdjustmentPatch second = first;
+  second.params_json           = R"({"value":0.2})";
+  second.target.node_id        = NodeId{"grade.b"};
+  ASSERT_EQ(service_->EnqueueAdjustmentInput(second).kind, EditorSessionResultKind::Accepted);
+
+  const auto pending = service_->PeekPendingInput();
+  ASSERT_EQ(pending.sequences.size(), 2u);
+  EXPECT_EQ(pending.sequences[0].captured_target.node_id, NodeId{"grade.a"});
+  EXPECT_EQ(pending.sequences[1].captured_target.node_id, NodeId{"grade.b"});
+  EXPECT_EQ(history_->capture_count, captures_before);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/editor_pending_input_test.cpp
+++ b/alcedo_studio/tests/app/editor_pending_input_test.cpp
@@ -1,0 +1,156 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_pending_input.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace alcedo {
+namespace {
+
+auto TestIdentity() -> EditorSessionIdentity {
+  EditorSessionIdentity identity;
+  identity.element_id = 7;
+  identity.image_id   = 70;
+  return identity;
+}
+
+auto GradeTarget(std::string node, std::string field) -> EditorParameterTarget {
+  EditorParameterTarget target;
+  target.owner_kind             = EditorParameterOwnerKind::ColorGrade;
+  target.node_id                = NodeId{std::move(node)};
+  target.adjustment_instance_id = AdjustmentInstanceId{"tone"};
+  target.field_key              = std::move(field);
+  return target;
+}
+
+auto MakePatch(std::string field, std::string json, bool settled = false) -> EditorAdjustmentPatch {
+  EditorAdjustmentPatch patch;
+  patch.field_key   = std::move(field);
+  patch.params_json = std::move(json);
+  patch.settled     = settled;
+  return patch;
+}
+
+TEST(EditorPendingInputTest, ReplacesAbsoluteSameFieldAndKeepsNewestWritePayload) {
+  EditorPendingInputQueue queue;
+  auto                    first = MakePatch("exposure", R"({"value":0.10})");
+  first.target                  = GradeTarget("grade.a", "exposure");
+  auto second                   = MakePatch("exposure", R"({"value":0.30})");
+  second.target                 = GradeTarget("grade.a", "exposure");
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), first).accepted);
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), second).accepted);
+
+  const auto view = queue.Peek();
+  ASSERT_EQ(view.sequences.size(), 1u);
+  EXPECT_EQ(view.sequences.front().fields.size(), 1u);
+  EXPECT_EQ(view.sequences.front().fields.front().params_json, R"({"value":0.30})");
+  EXPECT_EQ(view.sequences.front().captured_target.node_id, NodeId{"grade.a"});
+  EXPECT_TRUE(view.sequences.front().captured_target.field_key.empty());
+}
+
+TEST(EditorPendingInputTest, PendingDifferentFieldsSurviveInputCoalescing) {
+  EditorPendingInputQueue queue;
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), MakePatch("exposure", R"({"value":0.2})"))
+                  .accepted);
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), MakePatch("contrast", R"({"value":12})"))
+                  .accepted);
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), MakePatch("exposure", R"({"value":0.8})"))
+                  .accepted);
+
+  const auto view = queue.Peek();
+  ASSERT_EQ(view.sequences.size(), 1u);
+  EXPECT_EQ(view.sequences.front().fields.size(), 2u);
+  const auto* exposure = FindPendingField(view, "exposure");
+  const auto* contrast = FindPendingField(view, "contrast");
+  ASSERT_NE(exposure, nullptr);
+  ASSERT_NE(contrast, nullptr);
+  EXPECT_EQ(exposure->params_json, R"({"value":0.8})");
+  EXPECT_EQ(contrast->params_json, R"({"value":12})");
+}
+
+TEST(EditorPendingInputTest, ReleaseBeforeFirstPreviewKeepsFinalQueuedValuesOnce) {
+  EditorPendingInputQueue queue;
+  auto                    patch = MakePatch("exposure", R"({"value":1.25})", true);
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), patch).accepted);
+
+  const auto view = queue.Peek();
+  ASSERT_EQ(view.sequences.size(), 1u);
+  EXPECT_EQ(view.sequences.front().seal, EditorPendingInputBoundaryKind::Release);
+  EXPECT_EQ(view.sequences.front().fields.size(), 1u);
+  EXPECT_EQ(view.sequences.front().fields.front().params_json, R"({"value":1.25})");
+}
+
+TEST(EditorPendingInputTest, NodeSwitchKeepsQueuedEditOnOriginalTarget) {
+  EditorPendingInputQueue queue;
+  auto                    first = MakePatch("exposure", R"({"value":0.4})");
+  first.target                  = GradeTarget("grade.a", "exposure");
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), first).accepted);
+  ASSERT_TRUE(
+      queue.AdmitBoundary(TestIdentity(), EditorPendingInputBoundaryKind::NodeSwitch).accepted);
+
+  auto second      = MakePatch("exposure", R"({"value":0.9})");
+  second.target    = GradeTarget("grade.b", "exposure");
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), second).accepted);
+
+  const auto view = queue.Peek();
+  ASSERT_EQ(view.sequences.size(), 2u);
+  EXPECT_EQ(view.sequences[0].seal, EditorPendingInputBoundaryKind::NodeSwitch);
+  EXPECT_EQ(view.sequences[0].captured_target.node_id, NodeId{"grade.a"});
+  EXPECT_EQ(view.sequences[0].fields.front().target.node_id, NodeId{"grade.a"});
+  EXPECT_EQ(view.sequences[0].fields.front().params_json, R"({"value":0.4})");
+  EXPECT_EQ(view.sequences[1].captured_target.node_id, NodeId{"grade.b"});
+  EXPECT_EQ(view.sequences[1].fields.front().params_json, R"({"value":0.9})");
+}
+
+TEST(EditorPendingInputTest, RejectsRetargetingADifferentNodeInTheSameSequence) {
+  EditorPendingInputQueue queue;
+  auto                    first = MakePatch("exposure", R"({"value":0.1})");
+  first.target                  = GradeTarget("grade.a", "exposure");
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), first).accepted);
+  auto second   = MakePatch("exposure", R"({"value":0.2})");
+  second.target = GradeTarget("grade.b", "exposure");
+  const auto rejected = queue.AdmitFieldChange(TestIdentity(), second);
+  EXPECT_FALSE(rejected.accepted);
+  EXPECT_NE(rejected.error.find("retarget"), std::string::npos);
+  const auto view = queue.Peek();
+  ASSERT_EQ(view.sequences.size(), 1u);
+  EXPECT_EQ(view.sequences.front().fields.front().params_json, R"({"value":0.1})");
+}
+
+TEST(EditorPendingInputTest, CancelDiscardsUnappliedFieldsAndKeepsBoundary) {
+  EditorPendingInputQueue queue;
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), MakePatch("exposure", R"({"value":0.5})"))
+                  .accepted);
+  ASSERT_TRUE(queue.AdmitBoundary(TestIdentity(), EditorPendingInputBoundaryKind::Cancel).accepted);
+  const auto view = queue.Peek();
+  ASSERT_EQ(view.sequences.size(), 1u);
+  EXPECT_EQ(view.sequences.front().seal, EditorPendingInputBoundaryKind::Cancel);
+  EXPECT_TRUE(view.sequences.front().fields.empty());
+}
+
+TEST(EditorPendingInputTest, QueuedItemCarriesOnlyChangedFieldPayload) {
+  EditorPendingInputQueue queue;
+  auto                    patch = MakePatch("exposure", R"({"exposure_ev":0.5})");
+  patch.target                  = GradeTarget("grade.primary", "exposure");
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), patch).accepted);
+  const auto view = queue.Peek();
+  ASSERT_EQ(view.sequences.front().fields.size(), 1u);
+  EXPECT_EQ(view.sequences.front().fields.front().params_json, R"({"exposure_ev":0.5})");
+  EXPECT_EQ(view.sequences.front().fields.front().params_json.find("contrast"), std::string::npos);
+  EXPECT_EQ(view.sequences.front().fields.front().params_json.find("lut"), std::string::npos);
+  EXPECT_TRUE(view.sequences.front().captured_target.field_key.empty());
+}
+
+TEST(EditorPendingInputTest, RejectsEmptyFieldKeyAndMissingIdentity) {
+  EditorPendingInputQueue queue;
+  EXPECT_FALSE(queue.AdmitFieldChange(TestIdentity(), MakePatch("", "{}")).accepted);
+  EditorSessionIdentity missing;
+  EXPECT_FALSE(queue.AdmitFieldChange(missing, MakePatch("exposure", "{}")).accepted);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
+++ b/alcedo_studio/tests/app/editor_render_coordinator_test.cpp
@@ -4,6 +4,9 @@
 
 #include "app/editor_render_coordinator.hpp"
 
+#include "support/latch_blocked_pipeline_scheduler_port.hpp"
+#include "support/manual_monotonic_clock.hpp"
+
 #include <gtest/gtest.h>
 
 #include <atomic>
@@ -817,6 +820,38 @@ TEST_F(EditorRenderCoordinatorTest, DiagnosticsTrackRejectReplaceCancelAndReadyF
     EXPECT_EQ(diag.pending_count, 0u);
     EXPECT_GE(diag.cancelled_count, 1u);
   }
+}
+
+TEST_F(EditorRenderCoordinatorTest,
+       BlockedRendererKeepsOneInflightUntilCompletionLatchReleases) {
+  auto latch = std::make_shared<test::LatchBlockedPipelineSchedulerPort>();
+  coordinator_->SetPipelineSchedulerPort(latch);
+  test::ManualMonotonicClock clock;
+
+  const auto first = coordinator_->Submit(
+      MakeIntent(EditorRenderQuality::Interactive, EditorRenderPriority::Normal));
+  EXPECT_EQ(first.kind, EditorRenderResultKind::RequestAccepted);
+  EXPECT_TRUE(coordinator_->has_inflight());
+  EXPECT_TRUE(latch->running());
+  EXPECT_EQ(latch->scheduled().size(), 1u);
+
+  const auto second = coordinator_->Submit(
+      MakeIntent(EditorRenderQuality::Interactive, EditorRenderPriority::High));
+  EXPECT_EQ(second.kind, EditorRenderResultKind::RequestAccepted);
+  EXPECT_EQ(coordinator_->pending_count(), 1u);
+  EXPECT_EQ(latch->scheduled().size(), 1u);
+  EXPECT_EQ(latch->rejected_while_running(), 0);
+
+  clock.advance_ns(16'000'000);
+  EXPECT_TRUE(latch->running());
+  EXPECT_EQ(latch->scheduled().size(), 1u);
+
+  latch->Complete(true, "first");
+  EXPECT_EQ(latch->scheduled().size(), 2u);
+  EXPECT_TRUE(latch->running());
+  latch->Complete(true, "second");
+  EXPECT_FALSE(coordinator_->has_inflight());
+  EXPECT_EQ(coordinator_->pending_count(), 0u);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/app/editor_session_command_queue_baseline_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_command_queue_baseline_test.cpp
@@ -33,6 +33,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -52,9 +53,21 @@ auto MakeExposureTransferPackage(double /*exposure*/) -> AdjustmentTransferPacka
   return package;
 }
 
-/// Recording scheduler: accepts every render request and returns a non-zero
-/// job id so the coordinator marks it in-flight. Completion is driven manually
-/// by the test through `EditorRenderCoordinator::Notify*`.
+class LockingEditorHistoryPort final : public ControllableEditorHistoryPort {
+ public:
+  std::promise<void> about_to_lock;
+
+  auto CaptureAdjustmentBeforePreview(const EditorHistoryGuardHandle& guard,
+                                      const EditorAdjustmentPatch& patch, std::string* error)
+      -> bool override {
+    about_to_lock.set_value();
+    std::unique_lock<std::mutex> held;
+    if (render_lock != nullptr) {
+      held = std::unique_lock<std::mutex>(*render_lock);
+    }
+    return FakeEditorHistoryPort::CaptureAdjustmentBeforePreview(guard, patch, error);
+  }
+};
 class RecordingScheduler final : public IEditorPipelineSchedulerPort {
  public:
   auto Schedule(const EditorRenderRequest& request,
@@ -79,8 +92,9 @@ class EditorSessionCommandQueueBaselineTest : public ::testing::Test {
 
   /// Rebuild the full session runtime with fresh ports and recorder. Tests
   /// that compare two runs of the same scenario call this between runs.
-  void RebuildSession() {
-    history_          = std::make_shared<ControllableEditorHistoryPort>();
+  void RebuildSession(std::shared_ptr<ControllableEditorHistoryPort> history = nullptr) {
+    history_          = history ? std::move(history)
+                                : std::make_shared<ControllableEditorHistoryPort>();
     pipeline_         = std::make_shared<FakeEditorPipelinePort>();
     tasks_            = std::make_shared<FakeEditorTaskPort>();
     journal_          = std::make_shared<OrderRecordingJournalPort>();
@@ -564,6 +578,59 @@ TEST_F(EditorSessionCommandQueueBaselineTest,
   const auto late = service_->Open(50, 60);
   EXPECT_EQ(late.kind, EditorSessionResultKind::Rejected);
   EXPECT_EQ(service_->state(), EditorSessionState::ShuttingDown);
+}
+
+TEST_F(EditorSessionCommandQueueBaselineTest,
+       OwnerThreadPatchCapturesHistoryAndRoutesRenderBeforeReturn) {
+  openInteractive(10, 20);
+  const auto captures_before = history_->capture_count;
+  const auto scheduled_before = scheduler_->scheduled_.size();
+
+  EditorAdjustmentPatch patch;
+  patch.field_key   = "exposure";
+  patch.params_json = R"({"exposure":0.5})";
+  patch.settled     = false;
+  const auto result = service_->Patch(patch);
+
+  EXPECT_EQ(result.kind, EditorSessionResultKind::RenderRouted);
+  EXPECT_EQ(history_->capture_count, captures_before + 1);
+  EXPECT_EQ(history_->last_captured_patch.field_key, "exposure");
+  EXPECT_GT(scheduler_->scheduled_.size(), scheduled_before);
+  EXPECT_TRUE(runtime_->coordinator->has_inflight());
+}
+
+TEST_F(EditorSessionCommandQueueBaselineTest,
+       PatchWaitsWhenHistoryCaptureHoldsRenderLock) {
+  auto locking = std::make_shared<LockingEditorHistoryPort>();
+  RebuildSession(locking);
+  openInteractive(10, 20);
+
+  std::mutex           render_lock;
+  locking->render_lock = &render_lock;
+  std::promise<void>   renderer_holds;
+  std::promise<void>   release_renderer;
+  std::thread          renderer([&] {
+    std::unique_lock<std::mutex> held(render_lock);
+    renderer_holds.set_value();
+    release_renderer.get_future().wait();
+  });
+  renderer_holds.get_future().wait();
+
+  std::thread releaser([&] {
+    locking->about_to_lock.get_future().wait();
+    EXPECT_EQ(locking->capture_count, 0);
+    release_renderer.set_value();
+  });
+
+  EditorAdjustmentPatch patch;
+  patch.field_key   = "exposure";
+  patch.params_json = R"({"exposure":0.25})";
+  const auto result = service_->Patch(patch);
+  releaser.join();
+  renderer.join();
+
+  EXPECT_EQ(result.kind, EditorSessionResultKind::RenderRouted);
+  EXPECT_EQ(locking->capture_count, 1);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -338,9 +338,11 @@ add_executable(GpuDagRawInputTest
   ${ALCEDO_TEST_ROOT}/edit/runtime/graph_compiler_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/renderer_metal_instantiate_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/result_content_key_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/runtime/cached_versus_fresh_pixel_fixture_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/branch_join_plan_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/static_execution_plan_cache_test.cpp)
-target_include_directories(GpuDagRawInputTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_include_directories(GpuDagRawInputTest PUBLIC ${ALCEDO_INCLUDE_DIR}
+  PRIVATE ${ALCEDO_TEST_ROOT}/edit/runtime ${ALCEDO_TEST_ROOT}/edit)
 target_link_libraries(GpuDagRawInputTest PRIVATE GTest::gtest_main EditInput EditRuntime)
 if(ALCEDO_METAL_ENABLED)
   target_link_libraries(GpuDagRawInputTest PRIVATE EditRuntimeMetal)

--- a/alcedo_studio/tests/edit/runtime/cached_versus_fresh_pixel_fixture.hpp
+++ b/alcedo_studio/tests/edit/runtime/cached_versus_fresh_pixel_fixture.hpp
@@ -1,0 +1,109 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+/// Deterministic ACEScc RGB fixture for later cached-versus-fresh Grade/LLF
+/// pixel checks. Independent expected values use the same exposure formula as
+/// production Grade tests (`ApplyExposureAcescc`). A cache hit must match both a
+/// fresh execution of the same edit and this independent expected buffer.
+///
+/// Comparison rule (fixed before later execution, not tuned to a failing run):
+/// - working space: ACEScc samples stored as linear-ish float RGB in [0, 1]
+///   ramps (same layout as `gpu_dag_test::MakeF32RgbaPlane`);
+/// - metric: maximum absolute error on R, G, and B; alpha is ignored;
+/// - absolute tolerance: 1.0e-5f (matches existing Grade `EXPECT_NEAR` uses of
+///   `ApplyExposureAcescc`);
+/// - relative tolerance: unused; absolute error is the pass rule;
+/// - non-finite handling: any NaN/Inf in either buffer fails the comparison.
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "multi_grade_runtime_test_support.hpp"
+
+namespace alcedo::cached_result_pixel {
+
+struct RgbaF32 {
+  float r = 0.0f;
+  float g = 0.0f;
+  float b = 0.0f;
+  float a = 1.0f;
+};
+
+struct PixelCompareRule {
+  static constexpr float kMaxAbsTolerance = 1.0e-5f;
+};
+
+struct PixelCompareResult {
+  bool  passed              = false;
+  float max_abs_error       = 0.0f;
+  bool  saw_non_finite      = false;
+  bool  size_mismatch       = false;
+};
+
+inline constexpr std::uint32_t kFixtureWidth  = 16;
+inline constexpr std::uint32_t kFixtureHeight = 12;
+
+/// Same sample formula as `gpu_dag_test::MakeF32RgbaPlane` so later GPU paths
+/// can reuse that packed plane without a second identity.
+inline auto SampleAt(std::uint32_t x, std::uint32_t y, std::uint32_t width, std::uint32_t height)
+    -> RgbaF32 {
+  return RgbaF32{(static_cast<float>(x) + 0.5f) / static_cast<float>(width),
+                 (static_cast<float>(y) + 0.5f) / static_cast<float>(height), 0.25f, 1.0f};
+}
+
+inline auto MakeDeterministicRgbRamp(std::uint32_t width = kFixtureWidth,
+                                     std::uint32_t height = kFixtureHeight) -> std::vector<RgbaF32> {
+  std::vector<RgbaF32> pixels(static_cast<std::size_t>(width) * height);
+  for (std::uint32_t y = 0; y < height; ++y) {
+    for (std::uint32_t x = 0; x < width; ++x) {
+      pixels[static_cast<std::size_t>(y) * width + x] = SampleAt(x, y, width, height);
+    }
+  }
+  return pixels;
+}
+
+inline auto ApplyIndependentExposure(const std::vector<RgbaF32>& input, float exposure_ev)
+    -> std::vector<RgbaF32> {
+  std::vector<RgbaF32> output = input;
+  for (auto& pixel : output) {
+    pixel.r = multi_grade_test::ApplyExposureAcescc(pixel.r, exposure_ev);
+    pixel.g = multi_grade_test::ApplyExposureAcescc(pixel.g, exposure_ev);
+    pixel.b = multi_grade_test::ApplyExposureAcescc(pixel.b, exposure_ev);
+  }
+  return output;
+}
+
+inline auto CompareRgba(const std::vector<RgbaF32>& left, const std::vector<RgbaF32>& right,
+                        float tolerance = PixelCompareRule::kMaxAbsTolerance) -> PixelCompareResult {
+  PixelCompareResult result;
+  if (left.size() != right.size()) {
+    result.size_mismatch = true;
+    result.max_abs_error = std::numeric_limits<float>::infinity();
+    return result;
+  }
+  float max_abs = 0.0f;
+  for (std::size_t i = 0; i < left.size(); ++i) {
+    const float samples[6] = {left[i].r,  left[i].g,  left[i].b,
+                              right[i].r, right[i].g, right[i].b};
+    for (float sample : samples) {
+      if (!std::isfinite(sample)) {
+        result.saw_non_finite = true;
+        result.max_abs_error  = std::numeric_limits<float>::infinity();
+        return result;
+      }
+    }
+    max_abs = std::max(max_abs, std::abs(left[i].r - right[i].r));
+    max_abs = std::max(max_abs, std::abs(left[i].g - right[i].g));
+    max_abs = std::max(max_abs, std::abs(left[i].b - right[i].b));
+  }
+  result.max_abs_error = max_abs;
+  result.passed        = max_abs <= tolerance;
+  return result;
+}
+
+}  // namespace alcedo::cached_result_pixel

--- a/alcedo_studio/tests/edit/runtime/cached_versus_fresh_pixel_fixture_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cached_versus_fresh_pixel_fixture_test.cpp
@@ -1,0 +1,61 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "cached_versus_fresh_pixel_fixture.hpp"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "../input/prepared_raw_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+TEST(CachedVersusFreshPixelFixture,
+     IndependentExposureMatchesAcesccFormulaOnDeterministicRamp) {
+  const auto input    = cached_result_pixel::MakeDeterministicRgbRamp();
+  const auto expected = cached_result_pixel::ApplyIndependentExposure(input, 1.0f);
+  ASSERT_EQ(expected.size(), static_cast<std::size_t>(cached_result_pixel::kFixtureWidth) *
+                                 cached_result_pixel::kFixtureHeight);
+  const auto& first = input.front();
+  EXPECT_NEAR(expected.front().r, multi_grade_test::ApplyExposureAcescc(first.r, 1.0f),
+              cached_result_pixel::PixelCompareRule::kMaxAbsTolerance);
+  EXPECT_NEAR(expected.front().g, multi_grade_test::ApplyExposureAcescc(first.g, 1.0f),
+              cached_result_pixel::PixelCompareRule::kMaxAbsTolerance);
+  EXPECT_NEAR(expected.front().b, multi_grade_test::ApplyExposureAcescc(first.b, 1.0f),
+              cached_result_pixel::PixelCompareRule::kMaxAbsTolerance);
+  EXPECT_FLOAT_EQ(expected.front().a, 1.0f);
+}
+
+TEST(CachedVersusFreshPixelFixture,
+     RepeatedIndependentExposureAgreesWithItselfAndWithPackedPlaneLayout) {
+  const auto packed = gpu_dag_test::MakeF32RgbaPlane(cached_result_pixel::kFixtureWidth,
+                                                     cached_result_pixel::kFixtureHeight);
+  const auto* packed_px = reinterpret_cast<const float*>(packed.bytes.get());
+  const auto ramp       = cached_result_pixel::MakeDeterministicRgbRamp();
+  ASSERT_EQ(ramp.size() * 4U, packed.extent.width * packed.extent.height * 4U);
+  EXPECT_FLOAT_EQ(ramp.front().r, packed_px[0]);
+  EXPECT_FLOAT_EQ(ramp.front().g, packed_px[1]);
+  EXPECT_FLOAT_EQ(ramp.front().b, packed_px[2]);
+
+  const auto first  = cached_result_pixel::ApplyIndependentExposure(ramp, -0.5f);
+  const auto second = cached_result_pixel::ApplyIndependentExposure(ramp, -0.5f);
+  const auto same   = cached_result_pixel::CompareRgba(first, second);
+  EXPECT_FALSE(same.size_mismatch);
+  EXPECT_FALSE(same.saw_non_finite);
+  EXPECT_TRUE(same.passed) << "max_abs_error=" << same.max_abs_error;
+}
+
+TEST(CachedVersusFreshPixelFixture, NonFiniteSampleFailsComparisonWithoutTuningTolerance) {
+  auto left  = cached_result_pixel::MakeDeterministicRgbRamp(2, 1);
+  auto right = left;
+  right[0].r = std::numeric_limits<float>::quiet_NaN();
+  const auto result = cached_result_pixel::CompareRgba(left, right);
+  EXPECT_TRUE(result.saw_non_finite);
+  EXPECT_FALSE(result.passed);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/support/latch_blocked_pipeline_scheduler_port.hpp
+++ b/alcedo_studio/tests/support/latch_blocked_pipeline_scheduler_port.hpp
@@ -1,0 +1,96 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+/// Test-only scheduler that accepts one job and withholds completion until the
+/// test calls Complete(). Ordering is latch-driven; tests must not sleep to
+/// prove that a frame is still in flight.
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "app/editor_render_coordinator.hpp"
+
+namespace alcedo::test {
+
+class LatchBlockedPipelineSchedulerPort final : public IEditorPipelineSchedulerPort {
+ public:
+  auto Schedule(const EditorRenderRequest& request,
+                EditorPipelineScheduleCompletion on_complete = {}) -> std::uint64_t override {
+    std::scoped_lock lock(mutex_);
+    if (running_) {
+      ++rejected_while_running_;
+      return 0;
+    }
+    running_      = true;
+    job_id_       = ++next_job_id_;
+    request_      = request;
+    on_complete_  = std::move(on_complete);
+    scheduled_.push_back(request);
+    return job_id_;
+  }
+
+  void Cancel(std::uint64_t job_id) override {
+    std::scoped_lock lock(mutex_);
+    cancelled_.push_back(job_id);
+  }
+
+  void WaitForSessionIdle(std::uint64_t session_epoch) override {
+    std::scoped_lock lock(mutex_);
+    waited_sessions_.push_back(session_epoch);
+  }
+
+  /// Invoke the stored completion on the calling thread. Safe to call once the
+  /// test has asserted in-flight state; does nothing when no job is running.
+  void Complete(bool success = true, std::string message = {}) {
+    EditorPipelineScheduleCompletion on_complete;
+    {
+      std::scoped_lock lock(mutex_);
+      if (!running_) {
+        return;
+      }
+      running_     = false;
+      on_complete  = std::move(on_complete_);
+      on_complete_ = {};
+    }
+    if (on_complete) {
+      on_complete(success, std::move(message));
+    }
+  }
+
+  [[nodiscard]] auto running() const -> bool {
+    std::scoped_lock lock(mutex_);
+    return running_;
+  }
+  [[nodiscard]] auto scheduled() const -> std::vector<EditorRenderRequest> {
+    std::scoped_lock lock(mutex_);
+    return scheduled_;
+  }
+  [[nodiscard]] auto rejected_while_running() const -> int {
+    std::scoped_lock lock(mutex_);
+    return rejected_while_running_;
+  }
+  [[nodiscard]] auto last_job_id() const -> std::uint64_t {
+    std::scoped_lock lock(mutex_);
+    return job_id_;
+  }
+
+  std::vector<std::uint64_t> cancelled_;
+  std::vector<std::uint64_t> waited_sessions_;
+
+ private:
+  mutable std::mutex                   mutex_;
+  bool                                 running_                = false;
+  std::uint64_t                        next_job_id_            = 0;
+  std::uint64_t                        job_id_                 = 0;
+  int                                  rejected_while_running_ = 0;
+  EditorRenderRequest                  request_{};
+  EditorPipelineScheduleCompletion     on_complete_;
+  std::vector<EditorRenderRequest>     scheduled_;
+};
+
+}  // namespace alcedo::test

--- a/alcedo_studio/tests/support/manual_monotonic_clock.hpp
+++ b/alcedo_studio/tests/support/manual_monotonic_clock.hpp
@@ -1,0 +1,33 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+/// Test-only monotonic clock. Tests stamp enqueue / apply / completion events
+/// and advance time explicitly. Wall-clock sleeps are not used as ordering proof.
+
+#include <atomic>
+#include <cstdint>
+
+namespace alcedo::test {
+
+class ManualMonotonicClock {
+ public:
+  using nanoseconds = std::int64_t;
+
+  [[nodiscard]] auto now_ns() const -> nanoseconds {
+    return now_ns_.load(std::memory_order_acquire);
+  }
+
+  void advance_ns(nanoseconds delta) {
+    now_ns_.fetch_add(delta, std::memory_order_acq_rel);
+  }
+
+  void set_ns(nanoseconds value) { now_ns_.store(value, std::memory_order_release); }
+
+ private:
+  std::atomic<nanoseconds> now_ns_{0};
+};
+
+}  // namespace alcedo::test

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -595,6 +595,39 @@ target_link_libraries(EditorAdjustmentModelTest
 alcedo_ui_gtest_discover_tests(EditorAdjustmentModelTest TEST_PREFIX "EditorAdjustmentModelTest.")
 alcedo_register_test_target(EditorAdjustmentModelTest ui)
 
+# Slider-to-history-to-coordinator ownership boundaries. Uses a latch-blocked
+# renderer and the live Mini-Git history port; no GPU.
+add_executable(EditorSerialInputBoundaryTest
+    ${ALCEDO_TEST_ROOT}/ui/editor_serial_input_boundary_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/ui_test_main.cpp
+)
+target_include_directories(EditorSerialInputBoundaryTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR}
+)
+target_link_libraries(EditorSerialInputBoundaryTest
+  PRIVATE
+    AlbumBackendLib
+    EditorSessionService
+    Operators
+    EditPipeline
+    EditHistory
+    EditorAdjustmentPipeline
+    EditorPipelineCommandService
+    GTest::gtest
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Qml
+    Qt6::Quick
+    Qt6::Test
+    Qt6::Widgets
+)
+alcedo_ui_gtest_discover_tests(EditorSerialInputBoundaryTest
+    TEST_PREFIX "EditorSerialInputBoundaryTest."
+    PROPERTIES LABELS "editor_session"
+)
+alcedo_register_test_target(EditorSerialInputBoundaryTest ui)
+
 # Phase 6A: shared QML adjustment controls. Loads the controls from source via
 # an inline harness; a RecordingSubmitter stands in for editorSession.
 add_executable(EditorAdjustmentControlQmlTest

--- a/alcedo_studio/tests/ui/editor_adjustment_model_test.cpp
+++ b/alcedo_studio/tests/ui/editor_adjustment_model_test.cpp
@@ -151,6 +151,21 @@ TEST(EditorAdjustmentModelTest, PointerDragSubmitsInteractivePerUpdateAndOneSett
   EXPECT_DOUBLE_EQ(RecordingSubmitter::numericValue(sub.lastSettledParams()), 0.3);
 }
 
+// Control value and submitted live patch are the same object-state at return:
+// updateDrag writes value_ then calls submitPatch before returning. There is no
+// queued-but-unapplied live value on this path.
+TEST(EditorAdjustmentModelTest, PointerDragWritesControlValueAndSubmitsLivePatchBeforeReturn) {
+  RecordingSubmitter sub;
+  auto               m = makeValueModel(sub);
+  m->beginDrag();
+  m->updateDrag(0.4);
+  ASSERT_EQ(sub.calls.size(), 1u);
+  EXPECT_FALSE(sub.calls.front().settled);
+  EXPECT_DOUBLE_EQ(m->value(), 0.4);
+  EXPECT_DOUBLE_EQ(RecordingSubmitter::numericValue(sub.calls.front().params), m->value());
+  m->finishDrag();
+}
+
 // 2. A wheel/keyboard burst submits one interactive patch per value and one
 // settled patch after the debounce stabilizes.
 TEST(EditorAdjustmentModelTest, WheelBurstSubmitsInteractivePerValueAndOneSettledAfterDebounce) {

--- a/alcedo_studio/tests/ui/editor_adjustment_model_test.cpp
+++ b/alcedo_studio/tests/ui/editor_adjustment_model_test.cpp
@@ -151,10 +151,10 @@ TEST(EditorAdjustmentModelTest, PointerDragSubmitsInteractivePerUpdateAndOneSett
   EXPECT_DOUBLE_EQ(RecordingSubmitter::numericValue(sub.lastSettledParams()), 0.3);
 }
 
-// Control value and submitted live patch are the same object-state at return:
-// updateDrag writes value_ then calls submitPatch before returning. There is no
-// queued-but-unapplied live value on this path.
-TEST(EditorAdjustmentModelTest, PointerDragWritesControlValueAndSubmitsLivePatchBeforeReturn) {
+// Control value is written and submitPatch is called before updateDrag returns.
+// The submitter records the enqueue; live document mutation is a later owner
+// consume step and is not part of this model seam.
+TEST(EditorAdjustmentModelTest, PointerDragWritesControlValueAndEnqueuesPatchBeforeReturn) {
   RecordingSubmitter sub;
   auto               m = makeValueModel(sub);
   m->beginDrag();

--- a/alcedo_studio/tests/ui/editor_multi_slider_quicktest.cpp
+++ b/alcedo_studio/tests/ui/editor_multi_slider_quicktest.cpp
@@ -79,9 +79,8 @@ auto MakeGuard(sl_element_id_t element_id) -> std::shared_ptr<alcedo::PipelineGu
 }
 
 /// Production-shaped session backend: real Mini-Git history + pipeline guard.
-/// Patch/Commit call history Capture/Commit (GUI-thread, same as service).
-/// After each patch, a render worker holds GetRenderLock and may BlockingQueued
-/// to the GUI — the cross-thread shape of Apply + present.
+/// submitPatch enqueues typed input without taking the render lock. Patch/Commit
+/// remain available for owner consume tests that call them directly.
 class ProductionSessionBackend final : public alcedo::IEditorSessionBackend {
  public:
   explicit ProductionSessionBackend(QObject* gui_anchor) : gui_anchor_(gui_anchor) {
@@ -172,6 +171,47 @@ class ProductionSessionBackend final : public alcedo::IEditorSessionBackend {
   auto CommitAdjustment(alcedo::EditorAdjustmentPatch patch)
       -> alcedo::EditorSessionResult override {
     return ApplyPatch(std::move(patch), /*settled=*/true);
+  }
+
+  auto EnqueueAdjustmentInput(alcedo::EditorAdjustmentPatch patch)
+      -> alcedo::EditorSessionResult override {
+    const auto admitted = pending_input_.AdmitFieldChange(identity_, patch);
+    alcedo::EditorSessionResult result;
+    result.state    = state_;
+    result.identity = identity_;
+    if (!admitted.accepted) {
+      result.kind    = alcedo::EditorSessionResultKind::Rejected;
+      result.message = admitted.error;
+      return result;
+    }
+    if (patch.settled) {
+      ++commit_count_;
+    } else {
+      ++patch_count_;
+    }
+    result.kind    = alcedo::EditorSessionResultKind::Accepted;
+    result.message = "Adjustment input queued";
+    return result;
+  }
+
+  auto EnqueuePendingInputBoundary(alcedo::EditorPendingInputBoundaryKind kind)
+      -> alcedo::EditorSessionResult override {
+    const auto admitted = pending_input_.AdmitBoundary(identity_, kind);
+    alcedo::EditorSessionResult result;
+    result.state    = state_;
+    result.identity = identity_;
+    if (!admitted.accepted) {
+      result.kind    = alcedo::EditorSessionResultKind::Rejected;
+      result.message = admitted.error;
+      return result;
+    }
+    result.kind    = alcedo::EditorSessionResultKind::Accepted;
+    result.message = "Adjustment input boundary queued";
+    return result;
+  }
+
+  [[nodiscard]] auto PeekPendingInput() const -> alcedo::EditorPendingInputView override {
+    return pending_input_.Peek();
   }
 
   // --- stats for QML ---
@@ -350,6 +390,7 @@ class ProductionSessionBackend final : public alcedo::IEditorSessionBackend {
   alcedo::EditorSessionIdentity              identity_{};
   alcedo::ImageLoadRequestId                 image_load_request_{};
   std::string                                last_error_;
+  alcedo::EditorPendingInputQueue            pending_input_;
 
   int                                        patch_count_        = 0;
   int                                        commit_count_       = 0;

--- a/alcedo_studio/tests/ui/editor_real_raw_gpu_e2e_test.cpp
+++ b/alcedo_studio/tests/ui/editor_real_raw_gpu_e2e_test.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include "app/editor_pending_input.hpp"
 #include "app/editor_render_intent.hpp"
 #include "edit/pipeline/pipeline_accelerator.hpp"
 #include "ui/album_backend_test_fixture.hpp"
@@ -389,10 +390,12 @@ TEST_F(EditorRealRawGpuE2eTest, RealRawGpuFramesRemainReadyAcrossSustainedImageS
       EXPECT_EQ(viewport->adjustmentFrameRequestCount(), wakeups_before_drag + 3);
       EXPECT_TRUE(viewport->interactivePresentLoopActive())
           << "unsettled adjustment must arm vsync-sampled consume";
-      ASSERT_TRUE(WaitUntil([&] { return viewport->presentedFrameCount() > composed_before_drag; },
-                            std::chrono::minutes(2)))
-          << "FAST adjustment frame was not composed before pointer release; status="
-          << viewport->statusText().toStdString() << " liveTargets=" << viewport->liveTargetCount();
+      const auto pending = host.editor_session_service()->PeekPendingInput();
+      const auto* exposure = alcedo::FindPendingField(pending, "exposure");
+      ASSERT_NE(exposure, nullptr);
+      EXPECT_NE(exposure->params_json.find("0.30"), std::string::npos);
+      EXPECT_EQ(viewport->presentedFrameCount(), composed_before_drag)
+          << "queued input must not apply or render until the owner consumes it";
     }
 
     EXPECT_EQ(viewport->lastPresentedSessionEpoch(), viewport->sessionEpoch());

--- a/alcedo_studio/tests/ui/editor_serial_input_boundary_test.cpp
+++ b/alcedo_studio/tests/ui/editor_serial_input_boundary_test.cpp
@@ -2,15 +2,12 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
-/// Slider → history → coordinator boundary characterization. These tests record
-/// the current synchronous live mutation: UI control values and live document
-/// parameters are distinct storage, but pointer-drag submit acquires the live
-/// render lock on the calling thread and writes the document before the blocked
-/// renderer completes. Later input-queue work inverts the live-write timing;
-/// this file must keep passing on the current path.
+/// Slider and typed-model input enqueue without live document mutation.
+/// GUI callbacks update local controls and admit change descriptions; they do
+/// not take the render lock or capture history.
 
+#include "app/editor_pending_input.hpp"
 #include "app/editor_pipeline_command_service.hpp"
-#include "app/editor_render_coordinator.hpp"
 #include "app/pipeline_service.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/history/commit_graph.hpp"
@@ -20,24 +17,23 @@
 #include "image/metadata.hpp"
 #include "json.hpp"
 #include "support/editor_parameter_target_test.hpp"
-#include "support/latch_blocked_pipeline_scheduler_port.hpp"
-#include "support/manual_monotonic_clock.hpp"
 #include "ui/alcedo_main/album_backend/editor_adjustment_models.hpp"
 #include "ui/alcedo_main/album_backend/editor_adjustment_submitter.hpp"
+#include "ui/alcedo_main/album_backend/editor_color_temp_model.hpp"
+#include "ui/alcedo_main/album_backend/editor_lut_catalog_model.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_history_port.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_pipeline_port.hpp"
+#include "ui/alcedo_main/album_backend/editor_tone_curve_model.hpp"
 
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QString>
+#include <QVariantList>
+#include <QVariantMap>
 
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <condition_variable>
 #include <filesystem>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <thread>
 
@@ -67,84 +63,38 @@ auto DocumentExposureEv(const alcedo::PipelineDocument& document) -> float {
   return json.at("exposure_ev").get<float>();
 }
 
-class LiveHistorySubmitter final : public QObject, public IEditorAdjustmentSubmitter {
+class QueuedInputSubmitter final : public QObject, public IEditorAdjustmentSubmitter {
  public:
-  explicit LiveHistorySubmitter(EditorSessionHistoryPort* history,
-                                alcedo::EditorHistoryGuardHandle handle,
-                                alcedo::EditorRenderCoordinator* coordinator)
-      : history_(history), handle_(handle), coordinator_(coordinator) {}
+  explicit QueuedInputSubmitter(alcedo::EditorPendingInputQueue* queue,
+                                alcedo::EditorSessionIdentity    identity)
+      : queue_(queue), identity_(identity) {}
 
   auto submitPatch(QString fieldKey, QString paramsJson, bool settled) -> bool override {
-    control_value_at_submit_ = control_value_reader_ ? control_value_reader_() : 0.0;
-    if (clock_ != nullptr) {
-      clock_->set_ns(submit_ns_);
-    }
-    {
-      std::lock_guard lock(mutex_);
-      submit_entered_ = true;
-    }
-    submit_cv_.notify_all();
-
-    alcedo::EditorAdjustmentPatch patch;
-    patch.field_key   = fieldKey.toStdString();
-    patch.settled     = settled;
-    const auto doc    = QJsonDocument::fromJson(paramsJson.toUtf8());
-    const auto object = doc.object();
-    double     value  = object.value(QStringLiteral("value")).toDouble();
-    if (object.contains(QStringLiteral("exposure"))) {
-      value = object.value(QStringLiteral("exposure")).toDouble();
-    }
-    patch.params_json = nlohmann::json{{"exposure_ev", value}}.dump();
-
-    std::string error;
-    const bool  captured = history_->CaptureAdjustmentBeforePreview(handle_, patch, &error);
-    if (clock_ != nullptr) {
-      clock_->set_ns(apply_ns_);
-    }
-    live_after_capture_ = live_reader_ ? live_reader_() : 0.0f;
-    if (!captured) {
-      last_error_ = error;
+    if (!can_edit_ || queue_ == nullptr) {
       return false;
     }
-    if (coordinator_ != nullptr) {
-      alcedo::EditorRenderIntent intent;
-      intent.element_id               = handle_.element_id;
-      intent.image_id                 = 84;
-      intent.image_load_request_id    = alcedo::ImageLoadRequestId{1};
-      intent.quality                  = alcedo::EditorRenderQuality::Interactive;
-      intent.priority                 = alcedo::EditorRenderPriority::Normal;
-      intent.frame_role               = alcedo::FrameRoleForQuality(intent.quality);
-      intent.reason                   = settled ? alcedo::EditorRenderReason::SettledAdjustment
-                                                : alcedo::EditorRenderReason::InteractiveAdjustment;
-      coordinator_->Submit(intent);
+    alcedo::EditorAdjustmentPatch patch;
+    patch.field_key   = fieldKey.toStdString();
+    patch.params_json = paramsJson.toStdString();
+    patch.settled     = settled;
+    if (target_.owner_kind != alcedo::EditorParameterOwnerKind::Unspecified) {
+      patch.target           = target_;
+      patch.target.field_key = patch.field_key;
     }
-    return true;
+    const auto admitted = queue_->AdmitFieldChange(identity_, patch);
+    last_error_         = admitted.error;
+    return admitted.accepted;
   }
 
   auto canEdit() const -> bool override { return can_edit_; }
 
-  void WaitUntilSubmitEntered() {
-    std::unique_lock lock(mutex_);
-    submit_cv_.wait(lock, [&] { return submit_entered_; });
-  }
-
-  std::function<double()> control_value_reader_;
-  std::function<float()>  live_reader_;
-  alcedo::test::ManualMonotonicClock* clock_ = nullptr;
-  alcedo::test::ManualMonotonicClock::nanoseconds submit_ns_ = 1;
-  alcedo::test::ManualMonotonicClock::nanoseconds apply_ns_  = 2;
-  double control_value_at_submit_ = 0.0;
-  float  live_after_capture_      = 0.0f;
-  bool   can_edit_                = true;
-  std::string last_error_;
+  alcedo::EditorParameterTarget target_{};
+  bool                          can_edit_ = true;
+  std::string                   last_error_;
 
  private:
-  EditorSessionHistoryPort*            history_     = nullptr;
-  alcedo::EditorHistoryGuardHandle     handle_{};
-  alcedo::EditorRenderCoordinator*     coordinator_ = nullptr;
-  std::mutex                           mutex_;
-  std::condition_variable              submit_cv_;
-  bool                                 submit_entered_ = false;
+  alcedo::EditorPendingInputQueue* queue_ = nullptr;
+  alcedo::EditorSessionIdentity    identity_{};
 };
 
 class SerialInputBoundaryTest : public ::testing::Test {
@@ -164,9 +114,8 @@ class SerialInputBoundaryTest : public ::testing::Test {
     std::string error;
     handle_ = history_.Acquire(42, &error);
     ASSERT_TRUE(handle_.valid) << error;
-    scheduler_   = std::make_shared<alcedo::test::LatchBlockedPipelineSchedulerPort>();
-    coordinator_ = std::make_unique<alcedo::EditorRenderCoordinator>(scheduler_);
-    coordinator_->SetActiveImageLoadRequest(1);
+    identity_.element_id = 42;
+    identity_.image_id   = 84;
   }
 
   void TearDown() override {
@@ -177,92 +126,208 @@ class SerialInputBoundaryTest : public ::testing::Test {
     std::filesystem::remove(journal_path_, ec);
   }
 
-  std::filesystem::path                                          journal_path_;
-  std::shared_ptr<alcedo::PipelineGuard>                         guard_;
-  std::shared_ptr<EditorSessionPipelinePort>                     pipeline_;
-  EditorSessionHistoryPort                                       history_;
-  alcedo::EditorHistoryGuardHandle                               handle_{};
-  std::shared_ptr<alcedo::test::LatchBlockedPipelineSchedulerPort> scheduler_;
-  std::unique_ptr<alcedo::EditorRenderCoordinator>               coordinator_;
+  std::filesystem::path                  journal_path_;
+  std::shared_ptr<alcedo::PipelineGuard> guard_;
+  std::shared_ptr<EditorSessionPipelinePort> pipeline_;
+  EditorSessionHistoryPort               history_;
+  alcedo::EditorHistoryGuardHandle       handle_{};
+  alcedo::EditorSessionIdentity          identity_{};
+  alcedo::EditorPendingInputQueue        queue_;
 };
 
-TEST_F(SerialInputBoundaryTest,
-       PointerDragUpdatesControlValueBeforeLiveWriteAndMutatesLiveBeforeRenderCompletes) {
-  LiveHistorySubmitter submitter(&history_, handle_, coordinator_.get());
-  alcedo::test::ManualMonotonicClock clock;
-  submitter.clock_ = &clock;
-  auto model       = std::make_unique<EditorAdjustmentValueModel>();
-  model->setSubmitter(&submitter);
-  model->setFieldKey("exposure");
-  model->setMinimum(-5.0);
-  model->setMaximum(5.0);
-  model->setValue(0.0);
-  submitter.control_value_reader_ = [&] { return model->value(); };
-  submitter.live_reader_          = [&] { return DocumentExposureEv(*guard_->document_); };
-
-  const float live_before = DocumentExposureEv(*guard_->document_);
-  EXPECT_FLOAT_EQ(live_before, alcedo::kDefaultPipelineExposureEv);
-
-  std::unique_lock render_held(guard_->pipeline_->GetRenderLock());
-  std::thread      drag([&] {
-    model->beginDrag();
-    model->updateDrag(0.5);
-  });
-  submitter.WaitUntilSubmitEntered();
-  EXPECT_DOUBLE_EQ(model->value(), 0.5);
-  EXPECT_DOUBLE_EQ(submitter.control_value_at_submit_, 0.5);
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), live_before);
-  EXPECT_FALSE(coordinator_->has_inflight());
-  EXPECT_TRUE(scheduler_->scheduled().empty());
-
-  render_held.unlock();
-  drag.join();
-
-  EXPECT_TRUE(submitter.last_error_.empty()) << submitter.last_error_;
-  EXPECT_FLOAT_EQ(submitter.live_after_capture_, 0.5f);
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), 0.5f);
-  EXPECT_TRUE(coordinator_->has_inflight());
-  EXPECT_TRUE(scheduler_->running());
-  EXPECT_EQ(scheduler_->scheduled().size(), 1u);
-  EXPECT_LT(submitter.submit_ns_, submitter.apply_ns_);
-  EXPECT_GE(clock.now_ns(), submitter.apply_ns_);
-
-  clock.advance_ns(16'000'000);
-  EXPECT_TRUE(scheduler_->running())
-      << "advancing a test clock must not complete the blocked renderer";
-  scheduler_->Complete(true, "frame");
-  EXPECT_FALSE(scheduler_->running());
-}
-
-TEST_F(SerialInputBoundaryTest,
-       InteractivePatchMutatesLiveDocumentWhileCoordinatorStillHasInflightFrame) {
-  LiveHistorySubmitter submitter(&history_, handle_, coordinator_.get());
+TEST_F(SerialInputBoundaryTest, SliderMovesWhileBlockedRenderLeaveLiveParametersUnchanged) {
+  QueuedInputSubmitter submitter(&queue_, identity_);
   auto                 model = std::make_unique<EditorAdjustmentValueModel>();
   model->setSubmitter(&submitter);
   model->setFieldKey("exposure");
   model->setMinimum(-5.0);
   model->setMaximum(5.0);
   model->setValue(0.0);
-  submitter.control_value_reader_ = [&] { return model->value(); };
-  submitter.live_reader_          = [&] { return DocumentExposureEv(*guard_->document_); };
+
+  const float live_before = DocumentExposureEv(*guard_->document_);
+  EXPECT_FLOAT_EQ(live_before, alcedo::kDefaultPipelineExposureEv);
+  const auto live_json_before = guard_->document_->ToJson().dump();
+
+  std::unique_lock render_held(guard_->pipeline_->GetRenderLock());
+  std::thread      drag([&] {
+    model->beginDrag();
+    model->updateDrag(0.10);
+    model->updateDrag(0.20);
+    model->updateDrag(0.30);
+    model->updateDrag(0.50);
+  });
+  drag.join();
+
+  EXPECT_TRUE(submitter.last_error_.empty()) << submitter.last_error_;
+  EXPECT_DOUBLE_EQ(model->value(), 0.50);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), live_before);
+  EXPECT_EQ(guard_->document_->ToJson().dump(), live_json_before);
+  const auto pending = queue_.Peek();
+  ASSERT_EQ(pending.sequences.size(), 1u);
+  EXPECT_EQ(pending.sequences.front().seal, alcedo::EditorPendingInputBoundaryKind::None);
+  const auto* exposure = alcedo::FindPendingField(pending, "exposure");
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_EQ(exposure->params_json.find("0.5") != std::string::npos ||
+                exposure->params_json.find("0.50") != std::string::npos,
+            true);
+  EXPECT_EQ(exposure->identity.element_id, identity_.element_id);
+  EXPECT_EQ(exposure->identity.image_id, identity_.image_id);
+
+  render_held.unlock();
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), live_before);
+  EXPECT_EQ(guard_->document_->ToJson().dump(), live_json_before);
+}
+
+TEST_F(SerialInputBoundaryTest, PendingDifferentFieldsSurviveInputCoalescing) {
+  QueuedInputSubmitter exposure_submitter(&queue_, identity_);
+  QueuedInputSubmitter contrast_submitter(&queue_, identity_);
+  auto                 exposure = std::make_unique<EditorAdjustmentValueModel>();
+  exposure->setSubmitter(&exposure_submitter);
+  exposure->setFieldKey("exposure");
+  exposure->setMinimum(-5.0);
+  exposure->setMaximum(5.0);
+  exposure->setValue(0.0);
+  auto contrast = std::make_unique<EditorAdjustmentValueModel>();
+  contrast->setSubmitter(&contrast_submitter);
+  contrast->setFieldKey("contrast");
+  contrast->setMinimum(-100.0);
+  contrast->setMaximum(100.0);
+  contrast->setValue(0.0);
+
+  exposure->beginDrag();
+  exposure->updateDrag(0.25);
+  exposure->updateDrag(0.75);
+  contrast->beginDrag();
+  contrast->updateDrag(12.0);
+  contrast->updateDrag(18.0);
+
+  EXPECT_DOUBLE_EQ(exposure->value(), 0.75);
+  EXPECT_DOUBLE_EQ(contrast->value(), 18.0);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), alcedo::kDefaultPipelineExposureEv);
+
+  const auto pending = queue_.Peek();
+  ASSERT_EQ(pending.sequences.size(), 1u);
+  EXPECT_EQ(pending.sequences.front().fields.size(), 2u);
+  const auto* exposure_field = alcedo::FindPendingField(pending, "exposure");
+  const auto* contrast_field = alcedo::FindPendingField(pending, "contrast");
+  ASSERT_NE(exposure_field, nullptr);
+  ASSERT_NE(contrast_field, nullptr);
+  EXPECT_NE(exposure_field->params_json.find("0.75"), std::string::npos);
+  EXPECT_NE(contrast_field->params_json.find("18"), std::string::npos);
+}
+
+TEST_F(SerialInputBoundaryTest, ReleaseBeforeFirstPreviewKeepsFinalQueuedValuesOnce) {
+  QueuedInputSubmitter submitter(&queue_, identity_);
+  auto                 model = std::make_unique<EditorAdjustmentValueModel>();
+  model->setSubmitter(&submitter);
+  model->setFieldKey("exposure");
+  model->setMinimum(-5.0);
+  model->setMaximum(5.0);
+  model->setDefaultValue(1.25);
+  model->setValue(0.0);
+  submitter.last_error_.clear();
+
+  model->reset();
+
+  EXPECT_DOUBLE_EQ(model->value(), 1.25);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), alcedo::kDefaultPipelineExposureEv);
+  const auto pending = queue_.Peek();
+  ASSERT_EQ(pending.sequences.size(), 1u);
+  EXPECT_EQ(pending.sequences.front().seal, alcedo::EditorPendingInputBoundaryKind::Release);
+  EXPECT_EQ(pending.sequences.front().fields.size(), 1u);
+  const auto* exposure = alcedo::FindPendingField(pending, "exposure");
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_NE(exposure->params_json.find("1.25"), std::string::npos);
+}
+
+TEST_F(SerialInputBoundaryTest, NodeSwitchKeepsQueuedEditOnOriginalTarget) {
+  QueuedInputSubmitter submitter(&queue_, identity_);
+  submitter.target_.owner_kind             = alcedo::EditorParameterOwnerKind::ColorGrade;
+  submitter.target_.node_id                = alcedo::NodeId{"grade.a"};
+  submitter.target_.adjustment_instance_id = alcedo::AdjustmentInstanceId{"tone"};
+  auto model = std::make_unique<EditorAdjustmentValueModel>();
+  model->setSubmitter(&submitter);
+  model->setFieldKey("exposure");
+  model->setMinimum(-5.0);
+  model->setMaximum(5.0);
+  model->setValue(0.0);
 
   model->beginDrag();
-  model->updateDrag(0.25);
-  ASSERT_TRUE(coordinator_->has_inflight());
-  ASSERT_TRUE(scheduler_->running());
-  const auto inflight_id = coordinator_->last_scheduled_request_id();
+  model->updateDrag(0.40);
+  const auto sealed =
+      queue_.AdmitBoundary(identity_, alcedo::EditorPendingInputBoundaryKind::NodeSwitch);
+  ASSERT_TRUE(sealed.accepted) << sealed.error;
+  submitter.target_.node_id = alcedo::NodeId{"grade.b"};
+  model->updateDrag(0.90);
 
-  model->updateDrag(0.75);
-  EXPECT_DOUBLE_EQ(model->value(), 0.75);
-  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), 0.75f);
-  EXPECT_TRUE(coordinator_->has_inflight());
-  EXPECT_EQ(coordinator_->last_scheduled_request_id(), inflight_id);
-  EXPECT_EQ(scheduler_->scheduled().size(), 1u);
-  EXPECT_EQ(coordinator_->pending_count(), 1u);
+  const auto pending = queue_.Peek();
+  ASSERT_EQ(pending.sequences.size(), 2u);
+  EXPECT_EQ(pending.sequences[0].captured_target.node_id, alcedo::NodeId{"grade.a"});
+  EXPECT_EQ(pending.sequences[0].seal, alcedo::EditorPendingInputBoundaryKind::NodeSwitch);
+  ASSERT_EQ(pending.sequences[0].fields.size(), 1u);
+  EXPECT_EQ(pending.sequences[0].fields.front().target.node_id, alcedo::NodeId{"grade.a"});
+  EXPECT_NE(pending.sequences[0].fields.front().params_json.find("0.4"), std::string::npos);
+  EXPECT_EQ(pending.sequences[1].captured_target.node_id, alcedo::NodeId{"grade.b"});
+  ASSERT_FALSE(pending.sequences[1].fields.empty());
+  EXPECT_EQ(pending.sequences[1].fields.front().target.node_id, alcedo::NodeId{"grade.b"});
+}
 
-  scheduler_->Complete(true, "frame");
-  if (scheduler_->running()) {
-    scheduler_->Complete(true, "queued");
+TEST_F(SerialInputBoundaryTest, TypedModelsEnqueueThroughSameOwnerRuleWithoutLiveWrite) {
+  QueuedInputSubmitter submitter(&queue_, identity_);
+  auto                 value = std::make_unique<EditorAdjustmentValueModel>();
+  value->setSubmitter(&submitter);
+  value->setFieldKey("exposure");
+  value->setMinimum(-5.0);
+  value->setMaximum(5.0);
+  value->setValue(0.0);
+  value->editValue(0.15);
+
+  auto enum_model = std::make_unique<EditorAdjustmentEnumModel>();
+  enum_model->setSubmitter(&submitter);
+  enum_model->setFieldKey("color_temp_mode");
+  QVariantMap as_shot;
+  as_shot["value"] = QStringLiteral("as_shot");
+  as_shot["label"] = QStringLiteral("As Shot");
+  QVariantMap custom;
+  custom["value"] = QStringLiteral("custom");
+  custom["label"] = QStringLiteral("Custom");
+  enum_model->setEntries(QVariantList{as_shot, custom});
+  enum_model->setCurrentIndex(0);
+  enum_model->selectIndex(1);
+
+  auto toggle = std::make_unique<EditorAdjustmentToggleModel>();
+  toggle->setSubmitter(&submitter);
+  toggle->setFieldKey("lens_calib_enabled");
+  toggle->setValue(false);
+  toggle->commitValue(true);
+
+  auto curve = std::make_unique<EditorToneCurveModel>();
+  curve->setSubmitter(&submitter);
+  curve->setFieldKey("curve");
+  curve->beginDrag(0);
+  curve->updateDrag(0.0, 0.25);
+
+  auto lut = std::make_unique<EditorLutCatalogModel>();
+  lut->setSubmitter(&submitter);
+  lut->setFieldKey("lut");
+  lut->selectPath(QStringLiteral("C:/luts/look.cube"));
+
+  auto color_temp = std::make_unique<EditorColorTempModel>();
+  color_temp->setSubmitter(&submitter);
+  color_temp->editCct(6500.0);
+
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), alcedo::kDefaultPipelineExposureEv);
+  const auto pending = queue_.Peek();
+  ASSERT_FALSE(pending.sequences.empty());
+  EXPECT_NE(alcedo::FindPendingField(pending, "exposure"), nullptr);
+  EXPECT_NE(alcedo::FindPendingField(pending, "color_temp_mode"), nullptr);
+  EXPECT_NE(alcedo::FindPendingField(pending, "lens_calib_enabled"), nullptr);
+  EXPECT_NE(alcedo::FindPendingField(pending, "curve"), nullptr);
+  EXPECT_NE(alcedo::FindPendingField(pending, "lut"), nullptr);
+  EXPECT_NE(alcedo::FindPendingField(pending, "color_temp"), nullptr);
+  for (const auto& sequence : pending.sequences) {
+    EXPECT_EQ(sequence.identity.element_id, identity_.element_id);
+    EXPECT_EQ(sequence.identity.image_id, identity_.image_id);
   }
 }
 

--- a/alcedo_studio/tests/ui/editor_serial_input_boundary_test.cpp
+++ b/alcedo_studio/tests/ui/editor_serial_input_boundary_test.cpp
@@ -1,0 +1,291 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+/// Slider → history → coordinator boundary characterization. These tests record
+/// the current synchronous live mutation: UI control values and live document
+/// parameters are distinct storage, but pointer-drag submit acquires the live
+/// render lock on the calling thread and writes the document before the blocked
+/// renderer completes. Later input-queue work inverts the live-write timing;
+/// this file must keep passing on the current path.
+
+#include "app/editor_pipeline_command_service.hpp"
+#include "app/editor_render_coordinator.hpp"
+#include "app/pipeline_service.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/history/commit_graph.hpp"
+#include "edit/operators/operator_registeration.hpp"
+#include "edit/pipeline/pipeline_cpu.hpp"
+#include "image/image.hpp"
+#include "image/metadata.hpp"
+#include "json.hpp"
+#include "support/editor_parameter_target_test.hpp"
+#include "support/latch_blocked_pipeline_scheduler_port.hpp"
+#include "support/manual_monotonic_clock.hpp"
+#include "ui/alcedo_main/album_backend/editor_adjustment_models.hpp"
+#include "ui/alcedo_main/album_backend/editor_adjustment_submitter.hpp"
+#include "ui/alcedo_main/album_backend/editor_session_history_port.hpp"
+#include "ui/alcedo_main/album_backend/editor_session_pipeline_port.hpp"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace alcedo::ui {
+namespace {
+
+auto MakePipelineGuard(sl_element_id_t element_id) -> std::shared_ptr<alcedo::PipelineGuard> {
+  auto guard       = std::make_shared<alcedo::PipelineGuard>();
+  guard->id_       = element_id;
+  guard->pipeline_ = std::make_shared<alcedo::CPUPipelineExecutor>();
+  guard->document_ =
+      std::make_shared<alcedo::PipelineDocument>(alcedo::CreateDefaultPipelineDocument());
+  guard->commit_graph_ =
+      std::make_shared<alcedo::CommitGraph>(alcedo::CommitGraph::CreateEmpty(element_id));
+  guard->root_id_ = guard->commit_graph_->GetRootId();
+  guard->root_document_ =
+      std::make_shared<alcedo::PipelineDocument>(alcedo::ClonePipelineDocument(*guard->document_));
+  return guard;
+}
+
+auto DocumentExposureEv(const alcedo::PipelineDocument& document) -> float {
+  nlohmann::json json;
+  std::string    error;
+  EXPECT_TRUE(alcedo::ReadEditorParameterJson(document, alcedo::test::ColorGradeFieldTarget("exposure"),
+                                              &json, &error))
+      << error;
+  return json.at("exposure_ev").get<float>();
+}
+
+class LiveHistorySubmitter final : public QObject, public IEditorAdjustmentSubmitter {
+ public:
+  explicit LiveHistorySubmitter(EditorSessionHistoryPort* history,
+                                alcedo::EditorHistoryGuardHandle handle,
+                                alcedo::EditorRenderCoordinator* coordinator)
+      : history_(history), handle_(handle), coordinator_(coordinator) {}
+
+  auto submitPatch(QString fieldKey, QString paramsJson, bool settled) -> bool override {
+    control_value_at_submit_ = control_value_reader_ ? control_value_reader_() : 0.0;
+    if (clock_ != nullptr) {
+      clock_->set_ns(submit_ns_);
+    }
+    {
+      std::lock_guard lock(mutex_);
+      submit_entered_ = true;
+    }
+    submit_cv_.notify_all();
+
+    alcedo::EditorAdjustmentPatch patch;
+    patch.field_key   = fieldKey.toStdString();
+    patch.settled     = settled;
+    const auto doc    = QJsonDocument::fromJson(paramsJson.toUtf8());
+    const auto object = doc.object();
+    double     value  = object.value(QStringLiteral("value")).toDouble();
+    if (object.contains(QStringLiteral("exposure"))) {
+      value = object.value(QStringLiteral("exposure")).toDouble();
+    }
+    patch.params_json = nlohmann::json{{"exposure_ev", value}}.dump();
+
+    std::string error;
+    const bool  captured = history_->CaptureAdjustmentBeforePreview(handle_, patch, &error);
+    if (clock_ != nullptr) {
+      clock_->set_ns(apply_ns_);
+    }
+    live_after_capture_ = live_reader_ ? live_reader_() : 0.0f;
+    if (!captured) {
+      last_error_ = error;
+      return false;
+    }
+    if (coordinator_ != nullptr) {
+      alcedo::EditorRenderIntent intent;
+      intent.element_id               = handle_.element_id;
+      intent.image_id                 = 84;
+      intent.image_load_request_id    = alcedo::ImageLoadRequestId{1};
+      intent.quality                  = alcedo::EditorRenderQuality::Interactive;
+      intent.priority                 = alcedo::EditorRenderPriority::Normal;
+      intent.frame_role               = alcedo::FrameRoleForQuality(intent.quality);
+      intent.reason                   = settled ? alcedo::EditorRenderReason::SettledAdjustment
+                                                : alcedo::EditorRenderReason::InteractiveAdjustment;
+      coordinator_->Submit(intent);
+    }
+    return true;
+  }
+
+  auto canEdit() const -> bool override { return can_edit_; }
+
+  void WaitUntilSubmitEntered() {
+    std::unique_lock lock(mutex_);
+    submit_cv_.wait(lock, [&] { return submit_entered_; });
+  }
+
+  std::function<double()> control_value_reader_;
+  std::function<float()>  live_reader_;
+  alcedo::test::ManualMonotonicClock* clock_ = nullptr;
+  alcedo::test::ManualMonotonicClock::nanoseconds submit_ns_ = 1;
+  alcedo::test::ManualMonotonicClock::nanoseconds apply_ns_  = 2;
+  double control_value_at_submit_ = 0.0;
+  float  live_after_capture_      = 0.0f;
+  bool   can_edit_                = true;
+  std::string last_error_;
+
+ private:
+  EditorSessionHistoryPort*            history_     = nullptr;
+  alcedo::EditorHistoryGuardHandle     handle_{};
+  alcedo::EditorRenderCoordinator*     coordinator_ = nullptr;
+  std::mutex                           mutex_;
+  std::condition_variable              submit_cv_;
+  bool                                 submit_entered_ = false;
+};
+
+class SerialInputBoundaryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    RegisterAllOperators();
+    const auto stamp =
+        std::to_string(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    journal_path_ = std::filesystem::temp_directory_path() / ("serial_input_" + stamp + ".wal");
+    guard_        = MakePipelineGuard(42);
+    pipeline_     = std::make_shared<EditorSessionPipelinePort>();
+    pipeline_->SetServices(
+        EditorSessionPipelineMappers{{}, [g = guard_](sl_element_id_t) { return g; }});
+    history_.SetServices(
+        EditorSessionHistoryPort::Services{[this](sl_element_id_t) { return journal_path_; }});
+    history_.SetPipelinePort(pipeline_);
+    std::string error;
+    handle_ = history_.Acquire(42, &error);
+    ASSERT_TRUE(handle_.valid) << error;
+    scheduler_   = std::make_shared<alcedo::test::LatchBlockedPipelineSchedulerPort>();
+    coordinator_ = std::make_unique<alcedo::EditorRenderCoordinator>(scheduler_);
+    coordinator_->SetActiveImageLoadRequest(1);
+  }
+
+  void TearDown() override {
+    if (handle_.valid) {
+      history_.Release(handle_);
+    }
+    std::error_code ec;
+    std::filesystem::remove(journal_path_, ec);
+  }
+
+  std::filesystem::path                                          journal_path_;
+  std::shared_ptr<alcedo::PipelineGuard>                         guard_;
+  std::shared_ptr<EditorSessionPipelinePort>                     pipeline_;
+  EditorSessionHistoryPort                                       history_;
+  alcedo::EditorHistoryGuardHandle                               handle_{};
+  std::shared_ptr<alcedo::test::LatchBlockedPipelineSchedulerPort> scheduler_;
+  std::unique_ptr<alcedo::EditorRenderCoordinator>               coordinator_;
+};
+
+TEST_F(SerialInputBoundaryTest,
+       PointerDragUpdatesControlValueBeforeLiveWriteAndMutatesLiveBeforeRenderCompletes) {
+  LiveHistorySubmitter submitter(&history_, handle_, coordinator_.get());
+  alcedo::test::ManualMonotonicClock clock;
+  submitter.clock_ = &clock;
+  auto model       = std::make_unique<EditorAdjustmentValueModel>();
+  model->setSubmitter(&submitter);
+  model->setFieldKey("exposure");
+  model->setMinimum(-5.0);
+  model->setMaximum(5.0);
+  model->setValue(0.0);
+  submitter.control_value_reader_ = [&] { return model->value(); };
+  submitter.live_reader_          = [&] { return DocumentExposureEv(*guard_->document_); };
+
+  const float live_before = DocumentExposureEv(*guard_->document_);
+  EXPECT_FLOAT_EQ(live_before, alcedo::kDefaultPipelineExposureEv);
+
+  std::unique_lock render_held(guard_->pipeline_->GetRenderLock());
+  std::thread      drag([&] {
+    model->beginDrag();
+    model->updateDrag(0.5);
+  });
+  submitter.WaitUntilSubmitEntered();
+  EXPECT_DOUBLE_EQ(model->value(), 0.5);
+  EXPECT_DOUBLE_EQ(submitter.control_value_at_submit_, 0.5);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), live_before);
+  EXPECT_FALSE(coordinator_->has_inflight());
+  EXPECT_TRUE(scheduler_->scheduled().empty());
+
+  render_held.unlock();
+  drag.join();
+
+  EXPECT_TRUE(submitter.last_error_.empty()) << submitter.last_error_;
+  EXPECT_FLOAT_EQ(submitter.live_after_capture_, 0.5f);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), 0.5f);
+  EXPECT_TRUE(coordinator_->has_inflight());
+  EXPECT_TRUE(scheduler_->running());
+  EXPECT_EQ(scheduler_->scheduled().size(), 1u);
+  EXPECT_LT(submitter.submit_ns_, submitter.apply_ns_);
+  EXPECT_GE(clock.now_ns(), submitter.apply_ns_);
+
+  clock.advance_ns(16'000'000);
+  EXPECT_TRUE(scheduler_->running())
+      << "advancing a test clock must not complete the blocked renderer";
+  scheduler_->Complete(true, "frame");
+  EXPECT_FALSE(scheduler_->running());
+}
+
+TEST_F(SerialInputBoundaryTest,
+       InteractivePatchMutatesLiveDocumentWhileCoordinatorStillHasInflightFrame) {
+  LiveHistorySubmitter submitter(&history_, handle_, coordinator_.get());
+  auto                 model = std::make_unique<EditorAdjustmentValueModel>();
+  model->setSubmitter(&submitter);
+  model->setFieldKey("exposure");
+  model->setMinimum(-5.0);
+  model->setMaximum(5.0);
+  model->setValue(0.0);
+  submitter.control_value_reader_ = [&] { return model->value(); };
+  submitter.live_reader_          = [&] { return DocumentExposureEv(*guard_->document_); };
+
+  model->beginDrag();
+  model->updateDrag(0.25);
+  ASSERT_TRUE(coordinator_->has_inflight());
+  ASSERT_TRUE(scheduler_->running());
+  const auto inflight_id = coordinator_->last_scheduled_request_id();
+
+  model->updateDrag(0.75);
+  EXPECT_DOUBLE_EQ(model->value(), 0.75);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), 0.75f);
+  EXPECT_TRUE(coordinator_->has_inflight());
+  EXPECT_EQ(coordinator_->last_scheduled_request_id(), inflight_id);
+  EXPECT_EQ(scheduler_->scheduled().size(), 1u);
+  EXPECT_EQ(coordinator_->pending_count(), 1u);
+
+  scheduler_->Complete(true, "frame");
+  if (scheduler_->running()) {
+    scheduler_->Complete(true, "queued");
+  }
+}
+
+TEST_F(SerialInputBoundaryTest, ImageExifDisplayFieldsAreOwnedByImageNotPipelineDocument) {
+  alcedo::Image image(11);
+  alcedo::ExifDisplayMetaData meta;
+  meta.shutter_speed_ = {1, 250};
+  meta.iso_           = 100;
+  meta.aperture_      = 2.8f;
+  meta.focal_         = 50.0f;
+  meta.focal_35mm_    = 75.0f;
+  image.SetExifDisplayMetaData(std::move(meta));
+
+  EXPECT_TRUE(image.has_exif_display_.load());
+  EXPECT_EQ(image.exif_display_.shutter_speed_.first, 1);
+  EXPECT_EQ(image.exif_display_.shutter_speed_.second, 250);
+  EXPECT_EQ(image.exif_display_.iso_, 100u);
+  EXPECT_FLOAT_EQ(image.exif_display_.aperture_, 2.8f);
+  EXPECT_FLOAT_EQ(image.exif_display_.focal_, 50.0f);
+  EXPECT_NE(image.exif_display_.focal_, image.exif_display_.focal_35mm_);
+  EXPECT_EQ(guard_->document_->ToJson().dump().find("shutter_speed"), std::string::npos);
+  EXPECT_EQ(guard_->document_->ToJson().dump().find("\"iso\""), std::string::npos);
+}
+
+}  // namespace
+}  // namespace alcedo::ui

--- a/alcedo_studio/tests/ui/editor_session_controller_phase5a_test.cpp
+++ b/alcedo_studio/tests/ui/editor_session_controller_phase5a_test.cpp
@@ -217,10 +217,13 @@ class FakeSessionBackend final : public IEditorSessionBackend {
 
   void NotifyWithoutStateChange() { NotifyChange(); }
 
-  // Phase 6D multi-slider: Patch/Commit update the live snapshot and NotifyChange
-  // the same way EditorSessionService::Emit does after HandlePatch.
-  int  patch_count  = 0;
-  int  commit_count = 0;
+  // Patch/Commit remain owner-consume APIs for tests that call them directly.
+  // GUI submitPatch uses EnqueueAdjustmentInput and must not copy live params
+  // into the panel snapshot.
+  int  patch_count   = 0;
+  int  commit_count  = 0;
+  int  enqueue_count = 0;
+  EditorPendingInputQueue pending_input_;
 
   auto Patch(EditorAdjustmentPatch patch) -> EditorSessionResult override {
     ++patch_count;
@@ -236,9 +239,8 @@ class FakeSessionBackend final : public IEditorSessionBackend {
   auto CommitAdjustment(EditorAdjustmentPatch patch) -> EditorSessionResult override {
     ++commit_count;
     UpsertSnapshotPatch(std::move(patch));
-    // Phase 7A R2: a settled commit mutates history, so bump the revision the
-    // same way EditorSessionService::CommitAdjustment does. Interactive Patch
-    // below does not bump, so previews stay off the history projection path.
+    // A settled consume mutates history, so bump the revision the same way
+    // EditorSessionService::CommitAdjustment does. Enqueue below does not.
     ++history_revision_;
     EditorSessionResult result;
     result.kind     = EditorSessionResultKind::RenderRouted;
@@ -246,6 +248,42 @@ class FakeSessionBackend final : public IEditorSessionBackend {
     result.identity = identity_;
     NotifyChange();
     return result;
+  }
+
+  auto EnqueueAdjustmentInput(EditorAdjustmentPatch patch) -> EditorSessionResult override {
+    ++enqueue_count;
+    const auto admitted = pending_input_.AdmitFieldChange(identity_, patch);
+    EditorSessionResult result;
+    result.state    = state_;
+    result.identity = identity_;
+    if (!admitted.accepted) {
+      result.kind    = EditorSessionResultKind::Rejected;
+      result.message = admitted.error;
+      return result;
+    }
+    result.kind    = EditorSessionResultKind::Accepted;
+    result.message = "Adjustment input queued";
+    return result;
+  }
+
+  auto EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind kind)
+      -> EditorSessionResult override {
+    const auto admitted = pending_input_.AdmitBoundary(identity_, kind);
+    EditorSessionResult result;
+    result.state    = state_;
+    result.identity = identity_;
+    if (!admitted.accepted) {
+      result.kind    = EditorSessionResultKind::Rejected;
+      result.message = admitted.error;
+      return result;
+    }
+    result.kind    = EditorSessionResultKind::Accepted;
+    result.message = "Adjustment input boundary queued";
+    return result;
+  }
+
+  [[nodiscard]] auto PeekPendingInput() const -> EditorPendingInputView override {
+    return pending_input_.Peek();
   }
 
   // Phase 7A R0: deterministic counters + async Version-operation modeling for
@@ -829,8 +867,8 @@ TEST(EditorSessionControllerPhase5ATest, EditorSessionServiceCMakeDoesNotLinkQtW
       text.substr(start, next == std::string::npos ? std::string::npos : next - start);
   // Match real link dependency tokens, not comments that mention Widgets.
   // The facade may declare PRIVATE_DEPS on internal module libraries
-  // (EditorSaveCheckpointService, EditorSessionLifecycle, etc.) as part of
-  // Fix-1B; it must never link Qt Widgets or expose PUBLIC_DEPS.
+  // (EditorPendingInput, EditorSaveCheckpointService, EditorSessionLifecycle,
+  // etc.). It must never link Qt Widgets or expose PUBLIC_DEPS.
   EXPECT_EQ(block.find("PUBLIC_DEPS"), std::string::npos)
       << "EditorSessionService must not declare PUBLIC_DEPS";
   EXPECT_EQ(block.find("Qt6::Widgets"), std::string::npos)
@@ -976,18 +1014,27 @@ TEST(EditorSessionControllerPhase5ATest,
                                        QStringLiteral("{\"vibrance\":%1}").arg(i * 3), false));
   }
 
-  EXPECT_EQ(backend.patch_count, 16);
+  EXPECT_EQ(backend.patch_count, 0);
+  EXPECT_EQ(backend.commit_count, 0);
+  EXPECT_EQ(backend.enqueue_count, 16);
+  const auto pending = backend.PeekPendingInput();
+  ASSERT_EQ(pending.sequences.size(), 1u);
+  EXPECT_EQ(pending.sequences.front().seal, EditorPendingInputBoundaryKind::None);
+  const auto* saturation = FindPendingField(pending, "saturation");
+  const auto* vibrance   = FindPendingField(pending, "vibrance");
+  ASSERT_NE(saturation, nullptr);
+  ASSERT_NE(vibrance, nullptr);
+  EXPECT_EQ(saturation->params_json, "{\"saturation\":40}");
+  EXPECT_EQ(vibrance->params_json, "{\"vibrance\":24}");
   EXPECT_EQ(snapshot_signals, 0)
       << "interactive submitPatch must not flood AdjustmentSnapshotChanged "
          "(each emit re-enters QML loadFromSnapshot during pointer moves)";
-  EXPECT_GE(state_signals, 1) << "StateChanged must still fire for renderBusy bindings";
-  // Cache stays warm so a later external NotifyChange does not look brand-new
-  // unless params actually change again.
-  EXPECT_TRUE(controller.adjustment_snapshot().contains(QStringLiteral("saturation")));
-  EXPECT_TRUE(controller.adjustment_snapshot().contains(QStringLiteral("vibrance")));
+  EXPECT_EQ(state_signals, 0) << "enqueue must not NotifyChange or apply live parameters";
+  EXPECT_FALSE(controller.adjustment_snapshot().contains(QStringLiteral("saturation")));
+  EXPECT_FALSE(controller.adjustment_snapshot().contains(QStringLiteral("vibrance")));
 }
 
-TEST(EditorSessionControllerPhase5ATest, SettledSubmitPatchEmitsAdjustmentSnapshotChanged) {
+TEST(EditorSessionControllerPhase5ATest, SettledSubmitPatchDoesNotCommitOrPublishAdjustmentSnapshot) {
   FakeSessionBackend backend;
   backend.state_               = EditorSessionState::Interactive;
   backend.image_load_request_  = ImageLoadRequestId{1};
@@ -999,15 +1046,22 @@ TEST(EditorSessionControllerPhase5ATest, SettledSubmitPatchEmitsAdjustmentSnapsh
   QObject::connect(&controller, &EditorSessionController::AdjustmentSnapshotChanged,
                    [&] { ++snapshot_signals; });
 
-  // Interactive first (no signal), then settled (must signal for panel sync).
   ASSERT_TRUE(controller.submitPatch(QStringLiteral("exposure"),
                                      QStringLiteral("{\"exposure\":0.5}"), false));
   EXPECT_EQ(snapshot_signals, 0);
 
   ASSERT_TRUE(controller.submitPatch(QStringLiteral("exposure"),
                                      QStringLiteral("{\"exposure\":0.8}"), true));
-  EXPECT_GE(snapshot_signals, 1) << "settled submitPatch must publish AdjustmentSnapshotChanged";
-  EXPECT_EQ(backend.commit_count, 1);
+  EXPECT_EQ(snapshot_signals, 0) << "settled enqueue is accepted, not history-committed";
+  EXPECT_EQ(backend.commit_count, 0);
+  EXPECT_EQ(backend.patch_count, 0);
+  EXPECT_EQ(backend.enqueue_count, 2);
+  const auto pending = backend.PeekPendingInput();
+  ASSERT_EQ(pending.sequences.size(), 1u);
+  EXPECT_EQ(pending.sequences.front().seal, EditorPendingInputBoundaryKind::Release);
+  const auto* exposure = FindPendingField(pending, "exposure");
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_EQ(exposure->params_json, "{\"exposure\":0.8}");
 }
 
 TEST(EditorSessionControllerPhase5ATest, InteractiveSubmitStartsPresentLoopAndSettledStopsIt) {
@@ -1199,12 +1253,62 @@ TEST(EditorSessionControllerPhase5ATest, SettledCommitPublishesOneHistoryRevisio
   QObject::connect(&model, &EditorHistoryModel::StateChanged, [&] { ++model_refreshes; });
   backend.history_snapshot_count_ = 0;
 
-  ASSERT_TRUE(controller.submitPatch(QStringLiteral("exposure"),
-                                     QStringLiteral(R"({"exposure":0.8})"), true));
+  EditorAdjustmentPatch patch;
+  patch.field_key   = "exposure";
+  patch.params_json = R"({"exposure":0.8})";
+  patch.settled     = true;
+  const auto result = backend.CommitAdjustment(std::move(patch));
+  EXPECT_EQ(result.kind, EditorSessionResultKind::RenderRouted);
+  controller.OnBackendChanged();
 
   EXPECT_EQ(history_signals, 1) << "one settled commit publishes one history revision";
   EXPECT_EQ(model_refreshes, 1) << "one settled commit performs one projection";
   EXPECT_EQ(backend.history_snapshot_count_, 1) << "one settled commit reads one history snapshot";
+}
+
+TEST(EditorSessionControllerPhase5ATest, SubmitPatchSettledDoesNotPublishHistoryRevision) {
+  FakeSessionBackend backend;
+  backend.state_    = EditorSessionState::Interactive;
+  backend.identity_ = {42, 84};
+  EditorSessionController controller(&backend);
+  EditorHistoryModel      model;
+  model.setEditorSession(&controller);
+
+  int history_signals = 0;
+  QObject::connect(&controller, &EditorSessionController::HistoryChanged,
+                   [&] { ++history_signals; });
+  backend.history_snapshot_count_ = 0;
+
+  ASSERT_TRUE(controller.submitPatch(QStringLiteral("exposure"),
+                                     QStringLiteral(R"({"exposure":0.8})"), true));
+
+  EXPECT_EQ(history_signals, 0);
+  EXPECT_EQ(backend.history_snapshot_count_, 0);
+  EXPECT_EQ(backend.commit_count, 0);
+  EXPECT_EQ(backend.history_revision(), 0u);
+}
+
+TEST(EditorSessionControllerPhase5ATest, NodeSwitchBoundaryStartsANewQueuedSequence) {
+  FakeSessionBackend backend;
+  backend.state_    = EditorSessionState::Interactive;
+  backend.identity_ = {42, 84};
+  EditorSessionController controller(&backend);
+
+  ASSERT_TRUE(controller.submitPatch(QStringLiteral("exposure"),
+                                     QStringLiteral(R"({"value":0.4})"), false));
+  ASSERT_TRUE(controller.enqueueNodeSwitchBoundary());
+  ASSERT_TRUE(controller.submitPatch(QStringLiteral("exposure"),
+                                     QStringLiteral(R"({"value":0.9})"), false));
+
+  EXPECT_EQ(backend.patch_count, 0);
+  EXPECT_EQ(backend.commit_count, 0);
+  const auto pending = backend.PeekPendingInput();
+  ASSERT_EQ(pending.sequences.size(), 2u);
+  EXPECT_EQ(pending.sequences[0].seal, EditorPendingInputBoundaryKind::NodeSwitch);
+  ASSERT_EQ(pending.sequences[0].fields.size(), 1u);
+  EXPECT_NE(pending.sequences[0].fields.front().params_json.find("0.4"), std::string::npos);
+  ASSERT_FALSE(pending.sequences[1].fields.empty());
+  EXPECT_NE(pending.sequences[1].fields.front().params_json.find("0.9"), std::string::npos);
 }
 
 TEST(EditorSessionControllerPhase5ATest, RenderBusyAndFrameCompletionDoNotRefreshHistoryModels) {

--- a/alcedo_studio/tests/ui/workspace_shell_test.cpp
+++ b/alcedo_studio/tests/ui/workspace_shell_test.cpp
@@ -22,6 +22,7 @@
 
 #include <chrono>
 
+#include "app/editor_pending_input.hpp"
 #include "ui/main_qml_test_fixture.hpp"
 
 #ifdef HAVE_CUDA
@@ -1095,13 +1096,12 @@ TEST_F(WorkspaceShellTests, ProductionFirstFramePathWritesAndSubmitsRealFrameDat
   EXPECT_EQ(viewport->adjustmentFrameRequestCount(), wakeups_before_drag + 3);
   EXPECT_TRUE(viewport->interactivePresentLoopActive())
       << "unsettled adjustment must arm vsync-sampled consume";
-  const auto interactive_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
-  while (viewport->presentedFrameCount() <= composed_before_drag &&
-         std::chrono::steady_clock::now() < interactive_deadline) {
-    ProcessEvents(20);
-  }
-  EXPECT_GT(viewport->presentedFrameCount(), composed_before_drag)
-      << "Interactive adjustment did not compose until pointer release";
+  const auto pending = loaded->host.editor_session_service()->PeekPendingInput();
+  const auto* exposure = alcedo::FindPendingField(pending, "exposure");
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_NE(exposure->params_json.find("0.30"), std::string::npos);
+  EXPECT_EQ(composed_before_drag, viewport->presentedFrameCount())
+      << "queued input must not apply or render until the owner consumes it";
 
   // A→B→A: late frame from the first A session must not replace the current A.
   const auto gen_a1 = viewport->sessionEpoch();

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
@@ -1,0 +1,699 @@
+# Phase NM6 — Node-aware Adjustments and Serial Interactive Rendering
+
+Date: 2026-09-05
+
+Status: NM6.1 complete; NM6.2–NM6.9 planned.
+
+Prerequisites: NM5 is complete. Preserve NM1 single live document/executor ownership,
+NM2 multi-Grade execution, NM3 multi-Mask data, and NM4 history/recovery guarantees.
+
+Parent: [Node-aware Pipeline Editing and Mask Authoring](../node_mask_editor_master_plan.md),
+Sections 17, 21.7, 23, and 24.
+
+## 1. Approved scope and decisions
+
+本阶段让右侧调整栈实际编辑所选节点，并修正接入过程中发现的调度与缓存基础问题。
+2026-09-05 用户审核已确定以下约束；它们取代此前讨论中的并发参数修改、逐帧全参数
+内容哈希、为 Undo 保留历史结果的建议。
+
+1. 滑块滑动、渲染侧应用参数、松手提交历史是三个不同操作。UI 持续响应输入；
+   输入进入待处理队列，只有渲染侧消费时才修改 live document。
+2. 同一 live pipeline 严格执行：应用参数 → 请求/执行本帧 → 本帧完成 → 下一次应用参数。
+   不允许本帧渲染与下一批 live 参数修改重叠，不通过整图副本实现隔离。
+3. Interactive 的一轮总目标为 16 ms，包括消费、参数应用、失效处理和渲染；
+   不是渲染结束后再等待 16 ms。超时等待本帧完成，不重叠执行，不降低质量。
+4. CUDA、OpenCL、Metal 共用执行和缓存决策。模板拥有流程，后端只特化具体 GPU 步骤。
+5. 会话结果有效性使用变化版本与结果表示条件；不逐帧序列化、哈希整个节点参数体。
+6. 每个计算结果在一个工作区只保留当前有效版本。Undo/Redo 请求正常 Quality base，
+   不检索旧参数结果，不增加历史结果索引或 Undo 缓存策略。
+7. 右侧 scope 下方：左边仅节点名称，右边从上到下为快门、ISO、光圈、焦距，
+   中间竖线分隔。没有节点类型副标题、额外说明标题或 Mask 名称副标题。
+8. Geometry 是文档级参数；节点选择只改变编辑上下文，不单独发起图像渲染。
+
+### 1.1 Scope exclusions
+
+- 不实现 NM7 的 Brush/Radial/Linear viewer authoring；本阶段测试临时 Mask 更新的运行时入口。
+- 不更换 QuickQanava，不新增图结构或节点 Enable/Disable 产品入口。
+- 不改变算法、FULL decode、Interactive/Quality 的既定质量策略或 backend 选择。
+- 不增加通用任务调度平台、全局显存预算调度器、第二份可写图或独立历史 executor。
+- 不按廉价算子数量新增长期图像缓存，不为所有 LLF pyramid 层建立持久缓存。
+- 不删除 Mask asset、文件身份等确实需要的内容寻址；只移除会话结果热路径上的全参数哈希。
+
+## 2. Source audit at plan creation
+
+以下为源码事实与风险分析，不是本轮测试通过记录。实施开始时重新确认当前提交和行号。
+
+| Evidence | Current behavior | Required change |
+| --- | --- | --- |
+| [AdjustmentSlider.qml](../../../../../alcedo_studio/src/ui/alcedo_main/qml/AdjustmentSlider.qml), [adjustment models](../../../../../alcedo_studio/src/ui/alcedo_main/album_backend/editor_adjustment_models.cpp) | Position changes call updateDrag; updateDrag applies the UI value and immediately calls submitInteractive. finishDrag submits settled input. | Separate local UI values, queued input, live mutation, and history completion. |
+| [session controller](../../../../../alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp), [session service](../../../../../alcedo_studio/src/app/editor_session_service.cpp), [edit controller](../../../../../alcedo_studio/src/app/editor_session_edit_controller.cpp) | submitPatch routes to Patch/CommitAdjustment; HandlePatch calls CaptureAdjustmentBeforePreview before routing a render. | UI acceptance must not synchronously acquire live ownership or mutate document/history. |
+| [command queue](../../../../../alcedo_studio/src/app/editor_session_command_queue.cpp) | Owner-thread submissions drain immediately. This queue is not a render-paced input consumer. | Extend the existing session flow with an explicit pending-input boundary; do not equate its current name with the required behavior. |
+| [history mutation](../../../../../alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp), [live lock helper](../../../../../alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_shared_helpers.cpp) | Preview capture acquires GetRenderLock and applies the parameter patch. LockLivePipeline performs a blocking lock. | Move the mutation/history ownership step out of pointer handling. Remove GUI waits rather than pumping nested events. |
+| [coordinator](../../../../../alcedo_studio/src/app/editor_render_coordinator.cpp) | ScheduleNext stops while inflight exists; pending requests are replaced per quality slot; completion pumps the next request. | Preserve one in-flight frame. Merge input deltas before slot replacement so different fields cannot disappear. |
+| [scheduler port](../../../../../alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp), [pipeline scheduler](../../../../../alcedo_studio/src/renderer/pipeline_scheduler.cpp) | Scheduler rejects a second running job. Configuration, Apply and present handoff share render ownership; completion notification is deferred beyond the lock scope. | Reuse this serial boundary; eliminate duplicate parameter application and establish the precise GPU completion requirement. |
+| [viewport](../../../../../alcedo_studio/src/ui/editor_rhi/editor_viewport_item.cpp) | Interactive present loop requests QQuick updates. Inspected producer paths do not establish a 16 ms total-budget consumer. | Keep presentation wakeups; add measured producer pacing instead of treating a vsync wakeup as parameter consumption. |
+| [parameter target resolution](../../../../../alcedo_studio/src/app/editor_pipeline_command_service.cpp), [adjustment stack](../../../../../alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml) | CurrentPanelColorGrade prefers PrimaryGrade; stack loads one session adjustment map. | Use the selected NodeId and exact AdjustmentInstanceId. |
+| [result keys](../../../../../alcedo_studio/src/edit/runtime/result_content_key.cpp) | MixGrade/MixDrtPost serialize adjustment JSON; LLF re-traverses upstream grades. LLF shared identity omits some sensor/linearization inputs; its Mask traversal passes no active raster revisions. | Replace session validity with shared dependency invalidation; cover sensor and active Mask changes. |
+| [PlanExecutor](../../../../../alcedo_studio/src/include/edit/runtime/plan_executor.hpp), [PassEncoder](../../../../../alcedo_studio/src/include/edit/runtime/pass_encoder.hpp) | Outer execution is templated; Grade and LLF internals still have three implementations. | Move decisions into common Grade/LLF templates and specialize individual GPU operations. |
+| [GraphImageCache](../../../../../alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp), [NodeResultCache](../../../../../alcedo_studio/src/include/edit/runtime/node_result_cache.hpp) | Image results retain content identities; LLF buffers/metadata use different paths across backends. | One current result per output; common validity/publication rules for image and LLF results. |
+| [operator model base](../../../../../alcedo_studio/src/include/edit/operators/models/operator_model_base.hpp), [ParameterArena](../../../../../alcedo_studio/src/include/edit/runtime/parameter_arena.hpp) | Dirty patches are consumed/cleared; arena already supports field-range updates. | Keep upload dirty state separate from persistent result invalidation. Do not add full parameter copies for version tracking. |
+
+Existing test sources: [coordinator tests](../../../../../alcedo_studio/tests/app/editor_render_coordinator_test.cpp),
+[scheduler port tests](../../../../../alcedo_studio/tests/ui/editor_session_render_scheduler_port_test.cpp),
+[adjustment model tests](../../../../../alcedo_studio/tests/ui/editor_adjustment_model_test.cpp),
+[result key tests](../../../../../alcedo_studio/tests/edit/runtime/result_content_key_test.cpp),
+[multi-Grade test support](../../../../../alcedo_studio/tests/edit/runtime/multi_grade_runtime_test_support.hpp),
+[Metal LLF tests](../../../../../alcedo_studio/tests/edit/runtime/metal_llf_test.cpp).
+Existing source/tests are starting points; their presence is not completion evidence.
+
+### 2.1 External boundary
+
+Official pages checked on 2026-09-05: [Graph data model](https://cneben.github.io/QuickQanava/graph.html),
+[node selection](https://cneben.github.io/QuickQanava/nodes.html),
+[topology observation](https://cneben.github.io/QuickQanava/advanced.html).
+They describe topology, visual items and selection observation. Alcedo retains parameter ownership,
+input pacing and history. Verify APIs against the pinned local checkout; documentation examples
+do not change Alcedo's Qt Quick Basic style requirement.
+
+## 3. Serial input and frame ownership
+
+### 3.1 Three operations and one writer
+
+```text
+GUI pointer/keyboard input
+  -> local control value
+  -> enqueue minimal typed parameter change / ordered boundary
+  -> return to Qt event loop
+
+existing session/render owner, when idle and eligible
+  -> take pending changes up to the next boundary
+  -> acquire existing live pipeline ownership off the GUI thread
+  -> validate complete batch and capture required history before-values
+  -> apply live changes once and record affected dependencies
+  -> render and safely hand off the resulting frame
+  -> finish ownership, publish completion
+  -> permit next input batch
+```
+
+Use the existing executor and render ownership mechanism. Identify the owner of history state and
+its thread-affine collaborators before relocating any call. Queue minimal operations to that owner;
+do not move QObject-dependent history code to a worker without adapting its boundaries. A GUI
+notification contains only the required read-only presentation fields and follows the completed
+owner operation. UI-only selection can remain responsive without reading mutable pipeline state.
+
+The one-writer rule also covers node edits, Undo/Redo, checkout, Paste, RAW settings, image geometry,
+Mask parameter updates and active raster updates. They share the owner admission boundary;
+background export/save uses the existing NM1 ownership/recipe mechanism. Do not create another
+document or executor to evade waiting. The UI queues work instead of waiting on that ownership.
+
+### 3.2 Pending input representation
+
+Reuse EditorAdjustmentPatch/EditorParameterTarget where possible. An input needs session/image
+identity, NodeId, AdjustmentInstanceId or explicit document/endpoint owner, changed fields/values,
+and an input-sequence identity. It must not contain the entire node/document/parameter collection.
+Capture the target at input-sequence start; never resolve it from whatever node is selected later.
+
+- Replace successive absolute assignments to the same target and field within the same sequence
+  by the newest value. Merge distinct fields instead of dropping the older entire request.
+- Preserve order across noncommuting operations, release, cancellation, selection handoff,
+  topology edits, Undo/Redo, checkout and image switch. Relative edits require composition,
+  not latest-value replacement. Brush point streams are not scalar replacement candidates.
+- A bounded pending map for the current sequence plus ordered boundaries is sufficient;
+  do not retain every pointer sample or add a generic event-stream subsystem.
+- Queue acceptance means accepted for processing, not committed. Publish final success/failure
+  asynchronously and keep the latest local control value from being overwritten by an older echo.
+- Rejected/no-op normalized changes do not mark render dependencies or create history entries.
+
+### 3.3 Release, cancellation and selection
+
+First actually applied change captures the original parameter fields in existing NM4 history
+representation. Release seals the sequence with its final values. The owner applies any remaining
+values, commits once using NM4 failure semantics, and requests Quality base. A sequence released
+before any preview still produces its final edit. A release identical to the last preview must
+still commit that edit and request Quality; it does not pretend that a second parameter change occurred.
+
+Cancel discards unapplied input and restores any applied provisional fields through the existing
+history owner without committing. Request a restore frame only if visible/live content changed.
+A failed commit follows NM4 restoration/WAL rules; never report success or leave a partially
+applied multi-field mutation. Rendering failure reports the real error, keeps result caches invalid,
+and does not silently undo an already durable history commit.
+
+Selecting another node seals the current edit before retargeting future input. Old sequence IDs
+cannot write to the new node. A pure selection has no render; a necessary release/restore render
+belongs to the old edit, not to selection. Checkout/image switch uses existing lifecycle semantics
+and rejects stale queued input. No implicit application of an old delta to a new document.
+
+### 3.4 What completion means
+
+The worker finishing CPU command encoding is not by itself proof that GPU parameter buffers can
+be overwritten. Audit PipelineScheduler, renderer, sink, workspace and backend submission leases.
+The next owner mutation is permitted only after the prior task no longer reads live parameters
+and any reused GPU parameter/output storage is safe under its fence/lease rules. If a backend
+still references shared parameter storage, its completion must wait for that use to finish.
+
+Qt can continue presenting an immutable finished image after this boundary. Do not wait for the
+monitor's next physical scanout as a parameter-ownership rule. Keep present wakeups and resource
+leases; never make the GUI take a lock while the worker needs the GUI to release a present slot.
+Completion/error/cancel paths must all release ownership and wake pending work exactly once.
+
+### 3.5 Interactive 16 ms total target
+
+Use a monotonic clock and an injectable clock/wakeup in tests. One Interactive cycle begins when
+the owner starts consuming a batch; it ends at the safe completion/handoff boundary above.
+Its total includes input application, required history preview bookkeeping, invalidation,
+parameter upload, GPU work and necessary handoff waits. Track queue latency and Qt presentation
+latency separately so budget accounting cannot hide either behind a different timestamp.
+
+With continuously pending Interactive input, the next start is no earlier than both the prior
+safe completion and prior start + 16 ms. A 5 ms cycle has at most 11 ms of pacing remainder;
+a 22 ms cycle starts the next batch when complete, with no extra 16 ms delay. Idle input can start
+immediately when eligible. Do not manufacture empty frames or replay missed timer ticks.
+
+Release/Quality, Undo/Redo and other non-Interactive work bypass the Interactive pacing wait
+after current ownership completes. They never bypass the ownership barrier. Coalesce obsolete
+Interactive updates into their final sequence values before Quality, without crossing boundaries.
+16 ms is a target and cadence, not permission to interrupt GPU work or lower decode/algorithm quality.
+
+## 4. Runtime invalidation and current-result storage
+
+### 4.1 Owner-maintained validity
+
+Attach runtime invalidation metadata to the existing live document/runtime owner. It contains
+only versions and dependency state, not parameter mirrors. Use compiled value/segment identities
+and downstream adjacency from the actual execution plan; do not maintain a separate UI dependency graph.
+
+At successful owner mutation, accumulate the precise changed model fields/structure. Before this
+batch renders, propagate to affected cached results once. Parameters stay stable until this render
+finishes. There is no design for required_revision changing halfway through that frame.
+
+Each result has required_revision and completed_revision, plus its representation descriptor.
+Revisions are monotonically assigned runtime values, not content hashes and not persisted history
+numbers. Multiple mutations coalesced into one applied batch can share one new change version.
+Untouched upstream results retain their version. A workspace compares its completed version with
+the owner's required version; consuming GPU upload dirty bits does not erase invalidation.
+
+Descriptors cover all pixel-affecting representation choices: source identity/generation,
+document runtime generation, extent/format, reference/crop mapping, viewport where applicable,
+sampling/decode/quality requirements and relevant implementation/backend capabilities. Compare
+small stable fields or owner-maintained descriptor versions. Do not serialize parameters or hash
+image bytes per frame. Immutable prepared-source and asset identities can be computed at load/change.
+
+Version checkout/replacement must establish new runtime identity even if NodeIds repeat. Returning
+to an earlier numeric parameter value is a new edit; no search for a previous result is performed.
+Topology compilation happens on actual structure/source-layout changes, not ordinary slider values.
+Remove hot-path whole-graph traversal used only to rediscover unchanged static identity as well.
+
+### 4.2 Dependency boundaries
+
+```text
+sensor/develop content -> geometry/camera color -> upstream Grade output
+  -> current pre-LLF segment -> LLF source -> LLF result
+  -> current post-LLF segment -> current Mix/Mask -> current Grade output -> downstream
+```
+
+Use actual compiled operator order and resource dependencies, not hard-coded panel-name lists.
+This is a validity graph; it does not require a persistent image allocation at every arrow.
+
+| Mutation | LLF source in current Grade | LLF result in current Grade | Grade output/downstream |
+| --- | --- | --- | --- |
+| Pixel-affecting sensor/linearization/develop input | Invalidate | Invalidate | Invalidate |
+| Upstream Grade output, including upstream active Brush revision | Invalidate | Invalidate | Invalidate |
+| Current pre-LLF adjustment | Invalidate | Invalidate | Invalidate |
+| Current LLF Shadows/Highlights | Retain | Invalidate | Invalidate |
+| Current post-LLF adjustment | Retain | Retain | Invalidate |
+| Current final Mix/Mask where applied after LLF | Retain | Retain | Invalidate |
+| UI node selection or EXIF display refresh | Retain | Retain | Retain |
+
+Camera WB/profile, demosaic method, highlight reconstruction, lens settings and linearization
+must reach LLF through their real upstream dependencies. Mask union remains dependent on enabled
+sources and their geometry; preserve sibling Mask results when only one source changes.
+Viewport sampling and canonical reference validity remain separate. Panning must not rebuild a
+valid canonical source merely because screen coordinates changed; crop/input changes must not
+reuse an incompatible reference. A higher source-detail requirement invalidates insufficient data.
+
+### 4.3 Allocation, failure and cache count
+
+Refactor GraphImageCache to one current result per output in a workspace, with an unpublished
+write while replacement is produced. Old buffers can survive only while GPU/presentation leases
+require them; release/recycle afterward. No map of previous parameter-content identities.
+Retain existing resource budget/eviction behavior for current reusable results. Eviction causes
+recomputation with unchanged quality; it does not authorize an alternate execution path.
+
+Publish completed_revision only after the result's producer succeeds and the GPU completion rule
+is satisfied. A failed write must not leave newly stamped LLF metadata pointing at incomplete data.
+Reuse existing transaction/fence machinery; do not add an independent multi-version publication layer.
+Apply the same rule to CUDA buffers, Metal buffers and OpenCL images. A released node removes its
+cache entries after leases permit. Background/one-shot renders preserve their existing isolation.
+
+## 5. Shared Grade and LLF execution
+
+Extend the current PlanExecutor/PassEncoder architecture with common Grade and LLF orchestration.
+Proposed template names GradeExecutor and LocalToneExecutor are implementation targets, not
+claims that those classes already exist. Prefer existing types if they can express these boundaries.
+
+Shared code owns operator segmentation/fusion order, neighbor-operation barriers, ping-pong
+destination selection, cache checks, source/result reuse, pyramid layout/traversal, remap/rebuild
+order, final mixing, parameter-update decisions and success/error cleanup.
+
+Backend operations expose allocation/binding, dispatch, copy, synchronization and native error
+reporting. Do not fully specialize a complete Grade/LLF executor three times. Keep CUDA/OpenCL/Metal
+kernels where platform syntax requires it, using the same host parameter definitions and algorithm
+constants. Layout differences may change binding/dispatch, never cache decisions or quality.
+
+Persist only current LLF source plane and adjusted result plane. Higher pyramid/remap/reconstruction
+levels are scratch with common lifetime rules. A local-tone parameter edit retains source extraction
+but rebuilds necessary pyramid/result work. Do not claim all pyramid levels are cached. CUDA moves
+to the same source/result split and scratch policy as the common implementation. Preserve current
+canonical-reference algorithm and sampling requirements without adding any substitute ROI policy.
+
+Only changed adjustment parameter slots are repacked/uploaded. Audit MakeGradeRuntimeParams and
+MakeFullDto callers so removing JSON hashing does not leave a full-node copy loop in the same path.
+Use owner-scoped reads/minimal changed fields with existing ParameterArena; no extra parameter mirror.
+
+## 6. Selected-node context and approved UI
+
+EditorNodeController.selectedNodeId remains the sole selection. EditorAdjustmentContext is a
+read-only application/QML projection of the selected node's supported parameters and capabilities;
+it never owns another mutable NodeId or graph. Reuse the existing selected-parameter presentation
+representation, with only the fields needed for UI load. Document its owner, GUI lifetime, atomic
+publication and load-only use; a queued GUI projection cannot safely retain mutable worker references.
+Never write that projection wholesale back into live state.
+
+| Selection | Panels |
+| --- | --- |
+| Develop | RAW Decode, Develop-owned controls including WB/lens as appropriate, Geometry |
+| Color Grade | Tone, Look, LUT, Masks context, Geometry |
+| DRT/Post | Display, Detail containing Clarity/Sharpen/Halation/Film Grain, Geometry |
+
+Use one capability/panel-key registry for navigation and body lookup. Keep Geometry if active;
+otherwise keep a supported active page; otherwise choose RAW, Tone or Display respectively.
+NM6 Masks content identifies the current node's Mask context; no new viewer authoring controls.
+An absent adjustment instance must be handled by an explicit owner operation if creation is legal;
+never target another node or silently submit by type to the first matching Grade.
+
+### 6.1 Context header
+
+```text
+scope area
+-------------------------------------------------
+                         | Shutter       1/250 s
+Color Grade 2            | ISO               100
+                         | Aperture        f/2.8
+                         | Focal length    50 mm
+-------------------------------------------------
+supported adjustment navigation
+selected panel
+```
+
+Values above are illustration only. Actual EXIF comes from the current image metadata owner via
+an application read API. Use actual focal length, not the 35 mm equivalent. Format valid rational
+shutter times, positive aperture/ISO/focal values with units; missing/invalid values display an em
+dash. Keep four stable rows. Node switching must not reread/parse EXIF; image/metadata change updates it.
+
+Left: node display name only, vertically centered, up to two lines, elided with full accessible
+name/tooltip. No node kind, current-node prefix or Mask subtitle. Right: four rows in the exact
+order shown. The vertical separator is structural. No independent panel fill, badges or status dots.
+
+Map surface/dividers to cardSurfaceColor/cardBorderColor/dividerColor; node name to uiFontFamily,
+fontSizeTitle/fontWeightStrong; labels to caption/muted tokens; numbers to dataFontFamily.
+Spacing uses existing space tokens. Keep editorSidePanelWidthMin/Max and minimum hit areas.
+Any required new header geometry tokens must be added to AppTheme and DESIGN.md together during
+implementation. Register new QML in ALCEDO_MAIN_QML_FILES. Preserve Basic style and shared controls.
+
+Geometry body explicitly states whole-image scope. Context reloads on initial construction,
+session rebind, node selection, panel re-entry, Undo/Redo and checkout. Loading never submits an edit,
+restarts an input timer, rebuilds a stable LUT list or triggers photo rendering. UI draft values
+belong to their active input sequence; an older completion cannot overwrite them.
+
+## 7. Ordered implementation phases
+
+NM6.1 is complete. NM6.2–NM6.9 remain planned. Each phase must leave a buildable product path and
+write its actual call chain and evidence into Section 10. New-file names are proposed; existing
+links are verified entry points. Do not declare a phase complete based on implementation
+inspection alone.
+
+### NM6.1 — Prove input, ownership and completion boundaries
+
+**Changes:** add focused deterministic tests around current slider-to-history calls, one in-flight
+render, GUI lock avoidance and GPU-safe completion. Record the failing current behavior before
+changing it. Trace current history thread affinity and image/source owner APIs, including EXIF.
+
+**Primary call chain:** AdjustmentSlider → EditorAdjustmentValueModel → session Patch → history
+preview mutation → coordinator → scheduler port → PipelineScheduler → renderer/sink → completion.
+
+**Files/APIs:** Section 2 source links; extend existing adjustment model, session, coordinator and
+scheduler tests. Use a controllable blocked renderer, completion latch and fake clock; do not use
+timing sleeps as proof of ordering. Establish exact cache-hit/reference pixel fixtures for NM6.4/5.
+
+**Acceptance:** tests distinguish UI values from live values and reproduce the unwanted synchronous
+mutation path. A written ownership table names each state owner/thread and the safe completion event.
+Tests destined to pass after NM6.2/3 stay in a reviewable change together with the fix, not a broken main.
+
+##### NM6.1 completion record (2026-09-05)
+
+**Status:** complete — characterization of the current slider → history → coordinator path.
+No pending-input queue, serial consume/pacing, or GPU-safe completion was implemented. Product
+behavior is unchanged; tests pass because they record the current synchronous live write.
+
+**Revision:** branch `feature/queued-typed-adjustment-input`, base `ee6247c8`. This branch also
+holds the following typed pending-input work so both land in one PR.
+
+**Ownership table (current product, 2026-09-05):**
+
+| State | Owner | Thread | Safe completion / mutation event today |
+| --- | --- | --- | --- |
+| UI control `value_` | `EditorAdjustmentValueModel` | GUI / QML | `applyValue` writes `value_` then `submitInteractive` before `updateDrag` returns |
+| Session command queue | `EditorSessionService` + `QtEditorSessionCommandExecutor` | GUI (`QThread::currentThread() == target_->thread()`). Owner-thread `Submit` drains immediately | command handler returns after `Patch` / `CommitAdjustment` |
+| History preview capture | `EditorHistoryMutation` via `EditorSessionHistoryPort` | same thread as `Patch` (GUI in production) | after blocking `LockLivePipeline` (`GetRenderLock`) and `ApplyEditorParameterPatch` |
+| Live `PipelineDocument` | `PipelineGuard::document_` under `CPUPipelineExecutor::GetRenderLock()` | the thread that holds the unique lock; adjustment `Patch` takes this lock on the GUI/owner thread | mutex unlock after apply. **Not** gated on coordinator in-flight |
+| In-flight render | `EditorRenderCoordinator` + `IEditorPipelineSchedulerPort` | scheduler / render worker | `EditorPipelineScheduleCompletion` is `(bool success, std::string message)`. Production completion is CPU Apply + render-lock release + that callback. **No GPU fence** is part of the callback |
+| EXIF display | `Image::exif_display_` (`shutter_speed_`, `iso_`, `aperture_`, `focal_`; not `focal_35mm_`) | image object | not stored on `PipelineDocument` |
+
+`LockLivePipeline` documents that GUI must not take this lock while still required for present;
+adjustment `Patch` still does.
+
+**Primary success call chain (current, unwanted for later phases):**
+
+```text
+AdjustmentSlider / updateDrag
+  -> EditorAdjustmentValueModel.applyValue (UI value_)
+  -> submitInteractive / submitNow
+  -> EditorSessionController.submitPatch (Q_INVOKABLE, GUI)
+  -> EditorSessionService::Patch (owner-thread command queue drains inline)
+  -> EditorSessionEditController::HandlePatch
+  -> CaptureAdjustmentBeforePreview
+  -> LockLivePipeline(GetRenderLock) + ApplyEditorParameterPatch on live PipelineDocument
+  -> RouteInitialRender -> EditorRenderCoordinator::Submit
+  -> IEditorPipelineSchedulerPort::Schedule (one in-flight)
+  -> completion: (bool, string) after CPU Apply / lock release; no GPU fence
+```
+
+**Primary failure / blocking call chain:**
+
+```text
+GUI Patch while renderer holds GetRenderLock
+  -> CaptureAdjustmentBeforePreview blocks in LockLivePipeline
+  -> UI callback does not return until the worker unlocks
+  -> live document then mutates; coordinator may already have a different in-flight frame
+```
+
+```text
+HandlePatch / CaptureAdjustmentBeforePreview rejects (unknown field, JSON, missing document)
+  -> EditorSessionService::Reject
+  -> submitPatch returns false
+  -> UI value_ already updated; live document unchanged
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| UI value written and live patch submitted before `updateDrag` returns | `EditorAdjustmentModelTest.PointerDragWritesControlValueAndSubmitsLivePatchBeforeReturn` | PASS |
+| UI value visible while render lock blocks live write; live mutates before latch completion | `EditorSerialInputBoundaryTest.PointerDragUpdatesControlValueBeforeLiveWriteAndMutatesLiveBeforeRenderCompletes` | PASS |
+| Second interactive patch mutates live while coordinator still has in-flight | `EditorSerialInputBoundaryTest.InteractivePatchMutatesLiveDocumentWhileCoordinatorStillHasInflightFrame` | PASS |
+| EXIF shutter/ISO/aperture/focal owned by `Image`, not `PipelineDocument` | `EditorSerialInputBoundaryTest.ImageExifDisplayFieldsAreOwnedByImageNotPipelineDocument` | PASS |
+| One in-flight until completion latch; clock advance does not complete | `EditorRenderCoordinatorTest.BlockedRendererKeepsOneInflightUntilCompletionLatchReleases` | PASS |
+| Owner-thread Patch captures history and routes render before return | `EditorSessionCommandQueueBaselineTest.OwnerThreadPatchCapturesHistoryAndRoutesRenderBeforeReturn` | PASS |
+| Patch waits when history capture holds render lock (lock released by owning thread) | `EditorSessionCommandQueueBaselineTest.PatchWaitsWhenHistoryCaptureHoldsRenderLock` | PASS |
+| Independent ACEScc expected pixels, packed-plane layout, non-finite fail | `GpuDagRawInputTest.CachedVersusFreshPixelFixture.*` (3 tests) | PASS |
+
+Pixel comparison rule (fixed before later Grade/LLF execution): working space ACEScc RGB ramp
+matching `gpu_dag_test::MakeF32RgbaPlane` at 16×12; metric max-abs on R/G/B; absolute tolerance
+`1.0e-5f`; relative unused; any NaN/Inf fails. Independent expected values use
+`multi_grade_test::ApplyExposureAcescc`.
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/misc/Qt/6.9.3/msvc2022_64/lib/cmake"
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorSerialInputBoundaryTest --target EditorAdjustmentModelTest --target EditorRenderCoordinatorTest --target EditorSessionCommandQueueBaselineTest --target GpuDagRawInputTest
+ctest --test-dir build/debug --output-on-failure -R "EditorSerialInputBoundaryTest|EditorAdjustmentModelTest\.PointerDragWritesControlValue|EditorRenderCoordinatorTest\.BlockedRendererKeepsOneInflight|EditorSessionCommandQueueBaselineTest\.(OwnerThreadPatchCapturesHistory|PatchWaitsWhenHistoryCapture)|CachedVersusFreshPixelFixture"
+```
+
+Focused suite: 10/10 PASS.
+
+Related binaries (regression scan, not NM6.1 acceptance): 65/66 PASS.
+`EditorSessionCommandQueueBaselineTest.RapidImageSelectionKeepsRunningTargetAndReplacesOnlyUnstartedSelection`
+fails on `ee6247c8` without these edits (identity stays 30 instead of promoting 50). Out of scope.
+
+**Checklist / exit condition:** all NM6.1 acceptance items met. Latch-blocked scheduler, completion
+latch, and injectable monotonic clock are used; wall-clock sleeps are not ordering proof. Desired
+later names such as `SliderMovesWhileBlockedRenderLeaveLiveParametersUnchanged` were **not** added
+as failing tests.
+
+**LOC note (grill-code-review):** no production source changes. New test support: latch scheduler
+~83, manual clock ~23, pixel fixture header/test ~146, serial-boundary binary ~259. Extended
+existing model/coordinator/command-queue tests. Largest touched test file remains
+`editor_render_coordinator_test.cpp` (~746 lines). No new production type above the split threshold.
+
+**Remaining gaps:** pending-input queue is NM6.2. Serial consume, 16 ms pacing, and GPU-safe
+completion (fence/lease) are NM6.3. Node-aware targeting, header UI, and cache-version work remain
+NM6.4+. Current `(bool, string)` completion is not GPU-buffer-safe ownership.
+
+### NM6.2 — Queue typed input without GUI live mutation
+
+**Changes:** add the bounded pending-input representation to the existing session flow; capture full
+target/sequence identity; update models so UI changes enqueue. Separate accepted versus committed
+signals. Merge absolute same-field updates and preserve independent fields/ordered boundaries.
+
+**Primary call chain:** updateDrag/editValue/finishDrag → local model → enqueue typed input/boundary
+→ owner wakeup; no CaptureAdjustmentBeforePreview or live lock inside the GUI event callback.
+
+**Files/APIs:** editor_adjustment_models, editor_adjustment_submitter.hpp, editor_session_controller,
+editor_session_service/command_queue and their existing headers. Proposed enqueue/sequence methods
+replace the ambiguous synchronous result interpretation; keep compatibility inside this change only
+where it still follows the approved queue, never as a second production mutation path.
+
+**Acceptance:** with renderer paused, many UI updates return and update controls while live values
+remain fixed. Independent parameters survive merging; release and node boundaries are not dropped.
+Mouse, keyboard, wheel, reset, enum, toggle, curve and LUT entry paths use the same owner rule.
+
+### NM6.3 — Consume one batch, render one frame, then consume again
+
+**Changes:** make coordinator admission consume queued changes under the existing off-GUI owner;
+move history before/apply/commit to that boundary and eliminate configure-time double application.
+Implement Section 3.5 pacing and safe completion. Integrate cancellation, errors and structural edits.
+
+**Primary call chain:** idle/deadline wakeup → consume next batch → validate/history before → apply
+once → coordinator/scheduler → locked configure/Apply/handoff → safe completion → next admission.
+
+**Files/APIs:** editor_render_coordinator, editor_session_render_controller/edit_controller,
+editor_history_mutation/shared_helpers, scheduler port, renderer/pipeline_scheduler, viewport and
+existing sink/workspace completion APIs. Adapt thread-affine history notifications through the session
+owner. Document callback ordering and ensure completion cannot reenter admission before inflight setup.
+
+**Acceptance:** fake-clock 5/16/22 ms cycles, no empty ticks, no overlap, no additional 16 ms after
+overrun; release bypasses pacing after current completion; first-before/final-after history is correct.
+Cancel/exception/hidden viewport cannot strand ownership or deadlock GUI presentation. Quality requests
+remain distinct from Interactive; no quality reduction or input loss is accepted to meet timing.
+
+### NM6.4 — Replace session parameter hashes with dependency versions
+
+**Changes:** add owner-maintained invalidation metadata and compiled downstream edges; update cache
+lookup/publication to Section 4. Remove per-frame full parameter JSON hashing and repeated static-plan
+identity construction. Keep immutable source/asset identities. Convert current-result storage and
+cover history/structural/Mask mutations, not only panel edits.
+
+**Primary call chain:** owner mutation → changed field/structure marks → coalesced dependency walk
+→ PlanExecutor validity check → execute/skip → safe publication of completed version.
+
+**Files/APIs:** pipeline_document/runtime owner, graph_compiler/execution_plan,
+static_execution_plan_cache, result_content_key, plan_executor, graph_image_cache/node_result_cache,
+operator model mutation APIs and ParameterArena. Reuse owner metadata; no parallel parameter state.
+
+**Acceptance:** only affected results invalidate; no-op/selection keeps valid results; active raster
+and all pixel-affecting Develop changes reach downstream LLF; quality/extent mismatch forces correct
+recompute; dirty upload consumption cannot clear invalidation; checkout same NodeIds cannot reuse
+old-document output. Repeated edits/Undo do not increase retained historical result count.
+
+### NM6.5 — Share Grade and LLF decisions across all three backends
+
+**Changes:** introduce common template orchestration and per-step backend operations; unify LLF
+source/result reuse, scratch policy, parameter packing and publication. Remove replaced independent
+decision loops in the same phase. Maintain present submission/resource ownership guarantees.
+
+**Primary call chain:** PlanExecutor<Backend> → GradeExecutor<Backend> → LocalToneExecutor<Backend>
+→ specialized GPU operation → common success/cleanup → current-result publication.
+
+**Files/APIs:** pass_encoder/adjustment_runtime and CUDA, OpenCL, Metal primary_grade/local_tone
+sources; shared host parameters and CMake source registration where needed. Follow OpenCL program
+registry and Windows build skills when their respective code is touched. Shader mathematics stays
+equivalent; shared host logic must not select a different algorithm per backend.
+
+**Acceptance:** one common decision trace for equivalent inputs/edits; source-only versus result
+rebuild tests on all three backends; failed LLF work does not publish reusable metadata; scratch
+released at safe completion. Pixel output meets declared tolerances against independent expected
+behavior and fresh execution. Backend-native submission APIs may differ, decisions may not.
+
+### NM6.6 — Resolve context and exact node-owned edits
+
+**Changes:** implement read-only EditorAdjustmentContext, selected-target resolution and one panel
+capability registry. Reuse NM5 selection restoration and NM4 exact history targets. Provide focused
+application reads of selected parameters and current image's four EXIF fields.
+
+**Primary call chain:** EditorNodeController.SelectionChanged → application context read → atomic
+GUI projection → selected model; input sequence captures target → NM6.2 queue → NM6.3 owner.
+
+**Files/APIs:** editor_node_controller, editor_session_controller/service,
+editor_pipeline_command_service, editor_adjustment_pipeline, image metadata application API;
+new context implementation/header if needed. Reuse Image/ExifDisplayMetaData owner access instead
+of cloning image_controller JSON parsing into every panel load.
+
+**Acceptance:** two Grades with the same operator type edit independently; no implicit PrimaryGrade
+target in panel submit/read; missing/wrong-owner instance fails explicitly. Selection does not
+render or commit; queued old-target input cannot land on the new selection. EXIF is image-scoped.
+
+### NM6.7 — Build node-name/EXIF header and capability-filtered panels
+
+**Changes:** implement Section 6 header in the existing stack; bind navigation/body to the registry;
+separate Develop, Grade, DRT/Post controls; make Geometry ownership explicit; retain Mask context
+without NM7 authoring. Integrate sequence-aware UI values and load-only restore.
+
+**Primary call chain:** published context → header/EXIF + supported navigation → panel
+loadFromSnapshot → plain model setters; user edit alone enters the queued command path.
+
+**Files/APIs:** EditorAdjustmentStack.qml, EditorTonePanel.qml, Look/LUT/RAW/Display/Geometry
+components, any new Detail/header component, AppTheme, DESIGN.md, alcedo_main/CMakeLists.txt.
+Use alcedo-qml-ui and qt-qml skills for implementation; do not introduce new QML style conventions.
+
+**Acceptance:** production QML tests at 260/320/460 px, long names, missing EXIF, enlarged text,
+reduced motion and both themes. Names and EXIF remain legible without covering navigation.
+Node switches keep compatible pages; LUT selection/scroll survives re-entry without submitting.
+
+### NM6.8 — Verify history, lifecycle and end-to-end routing
+
+**Changes:** complete boundary integration and remove old synchronous panel mutation routes;
+cover release, cancel, rapid node switching, delete selection, Undo/Redo, checkout, Paste, close/reopen.
+Update automation/UI harnesses that previously equated pointer movement with immediate live mutation.
+
+**Primary call chain:** real panel input → owner batch → render → settled history → Undo/checkout
+→ owner restore → correct context → Quality base → reopen/replay equivalence.
+
+**Files/APIs:** session/history/selection tests, production QML harnesses, NM4 recovery/real-project
+test support, coordinator and scheduler adapters. Do not move failures to NM8 merely because the
+reproduction spans UI and runtime.
+
+**Acceptance:** one commit per changed sequence, exact NodeId/AdjustmentInstanceId in history,
+valid selection after deletion/re-entry/checkout, unchanged document on pure selection, consistent
+save/reopen values, no deadlocks or stale input under pending frames and lifecycle boundaries.
+
+### NM6.9 — Qualify correctness, resource bounds and Interactive cost
+
+**Changes:** run the full relevant test matrix and collect real RAW results on CUDA/OpenCL/Metal.
+Record release-build Interactive measurements, queue latency, stage costs, dispatch/skip counters,
+source/result rebuilds and retained/scratch bytes. Debug build timing is diagnostic only.
+
+**Primary call chain:** reproducible input replay → production queue/pacing → common executor
+→ backend rendering/present → pixel/resource/timing evidence → completion record.
+
+**Files/APIs:** existing multi-Grade/LLF qualification support and tests/perf, production editor
+diagnostics, this plan's Section 10. Permanent performance tools go in existing tests/perf;
+temporary logs/manifests/images go only in build/tmp/nm6/<phase>/.
+
+**Acceptance:** all mandatory cases in Section 8 pass on applicable platforms. Missing Metal
+execution remains incomplete platform qualification, never a Windows pass proxy. Report measured
+over-budget cycles honestly; resolve regressions in scope without lowering quality. NM6 is complete
+only when functional, cross-backend and lifecycle evidence exists, not when the document is written.
+
+## 8. Required test and performance evidence
+
+### 8.1 Deterministic scheduling and input cases
+
+- SliderMovesWhileBlockedRenderLeaveLiveParametersUnchanged.
+- PendingDifferentFieldsSurviveInputCoalescing.
+- ReleaseBeforeFirstPreviewCommitsFinalValuesOnce.
+- NodeSwitchKeepsQueuedEditOnOriginalTarget.
+- InteractiveCycleUsesRemainingTimeWithinSixteenMilliseconds.
+- OverBudgetInteractiveCycleStartsNextOnlyAfterCompletion.
+- QualityReleaseBypassesPacingAfterCurrentFrameCompletes.
+- FailedOrCancelledRenderReleasesOwnerWithoutPublishingResult.
+- GuiRemainsResponsiveWhilePresentNeedsAnUpdate.
+- UndoAndCheckoutWaitForOwnerWithoutBlockingGui.
+
+Names state required behavior; place cases in existing harnesses where possible. Use worker
+latches/fake clocks and assertions on write timestamps/ownership, not arbitrary sleeps.
+
+### 8.2 Pixel and dependency cases
+
+Use at least three Grades and a real RAW fixture plus small deterministic image/parameter cases.
+Compare cached execution to fresh execution for each edited state; also use independent expected
+operator/pixel cases so a shared bug cannot pass solely because cached and fresh paths agree.
+Before execution define metric, color space, absolute/relative tolerance and non-finite handling
+from existing backend/operator numerical evidence. Do not invent passing tolerances afterward.
+
+- Edit middle Grade: upstream execution counters unchanged, middle/downstream recompute.
+- Edit pre-LLF, LLF, post-LLF, final Mix/Mask: assert the Section 4.2 reuse matrix and pixels.
+- Change demosaic/highlight reconstruction/linearization/WB/profile/lens input with stable dimensions:
+  assert downstream LLF recompute and cached-versus-fresh agreement.
+- Change upstream active Brush revision before asset commit: downstream LLF sees the new pixels;
+  unchanged sibling Mask outputs stay reusable.
+- Change viewport, crop, decode/quality and source detail: canonical sampling/validity are correct.
+- Inject failure after source allocation and before result completion: retry cannot reuse partial data.
+- Long edit/Undo sequence: current-result count is bounded by live plan outputs, not edit count;
+  account separately for unavoidable outstanding presentation leases and temporary scratch.
+
+### 8.3 UI and persistence cases
+
+Test all three contexts, two same-type Grades, shared Geometry, EXIF missing/invalid formatting,
+read-only loads, selection restore and rapid sequences. Run production Basic QML and real-project
+history/reopen tests. Verify parameter echoes never reset an active newer UI value. Scope/EXIF/UI
+updates must not generate parameter input or photo renders.
+
+### 8.4 Measurements and commands
+
+Record git revision, hardware/backend/driver, build preset, fixture identity, viewport, decode,
+quality, LLF/Grade/Mask counts and warm/cold state. Measure p50/p95/max cycle, enqueue-to-consume,
+GUI callback time, CPU preparation/invalidation, GPU work and presentation handoff separately.
+Instrument full-parameter serialization/packing calls: session cache validation must perform zero
+full-node serialization, and unchanged parameter slots must not be repacked each frame.
+
+Windows commands run from repository root using scripts/msvc_env.cmd. Discover exact test/target
+names from CMake/CTest after adding cases; do not assume a source filename is a registered target.
+
+```powershell
+cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4
+ctest --test-dir build/debug -N
+ctest --test-dir build/debug --output-on-failure
+cmd /c scripts\msvc_env.cmd --preset win_release -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"
+cmd /c scripts\msvc_env.cmd --build --preset win_release --parallel 4
+```
+
+Implementation records must include the actual focused commands/results before the wider suite.
+Use corresponding macOS presets and real Metal execution for platform evidence. A test that skips
+for unavailable GPU/fixture is recorded as skipped, not passed. No tests/builds were run when this
+planning document was created.
+
+## 9. Delivery order and risk controls
+
+NM6.1 → NM6.2 → NM6.3 → NM6.4 → NM6.5 → NM6.6 → NM6.7 → NM6.8 → NM6.9.
+Split reviewable PRs by these engineering boundaries. NM6.1 red-test evidence and its immediate
+fix can share a PR. Do not expose node-aware controls until their exact-target serial write path works.
+
+Highest-risk checks are GUI/history thread affinity, GPU parameter-buffer lifetime, lost independent
+fields during quality-slot replacement, failure publication of LLF buffers, and incomplete mutation
+coverage after removing parameter hashes. Each has a corresponding deterministic or pixel test above.
+Cache validity cannot depend on every UI author remembering to call an invalidation helper; owner
+operations and compiled dependencies are the enforcement points.
+
+Review touched files for project terminology, data copies, owner boundaries and documentation.
+For roadmap changes search the whole roadmap tree and filenames; fix violations in touched prose
+and any renamed linked files together. No runtime metadata is written into document serialization.
+
+## 10. Completion records
+
+| Phase | Status | Implementation revision/PR | Actual call chain | Tests/evidence | Remaining work |
+| --- | --- | --- | --- | --- | --- |
+| NM6.1 | complete 2026-09-05 | `feature/queued-typed-adjustment-input` @ `ee6247c8` | slider → Patch → `LockLivePipeline` + live apply → coordinator; completion `(bool, string)`, no GPU fence | 10/10 focused PASS; see NM6.1 completion record | Queue/pacing/GPU-safe completion are NM6.2/3 |
+| NM6.2 | planned | — | — | — | Typed pending input |
+| NM6.3 | planned | — | — | — | Serial consumption and pacing |
+| NM6.4 | planned | — | — | — | Dependency validity/current results |
+| NM6.5 | planned | — | — | — | Shared three-backend execution |
+| NM6.6 | planned | — | — | — | Node context/target routing |
+| NM6.7 | planned | — | — | — | Approved header and panel UI |
+| NM6.8 | planned | — | — | — | Lifecycle/history integration |
+| NM6.9 | planned | — | — | — | Cross-platform qualification |
+
+Plan creation record: 2026-09-05, source audit and user-approved design only. NM5 completion is
+recorded in the [NM5 plan](phase_nm5_nodes_panel_plan.md). Update this table with implementation,
+actual primary call chains, exact commands/results, measurements and unresolved failures as work lands.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-05
 
-Status: NM6.1 complete; NM6.2–NM6.9 planned.
+Status: NM6.1–NM6.2 complete; NM6.3–NM6.9 planned.
 
 Prerequisites: NM5 is complete. Preserve NM1 single live document/executor ownership,
 NM2 multi-Grade execution, NM3 multi-Mask data, and NM4 history/recovery guarantees.
@@ -327,7 +327,7 @@ belong to their active input sequence; an older completion cannot overwrite them
 
 ## 7. Ordered implementation phases
 
-NM6.1 is complete. NM6.2–NM6.9 remain planned. Each phase must leave a buildable product path and
+NM6.1 and NM6.2 are complete. NM6.3–NM6.9 remain planned. Each phase must leave a buildable product path and
 write its actual call chain and evidence into Section 10. New-file names are proposed; existing
 links are verified entry points. Do not declare a phase complete based on implementation
 inspection alone.
@@ -467,6 +467,76 @@ where it still follows the approved queue, never as a second production mutation
 **Acceptance:** with renderer paused, many UI updates return and update controls while live values
 remain fixed. Independent parameters survive merging; release and node boundaries are not dropped.
 Mouse, keyboard, wheel, reset, enum, toggle, curve and LUT entry paths use the same owner rule.
+
+##### Phase NM6.2 completion record (2026-09-05)
+
+**Status:** complete — GUI typed input enqueues change descriptions; live document and history stay unchanged until NM6.3 consume.
+
+**Snapshot / copy decision (AGENTS.md owner-update rule):** Section 3.2 is a change description, not a live-parameter snapshot, when implemented as session/image ids, `EditorParameterTarget` ids captured at sequence start, the caller's field write payload, and ordered Release/Cancel/NodeSwitch seals. That path is what landed.
+
+Forbidden copies that were not added:
+
+- queueing `EditorRenderAdjustmentSnapshot` or full pipeline/panel `params_json`
+- `CaptureAdjustmentBeforePreview` / `ReadEditorParameterJson` / `MakeAdjustmentSnapshotFromLivePipeline` on enqueue
+- cloning `PipelineDocument` or `GetParams()` into the queue
+- storing history `before_model_json` at enqueue
+- using `EditorSessionIntent.adjustment` as the queue item
+
+Allowed and used: `EditorAdjustmentPatch.params_json` as the UI field write payload (including nested ODT/lens/RAW JSON that QML already builds from local control models). That is not a copy of live document state. `PeekPendingInput` copies the queue's own contents for inspection.
+
+Nested ODT/RAW/lens builders still send one field_key's full nested write object assembled from panel models. That pre-existed; NM6.2 stores the same write payload instead of capturing a live param body. History before-values remain NM6.3.
+
+**Primary success call chain:**
+
+```text
+updateDrag / editValue / finishDrag / selectIndex / commitValue / curve drag / LUT selectPath
+  -> typed model local value
+  -> IEditorAdjustmentSubmitter::submitPatch
+  -> EditorSessionController (present wakeup only; no Patch/CommitAdjustment)
+  -> EditorSessionService::EnqueueAdjustmentInput
+  -> EditorPendingInputQueue::AdmitFieldChange
+  -> Accepted; live PipelineDocument and history unchanged
+```
+
+**Primary failure call chain:**
+
+```text
+canEdit false / not Interactive / empty field / missing image identity / in-sequence node retarget
+  -> Reject; queue unchanged (or prior sequence preserved)
+  -> UI control value may still update locally; live document unchanged
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| Slider moves while render lock held leave live parameters and full document JSON unchanged | `EditorSerialInputBoundaryTest.SliderMovesWhileBlockedRenderLeaveLiveParametersUnchanged` | PASS |
+| Distinct fields survive same-sequence coalescing | `EditorPendingInputTest` + `EditorSerialInputBoundaryTest.PendingDifferentFieldsSurviveInputCoalescing` | PASS |
+| Release before consume keeps the final queued write once (commit is NM6.3) | `ReleaseBeforeFirstPreviewKeepsFinalQueuedValuesOnce` (maps 8.1 `ReleaseBeforeFirstPreviewCommitsFinalValuesOnce`) | PASS |
+| Node switch seals the original target; later writes start a new sequence | `NodeSwitchKeepsQueuedEditOnOriginalTarget` + session/controller NodeSwitch cases | PASS |
+| Value/enum/toggle/curve/LUT/color-temp enqueue without live write | `TypedModelsEnqueueThroughSameOwnerRuleWithoutLiveWrite` | PASS |
+| Wheel/keyboard debounce still uses the same submitter seam | `EditorAdjustmentModelTest.WheelBurstSubmitsInteractivePerValueAndOneSettledAfterDebounce` | PASS |
+| Enqueue does not capture history or copy `current_snapshot` | `EditorPendingInputSessionTest.EnqueueDoesNotCaptureHistoryOrApplyLivePatch` | PASS |
+| Queued item is the changed-field payload only | `EditorPendingInputTest.QueuedItemCarriesOnlyChangedFieldPayload` | PASS |
+| Interactive `submitPatch` does not emit `AdjustmentSnapshotChanged` or call Patch | `EditorSessionControllerPhase5ATest.InteractiveSubmitPatchDoesNotEmitAdjustmentSnapshotChanged` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorPendingInputTest --target EditorPendingInputSessionTest --target EditorSerialInputBoundaryTest --target EditorAdjustmentModelTest --target EditorSessionControllerPhase5ATest --target EditorSessionCommandQueueBaselineTest
+ctest --test-dir build/debug --output-on-failure -R "EditorPendingInputTest|EditorPendingInputSessionTest|EditorSerialInputBoundaryTest|EditorAdjustmentModelTest|EditorSessionControllerPhase5ATest|EditorSessionCommandQueueBaselineTest" -E "RapidImageSelectionKeepsRunningTarget"
+```
+
+Focused suite: 90/90 PASS.
+
+Related: `EditorSessionCommandQueueBaselineTest.RapidImageSelectionKeepsRunningTargetAndReplacesOnlyUnstartedSelection` still fails at identity 30 vs 50. Recorded as pre-existing on NM6.1 (`ee6247c8`); not caused by this enqueue path (`Patch` remains the live-apply API).
+
+**Checklist / exit condition:** NM6.2 acceptance items met. GUI callbacks do not take the render lock or capture history. Same-field replacement is bounded; independent fields and Release/Cancel/NodeSwitch seals are retained. `submitPatch` is not a second live-mutation path.
+
+**LOC note (grill-code-review):** new queue type is 174 header + 188 cpp. Session facade `editor_session_service.cpp` remains 1609 lines and `editor_session_controller.cpp` 1354; NM6.2 only added enqueue methods and rerouted `submitPatch`. Pending-input rules live in `EditorPendingInputQueue`, not a method split of the facade. Largest touched test file `editor_session_controller_phase5a_test.cpp` is 1493 lines (pre-existing concentration plus one NodeSwitch case).
+
+**Remaining gaps:** owner consume, history before/apply/commit, 16 ms pacing, and GPU-safe completion are NM6.3. Production `submitPatch` still does not stamp NodeId/AdjustmentInstanceId; sequence target capture from selection is NM6.6. `Patch`/`CommitAdjustment` still live-apply when called directly so NM6.3 can consume through them. Present-loop wakeup is presentation-only and does not apply queued fields.
 
 ### NM6.3 — Consume one batch, render one frame, then consume again
 
@@ -685,7 +755,7 @@ and any renamed linked files together. No runtime metadata is written into docum
 | Phase | Status | Implementation revision/PR | Actual call chain | Tests/evidence | Remaining work |
 | --- | --- | --- | --- | --- | --- |
 | NM6.1 | complete 2026-09-05 | `feature/queued-typed-adjustment-input` @ `ee6247c8` | slider → Patch → `LockLivePipeline` + live apply → coordinator; completion `(bool, string)`, no GPU fence | 10/10 focused PASS; see NM6.1 completion record | Queue/pacing/GPU-safe completion are NM6.2/3 |
-| NM6.2 | planned | — | — | — | Typed pending input |
+| NM6.2 | complete 2026-09-05 | uncommitted on `feature/queued-typed-adjustment-input` @ `3a7a3825` | slider/model → `submitPatch` → `EnqueueAdjustmentInput` → `EditorPendingInputQueue::AdmitFieldChange`; live document/history unchanged | 90/90 focused PASS excluding pre-existing RapidImageSelection; see NM6.2 completion record | Consume, 16 ms pacing, GPU-safe completion are NM6.3 |
 | NM6.3 | planned | — | — | — | Serial consumption and pacing |
 | NM6.4 | planned | — | — | — | Dependency validity/current results |
 | NM6.5 | planned | — | — | — | Shared three-backend execution |

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-29
 
-Status: NM0, NM2, NM3, and NM4 complete; NM1 in progress; NM5-NM8 planned. NML was
+Status: NM0, NM2, NM3, NM4, and NM5 complete; NM6.1 complete; NM1 status retained below; NM6.2-NM8 planned. NML was
 cancelled on 2026-08-30.
 
 2026-08-30 简化修订：每张图片只有一个 live document，领域函数原地修改，后台任务共用
@@ -17,6 +17,14 @@ disk cache service 拥有写回/失效机制；不在 R 中实施，也不作为
 2026-09-02 UI revision: NM4 is complete. The approved node-editor UI, VI mapping,
 QuickQanava boundary, and official documentation sources for NM5-NM8 are fixed before NM5 starts.
 See the [NM5 execution plan](node_mask_editor/phase_nm5_nodes_panel_plan.md) for its sub-phases.
+
+2026-09-05 NM6 design approval: NM5 is complete. The
+[NM6 execution plan](node_mask_editor/phase_nm6_node_aware_adjustments_plan.md) now defines
+serial render-paced input consumption, the Interactive 16 ms total target, shared three-backend
+Grade/LLF execution, dependency-version session caches, and the node-name/EXIF header.
+These decisions replace per-frame whole-parameter hashing and retaining old results for Undo.
+NM6.1 characterization of current input, ownership, and completion boundaries is complete.
+NM6.2+ has not started. Earlier NM1 status is not re-qualified by this documentation update.
 
 本方案承接 [GPU DAG 编辑管线重构 Phase 计划](gpu_dag_pipeline_rebuild_phase_plan.md)。前一份
 计划建立了 `PipelineDocument`、`PipelineGraph`、GPU execution plan、三后端管线、MaskStore
@@ -1226,16 +1234,18 @@ not create three Geometry instances.
 The adjustment stack has one fixed context header below the scope area and above the adjustment
 navigation.
 
-The header shows:
+The header has two columns separated by a structural vertical divider:
 
-- the current node display name;
-- the node kind on a separate plain-text line;
-- the selected Mask name when the Masks panel has a valid Mask selection.
+- left: only the current node display name, vertically centered, with at most two lines;
+- right: current-image shutter speed, ISO, aperture, and focal length, in that order, one per row.
 
-The header uses a flat layout and a bottom divider. It does not use a new panel surface. It does not
-use a pill, badge, chip, tag, or status dot. It does not join values with a decorative separator.
-The node display name uses `fontSizeTitle` and `fontWeightStrong`. The node kind and Mask name use
-caption tokens.
+Do not add a node-kind, Mask-name, or current-node subtitle. Missing EXIF values display an em dash
+in the same four-row layout. Node selection changes the name and adjustment content; EXIF changes
+only with the image or its metadata. Focal length is the actual lens focal length, not its 35 mm equivalent.
+
+The header uses the existing flat surface and bottom divider. It does not add a pill, badge, chip,
+tag, status dot, or decorative combined label. The node name uses `fontSizeTitle` and
+`fontWeightStrong`; EXIF labels use caption tokens and values use `dataFontFamily`.
 
 The header identifies the owner of the visible parameters. It does not store a second selection.
 It does not show or change a Color Grade On/Off value.
@@ -1292,6 +1302,29 @@ The adjustment stack continues to use `editorSidePanelWidthMin` and
 width. User-visible text uses `qsTr()`. The header elides a long name and exposes the full name to
 assistive technology. A large system font does not cover the navigation or the first panel
 control.
+
+### 17.5 Serial input, rendering and cache validity
+
+UI motion updates local control values and enqueues minimal typed changes. It does not synchronously
+take the live render lock or mutate history/document state. The existing owner consumes queued input
+only between frames: apply parameters once, update dependency invalidation, render, complete safely,
+then consume the next batch. Release is an ordered boundary that commits the final edit once and
+requests Quality base. A pure selection remains UI-only; finishing an existing edit retains its own
+history/render semantics. Do not design concurrent live-parameter writes during rendering.
+
+Interactive consumption and rendering have a 16 ms total target. Count parameter application,
+invalidation and necessary GPU/handoff work in the same cycle. Use only the remaining pacing time;
+an over-budget cycle waits for completion without an extra 16 ms or a quality reduction.
+Quality requests bypass that pacing wait after existing ownership completes. Qt presentation
+wakeups alone do not establish this producer budget.
+
+Session result validity uses owner-maintained dependency revisions plus source/document identity
+and representation conditions. Do not serialize or hash whole node parameters on each frame.
+Shared templates own Grade/LLF decisions and dependency propagation; backend specializations own
+individual GPU operations. LLF source/result validity follows actual upstream operations, including
+sensor parameters and active raster changes. Each workspace retains only the current result per
+output. Undo/Redo requests normal Quality base; GPU leases may temporarily retain replaced buffers
+but do not form a history cache. See the NM6 plan for precise ownership, failure and test requirements.
 
 ---
 
@@ -1453,7 +1486,7 @@ project and does not recalculate an old commit.
 
 NM1 uses the development graph format to complete model and document I/O. NM2 and NM3 change node
 fields and ownership. These changes do not require NM1 to publish the final project format. NM4
-proves golden JSON, round-trip behavior, error handling, history recovery, and real-project reopen
+proves expected serialized JSON, round-trip behavior, error handling, history recovery, and real-project reopen
 for the new format. Validate data at the read boundary. Do not distribute format checks across
 render callers.
 
@@ -1564,8 +1597,8 @@ path with a Markdown link when the file exists.
 | NM2 — Multi-Grade Runtime and Ownership | complete | [node_mask_editor/phase_nm2_multi_grade_runtime_plan.md](node_mask_editor/phase_nm2_multi_grade_runtime_plan.md) | Execute multiple Color Grade nodes in all three backends and apply parameter ownership. |
 | NM3 — Multi-Mask Model and Runtime | complete | [node_mask_editor/phase_nm3_multi_mask_runtime_plan.md](node_mask_editor/phase_nm3_multi_mask_runtime_plan.md) | Support multiple Masks per node, Union, range fields, and immutable raster assets. |
 | NM4 — History, Version, Recovery, and Paste | complete | [node_mask_editor/phase_nm4_history_version_paste_plan.md](node_mask_editor/phase_nm4_history_version_paste_plan.md) | Complete typed history, one DAG per Version, recovery, and Paste-only transfer. |
-| NM5 — QuickQanava Nodes Panel | planned | [node_mask_editor/phase_nm5_nodes_panel_plan.md](node_mask_editor/phase_nm5_nodes_panel_plan.md) | Connect the left Nodes panel to the real command, history, and render paths. |
-| NM6 — Node-aware Adjustment Stack | planned | `node_mask_editor/phase_nm6_node_aware_adjustments_plan.md` | Make the right adjustment panel use Develop, Color Grade, and DRT/Post context. |
+| NM5 — QuickQanava Nodes Panel | complete 2026-09-05 | [node_mask_editor/phase_nm5_nodes_panel_plan.md](node_mask_editor/phase_nm5_nodes_panel_plan.md) | Connect the left Nodes panel to the real command, history, and render paths. |
+| NM6 — Node-aware Adjustment Stack | in progress (NM6.1 complete 2026-09-05) | [node_mask_editor/phase_nm6_node_aware_adjustments_plan.md](node_mask_editor/phase_nm6_node_aware_adjustments_plan.md) | Add node-aware panels and EXIF header with serial Interactive input, shared backend execution, and dependency-version caches. |
 | NM7 — Viewer Mask Authoring | planned | `node_mask_editor/phase_nm7_viewer_mask_authoring_plan.md` | Connect Brush, Radial, and Linear Gradient authoring to QSG overlays, Interactive and Quality rendering, and history. |
 | NM8 — Product Qualification and Cutover | planned | `node_mask_editor/phase_nm8_product_qualification_plan.md` | Qualify all three backends, real RAW files, reopen, Version, Paste, performance, and package behavior. |
 
@@ -1818,15 +1851,21 @@ metadata, reduced-motion behavior, and package load pass their tests.
 post-delete selection rule, and Version-checkout selection restore. An earlier change to the right
 panel would continue to depend on an implicit primary Color Grade.
 
-**Scope:** Add `EditorAdjustmentContext`. Show only the valid panels for Develop, Color Grade, and
-DRT/Post. Keep Geometry at document scope. Make each panel `loadFromSnapshot()` read the current
-context. Make the shared slider interface capture `NodeId` and `AdjustmentInstanceId`. A node
-selection change updates the UI and does not request a photo render. The context header does not
-show a Color Grade On/Off value, pill, badge, chip, tag, status dot, or decorative separator label.
+**Scope:** Follow the [NM6 execution plan](node_mask_editor/phase_nm6_node_aware_adjustments_plan.md).
+Add read-only `EditorAdjustmentContext`, supported Develop/Color Grade/DRT/Post panels, shared
+document Geometry and a node-name/EXIF header. Capture exact input targets and load values without
+submitting edits. Establish queued UI input and serial owner apply/render cycles with a 16 ms
+Interactive total target. Unify three-backend Grade/LLF orchestration and replace whole-parameter
+session result hashes with dependency revisions. Retain only current results, not Undo history caches.
+A pure node selection does not request a photo render. The header has no node-type subtitle,
+Color Grade On/Off value, pill, badge, chip, tag, status dot, or decorative combined label.
 
 **Exit criteria:** Tests pass for all three node contexts, selection restore, panel re-entry,
 Version checkout, load-only paths, provisional and settled input, and full history targets. A Color
-Grade context does not contain RAW Decode or DRT/Post-only controls.
+Grade context does not contain RAW Decode or DRT/Post-only controls. Tests prove no live mutation
+during rendering, no GUI render-lock wait from input, correct pacing and final-value delivery,
+shared backend decisions, LLF dependency completeness, cached/fresh pixel agreement, and bounded
+current-result storage. Runtime/platform evidence is required; this design approval is not test evidence.
 
 **Required official QuickQanava documentation:**
 
@@ -2054,7 +2093,11 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - Brush provisional update 合并 dirty rectangle；
 - settled stroke 只保存一次完整新 asset；
 - graph static plan 只在 topology/adjustment structure 改变时重建；
-- 多 Color Grade 结果缓存按 NodeId + input content + node params/mask content 分层；
+- 多 Color Grade 会话结果按输出身份、依赖变化版本和表示条件验证；不逐帧序列化或哈希整个节点参数体；
+- UI 滑动只更新局部显示并入队；owner 在帧间消费参数，应用、失效处理与渲染严格串行；
+- Interactive 16 ms 为消费到安全完成的一轮总目标；超时不重叠、不额外等待 16 ms、不降低质量；
+- 三后端共用 Grade/LLF 编排与有效性决策，具体 GPU 操作由 backend 特化；
+- 每个工作区每个输出只保留当前有效结果；不为 Undo 保存旧参数结果，临时 GPU lease 保留单独计量；
 - node deletion/reconnect 允许淘汰不可达 node cache，但必须遵守 GPU submission lease；
 - panel close 后没有残留 Qan delegates 或 QML connection 泄漏；
 - NM8 必须记录同一真实 RAW、同一 viewport、同一 backend 的单节点基线和多节点/多 Mask 数据。
@@ -2087,7 +2130,7 @@ NM1.4 删除整图复制和产品 Apply 的 stage 覆盖，再复用后台 execu
 
 症状：控制点显示范围与最终导出 coverage 不一致。
 
-处理：共享坐标、参数和公式；golden/reference tests 同时验证 overlay 输入与 evaluator 输出。
+处理：共享坐标、参数和公式；使用有明确容差的参考结果测试同时验证 overlay 输入与 evaluator 输出。
 
 ### 25.4 Brush asset 可变导致 Undo 损坏
 


### PR DESCRIPTION
## Summary
- Record NM6.1 evidence that GUI slider writes currently take the live render lock and mutate the document, using latch-blocked renderer and ownership tests.
- Add a pending-input queue so NM6.2 GUI writes enqueue field change descriptions (ids + field payload + sequence seals) instead of applying live parameters or capturing history.
- Same-field updates keep the newest write; independent fields and Release/Cancel/NodeSwitch seals are retained. `submitPatch` is no longer a second live-mutation path.

## Test plan
- [ ] `ctest --test-dir build/debug --output-on-failure -R "EditorPendingInputTest|EditorPendingInputSessionTest|EditorSerialInputBoundaryTest|EditorAdjustmentModelTest|EditorSessionControllerPhase5ATest"`
- [ ] Drag exposure while a render is in flight: controls update, live document stays fixed, queued field is the latest value.
- [ ] Drag two different fields, then release: both fields remain queued; Release seal is present once.
- [ ] Confirm interactive `submitPatch` does not emit `AdjustmentSnapshotChanged` or bump history.
- [ ] Note: live preview will not change until NM6.3 consumes the queue. `Patch`/`CommitAdjustment` still live-apply when called directly.

Made with [Cursor](https://cursor.com)