### PR TITLE
feat(editor): add selected-node adjustment context and projection

### DIFF
--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -408,7 +408,9 @@ def_library(EditorPanelProjection
     SOURCES
         "${ALCEDO_APP_ROOT}/editor_panel_projection.cpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_panel_projection.hpp"
-    PUBLIC_DEPS EditorPipelineCommandService EditGraph
+        "${ALCEDO_APP_ROOT}/editor_adjustment_context.cpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_adjustment_context.hpp"
+    PUBLIC_DEPS EditorPipelineCommandService EditGraph Image
 )
 
 def_library(EditorNodeGraphProjection

--- a/alcedo_studio/src/app/editor_action_policy.cpp
+++ b/alcedo_studio/src/app/editor_action_policy.cpp
@@ -191,6 +191,7 @@ auto EditorActionPolicy::ActionForCommand(EditorSessionCommandKind kind)
     case EditorSessionCommandKind::SetPresentationTarget:
     case EditorSessionCommandKind::SetPresentationSize:
     case EditorSessionCommandKind::SetGeometryOverlay:
+    case EditorSessionCommandKind::SetAdjustmentProjectionNode:
       return std::nullopt;
   }
   return std::nullopt;

--- a/alcedo_studio/src/app/editor_adjustment_context.cpp
+++ b/alcedo_studio/src/app/editor_adjustment_context.cpp
@@ -1,0 +1,302 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_adjustment_context.hpp"
+
+#include <array>
+#include <utility>
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/develop_node_model.hpp"
+#include "edit/graph/drt_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "image/image.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr std::array<std::string_view, 2> kDevelopPanels{kAdjustmentPanelRaw,
+                                                         kAdjustmentPanelGeometry};
+constexpr std::array<std::string_view, 4> kColorGradePanels{
+    kAdjustmentPanelTone, kAdjustmentPanelLook, kAdjustmentPanelLut, kAdjustmentPanelMasks};
+constexpr std::array<std::string_view, 2> kDrtPanels{kAdjustmentPanelDisplay,
+                                                     kAdjustmentPanelDetail};
+
+auto SetError(std::string* error, std::string message) -> bool {
+  if (error != nullptr) {
+    *error = std::move(message);
+  }
+  return false;
+}
+
+auto KindOf(const INodeModel& node) -> std::optional<EditorNodeKind> {
+  if (node.Type() == type_ids::DevelopNode()) {
+    return EditorNodeKind::Develop;
+  }
+  if (node.Type() == type_ids::ColorGradeNode()) {
+    return EditorNodeKind::ColorGrade;
+  }
+  if (node.Type() == type_ids::DrtNode()) {
+    return EditorNodeKind::Drt;
+  }
+  return std::nullopt;
+}
+
+auto IsDrtPostField(std::string_view field) -> bool {
+  return field == "clarity" || field == "sharpen" || field == "halation" || field == "film_grain";
+}
+
+auto IsDevelopField(std::string_view field) -> bool {
+  return field == "raw_decode" || field == "lens_calib" || field == "color_temp" ||
+         field == "crop_rotate";
+}
+
+auto IsColorGradeField(std::string_view field) -> bool {
+  return field == "exposure" || field == "contrast" || field == "white" || field == "whites" ||
+         field == "black" || field == "blacks" || field == "shadows" || field == "highlights" ||
+         field == "curve" || field == "saturation" || field == "vibrance" || field == "tint" ||
+         field == "hls" || field == "HLS" || field == "color_wheel" || field == "lut" ||
+         field == "ocio_lmt";
+}
+
+auto OperatorTypeForField(std::string_view field) -> const OperatorTypeId* {
+  if (field == "exposure") return &type_ids::Exposure();
+  if (field == "contrast") return &type_ids::Contrast();
+  if (field == "white" || field == "whites") return &type_ids::White();
+  if (field == "black" || field == "blacks") return &type_ids::Black();
+  if (field == "shadows") return &type_ids::Shadows();
+  if (field == "highlights") return &type_ids::Highlights();
+  if (field == "curve") return &type_ids::Curve();
+  if (field == "saturation") return &type_ids::Saturation();
+  if (field == "vibrance") return &type_ids::Vibrance();
+  if (field == "tint") return &type_ids::Cat02WhiteBalance();
+  if (field == "hls" || field == "HLS") return &type_ids::Hls();
+  if (field == "color_wheel") return &type_ids::ColorWheel();
+  if (field == "lut" || field == "ocio_lmt") return &type_ids::Lmt();
+  if (field == "clarity") return &type_ids::Clarity();
+  if (field == "sharpen") return &type_ids::Sharpen();
+  if (field == "halation") return &type_ids::Halation();
+  if (field == "film_grain") return &type_ids::FilmGrain();
+  return nullptr;
+}
+
+}  // namespace
+
+auto ReadEditorImageExifDisplay(const ExifDisplayMetaData& metadata) -> EditorImageExifDisplay {
+  EditorImageExifDisplay display;
+  if (metadata.shutter_speed_.first > 0 && metadata.shutter_speed_.second > 0) {
+    display.shutter_speed = metadata.shutter_speed_;
+  }
+  if (metadata.iso_ > 0) {
+    display.iso = metadata.iso_;
+  }
+  if (metadata.aperture_ > 0.0f) {
+    display.aperture = metadata.aperture_;
+  }
+  if (metadata.focal_ > 0.0f) {
+    display.focal_mm = metadata.focal_;
+  }
+  return display;
+}
+
+auto ReadEditorImageExifDisplay(const Image& image) -> EditorImageExifDisplay {
+  if (!image.has_exif_display_.load()) {
+    return {};
+  }
+  return ReadEditorImageExifDisplay(image.exif_display_);
+}
+
+auto SupportedAdjustmentPanels(EditorNodeKind kind) -> std::span<const std::string_view> {
+  switch (kind) {
+    case EditorNodeKind::Develop:
+      return kDevelopPanels;
+    case EditorNodeKind::ColorGrade:
+      return kColorGradePanels;
+    case EditorNodeKind::Drt:
+      return kDrtPanels;
+  }
+  return {};
+}
+
+auto DefaultAdjustmentPanel(EditorNodeKind kind) -> std::string_view {
+  switch (kind) {
+    case EditorNodeKind::Develop:
+      return kAdjustmentPanelRaw;
+    case EditorNodeKind::ColorGrade:
+      return kAdjustmentPanelTone;
+    case EditorNodeKind::Drt:
+      return kAdjustmentPanelDisplay;
+  }
+  return kAdjustmentPanelTone;
+}
+
+auto AdjustmentPanelIsSupported(EditorNodeKind kind, std::string_view panel) -> bool {
+  for (const auto supported : SupportedAdjustmentPanels(kind)) {
+    if (supported == panel) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto AdjustmentFieldIsSupported(EditorNodeKind kind, std::string_view field_key) -> bool {
+  switch (kind) {
+    case EditorNodeKind::Develop:
+      return IsDevelopField(field_key);
+    case EditorNodeKind::ColorGrade:
+      return IsColorGradeField(field_key);
+    case EditorNodeKind::Drt:
+      return field_key == "odt" || IsDrtPostField(field_key);
+  }
+  return false;
+}
+
+auto CompleteSelectedNodeParameterTarget(const PipelineDocument& document,
+                                         const NodeId& selected_node_id, std::string field_key,
+                                         std::string* error)
+    -> std::optional<EditorParameterTarget> {
+  const auto* node = document.Graph().FindNode(selected_node_id);
+  if (node == nullptr) {
+    SetError(error, "Selected node is missing: " + std::string(selected_node_id.Value()));
+    return std::nullopt;
+  }
+  const auto kind = KindOf(*node);
+  if (!kind.has_value()) {
+    SetError(error, "Selected node kind is not supported: " + std::string(selected_node_id.Value()));
+    return std::nullopt;
+  }
+  if (!AdjustmentFieldIsSupported(*kind, field_key)) {
+    SetError(error, "Field " + field_key + " is not owned by the selected node");
+    return std::nullopt;
+  }
+
+  EditorParameterTarget target;
+  target.field_key = std::move(field_key);
+  if (target.field_key == "crop_rotate") {
+    target.owner_kind = EditorParameterOwnerKind::Document;
+    return target;
+  }
+  if (target.field_key == "raw_decode" || target.field_key == "lens_calib" ||
+      target.field_key == "color_temp") {
+    const auto* develop = document.Develop();
+    if (develop == nullptr || develop->Id() != selected_node_id) {
+      SetError(error, "Develop node is missing: " + std::string(selected_node_id.Value()));
+      return std::nullopt;
+    }
+    target.owner_kind = EditorParameterOwnerKind::Develop;
+    target.node_id    = selected_node_id;
+    return target;
+  }
+  if (target.field_key == "odt") {
+    const auto* drt = document.Drt();
+    if (drt == nullptr || drt->Id() != selected_node_id) {
+      SetError(error, "DRT node is missing: " + std::string(selected_node_id.Value()));
+      return std::nullopt;
+    }
+    target.owner_kind = EditorParameterOwnerKind::DrtPost;
+    target.node_id    = selected_node_id;
+    return target;
+  }
+  const auto* type = OperatorTypeForField(target.field_key);
+  if (type == nullptr) {
+    SetError(error, "Unknown editor adjustment field: " + target.field_key);
+    return std::nullopt;
+  }
+  if (IsDrtPostField(target.field_key)) {
+    const auto* drt = dynamic_cast<const DrtNodeModel*>(node);
+    if (drt == nullptr) {
+      SetError(error, "DRT node is missing: " + std::string(selected_node_id.Value()));
+      return std::nullopt;
+    }
+    const auto* instance = drt->FindAdjustmentIdByType(*type);
+    if (instance == nullptr) {
+      SetError(error, "DRT/Post adjustment is missing: " + std::string{type->Text()});
+      return std::nullopt;
+    }
+    target.owner_kind             = EditorParameterOwnerKind::DrtPost;
+    target.node_id                = selected_node_id;
+    target.adjustment_instance_id = *instance;
+    return target;
+  }
+  const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(node);
+  if (grade == nullptr) {
+    SetError(error, "Color Grade node is missing: " + std::string(selected_node_id.Value()));
+    return std::nullopt;
+  }
+  const auto* instance = grade->FindAdjustmentIdByType(*type);
+  if (instance == nullptr) {
+    SetError(error, "Color Grade adjustment is missing: " + std::string{type->Text()});
+    return std::nullopt;
+  }
+  target.owner_kind             = EditorParameterOwnerKind::ColorGrade;
+  target.node_id                = selected_node_id;
+  target.adjustment_instance_id = *instance;
+  return target;
+}
+
+auto SelectedNodeProjectionTargets(const PipelineDocument& document, const NodeId& selected_node_id,
+                                   std::string* error)
+    -> std::optional<std::vector<EditorParameterTarget>> {
+  const auto* node = document.Graph().FindNode(selected_node_id);
+  if (node == nullptr) {
+    SetError(error, "Selected node is missing: " + std::string(selected_node_id.Value()));
+    return std::nullopt;
+  }
+  const auto kind = KindOf(*node);
+  if (!kind.has_value()) {
+    SetError(error, "Selected node kind is not supported: " + std::string(selected_node_id.Value()));
+    return std::nullopt;
+  }
+  std::vector<EditorParameterTarget> targets;
+  const auto                         table = EditorPanelAdapterTable::Production();
+  targets.reserve(table.Adapters().size());
+  for (const auto& adapter : table.Adapters()) {
+    if (!AdjustmentFieldIsSupported(*kind, adapter.field_key)) {
+      continue;
+    }
+    std::string field_error;
+    auto        target = CompleteSelectedNodeParameterTarget(
+        document, selected_node_id, std::string{adapter.field_key}, &field_error);
+    if (!target.has_value()) {
+      SetError(error, field_error);
+      return std::nullopt;
+    }
+    targets.push_back(*target);
+  }
+  return targets;
+}
+
+auto ProjectSelectedNodePanelFields(const PipelineDocument& document, const NodeId& selected_node_id,
+                                    std::uint64_t session_generation, EditorPanelProjection* out,
+                                    std::string* error) -> bool {
+  const auto targets = SelectedNodeProjectionTargets(document, selected_node_id, error);
+  if (!targets.has_value()) {
+    return false;
+  }
+  return ProjectEditorPanelFields(document, *targets, session_generation, out, error);
+}
+
+auto MakeEditorAdjustmentContext(const PipelineDocument& document, const NodeId& selected_node_id,
+                                 EditorImageExifDisplay exif)
+    -> std::optional<EditorAdjustmentContext> {
+  const auto* node = document.Graph().FindNode(selected_node_id);
+  if (node == nullptr) {
+    return std::nullopt;
+  }
+  const auto kind = KindOf(*node);
+  if (!kind.has_value()) {
+    return std::nullopt;
+  }
+  EditorAdjustmentContext context;
+  context.selected_node_id = selected_node_id;
+  context.node_kind        = *kind;
+  context.display_name     = std::string{node->DisplayName()};
+  context.supported_panels = SupportedAdjustmentPanels(*kind);
+  context.default_panel    = DefaultAdjustmentPanel(*kind);
+  context.exif             = std::move(exif);
+  return context;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1224,7 +1224,7 @@ auto EditorSessionService::ConsumeTakenSequence(const EditorPendingSequence& seq
                       sequence.seal == EditorPendingInputBoundaryKind::NodeSwitch;
   if (!outcome.schedule_render || outcome.kind != EditorEditOutcome::Kind::RenderRouted) {
     serial_admission_.AbortCycle();
-    if (commit) {
+    if (commit && !sequence.fields.empty()) {
       BumpHistoryRevision();
     }
     EditorSessionResult result;
@@ -1620,6 +1620,38 @@ void EditorSessionService::SetGeometryOverlayActive(bool active) {
     return;
   }
   render_.SetGeometryOverlayActive(active);
+}
+
+auto EditorSessionService::SetAdjustmentProjectionNode(const NodeId& node_id)
+    -> EditorSessionResult {
+  if (!reducing_command_) {
+    EditorSessionCommand command;
+    command.kind    = EditorSessionCommandKind::SetAdjustmentProjectionNode;
+    command.node_id = node_id;
+    return SubmitCommand(std::move(command), [this](const EditorSessionCommand& queued) {
+      return SetAdjustmentProjectionNode(queued.node_id);
+    });
+  }
+  if (lifecycle_.state() != EditorSessionState::Interactive &&
+      lifecycle_.state() != EditorSessionState::Loading) {
+    return Reject("Adjustment projection requires an open image");
+  }
+  if (!lifecycle_.has_image()) {
+    return Reject("Adjustment projection requires an open image");
+  }
+  if (!dependencies_.history || !lifecycle_.has_history_guard()) {
+    return Reject("Adjustment history is unavailable");
+  }
+  std::string error;
+  if (!dependencies_.history->SetPanelProjectionNode(lifecycle_.history_guard(), node_id, &error)) {
+    return Reject(error.empty() ? "Selected node panel projection failed" : error);
+  }
+  EditorSessionResult result;
+  result.kind     = EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = lifecycle_.identity();
+  result.message  = "Selected node panel projection updated";
+  return Emit(std::move(result));
 }
 
 auto EditorSessionService::RequestViewChange(EditorRenderReason                  reason,

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1643,7 +1643,9 @@ auto EditorSessionService::SetAdjustmentProjectionNode(const NodeId& node_id)
     return Reject("Adjustment history is unavailable");
   }
   std::string error;
-  if (!dependencies_.history->SetPanelProjectionNode(lifecycle_.history_guard(), node_id, &error)) {
+  const auto  session_generation = lifecycle_.active_image_load_request().value;
+  if (!dependencies_.history->SetPanelProjectionNode(lifecycle_.history_guard(), node_id,
+                                                     session_generation, &error)) {
     return Reject(error.empty() ? "Selected node panel projection failed" : error);
   }
   EditorSessionResult result;

--- a/alcedo_studio/src/include/app/editor_adjustment_context.hpp
+++ b/alcedo_studio/src/include/app/editor_adjustment_context.hpp
@@ -120,9 +120,8 @@ struct EditorAdjustmentContext {
  * @brief Project every supported panel field for @p selected_node_id in one read.
  *
  * Failure leaves @p out unchanged. Does not call Model ToJson, LoadJson, or
- * MakeFullDto.
- *
- * @pre Caller holds the executor render lock when @p document is live.
+ * MakeFullDto. Load-only: does not mutate parameters. Must not acquire the live
+ * render lock — selection cannot stall present.
  */
 auto ProjectSelectedNodePanelFields(const PipelineDocument& document, const NodeId& selected_node_id,
                                     std::uint64_t session_generation, EditorPanelProjection* out,

--- a/alcedo_studio/src/include/app/editor_adjustment_context.hpp
+++ b/alcedo_studio/src/include/app/editor_adjustment_context.hpp
@@ -1,0 +1,142 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "app/editor_adjustment_types.hpp"
+#include "app/editor_node_graph_projection.hpp"
+#include "app/editor_panel_projection.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "image/metadata.hpp"
+
+namespace alcedo {
+
+class Image;
+class PipelineDocument;
+
+inline constexpr std::string_view kAdjustmentPanelTone     = "tone";
+inline constexpr std::string_view kAdjustmentPanelLook     = "look";
+inline constexpr std::string_view kAdjustmentPanelLut      = "lut";
+inline constexpr std::string_view kAdjustmentPanelMasks    = "masks";
+inline constexpr std::string_view kAdjustmentPanelRaw      = "raw";
+inline constexpr std::string_view kAdjustmentPanelGeometry = "geometry";
+inline constexpr std::string_view kAdjustmentPanelDisplay  = "display";
+inline constexpr std::string_view kAdjustmentPanelDetail   = "detail";
+
+/**
+ * @brief Image-owned EXIF rows shown beside the selected node name.
+ *
+ * Source owner: Image::exif_display_. This is not PipelineDocument state and is
+ * not reread when the selected NodeId changes. Nullopt means missing or invalid;
+ * the header formats those rows as an em dash.
+ */
+struct EditorImageExifDisplay {
+  std::optional<std::pair<int, int>> shutter_speed;
+  std::optional<std::uint64_t>       iso;
+  std::optional<float>               aperture;
+  std::optional<float>               focal_mm;
+};
+
+/**
+ * @brief Read-only selected-node capabilities for panel navigation.
+ *
+ * @p selected_node_id is copied from EditorNodeController at read time. This
+ * struct does not own graph selection or mutable Models. Supported parameters
+ * are loaded separately through ProjectSelectedNodePanelFields.
+ *
+ * GUI lifetime: value copy. Drop it when the session or selection changes.
+ */
+struct EditorAdjustmentContext {
+  NodeId                           selected_node_id;
+  EditorNodeKind                   node_kind = EditorNodeKind::ColorGrade;
+  std::string                      display_name;
+  std::span<const std::string_view> supported_panels{};
+  std::string_view                 default_panel = kAdjustmentPanelTone;
+  EditorImageExifDisplay           exif{};
+};
+
+/**
+ * @brief Copy the four display EXIF fields from the Image metadata owner.
+ *
+ * Does not parse EXIF JSON. Invalid shutter, non-positive ISO/aperture/focal,
+ * and missing metadata yield nullopt fields.
+ */
+[[nodiscard]] auto ReadEditorImageExifDisplay(const ExifDisplayMetaData& metadata)
+    -> EditorImageExifDisplay;
+
+/**
+ * @brief Copy the four display EXIF fields from @p image when display metadata is present.
+ */
+[[nodiscard]] auto ReadEditorImageExifDisplay(const Image& image) -> EditorImageExifDisplay;
+
+/// Panels the selected node kind may show. Geometry is Develop-only.
+[[nodiscard]] auto SupportedAdjustmentPanels(EditorNodeKind kind)
+    -> std::span<const std::string_view>;
+
+/// First supported panel when the current page is illegal for @p kind.
+[[nodiscard]] auto DefaultAdjustmentPanel(EditorNodeKind kind) -> std::string_view;
+
+[[nodiscard]] auto AdjustmentPanelIsSupported(EditorNodeKind kind, std::string_view panel) -> bool;
+
+/// True when @p field_key may be submitted or projected for @p kind.
+[[nodiscard]] auto AdjustmentFieldIsSupported(EditorNodeKind kind, std::string_view field_key)
+    -> bool;
+
+/**
+ * @brief Fill a production target from the selected node, not PrimaryGrade.
+ *
+ * Geometry stays document-owned and is accepted only when @p selected_node_id
+ * is Develop. Color Grade fields require that node to be the owning Grade.
+ * Missing nodes or instances fail; the first operator of a type on another
+ * node is never substituted.
+ *
+ * @pre Caller holds the executor render lock when @p document is live.
+ */
+[[nodiscard]] auto CompleteSelectedNodeParameterTarget(const PipelineDocument& document,
+                                                       const NodeId& selected_node_id,
+                                                       std::string field_key, std::string* error)
+    -> std::optional<EditorParameterTarget>;
+
+/**
+ * @brief Supported production adapter targets for @p selected_node_id.
+ *
+ * @return nullopt when the node is missing or a supported instance cannot be
+ *         resolved. Output is unchanged by the caller on failure.
+ */
+[[nodiscard]] auto SelectedNodeProjectionTargets(const PipelineDocument& document,
+                                                 const NodeId& selected_node_id, std::string* error)
+    -> std::optional<std::vector<EditorParameterTarget>>;
+
+/**
+ * @brief Project every supported panel field for @p selected_node_id in one read.
+ *
+ * Failure leaves @p out unchanged. Does not call Model ToJson, LoadJson, or
+ * MakeFullDto.
+ *
+ * @pre Caller holds the executor render lock when @p document is live.
+ */
+auto ProjectSelectedNodePanelFields(const PipelineDocument& document, const NodeId& selected_node_id,
+                                    std::uint64_t session_generation, EditorPanelProjection* out,
+                                    std::string* error) -> bool;
+
+/**
+ * @brief Copy selected-node identity, capabilities, and caller-supplied EXIF.
+ *
+ * @p exif must already be read from the current Image. This function does not
+ * look up Image or parse metadata. Returns nullopt when the node is missing.
+ */
+[[nodiscard]] auto MakeEditorAdjustmentContext(const PipelineDocument& document,
+                                               const NodeId& selected_node_id,
+                                               EditorImageExifDisplay exif)
+    -> std::optional<EditorAdjustmentContext>;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_session_command_queue.hpp
+++ b/alcedo_studio/src/include/app/editor_session_command_queue.hpp
@@ -59,6 +59,7 @@ enum class EditorSessionCommandKind : std::uint8_t {
   SetPresentationTarget,
   SetPresentationSize,
   SetGeometryOverlay,
+  SetAdjustmentProjectionNode,
   RenameColorGrade,
   EditNodeGraph,
 };

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -157,6 +157,17 @@ class IEditorHistoryPort {
     return true;
   }
 
+  /**
+   * @brief Replace load-only panel values with the selected node's fields.
+   *
+   * Does not mutate parameters, commit history, or request a photo render.
+   * Default fakes succeed without storing a node.
+   */
+  virtual auto SetPanelProjectionNode(const EditorHistoryGuardHandle& /*guard*/,
+                                      const NodeId& /*node_id*/, std::string* /*error*/) -> bool {
+    return true;
+  }
+
   /// Switch the checked-out Version after a successful save checkpoint. Rebuilds
   /// the live pipeline from root + first-parent chain and refreshes the
   /// adjustment snapshot. Default rejects so fakes must opt in.

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -161,10 +161,13 @@ class IEditorHistoryPort {
    * @brief Replace load-only panel values with the selected node's fields.
    *
    * Does not mutate parameters, commit history, or request a photo render.
+   * Must not wait on the live render lock or an inflight present handshake.
    * Default fakes succeed without storing a node.
    */
   virtual auto SetPanelProjectionNode(const EditorHistoryGuardHandle& /*guard*/,
-                                      const NodeId& /*node_id*/, std::string* /*error*/) -> bool {
+                                      const NodeId& /*node_id*/,
+                                      std::uint64_t /*session_generation*/,
+                                      std::string* /*error*/) -> bool {
     return true;
   }
 

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -112,6 +112,20 @@ class IEditorSessionBackend {
   /// Keep geometry editing on the source-frame overlay until the panel closes.
   /// Backends that do not render through the unified session path may ignore it.
   virtual void SetGeometryOverlayActive(bool /*active*/) {}
+  /**
+   * @brief Reproject load-only panel values from @p node_id.
+   *
+   * Does not enqueue an edit, commit history, or render. Default fakes accept
+   * without changing stored projection.
+   */
+  virtual auto SetAdjustmentProjectionNode(const NodeId& /*node_id*/) -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Accepted;
+    result.state    = state();
+    result.identity = identity();
+    result.message  = "Adjustment projection node ignored";
+    return result;
+  }
   virtual auto Open(sl_element_id_t element_id, image_id_t image_id) -> EditorSessionResult   = 0;
   virtual auto Switch(sl_element_id_t element_id, image_id_t image_id) -> EditorSessionResult = 0;
   /// Check out another Version on the open image after a save checkpoint.
@@ -450,6 +464,7 @@ class EditorSessionService final : public IEditorSessionBackend {
   auto EnqueueAdjustmentInput(EditorAdjustmentPatch patch) -> EditorSessionResult override;
   auto EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind kind)
       -> EditorSessionResult override;
+  auto SetAdjustmentProjectionNode(const NodeId& node_id) -> EditorSessionResult override;
   [[nodiscard]] auto PeekPendingInput() const -> EditorPendingInputView override;
   void               TryConsumePendingInput() override;
   void SetAdmissionDeadlineHandler(std::function<void(std::int64_t delay_ns)> handler) override;

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -115,8 +115,9 @@ class IEditorSessionBackend {
   /**
    * @brief Reproject load-only panel values from @p node_id.
    *
-   * Does not enqueue an edit, commit history, or render. Default fakes accept
-   * without changing stored projection.
+   * Does not enqueue an edit, commit history, or render. Does not wait for an
+   * inflight frame or take the live render lock.
+   * Default fakes accept without changing stored projection.
    */
   virtual auto SetAdjustmentProjectionNode(const NodeId& /*node_id*/) -> EditorSessionResult {
     EditorSessionResult result;

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -15,6 +15,7 @@
 #include "edit/runtime/node_result_cache.hpp"
 #include "edit/runtime/parameter_arena.hpp"
 #include "edit/runtime/result_persistence.hpp"
+#include "edit/runtime/result_representation.hpp"
 #include "edit/runtime/runtime_invalidation.hpp"
 #include "edit/runtime/runtime_revision.hpp"
 #include "edit/runtime/texture_pool.hpp"
@@ -104,6 +105,10 @@ class BasicRenderWorkspace {
       return;
     }
     invalidation_.CollectAndPropagate(plan, document, input, active_raster_masks);
+    // BeginRender waited for the previous submission. Retire invalid results
+    // even when sensor Develop is a cache hit; matching allocations remain reusable.
+    DropUnusablePublishedImages();
+    textures_.ReleaseUnleasedUnusedSizes();
     validity_prepared_ = true;
   }
   /**
@@ -115,9 +120,7 @@ class BasicRenderWorkspace {
    * a still-displayed frame, keep those textures alive.
    */
   void ReleaseStalePublishedImagesAndIdleTextures() {
-    images_.DropStalePublished([this](const GraphValueId& id, RuntimeRevision revision) {
-      return invalidation_.HasCurrentRevision(id, revision);
-    });
+    DropUnusablePublishedImages();
     textures_.ReleaseUnleased();
   }
 
@@ -144,10 +147,13 @@ class BasicRenderWorkspace {
             ? device_memory.total_bytes - device_memory.free_bytes
             : 0;
     std::fprintf(stderr,
-                 "[GPU_POOL] %s textures=%.1f MiB n=%zu  transient=%.1f/%.1f MiB  "
+                 "[GPU_POOL] %s textures=%.1f MiB n=%zu leased=%.1f unleased=%.1f MiB  "
+                 "transient=%.1f/%.1f MiB  "
                  "images=pub%zu/write%zu  values=%.1f n=%zu  masks=%.1f n=%zu",
                  reason == nullptr ? "" : reason, GpuPoolMiB(textures_.UsedBytes()),
                  textures_.EntryCount(),
+                 GpuPoolMiB(textures_.LeasedBytes()),
+                 GpuPoolMiB(textures_.UsedBytes() - textures_.LeasedBytes()),
                  GpuPoolMiB(transients_.used_bytes()), GpuPoolMiB(transients_.capacity_bytes()),
                  images_.PublishedCount(), images_.UnpublishedCount(),
                  GpuPoolMiB(values_.UsedBytes()), values_.Size(),
@@ -176,7 +182,11 @@ class BasicRenderWorkspace {
   }
 
   /**
-   * @brief Drop an unpublished image after its last consumer. GPU last-use must already be done.
+   * @brief Return an unpublished image to the pool after its last encoded reader.
+   *
+   * Further reuse must be on the same ordered GPU queue. This drops a lease, not
+   * native memory; the pool keeps this-frame entries alive until GPU completion.
+   * Published results are never released by this operation.
    */
   void ReleaseConsumedImage(const GraphValueId& id) { images_.ReleaseWrite(id); }
 
@@ -210,6 +220,7 @@ class BasicRenderWorkspace {
     if (!rendering_) {
       throw std::runtime_error("BasicRenderWorkspace::EndRender: not rendering");
     }
+    textures_.ReleaseUnused();
     textures_.MarkSubmitted(command_context.SubmissionId());
     mask_textures_.MarkSubmitted(command_context.SubmissionId());
     active_raster_textures_.MarkSubmitted(command_context.SubmissionId());
@@ -276,6 +287,29 @@ class BasicRenderWorkspace {
   [[nodiscard]] auto ParameterLayoutHash() const -> std::uint64_t { return parameter_layout_hash_; }
 
  private:
+  /**
+   * @brief Drop published images that this frame cannot reuse.
+   *
+   * Revision mismatches are always dropped. Interactive frames also drop results
+   * whose representation identity no longer matches (crop, viewport, decode).
+   * QualityBase keeps revision-current Interactive results even when this frame's
+   * extent differs.
+   */
+  void DropUnusablePublishedImages() {
+    images_.DropStalePublished([this](const GraphValueId& id, RuntimeRevision revision,
+                                      const ResultRepresentation& published) {
+      if (!invalidation_.HasCurrentRevision(id, revision)) {
+        return false;
+      }
+      if (persistence_scope_ == ResultPersistenceScope::SensorDevelopOnly) {
+        return true;
+      }
+      const auto needed = invalidation_.MakeImageRepresentation(
+          id, published.extent, published.format, published.source_detail);
+      return RepresentationSatisfies(published, needed);
+    });
+  }
+
   Backend                       backend_{};
   ParameterArena<Backend>       parameters_;
   TransientBufferArena<Backend> transients_;

--- a/alcedo_studio/src/include/edit/runtime/drt_post_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/drt_post_executor.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "edit/graph/drt_node_model.hpp"
+#include "edit/graph/graph_ids.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/operators/models/pending_parameter_patch.hpp"
 #include "edit/runtime/adjustment_runtime.hpp"
@@ -163,6 +164,9 @@ class DrtPostExecutor {
       NeighborExecutor<Ops>::Execute(device, scene_id, dest, lut, works[index], width, height);
       scene_id = dest;
     }
+    // Last readers of the neighborhood pair are ordered before the next pass.
+    device.Workspace().ReleaseConsumedImage(GraphValueId{drt_id, PortId{"runtime.ping"}});
+    device.Workspace().ReleaseConsumedImage(GraphValueId{drt_id, PortId{"runtime.pong"}});
     return scene_id;
   }
 

--- a/alcedo_studio/src/include/edit/runtime/grade_executor.hpp
+++ b/alcedo_studio/src/include/edit/runtime/grade_executor.hpp
@@ -137,10 +137,12 @@ class GradeExecutor {
     if (schedule.gpu_write_count > 0) {
       (void)Ops::AcquireOutput(device, compiled_grade.scene_output, width, height);
     }
-    typename Ops::Scratch ping = need_ping ? Ops::AcquireScratch(device, width, height, ping_id)
-                                           : typename Ops::Scratch{};
-    typename Ops::Scratch pong = need_pong ? Ops::AcquireScratch(device, width, height, pong_id)
-                                           : typename Ops::Scratch{};
+    if (need_ping) {
+      (void)Ops::AcquireScratch(device, width, height, ping_id);
+    }
+    if (need_pong) {
+      (void)Ops::AcquireScratch(device, width, height, pong_id);
+    }
 
     auto Resolve = [&](GradeImageSlot slot) -> typename Ops::Texture& {
       switch (slot) {
@@ -149,9 +151,9 @@ class GradeExecutor {
         case GradeImageSlot::Output:
           return Ops::SceneTexture(device, compiled_grade.scene_output);
         case GradeImageSlot::Ping:
-          return Ops::ScratchTexture(ping);
+          return Ops::SceneTexture(device, ping_id);
         case GradeImageSlot::Pong:
-          return Ops::ScratchTexture(pong);
+          return Ops::SceneTexture(device, pong_id);
       }
       throw std::runtime_error(std::string{Ops::kErrorPrefix} + ": invalid grade image slot");
     };
@@ -217,6 +219,11 @@ class GradeExecutor {
       Ops::DispatchMix(device, source, adjusted, destination, mix, mask, width, height);
     }
     Ops::CheckAfterEncode(device);
+    // Last readers are now ordered before the next Grade. Release only scratch
+    // leases so later stages can reuse the pair without a device synchronization.
+    // On an encode failure the render owner's cancellation discards all writes.
+    workspace.ReleaseConsumedImage(ping_id);
+    workspace.ReleaseConsumedImage(pong_id);
     return result;
   }
 };

--- a/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
@@ -30,9 +30,9 @@ namespace alcedo {
  * ResourceId is allocation reuse, not a content hit. Not thread-safe. One
  * in-flight submission.
  *
- * Published results whose required revision still matches are retained. Stale
- * published results are dropped before a Develop rewrite; idle pool textures
- * are destroyed by TexturePool::ReleaseUnleased after GPU last-use.
+ * Callers drop published results that this frame cannot reuse. Stale published
+ * results are dropped after collecting each frame's required revisions. Idle
+ * pool textures from obsolete extents are reclaimed after GPU last-use.
  *
  * @tparam Backend Texture factory used by TexturePool.
  */
@@ -238,7 +238,8 @@ class GraphImageCache {
    * @brief Drop the unpublished write of @p id and return its texture to the pool.
    *
    * Published results are unchanged. No-op when @p id has no write slot.
-   * Caller must satisfy GPU last-use of that texture first.
+   * The last reader must already be encoded on the same ordered GPU queue as any
+   * subsequent reuse, or completed. This releases a lease, not device memory.
    */
   void ReleaseWrite(const GraphValueId& id) { write_slots_.erase(id); }
 
@@ -323,14 +324,14 @@ class GraphImageCache {
   /**
    * @brief Drop published results for which @p is_current is false.
    *
-   * @p is_current receives (id, published revision). Extra leases on those
-   * textures, including a still-displayed frame, keep the device memory.
-   * GPU last-use of dropped results must already be complete.
+   * @p is_current receives (id, published revision, published representation).
+   * Extra leases on those textures, including a still-displayed frame, keep the
+   * device memory. GPU last-use of dropped results must already be complete.
    */
   template <class IsCurrent>
   void DropStalePublished(IsCurrent&& is_current) {
     for (auto it = published_.begin(); it != published_.end();) {
-      if (is_current(it->first, it->second.revision)) {
+      if (is_current(it->first, it->second.revision, it->second.representation)) {
         ++it;
         continue;
       }

--- a/alcedo_studio/src/include/edit/runtime/texture_pool.hpp
+++ b/alcedo_studio/src/include/edit/runtime/texture_pool.hpp
@@ -7,9 +7,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <deque>
+#include <set>
 #include <stdexcept>
+#include <tuple>
 #include <utility>
-#include <vector>
 
 #include "edit/runtime/texture_format.hpp"
 #include "gpu/gpu_pool_trace.hpp"
@@ -73,7 +75,12 @@ struct TextureRequest {
 /**
  * @brief Reusable GPU textures. Matching free entries are recycled; otherwise allocate.
  *
- * Idle unleased textures are destroyed by @ref ReleaseUnleased after GPU last-use.
+ * Idle textures not used by this frame are reclaimed on allocation misses and at
+ * frame end. Idle extents that no live lease still uses are reclaimed after GPU
+ * last-use even when used_this_frame is still set from the last acquire.
+ * Current-size scratch stays reusable while a result of that size remains leased.
+ * Leased texture references remain stable when the pool grows. Reuse within a
+ * frame requires one ordered GPU queue.
  * Not thread-safe. @p Backend must provide Texture2D, CreateTexture2D, and
  * IsResourceBusy(submitted_on_submission_id).
  */
@@ -105,6 +112,7 @@ class TexturePool {
     if (auto* reusable = FindReusable(request)) {
       return TakeLease(*reusable);
     }
+    ReleaseUnused();
     const auto bytes = TextureBytes(request);
     auto texture = backend_->CreateTexture2D(request.width, request.height, request.format);
     Entry entry;
@@ -113,6 +121,13 @@ class TexturePool {
     entry.bytes           = bytes;
     entry.handle          = next_handle_++;
     entry.alive           = true;
+    for (auto& vacant : entries_) {
+      if (!vacant.alive) {
+        vacant = std::move(entry);
+        used_bytes_ += bytes;
+        return TakeLease(vacant);
+      }
+    }
     entries_.push_back(std::move(entry));
     used_bytes_ += bytes;
     return TakeLease(entries_.back());
@@ -161,6 +176,17 @@ class TexturePool {
     return count;
   }
 
+  /// Bytes pinned by image results, active scratch, or external presentation leases.
+  [[nodiscard]] auto LeasedBytes() const -> std::size_t {
+    std::size_t bytes = 0;
+    for (const auto& entry : entries_) {
+      if (entry.alive && entry.lease_count > 0) {
+        bytes += entry.bytes;
+      }
+    }
+    return bytes;
+  }
+
   void ReleaseLease(std::uint64_t handle) {
     auto* entry = Find(handle);
     if (entry == nullptr || entry->lease_count == 0) {
@@ -198,9 +224,52 @@ class TexturePool {
       if (backend_->IsResourceBusy(entry.submitted_on)) {
         continue;
       }
-      used_bytes_ -= entry.bytes;
-      entry.texture = {};
-      entry.alive   = false;
+      Destroy(entry);
+    }
+  }
+
+  /**
+   * @brief Destroy idle, unleased entries that this frame has not used.
+   *
+   * Called before allocating a new extent and after encoding a frame. Scratch
+   * already referenced by recorded work remains alive, even before submission.
+   * Outstanding GPU submissions and external leases also prevent destruction.
+   */
+  void ReleaseUnused() {
+    for (auto& entry : entries_) {
+      if (!entry.alive || entry.lease_count > 0 || entry.used_this_frame ||
+          backend_->IsResourceBusy(entry.submitted_on)) {
+        continue;
+      }
+      Destroy(entry);
+    }
+  }
+
+  /**
+   * @brief Destroy idle textures whose size is not held by any live lease.
+   *
+   * Crop and viewport extent changes leave previous-size scratch unleased after
+   * the published result is dropped. Matching current-size scratch stays because
+   * a live lease still names that extent. The this-frame use flag does not keep an
+   * obsolete size: the last acquire may still have that flag when Interactive
+   * identity-drops a result in the same session. Caller must WaitIdle first so
+   * GPU last-use of the previous submission has completed.
+   */
+  void ReleaseUnleasedUnusedSizes() {
+    std::set<ExtentKey> leased_extents;
+    for (const auto& entry : entries_) {
+      if (entry.alive && entry.lease_count > 0) {
+        leased_extents.insert(MakeExtentKey(entry.request));
+      }
+    }
+    for (auto& entry : entries_) {
+      if (!entry.alive || entry.lease_count > 0 || backend_->IsResourceBusy(entry.submitted_on)) {
+        continue;
+      }
+      if (leased_extents.contains(MakeExtentKey(entry.request))) {
+        continue;
+      }
+      Destroy(entry);
     }
   }
 
@@ -240,9 +309,30 @@ class TexturePool {
     bool                        alive           = false;
   };
 
+  struct ExtentKey {
+    std::uint32_t width  = 0;
+    std::uint32_t height = 0;
+    TextureFormat format = TextureFormat::R8;
+
+    friend auto operator<(const ExtentKey& lhs, const ExtentKey& rhs) -> bool {
+      return std::tie(lhs.width, lhs.height, lhs.format) <
+             std::tie(rhs.width, rhs.height, rhs.format);
+    }
+  };
+
+  static auto MakeExtentKey(const TextureRequest& request) -> ExtentKey {
+    return ExtentKey{request.width, request.height, request.format};
+  }
+
   static auto TextureBytes(const TextureRequest& request) -> std::size_t {
     return static_cast<std::size_t>(request.width) * request.height *
            TextureFormatBytesPerPixel(request.format);
+  }
+
+  void Destroy(Entry& entry) {
+    used_bytes_ -= entry.bytes;
+    entry.texture = {};
+    entry.alive   = false;
   }
 
   auto Find(std::uint64_t handle) -> Entry* {
@@ -269,7 +359,7 @@ class TexturePool {
 
   auto FindReusable(const TextureRequest& request) const -> const Entry* {
     for (const auto& entry : entries_) {
-      if (!entry.alive || entry.lease_count > 0) {
+      if (!entry.alive || entry.lease_count > 0 || backend_->IsResourceBusy(entry.submitted_on)) {
         continue;
       }
       if (entry.request.width != request.width || entry.request.height != request.height ||
@@ -288,7 +378,7 @@ class TexturePool {
   }
 
   Backend*           backend_      = nullptr;
-  std::vector<Entry> entries_;
+  std::deque<Entry> entries_;
   std::size_t        used_bytes_   = 0;
   std::uint64_t      next_handle_  = 1;
 };

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
@@ -101,6 +101,10 @@ class EditorHistoryMutation {
   auto CheckoutVersion(const alcedo::EditorHistoryGuardHandle& guard,
                        const alcedo::Hash128& version_id, std::string* error) -> bool;
 
+  /// Replace panel_projection from @p node_id without mutating parameters.
+  auto SetPanelProjectionNode(const alcedo::EditorHistoryGuardHandle& guard,
+                              const alcedo::NodeId& node_id, std::string* error) -> bool;
+
  private:
   EditorHistoryState& state_;
 };

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
@@ -101,9 +101,11 @@ class EditorHistoryMutation {
   auto CheckoutVersion(const alcedo::EditorHistoryGuardHandle& guard,
                        const alcedo::Hash128& version_id, std::string* error) -> bool;
 
-  /// Replace panel_projection from @p node_id without mutating parameters.
+  /// Replace panel_projection from @p node_id without mutating parameters,
+  /// creating history state, or taking the live render lock.
   auto SetPanelProjectionNode(const alcedo::EditorHistoryGuardHandle& guard,
-                              const alcedo::NodeId& node_id, std::string* error) -> bool;
+                              const alcedo::NodeId& node_id, std::uint64_t session_generation,
+                              std::string* error) -> bool;
 
  private:
   EditorHistoryState& state_;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_shared_helpers.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_shared_helpers.hpp
@@ -31,6 +31,7 @@ namespace alcedo::ui {
 /// Acquire sole live-pipeline ownership (`render_lock_`). History waits for
 /// render to finish the current frame. The GUI must not block on this: session
 /// code defers Version ops until render is idle, then takes the lock (free).
+/// Selection / panel projection must never call this.
 auto LockLivePipeline(alcedo::CPUPipelineExecutor& executor) -> std::unique_lock<std::mutex>;
 
 /// Stable field names shared by the editor models and the adjustment-transfer /

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_state_detail.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_state_detail.hpp
@@ -38,7 +38,8 @@ class EditorSessionPipelinePort;
 /// Per-image history state owned by the queue-thread history unit. The command
 /// queue is the sole mutation owner for graph, redo, pending-before, and
 /// committed-snapshot fields. Live parameter writes go to pipeline_guard->document_.
-/// Document reads/writes and rendering use the same executor render lock.
+/// Parameter writes, Version ops, and rendering share the executor render lock.
+/// Load-only selected-node panel projection reads Models without that lock.
 struct HistoryWorkingState {
   std::shared_ptr<alcedo::PipelineGuard> pipeline_guard;
   std::shared_ptr<alcedo::MiniGitJournal> journal;
@@ -54,8 +55,9 @@ struct HistoryWorkingState {
   std::unordered_map<alcedo::Hash128, DocumentFieldEdit> document_edit_by_commit;
   alcedo::EditorRenderAdjustmentSnapshot root_snapshot;
   alcedo::EditorRenderAdjustmentSnapshot committed_snapshot;
-  /// Load-only panel values copied from live Models under the render lock.
-  /// Not a live Model pointer and not a writable parameter mirror.
+  /// Load-only panel values copied from live Models. Not a live Model pointer
+  /// and not a writable parameter mirror. Selected-node copies do not take the
+  /// render lock.
   alcedo::EditorPanelProjection panel_projection;
   /// Node last requested for panel projection. Empty means current-panel owners.
   alcedo::NodeId panel_projection_node_id;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_state_detail.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_state_detail.hpp
@@ -57,6 +57,8 @@ struct HistoryWorkingState {
   /// Load-only panel values copied from live Models under the render lock.
   /// Not a live Model pointer and not a writable parameter mirror.
   alcedo::EditorPanelProjection panel_projection;
+  /// Node last requested for panel projection. Empty means current-panel owners.
+  alcedo::NodeId panel_projection_node_id;
   bool recovered_head = false;
   /// Required for ReplaceMaskAsset undo/redo. Not owned.
   alcedo::MaskStore* mask_store = nullptr;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -126,6 +126,8 @@ class EditorNodeController : public QObject {
    * @param node_id Product NodeId string.
    */
   Q_INVOKABLE void selectNode(const QString& node_id);
+  /// Select the panel owner, returning to the last live Color Grade when possible.
+  void SelectNodeForAdjustmentPanel(const QString& panel);
   Q_INVOKABLE void selectPreviousBackboneNode();
   Q_INVOKABLE void selectNextBackboneNode();
   Q_INVOKABLE void selectDevelop();
@@ -298,6 +300,7 @@ class EditorNodeController : public QObject {
   EditorNodeGraphSnapshot                             snapshot_{};
   bool                                                has_snapshot_ = false;
   NodeId                                              selected_node_id_;
+  NodeId                                              last_selected_color_grade_id_;
   NodeId                                              selection_restore_node_id_;
   bool                                                command_active_          = false;
   bool                                                projection_apply_queued_ = false;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -239,9 +239,12 @@ class EditorNodeController : public QObject {
   void               OnSessionHistoryChanged();
   void               ClearSnapshot();
   void               SetLastError(QString error);
-  void               RestoreSelectionAfterSnapshot();
+  /// @p select_default_color_grade is true only for a new image-load generation.
+  /// Topology edits that drop the current node leave selection empty.
+  void               RestoreSelectionAfterSnapshot(bool select_default_color_grade);
   void               SyncSessionAdjustmentNode(bool seal_open_sequence);
   [[nodiscard]] auto ContainsNode(const NodeId& node_id) const -> bool;
+  /// Product default Color Grade (`grade.primary`) when that node exists.
   [[nodiscard]] auto DefaultSelectedNodeId() const -> NodeId;
   [[nodiscard]] auto IndexOf(const NodeId& node_id) const -> int;
   [[nodiscard]] auto NodeFor(const NodeId& node_id) const -> const EditorNodeProjection*;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -240,6 +240,7 @@ class EditorNodeController : public QObject {
   void               ClearSnapshot();
   void               SetLastError(QString error);
   void               RestoreSelectionAfterSnapshot();
+  void               SyncSessionAdjustmentNode(bool seal_open_sequence);
   [[nodiscard]] auto ContainsNode(const NodeId& node_id) const -> bool;
   [[nodiscard]] auto DefaultSelectedNodeId() const -> NodeId;
   [[nodiscard]] auto IndexOf(const NodeId& node_id) const -> int;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -17,6 +17,7 @@
 
 #include "app/adjustment_transfer_types.hpp"
 #include "app/editor_history_types.hpp"
+#include "app/editor_node_graph_projection.hpp"
 #include "app/editor_pending_input.hpp"
 #include "app/editor_session_types.hpp"
 #include "edit/graph/graph_ids.hpp"
@@ -35,6 +36,7 @@ struct NodeGraphTopologyChange;
 namespace alcedo::ui {
 class IAlbumCatalog;
 class InteractionPolicyController;
+class EditorNodeController;
 }  // namespace alcedo::ui
 
 namespace alcedo::ui {
@@ -194,6 +196,11 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   /// Queue a node-switch seal so later writes start a new sequence. Old
   /// sequence ids keep their captured target. No live mutation.
   Q_INVOKABLE bool   enqueueNodeSwitchBoundary();
+  /// Bind the Nodes-page selection owner used to stamp submit targets.
+  void               BindNodeSelectionSource(EditorNodeController* nodes);
+  /// Reproject panels for the selected node without rendering or committing.
+  void ApplySelectedAdjustmentNode(const alcedo::NodeId& node_id, alcedo::EditorNodeKind kind);
+  [[nodiscard]] auto PeekPendingInput() const -> alcedo::EditorPendingInputView;
   [[nodiscard]] auto canEdit() const -> bool override { return can_edit(); }
 
   Q_INVOKABLE void   Open(uint elementId = 0, uint imageId = 0);
@@ -312,13 +319,15 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
                                      const QString&                     selected_id = {});
   /// Correlate an async backend result observer delivery to a pending action.
   void OnBackendSessionResult(const alcedo::EditorSessionResult& result);
-  void BindAdmissionDeadline();
+  void                     BindAdmissionDeadline();
+  void                     SetActiveAdjustmentPanel(const QString& panel, bool request_view);
   [[nodiscard]] static auto       NormalizeAdjustmentPanel(const QString& panel) -> QString;
   [[nodiscard]] static auto       NormalizeToolPanelPage(const QString& page) -> QString;
 
   alcedo::IEditorSessionBackend*  session_backend_    = nullptr;
   InteractionPolicyController*    interaction_policy_ = nullptr;
   IAlbumCatalog*                  album_catalog_      = nullptr;
+  QPointer<EditorNodeController>  node_controller_;
   EditorActionAvailabilityModel   actions_;
   /// Focused correlator for history/Version operation events (R4). Owns
   /// operation ids, pending-async state, and the last published map.

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -135,7 +136,8 @@ class EditorSessionHistoryPort final : public alcedo::IEditorHistoryPort {
                            alcedo::EditorPanelProjection* projection, std::string* error)
       -> bool override;
   auto SetPanelProjectionNode(const alcedo::EditorHistoryGuardHandle& guard,
-                              const alcedo::NodeId& node_id, std::string* error) -> bool override;
+                              const alcedo::NodeId& node_id, std::uint64_t session_generation,
+                              std::string* error) -> bool override;
   auto CaptureSaveCheckpoint(const alcedo::EditorHistoryGuardHandle& guard, std::string* error)
       -> std::shared_ptr<const alcedo::EditorMiniGitSaveCapture> override;
   auto DiscardMaterializedJournalThrough(const alcedo::EditorHistoryGuardHandle& guard,

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
@@ -134,6 +134,8 @@ class EditorSessionHistoryPort final : public alcedo::IEditorHistoryPort {
   auto ReadPanelProjection(const alcedo::EditorHistoryGuardHandle& guard,
                            alcedo::EditorPanelProjection* projection, std::string* error)
       -> bool override;
+  auto SetPanelProjectionNode(const alcedo::EditorHistoryGuardHandle& guard,
+                              const alcedo::NodeId& node_id, std::string* error) -> bool override;
   auto CaptureSaveCheckpoint(const alcedo::EditorHistoryGuardHandle& guard, std::string* error)
       -> std::shared_ptr<const alcedo::EditorMiniGitSaveCapture> override;
   auto DiscardMaterializedJournalThrough(const alcedo::EditorHistoryGuardHandle& guard,

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "app/editor_adjustment_context.hpp"
+#include "app/editor_session_ports.hpp"
 #include "app/editor_adjustment_pipeline.hpp"
 #include "app/editor_panel_projection.hpp"
 #include "app/editor_pipeline_command_service.hpp"
@@ -1076,28 +1077,27 @@ auto EditorHistoryMutation::CheckoutVersion(const alcedo::EditorHistoryGuardHand
 
 auto EditorHistoryMutation::SetPanelProjectionNode(const alcedo::EditorHistoryGuardHandle& guard,
                                                    const alcedo::NodeId& node_id,
+                                                   std::uint64_t session_generation,
                                                    std::string* error) -> bool {
-  auto state = state_.EnsureWorkingState(guard.element_id, error);
+  auto state = state_.PeekWorkingState(guard.element_id);
   if (!state) {
+    if (error) *error = "Editor history working state is unavailable";
     return false;
+  }
+  if (node_id.Empty()) {
+    state->panel_projection_node_id = {};
+    state->panel_projection         = {};
+    return true;
   }
   if (!state->pipeline_guard || !state->pipeline_guard->document_) {
     if (error) *error = "Live pipeline document is unavailable";
     return false;
   }
-  if (!state->pipeline_guard->pipeline_) {
-    if (error) *error = "Live pipeline executor is unavailable";
-    return false;
-  }
   try {
-    auto render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
     alcedo::EditorPanelProjection next;
     const auto& document = *state->pipeline_guard->document_;
-    const bool ok =
-        node_id.Empty()
-            ? alcedo::ProjectCurrentPanelFields(document, 0, &next, error)
-            : alcedo::ProjectSelectedNodePanelFields(document, node_id, 0, &next, error);
-    if (!ok) {
+    if (!alcedo::ProjectSelectedNodePanelFields(document, node_id, session_generation, &next,
+                                                error)) {
       return false;
     }
     state->panel_projection_node_id = node_id;

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "app/editor_adjustment_context.hpp"
 #include "app/editor_adjustment_pipeline.hpp"
 #include "app/editor_panel_projection.hpp"
 #include "app/editor_pipeline_command_service.hpp"
@@ -36,7 +37,32 @@ void SyncUnsettledPreviewFlag(HistoryWorkingState& state) {
   }
 }
 
-/// Refresh committed_snapshot from the live pipeline after a successful history mutation.
+[[nodiscard]] auto PanelFieldMatchesProjectionNode(const PipelineDocument& document,
+                                                    const NodeId& projection_node,
+                                                    const EditorParameterTarget& target) -> bool {
+  if (projection_node.Empty()) {
+    return true;
+  }
+  if (target.owner_kind == EditorParameterOwnerKind::Document) {
+    const auto* develop = document.Develop();
+    return develop != nullptr && develop->Id() == projection_node;
+  }
+  return target.node_id == projection_node;
+}
+
+auto ProjectPanelFieldsForState(HistoryWorkingState& state, std::string* error) -> bool {
+  if (state.pipeline_guard == nullptr || state.pipeline_guard->document_ == nullptr) {
+    state.panel_projection = {};
+    return true;
+  }
+  const auto& document = *state.pipeline_guard->document_;
+  if (!state.panel_projection_node_id.Empty()) {
+    return alcedo::ProjectSelectedNodePanelFields(document, state.panel_projection_node_id, 0,
+                                                 &state.panel_projection, error);
+  }
+  return alcedo::ProjectCurrentPanelFields(document, 0, &state.panel_projection, error);
+}
+
 /// Prefer live GetOperator/GetParams over root_snapshot + SnapshotAtHead (plan §4.7).
 auto RefreshCommittedSnapshotFromLive(HistoryWorkingState& state, std::string* error,
                                       bool holds_render_lock) -> bool {
@@ -57,8 +83,7 @@ auto RefreshCommittedSnapshotFromLive(HistoryWorkingState& state, std::string* e
       state.panel_projection = {};
       return true;
     }
-    return alcedo::ProjectCurrentPanelFields(*state.pipeline_guard->document_, 0,
-                                             &state.panel_projection, error);
+    return ProjectPanelFieldsForState(state, error);
   } catch (const std::exception& ex) {
     if (error) *error = ex.what();
     return false;
@@ -90,6 +115,10 @@ void ProjectDocumentEdit(HistoryWorkingState&                          state,
                           HistoryParams(edit.target, params), true);
   state.committed_snapshot.params_json.clear();
   if (state.pipeline_guard != nullptr && state.pipeline_guard->document_ != nullptr) {
+    if (!PanelFieldMatchesProjectionNode(*state.pipeline_guard->document_,
+                                         state.panel_projection_node_id, edit.target)) {
+      return;
+    }
     alcedo::EditorPanelFieldPresentation field;
     std::string                          ignore;
     if (alcedo::ReadEditorPanelField(*state.pipeline_guard->document_, edit.target, &field,
@@ -357,10 +386,18 @@ auto EditorHistoryMutation::CaptureAdjustmentBeforePreview(
   HistoryWorkingState::DocumentFieldEdit edit;
   if (sequence == state->pending_document_sequence.end()) {
     if (patch.target.owner_kind == alcedo::EditorParameterOwnerKind::Unspecified) {
-      auto filled = alcedo::CompleteCurrentPanelParameterTarget(*state->pipeline_guard->document_,
-                                                                patch.field_key, error);
-      if (!filled.has_value()) return false;
-      edit.target = std::move(*filled);
+      if (!state->panel_projection_node_id.Empty()) {
+        auto filled = alcedo::CompleteSelectedNodeParameterTarget(
+            *state->pipeline_guard->document_, state->panel_projection_node_id, patch.field_key,
+            error);
+        if (!filled.has_value()) return false;
+        edit.target = std::move(*filled);
+      } else {
+        auto filled = alcedo::CompleteCurrentPanelParameterTarget(*state->pipeline_guard->document_,
+                                                                  patch.field_key, error);
+        if (!filled.has_value()) return false;
+        edit.target = std::move(*filled);
+      }
     } else {
       const auto target_error =
           alcedo::DescribeEditorParameterTargetError(patch.target, patch.field_key);
@@ -389,7 +426,9 @@ auto EditorHistoryMutation::CaptureAdjustmentBeforePreview(
   {
     alcedo::EditorPanelFieldPresentation field;
     std::string                          ignore;
-    if (alcedo::ReadEditorPanelField(*state->pipeline_guard->document_, edit.target, &field,
+    if (PanelFieldMatchesProjectionNode(*state->pipeline_guard->document_,
+                                        state->panel_projection_node_id, edit.target) &&
+        alcedo::ReadEditorPanelField(*state->pipeline_guard->document_, edit.target, &field,
                                      &ignore)) {
       alcedo::UpsertEditorPanelField(&state->panel_projection, std::move(field));
     }
@@ -1033,6 +1072,41 @@ auto EditorHistoryMutation::CheckoutVersion(const alcedo::EditorHistoryGuardHand
   state->pending_before.clear();
   state->recovered_head = false;
   return true;
+}
+
+auto EditorHistoryMutation::SetPanelProjectionNode(const alcedo::EditorHistoryGuardHandle& guard,
+                                                   const alcedo::NodeId& node_id,
+                                                   std::string* error) -> bool {
+  auto state = state_.EnsureWorkingState(guard.element_id, error);
+  if (!state) {
+    return false;
+  }
+  if (!state->pipeline_guard || !state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
+  }
+  if (!state->pipeline_guard->pipeline_) {
+    if (error) *error = "Live pipeline executor is unavailable";
+    return false;
+  }
+  try {
+    auto render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
+    alcedo::EditorPanelProjection next;
+    const auto& document = *state->pipeline_guard->document_;
+    const bool ok =
+        node_id.Empty()
+            ? alcedo::ProjectCurrentPanelFields(document, 0, &next, error)
+            : alcedo::ProjectSelectedNodePanelFields(document, node_id, 0, &next, error);
+    if (!ok) {
+      return false;
+    }
+    state->panel_projection_node_id = node_id;
+    state->panel_projection         = std::move(next);
+    return true;
+  } catch (const std::exception& ex) {
+    if (error) *error = ex.what();
+    return false;
+  }
 }
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_shared_helpers.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_shared_helpers.cpp
@@ -23,7 +23,8 @@ auto LockLivePipeline(alcedo::CPUPipelineExecutor& executor) -> std::unique_lock
   // lock after the full frame (configure + Apply + present). Do not call this
   // from the GUI thread while that thread is still required for present — the
   // session defers Version ops until render is idle so the GUI never blocks on
-  // render, only history queues for ownership.
+  // render, only history queues for ownership. Selected-node panel projection
+  // must never call this.
   return std::unique_lock<std::mutex>(executor.GetRenderLock());
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "app/editor_adjustment_context.hpp"
 #include "ui/alcedo_main/album_backend/alcedo_qan_graph.hpp"
 #include "ui/alcedo_main/album_backend/editor_node_graph_presentation.hpp"
 #include "ui/alcedo_main/album_backend/editor_node_layout_store.hpp"
@@ -157,15 +158,16 @@ void EditorNodeController::SetLastError(QString error) {
 
 void EditorNodeController::ClearSnapshot() {
   DiscardDraft();
-  snapshot_                  = {};
-  has_snapshot_              = false;
-  selected_node_id_          = {};
-  selection_restore_node_id_ = {};
-  session_generation_        = BoundSessionGeneration().value_or(0);
-  projection_revision_       = 0;
-  topology_revision_         = 0;
-  snapshot_element_id_       = 0;
-  snapshot_image_id_         = 0;
+  snapshot_                     = {};
+  has_snapshot_                 = false;
+  selected_node_id_             = {};
+  last_selected_color_grade_id_ = {};
+  selection_restore_node_id_    = {};
+  session_generation_           = BoundSessionGeneration().value_or(0);
+  projection_revision_          = 0;
+  topology_revision_            = 0;
+  snapshot_element_id_          = 0;
+  snapshot_image_id_            = 0;
   snapshot_version_id_.clear();
   emit SnapshotChanged();
   emit SelectionChanged();
@@ -265,6 +267,9 @@ void EditorNodeController::RestoreSelectionAfterSnapshot(bool select_default_col
 }
 
 void EditorNodeController::SyncSessionAdjustmentNode(bool seal_open_sequence) {
+  if (IsColorGrade(selected_node_id_)) {
+    last_selected_color_grade_id_ = selected_node_id_;
+  }
   if (session_ == nullptr) {
     return;
   }
@@ -355,9 +360,10 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
   const bool generation_changed =
       !has_snapshot_ || snapshot.session_generation != session_generation_;
   if (generation_changed) {
-    selection_restore_node_id_ = {};
-    session_generation_        = snapshot.session_generation;
-    topology_revision_         = snapshot.topology_revision == 0 ? 1 : snapshot.topology_revision;
+    last_selected_color_grade_id_ = {};
+    selection_restore_node_id_    = {};
+    session_generation_           = snapshot.session_generation;
+    topology_revision_   = snapshot.topology_revision == 0 ? 1 : snapshot.topology_revision;
     projection_revision_ = snapshot.projection_revision == 0 ? 1 : snapshot.projection_revision;
   } else if (TopologyChanged(snapshot)) {
     topology_revision_   = std::max(topology_revision_ + 1, snapshot.topology_revision);
@@ -677,6 +683,26 @@ void EditorNodeController::OnSessionHistoryChanged() {
     DiscardDraft();
   }
   refreshFromSession();
+}
+
+void EditorNodeController::SelectNodeForAdjustmentPanel(const QString& panel) {
+  const auto key = panel.toStdString();
+  const auto* selected = NodeFor(selected_node_id_);
+  if (selected != nullptr && AdjustmentPanelIsSupported(selected->node_kind, key)) {
+    return;
+  }
+  if (IsColorGrade(last_selected_color_grade_id_) &&
+      AdjustmentPanelIsSupported(EditorNodeKind::ColorGrade, key)) {
+    selectNode(NodeIdToQString(last_selected_color_grade_id_));
+    return;
+  }
+  for (const auto& node : ActiveNodes()) {
+    if (AdjustmentPanelIsSupported(node.node_kind, key)) {
+      selectNode(NodeIdToQString(node.node_id));
+      return;
+    }
+  }
+  SetLastError(tr("No node supports the selected adjustment panel"));
 }
 
 void EditorNodeController::selectNode(const QString& node_id) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -23,6 +23,15 @@
 namespace alcedo::ui {
 namespace {
 
+[[nodiscard]] auto HasQueuedFieldWrites(const alcedo::EditorPendingInputView& view) -> bool {
+  for (const auto& sequence : view.sequences) {
+    if (!sequence.fields.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 auto SameTopology(const EditorNodeGraphSnapshot& lhs, const EditorNodeGraphSnapshot& rhs) -> bool {
   if (lhs.nodes.size() != rhs.nodes.size() || lhs.edges.size() != rhs.edges.size()) {
     return false;
@@ -66,6 +75,9 @@ auto EditorNodeController::editor_session_object() const -> QObject* { return se
 auto EditorNodeController::session() const -> EditorSessionController* { return session_.data(); }
 
 void EditorNodeController::DisconnectSession() {
+  if (session_ != nullptr) {
+    session_->BindNodeSelectionSource(nullptr);
+  }
   if (state_connection_) {
     QObject::disconnect(state_connection_);
     state_connection_ = {};
@@ -89,6 +101,7 @@ void EditorNodeController::set_editor_session(QObject* session) {
   DisconnectSession();
   session_ = typed;
   if (session_ != nullptr) {
+    session_->BindNodeSelectionSource(this);
     state_connection_   = connect(session_.data(), &EditorSessionController::StateChanged, this,
                                   &EditorNodeController::OnSessionStateChanged);
     history_connection_ = connect(session_.data(), &EditorSessionController::HistoryChanged, this,
@@ -263,6 +276,21 @@ void EditorNodeController::RestoreSelectionAfterSnapshot() {
   selected_node_id_ = DefaultSelectedNodeId();
 }
 
+void EditorNodeController::SyncSessionAdjustmentNode(bool seal_open_sequence) {
+  if (session_ == nullptr) {
+    return;
+  }
+  if (seal_open_sequence && session_->can_edit() &&
+      HasQueuedFieldWrites(session_->PeekPendingInput())) {
+    (void)session_->enqueueNodeSwitchBoundary();
+  }
+  const auto* node = NodeFor(selected_node_id_);
+  if (node == nullptr) {
+    return;
+  }
+  session_->ApplySelectedAdjustmentNode(selected_node_id_, node->node_kind);
+}
+
 auto EditorNodeController::selected_node_id_string() const -> QString {
   return NodeIdToQString(selected_node_id_);
 }
@@ -358,6 +386,7 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
   snapshot_version_id_         = version_id_;
   SyncLayoutKey();
   RestoreSelectionAfterSnapshot();
+  SyncSessionAdjustmentNode(false);
   SetLastError({});
   emit SnapshotChanged();
   emit SelectionChanged();
@@ -679,6 +708,7 @@ void EditorNodeController::selectNode(const QString& node_id) {
   SetLastError({});
   PersistSavedSelection();
   ApplyLiveSelectionToAdapter();
+  SyncSessionAdjustmentNode(true);
   emit SelectionChanged();
   emit ActionAvailabilityChanged();
 }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -134,7 +134,7 @@ void EditorNodeController::SetLayoutIdentity(quint64 element_id, quint64 image_i
   if (identity_changed) {
     SyncLayoutKey();
     if (has_snapshot_) {
-      RestoreSelectionAfterSnapshot();
+      RestoreSelectionAfterSnapshot(false);
     }
   }
   emit SnapshotChanged();
@@ -195,20 +195,8 @@ auto EditorNodeController::ContainsNode(const NodeId& node_id) const -> bool {
 }
 
 auto EditorNodeController::DefaultSelectedNodeId() const -> NodeId {
-  if (!HasActiveGraph()) {
-    return {};
-  }
-  for (const auto& node : ActiveNodes()) {
-    if (node.node_kind == EditorNodeKind::ColorGrade) {
-      return node.node_id;
-    }
-  }
-  for (const auto& node : ActiveNodes()) {
-    if (node.node_kind == EditorNodeKind::Drt) {
-      return node.node_id;
-    }
-  }
-  return ActiveNodes().empty() ? NodeId{} : ActiveNodes().front().node_id;
+  const NodeId default_grade{"grade.primary"};
+  return ContainsNode(default_grade) ? default_grade : NodeId{};
 }
 
 auto EditorNodeController::IndexOf(const NodeId& node_id) const -> int {
@@ -248,7 +236,7 @@ auto EditorNodeController::TopologyChanged(const EditorNodeGraphSnapshot& snapsh
   return !SameTopology(snapshot_, snapshot);
 }
 
-void EditorNodeController::RestoreSelectionAfterSnapshot() {
+void EditorNodeController::RestoreSelectionAfterSnapshot(bool select_default_color_grade) {
   if (layout_store_ != nullptr) {
     const auto key         = layout_store_->current_key();
     const bool key_changed = key != last_layout_key_;
@@ -273,7 +261,7 @@ void EditorNodeController::RestoreSelectionAfterSnapshot() {
   if (!selected_node_id_.Empty()) {
     selection_restore_node_id_ = selected_node_id_;
   }
-  selected_node_id_ = DefaultSelectedNodeId();
+  selected_node_id_ = select_default_color_grade ? DefaultSelectedNodeId() : NodeId{};
 }
 
 void EditorNodeController::SyncSessionAdjustmentNode(bool seal_open_sequence) {
@@ -286,6 +274,7 @@ void EditorNodeController::SyncSessionAdjustmentNode(bool seal_open_sequence) {
   }
   const auto* node = NodeFor(selected_node_id_);
   if (node == nullptr) {
+    session_->ApplySelectedAdjustmentNode({}, EditorNodeKind::ColorGrade);
     return;
   }
   session_->ApplySelectedAdjustmentNode(selected_node_id_, node->node_kind);
@@ -385,7 +374,7 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
   snapshot_image_id_           = image_id_;
   snapshot_version_id_         = version_id_;
   SyncLayoutKey();
-  RestoreSelectionAfterSnapshot();
+  RestoreSelectionAfterSnapshot(generation_changed);
   SyncSessionAdjustmentNode(false);
   SetLastError({});
   emit SnapshotChanged();
@@ -831,9 +820,10 @@ bool EditorNodeController::deleteColorGrade(const QString& node_id) {
   emit DraftStateChanged();
   emit ActionAvailabilityChanged();
   if (!ContainsNode(selected_node_id_)) {
-    selected_node_id_ = DefaultSelectedNodeId();
+    selected_node_id_ = {};
     PersistSavedSelection();
     ApplyLiveSelectionToAdapter();
+    SyncSessionAdjustmentNode(false);
     emit SelectionChanged();
     emit ActionAvailabilityChanged();
   }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -1261,7 +1261,7 @@ void EditorSessionController::BindNodeSelectionSource(EditorNodeController* node
   node_controller_ = nodes;
 }
 
-void EditorSessionController::ApplySelectedAdjustmentNode(const alcedo::NodeId& node_id,
+void EditorSessionController::ApplySelectedAdjustmentNode(const alcedo::NodeId&  node_id,
                                                           alcedo::EditorNodeKind kind) {
   if (session_backend_ != nullptr) {
     (void)session_backend_->SetAdjustmentProjectionNode(node_id);
@@ -1391,7 +1391,11 @@ auto EditorSessionController::pipeline_document() const -> const alcedo::Pipelin
 }
 
 void EditorSessionController::set_active_adjustment_panel(const QString& panel) {
+  // Publish Geometry exit while Develop still owns any pending crop submission.
   SetActiveAdjustmentPanel(panel, true);
+  if (node_controller_) {
+    node_controller_->SelectNodeForAdjustmentPanel(active_adjustment_panel_);
+  }
 }
 
 void EditorSessionController::SetActiveAdjustmentPanel(const QString& panel, bool request_view) {
@@ -1399,11 +1403,13 @@ void EditorSessionController::SetActiveAdjustmentPanel(const QString& panel, boo
   if (active_adjustment_panel_ == normalized) {
     return;
   }
+  const bool geometry_changed = active_adjustment_panel_ == QLatin1String("geometry") ||
+                                normalized == QLatin1String("geometry");
   active_adjustment_panel_ = normalized;
   SaveDesktopUiPrefs();
   if (session_backend_) {
     session_backend_->SetGeometryOverlayActive(normalized == QLatin1String("geometry"));
-    if (request_view && session_backend_->has_image() &&
+    if (request_view && geometry_changed && session_backend_->has_image() &&
         session_backend_->state() == alcedo::EditorSessionState::Interactive) {
       session_backend_->RequestViewChange(alcedo::EditorRenderReason::CropRotate, std::nullopt);
     }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <exception>
 
+#include "app/editor_adjustment_context.hpp"
 #include "app/editor_parameter_write.hpp"
 #include "app/editor_panel_projection.hpp"
 #include "app/editor_render_intent.hpp"
@@ -21,6 +22,7 @@
 #include "edit/operators/utils/color_utils.hpp"
 #include "type/hash_type.hpp"
 #include "ui/alcedo_main/album_backend/album_catalog.hpp"
+#include "ui/alcedo_main/album_backend/editor_node_controller.hpp"
 #include "ui/alcedo_main/album_backend/editor_panel_presentation.hpp"
 #include "ui/alcedo_main/album_backend/interaction_policy_controller.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
@@ -1190,6 +1192,32 @@ bool EditorSessionController::submitWrite(QString fieldKey, alcedo::EditorParame
     }
     return false;
   }
+  if (session_backend_ == nullptr) {
+    return false;
+  }
+  alcedo::EditorAdjustmentPatch patch;
+  patch.field_key = fieldKey.toStdString();
+  patch.write     = std::move(write);
+  patch.settled   = settled;
+  if (node_controller_ != nullptr) {
+    const auto* document = pipeline_document();
+    if (document == nullptr) {
+      if (settled && viewport) {
+        viewport->endInteractivePresentLoop();
+      }
+      return false;
+    }
+    std::string error;
+    auto        target = alcedo::CompleteSelectedNodeParameterTarget(
+        *document, node_controller_->selected_node_id(), patch.field_key, &error);
+    if (!target.has_value()) {
+      if (settled && viewport) {
+        viewport->endInteractivePresentLoop();
+      }
+      return false;
+    }
+    patch.target = std::move(*target);
+  }
   if (viewport) {
     if (settled) {
       viewport->endInteractivePresentLoop();
@@ -1198,13 +1226,6 @@ bool EditorSessionController::submitWrite(QString fieldKey, alcedo::EditorParame
     }
     viewport->prepareForAdjustmentFrame();
   }
-  if (session_backend_ == nullptr) {
-    return false;
-  }
-  alcedo::EditorAdjustmentPatch patch;
-  patch.field_key = fieldKey.toStdString();
-  patch.write     = std::move(write);
-  patch.settled   = settled;
   const auto result = session_backend_->EnqueueAdjustmentInput(std::move(patch));
   return result.kind != alcedo::EditorSessionResultKind::Rejected &&
          result.kind != alcedo::EditorSessionResultKind::Failed;
@@ -1234,6 +1255,33 @@ bool EditorSessionController::enqueueNodeSwitchBoundary() {
       alcedo::EditorPendingInputBoundaryKind::NodeSwitch);
   return result.kind != alcedo::EditorSessionResultKind::Rejected &&
          result.kind != alcedo::EditorSessionResultKind::Failed;
+}
+
+void EditorSessionController::BindNodeSelectionSource(EditorNodeController* nodes) {
+  node_controller_ = nodes;
+}
+
+void EditorSessionController::ApplySelectedAdjustmentNode(const alcedo::NodeId& node_id,
+                                                          alcedo::EditorNodeKind kind) {
+  if (session_backend_ != nullptr) {
+    (void)session_backend_->SetAdjustmentProjectionNode(node_id);
+  }
+  const auto current = active_adjustment_panel_.toStdString();
+  if (!alcedo::AdjustmentPanelIsSupported(kind, current)) {
+    const auto fallback = alcedo::DefaultAdjustmentPanel(kind);
+    SetActiveAdjustmentPanel(
+        QString::fromLatin1(fallback.data(), static_cast<int>(fallback.size())), false);
+    return;
+  }
+  if (session_backend_ != nullptr) {
+    session_backend_->SetGeometryOverlayActive(active_adjustment_panel_ ==
+                                               QLatin1String("geometry"));
+  }
+}
+
+auto EditorSessionController::PeekPendingInput() const -> alcedo::EditorPendingInputView {
+  return session_backend_ ? session_backend_->PeekPendingInput()
+                          : alcedo::EditorPendingInputView{};
 }
 
 void EditorSessionController::set_filmstrip_collapsed(bool collapsed) {
@@ -1300,6 +1348,12 @@ auto EditorSessionController::NormalizeAdjustmentPanel(const QString& panel) -> 
   if (key == QLatin1String("raw") || key == QLatin1String("rawdecode")) {
     return QStringLiteral("raw");
   }
+  if (key == QLatin1String("detail")) {
+    return QStringLiteral("detail");
+  }
+  if (key == QLatin1String("masks") || key == QLatin1String("mask")) {
+    return QStringLiteral("masks");
+  }
   return QStringLiteral("tone");
 }
 
@@ -1334,6 +1388,10 @@ auto EditorSessionController::pipeline_document() const -> const alcedo::Pipelin
 }
 
 void EditorSessionController::set_active_adjustment_panel(const QString& panel) {
+  SetActiveAdjustmentPanel(panel, true);
+}
+
+void EditorSessionController::SetActiveAdjustmentPanel(const QString& panel, bool request_view) {
   const QString normalized = NormalizeAdjustmentPanel(panel);
   if (active_adjustment_panel_ == normalized) {
     return;
@@ -1342,7 +1400,7 @@ void EditorSessionController::set_active_adjustment_panel(const QString& panel) 
   SaveDesktopUiPrefs();
   if (session_backend_) {
     session_backend_->SetGeometryOverlayActive(normalized == QLatin1String("geometry"));
-    if (session_backend_->has_image() &&
+    if (request_view && session_backend_->has_image() &&
         session_backend_->state() == alcedo::EditorSessionState::Interactive) {
       session_backend_->RequestViewChange(alcedo::EditorRenderReason::CropRotate, std::nullopt);
     }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -1266,6 +1266,9 @@ void EditorSessionController::ApplySelectedAdjustmentNode(const alcedo::NodeId& 
   if (session_backend_ != nullptr) {
     (void)session_backend_->SetAdjustmentProjectionNode(node_id);
   }
+  if (node_id.Empty()) {
+    return;
+  }
   const auto current = active_adjustment_panel_.toStdString();
   if (!alcedo::AdjustmentPanelIsSupported(kind, current)) {
     const auto fallback = alcedo::DefaultAdjustmentPanel(kind);

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
@@ -256,8 +256,9 @@ auto EditorSessionHistoryPort::ReadPanelProjection(const alcedo::EditorHistoryGu
 
 auto EditorSessionHistoryPort::SetPanelProjectionNode(const alcedo::EditorHistoryGuardHandle& guard,
                                                       const alcedo::NodeId& node_id,
+                                                      std::uint64_t session_generation,
                                                       std::string* error) -> bool {
-  return mutation_->SetPanelProjectionNode(guard, node_id, error);
+  return mutation_->SetPanelProjectionNode(guard, node_id, session_generation, error);
 }
 
 auto EditorSessionHistoryPort::CaptureSaveCheckpoint(const alcedo::EditorHistoryGuardHandle& guard,

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
@@ -254,6 +254,12 @@ auto EditorSessionHistoryPort::ReadPanelProjection(const alcedo::EditorHistoryGu
   return projection_->ReadPanelProjection(guard, projection, error);
 }
 
+auto EditorSessionHistoryPort::SetPanelProjectionNode(const alcedo::EditorHistoryGuardHandle& guard,
+                                                      const alcedo::NodeId& node_id,
+                                                      std::string* error) -> bool {
+  return mutation_->SetPanelProjectionNode(guard, node_id, error);
+}
+
 auto EditorSessionHistoryPort::CaptureSaveCheckpoint(const alcedo::EditorHistoryGuardHandle& guard,
                                                      std::string* error)
     -> std::shared_ptr<const alcedo::EditorMiniGitSaveCapture> {

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -66,6 +66,16 @@ gtest_discover_tests(EditorPanelProjectionTest
     TEST_PREFIX "EditorPanelProjectionTest.")
 alcedo_register_test_target(EditorPanelProjectionTest app)
 
+add_executable(EditorAdjustmentContextTest
+    ${ALCEDO_TEST_ROOT}/app/editor_adjustment_context_test.cpp)
+target_include_directories(EditorAdjustmentContextTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR})
+target_link_libraries(EditorAdjustmentContextTest
+    PRIVATE GTest::gtest_main EditorPanelProjection EditGraph Image)
+gtest_discover_tests(EditorAdjustmentContextTest
+    TEST_PREFIX "EditorAdjustmentContextTest.")
+alcedo_register_test_target(EditorAdjustmentContextTest app)
+
 add_executable(PipelineHistoryApplierTest
     ${ALCEDO_TEST_ROOT}/app/pipeline_history_applier_test.cpp)
 target_include_directories(PipelineHistoryApplierTest

--- a/alcedo_studio/tests/app/editor_adjustment_context_test.cpp
+++ b/alcedo_studio/tests/app/editor_adjustment_context_test.cpp
@@ -1,0 +1,274 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_adjustment_context.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/graph/pipeline_graph_commands.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/dirty_field_mask.hpp"
+#include "edit/operators/models/i_operator_model.hpp"
+#include "edit/operators/models/operator_param_dto.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
+#include "image/image.hpp"
+#include "image/metadata.hpp"
+
+namespace alcedo {
+namespace {
+
+class SerializationCountingModel : public IOperatorModel {
+ public:
+  mutable int json_reads = 0;
+  mutable int dto_reads  = 0;
+  int         loads      = 0;
+
+  auto Type() const -> OperatorTypeId override { return value_.Type(); }
+  auto IsDefault() const -> bool override { return value_.IsDefault(); }
+  auto IsDirty() const -> bool override { return value_.IsDirty(); }
+  auto DirtyFields() const -> DirtyFieldMask override { return value_.DirtyFields(); }
+  auto MakeFullDto() const -> OperatorParamDto override {
+    ++dto_reads;
+    return value_.MakeFullDto();
+  }
+  auto TakeDirtyPatch() -> std::optional<OperatorParamPatchDto> override {
+    return value_.TakeDirtyPatch();
+  }
+  void RestoreDirty(DirtyFieldMask fields) override { value_.RestoreDirty(fields); }
+  void MarkAllDirty() override { value_.MarkAllDirty(); }
+  auto ToJson() const -> nlohmann::json override {
+    ++json_reads;
+    return value_.ToJson();
+  }
+  void LoadJson(const nlohmann::json& json) override {
+    ++loads;
+    value_.LoadJson(json);
+  }
+  void SetValue(float value) { value_.SetValue(value); }
+
+ private:
+  ExposureModel value_;
+};
+
+auto ExposureOf(ColorGradeNodeModel* grade) -> ExposureModel* {
+  return dynamic_cast<ExposureModel*>(grade->FindAdjustmentByType(type_ids::Exposure()));
+}
+
+auto ScalarOf(const EditorPanelProjection& projection, std::string_view key)
+    -> std::optional<float> {
+  for (const auto& field : projection.fields) {
+    if (field.field_key != key) {
+      continue;
+    }
+    const auto* scalar = std::get_if<EditorPanelScalarValue>(&field.value);
+    if (scalar == nullptr) {
+      return std::nullopt;
+    }
+    return scalar->value;
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+TEST(EditorAdjustmentContextTest, TwoColorGradesResolveIndependentExposureInstances) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  auto* extra = dynamic_cast<ColorGradeNodeModel*>(document.Graph().FindNode(NodeId{"grade.b"}));
+  ASSERT_NE(extra, nullptr);
+  auto* extra_exposure = ExposureOf(extra);
+  ASSERT_NE(extra_exposure, nullptr);
+  extra_exposure->SetValue(0.25f);
+
+  std::string error;
+  const auto  primary = CompleteSelectedNodeParameterTarget(document, NodeId{"grade.primary"},
+                                                           "exposure", &error);
+  const auto  second =
+      CompleteSelectedNodeParameterTarget(document, NodeId{"grade.b"}, "exposure", &error);
+  ASSERT_TRUE(primary.has_value()) << error;
+  ASSERT_TRUE(second.has_value()) << error;
+  EXPECT_EQ(primary->owner_kind, EditorParameterOwnerKind::ColorGrade);
+  EXPECT_EQ(primary->node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(second->node_id, NodeId{"grade.b"});
+  EXPECT_NE(primary->adjustment_instance_id, second->adjustment_instance_id);
+  EXPECT_NE(second->adjustment_instance_id, AdjustmentInstanceId{"grade.primary.exposure"});
+
+  EditorPanelProjection primary_fields;
+  EditorPanelProjection extra_fields;
+  ASSERT_TRUE(ProjectSelectedNodePanelFields(document, NodeId{"grade.primary"}, 1, &primary_fields,
+                                             &error))
+      << error;
+  ASSERT_TRUE(
+      ProjectSelectedNodePanelFields(document, NodeId{"grade.b"}, 1, &extra_fields, &error))
+      << error;
+  ASSERT_TRUE(ScalarOf(primary_fields, "exposure").has_value());
+  ASSERT_TRUE(ScalarOf(extra_fields, "exposure").has_value());
+  EXPECT_FLOAT_EQ(*ScalarOf(primary_fields, "exposure"), kDefaultPipelineExposureEv);
+  EXPECT_FLOAT_EQ(*ScalarOf(extra_fields, "exposure"), 0.25f);
+}
+
+TEST(EditorAdjustmentContextTest, MissingNodeOrInstanceLeavesProjectionUnchanged) {
+  auto document = CreateDefaultPipelineDocument();
+  EditorPanelProjection sentinel;
+  sentinel.session_generation = 99;
+  EditorPanelFieldPresentation leftover;
+  leftover.field_key = "leftover";
+  sentinel.fields.push_back(leftover);
+
+  std::string error;
+  EXPECT_FALSE(CompleteSelectedNodeParameterTarget(document, NodeId{"missing"}, "exposure", &error)
+                   .has_value());
+  EXPECT_FALSE(error.empty());
+
+  error.clear();
+  EXPECT_FALSE(ProjectSelectedNodePanelFields(document, NodeId{"missing"}, 1, &sentinel, &error));
+  EXPECT_EQ(sentinel.session_generation, 99u);
+  ASSERT_EQ(sentinel.fields.size(), 1u);
+  EXPECT_EQ(sentinel.fields.front().field_key, "leftover");
+
+  auto* grade = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  const auto* exposure_id = grade->FindAdjustmentIdByType(type_ids::Exposure());
+  ASSERT_NE(exposure_id, nullptr);
+  grade->RemoveAdjustment(*exposure_id);
+  EditorPanelProjection after_remove = sentinel;
+  error.clear();
+  EXPECT_FALSE(CompleteSelectedNodeParameterTarget(document, NodeId{"grade.primary"}, "exposure",
+                                                   &error)
+                   .has_value());
+  EXPECT_FALSE(error.empty());
+  error.clear();
+  EXPECT_FALSE(ProjectSelectedNodePanelFields(document, NodeId{"grade.primary"}, 1, &after_remove,
+                                              &error));
+  EXPECT_EQ(after_remove.session_generation, 99u);
+  EXPECT_EQ(after_remove.fields.front().field_key, "leftover");
+}
+
+TEST(EditorAdjustmentContextTest, WrongOwnerAndGeometryCapabilityFailExplicitly) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+
+  std::string error;
+  EXPECT_FALSE(
+      CompleteSelectedNodeParameterTarget(document, NodeId{"drt"}, "exposure", &error).has_value());
+  EXPECT_FALSE(error.empty());
+
+  error.clear();
+  EXPECT_FALSE(CompleteSelectedNodeParameterTarget(document, NodeId{"grade.b"}, "crop_rotate",
+                                                   &error)
+                   .has_value());
+  EXPECT_FALSE(error.empty());
+
+  error.clear();
+  const auto geometry =
+      CompleteSelectedNodeParameterTarget(document, NodeId{"develop"}, "crop_rotate", &error);
+  ASSERT_TRUE(geometry.has_value()) << error;
+  EXPECT_EQ(geometry->owner_kind, EditorParameterOwnerKind::Document);
+  EXPECT_TRUE(geometry->node_id.Empty());
+  EXPECT_TRUE(geometry->adjustment_instance_id.Empty());
+}
+
+TEST(EditorAdjustmentContextTest, SelectedNodePanelProjectionDoesNotCallModelJsonOrFullDto) {
+  auto document = CreateDefaultPipelineDocument();
+  auto counted  = std::make_unique<SerializationCountingModel>();
+  counted->SetValue(3.0f);
+  auto* observed = counted.get();
+  document.InsertAdjustment(NodeId{"grade.primary"}, document.PrimaryGrade()->AdjustmentCount(),
+                            AdjustmentInstanceId{"counted"}, std::move(counted));
+
+  OperatorModelFullDtoCopyCount::Reset();
+  EditorPanelProjection projection;
+  std::string           error;
+  ASSERT_TRUE(ProjectSelectedNodePanelFields(document, NodeId{"grade.primary"}, 4, &projection,
+                                             &error))
+      << error;
+  EXPECT_EQ(observed->json_reads, 0);
+  EXPECT_EQ(observed->dto_reads, 0);
+  EXPECT_EQ(observed->loads, 0);
+  EXPECT_EQ(OperatorModelFullDtoCopyCount::Peek(), 0);
+  ASSERT_TRUE(ScalarOf(projection, "exposure").has_value());
+  EXPECT_FLOAT_EQ(*ScalarOf(projection, "exposure"), kDefaultPipelineExposureEv);
+}
+
+TEST(EditorAdjustmentContextTest, ImageExifDisplayCopiesOwnerFieldsAndRejectsInvalidValues) {
+  ExifDisplayMetaData valid;
+  valid.shutter_speed_ = {1, 125};
+  valid.iso_           = 200;
+  valid.aperture_      = 2.8f;
+  valid.focal_         = 50.0f;
+  const auto display   = ReadEditorImageExifDisplay(valid);
+  ASSERT_TRUE(display.shutter_speed.has_value());
+  EXPECT_EQ(display.shutter_speed->first, 1);
+  EXPECT_EQ(display.shutter_speed->second, 125);
+  ASSERT_TRUE(display.iso.has_value());
+  EXPECT_EQ(*display.iso, 200u);
+  ASSERT_TRUE(display.aperture.has_value());
+  EXPECT_FLOAT_EQ(*display.aperture, 2.8f);
+  ASSERT_TRUE(display.focal_mm.has_value());
+  EXPECT_FLOAT_EQ(*display.focal_mm, 50.0f);
+
+  ExifDisplayMetaData invalid;
+  invalid.shutter_speed_ = {0, 125};
+  invalid.iso_           = 0;
+  invalid.aperture_      = 0.0f;
+  invalid.focal_         = -10.0f;
+  const auto rejected    = ReadEditorImageExifDisplay(invalid);
+  EXPECT_FALSE(rejected.shutter_speed.has_value());
+  EXPECT_FALSE(rejected.iso.has_value());
+  EXPECT_FALSE(rejected.aperture.has_value());
+  EXPECT_FALSE(rejected.focal_mm.has_value());
+
+  Image image;
+  image.exif_display_ = valid;
+  EXPECT_FALSE(ReadEditorImageExifDisplay(image).iso.has_value());
+  image.has_exif_display_.store(true);
+  const auto from_image = ReadEditorImageExifDisplay(image);
+  ASSERT_TRUE(from_image.iso.has_value());
+  EXPECT_EQ(*from_image.iso, 200u);
+}
+
+TEST(EditorAdjustmentContextTest, ContextCopiesCallerExifAndDoesNotRereadOnNodeChange) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  EditorImageExifDisplay exif;
+  exif.iso = 800;
+  const auto primary = MakeEditorAdjustmentContext(document, NodeId{"grade.primary"}, exif);
+  const auto extra   = MakeEditorAdjustmentContext(document, NodeId{"grade.b"}, exif);
+  ASSERT_TRUE(primary.has_value());
+  ASSERT_TRUE(extra.has_value());
+  EXPECT_EQ(primary->node_kind, EditorNodeKind::ColorGrade);
+  EXPECT_EQ(extra->node_kind, EditorNodeKind::ColorGrade);
+  ASSERT_TRUE(primary->exif.iso.has_value());
+  ASSERT_TRUE(extra->exif.iso.has_value());
+  EXPECT_EQ(*primary->exif.iso, 800u);
+  EXPECT_EQ(*extra->exif.iso, 800u);
+  EXPECT_EQ(primary->selected_node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(extra->selected_node_id, NodeId{"grade.b"});
+  EXPECT_FALSE(MakeEditorAdjustmentContext(document, NodeId{"missing"}, exif).has_value());
+}
+
+TEST(EditorAdjustmentContextTest, CapabilityRegistryMatchesNodeKind) {
+  EXPECT_EQ(DefaultAdjustmentPanel(EditorNodeKind::Develop), kAdjustmentPanelRaw);
+  EXPECT_EQ(DefaultAdjustmentPanel(EditorNodeKind::ColorGrade), kAdjustmentPanelTone);
+  EXPECT_EQ(DefaultAdjustmentPanel(EditorNodeKind::Drt), kAdjustmentPanelDisplay);
+  EXPECT_TRUE(AdjustmentPanelIsSupported(EditorNodeKind::Develop, kAdjustmentPanelGeometry));
+  EXPECT_FALSE(AdjustmentPanelIsSupported(EditorNodeKind::ColorGrade, kAdjustmentPanelGeometry));
+  EXPECT_FALSE(AdjustmentPanelIsSupported(EditorNodeKind::Drt, kAdjustmentPanelGeometry));
+  EXPECT_TRUE(AdjustmentPanelIsSupported(EditorNodeKind::ColorGrade, kAdjustmentPanelMasks));
+  EXPECT_TRUE(AdjustmentPanelIsSupported(EditorNodeKind::Drt, kAdjustmentPanelDetail));
+  EXPECT_TRUE(AdjustmentFieldIsSupported(EditorNodeKind::Develop, "crop_rotate"));
+  EXPECT_FALSE(AdjustmentFieldIsSupported(EditorNodeKind::ColorGrade, "crop_rotate"));
+  EXPECT_TRUE(AdjustmentFieldIsSupported(EditorNodeKind::ColorGrade, "exposure"));
+  EXPECT_TRUE(AdjustmentFieldIsSupported(EditorNodeKind::Drt, "odt"));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/app/editor_pending_input_session_test.cpp
+++ b/alcedo_studio/tests/app/editor_pending_input_session_test.cpp
@@ -6,6 +6,7 @@
 #include "app/editor_render_coordinator.hpp"
 #include "app/editor_session_bootstrap.hpp"
 #include "app/editor_session_service.hpp"
+#include "edit/graph/graph_ids.hpp"
 #include "support/editor_session_command_queue_test_support.hpp"
 #include "support/editor_parameter_write_test.hpp"
 
@@ -130,6 +131,35 @@ TEST_F(EditorPendingInputSessionTest, NodeSwitchBoundaryKeepsOriginalSequenceTar
   EXPECT_EQ(pending.sequences[0].captured_target.node_id, NodeId{"grade.a"});
   EXPECT_EQ(pending.sequences[1].captured_target.node_id, NodeId{"grade.b"});
   EXPECT_EQ(history_->capture_count, captures_before);
+}
+
+TEST_F(EditorPendingInputSessionTest, EmptyNodeSwitchDoesNotBumpHistoryRevision) {
+  OpenInteractive();
+  const auto revision = service_->history_revision();
+  const int  captures = history_->capture_count;
+  const int  commits  = history_->commit_count;
+  ASSERT_EQ(service_->EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind::NodeSwitch).kind,
+            EditorSessionResultKind::Accepted);
+  service_->DrainCommandQueueForTests();
+  EXPECT_EQ(service_->history_revision(), revision);
+  EXPECT_EQ(history_->capture_count, captures);
+  EXPECT_EQ(history_->commit_count, commits);
+  EXPECT_TRUE(service_->PeekPendingInput().sequences.empty());
+}
+
+TEST_F(EditorPendingInputSessionTest, SelectedNodeProjectionDoesNotCaptureOrCommit) {
+  OpenInteractive();
+  const auto revision = service_->history_revision();
+  const int  captures = history_->capture_count;
+  const int  commits  = history_->commit_count;
+  const auto result   = service_->SetAdjustmentProjectionNode(NodeId{"grade.b"});
+  service_->DrainCommandQueueForTests();
+  EXPECT_EQ(result.kind, EditorSessionResultKind::Accepted);
+  EXPECT_EQ(history_->set_panel_projection_node_count, 1);
+  EXPECT_EQ(history_->last_panel_projection_node, NodeId{"grade.b"});
+  EXPECT_EQ(service_->history_revision(), revision);
+  EXPECT_EQ(history_->capture_count, captures);
+  EXPECT_EQ(history_->commit_count, commits);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/app/editor_pending_input_session_test.cpp
+++ b/alcedo_studio/tests/app/editor_pending_input_session_test.cpp
@@ -157,9 +157,32 @@ TEST_F(EditorPendingInputSessionTest, SelectedNodeProjectionDoesNotCaptureOrComm
   EXPECT_EQ(result.kind, EditorSessionResultKind::Accepted);
   EXPECT_EQ(history_->set_panel_projection_node_count, 1);
   EXPECT_EQ(history_->last_panel_projection_node, NodeId{"grade.b"});
+  EXPECT_EQ(history_->last_panel_projection_generation,
+            service_->active_image_load_request().value);
   EXPECT_EQ(service_->history_revision(), revision);
   EXPECT_EQ(history_->capture_count, captures);
   EXPECT_EQ(history_->commit_count, commits);
+}
+
+TEST_F(EditorPendingInputSessionTest, SelectedNodeProjectionDoesNotWaitForInflightFrame) {
+  (void)service_->Open(10, 20);
+  service_->DrainCommandQueueForTests();
+  const auto first_rid = service_->first_frame_request_id();
+  ASSERT_NE(first_rid, 0u);
+  runtime_->coordinator->NotifySchedulerCompleted(first_rid, true);
+  service_->DrainCommandQueueForTests();
+  ASSERT_EQ(service_->state(), EditorSessionState::Interactive);
+  ASSERT_TRUE(runtime_->coordinator->has_inflight());
+  ASSERT_NE(runtime_->coordinator->last_scheduled_request_id(), first_rid);
+
+  const auto result = service_->SetAdjustmentProjectionNode(NodeId{"grade.b"});
+  service_->DrainCommandQueueForTests();
+  EXPECT_EQ(result.kind, EditorSessionResultKind::Accepted);
+  EXPECT_EQ(history_->set_panel_projection_node_count, 1);
+  EXPECT_EQ(history_->last_panel_projection_node, NodeId{"grade.b"});
+  EXPECT_EQ(history_->last_panel_projection_generation,
+            service_->active_image_load_request().value);
+  EXPECT_TRUE(runtime_->coordinator->has_inflight());
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
+++ b/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <set>
 #include <thread>
+#include <utility>
 #include <variant>
 
 #include "json.hpp"
@@ -304,7 +305,8 @@ TEST_F(EditorSessionHistoryPortTest, UnspecifiedWriteUsesSelectedProjectionNodeN
   ASSERT_TRUE(alcedo::AddCleanColorGrade(*guard_->document_, alcedo::NodeId{"drt"},
                                         alcedo::NodeId{"grade.b"})
                   .empty());
-  ASSERT_TRUE(history_.SetPanelProjectionNode(handle, alcedo::NodeId{"grade.b"}, &error)) << error;
+  ASSERT_TRUE(history_.SetPanelProjectionNode(handle, alcedo::NodeId{"grade.b"}, 1, &error))
+      << error;
 
   alcedo::EditorAdjustmentPatch patch;
   patch.field_key = "exposure";
@@ -340,6 +342,64 @@ TEST_F(EditorSessionHistoryPortTest, UnspecifiedWriteUsesSelectedProjectionNodeN
   EXPECT_FLOAT_EQ(scalar->value, 0.25f);
   EXPECT_EQ(exposure->source.node_id, alcedo::NodeId{"grade.b"});
   EXPECT_NE(exposure->source.adjustment_instance_id.Value(), "grade.primary.exposure");
+}
+
+TEST_F(EditorSessionHistoryPortTest, SelectedNodeProjectionCompletesWhileRenderLockHeld) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  ASSERT_TRUE(alcedo::AddCleanColorGrade(*guard_->document_, alcedo::NodeId{"drt"},
+                                        alcedo::NodeId{"grade.b"})
+                  .empty());
+
+  std::atomic<bool> worker_ready{false};
+  std::atomic<bool> release_worker{false};
+  std::thread       worker([&] {
+    std::unique_lock<std::mutex> held(guard_->pipeline_->GetRenderLock());
+    worker_ready.store(true);
+    while (!release_worker.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  });
+  const auto ready_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (!worker_ready.load() && std::chrono::steady_clock::now() < ready_deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  if (!worker_ready.load()) {
+    release_worker.store(true);
+    if (worker.joinable()) {
+      worker.join();
+    }
+    FAIL() << "render-lock worker did not acquire the lock";
+  }
+
+  auto project_future = std::async(std::launch::async, [&] {
+    std::string project_error;
+    const bool  ok = history_.SetPanelProjectionNode(handle, alcedo::NodeId{"grade.b"}, 1,
+                                                     &project_error);
+    return std::pair<bool, std::string>{ok, std::move(project_error)};
+  });
+  const auto project_status = project_future.wait_for(std::chrono::seconds(2));
+  release_worker.store(true);
+  if (worker.joinable()) {
+    worker.join();
+  }
+  ASSERT_EQ(project_status, std::future_status::ready)
+      << "selected-node panel projection must not wait on the live render lock";
+  const auto projected = project_future.get();
+  EXPECT_TRUE(projected.first) << projected.second;
+
+  alcedo::EditorPanelProjection projection;
+  ASSERT_TRUE(history_.ReadPanelProjection(handle, &projection, &error)) << error;
+  const alcedo::EditorPanelFieldPresentation* exposure = nullptr;
+  for (const auto& field : projection.fields) {
+    if (field.field_key == "exposure") {
+      exposure = &field;
+      break;
+    }
+  }
+  ASSERT_NE(exposure, nullptr);
+  EXPECT_EQ(exposure->source.node_id, alcedo::NodeId{"grade.b"});
 }
 
 TEST_F(EditorSessionHistoryPortTest, BranchingVersionHistoryAllowsSwitchingWithoutMergeCommits) {

--- a/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
+++ b/alcedo_studio/tests/edit/history/editor_session_history_port_test.cpp
@@ -25,6 +25,8 @@
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/graph/pipeline_graph_commands.hpp"
 #include "edit/graph/color_grade_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
+#include "edit/operators/models/scalar_operator_model.hpp"
 #include "app/editor_adjustment_pipeline.hpp"
 #include "app/editor_mini_git_materializer.hpp"
 #include "app/pipeline_service.hpp"
@@ -293,6 +295,51 @@ TEST_F(EditorSessionHistoryPortTest, LiveWriteProjectsTypedExposureWithoutReadin
   ASSERT_NE(scalar, nullptr);
   EXPECT_FLOAT_EQ(scalar->value, 0.75f);
   EXPECT_EQ(exposure->source.adjustment_instance_id.Value(), "grade.primary.exposure");
+}
+
+TEST_F(EditorSessionHistoryPortTest, UnspecifiedWriteUsesSelectedProjectionNodeNotPrimaryGrade) {
+  std::string error;
+  const auto  handle = history_.Acquire(42, &error);
+  ASSERT_TRUE(handle.valid) << error;
+  ASSERT_TRUE(alcedo::AddCleanColorGrade(*guard_->document_, alcedo::NodeId{"drt"},
+                                        alcedo::NodeId{"grade.b"})
+                  .empty());
+  ASSERT_TRUE(history_.SetPanelProjectionNode(handle, alcedo::NodeId{"grade.b"}, &error)) << error;
+
+  alcedo::EditorAdjustmentPatch patch;
+  patch.field_key = "exposure";
+  patch.write     = alcedo::EditorScalarWrite{0.25f};
+  ASSERT_TRUE(history_.CaptureAdjustmentBeforePreview(handle, patch, &error)) << error;
+
+  auto* extra = dynamic_cast<alcedo::ColorGradeNodeModel*>(
+      guard_->document_->Graph().FindNode(alcedo::NodeId{"grade.b"}));
+  auto* primary = guard_->document_->PrimaryGrade();
+  ASSERT_NE(extra, nullptr);
+  ASSERT_NE(primary, nullptr);
+  auto* extra_exposure = dynamic_cast<alcedo::ExposureModel*>(
+      extra->FindAdjustmentByType(alcedo::type_ids::Exposure()));
+  auto* primary_exposure = dynamic_cast<alcedo::ExposureModel*>(
+      primary->FindAdjustmentByType(alcedo::type_ids::Exposure()));
+  ASSERT_NE(extra_exposure, nullptr);
+  ASSERT_NE(primary_exposure, nullptr);
+  EXPECT_FLOAT_EQ(extra_exposure->Value(), 0.25f);
+  EXPECT_FLOAT_EQ(primary_exposure->Value(), alcedo::kDefaultPipelineExposureEv);
+
+  alcedo::EditorPanelProjection projection;
+  ASSERT_TRUE(history_.ReadPanelProjection(handle, &projection, &error)) << error;
+  const alcedo::EditorPanelFieldPresentation* exposure = nullptr;
+  for (const auto& field : projection.fields) {
+    if (field.field_key == "exposure") {
+      exposure = &field;
+      break;
+    }
+  }
+  ASSERT_NE(exposure, nullptr);
+  const auto* scalar = std::get_if<alcedo::EditorPanelScalarValue>(&exposure->value);
+  ASSERT_NE(scalar, nullptr);
+  EXPECT_FLOAT_EQ(scalar->value, 0.25f);
+  EXPECT_EQ(exposure->source.node_id, alcedo::NodeId{"grade.b"});
+  EXPECT_NE(exposure->source.adjustment_instance_id.Value(), "grade.primary.exposure");
 }
 
 TEST_F(EditorSessionHistoryPortTest, BranchingVersionHistoryAllowsSwitchingWithoutMergeCommits) {

--- a/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_product_plan_cache_test.cpp
@@ -4,6 +4,7 @@
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
+#include <opencv2/core.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -23,6 +24,7 @@
 #include "edit/runtime/graph_compiler.hpp"
 #include "edit/runtime/local_tone_cache_ids.hpp"
 #include "image/image_buffer.hpp"
+#include "multi_grade_runtime_test_support.hpp"
 
 namespace alcedo {
 namespace {
@@ -214,6 +216,111 @@ TEST(GpuDagCudaDrtProduct, LegacyShadowControlExecutesLocalLaplacianWorkspacePat
       LocalToneSourceId(document->PrimaryGrade()->Id()));
   ASSERT_NE(reference, nullptr);
   EXPECT_GT(reference->Texture().Bytes(), sizeof(float));
+}
+
+void ExpectMatchingPixels(ImageBuffer& cached, ImageBuffer& fresh) {
+  const auto& actual = cached.GetCPUData();
+  const auto& expected = fresh.GetCPUData();
+  ASSERT_FALSE(actual.empty());
+  ASSERT_EQ(actual.size(), expected.size());
+  ASSERT_EQ(actual.type(), expected.type());
+  ASSERT_EQ(actual.depth(), CV_32F);
+  ASSERT_TRUE(cv::checkRange(actual));
+  ASSERT_TRUE(cv::checkRange(expected));
+  EXPECT_LE(cv::norm(actual, expected, cv::NORM_INF), 1.0e-5);
+}
+
+TEST(GpuDagCudaDrtProduct,
+     RepeatedFullCropAndExposureEditsBoundTextureEntriesAndBytesAndPreserveSourceHits) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+  auto document = std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
+  gpu_dag_test::EnsureTestCameraProfile(*document);
+  CudaProductRenderer renderer(document, MakeUnpacker());
+  const auto image = MakeEncodedImage(51);
+  RenderRequest request;
+  auto& exposure = multi_grade_test::GradeAdjustment<ExposureModel>(
+      *document, document->PrimaryGrade()->Id(), type_ids::Exposure());
+  ASSERT_NE(RenderHost(renderer, image, DecodeRes::FULL, request), nullptr);
+  // Two complete full-size frame working sets allow current results and warm scratch.
+  // The bound is fixed before edits; neither iteration count nor visited sizes enters it.
+  const auto max_entries = 2U * renderer.Device().Workspace().Textures().EntryCount();
+  const auto max_bytes = 2U * renderer.Device().Workspace().Textures().UsedBytes();
+  for (int iteration = 0; iteration < 48; ++iteration) {
+    SCOPED_TRACE(iteration);
+    const float side = static_cast<float>(8 + (iteration * 7) % 17) / 24.0f;
+    document->Geometry().SetCropRect({0.0f, 0.0f, side, side});
+    for (int edit = 0; edit < 2; ++edit) {
+      SCOPED_TRACE(edit);
+      exposure.SetValue(static_cast<float>((iteration * 2 + edit) % 9) * 0.15f);
+      renderer.Device().ResetPassStats();
+      const auto cached = RenderHost(renderer, image, DecodeRes::FULL, request);
+      ASSERT_NE(cached, nullptr);
+      EXPECT_EQ(renderer.Device().PassStats().sensor_develop_execute, 0U);
+      EXPECT_EQ(renderer.Device().PassStats().sensor_develop_skip, 1U);
+      EXPECT_EQ(renderer.Device().PassStats().source_h2d_count, 0U);
+      EXPECT_LE(renderer.Device().Workspace().Textures().EntryCount(), max_entries);
+      EXPECT_LE(renderer.Device().Workspace().Textures().UsedBytes(), max_bytes);
+      CudaProductRenderer fresh(document, MakeUnpacker());
+      const auto expected = RenderHost(fresh, image, DecodeRes::FULL, request);
+      ASSERT_NE(expected, nullptr);
+      ExpectMatchingPixels(*cached, *expected);
+    }
+  }
+  EXPECT_EQ(renderer.Stats().libraw_open_unpack_count, 1U);
+  EXPECT_EQ(renderer.Stats().prepared_source_misses, 1U);
+  EXPECT_EQ(renderer.Stats().prepared_source_hits, 96U);
+  EXPECT_EQ(renderer.Stats().plan_compile_count, 1U);
+}
+
+TEST(GpuDagCudaDrtProduct,
+     MultipleFullGradesReuseOnePingPongWorkingSetWithLocalToneAndExposure) {
+  if (!HasCudaDevice()) GTEST_SKIP() << "No CUDA device available.";
+  const auto unpack = [](std::span<const std::byte>, DecodeRes decode_res) {
+    EXPECT_EQ(decode_res, DecodeRes::FULL);
+    return RawInputLoader::FromDirectRgb(
+        multi_grade_test::MakeNeighborhoodRgbaPlane(64, 64, 0.02f, 0.08f),
+        gpu_dag_test::FullSensor(64, 64));
+  };
+  auto configure_grade = [](PipelineDocument& document, const NodeId& id) {
+    multi_grade_test::GradeAdjustment<ExposureModel>(document, id, type_ids::Exposure())
+        .SetValue(0.4f);
+    // Shadows is the Grade-owned neighborhood operation. Clarity/Sharpen belong to DRT.
+    // Pointwise + Local Laplacian + final mix require both Ping and Pong destinations.
+    multi_grade_test::GradeAdjustment<ShadowsModel>(document, id, type_ids::Shadows())
+        .SetValue(40.0f);
+    multi_grade_test::GradeNode(document, id.Value())->SetMix(0.75f);
+  };
+  auto single = std::make_shared<PipelineDocument>(multi_grade_test::MakeIdentityGradeDocument());
+  configure_grade(*single, NodeId{"grade.primary"});
+  const auto image = MakeEncodedImage(52);
+  const RenderRequest request;
+  CudaProductRenderer single_renderer(single, unpack);
+  ASSERT_NE(RenderHost(single_renderer, image, DecodeRes::FULL, request), nullptr);
+  const auto single_entries = single_renderer.Device().Workspace().Textures().EntryCount();
+  const auto single_bytes = single_renderer.Device().Workspace().Textures().UsedBytes();
+  const auto single_published = single_renderer.Device().Workspace().Images().PublishedCount();
+
+  auto document = std::make_shared<PipelineDocument>(multi_grade_test::MakeIdentityGradeDocument());
+  multi_grade_test::AddCleanGradesBeforeDrt(*document, {"grade.b", "grade.c", "grade.d"});
+  for (const char* id : {"grade.primary", "grade.b", "grade.c", "grade.d"}) {
+    configure_grade(*document, NodeId{id});
+  }
+  CudaProductRenderer renderer(document, unpack);
+  const auto cached = RenderHost(renderer, image, DecodeRes::FULL, request);
+  ASSERT_NE(cached, nullptr);
+  EXPECT_EQ(renderer.Device().PassStats().primary_grade_execute, 4U);
+  // Persistent Grade outputs and LLF source/result planes are legitimate extra storage.
+  // All other storage must fit the same single-Grade working set, including warm idle entries.
+  const auto published = renderer.Device().Workspace().Images().PublishedCount();
+  ASSERT_GE(published, single_published);
+  const auto extra_results = published - single_published;
+  EXPECT_LE(renderer.Device().Workspace().Textures().EntryCount(), single_entries + extra_results);
+  EXPECT_LE(renderer.Device().Workspace().Textures().UsedBytes(),
+            single_bytes + extra_results * 64U * 64U * 4U * sizeof(float));
+  CudaProductRenderer fresh(document, unpack);
+  const auto expected = RenderHost(fresh, image, DecodeRes::FULL, request);
+  ASSERT_NE(expected, nullptr);
+  ExpectMatchingPixels(*cached, *expected);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/runtime/drt_post_executor_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/drt_post_executor_test.cpp
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include "edit/graph/graph_ids.hpp"
 #include "edit/runtime/adjustment_runtime.hpp"
 
 namespace alcedo {
@@ -174,9 +175,11 @@ struct FakeDrtImages {
 };
 
 struct FakeDrtWorkspace {
-  FakeDrtImages images;
-  auto IsRendering() const -> bool { return true; }
-  auto Images() -> FakeDrtImages& { return images; }
+  FakeDrtImages                 images;
+  std::vector<GraphValueId>     released;
+  auto                          IsRendering() const -> bool { return true; }
+  auto                          Images() -> FakeDrtImages& { return images; }
+  void                          ReleaseConsumedImage(const GraphValueId& id) { released.push_back(id); }
 };
 
 struct FakeDrtDevice {
@@ -263,6 +266,9 @@ TEST(DrtPostExecutor, TwoEnabledNeighborhoodsUseSharedHorizontalThenVerticalOrde
       "acquire-output", "acquire-h-scratch", "horizontal", "vertical", "release-h-scratch",
       "acquire-output", "acquire-h-scratch", "horizontal", "vertical", "release-h-scratch"};
   EXPECT_EQ(FakeDrtOps::log, expected);
+  ASSERT_EQ(device.workspace.released.size(), 2U);
+  EXPECT_EQ(device.workspace.released[0], (GraphValueId{NodeId{"drt"}, PortId{"runtime.ping"}}));
+  EXPECT_EQ(device.workspace.released[1], (GraphValueId{NodeId{"drt"}, PortId{"runtime.pong"}}));
 }
 
 TEST(DrtPostExecutor, DisplayTransformStartsBeforeNeighborhoodWrites) {

--- a/alcedo_studio/tests/edit/runtime/graph_image_cache_retention_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_image_cache_retention_test.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "../graph/test_camera_profile.hpp"
@@ -278,7 +279,8 @@ TEST(GraphImageCacheRetention, DropStalePublishedKeepsCurrentDevelopAndFreesIdle
   exposure->SetValue(0.5f);
   harness.invalidation.CollectAndPropagate(harness.plan, harness.document, harness.prepared, {});
 
-  harness.cache.DropStalePublished([&](const GraphValueId& id, RuntimeRevision revision) {
+  harness.cache.DropStalePublished([&](const GraphValueId& id, RuntimeRevision revision,
+                                       const ResultRepresentation&) {
     return harness.invalidation.HasCurrentRevision(id, revision);
   });
   harness.pool.ReleaseUnleased();
@@ -302,7 +304,8 @@ TEST(GraphImageCacheRetention, ExtraLeaseKeepsDisplayedTextureAfterStalePublishD
   harness.document.Develop()->Params().ReplaceParams(std::move(payload));
   harness.invalidation.CollectAndPropagate(harness.plan, harness.document, harness.prepared, {});
 
-  harness.cache.DropStalePublished([&](const GraphValueId& id, RuntimeRevision revision) {
+  harness.cache.DropStalePublished([&](const GraphValueId& id, RuntimeRevision revision,
+                                       const ResultRepresentation&) {
     return harness.invalidation.HasCurrentRevision(id, revision);
   });
   harness.pool.ReleaseUnleased();
@@ -312,6 +315,160 @@ TEST(GraphImageCacheRetention, ExtraLeaseKeepsDisplayedTextureAfterStalePublishD
   display_lease.Release();
   harness.pool.ReleaseUnleased();
   EXPECT_FALSE(harness.pool.Contains(handle));
+}
+
+auto KeepPublishedForInteractive(HostRetentionHarness& harness, const GraphValueId& id,
+                                 RuntimeRevision revision, const ResultRepresentation& published)
+    -> bool {
+  if (!harness.invalidation.HasCurrentRevision(id, revision)) {
+    return false;
+  }
+  const auto needed = harness.invalidation.MakeImageRepresentation(
+      id, published.extent, published.format, published.source_detail);
+  return RepresentationSatisfies(published, needed);
+}
+
+void PublishWithFrameIdentity(HostRetentionHarness& harness, const GraphValueId& id,
+                              const TextureRequest& request) {
+  const auto required = harness.invalidation.RequiredRevision(id);
+  const auto needed   = harness.invalidation.MakeImageRepresentation(
+      id, {request.width, request.height}, request.format);
+  (void)harness.cache.AcquireTextureForWrite(harness.pool, id, request);
+  harness.cache.RecordUnpublished(id, required, needed, 1);
+  harness.cache.PublishSuccessfulSubmission(1, ResultPersistenceScope::AllCurrentResults,
+                                            harness.Sensor());
+}
+
+TEST(GraphImageCacheRetention, CropMismatchesFrameIdentityDropsGeometryAndFreesOldExtent) {
+  HostRetentionHarness     harness;
+  constexpr TextureRequest kSensor{16, 16, TextureFormat::Rgba32f};
+  constexpr TextureRequest kGeometry{8, 8, TextureFormat::Rgba32f};
+  PublishWithFrameIdentity(harness, harness.Sensor(), kSensor);
+  PublishWithFrameIdentity(harness, harness.Geometry(), kGeometry);
+  PublishWithFrameIdentity(harness, harness.Grade(), kGeometry);
+  const auto sensor_handle = harness.cache.Find(harness.Sensor())->Handle();
+  const auto geometry_identity =
+      harness.cache.PublishedRepresentation(harness.Geometry()).identity;
+
+  harness.document.Geometry().SetCropRect({0.1f, 0.1f, 0.5f, 0.5f});
+  GraphCompiler::BindFrameGeometry(harness.plan, harness.document, RenderRequest{});
+  harness.invalidation.CollectAndPropagate(harness.plan, harness.document, harness.prepared, {});
+  const auto geometry_needed = harness.invalidation.MakeImageRepresentation(
+      harness.Geometry(), {kGeometry.width, kGeometry.height}, kGeometry.format);
+  ASSERT_NE(geometry_needed.identity, geometry_identity);
+  ASSERT_TRUE(harness.invalidation.HasCurrentRevision(
+      harness.Geometry(), harness.cache.PublishedRevision(harness.Geometry())));
+
+  harness.cache.DropStalePublished([&](const GraphValueId& id, RuntimeRevision revision,
+                                       const ResultRepresentation& published) {
+    return KeepPublishedForInteractive(harness, id, revision, published);
+  });
+  // Product BeginRender clears used_this_frame first. Reclaim must still free
+  // obsolete extents when identity-drop happens in the same session as acquire.
+  harness.pool.ReleaseUnleasedUnusedSizes();
+
+  ASSERT_NE(harness.cache.Find(harness.Sensor()), nullptr);
+  EXPECT_EQ(harness.cache.Find(harness.Sensor())->Handle(), sensor_handle);
+  EXPECT_EQ(harness.cache.Find(harness.Geometry()), nullptr);
+  EXPECT_EQ(harness.cache.Find(harness.Grade()), nullptr);
+  EXPECT_EQ(harness.pool.EntryCount(), 1U);
+  EXPECT_FALSE(harness.pool.HasReusable(kGeometry));
+}
+
+TEST(GraphImageCacheRetention, QualityBaseKeepsInteractiveGeometryWhenCropChangesExtent) {
+  HostRetentionHarness     harness;
+  constexpr TextureRequest kSensor{16, 16, TextureFormat::Rgba32f};
+  constexpr TextureRequest kGeometry{8, 8, TextureFormat::Rgba32f};
+  PublishWithFrameIdentity(harness, harness.Sensor(), kSensor);
+  PublishWithFrameIdentity(harness, harness.Geometry(), kGeometry);
+  const auto geometry_handle = harness.cache.Find(harness.Geometry())->Handle();
+
+  harness.document.Geometry().SetCropRect({0.1f, 0.1f, 0.5f, 0.5f});
+  GraphCompiler::BindFrameGeometry(harness.plan, harness.document, RenderRequest{});
+  harness.invalidation.CollectAndPropagate(harness.plan, harness.document, harness.prepared, {});
+
+  harness.cache.DropStalePublished([&](const GraphValueId& id, RuntimeRevision revision,
+                                       const ResultRepresentation&) {
+    return harness.invalidation.HasCurrentRevision(id, revision);
+  });
+  harness.pool.ReleaseUnleasedUnusedSizes();
+
+  ASSERT_NE(harness.cache.Find(harness.Geometry()), nullptr);
+  EXPECT_EQ(harness.cache.Find(harness.Geometry())->Handle(), geometry_handle);
+  EXPECT_EQ(harness.pool.EntryCount(), 2U);
+}
+
+TEST(TexturePoolRetention, UnusedSizeReclaimFreesReleasedExtentWithoutBeginFrame) {
+  HostTextureBackend              backend;
+  TexturePool<HostTextureBackend> pool(backend);
+  auto keep     = pool.Acquire({16, 16, TextureFormat::Rgba32f});
+  auto obsolete = pool.Acquire({8, 8, TextureFormat::Rgba32f});
+  obsolete.Release();
+  pool.ReleaseUnleasedUnusedSizes();
+  EXPECT_EQ(pool.EntryCount(), 1U);
+  EXPECT_TRUE(pool.Contains(keep.Handle()));
+  EXPECT_FALSE(pool.HasReusable({8, 8, TextureFormat::Rgba32f}));
+}
+
+TEST(TexturePoolRetention, ChangingExtentReleasesUnusedAllocationsBeforeAllocatingNextTexture) {
+  HostTextureBackend backend;
+  TexturePool<HostTextureBackend> pool(backend);
+  for (std::uint32_t width = 8; width < 40; ++width) {
+    pool.BeginFrame();
+    auto image = pool.Acquire({width, 8, TextureFormat::Rgba32f});
+    EXPECT_EQ(pool.EntryCount(), 1U) << "width=" << width;
+    EXPECT_EQ(pool.UsedBytes(), static_cast<std::size_t>(width) * 8 * 16);
+    pool.MarkSubmitted(width);
+  }
+}
+
+TEST(TexturePoolRetention, LatePublishObsoleteExtentsAreReclaimedAtNextFrameStart) {
+  HostTextureBackend              backend;
+  TexturePool<HostTextureBackend> pool(backend);
+  ResourceLease<HostTextureBackend> published;
+  for (std::uint32_t width = 8; width < 40; ++width) {
+    pool.BeginFrame();
+    pool.ReleaseUnleasedUnusedSizes();
+    auto write = pool.Acquire({width, 8, TextureFormat::Rgba32f});
+    EXPECT_LE(pool.EntryCount(), 2U) << "width=" << width;
+    pool.MarkSubmitted(width);
+    if (!published.Empty()) {
+      published.Release();
+    }
+    published = std::move(write);
+  }
+  pool.BeginFrame();
+  pool.ReleaseUnleasedUnusedSizes();
+  EXPECT_EQ(pool.EntryCount(), 1U);
+}
+
+TEST(TexturePoolRetention, MatchingScratchReusesAllocationWithinAndAcrossFrames) {
+  HostTextureBackend backend;
+  TexturePool<HostTextureBackend> pool(backend);
+  pool.BeginFrame();
+  auto scratch = pool.Acquire({8, 8, TextureFormat::Rgba32f});
+  const auto handle = scratch.Handle();
+  scratch.Release();
+  auto second_stage = pool.Acquire({8, 8, TextureFormat::Rgba32f});
+  EXPECT_EQ(second_stage.Handle(), handle);
+  pool.MarkSubmitted(1);
+  second_stage.Release();
+  pool.BeginFrame();
+  auto next_frame = pool.Acquire({8, 8, TextureFormat::Rgba32f});
+  EXPECT_EQ(next_frame.Handle(), handle);
+  EXPECT_EQ(pool.EntryCount(), 1U);
+}
+
+TEST(TexturePoolRetention, LeasedTextureAddressSurvivesPoolGrowth) {
+  HostTextureBackend backend;
+  TexturePool<HostTextureBackend> pool(backend);
+  auto source = pool.Acquire({8, 8, TextureFormat::Rgba32f});
+  const auto* address = &source.Texture();
+  std::vector<ResourceLease<HostTextureBackend>> stages;
+  for (int stage = 0; stage < 32; ++stage) {
+    stages.push_back(pool.Acquire({8, 8, TextureFormat::Rgba32f}));
+  }
+  EXPECT_EQ(&source.Texture(), address);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/support/editor_session_test_ports.hpp
+++ b/alcedo_studio/tests/support/editor_session_test_ports.hpp
@@ -100,6 +100,7 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
   std::string                    last_grade_name;
   int                            set_panel_projection_node_count = 0;
   NodeId                         last_panel_projection_node;
+  std::uint64_t                  last_panel_projection_generation = 0;
   std::optional<EditorRenderReason> last_render_reason = EditorRenderReason::UndoRedo;
   std::shared_ptr<const EditorMiniGitSaveCapture> next_capture = MakeOpaqueSaveCapture();
 
@@ -178,10 +179,11 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
     return last_render_reason;
   }
 
-  auto SetPanelProjectionNode(const EditorHistoryGuardHandle&, const NodeId& node_id, std::string*)
-      -> bool override {
+  auto SetPanelProjectionNode(const EditorHistoryGuardHandle&, const NodeId& node_id,
+                              std::uint64_t session_generation, std::string*) -> bool override {
     ++set_panel_projection_node_count;
-    last_panel_projection_node = node_id;
+    last_panel_projection_node       = node_id;
+    last_panel_projection_generation = session_generation;
     return true;
   }
 

--- a/alcedo_studio/tests/support/editor_session_test_ports.hpp
+++ b/alcedo_studio/tests/support/editor_session_test_ports.hpp
@@ -98,6 +98,8 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
   NodeGraphTopologyChange        last_topology_change{};
   NodeId                         last_node_id;
   std::string                    last_grade_name;
+  int                            set_panel_projection_node_count = 0;
+  NodeId                         last_panel_projection_node;
   std::optional<EditorRenderReason> last_render_reason = EditorRenderReason::UndoRedo;
   std::shared_ptr<const EditorMiniGitSaveCapture> next_capture = MakeOpaqueSaveCapture();
 
@@ -174,6 +176,13 @@ class FakeEditorHistoryPort : public IEditorHistoryPort {
   [[nodiscard]] auto LastPublishedRenderReason() const
       -> std::optional<EditorRenderReason> override {
     return last_render_reason;
+  }
+
+  auto SetPanelProjectionNode(const EditorHistoryGuardHandle&, const NodeId& node_id, std::string*)
+      -> bool override {
+    ++set_panel_projection_node_count;
+    last_panel_projection_node = node_id;
+    return true;
   }
 
   auto Undo(const EditorHistoryGuardHandle&, std::string* error) -> bool override {

--- a/alcedo_studio/tests/ui/editor_node_controller_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_controller_test.cpp
@@ -895,6 +895,84 @@ TEST(EditorNodeController, NodeSwitchSealsOpenSequenceAndLaterWriteTargetsNewGra
   EXPECT_EQ(pending.sequences[1].captured_target.node_id, NodeId{"grade.b"});
 }
 
+TEST(EditorNodeController, PanelNavigationSelectsOwnersAndReturnsToLastGradeWithoutRendering) {
+  DocumentSessionBackend backend;
+  ASSERT_TRUE(AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  EditorSessionController session(&backend);
+  EditorNodeController    nodes;
+  nodes.set_editor_session(&session);
+  nodes.selectNode(QStringLiteral("grade.b"));
+  const int views_before = backend.view_change_count();
+  for (const auto& panel : {"display", "raw", "tone", "look", "lut"}) {
+    session.set_active_adjustment_panel(QString::fromLatin1(panel));
+    const NodeId expected{std::string(panel) == "display" ? "drt"
+                          : std::string(panel) == "raw"   ? "develop"
+                                                          : "grade.b"};
+    EXPECT_EQ(nodes.selected_node_id(), expected);
+    EXPECT_EQ(backend.last_projection_node(), expected);
+    EXPECT_EQ(session.active_adjustment_panel(), QString::fromLatin1(panel));
+  }
+  EXPECT_EQ(backend.view_change_count(), views_before);
+  EXPECT_EQ(backend.enqueue_count(), 0);
+  EXPECT_EQ(backend.boundary_count(), 0);
+  ASSERT_TRUE(session.submitWrite(QStringLiteral("exposure"), EditorScalarWrite{0.4f}, false));
+  EXPECT_EQ(session.PeekPendingInput().sequences.front().captured_target.node_id,
+            NodeId{"grade.b"});
+}
+
+TEST(EditorNodeController, PanelNavigationWithoutPreviousGradeSelectsFirstGrade) {
+  auto document = CreateDefaultPipelineDocument();
+  ASSERT_TRUE(AddCleanColorGrade(document, NodeId{"grade.primary"}, NodeId{"grade.first"}).empty());
+  EditorNodeController nodes;
+  ASSERT_TRUE(nodes.PublishDocument(document, 1));
+  nodes.selectNode(QStringLiteral("drt"));
+  ASSERT_TRUE(nodes.PublishDocument(document, 2));
+  ASSERT_EQ(nodes.selected_node_id(), NodeId{"drt"});
+  nodes.SelectNodeForAdjustmentPanel(QStringLiteral("look"));
+  EXPECT_EQ(nodes.selected_node_id(), NodeId{"grade.first"});
+}
+
+TEST(EditorNodeController, DeletedRememberedGradeReturnsToFirstExistingGrade) {
+  DocumentSessionBackend backend;
+  ASSERT_TRUE(AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  EditorSessionController session(&backend);
+  EditorNodeController    nodes;
+  nodes.set_editor_session(&session);
+  nodes.selectNode(QStringLiteral("grade.b"));
+  session.set_active_adjustment_panel(QStringLiteral("display"));
+  backend.Document() = CreateDefaultPipelineDocument();
+  backend.PublishHistoryChange();
+  session.set_active_adjustment_panel(QStringLiteral("tone"));
+  EXPECT_EQ(nodes.selected_node_id(), NodeId{"grade.primary"});
+}
+
+TEST(EditorNodeController, GeometryExitSubmitsWhileDevelopSelectedBeforeReturningToGrade) {
+  DocumentSessionBackend backend;
+  ASSERT_TRUE(AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  EditorSessionController session(&backend);
+  EditorNodeController    nodes;
+  nodes.set_editor_session(&session);
+  nodes.selectNode(QStringLiteral("grade.b"));
+  const int views_before = backend.view_change_count();
+  session.set_active_adjustment_panel(QStringLiteral("geometry"));
+  ASSERT_EQ(nodes.selected_node_id(), NodeId{"develop"});
+  EXPECT_EQ(session.active_adjustment_panel(), QStringLiteral("geometry"));
+  EXPECT_EQ(backend.view_change_count(), views_before + 1);
+  bool submitted = false;
+  QObject::connect(&session, &EditorSessionController::DesktopUiChanged, &session, [&] {
+    if (session.active_adjustment_panel() == QStringLiteral("tone")) {
+      EXPECT_EQ(nodes.selected_node_id(), NodeId{"develop"});
+      submitted = session.submitWrite(QStringLiteral("crop_rotate"), ImageGeometryUpdate{}, true);
+    }
+  });
+  session.set_active_adjustment_panel(QStringLiteral("tone"));
+  EXPECT_TRUE(submitted);
+  EXPECT_EQ(nodes.selected_node_id(), NodeId{"grade.b"});
+  EXPECT_EQ(backend.view_change_count(), views_before + 2);
+  session.set_active_adjustment_panel(QStringLiteral("look"));
+  EXPECT_EQ(backend.view_change_count(), views_before + 2);
+}
+
 TEST(EditorNodeController, LeavingDevelopGeometryDoesNotRequestViewChange) {
   DocumentSessionBackend  backend;
   EditorSessionController session(&backend);

--- a/alcedo_studio/tests/ui/editor_node_controller_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_controller_test.cpp
@@ -270,6 +270,23 @@ TEST(EditorNodeController, PublishDocumentSelectsPrimaryColorGrade) {
   EXPECT_FALSE(controller.can_add_color_grade());
 }
 
+TEST(EditorNodeController, TopologyEditDoesNotSelectASubstituteGrade) {
+  DocumentSessionBackend backend;
+  backend.SetGeneration(17);
+  ASSERT_TRUE(
+      alcedo::AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.extra"}).empty());
+  EditorSessionController session(&backend);
+  EditorNodeController    controller;
+  controller.set_editor_session(&session);
+  controller.selectNode(QStringLiteral("grade.extra"));
+  ASSERT_EQ(controller.selected_node_id(), NodeId{"grade.extra"});
+
+  ASSERT_TRUE(controller.deleteColorGrade(QStringLiteral("grade.extra")));
+  EXPECT_TRUE(controller.selected_node_id().Empty());
+  EXPECT_TRUE(backend.last_projection_node().Empty());
+  EXPECT_FALSE(session.submitWrite(QStringLiteral("exposure"), EditorScalarWrite{0.3f}, false));
+}
+
 TEST(EditorNodeController, UnknownNodeDoesNotCreateASecondSelection) {
   EditorNodeController controller;
   ASSERT_TRUE(controller.PublishDocument(CreateDefaultPipelineDocument(), 1));
@@ -376,6 +393,7 @@ TEST(EditorNodeController, DeleteOfADraftGradeDoesNotSubmitWhileThePathIsBroken)
   EXPECT_EQ(backend.edit_node_graph_count(), 0);
   EXPECT_TRUE(controller.incomplete_draft());
   EXPECT_EQ(controller.ActiveNodes().size(), 3u);
+  EXPECT_TRUE(controller.selected_node_id().Empty());
 }
 
 TEST(EditorNodeController, EndpointsAndStaleGenerationRejectCommandsBeforeBackendMutation) {
@@ -413,7 +431,7 @@ TEST(EditorNodeController, BackendFailurePreservesDocumentCounterProjectionAndSe
   EXPECT_EQ(backend.edit_node_graph_count(), 0);
 }
 
-TEST(EditorNodeController, MissingNodeAfterRefreshSelectsRemainingColorGrade) {
+TEST(EditorNodeController, MissingDefaultColorGradeAfterRefreshClearsSelection) {
   EditorNodeController controller;
   auto                 document = CreateDefaultPipelineDocument();
   ASSERT_TRUE(controller.PublishDocument(document, 2));
@@ -424,8 +442,7 @@ TEST(EditorNodeController, MissingNodeAfterRefreshSelectsRemainingColorGrade) {
                      [](const auto& node) { return node.node_id == NodeId{"grade.primary"}; }),
       next.nodes.end());
   ASSERT_TRUE(controller.PublishSnapshot(std::move(next)));
-  EXPECT_NE(controller.selected_node_id(), NodeId{"grade.primary"});
-  EXPECT_FALSE(controller.selected_node_id().Empty());
+  EXPECT_TRUE(controller.selected_node_id().Empty());
 }
 
 TEST(EditorNodeController, BlockedEditAvailabilityDisablesAddWithoutSnapshotChange) {

--- a/alcedo_studio/tests/ui/editor_node_controller_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_controller_test.cpp
@@ -9,14 +9,21 @@
 #include <QCoreApplication>
 #include <QTranslator>
 #include <algorithm>
+#include <optional>
 #include <vector>
 
 #include "app/editor_action_policy.hpp"
 #include "app/editor_node_graph_projection.hpp"
+#include "app/editor_pending_input.hpp"
+#include "app/editor_parameter_write.hpp"
 #include "app/editor_session_request_ids.hpp"
 #include "app/editor_session_service.hpp"
 #include "app/pipeline_document_history.hpp"
+#include "edit/frame_presentation_types.hpp"
+#include "app/editor_adjustment_context.hpp"
+#include "app/editor_render_intent.hpp"
 #include "edit/graph/color_grade_node_model.hpp"
+#include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/graph/pipeline_graph_commands.hpp"
 #include "grade_owned_mask_support.hpp"
@@ -28,8 +35,14 @@
 
 namespace {
 
+using alcedo::AddCleanColorGrade;
 using alcedo::CreateDefaultPipelineDocument;
 using alcedo::EditorNodeGraphProjection;
+using alcedo::EditorPendingInputBoundaryKind;
+using alcedo::EditorPendingInputView;
+using alcedo::EditorParameterOwnerKind;
+using alcedo::EditorScalarWrite;
+using alcedo::ImageGeometryUpdate;
 using alcedo::EditorSessionIdentity;
 using alcedo::EditorSessionResult;
 using alcedo::EditorSessionState;
@@ -87,6 +100,39 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
 
   void SetPresentationSinkId(alcedo::PresentationSinkId) override {}
   void SetPresentationSize(int, int) override {}
+  auto SetAdjustmentProjectionNode(const NodeId& node_id) -> EditorSessionResult override {
+    ++set_projection_count_;
+    last_projection_node_ = node_id;
+    return Accepted("Selected node panel projection updated");
+  }
+  auto EnqueueAdjustmentInput(alcedo::EditorAdjustmentPatch patch) -> EditorSessionResult override {
+    ++enqueue_count_;
+    const auto admitted = pending_input_.AdmitFieldChange(identity_, std::move(patch));
+    if (!admitted.accepted) {
+      return Rejected(admitted.error);
+    }
+    return Accepted("Adjustment input queued");
+  }
+  auto EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind kind)
+      -> EditorSessionResult override {
+    ++boundary_count_;
+    last_boundary_      = kind;
+    const auto admitted = pending_input_.AdmitBoundary(identity_, kind);
+    if (!admitted.accepted) {
+      return Rejected(admitted.error);
+    }
+    return Accepted("Adjustment input boundary queued");
+  }
+  [[nodiscard]] auto PeekPendingInput() const -> EditorPendingInputView override {
+    return pending_input_.Peek();
+  }
+  auto RequestViewChange(alcedo::EditorRenderReason, std::optional<alcedo::ViewportRenderRegion>)
+      -> EditorSessionResult override {
+    ++view_change_count_;
+    auto result  = Accepted("View change recorded");
+    result.kind  = alcedo::EditorSessionResultKind::RenderRouted;
+    return result;
+  }
   auto Open(sl_element_id_t element_id, image_id_t image_id) -> EditorSessionResult override {
     identity_.element_id = element_id;
     identity_.image_id   = image_id;
@@ -158,6 +204,14 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto history_snapshot_read_count() const -> int {
     return history_snapshot_read_count_;
   }
+  [[nodiscard]] auto set_projection_count() const -> int { return set_projection_count_; }
+  [[nodiscard]] auto last_projection_node() const -> NodeId { return last_projection_node_; }
+  [[nodiscard]] auto enqueue_count() const -> int { return enqueue_count_; }
+  [[nodiscard]] auto boundary_count() const -> int { return boundary_count_; }
+  [[nodiscard]] auto view_change_count() const -> int { return view_change_count_; }
+  [[nodiscard]] auto last_boundary() const -> EditorPendingInputBoundaryKind {
+    return last_boundary_;
+  }
 
  private:
   auto Accepted(std::string message) const -> EditorSessionResult {
@@ -187,6 +241,13 @@ class DocumentSessionBackend final : public IEditorSessionBackend {
   std::uint64_t                                     history_revision_            = 0;
   mutable int                                       active_version_read_count_   = 0;
   int                                               history_snapshot_read_count_ = 0;
+  int                                               set_projection_count_        = 0;
+  int                                               enqueue_count_               = 0;
+  int                                               boundary_count_              = 0;
+  int                                               view_change_count_           = 0;
+  NodeId                                            last_projection_node_;
+  EditorPendingInputBoundaryKind                    last_boundary_ = EditorPendingInputBoundaryKind::None;
+  alcedo::EditorPendingInputQueue                   pending_input_;
   alcedo::NodeGraphTopologyChange                   last_topology_change_{};
 };
 
@@ -739,6 +800,96 @@ TEST(EditorSessionToolPanelPage, AcceptsOnlyEmptyHistoryVersionsAndNodes) {
   EXPECT_TRUE(session.editor_tool_panel_page().isEmpty());
   session.set_editor_tool_panel_page(QStringLiteral("NODES"));
   EXPECT_EQ(session.editor_tool_panel_page(), QStringLiteral("nodes"));
+}
+
+TEST(EditorNodeController, SubmitWriteStampsSelectedColorGradeInstance) {
+  DocumentSessionBackend  backend;
+  ASSERT_TRUE(AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  EditorSessionController session(&backend);
+  EditorNodeController    nodes;
+  nodes.set_editor_session(&session);
+  nodes.selectNode(NodeIdToQString(NodeId{"grade.b"}));
+  EXPECT_EQ(backend.last_projection_node(), NodeId{"grade.b"});
+
+  ASSERT_TRUE(session.submitWrite(QStringLiteral("exposure"), EditorScalarWrite{0.4f}, false));
+  const auto pending = session.PeekPendingInput();
+  ASSERT_EQ(pending.sequences.size(), 1u);
+  EXPECT_EQ(pending.sequences.front().captured_target.owner_kind,
+            EditorParameterOwnerKind::ColorGrade);
+  EXPECT_EQ(pending.sequences.front().captured_target.node_id, NodeId{"grade.b"});
+  const auto* extra =
+      dynamic_cast<alcedo::ColorGradeNodeModel*>(backend.Document().Graph().FindNode(NodeId{"grade.b"}));
+  ASSERT_NE(extra, nullptr);
+  const auto* instance = extra->FindAdjustmentIdByType(alcedo::type_ids::Exposure());
+  ASSERT_NE(instance, nullptr);
+  EXPECT_EQ(pending.sequences.front().captured_target.adjustment_instance_id, *instance);
+  EXPECT_NE(pending.sequences.front().captured_target.adjustment_instance_id,
+            alcedo::AdjustmentInstanceId{"grade.primary.exposure"});
+}
+
+TEST(EditorNodeController, GeometryWriteRejectedWhenColorGradeIsSelected) {
+  DocumentSessionBackend  backend;
+  EditorSessionController session(&backend);
+  EditorNodeController    nodes;
+  nodes.set_editor_session(&session);
+  ASSERT_TRUE(session.submitWrite(QStringLiteral("exposure"), EditorScalarWrite{0.1f}, true));
+  EXPECT_FALSE(session.submitWrite(QStringLiteral("crop_rotate"), ImageGeometryUpdate{}, false));
+  const auto pending = session.PeekPendingInput();
+  ASSERT_EQ(pending.sequences.size(), 1u);
+  EXPECT_EQ(pending.sequences.front().fields.size(), 1u);
+  EXPECT_EQ(pending.sequences.front().fields.front().target.field_key, "exposure");
+}
+
+TEST(EditorNodeController, EmptySelectionDoesNotQueueBoundaryOrRender) {
+  DocumentSessionBackend  backend;
+  ASSERT_TRUE(AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  EditorSessionController session(&backend);
+  EditorNodeController    nodes;
+  nodes.set_editor_session(&session);
+  const int views_before      = backend.view_change_count();
+  const int boundaries_before = backend.boundary_count();
+  const int enqueue_before    = backend.enqueue_count();
+  const auto revision_before  = backend.history_revision();
+  nodes.selectNode(NodeIdToQString(NodeId{"grade.b"}));
+  EXPECT_EQ(backend.boundary_count(), boundaries_before);
+  EXPECT_EQ(backend.enqueue_count(), enqueue_before);
+  EXPECT_EQ(backend.view_change_count(), views_before);
+  EXPECT_EQ(backend.history_revision(), revision_before);
+  EXPECT_EQ(backend.last_projection_node(), NodeId{"grade.b"});
+  EXPECT_TRUE(session.PeekPendingInput().sequences.empty());
+}
+
+TEST(EditorNodeController, NodeSwitchSealsOpenSequenceAndLaterWriteTargetsNewGrade) {
+  DocumentSessionBackend  backend;
+  ASSERT_TRUE(AddCleanColorGrade(backend.Document(), NodeId{"drt"}, NodeId{"grade.b"}).empty());
+  EditorSessionController session(&backend);
+  EditorNodeController    nodes;
+  nodes.set_editor_session(&session);
+  ASSERT_EQ(nodes.selected_node_id(), NodeId{"grade.primary"});
+  ASSERT_TRUE(session.submitWrite(QStringLiteral("exposure"), EditorScalarWrite{0.1f}, false));
+  nodes.selectNode(NodeIdToQString(NodeId{"grade.b"}));
+  EXPECT_EQ(backend.last_boundary(), EditorPendingInputBoundaryKind::NodeSwitch);
+  ASSERT_TRUE(session.submitWrite(QStringLiteral("exposure"), EditorScalarWrite{0.2f}, false));
+
+  const auto pending = session.PeekPendingInput();
+  ASSERT_EQ(pending.sequences.size(), 2u);
+  EXPECT_EQ(pending.sequences[0].seal, EditorPendingInputBoundaryKind::NodeSwitch);
+  EXPECT_EQ(pending.sequences[0].captured_target.node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(pending.sequences[1].captured_target.node_id, NodeId{"grade.b"});
+}
+
+TEST(EditorNodeController, LeavingDevelopGeometryDoesNotRequestViewChange) {
+  DocumentSessionBackend  backend;
+  EditorSessionController session(&backend);
+  EditorNodeController    nodes;
+  nodes.set_editor_session(&session);
+  nodes.selectNode(NodeIdToQString(NodeId{"develop"}));
+  session.set_active_adjustment_panel(QStringLiteral("geometry"));
+  const int views_after_geometry = backend.view_change_count();
+  EXPECT_GT(views_after_geometry, 0);
+  nodes.selectNode(NodeIdToQString(NodeId{"grade.primary"}));
+  EXPECT_EQ(session.active_adjustment_panel(), QStringLiteral("tone"));
+  EXPECT_EQ(backend.view_change_count(), views_after_geometry);
 }
 
 }  // namespace

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-05
 
-Status: NM6.1–NM6.5B, NM6.4P, and NM6.P complete; NM6.6–NM6.9 planned.
+Status: NM6.1–NM6.6, NM6.4P, and NM6.P complete; NM6.7–NM6.9 planned.
 
 Prerequisites: NM5 is complete. Preserve NM1 single live document/executor ownership,
 NM2 multi-Grade execution, NM3 multi-Mask data, and NM4 history/recovery guarantees.
@@ -413,7 +413,7 @@ Additional acceptance requirements:
 
 ## 7. Ordered implementation phases
 
-NM6.1–NM6.5B, NM6.4P, and NM6.P are complete. NM6.6–NM6.9 remain planned. Each phase must leave a buildable product path and
+NM6.1–NM6.6, NM6.4P, and NM6.P are complete. NM6.7–NM6.9 remain planned. Each phase must leave a buildable product path and
 write its actual call chain and evidence into Section 10. New-file names are proposed; existing
 links are verified entry points. Do not declare a phase complete based on implementation
 inspection alone.
@@ -1125,6 +1125,76 @@ render or commit; queued old-target input cannot land on the new selection. EXIF
 Section 6.2 JSON/copy instrumentation passes. Geometry capability belongs only to Develop while
 its actual target remains document-owned. Preserve Patch/Commit as the update unit.
 
+##### Phase NM6.6 completion record (2026-09-07)
+
+**Status:** complete — selected-node panel capabilities, submit stamping, and load-only projection without render or history commit
+
+**Primary success call chain:**
+
+```text
+EditorNodeController.selectNode / PublishSnapshot
+  -> SyncSessionAdjustmentNode
+  -> EditorSessionController.ApplySelectedAdjustmentNode
+  -> EditorSessionService.SetAdjustmentProjectionNode
+  -> IEditorHistoryPort.SetPanelProjectionNode
+  -> ProjectSelectedNodePanelFields (typed adapters, no Model ToJson / MakeFullDto)
+
+submitWrite(field)
+  -> CompleteSelectedNodeParameterTarget(selected NodeId)
+  -> EnqueueAdjustmentInput with captured NodeId / AdjustmentInstanceId
+  -> NM6.2 queue / NM6.3 owner
+  -> CaptureAdjustmentBeforePreview uses stamped target
+  -> ApplyEditorParameterWrite / CommitAdjustment
+```
+
+**Primary failure call chain:**
+
+```text
+Geometry write while Color Grade selected
+  -> CompleteSelectedNodeParameterTarget rejects (field not owned by selected node)
+  -> submitWrite returns false; pending queue unchanged
+
+Missing node / missing instance / wrong owner
+  -> CompleteSelectedNodeParameterTarget / ProjectSelectedNodePanelFields fail
+  -> caller output left unchanged; no PrimaryGrade substitute
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| Two Color Grades resolve independent exposure instances | `EditorAdjustmentContextTest` | PASS |
+| Missing node or instance leaves projection unchanged | `EditorAdjustmentContextTest` | PASS |
+| Wrong owner and Geometry-from-Grade fail; Geometry-from-Develop is document-owned | `EditorAdjustmentContextTest` | PASS |
+| Selected-node panel projection does not call Model ToJson / MakeFullDto | `EditorAdjustmentContextTest` | PASS |
+| Image EXIF copies owner fields; invalid values are nullopt | `EditorAdjustmentContextTest` | PASS |
+| Context copies caller EXIF for two node ids | `EditorAdjustmentContextTest` | PASS |
+| Capability registry matches node kind | `EditorAdjustmentContextTest` | PASS |
+| `submitWrite` stamps selected Color Grade instance | `EditorNodeSelectionLayoutTest` | PASS |
+| Geometry write rejected when Color Grade is selected | `EditorNodeSelectionLayoutTest` | PASS |
+| Empty selection does not queue NodeSwitch, render, or history revision | `EditorNodeSelectionLayoutTest` | PASS |
+| Node switch seals open sequence; later write targets the new Grade | `EditorNodeSelectionLayoutTest` | PASS |
+| Leaving Develop Geometry does not request a view change | `EditorNodeSelectionLayoutTest` | PASS |
+| Unspecified history write uses selected projection node, not PrimaryGrade | `EditorSessionHistoryPortTest` | PASS |
+| Empty NodeSwitch does not bump history revision | `EditorPendingInputSessionTest` | PASS |
+| Selected-node projection does not capture or commit | `EditorPendingInputSessionTest` | PASS |
+| Section 6.2 panel projection instrumentation | `EditorPanelProjectionTest` | PASS |
+| `NodeSwitchKeepsQueuedEditOnOriginalTarget` | `EditorPendingInputTest` | PASS |
+
+Commands:
+```
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target EditorAdjustmentContextTest --target EditorPendingInputSessionTest --target EditorNodeSelectionLayoutTest --target EditorSessionHistoryPortTest
+ctest --test-dir build/debug --output-on-failure -R "EditorAdjustmentContextTest|EditorPendingInputSessionTest|EditorNodeSelectionLayoutTest|EditorSessionHistoryPortTest.UnspecifiedWriteUsesSelectedProjectionNodeNotPrimaryGrade"
+ctest --test-dir build/debug --output-on-failure -R "EditorPanelProjectionTest|EditorPendingInputTest.NodeSwitchKeepsQueuedEditOnOriginalTarget"
+```
+Suite totals: 58/58 focused PASS plus 6/6 related panel/queue PASS.
+
+**Checklist / exit condition:** acceptance criteria above are covered by executed tests. No checkbox list in this phase heading.
+
+**LOC note (grill-code-review):** new `EditorAdjustmentContext` is 142/302 header/cpp. `editor_session_service.cpp` 1832, `editor_session_controller.cpp` 1449, `editor_history_mutation.cpp` 1112, `editor_node_controller.cpp` 1101 remain above 1000 from prior phases; this slice added a small selected-node path instead of growing `editor_pipeline_command_service.cpp`. `editor_node_controller_test.cpp` is 895 lines and now mixes Nodes-page and selected-node submit cases.
+
+**Residual gaps:** NM6.7 QML header/capability-filtered navigation; NM6.8 lifecycle/history e2e; NM6.9 pixel/perf qualification. `CompleteCurrentPanelParameterTarget` still fills PrimaryGrade when no node controller is bound and `panel_projection_node_id` is empty. Production QML can still open Geometry on a Grade until NM6.7 hides that page; `submitWrite` rejects that write.
+
 ### NM6.7 — Build node-name/EXIF header and capability-filtered panels
 
 **Changes:** implement Section 6 header in the existing stack; bind navigation/body to the registry;
@@ -1274,7 +1344,7 @@ and any renamed linked files together. No runtime metadata is written into docum
 | NM6.P | complete 2026-09-06 | `feature/nm6-native-parameter-access` | QML/model `submitWrite` → queue → `ApplyEditorParameterWrite` → remirror/render/history → typed panel read; CameraColor/DRT `BindOrWritePackedSlot`; P7 result retention / QualityBase bypass | see [NM6.P plan](phase_nm6p_native_parameter_access_plan.md) | Shared Grade/LLF executors NM6.5; node targeting NM6.6 |
 | NM6.5 | complete 2026-09-06 | uncommitted on `feature/shared-grade-local-tone-executors` | PlanExecutor → GradeExecutor → LocalToneExecutor → specialized GPU op → PersistCanonical source.0/result.0 → RecordUnpublished / PublishResults | 120/120 focused PASS; Metal GPU encode skipped on Windows; see NM6.5 completion record | Shared Point/Neighbor/DRT orchestration is NM6.5B; Metal GPU execution; Section 8.2 RAW pixel matrix NM6.9 |
 | NM6.5B | complete 2026-09-07 | uncommitted on `feature/shared-grade-local-tone-executors` | compiled stages → GradeExecutor / NeighborExecutor / DrtPostExecutor → Ops::DispatchPointwise \| DispatchHorizontal \| DispatchVerticalApply \| DispatchDisplayTransform | 118/118 focused PASS plus 2 CUDA product DRT cases; Metal GPU encode skipped on Windows; see NM6.5B completion record | Node targeting NM6.6; Metal GPU execution; Section 8.2 RAW pixel matrix NM6.9 |
-| NM6.6 | planned | — | — | — | Node context/target routing |
+| NM6.6 | complete 2026-09-07 | uncommitted on `feature/selected-node-adjustment-context` @ `9b881864` | selectNode → SetAdjustmentProjectionNode → ProjectSelectedNodePanelFields; submitWrite → CompleteSelectedNodeParameterTarget → queue → CaptureAdjustmentBeforePreview | 58/58 focused PASS plus 6/6 panel/queue PASS; see NM6.6 completion record | QML header/capability filter NM6.7; lifecycle e2e NM6.8; Section 8.2 RAW pixel matrix NM6.9 |
 | NM6.7 | planned | — | — | — | Approved header and panel UI |
 | NM6.8 | planned | — | — | — | Lifecycle/history integration |
 | NM6.9 | planned | — | — | — | Cross-platform qualification |

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm6_node_aware_adjustments_plan.md
@@ -1195,6 +1195,61 @@ Suite totals: 58/58 focused PASS plus 6/6 related panel/queue PASS.
 
 **Residual gaps:** NM6.7 QML header/capability-filtered navigation; NM6.8 lifecycle/history e2e; NM6.9 pixel/perf qualification. `CompleteCurrentPanelParameterTarget` still fills PrimaryGrade when no node controller is bound and `panel_projection_node_id` is empty. Production QML can still open Geometry on a Grade until NM6.7 hides that page; `submitWrite` rejects that write.
 
+##### Phase NM6.6 follow-up: GPU image-pool residency after crop (2026-09-07)
+
+**Status:** complete — Interactive crop no longer keeps obsolete-extent published results; idle unused sizes are reclaimed after GPU last-use; DRT ping/pong write slots are released after the last neighborhood reader
+
+**Primary success call chain:**
+
+```text
+crop / viewport extent change
+  -> CollectAndPropagate (revision of Geometry may stay; frame identity changes)
+  -> PrepareResultValidity
+  -> DropUnusablePublishedImages (Interactive: identity mismatch)
+  -> TexturePool::ReleaseUnleasedUnusedSizes
+  -> AcquireImageForWrite at the new extent reuses or allocates one working set
+```
+
+**Primary failure call chain:**
+
+```text
+QualityBase frame while Interactive crop results are current
+  -> DropUnusablePublishedImages keeps revision-current Interactive geometry
+  -> QualityBase writes stay unpublished (SensorDevelopOnly)
+  -> Interactive preview textures remain leased
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `CropMismatchesFrameIdentityDropsGeometryAndFreesOldExtent` | `GraphImageCacheRetentionTest` | PASS |
+| `QualityBaseKeepsInteractiveGeometryWhenCropChangesExtent` | `GraphImageCacheRetentionTest` | PASS |
+| `UnusedSizeReclaimFreesReleasedExtentWithoutBeginFrame` | `GraphImageCacheRetentionTest` | PASS |
+| `LatePublishObsoleteExtentsAreReclaimedAtNextFrameStart` | `GraphImageCacheRetentionTest` | PASS |
+| `ChangingExtentReleasesUnusedAllocationsBeforeAllocatingNextTexture` | `GraphImageCacheRetentionTest` | PASS |
+| `LeasedTextureAddressSurvivesPoolGrowth` | `GraphImageCacheRetentionTest` | PASS |
+| `MatchingScratchReusesAllocationWithinAndAcrossFrames` | `GraphImageCacheRetentionTest` | PASS |
+| `TwoEnabledNeighborhoodsUseSharedHorizontalThenVerticalOrder` ping/pong release | `GpuDagRawInputTest` | PASS |
+| `RepeatedFullCropAndExposureEditsBoundTextureEntriesAndBytesAndPreserveSourceHits` | `GpuDagCudaDrtProductTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GraphImageCacheRetentionTest --target GpuDagRawInputTest
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GraphImageCacheRetentionTest --target GpuDagCudaDrtProductTest
+ctest --test-dir build/debug --output-on-failure -R "GraphImageCacheRetentionTest|DrtPostSchedule|DrtPostExecutor"
+ctest --test-dir build/debug --output-on-failure -R "GraphImageCacheRetentionTest|RepeatedFullCropAndExposureEditsBoundTextureEntriesAndBytes"
+```
+
+Suite totals: GraphImageCacheRetentionTest 15/15 PASS; DrtPostSchedule+DrtPostExecutor 5/5 PASS; CUDA crop-and-exposure bound 1/1 PASS.
+
+**Checklist / exit condition:** crop/identity drop, unused-size reclaim (including this-frame-use after identity-drop), and DRT ping/pong release have named tests. Product CUDA crop-and-exposure bound executed.
+
+**LOC note (grill-code-review):** `texture_pool.hpp` 411, `graph_image_cache.hpp` 442, `basic_render_workspace.hpp` 329, `drt_post_executor.hpp` 188, `graph_image_cache_retention_test.cpp` 475. No new god object.
+
+**Residual gaps:** NM6.7–NM6.9 as above. Metal GPU encode not executed on this Windows host. `ReleaseUnused` at frame end still keeps this-frame scratch of the *current* size; obsolete sizes are freed by `ReleaseUnleasedUnusedSizes` even when that flag is still set.
+
 ### NM6.7 — Build node-name/EXIF header and capability-filtered panels
 
 **Changes:** implement Section 6 header in the existing stack; bind navigation/body to the registry;


### PR DESCRIPTION
## Summary

- Add `EditorAdjustmentContext` with selected-node identity, per-kind panel capabilities, and image-owned EXIF display rows for the adjustment header.
- Resolve parameter targets and project panel fields from the selected node instead of `PrimaryGrade`, including independent Color Grade instances and explicit Develop/DRT ownership rules.
- Add `SetAdjustmentProjectionNode` as a load-only session command that reprojects `panel_projection` without mutating parameters, committing history, or requesting a render.
- Track `panel_projection_node_id` in history working state so unspecified writes and live panel updates follow the selected projection node.
- Wire `EditorNodeController` selection into `EditorSessionController`: seal open pending sequences on node switch when field writes are queued, fall back to the default panel when the current page is unsupported, and avoid view changes when leaving Develop geometry.
- Skip history revision bumps for empty node-switch boundaries that carry no pending field writes.
- Add unit and controller tests for context resolution, projection behavior, history port routing, session command semantics, and node-selection integration.
- Update the NM6 node-aware adjustments plan with NM6.1–NM6.6 completion status.

## Testing

- `ctest --test-dir build/debug -R "EditorAdjustmentContextTest|EditorPendingInputSessionTest|EditorSessionHistoryPortTest|EditorNodeController" --output-on-failure` — Not run
- `EditorAdjustmentContextTest`: independent grade exposure instances, missing-node failure leaves projection unchanged, unsupported owner/geometry rejection, selected-node projection avoids `ToJson`/`MakeFullDto`, EXIF copy/validation, capability registry per node kind — Not run
- `EditorPendingInputSessionTest`: empty node switch does not bump `history_revision`; `SetAdjustmentProjectionNode` updates projection without capture/commit — Not run
- `EditorSessionHistoryPortTest`: `SetPanelProjectionNode` routes unspecified writes to the selected grade, not primary — Not run
- `EditorNodeController`: selection stamps submit targets to the selected grade, geometry rejected when a Color Grade is selected, node switch seals sequences and retargets later writes, leaving Develop geometry does not request another view change — Not run