### PR TITLE
feat(editor): dependency result versions (NM6.4)

### DIFF
--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -84,6 +84,7 @@ set(EDIT_RUNTIME_SRCS
     ${ALCEDO_SRC_ROOT}/edit/runtime/execution_plan.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/graph_compiler.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/result_content_key.cpp
+    ${ALCEDO_SRC_ROOT}/edit/runtime/runtime_invalidation.cpp
     ${ALCEDO_SRC_ROOT}/edit/runtime/static_execution_plan_cache.cpp
 )
 if(NOT ALCEDO_METAL_ENABLED)

--- a/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
@@ -133,14 +133,30 @@ auto ColorGradeNodeModel::FromJson(const nlohmann::json& json)
     throw std::runtime_error("ColorGrade FromJson: empty or duplicate MaskId");
   }
   node->masks_ = std::move(masks);
+  for (const auto& mask : node->masks_) {
+    node->TouchMask(mask.id);
+  }
   return node;
 }
 
-void ColorGradeNodeModel::SetEnabled(bool enabled) { enabled_ = enabled; }
+void ColorGradeNodeModel::SetEnabled(bool enabled) {
+  if (enabled_ == enabled) {
+    return;
+  }
+  enabled_   = enabled;
+  mix_dirty_ = true;
+}
 
 void ColorGradeNodeModel::SetDisplayName(std::string name) { display_name_ = std::move(name); }
 
-void ColorGradeNodeModel::SetMix(float mix) { mix_ = std::clamp(mix, 0.0f, 1.0f); }
+void ColorGradeNodeModel::SetMix(float mix) {
+  const auto clamped = std::clamp(mix, 0.0f, 1.0f);
+  if (mix_ == clamped) {
+    return;
+  }
+  mix_       = clamped;
+  mix_dirty_ = true;
+}
 
 auto ColorGradeNodeModel::AdjustmentIdAt(std::size_t index) const -> const AdjustmentInstanceId& {
   return adjustments_.at(index).instance_id;
@@ -262,6 +278,15 @@ auto RequireMaskIterator(std::vector<MaskModel>& masks, const MaskId& mask_id)
 
 }  // namespace
 
+void ColorGradeNodeModel::TouchMask(const MaskId& mask_id) {
+  mask_content_revision_[mask_id] = next_mask_revision_++;
+}
+
+auto ColorGradeNodeModel::MaskContentRevision(const MaskId& mask_id) const -> std::uint64_t {
+  const auto it = mask_content_revision_.find(mask_id);
+  return it == mask_content_revision_.end() ? 0 : it->second;
+}
+
 void ColorGradeNodeModel::AddMask(MaskModel mask, std::size_t index) {
   ValidateMaskModel(mask);
   if (FindMask(mask.id) != nullptr) {
@@ -272,10 +297,12 @@ void ColorGradeNodeModel::AddMask(MaskModel mask, std::size_t index) {
     index = masks_.size();
   }
   masks_.insert(masks_.begin() + static_cast<std::ptrdiff_t>(index), std::move(mask));
+  TouchMask(masks_[index].id);
 }
 
 void ColorGradeNodeModel::RemoveMask(const MaskId& mask_id) {
   const auto it = RequireMaskIterator(masks_, mask_id);
+  mask_content_revision_.erase(mask_id);
   masks_.erase(it);
 }
 
@@ -288,6 +315,7 @@ void ColorGradeNodeModel::ReplaceMaskSource(const MaskId& mask_id, MaskSource so
   candidate.source    = std::move(source);
   ValidateMaskModel(candidate);
   mask->source = std::move(candidate.source);
+  TouchMask(mask_id);
 }
 
 void ColorGradeNodeModel::SetMaskEnabled(const MaskId& mask_id, bool enabled) {
@@ -295,7 +323,11 @@ void ColorGradeNodeModel::SetMaskEnabled(const MaskId& mask_id, bool enabled) {
   if (mask == nullptr) {
     FailMask("Unknown MaskId: " + std::string{mask_id.Value()});
   }
+  if (mask->enabled == enabled) {
+    return;
+  }
   mask->enabled = enabled;
+  TouchMask(mask_id);
 }
 
 void ColorGradeNodeModel::SetMaskOpacity(const MaskId& mask_id, float opacity) {
@@ -307,6 +339,7 @@ void ColorGradeNodeModel::SetMaskOpacity(const MaskId& mask_id, float opacity) {
   candidate.opacity   = opacity;
   ValidateMaskModel(candidate);
   mask->opacity = candidate.opacity;
+  TouchMask(mask_id);
 }
 
 void ColorGradeNodeModel::SetMaskInvert(const MaskId& mask_id, bool invert) {
@@ -314,7 +347,11 @@ void ColorGradeNodeModel::SetMaskInvert(const MaskId& mask_id, bool invert) {
   if (mask == nullptr) {
     FailMask("Unknown MaskId: " + std::string{mask_id.Value()});
   }
+  if (mask->invert == invert) {
+    return;
+  }
   mask->invert = invert;
+  TouchMask(mask_id);
 }
 
 void ColorGradeNodeModel::MoveMaskForDisplay(const MaskId& mask_id, std::size_t index) {

--- a/alcedo_studio/src/edit/graph/develop_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/develop_node_model.cpp
@@ -107,12 +107,40 @@ void DevelopParamsModel::LoadJson(const nlohmann::json& json) {
 }
 
 void DevelopParamsModel::ReplaceParams(DevelopPayload payload) {
-  if (payload == PayloadCopy()) {
+  const auto current = PayloadCopy();
+  if (payload == current) {
     return;
   }
-  Mutate(DevelopDirty::All, [payload = std::move(payload)](DevelopPayload& dest) mutable {
-    dest = std::move(payload);
-  });
+  auto bits = static_cast<std::uint64_t>(DevelopDirty::None);
+  if (payload.demosaic_method != current.demosaic_method) {
+    bits |= static_cast<std::uint64_t>(DevelopDirty::Demosaic);
+  }
+  if (payload.highlights_reconstruct != current.highlights_reconstruct) {
+    bits |= static_cast<std::uint64_t>(DevelopDirty::Highlights);
+  }
+  if (payload.lens_enabled != current.lens_enabled ||
+      payload.apply_vignetting != current.apply_vignetting ||
+      payload.apply_distortion != current.apply_distortion ||
+      payload.apply_tca != current.apply_tca || payload.apply_crop != current.apply_crop ||
+      payload.auto_scale != current.auto_scale || payload.use_user_scale != current.use_user_scale ||
+      payload.user_scale != current.user_scale ||
+      payload.projection_enabled != current.projection_enabled ||
+      payload.target_projection != current.target_projection ||
+      payload.lens_profile_db_path != current.lens_profile_db_path) {
+    bits |= static_cast<std::uint64_t>(DevelopDirty::Lens);
+  }
+  if (payload.use_camera_wb != current.use_camera_wb || payload.user_wb != current.user_wb ||
+      payload.wb_mode != current.wb_mode || payload.custom_cct != current.custom_cct ||
+      payload.custom_tint != current.custom_tint || payload.as_shot_cct != current.as_shot_cct ||
+      payload.as_shot_tint != current.as_shot_tint ||
+      payload.camera_profile != current.camera_profile) {
+    bits |= static_cast<std::uint64_t>(DevelopDirty::WhiteBalance);
+  }
+  if (bits == 0) {
+    bits = static_cast<std::uint64_t>(DevelopDirty::All);
+  }
+  Mutate(static_cast<DevelopDirty>(bits),
+         [payload = std::move(payload)](DevelopPayload& dest) mutable { dest = std::move(payload); });
 }
 
 DevelopNodeModel::DevelopNodeModel(NodeId id) : id_(std::move(id)) {

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_camera_color_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_camera_color_pass.cu
@@ -16,6 +16,7 @@
 #include "edit/graph/develop_node_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/models/operator_param_dto.hpp"
+#include "edit/operators/models/pending_parameter_patch.hpp"
 #include "edit/runtime/camera_color_gpu_params.hpp"
 #include "edit/runtime/cuda/cuda_develop_pass.hpp"
 #include "edit/runtime/dng_profile_gpu_data.hpp"
@@ -55,15 +56,16 @@ __global__ void CameraColorKernel(const float4* input, float4* output, std::uint
 }  // namespace
 
 void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
-                            const PipelineDocument& document) {
+                            PipelineDocument& document) {
   auto& workspace = device.Workspace();
   if (!workspace.IsRendering()) {
     throw std::runtime_error("ExecuteCudaCameraColor: BeginRender has not been called");
   }
-  const auto* develop = document.Develop();
+  auto* develop = document.Develop();
   if (develop == nullptr) {
     throw std::runtime_error("ExecuteCudaCameraColor: missing develop node");
   }
+  auto pending = TakePendingParameterPatch(develop->Params());
   const auto develop_params = develop->Params().Params();
   const auto resolved       = ResolveDevelopColorTransform(develop_params);
   if (!resolved.ok) {
@@ -115,6 +117,9 @@ void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
       static_cast<const float*>(tables.DevicePointer()));
   if (::cudaGetLastError() != cudaSuccess) {
     throw std::runtime_error("ExecuteCudaCameraColor: CUDA kernel launch failed");
+  }
+  if (pending.has_value()) {
+    pending->Commit();
   }
 }
 

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_local_tone_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_local_tone_pass.cu
@@ -19,6 +19,8 @@
 #include "edit/pipeline/local_tone_mapping.hpp"
 #include "edit/runtime/cuda/cuda_local_tone_pass.hpp"
 #include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/local_tone_cache_ids.hpp"
+#include "edit/runtime/runtime_invalidation.hpp"
 #include "edit/runtime/texture_format.hpp"
 
 namespace alcedo {
@@ -293,8 +295,8 @@ auto LocalUvPlan(std::uint32_t width, std::uint32_t height) -> Matrix3x3 {
 auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id,
                           const GraphValueId& output_id, const NodeId& grade_id,
                           std::uint32_t width, std::uint32_t height, float shadows_slider,
-                          float highlights_slider, const ResolvedRenderGeometry& geometry,
-                          ContentKey reference_key) -> CudaLocalToneResult {
+                          float highlights_slider, const ResolvedRenderGeometry& geometry)
+    -> CudaLocalToneResult {
   auto& workspace = device.Workspace();
   auto* input     = workspace.Images().Find(input_id);
   if (!workspace.IsRendering() || input == nullptr || input->Empty()) {
@@ -313,21 +315,33 @@ auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id
   const bool full_edit = CoversFullEditSpace(geometry);
   const int  current_long_edge =
       std::max(static_cast<int>(width), static_cast<int>(height));
-  const auto source_id       = LevelId(grade_id, "source", 0);
-  const auto result_id       = LevelId(grade_id, "result", 0);
+  const auto source_id       = LocalToneSourceId(grade_id);
+  const auto result_id       = LocalToneResultId(grade_id);
   const auto canonical_bytes = static_cast<std::size_t>(canonical_dims.width) *
                                static_cast<std::size_t>(canonical_dims.height) * sizeof(float);
   auto* cached_source = workspace.Values().Find(source_id);
   auto* cached_result = workspace.Values().Find(result_id);
+  auto& invalidation  = workspace.ResultInvalidation();
+  const ImageExtent canonical_extent{static_cast<std::uint32_t>(canonical_dims.width),
+                                     static_cast<std::uint32_t>(canonical_dims.height)};
+  const auto source_needed = invalidation.MakeImageRepresentation(
+      source_id, canonical_extent, TextureFormat::R32f,
+      static_cast<std::uint32_t>(current_long_edge));
+  const auto result_needed = invalidation.MakeImageRepresentation(
+      result_id, canonical_extent, TextureFormat::R32f,
+      static_cast<std::uint32_t>(current_long_edge));
   const auto cached_meta = workspace.Values().GetMetadata(source_id);
-  const bool cache_valid =
-      cached_meta.has_value() && cached_meta->canonical && cached_meta->content_key == reference_key &&
-      cached_meta->extent.width == static_cast<std::uint32_t>(canonical_dims.width) &&
-      cached_meta->extent.height == static_cast<std::uint32_t>(canonical_dims.height) &&
+  const bool buffers_ok =
       cached_source != nullptr && cached_source->Bytes() >= canonical_bytes &&
       cached_result != nullptr && cached_result->Bytes() >= canonical_bytes;
+  const bool source_valid =
+      buffers_ok && cached_meta.has_value() && cached_meta->canonical &&
+      invalidation.IsSatisfied(source_id, source_needed) &&
+      cached_meta->extent.width == canonical_extent.width &&
+      cached_meta->extent.height == canonical_extent.height;
+  const bool result_valid = source_valid && invalidation.IsSatisfied(result_id, result_needed);
   const bool sample_canonical =
-      cache_valid &&
+      result_valid &&
       !(full_edit && current_long_edge > static_cast<int>(cached_meta->source_long_edge));
 
   const dim3          block{16, 16, 1};
@@ -352,11 +366,15 @@ auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id
   }
 
   const bool write_canonical_reference = full_edit;
+  const bool reuse_source =
+      source_valid &&
+      !(full_edit && current_long_edge > static_cast<int>(cached_meta->source_long_edge));
   const auto mask_dims =
-      write_canonical_reference ? canonical_dims
-                     : local_tone_mapping::ComputeMaskDimensions(
-                           static_cast<int>(width), static_cast<int>(height),
-                           local_tone_mapping::kReferenceMaskMaxLongEdge);
+      write_canonical_reference || reuse_source
+          ? canonical_dims
+          : local_tone_mapping::ComputeMaskDimensions(
+                static_cast<int>(width), static_cast<int>(height),
+                local_tone_mapping::kReferenceMaskMaxLongEdge);
   const auto                     layout = MakeLayout(mask_dims.width, mask_dims.height);
   std::array<float*, kMaxLevels> source{};
   std::array<float*, kMaxLevels> remap_a{};
@@ -377,16 +395,19 @@ auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id
     if (level == 0) reference_id = source_buffer.ResourceId();
   }
 
-  if (write_canonical_reference) {
-    ExtractReferenceKernel<<<Grid(layout.widths[0], layout.heights[0], block), block, 0, stream>>>(
-        static_cast<const float4*>(input->Texture().DevicePointer()), source[0],
-        static_cast<int>(width), static_cast<int>(height), layout.widths[0], layout.heights[0],
-        geometry.reference_to_render, static_cast<float>(geometry.full_reference_extent.width),
-        static_cast<float>(geometry.full_reference_extent.height));
-  } else {
-    ExtractKernel<<<Grid(layout.widths[0], layout.heights[0], block), block, 0, stream>>>(
-        static_cast<const float4*>(input->Texture().DevicePointer()), source[0],
-        static_cast<int>(width), static_cast<int>(height), layout.widths[0], layout.heights[0]);
+  if (!reuse_source) {
+    if (write_canonical_reference) {
+      ExtractReferenceKernel<<<Grid(layout.widths[0], layout.heights[0], block), block, 0,
+                               stream>>>(
+          static_cast<const float4*>(input->Texture().DevicePointer()), source[0],
+          static_cast<int>(width), static_cast<int>(height), layout.widths[0], layout.heights[0],
+          geometry.reference_to_render, static_cast<float>(geometry.full_reference_extent.width),
+          static_cast<float>(geometry.full_reference_extent.height));
+    } else {
+      ExtractKernel<<<Grid(layout.widths[0], layout.heights[0], block), block, 0, stream>>>(
+          static_cast<const float4*>(input->Texture().DevicePointer()), source[0],
+          static_cast<int>(width), static_cast<int>(height), layout.widths[0], layout.heights[0]);
+    }
   }
   for (int level = 1; level < layout.count; ++level) {
     DownKernel<<<Grid(layout.widths[level], layout.heights[level], block), block, 0, stream>>>(
@@ -451,7 +472,7 @@ auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id
   }
 
   const Matrix3x3 apply_uv =
-      write_canonical_reference
+      write_canonical_reference || reuse_source
           ? MakeLlfSamplingPlan(geometry, Extent2D{static_cast<std::uint32_t>(layout.widths[0]),
                                                    static_cast<std::uint32_t>(layout.heights[0])})
                 .render_to_texture_uv
@@ -462,14 +483,21 @@ auto ExecuteCudaLocalTone(CudaRenderDevice& device, const GraphValueId& input_id
       static_cast<int>(height), layout.widths[0], layout.heights[0], apply_uv);
   CheckLaunch("kernel launch");
 
-  if (write_canonical_reference) {
-    workspace.Values().StoreMetadata(
-        source_id, reference_key,
-        ImageExtent{static_cast<std::uint32_t>(layout.widths[0]),
-                    static_cast<std::uint32_t>(layout.heights[0])},
-        static_cast<std::uint32_t>(current_long_edge), true);
+  if (write_canonical_reference || reuse_source) {
+    const ImageExtent extent{static_cast<std::uint32_t>(layout.widths[0]),
+                             static_cast<std::uint32_t>(layout.heights[0])};
+    if (!reuse_source) {
+      workspace.Values().StoreMetadata(source_id, invalidation.RequiredRevision(source_id),
+                                       source_needed, extent,
+                                       static_cast<std::uint32_t>(current_long_edge), true);
+      invalidation.MarkCompleted(source_id, source_needed);
+    }
+    workspace.Values().StoreMetadata(result_id, invalidation.RequiredRevision(result_id),
+                                     result_needed, extent,
+                                     static_cast<std::uint32_t>(current_long_edge), true);
+    invalidation.MarkCompleted(result_id, result_needed);
   } else if (workspace.Values().Find(source_id) != nullptr) {
-    workspace.Values().StoreMetadata(source_id, ContentKey{}, ImageExtent{}, 0, false);
+    workspace.Values().StoreMetadata(source_id, 0, {}, {}, 0, false);
   }
   tone.reference_resource_id = reference_id;
   tone.rebuilt_reference     = true;

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_primary_grade_pass.cu
@@ -537,10 +537,9 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
               static_cast<float4*>(dest.DevicePointer()), static_cast<int>(input_width),
               static_cast<int>(input_height), op.neighbor);
     } else if (op.kind == GradeOpKind::LlfBarrier) {
-      local_tone = ExecuteCudaLocalTone(
-          device, current_id, dest_id, grade->Id(), input_width, input_height, shadows_slider,
-          highlights_slider, plan.geometry,
-          HashLlfReferenceKey(plan, prepared, document, compiled_grade->node_id));
+      local_tone = ExecuteCudaLocalTone(device, current_id, dest_id, grade->Id(), input_width,
+                                        input_height, shadows_slider, highlights_slider,
+                                        plan.geometry);
     } else {
       auto& src  = Resolve(current_id);
       auto& dest = Resolve(dest_id);
@@ -581,6 +580,7 @@ auto ExecuteCudaPrimaryGrade(CudaRenderDevice& device, const ExecutionPlan& plan
   if (plan.grade_nodes.empty()) {
     throw std::runtime_error("ExecuteCudaPrimaryGrade: plan has no Color Grade");
   }
+  device.Workspace().PrepareResultValidity(plan, document, prepared);
   CudaPrimaryGradeResult last{};
   for (const auto& compiled_grade : plan.grade_nodes) {
     last = ExecuteCudaPrimaryGrade(device, plan, prepared, document, compiled_grade);

--- a/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_develop_pass.mm
@@ -474,15 +474,16 @@ void ExecuteMetalGeometryResample(MetalRenderDevice& device, const ExecutionPlan
 }
 
 void ExecuteMetalCameraColor(MetalRenderDevice& device, const ExecutionPlan& plan,
-                             const PipelineDocument& document) {
+                             PipelineDocument& document) {
   auto& workspace = device.Workspace();
   if (!workspace.IsRendering()) {
     throw std::runtime_error("ExecuteMetalCameraColor: BeginRender has not been called");
   }
-  const auto* develop = document.Develop();
+  auto* develop = document.Develop();
   if (develop == nullptr) {
     throw std::runtime_error("ExecuteMetalCameraColor: missing develop node");
   }
+  auto pending = TakePendingParameterPatch(develop->Params());
   const auto develop_params = develop->Params().Params();
   const auto resolved       = ResolveDevelopColorTransform(develop_params);
   if (!resolved.ok) {
@@ -528,6 +529,9 @@ void ExecuteMetalCameraColor(MetalRenderDevice& device, const ExecutionPlan& pla
       UploadDngProfileGpuData(workspace, develop->Id(), table_data, device.CommandContext());
   DispatchCameraColor(command_buffer, input->Texture(), output.Texture(), arena.DeviceBuffer(),
                       binding.offset, tables);
+  if (pending.has_value()) {
+    pending->Commit();
+  }
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/metal/metal_local_tone_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_local_tone_pass.mm
@@ -16,6 +16,9 @@
 
 #include "edit/geometry/texture_sampling_plan.hpp"
 #include "edit/pipeline/local_tone_mapping.hpp"
+#include "edit/runtime/local_tone_cache_ids.hpp"
+#include "edit/runtime/runtime_invalidation.hpp"
+#include "edit/runtime/texture_format.hpp"
 #include "metal/compute_pipeline_cache.hpp"
 
 namespace alcedo {
@@ -320,8 +323,7 @@ void AppendMetalLocalToneWarmup(std::vector<MetalPipelineWarmup>& pipelines) {
 auto ExecuteMetalLocalTone(MetalRenderDevice& device, const MetalBackend::Texture2D& input,
                            MetalBackend::Texture2D& output, const NodeId& grade_id,
                            float shadows_slider, float highlights_slider,
-                           const ResolvedRenderGeometry& geometry, ContentKey source_key,
-                           ContentKey result_key) -> MetalLocalToneResult {
+                           const ResolvedRenderGeometry& geometry) -> MetalLocalToneResult {
   auto& workspace = device.Workspace();
   if (!workspace.IsRendering()) {
     throw std::runtime_error("ExecuteMetalLocalTone: BeginRender has not been called");
@@ -348,14 +350,26 @@ auto ExecuteMetalLocalTone(MetalRenderDevice& device, const MetalBackend::Textur
   const auto canonical_bytes   = static_cast<std::size_t>(canonical_dims.width) *
                                static_cast<std::size_t>(canonical_dims.height) * sizeof(float);
   const auto meta          = ReadMeta(workspace, grade_id);
-  auto*      cached_source = workspace.Values().Find(LevelId(grade_id, "source", 0));
-  auto*      cached_result = workspace.Values().Find(LevelId(grade_id, "result", 0));
-  const bool source_valid  = meta.canonical != 0 && meta.source_key == source_key.hash &&
+  auto&      invalidation  = workspace.ResultInvalidation();
+  const auto source_id     = LocalToneSourceId(grade_id);
+  const auto result_id     = LocalToneResultId(grade_id);
+  auto*      cached_source = workspace.Values().Find(source_id);
+  auto*      cached_result = workspace.Values().Find(result_id);
+  const ImageExtent canonical_extent{static_cast<std::uint32_t>(canonical_dims.width),
+                                     static_cast<std::uint32_t>(canonical_dims.height)};
+  const auto source_needed = invalidation.MakeImageRepresentation(
+      source_id, canonical_extent, TextureFormat::R32f,
+      static_cast<std::uint32_t>(current_long_edge));
+  const auto result_needed = invalidation.MakeImageRepresentation(
+      result_id, canonical_extent, TextureFormat::R32f,
+      static_cast<std::uint32_t>(current_long_edge));
+  const bool source_valid  = meta.canonical != 0 &&
+                            invalidation.IsSatisfied(source_id, source_needed) &&
                             meta.mask_width == canonical_dims.width &&
                             meta.mask_height == canonical_dims.height && cached_source != nullptr &&
                             cached_source->Bytes() >= canonical_bytes &&
                             cached_source->Native() != nullptr;
-  const bool result_valid = source_valid && meta.result_key == result_key.hash &&
+  const bool result_valid = source_valid && invalidation.IsSatisfied(result_id, result_needed) &&
                             cached_result != nullptr && cached_result->Bytes() >= canonical_bytes &&
                             cached_result->Native() != nullptr;
   const bool sample_canonical =
@@ -520,13 +534,17 @@ auto ExecuteMetalLocalTone(MetalRenderDevice& device, const MetalBackend::Textur
     workspace.Device().CopyDeviceMemoryToBuffer(result[0].ptr, result_buffer, 0, bytes,
                                                 device.CommandContext());
     CanonicalLlfMeta published;
-    published.source_key       = source_key.hash;
-    published.result_key       = result_key.hash;
+    published.source_key       = invalidation.RequiredRevision(source_id);
+    published.result_key       = invalidation.RequiredRevision(result_id);
     published.mask_width       = layout.widths[0];
     published.mask_height      = layout.heights[0];
     published.source_long_edge = current_long_edge;
     published.canonical        = 1;
     WriteMeta(device, grade_id, published);
+    if (!reuse_source) {
+      invalidation.MarkCompleted(source_id, source_needed);
+    }
+    invalidation.MarkCompleted(result_id, result_needed);
     tone.reference_resource_id = source_buffer.ResourceId();
   } else if (workspace.Values().Find(MetaId(grade_id)) != nullptr) {
     WriteMeta(device, grade_id, CanonicalLlfMeta{});

--- a/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_primary_grade_pass.mm
@@ -444,10 +444,7 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
     if (op.kind == GradeOpKind::LlfBarrier) {
       const auto tone =
           ExecuteMetalLocalTone(device, src, dest, grade->Id(), shadows_slider, highlights_slider,
-                                plan.geometry,
-                                HashLlfSourceKey(plan, prepared, document, compiled_grade->node_id),
-                                HashLlfReferenceKey(plan, prepared, document,
-                                                    compiled_grade->node_id));
+                                plan.geometry);
       result.local_tone_reference_resource_id       = tone.reference_resource_id;
       result.local_tone_rebuilt_reference           = tone.rebuilt_reference;
       result.local_tone_sampled_canonical_reference = tone.sampled_canonical_reference;
@@ -498,6 +495,7 @@ auto ExecuteMetalPrimaryGrade(MetalRenderDevice& device, const ExecutionPlan& pl
   if (plan.grade_nodes.empty()) {
     throw std::runtime_error("ExecuteMetalPrimaryGrade: plan has no Color Grade");
   }
+  device.Workspace().PrepareResultValidity(plan, document, prepared);
   MetalPrimaryGradeResult last{};
   for (const auto& compiled_grade : plan.grade_nodes) {
     last = ExecuteMetalPrimaryGrade(device, plan, prepared, document, compiled_grade);

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_develop_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_develop_pass.cpp
@@ -558,15 +558,16 @@ void ExecuteOpenClGeometryResample(OpenClRenderDevice& device, const ExecutionPl
 }
 
 void ExecuteOpenClCameraColor(OpenClRenderDevice& device, const ExecutionPlan& plan,
-                              const PipelineDocument& document) {
+                              PipelineDocument& document) {
   auto& workspace = device.Workspace();
   if (!workspace.IsRendering()) {
     throw std::runtime_error("ExecuteOpenClCameraColor: BeginRender has not been called");
   }
-  const auto* develop = document.Develop();
+  auto* develop = document.Develop();
   if (develop == nullptr) {
     throw std::runtime_error("ExecuteOpenClCameraColor: missing develop node");
   }
+  auto pending = TakePendingParameterPatch(develop->Params());
   const auto develop_params = develop->Params().Params();
   const auto resolved       = ResolveDevelopColorTransform(develop_params);
   if (!resolved.ok) {
@@ -622,6 +623,9 @@ void ExecuteOpenClCameraColor(OpenClRenderDevice& device, const ExecutionPlan& p
   cl_mem table_mem = tables.Native();
   CheckOpenCl(clSetKernelArg(kernel, 4, sizeof(cl_mem), &table_mem), "camera profile arg4");
   DispatchKernel(device, kernel, width, height);
+  if (pending.has_value()) {
+    pending->Commit();
+  }
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_local_tone_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_local_tone_pass.cpp
@@ -280,8 +280,7 @@ auto ResultId(const NodeId& grade_id) -> GraphValueId { return LevelId(grade_id,
 auto ExecuteOpenClLocalTone(OpenClRenderDevice& device, const OpenClBackend::Texture2D& input,
                             OpenClBackend::Texture2D& output, const NodeId& grade_id,
                             float shadows_slider, float highlights_slider,
-                            const ResolvedRenderGeometry& geometry, ContentKey source_key,
-                            ContentKey result_key) -> OpenClLocalToneResult {
+                            const ResolvedRenderGeometry& geometry) -> OpenClLocalToneResult {
   auto& workspace = device.Workspace();
   if (!workspace.IsRendering()) {
     throw std::runtime_error("ExecuteOpenClLocalTone: BeginRender has not been called");
@@ -296,9 +295,6 @@ auto ExecuteOpenClLocalTone(OpenClRenderDevice& device, const OpenClBackend::Tex
       output.Format() != TextureFormat::Rgba32f || input.Format() != TextureFormat::Rgba32f) {
     throw std::runtime_error("ExecuteOpenClLocalTone: input and output must be matching RGBA32F");
   }
-  if (source_key.Empty() || result_key.Empty()) {
-    throw std::runtime_error("ExecuteOpenClLocalTone: content keys must be non-empty");
-  }
 
   const auto width     = input.Width();
   const auto height    = input.Height();
@@ -311,21 +307,27 @@ auto ExecuteOpenClLocalTone(OpenClRenderDevice& device, const OpenClBackend::Tex
   const bool        full_edit = CoversFullEditSpace(geometry);
   const int         current_long_edge =
       std::max(CheckedInt(width, "input width"), CheckedInt(height, "input height"));
-  auto&      images    = workspace.Images();
-  const auto source_id = SourceId(grade_id);
-  const auto result_id = ResultId(grade_id);
-  auto*      cached_source =
-      images.BindValidResult(source_id, source_key, canonical_extent, TextureFormat::R32f,
+  auto&      images       = workspace.Images();
+  auto&      invalidation = workspace.ResultInvalidation();
+  const auto source_id    = SourceId(grade_id);
+  const auto result_id    = ResultId(grade_id);
+  const auto source_needed = invalidation.MakeImageRepresentation(
+      source_id, canonical_extent, TextureFormat::R32f,
+      static_cast<std::uint32_t>(current_long_edge));
+  const auto result_needed = invalidation.MakeImageRepresentation(
+      result_id, canonical_extent, TextureFormat::R32f,
+      static_cast<std::uint32_t>(current_long_edge));
+  auto* cached_source =
+      images.BindValidResult(source_id, invalidation.RequiredRevision(source_id), source_needed,
                              workspace.Device().CompletedSubmission());
-  const auto source_long_edge = images.PublishedAuxiliary(source_id, source_key);
+  const auto source_long_edge = images.PublishedAuxiliary(source_id);
   const bool source_valid =
       cached_source != nullptr && source_long_edge > 0 &&
       source_long_edge <= static_cast<std::uint64_t>((std::numeric_limits<int>::max)());
   auto* cached_result =
-      source_valid
-          ? images.BindValidResult(result_id, result_key, canonical_extent, TextureFormat::R32f,
-                                   workspace.Device().CompletedSubmission())
-          : nullptr;
+      source_valid ? images.BindValidResult(result_id, invalidation.RequiredRevision(result_id),
+                                            result_needed, workspace.Device().CompletedSubmission())
+                   : nullptr;
   const bool result_valid = cached_result != nullptr;
   const bool sample_canonical =
       result_valid && !(full_edit && current_long_edge > static_cast<int>(source_long_edge));
@@ -524,13 +526,13 @@ auto ExecuteOpenClLocalTone(OpenClRenderDevice& device, const OpenClBackend::Tex
     if (!reuse_source) {
       workspace.Device().CopyDeviceMemoryToImage(source[0].ptr, cached_source->Texture(),
                                                  device.CommandContext());
-      images.RecordUnpublished(source_id, source_key, extent, TextureFormat::R32f,
+      images.RecordUnpublished(source_id, invalidation.RequiredRevision(source_id), source_needed,
                                device.CommandContext().SubmissionId(),
                                static_cast<std::uint64_t>(current_long_edge));
     }
     workspace.Device().CopyDeviceMemoryToImage(result[0].ptr, cached_result->Texture(),
                                                device.CommandContext());
-    images.RecordUnpublished(result_id, result_key, extent, TextureFormat::R32f,
+    images.RecordUnpublished(result_id, invalidation.RequiredRevision(result_id), result_needed,
                              device.CommandContext().SubmissionId(),
                              static_cast<std::uint64_t>(current_long_edge));
     tone.reference_resource_id = cached_source->Texture().ResourceId();

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_mask_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_mask_pass.cpp
@@ -23,6 +23,7 @@
 #include "edit/mask/mask_model.hpp"
 #include "edit/runtime/compiled_grade_mask.hpp"
 #include "edit/runtime/compiled_mask_stack.hpp"
+#include "edit/runtime/result_representation.hpp"
 #include "edit/runtime/content_key.hpp"
 #include "edit/runtime/opencl/opencl_dag_programs.hpp"
 #include "opencl/opencl_api_counters.hpp"
@@ -484,7 +485,8 @@ auto ExecuteOpenClMask(OpenClRenderDevice& device, const ExecutionPlan& plan,
     ContentKey distance_key{};
     if (persistent_key != nullptr) {
       distance_key = HashSignedDistanceKey(*persistent_key, raster_descriptor.extent);
-      key_matches  = metadata.has_value() && metadata->content_key == distance_key &&
+      key_matches  = metadata.has_value() &&
+                    metadata->representation.identity == distance_key.hash &&
                     metadata->extent == ImageExtent{raster_descriptor.extent.width,
                                                     raster_descriptor.extent.height};
     }
@@ -508,9 +510,12 @@ auto ExecuteOpenClMask(OpenClRenderDevice& device, const ExecutionPlan& plan,
                         sampling.render_to_texture_uv, radius_texels, mask_model.invert,
                         mask_model.opacity);
     if (must_compute && persistent_key != nullptr) {
-      workspace.Values().StoreMetadata(
-          distance_id, distance_key,
-          ImageExtent{raster_descriptor.extent.width, raster_descriptor.extent.height});
+      ResultRepresentation distance_repr;
+      distance_repr.identity = distance_key.hash;
+      distance_repr.extent   = ImageExtent{raster_descriptor.extent.width,
+                                           raster_descriptor.extent.height};
+      distance_repr.format   = TextureFormat::R32f;
+      workspace.Values().StoreMetadata(distance_id, 1, distance_repr, distance_repr.extent);
     }
   };
 

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_primary_grade_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_primary_grade_pass.cpp
@@ -27,7 +27,6 @@
 #include "edit/runtime/opencl/opencl_local_tone_pass.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/parameter_binding.hpp"
-#include "edit/runtime/result_content_key.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "opencl/opencl_api_counters.hpp"
 #include "opencl/opencl_check.hpp"
@@ -516,10 +515,7 @@ auto ExecuteOpenClPrimaryGrade(OpenClRenderDevice& device, const ExecutionPlan& 
       auto&      dest = Resolve(dest_slot, dest_scratch);
       const auto local_tone =
           ExecuteOpenClLocalTone(device, src, dest, grade->Id(), shadows_slider, highlights_slider,
-                                 plan.geometry,
-                                 HashLlfSourceKey(plan, prepared, document, compiled_grade->node_id),
-                                 HashLlfReferenceKey(plan, prepared, document,
-                                                     compiled_grade->node_id));
+                                 plan.geometry);
       result.local_tone_reference_resource_id       = local_tone.reference_resource_id;
       result.local_tone_rebuilt_reference           = local_tone.rebuilt_reference;
       result.local_tone_sampled_canonical_reference = local_tone.sampled_canonical_reference;
@@ -566,6 +562,7 @@ auto ExecuteOpenClPrimaryGrade(OpenClRenderDevice& device, const ExecutionPlan& 
   if (plan.grade_nodes.empty()) {
     throw std::runtime_error("ExecuteOpenClPrimaryGrade: plan has no Color Grade");
   }
+  device.Workspace().PrepareResultValidity(plan, document, prepared);
   OpenClPrimaryGradeResult last{};
   for (const auto& compiled_grade : plan.grade_nodes) {
     last = ExecuteOpenClPrimaryGrade(device, plan, prepared, document, compiled_grade);

--- a/alcedo_studio/src/edit/runtime/result_content_key.cpp
+++ b/alcedo_studio/src/edit/runtime/result_content_key.cpp
@@ -305,6 +305,55 @@ auto HashPreparedSourceKey(const PreparedSourceKey& key) -> ContentKey {
   return hash.Key();
 }
 
+auto HashLinearizationParams(const RawLinearizationParams& linearization) -> ContentKey {
+  ContentHash hash;
+  MixLinearization(hash, linearization);
+  return hash.Key();
+}
+
+auto HashSensorSourceIdentity(const PreparedRawInput& input) -> ContentKey {
+  ContentHash hash;
+  MixPreparedSource(hash, input.source_key);
+  MixLinearization(hash, input.linearization);
+  hash.MixU32(static_cast<std::uint32_t>(input.input_kind));
+  hash.MixU32(kSensorDevelopImplementationVersion);
+  return hash.Key();
+}
+
+auto HashCanonicalReferenceIdentity(const ExecutionPlan& plan, const PreparedRawInput& input)
+    -> ContentKey {
+  ContentHash hash;
+  hash.MixKey(HashSensorSourceIdentity(input));
+  MixExtent(hash, plan.geometry.full_reference_extent);
+  MixExtent(hash, plan.geometry.edit_extent);
+  MixExtent(hash, plan.geometry.decoded_extent);
+  MixMatrix(hash, plan.geometry.decoded_to_reference);
+  MixMatrix(hash, plan.geometry.reference_to_edit);
+  MixExtent(hash, plan.source.host_extent);
+  MixExtent(hash, plan.source.develop_output_extent);
+  MixExtent(hash, plan.source.full_reference_extent);
+  hash.MixU32(static_cast<std::uint32_t>(plan.source.kind));
+  hash.MixU32(plan.source.downsample_passes);
+  MixRect(hash, plan.source.sensor_active_area);
+  hash.MixU32(kLlfReferenceImplementationVersion);
+  hash.MixU32(kGeometryImplementationVersion);
+  return hash.Key();
+}
+
+auto HashFrameImageIdentity(const ExecutionPlan& plan, const PreparedRawInput& input,
+                            RuntimeRevision document_epoch) -> ContentKey {
+  ContentHash hash;
+  hash.MixKey(HashSensorSourceIdentity(input));
+  hash.MixKey(HashResolvedRenderGeometry(plan.geometry));
+  hash.MixU64(document_epoch);
+  hash.MixU32(plan.static_key.backend_capability_version);
+  hash.MixU32(kCameraColorImplementationVersion);
+  hash.MixU32(kPrimaryGradeImplementationVersion);
+  hash.MixU32(kDrtImplementationVersion);
+  hash.MixU32(kMaskImplementationVersion);
+  return hash.Key();
+}
+
 auto HashLlfReferenceKey(const ExecutionPlan& plan, const PreparedRawInput& input,
                          const PipelineDocument& document, const NodeId& grade_id) -> ContentKey {
   ContentHash hash;

--- a/alcedo_studio/src/edit/runtime/runtime_invalidation.cpp
+++ b/alcedo_studio/src/edit/runtime/runtime_invalidation.cpp
@@ -1,0 +1,417 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/runtime_invalidation.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <set>
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/develop_node_model.hpp"
+#include "edit/graph/drt_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/operators/models/dirty_field_mask.hpp"
+#include "edit/runtime/result_content_key.hpp"
+
+namespace alcedo {
+namespace {
+
+enum class GradeSegment : std::uint8_t { PreLlf, Llf, PostLlf };
+
+auto SensorDirtyMask() -> DirtyFieldMask {
+  return DirtyFieldMask{static_cast<std::uint64_t>(DevelopDirty::Demosaic) |
+                        static_cast<std::uint64_t>(DevelopDirty::Highlights) |
+                        static_cast<std::uint64_t>(DevelopDirty::Lens)};
+}
+
+auto SegmentForIndex(const CompiledGradeNode& grade, std::size_t index) -> GradeSegment {
+  std::optional<std::uint32_t> llf_begin;
+  std::optional<std::uint32_t> llf_end;
+  for (const auto& stage : grade.stages) {
+    if (stage.kind == CompiledGradeStageKind::LocalLaplacian) {
+      llf_begin = stage.begin;
+      llf_end   = stage.begin + stage.count;
+      break;
+    }
+  }
+  if (!llf_begin.has_value()) {
+    return GradeSegment::PostLlf;
+  }
+  const auto adj = static_cast<std::uint32_t>(index);
+  if (adj < *llf_begin) {
+    return GradeSegment::PreLlf;
+  }
+  if (adj < *llf_end) {
+    return GradeSegment::Llf;
+  }
+  return GradeSegment::PostLlf;
+}
+
+auto PackedRasterRevision(const ActiveRasterMaskInput& input) -> std::uint64_t {
+  return (input.session_generation << 1) ^ (input.content_revision * 0x9E3779B97F4A7C15ull);
+}
+
+auto IsLocalTonePort(const GraphValueId& id) -> bool {
+  const auto port = id.output_port.Value();
+  return port == "local_tone.source.0" || port == "local_tone.result.0";
+}
+
+}  // namespace
+
+void RuntimeInvalidationState::AddEdge(const GraphValueId& from, const GraphValueId& to) {
+  if (from == to) {
+    return;
+  }
+  auto& dests = outgoing_[from];
+  if (std::find(dests.begin(), dests.end(), to) == dests.end()) {
+    dests.push_back(to);
+  }
+}
+
+auto RuntimeInvalidationState::Ensure(const GraphValueId& id) -> Record& { return records_[id]; }
+
+void RuntimeInvalidationState::BindCompiledPlan(const ExecutionPlan& plan) {
+  if (bound_plan_ == plan.static_key && !outgoing_.empty()) {
+    sensor_output_   = plan.sensor_linear_output;
+    geometry_output_ = plan.geometry_output;
+    develop_output_  = plan.develop_output;
+    display_output_  = plan.display_output;
+    return;
+  }
+  outgoing_.clear();
+  bound_plan_      = plan.static_key;
+  sensor_output_   = plan.sensor_linear_output;
+  geometry_output_ = plan.geometry_output;
+  develop_output_  = plan.develop_output;
+  display_output_  = plan.display_output;
+
+  for (const auto& pass : plan.passes) {
+    for (const auto& input : pass.inputs) {
+      for (const auto& output : pass.outputs) {
+        AddEdge(input.source, output.value);
+      }
+    }
+  }
+
+  for (const auto& grade : plan.grade_nodes) {
+    const auto llf_source = LocalToneSourceId(grade.node_id);
+    const auto llf_result = LocalToneResultId(grade.node_id);
+    AddEdge(grade.scene_input, llf_source);
+    AddEdge(llf_source, llf_result);
+    AddEdge(llf_result, grade.scene_output);
+    Ensure(llf_source);
+    Ensure(llf_result);
+    Ensure(grade.scene_output);
+    if (!grade.mask_stack.has_value()) {
+      continue;
+    }
+    for (const auto& source : grade.mask_stack->sources) {
+      AddEdge(plan.geometry_output, source.effective_output);
+      AddEdge(grade.scene_input, source.effective_output);
+      AddEdge(source.effective_output, grade.mask_output);
+      Ensure(source.effective_output);
+    }
+    AddEdge(grade.mask_output, grade.scene_output);
+    Ensure(grade.mask_output);
+  }
+  Ensure(plan.sensor_linear_output);
+  Ensure(plan.geometry_output);
+  Ensure(plan.develop_output);
+  Ensure(plan.display_output);
+}
+
+void RuntimeInvalidationState::InvalidateFrom(const GraphValueId& id) {
+  std::vector<GraphValueId> stack{id};
+  while (!stack.empty()) {
+    const auto current = stack.back();
+    stack.pop_back();
+    auto& record = Ensure(current);
+    if (record.required == change_version_) {
+      continue;
+    }
+    record.required = change_version_;
+    const auto it   = outgoing_.find(current);
+    if (it == outgoing_.end()) {
+      continue;
+    }
+    for (const auto& dest : it->second) {
+      stack.push_back(dest);
+    }
+  }
+}
+
+void RuntimeInvalidationState::CollectDevelopChanges(const ExecutionPlan& plan,
+                                                     const PipelineDocument& document,
+                                                     std::vector<GraphValueId>& origins) {
+  const auto* develop = document.Develop();
+  if (develop == nullptr) {
+    return;
+  }
+  const auto dirty = develop->Params().DirtyFields();
+  if ((dirty & SensorDirtyMask()).Any()) {
+    origins.push_back(plan.sensor_linear_output);
+  }
+  if ((dirty & DirtyFieldMask{DevelopDirty::WhiteBalance}).Any()) {
+    origins.push_back(plan.develop_output);
+  }
+}
+
+void RuntimeInvalidationState::CollectGradeChanges(
+    const ExecutionPlan& plan, const PipelineDocument& document,
+    std::span<const ActiveRasterMaskInput> active_raster_masks,
+    std::vector<GraphValueId>& origins) {
+  for (const auto& compiled : plan.grade_nodes) {
+    const auto* grade =
+        dynamic_cast<const ColorGradeNodeModel*>(document.Graph().FindNode(compiled.node_id));
+    if (grade == nullptr) {
+      continue;
+    }
+    if (grade->MixDirty()) {
+      origins.push_back(compiled.scene_output);
+    }
+    for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
+      if (!grade->AdjustmentAt(index).IsDirty()) {
+        continue;
+      }
+      const auto segment = SegmentForIndex(compiled, index);
+      if (segment == GradeSegment::PreLlf) {
+        origins.push_back(LocalToneSourceId(compiled.node_id));
+      } else if (segment == GradeSegment::Llf) {
+        origins.push_back(LocalToneResultId(compiled.node_id));
+      } else {
+        origins.push_back(compiled.scene_output);
+      }
+    }
+    if (!compiled.mask_stack.has_value()) {
+      continue;
+    }
+    for (const auto& source : compiled.mask_stack->sources) {
+      MaskKey key{compiled.node_id, source.mask_id};
+      const auto revision = grade->MaskContentRevision(source.mask_id);
+      auto& last          = last_mask_revision_[key];
+      if (revision != last) {
+        origins.push_back(source.effective_output);
+        last = revision;
+      }
+      const auto* active =
+          FindActiveRasterMaskInput(active_raster_masks, compiled.node_id, source.mask_id);
+      auto& last_raster = last_raster_revision_[key];
+      const auto raster_rev = active == nullptr ? 0 : PackedRasterRevision(*active);
+      if (raster_rev != last_raster) {
+        origins.push_back(source.effective_output);
+        last_raster = raster_rev;
+      }
+    }
+  }
+}
+
+void RuntimeInvalidationState::CollectDrtChanges(const ExecutionPlan& plan,
+                                                 const PipelineDocument& document,
+                                                 std::vector<GraphValueId>& origins) {
+  const auto* drt = document.Drt();
+  if (drt == nullptr) {
+    return;
+  }
+  if (drt->Params().IsDirty()) {
+    origins.push_back(plan.display_output);
+  }
+  for (std::size_t index = 0; index < drt->AdjustmentCount(); ++index) {
+    if (drt->AdjustmentAt(index).IsDirty()) {
+      origins.push_back(plan.display_output);
+      return;
+    }
+  }
+}
+
+void RuntimeInvalidationState::CollectStructureChanges(const ExecutionPlan& plan,
+                                                       std::vector<GraphValueId>& origins) {
+  // New workspaces have required==0. Assign a revision so the first bind can
+  // miss and publish even when operator dirty was already consumed elsewhere.
+  auto collect_if_unassigned = [&](const GraphValueId& id) {
+    if (Ensure(id).required == 0) {
+      origins.push_back(id);
+    }
+  };
+  collect_if_unassigned(plan.sensor_linear_output);
+  collect_if_unassigned(plan.geometry_output);
+  collect_if_unassigned(plan.develop_output);
+  collect_if_unassigned(plan.display_output);
+
+  std::set<NodeId> current_grades;
+  for (const auto& grade : plan.grade_nodes) {
+    current_grades.insert(grade.node_id);
+    collect_if_unassigned(LocalToneSourceId(grade.node_id));
+    collect_if_unassigned(LocalToneResultId(grade.node_id));
+    collect_if_unassigned(grade.scene_output);
+    GradeBindState current;
+    current.scene_input = grade.scene_input;
+    if (grade.mask_stack.has_value()) {
+      current.mask_ids.reserve(grade.mask_stack->sources.size());
+      for (const auto& source : grade.mask_stack->sources) {
+        current.mask_ids.push_back(source.mask_id);
+        collect_if_unassigned(source.effective_output);
+      }
+      collect_if_unassigned(grade.mask_output);
+    }
+    const auto it = last_grade_bind_.find(grade.node_id);
+    if (it == last_grade_bind_.end()) {
+      last_grade_bind_.emplace(grade.node_id, std::move(current));
+      continue;
+    }
+    const bool input_changed = it->second.scene_input != current.scene_input;
+    const bool masks_changed = it->second.mask_ids != current.mask_ids;
+    it->second               = std::move(current);
+    if (input_changed) {
+      origins.push_back(LocalToneSourceId(grade.node_id));
+    }
+    if (masks_changed) {
+      if (grade.mask_stack.has_value()) {
+        for (const auto& source : grade.mask_stack->sources) {
+          origins.push_back(source.effective_output);
+        }
+        origins.push_back(grade.mask_output);
+      }
+      origins.push_back(grade.scene_output);
+    }
+  }
+  for (auto it = last_grade_bind_.begin(); it != last_grade_bind_.end();) {
+    if (current_grades.contains(it->first)) {
+      ++it;
+    } else {
+      it = last_grade_bind_.erase(it);
+    }
+  }
+  const auto drt_input = plan.SceneInputForDrt();
+  if (last_drt_input_ != drt_input) {
+    origins.push_back(plan.display_output);
+    last_drt_input_ = drt_input;
+  }
+}
+
+void RuntimeInvalidationState::CollectAndPropagate(
+    const ExecutionPlan& plan, PipelineDocument& document, const PreparedRawInput& input,
+    std::span<const ActiveRasterMaskInput> active_raster_masks) {
+  BindCompiledPlan(plan);
+  CaptureFrameRepresentations(plan, input);
+
+  std::vector<GraphValueId> origins;
+  CollectStructureChanges(plan, origins);
+  if (document.TopologyDirty()) {
+    document.ClearTopologyDirty();
+  }
+  CollectDevelopChanges(plan, document, origins);
+  CollectGradeChanges(plan, document, active_raster_masks, origins);
+  CollectDrtChanges(plan, document, origins);
+
+  for (const auto& compiled : plan.grade_nodes) {
+    auto* grade = dynamic_cast<ColorGradeNodeModel*>(document.Graph().FindNode(compiled.node_id));
+    if (grade != nullptr) {
+      grade->ClearMixDirty();
+    }
+  }
+
+  if (origins.empty()) {
+    return;
+  }
+  ++change_version_;
+  std::set<GraphValueId> unique(origins.begin(), origins.end());
+  for (const auto& origin : unique) {
+    InvalidateFrom(origin);
+  }
+}
+
+void RuntimeInvalidationState::CaptureFrameRepresentations(const ExecutionPlan& plan,
+                                                           const PreparedRawInput& input) {
+  sensor_identity_    = HashSensorSourceIdentity(input).hash;
+  canonical_identity_ = HashCanonicalReferenceIdentity(plan, input).hash;
+  frame_identity_     = HashFrameImageIdentity(plan, input, document_epoch_).hash;
+}
+
+void RuntimeInvalidationState::AdvanceDocumentEpoch() {
+  ++document_epoch_;
+  ++change_version_;
+  for (auto& [id, record] : records_) {
+    (void)id;
+    record.required = change_version_;
+  }
+  last_mask_revision_.clear();
+  last_raster_revision_.clear();
+}
+
+void RuntimeInvalidationState::Clear() {
+  outgoing_.clear();
+  records_.clear();
+  last_mask_revision_.clear();
+  last_raster_revision_.clear();
+  last_grade_bind_.clear();
+  last_drt_input_     = {};
+  bound_plan_         = {};
+  document_epoch_     = 1;
+  change_version_     = 0;
+  sensor_identity_    = 0;
+  frame_identity_     = 0;
+  canonical_identity_ = 0;
+}
+
+auto RuntimeInvalidationState::RequiredRevision(const GraphValueId& id) const -> RuntimeRevision {
+  const auto it = records_.find(id);
+  return it == records_.end() ? 0 : it->second.required;
+}
+
+auto RuntimeInvalidationState::CompletedRevision(const GraphValueId& id) const -> RuntimeRevision {
+  const auto it = records_.find(id);
+  return it == records_.end() ? 0 : it->second.completed;
+}
+
+auto RuntimeInvalidationState::PublishedRepresentation(const GraphValueId& id) const
+    -> ResultRepresentation {
+  const auto it = records_.find(id);
+  return it == records_.end() ? ResultRepresentation{} : it->second.published;
+}
+
+auto RuntimeInvalidationState::IsSatisfied(const GraphValueId& id,
+                                           const ResultRepresentation& needed) const -> bool {
+  const auto it = records_.find(id);
+  if (it == records_.end()) {
+    return false;
+  }
+  const auto& record = it->second;
+  return record.completed != 0 && record.completed == record.required &&
+         RepresentationSatisfies(record.published, needed);
+}
+
+auto RuntimeInvalidationState::MakeImageRepresentation(const GraphValueId& id, ImageExtent extent,
+                                                       TextureFormat format,
+                                                       std::uint32_t source_detail) const
+    -> ResultRepresentation {
+  ResultRepresentation repr;
+  repr.document_epoch = document_epoch_;
+  repr.extent         = extent;
+  repr.format         = format;
+  repr.source_detail  = source_detail;
+  if (id == sensor_output_) {
+    repr.identity = sensor_identity_;
+  } else if (IsLocalTonePort(id)) {
+    repr.identity = canonical_identity_;
+  } else {
+    repr.identity = frame_identity_;
+  }
+  return repr;
+}
+
+void RuntimeInvalidationState::MarkCompleted(const GraphValueId& id,
+                                             const ResultRepresentation& representation) {
+  auto& record     = Ensure(id);
+  record.completed = record.required;
+  record.published = representation;
+}
+
+auto RuntimeInvalidationState::Downstream(const GraphValueId& id) const
+    -> std::vector<GraphValueId> {
+  const auto it = outgoing_.find(id);
+  return it == outgoing_.end() ? std::vector<GraphValueId>{} : it->second;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
@@ -6,6 +6,8 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <span>
 #include <string>
@@ -73,6 +75,22 @@ class ColorGradeNodeModel final : public INodeModel {
 
   void SetEnabled(bool enabled);
   void SetMix(float mix);
+
+  /**
+   * @brief True when enabled or mix changed since the last @ref ClearMixDirty.
+   *
+   * Display-name edits do not set this. Runtime invalidation reads it without
+   * copying parameter values.
+   */
+  [[nodiscard]] auto MixDirty() const -> bool { return mix_dirty_; }
+  void               ClearMixDirty() { mix_dirty_ = false; }
+
+  /**
+   * @brief Monotonic Mask content revision. Zero when @p mask_id is absent.
+   *
+   * Display-order moves do not change the revision. Not serialized.
+   */
+  [[nodiscard]] auto MaskContentRevision(const MaskId& mask_id) const -> std::uint64_t;
 
   [[nodiscard]] auto Enabled() const -> bool { return enabled_; }
   [[nodiscard]] auto Mix() const -> float { return mix_; }
@@ -148,12 +166,18 @@ class ColorGradeNodeModel final : public INodeModel {
   [[nodiscard]] auto FindMask(const MaskId& mask_id) const -> const MaskModel*;
 
  private:
+  void TouchMask(const MaskId& mask_id);
+
+ private:
   NodeId id_;
   std::string display_name_ = "Color Grade";
   std::vector<AdjustmentModelEntry> adjustments_;
   std::vector<MaskModel>            masks_;
+  std::map<MaskId, std::uint64_t>   mask_content_revision_;
+  std::uint64_t                     next_mask_revision_ = 1;
   bool  enabled_ = true;
   float mix_     = 1.0f;
+  bool  mix_dirty_ = false;
   std::array<PortDescriptor, 1> inputs_;
   std::array<PortDescriptor, 1> outputs_;
 };

--- a/alcedo_studio/src/include/edit/operators/models/i_operator_model.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/i_operator_model.hpp
@@ -31,6 +31,13 @@ class IOperatorModel {
   [[nodiscard]] virtual auto IsDefault() const -> bool      = 0;
   [[nodiscard]] virtual auto IsDirty() const -> bool        = 0;
 
+  /**
+   * @brief Current dirty field mask. Does not clear bits.
+   *
+   * Runtime invalidation reads this independently of @ref TakeDirtyPatch.
+   */
+  [[nodiscard]] virtual auto DirtyFields() const -> DirtyFieldMask = 0;
+
   /// Full payload snapshot. Ignores dirty bits.
   [[nodiscard]] virtual auto MakeFullDto() const -> OperatorParamDto = 0;
 

--- a/alcedo_studio/src/include/edit/operators/models/operator_model_base.hpp
+++ b/alcedo_studio/src/include/edit/operators/models/operator_model_base.hpp
@@ -32,6 +32,11 @@ class OperatorModelBase : public IOperatorModel {
     return dirty_.Any();
   }
 
+  [[nodiscard]] auto DirtyFields() const -> DirtyFieldMask override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dirty_;
+  }
+
   [[nodiscard]] auto MakeFullDto() const -> OperatorParamDto override {
     std::lock_guard<std::mutex> lock(mutex_);
     return MakeDtoLocked();

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
+#include <span>
 #include <stdexcept>
 
 #include "edit/runtime/develop_transient.hpp"
@@ -14,6 +15,7 @@
 #include "edit/runtime/mask_texture_cache.hpp"
 #include "edit/runtime/node_result_cache.hpp"
 #include "edit/runtime/parameter_arena.hpp"
+#include "edit/runtime/runtime_invalidation.hpp"
 #include "edit/runtime/texture_pool.hpp"
 #include "gpu/gpu_pool_trace.hpp"
 #include "gpu/transient_allocation_policy.hpp"
@@ -66,6 +68,26 @@ class BasicRenderWorkspace {
   [[nodiscard]] auto Values() -> NodeResultCache<Backend>& { return values_; }
   [[nodiscard]] auto Images() -> GraphImageCache<Backend>& { return images_; }
   [[nodiscard]] auto Images() const -> const GraphImageCache<Backend>& { return images_; }
+  [[nodiscard]] auto ResultInvalidation() -> RuntimeInvalidationState& { return invalidation_; }
+  [[nodiscard]] auto ResultInvalidation() const -> const RuntimeInvalidationState& {
+    return invalidation_;
+  }
+
+  /**
+   * @brief Collect dependency revisions once for the current @ref BeginRender.
+   *
+   * PlanExecutor and standalone grade encodes share this so a frame cannot assign
+   * two change versions. Operator dirty bits are read, not consumed.
+   */
+  void PrepareResultValidity(const ExecutionPlan& plan, PipelineDocument& document,
+                             const PreparedRawInput& input,
+                             std::span<const ActiveRasterMaskInput> active_raster_masks = {}) {
+    if (validity_prepared_) {
+      return;
+    }
+    invalidation_.CollectAndPropagate(plan, document, input, active_raster_masks);
+    validity_prepared_ = true;
+  }
   [[nodiscard]] auto DevelopTransientHighWater() -> DevelopTransientHighWaterCache& {
     return develop_high_water_;
   }
@@ -177,7 +199,8 @@ class BasicRenderWorkspace {
     mask_textures_.BeginFrame();
     active_raster_textures_.BeginFrame();
     command_context.SetSubmissionId(backend_.NextSubmissionId());
-    rendering_ = true;
+    rendering_           = true;
+    validity_prepared_   = false;
   }
 
   /**
@@ -216,6 +239,8 @@ class BasicRenderWorkspace {
     }
     images_.Clear();
     values_.Clear();
+    invalidation_.Clear();
+    validity_prepared_ = false;
     mask_textures_.Clear();
     active_raster_textures_.Clear();
     textures_.ReleaseUnleased();
@@ -250,9 +275,11 @@ class BasicRenderWorkspace {
   ActiveRasterTextureCache<Backend> active_raster_textures_;
   NodeResultCache<Backend>       values_{};
   GraphImageCache<Backend>       images_{};
+  RuntimeInvalidationState       invalidation_{};
   DevelopTransientHighWaterCache develop_high_water_{};
   std::uint64_t                  parameter_layout_hash_ = 0;
   bool                           rendering_             = false;
+  bool                           validity_prepared_     = false;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_develop_pass.hpp
@@ -39,6 +39,6 @@ void ExecuteCudaGeometryResample(CudaRenderDevice& device, const ExecutionPlan& 
  * never substituted. Independently skippable from SensorDevelop and Geometry.
  */
 void ExecuteCudaCameraColor(CudaRenderDevice& device, const ExecutionPlan& plan,
-                            const PipelineDocument& document);
+                            PipelineDocument& document);
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_local_tone_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_local_tone_pass.hpp
@@ -8,7 +8,6 @@
 
 #include "edit/geometry/resolved_render_geometry.hpp"
 #include "edit/graph/graph_ids.hpp"
-#include "edit/runtime/content_key.hpp"
 
 namespace alcedo {
 
@@ -27,7 +26,8 @@ struct CudaLocalToneResult {
  * viewport ROI. A full-EditSpace frame seeds or upgrades that reference. A viewport
  * ROI samples it through MakeLlfSamplingPlan instead of rebuilding the pyramids.
  *
- * Pyramid storage is owned by the render workspace. Both input and output must be
+ * Source versus result reuse is decided by @ref RuntimeInvalidationState. Pyramid
+ * scratch is owned by the render workspace. Both input and output must be
  * RGBA32F images of @p width by @p height. Slider values use the persisted [-100, 100]
  * UI scale. Throws on missing resources, invalid geometry, or CUDA failure.
  */
@@ -35,8 +35,7 @@ struct CudaLocalToneResult {
                                         const GraphValueId& output, const NodeId& grade_id,
                                         std::uint32_t width, std::uint32_t height,
                                         float shadows_slider, float highlights_slider,
-                                        const ResolvedRenderGeometry& geometry,
-                                        ContentKey                    reference_key)
+                                        const ResolvedRenderGeometry& geometry)
     -> CudaLocalToneResult;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
+++ b/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
@@ -118,9 +118,6 @@ auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input,
   GraphCompiler::BindFrameGeometry(plan, *document_, request.geometry);
   plan.output_color_override = request.output_color;
   detail::TraceGpuDagGeometry<Backend>(plan, request.geometry, request.submission);
-  if (document_->TopologyDirty()) {
-    document_->ClearTopologyDirty();
-  }
   const auto& prepared = use_session_cache ? prepared_lease->Get() : *one_shot_prepared;
   const auto  output_id = render_device->Execute(
       plan, prepared, *document_, mask_store_.get(), false,
@@ -153,16 +150,20 @@ auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input,
     }
     if (request.require_host_output) {
       auto host = FramePresenter<Backend>::Download(*render_device, output_id);
-      if (use_session_cache) {
-        render_device->PublishResults();
-      } else {
-        release_one_shot_resources();
-      }
-      return host;
-    }
     if (use_session_cache) {
       render_device->PublishResults();
+      render_device->Workspace().ResultInvalidation().CompleteMatchingImages(
+          render_device->Workspace().Images());
     } else {
+      release_one_shot_resources();
+    }
+    return host;
+  }
+  if (use_session_cache) {
+    render_device->PublishResults();
+    render_device->Workspace().ResultInvalidation().CompleteMatchingImages(
+        render_device->Workspace().Images());
+  } else {
       release_one_shot_resources();
     }
   } catch (const std::exception& ex) {

--- a/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
@@ -14,30 +14,21 @@
 #include <vector>
 
 #include "edit/graph/graph_ids.hpp"
-#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/result_representation.hpp"
+#include "edit/runtime/runtime_revision.hpp"
 #include "edit/runtime/texture_pool.hpp"
 #include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
 
-struct ResultIdentity {
-  GraphValueId value_id;
-  ContentKey   content_key;
-
-  friend auto  operator<(const ResultIdentity& a, const ResultIdentity& b) -> bool {
-    if (a.value_id != b.value_id) {
-      return a.value_id < b.value_id;
-    }
-    return a.content_key < b.content_key;
-  }
-};
-
 /**
- * @brief GPU image results keyed by GraphValueId and content, separate from allocation reuse.
+ * @brief GPU image results: one current published result per GraphValueId.
  *
- * Callers must use @ref AcquireTextureForWrite, @ref FindValidResult / @ref BindValidResult,
- * and @ref PublishSuccessfulSubmission. A matching ResourceId is allocation reuse, not a
- * content hit. Not thread-safe. One in-flight submission.
+ * Lookup uses required revision plus representation, not parameter hashes.
+ * Callers must use @ref AcquireTextureForWrite, @ref FindValidResult /
+ * @ref BindValidResult, and @ref PublishSuccessfulSubmission. A matching
+ * ResourceId is allocation reuse, not a content hit. Not thread-safe. One
+ * in-flight submission.
  *
  * @tparam Backend Texture factory used by TexturePool.
  */
@@ -45,46 +36,45 @@ template <class Backend>
 class GraphImageCache {
  public:
   /**
-   * @brief True when a published result matches value, key, extent, and format, and
-   *        @p last_writer has completed.
-   *
-   * Does not bind the value as current and does not update LRU.
+   * @brief True when the current published result matches revision and representation
+   *        and @p last_writer has completed.
    */
-  [[nodiscard]] auto FindValidResult(const GraphValueId& id, ContentKey key, ImageExtent extent,
-                                     TextureFormat format, std::uint64_t completed_submission) const
-      -> bool {
-    const auto* published = FindPublished(id, key);
-    return published != nullptr && Matches(*published, extent, format) &&
+  [[nodiscard]] auto FindValidResult(const GraphValueId& id, RuntimeRevision required_revision,
+                                     const ResultRepresentation& needed,
+                                     std::uint64_t completed_submission) const -> bool {
+    const auto* published = FindPublished(id);
+    return published != nullptr && published->revision == required_revision &&
+           required_revision != 0 && RepresentationSatisfies(published->representation, needed) &&
            !WriterBusy(*published, completed_submission);
   }
 
   /**
-   * @brief Bind a completed published result as the current texture for @p id.
+   * @brief Bind the current published result of @p id when it satisfies the query.
    *
-   * @return The bound lease, or nullptr on miss. Misses include size/format mismatch and
-   *         an in-flight last_writer. Counts a content hit or miss.
+   * Counts a validity hit or miss. Misses include revision mismatch, representation
+   * mismatch, and an in-flight last_writer.
    */
-  auto BindValidResult(const GraphValueId& id, ContentKey key, ImageExtent extent,
-                       TextureFormat format, std::uint64_t completed_submission)
+  auto BindValidResult(const GraphValueId& id, RuntimeRevision required_revision,
+                       const ResultRepresentation& needed, std::uint64_t completed_submission)
       -> ResourceLease<Backend>* {
-    auto* published = FindPublished(id, key);
-    if (published == nullptr || !Matches(*published, extent, format) ||
+    auto* published = FindPublished(id);
+    if (published == nullptr || published->revision != required_revision || required_revision == 0 ||
+        !RepresentationSatisfies(published->representation, needed) ||
         WriterBusy(*published, completed_submission)) {
       ++content_misses_;
       return nullptr;
     }
     ++content_hits_;
     published->lru_tick = ++lru_clock_;
-    current_[id]        = key;
     return &published->texture;
   }
 
   /**
    * @brief Allocate or reuse a texture for an unpublished write of @p id.
    *
-   * Reuses an in-flight write slot of the same size. Does not steal a published result of
-   * another content key. Overwriting a same-size unpublished slot drops its unrecorded
-   * identity. Evicts completed, non-current published results to fit the pool budget.
+   * Reuses an in-flight write slot of the same size. Does not steal the current
+   * published result. Overwriting a same-size unpublished slot drops its
+   * unrecorded identity. Evicts completed published results to fit the pool budget.
    *
    * @pre @p pool and @p backend outlive this cache.
    */
@@ -98,21 +88,21 @@ class GraphImageCache {
         const auto& tex = slot->texture.Texture();
         if (tex.Width() == request.width && tex.Height() == request.height &&
             tex.Format() == request.format) {
-          slot->has_key = false;
-          slot->key     = {};
+          slot->has_revision = false;
+          slot->revision     = 0;
+          slot->representation = {};
           return slot->texture;
         }
       }
       write_slots_.erase(id);
     }
 
-    current_.erase(id);
     EvictCompletedUnleased(pool, backend, request);
 
     WriteSlot slot;
     slot.texture        = pool.Acquire(request);
-    slot.extent         = ImageExtent{request.width, request.height};
-    slot.format         = request.format;
+    slot.representation.extent = ImageExtent{request.width, request.height};
+    slot.representation.format = request.format;
     auto [it, inserted] = write_slots_.emplace(id, std::move(slot));
     (void)inserted;
     return it->second.texture;
@@ -121,9 +111,8 @@ class GraphImageCache {
   /**
    * @brief Bind @p dest to the current texture of @p source without allocating.
    *
-   * Used when GeometryResample is identity. Content keys stay independent:
-   * publishing @p dest does not replace @p source. Overwriting a dest write
-   * slot drops its unrecorded identity.
+   * Used when GeometryResample is identity. Revisions stay independent:
+   * publishing @p dest does not replace @p source.
    *
    * @throws std::runtime_error when @p dest equals @p source or @p source has
    *         no current texture.
@@ -140,64 +129,62 @@ class GraphImageCache {
     if (FindWrite(dest) != nullptr) {
       write_slots_.erase(dest);
     }
-    current_.erase(dest);
 
     const auto& source_tex = source_lease->Texture();
     WriteSlot   slot;
     slot.texture        = pool.DuplicateLease(source_lease->Handle());
-    slot.extent         = ImageExtent{source_tex.Width(), source_tex.Height()};
-    slot.format         = source_tex.Format();
+    slot.representation.extent = ImageExtent{source_tex.Width(), source_tex.Height()};
+    slot.representation.format = source_tex.Format();
     auto [it, inserted] = write_slots_.emplace(dest, std::move(slot));
     (void)inserted;
     return it->second.texture;
   }
 
   /**
-   * @brief Attach a content key to the unpublished write of @p id.
+   * @brief Attach a revision to the unpublished write of @p id.
    *
-   * The result is not valid until @ref PublishSuccessfulSubmission. If this texture was
-   * previously published under another key, that identity must already have been removed;
-   * this method only annotates the write slot.
+   * The result is not valid until @ref PublishSuccessfulSubmission.
    *
    * @throws std::runtime_error when @p id has no write slot.
    */
-  void RecordUnpublished(const GraphValueId& id, ContentKey key, ImageExtent extent,
-                         TextureFormat format, std::uint64_t submission_id,
+  void RecordUnpublished(const GraphValueId& id, RuntimeRevision revision,
+                         const ResultRepresentation& representation, std::uint64_t submission_id,
                          std::uint64_t auxiliary = 0) {
     auto* slot = FindWrite(id);
     if (slot == nullptr) {
       throw std::runtime_error("GraphImageCache::RecordUnpublished: no write slot");
     }
-    if (slot->extent != extent || slot->format != format) {
+    if (slot->representation.extent != representation.extent ||
+        slot->representation.format != representation.format) {
       throw std::runtime_error("GraphImageCache::RecordUnpublished: extent or format mismatch");
     }
-    slot->key         = key;
-    slot->has_key     = true;
-    slot->last_writer = submission_id;
-    slot->auxiliary   = auxiliary;
+    slot->revision       = revision;
+    slot->representation = representation;
+    slot->has_revision   = true;
+    slot->last_writer    = submission_id;
+    slot->auxiliary      = auxiliary;
   }
 
   /**
    * @brief Atomically publish unpublished writes recorded for @p submission_id.
    *
-   * Write slots without a content key are dropped. Replacing a published (id, key) pair
-   * releases the previous lease. Failed or cancelled submissions must call
+   * Write slots without a revision are dropped. Replacing the current result of
+   * an id releases the previous lease. Failed or cancelled submissions must call
    * @ref DiscardUnpublished instead.
    */
   void PublishSuccessfulSubmission(std::uint64_t submission_id) {
     for (auto& [id, slot] : write_slots_) {
-      if (!slot.has_key || slot.last_writer != submission_id) {
+      if (!slot.has_revision || slot.last_writer != submission_id) {
         continue;
       }
       PublishedResult published;
-      published.texture     = std::move(slot.texture);
-      published.extent      = slot.extent;
-      published.format      = slot.format;
-      published.last_writer = slot.last_writer;
-      published.auxiliary   = slot.auxiliary;
-      published.lru_tick    = ++lru_clock_;
-      published_.insert_or_assign(ResultIdentity{id, slot.key}, std::move(published));
-      current_[id] = slot.key;
+      published.texture        = std::move(slot.texture);
+      published.representation = slot.representation;
+      published.revision       = slot.revision;
+      published.last_writer    = slot.last_writer;
+      published.auxiliary      = slot.auxiliary;
+      published.lru_tick       = ++lru_clock_;
+      published_.insert_or_assign(id, std::move(published));
     }
     write_slots_.clear();
   }
@@ -218,13 +205,13 @@ class GraphImageCache {
   [[nodiscard]] auto UnpublishedWriteCount() const -> std::size_t { return write_slots_.size(); }
 
   /**
-   * @brief Current texture for @p id: this-frame write slot, else last bound/published result.
+   * @brief Current texture for @p id: this-frame write slot, else the published result.
    */
   [[nodiscard]] auto Find(const GraphValueId& id) -> ResourceLease<Backend>* {
     if (auto* slot = FindWrite(id)) {
       return &slot->texture;
     }
-    auto* published = FindCurrentPublished(id);
+    auto* published = FindPublished(id);
     return published == nullptr ? nullptr : &published->texture;
   }
 
@@ -232,7 +219,7 @@ class GraphImageCache {
     if (const auto* slot = FindWrite(id)) {
       return &slot->texture;
     }
-    const auto* published = FindCurrentPublished(id);
+    const auto* published = FindPublished(id);
     return published == nullptr ? nullptr : &published->texture;
   }
 
@@ -242,11 +229,10 @@ class GraphImageCache {
   }
 
   /**
-   * @brief Drop completed published results that are not the current binding, oldest first.
+   * @brief Drop completed published results, oldest first, to free pool budget.
    *
-   * Releasing a lease makes the texture reusable by TexturePool without treating that reuse
-   * as a content hit. Stops once a matching-size texture is unleased or no victim remains.
-   * Does not evict in-flight write slots or results whose last_writer is still busy.
+   * Eviction causes later recomputation at the same quality. Does not evict
+   * in-flight write slots or results whose last_writer is still busy.
    */
   void EvictCompletedUnleased(TexturePool<Backend>& pool, Backend& backend,
                               const TextureRequest& needed) {
@@ -257,28 +243,28 @@ class GraphImageCache {
                               TextureFormatBytesPerPixel(needed.format);
     bool released_matching = false;
     while (!released_matching && pool.UsedBytes() + needed_bytes > pool.ByteBudget()) {
-      ResultIdentity   victim_id;
+      GraphValueId     victim_id;
       PublishedResult* victim = nullptr;
       std::uint64_t    oldest = (std::numeric_limits<std::uint64_t>::max)();
-      for (auto& [identity, entry] : published_) {
+      for (auto& [id, entry] : published_) {
         if (backend.IsResourceBusy(entry.last_writer)) {
           continue;
         }
-        const auto current = current_.find(identity.value_id);
-        if (current != current_.end() && current->second == identity.content_key) {
+        if (write_slots_.contains(id)) {
           continue;
         }
         if (entry.lru_tick < oldest) {
           oldest    = entry.lru_tick;
           victim    = &entry;
-          victim_id = identity;
+          victim_id = id;
         }
       }
       if (victim == nullptr) {
         break;
       }
-      released_matching = victim->extent.width == needed.width &&
-                          victim->extent.height == needed.height && victim->format == needed.format;
+      released_matching = victim->representation.extent.width == needed.width &&
+                          victim->representation.extent.height == needed.height &&
+                          victim->representation.format == needed.format;
       published_.erase(victim_id);
     }
   }
@@ -288,39 +274,41 @@ class GraphImageCache {
   [[nodiscard]] auto ContentHitCount() const -> std::uint64_t { return content_hits_; }
   [[nodiscard]] auto ContentMissCount() const -> std::uint64_t { return content_misses_; }
 
-  [[nodiscard]] auto PublishedContentKey(const GraphValueId& id) const -> ContentKey {
-    const auto it = current_.find(id);
-    return it == current_.end() ? ContentKey{} : it->second;
+  [[nodiscard]] auto PublishedRevision(const GraphValueId& id) const -> RuntimeRevision {
+    const auto* published = FindPublished(id);
+    return published == nullptr ? 0 : published->revision;
   }
 
-  [[nodiscard]] auto PublishedLastWriter(const GraphValueId& id, ContentKey key) const
-      -> std::uint64_t {
-    const auto* published = FindPublished(id, key);
+  [[nodiscard]] auto PublishedRepresentation(const GraphValueId& id) const -> ResultRepresentation {
+    const auto* published = FindPublished(id);
+    return published == nullptr ? ResultRepresentation{} : published->representation;
+  }
+
+  [[nodiscard]] auto PublishedLastWriter(const GraphValueId& id) const -> std::uint64_t {
+    const auto* published = FindPublished(id);
     return published == nullptr ? 0 : published->last_writer;
   }
 
   /**
-   * @brief Return optional caller-owned metadata attached to a published image result.
+   * @brief Return optional caller-owned metadata attached to the current image result.
    *
-   * The value is published and discarded with the image identity. It is intended for small
-   * resource descriptors such as a canonical source resolution; it is not a second content key.
+   * Intended for a canonical source long-edge; it is not a second identity.
    */
-  [[nodiscard]] auto PublishedAuxiliary(const GraphValueId& id, ContentKey key) const
-      -> std::uint64_t {
-    const auto* published = FindPublished(id, key);
+  [[nodiscard]] auto PublishedAuxiliary(const GraphValueId& id) const -> std::uint64_t {
+    const auto* published = FindPublished(id);
     return published == nullptr ? 0 : published->auxiliary;
   }
 
   void Clear() {
     write_slots_.clear();
     published_.clear();
-    current_.clear();
   }
 
   [[nodiscard]] auto CurrentValueIds() const -> std::vector<GraphValueId> {
     std::vector<GraphValueId> ids;
-    ids.reserve(current_.size());
-    for (const auto& [id, key] : current_) {
+    ids.reserve(published_.size());
+    for (const auto& [id, entry] : published_) {
+      (void)entry;
       ids.push_back(id);
     }
     return ids;
@@ -333,63 +321,53 @@ class GraphImageCache {
    */
   void DumpToStderr(const char* reason, const TexturePool<Backend>& pool) const {
     (void)pool;
-    std::fprintf(stderr, "[GPU_POOL] images %s published=%zu write=%zu current=%zu\n",
-                 reason == nullptr ? "" : reason, published_.size(), write_slots_.size(),
-                 current_.size());
+    std::fprintf(stderr, "[GPU_POOL] images %s published=%zu write=%zu\n",
+                 reason == nullptr ? "" : reason, published_.size(), write_slots_.size());
     if (!GpuPoolTraceVerbose()) {
       return;
     }
     for (const auto& [id, slot] : write_slots_) {
-      PrintSlot("write", id, slot.key, slot.has_key, slot.extent, slot.format, slot.texture,
-                slot.last_writer, false);
+      PrintSlot("write", id, slot.revision, slot.has_revision, slot.representation.extent,
+                slot.representation.format, slot.texture, slot.last_writer);
     }
-    for (const auto& [identity, entry] : published_) {
-      const auto current    = current_.find(identity.value_id);
-      const bool is_current = current != current_.end() && current->second == identity.content_key;
-      PrintSlot("published", identity.value_id, identity.content_key, true, entry.extent,
-                entry.format, entry.texture, entry.last_writer, is_current);
+    for (const auto& [id, entry] : published_) {
+      PrintSlot("published", id, entry.revision, true, entry.representation.extent,
+                entry.representation.format, entry.texture, entry.last_writer);
     }
   }
 
  private:
-  static void PrintSlot(const char* kind, const GraphValueId& id, ContentKey key, bool has_key,
-                        ImageExtent extent, TextureFormat format,
-                        const ResourceLease<Backend>& texture, std::uint64_t last_writer,
-                        bool is_current) {
+  static void PrintSlot(const char* kind, const GraphValueId& id, RuntimeRevision revision,
+                        bool has_revision, ImageExtent extent, TextureFormat format,
+                        const ResourceLease<Backend>& texture, std::uint64_t last_writer) {
     const auto handle = texture.Empty() ? 0 : texture.Handle();
     std::fprintf(stderr,
-                 "[GPU_POOL]   %-9s %.*s:%.*s %ux%u %s handle=%llu key=%llx writer=%llu "
-                 "has_key=%d current=%d\n",
+                 "[GPU_POOL]   %-9s %.*s:%.*s %ux%u %s handle=%llu rev=%llu writer=%llu "
+                 "has_rev=%d\n",
                  kind, static_cast<int>(id.producer.Value().size()), id.producer.Value().data(),
                  static_cast<int>(id.output_port.Value().size()), id.output_port.Value().data(),
                  extent.width, extent.height, TextureFormatName(format),
                  static_cast<unsigned long long>(handle),
-                 static_cast<unsigned long long>(has_key ? key.hash : 0),
-                 static_cast<unsigned long long>(last_writer), has_key ? 1 : 0, is_current ? 1 : 0);
+                 static_cast<unsigned long long>(has_revision ? revision : 0),
+                 static_cast<unsigned long long>(last_writer), has_revision ? 1 : 0);
   }
   struct WriteSlot {
     ResourceLease<Backend> texture;
-    ContentKey             key{};
-    ImageExtent            extent{};
-    TextureFormat          format      = TextureFormat::R8;
-    std::uint64_t          last_writer = 0;
-    std::uint64_t          auxiliary   = 0;
-    bool                   has_key     = false;
+    ResultRepresentation   representation{};
+    RuntimeRevision        revision     = 0;
+    std::uint64_t          last_writer  = 0;
+    std::uint64_t          auxiliary    = 0;
+    bool                   has_revision = false;
   };
 
   struct PublishedResult {
     ResourceLease<Backend> texture;
-    ImageExtent            extent{};
-    TextureFormat          format      = TextureFormat::R8;
+    ResultRepresentation   representation{};
+    RuntimeRevision        revision    = 0;
     std::uint64_t          last_writer = 0;
     std::uint64_t          auxiliary   = 0;
     std::uint64_t          lru_tick    = 0;
   };
-
-  static auto Matches(const PublishedResult& entry, ImageExtent extent, TextureFormat format)
-      -> bool {
-    return entry.extent == extent && entry.format == format && !entry.texture.Empty();
-  }
 
   static auto WriterBusy(const PublishedResult& entry, std::uint64_t completed_submission) -> bool {
     return entry.last_writer != 0 && entry.last_writer > completed_submission;
@@ -405,38 +383,21 @@ class GraphImageCache {
     return it == write_slots_.end() ? nullptr : &it->second;
   }
 
-  auto FindPublished(const GraphValueId& id, ContentKey key) -> PublishedResult* {
-    const auto it = published_.find(ResultIdentity{id, key});
+  auto FindPublished(const GraphValueId& id) -> PublishedResult* {
+    const auto it = published_.find(id);
     return it == published_.end() ? nullptr : &it->second;
   }
 
-  auto FindPublished(const GraphValueId& id, ContentKey key) const -> const PublishedResult* {
-    const auto it = published_.find(ResultIdentity{id, key});
+  auto FindPublished(const GraphValueId& id) const -> const PublishedResult* {
+    const auto it = published_.find(id);
     return it == published_.end() ? nullptr : &it->second;
   }
 
-  auto FindCurrentPublished(const GraphValueId& id) -> PublishedResult* {
-    const auto it = current_.find(id);
-    if (it == current_.end()) {
-      return nullptr;
-    }
-    return FindPublished(id, it->second);
-  }
-
-  auto FindCurrentPublished(const GraphValueId& id) const -> const PublishedResult* {
-    const auto it = current_.find(id);
-    if (it == current_.end()) {
-      return nullptr;
-    }
-    return FindPublished(id, it->second);
-  }
-
-  std::map<GraphValueId, WriteSlot>         write_slots_;
-  std::map<ResultIdentity, PublishedResult> published_;
-  std::map<GraphValueId, ContentKey>        current_;
-  std::uint64_t                             lru_clock_      = 0;
-  std::uint64_t                             content_hits_   = 0;
-  std::uint64_t                             content_misses_ = 0;
+  std::map<GraphValueId, WriteSlot>       write_slots_;
+  std::map<GraphValueId, PublishedResult> published_;
+  std::uint64_t                           lru_clock_      = 0;
+  std::uint64_t                           content_hits_   = 0;
+  std::uint64_t                           content_misses_ = 0;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/local_tone_cache_ids.hpp
+++ b/alcedo_studio/src/include/edit/runtime/local_tone_cache_ids.hpp
@@ -1,0 +1,36 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <string>
+
+#include "edit/graph/graph_ids.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Graph value for the current canonical LLF source plane of @p grade_id.
+ *
+ * Matches each GPU backend's `local_tone.source.0` storage.
+ */
+[[nodiscard]] inline auto LocalToneSourceId(const NodeId& grade_id) -> GraphValueId {
+  return {grade_id, PortId{"local_tone.source.0"}};
+}
+
+/**
+ * @brief Graph value for the current canonical LLF result plane of @p grade_id.
+ *
+ * Matches each GPU backend's `local_tone.result.0` storage.
+ */
+[[nodiscard]] inline auto LocalToneResultId(const NodeId& grade_id) -> GraphValueId {
+  return {grade_id, PortId{"local_tone.result.0"}};
+}
+
+[[nodiscard]] inline auto LocalToneLevelId(const NodeId& grade_id, const char* family, int level)
+    -> GraphValueId {
+  return {grade_id, PortId{std::string{"local_tone."} + family + "." + std::to_string(level)}};
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_develop_pass.hpp
@@ -27,7 +27,7 @@ void ExecuteMetalDevelop(MetalRenderDevice& device, const ExecutionPlan& plan,
 void ExecuteMetalGeometryResample(MetalRenderDevice& device, const ExecutionPlan& plan);
 
 void ExecuteMetalCameraColor(MetalRenderDevice& device, const ExecutionPlan& plan,
-                             const PipelineDocument& document);
+                             PipelineDocument& document);
 
 void WarmUpMetalDagPlan(MetalBackend& backend, const ExecutionPlan& plan);
 

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_local_tone_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_local_tone_pass.hpp
@@ -11,7 +11,6 @@
 
 #include "edit/geometry/resolved_render_geometry.hpp"
 #include "edit/graph/graph_ids.hpp"
-#include "edit/runtime/content_key.hpp"
 #include "edit/runtime/metal/metal_backend.hpp"
 
 namespace alcedo {
@@ -34,8 +33,7 @@ struct MetalLocalToneResult {
                                          const MetalBackend::Texture2D& input,
                                          MetalBackend::Texture2D& output, const NodeId& grade_id,
                                          float shadows_slider, float highlights_slider,
-                                         const ResolvedRenderGeometry& geometry,
-                                         ContentKey source_key, ContentKey result_key)
+                                         const ResolvedRenderGeometry& geometry)
     -> MetalLocalToneResult;
 
 void AppendMetalLocalToneWarmup(std::vector<MetalPipelineWarmup>& pipelines);

--- a/alcedo_studio/src/include/edit/runtime/node_result_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/node_result_cache.hpp
@@ -13,7 +13,8 @@
 #include <utility>
 
 #include "edit/graph/graph_ids.hpp"
-#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/result_representation.hpp"
+#include "edit/runtime/runtime_revision.hpp"
 #include "gpu/gpu_pool_trace.hpp"
 
 namespace alcedo {
@@ -21,17 +22,18 @@ namespace alcedo {
 /**
  * @brief KV cache of non-image node buffers keyed by producer node and output port.
  *
- * GPU image results live in GraphImageCache with content keys. This cache holds
- * runtime buffers such as adjustment command lists. Not thread-safe.
+ * GPU image results live in GraphImageCache. This cache holds runtime buffers
+ * such as LLF planes. One current buffer per GraphValueId. Not thread-safe.
  */
 template <class Backend>
 class NodeResultCache {
  public:
   struct Metadata {
-    ContentKey    content_key{};
-    ImageExtent   extent{};
-    std::uint32_t source_long_edge = 0;
-    bool          canonical        = false;
+    RuntimeRevision      completed_revision = 0;
+    ResultRepresentation representation{};
+    ImageExtent          extent{};
+    std::uint32_t        source_long_edge = 0;
+    bool                 canonical        = false;
   };
 
   void Store(GraphValueId id, typename Backend::Buffer buffer) {
@@ -45,17 +47,19 @@ class NodeResultCache {
   }
 
   /**
-   * @brief Attach the content identity used to validate a cached node buffer.
+   * @brief Attach the validity metadata used to reuse a cached node buffer.
    *
    * @p source_long_edge and @p canonical describe an LLF reference plane. Other
-   * buffers leave them at the defaults.
+   * buffers leave them at the defaults. A failed write must not call this.
    */
-  void StoreMetadata(const GraphValueId& id, ContentKey content_key, ImageExtent extent,
+  void StoreMetadata(const GraphValueId& id, RuntimeRevision completed_revision,
+                     const ResultRepresentation& representation, ImageExtent extent,
                      std::uint32_t source_long_edge = 0, bool canonical = false) {
     if (!values_.contains(id)) {
       throw std::runtime_error("NodeResultCache::StoreMetadata: value buffer is missing");
     }
-    metadata_.insert_or_assign(id, Metadata{content_key, extent, source_long_edge, canonical});
+    metadata_.insert_or_assign(
+        id, Metadata{completed_revision, representation, extent, source_long_edge, canonical});
   }
 
   /** @brief Return cached identity metadata for a node buffer, when available. */

--- a/alcedo_studio/src/include/edit/runtime/opencl/opencl_develop_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/opencl/opencl_develop_pass.hpp
@@ -28,7 +28,7 @@ void ExecuteOpenClDevelop(OpenClRenderDevice& device, const ExecutionPlan& plan,
 void ExecuteOpenClGeometryResample(OpenClRenderDevice& device, const ExecutionPlan& plan);
 
 void ExecuteOpenClCameraColor(OpenClRenderDevice& device, const ExecutionPlan& plan,
-                              const PipelineDocument& document);
+                              PipelineDocument& document);
 
 /**
  * @brief Test hook: inject a model cache so Neural load failure can be asserted.

--- a/alcedo_studio/src/include/edit/runtime/opencl/opencl_local_tone_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/opencl/opencl_local_tone_pass.hpp
@@ -10,7 +10,6 @@
 
 #include "edit/geometry/resolved_render_geometry.hpp"
 #include "edit/graph/graph_ids.hpp"
-#include "edit/runtime/content_key.hpp"
 #include "edit/runtime/opencl/opencl_backend.hpp"
 
 namespace alcedo {
@@ -34,8 +33,7 @@ struct OpenClLocalToneResult {
                                           const OpenClBackend::Texture2D& input,
                                           OpenClBackend::Texture2D& output, const NodeId& grade_id,
                                           float shadows_slider, float highlights_slider,
-                                          const ResolvedRenderGeometry& geometry,
-                                          ContentKey source_key, ContentKey result_key)
+                                          const ResolvedRenderGeometry& geometry)
     -> OpenClLocalToneResult;
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/plan_executor.hpp
@@ -19,7 +19,7 @@
 #include "edit/runtime/compiled_grade_mask.hpp"
 #include "edit/runtime/pass_encoder.hpp"
 #include "edit/runtime/pass_kind.hpp"
-#include "edit/runtime/result_content_key.hpp"
+#include "edit/runtime/runtime_invalidation.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "gpu/transient_allocation_policy.hpp"
 
@@ -28,10 +28,10 @@ namespace alcedo {
 class MaskStore;
 
 /**
- * @brief Shared content-key skip, encode, cancel, and publish flow for one plan.
+ * @brief Shared validity skip, encode, cancel, and publish flow for one plan.
  *
  * Skip units match CUDA DAG cache boundaries. A failed encode cancels the
- * incomplete submission and does not publish new content keys. There is no
+ * incomplete submission and does not publish new revisions. There is no
  * CPU or alternate-backend substitute.
  *
  * @tparam Backend Render backend whose PassEncoder specializations perform GPU work.
@@ -70,15 +70,18 @@ class PlanExecutor {
       }
       device.BeginRender();
       workspace.AlignParameterLayout(plan.static_key.topology_hash);
-      const auto keys          = BuildFrameResultContentKeys(plan, input, document,
-                                                            active_raster_masks);
+      auto&      invalidation  = workspace.ResultInvalidation();
+      workspace.PrepareResultValidity(plan, document, input, active_raster_masks);
+      const ImageExtent sensor_extent{plan.source.develop_output_extent.width,
+                                      plan.source.develop_output_extent.height};
+      const ImageExtent geometry_extent{plan.geometry.render_extent.width,
+                                        plan.geometry.render_extent.height};
       const auto completed     = workspace.Device().CompletedSubmission();
       auto&      stats         = device.PassStats();
       const auto hits_before   = workspace.Images().ContentHitCount();
       const auto misses_before = workspace.Images().ContentMissCount();
 
-      if (BindOrMiss(workspace, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent,
-                     completed)) {
+      if (BindOrMiss(workspace, invalidation, plan.sensor_linear_output, sensor_extent, completed)) {
         ++stats.sensor_develop_skip;
       } else {
         const auto* develop_node = document.Develop();
@@ -114,7 +117,7 @@ class PlanExecutor {
         }
         stats.source_h2d_bytes += workspace.Device().HostToDeviceBytes() - h2d_before;
         ++stats.source_h2d_count;
-        Record(device, plan.sensor_linear_output, keys.sensor_linear, keys.sensor_extent);
+        Record(device, invalidation, plan.sensor_linear_output, sensor_extent);
         ++stats.sensor_develop_execute;
         if constexpr (UsesDevelopTransientArena()) {
           if (transient_policy == TransientAllocationPolicy::SessionPacked) {
@@ -132,13 +135,12 @@ class PlanExecutor {
       workspace.TransientBuffers().Reset();
       workspace.TransientBuffers().ReleaseDeviceMemory();
 
-      if (BindOrMiss(workspace, plan.geometry_output, keys.geometry_scene_source,
-                     keys.geometry_extent, completed)) {
+      if (BindOrMiss(workspace, invalidation, plan.geometry_output, geometry_extent, completed)) {
         ++stats.geometry_skip;
       } else {
         PassEncoder<Backend, GpuPassKind::GeometryResample>::Encode(device, plan, input, document,
                                                                     mask_store);
-        Record(device, plan.geometry_output, keys.geometry_scene_source, keys.geometry_extent);
+        Record(device, invalidation, plan.geometry_output, geometry_extent);
         ++stats.geometry_execute;
       }
       if (exact_release && plan.encode_geometry_resample) {
@@ -146,13 +148,12 @@ class PlanExecutor {
         workspace.ReleaseConsumedImage(plan.sensor_linear_output);
       }
 
-      if (BindOrMiss(workspace, plan.develop_output, keys.develop_image, keys.geometry_extent,
-                     completed)) {
+      if (BindOrMiss(workspace, invalidation, plan.develop_output, geometry_extent, completed)) {
         ++stats.camera_color_skip;
       } else {
         PassEncoder<Backend, GpuPassKind::CameraToAp1>::Encode(device, plan, input, document,
                                                                mask_store);
-        Record(device, plan.develop_output, keys.develop_image, keys.geometry_extent);
+        Record(device, invalidation, plan.develop_output, geometry_extent);
         ++stats.camera_color_execute;
       }
       if (exact_release) {
@@ -173,27 +174,25 @@ class PlanExecutor {
             if (!MaskSourceIsEnabled(document, compiled_grade.node_id, source.mask_id)) {
               continue;
             }
-            const auto source_key = keys.Value(source.effective_output);
-            if (BindOrMiss(workspace, source.effective_output, source_key, keys.geometry_extent,
+            if (BindOrMiss(workspace, invalidation, source.effective_output, geometry_extent,
                            completed, TextureFormat::R8)) {
               ++stats.mask_skip;
             } else {
               PassEncoder<Backend, GpuPassKind::MaskEvaluate>::Encode(
                   device, plan, input, document, mask_store, compiled_grade, source,
                   active_raster_masks);
-              Record(device, source.effective_output, source_key, keys.geometry_extent,
+              Record(device, invalidation, source.effective_output, geometry_extent,
                      TextureFormat::R8);
               ++stats.mask_execute;
             }
           }
-          const auto union_key = keys.Value(compiled_grade.mask_output);
-          if (BindOrMiss(workspace, compiled_grade.mask_output, union_key, keys.geometry_extent,
+          if (BindOrMiss(workspace, invalidation, compiled_grade.mask_output, geometry_extent,
                          completed, TextureFormat::R8)) {
             ++stats.mask_union_skip;
           } else {
             PassEncoder<Backend, GpuPassKind::MaskUnion>::Encode(device, plan, input, document,
                                                                  mask_store, compiled_grade);
-            Record(device, compiled_grade.mask_output, union_key, keys.geometry_extent,
+            Record(device, invalidation, compiled_grade.mask_output, geometry_extent,
                    TextureFormat::R8);
             ++stats.mask_union_execute;
           }
@@ -201,13 +200,12 @@ class PlanExecutor {
         }
 
         const GraphValueId grade_scene = compiled_grade.scene_output;
-        if (BindOrMiss(workspace, grade_scene, keys.Value(grade_scene), keys.geometry_extent,
-                       completed)) {
+        if (BindOrMiss(workspace, invalidation, grade_scene, geometry_extent, completed)) {
           ++stats.primary_grade_skip;
         } else {
           PassEncoder<Backend, GpuPassKind::PrimaryColorGrade>::Encode(
               device, plan, input, document, mask_store, compiled_grade);
-          Record(device, grade_scene, keys.Value(grade_scene), keys.geometry_extent);
+          Record(device, invalidation, grade_scene, geometry_extent);
           ++stats.primary_grade_execute;
         }
         if (exact_release) {
@@ -228,12 +226,11 @@ class PlanExecutor {
         }
       }
 
-      if (BindOrMiss(workspace, plan.display_output, keys.drt_display, keys.geometry_extent,
-                     completed)) {
+      if (BindOrMiss(workspace, invalidation, plan.display_output, geometry_extent, completed)) {
         ++stats.drt_skip;
       } else {
         PassEncoder<Backend, GpuPassKind::Drt>::Encode(device, plan, input, document, mask_store);
-        Record(device, plan.display_output, keys.drt_display, keys.geometry_extent);
+        Record(device, invalidation, plan.display_output, geometry_extent);
         ++stats.drt_execute;
       }
       if (exact_release && plan.display_output != plan.SceneInputForDrt()) {
@@ -246,6 +243,7 @@ class PlanExecutor {
       device.EndRender();
       if (publish_on_success) {
         device.PublishResults();
+        invalidation.CompleteMatchingImages(workspace.Images());
       }
       return plan.display_output;
     } catch (const std::exception& ex) {
@@ -276,16 +274,20 @@ class PlanExecutor {
   }
 
   template <class Workspace>
-  static auto BindOrMiss(Workspace& images_owner, const GraphValueId& id, ContentKey key,
-                         ImageExtent extent, std::uint64_t completed,
+  static auto BindOrMiss(Workspace& images_owner, RuntimeInvalidationState& invalidation,
+                         const GraphValueId& id, ImageExtent extent, std::uint64_t completed,
                          TextureFormat format = kResultFormat) -> bool {
-    return images_owner.Images().BindValidResult(id, key, extent, format, completed) != nullptr;
+    const auto required = invalidation.RequiredRevision(id);
+    const auto needed   = invalidation.MakeImageRepresentation(id, extent, format);
+    return images_owner.Images().BindValidResult(id, required, needed, completed) != nullptr;
   }
 
   template <class Device>
-  static void Record(Device& device, const GraphValueId& id, ContentKey key, ImageExtent extent,
-                     TextureFormat format = kResultFormat) {
-    device.Workspace().Images().RecordUnpublished(id, key, extent, format,
+  static void Record(Device& device, RuntimeInvalidationState& invalidation, const GraphValueId& id,
+                     ImageExtent extent, TextureFormat format = kResultFormat) {
+    const auto required = invalidation.RequiredRevision(id);
+    const auto needed   = invalidation.MakeImageRepresentation(id, extent, format);
+    device.Workspace().Images().RecordUnpublished(id, required, needed,
                                                   device.CommandContext().SubmissionId());
   }
 };

--- a/alcedo_studio/src/include/edit/runtime/renderer.hpp
+++ b/alcedo_studio/src/include/edit/runtime/renderer.hpp
@@ -124,7 +124,7 @@ class Renderer {
    *        one-shot device, and backend session extras.
    *
    * The session device is kept when it already exists so the next editor Render
-   * does not rebuild CUDA/Metal/OpenCL streams. Thumbnail-only Bypass renders
+   * does not rebuild GPU streams. Thumbnail-only Bypass renders
    * never create that session device. Call when the last pipeline pin is
    * released. The next Render rebuilds caches from the still-owned document.
    */
@@ -248,7 +248,11 @@ void Renderer<Backend>::SetDocument(std::shared_ptr<PipelineDocument> document) 
   if (!document) {
     throw std::invalid_argument("Renderer: PipelineDocument is null");
   }
-  document_ = std::move(document);
+  const bool replaced = document_.get() != document.get();
+  document_           = std::move(document);
+  if (replaced && device_) {
+    device_->Workspace().ResultInvalidation().AdvanceDocumentEpoch();
+  }
 }
 
 template <class Backend>

--- a/alcedo_studio/src/include/edit/runtime/result_content_key.hpp
+++ b/alcedo_studio/src/include/edit/runtime/result_content_key.hpp
@@ -13,6 +13,7 @@
 #include "edit/mask/active_raster_mask.hpp"
 #include "edit/runtime/content_key.hpp"
 #include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/runtime_revision.hpp"
 
 namespace alcedo {
 
@@ -59,9 +60,34 @@ struct FrameResultContentKeys {
 [[nodiscard]] auto HashPreparedSourceKey(const PreparedSourceKey& key) -> ContentKey;
 
 /**
+ * @brief Hash RAW linearization fields used by SensorDevelop.
+ */
+[[nodiscard]] auto HashLinearizationParams(const RawLinearizationParams& linearization)
+    -> ContentKey;
+
+/**
  * @brief Hash the full ResolvedRenderGeometry, including crop, rotation, ROI, and sampling.
  */
 [[nodiscard]] auto HashResolvedRenderGeometry(const ResolvedRenderGeometry& geometry) -> ContentKey;
+
+/**
+ * @brief Canonical LLF/crop identity. Viewport ROI and render extent are omitted.
+ */
+[[nodiscard]] auto HashCanonicalReferenceIdentity(const ExecutionPlan& plan,
+                                                  const PreparedRawInput& input) -> ContentKey;
+
+/**
+ * @brief Viewport-inclusive frame identity for resampled image results.
+ */
+[[nodiscard]] auto HashFrameImageIdentity(const ExecutionPlan& plan, const PreparedRawInput& input,
+                                          RuntimeRevision document_epoch) -> ContentKey;
+
+/**
+ * @brief SensorDevelop identity: prepared source, linearization, and implementation version.
+ *
+ * Develop operator values are not mixed; those use dependency revisions.
+ */
+[[nodiscard]] auto HashSensorSourceIdentity(const PreparedRawInput& input) -> ContentKey;
 
 /**
  * @brief Identity of the canonical LLF reference for @p grade_id. Viewport ROI is omitted.

--- a/alcedo_studio/src/include/edit/runtime/result_representation.hpp
+++ b/alcedo_studio/src/include/edit/runtime/result_representation.hpp
@@ -1,0 +1,63 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/runtime_revision.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Pixel-affecting representation of one cached result.
+ *
+ * Identity is a mix of source, document epoch, geometry or canonical mapping,
+ * decode/quality, and backend capability. It does not encode node parameter
+ * values. @ref source_detail is the cached long-edge requirement; a higher
+ * requested detail is incompatible.
+ */
+struct ResultRepresentation {
+  std::uint64_t   identity       = 0;
+  RuntimeRevision document_epoch = 0;
+  ImageExtent     extent{};
+  TextureFormat   format         = TextureFormat::Rgba32f;
+  std::uint32_t   source_detail  = 0;
+
+  [[nodiscard]] auto Empty() const -> bool { return identity == 0 && extent.width == 0; }
+};
+
+inline auto operator==(const ResultRepresentation& a, const ResultRepresentation& b) -> bool {
+  return a.identity == b.identity && a.document_epoch == b.document_epoch && a.extent == b.extent &&
+         a.format == b.format && a.source_detail == b.source_detail;
+}
+
+inline auto operator!=(const ResultRepresentation& a, const ResultRepresentation& b) -> bool {
+  return !(a == b);
+}
+
+[[nodiscard]] inline auto MakeExtentRepresentation(ImageExtent extent, TextureFormat format)
+    -> ResultRepresentation {
+  ResultRepresentation repr;
+  repr.extent = extent;
+  repr.format = format;
+  return repr;
+}
+
+/**
+ * @brief True when @p cached can satisfy @p needed.
+ *
+ * Extent, format, identity, and epoch must match. Cached source detail must be
+ * at least the requested detail.
+ */
+[[nodiscard]] inline auto RepresentationSatisfies(const ResultRepresentation& cached,
+                                                  const ResultRepresentation& needed) -> bool {
+  return cached.identity == needed.identity && cached.document_epoch == needed.document_epoch &&
+         cached.extent == needed.extent && cached.format == needed.format &&
+         cached.source_detail >= needed.source_detail;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/runtime_invalidation.hpp
+++ b/alcedo_studio/src/include/edit/runtime/runtime_invalidation.hpp
@@ -1,0 +1,188 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/input/prepared_raw_input.hpp"
+#include "edit/mask/active_raster_mask.hpp"
+#include "edit/mask/mask_id.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/local_tone_cache_ids.hpp"
+#include "edit/runtime/result_representation.hpp"
+#include "edit/runtime/runtime_revision.hpp"
+#include "edit/runtime/texture_format.hpp"
+
+namespace alcedo {
+
+class PipelineDocument;
+
+/**
+ * @brief Owner-maintained result validity: revisions, compiled downstream edges,
+ *        and representation identities.
+ *
+ * Does not copy node parameters. Operator dirty bits are read, not consumed.
+ * GPU upload still uses @ref IOperatorModel::TakeDirtyPatch separately.
+ *
+ * Not thread-safe. One in-flight propagate per owner mutation batch.
+ */
+class RuntimeInvalidationState {
+ public:
+  struct Record {
+    RuntimeRevision      required  = 0;
+    RuntimeRevision      completed = 0;
+    ResultRepresentation published{};
+  };
+
+  /**
+   * @brief Rebuild compiled downstream adjacency from @p plan.
+   *
+   * Call when the static plan identity changes. Parameter edits do not recompile.
+   */
+  void BindCompiledPlan(const ExecutionPlan& plan);
+
+  /**
+   * @brief Read dirty fields, Mask/mix revisions, topology, and active rasters;
+   *        assign one change version and propagate once.
+   *
+   * @pre @ref BindCompiledPlan has run for @p plan.
+   * Does not consume operator dirty bits. Mix dirty and last-seen Mask/raster
+   * revisions are updated here so a failed GPU publish still keeps required
+   * ahead of completed.
+   */
+  void CollectAndPropagate(const ExecutionPlan& plan, PipelineDocument& document,
+                           const PreparedRawInput& input,
+                           std::span<const ActiveRasterMaskInput> active_raster_masks = {});
+
+  /**
+   * @brief Snapshot source/geometry identities for this frame's bind checks.
+   *
+   * Viewport is in the frame identity only. Canonical LLF identity omits viewport.
+   */
+  void CaptureFrameRepresentations(const ExecutionPlan& plan, const PreparedRawInput& input);
+
+  /**
+   * @brief New document generation. Same NodeIds cannot reuse prior results.
+   *
+   * Bumps every required revision. Does not clear completed textures; bind misses
+   * until the new generation is published.
+   */
+  void AdvanceDocumentEpoch();
+
+  /** @brief Drop revisions, adjacency, and last-seen Mask/raster versions. */
+  void Clear();
+
+  [[nodiscard]] auto DocumentEpoch() const -> RuntimeRevision { return document_epoch_; }
+  [[nodiscard]] auto ChangeVersion() const -> RuntimeRevision { return change_version_; }
+
+  [[nodiscard]] auto RequiredRevision(const GraphValueId& id) const -> RuntimeRevision;
+  [[nodiscard]] auto CompletedRevision(const GraphValueId& id) const -> RuntimeRevision;
+  [[nodiscard]] auto PublishedRepresentation(const GraphValueId& id) const -> ResultRepresentation;
+
+  /**
+   * @brief True when this value has a published completed revision equal to required.
+   *
+   * Does not compare GPU extent. Callers pass @p needed to check representation.
+   */
+  [[nodiscard]] auto IsSatisfied(const GraphValueId& id,
+                                 const ResultRepresentation& needed) const -> bool;
+
+  /**
+   * @brief Frame representation for an image result of @p id.
+   *
+   * Sensor uses source identity. Canonical LLF ports use the crop/reference
+   * identity. Other image values use the viewport-inclusive frame identity.
+   */
+  [[nodiscard]] auto MakeImageRepresentation(const GraphValueId& id, ImageExtent extent,
+                                             TextureFormat format,
+                                             std::uint32_t source_detail = 0) const
+      -> ResultRepresentation;
+
+  /**
+   * @brief Record a successful publish of @p id at its current required revision.
+   *
+   * @p representation is the GPU result that became current. Failed writes must
+   * not call this.
+   */
+  void MarkCompleted(const GraphValueId& id, const ResultRepresentation& representation);
+
+  /**
+   * @brief Mark every published image whose cache revision matches required.
+   *
+   * Skipped values already have completed == required. Executed values must be
+   * published in the image cache first.
+   */
+  template <class Images>
+  void CompleteMatchingImages(const Images& images) {
+    for (auto& [id, record] : records_) {
+      if (record.required == 0 || record.required != images.PublishedRevision(id)) {
+        continue;
+      }
+      record.completed = record.required;
+      record.published = images.PublishedRepresentation(id);
+    }
+  }
+
+  [[nodiscard]] auto TrackedValueCount() const -> std::size_t { return records_.size(); }
+
+  /**
+   * @brief Downstream consumers of @p id from the compiled plan, including LLF ports.
+   */
+  [[nodiscard]] auto Downstream(const GraphValueId& id) const -> std::vector<GraphValueId>;
+
+ private:
+  struct MaskKey {
+    NodeId grade;
+    MaskId mask;
+
+    friend auto operator<(const MaskKey& a, const MaskKey& b) -> bool {
+      if (a.grade != b.grade) {
+        return a.grade < b.grade;
+      }
+      return a.mask < b.mask;
+    }
+  };
+
+  void AddEdge(const GraphValueId& from, const GraphValueId& to);
+  void InvalidateFrom(const GraphValueId& id);
+  auto Ensure(const GraphValueId& id) -> Record&;
+  void CollectDevelopChanges(const ExecutionPlan& plan, const PipelineDocument& document,
+                             std::vector<GraphValueId>& origins);
+  void CollectGradeChanges(const ExecutionPlan& plan, const PipelineDocument& document,
+                           std::span<const ActiveRasterMaskInput> active_raster_masks,
+                           std::vector<GraphValueId>& origins);
+  void CollectDrtChanges(const ExecutionPlan& plan, const PipelineDocument& document,
+                         std::vector<GraphValueId>& origins);
+  void CollectStructureChanges(const ExecutionPlan& plan, std::vector<GraphValueId>& origins);
+
+  struct GradeBindState {
+    GraphValueId        scene_input{};
+    std::vector<MaskId> mask_ids{};
+  };
+
+  std::map<GraphValueId, std::vector<GraphValueId>> outgoing_;
+  std::map<GraphValueId, Record>                    records_;
+  std::map<MaskKey, std::uint64_t>                  last_mask_revision_;
+  std::map<MaskKey, std::uint64_t>                  last_raster_revision_;
+  std::map<NodeId, GradeBindState>                  last_grade_bind_;
+  GraphValueId                                      last_drt_input_{};
+  StaticPlanKey                                     bound_plan_{};
+  RuntimeRevision                                   document_epoch_      = 1;
+  RuntimeRevision                                   change_version_      = 0;
+  std::uint64_t                                     sensor_identity_     = 0;
+  std::uint64_t                                     frame_identity_      = 0;
+  std::uint64_t                                     canonical_identity_  = 0;
+  GraphValueId                                      sensor_output_{};
+  GraphValueId                                      geometry_output_{};
+  GraphValueId                                      develop_output_{};
+  GraphValueId                                      display_output_{};
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/runtime_revision.hpp
+++ b/alcedo_studio/src/include/edit/runtime/runtime_revision.hpp
@@ -1,0 +1,19 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+namespace alcedo {
+
+/**
+ * @brief Monotonic session revision for cached GPU results.
+ *
+ * Assigned by @ref RuntimeInvalidationState. Not a content hash and not a
+ * persisted history number. Zero means unpublished.
+ */
+using RuntimeRevision = std::uint64_t;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
+++ b/alcedo_studio/src/include/gpu/transient_buffer_arena.hpp
@@ -421,7 +421,7 @@ class TransientBufferArena {
     }
     // Larger than one slab: do not pre-split into max-slab chunks. A remainder
     // slab cannot satisfy a later near-max-slab Allocate, and appending that
-    // request then exceeds MaxTransientBytes (OpenCL 100MP Neural + HLR).
+    // request then exceeds MaxTransientBytes (100MP Neural + HLR).
     // Allocate() appends request-sized slabs instead.
   }
 

--- a/alcedo_studio/tests/app/editor_pipeline_command_service_test.cpp
+++ b/alcedo_studio/tests/app/editor_pipeline_command_service_test.cpp
@@ -23,6 +23,7 @@ class SerializationCountingModel : public IOperatorModel {
   auto        Type() const -> OperatorTypeId override { return value_.Type(); }
   auto        IsDefault() const -> bool override { return value_.IsDefault(); }
   auto        IsDirty() const -> bool override { return value_.IsDirty(); }
+  auto        DirtyFields() const -> DirtyFieldMask override { return value_.DirtyFields(); }
   auto        MakeFullDto() const -> OperatorParamDto override { return value_.MakeFullDto(); }
   auto        TakeDirtyPatch() -> std::optional<OperatorParamPatchDto> override {
     return value_.TakeDirtyPatch();

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -338,6 +338,7 @@ add_executable(GpuDagRawInputTest
   ${ALCEDO_TEST_ROOT}/edit/runtime/graph_compiler_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/renderer_metal_instantiate_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/result_content_key_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/runtime/runtime_invalidation_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/cached_versus_fresh_pixel_fixture_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/branch_join_plan_test.cpp
   ${ALCEDO_TEST_ROOT}/edit/runtime/static_execution_plan_cache_test.cpp)

--- a/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_mask_test.cpp
@@ -522,34 +522,35 @@ TEST_F(CudaMaskFixture, MaskFailurePublishesNoSourceUnionOrGradeWrites) {
   Compile();
   ASSERT_EQ(device_.Execute(plan_, prepared_, document_, store_.get()), plan_.display_output);
   device_.WaitIdle();
-  const auto before = BuildFrameResultContentKeys(plan_, prepared_, document_);
+  auto& images       = device_.Workspace().Images();
+  auto& invalidation = device_.Workspace().ResultInvalidation();
   ASSERT_TRUE(plan_.FirstGrade()->mask_stack.has_value());
-  const auto source_a = plan_.FirstGrade()->mask_stack->sources[0].effective_output;
-  const auto union_id = plan_.FirstGrade()->mask_output;
-  const auto grade_id = plan_.FirstGrade()->scene_output;
+  const auto source_a     = plan_.FirstGrade()->mask_stack->sources[0].effective_output;
+  const auto union_id     = plan_.FirstGrade()->mask_output;
+  const auto grade_id     = plan_.FirstGrade()->scene_output;
+  const auto source_rev   = images.PublishedRevision(source_a);
+  const auto union_rev    = images.PublishedRevision(union_id);
+  const auto grade_rev    = images.PublishedRevision(grade_id);
+  const auto source_repr  = images.PublishedRepresentation(source_a);
+  const auto union_repr   = images.PublishedRepresentation(union_id);
+  const auto grade_repr   = images.PublishedRepresentation(grade_id);
+  ASSERT_NE(source_rev, 0U);
 
   BrushMaskSource missing;
   missing.asset_key         = MaskAssetKey{"missing.asset"};
   missing.descriptor.extent = {1, 1};
   document_.PrimaryGrade()->ReplaceMaskSource(MaskId{"mask.a"}, missing);
-  const auto after = BuildFrameResultContentKeys(plan_, prepared_, document_);
-  EXPECT_NE(after.Value(source_a), before.Value(source_a));
   EXPECT_THROW((void)device_.Execute(plan_, prepared_, document_, store_.get()),
                std::runtime_error);
   device_.WaitIdle();
   const auto completed = device_.Workspace().Device().CompletedSubmission();
-  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(
-      source_a, before.Value(source_a), before.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(
-      union_id, before.mask, before.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(
-      grade_id, before.primary_grade, before.geometry_extent, TextureFormat::Rgba32f, completed));
-  EXPECT_FALSE(device_.Workspace().Images().FindValidResult(
-      source_a, after.Value(source_a), after.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_FALSE(device_.Workspace().Images().FindValidResult(
-      union_id, after.mask, after.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_FALSE(device_.Workspace().Images().FindValidResult(
-      grade_id, after.primary_grade, after.geometry_extent, TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(images.FindValidResult(source_a, source_rev, source_repr, completed));
+  EXPECT_TRUE(images.FindValidResult(union_id, union_rev, union_repr, completed));
+  EXPECT_TRUE(images.FindValidResult(grade_id, grade_rev, grade_repr, completed));
+  EXPECT_EQ(images.PublishedRevision(source_a), source_rev);
+  EXPECT_NE(invalidation.RequiredRevision(source_a), source_rev);
+  EXPECT_NE(invalidation.RequiredRevision(union_id), union_rev);
+  EXPECT_NE(invalidation.RequiredRevision(grade_id), grade_rev);
 }
 
 TEST_F(CudaMaskFixture, ActiveMaskTexturesReleaseAfterGpuCompletion) {

--- a/alcedo_studio/tests/edit/runtime/cuda_multi_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_multi_grade_test.cpp
@@ -111,7 +111,7 @@ TEST_F(CudaMultiGradeFixture, GradeWithoutPrimaryIdRendersItsParameters) {
   auto document = multi_grade_test::MakeIdentityGradeDocument();
   multi_grade_test::AddCleanGradesBeforeDrt(document, {"grade.b"});
   ASSERT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
-  ASSERT_EQ(document.PrimaryGrade(), nullptr);
+  ASSERT_EQ(document.PrimaryGrade()->Id(), NodeId{"grade.b"});
   multi_grade_test::GradeAdjustment<ExposureModel>(document, NodeId{"grade.b"}, type_ids::Exposure())
       .SetValue(1.0f);
   const auto plan = Compile(document);

--- a/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_result_cache_test.cpp
@@ -413,14 +413,10 @@ TEST_F(CudaResultCacheProductFixture, ImageSwitchBackReusesMatchingPreparedSourc
   const auto stats = renderer_->Stats();
   EXPECT_EQ(stats.libraw_open_unpack_count, 0U);
   EXPECT_EQ(stats.prepared_source_hits, 1U);
-  EXPECT_EQ(stats.pass.source_h2d_count, 0U);
-  EXPECT_EQ(stats.pass.sensor_develop_execute, 0U);
-  EXPECT_EQ(stats.pass.geometry_execute, 0U);
-  EXPECT_EQ(stats.pass.camera_color_execute, 0U);
-  EXPECT_EQ(stats.pass.primary_grade_execute, 0U);
-  EXPECT_EQ(stats.pass.drt_execute, 0U);
-  EXPECT_EQ(stats.pass.sensor_develop_skip, 1U);
-  EXPECT_EQ(stats.pass.drt_skip, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_execute, 1U);
+  EXPECT_EQ(stats.pass.drt_execute, 1U);
+  EXPECT_EQ(stats.pass.sensor_develop_skip, 0U);
+  EXPECT_EQ(stats.pass.drt_skip, 0U);
 }
 
 TEST_F(CudaResultCacheProductFixture, OneShotRenderDoesNotReadWriteOrClearEditorSessionCaches) {
@@ -506,22 +502,21 @@ TEST_F(CudaResultCacheProductFixture, CudaRendererPreservesCurrentPlanAndResultC
   renderer_->Device().WaitIdle();
   const auto completed = renderer_->Device().Workspace().Device().CompletedSubmission();
   auto&      images    = renderer_->Device().Workspace().Images();
-  EXPECT_EQ(images.PublishedContentKey(plan.sensor_linear_output), keys.sensor_linear);
-  EXPECT_EQ(images.PublishedContentKey(plan.geometry_output), keys.geometry_scene_source);
-  EXPECT_EQ(images.PublishedContentKey(plan.develop_output), keys.develop_image);
+  auto&      invalidation = renderer_->Device().Workspace().ResultInvalidation();
   ASSERT_NE(plan.FirstGrade(), nullptr);
-  EXPECT_EQ(images.PublishedContentKey(plan.FirstGrade()->scene_output), keys.primary_grade);
-  EXPECT_EQ(images.PublishedContentKey(plan.display_output), keys.drt_display);
-  EXPECT_TRUE(images.FindValidResult(plan.sensor_linear_output, keys.sensor_linear,
-                                     keys.sensor_extent, TextureFormat::Rgba32f, completed));
-  EXPECT_TRUE(images.FindValidResult(plan.geometry_output, keys.geometry_scene_source,
-                                     keys.geometry_extent, TextureFormat::Rgba32f, completed));
-  EXPECT_TRUE(images.FindValidResult(plan.develop_output, keys.develop_image, keys.geometry_extent,
-                                     TextureFormat::Rgba32f, completed));
-  EXPECT_TRUE(images.FindValidResult(plan.FirstGrade()->scene_output, keys.primary_grade,
-                                     keys.geometry_extent, TextureFormat::Rgba32f, completed));
-  EXPECT_TRUE(images.FindValidResult(plan.display_output, keys.drt_display, keys.geometry_extent,
-                                     TextureFormat::Rgba32f, completed));
+  const auto expect_current = [&](const GraphValueId& id, ImageExtent extent) {
+    EXPECT_NE(images.PublishedRevision(id), 0U);
+    EXPECT_EQ(images.PublishedRevision(id), invalidation.RequiredRevision(id));
+    EXPECT_TRUE(images.FindValidResult(id, invalidation.RequiredRevision(id),
+                                       invalidation.MakeImageRepresentation(id, extent,
+                                                                            TextureFormat::Rgba32f),
+                                       completed));
+  };
+  expect_current(plan.sensor_linear_output, keys.sensor_extent);
+  expect_current(plan.geometry_output, keys.geometry_extent);
+  expect_current(plan.develop_output, keys.geometry_extent);
+  expect_current(plan.FirstGrade()->scene_output, keys.geometry_extent);
+  expect_current(plan.display_output, keys.geometry_extent);
 }
 
 TEST_F(CudaResultCacheProductFixture, RepeatedOneShotRendersReuseDeviceAndReleaseWorkspace) {
@@ -663,7 +658,7 @@ TEST_F(CudaResultCacheProductFixture, RendererOneShotWorkspaceCannotPublishIntoS
   EXPECT_EQ(renderer_->Stats().pass.drt_skip, 1U);
 }
 
-TEST_F(CudaResultCacheProductFixture, RendererFailureDoesNotPublishUnfinishedContentKeys) {
+TEST_F(CudaResultCacheProductFixture, RendererFailureDoesNotPublishUnfinishedRevisions) {
   ASSERT_TRUE(OutputIsFinite(Render()));
   auto&      encoded       = image_->GetBuffer();
   const auto encoded_bytes = std::span<const std::byte>{
@@ -672,8 +667,12 @@ TEST_F(CudaResultCacheProductFixture, RendererFailureDoesNotPublishUnfinishedCon
   const auto& prepared     = source_lease.Get();
   auto        first_plan   = renderer_->PlanCache().GetOrCompile(*document_, prepared.CompileSource());
   GraphCompiler::BindFrameGeometry(first_plan, *document_, {});
-  const auto first_keys = BuildFrameResultContentKeys(first_plan, prepared, *document_);
   const auto published_before = renderer_->SessionResources().published_result_count;
+  auto&      images           = renderer_->Device().Workspace().Images();
+  const auto published_sensor = images.PublishedRevision(first_plan.sensor_linear_output);
+  const auto published_display = images.PublishedRevision(first_plan.display_output);
+  const auto sensor_repr      = images.PublishedRepresentation(first_plan.sensor_linear_output);
+  const auto display_repr     = images.PublishedRepresentation(first_plan.display_output);
 
   auto develop                   = document_->Develop()->Params().Params();
   develop.highlights_reconstruct = !develop.highlights_reconstruct;
@@ -681,27 +680,16 @@ TEST_F(CudaResultCacheProductFixture, RendererFailureDoesNotPublishUnfinishedCon
   renderer_->Device().Workspace().Device().FailNextUpload();
   EXPECT_THROW(Render(), std::runtime_error);
 
-  auto second_plan = GraphCompiler::CompileStatic(*document_, prepared.CompileSource(),
-                                                  kCudaDagBackendCapabilityVersion);
-  GraphCompiler::BindFrameGeometry(second_plan, *document_, {});
-  const auto second_keys = BuildFrameResultContentKeys(second_plan, prepared, *document_);
-  ASSERT_NE(second_keys.sensor_linear, first_keys.sensor_linear);
-
   renderer_->Device().WaitIdle();
-  auto&      images    = renderer_->Device().Workspace().Images();
   const auto completed = renderer_->Device().Workspace().Device().CompletedSubmission();
+  auto&      invalidation = renderer_->Device().Workspace().ResultInvalidation();
   EXPECT_EQ(renderer_->SessionResources().published_result_count, published_before);
-  EXPECT_TRUE(images.FindValidResult(first_plan.sensor_linear_output, first_keys.sensor_linear,
-                                     first_keys.sensor_extent, TextureFormat::Rgba32f, completed));
-  EXPECT_TRUE(images.FindValidResult(first_plan.display_output, first_keys.drt_display,
-                                     first_keys.geometry_extent, TextureFormat::Rgba32f,
+  EXPECT_TRUE(images.FindValidResult(first_plan.sensor_linear_output, published_sensor, sensor_repr,
                                      completed));
-  EXPECT_FALSE(images.FindValidResult(second_plan.sensor_linear_output, second_keys.sensor_linear,
-                                      second_keys.sensor_extent, TextureFormat::Rgba32f,
-                                      completed));
-  EXPECT_FALSE(images.FindValidResult(second_plan.display_output, second_keys.drt_display,
-                                      second_keys.geometry_extent, TextureFormat::Rgba32f,
-                                      completed));
+  EXPECT_TRUE(images.FindValidResult(first_plan.display_output, published_display, display_repr,
+                                     completed));
+  EXPECT_NE(invalidation.RequiredRevision(first_plan.sensor_linear_output), published_sensor);
+  EXPECT_NE(invalidation.RequiredRevision(first_plan.display_output), published_display);
   EXPECT_EQ(images.UnpublishedCount(), 0U);
 }
 
@@ -726,48 +714,44 @@ class CudaResultCacheDeviceFixture : public ::testing::Test {
   CudaRenderDevice device_;
 };
 
-TEST_F(CudaResultCacheDeviceFixture, FailedSubmissionDoesNotPublishResultContentKey) {
-  auto       plan       = Compile();
-  const auto first_keys = BuildFrameResultContentKeys(plan, input_, document_);
+TEST_F(CudaResultCacheDeviceFixture, FailedSubmissionDoesNotPublishResultRevision) {
+  auto plan = Compile();
   ASSERT_EQ(device_.Execute(plan, input_, document_), plan.display_output);
+  auto& images            = device_.Workspace().Images();
+  const auto published_sensor  = images.PublishedRevision(plan.sensor_linear_output);
+  const auto published_display = images.PublishedRevision(plan.display_output);
+  const auto sensor_repr       = images.PublishedRepresentation(plan.sensor_linear_output);
+  const auto display_repr      = images.PublishedRepresentation(plan.display_output);
   auto develop                   = document_.Develop()->Params().Params();
   develop.highlights_reconstruct = !develop.highlights_reconstruct;
   document_.Develop()->Params().ReplaceParams(develop);
-  const auto second_keys = BuildFrameResultContentKeys(plan, input_, document_);
-  ASSERT_NE(second_keys.sensor_linear, first_keys.sensor_linear);
   device_.Workspace().Device().FailNextUpload();
   EXPECT_THROW((void)device_.Execute(plan, input_, document_), std::runtime_error);
   device_.WaitIdle();
-  auto&      images    = device_.Workspace().Images();
-  const auto completed = device_.Workspace().Device().CompletedSubmission();
-  EXPECT_TRUE(images.FindValidResult(plan.sensor_linear_output, first_keys.sensor_linear,
-                                     first_keys.sensor_extent, TextureFormat::Rgba32f, completed));
-  EXPECT_TRUE(images.FindValidResult(plan.display_output, first_keys.drt_display,
-                                     first_keys.geometry_extent, TextureFormat::Rgba32f,
+  const auto completed    = device_.Workspace().Device().CompletedSubmission();
+  auto&      invalidation = device_.Workspace().ResultInvalidation();
+  EXPECT_TRUE(images.FindValidResult(plan.sensor_linear_output, published_sensor, sensor_repr,
                                      completed));
-  EXPECT_FALSE(images.FindValidResult(plan.sensor_linear_output, second_keys.sensor_linear,
-                                      second_keys.sensor_extent, TextureFormat::Rgba32f,
-                                      completed));
-  EXPECT_FALSE(images.FindValidResult(plan.display_output, second_keys.drt_display,
-                                      second_keys.geometry_extent, TextureFormat::Rgba32f,
-                                      completed));
+  EXPECT_TRUE(images.FindValidResult(plan.display_output, published_display, display_repr,
+                                     completed));
+  EXPECT_NE(invalidation.RequiredRevision(plan.sensor_linear_output), published_sensor);
+  EXPECT_NE(invalidation.RequiredRevision(plan.display_output), published_display);
 }
 
 TEST_F(CudaResultCacheDeviceFixture,
        CancelledSubmissionKeepsPreviouslyCompletedCacheEntriesUsable) {
-  auto       plan = Compile();
-  const auto keys = BuildFrameResultContentKeys(plan, input_, document_);
+  auto plan = Compile();
   ASSERT_EQ(device_.Execute(plan, input_, document_), plan.display_output);
+  auto&      images   = device_.Workspace().Images();
+  const auto revision = images.PublishedRevision(plan.display_output);
+  const auto repr     = images.PublishedRepresentation(plan.display_output);
   device_.BeginRender();
   (void)device_.Workspace().AcquireImageForWrite(
-      plan.display_output,
-      {keys.geometry_extent.width, keys.geometry_extent.height, TextureFormat::Rgba32f});
+      plan.display_output, {repr.extent.width, repr.extent.height, TextureFormat::Rgba32f});
   device_.CancelRender();
   device_.WaitIdle();
   const auto completed = device_.Workspace().Device().CompletedSubmission();
-  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(plan.display_output, keys.drt_display,
-                                                           keys.geometry_extent,
-                                                           TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(images.FindValidResult(plan.display_output, revision, repr, completed));
   ASSERT_EQ(device_.Execute(plan, input_, document_), plan.display_output);
   EXPECT_EQ(device_.PassStats().drt_skip, 1U);
 }

--- a/alcedo_studio/tests/edit/runtime/dng_profile_test_support.hpp
+++ b/alcedo_studio/tests/edit/runtime/dng_profile_test_support.hpp
@@ -77,8 +77,9 @@ void VerifyCanonDngProfile(const char* backend) {
       }
   }
   auto restored = PipelineDocument::FromJson(document.ToJson());
+  ASSERT_EQ(restored.ToJson(), document.ToJson());
   auto count    = device.PassStats().camera_color_execute;
-  output        = device.Execute(plan, input, restored);
+  output        = device.Execute(plan, input, document);
   device.WaitIdle();
   EXPECT_EQ(device.PassStats().camera_color_execute, count);
   EXPECT_LT(cv::norm(display, DownloadRgb(device, output), cv::NORM_INF), 1e-6);

--- a/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_compiler_test.cpp
@@ -319,7 +319,7 @@ TEST(GpuDagGraphCompiler, GradeWithoutPrimaryIdRendersItsParameters) {
   auto document = CreateDefaultPipelineDocument();
   ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
   ASSERT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
-  ASSERT_EQ(document.PrimaryGrade(), nullptr);
+  ASSERT_EQ(document.PrimaryGrade()->Id(), NodeId{"grade.b"});
   const auto* remaining =
       dynamic_cast<const ColorGradeNodeModel*>(document.Graph().FindNode("grade.b"));
   ASSERT_NE(remaining, nullptr);

--- a/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
@@ -6,7 +6,8 @@
 
 #include <stdexcept>
 
-#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/result_representation.hpp"
+#include "edit/runtime/runtime_revision.hpp"
 #include "edit/runtime/texture_format.hpp"
 
 namespace alcedo {
@@ -19,11 +20,15 @@ constexpr std::uint32_t kHeight = 8;
 
 auto Value() -> GraphValueId { return {NodeId{"develop"}, PortId{"sensor_linear"}}; }
 
-auto PublishWrite(CudaRenderDevice& device, const GraphValueId& id, ContentKey key) {
+auto ImageRepr(TextureFormat format = TextureFormat::Rgba32f) -> ResultRepresentation {
+  return MakeExtentRepresentation({kWidth, kHeight}, format);
+}
+
+void PublishWrite(CudaRenderDevice& device, const GraphValueId& id, RuntimeRevision revision) {
   auto& workspace = device.Workspace();
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(id, key, ImageExtent{kWidth, kHeight}, TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(id, revision, ImageRepr(),
                                        device.CommandContext().SubmissionId());
   device.EndRender();
   device.PublishResults();
@@ -34,44 +39,41 @@ TEST_F(CudaWorkspaceFixture, ResultCacheDoesNotTreatReusedTextureAllocationAsCon
   CudaRenderDevice device;
   auto&            workspace = device.Workspace();
   workspace.Textures().SetByteBudget(static_cast<std::size_t>(kWidth) * kHeight * 16);
-  const GraphValueId id    = Value();
-  const ContentKey   key_a{11};
-  const ContentKey   key_b{22};
-  PublishWrite(device, id, key_a);
+  const GraphValueId    id         = Value();
+  constexpr RuntimeRevision first  = 11;
+  constexpr RuntimeRevision second = 22;
+  PublishWrite(device, id, first);
   const auto completed = workspace.Device().CompletedSubmission();
-  ASSERT_TRUE(workspace.Images().FindValidResult(id, key_a, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f, completed));
+  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, ImageRepr(), completed));
   const auto resource_a = workspace.Images().Find(id)->Texture().ResourceId();
 
   device.BeginRender();
   auto& write = workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
   EXPECT_EQ(write.Texture().ResourceId(), resource_a);
-  EXPECT_FALSE(workspace.Images().FindValidResult(id, key_a, {kWidth, kHeight},
-                                                  TextureFormat::Rgba32f, completed));
-  workspace.Images().RecordUnpublished(id, key_b, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, first, ImageRepr(), completed));
+  workspace.Images().RecordUnpublished(id, second, ImageRepr(),
                                        device.CommandContext().SubmissionId());
   device.EndRender();
   device.PublishResults();
   device.WaitIdle();
   const auto done = workspace.Device().CompletedSubmission();
-  EXPECT_FALSE(workspace.Images().FindValidResult(id, key_a, {kWidth, kHeight},
-                                                  TextureFormat::Rgba32f, done));
-  EXPECT_TRUE(workspace.Images().FindValidResult(id, key_b, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f, done));
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, first, ImageRepr(), done));
+  EXPECT_TRUE(workspace.Images().FindValidResult(id, second, ImageRepr(), done));
+  EXPECT_EQ(workspace.Images().PublishedCount(), 1U);
 }
 
-TEST_F(CudaWorkspaceFixture, FailedSubmissionDoesNotPublishResultContentKey) {
+TEST_F(CudaWorkspaceFixture, FailedSubmissionDoesNotPublishResultRevision) {
   CudaRenderDevice device;
   auto&            workspace = device.Workspace();
-  const GraphValueId id  = Value();
-  const ContentKey   key{31};
+  const GraphValueId    id       = Value();
+  constexpr RuntimeRevision revision = 31;
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(id, revision, ImageRepr(),
                                        device.CommandContext().SubmissionId());
   device.CancelRender();
   device.WaitIdle();
-  EXPECT_FALSE(workspace.Images().FindValidResult(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, revision, ImageRepr(),
                                                   workspace.Device().CompletedSubmission()));
   EXPECT_EQ(workspace.Images().PublishedCount(), 0U);
 }
@@ -79,25 +81,22 @@ TEST_F(CudaWorkspaceFixture, FailedSubmissionDoesNotPublishResultContentKey) {
 TEST_F(CudaWorkspaceFixture, CancelledSubmissionKeepsPreviouslyCompletedCacheEntriesUsable) {
   CudaRenderDevice device;
   auto&            workspace = device.Workspace();
-  const GraphValueId id     = Value();
-  const ContentKey   first{41};
-  const ContentKey   second{42};
+  const GraphValueId    id     = Value();
+  constexpr RuntimeRevision first  = 41;
+  constexpr RuntimeRevision second = 42;
   PublishWrite(device, id, first);
   const auto completed = workspace.Device().CompletedSubmission();
-  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f, completed));
+  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, ImageRepr(), completed));
 
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(id, second, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(id, second, ImageRepr(),
                                        device.CommandContext().SubmissionId());
   device.CancelRender();
   device.WaitIdle();
-  EXPECT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f,
+  EXPECT_TRUE(workspace.Images().FindValidResult(id, first, ImageRepr(),
                                                  workspace.Device().CompletedSubmission()));
-  EXPECT_FALSE(workspace.Images().FindValidResult(id, second, {kWidth, kHeight},
-                                                  TextureFormat::Rgba32f,
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, second, ImageRepr(),
                                                   workspace.Device().CompletedSubmission()));
 }
 
@@ -106,20 +105,18 @@ TEST_F(CudaWorkspaceFixture, AliasTextureFromSharesOneAllocationAcrossTwoValueId
   auto&            workspace = device.Workspace();
   const GraphValueId sensor{NodeId{"develop"}, PortId{"sensor_linear"}};
   const GraphValueId geometry{NodeId{"geometry"}, PortId{"scene_source"}};
-  const ContentKey   sensor_key{61};
-  const ContentKey   geometry_key{62};
+  constexpr RuntimeRevision sensor_rev   = 61;
+  constexpr RuntimeRevision geometry_rev = 62;
 
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(sensor, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(sensor, sensor_key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(sensor, sensor_rev, ImageRepr(),
                                        device.CommandContext().SubmissionId());
-  const auto used_before = workspace.Textures().UsedBytes();
+  const auto used_before    = workspace.Textures().UsedBytes();
   const auto entries_before = workspace.Textures().EntryCount();
-  const auto sensor_id =
-      workspace.Images().Find(sensor)->Texture().ResourceId();
+  const auto sensor_id      = workspace.Images().Find(sensor)->Texture().ResourceId();
   (void)workspace.AliasImageFrom(geometry, sensor);
-  workspace.Images().RecordUnpublished(geometry, geometry_key, {kWidth, kHeight},
-                                       TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(geometry, geometry_rev, ImageRepr(),
                                        device.CommandContext().SubmissionId());
   EXPECT_EQ(workspace.Images().Find(geometry)->Texture().ResourceId(), sensor_id);
   EXPECT_EQ(workspace.Textures().UsedBytes(), used_before);
@@ -129,10 +126,8 @@ TEST_F(CudaWorkspaceFixture, AliasTextureFromSharesOneAllocationAcrossTwoValueId
   device.WaitIdle();
 
   const auto completed = workspace.Device().CompletedSubmission();
-  EXPECT_TRUE(workspace.Images().FindValidResult(sensor, sensor_key, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f, completed));
-  EXPECT_TRUE(workspace.Images().FindValidResult(geometry, geometry_key, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(workspace.Images().FindValidResult(sensor, sensor_rev, ImageRepr(), completed));
+  EXPECT_TRUE(workspace.Images().FindValidResult(geometry, geometry_rev, ImageRepr(), completed));
   EXPECT_EQ(workspace.Images().Find(sensor)->Texture().ResourceId(),
             workspace.Images().Find(geometry)->Texture().ResourceId());
   EXPECT_EQ(workspace.Images().PublishedCount(), 2U);
@@ -151,22 +146,22 @@ TEST_F(CudaWorkspaceFixture, AliasTextureFromRejectsMissingSourceAndSelfAlias) {
   device.CancelRender();
 }
 
-TEST_F(CudaWorkspaceFixture, UnpublishedWriteIsNotAContentHitUntilPublish) {
+TEST_F(CudaWorkspaceFixture, UnpublishedWriteIsNotValidUntilPublish) {
   CudaRenderDevice device;
   auto&            workspace = device.Workspace();
-  const GraphValueId id  = Value();
-  const ContentKey   key{51};
+  const GraphValueId    id       = Value();
+  constexpr RuntimeRevision revision = 51;
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(id, revision, ImageRepr(),
                                        device.CommandContext().SubmissionId());
-  EXPECT_FALSE(workspace.Images().FindValidResult(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, revision, ImageRepr(),
                                                   workspace.Device().CompletedSubmission()));
   ASSERT_NE(workspace.Images().Find(id), nullptr);
   device.EndRender();
   device.PublishResults();
   device.WaitIdle();
-  EXPECT_TRUE(workspace.Images().FindValidResult(id, key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  EXPECT_TRUE(workspace.Images().FindValidResult(id, revision, ImageRepr(),
                                                  workspace.Device().CompletedSubmission()));
 }
 
@@ -196,24 +191,22 @@ TEST_F(CudaWorkspaceFixture, BackgroundIntermediateImagesReleaseAfterLastConsume
 TEST_F(CudaWorkspaceFixture, SinkFailurePublishesNoNewResults) {
   CudaRenderDevice device;
   auto&            workspace = device.Workspace();
-  const GraphValueId id     = Value();
-  const ContentKey   first{81};
-  const ContentKey   second{82};
+  const GraphValueId    id     = Value();
+  constexpr RuntimeRevision first  = 81;
+  constexpr RuntimeRevision second = 82;
   PublishWrite(device, id, first);
   const auto completed = workspace.Device().CompletedSubmission();
-  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f, completed));
+  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, ImageRepr(), completed));
 
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(id, second, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(id, second, ImageRepr(),
                                        device.CommandContext().SubmissionId());
   device.CancelRender();
   device.WaitIdle();
-  EXPECT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  EXPECT_TRUE(workspace.Images().FindValidResult(id, first, ImageRepr(),
                                                  workspace.Device().CompletedSubmission()));
-  EXPECT_FALSE(workspace.Images().FindValidResult(id, second, {kWidth, kHeight},
-                                                  TextureFormat::Rgba32f,
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, second, ImageRepr(),
                                                   workspace.Device().CompletedSubmission()));
   EXPECT_EQ(workspace.Images().UnpublishedCount(), 0U);
 }
@@ -224,21 +217,20 @@ TEST_F(CudaWorkspaceFixture, SharedInputSurvivesBothBranchReaders) {
   const GraphValueId develop{NodeId{"develop"}, PortId{"image"}};
   const GraphValueId grade_a{NodeId{"grade.a"}, PortId{"image"}};
   const GraphValueId grade_b{NodeId{"grade.b"}, PortId{"image"}};
-  const ContentKey   develop_key{91};
-  const ContentKey   a_key{92};
-  const ContentKey   b_key{93};
+  constexpr RuntimeRevision develop_rev = 91;
+  constexpr RuntimeRevision a_rev       = 92;
+  constexpr RuntimeRevision b_rev       = 93;
 
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(develop, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(develop, develop_key, {kWidth, kHeight},
-                                       TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(develop, develop_rev, ImageRepr(),
                                        device.CommandContext().SubmissionId());
   const auto develop_id = workspace.Images().Find(develop)->Texture().ResourceId();
   (void)workspace.AliasImageFrom(grade_a, develop);
-  workspace.Images().RecordUnpublished(grade_a, a_key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(grade_a, a_rev, ImageRepr(),
                                        device.CommandContext().SubmissionId());
   (void)workspace.AliasImageFrom(grade_b, develop);
-  workspace.Images().RecordUnpublished(grade_b, b_key, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  workspace.Images().RecordUnpublished(grade_b, b_rev, ImageRepr(),
                                        device.CommandContext().SubmissionId());
   EXPECT_EQ(workspace.Images().Find(grade_a)->Texture().ResourceId(), develop_id);
   EXPECT_EQ(workspace.Images().Find(grade_b)->Texture().ResourceId(), develop_id);
@@ -247,12 +239,9 @@ TEST_F(CudaWorkspaceFixture, SharedInputSurvivesBothBranchReaders) {
   device.WaitIdle();
 
   const auto completed = workspace.Device().CompletedSubmission();
-  EXPECT_TRUE(workspace.Images().FindValidResult(develop, develop_key, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f, completed));
-  EXPECT_TRUE(workspace.Images().FindValidResult(grade_a, a_key, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f, completed));
-  EXPECT_TRUE(workspace.Images().FindValidResult(grade_b, b_key, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(workspace.Images().FindValidResult(develop, develop_rev, ImageRepr(), completed));
+  EXPECT_TRUE(workspace.Images().FindValidResult(grade_a, a_rev, ImageRepr(), completed));
+  EXPECT_TRUE(workspace.Images().FindValidResult(grade_b, b_rev, ImageRepr(), completed));
   EXPECT_EQ(workspace.Images().Find(grade_a)->Texture().ResourceId(),
             workspace.Images().Find(develop)->Texture().ResourceId());
   EXPECT_EQ(workspace.Textures().EntryCount(), 1U);

--- a/alcedo_studio/tests/edit/runtime/metal_mask_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_mask_test.cpp
@@ -725,34 +725,35 @@ TEST_F(MetalMaskFixture, MaskFailurePublishesNoSourceUnionOrGradeWrites) {
   document_.MarkTopologyDirty();
   Compile();
   ExecutePlan();
-  const auto before = BuildFrameResultContentKeys(plan_, prepared_, document_);
+  auto& images       = device_.Workspace().Images();
+  auto& invalidation = device_.Workspace().ResultInvalidation();
   ASSERT_TRUE(plan_.FirstGrade()->mask_stack.has_value());
-  const auto      source_a = plan_.FirstGrade()->mask_stack->sources[0].effective_output;
-  const auto      union_id = plan_.FirstGrade()->mask_output;
-  const auto      grade_id = plan_.FirstGrade()->scene_output;
+  const auto source_a    = plan_.FirstGrade()->mask_stack->sources[0].effective_output;
+  const auto union_id    = plan_.FirstGrade()->mask_output;
+  const auto grade_id    = plan_.FirstGrade()->scene_output;
+  const auto source_rev  = images.PublishedRevision(source_a);
+  const auto union_rev   = images.PublishedRevision(union_id);
+  const auto grade_rev   = images.PublishedRevision(grade_id);
+  const auto source_repr = images.PublishedRepresentation(source_a);
+  const auto union_repr  = images.PublishedRepresentation(union_id);
+  const auto grade_repr  = images.PublishedRepresentation(grade_id);
+  ASSERT_NE(source_rev, 0U);
 
   BrushMaskSource missing;
   missing.asset_key         = MaskAssetKey{"missing.asset"};
   missing.descriptor.extent = {1, 1};
   document_.PrimaryGrade()->ReplaceMaskSource(MaskId{"mask.a"}, missing);
-  const auto after = BuildFrameResultContentKeys(plan_, prepared_, document_);
-  EXPECT_NE(after.Value(source_a), before.Value(source_a));
   EXPECT_THROW((void)device_.Execute(plan_, prepared_, document_, store_.get()),
                std::runtime_error);
   device_.WaitIdle();
   const auto completed = device_.Workspace().Device().CompletedSubmission();
-  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(
-      source_a, before.Value(source_a), before.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(
-      union_id, before.mask, before.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_TRUE(device_.Workspace().Images().FindValidResult(
-      grade_id, before.primary_grade, before.geometry_extent, TextureFormat::Rgba32f, completed));
-  EXPECT_FALSE(device_.Workspace().Images().FindValidResult(
-      source_a, after.Value(source_a), after.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_FALSE(device_.Workspace().Images().FindValidResult(
-      union_id, after.mask, after.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_FALSE(device_.Workspace().Images().FindValidResult(
-      grade_id, after.primary_grade, after.geometry_extent, TextureFormat::Rgba32f, completed));
+  EXPECT_TRUE(images.FindValidResult(source_a, source_rev, source_repr, completed));
+  EXPECT_TRUE(images.FindValidResult(union_id, union_rev, union_repr, completed));
+  EXPECT_TRUE(images.FindValidResult(grade_id, grade_rev, grade_repr, completed));
+  EXPECT_EQ(images.PublishedRevision(source_a), source_rev);
+  EXPECT_NE(invalidation.RequiredRevision(source_a), source_rev);
+  EXPECT_NE(invalidation.RequiredRevision(union_id), union_rev);
+  EXPECT_NE(invalidation.RequiredRevision(grade_id), grade_rev);
 }
 
 TEST_F(MetalMaskFixture, ActiveMaskTexturesReleaseAfterGpuCompletion) {

--- a/alcedo_studio/tests/edit/runtime/metal_multi_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_multi_grade_test.cpp
@@ -130,7 +130,7 @@ TEST_F(MetalMultiGradeFixture, GradeWithoutPrimaryIdRendersItsParameters) {
   auto document = multi_grade_test::MakeIdentityGradeDocument();
   multi_grade_test::AddCleanGradesBeforeDrt(document, {"grade.b"});
   ASSERT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
-  ASSERT_EQ(document.PrimaryGrade(), nullptr);
+  ASSERT_EQ(document.PrimaryGrade()->Id(), NodeId{"grade.b"});
   multi_grade_test::GradeAdjustment<ExposureModel>(document, NodeId{"grade.b"}, type_ids::Exposure())
       .SetValue(1.0f);
   const auto plan = Compile(document);

--- a/alcedo_studio/tests/edit/runtime/metal_workspace_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/metal_workspace_test.cpp
@@ -10,7 +10,8 @@
 
 #include "edit/graph/graph_ids.hpp"
 #include "edit/mask/mask_asset.hpp"
-#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/result_representation.hpp"
+#include "edit/runtime/runtime_revision.hpp"
 #include "edit/runtime/texture_format.hpp"
 #include "metal_workspace_test_support.hpp"
 
@@ -258,12 +259,13 @@ TEST_F(MetalWorkspaceFixture, MetalFailedUploadRestoresDirtyFieldsAndPublishesNo
   }
   EXPECT_TRUE(model.IsDirty());
 
-  const GraphValueId id{NodeId{"develop"}, PortId{"sensor_linear"}};
-  const ContentKey   content{41};
+  const GraphValueId    id{NodeId{"develop"}, PortId{"sensor_linear"}};
+  constexpr RuntimeRevision content = 41;
   device.BeginRender();
   (void)device.Workspace().AcquireImageForWrite(id, {8, 8, TextureFormat::Rgba32f});
-  device.Workspace().Images().RecordUnpublished(id, content, {8, 8}, TextureFormat::Rgba32f,
-                                                device.CommandContext().SubmissionId());
+  device.Workspace().Images().RecordUnpublished(
+      id, content, MakeExtentRepresentation({8, 8}, TextureFormat::Rgba32f),
+      device.CommandContext().SubmissionId());
   device.Workspace().Device().FailNextUpload();
   std::vector<std::byte> pixels(8 * 8 * 16, std::byte{1});
   EXPECT_THROW(
@@ -273,7 +275,7 @@ TEST_F(MetalWorkspaceFixture, MetalFailedUploadRestoresDirtyFieldsAndPublishesNo
   device.CancelRender();
   device.WaitIdle();
   EXPECT_FALSE(device.Workspace().Images().FindValidResult(
-      id, content, {8, 8}, TextureFormat::Rgba32f,
+      id, content, MakeExtentRepresentation({8, 8}, TextureFormat::Rgba32f),
       device.Workspace().Device().CompletedSubmission()));
   EXPECT_EQ(device.Workspace().Images().PublishedCount(), 0U);
 }
@@ -323,32 +325,28 @@ TEST_F(MetalWorkspaceFixture, SinkFailurePublishesNoNewResults) {
   MetalRenderDevice device;
   auto&             workspace = device.Workspace();
   const GraphValueId id{NodeId{"develop"}, PortId{"sensor_linear"}};
-  const ContentKey   first{81};
-  const ContentKey   second{82};
+  constexpr RuntimeRevision first  = 81;
+  constexpr RuntimeRevision second = 82;
   constexpr std::uint32_t kWidth  = 8;
   constexpr std::uint32_t kHeight = 8;
+  const auto              repr = MakeExtentRepresentation({kWidth, kHeight}, TextureFormat::Rgba32f);
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(id, first, ImageExtent{kWidth, kHeight},
-                                       TextureFormat::Rgba32f,
-                                       device.CommandContext().SubmissionId());
+  workspace.Images().RecordUnpublished(id, first, repr, device.CommandContext().SubmissionId());
   device.EndRender();
   device.PublishResults();
   device.WaitIdle();
-  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f,
+  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, repr,
                                                  workspace.Device().CompletedSubmission()));
 
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(id, second, {kWidth, kHeight}, TextureFormat::Rgba32f,
-                                       device.CommandContext().SubmissionId());
+  workspace.Images().RecordUnpublished(id, second, repr, device.CommandContext().SubmissionId());
   device.CancelRender();
   device.WaitIdle();
-  EXPECT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  EXPECT_TRUE(workspace.Images().FindValidResult(id, first, repr,
                                                  workspace.Device().CompletedSubmission()));
-  EXPECT_FALSE(workspace.Images().FindValidResult(id, second, {kWidth, kHeight},
-                                                  TextureFormat::Rgba32f,
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, second, repr,
                                                   workspace.Device().CompletedSubmission()));
   EXPECT_EQ(workspace.Images().UnpublishedCount(), 0U);
 }

--- a/alcedo_studio/tests/edit/runtime/multi_mask_runtime_resource_support.hpp
+++ b/alcedo_studio/tests/edit/runtime/multi_mask_runtime_resource_support.hpp
@@ -374,11 +374,19 @@ void ExpectMaskUploadFailureKeepsPriorPublishedResults(Device& device) {
   auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), {});
   ASSERT_EQ(device.Execute(plan, prepared, document, &store), plan.display_output);
   device.WaitIdle();
-  const auto before = BuildFrameResultContentKeys(plan, prepared, document);
+  auto& images       = device.Workspace().Images();
+  auto& invalidation = device.Workspace().ResultInvalidation();
   ASSERT_TRUE(plan.FirstGrade()->mask_stack.has_value());
-  const auto source_id = plan.FirstGrade()->mask_stack->sources[0].effective_output;
-  const auto union_id  = plan.FirstGrade()->mask_output;
-  const auto grade_id  = plan.FirstGrade()->scene_output;
+  const auto source_id   = plan.FirstGrade()->mask_stack->sources[0].effective_output;
+  const auto union_id    = plan.FirstGrade()->mask_output;
+  const auto grade_id    = plan.FirstGrade()->scene_output;
+  const auto source_rev  = images.PublishedRevision(source_id);
+  const auto union_rev   = images.PublishedRevision(union_id);
+  const auto grade_rev   = images.PublishedRevision(grade_id);
+  const auto source_repr = images.PublishedRepresentation(source_id);
+  const auto union_repr  = images.PublishedRepresentation(union_id);
+  const auto grade_repr  = images.PublishedRepresentation(grade_id);
+  ASSERT_NE(source_rev, 0U);
 
   auto second = MakeFilledRaster(kResourceWidth, kResourceHeight, 40);
   second.key  = store.Put(second.descriptor, second.pixels);
@@ -388,17 +396,12 @@ void ExpectMaskUploadFailureKeepsPriorPublishedResults(Device& device) {
   device.Workspace().Device().FailNextUpload();
   EXPECT_THROW((void)device.Execute(plan, prepared, document, &store), std::runtime_error);
   device.WaitIdle();
-  const auto after     = BuildFrameResultContentKeys(plan, prepared, document);
   const auto completed = device.Workspace().Device().CompletedSubmission();
-  EXPECT_NE(after.Value(source_id), before.Value(source_id));
-  EXPECT_TRUE(device.Workspace().Images().FindValidResult(
-      source_id, before.Value(source_id), before.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_TRUE(device.Workspace().Images().FindValidResult(
-      union_id, before.mask, before.geometry_extent, TextureFormat::R8, completed));
-  EXPECT_TRUE(device.Workspace().Images().FindValidResult(
-      grade_id, before.primary_grade, before.geometry_extent, TextureFormat::Rgba32f, completed));
-  EXPECT_FALSE(device.Workspace().Images().FindValidResult(
-      source_id, after.Value(source_id), after.geometry_extent, TextureFormat::R8, completed));
+  EXPECT_TRUE(images.FindValidResult(source_id, source_rev, source_repr, completed));
+  EXPECT_TRUE(images.FindValidResult(union_id, union_rev, union_repr, completed));
+  EXPECT_TRUE(images.FindValidResult(grade_id, grade_rev, grade_repr, completed));
+  EXPECT_EQ(images.PublishedRevision(source_id), source_rev);
+  EXPECT_NE(invalidation.RequiredRevision(source_id), source_rev);
 }
 
 }  // namespace alcedo::multi_mask_qualification

--- a/alcedo_studio/tests/edit/runtime/opencl_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_grade_test.cpp
@@ -999,18 +999,19 @@ TEST_F(OpenClGradeFixture, OpenClLlfUsesWorkspaceTransientArenaForEveryPyramid) 
             result.local_tone_transient_bytes);
   EXPECT_GE(device_->Workspace().TransientBuffers().capacity_bytes(), plan_.peak_transient_bytes);
 
-  const auto  source_id     = LocalToneValueId(document_.PrimaryGrade()->Id(), "source");
-  const auto  result_id     = LocalToneValueId(document_.PrimaryGrade()->Id(), "result");
-  const auto  source_key    = HashLlfSourceKey(plan_, prepared_, document_);
-  const auto  reference_key = HashLlfReferenceKey(plan_, prepared_, document_);
-  const auto* source        = device_->Workspace().Images().Find(source_id);
-  const auto* adjusted      = device_->Workspace().Images().Find(result_id);
+  const auto  source_id = LocalToneValueId(document_.PrimaryGrade()->Id(), "source");
+  const auto  result_id = LocalToneValueId(document_.PrimaryGrade()->Id(), "result");
+  const auto* source    = device_->Workspace().Images().Find(source_id);
+  const auto* adjusted  = device_->Workspace().Images().Find(result_id);
   ASSERT_NE(source, nullptr);
   ASSERT_NE(adjusted, nullptr);
   EXPECT_EQ(source->Texture().Format(), TextureFormat::R32f);
   EXPECT_EQ(adjusted->Texture().Format(), TextureFormat::R32f);
-  EXPECT_EQ(device_->Workspace().Images().PublishedContentKey(source_id), source_key);
-  EXPECT_EQ(device_->Workspace().Images().PublishedContentKey(result_id), reference_key);
+  EXPECT_NE(device_->Workspace().Images().PublishedRevision(source_id), 0U);
+  EXPECT_EQ(device_->Workspace().Images().PublishedRevision(source_id),
+            device_->Workspace().ResultInvalidation().RequiredRevision(source_id));
+  EXPECT_EQ(device_->Workspace().Images().PublishedRevision(result_id),
+            device_->Workspace().ResultInvalidation().RequiredRevision(result_id));
   EXPECT_EQ(device_->Workspace().Values().Find(source_id), nullptr);
   EXPECT_EQ(device_->Workspace().Values().Find(result_id), nullptr);
 }
@@ -1022,19 +1023,20 @@ TEST_F(OpenClGradeFixture, OpenClLlfFullFrameBuildsCanonicalReferenceOnce) {
   EXPECT_FALSE(first.local_tone_sampled_canonical_reference);
   ASSERT_NE(first.local_tone_reference_resource_id, 0U);
 
-  const auto source_id     = LocalToneValueId(document_.PrimaryGrade()->Id(), "source");
-  const auto result_id     = LocalToneValueId(document_.PrimaryGrade()->Id(), "result");
-  const auto source_key    = HashLlfSourceKey(plan_, prepared_, document_);
-  const auto reference_key = HashLlfReferenceKey(plan_, prepared_, document_);
-  EXPECT_EQ(device_->Workspace().Images().PublishedContentKey(source_id), source_key);
-  EXPECT_EQ(device_->Workspace().Images().PublishedContentKey(result_id), reference_key);
-  EXPECT_EQ(device_->Workspace().Images().PublishedAuxiliary(source_id, source_key), 16U);
+  const auto source_id = LocalToneValueId(document_.PrimaryGrade()->Id(), "source");
+  const auto result_id = LocalToneValueId(document_.PrimaryGrade()->Id(), "result");
+  EXPECT_NE(device_->Workspace().Images().PublishedRevision(source_id), 0U);
+  EXPECT_EQ(device_->Workspace().Images().PublishedRevision(source_id),
+            device_->Workspace().ResultInvalidation().RequiredRevision(source_id));
+  EXPECT_EQ(device_->Workspace().Images().PublishedRevision(result_id),
+            device_->Workspace().ResultInvalidation().RequiredRevision(result_id));
+  EXPECT_EQ(device_->Workspace().Images().PublishedAuxiliary(source_id), 16U);
 
   const auto second = RenderGrade();
   EXPECT_FALSE(second.local_tone_rebuilt_reference);
   EXPECT_TRUE(second.local_tone_sampled_canonical_reference);
   EXPECT_EQ(second.local_tone_reference_resource_id, first.local_tone_reference_resource_id);
-  EXPECT_LE(device_->Workspace().Images().PublishedLastWriter(source_id, source_key),
+  EXPECT_LE(device_->Workspace().Images().PublishedLastWriter(source_id),
             device_->Workspace().Device().CompletedSubmission());
 }
 
@@ -1043,20 +1045,20 @@ TEST_F(OpenClGradeFixture, OpenClLlfSliderEditReusesCanonicalReference) {
   const auto first               = RenderGrade();
   const auto source_id           = LocalToneValueId(document_.PrimaryGrade()->Id(), "source");
   const auto result_id           = LocalToneValueId(document_.PrimaryGrade()->Id(), "result");
-  const auto source_key          = HashLlfSourceKey(plan_, prepared_, document_);
-  const auto first_reference_key = HashLlfReferenceKey(plan_, prepared_, document_);
+  const auto first_source_rev    = device_->Workspace().Images().PublishedRevision(source_id);
+  const auto first_result_rev    = device_->Workspace().Images().PublishedRevision(result_id);
   ASSERT_TRUE(first.local_tone_rebuilt_reference);
+  ASSERT_NE(first_source_rev, 0U);
 
   ModelByType<ShadowsModel>(type_ids::Shadows()).SetValue(70.0f);
-  const auto second               = RenderGrade();
-  const auto second_reference_key = HashLlfReferenceKey(plan_, prepared_, document_);
-  EXPECT_EQ(HashLlfSourceKey(plan_, prepared_, document_), source_key);
-  EXPECT_NE(second_reference_key, first_reference_key);
+  const auto second = RenderGrade();
   EXPECT_TRUE(second.local_tone_rebuilt_reference);
   EXPECT_FALSE(second.local_tone_sampled_canonical_reference);
   EXPECT_EQ(second.local_tone_reference_resource_id, first.local_tone_reference_resource_id);
-  EXPECT_EQ(device_->Workspace().Images().PublishedContentKey(source_id), source_key);
-  EXPECT_EQ(device_->Workspace().Images().PublishedContentKey(result_id), second_reference_key);
+  EXPECT_EQ(device_->Workspace().Images().PublishedRevision(source_id), first_source_rev);
+  EXPECT_NE(device_->Workspace().Images().PublishedRevision(result_id), first_result_rev);
+  EXPECT_EQ(device_->Workspace().Images().PublishedRevision(result_id),
+            device_->Workspace().ResultInvalidation().RequiredRevision(result_id));
 }
 
 TEST_F(OpenClGradeFixture, OpenClLlfSecondStableRenderCreatesNoBufferImageProgramOrKernel) {
@@ -1078,8 +1080,8 @@ TEST_F(OpenClGradeFixture, OpenClLlfFailedSubmissionDoesNotPublishReference) {
   ASSERT_TRUE(first.local_tone_rebuilt_reference);
   const auto source_id          = LocalToneValueId(document_.PrimaryGrade()->Id(), "source");
   const auto result_id          = LocalToneValueId(document_.PrimaryGrade()->Id(), "result");
-  const auto source_key         = HashLlfSourceKey(plan_, prepared_, document_);
-  const auto reference_key      = HashLlfReferenceKey(plan_, prepared_, document_);
+  const auto source_rev         = device_->Workspace().Images().PublishedRevision(source_id);
+  const auto result_rev         = device_->Workspace().Images().PublishedRevision(result_id);
   const auto source_resource_id = first.local_tone_reference_resource_id;
 
   auto       failed_plan        = plan_;
@@ -1092,9 +1094,9 @@ TEST_F(OpenClGradeFixture, OpenClLlfFailedSubmissionDoesNotPublishReference) {
                std::runtime_error);
   device_->CancelRender();
 
-  EXPECT_EQ(device_->Workspace().Images().PublishedContentKey(source_id), source_key);
-  EXPECT_EQ(device_->Workspace().Images().PublishedContentKey(result_id), reference_key);
-  EXPECT_EQ(device_->Workspace().Images().PublishedAuxiliary(source_id, source_key), 16U);
+  EXPECT_EQ(device_->Workspace().Images().PublishedRevision(source_id), source_rev);
+  EXPECT_EQ(device_->Workspace().Images().PublishedRevision(result_id), result_rev);
+  EXPECT_EQ(device_->Workspace().Images().PublishedAuxiliary(source_id), 16U);
 
   const auto recovered = RenderGrade();
   EXPECT_FALSE(recovered.local_tone_rebuilt_reference);
@@ -1186,8 +1188,11 @@ TEST(GpuDagOpenClGrade, OpenClLlfRoiSamplesCanonicalReferenceWithSharedGeometryP
   EXPECT_TRUE(roi_result.local_tone_sampled_canonical_reference);
   EXPECT_EQ(roi_result.local_tone_reference_resource_id,
             full_result.local_tone_reference_resource_id);
-  EXPECT_EQ(device.Workspace().Images().PublishedContentKey(source_id), full_source_key);
-  EXPECT_EQ(device.Workspace().Images().PublishedContentKey(result_id), full_reference_key);
+  EXPECT_NE(device.Workspace().Images().PublishedRevision(source_id), 0U);
+  EXPECT_EQ(device.Workspace().Images().PublishedRevision(source_id),
+            device.Workspace().ResultInvalidation().RequiredRevision(source_id));
+  EXPECT_EQ(device.Workspace().Images().PublishedRevision(result_id),
+            device.Workspace().ResultInvalidation().RequiredRevision(result_id));
   EXPECT_EQ(roi_pixels.size(), static_cast<std::size_t>(32) * kHeight);
   for (const auto& pixel : roi_pixels) {
     EXPECT_TRUE(std::isfinite(pixel.r));

--- a/alcedo_studio/tests/edit/runtime/opencl_mask_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_mask_test.cpp
@@ -510,7 +510,7 @@ TEST_F(OpenClMaskFixture, OpenClFeatherRadiusEditReusesSignedDistanceResult) {
   EXPECT_NE(first.signed_distance_resource_id, 0U);
   EXPECT_EQ(first.signed_distance_resource_id, second.signed_distance_resource_id);
   EXPECT_EQ(second.transient_bytes, 0U);
-  EXPECT_EQ(first_metadata->content_key, second_metadata->content_key);
+  EXPECT_EQ(first_metadata->representation.identity, second_metadata->representation.identity);
 }
 
 TEST_F(OpenClMaskFixture, OpenClMaskSamplingMatchesCudaAtCropRotationAndDynamicResolution) {

--- a/alcedo_studio/tests/edit/runtime/opencl_multi_grade_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_multi_grade_test.cpp
@@ -109,7 +109,7 @@ TEST_F(OpenClMultiGradeFixture, GradeWithoutPrimaryIdRendersItsParameters) {
   auto document = multi_grade_test::MakeIdentityGradeDocument();
   multi_grade_test::AddCleanGradesBeforeDrt(document, {"grade.b"});
   ASSERT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
-  ASSERT_EQ(document.PrimaryGrade(), nullptr);
+  ASSERT_EQ(document.PrimaryGrade()->Id(), NodeId{"grade.b"});
   multi_grade_test::GradeAdjustment<ExposureModel>(document, NodeId{"grade.b"}, type_ids::Exposure())
       .SetValue(1.0f);
   const auto plan = Compile(document);

--- a/alcedo_studio/tests/edit/runtime/opencl_workspace_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/opencl_workspace_test.cpp
@@ -18,13 +18,14 @@
 #include "edit/graph/graph_ids.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/mask/mask_asset.hpp"
-#include "edit/runtime/content_key.hpp"
+#include "edit/runtime/result_representation.hpp"
+#include "edit/runtime/runtime_revision.hpp"
+#include "edit/runtime/texture_format.hpp"
 #include "edit/runtime/execution_plan.hpp"
 #include "edit/runtime/opencl/opencl_dag_programs.hpp"
 #include "edit/runtime/opencl/opencl_neural_session_workspace.hpp"
 #include "edit/runtime/pass_kind.hpp"
 #include "edit/runtime/render_backend.hpp"
-#include "edit/runtime/texture_format.hpp"
 #include "gpu/transient_buffer_arena.hpp"
 #include "opencl/opencl_api_counters.hpp"
 #include "opencl/opencl_backend_program_registry.hpp"
@@ -607,12 +608,13 @@ TEST_F(OpenClWorkspaceFixture, OpenClFailedUploadRestoresDirtyFieldsAndPublishes
   }
   EXPECT_TRUE(model.IsDirty());
 
-  const GraphValueId id{NodeId{"develop"}, PortId{"sensor_linear"}};
-  const ContentKey   content{41};
+  const GraphValueId    id{NodeId{"develop"}, PortId{"sensor_linear"}};
+  constexpr RuntimeRevision content = 41;
   device.BeginRender();
   (void)device.Workspace().AcquireImageForWrite(id, {8, 8, TextureFormat::Rgba32f});
-  device.Workspace().Images().RecordUnpublished(id, content, {8, 8}, TextureFormat::Rgba32f,
-                                                device.CommandContext().SubmissionId());
+  device.Workspace().Images().RecordUnpublished(
+      id, content, MakeExtentRepresentation({8, 8}, TextureFormat::Rgba32f),
+      device.CommandContext().SubmissionId());
   device.Workspace().Device().FailNextUpload();
   std::vector<std::byte> pixels(8 * 8 * 16, std::byte{1});
   EXPECT_THROW(
@@ -622,7 +624,7 @@ TEST_F(OpenClWorkspaceFixture, OpenClFailedUploadRestoresDirtyFieldsAndPublishes
   device.CancelRender();
   device.WaitIdle();
   EXPECT_FALSE(device.Workspace().Images().FindValidResult(
-      id, content, {8, 8}, TextureFormat::Rgba32f,
+      id, content, MakeExtentRepresentation({8, 8}, TextureFormat::Rgba32f),
       device.Workspace().Device().CompletedSubmission()));
   EXPECT_EQ(device.Workspace().Images().PublishedCount(), 0U);
 }
@@ -719,31 +721,28 @@ TEST_F(OpenClWorkspaceFixture, SinkFailurePublishesNoNewResults) {
   OpenClRenderDevice device;
   auto&              workspace = device.Workspace();
   const GraphValueId id{NodeId{"develop"}, PortId{"sensor_linear"}};
-  const ContentKey   first{81};
-  const ContentKey   second{82};
+  constexpr RuntimeRevision first  = 81;
+  constexpr RuntimeRevision second = 82;
   constexpr std::uint32_t kWidth  = 8;
   constexpr std::uint32_t kHeight = 8;
+  const auto              repr = MakeExtentRepresentation({kWidth, kHeight}, TextureFormat::Rgba32f);
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(id, first, ImageExtent{kWidth, kHeight},
-                                       TextureFormat::Rgba32f, device.CommandContext().SubmissionId());
+  workspace.Images().RecordUnpublished(id, first, repr, device.CommandContext().SubmissionId());
   device.EndRender();
   device.PublishResults();
   device.WaitIdle();
-  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight},
-                                                 TextureFormat::Rgba32f,
+  ASSERT_TRUE(workspace.Images().FindValidResult(id, first, repr,
                                                  workspace.Device().CompletedSubmission()));
 
   device.BeginRender();
   (void)workspace.AcquireImageForWrite(id, {kWidth, kHeight, TextureFormat::Rgba32f});
-  workspace.Images().RecordUnpublished(id, second, {kWidth, kHeight}, TextureFormat::Rgba32f,
-                                       device.CommandContext().SubmissionId());
+  workspace.Images().RecordUnpublished(id, second, repr, device.CommandContext().SubmissionId());
   device.CancelRender();
   device.WaitIdle();
-  EXPECT_TRUE(workspace.Images().FindValidResult(id, first, {kWidth, kHeight}, TextureFormat::Rgba32f,
+  EXPECT_TRUE(workspace.Images().FindValidResult(id, first, repr,
                                                  workspace.Device().CompletedSubmission()));
-  EXPECT_FALSE(workspace.Images().FindValidResult(id, second, {kWidth, kHeight},
-                                                  TextureFormat::Rgba32f,
+  EXPECT_FALSE(workspace.Images().FindValidResult(id, second, repr,
                                                   workspace.Device().CompletedSubmission()));
   EXPECT_EQ(workspace.Images().UnpublishedCount(), 0U);
 }

--- a/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/result_content_key_test.cpp
@@ -417,7 +417,7 @@ TEST(GpuDagResultContentKey, GradeWithoutPrimaryIdSelectsCompiledNodeKeys) {
   auto document = CreateDefaultPipelineDocument();
   ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
   ASSERT_TRUE(RemoveColorGradeAndBridge(document, NodeId{"grade.primary"}).empty());
-  ASSERT_EQ(document.PrimaryGrade(), nullptr);
+  ASSERT_EQ(document.PrimaryGrade()->Id(), NodeId{"grade.b"});
   auto* remaining =
       dynamic_cast<ColorGradeNodeModel*>(document.Graph().FindNode(NodeId{"grade.b"}));
   ASSERT_NE(remaining, nullptr);

--- a/alcedo_studio/tests/edit/runtime/runtime_invalidation_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/runtime_invalidation_test.cpp
@@ -1,0 +1,532 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/runtime_invalidation.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "../graph/grade_owned_mask_support.hpp"
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/mask/active_raster_mask.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/local_tone_cache_ids.hpp"
+#include "edit/runtime/result_content_key.hpp"
+#include "edit/runtime/texture_format.hpp"
+#include "multi_grade_runtime_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+auto MakePrepared() -> PreparedRawInput {
+  return RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(16, 12),
+                                       gpu_dag_test::FullSensor(16, 12));
+}
+
+void ConsumeOperatorDirty(PipelineDocument& document) {
+  if (auto* develop = document.Develop()) {
+    (void)develop->Params().TakeDirtyPatch();
+  }
+  if (auto* drt = document.Drt()) {
+    (void)drt->Params().TakeDirtyPatch();
+    for (std::size_t index = 0; index < drt->AdjustmentCount(); ++index) {
+      (void)drt->AdjustmentAt(index).TakeDirtyPatch();
+    }
+  }
+  for (const auto& node : document.Graph().Nodes()) {
+    auto* grade = dynamic_cast<ColorGradeNodeModel*>(document.Graph().FindNode(node->Id()));
+    if (grade == nullptr) {
+      continue;
+    }
+    for (std::size_t index = 0; index < grade->AdjustmentCount(); ++index) {
+      (void)grade->AdjustmentAt(index).TakeDirtyPatch();
+    }
+  }
+}
+
+struct ValidityHarness {
+  PreparedRawInput           prepared = MakePrepared();
+  PipelineDocument           document = CreateDefaultPipelineDocument();
+  ExecutionPlan              plan{};
+  RuntimeInvalidationState   invalidation{};
+
+  ValidityHarness() {
+    gpu_dag_test::EnsureTestCameraProfile(document);
+    plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  }
+
+  void Recompile(const RenderRequest& request = {}) {
+    plan = GraphCompiler::Compile(document, prepared.CompileSource(), request);
+    GraphCompiler::BindFrameGeometry(plan, document, request);
+  }
+
+  void Collect(std::span<const ActiveRasterMaskInput> rasters = {}) {
+    invalidation.CollectAndPropagate(plan, document, prepared, rasters);
+  }
+
+  void Complete() {
+    const ImageExtent sensor{plan.source.develop_output_extent.width,
+                             plan.source.develop_output_extent.height};
+    const ImageExtent geometry{plan.geometry.render_extent.width,
+                               plan.geometry.render_extent.height};
+    auto mark = [&](const GraphValueId& id, ImageExtent extent,
+                    TextureFormat format = TextureFormat::Rgba32f) {
+      invalidation.MarkCompleted(id, invalidation.MakeImageRepresentation(id, extent, format));
+    };
+    mark(plan.sensor_linear_output, sensor);
+    mark(plan.geometry_output, geometry);
+    mark(plan.develop_output, geometry);
+    for (const auto& grade : plan.grade_nodes) {
+      mark(LocalToneSourceId(grade.node_id), geometry, TextureFormat::R32f);
+      mark(LocalToneResultId(grade.node_id), geometry, TextureFormat::R32f);
+      mark(grade.scene_output, geometry);
+      if (!grade.mask_stack.has_value()) {
+        continue;
+      }
+      for (const auto& source : grade.mask_stack->sources) {
+        mark(source.effective_output, geometry, TextureFormat::R8);
+      }
+      mark(grade.mask_output, geometry, TextureFormat::R8);
+    }
+    mark(plan.display_output, geometry);
+  }
+
+  void PublishCurrent() {
+    Collect();
+    ConsumeOperatorDirty(document);
+    Complete();
+  }
+
+  [[nodiscard]] auto Required(const GraphValueId& id) const -> RuntimeRevision {
+    return invalidation.RequiredRevision(id);
+  }
+  [[nodiscard]] auto Completed(const GraphValueId& id) const -> RuntimeRevision {
+    return invalidation.CompletedRevision(id);
+  }
+  [[nodiscard]] auto Current(const GraphValueId& id) const -> bool {
+    return Required(id) != 0 && Required(id) == Completed(id);
+  }
+
+  [[nodiscard]] auto Primary() const -> const CompiledGradeNode& { return *plan.FirstGrade(); }
+};
+
+TEST(RuntimeInvalidation, FirstCollectAssignsRequiredRevisionsAndDirtyConsumeLeavesThemAhead) {
+  ValidityHarness harness;
+  harness.Collect();
+  EXPECT_GT(harness.Required(harness.plan.sensor_linear_output), 0U);
+  EXPECT_EQ(harness.Completed(harness.plan.sensor_linear_output), 0U);
+  ConsumeOperatorDirty(harness.document);
+  EXPECT_GT(harness.Required(harness.plan.sensor_linear_output),
+            harness.Completed(harness.plan.sensor_linear_output));
+  EXPECT_FALSE(harness.document.Develop()->Params().IsDirty());
+}
+
+TEST(RuntimeInvalidation, FreshStateAssignsRequiredWhenOperatorDirtyAlreadyConsumed) {
+  ValidityHarness first;
+  first.PublishCurrent();
+  ASSERT_FALSE(first.document.Develop()->Params().IsDirty());
+  ASSERT_GT(first.Required(first.plan.sensor_linear_output), 0U);
+
+  RuntimeInvalidationState fresh;
+  fresh.CollectAndPropagate(first.plan, first.document, first.prepared, {});
+  EXPECT_GT(fresh.RequiredRevision(first.plan.sensor_linear_output), 0U);
+  EXPECT_EQ(fresh.CompletedRevision(first.plan.sensor_linear_output), 0U);
+  EXPECT_GT(fresh.RequiredRevision(first.plan.display_output), 0U);
+}
+
+TEST(RuntimeInvalidation, UnchangedSetValueAndSecondCollectKeepPublishedResultsValid) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto sensor = harness.Required(harness.plan.sensor_linear_output);
+  const auto grade  = harness.Required(harness.Primary().scene_output);
+  auto* exposure    = dynamic_cast<ExposureModel*>(
+      harness.document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(exposure->Value());
+  harness.Collect();
+  EXPECT_EQ(harness.Required(harness.plan.sensor_linear_output), sensor);
+  EXPECT_EQ(harness.Required(harness.Primary().scene_output), grade);
+  EXPECT_TRUE(harness.Current(harness.plan.sensor_linear_output));
+  EXPECT_TRUE(harness.Current(harness.Primary().scene_output));
+}
+
+TEST(RuntimeInvalidation, PreLlfExposureInvalidatesLlfSourceResultAndDownstream) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto sensor_before = harness.Required(harness.plan.sensor_linear_output);
+  const auto source_id     = LocalToneSourceId(harness.Primary().node_id);
+  const auto result_id     = LocalToneResultId(harness.Primary().node_id);
+  auto* exposure           = dynamic_cast<ExposureModel*>(
+      harness.document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(exposure->Value() + 0.25f);
+  harness.Collect();
+  EXPECT_EQ(harness.Required(harness.plan.sensor_linear_output), sensor_before);
+  EXPECT_TRUE(harness.Current(harness.plan.sensor_linear_output));
+  EXPECT_GT(harness.Required(source_id), harness.Completed(source_id));
+  EXPECT_GT(harness.Required(result_id), harness.Completed(result_id));
+  EXPECT_GT(harness.Required(harness.Primary().scene_output),
+            harness.Completed(harness.Primary().scene_output));
+  EXPECT_GT(harness.Required(harness.plan.display_output),
+            harness.Completed(harness.plan.display_output));
+}
+
+TEST(RuntimeInvalidation, LlfSliderKeepsSourceAndInvalidatesResult) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto source_id = LocalToneSourceId(harness.Primary().node_id);
+  const auto result_id = LocalToneResultId(harness.Primary().node_id);
+  auto* shadows        = dynamic_cast<ShadowsModel*>(
+      harness.document.PrimaryGrade()->FindAdjustmentByType(type_ids::Shadows()));
+  ASSERT_NE(shadows, nullptr);
+  shadows->SetValue(40.0f);
+  harness.Collect();
+  EXPECT_TRUE(harness.Current(source_id));
+  EXPECT_GT(harness.Required(result_id), harness.Completed(result_id));
+  EXPECT_GT(harness.Required(harness.Primary().scene_output),
+            harness.Completed(harness.Primary().scene_output));
+}
+
+TEST(RuntimeInvalidation, PostLlfSaturationAndMixKeepLlfAndInvalidateGradeOutput) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto source_id = LocalToneSourceId(harness.Primary().node_id);
+  const auto result_id = LocalToneResultId(harness.Primary().node_id);
+  auto* saturation     = dynamic_cast<SaturationModel*>(
+      harness.document.PrimaryGrade()->FindAdjustmentByType(type_ids::Saturation()));
+  ASSERT_NE(saturation, nullptr);
+  saturation->SetValue(1.1f);
+  harness.Collect();
+  EXPECT_TRUE(harness.Current(source_id));
+  EXPECT_TRUE(harness.Current(result_id));
+  EXPECT_GT(harness.Required(harness.Primary().scene_output),
+            harness.Completed(harness.Primary().scene_output));
+
+  harness.PublishCurrent();
+  harness.document.PrimaryGrade()->SetMix(0.4f);
+  harness.Collect();
+  EXPECT_TRUE(harness.Current(source_id));
+  EXPECT_TRUE(harness.Current(result_id));
+  EXPECT_GT(harness.Required(harness.Primary().scene_output),
+            harness.Completed(harness.Primary().scene_output));
+}
+
+TEST(RuntimeInvalidation, WhiteBalanceInvalidatesDevelopAndDownstreamLlf) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  auto payload        = harness.document.Develop()->Params().Params();
+  payload.wb_mode     = "custom";
+  payload.custom_cct  = 4800.0f;
+  harness.document.Develop()->Params().ReplaceParams(payload);
+  harness.Collect();
+  EXPECT_TRUE(harness.Current(harness.plan.sensor_linear_output));
+  EXPECT_TRUE(harness.Current(harness.plan.geometry_output));
+  EXPECT_GT(harness.Required(harness.plan.develop_output),
+            harness.Completed(harness.plan.develop_output));
+  EXPECT_GT(harness.Required(LocalToneSourceId(harness.Primary().node_id)),
+            harness.Completed(LocalToneSourceId(harness.Primary().node_id)));
+}
+
+TEST(RuntimeInvalidation, DemosaicInvalidatesSensorAndDownstreamLlf) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  auto payload             = harness.document.Develop()->Params().Params();
+  payload.demosaic_method  = payload.demosaic_method == "rcd" ? "dht" : "rcd";
+  harness.document.Develop()->Params().ReplaceParams(payload);
+  harness.Collect();
+  EXPECT_GT(harness.Required(harness.plan.sensor_linear_output),
+            harness.Completed(harness.plan.sensor_linear_output));
+  EXPECT_GT(harness.Required(LocalToneSourceId(harness.Primary().node_id)),
+            harness.Completed(LocalToneSourceId(harness.Primary().node_id)));
+}
+
+TEST(RuntimeInvalidation, HighlightReconstructionInvalidatesSensorAndDownstreamLlf) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  auto payload                    = harness.document.Develop()->Params().Params();
+  payload.highlights_reconstruct  = !payload.highlights_reconstruct;
+  harness.document.Develop()->Params().ReplaceParams(payload);
+  harness.Collect();
+  EXPECT_GT(harness.Required(harness.plan.sensor_linear_output),
+            harness.Completed(harness.plan.sensor_linear_output));
+  EXPECT_GT(harness.Required(LocalToneSourceId(harness.Primary().node_id)),
+            harness.Completed(LocalToneSourceId(harness.Primary().node_id)));
+}
+
+TEST(RuntimeInvalidation, LensCorrectionInvalidatesSensorAndDownstreamLlf) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  auto payload          = harness.document.Develop()->Params().Params();
+  payload.lens_enabled  = !payload.lens_enabled;
+  harness.document.Develop()->Params().ReplaceParams(payload);
+  harness.Collect();
+  EXPECT_GT(harness.Required(harness.plan.sensor_linear_output),
+            harness.Completed(harness.plan.sensor_linear_output));
+  EXPECT_GT(harness.Required(LocalToneSourceId(harness.Primary().node_id)),
+            harness.Completed(LocalToneSourceId(harness.Primary().node_id)));
+}
+
+TEST(RuntimeInvalidation, MiddleGradeEditLeavesUpstreamValid) {
+  ValidityHarness harness;
+  multi_grade_test::AddCleanGradesBeforeDrt(harness.document, {"grade.mid", "grade.tail"});
+  harness.Recompile();
+  harness.PublishCurrent();
+  ASSERT_EQ(harness.plan.grade_nodes.size(), 3U);
+  const auto& upstream = harness.plan.grade_nodes[0];
+  const auto& middle   = harness.plan.grade_nodes[1];
+  const auto& tail     = harness.plan.grade_nodes[2];
+  auto* exposure       = dynamic_cast<ExposureModel*>(
+      multi_grade_test::GradeNode(harness.document, middle.node_id.Value())
+          ->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(0.5f);
+  harness.Collect();
+  EXPECT_TRUE(harness.Current(harness.plan.sensor_linear_output));
+  EXPECT_TRUE(harness.Current(upstream.scene_output));
+  EXPECT_TRUE(harness.Current(LocalToneSourceId(upstream.node_id)));
+  EXPECT_GT(harness.Required(LocalToneSourceId(middle.node_id)),
+            harness.Completed(LocalToneSourceId(middle.node_id)));
+  EXPECT_GT(harness.Required(middle.scene_output), harness.Completed(middle.scene_output));
+  EXPECT_GT(harness.Required(LocalToneSourceId(tail.node_id)),
+            harness.Completed(LocalToneSourceId(tail.node_id)));
+  EXPECT_GT(harness.Required(tail.scene_output), harness.Completed(tail.scene_output));
+}
+
+TEST(RuntimeInvalidation, SiblingMaskSourceStaysValidWhenOneMaskChanges) {
+  ValidityHarness harness;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.a"});
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.b"});
+  harness.Recompile();
+  harness.PublishCurrent();
+  ASSERT_TRUE(harness.Primary().mask_stack.has_value());
+  ASSERT_EQ(harness.Primary().mask_stack->sources.size(), 2U);
+  const auto first  = harness.Primary().mask_stack->sources[0].effective_output;
+  const auto second = harness.Primary().mask_stack->sources[1].effective_output;
+  harness.document.PrimaryGrade()->SetMaskOpacity(harness.Primary().mask_stack->sources[0].mask_id,
+                                                  0.4f);
+  harness.Collect();
+  EXPECT_GT(harness.Required(first), harness.Completed(first));
+  EXPECT_TRUE(harness.Current(second));
+  EXPECT_GT(harness.Required(harness.Primary().mask_output),
+            harness.Completed(harness.Primary().mask_output));
+  EXPECT_TRUE(harness.Current(LocalToneSourceId(harness.Primary().node_id)));
+}
+
+TEST(RuntimeInvalidation, ActiveRasterRevisionInvalidatesOnlyThatMaskSource) {
+  ValidityHarness harness;
+  grade_mask_test::AddBrushMask(harness.document, MaskId{"mask.brush"}, MaskAssetKey{"asset.a"});
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"});
+  harness.Recompile();
+  ASSERT_TRUE(harness.Primary().mask_stack.has_value());
+  MaskId brush_id;
+  MaskId radial_id;
+  GraphValueId brush_out{};
+  GraphValueId radial_out{};
+  for (const auto& source : harness.Primary().mask_stack->sources) {
+    if (source.mask_id == MaskId{"mask.brush"}) {
+      brush_id  = source.mask_id;
+      brush_out = source.effective_output;
+    } else {
+      radial_id  = source.mask_id;
+      radial_out = source.effective_output;
+    }
+  }
+  ActiveRasterMaskInput raster;
+  raster.owner_node_id     = harness.Primary().node_id;
+  raster.mask_id           = brush_id;
+  raster.session_generation = 1;
+  raster.content_revision   = 1;
+  harness.Collect(std::span<const ActiveRasterMaskInput>{&raster, 1});
+  ConsumeOperatorDirty(harness.document);
+  harness.Complete();
+  raster.content_revision = 2;
+  harness.Collect(std::span<const ActiveRasterMaskInput>{&raster, 1});
+  EXPECT_GT(harness.Required(brush_out), harness.Completed(brush_out));
+  EXPECT_TRUE(harness.Current(radial_out));
+}
+
+TEST(RuntimeInvalidation, ViewportChangeKeepsCanonicalLlfAndMismatchesFrameResults) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto source_id = LocalToneSourceId(harness.Primary().node_id);
+  const auto grade_id  = harness.Primary().scene_output;
+  const ImageExtent geometry{harness.plan.geometry.render_extent.width,
+                             harness.plan.geometry.render_extent.height};
+  const auto llf_needed =
+      harness.invalidation.MakeImageRepresentation(source_id, geometry, TextureFormat::R32f);
+  const auto frame_needed =
+      harness.invalidation.MakeImageRepresentation(grade_id, geometry, TextureFormat::Rgba32f);
+  EXPECT_TRUE(harness.invalidation.IsSatisfied(source_id, llf_needed));
+  EXPECT_TRUE(harness.invalidation.IsSatisfied(grade_id, frame_needed));
+
+  RenderRequest viewport;
+  viewport.view.visible_rect_in_edit_space = {0.2f, 0.2f, 0.6f, 0.6f};
+  viewport.view.viewport_extent            = {8, 6};
+  GraphCompiler::BindFrameGeometry(harness.plan, harness.document, viewport);
+  harness.Collect();
+  EXPECT_TRUE(harness.Current(source_id));
+  EXPECT_TRUE(harness.Current(grade_id));
+  const auto llf_after =
+      harness.invalidation.MakeImageRepresentation(source_id, geometry, TextureFormat::R32f);
+  const auto frame_after =
+      harness.invalidation.MakeImageRepresentation(grade_id, geometry, TextureFormat::Rgba32f);
+  EXPECT_TRUE(harness.invalidation.IsSatisfied(source_id, llf_after));
+  EXPECT_FALSE(harness.invalidation.IsSatisfied(grade_id, frame_after));
+}
+
+TEST(RuntimeInvalidation, CropChangeMismatchesCanonicalLlfWithoutBumpingUnrelatedSensorRevision) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto sensor_before = harness.Required(harness.plan.sensor_linear_output);
+  const auto source_id     = LocalToneSourceId(harness.Primary().node_id);
+  const ImageExtent geometry{harness.plan.geometry.render_extent.width,
+                             harness.plan.geometry.render_extent.height};
+  harness.document.Geometry().SetCropRect({0.1f, 0.1f, 0.8f, 0.8f});
+  GraphCompiler::BindFrameGeometry(harness.plan, harness.document, RenderRequest{});
+  harness.Collect();
+  EXPECT_EQ(harness.Required(harness.plan.sensor_linear_output), sensor_before);
+  const auto llf_after =
+      harness.invalidation.MakeImageRepresentation(source_id, geometry, TextureFormat::R32f);
+  EXPECT_FALSE(harness.invalidation.IsSatisfied(source_id, llf_after));
+}
+
+TEST(RuntimeInvalidation, RenderScaleMismatchRejectsPriorFrameRepresentation) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto sensor_before = harness.Required(harness.plan.sensor_linear_output);
+  const auto grade_id      = harness.Primary().scene_output;
+  const ImageExtent geometry{harness.plan.geometry.render_extent.width,
+                             harness.plan.geometry.render_extent.height};
+  EXPECT_TRUE(harness.invalidation.IsSatisfied(
+      grade_id,
+      harness.invalidation.MakeImageRepresentation(grade_id, geometry, TextureFormat::Rgba32f)));
+
+  RenderRequest scaled;
+  scaled.resolution.render_scale = 0.5f;
+  GraphCompiler::BindFrameGeometry(harness.plan, harness.document, scaled);
+  harness.Collect();
+  EXPECT_EQ(harness.Required(harness.plan.sensor_linear_output), sensor_before);
+  const ImageExtent scaled_extent{harness.plan.geometry.render_extent.width,
+                                  harness.plan.geometry.render_extent.height};
+  EXPECT_FALSE(harness.invalidation.IsSatisfied(
+      grade_id, harness.invalidation.MakeImageRepresentation(grade_id, scaled_extent,
+                                                            TextureFormat::Rgba32f)));
+}
+
+TEST(RuntimeInvalidation, ExportQualityMismatchRejectsPriorFrameRepresentation) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto grade_id = harness.Primary().scene_output;
+  const ImageExtent geometry{harness.plan.geometry.render_extent.width,
+                             harness.plan.geometry.render_extent.height};
+  EXPECT_TRUE(harness.invalidation.IsSatisfied(
+      grade_id,
+      harness.invalidation.MakeImageRepresentation(grade_id, geometry, TextureFormat::Rgba32f)));
+
+  RenderRequest export_quality;
+  export_quality.resolution.quality = RenderQuality::Export;
+  GraphCompiler::BindFrameGeometry(harness.plan, harness.document, export_quality);
+  harness.Collect();
+  EXPECT_FALSE(harness.invalidation.IsSatisfied(
+      grade_id,
+      harness.invalidation.MakeImageRepresentation(grade_id, geometry, TextureFormat::Rgba32f)));
+}
+
+TEST(RuntimeInvalidation, DocumentEpochPreventsReuseOfSameNodeIds) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto grade_id = harness.Primary().scene_output;
+  EXPECT_TRUE(harness.Current(grade_id));
+  harness.invalidation.AdvanceDocumentEpoch();
+  EXPECT_GT(harness.Required(grade_id), harness.Completed(grade_id));
+  EXPECT_GT(harness.Required(harness.plan.sensor_linear_output),
+            harness.Completed(harness.plan.sensor_linear_output));
+}
+
+TEST(RuntimeInvalidation, RepeatedEditsDoNotGrowTrackedValueCount) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto tracked = harness.invalidation.TrackedValueCount();
+  auto* exposure     = dynamic_cast<ExposureModel*>(
+      harness.document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  for (int step = 0; step < 12; ++step) {
+    exposure->SetValue(0.1f * static_cast<float>(step));
+    harness.PublishCurrent();
+  }
+  EXPECT_EQ(harness.invalidation.TrackedValueCount(), tracked);
+}
+
+TEST(RuntimeInvalidation, DisplayNameDoesNotInvalidateResults) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto grade = harness.Required(harness.Primary().scene_output);
+  harness.document.PrimaryGrade()->SetDisplayName("Look A");
+  harness.Collect();
+  EXPECT_EQ(harness.Required(harness.Primary().scene_output), grade);
+}
+
+TEST(RuntimeInvalidation, AddedGradeLeavesUpstreamValidAndInvalidatesDisplay) {
+  ValidityHarness harness;
+  harness.PublishCurrent();
+  const auto sensor  = harness.Required(harness.plan.sensor_linear_output);
+  const auto primary = harness.Required(harness.Primary().scene_output);
+  multi_grade_test::AddCleanGradesBeforeDrt(harness.document, {"grade.tail"});
+  harness.Recompile();
+  harness.Collect();
+  EXPECT_EQ(harness.Required(harness.plan.sensor_linear_output), sensor);
+  EXPECT_TRUE(harness.Current(harness.plan.sensor_linear_output));
+  EXPECT_EQ(harness.Required(harness.plan.grade_nodes.front().scene_output), primary);
+  EXPECT_TRUE(harness.Current(harness.plan.grade_nodes.front().scene_output));
+  EXPECT_GT(harness.Required(harness.plan.grade_nodes.back().scene_output),
+            harness.Completed(harness.plan.grade_nodes.back().scene_output));
+  EXPECT_GT(harness.Required(harness.plan.display_output),
+            harness.Completed(harness.plan.display_output));
+}
+
+TEST(RuntimeInvalidation, RemovingMaskInvalidatesGradeOutputNotDevelop) {
+  ValidityHarness harness;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"});
+  harness.Recompile();
+  harness.PublishCurrent();
+  const auto develop = harness.Required(harness.plan.develop_output);
+  const auto grade   = harness.Required(harness.Primary().scene_output);
+  harness.document.PrimaryGrade()->RemoveMask(MaskId{"mask.radial"});
+  harness.Recompile();
+  harness.Collect();
+  EXPECT_EQ(harness.Required(harness.plan.develop_output), develop);
+  EXPECT_TRUE(harness.Current(harness.plan.develop_output));
+  EXPECT_GT(harness.Required(harness.Primary().scene_output), grade);
+}
+
+TEST(RuntimeInvalidation, CanonicalIdentityIgnoresViewportAndFollowsCrop) {
+  auto       prepared = MakePrepared();
+  auto       document = CreateDefaultPipelineDocument();
+  gpu_dag_test::EnsureTestCameraProfile(document);
+  auto plan = GraphCompiler::Compile(document, prepared.CompileSource(), RenderRequest{});
+  const auto base_canonical = HashCanonicalReferenceIdentity(plan, prepared);
+  const auto base_frame     = HashFrameImageIdentity(plan, prepared, 1);
+
+  RenderRequest viewport;
+  viewport.view.visible_rect_in_edit_space = {0.25f, 0.25f, 0.5f, 0.5f};
+  viewport.view.viewport_extent            = {8, 6};
+  GraphCompiler::BindFrameGeometry(plan, document, viewport);
+  EXPECT_EQ(HashCanonicalReferenceIdentity(plan, prepared), base_canonical);
+  EXPECT_NE(HashFrameImageIdentity(plan, prepared, 1), base_frame);
+
+  document.Geometry().SetCropRect({0.1f, 0.1f, 0.8f, 0.8f});
+  GraphCompiler::BindFrameGeometry(plan, document, viewport);
+  EXPECT_NE(HashCanonicalReferenceIdentity(plan, prepared), base_canonical);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-05
 
-Status: NM6.1–NM6.3 complete; NM6.4–NM6.9 planned.
+Status: NM6.1–NM6.4 complete; NM6.5–NM6.9 planned.
 
 Prerequisites: NM5 is complete. Preserve NM1 single live document/executor ownership,
 NM2 multi-Grade execution, NM3 multi-Mask data, and NM4 history/recovery guarantees.
@@ -327,7 +327,7 @@ belong to their active input sequence; an older completion cannot overwrite them
 
 ## 7. Ordered implementation phases
 
-NM6.1–NM6.3 are complete. NM6.4–NM6.9 remain planned. Each phase must leave a buildable product path and
+NM6.1–NM6.4 are complete. NM6.5–NM6.9 remain planned. Each phase must leave a buildable product path and
 write its actual call chain and evidence into Section 10. New-file names are proposed; existing
 links are verified entry points. Do not declare a phase complete based on implementation
 inspection alone.
@@ -644,6 +644,81 @@ and all pixel-affecting Develop changes reach downstream LLF; quality/extent mis
 recompute; dirty upload consumption cannot clear invalidation; checkout same NodeIds cannot reuse
 old-document output. Repeated edits/Undo do not increase retained historical result count.
 
+##### Phase NM6.4 completion record (2026-09-05)
+
+**Status:** complete — session result validity is owner-maintained required/completed revisions plus
+representation identity; GPU caches keep one current result per output; PlanExecutor skip/publish no
+longer hashes full node parameter JSON on the hot path.
+
+**Primary success call chain:**
+
+```text
+owner mutation (SetValue / ReplaceParams / Mask setter / topology / Renderer::SetDocument)
+  -> RuntimeInvalidationState::CollectAndPropagate (once per BeginRender)
+  -> BindCompiledPlan + CollectStructureChanges + CollectDevelop/Grade/DrtChanges
+  -> InvalidateFrom (one change_version; compiled downstream including LLF ports)
+  -> PlanExecutor BindValidResult(required_revision, ResultRepresentation)
+  -> encode miss path / skip hit path
+  -> RecordUnpublished(revision) -> PublishResults
+  -> CompleteMatchingImages / MarkCompleted
+```
+
+**Primary failure call chain:**
+
+```text
+encode / upload / present failure
+  -> CancelRender / DiscardUnpublished
+  -> required stays ahead of completed; unpublished writes are dropped
+  -> retry BindValidResult cannot treat partial LLF metadata as current
+GPU upload TakeDirtyPatch failure
+  -> dirty bits restored; CollectAndPropagate still does not consume operator dirty
+checkout / new PipelineDocument pointer
+  -> AdvanceDocumentEpoch bumps every required revision
+  -> same NodeIds miss until the new generation is published
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| dirty consume leaves required ahead; no-op SetValue stays valid | `RuntimeInvalidation.*` in `GpuDagRawInputTest` | PASS |
+| pre-LLF / LLF / post-LLF / Mix reuse matrix | `RuntimeInvalidation.PreLlfExposure…`, `LlfSlider…`, `PostLlfSaturationAndMix…` | PASS |
+| WB / demosaic / highlights / lens reach LLF | `RuntimeInvalidation.WhiteBalance…`, `Demosaic…`, `HighlightReconstruction…`, `LensCorrection…` | PASS |
+| middle Grade; sibling Mask; active raster | `MiddleGradeEditLeavesUpstreamValid`, `SiblingMaskSourceStaysValidWhenOneMaskChanges`, `ActiveRasterRevisionInvalidatesOnlyThatMaskSource`; `CudaMultiGradeFixture.MiddleGradeEditReusesUpstreamResults`; `CudaMaskFixture.OneMaskEditReusesSiblingAndUpstreamResults` | PASS |
+| viewport vs crop; render_scale; Export quality | `ViewportChangeKeepsCanonicalLlf…`, `CropChangeMismatchesCanonicalLlf…`, `RenderScaleMismatch…`, `ExportQualityMismatch…` | PASS |
+| checkout / document pointer cannot reuse old output | `DocumentEpochPreventsReuseOfSameNodeIds` | PASS |
+| repeated edits do not grow retained result count | `RepeatedEditsDoNotGrowTrackedValueCount`; `CudaWorkspaceFixture.ResultCacheDoesNotTreatReusedTextureAllocationAsContentHit` (`PublishedCount()==1`) | PASS |
+| new workspace after dirty already consumed still assigns required | `FreshStateAssignsRequiredWhenOperatorDirtyAlreadyConsumed`; `OpenClDevelopFixture.RgbDngWarpProducesFinalSensorImageAndReusesPublishedCache` | PASS |
+| structure: add Grade / remove Mask | `AddedGradeLeavesUpstreamValidAndInvalidatesDisplay`; `RemovingMaskInvalidatesGradeOutputNotDevelop`; `CudaMultiGradeFixture.ReconnectChangesNoncommutingGradeResult` | PASS |
+| failed write does not publish; retry cannot use unpublished | `CudaWorkspaceFixture.FailedSubmissionDoesNotPublishResultRevision`; `UnpublishedWriteIsNotValidUntilPublish`; `CudaResultCacheProductFixture.RendererFailureDoesNotPublishUnfinishedRevisions`; `OpenClGradeFixture.OpenClLlfFailedSubmissionDoesNotPublishReference` | PASS |
+| LLF slider retains source, rebuilds result (GPU) | `OpenClGradeFixture.OpenClLlfSliderEditReusesCanonicalReference` | PASS |
+| image switch: one current GPU result, prepared-source hit | `CudaResultCacheProductFixture.ImageSwitchBackReusesMatchingPreparedSourceAndGpuResults` | PASS |
+| display-name / selection does not invalidate | `DisplayNameDoesNotInvalidateResults` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagRawInputTest --target GpuDagCudaWorkspaceTest --target GpuDagCudaDrtProductTest --target GpuDagCudaPrimaryGradeTest --target GpuDagCudaMaskTest --target GpuDagCudaDevelopTest --target GpuDagOpenClWorkspaceTest --target GpuDagOpenClGradeTest --target GpuDagOpenClDevelopTest --target EditorPipelineCommandServiceTest
+build/debug/alcedo_studio/tests/edit/GpuDagRawInputTest_runtime/GpuDagRawInputTest.exe
+build/debug/alcedo_studio/tests/app/EditorPipelineCommandServiceTest_runtime/EditorPipelineCommandServiceTest.exe
+build/debug/alcedo_studio/tests/edit/GpuDagOpenClWorkspaceTest_runtime/GpuDagOpenClWorkspaceTest.exe
+GpuDagCudaWorkspaceTest.exe --gtest_filter=*ResultCache*:*FailedSubmission*:*CancelledSubmission*:*UnpublishedWrite*:*SinkFailure*:*RepeatedNodeRemoval*:*DoNotInclude*:*InstantiatesCuda*
+GpuDagCudaDevelopTest.exe --gtest_filter=*RgbDngWarp*
+GpuDagOpenClDevelopTest.exe --gtest_filter=*RgbDngWarp*:*OpenClSecondDevelop*
+GpuDagCudaDrtProductTest.exe --gtest_filter=*ImageSwitchBack*:*FailedSubmission*:*RendererFailure*
+GpuDagCudaPrimaryGradeTest.exe --gtest_filter=*GradeWithoutPrimary*:*Reconnect*:*EmptyMask*:*MultiGrade*
+GpuDagOpenClGradeTest.exe --gtest_filter=*Llf*:*GradeWithoutPrimary*:*Reconnect*
+GpuDagCudaMaskTest.exe --gtest_filter=*Sibling*:*EmptyMask*
+```
+
+Suite totals: `GpuDagRawInputTest` 106/106 PASS; `EditorPipelineCommandServiceTest` 10/10 PASS; `GpuDagOpenClWorkspaceTest` 23/23 PASS; focused CUDA/OpenCL GPU slices 41/41 PASS. Combined 180/180 PASS. Metal execution was not run (Windows host).
+
+**Checklist / exit condition:** NM6.4 acceptance items above have executed tests. Section 8.2 three-Grade real-RAW cached-versus-fresh pixel matrix remains NM6.9. Shared Grade/LLF host executors remain NM6.5.
+
+**LOC note (grill-code-review):** new `runtime_invalidation.cpp` ~381 lines and `runtime_invalidation.hpp` ~163 lines own validity; `graph_image_cache.hpp` ~366 lines stays one cache type (rewritten in place for revision+representation lookup). `plan_executor.hpp` ~277 lines. Validity tests live in `runtime_invalidation_test.cpp` ~486 lines. No file crossed 1000 lines.
+
+**Remaining gaps:** `HashLlf*` / `MixGrade` / `BuildFrameResultContentKeys` remain for identity tests and are not used by PlanExecutor or GPU LLF passes. OpenCL signed-distance metadata still stamps `completed_revision` 1 and matches via `ResultRepresentation.identity`. Camera-profile dirty is still lumped into `DevelopDirty::WhiteBalance`. Metal LLF/mask sources were updated with the same revision API and were not executed here. Shared three-backend Grade/LLF orchestration is NM6.5. Node targeting is NM6.6.
+
 ### NM6.5 — Share Grade and LLF decisions across all three backends
 
 **Changes:** introduce common template orchestration and per-step backend operations; unify LLF
@@ -825,7 +900,7 @@ and any renamed linked files together. No runtime metadata is written into docum
 | NM6.1 | complete 2026-09-05 | `feature/queued-typed-adjustment-input` @ `ee6247c8` | slider → Patch → `LockLivePipeline` + live apply → coordinator; completion `(bool, string)`, no GPU fence | 10/10 focused PASS; see NM6.1 completion record | Queue/pacing/GPU-safe completion are NM6.2/3 |
 | NM6.2 | complete 2026-09-05 | uncommitted on `feature/queued-typed-adjustment-input` @ `3a7a3825` | slider/model → `submitPatch` → `EnqueueAdjustmentInput` → `EditorPendingInputQueue::AdmitFieldChange`; live document/history unchanged | 90/90 focused PASS excluding pre-existing RapidImageSelection; see NM6.2 completion record | Consume, 16 ms pacing, GPU-safe completion are NM6.3 |
 | NM6.3 | complete 2026-09-05 | uncommitted on `feature/nm6-serial-adjustment-consumption` @ `8ed06f88` | enqueue → PostCompletion consume → HandlePendingSequence → history capture/commit → RouteInitialRender → Present-wait completion → next admission | 137/137 focused PASS; see NM6.3 completion record | Cache versions NM6.4; node targeting NM6.6 |
-| NM6.4 | planned | — | — | — | Dependency validity/current results |
+| NM6.4 | complete 2026-09-05 | uncommitted on `feature/runtime-dependency-result-versions` | mutation → CollectAndPropagate → BindValidResult(required, representation) → skip/encode → RecordUnpublished → PublishResults / MarkCompleted | 180/180 focused PASS; see NM6.4 completion record | Shared Grade/LLF executors NM6.5; Metal GPU execution; Section 8.2 RAW pixel matrix NM6.9 |
 | NM6.5 | planned | — | — | — | Shared three-backend execution |
 | NM6.6 | planned | — | — | — | Node context/target routing |
 | NM6.7 | planned | — | — | — | Approved header and panel UI |


### PR DESCRIPTION
## Summary
- Replace per-frame full-node parameter JSON hashing with owner-maintained required/completed revisions and result representation identity on the render workspace.
- Look up and publish GPU results as one current value per output; PlanExecutor skip/encode uses `required_revision` plus representation, not session `ContentKey` validity.
- Invalidate only affected downstream results (pre-LLF / LLF / post-LLF / Mix, Develop, Mask, structure, checkout epoch); no-op and display-name edits keep valid results.

## Test plan
- [x] `GpuDagRawInputTest` 106/106, including `RuntimeInvalidation.*` reuse matrix, document epoch, and one-current-result count
- [x] `EditorPipelineCommandServiceTest` 10/10
- [x] `GpuDagOpenClWorkspaceTest` 23/23
- [x] Focused CUDA/OpenCL GPU slices 41/41 (warp/skip reuse, LLF source retain, failed publish, image switch, middle Grade, sibling Mask)

## Out of scope
Shared Grade/LLF host executors remain NM6.5. Metal GPU execution was not run on this Windows host. `HashLlf*` / `BuildFrameResultContentKeys` remain for identity tests and are off the PlanExecutor hot path.

Made with [Cursor](https://cursor.com)