### PR TITLE
feat(editor): serial adjustment consumption (NM6.3)

### DIFF
--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -356,7 +356,7 @@ def_library(EditorSessionEditController
     SOURCES
         "${ALCEDO_APP_ROOT}/editor_session_edit_controller.cpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_session_edit_controller.hpp"
-    PUBLIC_DEPS xxHash JSON ${ALCEDO_OPENCV_CORE_DEPS}
+    PUBLIC_DEPS xxHash JSON ${ALCEDO_OPENCV_CORE_DEPS} EditorPendingInput
     PRIVATE_DEPS EditHistory EditorAdjustmentPipeline
 )
 
@@ -432,6 +432,14 @@ def_library(EditorPendingInput
         "${ALCEDO_INCLUDE_ROOT}/app/editor_session_types.hpp"
 )
 
+def_library(EditorSerialFrameAdmission
+    SOURCES
+        "${ALCEDO_APP_ROOT}/editor_serial_frame_admission.cpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_serial_frame_admission.hpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_interactive_pacing.hpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_monotonic_clock.hpp"
+)
+
 def_library(EditorSessionService
     SOURCES
         "${ALCEDO_APP_ROOT}/editor_session_service.cpp"
@@ -451,6 +459,7 @@ def_library(EditorSessionService
                  EditHistory EditorMiniGitMaterializer EditorSaveCheckpointService EditorSessionLifecycle
                  EditorSessionNavigationController EditorSessionRenderController
                  EditorSessionEditController EditorSessionCommandQueue EditorActionPolicy
+                 EditorSerialFrameAdmission
 )
 
 # Facade consumers (tests/UI) include session headers that pull metal_image.hpp

--- a/alcedo_studio/src/app/editor_adjustment_pipeline.cpp
+++ b/alcedo_studio/src/app/editor_adjustment_pipeline.cpp
@@ -397,19 +397,42 @@ constexpr const char* kCurrentPanelFields[] = {
     "clarity",    "sharpen",  "odt",  "film_grain", "halation",   "crop_rotate", "raw_decode",
     "lens_calib", "color_temp"};
 
-auto CpuParamsFromModelJson(const std::string& field_key, nlohmann::json params) -> nlohmann::json {
-  if (field_key == "exposure" && params.contains("exposure_ev")) {
-    params["exposure"] = params.at("exposure_ev");
-    params.erase("exposure_ev");
+void RenameJsonKeyIfAbsent(nlohmann::json& params, const char* from, const char* to) {
+  if (params.contains(from) && !params.contains(to)) {
+    params[to] = params.at(from);
+    params.erase(from);
   }
-  if (field_key == "lut" && params.contains("cube_path") && !params.contains("ocio_lmt")) {
-    params["ocio_lmt"] = params.at("cube_path");
-    params.erase("cube_path");
+}
+
+auto CpuParamsFromModelJson(const std::string& field_key, nlohmann::json params) -> nlohmann::json {
+  if (field_key == "exposure") {
+    RenameJsonKeyIfAbsent(params, "exposure_ev", "exposure");
+    RenameJsonKeyIfAbsent(params, "value", "exposure");
+  }
+  if (field_key == "lut") {
+    RenameJsonKeyIfAbsent(params, "cube_path", "ocio_lmt");
   }
   return params;
 }
 
 }  // namespace
+
+auto EditorAdjustmentDocumentParamsFromWrite(const std::string& field_key, nlohmann::json params)
+    -> nlohmann::json {
+  if (field_key == "exposure") {
+    RenameJsonKeyIfAbsent(params, "exposure", "exposure_ev");
+    RenameJsonKeyIfAbsent(params, "value", "exposure_ev");
+  }
+  if (field_key == "lut") {
+    RenameJsonKeyIfAbsent(params, "ocio_lmt", "cube_path");
+  }
+  return params;
+}
+
+auto EditorAdjustmentExecutorParamsFromWrite(const std::string& field_key, nlohmann::json params)
+    -> nlohmann::json {
+  return CpuParamsFromModelJson(field_key, std::move(params));
+}
 
 auto ResetEditableOperatorsToDefaultsPreservingImageLocal(CPUPipelineExecutor& executor,
                                                           std::string*         error) -> bool {

--- a/alcedo_studio/src/app/editor_pending_input.cpp
+++ b/alcedo_studio/src/app/editor_pending_input.cpp
@@ -65,9 +65,37 @@ auto EditorPendingInputQueue::Peek() const -> EditorPendingInputView {
   return PeekLocked();
 }
 
+auto EditorPendingInputQueue::TakeReadyBatch() -> std::optional<EditorPendingSequence> {
+  std::scoped_lock lock(mutex_);
+  if (!sealed_.empty()) {
+    EditorPendingSequence batch = std::move(sealed_.front());
+    sealed_.erase(sealed_.begin());
+    return batch;
+  }
+  if (open_.has_value() && !open_->fields.empty()) {
+    EditorPendingSequence batch = *open_;
+    open_->fields.clear();
+    open_field_index_.clear();
+    return batch;
+  }
+  return std::nullopt;
+}
+
+auto EditorPendingInputQueue::HasConsumableWork() const -> bool {
+  std::scoped_lock lock(mutex_);
+  return HasConsumableWorkLocked();
+}
+
 auto EditorPendingInputQueue::empty() const -> bool {
   std::scoped_lock lock(mutex_);
   return sealed_.empty() && !open_.has_value();
+}
+
+auto EditorPendingInputQueue::HasConsumableWorkLocked() const -> bool {
+  if (!sealed_.empty()) {
+    return true;
+  }
+  return open_.has_value() && !open_->fields.empty();
 }
 
 auto EditorPendingInputQueue::AdmitFieldChangeLocked(EditorSessionIdentity        identity,

--- a/alcedo_studio/src/app/editor_serial_frame_admission.cpp
+++ b/alcedo_studio/src/app/editor_serial_frame_admission.cpp
@@ -1,0 +1,128 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_serial_frame_admission.hpp"
+
+#include <utility>
+
+namespace alcedo {
+
+EditorSerialFrameAdmission::EditorSerialFrameAdmission()
+    : clock_(std::make_shared<SteadyEditorMonotonicClock>()) {}
+
+void EditorSerialFrameAdmission::SetClock(std::shared_ptr<IEditorMonotonicClock> clock) {
+  clock_ = clock ? std::move(clock) : std::make_shared<SteadyEditorMonotonicClock>();
+}
+
+void EditorSerialFrameAdmission::SetDeadlineHandler(DeadlineHandler handler) {
+  deadline_handler_ = std::move(handler);
+}
+
+auto EditorSerialFrameAdmission::NowNs() const -> std::int64_t {
+  return clock_ ? clock_->NowNs() : 0;
+}
+
+auto EditorSerialFrameAdmission::TryBeginCycle(bool interactive) -> bool {
+  if (holding_ownership_) {
+    return false;
+  }
+  if (interactive) {
+    const auto wait_ns = pacing_.InteractiveWaitNs(NowNs());
+    if (wait_ns > 0) {
+      last_deadline_delay_ns_ = wait_ns;
+      if (deadline_handler_) {
+        deadline_handler_(wait_ns);
+      }
+      return false;
+    }
+  }
+  holding_ownership_    = true;
+  cycle_is_interactive_ = interactive;
+  inflight_request_id_  = 0;
+  if (interactive) {
+    const auto now = NowNs();
+    pacing_.NoteInteractiveStart(now);
+    interactive_start_times_ns_.push_back(now);
+  }
+  return true;
+}
+
+void EditorSerialFrameAdmission::NoteScheduledRequest(std::uint64_t request_id) {
+  inflight_request_id_ = request_id;
+}
+
+void EditorSerialFrameAdmission::AbortCycle() {
+  if (!holding_ownership_) {
+    return;
+  }
+  if (cycle_is_interactive_) {
+    pacing_.CancelInteractiveStart();
+  }
+  holding_ownership_    = false;
+  cycle_is_interactive_ = false;
+  inflight_request_id_  = 0;
+}
+
+auto EditorSerialFrameAdmission::CompleteIfMatches(std::uint64_t request_id, bool published_frame)
+    -> bool {
+  if (!holding_ownership_) {
+    return false;
+  }
+  if (inflight_request_id_ == 0 || request_id != inflight_request_id_) {
+    return false;
+  }
+  const auto now         = NowNs();
+  const bool interactive = cycle_is_interactive_;
+  holding_ownership_     = false;
+  cycle_is_interactive_  = false;
+  inflight_request_id_   = 0;
+  if (interactive && published_frame) {
+    pacing_.NoteInteractiveComplete(now);
+    interactive_complete_times_ns_.push_back(now);
+  } else {
+    pacing_.ResetAfterNonInteractive();
+  }
+  return true;
+}
+
+void EditorSerialFrameAdmission::ResetPacingAfterNonInteractiveWork() {
+  pacing_.ResetAfterNonInteractive();
+}
+
+auto EditorSerialFrameAdmission::InteractiveWaitNs() const -> std::int64_t {
+  return pacing_.InteractiveWaitNs(NowNs());
+}
+
+void EditorSerialFrameAdmission::RequestInteractiveDeadlineIfNeeded() {
+  const auto wait_ns = InteractiveWaitNs();
+  if (wait_ns <= 0 || holding_ownership_) {
+    return;
+  }
+  last_deadline_delay_ns_ = wait_ns;
+  if (deadline_handler_) {
+    deadline_handler_(wait_ns);
+  }
+}
+
+void EditorSerialFrameAdmission::DeferOwnerWork(DeferredOwnerWork work) {
+  if (!work) {
+    return;
+  }
+  deferred_.push(std::move(work));
+}
+
+auto EditorSerialFrameAdmission::HasDeferredOwnerWork() const -> bool {
+  return !deferred_.empty();
+}
+
+auto EditorSerialFrameAdmission::TakeDeferredOwnerWork() -> DeferredOwnerWork {
+  if (deferred_.empty()) {
+    return {};
+  }
+  auto taken = std::move(deferred_.front());
+  deferred_.pop();
+  return taken;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/app/editor_session_edit_controller.cpp
+++ b/alcedo_studio/src/app/editor_session_edit_controller.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "app/editor_adjustment_pipeline.hpp"
+#include "app/editor_pending_input.hpp"
 #include "edit/history/edit_transaction.hpp"
 
 namespace alcedo {
@@ -69,6 +70,130 @@ auto EditorSessionEditController::HandlePatch(EditorAdjustmentPatch patch, bool 
                                               : EditorRenderReason::InteractiveAdjustment;
   outcome.render_command.reason     = outcome.reason;
   outcome.render_command.adjustment = std::move(render_delta);
+  outcome.render_command.live_parameters_applied = true;
+  return outcome;
+}
+
+namespace {
+
+[[nodiscard]] auto PatchFromPendingField(const EditorPendingFieldChange& field)
+    -> EditorAdjustmentPatch {
+  EditorAdjustmentPatch patch;
+  patch.field_key   = field.target.field_key;
+  patch.params_json = field.params_json;
+  patch.enabled     = field.enabled;
+  patch.target      = field.target;
+  return patch;
+}
+
+}  // namespace
+
+auto EditorSessionEditController::HandlePendingSequence(const EditorPendingSequence& sequence,
+                                                        const EditorHistoryGuardHandle& guard,
+                                                        const EditorSessionIdentity& identity)
+    -> EditorEditOutcome {
+  EditorEditOutcome outcome;
+  outcome.identity = identity;
+
+  if (!deps_.history || !guard.valid) {
+    outcome.kind    = EditorEditOutcome::Kind::Rejected;
+    outcome.message = "Adjustment history is unavailable";
+    return outcome;
+  }
+
+  if (sequence.seal == EditorPendingInputBoundaryKind::Cancel) {
+    bool        live_changed = false;
+    std::string history_error;
+    if (!deps_.history->RestoreUnsettledPreview(guard, &live_changed, &history_error)) {
+      outcome.kind    = EditorEditOutcome::Kind::Failed;
+      outcome.message = history_error.empty() ? "Failed to restore cancelled adjustment"
+                                              : history_error;
+      return outcome;
+    }
+    if (!live_changed) {
+      outcome.kind    = EditorEditOutcome::Kind::Accepted;
+      outcome.schedule_render = false;
+      outcome.message = "Cancelled unapplied adjustment input";
+      return outcome;
+    }
+    outcome.kind                                 = EditorEditOutcome::Kind::RenderRouted;
+    outcome.reason                               = EditorRenderReason::InteractiveAdjustment;
+    outcome.render_command.reason                = outcome.reason;
+    outcome.render_command.live_parameters_applied = true;
+    outcome.message                              = "Cancelled applied adjustment preview";
+    return outcome;
+  }
+
+  if (sequence.fields.empty()) {
+    outcome.kind            = EditorEditOutcome::Kind::Accepted;
+    outcome.schedule_render = false;
+    outcome.message         = "Pending adjustment sequence had no field writes";
+    return outcome;
+  }
+
+  const bool commit = sequence.seal == EditorPendingInputBoundaryKind::Release ||
+                      sequence.seal == EditorPendingInputBoundaryKind::NodeSwitch;
+  EditorRenderAdjustmentSnapshot render_delta;
+  for (const auto& field : sequence.fields) {
+    auto        patch = PatchFromPendingField(field);
+    patch.settled     = commit;
+    if (patch.field_key.empty()) {
+      outcome.kind    = EditorEditOutcome::Kind::Rejected;
+      outcome.message = "Adjustment patch requires a field key";
+      return outcome;
+    }
+    if (patch.target.owner_kind != EditorParameterOwnerKind::Unspecified) {
+      const auto target_error =
+          DescribeEditorParameterTargetError(patch.target, patch.field_key);
+      if (!target_error.empty()) {
+        bool        live_changed = false;
+        std::string restore_error;
+        (void)deps_.history->RestoreUnsettledPreview(guard, &live_changed, &restore_error);
+        outcome.kind    = EditorEditOutcome::Kind::Rejected;
+        outcome.message = target_error;
+        return outcome;
+      }
+    }
+    if (!ResolveEditorAdjustmentField(patch.field_key).has_value()) {
+      bool        live_changed = false;
+      std::string restore_error;
+      (void)deps_.history->RestoreUnsettledPreview(guard, &live_changed, &restore_error);
+      outcome.kind    = EditorEditOutcome::Kind::Rejected;
+      outcome.message = "Unknown editor adjustment field: " + patch.field_key;
+      return outcome;
+    }
+    std::string history_error;
+    if (!deps_.history->CaptureAdjustmentBeforePreview(guard, patch, &history_error)) {
+      bool        live_changed = false;
+      std::string restore_error;
+      (void)deps_.history->RestoreUnsettledPreview(guard, &live_changed, &restore_error);
+      outcome.kind    = EditorEditOutcome::Kind::Rejected;
+      outcome.message = history_error.empty() ? "Failed to capture committed adjustment state"
+                                              : history_error;
+      return outcome;
+    }
+    if (commit && !deps_.history->CommitAdjustment(guard, patch, &history_error)) {
+      bool        live_changed = false;
+      std::string restore_error;
+      (void)deps_.history->RestoreUnsettledPreview(guard, &live_changed, &restore_error);
+      outcome.kind    = EditorEditOutcome::Kind::Rejected;
+      outcome.message = history_error.empty() ? "Failed to commit settled adjustment"
+                                              : history_error;
+      return outcome;
+    }
+    if (!render_delta.fingerprint.empty()) {
+      render_delta.fingerprint += "|";
+    }
+    render_delta.fingerprint += patch.field_key;
+    render_delta.patches.push_back(std::move(patch));
+  }
+
+  outcome.kind                                 = EditorEditOutcome::Kind::RenderRouted;
+  outcome.reason                               = commit ? EditorRenderReason::SettledAdjustment
+                                                        : EditorRenderReason::InteractiveAdjustment;
+  outcome.render_command.reason                = outcome.reason;
+  outcome.render_command.adjustment            = std::move(render_delta);
+  outcome.render_command.live_parameters_applied = true;
   return outcome;
 }
 

--- a/alcedo_studio/src/app/editor_session_render_controller.cpp
+++ b/alcedo_studio/src/app/editor_session_render_controller.cpp
@@ -83,6 +83,7 @@ auto EditorSessionRenderController::MakeRenderIntent(const EditorRenderCommand& 
   intent.priority              = DefaultPriorityForReason(command.reason);
   intent.frame_role            = FrameRoleForQuality(intent.quality);
   intent.adjustment            = command.adjustment;
+  intent.live_parameters_applied = command.live_parameters_applied;
   intent.geometry_overlay_only = geometry_overlay_active_.load(std::memory_order_acquire);
   intent.requested_width       = presentation_width_;
   intent.requested_height      = presentation_height_;

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -487,6 +487,11 @@ auto EditorSessionService::Open(sl_element_id_t element_id, image_id_t image_id)
 auto EditorSessionService::CheckoutVersion(const version_ref_id_t& version_id)
     -> EditorSessionResult {
   if (!reducing_command_) {
+    if (auto deferred = DeferIfLiveOwnershipHeld(
+            [this, version_id] { return CheckoutVersion(version_id); },
+            "Checkout queued behind in-flight frame")) {
+      return *deferred;
+    }
     EditorSessionCommand command;
     command.kind       = EditorSessionCommandKind::CheckoutVersion;
     command.version_id = version_id;
@@ -494,6 +499,7 @@ auto EditorSessionService::CheckoutVersion(const version_ref_id_t& version_id)
       return CheckoutVersion(queued.version_id);
     });
   }
+  serial_admission_.ResetPacingAfterNonInteractiveWork();
   const auto outcome = navigation_.RequestCheckoutVersion(version_id);
   return FinishVersionNavigation(outcome);
 }
@@ -1081,6 +1087,7 @@ auto EditorSessionService::EnqueueAdjustmentInput(EditorAdjustmentPatch patch)
     return Reject(admitted.error.empty() ? "Queued adjustment input was rejected"
                                          : admitted.error);
   }
+  RequestPendingInputConsume();
   EditorSessionResult result;
   result.kind     = EditorSessionResultKind::Accepted;
   result.state    = lifecycle_.state();
@@ -1103,6 +1110,7 @@ auto EditorSessionService::EnqueuePendingInputBoundary(EditorPendingInputBoundar
     return Reject(admitted.error.empty() ? "Queued adjustment boundary was rejected"
                                          : admitted.error);
   }
+  RequestPendingInputConsume();
   EditorSessionResult result;
   result.kind     = EditorSessionResultKind::Accepted;
   result.state    = lifecycle_.state();
@@ -1113,6 +1121,163 @@ auto EditorSessionService::EnqueuePendingInputBoundary(EditorPendingInputBoundar
 
 auto EditorSessionService::PeekPendingInput() const -> EditorPendingInputView {
   return pending_input_.Peek();
+}
+
+void EditorSessionService::SetAdmissionDeadlineHandler(
+    std::function<void(std::int64_t delay_ns)> handler) {
+  serial_admission_.SetDeadlineHandler(std::move(handler));
+}
+
+void EditorSessionService::SetMonotonicClock(std::shared_ptr<IEditorMonotonicClock> clock) {
+  serial_admission_.SetClock(std::move(clock));
+}
+
+void EditorSessionService::RequestPendingInputConsume() {
+  command_queue_.PostCompletion([this] {
+    const auto previous_reducing  = reducing_command_;
+    const auto previous_operation = current_operation_id_;
+    reducing_command_             = true;
+    BeginPublication();
+    TryConsumePendingInput();
+    EndPublication();
+    reducing_command_     = previous_reducing;
+    current_operation_id_ = previous_operation;
+  });
+}
+
+void EditorSessionService::TryConsumePendingInput() {
+  if (lifecycle_.state() != EditorSessionState::Interactive || !lifecycle_.has_image()) {
+    return;
+  }
+  if (serial_admission_.HoldsOwnership()) {
+    return;
+  }
+  if (render_.render_diagnostics().has_inflight) {
+    serial_admission_.RequestInteractiveDeadlineIfNeeded();
+    return;
+  }
+  if (serial_admission_.HasDeferredOwnerWork()) {
+    auto work = serial_admission_.TakeDeferredOwnerWork();
+    if (work) {
+      work();
+    }
+    return;
+  }
+  if (!pending_input_.HasConsumableWork()) {
+    return;
+  }
+  const auto peek = pending_input_.Peek();
+  if (peek.sequences.empty()) {
+    return;
+  }
+  const bool interactive =
+      peek.sequences.front().seal == EditorPendingInputBoundaryKind::None;
+  if (!serial_admission_.TryBeginCycle(interactive)) {
+    return;
+  }
+  auto batch = pending_input_.TakeReadyBatch();
+  if (!batch.has_value()) {
+    serial_admission_.AbortCycle();
+    return;
+  }
+  const auto result = ConsumeTakenSequence(*batch);
+  if (result.kind == EditorSessionResultKind::Rejected ||
+      result.kind == EditorSessionResultKind::Failed) {
+    serial_admission_.AbortCycle();
+    (void)Emit(result);
+    RequestPendingInputConsume();
+  }
+}
+
+auto EditorSessionService::ConsumeTakenSequence(const EditorPendingSequence& sequence)
+    -> EditorSessionResult {
+  const auto guard = lifecycle_.history_guard();
+  const auto ident = lifecycle_.identity();
+  auto       outcome = edit_.HandlePendingSequence(sequence, guard, ident);
+  if (outcome.kind == EditorEditOutcome::Kind::Rejected ||
+      outcome.kind == EditorEditOutcome::Kind::Failed) {
+    EditorSessionResult result;
+    result.kind     = outcome.kind == EditorEditOutcome::Kind::Failed
+                          ? EditorSessionResultKind::Failed
+                          : EditorSessionResultKind::Rejected;
+    result.state    = lifecycle_.state();
+    result.identity = ident;
+    result.message  = outcome.message;
+    return result;
+  }
+  const bool commit = sequence.seal == EditorPendingInputBoundaryKind::Release ||
+                      sequence.seal == EditorPendingInputBoundaryKind::NodeSwitch;
+  if (!outcome.schedule_render || outcome.kind != EditorEditOutcome::Kind::RenderRouted) {
+    serial_admission_.AbortCycle();
+    if (commit) {
+      BumpHistoryRevision();
+    }
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Accepted;
+    result.state    = lifecycle_.state();
+    result.identity = ident;
+    result.message  = outcome.message;
+    return result;
+  }
+  const auto route_identity           = lifecycle_.identity();
+  const auto load_request             = lifecycle_.active_image_load_request();
+  outcome.render_command.operation_id = current_operation_id_;
+  const auto request_id =
+      render_.RouteInitialRender(outcome.render_command, route_identity, load_request);
+  if (request_id == 0) {
+    serial_admission_.AbortCycle();
+  } else {
+    serial_admission_.NoteScheduledRequest(request_id);
+  }
+  if (commit) {
+    BumpHistoryRevision();
+  }
+  EditorSessionResult result;
+  result.kind              = EditorSessionResultKind::RenderRouted;
+  result.state             = lifecycle_.state();
+  result.identity          = route_identity;
+  result.render_request_id = request_id;
+  result.message           = outcome.message;
+  return result;
+}
+
+void EditorSessionService::FinishSerialFrameIfNeeded(const EditorRenderResult& render_result) {
+  switch (render_result.kind) {
+    case EditorRenderResultKind::FrameReady:
+    case EditorRenderResultKind::Failed:
+    case EditorRenderResultKind::Cancelled:
+      break;
+    default:
+      return;
+  }
+  const bool published = render_result.kind == EditorRenderResultKind::FrameReady;
+  (void)serial_admission_.CompleteIfMatches(render_result.request_id, published);
+  if (serial_admission_.HoldsOwnership()) {
+    return;
+  }
+  if (serial_admission_.HasDeferredOwnerWork()) {
+    auto work = serial_admission_.TakeDeferredOwnerWork();
+    if (work) {
+      work();
+    }
+    return;
+  }
+  TryConsumePendingInput();
+}
+
+auto EditorSessionService::DeferIfLiveOwnershipHeld(std::function<EditorSessionResult()> retry,
+                                                    std::string message)
+    -> std::optional<EditorSessionResult> {
+  if (!serial_admission_.HoldsOwnership() || !retry) {
+    return std::nullopt;
+  }
+  serial_admission_.DeferOwnerWork([retry = std::move(retry)]() { (void)retry(); });
+  EditorSessionResult result;
+  result.kind     = EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = lifecycle_.identity();
+  result.message  = std::move(message);
+  return result;
 }
 
 auto EditorSessionService::PublishTypedNodeHistorySuccess(std::string message)
@@ -1194,6 +1359,10 @@ auto EditorSessionService::CommitAdjustment(std::string patch_key) -> EditorSess
 
 auto EditorSessionService::Undo() -> EditorSessionResult {
   if (!reducing_command_) {
+    if (auto deferred = DeferIfLiveOwnershipHeld([this] { return Undo(); },
+                                                "Undo queued behind in-flight frame")) {
+      return *deferred;
+    }
     EditorSessionCommand command;
     command.kind = EditorSessionCommandKind::Undo;
     return SubmitCommand(std::move(command),
@@ -1211,6 +1380,7 @@ auto EditorSessionService::Undo() -> EditorSessionResult {
   if (outcome.kind == EditorEditOutcome::Kind::Failed) {
     return Reject(outcome.message);
   }
+  serial_admission_.ResetPacingAfterNonInteractiveWork();
   const auto undo_identity            = lifecycle_.identity();
   const auto load_request             = lifecycle_.active_image_load_request();
   outcome.render_command.operation_id = current_operation_id_;
@@ -1228,6 +1398,10 @@ auto EditorSessionService::Undo() -> EditorSessionResult {
 
 auto EditorSessionService::Redo() -> EditorSessionResult {
   if (!reducing_command_) {
+    if (auto deferred = DeferIfLiveOwnershipHeld([this] { return Redo(); },
+                                                "Redo queued behind in-flight frame")) {
+      return *deferred;
+    }
     EditorSessionCommand command;
     command.kind = EditorSessionCommandKind::Redo;
     return SubmitCommand(std::move(command),
@@ -1245,6 +1419,7 @@ auto EditorSessionService::Redo() -> EditorSessionResult {
   if (outcome.kind == EditorEditOutcome::Kind::Failed) {
     return Reject(outcome.message);
   }
+  serial_admission_.ResetPacingAfterNonInteractiveWork();
   const auto redo_identity            = lifecycle_.identity();
   const auto load_request             = lifecycle_.active_image_load_request();
   outcome.render_command.operation_id = current_operation_id_;
@@ -1499,6 +1674,7 @@ void EditorSessionService::NotifyRenderResult(const EditorRenderResult& render_r
     BeginPublication();
     render_.NotifyRenderResult(completion.render_result, lifecycle_.identity(),
                                lifecycle_.active_image_load_request(), lifecycle_.state());
+    FinishSerialFrameIfNeeded(completion.render_result);
     EndPublication();
     reducing_command_     = previous_reducing;
     current_operation_id_ = previous_operation;

--- a/alcedo_studio/src/include/app/editor_adjustment_pipeline.hpp
+++ b/alcedo_studio/src/include/app/editor_adjustment_pipeline.hpp
@@ -33,6 +33,24 @@ struct EditorAdjustmentOperatorState {
 auto ResolveEditorAdjustmentField(const std::string& field_key)
     -> std::optional<EditorAdjustmentFieldSpec>;
 
+/**
+ * @brief Map a field write payload onto PipelineDocument Model JSON keys.
+ *
+ * Panel writes use field keys (`exposure`) or a scalar `value`. Document Models
+ * use `exposure_ev` / `cube_path`. Unknown keys are left unchanged.
+ */
+auto EditorAdjustmentDocumentParamsFromWrite(const std::string& field_key, nlohmann::json params)
+    -> nlohmann::json;
+
+/**
+ * @brief Map a field write or document Model JSON onto CPU operator keys.
+ *
+ * CPU operators use `exposure` / `ocio_lmt`. Document `exposure_ev` / `cube_path`
+ * and scalar `value` writes are rewritten. Unknown keys are left unchanged.
+ */
+auto EditorAdjustmentExecutorParamsFromWrite(const std::string& field_key, nlohmann::json params)
+    -> nlohmann::json;
+
 /// Return the canonical QML field key for a committed operator payload.
 auto EditorAdjustmentFieldKey(PipelineStageName stage_name, OperatorType operator_type)
     -> std::optional<std::string>;

--- a/alcedo_studio/src/include/app/editor_interactive_pacing.hpp
+++ b/alcedo_studio/src/include/app/editor_interactive_pacing.hpp
@@ -1,0 +1,84 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace alcedo {
+
+/**
+ * @brief Interactive consume cadence: 16 ms total cycle, not a post-frame delay.
+ *
+ * A cycle starts when the owner begins consuming a batch and ends at owner-safe
+ * completion. The next Interactive start is no earlier than both that completion
+ * and start + 16 ms. A 5 ms cycle leaves at most 11 ms of wait; a 22 ms cycle
+ * starts the next Interactive batch immediately when complete.
+ *
+ * Quality, Release, Undo, and other non-Interactive work ignore this wait after
+ * ownership is free. Idle input (no prior Interactive start) waits zero.
+ *
+ * Does not manufacture empty frames or replay missed timer ticks.
+ */
+class EditorInteractivePacing {
+ public:
+  static constexpr std::int64_t kCycleBudgetNs = 16'000'000;
+
+  /**
+   * @brief Nanoseconds to wait before the next Interactive consume may start.
+   *
+   * @param now_ns Current monotonic time from the injected clock.
+   * @return 0 when eligible now, otherwise remaining wait.
+   */
+  [[nodiscard]] auto InteractiveWaitNs(std::int64_t now_ns) const -> std::int64_t {
+    if (!next_interactive_eligible_ns_.has_value()) {
+      return 0;
+    }
+    if (now_ns >= *next_interactive_eligible_ns_) {
+      return 0;
+    }
+    return *next_interactive_eligible_ns_ - now_ns;
+  }
+
+  /// Record the start of an Interactive consume/render cycle.
+  void NoteInteractiveStart(std::int64_t now_ns) { interactive_start_ns_ = now_ns; }
+
+  /**
+   * @brief Record owner-safe completion of an Interactive cycle.
+   *
+   * Sets the next eligible time to max(completion, start + budget).
+   */
+  void NoteInteractiveComplete(std::int64_t now_ns) {
+    if (interactive_start_ns_.has_value()) {
+      const auto earliest = *interactive_start_ns_ + kCycleBudgetNs;
+      next_interactive_eligible_ns_ = now_ns > earliest ? now_ns : earliest;
+    } else {
+      next_interactive_eligible_ns_ = now_ns;
+    }
+    interactive_start_ns_.reset();
+  }
+
+  /// Drop an Interactive start that never reached a frame (failed apply).
+  void CancelInteractiveStart() { interactive_start_ns_.reset(); }
+
+  /// Non-Interactive ownership finished: next Interactive may start immediately.
+  void ResetAfterNonInteractive() {
+    interactive_start_ns_.reset();
+    next_interactive_eligible_ns_.reset();
+  }
+
+  [[nodiscard]] auto last_interactive_start_ns() const -> std::optional<std::int64_t> {
+    return interactive_start_ns_;
+  }
+  [[nodiscard]] auto next_interactive_eligible_ns() const -> std::optional<std::int64_t> {
+    return next_interactive_eligible_ns_;
+  }
+
+ private:
+  std::optional<std::int64_t> interactive_start_ns_;
+  std::optional<std::int64_t> next_interactive_eligible_ns_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_monotonic_clock.hpp
+++ b/alcedo_studio/src/include/app/editor_monotonic_clock.hpp
@@ -1,0 +1,39 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+namespace alcedo {
+
+/**
+ * @brief Monotonic nanosecond clock for Interactive consume pacing.
+ *
+ * Production uses the steady clock. Tests inject a manual clock so 5/16/22 ms
+ * cycles are proven by timestamp, not wall-clock sleeps.
+ *
+ * @thread_safety Implementations used by the session owner must be safe to read
+ *                from that owner thread. The steady clock is thread-safe.
+ */
+class IEditorMonotonicClock {
+ public:
+  virtual ~IEditorMonotonicClock() = default;
+
+  /// Monotonic time in nanoseconds. Epoch is implementation-defined.
+  [[nodiscard]] virtual auto NowNs() const -> std::int64_t = 0;
+};
+
+/// Production clock. Uses `std::chrono::steady_clock`.
+class SteadyEditorMonotonicClock final : public IEditorMonotonicClock {
+ public:
+  [[nodiscard]] auto NowNs() const -> std::int64_t override {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+  }
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_pending_input.hpp
+++ b/alcedo_studio/src/include/app/editor_pending_input.hpp
@@ -132,6 +132,21 @@ class EditorPendingInputQueue {
    */
   [[nodiscard]] auto Peek() const -> EditorPendingInputView;
 
+  /**
+   * @brief Take the next sequence the owner may apply.
+   *
+   * Sealed sequences are taken in admit order. When none are sealed, the open
+   * sequence's current field writes are taken and the sequence stays open so
+   * later pointer samples can merge. Empty open sequences are not taken.
+   * Cancel seals are taken even when fields were discarded at admit time.
+   *
+   * @return The batch, or nullopt when nothing is consumable.
+   */
+  auto TakeReadyBatch() -> std::optional<EditorPendingSequence>;
+
+  /// True when TakeReadyBatch would return a sequence.
+  [[nodiscard]] auto HasConsumableWork() const -> bool;
+
   /// True when no sealed or open sequences remain.
   [[nodiscard]] auto empty() const -> bool;
 
@@ -144,6 +159,7 @@ class EditorPendingInputQueue {
       -> EditorPendingSequence&;
   void SealOpenLocked(EditorPendingInputBoundaryKind kind);
   [[nodiscard]] auto PeekLocked() const -> EditorPendingInputView;
+  [[nodiscard]] auto HasConsumableWorkLocked() const -> bool;
 
   mutable std::mutex                                 mutex_;
   std::uint64_t                                      next_sequence_id_ = 1;

--- a/alcedo_studio/src/include/app/editor_render_intent.hpp
+++ b/alcedo_studio/src/include/app/editor_render_intent.hpp
@@ -113,6 +113,9 @@ struct EditorRenderIntent {
   // carried by the intent, but the scheduler disables CROP_ROTATE for this
   // preview frame so its aspect matches the overlay's source-image UV space.
   bool                                           geometry_overlay_only = false;
+  /// True when consume already wrote live document and CPU operators under the
+  /// render lock. Configure must not apply `adjustment` again.
+  bool                                           live_parameters_applied = false;
 };
 
 struct EditorRenderRequest {

--- a/alcedo_studio/src/include/app/editor_serial_frame_admission.hpp
+++ b/alcedo_studio/src/include/app/editor_serial_frame_admission.hpp
@@ -1,0 +1,111 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <vector>
+
+#include "app/editor_interactive_pacing.hpp"
+#include "app/editor_monotonic_clock.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief One-writer admission for consume/apply/render cycles.
+ *
+ * Owns whether a pending-input consume currently holds live ownership, the
+ * Interactive 16 ms cadence, and owner work deferred until the inflight frame
+ * is owner-safe. Does not own the pending-input queue, history, or coordinator.
+ *
+ * @thread_safety Session owner thread only. Not internally synchronized.
+ */
+class EditorSerialFrameAdmission {
+ public:
+  using DeadlineHandler  = std::function<void(std::int64_t delay_ns)>;
+  using DeferredOwnerWork = std::function<void()>;
+
+  EditorSerialFrameAdmission();
+
+  void SetClock(std::shared_ptr<IEditorMonotonicClock> clock);
+  void SetDeadlineHandler(DeadlineHandler handler);
+
+  [[nodiscard]] auto clock() const -> const std::shared_ptr<IEditorMonotonicClock>& {
+    return clock_;
+  }
+  [[nodiscard]] auto NowNs() const -> std::int64_t;
+
+  /// True between TryBeginCycle success and matching CompleteIfMatches / AbortCycle.
+  [[nodiscard]] auto HoldsOwnership() const -> bool { return holding_ownership_; }
+
+  [[nodiscard]] auto inflight_request_id() const -> std::uint64_t { return inflight_request_id_; }
+
+  [[nodiscard]] auto cycle_is_interactive() const -> bool { return cycle_is_interactive_; }
+
+  /**
+   * @brief Try to start one consume/render cycle.
+   *
+   * Interactive cycles honor remaining 16 ms wait and schedule a deadline
+   * wakeup when not yet eligible. Non-Interactive cycles bypass that wait.
+   *
+   * @return false when ownership is already held or Interactive pacing must wait.
+   */
+  auto TryBeginCycle(bool interactive) -> bool;
+
+  /// Remember the coordinator request id that releases this cycle.
+  void NoteScheduledRequest(std::uint64_t request_id);
+
+  /// Failed apply/route: drop ownership without consuming the Interactive budget.
+  void AbortCycle();
+
+  /**
+   * @brief Release ownership when @p request_id matches the inflight consume.
+   *
+   * Published Interactive cycles start the 16 ms cadence. Abandoned
+   * (failed/cancelled) cycles release ownership without that wait so the next
+   * batch can start as soon as the owner is free.
+   *
+   * @return true when this completion ended the current cycle.
+   */
+  auto CompleteIfMatches(std::uint64_t request_id, bool published_frame = true) -> bool;
+
+  /// Drop Interactive cadence after Undo, Checkout, or other owner work.
+  void ResetPacingAfterNonInteractiveWork();
+
+  [[nodiscard]] auto InteractiveWaitNs() const -> std::int64_t;
+
+  /// If Interactive work is waiting on cadence, arm the deadline handler once.
+  void RequestInteractiveDeadlineIfNeeded();
+
+  void DeferOwnerWork(DeferredOwnerWork work);
+  [[nodiscard]] auto HasDeferredOwnerWork() const -> bool;
+  auto               TakeDeferredOwnerWork() -> DeferredOwnerWork;
+
+  [[nodiscard]] auto interactive_start_times_ns() const -> const std::vector<std::int64_t>& {
+    return interactive_start_times_ns_;
+  }
+  [[nodiscard]] auto interactive_complete_times_ns() const -> const std::vector<std::int64_t>& {
+    return interactive_complete_times_ns_;
+  }
+  [[nodiscard]] auto last_deadline_delay_ns() const -> std::int64_t {
+    return last_deadline_delay_ns_;
+  }
+
+ private:
+  std::shared_ptr<IEditorMonotonicClock> clock_;
+  DeadlineHandler                        deadline_handler_;
+  EditorInteractivePacing                pacing_;
+  std::queue<DeferredOwnerWork>          deferred_;
+  bool                                   holding_ownership_     = false;
+  bool                                   cycle_is_interactive_  = false;
+  std::uint64_t                          inflight_request_id_   = 0;
+  std::int64_t                           last_deadline_delay_ns_ = 0;
+  std::vector<std::int64_t>              interactive_start_times_ns_;
+  std::vector<std::int64_t>              interactive_complete_times_ns_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_session_edit_controller.hpp
+++ b/alcedo_studio/src/include/app/editor_session_edit_controller.hpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "app/editor_adjustment_types.hpp"
+#include "app/editor_pending_input.hpp"
 #include "app/editor_render_intent.hpp"
 #include "app/editor_session_ports.hpp"
 #include "app/editor_session_types.hpp"
@@ -54,6 +55,19 @@ class EditorSessionEditController final {
   auto HandlePatch(EditorAdjustmentPatch patch, bool settled,
                    const EditorHistoryGuardHandle& guard,
                    const EditorSessionIdentity& identity) -> EditorEditOutcome;
+
+  /**
+   * @brief Apply one pending-input sequence under the history owner.
+   *
+   * Captures first-before values, applies every field once, commits Release and
+   * NodeSwitch sequences, restores Cancel without committing, and returns a
+   * single render command. Live parameters are applied during history capture;
+   * the render command sets @c live_parameters_applied so configure does not
+   * apply them again.
+   */
+  auto HandlePendingSequence(const EditorPendingSequence& sequence,
+                             const EditorHistoryGuardHandle& guard,
+                             const EditorSessionIdentity& identity) -> EditorEditOutcome;
 
   /// Undo or redo the last history operation. History rebuilds the live pipeline;
   /// the render command carries no adjustment replay.

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -75,6 +75,23 @@ class IEditorHistoryPort {
                                               std::string* /*error*/) -> bool {
     return true;
   }
+  /**
+   * @brief Restore applied provisional fields without committing history.
+   *
+   * Clears the current input-sequence before-values and writes them back to the
+   * live document and executor. Does not move the working head. Default is a
+   * no-op success so fakes can opt in.
+   *
+   * @return false on restore failure. @p live_changed is true when any
+   *         provisional field was present before the restore.
+   */
+  virtual auto RestoreUnsettledPreview(const EditorHistoryGuardHandle& /*guard*/,
+                                       bool* live_changed, std::string* /*error*/) -> bool {
+    if (live_changed != nullptr) {
+      *live_changed = false;
+    }
+    return true;
+  }
   /// Finalize one settled adjustment into the checked-out Version's working
   /// history. Production appends the mini-Git journal record before advancing
   /// the working head and transaction-chain hash.
@@ -445,6 +462,9 @@ struct EditorRenderCommand {
   std::uint64_t                       operation_id = 0;
   EditorRenderAdjustmentSnapshot      adjustment{};
   std::optional<ViewportRenderRegion> view_region;
+  /// True when live document/executor already hold this batch. Configure skips
+  /// snapshot application.
+  bool                                live_parameters_applied = false;
 };
 
 /// Sole path from the session service into pipeline work. Production wraps

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -15,6 +15,7 @@
 #include "app/adjustment_transfer_types.hpp"
 #include "app/editor_action_policy.hpp"
 #include "app/editor_pending_input.hpp"
+#include "app/editor_serial_frame_admission.hpp"
 #include "app/editor_session_request_ids.hpp"
 #include "app/editor_render_intent.hpp"
 #include "app/editor_save_checkpoint_service.hpp"
@@ -258,6 +259,16 @@ class IEditorSessionBackend {
    * The view is the pending-input queue itself, not a live parameter-body copy.
    */
   [[nodiscard]] virtual auto PeekPendingInput() const -> EditorPendingInputView { return {}; }
+  /**
+   * @brief Consume the next pending-input batch when the owner is idle.
+   *
+   * No-op on backends that do not own a pending-input queue. Must run on the
+   * session owner thread. Does not take the render lock from a GUI input
+   * callback.
+   */
+  virtual void TryConsumePendingInput() {}
+  virtual void SetAdmissionDeadlineHandler(std::function<void(std::int64_t /*delay_ns*/)> /*handler*/) {
+  }
   /// Rename a Color Grade as a metadata-only history change. Default backends reject.
   virtual auto RenameColorGrade(const NodeId& /*node_id*/, std::string /*display_name*/)
       -> EditorSessionResult {
@@ -434,6 +445,15 @@ class EditorSessionService final : public IEditorSessionBackend {
   auto EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind kind)
       -> EditorSessionResult override;
   [[nodiscard]] auto PeekPendingInput() const -> EditorPendingInputView override;
+  void               TryConsumePendingInput() override;
+  void SetAdmissionDeadlineHandler(std::function<void(std::int64_t delay_ns)> handler) override;
+  void SetMonotonicClock(std::shared_ptr<IEditorMonotonicClock> clock);
+  [[nodiscard]] auto serial_frame_admission() const -> const EditorSerialFrameAdmission& {
+    return serial_admission_;
+  }
+  [[nodiscard]] auto serial_frame_admission() -> EditorSerialFrameAdmission& {
+    return serial_admission_;
+  }
   auto RenameColorGrade(const NodeId& node_id, std::string display_name)
       -> EditorSessionResult override;
   auto EditNodeGraph(NodeGraphTopologyChange change) -> EditorSessionResult override;
@@ -525,6 +545,12 @@ class EditorSessionService final : public IEditorSessionBackend {
    */
   auto PublishTypedNodeHistorySuccess(std::string message) -> EditorSessionResult;
 
+  void RequestPendingInputConsume();
+  void FinishSerialFrameIfNeeded(const EditorRenderResult& render_result);
+  auto DeferIfLiveOwnershipHeld(std::function<EditorSessionResult()> retry, std::string message)
+      -> std::optional<EditorSessionResult>;
+  auto ConsumeTakenSequence(const EditorPendingSequence& sequence) -> EditorSessionResult;
+
   /// Queue-owned publish flavor for one in-flight history save checkpoint.
   /// Set by StartHistoryCheckpoint and consumed by the matching
   /// SaveCheckpointFinished completion.
@@ -542,6 +568,7 @@ class EditorSessionService final : public IEditorSessionBackend {
   EditorSessionEditController             edit_;
   EditorSessionNavigationController       navigation_;
   EditorPendingInputQueue                 pending_input_;
+  EditorSerialFrameAdmission              serial_admission_;
   bool                                    reducing_command_     = false;
   std::uint64_t                           current_operation_id_ = 0;
   std::size_t                             publication_depth_    = 0;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
@@ -28,18 +28,23 @@ class EditorHistoryState;
 /// Extracted mutation/navigation unit. Handles adjustment capture, settled
 /// commit, graph and Mask commands, Undo, Redo, explicit head movement, and
 /// Version checkout. Parameter operations run on the history queue and hold the
-/// executor render lock across document access and WAL publication. They never
-/// copy the document or update stage params.
+/// executor render lock across document access, CPU operator remirror, and WAL
+/// publication. They never copy the document.
 class EditorHistoryMutation {
  public:
   explicit EditorHistoryMutation(EditorHistoryState& state);
 
   /// Capture the target Model value once and apply preview under the render lock.
   /// Unspecified current-panel targets are completed from the live document.
-  /// Explicit incomplete targets are rejected.
+  /// Explicit incomplete targets are rejected. The matching CPU operator is
+  /// updated in the same lock so configure does not apply the patch again.
   auto CaptureAdjustmentBeforePreview(const alcedo::EditorHistoryGuardHandle& guard,
                                       const alcedo::EditorAdjustmentPatch& patch,
                                       std::string* error) -> bool;
+
+  /// Restore applied provisional fields without committing. Used by Cancel.
+  auto RestoreUnsettledPreview(const alcedo::EditorHistoryGuardHandle& guard, bool* live_changed,
+                               std::string* error) -> bool;
 
   /// Append one settled typed-batch adjustment and advance the live working head.
   /// The live document already holds after values from preview. WAL failure restores

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -8,6 +8,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QString>
+#include <QTimer>
 #include <QVariantMap>
 #include <QtGlobal>
 #include <memory>
@@ -308,6 +309,7 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
                                      const QString&                     selected_id = {});
   /// Correlate an async backend result observer delivery to a pending action.
   void OnBackendSessionResult(const alcedo::EditorSessionResult& result);
+  void BindAdmissionDeadline();
   [[nodiscard]] static auto       NormalizeAdjustmentPanel(const QString& panel) -> QString;
   [[nodiscard]] static auto       NormalizeToolPanelPage(const QString& page) -> QString;
 
@@ -351,6 +353,7 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   QMetaObject::Connection                        interaction_view_change_connection_;
   QMetaObject::Connection                        interaction_policy_connection_;
   mutable std::unique_ptr<EditorScopeController> scope_controller_;
+  QTimer*                                        admission_deadline_timer_ = nullptr;
 };
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
@@ -58,6 +58,8 @@ class EditorSessionHistoryPort final : public alcedo::IEditorHistoryPort {
   auto CaptureAdjustmentBeforePreview(const alcedo::EditorHistoryGuardHandle& guard,
                                       const alcedo::EditorAdjustmentPatch& patch,
                                       std::string* error) -> bool override;
+  auto RestoreUnsettledPreview(const alcedo::EditorHistoryGuardHandle& guard, bool* live_changed,
+                               std::string* error) -> bool override;
   auto CommitAdjustment(const alcedo::EditorHistoryGuardHandle& guard,
                         const alcedo::EditorAdjustmentPatch& patch, std::string* error)
       -> bool override;

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
@@ -15,6 +15,7 @@
 #include "app/pipeline_document_history.hpp"
 #include "app/pipeline_history_applier.hpp"
 #include "app/pipeline_service.hpp"
+#include "edit/pipeline/pipeline_cpu.hpp"
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/history/commit_graph.hpp"
@@ -94,6 +95,24 @@ auto RestoreDocumentFields(HistoryWorkingState&                                 
     }
   }
   return true;
+}
+
+auto MirrorPatchToExecutor(CPUPipelineExecutor& executor, const alcedo::EditorAdjustmentPatch& patch,
+                           std::string* error) -> bool {
+  nlohmann::json parsed;
+  try {
+    parsed = patch.params_json.empty() ? nlohmann::json::object()
+                                       : nlohmann::json::parse(patch.params_json);
+  } catch (const std::exception& ex) {
+    if (error) *error = ex.what();
+    return false;
+  }
+  alcedo::EditorAdjustmentPatch executor_patch = patch;
+  executor_patch.params_json =
+      alcedo::EditorAdjustmentExecutorParamsFromWrite(patch.field_key, std::move(parsed)).dump();
+  alcedo::EditorRenderAdjustmentSnapshot snapshot;
+  snapshot.patches = {std::move(executor_patch)};
+  return alcedo::ApplyEditorAdjustmentSnapshot(executor, snapshot, error);
 }
 
 auto ApplyContext(MaskStore* mask_store) -> PipelineHistoryApplyContext {
@@ -361,14 +380,66 @@ auto EditorHistoryMutation::CaptureAdjustmentBeforePreview(
   } else {
     edit = sequence->second;
   }
-  if (!ApplyEditorParameterPatch(*state->pipeline_guard->document_, edit.target, patch_params,
+  const auto document_params =
+      alcedo::EditorAdjustmentDocumentParamsFromWrite(patch.field_key, patch_params);
+  if (!ApplyEditorParameterPatch(*state->pipeline_guard->document_, edit.target, document_params,
                                  error)) {
+    return false;
+  }
+  if (!MirrorPatchToExecutor(*state->pipeline_guard->pipeline_, patch, error)) {
+    (void)ApplyEditorParameterPatch(*state->pipeline_guard->document_, edit.target,
+                                    edit.before_model_json, error);
     return false;
   }
   // Only the first successful patch locks a target. Rejected input does not capture state.
   if (sequence == state->pending_document_sequence.end()) {
     state->pending_document_sequence.emplace(patch.field_key, std::move(edit));
   }
+  SyncUnsettledPreviewFlag(*state);
+  return true;
+}
+
+auto EditorHistoryMutation::RestoreUnsettledPreview(const alcedo::EditorHistoryGuardHandle& guard,
+                                                    bool* live_changed, std::string* error)
+    -> bool {
+  auto state = state_.EnsureWorkingState(guard.element_id, error);
+  if (!state) return false;
+  if (!state->pipeline_guard || !state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
+  }
+  if (!state->pipeline_guard->pipeline_) {
+    if (error) *error = "Live pipeline executor is unavailable";
+    return false;
+  }
+  const bool changed = !state->pending_document_sequence.empty();
+  if (live_changed != nullptr) {
+    *live_changed = changed;
+  }
+  if (!changed) {
+    return true;
+  }
+  auto                                                      render_lock =
+      LockLivePipeline(*state->pipeline_guard->pipeline_);
+  std::vector<HistoryWorkingState::DocumentFieldEdit> fields;
+  fields.reserve(state->pending_document_sequence.size());
+  for (const auto& [_, edit] : state->pending_document_sequence) {
+    fields.push_back(edit);
+  }
+  if (!RestoreDocumentFields(*state, fields, error)) {
+    return false;
+  }
+  for (const auto& edit : fields) {
+    alcedo::EditorAdjustmentPatch patch;
+    patch.field_key   = edit.target.field_key;
+    patch.target      = edit.target;
+    patch.params_json = edit.before_model_json.dump();
+    if (!MirrorPatchToExecutor(*state->pipeline_guard->pipeline_, patch, error)) {
+      return false;
+    }
+    ProjectDocumentEdit(*state, edit, true);
+  }
+  state->pending_document_sequence.clear();
   SyncUnsettledPreviewFlag(*state);
   return true;
 }
@@ -423,7 +494,9 @@ auto EditorHistoryMutation::CommitAdjustment(const alcedo::EditorHistoryGuardHan
   }
   auto       render_lock   = LockLivePipeline(*state->pipeline_guard->pipeline_);
   const auto locked_target = sequence->second.target;
-  if (!ApplyEditorParameterPatch(*state->pipeline_guard->document_, locked_target, after_params,
+  const auto document_after =
+      alcedo::EditorAdjustmentDocumentParamsFromWrite(patch.field_key, after_params);
+  if (!ApplyEditorParameterPatch(*state->pipeline_guard->document_, locked_target, document_after,
                                  error))
     return false;
   HistoryWorkingState::DocumentFieldEdit recorded = sequence->second;

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -9,6 +9,7 @@
 #include <QJsonObject>
 #include <QSettings>
 #include <QThread>
+#include <QTimer>
 #include <QtGlobal>
 #include <algorithm>
 #include <cmath>
@@ -72,6 +73,7 @@ EditorSessionController::EditorSessionController(alcedo::IEditorSessionBackend* 
     ApplyActionAvailability();
   }
   InstallBackendNotifier();
+  BindAdmissionDeadline();
 }
 
 EditorSessionController::~EditorSessionController() {
@@ -79,7 +81,42 @@ EditorSessionController::~EditorSessionController() {
     session_backend_->SetChangeNotifier({});
     session_backend_->SetResultObserver({});
     session_backend_->SetActionAvailabilityObserver({});
+    session_backend_->SetAdmissionDeadlineHandler({});
   }
+}
+
+void EditorSessionController::BindAdmissionDeadline() {
+  if (!session_backend_) {
+    return;
+  }
+  if (admission_deadline_timer_ == nullptr) {
+    admission_deadline_timer_ = new QTimer(this);
+    admission_deadline_timer_->setSingleShot(true);
+    connect(admission_deadline_timer_, &QTimer::timeout, this, [this] {
+      if (session_backend_) {
+        session_backend_->TryConsumePendingInput();
+      }
+    });
+  }
+  QPointer<EditorSessionController> self(this);
+  session_backend_->SetAdmissionDeadlineHandler([self](std::int64_t delay_ns) {
+    if (!self || self->admission_deadline_timer_ == nullptr) {
+      return;
+    }
+    auto* timer = self->admission_deadline_timer_;
+    timer->stop();
+    if (delay_ns <= 0) {
+      QTimer::singleShot(0, self.data(), [self] {
+        if (self && self->session_backend_) {
+          self->session_backend_->TryConsumePendingInput();
+        }
+      });
+      return;
+    }
+    const int delay_ms =
+        static_cast<int>((delay_ns + 999999) / 1000000);
+    timer->start(std::max(1, delay_ms));
+  });
 }
 
 void EditorSessionController::InstallBackendNotifier() {
@@ -153,12 +190,14 @@ void EditorSessionController::SetSessionBackend(alcedo::IEditorSessionBackend* s
     session_backend_->SetChangeNotifier({});
     session_backend_->SetResultObserver({});
     session_backend_->SetActionAvailabilityObserver({});
+    session_backend_->SetAdmissionDeadlineHandler({});
   }
   session_backend_ = session_backend;
   if (session_backend_) {
     session_backend_->SetGeometryOverlayActive(active_adjustment_panel_ ==
                                                QLatin1String("geometry"));
     InstallBackendNotifier();
+    BindAdmissionDeadline();
     SyncIdentityFromBackend();
     ApplyActionAvailability();
   } else {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
@@ -65,6 +65,12 @@ auto EditorSessionHistoryPort::CaptureAdjustmentBeforePreview(
   return mutation_->CaptureAdjustmentBeforePreview(guard, patch, error);
 }
 
+auto EditorSessionHistoryPort::RestoreUnsettledPreview(
+    const alcedo::EditorHistoryGuardHandle& guard, bool* live_changed, std::string* error)
+    -> bool {
+  return mutation_->RestoreUnsettledPreview(guard, live_changed, error);
+}
+
 auto EditorSessionHistoryPort::CommitAdjustment(const alcedo::EditorHistoryGuardHandle& guard,
                                                 const alcedo::EditorAdjustmentPatch& patch,
                                                 std::string* error) -> bool {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_render_scheduler_port.cpp
@@ -450,15 +450,17 @@ void EditorSessionRenderSchedulerPort::DispatchPipelineFrame(Job job, alcedo::IF
     task.options_.is_blocking_                                         = false;
     const bool apply_adjustment =
         alcedo::ReasonAppliesAdjustmentSnapshot(job.request.intent.reason);
+    const bool live_parameters_applied = job.request.intent.live_parameters_applied;
     task.configure_under_render_lock_ = [snapshot = job.request.intent.adjustment, sink,
                                          geometry_overlay_only =
                                              job.request.intent.geometry_overlay_only,
-                                         apply_adjustment](alcedo::PipelineTask& locked_task) {
+                                         apply_adjustment,
+                                         live_parameters_applied](alcedo::PipelineTask& locked_task) {
       auto locked_exec = locked_task.pipeline_executor_;
       if (!locked_exec) {
         return false;
       }
-      if (apply_adjustment) {
+      if (apply_adjustment && !live_parameters_applied) {
         std::string apply_error;
         if (!alcedo::ApplyEditorAdjustmentSnapshot(*locked_exec, snapshot, &apply_error)) {
           throw std::runtime_error(apply_error.empty() ? "Failed to apply editor adjustment"

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -361,6 +361,37 @@ gtest_discover_tests(EditorPendingInputSessionTest
     PROPERTIES LABELS "ci_core_flow;editor_session")
 alcedo_register_test_target(EditorPendingInputSessionTest app ci_core)
 
+add_executable(EditorInteractivePacingTest
+    ${ALCEDO_TEST_ROOT}/app/editor_interactive_pacing_test.cpp)
+target_include_directories(EditorInteractivePacingTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(EditorInteractivePacingTest PRIVATE GTest::gtest_main)
+gtest_discover_tests(EditorInteractivePacingTest TEST_PREFIX "EditorInteractivePacingTest."
+    PROPERTIES LABELS "ci_core_flow;editor_session")
+alcedo_register_test_target(EditorInteractivePacingTest app ci_core)
+
+add_executable(EditorSerialFrameAdmissionTest
+    ${ALCEDO_TEST_ROOT}/app/editor_serial_frame_admission_test.cpp)
+target_include_directories(EditorSerialFrameAdmissionTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR})
+target_link_libraries(EditorSerialFrameAdmissionTest
+    PRIVATE EditorSerialFrameAdmission GTest::gtest_main)
+gtest_discover_tests(EditorSerialFrameAdmissionTest
+    TEST_PREFIX "EditorSerialFrameAdmissionTest."
+    PROPERTIES LABELS "ci_core_flow;editor_session")
+alcedo_register_test_target(EditorSerialFrameAdmissionTest app ci_core)
+
+add_executable(EditorSerialFrameConsumptionTest
+    ${ALCEDO_TEST_ROOT}/app/editor_serial_frame_consumption_test.cpp)
+target_include_directories(EditorSerialFrameConsumptionTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR})
+target_link_libraries(EditorSerialFrameConsumptionTest
+    PRIVATE EditorSessionService EditorSessionCommandQueue xxHash JSON
+            ${ALCEDO_TEST_OPENCV_MIN_DEPS} GTest::gtest_main)
+gtest_discover_tests(EditorSerialFrameConsumptionTest
+    TEST_PREFIX "EditorSerialFrameConsumptionTest."
+    PROPERTIES LABELS "ci_core_flow;editor_session")
+alcedo_register_test_target(EditorSerialFrameConsumptionTest app ci_core)
+
 add_executable(EditorSessionServiceFacadeTest ${ALCEDO_TEST_ROOT}/app/editor_session_service_facade_test.cpp)
 target_include_directories(EditorSessionServiceFacadeTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(EditorSessionServiceFacadeTest

--- a/alcedo_studio/tests/app/editor_adjustment_pipeline_test.cpp
+++ b/alcedo_studio/tests/app/editor_adjustment_pipeline_test.cpp
@@ -171,5 +171,33 @@ TEST_F(EditorAdjustmentPipelineTest, GeometryOverlayPreviewKeepsCropParametersBu
                   35.0f);
 }
 
+TEST_F(EditorAdjustmentPipelineTest, WritePayloadMapsOntoDocumentAndExecutorKeys) {
+  const auto from_field = EditorAdjustmentDocumentParamsFromWrite("exposure", {{"exposure", 1.25}});
+  EXPECT_FLOAT_EQ(from_field.at("exposure_ev").get<float>(), 1.25f);
+  EXPECT_FALSE(from_field.contains("exposure"));
+
+  const auto from_value = EditorAdjustmentDocumentParamsFromWrite("exposure", {{"value", 0.5}});
+  EXPECT_FLOAT_EQ(from_value.at("exposure_ev").get<float>(), 0.5f);
+
+  const auto from_model =
+      EditorAdjustmentExecutorParamsFromWrite("exposure", {{"exposure_ev", -0.75}});
+  EXPECT_FLOAT_EQ(from_model.at("exposure").get<float>(), -0.75f);
+  EXPECT_FALSE(from_model.contains("exposure_ev"));
+
+  CPUPipelineExecutor executor;
+  executor.ResetToCleanBaselineAdjustments();
+  EditorRenderAdjustmentSnapshot snapshot;
+  snapshot.patches = {EditorAdjustmentPatch{
+      "exposure", EditorAdjustmentExecutorParamsFromWrite("exposure", {{"value", 2.0}}).dump(),
+      false}};
+  std::string error;
+  ASSERT_TRUE(ApplyEditorAdjustmentSnapshot(executor, snapshot, &error)) << error;
+  const auto exposure =
+      executor.GetStage(PipelineStageName::Basic_Adjustment).GetOperator(OperatorType::EXPOSURE);
+  ASSERT_TRUE(exposure.has_value());
+  EXPECT_FLOAT_EQ(exposure.value()->ExportOperatorParams()["params"]["exposure"].get<float>(),
+                  2.0f);
+}
+
 }  // namespace
 }  // namespace alcedo

--- a/alcedo_studio/tests/app/editor_interactive_pacing_test.cpp
+++ b/alcedo_studio/tests/app/editor_interactive_pacing_test.cpp
@@ -1,0 +1,51 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_interactive_pacing.hpp"
+
+#include <gtest/gtest.h>
+
+namespace alcedo {
+namespace {
+
+TEST(EditorInteractivePacingTest, FiveMillisecondCycleWaitsRemainingBudget) {
+  EditorInteractivePacing pacing;
+  pacing.NoteInteractiveStart(0);
+  pacing.NoteInteractiveComplete(5'000'000);
+  EXPECT_EQ(pacing.InteractiveWaitNs(5'000'000), 11'000'000);
+  EXPECT_EQ(pacing.InteractiveWaitNs(16'000'000), 0);
+}
+
+TEST(EditorInteractivePacingTest, OverBudgetCycleIsEligibleAtCompletion) {
+  EditorInteractivePacing pacing;
+  pacing.NoteInteractiveStart(0);
+  pacing.NoteInteractiveComplete(22'000'000);
+  EXPECT_EQ(pacing.InteractiveWaitNs(22'000'000), 0);
+  EXPECT_EQ(pacing.next_interactive_eligible_ns(), 22'000'000);
+}
+
+TEST(EditorInteractivePacingTest, ExactBudgetCycleHasNoRemainingWait) {
+  EditorInteractivePacing pacing;
+  pacing.NoteInteractiveStart(1'000'000);
+  pacing.NoteInteractiveComplete(17'000'000);
+  EXPECT_EQ(pacing.InteractiveWaitNs(17'000'000), 0);
+}
+
+TEST(EditorInteractivePacingTest, NonInteractiveResetAllowsImmediateStart) {
+  EditorInteractivePacing pacing;
+  pacing.NoteInteractiveStart(0);
+  pacing.NoteInteractiveComplete(5'000'000);
+  pacing.ResetAfterNonInteractive();
+  EXPECT_EQ(pacing.InteractiveWaitNs(5'000'000), 0);
+}
+
+TEST(EditorInteractivePacingTest, IdleHasNoWaitAndDoesNotInventTicks) {
+  EditorInteractivePacing pacing;
+  EXPECT_EQ(pacing.InteractiveWaitNs(0), 0);
+  EXPECT_EQ(pacing.InteractiveWaitNs(32'000'000), 0);
+  EXPECT_FALSE(pacing.next_interactive_eligible_ns().has_value());
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/editor_pending_input_test.cpp
+++ b/alcedo_studio/tests/app/editor_pending_input_test.cpp
@@ -152,5 +152,60 @@ TEST(EditorPendingInputTest, RejectsEmptyFieldKeyAndMissingIdentity) {
   EXPECT_FALSE(queue.AdmitFieldChange(missing, MakePatch("exposure", "{}")).accepted);
 }
 
+TEST(EditorPendingInputTest, TakeReadyBatchRemovesOpenFieldsAndLeavesSequenceOpen) {
+  EditorPendingInputQueue queue;
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), MakePatch("exposure", R"({"value":0.2})"))
+                  .accepted);
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), MakePatch("contrast", R"({"value":4})"))
+                  .accepted);
+
+  const auto batch = queue.TakeReadyBatch();
+  ASSERT_TRUE(batch.has_value());
+  EXPECT_EQ(batch->seal, EditorPendingInputBoundaryKind::None);
+  EXPECT_EQ(batch->fields.size(), 2u);
+  EXPECT_FALSE(queue.HasConsumableWork());
+  const auto leftover = queue.Peek();
+  ASSERT_EQ(leftover.sequences.size(), 1u);
+  EXPECT_TRUE(leftover.sequences.front().fields.empty());
+
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), MakePatch("exposure", R"({"value":0.9})"))
+                  .accepted);
+  EXPECT_TRUE(queue.HasConsumableWork());
+  const auto second = queue.TakeReadyBatch();
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(second->fields.size(), 1u);
+  EXPECT_EQ(second->fields.front().params_json, R"({"value":0.9})");
+}
+
+TEST(EditorPendingInputTest, TakeReadyBatchPrefersSealedSequenceOverOpenWrites) {
+  EditorPendingInputQueue queue;
+  auto                    first = MakePatch("exposure", R"({"value":0.4})", true);
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), first).accepted);
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), MakePatch("contrast", R"({"value":8})"))
+                  .accepted);
+
+  const auto sealed = queue.TakeReadyBatch();
+  ASSERT_TRUE(sealed.has_value());
+  EXPECT_EQ(sealed->seal, EditorPendingInputBoundaryKind::Release);
+  EXPECT_EQ(sealed->fields.front().params_json, R"({"value":0.4})");
+  const auto open_batch = queue.TakeReadyBatch();
+  ASSERT_TRUE(open_batch.has_value());
+  EXPECT_EQ(open_batch->seal, EditorPendingInputBoundaryKind::None);
+  EXPECT_EQ(open_batch->fields.front().params_json, R"({"value":8})");
+  EXPECT_FALSE(queue.TakeReadyBatch().has_value());
+}
+
+TEST(EditorPendingInputTest, TakeReadyBatchKeepsEmptyCancelSeal) {
+  EditorPendingInputQueue queue;
+  ASSERT_TRUE(queue.AdmitFieldChange(TestIdentity(), MakePatch("exposure", R"({"value":0.5})"))
+                  .accepted);
+  ASSERT_TRUE(queue.AdmitBoundary(TestIdentity(), EditorPendingInputBoundaryKind::Cancel).accepted);
+  const auto batch = queue.TakeReadyBatch();
+  ASSERT_TRUE(batch.has_value());
+  EXPECT_EQ(batch->seal, EditorPendingInputBoundaryKind::Cancel);
+  EXPECT_TRUE(batch->fields.empty());
+  EXPECT_FALSE(queue.HasConsumableWork());
+}
+
 }  // namespace
 }  // namespace alcedo

--- a/alcedo_studio/tests/app/editor_serial_frame_admission_test.cpp
+++ b/alcedo_studio/tests/app/editor_serial_frame_admission_test.cpp
@@ -1,0 +1,94 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_monotonic_clock.hpp"
+#include "app/editor_serial_frame_admission.hpp"
+#include "support/manual_monotonic_clock.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace alcedo {
+namespace {
+
+class ManualEditorClock final : public IEditorMonotonicClock {
+ public:
+  test::ManualMonotonicClock clock;
+
+  [[nodiscard]] auto NowNs() const -> std::int64_t override { return clock.now_ns(); }
+};
+
+TEST(EditorSerialFrameAdmissionTest, InteractiveWaitDoesNotBeginUntilBudgetElapses) {
+  EditorSerialFrameAdmission admission;
+  auto                       clock = std::make_shared<ManualEditorClock>();
+  clock->clock.set_ns(0);
+  admission.SetClock(clock);
+  std::int64_t last_delay = 0;
+  admission.SetDeadlineHandler([&](std::int64_t delay_ns) { last_delay = delay_ns; });
+
+  ASSERT_TRUE(admission.TryBeginCycle(true));
+  admission.NoteScheduledRequest(4);
+  clock->clock.set_ns(5'000'000);
+  ASSERT_TRUE(admission.CompleteIfMatches(4));
+  EXPECT_FALSE(admission.TryBeginCycle(true));
+  EXPECT_EQ(last_delay, 11'000'000);
+  EXPECT_FALSE(admission.HoldsOwnership());
+
+  clock->clock.set_ns(16'000'000);
+  EXPECT_TRUE(admission.TryBeginCycle(true));
+  EXPECT_TRUE(admission.HoldsOwnership());
+}
+
+TEST(EditorSerialFrameAdmissionTest, CompleteIgnoresZeroInflightAndMismatchedIds) {
+  EditorSerialFrameAdmission admission;
+  ASSERT_TRUE(admission.TryBeginCycle(false));
+  EXPECT_FALSE(admission.CompleteIfMatches(1));
+  EXPECT_TRUE(admission.HoldsOwnership());
+  admission.NoteScheduledRequest(9);
+  EXPECT_FALSE(admission.CompleteIfMatches(8));
+  EXPECT_TRUE(admission.HoldsOwnership());
+  EXPECT_TRUE(admission.CompleteIfMatches(9));
+  EXPECT_FALSE(admission.HoldsOwnership());
+}
+
+TEST(EditorSerialFrameAdmissionTest, AbortAllowsImmediateRetryWithoutBudget) {
+  EditorSerialFrameAdmission admission;
+  auto                       clock = std::make_shared<ManualEditorClock>();
+  clock->clock.set_ns(0);
+  admission.SetClock(clock);
+  ASSERT_TRUE(admission.TryBeginCycle(true));
+  admission.AbortCycle();
+  EXPECT_FALSE(admission.HoldsOwnership());
+  clock->clock.set_ns(1'000'000);
+  EXPECT_TRUE(admission.TryBeginCycle(true));
+}
+
+TEST(EditorSerialFrameAdmissionTest, AbandonedCycleAllowsImmediateInteractiveRetry) {
+  EditorSerialFrameAdmission admission;
+  auto                       clock = std::make_shared<ManualEditorClock>();
+  clock->clock.set_ns(0);
+  admission.SetClock(clock);
+  ASSERT_TRUE(admission.TryBeginCycle(true));
+  admission.NoteScheduledRequest(3);
+  clock->clock.set_ns(5'000'000);
+  ASSERT_TRUE(admission.CompleteIfMatches(3, false));
+  EXPECT_FALSE(admission.HoldsOwnership());
+  EXPECT_TRUE(admission.TryBeginCycle(true));
+}
+
+TEST(EditorSerialFrameAdmissionTest, NonInteractiveCycleBypassesRemainingInteractiveWait) {
+  EditorSerialFrameAdmission admission;
+  auto                       clock = std::make_shared<ManualEditorClock>();
+  clock->clock.set_ns(0);
+  admission.SetClock(clock);
+  ASSERT_TRUE(admission.TryBeginCycle(true));
+  admission.NoteScheduledRequest(2);
+  clock->clock.set_ns(5'000'000);
+  ASSERT_TRUE(admission.CompleteIfMatches(2));
+  EXPECT_TRUE(admission.TryBeginCycle(false));
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/editor_serial_frame_consumption_test.cpp
+++ b/alcedo_studio/tests/app/editor_serial_frame_consumption_test.cpp
@@ -1,0 +1,264 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_monotonic_clock.hpp"
+#include "app/editor_render_coordinator.hpp"
+#include "app/editor_session_bootstrap.hpp"
+#include "app/editor_session_service.hpp"
+#include "support/editor_session_command_queue_test_support.hpp"
+#include "support/latch_blocked_pipeline_scheduler_port.hpp"
+#include "support/manual_monotonic_clock.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace alcedo {
+namespace {
+
+class ManualEditorClock final : public IEditorMonotonicClock {
+ public:
+  test::ManualMonotonicClock clock;
+
+  [[nodiscard]] auto NowNs() const -> std::int64_t override { return clock.now_ns(); }
+};
+
+class SerialFrameConsumptionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    history_          = std::make_shared<test::FakeEditorHistoryPort>();
+    pipeline_         = std::make_shared<test::FakeEditorPipelinePort>();
+    tasks_            = std::make_shared<test::FakeEditorTaskPort>();
+    journal_          = std::make_shared<test::FakeEditorJournalPort>();
+    checkpoint_store_ = std::make_shared<test::FakeEditorCheckpointStore>();
+    latch_            = std::make_shared<test::LatchBlockedPipelineSchedulerPort>();
+    clock_            = std::make_shared<ManualEditorClock>();
+    runtime_          = EditorSessionRuntime::CreateWithPorts(
+        pipeline_, history_, tasks_, journal_, latch_, checkpoint_store_);
+    service_ = runtime_->service.get();
+    service_->SetMonotonicClock(clock_);
+    service_->SetAdmissionDeadlineHandler(
+        [this](std::int64_t delay_ns) { last_deadline_delay_ns_ = delay_ns; });
+    service_->SetPresentationSinkId(1);
+    service_->SetPresentationSize(640, 480);
+  }
+
+  void CompleteInflightAndDrain() {
+    for (int i = 0; i < 16; ++i) {
+      service_->DrainCommandQueueForTests();
+      if (latch_->running()) {
+        latch_->Complete(true);
+        continue;
+      }
+      if (!runtime_->coordinator->has_inflight() &&
+          !service_->serial_frame_admission().HoldsOwnership()) {
+        return;
+      }
+    }
+  }
+
+  void OpenInteractive() {
+    (void)service_->Open(10, 20);
+    CompleteInflightAndDrain();
+    ASSERT_EQ(service_->state(), EditorSessionState::Interactive);
+    ASSERT_FALSE(latch_->running());
+    ASSERT_FALSE(runtime_->coordinator->has_inflight());
+  }
+
+  void EnqueueExposure(const std::string& json, bool settled = false) {
+    EditorAdjustmentPatch patch;
+    patch.field_key   = "exposure";
+    patch.params_json = json;
+    patch.settled     = settled;
+    ASSERT_EQ(service_->EnqueueAdjustmentInput(patch).kind, EditorSessionResultKind::Accepted);
+  }
+
+  void ConsumeQueued() {
+    service_->DrainCommandQueueForTests();
+    if (!runtime_->coordinator->has_inflight() &&
+        !service_->serial_frame_admission().HoldsOwnership()) {
+      service_->TryConsumePendingInput();
+    }
+  }
+
+  std::shared_ptr<test::FakeEditorHistoryPort>             history_;
+  std::shared_ptr<test::FakeEditorPipelinePort>            pipeline_;
+  std::shared_ptr<test::FakeEditorTaskPort>                tasks_;
+  std::shared_ptr<test::FakeEditorJournalPort>             journal_;
+  std::shared_ptr<test::FakeEditorCheckpointStore>         checkpoint_store_;
+  std::shared_ptr<test::LatchBlockedPipelineSchedulerPort> latch_;
+  std::shared_ptr<ManualEditorClock>                       clock_;
+  std::unique_ptr<EditorSessionRuntime>                    runtime_;
+  EditorSessionService*                                    service_                = nullptr;
+  std::int64_t                                             last_deadline_delay_ns_ = 0;
+};
+
+TEST_F(SerialFrameConsumptionTest, ReleaseBeforeFirstPreviewCommitsFinalValuesOnce) {
+  OpenInteractive();
+  const int captures_before = history_->capture_count;
+  EnqueueExposure(R"({"value":1.25})", true);
+  ConsumeQueued();
+  ASSERT_TRUE(latch_->running());
+  EXPECT_EQ(history_->capture_count, captures_before + 1);
+  EXPECT_EQ(history_->commit_count, 1);
+  EXPECT_EQ(history_->last_committed_patch.params_json, R"({"value":1.25})");
+  ASSERT_FALSE(latch_->scheduled().empty());
+  EXPECT_EQ(latch_->scheduled().back().intent.quality, EditorRenderQuality::Quality);
+  EXPECT_TRUE(latch_->scheduled().back().intent.live_parameters_applied);
+  EXPECT_TRUE(service_->PeekPendingInput().sequences.empty());
+}
+
+TEST_F(SerialFrameConsumptionTest, InteractiveCycleUsesRemainingTimeWithinSixteenMilliseconds) {
+  OpenInteractive();
+  const auto scheduled_open = latch_->scheduled().size();
+  clock_->clock.set_ns(0);
+  EnqueueExposure(R"({"value":0.10})");
+  ConsumeQueued();
+  ASSERT_TRUE(latch_->running());
+  EXPECT_EQ(latch_->scheduled().size(), scheduled_open + 1);
+  ASSERT_EQ(service_->serial_frame_admission().interactive_start_times_ns().size(), 1u);
+  EXPECT_EQ(service_->serial_frame_admission().interactive_start_times_ns().front(), 0);
+
+  EnqueueExposure(R"({"value":0.20})");
+  service_->DrainCommandQueueForTests();
+  EXPECT_EQ(latch_->scheduled().size(), scheduled_open + 1);
+  EXPECT_EQ(latch_->rejected_while_running(), 0);
+  EXPECT_TRUE(service_->serial_frame_admission().HoldsOwnership());
+
+  clock_->clock.set_ns(5'000'000);
+  latch_->Complete(true);
+  service_->DrainCommandQueueForTests();
+  EXPECT_FALSE(runtime_->coordinator->has_inflight());
+  EXPECT_EQ(last_deadline_delay_ns_, 11'000'000);
+  EXPECT_EQ(service_->serial_frame_admission().interactive_complete_times_ns().size(), 1u);
+  EXPECT_EQ(latch_->scheduled().size(), scheduled_open + 1);
+
+  clock_->clock.set_ns(16'000'000);
+  service_->TryConsumePendingInput();
+  ASSERT_TRUE(latch_->running());
+  ASSERT_EQ(service_->serial_frame_admission().interactive_start_times_ns().size(), 2u);
+  EXPECT_EQ(service_->serial_frame_admission().interactive_start_times_ns().back(), 16'000'000);
+}
+
+TEST_F(SerialFrameConsumptionTest, OverBudgetInteractiveCycleStartsNextOnlyAfterCompletion) {
+  OpenInteractive();
+  clock_->clock.set_ns(0);
+  EnqueueExposure(R"({"value":0.10})");
+  ConsumeQueued();
+  ASSERT_TRUE(latch_->running());
+  EnqueueExposure(R"({"value":0.30})");
+  clock_->clock.set_ns(22'000'000);
+  latch_->Complete(true);
+  service_->DrainCommandQueueForTests();
+  ASSERT_TRUE(latch_->running());
+  ASSERT_EQ(service_->serial_frame_admission().interactive_start_times_ns().size(), 2u);
+  EXPECT_EQ(service_->serial_frame_admission().interactive_start_times_ns().back(), 22'000'000);
+}
+
+TEST_F(SerialFrameConsumptionTest, QualityReleaseBypassesPacingAfterCurrentFrameCompletes) {
+  OpenInteractive();
+  clock_->clock.set_ns(0);
+  EnqueueExposure(R"({"value":0.10})");
+  ConsumeQueued();
+  ASSERT_TRUE(latch_->running());
+  EnqueueExposure(R"({"value":0.40})", true);
+  clock_->clock.set_ns(5'000'000);
+  latch_->Complete(true);
+  service_->DrainCommandQueueForTests();
+  ASSERT_TRUE(latch_->running());
+  EXPECT_EQ(latch_->scheduled().back().intent.quality, EditorRenderQuality::Quality);
+  EXPECT_EQ(history_->commit_count, 1);
+  ASSERT_EQ(service_->serial_frame_admission().interactive_start_times_ns().size(), 1u);
+}
+
+TEST_F(SerialFrameConsumptionTest, FailedOrCancelledRenderReleasesOwnerWithoutPublishingResult) {
+  OpenInteractive();
+  EnqueueExposure(R"({"value":0.15})");
+  ConsumeQueued();
+  ASSERT_TRUE(service_->serial_frame_admission().HoldsOwnership());
+  const auto ready_before = runtime_->coordinator->diagnostics().ready_count;
+  latch_->Complete(false, "pipeline failed");
+  service_->DrainCommandQueueForTests();
+  EXPECT_FALSE(service_->serial_frame_admission().HoldsOwnership());
+  EXPECT_EQ(runtime_->coordinator->diagnostics().ready_count, ready_before);
+  EXPECT_GT(runtime_->coordinator->diagnostics().failed_count, 0u);
+  EXPECT_FALSE(runtime_->coordinator->has_inflight());
+
+  EnqueueExposure(R"({"value":0.16})");
+  ConsumeQueued();
+  EXPECT_TRUE(service_->serial_frame_admission().HoldsOwnership());
+  EXPECT_TRUE(latch_->running());
+}
+
+TEST_F(SerialFrameConsumptionTest, GuiRemainsResponsiveWhilePresentNeedsAnUpdate) {
+  OpenInteractive();
+  EnqueueExposure(R"({"value":0.11})");
+  ConsumeQueued();
+  ASSERT_TRUE(latch_->running());
+  EditorAdjustmentPatch follow_up;
+  follow_up.field_key   = "exposure";
+  follow_up.params_json = R"({"value":0.12})";
+  const auto queued     = service_->EnqueueAdjustmentInput(follow_up);
+  EXPECT_EQ(queued.kind, EditorSessionResultKind::Accepted);
+  EXPECT_TRUE(latch_->running());
+  EXPECT_TRUE(service_->serial_frame_admission().HoldsOwnership());
+  const auto pending = service_->PeekPendingInput();
+  ASSERT_EQ(pending.sequences.size(), 1u);
+  ASSERT_FALSE(pending.sequences.front().fields.empty());
+  EXPECT_EQ(pending.sequences.front().fields.front().params_json, R"({"value":0.12})");
+}
+
+TEST_F(SerialFrameConsumptionTest, UndoAndCheckoutWaitForOwnerWithoutBlockingGui) {
+  OpenInteractive();
+  EnqueueExposure(R"({"value":0.21})");
+  ConsumeQueued();
+  ASSERT_TRUE(service_->serial_frame_admission().HoldsOwnership());
+  const int  undos_before = history_->undo_count;
+  const auto undo         = service_->Undo();
+  EXPECT_EQ(undo.kind, EditorSessionResultKind::Accepted);
+  EXPECT_NE(undo.message.find("queued"), std::string::npos);
+  EXPECT_EQ(history_->undo_count, undos_before);
+  EXPECT_TRUE(latch_->running());
+
+  latch_->Complete(true);
+  CompleteInflightAndDrain();
+  EXPECT_EQ(history_->undo_count, undos_before + 1);
+  EXPECT_FALSE(service_->serial_frame_admission().HasDeferredOwnerWork());
+
+  EnqueueExposure(R"({"value":0.22})");
+  ConsumeQueued();
+  ASSERT_TRUE(service_->serial_frame_admission().HoldsOwnership());
+  const int  checkouts_before = history_->checkout_count;
+  const auto checkout         = service_->CheckoutVersion(history_->last_root_version);
+  EXPECT_EQ(checkout.kind, EditorSessionResultKind::Accepted);
+  EXPECT_NE(checkout.message.find("queued"), std::string::npos);
+  EXPECT_EQ(history_->checkout_count, checkouts_before);
+  EXPECT_TRUE(latch_->running());
+  latch_->Complete(true);
+  CompleteInflightAndDrain();
+  EXPECT_FALSE(service_->serial_frame_admission().HasDeferredOwnerWork());
+}
+
+TEST_F(SerialFrameConsumptionTest, DeadlineWithEmptyQueueDoesNotScheduleAnEmptyFrame) {
+  OpenInteractive();
+  const auto scheduled_before = latch_->scheduled().size();
+  clock_->clock.set_ns(16'000'000);
+  service_->TryConsumePendingInput();
+  EXPECT_EQ(latch_->scheduled().size(), scheduled_before);
+  EXPECT_FALSE(runtime_->coordinator->has_inflight());
+  EXPECT_FALSE(service_->serial_frame_admission().HoldsOwnership());
+}
+
+TEST_F(SerialFrameConsumptionTest, HiddenViewportAbortsCycleWithoutStrandingOwnership) {
+  OpenInteractive();
+  service_->SetPresentationSinkId(0);
+  EnqueueExposure(R"({"value":0.33})");
+  ConsumeQueued();
+  EXPECT_FALSE(service_->serial_frame_admission().HoldsOwnership());
+  EXPECT_FALSE(runtime_->coordinator->has_inflight());
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/editor_session_edit_controller_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_edit_controller_test.cpp
@@ -3,6 +3,7 @@
 //  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
 
 #include "app/editor_session_edit_controller.hpp"
+#include "app/editor_pending_input.hpp"
 
 #include <gtest/gtest.h>
 
@@ -178,6 +179,58 @@ TEST_F(EditorSessionEditControllerTest, MaskTargetIsRejected) {
   EXPECT_EQ(result.kind, EditorEditOutcome::Kind::Rejected);
   EXPECT_EQ(result.message, "Mask parameter targets are rejected until NM3");
   EXPECT_EQ(history_->capture_count, 0);
+}
+
+TEST_F(EditorSessionEditControllerTest, PendingSequenceAppliesEveryFieldOnceThenCommitsRelease) {
+  EditorPendingSequence sequence;
+  sequence.seal = EditorPendingInputBoundaryKind::Release;
+  EditorPendingFieldChange exposure;
+  exposure.target.field_key = "exposure";
+  exposure.params_json      = R"({"exposure_ev":0.8})";
+  EditorPendingFieldChange contrast;
+  contrast.target.field_key = "contrast";
+  contrast.params_json      = R"({"value":12})";
+  sequence.fields           = {exposure, contrast};
+
+  const auto result = edit_->HandlePendingSequence(sequence, guard(), identity());
+  EXPECT_EQ(result.kind, EditorEditOutcome::Kind::RenderRouted);
+  EXPECT_EQ(result.reason, EditorRenderReason::SettledAdjustment);
+  EXPECT_EQ(history_->capture_count, 2);
+  EXPECT_EQ(history_->commit_count, 2);
+  EXPECT_TRUE(result.render_command.live_parameters_applied);
+  ASSERT_EQ(result.render_command.adjustment.patches.size(), 2u);
+}
+
+TEST_F(EditorSessionEditControllerTest, InteractiveSequenceCapturesWithoutCommit) {
+  EditorPendingSequence sequence;
+  sequence.seal = EditorPendingInputBoundaryKind::None;
+  EditorPendingFieldChange exposure;
+  exposure.target.field_key = "exposure";
+  exposure.params_json      = R"({"exposure_ev":0.4})";
+  sequence.fields           = {exposure};
+
+  const auto result = edit_->HandlePendingSequence(sequence, guard(), identity());
+  EXPECT_EQ(result.kind, EditorEditOutcome::Kind::RenderRouted);
+  EXPECT_EQ(result.reason, EditorRenderReason::InteractiveAdjustment);
+  EXPECT_EQ(history_->capture_count, 1);
+  EXPECT_EQ(history_->commit_count, 0);
+  EXPECT_TRUE(result.render_command.live_parameters_applied);
+}
+
+TEST_F(EditorSessionEditControllerTest, CancelRestoreRoutesRenderOnlyWhenLiveContentChanged) {
+  history_->restore_changes_live = false;
+  EditorPendingSequence empty_cancel;
+  empty_cancel.seal = EditorPendingInputBoundaryKind::Cancel;
+  auto skipped      = edit_->HandlePendingSequence(empty_cancel, guard(), identity());
+  EXPECT_EQ(skipped.kind, EditorEditOutcome::Kind::Accepted);
+  EXPECT_FALSE(skipped.schedule_render);
+  EXPECT_EQ(history_->restore_preview_count, 1);
+
+  history_->restore_changes_live = true;
+  auto restored = edit_->HandlePendingSequence(empty_cancel, guard(), identity());
+  EXPECT_EQ(restored.kind, EditorEditOutcome::Kind::RenderRouted);
+  EXPECT_TRUE(restored.render_command.live_parameters_applied);
+  EXPECT_EQ(history_->restore_preview_count, 2);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/support/editor_session_test_ports.hpp
+++ b/alcedo_studio/tests/support/editor_session_test_ports.hpp
@@ -71,6 +71,9 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
   int  release_count  = 0;
   int  capture_count  = 0;
   int  commit_count   = 0;
+  int  restore_preview_count = 0;
+  bool restore_changes_live  = false;
+  bool fail_restore_preview  = false;
   int  undo_count     = 0;
   int  redo_count     = 0;
   int  checkpoint_capture_count = 0;
@@ -118,6 +121,15 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
     ++capture_count;
     last_captured_patch = patch;
     return true;
+  }
+
+  auto RestoreUnsettledPreview(const EditorHistoryGuardHandle&, bool* live_changed, std::string*)
+      -> bool override {
+    ++restore_preview_count;
+    if (live_changed != nullptr) {
+      *live_changed = restore_changes_live;
+    }
+    return !fail_restore_preview;
   }
 
   auto CommitAdjustment(const EditorHistoryGuardHandle&, const EditorAdjustmentPatch& patch,

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -614,6 +614,7 @@ target_link_libraries(EditorSerialInputBoundaryTest
     EditHistory
     EditorAdjustmentPipeline
     EditorPipelineCommandService
+    EditorSessionEditController
     GTest::gtest
     Qt6::Core
     Qt6::Gui

--- a/alcedo_studio/tests/ui/editor_serial_input_boundary_test.cpp
+++ b/alcedo_studio/tests/ui/editor_serial_input_boundary_test.cpp
@@ -8,6 +8,7 @@
 
 #include "app/editor_pending_input.hpp"
 #include "app/editor_pipeline_command_service.hpp"
+#include "app/editor_session_edit_controller.hpp"
 #include "app/pipeline_service.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/history/commit_graph.hpp"
@@ -329,6 +330,35 @@ TEST_F(SerialInputBoundaryTest, TypedModelsEnqueueThroughSameOwnerRuleWithoutLiv
     EXPECT_EQ(sequence.identity.element_id, identity_.element_id);
     EXPECT_EQ(sequence.identity.image_id, identity_.image_id);
   }
+}
+
+TEST_F(SerialInputBoundaryTest, ReleaseBeforeFirstPreviewCommitsFinalValuesOnce) {
+  QueuedInputSubmitter submitter(&queue_, identity_);
+  auto                 model = std::make_unique<EditorAdjustmentValueModel>();
+  model->setSubmitter(&submitter);
+  model->setFieldKey("exposure");
+  model->setMinimum(-5.0);
+  model->setMaximum(5.0);
+  model->setDefaultValue(1.25);
+  model->setValue(0.0);
+  model->reset();
+
+  auto batch = queue_.TakeReadyBatch();
+  ASSERT_TRUE(batch.has_value());
+  EXPECT_EQ(batch->seal, alcedo::EditorPendingInputBoundaryKind::Release);
+
+  auto history_ptr = std::shared_ptr<alcedo::IEditorHistoryPort>(
+      static_cast<alcedo::IEditorHistoryPort*>(&history_), [](alcedo::IEditorHistoryPort*) {});
+  alcedo::EditorSessionEditController edit({history_ptr, nullptr});
+  const auto outcome = edit.HandlePendingSequence(*batch, handle_, identity_);
+  EXPECT_EQ(outcome.kind, alcedo::EditorEditOutcome::Kind::RenderRouted);
+  EXPECT_EQ(outcome.reason, alcedo::EditorRenderReason::SettledAdjustment);
+  EXPECT_TRUE(outcome.render_command.live_parameters_applied);
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), 1.25f);
+
+  std::string error;
+  ASSERT_TRUE(history_.Undo(handle_, &error)) << error;
+  EXPECT_FLOAT_EQ(DocumentExposureEv(*guard_->document_), alcedo::kDefaultPipelineExposureEv);
 }
 
 TEST_F(SerialInputBoundaryTest, ImageExifDisplayFieldsAreOwnedByImageNotPipelineDocument) {

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-05
 
-Status: NM6.1–NM6.2 complete; NM6.3–NM6.9 planned.
+Status: NM6.1–NM6.3 complete; NM6.4–NM6.9 planned.
 
 Prerequisites: NM5 is complete. Preserve NM1 single live document/executor ownership,
 NM2 multi-Grade execution, NM3 multi-Mask data, and NM4 history/recovery guarantees.
@@ -327,7 +327,7 @@ belong to their active input sequence; an older completion cannot overwrite them
 
 ## 7. Ordered implementation phases
 
-NM6.1 and NM6.2 are complete. NM6.3–NM6.9 remain planned. Each phase must leave a buildable product path and
+NM6.1–NM6.3 are complete. NM6.4–NM6.9 remain planned. Each phase must leave a buildable product path and
 write its actual call chain and evidence into Section 10. New-file names are proposed; existing
 links are verified entry points. Do not declare a phase complete based on implementation
 inspection alone.
@@ -557,6 +557,74 @@ overrun; release bypasses pacing after current completion; first-before/final-af
 Cancel/exception/hidden viewport cannot strand ownership or deadlock GUI presentation. Quality requests
 remain distinct from Interactive; no quality reduction or input loss is accepted to meet timing.
 
+##### Phase NM6.3 completion record (2026-09-05)
+
+**Status:** complete — session owner consumes one pending-input batch, applies/captures/commits once, renders one inflight frame, then admits the next; Interactive uses remaining time inside 16 ms; failed/cancelled cycles and Undo/Checkout do not strand ownership or block the GUI.
+
+**Primary success call chain:**
+
+```text
+GUI submitPatch / EnqueueAdjustmentInput
+  -> EditorPendingInputQueue::AdmitFieldChange (no live write)
+  -> EditorSessionService::RequestPendingInputConsume (PostCompletion)
+  -> TryConsumePendingInput
+  -> EditorSerialFrameAdmission::TryBeginCycle (Interactive wait or Release bypass)
+  -> TakeReadyBatch
+  -> EditorSessionEditController::HandlePendingSequence
+  -> IEditorHistoryPort::CaptureAdjustmentBeforePreview (document + executor remirror)
+  -> CommitAdjustment on Release/NodeSwitch
+  -> RouteInitialRender (live_parameters_applied, skip configure re-apply)
+  -> coordinator Schedule -> scheduler Complete (Present-wait in production adapters)
+  -> NotifyRenderResult -> FinishSerialFrameIfNeeded -> CompleteIfMatches
+  -> next TryConsumePendingInput or QTimer deadline wakeup
+```
+
+**Primary failure call chain:**
+
+```text
+scheduler Complete(false) / Cancelled
+  -> NotifySchedulerCompleted emits Failed|Cancelled (ready_count unchanged)
+  -> FinishSerialFrameIfNeeded CompleteIfMatches(published=false)
+  -> ownership released, Interactive cadence cleared
+  -> next queued batch may start immediately
+Undo/Checkout while HoldsOwnership
+  -> DeferIfLiveOwnershipHeld returns Accepted on the GUI stack
+  -> after CompleteIfMatches, deferred owner work runs on the session thread
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `ReleaseBeforeFirstPreviewCommitsFinalValuesOnce` | `EditorSerialFrameConsumptionTest`, `EditorSerialInputBoundaryTest` | PASS |
+| `InteractiveCycleUsesRemainingTimeWithinSixteenMilliseconds` | `EditorSerialFrameConsumptionTest` | PASS |
+| `OverBudgetInteractiveCycleStartsNextOnlyAfterCompletion` | `EditorSerialFrameConsumptionTest` | PASS |
+| `QualityReleaseBypassesPacingAfterCurrentFrameCompletes` | `EditorSerialFrameConsumptionTest` | PASS |
+| `FailedOrCancelledRenderReleasesOwnerWithoutPublishingResult` | `EditorSerialFrameConsumptionTest` | PASS |
+| `GuiRemainsResponsiveWhilePresentNeedsAnUpdate` | `EditorSerialFrameConsumptionTest` | PASS |
+| `UndoAndCheckoutWaitForOwnerWithoutBlockingGui` | `EditorSerialFrameConsumptionTest` | PASS |
+| empty-queue deadline does not invent a frame | `DeadlineWithEmptyQueueDoesNotScheduleAnEmptyFrame` | PASS |
+| hidden viewport aborts without stranding ownership | `HiddenViewportAbortsCycleWithoutStrandingOwnership` | PASS |
+| NM6.1/6.2 queue cases (`SliderMovesWhileBlocked…`, coalescing, node-switch) | `EditorSerialInputBoundaryTest` / `EditorPendingInputTest` | PASS |
+| first-before / final-after on live Mini-Git document | `EditorSerialInputBoundaryTest.ReleaseBeforeFirstPreviewCommitsFinalValuesOnce` (Undo restores default EV) | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorPendingInputTest EditorPendingInputSessionTest EditorInteractivePacingTest EditorSerialFrameAdmissionTest EditorSerialFrameConsumptionTest EditorSessionEditControllerTest EditorAdjustmentPipelineTest EditorSerialInputBoundaryTest EditorSessionHistoryPortTest
+ctest --test-dir build/debug --output-on-failure -C Debug -R "EditorSessionHistoryPortTest|EditorSerialInputBoundaryTest|EditorAdjustmentPipelineTest|EditorSessionEditControllerTest|EditorPendingInputTest|EditorPendingInputSessionTest|EditorInteractivePacingTest"
+ctest --test-dir build/debug --output-on-failure -C Debug -R "EditorSerialFrameAdmissionTest|EditorSerialFrameConsumptionTest"
+```
+
+Suite totals: `EditorSessionHistoryPortTest` 75/75 PASS; remaining focused (pending input, pacing, edit controller, adjustment pipeline, serial input boundary) 48/48 PASS; serial admission+consumption 14/14 PASS after failed-cycle pacing fix. Combined 137/137 PASS.
+
+**Checklist / exit condition:** all NM6.3 acceptance items above have executed tests. Section 8.1 names are implemented (NM6.2 queue names remain in the existing harnesses).
+
+**LOC note (grill-code-review):** `editor_session_service.cpp` is 1785 lines. Consume routing stays on the facade; `EditorSerialFrameAdmission` (~128 lines) owns cycle ownership, 16 ms cadence, deadline arming, and deferred Undo/Checkout. History remirror/restore stays in `EditorHistoryMutation`. Edit-controller batch apply stays in `EditorSessionEditController`.
+
+**Remaining gaps:** GPU-safe completion is the existing Present-wait (`cudaStreamSynchronize` / Metal `waitUntilCompleted` / OpenCL presentation events) plus coordinator `NotifySchedulerCompleted`; no new fence type. Multi-field Release still commits per field (a later WAL failure restores unsettled preview). Production `submitPatch` still does not stamp NodeId/AdjustmentInstanceId (NM6.6). Cache versions are NM6.4. Pixel/backend qualification is NM6.9. Debug-build Interactive cost is not a product quality change.
+
 ### NM6.4 — Replace session parameter hashes with dependency versions
 
 **Changes:** add owner-maintained invalidation metadata and compiled downstream edges; update cache
@@ -756,7 +824,7 @@ and any renamed linked files together. No runtime metadata is written into docum
 | --- | --- | --- | --- | --- | --- |
 | NM6.1 | complete 2026-09-05 | `feature/queued-typed-adjustment-input` @ `ee6247c8` | slider → Patch → `LockLivePipeline` + live apply → coordinator; completion `(bool, string)`, no GPU fence | 10/10 focused PASS; see NM6.1 completion record | Queue/pacing/GPU-safe completion are NM6.2/3 |
 | NM6.2 | complete 2026-09-05 | uncommitted on `feature/queued-typed-adjustment-input` @ `3a7a3825` | slider/model → `submitPatch` → `EnqueueAdjustmentInput` → `EditorPendingInputQueue::AdmitFieldChange`; live document/history unchanged | 90/90 focused PASS excluding pre-existing RapidImageSelection; see NM6.2 completion record | Consume, 16 ms pacing, GPU-safe completion are NM6.3 |
-| NM6.3 | planned | — | — | — | Serial consumption and pacing |
+| NM6.3 | complete 2026-09-05 | uncommitted on `feature/nm6-serial-adjustment-consumption` @ `8ed06f88` | enqueue → PostCompletion consume → HandlePendingSequence → history capture/commit → RouteInitialRender → Present-wait completion → next admission | 137/137 focused PASS; see NM6.3 completion record | Cache versions NM6.4; node targeting NM6.6 |
 | NM6.4 | planned | — | — | — | Dependency validity/current results |
 | NM6.5 | planned | — | — | — | Shared three-backend execution |
 | NM6.6 | planned | — | — | — | Node context/target routing |


### PR DESCRIPTION
## Summary
- Consume one pending-input batch on the session owner: capture/apply once, commit on Release, then render one inflight frame before the next admission.
- Interactive cycles use remaining time inside 16 ms; Release/Quality skip that wait; failed/cancelled frames and Undo/Checkout do not strand ownership or block the GUI.
- Configure skips a second live apply when `live_parameters_applied` is set; write payloads map onto document (`exposure_ev`) and CPU (`exposure`) keys.

## Test plan
- [ ] `ctest --test-dir build/debug --output-on-failure -C Debug -R "EditorSerialFrameAdmissionTest|EditorSerialFrameConsumptionTest|EditorPendingInputTest|EditorPendingInputSessionTest|EditorInteractivePacingTest|EditorSessionEditControllerTest|EditorAdjustmentPipelineTest|EditorSerialInputBoundaryTest"`
- [ ] Drag exposure while a frame is in flight: controls stay responsive; live document changes only after owner consume; next Interactive wait is the remainder of 16 ms.
- [ ] Over-budget Interactive (~22 ms) starts the next batch immediately after completion; Release after a 5 ms preview starts Quality without the leftover wait.
- [ ] Failed render does not publish FrameReady and allows the next queued batch; Undo/Checkout while inflight return immediately and run after completion.
- [ ] Release before first preview commits the final queued value once; Undo restores the previous document EV.

