### PR TITLE
feat(edit): persist parameterized Brush strokes and lock raster encoding

### DIFF
--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -35,6 +35,7 @@ def_library(EditMaskStore
         ${ALCEDO_SRC_ROOT}/edit/mask/mask_store.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/mask_asset.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/mask_model.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/brush_stroke.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_raster_encoding.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/active_raster_mask.cpp
     PUBLIC_DEPS EditGeometry JSON

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -35,6 +35,7 @@ def_library(EditMaskStore
         ${ALCEDO_SRC_ROOT}/edit/mask/mask_store.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/mask_asset.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/mask_model.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/brush_raster_encoding.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/active_raster_mask.cpp
     PUBLIC_DEPS EditGeometry JSON
     PRIVATE_DEPS xxHash

--- a/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
+++ b/alcedo_studio/src/edit/graph/color_grade_node_model.cpp
@@ -5,14 +5,17 @@
 #include "edit/graph/color_grade_node_model.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "edit/graph/adjustment_ownership.hpp"
+#include "edit/mask/brush_mask_commands.hpp"
 #include "edit/mask/mask_model.hpp"
 #include "edit/operators/models/adjustment_catalog.hpp"
 
@@ -362,6 +365,116 @@ void ColorGradeNodeModel::MoveMaskForDisplay(const MaskId& mask_id, std::size_t 
     index = masks_.size();
   }
   masks_.insert(masks_.begin() + static_cast<std::ptrdiff_t>(index), std::move(entry));
+}
+
+auto ColorGradeNodeModel::RequireBrushMask(const NodeId& node_id, const MaskId& mask_id,
+                                           std::uint64_t expected_revision) -> MaskModel& {
+  if (node_id != id_) {
+    FailMask("Brush command NodeId does not match this Color Grade");
+  }
+  auto* mask = FindMask(mask_id);
+  if (mask == nullptr) {
+    FailMask("Unknown MaskId: " + std::string{mask_id.Value()});
+  }
+  if (MaskContentRevision(mask_id) != expected_revision) {
+    FailMask("Brush command revision does not match Mask content revision");
+  }
+  if (!std::holds_alternative<BrushMaskSource>(mask->source)) {
+    FailMask("Mask is not a Brush source: " + std::string{mask_id.Value()});
+  }
+  return *mask;
+}
+
+void ColorGradeNodeModel::AppendBrushStroke(AppendBrushStrokeCommand command) {
+  const auto mask_id = command.mask_id;
+  MaskModel  candidate = RequireBrushMask(command.node_id, mask_id, command.expected_revision);
+  auto&      brush     = std::get<BrushMaskSource>(candidate.source);
+  ValidateBrushStroke(command.stroke);
+  if (FindBrushStrokeIndex(brush.strokes, command.stroke.id) != brush.strokes.size()) {
+    FailMask("Duplicate StrokeId: " + std::string{command.stroke.id.Value()});
+  }
+  brush.strokes.push_back(std::move(command.stroke));
+  ValidateMaskModel(candidate);
+  FindMask(mask_id)->source = std::move(candidate.source);
+  TouchMask(mask_id);
+}
+
+void ColorGradeNodeModel::RemoveBrushStroke(const RemoveBrushStrokeCommand& command) {
+  MaskModel candidate =
+      RequireBrushMask(command.node_id, command.mask_id, command.expected_revision);
+  auto&     brush     = std::get<BrushMaskSource>(candidate.source);
+  const auto index    = FindBrushStrokeIndex(brush.strokes, command.stroke_id);
+  if (index == brush.strokes.size()) {
+    FailMask("Unknown StrokeId: " + std::string{command.stroke_id.Value()});
+  }
+  brush.strokes.erase(brush.strokes.begin() + static_cast<std::ptrdiff_t>(index));
+  ValidateMaskModel(candidate);
+  FindMask(command.mask_id)->source = std::move(candidate.source);
+  TouchMask(command.mask_id);
+}
+
+void ColorGradeNodeModel::InsertBrushStroke(InsertBrushStrokeCommand command) {
+  const auto mask_id = command.mask_id;
+  MaskModel  candidate = RequireBrushMask(command.node_id, mask_id, command.expected_revision);
+  auto&      brush     = std::get<BrushMaskSource>(candidate.source);
+  ValidateBrushStroke(command.stroke);
+  if (FindBrushStrokeIndex(brush.strokes, command.stroke.id) != brush.strokes.size()) {
+    FailMask("Duplicate StrokeId: " + std::string{command.stroke.id.Value()});
+  }
+  auto index = command.index;
+  if (index > brush.strokes.size()) {
+    index = brush.strokes.size();
+  }
+  brush.strokes.insert(brush.strokes.begin() + static_cast<std::ptrdiff_t>(index),
+                       std::move(command.stroke));
+  ValidateMaskModel(candidate);
+  FindMask(mask_id)->source = std::move(candidate.source);
+  TouchMask(mask_id);
+}
+
+void ColorGradeNodeModel::SetBrushTranslation(const SetBrushTranslationCommand& command) {
+  if (!std::isfinite(command.before.x) || !std::isfinite(command.before.y) ||
+      !std::isfinite(command.after.x) || !std::isfinite(command.after.y)) {
+    FailMask("Brush translation must be finite");
+  }
+  MaskModel candidate =
+      RequireBrushMask(command.node_id, command.mask_id, command.expected_revision);
+  auto& brush = std::get<BrushMaskSource>(candidate.source);
+  if (brush.placement_translation != command.before) {
+    FailMask("Brush translation before-value does not match the current source");
+  }
+  if (brush.placement_translation == command.after) {
+    return;
+  }
+  brush.placement_translation = command.after;
+  ValidateMaskModel(candidate);
+  FindMask(command.mask_id)->source = std::move(candidate.source);
+  TouchMask(command.mask_id);
+}
+
+auto ColorGradeNodeModel::BrushStrokes(const MaskId& mask_id) const
+    -> std::span<const BrushStroke> {
+  const auto* mask = FindMask(mask_id);
+  if (mask == nullptr) {
+    FailMask("Unknown MaskId: " + std::string{mask_id.Value()});
+  }
+  const auto* brush = std::get_if<BrushMaskSource>(&mask->source);
+  if (brush == nullptr) {
+    FailMask("Mask is not a Brush source: " + std::string{mask_id.Value()});
+  }
+  return brush->strokes;
+}
+
+auto ColorGradeNodeModel::BrushPlacementTranslation(const MaskId& mask_id) const -> Vector2 {
+  const auto* mask = FindMask(mask_id);
+  if (mask == nullptr) {
+    FailMask("Unknown MaskId: " + std::string{mask_id.Value()});
+  }
+  const auto* brush = std::get_if<BrushMaskSource>(&mask->source);
+  if (brush == nullptr) {
+    FailMask("Mask is not a Brush source: " + std::string{mask_id.Value()});
+  }
+  return brush->placement_translation;
 }
 
 auto ColorGradeNodeModel::MaskAt(std::size_t index) -> MaskModel& { return masks_.at(index); }

--- a/alcedo_studio/src/edit/mask/brush_raster_encoding.cpp
+++ b/alcedo_studio/src/edit/mask/brush_raster_encoding.cpp
@@ -1,0 +1,168 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_raster_encoding.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+namespace alcedo {
+namespace {
+
+constexpr float kBoundsScaleEpsilon = 1.0e-6f;
+
+[[noreturn]] void Fail(std::string_view message) {
+  throw std::invalid_argument(std::string{message});
+}
+
+void RequireFinite(float value, std::string_view name) {
+  if (!std::isfinite(value)) {
+    Fail(std::string{name} + " must be finite");
+  }
+}
+
+void RequirePositiveExtent(Extent2D extent, std::string_view name) {
+  if (extent.Empty()) {
+    Fail(std::string{name} + " must be positive");
+  }
+}
+
+}  // namespace
+
+void ValidateBrushCanonicalSample(const BrushCanonicalSample& sample) {
+  RequireFinite(sample.local_x, "local_x");
+  RequireFinite(sample.local_y, "local_y");
+  RequireFinite(sample.radius, "radius");
+  RequireFinite(sample.strength, "strength");
+  RequireFinite(sample.hardness, "hardness");
+  if (!(sample.radius > 0.0f)) {
+    Fail("radius must be positive");
+  }
+  if (sample.strength < 0.0f || sample.strength > 1.0f) {
+    Fail("strength must stay in [0, 1]");
+  }
+  if (sample.hardness < 0.0f || sample.hardness > 1.0f) {
+    Fail("hardness must stay in [0, 1]");
+  }
+}
+
+auto QuantizeMaskCoverageToR8(float coverage) -> std::uint8_t {
+  RequireFinite(coverage, "coverage");
+  const float scaled = coverage * 255.0f + 0.5f;
+  const float clamped = std::min(std::max(scaled, 0.0f), 255.0f);
+  return static_cast<std::uint8_t>(clamped);
+}
+
+auto BrushDabCoverage(float distance, float radius, float strength, float hardness) -> float {
+  RequireFinite(distance, "distance");
+  if (distance < 0.0f) {
+    Fail("distance must be nonnegative");
+  }
+  BrushCanonicalSample sample;
+  sample.radius   = radius;
+  sample.strength = strength;
+  sample.hardness = hardness;
+  ValidateBrushCanonicalSample(sample);
+  if (hardness >= 1.0f) {
+    return distance <= radius ? strength : 0.0f;
+  }
+  const float inner = hardness * radius;
+  if (distance <= inner) {
+    return strength;
+  }
+  if (distance >= radius) {
+    return 0.0f;
+  }
+  const float span = radius - inner;
+  const float t    = (distance - inner) / span;
+  return strength * (1.0f - t);
+}
+
+auto CanonicalBrushRasterExtent(Extent2D full_reference) -> Extent2D {
+  RequirePositiveExtent(full_reference, "full_reference");
+  const auto long_edge = std::max(full_reference.width, full_reference.height);
+  if (long_edge <= kMaximumRasterMaskAxis) {
+    return full_reference;
+  }
+  const float scale = static_cast<float>(kMaximumRasterMaskAxis) / static_cast<float>(long_edge);
+  const auto width = static_cast<std::uint32_t>(
+      std::max(1.0f, std::ceil(static_cast<float>(full_reference.width) * scale)));
+  const auto height = static_cast<std::uint32_t>(
+      std::max(1.0f, std::ceil(static_cast<float>(full_reference.height) * scale)));
+  return {std::min(width, kMaximumRasterMaskAxis), std::min(height, kMaximumRasterMaskAxis)};
+}
+
+auto CanonicalBrushTexelReferenceCenter(std::uint32_t x, std::uint32_t y, Extent2D raster,
+                                        Extent2D full_reference) -> Vector2 {
+  RequirePositiveExtent(raster, "raster");
+  RequirePositiveExtent(full_reference, "full_reference");
+  if (x >= raster.width || y >= raster.height) {
+    Fail("texel is outside the canonical raster");
+  }
+  const auto center = PixelCenter(x, y);
+  return {center.x * static_cast<float>(full_reference.width) / static_cast<float>(raster.width),
+          center.y * static_cast<float>(full_reference.height) /
+              static_cast<float>(raster.height)};
+}
+
+auto BrushFeatherRadiusToSourceTexels(float feather_radius, Extent2D raster, NormalizedRect bounds,
+                                      Extent2D full_reference) -> float {
+  RequireFinite(feather_radius, "feather_radius");
+  if (feather_radius < 0.0f) {
+    Fail("feather_radius must be nonnegative");
+  }
+  RequirePositiveExtent(raster, "raster");
+  RequirePositiveExtent(full_reference, "full_reference");
+  RequireFinite(bounds.x, "reference_bounds.x");
+  RequireFinite(bounds.y, "reference_bounds.y");
+  RequireFinite(bounds.w, "reference_bounds.w");
+  RequireFinite(bounds.h, "reference_bounds.h");
+  const float x_scale = static_cast<float>(raster.width) /
+                        (static_cast<float>(full_reference.width) *
+                         std::max(bounds.w, kBoundsScaleEpsilon));
+  const float y_scale = static_cast<float>(raster.height) /
+                        (static_cast<float>(full_reference.height) *
+                         std::max(bounds.h, kBoundsScaleEpsilon));
+  return feather_radius * 0.5f * (x_scale + y_scale);
+}
+
+auto SamplePackedR8Bilinear(std::span<const std::uint8_t> pixels, Extent2D extent, float u, float v)
+    -> float {
+  RequirePositiveExtent(extent, "extent");
+  const auto required =
+      static_cast<std::size_t>(extent.width) * static_cast<std::size_t>(extent.height);
+  if (pixels.size() != required) {
+    Fail("pixels must be tightly packed R8");
+  }
+  if (!std::isfinite(u) || !std::isfinite(v) || u < 0.0f || v < 0.0f || u > 1.0f || v > 1.0f) {
+    return 0.0f;
+  }
+  const float x  = u * static_cast<float>(extent.width) - 0.5f;
+  const float y  = v * static_cast<float>(extent.height) - 0.5f;
+  const int   x0 = std::max(
+      0, std::min(static_cast<int>(extent.width) - 1, static_cast<int>(std::floor(x))));
+  const int y0 = std::max(
+      0, std::min(static_cast<int>(extent.height) - 1, static_cast<int>(std::floor(y))));
+  const int   x1 = std::min(x0 + 1, static_cast<int>(extent.width) - 1);
+  const int   y1 = std::min(y0 + 1, static_cast<int>(extent.height) - 1);
+  const float tx = std::min(std::max(x - std::floor(x), 0.0f), 1.0f);
+  const float ty = std::min(std::max(y - std::floor(y), 0.0f), 1.0f);
+  const float a  = static_cast<float>(pixels[static_cast<std::size_t>(y0) * extent.width +
+                                            static_cast<std::size_t>(x0)]) *
+                      (1.0f - tx) +
+                  static_cast<float>(pixels[static_cast<std::size_t>(y0) * extent.width +
+                                            static_cast<std::size_t>(x1)]) *
+                      tx;
+  const float b = static_cast<float>(pixels[static_cast<std::size_t>(y1) * extent.width +
+                                            static_cast<std::size_t>(x0)]) *
+                      (1.0f - tx) +
+                  static_cast<float>(pixels[static_cast<std::size_t>(y1) * extent.width +
+                                            static_cast<std::size_t>(x1)]) *
+                      tx;
+  return (a * (1.0f - ty) + b * ty) / 255.0f;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/mask/brush_stroke.cpp
+++ b/alcedo_studio/src/edit/mask/brush_stroke.cpp
@@ -1,0 +1,193 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_stroke.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace alcedo {
+namespace {
+
+[[noreturn]] void FailStroke(std::string_view message) {
+  throw std::runtime_error(std::string{message});
+}
+
+void RequireFiniteNumber(const nlohmann::json& json, const char* key, std::string_view owner) {
+  if (!json.contains(key) || !json[key].is_number()) {
+    FailStroke(std::string{owner} + " is missing number " + key);
+  }
+}
+
+auto ReadFiniteFloat(const nlohmann::json& json, const char* key, std::string_view owner) -> float {
+  RequireFiniteNumber(json, key, owner);
+  const auto value = json[key].get<float>();
+  if (!std::isfinite(value)) {
+    FailStroke(std::string{key} + " must be finite");
+  }
+  return value;
+}
+
+auto SampleToJson(const BrushCanonicalSample& sample) -> nlohmann::json {
+  return {{"local_x", sample.local_x},
+          {"local_y", sample.local_y},
+          {"radius", sample.radius},
+          {"strength", sample.strength},
+          {"hardness", sample.hardness}};
+}
+
+auto SampleFromJson(const nlohmann::json& json) -> BrushCanonicalSample {
+  if (!json.is_object()) {
+    FailStroke("stroke sample must be an object");
+  }
+  BrushCanonicalSample sample;
+  sample.local_x  = ReadFiniteFloat(json, "local_x", "stroke sample");
+  sample.local_y  = ReadFiniteFloat(json, "local_y", "stroke sample");
+  sample.radius   = ReadFiniteFloat(json, "radius", "stroke sample");
+  sample.strength = ReadFiniteFloat(json, "strength", "stroke sample");
+  sample.hardness = ReadFiniteFloat(json, "hardness", "stroke sample");
+  return sample;
+}
+
+void ValidateSampleEncoding(const BrushCanonicalSample& sample) {
+  try {
+    ValidateBrushCanonicalSample(sample);
+  } catch (const std::invalid_argument& ex) {
+    FailStroke(ex.what());
+  }
+}
+
+}  // namespace
+
+auto operator==(const BrushStroke& lhs, const BrushStroke& rhs) -> bool {
+  if (lhs.id != rhs.id || lhs.mode != rhs.mode) {
+    return false;
+  }
+  const auto lhs_empty = lhs.samples == nullptr || lhs.samples->empty();
+  const auto rhs_empty = rhs.samples == nullptr || rhs.samples->empty();
+  if (lhs_empty && rhs_empty) {
+    return true;
+  }
+  if (lhs_empty || rhs_empty) {
+    return false;
+  }
+  return *lhs.samples == *rhs.samples;
+}
+
+void ValidateBrushStroke(const BrushStroke& stroke) {
+  if (stroke.id.Empty()) {
+    FailStroke("StrokeId must not be empty");
+  }
+  if (stroke.mode != BrushStrokeMode::Paint && stroke.mode != BrushStrokeMode::Erase) {
+    FailStroke("stroke mode must be paint or erase");
+  }
+  if (stroke.samples == nullptr || stroke.samples->empty()) {
+    FailStroke("stroke samples must not be empty");
+  }
+  for (const auto& sample : *stroke.samples) {
+    ValidateSampleEncoding(sample);
+  }
+}
+
+void ValidateBrushStrokeList(std::span<const BrushStroke> strokes) {
+  std::unordered_set<std::string> seen;
+  seen.reserve(strokes.size());
+  for (const auto& stroke : strokes) {
+    ValidateBrushStroke(stroke);
+    if (!seen.insert(std::string{stroke.id.Value()}).second) {
+      FailStroke("Duplicate StrokeId: " + std::string{stroke.id.Value()});
+    }
+  }
+}
+
+auto MakeBrushStroke(StrokeId id, BrushStrokeMode mode, std::vector<BrushCanonicalSample> samples)
+    -> BrushStroke {
+  BrushStroke stroke;
+  stroke.id   = std::move(id);
+  stroke.mode = mode;
+  if (samples.empty()) {
+    FailStroke("stroke samples must not be empty");
+  }
+  for (const auto& sample : samples) {
+    ValidateSampleEncoding(sample);
+  }
+  stroke.samples = std::make_shared<const std::vector<BrushCanonicalSample>>(std::move(samples));
+  ValidateBrushStroke(stroke);
+  return stroke;
+}
+
+auto FindBrushStrokeIndex(std::span<const BrushStroke> strokes, const StrokeId& stroke_id)
+    -> std::size_t {
+  for (std::size_t index = 0; index < strokes.size(); ++index) {
+    if (strokes[index].id == stroke_id) {
+      return index;
+    }
+  }
+  return strokes.size();
+}
+
+auto BrushStrokeToJson(const BrushStroke& stroke) -> nlohmann::json {
+  ValidateBrushStroke(stroke);
+  nlohmann::json samples = nlohmann::json::array();
+  for (const auto& sample : *stroke.samples) {
+    samples.push_back(SampleToJson(sample));
+  }
+  return {{"id", std::string{stroke.id.Value()}},
+          {"mode", static_cast<int>(stroke.mode)},
+          {"samples", std::move(samples)}};
+}
+
+auto BrushStrokeFromJson(const nlohmann::json& json) -> BrushStroke {
+  if (!json.is_object()) {
+    FailStroke("stroke must be an object");
+  }
+  if (!json.contains("id") || !json["id"].is_string() || json["id"].get<std::string>().empty()) {
+    FailStroke("stroke is missing a non-empty id");
+  }
+  if (!json.contains("mode") || !json["mode"].is_number() || json["mode"].is_number_float()) {
+    FailStroke("stroke is missing integer mode");
+  }
+  const auto mode_value = json["mode"].get<std::int64_t>();
+  if (mode_value != 0 && mode_value != 1) {
+    FailStroke("stroke mode must be 0 (paint) or 1 (erase)");
+  }
+  if (!json.contains("samples") || !json["samples"].is_array() || json["samples"].empty()) {
+    FailStroke("stroke is missing a non-empty samples array");
+  }
+  std::vector<BrushCanonicalSample> samples;
+  samples.reserve(json["samples"].size());
+  for (const auto& item : json["samples"]) {
+    samples.push_back(SampleFromJson(item));
+  }
+  return MakeBrushStroke(StrokeId{json["id"].get<std::string>()},
+                         static_cast<BrushStrokeMode>(mode_value), std::move(samples));
+}
+
+auto BrushStrokeListToJson(std::span<const BrushStroke> strokes) -> nlohmann::json {
+  ValidateBrushStrokeList(strokes);
+  nlohmann::json json = nlohmann::json::array();
+  for (const auto& stroke : strokes) {
+    json.push_back(BrushStrokeToJson(stroke));
+  }
+  return json;
+}
+
+auto BrushStrokeListFromJson(const nlohmann::json& json) -> std::vector<BrushStroke> {
+  if (!json.is_array()) {
+    FailStroke("strokes must be an array");
+  }
+  std::vector<BrushStroke> strokes;
+  strokes.reserve(json.size());
+  for (const auto& item : json) {
+    strokes.push_back(BrushStrokeFromJson(item));
+  }
+  ValidateBrushStrokeList(strokes);
+  return strokes;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/mask/mask_model.cpp
+++ b/alcedo_studio/src/edit/mask/mask_model.cpp
@@ -5,6 +5,8 @@
 #include "edit/mask/mask_model.hpp"
 
 #include <cmath>
+#include <cstdint>
+#include <limits>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -12,6 +14,8 @@
 #include <unordered_set>
 #include <utility>
 #include <variant>
+
+#include "edit/mask/brush_stroke.hpp"
 
 namespace alcedo {
 namespace {
@@ -45,6 +49,37 @@ void RequireNumber(const nlohmann::json& json, const char* key, std::string_view
   if (!json.contains(key) || !json[key].is_number()) {
     Fail(std::string{owner} + " is missing number " + key);
   }
+}
+
+auto ReadRequiredUint32(const nlohmann::json& json, const char* key, std::string_view owner)
+    -> std::uint32_t {
+  if (!json.contains(key) || !json[key].is_number() || json[key].is_number_float()) {
+    Fail(std::string{owner} + " is missing unsigned integer " + key);
+  }
+  if (json[key].is_number_integer() && json[key].get<std::int64_t>() < 0) {
+    Fail(std::string{owner} + " field " + key + " must fit in uint32");
+  }
+  const auto value = json[key].get<std::uint64_t>();
+  if (value > std::numeric_limits<std::uint32_t>::max()) {
+    Fail(std::string{owner} + " field " + key + " must fit in uint32");
+  }
+  return static_cast<std::uint32_t>(value);
+}
+
+auto TranslationToJson(Vector2 translation) -> nlohmann::json {
+  return nlohmann::json::array({translation.x, translation.y});
+}
+
+auto TranslationFromJson(const nlohmann::json& json, std::string_view owner) -> Vector2 {
+  if (!json.is_array() || json.size() < 2) {
+    Fail(std::string{owner} + " placement_translation must be an array of two numbers");
+  }
+  Vector2 translation;
+  translation.x = json[0].get<float>();
+  translation.y = json[1].get<float>();
+  RequireFinite(translation.x, "placement_translation.x");
+  RequireFinite(translation.y, "placement_translation.y");
+  return translation;
 }
 
 auto ReadRequiredFloat(const nlohmann::json& json, const char* key, std::string_view owner)
@@ -92,6 +127,15 @@ void ValidateRangeObject(const nlohmann::json& json, std::string_view name) {
 
 void ValidateBrush(const BrushMaskSource& brush) {
   RequireNonNegative(brush.feather_radius, "feather_radius");
+  RequireFinite(brush.placement_translation.x, "placement_translation.x");
+  RequireFinite(brush.placement_translation.y, "placement_translation.y");
+  if (brush.source_format_version != kBrushSourceFormatVersion) {
+    Fail("brush source_format_version must be 1");
+  }
+  if (brush.raster_algorithm_version != kBrushRasterAlgorithmVersion) {
+    Fail("brush raster_algorithm_version must be 1");
+  }
+  ValidateBrushStrokeList(brush.strokes);
   RequireFinite(brush.descriptor.reference_bounds.x, "reference_bounds.x");
   RequireFinite(brush.descriptor.reference_bounds.y, "reference_bounds.y");
   RequireFinite(brush.descriptor.reference_bounds.w, "reference_bounds.w");
@@ -149,6 +193,21 @@ void ValidateRange(const std::optional<LuminanceRangeModel>& range, std::string_
 }
 
 auto BrushToJson(const BrushMaskSource& brush) -> nlohmann::json {
+  if (BrushSourceHasParameterizedPayload(brush)) {
+    nlohmann::json json{{"kind", "brush"},
+                        {"source_format_version", brush.source_format_version},
+                        {"raster_algorithm_version", brush.raster_algorithm_version},
+                        {"placement_translation", TranslationToJson(brush.placement_translation)},
+                        {"feather_radius", brush.feather_radius},
+                        {"strokes", BrushStrokeListToJson(brush.strokes)}};
+    if (brush.asset_key.has_value() && !brush.asset_key->Empty()) {
+      json["width"]            = brush.descriptor.extent.width;
+      json["height"]           = brush.descriptor.extent.height;
+      json["reference_bounds"] = BoundsToJson(brush.descriptor.reference_bounds);
+      json["asset_key"]        = std::string{brush.asset_key->Value()};
+    }
+    return json;
+  }
   nlohmann::json json{{"kind", "brush"},
                       {"feather_radius", brush.feather_radius},
                       {"width", brush.descriptor.extent.width},
@@ -201,30 +260,55 @@ auto RangeToJson(const std::optional<LuminanceRangeModel>& range) -> nlohmann::j
 auto BrushFromJson(const nlohmann::json& json) -> BrushMaskSource {
   BrushMaskSource brush;
   brush.feather_radius = ReadRequiredFloat(json, "feather_radius", "brush");
-  if (!json.contains("width") || !json["width"].is_number()) {
-    Fail("brush is missing number width");
+  const bool parameterized = json.contains("strokes") || json.contains("placement_translation") ||
+                             json.contains("source_format_version") ||
+                             json.contains("raster_algorithm_version");
+  if (parameterized) {
+    brush.source_format_version = ReadRequiredUint32(json, "source_format_version", "brush");
+    brush.raster_algorithm_version =
+        ReadRequiredUint32(json, "raster_algorithm_version", "brush");
+    if (brush.source_format_version != kBrushSourceFormatVersion) {
+      Fail("brush source_format_version must be 1");
+    }
+    if (brush.raster_algorithm_version != kBrushRasterAlgorithmVersion) {
+      Fail("brush raster_algorithm_version must be 1");
+    }
+    if (!json.contains("placement_translation")) {
+      Fail("brush is missing placement_translation");
+    }
+    if (!json.contains("strokes")) {
+      Fail("brush is missing strokes");
+    }
+    brush.placement_translation = TranslationFromJson(json["placement_translation"], "brush");
+    brush.strokes               = BrushStrokeListFromJson(json["strokes"]);
   }
-  if (!json.contains("height") || !json["height"].is_number()) {
-    Fail("brush is missing number height");
-  }
-  brush.descriptor.extent.width  = json["width"].get<std::uint32_t>();
-  brush.descriptor.extent.height = json["height"].get<std::uint32_t>();
-  if (!json.contains("reference_bounds")) {
-    Fail("brush is missing reference_bounds");
-  }
-  brush.descriptor.reference_bounds = BoundsFromJson(json["reference_bounds"], "brush");
-  if (!json.contains("asset_key") || json["asset_key"].is_null()) {
-    brush.asset_key.reset();
-    return brush;
-  }
-  if (!json["asset_key"].is_string()) {
-    Fail("brush asset_key must be a string or null");
-  }
-  auto key = json["asset_key"].get<std::string>();
-  if (key.empty()) {
-    brush.asset_key.reset();
-  } else {
-    brush.asset_key = MaskAssetKey{std::move(key)};
+  const bool has_legacy_raster = json.contains("width") || json.contains("height") ||
+                                 json.contains("reference_bounds") || json.contains("asset_key");
+  if (!parameterized || has_legacy_raster) {
+    if (!json.contains("width") || !json["width"].is_number()) {
+      Fail("brush is missing number width");
+    }
+    if (!json.contains("height") || !json["height"].is_number()) {
+      Fail("brush is missing number height");
+    }
+    brush.descriptor.extent.width  = json["width"].get<std::uint32_t>();
+    brush.descriptor.extent.height = json["height"].get<std::uint32_t>();
+    if (!json.contains("reference_bounds")) {
+      Fail("brush is missing reference_bounds");
+    }
+    brush.descriptor.reference_bounds = BoundsFromJson(json["reference_bounds"], "brush");
+    if (!json.contains("asset_key") || json["asset_key"].is_null()) {
+      brush.asset_key.reset();
+    } else if (!json["asset_key"].is_string()) {
+      Fail("brush asset_key must be a string or null");
+    } else {
+      auto key = json["asset_key"].get<std::string>();
+      if (key.empty()) {
+        brush.asset_key.reset();
+      } else {
+        brush.asset_key = MaskAssetKey{std::move(key)};
+      }
+    }
   }
   return brush;
 }
@@ -270,6 +354,11 @@ auto LuminanceRangeFromJson(const nlohmann::json& json) -> std::optional<Luminan
 }
 
 }  // namespace
+
+auto BrushSourceHasParameterizedPayload(const BrushMaskSource& brush) -> bool {
+  return !brush.strokes.empty() || brush.placement_translation.x != 0.0f ||
+         brush.placement_translation.y != 0.0f;
+}
 
 auto GetMaskSourceKind(const MaskSource& source) -> MaskSourceKind {
   if (std::holds_alternative<BrushMaskSource>(source)) {

--- a/alcedo_studio/src/edit/runtime/result_content_key.cpp
+++ b/alcedo_studio/src/edit/runtime/result_content_key.cpp
@@ -15,6 +15,7 @@
 #include "edit/graph/develop_node_model.hpp"
 #include "edit/graph/drt_node_model.hpp"
 #include "edit/mask/active_raster_mask.hpp"
+#include "edit/mask/brush_stroke.hpp"
 #include "edit/mask/mask_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/runtime/compiled_mask_stack.hpp"
@@ -190,6 +191,24 @@ auto MixMaskSourceModel(ContentHash& hash, const MaskModel& model,
     hash.MixU32(brush->descriptor.extent.height);
     MixNormalizedRect(hash, brush->descriptor.reference_bounds);
     hash.MixF32(brush->feather_radius);
+    hash.MixU32(brush->source_format_version);
+    hash.MixU32(brush->raster_algorithm_version);
+    hash.MixF32(brush->placement_translation.x);
+    hash.MixF32(brush->placement_translation.y);
+    hash.MixU32(static_cast<std::uint32_t>(brush->strokes.size()));
+    for (const auto& stroke : brush->strokes) {
+      hash.MixText(stroke.id.Value());
+      hash.MixU32(static_cast<std::uint32_t>(stroke.mode));
+      const auto samples = BrushStrokeSamples(stroke);
+      hash.MixU32(static_cast<std::uint32_t>(samples.size()));
+      for (const auto& sample : samples) {
+        hash.MixF32(sample.local_x);
+        hash.MixF32(sample.local_y);
+        hash.MixF32(sample.radius);
+        hash.MixF32(sample.strength);
+        hash.MixF32(sample.hardness);
+      }
+    }
     return;
   }
   if (const auto* radial = std::get_if<RadialMaskSource>(&model.source)) {

--- a/alcedo_studio/src/include/edit/geometry/types.hpp
+++ b/alcedo_studio/src/include/edit/geometry/types.hpp
@@ -52,6 +52,12 @@ struct Vector2 {
   float y = 0.0f;
 };
 
+inline auto operator==(const Vector2& a, const Vector2& b) -> bool {
+  return a.x == b.x && a.y == b.y;
+}
+
+inline auto operator!=(const Vector2& a, const Vector2& b) -> bool { return !(a == b); }
+
 /**
  * @brief Row-major 3x3 matrix mapping homogeneous 2D points (column vectors).
  *

--- a/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
+++ b/alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp
@@ -14,8 +14,10 @@
 #include <string_view>
 #include <vector>
 
+#include "edit/geometry/types.hpp"
 #include "edit/graph/adjustment_ownership.hpp"
 #include "edit/graph/i_node_model.hpp"
+#include "edit/mask/brush_mask_commands.hpp"
 #include "edit/mask/mask_model.hpp"
 #include "edit/operators/models/builtin_type_ids.hpp"
 #include "edit/operators/models/i_operator_model.hpp"
@@ -158,6 +160,55 @@ class ColorGradeNodeModel final : public INodeModel {
    */
   void MoveMaskForDisplay(const MaskId& mask_id, std::size_t index);
 
+  /**
+   * @brief Append one canonical stroke to an existing Brush Mask.
+   *
+   * @param command Exact NodeId, MaskId, StrokeId, sample body, and observed
+   *        Mask content revision. The sample body is shared, not copied.
+   * @throws std::runtime_error when the target is missing or not a Brush, the
+   *         revision does not match, or the stroke is invalid. The Mask list
+   *         is left unchanged. Runs on the document-owning thread.
+   */
+  void AppendBrushStroke(AppendBrushStrokeCommand command);
+  /**
+   * @brief Remove one stroke by StrokeId. Remaining sample bodies are not copied.
+   *
+   * @throws std::runtime_error when the target, revision, or StrokeId fail.
+   *         The Mask list is left unchanged.
+   */
+  void RemoveBrushStroke(const RemoveBrushStrokeCommand& command);
+  /**
+   * @brief Insert a stroke at @p command.index. Values past the end append.
+   *
+   * @throws std::runtime_error when the target, revision, or stroke fail.
+   *         The Mask list is left unchanged.
+   */
+  void InsertBrushStroke(InsertBrushStrokeCommand command);
+  /**
+   * @brief Set Brush placement_translation to @p command.after.
+   *
+   * @p command.before must equal the current translation. Canonical samples are
+   * not copied or rewritten. Equal before/after is a no-op and does not bump
+   * the Mask content revision.
+   *
+   * @throws std::runtime_error when the target, revision, or before-value fail.
+   *         The Mask list is left unchanged.
+   */
+  void SetBrushTranslation(const SetBrushTranslationCommand& command);
+
+  /**
+   * @brief Ordered strokes of a Brush Mask. Load-only; does not copy sample bodies.
+   *
+   * @throws std::runtime_error when @p mask_id is missing or the Mask is not a Brush.
+   */
+  [[nodiscard]] auto BrushStrokes(const MaskId& mask_id) const -> std::span<const BrushStroke>;
+  /**
+   * @brief Current placement_translation of a Brush Mask. Load-only.
+   *
+   * @throws std::runtime_error when @p mask_id is missing or the Mask is not a Brush.
+   */
+  [[nodiscard]] auto BrushPlacementTranslation(const MaskId& mask_id) const -> Vector2;
+
   [[nodiscard]] auto MaskCount() const -> std::size_t { return masks_.size(); }
   [[nodiscard]] auto Masks() const -> std::span<const MaskModel> { return masks_; }
   [[nodiscard]] auto MaskAt(std::size_t index) -> MaskModel&;
@@ -167,8 +218,9 @@ class ColorGradeNodeModel final : public INodeModel {
 
  private:
   void TouchMask(const MaskId& mask_id);
+  auto RequireBrushMask(const NodeId& node_id, const MaskId& mask_id,
+                        std::uint64_t expected_revision) -> MaskModel&;
 
- private:
   NodeId id_;
   std::string display_name_ = "Color Grade";
   std::vector<AdjustmentModelEntry> adjustments_;

--- a/alcedo_studio/src/include/edit/mask/brush_mask_commands.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_mask_commands.hpp
@@ -1,0 +1,71 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "edit/geometry/types.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/mask/brush_stroke.hpp"
+#include "edit/mask/mask_id.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Append one validated stroke to an existing Brush on a Color Grade.
+ *
+ * @p expected_revision is the Mask content revision observed before this
+ * operation. Admission is not a history commit.
+ */
+struct AppendBrushStrokeCommand {
+  NodeId      node_id;
+  MaskId      mask_id;
+  BrushStroke stroke;
+  std::uint64_t expected_revision = 0;
+};
+
+/**
+ * @brief Remove one stroke by StrokeId. Inverse of append/insert at the owner.
+ *
+ * Does not copy remaining sample bodies. @p expected_revision must match the
+ * Mask content revision before the removal.
+ */
+struct RemoveBrushStrokeCommand {
+  NodeId   node_id;
+  MaskId   mask_id;
+  StrokeId stroke_id;
+  std::uint64_t expected_revision = 0;
+};
+
+/**
+ * @brief Insert a stroke at a display/evaluation index on an existing Brush.
+ *
+ * @p index past the end appends. Duplicate StrokeId is rejected. The existing
+ * stroke list is left unchanged on failure.
+ */
+struct InsertBrushStrokeCommand {
+  NodeId      node_id;
+  MaskId      mask_id;
+  std::size_t index = 0;
+  BrushStroke stroke;
+  std::uint64_t expected_revision = 0;
+};
+
+/**
+ * @brief Replace Brush placement_translation with an exact after value.
+ *
+ * @p before must equal the current translation. The operation does not rewrite
+ * or copy canonical samples. Unchanged after equal to current is a no-op.
+ */
+struct SetBrushTranslationCommand {
+  NodeId  node_id;
+  MaskId  mask_id;
+  Vector2 before{};
+  Vector2 after{};
+  std::uint64_t expected_revision = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/brush_raster_encoding.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_raster_encoding.hpp
@@ -1,0 +1,157 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/mask_asset.hpp"
+
+namespace alcedo {
+
+/// First parameterized Brush source JSON identity. Loaders still require the published
+/// pipeline-document format until the persistence cutover writes this value.
+inline constexpr std::uint32_t kBrushSourceFormatVersion = 1;
+/// Host dab/paint/erase algorithm identity. Replay must reject any other value.
+inline constexpr std::uint32_t kBrushRasterAlgorithmVersion = 1;
+/// Project Mix-cache container identity. Distinct from @ref kMaskAssetFormatVersion.
+inline constexpr std::uint32_t kProjectMaskCacheFormatVersion = 1;
+/// Maximum spacing between canonical dabs, as a fraction of the local sample radius.
+inline constexpr float kBrushDabSpacingRadiusFraction = 0.25f;
+
+enum class BrushStrokeMode : std::uint8_t {
+  Paint = 0,
+  Erase = 1,
+};
+
+/**
+ * @brief One canonical Brush sample in untranslated reference-pixel coordinates.
+ *
+ * Values are IEEE-754 binary32. @p local_x / @p local_y are stored after subtracting
+ * @c placement_translation. @p radius is the dab radius in reference pixels.
+ * @p strength and @p hardness stay in `[0, 1]`.
+ */
+struct BrushCanonicalSample {
+  float local_x  = 0.0f;
+  float local_y  = 0.0f;
+  float radius   = 1.0f;
+  float strength = 1.0f;
+  float hardness = 1.0f;
+};
+
+/**
+ * @brief Reject NaN/Inf, non-positive radius, or strength/hardness outside `[0, 1]`.
+ *
+ * @param sample Candidate sample. Not mutated.
+ * @throws std::invalid_argument when a field fails the encoding rules.
+ */
+void ValidateBrushCanonicalSample(const BrushCanonicalSample& sample);
+
+/**
+ * @brief Quantize coverage in `[0, 1]` to packed R8 with round-half-up.
+ *
+ * Matches the native evaluator: `clamp(coverage * 255 + 0.5, 0, 255)`.
+ *
+ * @param coverage Finite coverage. Non-finite values throw.
+ * @return Byte in `[0, 255]`.
+ * @throws std::invalid_argument when @p coverage is not finite.
+ */
+[[nodiscard]] auto QuantizeMaskCoverageToR8(float coverage) -> std::uint8_t;
+
+/**
+ * @brief Decode one packed R8 sample to coverage in `[0, 1]`.
+ */
+[[nodiscard]] inline auto CoverageFromMaskR8(std::uint8_t value) -> float {
+  return static_cast<float>(value) / 255.0f;
+}
+
+/**
+ * @brief Unit dab coverage at @p distance from a sample center, before R8 quantization.
+ *
+ * Hardness `1` is a hard disk of radius @p radius. Otherwise coverage is 1 inside
+ * `hardness * radius`, 0 at and beyond @p radius, and linear between. The result is
+ * multiplied by @p strength. Distance and radius use the reference-pixel metric.
+ *
+ * @throws std::invalid_argument when radius, strength, or hardness fail
+ *         @ref ValidateBrushCanonicalSample, or when @p distance is negative or not finite.
+ */
+[[nodiscard]] auto BrushDabCoverage(float distance, float radius, float strength, float hardness)
+    -> float;
+
+/**
+ * @brief Canonical Brush raster extent covering full ReferenceSpace.
+ *
+ * Uses the same ceil-scale rule as LLF mask dimensions, but the long-edge cap is
+ * @ref kMaximumRasterMaskAxis (4096), not the LLF 2048 cap. Zoom, DPR, and Interactive
+ * output size must not be passed here.
+ *
+ * @param full_reference Developed full-frame extent in reference pixels.
+ * @return Positive extent with each axis in `[1, 4096]`.
+ * @throws std::invalid_argument when @p full_reference is empty.
+ */
+[[nodiscard]] auto CanonicalBrushRasterExtent(Extent2D full_reference) -> Extent2D;
+
+/**
+ * @brief Full-frame bounds stored with a parameterized Brush canonical raster.
+ */
+[[nodiscard]] inline auto CanonicalBrushReferenceBounds() -> NormalizedRect { return {}; }
+
+/**
+ * @brief Reference-pixel center of canonical raster texel `@p x, @p y`.
+ *
+ * Mapping is `(x + 0.5) * full_w / raster_w`. Pointer samples do not receive this
+ * half-texel offset; only raster/evaluator tests do.
+ *
+ * @throws std::invalid_argument when extents are empty or the texel is outside the raster.
+ */
+[[nodiscard]] auto CanonicalBrushTexelReferenceCenter(std::uint32_t x, std::uint32_t y,
+                                                      Extent2D raster, Extent2D full_reference)
+    -> Vector2;
+
+/**
+ * @brief Convert Brush source feather into source-texel radius for signed-distance feather.
+ *
+ * Matches the native Mask pass:
+ * `radius_texels = feather_radius * 0.5 * (x_scale + y_scale)` with
+ * `x_scale = raster_w / (full_w * max(bounds.w, 1e-6))`.
+ *
+ * @p feather_radius is the existing Brush source field, in the reference-pixel metric
+ * (equal to source texels when the raster matches full reference and bounds are full-frame).
+ *
+ * @throws std::invalid_argument when extents are empty or @p feather_radius is not finite
+ *         and nonnegative, or bounds components are not finite.
+ */
+[[nodiscard]] auto BrushFeatherRadiusToSourceTexels(float feather_radius, Extent2D raster,
+                                                    NormalizedRect bounds, Extent2D full_reference)
+    -> float;
+
+/**
+ * @brief Bilinear sample of tightly packed R8 at normalized UV, matching the native Mask pass.
+ *
+ * UV outside `[0, 1]` returns 0. Pixel centers use `u * width - 0.5`. The result is
+ * coverage in `[0, 1]`.
+ *
+ * @throws std::invalid_argument when @p extent is empty or @p pixels is not tightly packed.
+ */
+[[nodiscard]] auto SamplePackedR8Bilinear(std::span<const std::uint8_t> pixels, Extent2D extent,
+                                          float u, float v) -> float;
+
+/**
+ * @brief Paint combine on packed R8: `max(previous, dab)`.
+ */
+[[nodiscard]] inline auto PaintBrushR8(std::uint8_t previous, std::uint8_t dab) -> std::uint8_t {
+  return previous > dab ? previous : dab;
+}
+
+/**
+ * @brief Erase combine on packed R8: `min(previous, 255 - dab)`.
+ */
+[[nodiscard]] inline auto EraseBrushR8(std::uint8_t previous, std::uint8_t dab) -> std::uint8_t {
+  const auto inverted = static_cast<std::uint8_t>(255u - dab);
+  return previous < inverted ? previous : inverted;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/brush_raster_encoding.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_raster_encoding.hpp
@@ -12,8 +12,8 @@
 
 namespace alcedo {
 
-/// First parameterized Brush source JSON identity. Loaders still require the published
-/// pipeline-document format until the persistence cutover writes this value.
+/// First parameterized Brush source JSON identity. Raster-only documents still
+/// serialize without this key until the NM7.3 persistence cutover.
 inline constexpr std::uint32_t kBrushSourceFormatVersion = 1;
 /// Host dab/paint/erase algorithm identity. Replay must reject any other value.
 inline constexpr std::uint32_t kBrushRasterAlgorithmVersion = 1;
@@ -40,6 +40,8 @@ struct BrushCanonicalSample {
   float radius   = 1.0f;
   float strength = 1.0f;
   float hardness = 1.0f;
+
+  friend auto operator==(const BrushCanonicalSample&, const BrushCanonicalSample&) -> bool = default;
 };
 
 /**

--- a/alcedo_studio/src/include/edit/mask/brush_stroke.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_stroke.hpp
@@ -1,0 +1,151 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "json.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Stable identity for one Brush stroke during its lifetime.
+ *
+ * Distinct from @ref MaskId. Empty values are invalid. Order of strokes is the
+ * evaluation order; StrokeId is never used to reorder samples.
+ */
+class StrokeId {
+ public:
+  StrokeId() = default;
+  explicit StrokeId(std::string value) : value_(std::move(value)) {}
+
+  [[nodiscard]] auto Value() const -> std::string_view { return value_; }
+  [[nodiscard]] auto Empty() const -> bool { return value_.empty(); }
+
+  friend auto operator==(const StrokeId& lhs, const StrokeId& rhs) -> bool {
+    return lhs.value_ == rhs.value_;
+  }
+  friend auto operator!=(const StrokeId& lhs, const StrokeId& rhs) -> bool {
+    return !(lhs == rhs);
+  }
+  friend auto operator<(const StrokeId& lhs, const StrokeId& rhs) -> bool {
+    return lhs.value_ < rhs.value_;
+  }
+
+ private:
+  std::string value_;
+};
+
+/**
+ * @brief One ordered Brush stroke: identity, paint/erase, and an immutable sample body.
+ *
+ * @p samples is shared, not copied per read or per translation. The vector is
+ * immutable after @ref MakeBrushStroke. A null or empty body is invalid.
+ */
+struct BrushStroke {
+  StrokeId                                                 id;
+  BrushStrokeMode                                          mode = BrushStrokeMode::Paint;
+  std::shared_ptr<const std::vector<BrushCanonicalSample>> samples;
+};
+
+/**
+ * @brief Value equality for strokes. Compares sample contents, not pointer identity.
+ */
+[[nodiscard]] auto operator==(const BrushStroke& lhs, const BrushStroke& rhs) -> bool;
+[[nodiscard]] inline auto operator!=(const BrushStroke& lhs, const BrushStroke& rhs) -> bool {
+  return !(lhs == rhs);
+}
+
+/**
+ * @brief True when @p lhs and @p rhs share the same immutable sample body pointer.
+ *
+ * Translation must keep this true for existing strokes. Distinct allocations with
+ * equal sample values return false.
+ */
+[[nodiscard]] inline auto BrushStrokesShareSampleBody(const BrushStroke& lhs,
+                                                      const BrushStroke& rhs) -> bool {
+  return lhs.samples == rhs.samples;
+}
+
+/**
+ * @brief Read-only view of @p stroke samples. Empty when the body pointer is null.
+ */
+[[nodiscard]] inline auto BrushStrokeSamples(const BrushStroke& stroke)
+    -> std::span<const BrushCanonicalSample> {
+  if (stroke.samples == nullptr) {
+    return {};
+  }
+  return *stroke.samples;
+}
+
+/**
+ * @brief Validate StrokeId, mode, and every canonical sample.
+ *
+ * @param stroke Candidate stroke. Not mutated.
+ * @throws std::runtime_error when identity, mode, or sample encoding rules fail.
+ */
+void ValidateBrushStroke(const BrushStroke& stroke);
+
+/**
+ * @brief Validate ordered strokes, including unique non-empty StrokeIds.
+ *
+ * @throws std::runtime_error when any stroke is invalid or a StrokeId repeats.
+ */
+void ValidateBrushStrokeList(std::span<const BrushStroke> strokes);
+
+/**
+ * @brief Construct a stroke that owns one immutable sample body.
+ *
+ * @param id Non-empty StrokeId.
+ * @param mode Paint or erase.
+ * @param samples Non-empty canonical samples. Moved into the shared body.
+ * @return Stroke sharing that body.
+ * @throws std::runtime_error when validation fails. @p samples may be left
+ *         moved-from; no owner is mutated by this factory.
+ */
+[[nodiscard]] auto MakeBrushStroke(StrokeId id, BrushStrokeMode mode,
+                                   std::vector<BrushCanonicalSample> samples) -> BrushStroke;
+
+/**
+ * @brief Index of @p stroke_id in @p strokes, or @p strokes.size() when absent.
+ */
+[[nodiscard]] auto FindBrushStrokeIndex(std::span<const BrushStroke> strokes,
+                                        const StrokeId& stroke_id) -> std::size_t;
+
+/**
+ * @brief Serialize one stroke as canonical JSON.
+ *
+ * Keys: `id`, `mode` (0 paint / 1 erase), `samples` (objects with local_x,
+ * local_y, radius, strength, hardness).
+ */
+[[nodiscard]] auto BrushStrokeToJson(const BrushStroke& stroke) -> nlohmann::json;
+
+/**
+ * @brief Read one stroke object. Requires id, mode, and a non-empty samples array.
+ *
+ * @throws std::runtime_error on missing fields or invalid values.
+ */
+[[nodiscard]] auto BrushStrokeFromJson(const nlohmann::json& json) -> BrushStroke;
+
+/**
+ * @brief Serialize ordered strokes as a JSON array.
+ */
+[[nodiscard]] auto BrushStrokeListToJson(std::span<const BrushStroke> strokes) -> nlohmann::json;
+
+/**
+ * @brief Read an ordered stroke array. Duplicate StrokeIds are rejected.
+ *
+ * @throws std::runtime_error when the value is not an array or a stroke is invalid.
+ */
+[[nodiscard]] auto BrushStrokeListFromJson(const nlohmann::json& json) -> std::vector<BrushStroke>;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/mask_model.hpp
+++ b/alcedo_studio/src/include/edit/mask/mask_model.hpp
@@ -12,6 +12,9 @@
 #include <variant>
 #include <vector>
 
+#include "edit/geometry/types.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_stroke.hpp"
 #include "edit/mask/mask_asset.hpp"
 #include "edit/mask/mask_id.hpp"
 #include "json.hpp"
@@ -26,17 +29,33 @@ enum class MaskSourceKind : std::uint8_t {
 };
 
 /**
- * @brief Settled Brush coverage. A missing asset key is valid and yields zero coverage.
+ * @brief Brush coverage source owned by a Color Grade Mask.
  *
- * @p descriptor must satisfy the raster-axis rule when @p asset_key is present.
+ * Canonical persistent data is ordered immutable strokes, algorithm versions, and
+ * @p placement_translation. Samples live in local reference pixels; translation does
+ * not rewrite them. @p asset_key remains only for already-stored raster documents and
+ * current native evaluation until the NM7.3 format gate and later replay replace it.
+ * A missing asset key with empty strokes yields zero coverage.
  */
 struct BrushMaskSource {
+  std::uint32_t               source_format_version    = kBrushSourceFormatVersion;
+  std::uint32_t               raster_algorithm_version = kBrushRasterAlgorithmVersion;
+  Vector2                     placement_translation{};
+  std::vector<BrushStroke>    strokes;
+  float                       feather_radius = 0.0f;
   std::optional<MaskAssetKey> asset_key;
   MaskAssetDescriptor         descriptor{};
-  float                       feather_radius = 0.0f;
 
   friend auto operator==(const BrushMaskSource&, const BrushMaskSource&) -> bool = default;
 };
+
+/**
+ * @brief True when @p brush stores stroke bodies or a non-zero placement.
+ *
+ * Used to choose parameterized JSON. Raster-only documents without strokes keep
+ * the published asset_key encoding until NM7.3 rejects that format.
+ */
+[[nodiscard]] auto BrushSourceHasParameterizedPayload(const BrushMaskSource& brush) -> bool;
 
 /** @brief Radial ellipse in normalized reference space. */
 struct RadialMaskSource {

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -318,6 +318,18 @@ gtest_discover_tests(BrushSourceFormatBoundaryTest
   PROPERTIES LABELS "ci_core_flow;edit;mask")
 alcedo_register_test_target(BrushSourceFormatBoundaryTest edit)
 
+# NM7.2 parameterized Brush source, owner operations, and JSON without MaskStore.
+add_executable(BrushParameterizedSourceTest
+  ${ALCEDO_TEST_ROOT}/edit/mask/brush_parameterized_source_test.cpp)
+target_include_directories(BrushParameterizedSourceTest
+  PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_ROOT}/edit/graph)
+target_link_libraries(BrushParameterizedSourceTest
+  PRIVATE GTest::gtest_main EditGraph)
+gtest_discover_tests(BrushParameterizedSourceTest
+  TEST_PREFIX "BrushParameterizedSourceTest."
+  PROPERTIES LABELS "ci_core_flow;edit;mask")
+alcedo_register_test_target(BrushParameterizedSourceTest edit)
+
 # Host GraphImageCache retention: LRU budget vs live writes, injected allocation failure.
 add_executable(GraphImageCacheRetentionTest
   ${ALCEDO_TEST_ROOT}/edit/runtime/graph_image_cache_retention_test.cpp)

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -306,6 +306,18 @@ gtest_discover_tests(GpuDagMaskStoreTest TEST_PREFIX "GpuDagMaskStoreTest."
   PROPERTIES LABELS "ci_core_flow;edit;mask")
 alcedo_register_test_target(GpuDagMaskStoreTest edit)
 
+# Current Brush raster-key format boundary, encoding rules, and later test names.
+add_executable(BrushSourceFormatBoundaryTest
+  ${ALCEDO_TEST_ROOT}/edit/mask/brush_source_format_boundary_test.cpp)
+target_include_directories(BrushSourceFormatBoundaryTest
+  PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_ROOT}/edit/graph)
+target_link_libraries(BrushSourceFormatBoundaryTest
+  PRIVATE GTest::gtest_main EditMaskStore EditGraph)
+gtest_discover_tests(BrushSourceFormatBoundaryTest
+  TEST_PREFIX "BrushSourceFormatBoundaryTest."
+  PROPERTIES LABELS "ci_core_flow;edit;mask")
+alcedo_register_test_target(BrushSourceFormatBoundaryTest edit)
+
 # Host GraphImageCache retention: LRU budget vs live writes, injected allocation failure.
 add_executable(GraphImageCacheRetentionTest
   ${ALCEDO_TEST_ROOT}/edit/runtime/graph_image_cache_retention_test.cpp)

--- a/alcedo_studio/tests/edit/mask/brush_parameterized_source_test.cpp
+++ b/alcedo_studio/tests/edit/mask/brush_parameterized_source_test.cpp
@@ -1,0 +1,309 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/mask/brush_mask_commands.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_stroke.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "grade_owned_mask_support.hpp"
+#include "json.hpp"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace alcedo {
+namespace {
+
+auto MakeSample(float local_x, float local_y, float radius = 8.0f, float strength = 1.0f,
+                float hardness = 1.0f) -> BrushCanonicalSample {
+  return {local_x, local_y, radius, strength, hardness};
+}
+
+auto MakePaintStroke(std::string_view id, std::vector<BrushCanonicalSample> samples)
+    -> BrushStroke {
+  return MakeBrushStroke(StrokeId{std::string{id}}, BrushStrokeMode::Paint, std::move(samples));
+}
+
+auto MakeEraseStroke(std::string_view id, std::vector<BrushCanonicalSample> samples)
+    -> BrushStroke {
+  return MakeBrushStroke(StrokeId{std::string{id}}, BrushStrokeMode::Erase, std::move(samples));
+}
+
+void AddEmptyBrush(ColorGradeNodeModel& grade, MaskId id) {
+  MaskModel mask;
+  mask.id     = std::move(id);
+  mask.source = BrushMaskSource{};
+  grade.AddMask(std::move(mask), grade.MaskCount());
+}
+
+auto PrimaryGradeJson(nlohmann::json& document_json) -> nlohmann::json& {
+  for (auto& node : document_json.at("nodes")) {
+    if (node.at("id") == "grade.primary") {
+      return node;
+    }
+  }
+  throw std::runtime_error("document JSON is missing grade.primary");
+}
+
+TEST(BrushParameterizedSource, BrushSourceRoundTripsWithoutRasterFiles) {
+  auto  document = CreateDefaultPipelineDocument();
+  auto* grade    = document.PrimaryGrade();
+  AddEmptyBrush(*grade, MaskId{"mask.brush"});
+  const auto first = MakePaintStroke(
+      "stroke.paint", {MakeSample(12.0f, 8.0f, 6.0f, 1.0f, 1.0f), MakeSample(16.0f, 9.0f, 6.0f)});
+  const auto second =
+      MakeEraseStroke("stroke.erase", {MakeSample(14.0f, 8.5f, 4.0f, 0.5f, 0.25f)});
+  const auto mask_id = MaskId{"mask.brush"};
+  grade->AppendBrushStroke(
+      {grade->Id(), mask_id, first, grade->MaskContentRevision(mask_id)});
+  grade->AppendBrushStroke(
+      {grade->Id(), mask_id, second, grade->MaskContentRevision(mask_id)});
+  SetBrushTranslationCommand move;
+  move.node_id            = grade->Id();
+  move.mask_id            = MaskId{"mask.brush"};
+  move.before             = {};
+  move.after              = {3.5f, -2.0f};
+  move.expected_revision  = grade->MaskContentRevision(MaskId{"mask.brush"});
+  grade->SetBrushTranslation(move);
+
+  auto json = document.ToJson();
+  const auto source = PrimaryGradeJson(json).at("masks").at(0).at("source");
+  ASSERT_TRUE(source.is_object());
+  EXPECT_EQ(source.at("kind"), "brush");
+  EXPECT_EQ(source.at("source_format_version"), kBrushSourceFormatVersion);
+  EXPECT_EQ(source.at("raster_algorithm_version"), kBrushRasterAlgorithmVersion);
+  EXPECT_FALSE(source.contains("asset_key"));
+  EXPECT_FALSE(source.contains("width"));
+  ASSERT_EQ(source.at("strokes").size(), 2u);
+  EXPECT_EQ(source.at("strokes").at(0).at("id"), "stroke.paint");
+  EXPECT_EQ(source.at("strokes").at(1).at("mode"), 1);
+
+  const auto restored = PipelineDocument::FromJson(json);
+  const auto* mask    = restored.PrimaryGrade()->FindMask(MaskId{"mask.brush"});
+  ASSERT_NE(mask, nullptr);
+  const auto* brush = std::get_if<BrushMaskSource>(&mask->source);
+  ASSERT_NE(brush, nullptr);
+  EXPECT_FALSE(brush->asset_key.has_value());
+  EXPECT_EQ(brush->source_format_version, kBrushSourceFormatVersion);
+  EXPECT_EQ(brush->raster_algorithm_version, kBrushRasterAlgorithmVersion);
+  EXPECT_EQ(brush->placement_translation, (Vector2{3.5f, -2.0f}));
+  ASSERT_EQ(brush->strokes.size(), 2u);
+  EXPECT_EQ(brush->strokes[0].id, StrokeId{"stroke.paint"});
+  EXPECT_EQ(brush->strokes[1].id, StrokeId{"stroke.erase"});
+  EXPECT_EQ(brush->strokes[1].mode, BrushStrokeMode::Erase);
+  ASSERT_EQ(BrushStrokeSamples(brush->strokes[0]).size(), 2u);
+  EXPECT_EQ(BrushStrokeSamples(brush->strokes[0])[0], MakeSample(12.0f, 8.0f, 6.0f));
+  EXPECT_EQ(MaskModelToJson(*mask).at("source").dump(), source.dump());
+  EXPECT_EQ(*mask, restored.PrimaryGrade()->MaskAt(0));
+}
+
+TEST(BrushParameterizedSource, BrushAppendKeepsExistingStrokeIds) {
+  auto  document = CreateDefaultPipelineDocument();
+  auto* grade    = document.PrimaryGrade();
+  AddEmptyBrush(*grade, MaskId{"mask.a"});
+  AddEmptyBrush(*grade, MaskId{"mask.b"});
+  const auto first = MakePaintStroke("stroke.keep", {MakeSample(1.0f, 2.0f)});
+  grade->AppendBrushStroke(
+      {grade->Id(), MaskId{"mask.a"}, first, grade->MaskContentRevision(MaskId{"mask.a"})});
+  const auto kept_body = grade->BrushStrokes(MaskId{"mask.a"})[0].samples;
+  const auto first_revision = grade->MaskContentRevision(MaskId{"mask.a"});
+  const auto other_revision = grade->MaskContentRevision(MaskId{"mask.b"});
+
+  const auto second = MakePaintStroke("stroke.next", {MakeSample(4.0f, 5.0f, 10.0f, 0.8f, 0.5f)});
+  grade->AppendBrushStroke({grade->Id(), MaskId{"mask.a"}, second, first_revision});
+
+  const auto strokes = grade->BrushStrokes(MaskId{"mask.a"});
+  ASSERT_EQ(strokes.size(), 2u);
+  EXPECT_EQ(strokes[0].id, StrokeId{"stroke.keep"});
+  EXPECT_EQ(strokes[1].id, StrokeId{"stroke.next"});
+  EXPECT_EQ(kept_body.get(), strokes[0].samples.get());
+  EXPECT_EQ(BrushStrokeSamples(strokes[0])[0], MakeSample(1.0f, 2.0f));
+  EXPECT_NE(grade->MaskContentRevision(MaskId{"mask.a"}), first_revision);
+  EXPECT_EQ(grade->MaskContentRevision(MaskId{"mask.b"}), other_revision);
+  EXPECT_TRUE(grade->BrushStrokes(MaskId{"mask.b"}).empty());
+}
+
+TEST(BrushParameterizedSource, InvalidStrokeDoesNotPartiallyMutateSource) {
+  auto  document = CreateDefaultPipelineDocument();
+  auto* grade    = document.PrimaryGrade();
+  AddEmptyBrush(*grade, MaskId{"mask.brush"});
+  grade->AddMask(grade_mask_test::MakeRadialMask(MaskId{"mask.radial"}), 1);
+  const auto valid = MakePaintStroke("stroke.1", {MakeSample(0.0f, 0.0f)});
+  grade->AppendBrushStroke(
+      {grade->Id(), MaskId{"mask.brush"}, valid, grade->MaskContentRevision(MaskId{"mask.brush"})});
+  const auto before        = *grade->FindMask(MaskId{"mask.brush"});
+  const auto before_revision = grade->MaskContentRevision(MaskId{"mask.brush"});
+  const auto before_radial = *grade->FindMask(MaskId{"mask.radial"});
+  const auto original_body = std::get<BrushMaskSource>(before.source).strokes[0].samples;
+
+  BrushCanonicalSample nan_sample = MakeSample(1.0f, 1.0f);
+  nan_sample.local_x              = std::numeric_limits<float>::quiet_NaN();
+  EXPECT_THROW((void)MakeBrushStroke(StrokeId{"stroke.bad"}, BrushStrokeMode::Paint, {nan_sample}),
+               std::runtime_error);
+
+  auto duplicate = MakePaintStroke("stroke.1", {MakeSample(9.0f, 9.0f)});
+  EXPECT_THROW(grade->AppendBrushStroke({grade->Id(), MaskId{"mask.brush"}, duplicate,
+                                        before_revision}),
+               std::runtime_error);
+
+  auto empty_id = MakePaintStroke("stroke.2", {MakeSample(3.0f, 3.0f)});
+  empty_id.id   = StrokeId{};
+  EXPECT_THROW(
+      grade->AppendBrushStroke({grade->Id(), MaskId{"mask.brush"}, empty_id, before_revision}),
+      std::runtime_error);
+
+  auto next = MakePaintStroke("stroke.2", {MakeSample(3.0f, 3.0f)});
+  EXPECT_THROW(grade->AppendBrushStroke(
+                   {NodeId{"grade.other"}, MaskId{"mask.brush"}, next, before_revision}),
+               std::runtime_error);
+  EXPECT_THROW(
+      grade->AppendBrushStroke({grade->Id(), MaskId{"mask.missing"}, next, before_revision}),
+      std::runtime_error);
+  EXPECT_THROW(
+      grade->AppendBrushStroke({grade->Id(), MaskId{"mask.brush"}, next, before_revision - 1}),
+      std::runtime_error);
+  EXPECT_THROW(grade->AppendBrushStroke({grade->Id(), MaskId{"mask.radial"}, next,
+                                        grade->MaskContentRevision(MaskId{"mask.radial"})}),
+               std::runtime_error);
+
+  BrushCanonicalSample zero_radius = MakeSample(1.0f, 1.0f);
+  zero_radius.radius              = 0.0f;
+  EXPECT_THROW(
+      (void)MakeBrushStroke(StrokeId{"stroke.zero"}, BrushStrokeMode::Paint, {zero_radius}),
+      std::runtime_error);
+
+  EXPECT_EQ(*grade->FindMask(MaskId{"mask.brush"}), before);
+  EXPECT_EQ(grade->MaskContentRevision(MaskId{"mask.brush"}), before_revision);
+  EXPECT_EQ(std::get<BrushMaskSource>(grade->FindMask(MaskId{"mask.brush"})->source)
+                .strokes[0]
+                .samples.get(),
+            original_body.get());
+  EXPECT_EQ(*grade->FindMask(MaskId{"mask.radial"}), before_radial);
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"}).size(), 1u);
+}
+
+TEST(BrushParameterizedSource, BrushTranslationDoesNotCopyOrRewriteSamples) {
+  auto  document = CreateDefaultPipelineDocument();
+  auto* grade    = document.PrimaryGrade();
+  AddEmptyBrush(*grade, MaskId{"mask.brush"});
+  const auto stroke = MakePaintStroke("stroke.1", {MakeSample(10.0f, 20.0f, 5.0f, 0.75f, 0.5f)});
+  const auto mask_id = MaskId{"mask.brush"};
+  grade->AppendBrushStroke(
+      {grade->Id(), mask_id, stroke, grade->MaskContentRevision(mask_id)});
+  const auto* body_before =
+      grade->BrushStrokes(MaskId{"mask.brush"})[0].samples.get();
+  const auto sample_before = BrushStrokeSamples(grade->BrushStrokes(MaskId{"mask.brush"})[0])[0];
+  const auto revision      = grade->MaskContentRevision(MaskId{"mask.brush"});
+
+  SetBrushTranslationCommand move;
+  move.node_id           = grade->Id();
+  move.mask_id           = MaskId{"mask.brush"};
+  move.before            = {};
+  move.after             = {40.0f, -15.0f};
+  move.expected_revision = revision;
+  grade->SetBrushTranslation(move);
+
+  const auto strokes = grade->BrushStrokes(MaskId{"mask.brush"});
+  ASSERT_EQ(strokes.size(), 1u);
+  EXPECT_EQ(strokes[0].samples.get(), body_before);
+  EXPECT_EQ(BrushStrokeSamples(strokes[0])[0], sample_before);
+  EXPECT_EQ(BrushStrokeSamples(strokes[0])[0].local_x, 10.0f);
+  EXPECT_EQ(BrushStrokeSamples(strokes[0])[0].local_y, 20.0f);
+  EXPECT_EQ(grade->BrushPlacementTranslation(MaskId{"mask.brush"}), (Vector2{40.0f, -15.0f}));
+  EXPECT_NE(grade->MaskContentRevision(MaskId{"mask.brush"}), revision);
+
+  move.before            = {40.0f, -15.0f};
+  move.after             = {40.0f, -15.0f};
+  move.expected_revision = grade->MaskContentRevision(MaskId{"mask.brush"});
+  const auto no_op_revision = move.expected_revision;
+  grade->SetBrushTranslation(move);
+  EXPECT_EQ(grade->MaskContentRevision(MaskId{"mask.brush"}), no_op_revision);
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"})[0].samples.get(), body_before);
+
+  move.after = {1.0f, 1.0f};
+  move.before = {};
+  EXPECT_THROW(grade->SetBrushTranslation(move), std::runtime_error);
+  EXPECT_EQ(grade->BrushPlacementTranslation(MaskId{"mask.brush"}), (Vector2{40.0f, -15.0f}));
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"})[0].samples.get(), body_before);
+}
+
+TEST(BrushParameterizedSource, InsertAndRemoveKeepRemainingSampleBodies) {
+  auto  document = CreateDefaultPipelineDocument();
+  auto* grade    = document.PrimaryGrade();
+  AddEmptyBrush(*grade, MaskId{"mask.brush"});
+  grade->AppendBrushStroke({grade->Id(), MaskId{"mask.brush"},
+                            MakePaintStroke("stroke.a", {MakeSample(1.0f, 1.0f)}),
+                            grade->MaskContentRevision(MaskId{"mask.brush"})});
+  grade->AppendBrushStroke({grade->Id(), MaskId{"mask.brush"},
+                            MakePaintStroke("stroke.c", {MakeSample(3.0f, 3.0f)}),
+                            grade->MaskContentRevision(MaskId{"mask.brush"})});
+  const auto first_body  = grade->BrushStrokes(MaskId{"mask.brush"})[0].samples;
+  const auto second_body = grade->BrushStrokes(MaskId{"mask.brush"})[1].samples;
+
+  InsertBrushStrokeCommand insert;
+  insert.node_id           = grade->Id();
+  insert.mask_id           = MaskId{"mask.brush"};
+  insert.index             = 1;
+  insert.stroke            = MakePaintStroke("stroke.b", {MakeSample(2.0f, 2.0f)});
+  insert.expected_revision = grade->MaskContentRevision(MaskId{"mask.brush"});
+  grade->InsertBrushStroke(std::move(insert));
+  ASSERT_EQ(grade->BrushStrokes(MaskId{"mask.brush"}).size(), 3u);
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"})[0].id, StrokeId{"stroke.a"});
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"})[1].id, StrokeId{"stroke.b"});
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"})[2].id, StrokeId{"stroke.c"});
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"})[0].samples.get(), first_body.get());
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"})[2].samples.get(), second_body.get());
+
+  RemoveBrushStrokeCommand remove;
+  remove.node_id           = grade->Id();
+  remove.mask_id           = MaskId{"mask.brush"};
+  remove.stroke_id         = StrokeId{"stroke.b"};
+  remove.expected_revision = grade->MaskContentRevision(MaskId{"mask.brush"});
+  grade->RemoveBrushStroke(remove);
+  ASSERT_EQ(grade->BrushStrokes(MaskId{"mask.brush"}).size(), 2u);
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"})[0].samples.get(), first_body.get());
+  EXPECT_EQ(grade->BrushStrokes(MaskId{"mask.brush"})[1].samples.get(), second_body.get());
+}
+
+TEST(BrushParameterizedSource, ParameterizedBrushJsonRejectsUnsupportedAlgorithmVersion) {
+  auto document = CreateDefaultPipelineDocument();
+  AddEmptyBrush(*document.PrimaryGrade(), MaskId{"mask.brush"});
+  document.PrimaryGrade()->AppendBrushStroke(
+      {document.PrimaryGrade()->Id(), MaskId{"mask.brush"},
+       MakePaintStroke("stroke.1", {MakeSample(1.0f, 1.0f)}),
+       document.PrimaryGrade()->MaskContentRevision(MaskId{"mask.brush"})});
+  auto json = document.ToJson();
+  PrimaryGradeJson(json).at("masks").at(0).at("source")["raster_algorithm_version"] = 2;
+  EXPECT_THROW((void)PipelineDocument::FromJson(json), std::runtime_error);
+
+  json = document.ToJson();
+  PrimaryGradeJson(json).at("masks").at(0).at("source")["source_format_version"] = 0;
+  EXPECT_THROW((void)PipelineDocument::FromJson(json), std::runtime_error);
+
+  json = document.ToJson();
+  PrimaryGradeJson(json).at("masks").at(0).at("source").erase("placement_translation");
+  EXPECT_THROW((void)PipelineDocument::FromJson(json), std::runtime_error);
+
+  json = document.ToJson();
+  PrimaryGradeJson(json).at("masks").at(0).at("source")["strokes"].push_back(
+      nlohmann::json{{"id", "stroke.1"},
+                     {"mode", 0},
+                     {"samples", nlohmann::json::array({nlohmann::json{{"local_x", 2.0},
+                                                                     {"local_y", 2.0},
+                                                                     {"radius", 1.0},
+                                                                     {"strength", 1.0},
+                                                                     {"hardness", 1.0}}})}});
+  EXPECT_THROW((void)PipelineDocument::FromJson(json), std::runtime_error);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/mask/brush_source_format_boundary_test.cpp
+++ b/alcedo_studio/tests/edit/mask/brush_source_format_boundary_test.cpp
@@ -93,25 +93,24 @@ TEST(BrushSourceFormatBoundary, BrushJsonRoundTripStoresAssetKeyAndOmitsStrokeFi
   EXPECT_EQ(*brush->asset_key, MaskAssetKey{"asset_01"});
 }
 
-TEST(BrushSourceFormatBoundary, CurrentBrushLoaderIgnoresStrokeFieldsAndKeepsAssetKey) {
+TEST(BrushSourceFormatBoundary, MalformedStrokeFieldsOnAssetBrushAreRejected) {
   auto document = CreateDefaultPipelineDocument();
   grade_mask_test::AddBrushMask(document, MaskId{"mask.brush"}, MaskAssetKey{"asset_01"});
+  const auto before = document.ToJson().dump();
   auto json = document.ToJson();
   auto& source = PrimaryGradeJson(json).at("masks").at(0).at("source");
   source["strokes"] = nlohmann::json::array(
       {{{"id", "stroke.1"}, {"mode", "paint"}, {"samples", nlohmann::json::array({1.0, 2.0})}}});
   source["placement_translation"] = nlohmann::json::array({3.0, 4.0});
   source["source_format_version"] = 1;
-  const auto restored = PipelineDocument::FromJson(json);
-  const auto* mask    = restored.PrimaryGrade()->FindMask(MaskId{"mask.brush"});
-  ASSERT_NE(mask, nullptr);
-  const auto* brush = std::get_if<BrushMaskSource>(&mask->source);
+  source["raster_algorithm_version"] = 1;
+  EXPECT_THROW((void)PipelineDocument::FromJson(json), std::runtime_error);
+  EXPECT_EQ(document.ToJson().dump(), before);
+  const auto* brush = std::get_if<BrushMaskSource>(&document.PrimaryGrade()->FindMask(MaskId{"mask.brush"})->source);
   ASSERT_NE(brush, nullptr);
+  EXPECT_TRUE(brush->strokes.empty());
   ASSERT_TRUE(brush->asset_key.has_value());
   EXPECT_EQ(*brush->asset_key, MaskAssetKey{"asset_01"});
-  const auto rewritten = MaskModelToJson(*mask)["source"];
-  EXPECT_FALSE(rewritten.contains("strokes"));
-  EXPECT_EQ(rewritten.at("asset_key"), "asset_01");
 }
 
 TEST(BrushSourceFormatBoundary, UnsupportedPipelineDocumentFormatLeavesSourceFileUnchanged) {
@@ -235,10 +234,6 @@ TEST(BrushSourceFormatBoundary, PackedR8BilinearSampleMatchesNativeCenterFilter)
 
 TEST(BrushSourceFormatBoundary, PlannedParameterizedBrushTestsAreCatalogued) {
   constexpr std::string_view names[] = {
-      "BrushSourceRoundTripsWithoutRasterFiles",
-      "BrushAppendKeepsExistingStrokeIds",
-      "InvalidStrokeDoesNotPartiallyMutateSource",
-      "BrushTranslationDoesNotCopyOrRewriteSamples",
       "StrokeUndoRedoRestoresCommandOrderWithoutR8",
       "FirstBrushStrokeCreatesOneCommit",
       "BrushMoveUndoRestoresExactTranslation",
@@ -301,10 +296,10 @@ TEST(BrushSourceFormatBoundary, PlannedParameterizedBrushTestsAreCatalogued) {
       "InterruptedCacheReplaceLeavesNoPartialFile",
       "PastedBrushUsesTargetProjectStoragePolicy",
   };
-  EXPECT_EQ(std::size(names), 65u);
-  EXPECT_EQ(names[0], "BrushSourceRoundTripsWithoutRasterFiles");
-  EXPECT_EQ(names[9], "RasterOnlyFormatIsRejectedBeforeCacheCleanup");
-  EXPECT_EQ(names[64], "PastedBrushUsesTargetProjectStoragePolicy");
+  EXPECT_EQ(std::size(names), 61u);
+  EXPECT_EQ(names[0], "StrokeUndoRedoRestoresCommandOrderWithoutR8");
+  EXPECT_EQ(names[5], "RasterOnlyFormatIsRejectedBeforeCacheCleanup");
+  EXPECT_EQ(names[60], "PastedBrushUsesTargetProjectStoragePolicy");
 }
 
 }  // namespace

--- a/alcedo_studio/tests/edit/mask/brush_source_format_boundary_test.cpp
+++ b/alcedo_studio/tests/edit/mask/brush_source_format_boundary_test.cpp
@@ -1,0 +1,311 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_adjustment_types.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/history/pipeline_history_format.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "edit/mask/mask_store.hpp"
+#include "grade_owned_mask_support.hpp"
+#include "json.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace alcedo {
+namespace {
+
+auto TestRoot(std::string_view name) -> std::filesystem::path {
+  return std::filesystem::path{"build/tmp/brush_source_format_boundary"} / name;
+}
+
+auto ReadFileBytes(const std::filesystem::path& path) -> std::string {
+  std::ifstream stream(path, std::ios::binary);
+  return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+auto PrimaryGradeJson(nlohmann::json& document_json) -> nlohmann::json& {
+  for (auto& node : document_json.at("nodes")) {
+    if (node.at("id") == "grade.primary") {
+      return node;
+    }
+  }
+  throw std::runtime_error("document JSON is missing grade.primary");
+}
+
+TEST(BrushSourceFormatBoundary, CurrentHistoryIdentitiesMatchPublishedConstants) {
+  EXPECT_EQ(kProjectFileVersion, "0.5.0");
+  EXPECT_EQ(kMinSupportedProjectFileVersion, "0.5.0");
+  EXPECT_EQ(kMaxSupportedProjectFileVersion, "0.5.0");
+  EXPECT_EQ(kPackedProjectFormatVersion, 5u);
+  EXPECT_EQ(kPipelineDocumentFormatVersion, 5u);
+  EXPECT_EQ(kImageEditSchemaVersion, 3u);
+  EXPECT_EQ(kCommitFormatVersion, 3u);
+  EXPECT_EQ(kChainFormatVersion, 3u);
+  EXPECT_EQ(kPipelineEditBatchFormatVersion, 2u);
+  EXPECT_EQ(kRootStateFormatVersion, 3u);
+  EXPECT_EQ(kCheckpointStateFormatVersion, 3u);
+  EXPECT_EQ(kMiniGitJournalRecordFormatVersion, 4u);
+  EXPECT_EQ(kAdjustmentTransferSchema, "alcedo.adjustment_transfer.v3");
+  EXPECT_EQ(kMaskAssetFormatVersion, 1u);
+  EXPECT_EQ(kMaskAssetPackedR8FormatId, 1u);
+  EXPECT_EQ(kMaximumRasterMaskAxis, 4096u);
+  EXPECT_EQ(kBrushSourceFormatVersion, 1u);
+  EXPECT_EQ(kBrushRasterAlgorithmVersion, 1u);
+  EXPECT_EQ(kProjectMaskCacheFormatVersion, 1u);
+  EXPECT_EQ(kBrushDabSpacingRadiusFraction, 0.25f);
+  EXPECT_NE(kPipelineDocumentFormatVersion, 6u);
+  EXPECT_EQ(static_cast<std::uint8_t>(BrushStrokeMode::Paint), 0);
+  EXPECT_EQ(static_cast<std::uint8_t>(BrushStrokeMode::Erase), 1);
+}
+
+TEST(BrushSourceFormatBoundary, BrushJsonRoundTripStoresAssetKeyAndOmitsStrokeFields) {
+  auto document = CreateDefaultPipelineDocument();
+  grade_mask_test::AddBrushMask(document, MaskId{"mask.persisted"}, MaskAssetKey{"asset_01"});
+  auto       json   = document.ToJson();
+  const auto source = PrimaryGradeJson(json).at("masks").at(0).at("source");
+  ASSERT_TRUE(source.is_object());
+  EXPECT_EQ(source.at("kind"), "brush");
+  EXPECT_EQ(source.at("asset_key"), "asset_01");
+  EXPECT_FALSE(source.contains("strokes"));
+  EXPECT_FALSE(source.contains("placement_translation"));
+  EXPECT_FALSE(source.contains("source_format_version"));
+  EXPECT_FALSE(source.contains("raster_algorithm_version"));
+  EXPECT_EQ(json.at("format_version"), kPipelineDocumentFormatVersion);
+
+  const auto restored = PipelineDocument::FromJson(json);
+  const auto* mask    = restored.PrimaryGrade()->FindMask(MaskId{"mask.persisted"});
+  ASSERT_NE(mask, nullptr);
+  const auto* brush = std::get_if<BrushMaskSource>(&mask->source);
+  ASSERT_NE(brush, nullptr);
+  ASSERT_TRUE(brush->asset_key.has_value());
+  EXPECT_EQ(*brush->asset_key, MaskAssetKey{"asset_01"});
+}
+
+TEST(BrushSourceFormatBoundary, CurrentBrushLoaderIgnoresStrokeFieldsAndKeepsAssetKey) {
+  auto document = CreateDefaultPipelineDocument();
+  grade_mask_test::AddBrushMask(document, MaskId{"mask.brush"}, MaskAssetKey{"asset_01"});
+  auto json = document.ToJson();
+  auto& source = PrimaryGradeJson(json).at("masks").at(0).at("source");
+  source["strokes"] = nlohmann::json::array(
+      {{{"id", "stroke.1"}, {"mode", "paint"}, {"samples", nlohmann::json::array({1.0, 2.0})}}});
+  source["placement_translation"] = nlohmann::json::array({3.0, 4.0});
+  source["source_format_version"] = 1;
+  const auto restored = PipelineDocument::FromJson(json);
+  const auto* mask    = restored.PrimaryGrade()->FindMask(MaskId{"mask.brush"});
+  ASSERT_NE(mask, nullptr);
+  const auto* brush = std::get_if<BrushMaskSource>(&mask->source);
+  ASSERT_NE(brush, nullptr);
+  ASSERT_TRUE(brush->asset_key.has_value());
+  EXPECT_EQ(*brush->asset_key, MaskAssetKey{"asset_01"});
+  const auto rewritten = MaskModelToJson(*mask)["source"];
+  EXPECT_FALSE(rewritten.contains("strokes"));
+  EXPECT_EQ(rewritten.at("asset_key"), "asset_01");
+}
+
+TEST(BrushSourceFormatBoundary, UnsupportedPipelineDocumentFormatLeavesSourceFileUnchanged) {
+  const auto root = TestRoot("unsupported_document");
+  std::error_code ignored;
+  std::filesystem::remove_all(root, ignored);
+  std::filesystem::create_directories(root);
+  auto json = CreateDefaultPipelineDocument().ToJson();
+  json["format_version"] = 4;
+  const auto path        = root / "pipeline.json";
+  {
+    std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+    stream << json.dump();
+  }
+  const auto before = ReadFileBytes(path);
+  EXPECT_THROW((void)PipelineDocument::FromJson(nlohmann::json::parse(before)), std::runtime_error);
+  EXPECT_EQ(ReadFileBytes(path), before);
+  EXPECT_NE(before.find("\"format_version\":4"), std::string::npos);
+}
+
+TEST(BrushSourceFormatBoundary, UnknownBrushSourceKindIsRejectedWithoutDocumentMutation) {
+  auto       document = CreateDefaultPipelineDocument();
+  const auto before   = document.ToJson().dump();
+  auto json = document.ToJson();
+  PrimaryGradeJson(json)["masks"] = nlohmann::json::array(
+      {nlohmann::json{{"id", "mask.bad"},
+                      {"display_name", ""},
+                      {"enabled", true},
+                      {"opacity", 1.0},
+                      {"invert", false},
+                      {"source", {{"kind", "vector_path"}}},
+                      {"color_range", nullptr},
+                      {"luminance_range", nullptr}}});
+  EXPECT_THROW((void)PipelineDocument::FromJson(json), std::runtime_error);
+  EXPECT_EQ(document.ToJson().dump(), before);
+}
+
+TEST(BrushSourceFormatBoundary, HeldMaskStoreReaderKeepsImmutablePixelsAfterHostCacheEviction) {
+  const auto root = TestRoot("reader_lifetime");
+  std::error_code ignored;
+  std::filesystem::remove_all(root, ignored);
+  MaskAssetDescriptor descriptor;
+  descriptor.extent           = {4, 2};
+  descriptor.reference_bounds = CanonicalBrushReferenceBounds();
+  const std::vector<std::uint8_t> first_pixels(8, 17);
+  const std::vector<std::uint8_t> second_pixels(8, 19);
+  MaskStore store(root, 8);
+  const auto first_key  = store.Put(descriptor, first_pixels);
+  const auto first_held = store.Load(first_key);
+  ASSERT_NE(first_held, nullptr);
+  EXPECT_EQ(first_held.get(), store.Load(first_key).get());
+  const auto* first_data = first_held->pixels.data();
+  const auto second_key  = store.Put(descriptor, second_pixels);
+  EXPECT_NE(first_key, second_key);
+  EXPECT_EQ(store.HostCacheEntryCount(), 1u);
+  EXPECT_EQ(first_held->pixels, first_pixels);
+  EXPECT_EQ(first_held->pixels.data(), first_data);
+  const auto reloaded = store.Load(first_key);
+  EXPECT_EQ(reloaded->pixels, first_pixels);
+  EXPECT_NE(reloaded.get(), first_held.get());
+}
+
+TEST(BrushSourceFormatBoundary, OrdinaryAdjustmentPathStillRejectsMaskTargets) {
+  EditorParameterTarget target;
+  target.owner_kind = EditorParameterOwnerKind::ColorGradeMask;
+  target.node_id    = NodeId{"grade.primary"};
+  target.mask_id    = "mask.1";
+  target.field_key  = "opacity";
+  EXPECT_EQ(DescribeEditorParameterTargetError(target, "opacity"),
+            "Mask parameter targets are rejected until NM3");
+}
+
+TEST(BrushSourceFormatBoundary, BrushDabCoverageQuantizesWithRoundHalfUpAndHardEdge) {
+  EXPECT_EQ(QuantizeMaskCoverageToR8(0.0f), 0);
+  EXPECT_EQ(QuantizeMaskCoverageToR8(1.0f), 255);
+  EXPECT_EQ(QuantizeMaskCoverageToR8(0.5f), 128);
+  EXPECT_THROW((void)QuantizeMaskCoverageToR8(std::numeric_limits<float>::quiet_NaN()),
+               std::invalid_argument);
+  EXPECT_FLOAT_EQ(BrushDabCoverage(0.0f, 10.0f, 1.0f, 1.0f), 1.0f);
+  EXPECT_FLOAT_EQ(BrushDabCoverage(10.0f, 10.0f, 0.5f, 1.0f), 0.5f);
+  EXPECT_FLOAT_EQ(BrushDabCoverage(10.01f, 10.0f, 1.0f, 1.0f), 0.0f);
+  EXPECT_FLOAT_EQ(BrushDabCoverage(5.0f, 10.0f, 1.0f, 0.5f), 1.0f);
+  EXPECT_FLOAT_EQ(BrushDabCoverage(7.5f, 10.0f, 1.0f, 0.5f), 0.5f);
+  EXPECT_FLOAT_EQ(BrushDabCoverage(10.0f, 10.0f, 1.0f, 0.5f), 0.0f);
+  EXPECT_EQ(PaintBrushR8(30, 200), 200);
+  EXPECT_EQ(PaintBrushR8(90, 200), 200);
+  EXPECT_EQ(EraseBrushR8(200, 255), 0);
+  EXPECT_EQ(EraseBrushR8(200, 0), 200);
+  BrushCanonicalSample invalid;
+  invalid.radius = 0.0f;
+  EXPECT_THROW(ValidateBrushCanonicalSample(invalid), std::invalid_argument);
+  EXPECT_THROW((void)BrushDabCoverage(-1.0f, 10.0f, 1.0f, 1.0f), std::invalid_argument);
+}
+
+TEST(BrushSourceFormatBoundary, CanonicalBrushRasterExtentCapsLongEdgeAt4096) {
+  EXPECT_EQ(CanonicalBrushRasterExtent({800, 600}), (Extent2D{800, 600}));
+  EXPECT_EQ(CanonicalBrushRasterExtent({8000, 4000}), (Extent2D{4096, 2048}));
+  EXPECT_EQ(CanonicalBrushRasterExtent({4097, 1}), (Extent2D{4096, 1}));
+  EXPECT_TRUE(CanonicalBrushReferenceBounds().IsFullFrame());
+  EXPECT_THROW((void)CanonicalBrushRasterExtent({}), std::invalid_argument);
+  const auto center = CanonicalBrushTexelReferenceCenter(0, 0, {4096, 2048}, {8000, 4000});
+  EXPECT_NEAR(center.x, 0.5f * 8000.0f / 4096.0f, 1.0e-5f);
+  EXPECT_NEAR(center.y, 0.5f * 4000.0f / 2048.0f, 1.0e-5f);
+}
+
+TEST(BrushSourceFormatBoundary, BrushFeatherRadiusMatchesNativeTexelScale) {
+  const Extent2D     raster{64, 32};
+  const Extent2D     full{64, 32};
+  const auto         bounds = CanonicalBrushReferenceBounds();
+  EXPECT_FLOAT_EQ(BrushFeatherRadiusToSourceTexels(10.0f, raster, bounds, full), 10.0f);
+  NormalizedRect half = bounds;
+  half.w              = 0.5f;
+  EXPECT_NEAR(BrushFeatherRadiusToSourceTexels(10.0f, raster, half, full), 15.0f, 1.0e-5f);
+}
+
+TEST(BrushSourceFormatBoundary, PackedR8BilinearSampleMatchesNativeCenterFilter) {
+  const std::vector<std::uint8_t> pixels{0, 255};
+  EXPECT_FLOAT_EQ(SamplePackedR8Bilinear(pixels, {2, 1}, 0.5f, 0.5f), 0.5f);
+  EXPECT_FLOAT_EQ(SamplePackedR8Bilinear(pixels, {2, 1}, -0.1f, 0.5f), 0.0f);
+}
+
+TEST(BrushSourceFormatBoundary, PlannedParameterizedBrushTestsAreCatalogued) {
+  constexpr std::string_view names[] = {
+      "BrushSourceRoundTripsWithoutRasterFiles",
+      "BrushAppendKeepsExistingStrokeIds",
+      "InvalidStrokeDoesNotPartiallyMutateSource",
+      "BrushTranslationDoesNotCopyOrRewriteSamples",
+      "StrokeUndoRedoRestoresCommandOrderWithoutR8",
+      "FirstBrushStrokeCreatesOneCommit",
+      "BrushMoveUndoRestoresExactTranslation",
+      "AppendHistoryDoesNotRepeatEarlierSamples",
+      "ParameterizedBrushSurvivesWalRecoveryAndPaste",
+      "RasterOnlyFormatIsRejectedBeforeCacheCleanup",
+      "RegionalBrushReplayMatchesFullEvaluation",
+      "EraseUndoRestoresEarlierPaint",
+      "RemovingUnionMaximumPreservesOtherMasks",
+      "BrushEventGroupingPreservesCanonicalPixels",
+      "FeatherRebuildMatchesCompleteDistanceEvaluation",
+      "MaskReferenceMappingRoundTripsAcrossZoomPanAndDpr",
+      "BrushMoveThenDrawUsesTranslatedLocalCoordinates",
+      "RepeatedBrushMoveDoesNotBlurCoverage",
+      "DetailPatchDoesNotChangeMaskReferenceSpace",
+      "InvalidGeometryRejectsMaskPress",
+      "ExistingMaskEditHasControlsAndNoCoverageFill",
+      "MaskControlsUpdateWhileRenderIsHeld",
+      "MaskOverlayReusesNodesForMovement",
+      "MaskControlsRecreateAfterSceneInvalidation",
+      "MaskControlsKeepLogicalSizeAndThemeColors",
+      "ExistingRadialMoveUpdatesInteractivePixelsBeforeRelease",
+      "ExistingGradientMovePreservesDirectionAndUpdatesInteractivePixels",
+      "RadialFeatherControlsMatchEvaluator",
+      "DegenerateAnalyticCreationCreatesNoCommit",
+      "EscapeRestoresAnalyticSourceWithoutCommit",
+      "MultipleStrokesUseOneBrushMask",
+      "SizeAndStrengthChangesPersistInStrokeSamples",
+      "MovingExistingBrushUpdatesInteractivePixels",
+      "BrushMoveDoesNotAppendStroke",
+      "UndoLastStrokePreservesEarlierStrokes",
+      "BrushReleaseCreatesNoHistoricalRasterFile",
+      "MaskMoveNeverMutatesSourceDuringRender",
+      "LatestMoveValueSurvivesRelease",
+      "CurrentGradeCoverageHasOneRetainedResult",
+      "DelayedOldFrameCannotReplaceNewMaskPosition",
+      "QualityMaskEvaluationDoesNotOverwriteInteractiveCache",
+      "RebuiltMaskMatchesCacheHitPixels",
+      "ProjectMaskCacheSettingsSurviveSaveAndReopen",
+      "ThousandStrokesKeepOneRasterSlot",
+      "CacheClearCannotDeleteAnotherProjectsFiles",
+      "OldWriterCannotRecreateClearedCache",
+      "RootChangeFailurePreservesOldSetting",
+      "CacheWriteFailureDoesNotLoseStrokeHistory",
+      "CloseCleanupRunsAfterParameterSaveAndReadersFinish",
+      "MaskModePreservesSixTabs",
+      "MaskSelectionDoesNotSubmitOrJumpScroll",
+      "KeyboardMaskMoveUsesSameInteractiveRoute",
+      "CacheSettingsTargetSelectedProjectOnly",
+      "ProjectClearExplainsThatBrushHistoryIsRetained",
+      "GrabCancellationDoesNotCommitBrush",
+      "DuplicateReleaseCommitsOnce",
+      "VersionCheckoutRejectsOldMaskFrame",
+      "ProjectSwitchRejectsOldCacheWrite",
+      "MaskDeleteWithViewerFocusDoesNotDeleteGrade",
+      "WorkspaceHideRestoresUnfinishedMaskMove",
+      "CachelessProjectRestoresAllMaskVersions",
+      "NativeMaskReplayMatchesExpectedCoverage",
+      "RepeatedHistoryNavigationKeepsRasterFileCountBounded",
+      "InterruptedCacheReplaceLeavesNoPartialFile",
+      "PastedBrushUsesTargetProjectStoragePolicy",
+  };
+  EXPECT_EQ(std::size(names), 65u);
+  EXPECT_EQ(names[0], "BrushSourceRoundTripsWithoutRasterFiles");
+  EXPECT_EQ(names[9], "RasterOnlyFormatIsRejectedBeforeCacheCleanup");
+  EXPECT_EQ(names[64], "PastedBrushUsesTargetProjectStoragePolicy");
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
@@ -1,0 +1,429 @@
+# NM7 — Parameterized Mask Commands, Regional Replay and Project Cache
+
+Date: 2026-09-08
+
+Status: design and algorithm validation only; production implementation pending.
+
+Parent: [NM7 execution plan](phase_nm7_viewer_mask_creation_plan.md).
+This document defines NM7's revised algorithm, data ownership and storage behavior. It replaces
+the earlier NM7 proposal to persist an immutable R8 asset for every completed stroke. Earlier
+NM3/NM4 completion records remain historical implementation evidence, not the new product rule.
+
+## 1. 用户目标与准确的可逆含义
+
+用户要求已绘制 Brush、Radial、Linear Gradient 的移动实时改变照片，通过 Interactive preview
+显示真实结果。QSG 负责控件，不用蒙版覆盖区域高亮代替照片预览。笔刷必须支持 paint/erase、
+size/strength 修改、多次 stroke 累积；每个 Color Grade 用于 Mix 的当前 R8 结果只有一份。
+蒙版缓存按项目设置路径和清理策略，删掉缓存不应破坏编辑、Undo/Redo 或 Version。
+
+核心设计：
+
+```text
+project document + typed history
+  Brush stroke commands / analytic parameters / placement
+          ↓ deterministic evaluation
+  one current Grade coverage R8 cache
+          ↓ native Grade Mix
+  actual Interactive / Quality photograph
+```
+
+“只缓存一次”解释为一个稳定的当前缓存槽，而不是终身只写一次文件。状态改变后要更新这个槽，
+不能为每个 StrokeId、commit hash 或 Version 建立另一张长期 R8 图。
+
+### 1.1 为什么不能直接对 R8 做无损逆运算
+
+下面两种原始状态经过相同 paint 后得到同一个值：
+
+```text
+max(30, 200) = 200
+max(90, 200) = 200
+```
+
+擦除至 0、clamp 和 8-bit 量化也都是多对一映射。从最终像素和一次操作无法判断原值是 30
+还是 90。因此“擦除的 Undo 等于再画一次”“从结果减去该 stroke”“反向平移已经插值的 R8”
+不能保证恢复原状态。乘法累积再做除法同样在 alpha=1、零值及量化处失败。
+
+本方案使**文档命令可逆**：撤回笔画插入、恢复删除的笔画、恢复参数或 placement 的原值；
+然后由恢复的参数重算受影响像素。这满足无每步栅格副本的 Undo/Redo，同时保留原有笔刷语义。
+这不是承诺存在不可逆像素运算的代数逆函数。
+
+## 2. 算法依据与方案选择
+
+以下只引用实际查阅的一手资料；具体 Alcedo 算法是本节之后的设计推导，不声称照搬外部实现。
+
+| 来源 | 查阅内容与用途 |
+| --- | --- |
+| [darktable 官方 drawn masks 文档](https://darktable-org.github.io/dtdocs/en/darkroom/masking-and-blending/masks/drawn/) | Brush 在抬笔后可表示为连接节点，并支持修改节点和笔画形状；证明参数化笔刷可用于照片局部调整。该软件的平滑/图形组合规则不作为 Alcedo 的像素定义。 |
+| [Qt QUndoCommand](https://doc.qt.io/qt-6/qundocommand.html) | 文档操作的 redo/undo 和命令合并语义。只借鉴命令模式；继续扩展 NM4，不接入另一套 QUndoStack。 |
+| [Felzenszwalb / Huttenlocher, Distance Transforms of Sampled Functions](https://cs.brown.edu/people/pfelzens/papers/dt-final.pdf) | 通过一维变换分解计算精确平方欧氏距离；用于理解和核对现有 Brush signed-distance feather 的计算边界，不替换为近似 blur。 |
+| [Qt QSaveFile](https://doc.qt.io/qt-6/qsavefile.html) | 临时文件完成后替换目标、写失败保留旧文件；用于稳定缓存槽和项目设置保存。使用 Qt 6.9 可用 QString 路径重载。 |
+| [Qt QLockFile](https://doc.qt.io/qt-6/qlockfile.html) | 写入者协作锁及长期持锁的 stale-time 注意事项；缓存更新、切换根路径和清理必须服从同一所有权。 |
+
+不使用这些方案：
+
+- 每次 stroke 保存一张完整 R8、按 hash 永久积累历史栅格。
+- 每隔若干 stroke 自动产生长期 raster checkpoint 或 tile undo 图像。它们仍会随历史增长，
+  且用户没有授权此类例外；现有文档参数 checkpoint 可保留。
+- 为支持逆运算改变 paint/erase 混合规则，或对量化结果相减/相除。
+- 只移动旧 coverage texture 来冒充准确重算，导致重复移动模糊或 Union 覆盖错误。
+- 为追求“路径更短”自动用有损曲线拟合改变笔画。初版保留规范采样序列。
+
+## 3. 参数化数据与单一所有者
+
+以下类型/API 名是拟新增项；执行者先检查能否由现有 owner 表达，不增加另一份文档模型。
+
+### 3.1 BrushMaskSource
+
+将当前 `asset_key + descriptor` 的持久化 source 改为：
+
+```text
+BrushMaskSource (owned by ColorGradeNodeModel)
+  source_format_version
+  raster_algorithm_version
+  reference metric / canonical raster descriptor policy
+  placement_translation = (tx, ty)
+  ordered strokes:
+    StrokeId
+    paint_or_erase
+    immutable canonical samples:
+      local_reference_x, local_reference_y
+      radius_in_reference_pixels, strength, hardness
+  existing source feather parameter
+```
+
+规范 samples 是原始创建数据，持续存储在项目 document/history 中，不是缓存。StrokeId 在
+其生命周期内稳定；顺序是计算语义，不能按空间索引或 ID 重排。一次 stroke 只保留一份规范
+sample body；owner 和待提交历史可按现有不可变共享表示持有它，不能每帧复制整个 strokes 列表。
+
+UI 中仍是一个累积 Brush Mask；不为每个 stroke 添加 Mask 行。增加内部 StrokeId 不要求本期
+再做逐笔画节点编辑器。NM7 必须支持整张 Brush 移动、按 stroke Undo/Redo、继续 paint/erase。
+
+Radial/Linear 沿用解析参数。所有 Mask 仍有自己的 MaskId、enabled、opacity、invert、feather。
+Color Grade 的最终 Union R8 包含所有启用 source 的有效 coverage，且在 grade_mix **之前**。
+调节 grade_mix 不必重新栅格化，因其是 Mix 的独立标量输入。
+
+### 3.2 执行与历史 API
+
+| 操作 | Forward | Inverse / 恢复信息 |
+| --- | --- | --- |
+| 首个 Brush stroke | AddMask with first StrokeId and samples | RemoveMask；不先提交空 Mask |
+| 后续笔画 | AppendBrushStroke(exact target, stroke) | RemoveBrushStroke(same StrokeId) |
+| 删除笔画（底层历史能力） | RemoveBrushStroke | InsertBrushStroke(original order, original sample body) |
+| 移动 Brush | SetBrushTranslation(before, after) | 恢复精确 before 标量；不是对当前值累加负 delta |
+| 移动 Radial / Linear | Set source center / origin fields | 恢复原字段 |
+| 改已有参数 | SetMaskField / focused source fields | 恢复被修改字段 |
+| 删除整个 Mask / Grade | 现有 NM4 structural mutation | 保存该删除对象所必需的参数/笔画数据，复用原始 sample body |
+
+一次拖动合并为一个最终命令，内部 preview 只更新未提交的字段。一次 stroke 合并为一个追加
+命令，不能每个 sample 创建 history commit。多个已完成 stroke 仍逐笔可 Undo；history 增长
+是新增路径参数的大小，不是累计所有之前路径或全幅图像的大小。
+
+在 NM4 `PipelineEditBatch`、序列化、逆操作、WAL、materializer、checkpoint、Version/Paste
+中一次性补齐这些操作。History 是唯一命令链；不要另外维护独立可移动 cursor 的笔画历史栈。
+恢复一个 Version 得到该 Version 的参数化 Brush，再计算当前 R8；无需其旧缓存存在。
+
+### 3.3 临时数据和生命周期
+
+- 未提交 samples 是用户新增数据，由输入 owner 按顺序接收；已消费数据通过移动/不可变共享
+  交给 model 和 history，不保留第二份完整 stroke 集合。
+- 空间索引只存 StrokeId、sample/segment 范围、bounds、顺序号。它是 owner 派生索引，不能存
+  另一份可写样本、R8 或每个历史节点的栅格。
+- R8/float 工作缓冲是算法输出或 scratch，遵守独占 writer 和 GPU reader lease。不是历史状态。
+- Dirty bounds、generation 和 required/completed revision 是派生有效性信息，不进入编辑历史。
+- GUI 只接收最小的当前选择/控件数值投影；不获取整个笔刷路径容器用于回写。
+
+## 4. 确定性笔刷生成
+
+### 4.1 规范采样
+
+继续使用弧长间隔 dab 的可执行算法，避免先实现曲线拟合带来的额外形状变化：
+
+1. 通过现有 mapper 得到 ReferenceSpace 点。记录设备真实 press，不使用拖动阈值后的第一点。
+2. 将点映射到 Brush 局部空间：`local = reference - placement_translation`。
+3. 按 reference 像素度量弧长采样。每段间隔不超过局部 radius 的四分之一；跨输入批次保留
+   余数。radius/strength/hardness 改变作为有序边界保留；不跨边界丢弃信息。
+4. 开始 dab 一次、最终 stroke endpoint 一次；不在每个事件结尾额外加 dab。
+5. 存储规范 samples 和算法版本。重放使用这些持久值，不重新读取鼠标速度/设备 pressure。
+6. 规范坐标/半径编码、插值和量化顺序由一个共享定义规定，拒绝 NaN/Inf、重复 StrokeId 和
+   不支持的算法版本。不能通过静默加载另一个算法版本来重放旧历史。
+
+初始值沿用执行计划：size/strength 控件影响后续样本，Mask opacity 影响整张 Brush。无自动
+pressure 动态；不把用户调整过的 size/strength 在松手后丢失。
+
+### 4.2 Dab、paint 和 erase
+
+在像素中心求单位 dab：内半径 `hardness * radius` 内为 1，外半径处为 0，中间线性衰减，
+乘 strength。Hardness=1 单独定义硬边，避免除零。按固定 rounding 转成 `a8 ∈ [0,255]`。
+
+对一个 Brush 内所有规范 dab，按原始 stroke/sample 顺序：
+
+```text
+b0 = 0
+paint: b_next = max(b_previous, a8)
+erase: b_next = min(b_previous, 255 - a8)
+```
+
+这个规则保持此前计划的固定 coverage-strength 含义，不增加随停留时间积累的 flow。以后若要
+flow，应显式改变算法版本和测试，不能用不同采样速度无意引入它。
+
+先重放 Brush，再使用现有 source feather、invert、opacity；所有 Mask 按 NM3 Union 组合。
+别把 erase 命令应用到整个 Grade Union，否则会错误擦除 Radial/Gradient 的覆盖。
+
+### 4.3 精度与缩放
+
+保留 4096 的规范 R8 每轴上限和现有 full-reference 定义，不降低 RAW decode/preview 质量。
+Brush 的规范格网在新文档确定一次，大小随真实 reference extent 的既定规则选择，不随 zoom、
+DPR、拖动速度或 Interactive 输出尺寸变化。Brush 在固定格网上重放，再由原有 native sampling
+映射到请求表示；analytic sources 在请求的 reference 坐标求值。固定运算/量化顺序，缓存命中
+和无缓存路径必须满足同一数值标准。
+
+整张 Brush 的移动只更改 translation；samples 永远不做逐次原地平移。每次从原始局部路径
+计算目标位置，因此来回移动不累积插值损失。`before`/`after` 精确恢复，避免反复浮点加减漂移。
+
+## 5. Undo/Redo 的局部重放算法
+
+### 5.1 均匀分块空间索引
+
+使用简单固定网格（初始实现建议 64×64 规范 raster texel 一块；性能实测可调整，不改像素语义）。
+索引存与每块相交的 stroke/sample span，排序保留原计算顺序。长 stroke 按 segment/span bounds
+索引，不能只用整条曲折路径的大包围盒把每个 tile 都标成相关。索引不持久化，可以从参数重建。
+
+对平移的 Brush，在 local 空间保留索引，通过逆平移后的 tile bounds 查询。整张 Brush 移动
+不用逐帧重建所有 stroke 索引；只更新 owner placement 和输出脏范围。
+
+### 5.2 区域恢复与重合覆盖
+
+设发生变化的 source 旧支持域为 `A`，新支持域为 `B`：
+
+```text
+dirty = outward_round(A union B)
+for each affected output tile:
+    query surviving ordered source contributors
+    rebuild Brush coverage from b0 = 0 in the required region
+    evaluate feather/invert/opacity and other relevant Mask sources
+    recompute Grade Union from its defined empty/all-disabled base
+    replace the current output tile only after successful evaluation
+```
+
+撤回添加取旧支持域；Redo 取新支持域；移动取两者并集。擦除 Undo 必须重放该区域内更早的
+paint/erase；不能仅清零。删除或移动 Union 最大贡献者时要重新计算其他 source；不能从最大值
+中减去被移除的贡献。对拥有全图背景值的 invert、Linear Gradient 或 enabled/opacity 变化，
+必须使用其实际完整支持域，而不是误认为只有控件附近会变。
+
+正确性原因：对一个输出像素，不与它的求值域相交的 dab 是恒等操作。保留相关 dab 原始顺序
+从初始值重放，得到与完整重放相同的结果。该论证只覆盖逐像素 source 合成；邻域 feather 的
+依赖域必须另算。
+
+### 5.3 Feather 的完整依赖
+
+现有 native Brush feather 涉及 signed distance。它的中间距离场可能全局变化；不要因为 dab
+的 R8 写入范围小就断言 distance pass 也能只更新相同矩形。
+
+初版保留完整 native distance 求值作为需要该依赖的正常算法路径，复用已有分离方向 pass；
+只对已证明局部的无 feather 操作做 tile 重放。若实现有限 feather 半径的 halo 优化，必须证明
+输出域、输入 halo、边界条件和全量算法一致后才能启用。不能更换成 Gaussian blur 或裁掉长距离
+影响来满足 16 ms。Distance scratch 用完释放，不生成长期每-stroke 距离缓存。
+
+### 5.4 增量追加与单 R8 的限制
+
+只有当前完整源信息足够时才允许追加优化。最终 Grade R8 已混合了多个 Mask，并可能经过
+invert/opacity，因此不能把它当作原始 Brush 直接 max/min。默认按上面的区域重放生成改变部分，
+不要为省重算悄悄保留每个 Mask 一整张长期 source R8。
+
+需要的 source/feather/Union 临时缓冲由现有 executor scratch 提供，顺序复用并在最后 reader
+完成后释放。临时计算缓冲和一次原子文件替换的临时文件，不是“第二份长期缓存”；要分别测量。
+
+### 5.5 复杂度和已做的小型算法验证
+
+路径存储为 `O(S)`，S 是真实样本总数；追加一个 stroke 的 history 大小为该 stroke 的样本数，
+不是所有 S 的累计副本。索引大小取决于相交 span 数。一次局部重放成本取决于 dirty tiles 内
+相交样本数和像素数；重叠很多、全幅移动或全局 feather 的最坏情况仍可能需要完整重算。
+不承诺无条件常数时间 Undo 或任意复杂 Brush 都在 16 ms 内完成。
+
+2026-09-08 用临时纯算法脚本验证了 4,000 次有序添加/移除/移动：16×16 整数格网、4×4 tile、
+paint/erase max/min、越界 clipping、另一个 analytic-like source 的 Union；每次局部重算结果
+都与独立全量求值逐字节相等。脚本与输出在 `build/tmp/nm7_plan/check_replay.py` 和
+`build/tmp/nm7_plan/replay_result.txt`，不提交。它证明此简化实例的重放逻辑，不证明真实 dab
+插值、Qt 输入、feather、GPU、文件恢复或产品性能。产品测试仍须覆盖第 10 节。
+
+## 6. 一个当前 R8 槽的准确范围
+
+逻辑身份是 `(ProjectUUID, ImageId, NodeId)`。一个 Color Grade 的多 source 最终只产生一张
+供 Mix 使用的当前有效 coverage。磁盘上这个身份最多一个已发布 R8 cache 文件；Version、
+StrokeId、commit hash、content hash 不能作为新增文件的目录层级。
+
+示意路径（ID 使用受验证的安全编码，不使用用户节点名称）：
+
+```text
+<chosen-root>/alcedo-mask-cache/<ProjectUUID>/<ImageId>/<NodeId>.r8cache
+```
+
+文件内部包含 schema/algorithm version、身份、source 规范格网与当前输出 extent/ReferenceSpace 描述、完整 recipe
+fingerprint、checksum 和 R8 payload。Fingerprint 只用于验证内容，不作为多版本文件名。
+必须含有原始采样、placement、全部 source 参数、enabled/invert/opacity、raster 算法和 geometry
+表示依赖；还需记录 producer/backend 数值兼容标识，未经像素一致性证明不能跨 producer 复用。
+不要错误包含不影响 coverage 的节点显示名称。
+
+会话热路径用 NM6 required/completed revision 与表示条件，不每个鼠标事件序列化/hash 整个
+笔刷集合。跨重开验证的 fingerprint 在 owner 的 settle/save 边界计算；request 和写入者持有
+精确版本身份，不能给旧像素写上新 fingerprint。
+
+### 6.1 内存表示与 NM6 相容性
+
+- 每个 live workspace 为一个 Grade 保留一个当前 Interactive Mix coverage 结果；失效后在
+  reader 安全边界重新写入。单一 R8 指有效内容身份，不否定异步提交所需的短期 unpublished
+  输出缓冲；这些 lease 不得变成历史结果集合。
+- 磁盘槽保存最近一次 settled 状态的 Interactive Mix coverage，直接来自该当前结果；
+  不是再计算/保留一份不同分辨率的长期 full-reference Mix 图。source 的规范格网仍保持不变。
+  缓存仅在请求 extent/geometry/算法/producer 表示完全相符时命中，不 resize 不相符的缓存
+  来假定像素相等。新表示成功后替换同一个槽，不增加另一个表示文件。
+- 若 release 前没有产生最终值的 Interactive coverage，标记磁盘槽 stale；Quality 仍正常由
+  参数求值。没有合格结果时不贴错 fingerprint 写盘，也不为了落盘偷偷增加一个 Quality-like
+  持久结果；下次实际 Interactive 请求产生合格结果时再写该槽。
+- 落盘确需独立读回 buffer 时，仅为一个合格 settled 结果创建一次；说明其 owner、版本和
+  I/O reader lifetime，用完释放。不能每次 pointer move 复制一张 CPU 图等着写盘。
+- Interactive、Quality、Detail 的采样语义保持现有定义；QualityBase 在 RAW Develop 之后仍
+  不读写持久结果缓存，直接由参数求值到 submission-local coverage，Mix 后释放。
+- 不为每个表示/Version 各建磁盘 R8，也不新增长期 Brush/Radial/Gradient source 图。
+- 暂时持有的 GUI 图元、CPU 输出、上传暂存、native scratch 和读者 lease 分项计量并有上限。
+
+### 6.2 提交与缓存写回完全解耦
+
+```text
+pointer move -> focused provisional command -> region replay -> Interactive photograph
+release -> NM4 durable parameter command -> Quality photograph
+        -> mark stable cache slot dirty; coalesce pending cache write
+project save / safe idle / clean close -> validate captured settled identity -> atomic replace slot
+```
+
+R8 写回不在 pointer handler，不是每个 stroke 的 durable history 前置条件。采用一个项目后台
+writer，合并同槽尚未开始的写入；已有 reader/writer 完成后再复用缓冲，不排队保存所有版本。
+只写 settled state，不把取消前的 preview 作为重开缓存发布。短时间内很多 stroke 可以只落盘
+最新结果；即使每次都遇到 idle，文件槽数量也不随操作次数增加。
+
+使用原子替换，一次活动写入最多一个临时文件；成功/失败/启动恢复清理它。使用已验证文件 owner
+和作业身份删除临时文件，不按任意目录通配符清理。禁用 `QSaveFile::setDirectWriteFallback(true)`
+这类直接写坏旧槽的模式。Qt 原子替换不等于两个独立 metadata/R8 文件的共同事务，因此 header
+与 payload 写在同一容器内。项目持久历史仍遵循自己的 WAL 耐久规则。
+
+缓存写失败要报告具体错误并保留 dirty 状态，不宣称写成功、不换存储路径、不撤销已经成功的
+参数提交。后续重建来自完整参数的同一算法，这是本次明确指定的缓存模型，不是降低质量的替代
+算法。缺失或 checksum 不匹配的缓存不是用户数据损坏；参数/历史损坏则是真实错误，不能靠
+旧 R8 掩盖。持续 I/O 错误不忙循环重试。
+
+## 7. 项目级存储设置与清理
+
+### 7.1 所有权与界面
+
+由 `ProjectService` 拥有 Mask cache 设置，并提供拟新增 `ProjectMaskCacheService`。通过
+现有 project module 向设置界面投影；不能复用 thumbnail 全局配置键当成项目设置。
+设置入口建议放入现有 Settings > Cache 中独立的“项目蒙版缓存”区域，显示当前项目名称/UUID、
+路径、文件数、字节数与待写/失败状态。已注册项目可逐行管理，不遍历用户磁盘寻找项目。
+
+每项目设置：
+
+| 字段 / 操作 | 语义 |
+| --- | --- |
+| Cache directory | 用户选定 root；默认项目 metadata 所在持久目录下的专用 cache 子目录，不使用解包临时目录或全局 product_mask_store |
+| Retention policy | `Keep`（默认）或 `DeleteOnProjectClose`；项目 A 的选择不改变 B |
+| Clear this project's Mask cache | 删除选定项目的可重建 R8；保留参数、history、Version、RAW 和缩略图 |
+| Project removal choice | 删除/移除项目时单独选择保留或清理该项目 R8；不把移出最近项目列表当成删除文件授权 |
+| Move cache directory | 验证新路径并切换 owner；设置成功后清理旧的本项目缓存，失败残留可继续逐项目管理 |
+
+`ProjectService::SaveProject` 当前重新构造 metadata JSON，必须在 owner 中保存并 round-trip
+新增字段，不能只让 QML 写一个下次 Save 会消失的键。复用 project UUID。相对路径以持久项目
+位置解析；外部绝对路径按原值保存，路径不可用时显示错误并让用户重新选择，不转到系统 temp。
+设置不属于照片 edit history，修改设置不能新增 photo Version。
+
+### 7.2 安全切换路径
+
+1. UI 提交目标 project UUID、预期设置 revision、新 root。界面明确此操作将切换位置并清理原来的本项目缓存。
+2. owner 验证/创建专用 namespace、权限与路径关系；新路径必须在 UI Apply 前可具体检查。
+3. 停止该项目新 cache jobs，递增 storage generation，等待已有文件写入者/读取者到安全边界。
+   Photo history/数据保存使用原有 project 生命周期，不用 GUI 阻塞等锁。
+4. 原子保存新项目设置后才发布新 root。保存失败继续使用原 root，并保留原缓存。
+5. 缓存可由参数重建；无需复制每张缓存。所有旧 generation jobs 拒绝向新 root 写数据。
+6. 新设置成功后删除旧的本项目 cache namespace，完成“更改位置并清理旧缓存”操作。
+   不提供让每次换路径都积累旧缓存的默认行为。清理失败则记录旧 root 的所有权位置和错误，
+   供重试/逐项目清理；不能丢掉记录而留下无法管理的隐藏文件。
+
+项目级 owner 的存储位置记录只记录路径/UUID/格式，不镜像 Mask 参数。它必须随设置事务更新。
+如果 root 变更后的旧目录清理失败，报告残留路径；不把已经成功的新设置回滚成半迁移状态。
+
+### 7.3 清理算法与并发保证
+
+清理只针对带匹配 ProjectUUID/格式标记的专用 cache namespace。每个文件通过容器身份和
+受验证的路径定位，不递归删除用户选择的整个 root；不跟随逃离 namespace 的符号链接。
+不同项目可以共用上层 root，不能互删。历史不可变 `MaskAssetKey` 文件与新 cache namespace
+必须明确区分，旧文件没有完整参数可重建时绝不能作为 cache 清理。
+
+Clear 先建立维护边界，递增 cache generation、停止/合并写回，等读者/写者释放后删除，清除
+内存有效标记，再解除边界。正在编辑的项目可在下一次真实渲染请求重建；Clear 操作本身不要
+立即发一次重建写回而让用户看到“清理后立刻原样长回来”。已经排队的旧 writer 不能复活文件。
+
+DeleteOnProjectClose 在参数/WAL 保存成功、项目 reader/writer 停止后执行。崩溃没有可靠 close
+回调，下次恢复参数后再执行已保存策略的待清理工作。清理失败列出已删除/未删除字节及原因。
+不能因为缓存清理失败就删除项目参数或伪造历史保存失败。
+
+进程内所有 reader/writer/cleaner 共用 owner 维护锁；需要跨进程共享时复用项目独占机制，
+不足才用 QLockFile namespace 锁。长作业禁用 30 秒时间过期判定并处理真实锁错误。缓存配置
+不是绕过已存在项目多进程写保护的入口。
+
+## 8. 保存、Version、Paste、项目打包及格式切换
+
+Parameter document 和 typed history 必須包含全部 stroke samples、算法版本和 placement。
+新项目 package 即使不带任何 R8，也能完整恢复每个 Version 和 Undo/Redo。Portable Paste
+复制/复用必要的参数化 stroke body，重映射 NodeId/MaskId/StrokeId；不复制源机器绝对 cache
+路径或复制一组按历史版本堆积的 R8。目标项目使用自己的存储策略。
+
+这修改了 NM3/NM4 的 source/history schema，必须作为 NM7 内部**先行前置工作**完成，不能只
+改 viewer。更新项目版本 gate、document schema、typed operation 编码、canonical serialization、
+WAL recovery、package manifest 和 transfer validation。同一发布版本里不能用 R8 key 作为新
+Brush 的唯一恢复依据。NM3/NM4 旧测试通过不等于参数化格式通过。
+
+只有栅格而没有笔画参数的旧格式不能无损反推原始路径。遵守仓库“不自动迁移旧项目”的现有
+规则，在格式入口报告不支持并保持文件不变；不新增自动向量化、隐藏背景 bitmap 或“缓存就是
+原始数据”的兼容路径。修改文件版本前在测试 fixtures 和发布说明明确覆盖的格式范围。
+本轮只是计划，不执行旧项目转换或删除已有文件。
+
+## 9. 移动已有蒙版的完整预览链
+
+```text
+press move handle -> capture exact target + before translation/center/origin
+move -> normalized new fields -> enqueue (coalesce latest absolute placement)
+     -> QSG control position update only
+owner safe boundary -> apply fields -> invalidate old/new source domains
+                    -> regional/full-required replay -> Grade Union R8 -> native Mix
+                    -> Interactive photograph
+release -> one typed placement/parameter commit -> Quality photograph
+Escape -> restore before fields -> recompute correct previous result -> no commit
+```
+
+Brush 移动整个累积笔画集合，包括已记录 erase；在移后位置继续 paint，要用当前 placement
+的逆映射存新 samples。Radial 修改中心；Linear 修改 origin，保持其 normal/transition 不变。
+相邻 mouse moves 合并绝对 translation，不能丢失结束值；不是把最后一张照片临时平移。
+
+QSG 已有蒙版编辑只显示可交互 handles、方向/连线等必要控件，不显示整片填充、羽化区域高亮、
+已完成笔刷轨迹或 coverage heatmap。控件随输入定位；照片由 Interactive 更新。初次创建是否
+保留暂时轮廓/轨迹的细节在执行计划决策表中记录；任何模式都不以高亮代替真实照片求值。
+
+## 10. 必须完成的测试与证据
+
+| 测试组 | 具体断言 |
+| --- | --- |
+| 可逆命令 | append/remove/move/field forward+inverse 恢复原参数；no-op 不提交；多 stroke 同 MaskId |
+| 像素反例 | 证明 max/min 不可直接逆；擦除 Undo 与重放旧参数相等 |
+| 局部重放 | 随机 paint/erase/overlap/move/delete/undo/redo，与独立完整重放逐字节比较；halo 单独验证 |
+| 移动 | Brush/Radial/Linear 每次 owner consume 都有正确 Interactive；release 后才 Quality；旧域清除、新域正确、siblings 保留 |
+| 精度 | 同 translation A→B→A 后参数精确恢复，R8 与初始相同；重复移动无重采样模糊 |
+| 缓存数量 | 同节点 1,000 stroke + 1,000 Undo/Redo + Version 切换，稳定已发布 R8 文件数 ≤ 1 |
+| 磁盘上限 | 4,096² R8 = 16 MiB；一个槽加 bounded active replacement，不出现 1,000×16 MiB；history 大小随样本数记录 |
+| 全清理恢复 | 删除全部新 cache，重开及每个 Version/Undo/Redo 仍恢复相同参数和 coverage |
+| 写回失败 | 中断写/磁盘满/旧 generation/job：无半文件、无假成功、无每步残留 tmp、参数不丢 |
+| 项目隔离 | A/B 共用 root；A 清理/换路径/关闭，不影响 B；符号链接不能逃逸；原始 assets 不删除 |
+| 设置 | 重开、项目切换、保存/打包后设置正确；路径不可用报错；关闭清理和保留策略互不混用 |
+| 历史 | 新 payload 不含每-stroke R8 key 或整幅像素；节点删除恢复必要 samples；WAL/Version/Paste 完整 |
+| 性能 | event→Qt 控件、queue→owner、重放、feather、Union/Mix、Interactive completion、缓存 I/O 分项测量 |
+
+所有 native 测试在 CUDA/OpenCL/Metal 分别记录，保留现有数字容差和 NM6 串行/质量策略。
+不要因为复杂图超过 16 ms 就保留隐藏历史栅格、降低分辨率、丢样本或换 backend。

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-08
 
-Status: encoding rules specified; production parameterized Brush source pending.
+Status: NM7.2 parameterized Brush source and Grade owner operations landed; encoding rules specified; project/schema version gate still pending NM7.3.
 
 Parent: [NM7 execution plan](phase_nm7_viewer_mask_creation_plan.md).
 This document defines NM7's revised algorithm, data ownership and storage behavior. It replaces
@@ -205,7 +205,7 @@ native Mask pass 之间必须一致。`source_format_version` 或 `raster_algori
 | 求值顺序 | 固定 | 规范 R8 → signed-distance 羽化（若半径 > 0）→ invert → opacity → clamp → 再量化到请求 R8。Union 是启用 Mask 的逐像素 max，发生在 Grade Mix 之前 |
 | 输出采样 | 现有 `MakeRasterMaskSamplingPlan` | 渲染像素中心 `(x+0.5, y+0.5)` 经 `render_to_texture_uv` 得到归一化 UV。UV 在 `[0,1]` 外为 0。R8 为双线性，texel 中心 `u*width-0.5`。无羽化时按该 plan 的 mip；有羽化时对距离场做同样的双线性。`geometry.filter` 默认双线性。缓存命中要求 extent、geometry、算法版本和 producer 完全一致，禁止把不相符的槽 resize 后当作命中 |
 
-JSON 中的样本数组按上述 binary32 规则读写。非法值、重复 StrokeId 或不支持的算法版本不得部分写入 owner。当前已实现的 `BrushMaskSource` 仍只持久化 `asset_key` / descriptor / `feather_radius`；参数化字段的 owner 写入属于后续阶段。现有加载器会忽略未知 source 键，因此带 `strokes` 的旧格式文档在切换版本门之前不能当作已经参数化。
+JSON 中的样本数组按上述 binary32 规则读写。非法值、重复 StrokeId 或不支持的算法版本不得部分写入 owner。NM7.2 将规范笔画、算法版本和 `placement_translation` 写入 `BrushMaskSource`；无笔画且平移为零的现有文档仍序列化为 `asset_key` / descriptor / `feather_radius`。带完整 `strokes` 的 JSON 按本节身份读取，不再忽略笔画字段。项目文件版本门和 raster-only 拒绝仍属于 NM7.3。
 
 ## 5. Undo/Redo 的局部重放算法
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-08
 
-Status: design and algorithm validation only; production implementation pending.
+Status: encoding rules specified; production parameterized Brush source pending.
 
 Parent: [NM7 execution plan](phase_nm7_viewer_mask_creation_plan.md).
 This document defines NM7's revised algorithm, data ownership and storage behavior. It replaces
@@ -144,7 +144,7 @@ Color Grade 的最终 Union R8 包含所有启用 source 的有效 coverage，�
    余数。radius/strength/hardness 改变作为有序边界保留；不跨边界丢弃信息。
 4. 开始 dab 一次、最终 stroke endpoint 一次；不在每个事件结尾额外加 dab。
 5. 存储规范 samples 和算法版本。重放使用这些持久值，不重新读取鼠标速度/设备 pressure。
-6. 规范坐标/半径编码、插值和量化顺序由一个共享定义规定，拒绝 NaN/Inf、重复 StrokeId 和
+6. 规范坐标/半径编码、插值和量化顺序由第 4.4 节规定，拒绝 NaN/Inf、重复 StrokeId 和
    不支持的算法版本。不能通过静默加载另一个算法版本来重放旧历史。
 
 初始值沿用执行计划：size/strength 控件影响后续样本，Mask opacity 影响整张 Brush。无自动
@@ -153,7 +153,7 @@ pressure 动态；不把用户调整过的 size/strength 在松手后丢失。
 ### 4.2 Dab、paint 和 erase
 
 在像素中心求单位 dab：内半径 `hardness * radius` 内为 1，外半径处为 0，中间线性衰减，
-乘 strength。Hardness=1 单独定义硬边，避免除零。按固定 rounding 转成 `a8 ∈ [0,255]`。
+乘 strength。Hardness=1 单独定义硬边，避免除零。量化与组合公式见第 4.4 节。
 
 对一个 Brush 内所有规范 dab，按原始 stroke/sample 顺序：
 
@@ -172,13 +172,40 @@ flow，应显式改变算法版本和测试，不能用不同采样速度无意�
 ### 4.3 精度与缩放
 
 保留 4096 的规范 R8 每轴上限和现有 full-reference 定义，不降低 RAW decode/preview 质量。
-Brush 的规范格网在新文档确定一次，大小随真实 reference extent 的既定规则选择，不随 zoom、
+Brush 的规范格网按第 4.4 节由 `full_reference_extent` 派生，不随 zoom、
 DPR、拖动速度或 Interactive 输出尺寸变化。Brush 在固定格网上重放，再由原有 native sampling
 映射到请求表示；analytic sources 在请求的 reference 坐标求值。固定运算/量化顺序，缓存命中
 和无缓存路径必须满足同一数值标准。
 
 整张 Brush 的移动只更改 translation；samples 永远不做逐次原地平移。每次从原始局部路径
 计算目标位置，因此来回移动不累积插值损失。`before`/`after` 精确恢复，避免反复浮点加减漂移。
+
+### 4.4 规范编码、羽化单位与输出采样
+
+生产共享定义在 `edit/mask/brush_raster_encoding.hpp`。下列数值在 host 规范栅格化和
+native Mask pass 之间必须一致。`source_format_version` 或 `raster_algorithm_version`
+不等于 1 的输入在格式入口拒绝，文件保持原样，不做另一算法的静默重放。
+
+| 量 | 编码 | 规则 |
+| --- | --- | --- |
+| `source_format_version` | `uint32` | 参数化 Brush JSON 为 `kBrushSourceFormatVersion = 1` |
+| `raster_algorithm_version` | `uint32` | dab/paint/erase 为 `kBrushRasterAlgorithmVersion = 1` |
+| Mix cache 容器 | `uint32` | `kProjectMaskCacheFormatVersion = 1`，与 `kMaskAssetFormatVersion`（旧 `.r8mask`）分开 |
+| 样本坐标 / 半径 | IEEE-754 binary32 | 有限；局部坐标 = 参考像素坐标 − `placement_translation`；半径 > 0，单位是参考像素 |
+| strength / hardness | IEEE-754 binary32 | 闭区间 `[0, 1]` |
+| StrokeId | 非空字符串 | 生命周期内稳定；重复 ID 拒绝 |
+| 笔画模式 | `uint8` | `0` paint，`1` erase |
+| 弧长间隔 | 参考像素 | 不超过局部 radius 的 `kBrushDabSpacingRadiusFraction = 1/4`；跨事件批次保留余数 |
+| 规范格网 | `Extent2D` | `CanonicalBrushRasterExtent(full_reference)`：长边 `min(long_edge, 4096)`，ceil 比例缩放，每轴 `[1, 4096]`。`reference_bounds = {0,0,1,1}`。不使用 LLF 的 2048 上限。格网由当前 `full_reference_extent` 派生，不随 zoom、DPR、Interactive 输出尺寸或 DetailPatch 改变 |
+| 像素中心 | 参考像素 | 规范 texel `(i,j)` 的中心是 `(i+0.5)*full_w/raster_w`。连续指针位置不加半像素 |
+| dab 覆盖 | float `[0, 1]` | hardness `>= 1` 时 `distance <= radius` 为 strength，否则为 0。否则内半径 `hardness*radius` 内为 strength，外半径处为 0，中间线性。distance 为参考像素欧氏距离 |
+| R8 量化 | `uint8` | `clamp(coverage * 255 + 0.5, 0, 255)`（正方向 round-half-up）。反变换 `value / 255` |
+| paint / erase | 逐 dab 顺序 | `b0 = 0`；paint `max(prev, a8)`；erase `min(prev, 255-a8)`。max/min 不可从结果反推 |
+| 源羽化 | 现有 `BrushMaskSource.feather_radius` | 非负有限。单位是参考像素度量。native 转为 source texel：`radius_texels = feather_radius * 0.5 * (x_scale + y_scale)`，`x_scale = raster_w / (full_w * max(bounds.w, 1e-6))`。当规范格网等于 full reference 且 bounds 为全图时，该值等于 texel 半径 |
+| 求值顺序 | 固定 | 规范 R8 → signed-distance 羽化（若半径 > 0）→ invert → opacity → clamp → 再量化到请求 R8。Union 是启用 Mask 的逐像素 max，发生在 Grade Mix 之前 |
+| 输出采样 | 现有 `MakeRasterMaskSamplingPlan` | 渲染像素中心 `(x+0.5, y+0.5)` 经 `render_to_texture_uv` 得到归一化 UV。UV 在 `[0,1]` 外为 0。R8 为双线性，texel 中心 `u*width-0.5`。无羽化时按该 plan 的 mip；有羽化时对距离场做同样的双线性。`geometry.filter` 默认双线性。缓存命中要求 extent、geometry、算法版本和 producer 完全一致，禁止把不相符的槽 resize 后当作命中 |
+
+JSON 中的样本数组按上述 binary32 规则读写。非法值、重复 StrokeId 或不支持的算法版本不得部分写入 owner。当前已实现的 `BrushMaskSource` 仍只持久化 `asset_key` / descriptor / `feather_radius`；参数化字段的 owner 写入属于后续阶段。现有加载器会忽略未知 source 键，因此带 `strokes` 的旧格式文档在切换版本门之前不能当作已经参数化。
 
 ## 5. Undo/Redo 的局部重放算法
 
@@ -384,7 +411,57 @@ Brush 的唯一恢复依据。NM3/NM4 旧测试通过不等于参数化格式通
 只有栅格而没有笔画参数的旧格式不能无损反推原始路径。遵守仓库“不自动迁移旧项目”的现有
 规则，在格式入口报告不支持并保持文件不变；不新增自动向量化、隐藏背景 bitmap 或“缓存就是
 原始数据”的兼容路径。修改文件版本前在测试 fixtures 和发布说明明确覆盖的格式范围。
-本轮只是计划，不执行旧项目转换或删除已有文件。
+不执行旧项目转换或删除已有 `.r8mask` 文件。
+
+### 8.1 切换后接受的唯一格式身份
+
+当前生产加载器只接受 `pipeline_history_format.hpp` 中的已发布值（项目 `0.5.0`、packed `5`、
+document `5`、image-edit `3`、commit/chain `3`、batch `2`、root/checkpoint `3`、WAL `4`、
+transfer `alcedo.adjustment_transfer.v3`）。该集合仍把 `asset_key` 当作 Brush 的持久来源。
+参数化 Brush 写入 persistence 时，加载器必须改成**只**接受下表，每一项都是单一值而不是范围。
+旧身份立即不支持；不读取、不改写、不删除被拒绝的文件。
+
+| 身份 | 切换后唯一接受值 | 当前已发布值 |
+| --- | --- | --- |
+| Project metadata `kProjectFileVersion` | `0.6.0` | `0.5.0` |
+| Packed `.alcd` `kPackedProjectFormatVersion` | `6` | `5` |
+| Pipeline document `kPipelineDocumentFormatVersion` | `6` | `5` |
+| Image edit schema `kImageEditSchemaVersion` | `4` | `3` |
+| Commit hash input `kCommitFormatVersion` | `4` | `3` |
+| Chain-fold `kChainFormatVersion` | `4` | `3` |
+| Typed batch `kPipelineEditBatchFormatVersion` | `3` | `2` |
+| Root envelope `kRootStateFormatVersion` | `4` | `3` |
+| Checkpoint envelope `kCheckpointStateFormatVersion` | `4` | `3` |
+| Mini-Git WAL `kMiniGitJournalRecordFormatVersion` | `5` | `4` |
+| Transfer package `kAdjustmentTransferSchema` | `alcedo.adjustment_transfer.v4` | `alcedo.adjustment_transfer.v3` |
+| Brush `source_format_version` | `1` | 不存在；当前 JSON 无此键 |
+| Brush `raster_algorithm_version` | `1` | 不存在 |
+| Project Mix cache `kProjectMaskCacheFormatVersion` | `1` | 不存在 |
+| 旧 Mask 资产文件 `ALCR8MSK` / `kMaskAssetFormatVersion` | 新 Brush 不再写入或要求 | `1`（`.r8mask`） |
+
+拒绝条件（均保持原文件）：document/history/package 仍带 Brush `asset_key` 且没有完整规范
+strokes；`source_format_version`/`raster_algorithm_version` 缺失或不为 1；未知 source kind；
+非有限样本；重复 StrokeId。Radial/Linear 字段集合不变。运行时 `kMaskImplementationVersion`
+（现为 3）在 Brush 内容身份从 asset key 改为 stroke recipe 时再升到 4，它不是项目文件身份。
+
+### 8.2 `MaskAssetKey` 产品依赖与替换
+
+| 现有依赖 | 当前作用 | 参数化路径下的替换 |
+| --- | --- | --- |
+| `BrushMaskSource::asset_key` + descriptor | 持久 Brush 来源 | 有序 strokes、StrokeId、algorithm version、`placement_translation`；保留 `feather_radius` |
+| `MaskStore::Put` / `Load` / `DefaultProductMaskStoreRoot` | 内容寻址 `.r8mask` | 新 Brush 提交不再 `Put`。当前 Grade Mix 使用项目 cache 槽；旧 store 不得当 disposable cache 清理 |
+| `CollectPersistentMaskAssetKeys` / `VerifyPersistentMaskAssets` | 文档引用的 R8 必须存在 | 校验规范笔画；Mix cache 缺失时按同一算法重建，不把缺 cache 当成参数损坏 |
+| `CollectMaskAssetKeysFromBatch` / reachability / `DeleteUnreachableMaskAssetFiles` | 按 key 做 GC | 新 history 不含 per-stroke R8 key。GC 不得删除无法从参数重建的旧 `.r8mask` |
+| `ReplaceMaskAssetChange` 与 `EditorHistoryMutation::ReplaceMaskAsset` | Undo 换 key | `Append/Remove/InsertBrushStroke`、`SetBrushTranslation`；首笔是一次 `AddMask` |
+| `AddMaskChange` / `RemoveMaskChange` / `ReplaceMaskSourceChange` / `SetMaskFieldChange` | 结构与标量 | 保留；`AddMask` 的 JSON 改为笔画而不是 asset key |
+| `AdjustmentTransferPackage::mask_assets_` | Paste 复制 key+descriptor | 复制笔画 JSON；目标项目用自己的 cache 策略；不再要求 listed R8 key 集合 |
+| `result_content_key` 混合 `asset_key` | GPU 结果身份 | 混合 strokes / placement / algorithm version |
+| `MaskTextureCache` keyed by `MaskAssetKey` | 不可变持久纹理 | 每 Grade 一个当前 Mix coverage；source/feather 为 executor scratch |
+| `ActiveRasterMaskInput` / `ActiveRasterTextureCache` | 请求持有的预览 R8 | 仍是请求所有的不可变像素；内容改为规范重放输出，不与 `MaskAssetKey` 共用 key 空间 |
+| `Renderer::MaskAssets()` 临时目录 store | 产品默认根 | `ProjectService` + `ProjectMaskCacheService` 的每项目根 |
+| `EditorPendingInputQueue` 按 field 保留最新绝对写入 | 普通调整 | Brush 需要有序 append，不能把样本当成同一 field 的最新值替换 |
+| `DescribeEditorParameterTargetError` 拒绝 `ColorGradeMask` | 文案仍写 “until NM3” | 增加显式 Mask 命令路由；不能只删掉守卫 |
+| 测试夹具 `grade_mask_test::AddBrushMask(..., MaskAssetKey)` | 现行运行时/历史测试 | 保留作为旧格式证据；新测试走笔画 builder |
 
 ## 9. 移动已有蒙版的完整预览链
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,8 +2,8 @@
 
 Date: 2026-09-08
 
-Status: planned. This document records a source audit and implementation design, not executed
-qualification. NM7.1–NM7.14 are unimplemented at plan creation.
+Status: NM7.1 complete; NM7.2–NM7.14 planned. This document records the NM7.1 source
+audit and format-boundary evidence. Remaining sub-phases are unimplemented.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -181,6 +181,15 @@ current callers and tests when execution starts.
 | [Cache settings UI](../../../../../alcedo_studio/src/ui/alcedo_main/qml/CacheSettingsPanel.qml) | Thumbnail-specific settings/stats via library module | Add separate project Mask cache body/adapter; do not reuse thumbnail configuration keys |
 | [Project package](../../../../../alcedo_studio/src/app/project_package_backend.cpp) | Validates/materializes metadata and package contents | Carry source commands, not source-machine cache paths or raster history |
 | [Existing viewer tests](../../../../../alcedo_studio/tests/ui/editor_overlay_interaction_test.cpp) | Crop/ROI geometry and interaction infrastructure | Extend coverage while preserving navigation/crop behavior |
+
+Rechecked 2026-09-08 on Windows/MSVC debug (`build/debug`), Qt 6.9.3 (`D:/misc/Qt/6.9.3/msvc2022_64`),
+CUDA Toolkit 12.8. NM6.8 and NM6.9 remain planned (lifecycle e2e and cross-backend pixel/perf
+qualification). That does not authorize exposing Mask creation UI. Ordinary adjustment writes still
+reject `ColorGradeMask` with the existing “until NM3” message. `BrushMaskSource` still persists
+`asset_key`; `MaskStore` still publishes immutable `.r8mask` files; history still uses
+`ReplaceMaskAssetChange`; transfer packages still list `mask_assets` keys; native Mask passes still
+load `MaskStore` or request-owned active rasters. `EditorPendingInputQueue` still keeps the newest
+absolute write per field. Parameterized strokes are not present in production JSON.
 
 ### 3.1 Reconcile NM6 product revisions before exposing UI
 
@@ -583,6 +592,58 @@ plan executor/native Mask pass and existing tests.
 record evidence, not a claim that parameterized source already exists.
 
 **Exit:** ownership and replacement inventory complete; no unaccounted product dependency on old R8 history.
+
+##### Phase NM7.1 completion record (2026-09-08)
+
+**Status:** complete — current R8-asset Brush path characterized; encoding/format identities locked; parameterized source not claimed.
+
+**Primary success call chain:**
+
+```text
+saved Brush JSON (asset_key + descriptor + feather_radius)
+  -> PipelineDocument::FromJson / MaskModelFromJson
+  -> CollectPersistentMaskAssetKeys / VerifyPersistentMaskAssets
+  -> MaskStore::Load (shared immutable R8; GPU MaskTextureCache keyed by MaskAssetKey)
+  -> native Mask evaluate / Union / Grade Mix
+```
+
+**Primary failure call chain:**
+
+```text
+unsupported format_version, unknown source kind, or corrupt MaskStore payload
+  -> loader/store throws before owner mutation
+  -> source file bytes unchanged; no raster-to-stroke conversion
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| Current published history/document identities | `BrushSourceFormatBoundaryTest` | PASS |
+| Brush JSON stores `asset_key` and omits stroke fields | `BrushSourceFormatBoundaryTest` | PASS |
+| Current loader ignores extra stroke fields (parameterized source absent) | `BrushSourceFormatBoundaryTest` | PASS |
+| Unsupported document format leaves the source file unchanged | `BrushSourceFormatBoundaryTest` | PASS |
+| Unknown source kind rejects without mutating the live document | `BrushSourceFormatBoundaryTest` | PASS |
+| Held `MaskStore` readers keep immutable pixels after host-cache eviction | `BrushSourceFormatBoundaryTest` | PASS |
+| Ordinary adjustment path still rejects Mask targets | `BrushSourceFormatBoundaryTest` | PASS |
+| Dab coverage, round-half-up R8, paint/erase max/min | `BrushSourceFormatBoundaryTest` | PASS |
+| Canonical raster long-edge cap 4096 | `BrushSourceFormatBoundaryTest` | PASS |
+| Feather radius matches native texel scale | `BrushSourceFormatBoundaryTest` | PASS |
+| Packed R8 bilinear sample matches native center filter | `BrushSourceFormatBoundaryTest` | PASS |
+| 65 later parameterized-Brush test names catalogued | `BrushSourceFormatBoundaryTest` | PASS |
+
+Commands:
+`cmd /c scripts\msvc_env.cmd --preset win_debug`
+`cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target BrushSourceFormatBoundaryTest`
+`ctest --test-dir build/debug -R BrushSourceFormatBoundaryTest --output-on-failure`
+
+Suite totals: `12/12` PASS. Date / HEAD `6c0dae76` / Windows MSVC `win_debug` / Qt 6.9.3 / CUDA Toolkit 12.8 (no GPU tests in this phase).
+
+**Checklist / exit condition:** inventory is in companion Sections 4.4 and 8.1–8.2; current product still depends on `MaskAssetKey` for Brush, which is recorded rather than removed.
+
+**LOC note (grill-code-review):** `brush_raster_encoding.hpp` ~138, `brush_raster_encoding.cpp` ~152, `brush_source_format_boundary_test.cpp` ~290. No split required.
+
+**Residual gaps:** NM7.2 must change `BrushMaskSource` to strokes; NM7.3 must switch the version gate to the Section 8.1 identities and reject raster-only input. Current loaders still accept document format 5 with `asset_key` and ignore unknown source keys. Adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned. Catalogued later test names are not yet executing behavior cases.
 
 ### NM7.2 — Add parameterized Brush data and owner operations
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -1,0 +1,954 @@
+# Phase NM7 — Viewer Mask Creation and Editing
+
+Date: 2026-09-08
+
+Status: planned. This document records a source audit and implementation design, not executed
+qualification. NM7.1–NM7.14 are unimplemented at plan creation.
+
+Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
+Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
+
+Prerequisites: NM1–NM5 ownership, multi-Grade/multi-Mask runtime and typed history,
+and node selection; NM6 serial input consumption, native parameter access, result retention,
+and selected-node integration. The current NM6 record lists NM6.8–NM6.9 as planned. Planning NM7
+does not waive those exit conditions or authorize exposing incomplete dependent production actions.
+
+
+2026-09-08 revised user direction: Brush paths and analytic parameters are the persistent source;
+Undo/Redo applies reversible commands and recomputes affected regions. R8 is disposable current
+coverage, never a raster history entry. Each Grade has one current Mix coverage cache slot, managed
+under a user-configurable project root with per-project cleanup. Moving an existing Brush/Radial/
+Gradient must update actual Interactive pixels before release; QSG shows controls without coverage
+highlighting. This revision supersedes the earlier per-stroke immutable-asset design.
+
+Required algorithm/storage design:
+[Parameterized commands, regional replay and project cache](mask_command_replay_and_project_cache_plan.md).
+Read it before implementing NM7.2–NM7.14. It gives equations, inverse operations, replay bounds,
+cache lifecycle, project settings, failure behavior and an initial executable algorithm experiment.
+
+## 1. Purpose and background for the executor
+
+NM7 makes local adjustment possible directly on the photograph. A user selects a Color Grade,
+creates an area of influence with Brush, Radial, or Linear Gradient, and sees that Grade change
+only the covered pixels. Later edits, Undo, Version checkout, reopening, and export must reproduce
+that same area. The drawing is therefore an editing input to the existing image pipeline, not an
+independent illustration layered over an otherwise unchanged photograph.
+
+Three different things must remain distinct:
+
+| Thing | Purpose | Owner / lifetime |
+| --- | --- | --- |
+| Mask model | Defines which pixels receive a Grade; saved with history and Version | `ColorGradeNodeModel` in the single live `PipelineDocument` |
+| Editing input | Pointer position, active handle, tool settings, ordered stroke samples, unfinished operation | Application creation controller and existing serial input owner; one sequence |
+| Viewer overlay | Cursor and handles; temporary creation guides only; no affected-area highlighting | `EditorOverlayItem` retained QSG nodes; derived display geometry |
+
+The overlay should respond in the next available Qt Quick frame even when the image pipeline is
+busy. It must never enter the exported photograph. Conversely, a responsive overlay does not prove
+that the actual Mask was applied: the Interactive photograph must show the real native evaluator
+output, and settled edits must request Quality through the existing renderer.
+
+### 1.1 What the earlier phases already provide
+
+- NM1 establishes one writable document and one shared executor for each live image. UI code
+  cannot mutate document containers or build a second editable graph for preview.
+- NM2 runs the ordered Color Grades. A Mask targets an exact owning `NodeId`; it does not target
+  whichever Grade happens to be first or currently selected when queued work finishes.
+- NM3 puts an ordered Mask list inside each Grade, establishes three native evaluators, immutable
+  R8 assets, and request-owned active raster inputs with dirty rectangles. Those are source-audit
+  facts: the new NM7 source/cache design deliberately replaces persistent R8 as edit data.
+- NM4 gives structural/field/source/command mutations typed history, inverse application, Version
+  recovery and Paste. NM7 extends that path to parameterized strokes and replaces new Brush asset-key history.
+- NM5 owns selected-node identity and the QuickQanava projection. Mask rows identify children of
+  a Grade; masks are not graph vertices and cannot acquire scene-image connectors.
+- NM6 separates input acceptance from owner mutation and serial rendering. It keeps current
+  results by dependency and reader lifetime. A slow GPU must not block the GUI input handler.
+
+Read the earlier plans for historical decisions, but use their completion records and current
+source for what actually exists. Several introductory source tables deliberately describe the
+state before those phases were implemented.
+
+### 1.2 Pixel semantics that the UI must explain correctly
+
+For one Mask, source evaluation and feather precede invert and opacity. Range fields remain
+null/disabled. Enabled masks combine by per-pixel maximum. Grade mixing remains:
+
+```text
+M = 1                                 when the list is empty
+M = 0                                 when the nonempty list has no enabled masks
+M = max(effective enabled coverage)    otherwise
+output = input + clamp(M * grade_mix, 0, 1) * (adjusted - input)
+```
+
+Consequences worth testing and explaining in product copy:
+
+- Adding the first empty Brush changes a Grade from full-image coverage to zero coverage until
+  paint is applied. Delay the provisional insertion until valid creation input begins; merely
+  choosing a tool must not momentarily remove the Grade from the photograph.
+- Adding another Mask extends coverage; overlapping masks do not add their opacities.
+- Erasing within the accumulating Brush only changes that Brush. Another enabled
+  Mask can still cover the erased area. Erasing is not a new cross-Mask subtraction operation.
+- Removing the last Mask restores full-image Grade coverage. Disabling the last enabled Mask
+  yields zero coverage. These are intentionally different operations.
+- A clean Grade can have no visible color change even with a valid Mask. Do not inject an
+  exposure adjustment to make a Mask demonstration visible; tests explicitly prepare a Grade.
+- Mask order affects list presentation, not Union pixels. Preserve the existing display-order
+  policy; do not introduce pixel dependencies or photo history for a list-only move.
+
+## 2. Decision register and scope
+
+User decisions received on 2026-09-08:
+
+| Decision | Required behavior | Implementation dependency |
+| --- | --- | --- |
+| Brush operations | Paint/erase with size and strength controls | NM7.2, NM7.4, NM7.8 |
+| Persistent source | Parameterized ordered strokes; history stores reversible commands, not R8 revisions | NM7.2–NM7.3 |
+| Accumulation/cache | Same Grade's strokes accumulate in one Brush; one current final Grade Mix R8 cache slot | NM7.4, NM7.9–NM7.10 |
+| Radial initial drag | Center outward | NM7.7 |
+| Existing Mask movement | Brush/Radial/Gradient update real Interactive pixels during drag, Quality after release | NM7.5, NM7.7–NM7.9 |
+| QSG existing-mask display | Controls only, no affected-area fill or completed Brush path | NM7.6 |
+| Initial creation guides | Working interpretation: temporary cursor/outline/path guides are allowed only during initial drawing, never area-fill highlighting; clarification requested | NM7.6 |
+| Editing body | Temporary Masks body; preserve six adjustment tabs | NM7.11 |
+| Project storage | User-selected cache root, per-project Keep/DeleteOnProjectClose and Clear actions | NM7.10–NM7.11 |
+
+Size and strength are explicit user controls. Automatic pen-pressure modulation was not requested;
+this plan specifies manual size/strength, with stylus position accepted through the same input
+route. Adding pressure mapping later requires an explicit product decision about radius/strength
+curves and device behavior; do not infer pressure dynamics from stylus support.
+
+The single current Brush raster is a per-Grade accumulation rule, not a restriction to one total
+Mask: the Grade can also own multiple Radial and Linear Gradient masks. The Brush header action
+resumes that Grade's existing Brush, or creates it on the first valid stroke if absent. It must
+never create a new Mask row per stroke or per tool re-entry. Undo retains parameter commands; it never retains earlier raster revisions. Every enabled source
+contributes to the one current Grade coverage result used by Mix.
+
+Do not rewrite existing valid documents just to enforce a new UI creation rule. If a document
+already contains multiple Brush sources, preserve their data and require selection of the existing
+Brush target when entering from the header; do not silently flatten them, change opacity/invert,
+or add another Brush. Record this exceptional-input behavior in tests. NM7-created workflows
+produce one accumulating Brush per Grade. Raster-only old project formats are handled by the
+explicit version gate described in the companion design, not silently converted into paths.
+
+### 2.1 Included capability
+
+1. Create and select Brush, Radial and Linear Gradient masks on the selected Color Grade.
+2. Edit Radial center/axes/rotation/inner and outer feather, Linear origin/direction/transition,
+   and Brush strokes plus supported Brush/Mask controls.
+3. Expose existing Mask opacity, enabled, invert, rename and delete through focused owner calls.
+4. Provide immediate retained QSG assistance, real Interactive preview, and settled Quality.
+5. Support pointer release, Done/Enter, Escape/Cancel, keyboard editing, interruption, and stale
+   asynchronous work rejection with precise one-operation/one-commit behavior.
+6. Restore correct mask selection and values after Undo/Redo, checkout, re-entry, and image change.
+7. Parameterize Brush paths and add reversible commands plus exact regional replay.
+8. Add project cache settings, stable-slot writeback, per-project cleanup and cacheless recovery.
+9. Qualify the actual viewer/native paths, storage bounds and failures.
+
+### 2.2 Exclusions
+
+No Color Range/Luminance Range selection UI, AI segmentation, arbitrary mask combinations,
+new graph topology, a per-control-point stroke editor, second preview renderer, or automatic project
+migration. Stroke parameters/history are in scope. Retain the existing quality/decode policy;
+change Brush persistence and R8 caching as required by this revision. No CPU or
+alternate-backend recovery path, lower-quality preview substitute, or per-frame whole-model JSON.
+
+Pressure/tilt dynamics are not implied by accepting a stylus as a pointing device. Brush size,
+hardness and strength are tool inputs for new samples; Mask opacity and source feather modify
+existing coverage and have distinct persistence semantics.
+
+## 3. Source audit at plan creation
+
+Inspected working-tree revision: `0ccb7e1c`. Working tree was clean before this documentation
+change. Paths below are existing unless expressly marked proposed. Recheck revision, APIs,
+current callers and tests when execution starts.
+
+| Source | Observed behavior | NM7 implication |
+| --- | --- | --- |
+| [Mask model](../../../../../alcedo_studio/src/include/edit/mask/mask_model.hpp) | Brush stores optional asset/descriptor/feather; analytic sources store typed fields; Mask owns enabled/opacity/invert/name | Change Brush source to canonical strokes/placement through this existing type; no parallel writable model |
+| [Grade model](../../../../../alcedo_studio/src/include/edit/graph/color_grade_node_model.hpp) | Owns Mask list and focused add/remove/source/field APIs; tracks content revisions | Route changes through the owner and preserve revision propagation |
+| [Active raster input](../../../../../alcedo_studio/src/include/edit/mask/active_raster_mask.hpp) | Full immutable R8 pixels plus target, generation, content revision and clipped raster rectangle | Cannot mutate a published buffer while a render reads it |
+| [Mask store](../../../../../alcedo_studio/src/include/edit/mask/mask_store.hpp) | Content-addressed persistent asset API, not a disposable project cache | Replace new-Brush product consumers with parameter evaluation/project cache; never delete old assets as cache |
+| [Typed history](../../../../../alcedo_studio/src/include/edit/history/pipeline_edit_batch.hpp) | `AddMaskChange`, `RemoveMaskChange`, `ReplaceMaskSourceChange`, `ReplaceMaskAssetChange`, `SetMaskFieldChange` exist | Extend NM4 with stroke insert/remove and placement operations; no new-Brush asset-key history |
+| [Pending input](../../../../../alcedo_studio/src/include/app/editor_pending_input.hpp) | Coalesces absolute field writes and retains ordered release/cancel/node-switch boundaries | Brush streams need ordered append semantics, not newest-field replacement |
+| [Parameter API](../../../../../alcedo_studio/src/include/app/editor_pipeline_command_service.hpp), [target validation](../../../../../alcedo_studio/src/include/app/editor_adjustment_types.hpp) | Ordinary adjustment path excludes Mask targets; rejection text still references NM3 | Add an explicit supported Mask command route; deleting a guard alone is insufficient |
+| [Interaction controller](../../../../../alcedo_studio/src/include/ui/editor_rhi/editor_interaction_controller.hpp), [mapper](../../../../../alcedo_studio/src/include/ui/edit_viewer/viewport_mapper.hpp) | GUI owns view/crop mapping; item inputs are logical coordinates | Extend the existing mapping boundary, not QML formulas |
+| [Resolved render geometry](../../../../../alcedo_studio/src/include/edit/geometry/resolved_render_geometry.hpp) | One rounded geometry supplies `render_to_reference` and related matrices | Use actual reference geometry rather than the dimensions of the last DetailPatch |
+| [Overlay item](../../../../../alcedo_studio/src/ui/editor_rhi/editor_overlay_item.cpp) | Retained triangle geometry for crop/ROI, rebuild coalescing and node reuse | Extend this surface; factor Mask geometry into focused helpers |
+| [Workspace](../../../../../alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml) | Point/Drag handlers can both forward press/move/release; wheel/pinch/double-click use the same viewer | Mode routing and sequence identity must prevent duplicate Brush input |
+| [Adjustment header](../../../../../alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentHeader.qml) | Brush/Radial/Gradient actions are present without product commands | Wire these existing entry points, preserving header layout |
+| [Masks panel](../../../../../alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml) | Read-only type rows; NM6.7 says this module file is unused | Do not claim adding controls here alone makes the feature reachable |
+| [Mask drawer](../../../../../alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskDrawer.qml), [row](../../../../../alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskTypeRow.qml) | Approved compact type/icon rows | Add selection/open behavior without moving editors into graph nodes |
+| [Metal evaluator](../../../../../alcedo_studio/src/edit/runtime/metal/shader/mask.metal) | Analytic math uses normalized reference coordinates; Brush feather uses signed-distance work | Derive overlay boundaries from evaluator equations; audit native parity |
+| [Project service](../../../../../alcedo_studio/src/app/project_service.cpp) | Owns project UUID, Save/Load metadata; Save reconstructs JSON | Persist per-project cache settings through owner and atomic write |
+| [Cache settings UI](../../../../../alcedo_studio/src/ui/alcedo_main/qml/CacheSettingsPanel.qml) | Thumbnail-specific settings/stats via library module | Add separate project Mask cache body/adapter; do not reuse thumbnail configuration keys |
+| [Project package](../../../../../alcedo_studio/src/app/project_package_backend.cpp) | Validates/materializes metadata and package contents | Carry source commands, not source-machine cache paths or raster history |
+| [Existing viewer tests](../../../../../alcedo_studio/tests/ui/editor_overlay_interaction_test.cpp) | Crop/ROI geometry and interaction infrastructure | Extend coverage while preserving navigation/crop behavior |
+
+### 3.1 Reconcile NM6 product revisions before exposing UI
+
+[NM6.7 completion](phase_nm6_node_aware_adjustments_plan.md#nm67--build-node-nameexif-header-and-capability-filtered-panels)
+and [DESIGN.md](../../../../../alcedo_studio/src/ui/alcedo_main/DESIGN.md) supersede the older
+capability-filtered navbar and vertical EXIF layout: six tabs remain, EXIF occupies one row, and
+Mask tool actions sit beside the node name. NM7 must preserve those landed choices.
+
+The temporary Masks body approved in Section 2 makes the older master Masks panel reachable
+without adding a seventh tab. Store the previous ordinary panel key as session presentation state,
+restore it on Done/Cancel, and never submit edits just because a body opens or closes. This routing
+choice was approved on 2026-09-08 and is reflected in master Section 18.1.
+
+## 4. Official Qt documentation and drawing decisions
+
+Read on 2026-09-08. The project names Qt 6.9.3 in its supported packaging/build configuration.
+Current unversioned Qt pages describe newer releases, so API availability must be checked against
+the installed 6.9 headers. The Qt 6.9 `QQuickItem` archive was available; several other archived
+pages did not load during research, so the current official pages below were read with explicit
+version checks. No Qt upgrade is part of NM7.
+
+| Official source | Rule applied to this module |
+| --- | --- |
+| [Qt 6.9 QQuickItem: custom scene graph items and resource handling](https://doc.qt.io/archives/qt-6.9/qquickitem.html#custom-scene-graph-items) | `ItemHasContents`, `update()` and `updatePaintNode()` form the display boundary. Keep QSG access on the render thread and resource cleanup on the correct thread. |
+| [Scene Graph: Custom Geometry](https://doc.qt.io/qt-6/qtquick-scenegraph-customgeometry-example.html) | Reuse `oldNode`; setters schedule an update; geometry and materials have explicit node ownership. Borrow the lifecycle pattern, not the example's line-width choice. |
+| [QSGGeometry](https://doc.qt.io/qt-6/qsggeometry.html) | Triangle strokes are portable. Reallocation invalidates geometry data; rewrite vertices/indices after `allocate`. Mark geometry dirty; nondefault upload patterns also require data-dirty calls. `setVertexCount`/`setIndexCount` require Qt 6.10. |
+| [Qt Quick Scene Graph](https://doc.qt.io/qt-6/qtquick-visualcanvas-scenegraph.html) | Retained scene nodes are separate from the GUI object tree; custom graphics remain within the Qt Quick scene graph. |
+| [Scene Graph Default Renderer](https://doc.qt.io/qt-6/qtquick-visualcanvas-scenegraph-renderer.html) | Clipping and material changes affect batching. Use a viewport clip and deliberate antialiasing; do not create one clip/material/item for each dab. |
+| [Qt Quick Input Handlers](https://doc.qt.io/qt-6/qtquickhandlers-index.html) | Passive observation is distinct from exclusive input ownership. Mode gates must prevent multiple tools acting on the same input. |
+| [PointHandler](https://doc.qt.io/qt-6/qml-qtquick-pointhandler.html) | Tracks a point from press with a passive grab. It is not an exclusive brush lock. Account for authentic versus synthesized device events. |
+| [PointerHandler](https://doc.qt.io/qt-6/qml-qtquick-pointerhandler.html) | Handle `canceled` and `grabChanged`; inactive is not automatically a successful release. Disabling a handler cannot be relied on to finish domain work. |
+| [DragHandler](https://doc.qt.io/qt-6/qml-qtquick-draghandler.html) | Use `target: null` for controller-owned movement; drag threshold must not discard a Brush press or the start of a line. |
+| [handlerPoint](https://doc.qt.io/qt-6/qml-qtquick-handlerpoint.html), [eventPoint](https://doc.qt.io/qt-6/qml-qtquick-eventpoint.html) | Capture primitive position/device/point values during delivery. Do not retain Qt event objects; handler positions can reset after release. |
+| [Accessible](https://doc.qt.io/qt-6/qml-qtquick-accessible.html) | QSG handles need ordinary accessible control proxies with names, roles, values and actions. Use APIs available in Qt 6.9, not newer attached properties. |
+
+### 4.1 Retained QSG implementation specification
+
+These are Alcedo design choices derived from the documented lifecycle and current overlay code.
+
+- Keep the existing `EditorOverlayItem` above `EditorViewportItem`. The overlay receives no
+  pointer grab. Input remains in the workspace adapter and application creation controller.
+- Separate selected control outline/fill, necessary direction lines, Brush cursor and temporary
+  initial-creation guides. Do not create source-area fill or existing-Brush path subtrees. Reuse nodes
+  when only parameters or colors change. Do not append a QObject per sample.
+- Build line widths and handle discs from triangle lists. Do not rely on wide native lines,
+  `DrawLineLoop`, or runtime triangle fans. A CPU helper may expand a fan to triangles.
+- Tessellate Radial curves by projected error: proposed maximum chord deviation 0.25 logical px.
+  Clip to visible image/viewport and cap work by visible geometry, without altering the stored
+  Mask or the image evaluator. Small degenerate shapes use finite, explicit empty geometry.
+- Use explicit edge-alpha triangle fringes for antialiasing and premultiplied color consistently.
+  Do not assume `QQuickItem::antialiasing` automatically fixes custom geometry. Test control outlines, intersections, joins and caps for
+  dark seams or doubled alpha. Feather
+  controls may show a handle/connector, not a highlighted feather band.
+- QSG coordinates and handle hit areas are logical pixels. Image-space radius is transformed;
+  handle and outline widths remain constant in logical pixels at any zoom or DPR.
+- For a growing stroke under Qt 6.9, use bounded geometry chunks or exact allocations with full
+  rewrite after allocation. Reuse completed chunks within the active sequence. Release sequence
+  geometry after settle/cancel; do not retain every historic stroke for display.
+- GUI-side geometry calculations consume only current input and published read-only display
+  values. `updatePaintNode` synchronizes those derived values while Qt blocks the GUI thread;
+  it must not acquire a live pipeline lock, read mutable worker state, perform cache I/O, or
+  signal synchronous domain mutations.
+- Theme/size/DPR/mode changes schedule the required geometry/material update. Empty visibility
+  clears or disables stale content. If `oldNode` is null after scene invalidation, reconstruct
+  from current display state; no dangling pointers back to a destroyed node tree.
+- Prefer automatic node ownership for geometry/material cleanup. Any resource held outside that
+  tree needs the documented render-job/invalidation cleanup, not GUI `deleteLater()`.
+- During initial drawing only, temporary Brush path/contour guides may follow samples. Existing
+  Brush editing shows the Move handle and necessary controls, not the completed path or raster fill. Reopening loads actual persisted stroke parameters; completed paths are not rendered as
+  highlighted influence areas. Actual Grade pixels always use the real evaluator.
+
+### 4.2 Pointer routing specification
+
+Use one Mask input adapter in the existing viewport handler surface, enabled only for creation
+mode. Keep the current navigation adapter for ordinary viewing. A PointHandler may provide the
+single canonical press/move stream while competing left-button navigation is disabled. If a
+separate exclusive handler is needed, it arbitrates ownership only; it must not forward a second
+sample stream. Prove delivery on the pinned Qt version instead of trusting old source comments.
+
+Capture `(device identity, point id, sequence id)` at press. Pass plain values to the controller.
+Keep the last valid sample and consume a final release position when supplied by the event; never
+read a reset `(0,0)` handler position as a new final point. Every sequence accepts exactly one
+terminal release or cancellation. Ignore duplicates and delayed callbacks after termination.
+
+## 5. Ownership, reversible commands and history
+
+The [algorithm design](mask_command_replay_and_project_cache_plan.md#3-参数化数据与单一所有者)
+defines the new persistent source and inverse operations. R8 is never a before-state for Undo.
+
+`EditorMaskCreationController` is an application service; a thin album-backend adapter exposes it
+to QML. It owns mode, active handle and exact captured identities, not another writable document,
+Grade selection or Brush collection. Reuse `EditorNodeController` selected-node authority.
+
+Suggested calls: BeginCreation, SelectMask, BeginMaskInput, AppendMaskInput, FinishMaskInput,
+CancelMaskInput, BeginMaskMove, UpdateMaskPlacement, FinishCreationMode, CancelCreationMode,
+SetMaskField and RemoveMask. All change requests capture project/image/session/Version/NodeId/
+MaskId/sequence identity. Brush commands also capture stable StrokeId. Admission is not commit.
+
+### 5.1 Data and allowed independent state
+
+| Data | Owner and necessity | Lifetime / rule |
+| --- | --- | --- |
+| Canonical stroke samples | Brush source; primary creation data | Persist in document/NM4 history; no per-frame copy of the stroke collection |
+| Pending new input | Existing serial input owner | Ordered new samples/changed fields; move/share them into owner at consumption |
+| Inverse command payload | NM4 history | New/removed stroke body or changed scalar fields; no bitmap before/after |
+| Spatial index | Mask runtime owner | Derived IDs/spans/bounds only; rebuildable, no pixel history |
+| GUI display projection | GUI publication of selected controls | Minimal fields, identity/revision-tagged, load-only |
+| Grade R8 / source scratch | Existing native executor | Current result or algorithm output; writes wait for reader leases, no historic results |
+| QSG geometry | Qt render-thread nodes | Control geometry; no document access from updatePaintNode |
+
+### 5.2 One operation and one commit
+
+Choosing a source arms creation without document mutation. First valid input creates a provisional
+Mask; first Brush release commits AddMask with its first canonical stroke, later releases commit
+AppendBrushStroke on the same MaskId. An analytic drag commits its final source fields; a Brush
+move commits before/after translation, without rewriting any sample coordinates.
+
+Done after release only exits mode. Cancel rolls back unfinished commands and replays affected
+regions; earlier completed strokes remain. No-op creation or unchanged placement creates no
+commit. A release equal to the last provisional value still seals the actual earlier change.
+
+Undo removes/restores the relevant command data using NM4; deterministic evaluation updates the
+current R8. Deleting all caches must not alter this behavior. Do not create a second QUndoStack,
+per-stroke image checkpoint or full-source copy for every appended stroke.
+
+### 5.3 Serial preview and failure behavior
+
+GUI input moves controls and queues focused changes. The existing NM6 consumer applies one batch
+at a safe owner boundary, invalidates exact dependencies, replays required coverage and executes
+Interactive. Brush point ordering survives coalescing; absolute placement updates keep the latest
+value per exact sequence. Live parameters/buffers cannot change during native readers.
+
+After release, NM4 commits parameter data then requests Quality. Disk cache publication is an
+independent, coalesced stable-slot write, not a prerequisite for history. Command persistence
+failure restores source through inverse operations; native failure reports its real error; cache
+write failure reports its own error and cannot erase an already committed command.
+
+Rename, selection and future-tool size/strength change do not affect current pixels. Existing
+placement/opacity/invert/feather changes do, invalidate appropriate coverage and Grade/downstream
+results, and keep unaffected upstream image results according to NM6. This revision replaces
+persistent per-source Mask R8 retention with one current Grade Mix coverage and necessary scratch;
+it preserves QualityBase bypass after RAW Develop.
+
+## 6. Coordinate and evaluator specification
+
+### 6.1 One mapping chain
+
+```text
+pointer in handler's local logical coordinates
+  -> map to the actual viewport item (Qt item mapping if parents differ)
+  -> existing viewport inverse (letterbox, zoom, pan, presentation mapping)
+  -> full rendered/edit image position
+  -> resolved geometry render_to_reference
+  -> normalized ReferenceSpace (divide by full_reference_extent)
+```
+
+The inverse chain maps analytic boundaries and sample support to overlay coordinates. Trace the
+current viewport's source UV semantics before composing matrices: do not apply crop/orientation
+twice if a current owner mapping already accounts for it. Add explicit named mapping methods and
+round-trip tests at this owner boundary rather than a second QML coordinate system.
+
+DPR is applied only where the existing mapper crosses logical/physical space. DetailPatch extent,
+Interactive output size, viewport resize and panel animation must not redefine ReferenceSpace.
+Use pixel centers `(x + 0.5, y + 0.5)` for raster/evaluator tests; continuous pointer positions do
+not receive an extra half-pixel offset.
+
+Invalid/zero extents or noninvertible transforms reject input. A press outside image content does
+not create a Mask. During a captured drag allow off-image coordinates as the source validator
+permits; clip raster writes and display rather than clamping every input point onto an edge.
+Brush leaving/re-entering the image keeps the actual path, without painting along the border.
+Cancel the active operation before a document Geometry change. Navigation between operations
+updates display mapping while leaving stored parameters unchanged.
+
+### 6.2 Radial: use the actual normalized-space ellipse
+
+The existing evaluator forms normalized reference `q`, center `c`, and rotated local coordinates:
+
+```text
+u = ( cos(rotation)*(q.x-c.x) + sin(rotation)*(q.y-c.y)) / major_radius
+v = (-sin(rotation)*(q.x-c.x) + cos(rotation)*(q.y-c.y)) / minor_radius
+rho = sqrt(u*u + v*v)
+inner = max(0, 1-inner_feather)
+outer = 1+outer_feather
+coverage = 1-clamp((rho-inner)/max(outer-inner, evaluator_epsilon), 0, 1)
+```
+
+Generate each boundary at its `rho` from the inverse equation, then apply the shared viewport
+mapping. Use these boundaries to locate radius/feather controls. Initial creation may display outline
+guides; editing an existing Mask shows the necessary handles/connectors without area highlighting
+or filled feather bands.
+Rotation is stored in radians. It occurs in normalized coordinates; a rotated ellipse on a
+non-square image is not generally reproduced by QML rotation of a screen-space ellipse.
+
+Center drag translates. Axis handles update radii in the inverse local frame. Rotation uses
+normalized-space angle with continuous wrap handling. Feather handles update the corresponding
+boundary and do not silently alter radius. Keep axis identity stable when dragging across center;
+never swap handle identities merely because numeric radii cross. Respect validator limits.
+The approved center-out drag sets positive x/y radii; zero-area input stays transient until valid.
+
+### 6.3 Linear Gradient: direction and transition have separate roles
+
+For normalized reference `q`, origin `o`, and normalized direction `n`:
+
+```text
+d = dot(q-o, n)
+t = clamp(d / max(transition_distance, evaluator_epsilon) + 0.5, 0, 1)
+coverage = start_value + (end_value-start_value)*t
+```
+
+The three mathematical guide loci are `d = -distance/2`, `d = 0`, and `d = +distance/2`.
+During initial creation, these lines may form guides; for an existing Mask use them to position
+finite direction/width controls without filling or highlighting the affected area. Map control points
+through the shared item transform. On a
+non-square image, a normalized normal is not directly a screen normal. Handle hit tests and edits
+must use the same mapping as evaluation.
+
+Proposed initial drag from `a` to `b`: `origin=(a+b)/2`, `normal=normalize(b-a)`,
+`transition_distance=length(b-a)`, `start_value=1`, `end_value=0`. The press side is fully covered;
+the release side is uncovered. Move center to translate, direction handle to rotate, boundary
+handle to change width with fixed center. Invert uses the existing Mask field. Do not invent a
+second independent Linear feather parameter: transition distance is its existing softness control.
+
+### 6.4 Parameterized Brush, deterministic replay and movement
+
+Use [algorithm design Sections 3–5](mask_command_replay_and_project_cache_plan.md#4-确定性笔刷生成).
+Persist ordered canonical samples, paint/erase, radius/strength/hardness and algorithm version.
+Sample in the reference pixel metric; maintain arc-length spacing remainder across event batches.
+Use the same sample source for any permitted initial-creation guide, never resample Qt input twice.
+
+Proposed initial diameter is 2% of the shorter reference edge, strength/hardness 100%, source
+feather 0. Size and strength changes affect subsequent samples, including ordered changes inside
+an open stroke. Show size in reference pixels and strength in percent; do not relabel Mask opacity
+as Brush strength. Pressure dynamics remain outside the approved scope.
+
+Whole-Brush movement changes `placement_translation`; input after movement is stored through
+its inverse in local reference coordinates. Do not repeatedly resample or shift the prior R8.
+Repeated A→B→A movement restores the same source and pixels without blur. Brush Move and Paint
+are explicit modes, so relocating a Brush cannot accidentally append a stroke.
+
+Coverage replay uses the current parameter source, a span/tile index and the union of old/new
+affected domains. Erase/max/quantization are not pixel-invertible: restore commands, then replay.
+Reevaluate other Mask contributors when the maximum changes. Signed-distance feather keeps its
+complete required domain; small source damage is not proof of a local distance update.
+
+Host canonical Brush raster generation runs on the serial owner worker and feeds existing native
+source evaluation; selected CUDA/OpenCL/Metal feather/Union/Mix remain mandatory. No substitute
+backend or reduced-quality path is introduced.
+
+## 7. One current R8 cache and project storage
+
+The [algorithm/storage design](mask_command_replay_and_project_cache_plan.md#6-一个当前-r8-槽的准确范围)
+is authoritative for cache identity, writer ownership, representation and clearing behavior.
+
+- Persistent edit data is Brush samples/placement plus analytic fields and NM4 commands.
+- Each `(ProjectUUID, ImageId, NodeId)` has one stable current Grade coverage disk slot;
+  no filename keyed by stroke, commit, Version or content hash.
+- Current output replacement respects active readers. Source R8/float/feather work is transient
+  executor scratch, not an additional long-lived per-Mask cache.
+- Coalesce cache writes at safe idle/save/close boundaries; no full R8 asset per stroke.
+- Parameter commit succeeds independently of cache durability. A deleted/stale cache is rebuilt
+  by the same complete algorithm; corrupt parameter data must still fail explicitly.
+- ProjectService owns path and Keep/DeleteOnProjectClose policy. Provide Clear per project;
+  only remove owned cache files, never source samples/history/RAW or another project's namespace.
+- Path switching and Clear fence pending jobs, wait for reader/writer safety and persist settings
+  through the project owner. Old jobs cannot recreate cleared files or write to a new project's root.
+- Project packaging, Version and Paste work without R8; format validation rejects raster-only
+  unsupported documents before any cache deletion. No automatic raster-to-path conversion.
+
+**Movement chain:** input → focused placement fields → safe owner consume → replay affected
+coverage → one current Grade R8 → native Mix → Interactive photograph. Release → one parameter
+commit → Quality. QSG displays control positions and does not display affected-area highlighting.
+
+## 8. State machine and interruption rules
+
+Use the master states `Inactive`, `Selected`, `Creating`, `Editing`, `Painting`, `Settling`, `Failed`.
+A state has a single controller owner. An open operation captures image/session generation,
+Version/working-head generation, NodeId, MaskId, sequence id and mapping identity. Existing NM4
+before-values stay with history; they are not copied into another session model.
+
+| Event | Required behavior |
+| --- | --- |
+| Choose a creation tool | Resolve exact Grade; arm Creating; no AddMask/history/render until valid input |
+| Select an existing Mask | Load owner data, selected row and overlay; pure selection makes no photo render |
+| Valid press / move | Editing or Painting; immediate overlay; queue focused input for Interactive |
+| Release / Enter / Done with a valid open operation | Seal once, enter Settling, publish one commit and request Quality |
+| Escape / Cancel | Cancel unfinished input, restore before-state/remove provisional addition, zero commits; exit mode |
+| Enter / Done after a released operation | Leave mode without a duplicate commit |
+| New press while Settling | Keep the tool visibly unavailable for a new stroke until acknowledgement; preserve GUI responsiveness and never silently accept then drop a press |
+| Unexpected grab loss, touch cancellation, window deactivation or workspace hiding | Cancel open operation before disabling/destroying its input adapter; do not fabricate release |
+| Switch to another Mask/tool | Settle a valid current operation, then retarget; abandon an unstarted/degenerate creation |
+| Ordinary adjustment input | Resolve active Mask operation, hide overlay before adjustment; keep hidden until explicit Mask re-entry |
+| Image switch / Version checkout / Undo / Redo / owner deletion | Cancel unfinished operation first, then execute requested lifecycle command in order |
+| Explicit delete of selected Mask | Cancel its open operation, then issue one NM4 removal; deleting a never-committed new Mask only cancels it |
+| Viewport resize or DPR change during an open operation | Cancel the unfinished operation before installing the new mapping; keep earlier committed strokes and recompute the selected overlay |
+| Pan/zoom during an open drawing operation | Keep mapping fixed for that operation; do not route those same points to navigation |
+| Pan/zoom between operations | Use existing viewer navigation, recompute overlay placement, do not change Mask data |
+| Application close | Resolve the open operation before existing Save/Discard close policy runs |
+| Owner/commit/native failure | Restore by NM4 policy, show precise error, clear input ownership; no silent alternate path |
+
+While creation mode owns input, keep the owning Color Grade selected, disable graph structure and
+layout input, and keep the Masks controls available. Reenable graph interaction when mode ends.
+If an external command changes selection regardless, validate generations and terminate old input;
+never reinterpret it as an edit of the newly selected Grade.
+
+Suggested navigation binding: middle-button or Space+drag between operations, wheel/pinch zoom
+between operations; suppress ordinary left-button pan and double-click zoom while the Mask tool
+owns that button. A second touch cannot become another brush or steal half an edit; classify it
+before tool mutation. Keep mouse, stylus and touch device acceptance explicit.
+
+Fencing is required at input enqueue, owner consume, cache-job completion, commit acceptance and frame
+presentation. A content revision orders results within a session; it does not replace image/
+Version/sequence identity. A late result must release its resources even when presentation rejects it.
+
+## 9. UI, accessibility and integration behavior
+
+Implement Section 2's approved routing, preserving the landed header and six-tab product decision.
+The approved temporary body reuses `EditorMasksContextPanel.qml` as the actual Masks editor and
+loads through the adjustment shell; it is not a hidden unused QML module or a separate window.
+
+The list exposes type icon, Mask name, selection, and supported commands. Selected-row controls
+edit name, enabled, invert, opacity and source-specific values plus an explicit Brush Move action. Use exact IDs, stable row updates,
+and a panel-level `selectedMaskId` binding. No list rebuild or forced scroll containment on click.
+After deletion select the next row at the old position, otherwise previous, otherwise no selection.
+Undo restores IDs; select a restored mask only according to an explicit current-session selection
+rule, never by a reused index. Selection-only restore stays load-only.
+
+The compact viewer creation bar contains separate source-kind and name text plus Done/Cancel.
+Use existing shared actions and `cardSurfaceColor`, `cardBorderColor`, `panelRadius`, spacing,
+font and icon tokens. Place it in a reserved viewer edge area; if it would cover an active primary
+handle, relocate the bar within that area without moving the photo or changing coordinates.
+
+Use existing approved Brush/Radial/Gradient SVGs, including their documented 2 px exception.
+Define required Mask colors/handle geometry/hit-area/antialias widths as AppTheme semantic tokens
+and add their actual values to DESIGN.md in the implementation change. Suggested roles are the
+master's `maskOverlayControlColor`, `maskOverlayControlOutlineColor`, `maskOverlayInactiveColor`. Do not add a coverage-area color for the revised Mask UI. No ad-hoc palette, Material controls, badges, pills or status dots.
+
+QSG nodes are not accessible controls. Expose lightweight accessible proxies for the selected
+source's finite set of handles, or equivalent named numeric controls plus handle selection. Do
+not create a proxy for every dab. Tab reaches the list, selected controls and Done/Cancel; arrows
+move the focused handle, with a named numeric alternative for precision. Proposed step is one
+ReferenceSpace pixel, Shift ten; rotations and feather widths use explicitly labelled units.
+Text-input Delete/Escape/Enter must first obey text editing/rename semantics; graph Delete must
+never delete the owning Grade when a Mask handle has focus.
+
+Numeric controls and keyboard edits use the same begin/update/finish/cancel service as pointer
+edits. Keyboard repeat settles once on release or explicit confirmation and updates Interactive pixels
+while moving a control. Test shortcut conflicts
+with crop, graph, global Undo and existing viewer navigation. Register commands through the
+existing shortcut owner rather than scattering key codes through QML.
+
+Loading on initial construction, session rebind, panel re-entry, Undo/Redo and checkout never submits
+input. Reject older projection revisions when newer local input is still pending. Restore ordinary
+panel focus on mode exit. Theme switch updates all QSG colors; reduced motion makes mode/panel
+transitions immediate, and input-following geometry is never animated behind the pointer.
+
+## 10. Revised ordered implementation phases
+
+本次改变 NM3 source、NM4 history 与 runtime cache，因此先完成数据和重放能力，再开放 viewer。
+下面的 NM7.1–NM7.14 **替代上一版十二阶段拆分**；旧阶段没有本轮 production completion，
+不能把旧的 immutable asset 测试当作新格式验收。保持总体 NM1→NM6→NM7→NM8 顺序。
+
+| Phase | Result | Dependency |
+| --- | --- | --- |
+| NM7.1 | Source audit, numerical rules and new format boundary | NM6 production gates |
+| NM7.2 | Parameterized Brush source and focused owner operations | NM7.1 |
+| NM7.3 | Typed reversible stroke/placement history, WAL and Version | NM7.2 |
+| NM7.4 | Canonical rasterization, spatial index and regional replay | NM7.2–NM7.3 |
+| NM7.5 | Shared ReferenceSpace mapping, Brush placement and hit testing | NM7.4 |
+| NM7.6 | QSG control-only retained rendering | NM7.5 |
+| NM7.7 | Radial and Linear creation plus existing-mask movement | NM7.3, NM7.5–NM7.6 |
+| NM7.8 | Accumulating Brush creation, erase, tool settings and movement | NM7.4–NM7.6 |
+| NM7.9 | Serial Interactive replay and one current Grade R8 result | NM7.7–NM7.8 |
+| NM7.10 | Project-owned cache settings, writeback and cleanup service | NM7.3, NM7.9 |
+| NM7.11 | Production Mask controls and project storage UI | NM7.10 |
+| NM7.12 | Interruptions, late jobs and complete lifecycle | NM7.11 |
+| NM7.13 | Native pixel, persistence, cache bounds and recovery qualification | NM7.12 |
+| NM7.14 | Real viewer/package/performance qualification and NM8 handoff | NM7.13 |
+
+Each phase records actual files/APIs, success and failure call chains, commands, executed test
+counts and remaining gaps. Branch names describe the result, e.g. `feature/brush-command-replay`
+or `feature/project-mask-cache`. New names below are proposals, not existing APIs.
+
+### NM7.1 — Audit the revised source and format boundary
+
+**Purpose:** distinguish the old implemented R8 asset path from the new parameter-owned product.
+
+**Work:** record current commit/Qt/runtime; recheck NM6.8/6.9; trace Mask commands, source/Union
+caches, MaskStore, history assets, project settings and package/save consumers. Inventory all
+`MaskAssetKey` dependencies and their replacements. Fix raster/dab encoding, algorithm version,
+source feather units and output sampling rules in the companion design. Enumerate the exact
+project/schema versions accepted after this change; no automatic conversion of raster-only input.
+
+**Files/APIs:** Section 3 source table, project service/version constants, NM4 batch applier,
+plan executor/native Mask pass and existing tests.
+
+**Primary chain:** saved source/history → validated document → evaluator/cache → Grade Mix.
+**Failure chain:** unsupported parameter/format → load rejection → original files left intact.
+
+**Tests:** characterize current asset references and reader lifetime; register future test targets;
+record evidence, not a claim that parameterized source already exists.
+
+**Exit:** ownership and replacement inventory complete; no unaccounted product dependency on old R8 history.
+
+### NM7.2 — Add parameterized Brush data and owner operations
+
+**Purpose:** persist the information needed to recreate a Brush without any cache file.
+
+**Work:** change `BrushMaskSource` to ordered immutable canonical stroke bodies, StrokeId, algorithm
+version and placement; keep Radial/Linear definitions. Add validated append/remove/insert stroke
+and set-translation owner operations. Enforce exact NodeId/MaskId/StrokeId and before-revision;
+update dirty metadata once after successful mutation. Parameter read projections remain minimal.
+
+**Files/APIs:** `mask_model.hpp/.cpp`, `color_grade_node_model.hpp/.cpp`, document serialization;
+proposed `brush_stroke.hpp` / `brush_mask_commands.hpp`; include defining headers.
+
+**Primary chain:** exact source operation → validate complete input → Grade owner → revision.
+**Tests:** `BrushSourceRoundTripsWithoutRasterFiles`, `BrushAppendKeepsExistingStrokeIds`,
+`InvalidStrokeDoesNotPartiallyMutateSource`, `BrushTranslationDoesNotCopyOrRewriteSamples`.
+
+**Exit:** one Brush per new Grade workflow; source can be read independently of `MaskStore`.
+
+### NM7.3 — Extend NM4 reversible history and persistence
+
+**Purpose:** Undo/Redo changes parameters, not references to per-stroke raster files.
+
+**Work:** implement typed Append/Remove/InsertBrushStroke and SetBrushTranslation with exact inverse
+fields; first stroke is one AddMask commit. Extend canonical payload, validators, WAL recovery,
+materializer, checkpoint, Version checkout and Paste remapping. History stores only new/removed
+sample bodies or changed fields, not all earlier strokes with every append. Reuse NM4 structural
+inverse payloads for Mask/Grade deletion. Update project/package schema gate together.
+
+**Files/APIs:** `pipeline_edit_batch`, `pipeline_history_applier`, `pipeline_document_history`,
+history materializer, transfer/package and current project-version owner.
+
+**Primary chain:** final input → typed command → WAL/history success → Version-replayable source.
+**Failure chain:** persistence rejection → inverse through same owner → no new HEAD or half source.
+
+**Tests:** `StrokeUndoRedoRestoresCommandOrderWithoutR8`, `FirstBrushStrokeCreatesOneCommit`,
+`BrushMoveUndoRestoresExactTranslation`, `AppendHistoryDoesNotRepeatEarlierSamples`,
+`ParameterizedBrushSurvivesWalRecoveryAndPaste`, `RasterOnlyFormatIsRejectedBeforeCacheCleanup`.
+
+**Exit:** delete all new cache files and history/Version source restoration still succeeds.
+
+### NM7.4 — Implement deterministic Brush replay and spatial indexing
+
+**Purpose:** recover pixels from commands efficiently without raster history.
+
+**Work:** implement companion Sections 4–5: canonical samples, arc-length dabs, integer max/min,
+ordered span index, dirty old/new supports, surviving-source Union recomputation and full-required
+feather domain. Initialize each reconstructed region from its defined base. Do not persist source
+R8 per stroke or keep hidden raster checkpoints. Fixed finite-value and quantization rules are shared.
+
+**Files/APIs:** proposed `edit/mask/brush_rasterizer`, `brush_spatial_index`, source geometry helpers;
+existing native feather and shared execution interfaces where needed.
+
+**Primary chain:** reversible source mutation → affected bounds → ordered candidate spans →
+recomputed source → effective coverage → current Grade result.
+
+**Tests:** `RegionalBrushReplayMatchesFullEvaluation`, `EraseUndoRestoresEarlierPaint`,
+`RemovingUnionMaximumPreservesOtherMasks`, `BrushEventGroupingPreservesCanonicalPixels`,
+`FeatherRebuildMatchesCompleteDistanceEvaluation`.
+
+**Exit:** independent full-evaluation oracle passes paint/erase/overlap/translate/Undo/Redo; index
+uses only IDs/spans/bounds. The simplified prototype is not a substitute for these production tests.
+
+### NM7.5 — Implement shared mapping and parameterized movement
+
+**Purpose:** input, controls and native pixels refer to the same image locations.
+
+**Work:** trace item/logical → viewport → resolved reference mapping; avoid double crop/orientation.
+Add Brush translation with inverse mapping for newly added samples after movement. Use old/new
+supports for damage; preserve reference metric and stroke-local coordinates. Define logical handle
+hit areas, off-image movement, invalid transforms and resize/DPR interruption.
+
+**Files/APIs:** `editor_interaction_controller`, `viewport_mapper`, `resolved_render_geometry`,
+proposed `ui/edit_viewer/mask_edit_geometry`; application movement commands.
+
+**Primary chain:** item drag → reference delta → absolute placement/center/origin → owner replay
+and forward mapping of controls.
+
+**Tests:** `MaskReferenceMappingRoundTripsAcrossZoomPanAndDpr`,
+`BrushMoveThenDrawUsesTranslatedLocalCoordinates`, `RepeatedBrushMoveDoesNotBlurCoverage`,
+`DetailPatchDoesNotChangeMaskReferenceSpace`, `InvalidGeometryRejectsMaskPress`.
+
+**Exit:** normalized mapping error ≤ 1e-5 and item round-trip error ≤ 0.25 logical px over documented
+fixtures; move A→B→A recovers exact parameters and expected pixels.
+
+### NM7.6 — Implement retained QSG controls without affected-area highlighting
+
+**Purpose:** expose editable controls while the actual image supplies coverage feedback.
+
+**Work:** keep `EditorOverlayItem`/retained nodes; draw selected handles, direction/connector lines,
+Brush cursor and allowed creation guides. Existing-mask editing emits zero area-fill/heatmap/settled
+stroke-path geometry. Add theme/control tokens to AppTheme and DESIGN together. Reuse old nodes,
+triangle strokes and explicit antialiasing; preserve crop/ROI layer behavior and Qt 6.9 support.
+
+**Files/APIs:** overlay item + focused geometry helpers, AppTheme, DESIGN, UI geometry/window tests.
+**Primary chain:** local control change → `update()` → `updatePaintNode(oldNode)` → Qt frame.
+
+**Tests:** `ExistingMaskEditHasControlsAndNoCoverageFill`, `MaskControlsUpdateWhileRenderIsHeld`,
+`MaskOverlayReusesNodesForMovement`, `MaskControlsRecreateAfterSceneInvalidation`,
+`MaskControlsKeepLogicalSizeAndThemeColors`.
+
+**Exit:** real accelerated window captures show no mask-area tint while dragging an existing Mask;
+no live pipeline lock or raster I/O inside Qt synchronization.
+
+### NM7.7 — Complete analytic creation and movement
+
+**Purpose:** Radial and Linear support both first drawing and later real-time relocation.
+
+**Work:** center-out Radial; center/axes/rotation/inner/outer feather controls; Linear center/direction/
+transition controls and endpoint convention. Existing move keeps source shape fields fixed except
+center/origin. Begin/update/release/cancel use common exact-target owner calls. Do not wait until
+release to update the photographed result.
+
+**Files/APIs:** creation controller, analytic geometry, Grade owner and NM4 field/source commands.
+**Primary chain:** drag source → provisional fields → Interactive → one settled command → Quality.
+
+**Tests:** `ExistingRadialMoveUpdatesInteractivePixelsBeforeRelease`,
+`ExistingGradientMovePreservesDirectionAndUpdatesInteractivePixels`,
+`RadialFeatherControlsMatchEvaluator`, `DegenerateAnalyticCreationCreatesNoCommit`,
+`EscapeRestoresAnalyticSourceWithoutCommit`.
+
+**Exit:** both shapes move with actual native preview and control-only QSG on non-square images.
+
+### NM7.8 — Complete accumulating Brush creation, erase and movement
+
+**Purpose:** multiple strokes remain editable data in one Brush, with one current Grade raster.
+
+**Work:** header resumes existing Brush; append canonical paint/erase strokes with size/strength
+setting boundaries; move the whole accumulated Brush by translation, including erase operations.
+Keep move input separate from paint input. Retain samples for history, not QSG display. No
+`MaskStore::Put` or `ReplaceMaskAsset` on new Brush release.
+
+**Files/APIs:** creation controller, Brush source/command owner, canonical sampler, mapping helpers.
+**Primary chain:** paint input → append draft samples → replay; move control → set placement → replay;
+release → corresponding single typed command → Quality.
+
+**Tests:** `MultipleStrokesUseOneBrushMask`, `SizeAndStrengthChangesPersistInStrokeSamples`,
+`MovingExistingBrushUpdatesInteractivePixels`, `BrushMoveDoesNotAppendStroke`,
+`UndoLastStrokePreservesEarlierStrokes`, `BrushReleaseCreatesNoHistoricalRasterFile`.
+
+**Exit:** paint/erase/move/Undo/Redo work after deleting caches, with stable MaskId and StrokeIds.
+
+### NM7.9 — Integrate serial Interactive evaluation and one current Grade R8
+
+**Purpose:** connect all provisional movement to real pixels while respecting NM6 reader ownership.
+
+**Work:** extend the existing queued input/serial consumer. Latest absolute placement coalesces;
+ordered Brush samples do not. Replace persistent per-source R8 retention in this path with transient
+source/feather scratch and one current Grade Mix coverage. Recompute old/new damaged areas and
+surviving contributions; distinguish source-local from feather-global work. Tag identity/revision
+at consume and completion; QualityBase still bypasses persistent results after Develop.
+
+**Files/APIs:** pending input, session edit controller/coordinator, pipeline request/scheduler,
+plan executor, mask texture/result cache, native CUDA/OpenCL/Metal Mask passes.
+
+**Primary chain:** queued change → safe consume/apply → replay/Union → Grade Mix → Interactive
+presentation → next consume. Release seals → durable command → Quality.
+
+**Tests:** `MaskMoveNeverMutatesSourceDuringRender`, `LatestMoveValueSurvivesRelease`,
+`CurrentGradeCoverageHasOneRetainedResult`, `DelayedOldFrameCannotReplaceNewMaskPosition`,
+`QualityMaskEvaluationDoesNotOverwriteInteractiveCache`, `RebuiltMaskMatchesCacheHitPixels`.
+
+**Exit:** actual end-to-end native request path works; a control redraw alone does not pass.
+
+### NM7.10 — Add project-owned cache storage and maintenance
+
+**Purpose:** bounded, disposable R8 storage controlled per project.
+
+**Work:** companion Sections 6–8: ProjectService settings and metadata round-trip; stable file slot,
+identity header/checksum, coalesced writer, atomic replace, generations/locks; retain/delete-on-close,
+Clear, project-removal choice and root switching. Preserve original parameter data. Track previous
+registered roots for explicit later cleanup. Missing cache rebuilds through the same algorithm;
+unavailable configured storage produces a visible error with no silent path substitution.
+
+**Files/APIs:** `project_service`, proposed `project_mask_cache_service.hpp/.cpp`, project module,
+package service/backend, current MaskStore/reachability consumers for replacement inventory.
+
+**Primary chain:** project setting → validate → atomic setting publish → per-project cache jobs;
+Clear → maintenance boundary → stop old writer → delete only owned cache → invalidate.
+
+**Tests:** `ProjectMaskCacheSettingsSurviveSaveAndReopen`, `ThousandStrokesKeepOneRasterSlot`,
+`CacheClearCannotDeleteAnotherProjectsFiles`, `OldWriterCannotRecreateClearedCache`,
+`RootChangeFailurePreservesOldSetting`, `CacheWriteFailureDoesNotLoseStrokeHistory`,
+`CloseCleanupRunsAfterParameterSaveAndReadersFinish`.
+
+**Exit:** new cache namespace can be completely removed without losing any supported edit/Version.
+
+### NM7.11 — Wire Mask editing and project cache UI
+
+**Purpose:** make the fully working capability reachable through approved surfaces.
+
+**Work:** connect header tools/node Mask rows to temporary Masks body; preserve six tabs and prior
+panel restoration; expose paint/erase/size/strength/Move and existing source/Mask values. Add project
+cache section through app APIs with root chooser, policy and per-project usage/Clear. Existing
+cache settings are thumbnail-specific; keep the new project fields separate. Add keyboard/accessible
+controls, focus rules, theme/width/reduced-motion tests and QML registration.
+
+**Files/APIs:** header/stack/Masks body/node drawer/creation bar, `SettingDialog.qml`,
+`CacheSettingsPanel.qml`, proposed `ProjectMaskCacheSettingsPanel.qml`, project adapter, AppTheme/DESIGN.
+
+**Primary chain:** UI action → exact project/Mask owner → validated operation → completion projection.
+**Tests:** `MaskModePreservesSixTabs`, `MaskSelectionDoesNotSubmitOrJumpScroll`,
+`KeyboardMaskMoveUsesSameInteractiveRoute`, `CacheSettingsTargetSelectedProjectOnly`,
+`ProjectClearExplainsThatBrushHistoryIsRetained`.
+
+**Exit:** production QML at 260/320/460 px in both themes; no unregistered/unused-only implementation.
+
+### NM7.12 — Complete cancellation and project/session lifecycle
+
+**Purpose:** preserve state when operations terminate without a normal release.
+
+**Work:** route grab cancellation, deactivation, workspace hide, adjustment input, owner deletion,
+Undo/Redo, image/Version/project switch and close through ordered boundaries. Restore unfinished
+commands and rebuild affected results, with no raster before-state. Fence old cache jobs by project
+and storage generation in addition to image/Version/sequence identity. Keep graph actions disabled
+only while creation mode owns input; release resources even when results are rejected.
+
+**Files/APIs:** workspace input adapter, controller, session/project lifecycle, node/shortcut gates,
+cache service and frame validation.
+
+**Primary chain:** interruption → cancel/settle command → owner restore/commit → requested lifecycle
+operation → stale result rejection / old writer retirement.
+
+**Tests:** `GrabCancellationDoesNotCommitBrush`, `DuplicateReleaseCommitsOnce`,
+`VersionCheckoutRejectsOldMaskFrame`, `ProjectSwitchRejectsOldCacheWrite`,
+`MaskDeleteWithViewerFocusDoesNotDeleteGrade`, `WorkspaceHideRestoresUnfinishedMaskMove`.
+
+**Exit:** delayed native completion, write jobs and genuine Qt input all obey the same outcome.
+
+### NM7.13 — Qualify native pixels, bounded disk storage and recovery
+
+**Purpose:** verify source, command replay and disposable cache as one product path.
+
+**Work:** run the companion acceptance matrix plus main Section 11. Exercise 1,000 strokes,
+1,000 Undo/Redo, many Versions and Clear on multiple projects. Reopen/cacheless package/Paste,
+error injection, crash during atomic replacement and schema rejection. Record native backends
+separately; no CPU/other-backend substitution for unavailable qualification hardware.
+
+**Files/APIs:** shared native Mask fixtures, history/recovery/project/cache/UI tests and package tests.
+**Primary chain:** actual tool → source commands → clear/save/reopen/Version/Paste → fresh native
+coverage → expected pixels independent of any previous cache.
+
+**Tests:** `CachelessProjectRestoresAllMaskVersions`, `NativeMaskReplayMatchesExpectedCoverage`,
+`RepeatedHistoryNavigationKeepsRasterFileCountBounded`, `InterruptedCacheReplaceLeavesNoPartialFile`,
+`PastedBrushUsesTargetProjectStoragePolicy`.
+
+**Exit:** registered tests execute nonzero counts; actual file count/bytes and error cases recorded.
+
+### NM7.14 — Qualify real viewer, packages and performance
+
+**Purpose:** measure the requested Interactive editing and ensure it ships in installed builds.
+
+**Work:** real RAW, nonidentity Grade, three sources, existing-source moves, paint/erase, Undo/Redo,
+project cache root/clear/close, packaged reopen. Capture control-only QSG and actual image pixels;
+measure event/queue/replay/feather/Union/Mix/presentation/cache-write costs and memory separately.
+Update completion records and master status only after all required evidence exists.
+
+**Files/APIs:** package/viewer tooling, plan and master completion records; temporary outputs under
+`build/tmp/nm7/`. Preserve the source/owner naming and copy rules of AGENTS.md.
+
+**Primary chain:** installed app → real input → Interactive photo → parameter commit → Quality →
+cache clear → reopen/rebuild → same final photo.
+
+**Exit:** NM8 receives exact platforms, commands, fixtures, latency distributions, storage bounds,
+and explicitly unexecuted platform checks. No quality reduction or hidden raster-history cache.
+
+## 11. Acceptance matrix and independent oracles
+
+Test implementation and expected outputs must not share the same bug. Use independent analytic
+calculations at chosen sample points and hand-specified R8 dab results, not production geometry
+helpers to generate both sides of a comparison.
+
+| Area | Required cases | Evidence / tolerance |
+| --- | --- | --- |
+| Mapping | landscape/portrait; crop/rotation/orientation; fit/actual/zoomed; pan; DPR 1/1.25/1.5/2; DetailPatch | Reference and item round-trip tolerances in NM7.5; exact identity preservation |
+| Analytic coverage | Radial center/inside/feather/outside and rotated axes; Linear both ends/midpoint/direction | Independent scalar formulas; R8 error ≤ 1 code value unless existing tests are stricter |
+| Brush pixels | multiple strokes on one MaskId, size/strength changes, click, sparse/dense events, overlaps, duplicates, hard/soft edge, erase, zero changes | Exact R8 bytes for deterministic raster output; different event grouping gives same bytes |
+| Native runtime | CUDA/OpenCL/Metal, one/many Masks, two Grades, invert/opacity/feather, current-cache/fresh-replay | Existing NM3 numerical tolerances; record backend and runtime actually used |
+| Overlay | finite vertices, winding, clipping, alpha seams, constant handle widths, next available Qt frame | Geometry assertions plus accelerated window captures; contour deviation ≤ 0.25 logical px |
+| Movement | existing Brush/Radial/Gradient; old/new domains; repeated translation; press/move/release | Interactive pixels update before release; controls only, no coverage fill; one final commit |
+| Project cache | custom root, Clear, close cleanup, two projects, repeated Versions | Stable file count; delete-all-cache restores same history/coverage; no cross-project deletion |
+| Input | press under threshold, outside release, canceled grab, synthesized mouse, second touch, repeated Done | One source stream and exactly one terminal outcome; no duplicate commit |
+| Ownership | held GPU/request reader, late callback, load/checkout during settle, new image with reused IDs | No simultaneous raster read/write or live mutation/render; no stale publication |
+| History | creation, later edit, delete, cancel, no-op, Undo/Redo, cache corruption, WAL failure | Exact commit counts/HEAD, canonical document values and replayed expected coverage with no prior cache |
+| UI | header/node entry, six tabs, stable rows, focus, renamed/missing target, two themes/reduced motion | Production QML load; load-only emits zero commands/renders; actual reachable control path |
+| Persistence | reopen, two Versions, Paste, export | Same settled source-derived coverage; target RAW metadata retained; no overlay in exported pixels |
+
+For final RGB comparisons use existing pipeline fixture tolerances and record max/mean error plus
+failure coordinates. Do not loosen tolerances merely because R8 edges make a visual mismatch
+noticeable. Separate contour quantization tolerance from wrong transforms, wrong target or stale data.
+
+No native execution is required for this documentation-only change. During execution, discover
+registered targets with `ctest -N` and inspect CMake before naming exact commands in records.
+Use repository macOS presets and the MSVC wrapper on Windows. New tests must have behavior-specific
+names and be registered; a filter that executes zero tests is not qualification.
+
+## 12. Performance and resource evidence
+
+Preserve NM6's 16 ms total Interactive cycle target, including owner consumption, invalidation,
+Mask work, Grade processing and safe completion. Measure separately:
+
+- Qt event to overlay synchronization/presentation;
+- enqueue to owner consume and queue depth/sample backlog;
+- sample processing/raster update, dirty upload bytes and actual feather work;
+- owner cycle total and Qt photo presentation latency;
+- release to durable parameter commit and Quality presentation; coalesced cache publication separately;
+- current CPU raster bytes, pending sample bytes, QSG vertices/nodes, native allocations/leases.
+
+Run identical fixed sample paths on the same RAW/view/backend/build: one Mask and many Masks;
+small Brush and large soft Brush; cold and warm runtime; first and subsequent parameterized edits. Report
+p50/p95/max and actual operation counts. Do not compare Debug CUDA to Release Metal as a performance
+conclusion. Deliberately hold a render to prove overlay input and cancellation stay responsive.
+
+Expected bounds: no unnecessary full-raster copy/upload for local moves; full-domain changes
+and required feather work are measured explicitly, no R8 history file per stroke, no
+per-frame entire-stroke QML object rebuild, no repeated whole-prefix history copies, no overlapping
+owner cycles, and no valid upstream Interactive-result eviction. Initial texture creation and
+algorithm-required wide feather processing must be reported separately from local source uploads.
+If resources cannot satisfy a complete operation, report the error and restore unfinished work;
+do not drop data, lower quality or switch the backend.
+
+## 13. Failure matrix and completion record template
+
+| Failure | Required committed state | Required user/session behavior |
+| --- | --- | --- |
+| Invalid target / transform / fields | Unchanged | Precise rejection; no provisional half-Mask |
+| Cancel before owner consume | Unchanged | Drop queued sequence; no restore render needed |
+| Cancel after provisional application | Original state restored | Restore frame if pixels changed; no commit |
+| Required R8/scratch allocation failure | Original source remains recoverable | Restore unfinished operation if needed; real error; no lower quality |
+| Cache write failure | Durable parameter HEAD retained | Report I/O error, keep dirty status; no alternate directory or history rollback |
+| Stale cache-job completion | New session untouched | Reject old generation; release temp files/readers through project cache owner |
+| History persistence failure | Existing NM4 durable/restore rules | Never falsely report success; retain real error |
+| GPU failure before/after settle | No invalid output published; valid durable commit retained | Real backend error; no alternate evaluator |
+| Scene graph invalidation | Document/history unchanged | Recreate display geometry on next valid scene |
+
+Each executor appends this record under its sub-phase; do not replace planned tests with a vague
+“tested” line:
+
+```text
+NM7.x completion record
+Date / commit / platform / Qt version / native backend / build type:
+Status: planned | in progress | complete
+Resolved decisions and actual files/APIs:
+Primary success call chain:
+Primary cancel/failure call chain:
+Test name -> registered target -> command -> executed count -> result:
+Reference fixture / expected output / tolerance:
+Resource and latency measurements where applicable:
+Source/header ownership and naming checks:
+Remaining gaps and next dependency:
+```
+
+Global NM7 completion checklist:
+
+- [ ] Section 2 approved decisions are reflected in the master/UI specification and implementation.
+- [ ] All three source types work in the real viewer on the selected exact Color Grade.
+- [ ] QSG input/geometry, actual evaluator and ReferenceSpace agree.
+- [ ] Brush canonical input, parameterized strokes, one current Grade R8 slot, regional replay and reader ownership are proven.
+- [ ] Creation, each edit/stroke, cancellation and deletion have the specified history outcome.
+- [ ] Stale inputs, cache jobs and frames cannot cross image/Version/sequence boundaries.
+- [ ] UI entry points, accessibility, six-tab behavior and load-only selection restore are tested.
+- [ ] Native runtime, cacheless persistence/recovery and exported pixels pass the acceptance matrix.
+- [ ] One thousand strokes/Undo/Redo do not create per-step R8 files or pixel history.
+- [ ] Per-project paths, retain/close-cleanup/Clear and stale-writer rejection are qualified.
+- [ ] Resource/performance records include real platform results and no quality substitutions.
+- [ ] New headers include defining headers unless a documented include-cycle/PIMPL exception applies.
+- [ ] Added copies have the concrete owner/lifetime/consistency purpose specified in Section 5.1.
+- [ ] Touched first-party names and roadmap text/links satisfy repository terminology rules.
+- [ ] Master NM7 status and NM8 handoff accurately distinguish completion from remaining evidence.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,8 +2,8 @@
 
 Date: 2026-09-08
 
-Status: NM7.1 complete; NM7.2–NM7.14 planned. This document records the NM7.1 source
-audit and format-boundary evidence. Remaining sub-phases are unimplemented.
+Status: NM7.1–NM7.2 complete; NM7.3–NM7.14 planned. This document records the NM7.1 source
+audit and NM7.2 parameterized Brush owner operations. Remaining sub-phases are unimplemented.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -662,6 +662,74 @@ proposed `brush_stroke.hpp` / `brush_mask_commands.hpp`; include defining header
 `InvalidStrokeDoesNotPartiallyMutateSource`, `BrushTranslationDoesNotCopyOrRewriteSamples`.
 
 **Exit:** one Brush per new Grade workflow; source can be read independently of `MaskStore`.
+
+##### Phase NM7.2 completion record (2026-09-08)
+
+**Status:** complete — parameterized Brush strokes, versions, and placement are owned by
+`ColorGradeNodeModel`; JSON round-trips without `MaskStore`. Raster-only `asset_key` encoding
+remains for existing documents until NM7.3.
+
+**Primary success call chain:**
+
+```text
+AppendBrushStroke / InsertBrushStroke / RemoveBrushStroke / SetBrushTranslation
+  -> ColorGradeNodeModel (exact NodeId, MaskId, StrokeId, before-revision)
+  -> validate complete stroke or translation on a candidate source
+  -> commit source on the Grade Mask + one MaskContentRevision bump
+  -> MaskModelToJson writes strokes/placement (no asset_key when payload is parameterized)
+```
+
+**Primary failure call chain:**
+
+```text
+wrong NodeId / MaskId / kind / revision, duplicate StrokeId, NaN/empty samples,
+unsupported algorithm version, or stale translation before-value
+  -> throw before live source assignment
+  -> Mask list, stroke bodies, and revision unchanged
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `BrushSourceRoundTripsWithoutRasterFiles` | `BrushParameterizedSourceTest` | PASS |
+| `BrushAppendKeepsExistingStrokeIds` | `BrushParameterizedSourceTest` | PASS |
+| `InvalidStrokeDoesNotPartiallyMutateSource` | `BrushParameterizedSourceTest` | PASS |
+| `BrushTranslationDoesNotCopyOrRewriteSamples` | `BrushParameterizedSourceTest` | PASS |
+| Insert/remove keep remaining sample bodies | `BrushParameterizedSourceTest` | PASS |
+| Unsupported algorithm/version JSON rejected | `BrushParameterizedSourceTest` | PASS |
+| Asset-key documents still omit stroke fields | `BrushSourceFormatBoundaryTest` | PASS |
+| Malformed stroke fields on asset Brush rejected | `BrushSourceFormatBoundaryTest` | PASS |
+| Typed batch canonical dump matches stored expected JSON | `PipelineEditBatchTest` | PASS |
+| Grade Mask JSON round-trip and header hygiene | `GpuDagModelGraphTest` | PASS |
+| Result content key still distinguishes Mask edits | `GpuDagRawInputTest` | PASS |
+| Persistent asset-key collection still omits empty Brush | `PipelineHistoryApplierTest` | PASS |
+
+Commands:
+`cmd /c scripts\msvc_env.cmd --preset win_debug`
+`cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target BrushParameterizedSourceTest --target BrushSourceFormatBoundaryTest --target GpuDagModelGraphTest --target PipelineEditBatchTest`
+`ctest --test-dir build/debug -R "BrushParameterizedSourceTest|BrushSourceFormatBoundaryTest|GpuDagModelGraphTest|PipelineEditBatchTest" --output-on-failure`
+`cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagRawInputTest --target PipelineHistoryApplierTest`
+`ctest --test-dir build/debug -R "GpuDagRawInputTest|PipelineHistoryApplierTest" --output-on-failure`
+
+Suite totals: `6/6` `BrushParameterizedSourceTest` PASS; `12/12` `BrushSourceFormatBoundaryTest` PASS;
+`101/101` combined first filter PASS; `151/151` `GpuDagRawInputTest`+`PipelineHistoryApplierTest` PASS.
+Date / HEAD `f3d93ca2` (working tree) / Windows MSVC `win_debug` / Qt 6.9.3 / CUDA Toolkit 12.8
+(no GPU tests in this phase).
+
+**Checklist / exit condition:** parameterized Brush source is readable without `MaskStore`; append
+targets an existing MaskId (one accumulating Brush for new workflows). Multiple existing Brush
+Masks stay independent. Raster-only `asset_key` JSON is still accepted at document format 5.
+
+**LOC note (grill-code-review):** `brush_stroke.hpp` 151, `brush_stroke.cpp` 193,
+`brush_mask_commands.hpp` 71, `mask_model.hpp` 215, `mask_model.cpp` 533,
+`color_grade_node_model.hpp` 249, `color_grade_node_model.cpp` 503,
+`brush_parameterized_source_test.cpp` 305. No split required.
+
+**Residual gaps:** NM7.3 must add typed history/WAL/Version operations and the Section 8.1
+version gate, and reject raster-only Brush input. Native Mask passes still load `MaskStore` by
+`asset_key` when present. Ordinary adjustment writes still reject Mask targets with the existing
+“until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.3 — Extend NM4 reversible history and persistence
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
@@ -1,4 +1,4 @@
-# Node-aware Pipeline Editing and Mask Authoring Master Plan
+# Node-aware Pipeline Editing and Mask Creation Master Plan
 
 Date: 2026-08-29
 
@@ -19,6 +19,18 @@ disk cache service 拥有写回/失效机制；不在 R 中实施，也不作为
 2026-09-02 UI revision: NM4 is complete. The approved node-editor UI, VI mapping,
 QuickQanava boundary, and official documentation sources for NM5-NM8 are fixed before NM5 starts.
 See the [NM5 execution plan](node_mask_editor/phase_nm5_nodes_panel_plan.md) for its sub-phases.
+
+2026-09-08 NM7 revised user direction: the
+[NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md) now has fourteen
+sub-phases and a companion [algorithm/storage design](node_mask_editor/mask_command_replay_and_project_cache_plan.md).
+Brush paths are parameterized; NM4 records reversible stroke/placement commands. R8 is one
+current Grade Mix cache slot, never a per-stroke Undo asset. Project settings own its root and
+cleanup policy. Moving existing Brush/Radial/Gradient masks updates actual Interactive pixels;
+QSG displays controls without affected-area highlighting. Center-out Radial creation, adjustable
+Brush size/strength with paint/erase, and the temporary Masks body/six tabs remain approved.
+This supersedes the earlier immutable-raster-history requirement in Sections 8–12 and NM7.
+NM3/NM4 completion records remain historical evidence; their source/history/cache interfaces
+must be extended inside NM7 before exposing its UI. NM7 remains planned.
 
 2026-09-05 NM6 design approval: NM5 is complete. The
 [NM6 execution plan](node_mask_editor/phase_nm6_node_aware_adjustments_plan.md) now defines
@@ -169,13 +181,15 @@ NM4 才完成 history 对新图的持久化和重放，不能为填阶段空缺�
 现有 adjustment transfer merge 也以 stage/operator 字段冲突为核心。两个独立图之间没有
 足够自然、稳定的自动合并定义，因此本方案删除新的管线 merge 产品操作，只保留 Paste。
 
-### 2.7 MaskStore 写入语义不适合直接 Undo raster stroke
+### 2.7 Brush 持久源必须与 R8 缓存分离
 
-现有 `MaskStore::Save()` 接受调用者提供的 key，并原子替换同名文件。如果 history 只保存
-这个 key，后续 stroke 覆盖同一文件后，Undo 无法恢复旧像素。
+NM3/NM4 已实现不可变、内容寻址的 Mask asset 及 key replacement history。这解决了同名文件
+覆盖破坏 Undo 的问题，但每 stroke 持有完整 R8 会使存储随历史快速增长。2026-09-08 用户明确
+更改方向：持久保存参数化 Brush 路径及可逆命令，R8 只缓存当前 Grade Mix 结果。
 
-Raster mask 必须变为不可变、按内容寻址的资源：每次 settled stroke 产生一个新
-`MaskAssetKey`，历史只在新旧 key 之间切换。
+擦除、max/min 和量化不可直接从像素求逆。Undo 在模型层恢复操作，再按原顺序重放影响区域；
+不产生每步栅格或 tile history checkpoint。项目级路径/清理设置只能删除可重建缓存，不能把
+没有参数源的历史原始 asset 当成缓存删除。算法和格式前置条件由 NM7 详细方案负责。
 
 ### 2.8 Viewer 已有正确的扩展位置
 
@@ -187,7 +201,7 @@ EditorInteractionController    图像空间与输入状态
 EditorOverlayItem              retained QSG 辅助几何
 ```
 
-蒙版 authoring 应继续扩展这个结构，而不是在 QML 中创建第二套坐标系统或把辅助层烘焙到
+蒙版 creation 应继续扩展这个结构，而不是在 QML 中创建第二套坐标系统或把辅助层烘焙到
 最终照片帧。
 
 ---
@@ -277,7 +291,7 @@ Application layer
   EditorNodeController
   EditorAdjustmentContext
   EditorPipelineCommandService
-  EditorMaskAuthoringController
+  EditorMaskCreationController
   EditorHistory projection
           ↓ typed mutations
 Edit model
@@ -291,8 +305,8 @@ Runtime
   GraphCompiler
   ExecutionPlan
   CUDA / OpenCL / Metal workspaces
-          ↓ assets
-MaskStore
+          ↓ current derived coverage
+ProjectMaskCacheService (one current R8 slot per image / Grade)
 ```
 
 QuickQanava 处于 QML 和 app projection 之间。它负责节点图的视觉交互，不拥有
@@ -466,8 +480,11 @@ using MaskSource = std::variant<BrushMaskSource,
                                 LinearGradientMaskSource>;
 ```
 
-Brush 的长期结果是不可变 R8 asset；当前输入序列还可以持有临时 stroke 和 dirty rectangle。
+Brush 长期保存有序参数化 stroke：稳定 StrokeId、paint/erase、规范采样点、radius/strength/
+hardness、算法版本及 Brush placement。多次 stroke 累积到同一个 Brush Mask，不逐笔创建新 Mask。
+整张 Brush 移动只修改 placement；Undo/Redo 恢复命令/参数后重算，不保留每笔 R8 revision。
 Radial 与 Linear Gradient 保存解析参数，在 ReferenceSpace 中求值。
+每个 Grade 用于 Mix 的最终 R8 是所有启用 Mask 合成后的唯一当前缓存，可从这些参数重建。
 
 所有 source 使用稳定的归一化图像空间或现有 ReferenceSpace 约定。viewer zoom、pan、DPR、
 动态渲染分辨率和 ROI 不得改变长期参数含义。
@@ -533,38 +550,41 @@ output = input + node_coverage × (adjusted - input)
 
 ---
 
-## 9. MaskStore 与 raster Undo
+## 9. 参数化蒙版、可逆命令与项目 R8 缓存
 
-Mask asset 必须不可变并按内容寻址：
+2026-09-08 修订取代“每 stroke 保存新完整 R8 asset”的原方案。
+完整算法见 [NM7 参数重放与项目缓存](node_mask_editor/mask_command_replay_and_project_cache_plan.md)。
 
 ```text
-MaskStore::Put(descriptor, pixels)
-  -> 计算内容 key
-  -> 已存在则验证并复用
-  -> 不存在则写完整临时文件、flush、原子发布
-  -> 返回 MaskAssetKey
+Brush canonical samples / analytic fields / placement
+  -> typed reversible command in NM4 history
+  -> ordered regional replay + native feather / Union
+  -> one current Grade coverage R8
+  -> native Mix -> Interactive / Quality photograph
 ```
 
-不得用同一个 key 覆盖不同像素。一次 settled brush stroke：
+### 9.1 可逆对象是命令
 
-1. 输入序列开始时记录旧 `MaskAssetKey`；
-2. pointer move 使用临时 raster buffer 和 dirty rectangle 更新实际预览；
-3. pointer release 生成完整新 asset；
-4. `Put()` 返回新 key；
-5. history 记录 `old_key -> new_key`；
-6. Undo/Redo 只替换引用；
-7. 请求 Quality render。
+追加笔画的 inverse 是移除该 StrokeId；删除笔画的 inverse 恢复原顺序与 samples；移动恢复
+before translation/center/origin。擦除或 Union 的 Undo 通过重新求值恢复被遮盖的早期贡献，
+不能从最终 R8 相减。空间索引只存 ID/span/bounds，不缓存历史像素。Feather 的完整邻域依赖
+仍必须求值，不能以局部 preview 或近似 blur 替代。
 
-Mask 资源回收必须按可达性进行，至少扫描：
+### 9.2 当前缓存而非历史文件
 
-- 每个 image root；
-- 所有 Version head 可达的 commit；
-- 当前 working state；
-- 未 materialize 的 recovery records；
-- 正在进行的 mask authoring session。
+每个 `(ProjectUUID, ImageId, NodeId)` 一个稳定的已发布文件槽。内部 fingerprint、算法版本、
+geometry 与 checksum 验证当前内容；文件名不按 stroke/commit/Version/hash 扩展。
+更新是合并后的原子替换，临时文件和 reader/writer lease 有明确释放，不保留历史栅格。
+参数提交不等待 R8 写回；删光新缓存后，重开、Undo/Redo、Version、Paste 都必须正确。
+QualityBase 继续遵守 NM6 在 RAW Develop 之后的持久结果缓存旁路规则。
 
-不能根据 host/GPU LRU 删除磁盘用户数据。资源回收必须是独立、可审计的 clean-exit 或维护
-操作。
+### 9.3 逐项目设置与清理
+
+`ProjectService` 拥有用户选择的 cache root、Keep/DeleteOnProjectClose 策略及管理入口。
+设置页支持按项目查看字节/文件数、Clear、改路径和项目删除时的缓存保留选择。
+新 cache 使用专有 project UUID namespace；项目 A 清理不影响 B、RAW、stroke 参数或 history。
+停止旧写入者并递增 generation 后再清理；旧任务不得复活已删除文件。路径不可用报告原错误，
+不切换全局 temp。当前旧 raster-only asset 没有参数可重建，不得通过新 cache 清理入口删除。
 
 ---
 
@@ -587,28 +607,26 @@ Mask 资源回收必须按可达性进行，至少扫描：
 蒙版编辑辅助层：
 
 ```text
-Brush cursor / path / radius / feather
-Radial center / radii / rotation / feather / handles
-Linear Gradient line / direction / transition / handles
+Brush cursor / Move handle / temporary initial-creation guides
+Radial center / radii / rotation / feather controls
+Linear Gradient origin / direction / transition controls
   -> EditorOverlayItem retained QSG nodes
 ```
 
 这里的 overlay 特指 viewer 上方的 QSG mask editing overlay；实际调色结果仍然是
 `EditorViewportItem` 显示的管线渲染帧。
 
-### 10.2 简单 source 直接由 QSG 绘制
+### 10.2 QSG 只绘制编辑控件
 
-Brush、Radial 和 Linear Gradient 的辅助范围都可以由 QSG 直接绘制：
+已有 Brush/Radial/Linear Gradient 移动或参数编辑时，QSG 只显示 handles、必要方向线和操作
+连线，不显示受影响区域填充、高亮、heatmap 或已完成 Brush 路径。控件随当前输入定位；
+实际影响通过同一 pipeline 的 Interactive 照片结果实时呈现，不等 release 才更新。
 
-- Brush cursor 和已经采样的 path/dabs 使用 retained geometry；
-- Brush radius 和 feather 使用与实际 mask 相同的半径、硬度和 feather 参数；
-- Radial 使用同一 center、major/minor radius、rotation 和 feather 公式；
-- Linear Gradient 使用同一方向、起止位置、transition 和 feather 公式；
-- 控制点和边界使用已有 overlay 视觉 token；
-- overlay 更新不得等待 pipeline render 完成。
+初次绘制暂定允许随输入变化的 cursor/轮廓/路径创建引导；该细节的澄清记录在 NM7 决策表。
+不以整片蒙版高亮代替照片结果。QSG 与 evaluator 使用同一 ReferenceSpace 映射和参数；
+创建引导若消费笔刷 samples，必须来自同一规范样本序列，不能另行采样原始事件。
 
-QSG 和实际 Mask evaluator 必须共享参数定义、坐标映射和数学函数说明。Brush QSG 与 raster
-生成器消费同一份归一化 `BrushStroke` samples，不能分别从原始 pointer event 推导两条 path。
+---
 
 ### 10.3 内容相关 coverage 留给未来请求
 
@@ -622,21 +640,22 @@ QSG 和实际 Mask evaluator 必须共享参数定义、坐标映射和数学函
 
 | 操作 | Mask editing overlay | 实际管线预览 |
 | --- | ---: | ---: |
-| 选中 Mask | 显示 | 不必立即渲染 |
-| 绘制 Brush | 显示 | Interactive |
-| 修改 Brush radius/feather | 显示 | Interactive |
-| 移动/缩放/旋转 Radial | 显示 | Interactive |
-| 修改 Radial feather | 显示 | Interactive |
-| 修改 Linear Gradient | 显示 | Interactive |
-| 修改 Mask opacity | 显示 | Interactive |
+| 选中已有 Mask | 仅控件 | 不必立即渲染 |
+| 初次绘制 Brush | 控件与暂时创建引导，无区域填充 | Interactive |
+| 修改已有 Brush placement/source feather | 仅控件，无区域高亮 | Interactive |
+| 修改未来 Brush size/strength | 仅工具控件 | 不改变已有像素；后续 samples 使用新值 |
+| 移动/缩放/旋转 Radial | 仅控件，无区域高亮 | Interactive |
+| 修改 Radial feather | 仅控件 | Interactive |
+| 修改 Linear Gradient | 仅控件，无区域高亮 | Interactive |
+| 修改 Mask opacity | 仅控件 | Interactive |
 | 未来修改 Color/Luminance Range | 显示内容相关 coverage | Interactive |
 | 修改 Exposure/Curve/LUT 等调色参数 | 隐藏 | Interactive |
-| pointer release / settled edit | 根据当前 authoring mode 显示 | Quality |
+| pointer release / settled edit | 根据当前 creation mode 显示 | Quality |
 | 删除/重新连接节点 | 隐藏 | Quality |
 | Escape 取消输入序列 | 恢复输入前状态 | 不生成 history commit |
 
 开始调色参数输入时隐藏 overlay，但保留 selected Mask 身份。输入结束后不自动重新显示；用户
-重新进入 Mask 工具或 viewer authoring mode 时再显示，避免遮挡调色判断。
+重新进入 Mask 工具或 viewer creation mode 时再显示，避免遮挡调色判断。
 
 ---
 
@@ -683,7 +702,9 @@ Mask mutation
   AddMask
   RemoveMask
   ReplaceMaskSourceParams
-  ReplaceMaskAsset
+  AppendBrushStroke
+  RemoveBrushStroke / InsertBrushStroke
+  SetBrushTranslation
 ```
 
 Mask 列表 UI 重排和 QuickQanava layout 不属于照片 mutation。
@@ -692,7 +713,7 @@ Mask 列表 UI 重排和 QuickQanava layout 不属于照片 mutation。
 
 原子性表示外部看不到半次修改，输入或结构失败能够恢复；不要求整图复制或多对象发布协议。
 
-1. 解析输入，通过 Model 规范化值，检查目标、参数所有权、连接与 asset 引用；
+1. 解析输入，通过 Model 规范化值，检查目标、参数所有权、连接与 stroke 身份/参数引用；
 2. 预先准备必要的局部参数、节点或资源，保留受影响的 before 数据；
 3. 在统一的 live pipeline 访问互斥范围内原地应用领域函数；
 4. 结构变化验证 graph/Mask 不变量，失败只恢复受影响对象；普通参数修改不做整图拓扑验证；
@@ -728,7 +749,7 @@ PastedPipelineDocument
 | Mask transform/feather/opacity provisional | Interactive |
 | Mask transform/feather/opacity settled | Quality |
 | Brush stroke provisional dirty region | Interactive |
-| Brush stroke settled asset | Quality |
+| Settled Brush command / Mask placement | Quality |
 | 添加/删除 Mask | Quality |
 | 添加/删除/重新连接 Color Grade | Quality |
 | Undo/Redo | Quality |
@@ -737,7 +758,7 @@ PastedPipelineDocument
 | node selection / rename | 不渲染；rename 只进 history 与否由 13.4 决定 |
 | graph node layout / pan / zoom | 不渲染 |
 
-结构变化使 static plan key 变化并重新编译。纯参数值、简单 mask 几何参数和 raster asset key
+结构变化使 static plan key 变化并重新编译。纯参数值、简单 mask 几何参数和 Brush stroke/placement
 变化只更新参数/content key，不应误触发与拓扑无关的 compiler 工作。
 
 ---
@@ -765,7 +786,7 @@ commit hash 对 canonical typed payload 计算。历史回放不能重新推断�
 - Color Grade enabled、mix 和参数修改；
 - Mask 添加、删除；
 - Mask source 参数修改；
-- settled Brush stroke 形成的新 asset key；
+- settled Brush stroke 的规范参数命令，以及 placement 的 before/after 字段；
 - Mask enabled、opacity、invert、feather 等长期参数；
 - 未来 Color Range 和 Luminance Range 修改；
 - 影响导出结果的 Document/Develop/DRT/Post 参数。
@@ -854,7 +875,7 @@ Paste 是“把一份可转移 PipelineDocument 写成目标图片的新 Version
 2. 保留目标 Develop endpoint 及其 RAW metadata/camera profile/lens identity；
 3. 从 transfer package 导入 Color Grade 主链、参数、Mask 和 DRT/Post 可转移参数；
 4. 按目标图片重新映射 NodeId、AdjustmentInstanceId 和 MaskId；
-5. 复制或复用内容寻址 MaskAsset；
+5. 转移参数化 stroke/source，重映射 StrokeId，不复制源项目 R8 缓存或绝对缓存路径；
 6. 验证目标 image backbone 和参数所有权；
 7. 创建一个新的 named Version；
 8. 将该 Version 设为 active；
@@ -864,7 +885,7 @@ Paste 是“把一份可转移 PipelineDocument 写成目标图片的新 Version
 Document geometry 默认不随 Paste 转移，避免把源图片比例和 crop 直接套到目标图片；如果产品
 以后需要“同时粘贴 Geometry”，应作为明确选项和独立 typed mutation 加入，不应隐式发生。
 
-Paste 失败时不得创建空 Version、部分 Mask asset 引用或移动 active Version。
+Paste 失败时不得创建空 Version、部分 stroke/source 引用或移动 active Version。
 
 ---
 
@@ -1352,7 +1373,7 @@ but do not form a history cache. See the NM6 plan for precise ownership, failure
 
 ---
 
-## 18. Mask authoring state machine
+## 18. Mask creation state machine
 
 QuickQanava does not draw the Mask overlay. NM7 uses the official
 [Graph `Data Model`](https://cneben.github.io/QuickQanava/graph.html) section and the
@@ -1360,7 +1381,7 @@ QuickQanava does not draw the Mask overlay. NM7 uses the official
 owner Color Grade selected. The Alcedo viewer architecture continues to own viewer input, QSG
 overlays, and Mask pixels.
 
-`EditorMaskAuthoringController` owns the state. Do not distribute this state across QML handlers.
+`EditorMaskCreationController` owns the state. Do not distribute this state across QML handlers.
 
 ```text
 Inactive
@@ -1380,8 +1401,8 @@ version_id / working head generation
 NodeId
 MaskId
 Mask source kind
-before parameters of the edited mask
-provisional params or stroke
+NM4-owned inverse fields / structural payload (no second before-state copy)
+queued changed fields or canonical stroke samples
 dirty rectangle
 ```
 
@@ -1390,35 +1411,42 @@ Creation uses this call chain:
 ```text
 select Color Grade
   -> choose Brush / Radial / Linear Gradient
-  -> AddMask typed mutation
-  -> enter authoring mode
+  -> enter creation mode (no document change yet)
+  -> first valid input applies provisional AddMask, or resumes the existing Brush
   -> viewer input updates provisional source
   -> QSG overlay updates immediately
   -> pipeline Interactive preview
-  -> settle to one history commit and Quality render
+  -> settle to one final AddMask/stroke/placement history commit and Quality render
 ```
 
 Use these interruption rules:
 
-- Settle or cancel authoring before image switch, Version checkout, Undo/Redo, or node deletion.
+- Settle or cancel creation before image switch, Version checkout, Undo/Redo, or node deletion.
 - Reject an asynchronous render result from a stale session generation.
 - Escape restores the before parameters of the edited Mask.
 - Delete removes the selected Mask by `NodeId` and `MaskId`. It does not use a row index as identity.
-- Viewer pan/zoom and Mask authoring use an explicit mode and focus route. They do not interpret the
+- Viewer pan/zoom and Mask creation use an explicit mode and focus route. They do not interpret the
   same pointer input.
 - A keyboard user can select a Mask, move a control point, change a value, and leave the mode.
 
 ### 18.1 Masks panel
 
-Masks is a right-side panel for the Color Grade context. Its controls do not become QuickQanava
-graph content.
+2026-09-08 user decision: Masks is a temporary right-side editing body for the Color Grade
+context. The existing header Brush/Radial/Gradient actions and node Mask rows open it; the six
+ordinary adjustment tabs remain unchanged. Done/Cancel restores the previous ordinary body.
+Its controls do not become QuickQanava graph content.
 
 The panel has this structure:
 
 1. A header shows `Masks`.
-2. Three fixed actions create Brush, Radial, or Linear Gradient Masks.
+2. The existing header actions enter Brush, Radial, or Linear Gradient creation. Brush resumes
+   the selected Grade's current accumulating Brush Mask if present. It creates no extra row per stroke.
 3. A list shows the Masks that the selected Color Grade owns.
-4. The selected row exposes only supported Mask controls, including opacity, rename, and delete.
+4. The selected row exposes supported Mask controls, including opacity, rename, and delete.
+   Brush supports paint/erase and adjustable size/strength; these tool settings affect subsequent
+   samples, while Mask opacity affects the entire accumulated raster. Multiple strokes on a Grade
+   merge into the same current Brush raster and keep its MaskId. Each settled stroke remains
+   independently undoable through parameter commands and regional replay; R8 is only current cache. Radial creation drags from center outward.
 5. A range area shows only fields that the product implements.
 
 The Mask list uses the existing recessed list well. A selected row uses
@@ -1430,9 +1458,9 @@ for one.
 After Mask add, delete, or reorder, update the owning node's Mask drawer rows. Update row identity,
 order, type, and label only. Do not add a Mask count. Do not rebuild the full graph.
 
-### 18.2 Viewer authoring bar
+### 18.2 Viewer creation bar
 
-In authoring mode, the viewer shows a compact authoring bar. It shows the source kind, selected
+In creation mode, the viewer shows a compact creation bar. It shows the source kind, selected
 Mask name, Done, and Cancel. Each value has its own text element. Do not join values with a
 decorative separator.
 
@@ -1440,7 +1468,7 @@ The bar uses `cardSurfaceColor`, `cardBorderColor`, and `panelRadius`. Done and 
 shared action components. Escape is equivalent to Cancel. Enter is equivalent to Done when the
 current source can settle.
 
-The authoring bar does not cover a primary control point. It does not change the viewer coordinate
+The creation bar does not cover a primary control point. It does not change the viewer coordinate
 space.
 
 ### 18.3 QSG overlay VI
@@ -1450,19 +1478,18 @@ needs them:
 
 - `maskOverlayControlColor`
 - `maskOverlayControlOutlineColor`
-- `maskOverlayCoverageColor`
 - `maskOverlayInactiveColor`
 
-Control points use a two-layer, high-contrast stroke. The coverage preview uses a visible alpha and
-an outline. Selection, invalid input, and disabled input also use shape or text. Color is not the
+Control points use a two-layer, high-contrast stroke. Existing-mask editing has no coverage fill
+or affected-area highlight. Selection, invalid input, and disabled input also use shape or text. Color is not the
 only cue. A small point that only reports status is not permitted.
 
-During adjustment input, hide the overlay as specified in Section 10.4. After authoring ends,
+During adjustment input, hide the overlay as specified in Section 10.4. After creation ends,
 restore the overlay from controller state.
 
 ### 18.4 Cross-panel input ownership
 
-After Mask authoring starts:
+After Mask creation starts:
 
 - Nodes keeps the current Color Grade selected.
 - Graph structure actions are temporarily unavailable.
@@ -1471,7 +1498,7 @@ After Mask authoring starts:
 - The viewer receives Mask input.
 - History and Version checkout obey the settle-or-cancel rules.
 
-After authoring ends, graph input becomes available. Reject input and render results from an old
+After creation ends, graph input becomes available. Reject input and render results from an old
 session generation.
 
 ---
@@ -1489,7 +1516,7 @@ The new `PipelineDocument` schema stores at least:
 - each Color Grade Mask list;
 - each `MaskId`, source, enabled value, and opacity;
 - direct `color_range` and `luminance_range` fields;
-- each raster `MaskAssetKey` and descriptor;
+- canonical Brush stroke data, stable StrokeIds, algorithm version and placement;
 - DRT/Post and post-processing parameters.
 
 It does not store:
@@ -1503,7 +1530,9 @@ It does not store:
 - a render request;
 - the active panel page.
 
-NM4 changes the document, history, and project-metadata formats after node, Mask, and history data
+NM7 extends the NM4 document, history, and project-metadata formats for parameterized Mask data.
+The existing NM4 format cutover record below describes its earlier implementation. NM4 changed
+the document, history, and project-metadata formats after node, Mask, and history data
 are ready. The new release creates and reads only the new project format. The project-open boundary
 returns an unsupported-format error for an old project. It does not convert the current v2 or stage
 project and does not recalculate an old commit.
@@ -1550,9 +1579,9 @@ AdjustmentSlider
 ### 20.3 Edit a Radial Mask
 
 ```text
-Masks panel selects Radial
-  -> AddMask(NodeId, MaskId, Radial params)
-  -> viewer authoring mode
+Header action selects Radial
+  -> viewer creation mode and temporary Masks body
+  -> first valid input applies provisional AddMask(NodeId, MaskId, Radial params)
   -> pointer input mapped to ReferenceSpace
   -> provisional params shared by QSG + pipeline
   -> QSG overlay next frame
@@ -1567,14 +1596,14 @@ Masks panel selects Radial
 ```text
 pointer samples
   -> normalized BrushStroke
-  -> QSG retained path/dabs
-  -> temporary raster dirty rectangle
+  -> append provisional parameterized stroke
+  -> QSG controls / allowed initial-creation guides
+  -> regional replay into current Grade coverage
   -> InteractiveMaskEdit render
   -> pointer release
-  -> MaskStore::Put complete R8 asset
-  -> ReplaceMaskAsset(old_key, new_key)
-  -> one edit commit
+  -> one AddMask / AppendBrushStroke parameter commit
   -> Quality render
+  -> coalesced stable project cache write at idle/save/close
 ```
 
 ### 20.5 Version checkout
@@ -1583,7 +1612,7 @@ pointer samples
 Version selected
   -> finish/cancel provisional input
   -> reset the same live document to initial state and apply first-parent commits
-  -> validate graph/assets
+  -> validate graph / parameterized sources
   -> finish WAL/history head move; failure restores prior state through existing operations
   -> replace node/context/history projections
   -> VersionDocumentChanged Quality render
@@ -1594,8 +1623,8 @@ Version selected
 ```text
 Adjustment Transfer Paste
   -> read target initial state and image metadata
-  -> import transferable grade chain + DRT/Post params + Mask assets
-  -> remap IDs
+  -> import transferable grade chain + DRT/Post params + Mask stroke/source parameters
+  -> remap NodeId / MaskId / StrokeId
   -> validate local changes and apply to the same live document
   -> create and activate new Version
   -> finish WAL/history operation and use normal persistence
@@ -1623,7 +1652,7 @@ path with a Markdown link when the file exists.
 | NM4 — History, Version, Recovery, and Paste | complete | [node_mask_editor/phase_nm4_history_version_paste_plan.md](node_mask_editor/phase_nm4_history_version_paste_plan.md) | Complete typed history, one DAG per Version, recovery, and Paste-only transfer. |
 | NM5 — QuickQanava Nodes Panel | complete 2026-09-05 | [node_mask_editor/phase_nm5_nodes_panel_plan.md](node_mask_editor/phase_nm5_nodes_panel_plan.md) | Connect the left Nodes panel to the real command, history, and render paths. |
 | NM6 — Node-aware Adjustment Stack | in progress (NM6.1 complete 2026-09-05) | [node_mask_editor/phase_nm6_node_aware_adjustments_plan.md](node_mask_editor/phase_nm6_node_aware_adjustments_plan.md) | Add node-aware panels and EXIF header with serial Interactive input, shared backend execution, and dependency-version caches. |
-| NM7 — Viewer Mask Authoring | planned | `node_mask_editor/phase_nm7_viewer_mask_authoring_plan.md` | Connect Brush, Radial, and Linear Gradient authoring to QSG overlays, Interactive and Quality rendering, and history. |
+| NM7 — Viewer Mask Creation | planned | [NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md) | Parameterized reversible Masks, current project R8 cache, control-only QSG and real Interactive movement. |
 | NM8 — Product Qualification and Cutover | planned | `node_mask_editor/phase_nm8_product_qualification_plan.md` | Qualify all three backends, real RAW files, reopen, Version, Paste, performance, and package behavior. |
 
 ### 21.1 Phase NM0 — QuickQanava Integration Baseline
@@ -1901,15 +1930,23 @@ current-result storage. Runtime/platform evidence is required; this design appro
   use topology observations only to refresh the visual selection. They do not replace the
   application snapshot signal.
 
-### 21.8 Phase NM7 — Viewer Mask Authoring
+### 21.8 Phase NM7 — Viewer Mask Creation
 
-**Reason for this position:** Viewer authoring needs the selected-node context, multi-Mask runtime,
-immutable `MaskStore`, typed history, and Interactive and Quality rendering. A missing dependency
+2026-09-08 revision: NM7.2–NM7.4 extend the historical NM3/NM4 source/history interfaces before
+viewer integration; NM7.9–NM7.10 replace per-source/history raster retention with current project
+coverage cache. Historical NM3/NM4 asset tests do not qualify the new parameter format.
+
+
+**Reason for this position:** Viewer creation needs the selected-node context, multi-Mask runtime,
+parameterized source/history extensions, project cache ownership, and Interactive/Quality rendering. A missing dependency
 would produce an edit that cannot restore or preview correctly.
 
-**Scope:** Add the Masks panel actions, Brush, Radial, and Linear Gradient creation, viewer input
-routing, `ReferenceSpace` mapping, QSG Mask-editing overlay, provisional raster dirty rectangle,
-settled asset, Escape cancellation, mode interruption, and stale-session fencing. Hide the overlay
+**Scope:** Follow the [NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md).
+Connect the header actions and node Mask rows to a temporary Masks editing body while preserving
+the six ordinary adjustment tabs. Add Brush paint/erase with adjustable size and strength; accumulate
+all strokes for a Color Grade in one current Brush raster. Add center-out Radial creation, Linear
+Gradient creation, viewer input routing, `ReferenceSpace` mapping, QSG Mask-editing overlay, provisional raster dirty rectangle,
+settled parameter commands, project cache settings/cleanup, Escape cancellation, mode interruption, and stale-session fencing. Hide the overlay
 during adjustment input. Use the approved Mask type icons. Do not add an unrequested pill, badge,
 chip, tag, or status dot.
 
@@ -1922,7 +1959,7 @@ not create a commit. Image and Version changes reject old results.
 - [Graph `Data Model`](https://cneben.github.io/QuickQanava/graph.html): a Mask stays in the Alcedo
   model. It does not enter Qan topology.
 - [Nodes/Groups `Selection`](https://cneben.github.io/QuickQanava/nodes.html): keep the owner Color
-  Grade selected during authoring.
+  Grade selected during creation.
 
 QuickQanava does not own viewer input, the QSG overlay, or Mask coverage. NM7 does not infer these
 features from QuickQanava examples.
@@ -1930,7 +1967,7 @@ features from QuickQanava examples.
 ### 21.9 Phase NM8 — Product Qualification and Cutover
 
 **Reason for a separate phase:** Unit and component tests cannot prove that the packaged
-QuickQanava module, real RAW input, all backends, history recovery, Mask assets, and final frame use
+QuickQanava module, real RAW input, all backends, history recovery, parameterized Masks, and final frame use
 one correct product path.
 
 **Scope:** Run all tests in Section 23 and the real-RAW end-to-end cases. Record evidence for
@@ -1939,7 +1976,7 @@ cache behavior. Remove old UI and service paths that an earlier phase explicitly
 this document with the completion record.
 
 **Exit criteria:** All global completion criteria in Section 26 pass. There is no legacy-stage
-write-back, single-primary-Color-Grade product branch, mutable raster key, new merge UI, or substitute
+write-back, single-primary-Color-Grade product branch, per-stroke raster history, new merge UI, or substitute
 backend or CPU path.
 
 **Required official QuickQanava documentation:**
@@ -1966,7 +2003,7 @@ NM0 QuickQanava baseline
   -> NM4 History, Version, recovery, and Paste
   -> NM5 QuickQanava Nodes panel
   -> NM6 Node-aware adjustment stack
-  -> NM7 Viewer mask authoring
+  -> NM7 Viewer mask creation
   -> NM8 Product qualification and cutover
 ```
 
@@ -2009,7 +2046,7 @@ feature/color-grade-mask-union
 refactor/pipeline-edit-payload
 feature/editor-nodes-rail-panel
 feature/node-adjustment-context
-feature/radial-mask-viewer-authoring
+feature/radial-mask-viewer-creation
 ```
 
 实施以逐个合入 main 的 PR 为默认方式。只有同一执行方案内部确实无法独立评审的 2–3 个紧密
@@ -2038,7 +2075,7 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - 中间 Color Grade 无 DRT/Post 专属 adjustment；
 - 多 Mask Union 与 CPU reference 一致；
 - zero masks、all-disabled masks、one/many enabled masks 的边界行为；
-- MaskStore 同内容复用 key，不同内容不能覆盖旧 key；
+- 参数化 stroke 可重放；每 Grade 一个当前 R8 槽；删除新缓存不破坏 Undo/Redo；
 - 当前受支持格式的 JSON round-trip；旧项目 metadata 在入口被拒绝。
 
 ### 23.2 Runtime/backend tests
@@ -2059,7 +2096,7 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - Version checkout 得到对应 DAG，而不是当前全局 graph；
 - root Version 始终得到三节点默认文档；
 - Paste 创建新 Version，保留目标 Develop metadata；
-- Paste remap 后无 ID 冲突，Mask asset 可读取；
+- Paste remap 后 NodeId/MaskId/StrokeId 无冲突，无缓存仍能重建 coverage；
 - 不再创建新的 merge commit；
 - 旧项目拒绝打开，不迁移旧 stage/merge 提交；
 - journal/recovery/reopen 后 checkpoint 的 commit 标签与 history HEAD 对应，document 等于该提交链的重放结果。
@@ -2081,8 +2118,8 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 
 - item/logical -> image UV -> ReferenceSpace 映射在 zoom/pan/DPR 下稳定；
 - QSG Radial/Linear 边界与实际 evaluator 使用相同参数；
-- Brush QSG 和 rasterizer 使用同一 sample 序列；
-- mask input 期间 overlay 可见，grade slider 期间隐藏；
+- 初次 Brush 创建引导与 rasterizer 使用同一规范 sample 序列；已有 Mask 不显示影响区高亮；
+- 已有 Brush/Radial/Gradient 移动时仅控件可见，照片 Interactive 实时更新；grade slider 隐藏控件；
 - stale session/result 不污染新 image/Version；
 - pointer release 只产生一次 settled commit；
 - Escape 恢复 before state 且不产生 commit；
@@ -2098,12 +2135,12 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 4. 修改新节点 Exposure，验证只有该节点参数变化；
 5. 添加 Radial、Linear Gradient 和 Brush Mask；
 6. 验证多个 Mask 扩展同一节点范围；
-7. 调整大小/位置/feather 时显示 overlay 和实际 Interactive 结果；
+7. 移动已有 Brush/Radial/Gradient 以及修改 feather 时仅显示控件，照片 Interactive 实时改变；
 8. 调整 grade 参数时 overlay 隐藏；
 9. 删除、重新连接节点并 Undo/Redo；
 10. 创建/切换 Version，验证不同 DAG；
 11. Paste 到另一张 RAW 的新 Version，验证目标 RAW metadata 保留；
-12. 保存、关闭、重开，验证 history、Version、DAG、Mask assets 和最终帧；
+12. 保存、关闭、重开，验证 history、Version、DAG、Brush 参数命令和最终帧；清空项目 R8 后仍可恢复；
 13. 在 Windows/CUDA 与 macOS/Metal 执行产品路径；OpenCL 执行对应集成和一致性测试。
 
 ---
@@ -2115,7 +2152,8 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - parameter-only change 不重建全部 QuickQanava graph；
 - history projection 不监听每帧 render/busy 通知；
 - Brush provisional update 合并 dirty rectangle；
-- settled stroke 只保存一次完整新 asset；
+- settled stroke 仅持久化新增参数命令，不产生新 R8 历史文件；
+- 每项目/图片/Grade 稳定 R8 槽合并写回，千次操作及 Version 切换不增加每步文件；
 - graph static plan 只在 topology/adjustment structure 改变时重建；
 - 多 Color Grade 会话结果按输出身份、依赖变化版本和表示条件验证；不逐帧序列化或哈希整个节点参数体；
 - UI 滑动只更新局部显示并入队；owner 在帧间消费参数，应用、失效处理与渲染严格串行；
@@ -2156,9 +2194,11 @@ NM1.4 删除整图复制和产品 Apply 的 stage 覆盖，再复用后台 execu
 
 处理：共享坐标、参数和公式；使用有明确容差的参考结果测试同时验证 overlay 输入与 evaluator 输出。
 
-### 25.4 Brush asset 可变导致 Undo 损坏
+### 25.4 把缓存误当作历史源导致数据丢失或文件膨胀
 
-处理：N3 在 UI 绘制前完成 content-addressed immutable `Put()`；不允许临时继续覆盖同 key。
+处理：NM7 保存参数化 samples 和可逆命令；R8 是可删除的当前缓存。禁止每步 R8 或像素差分
+历史。缓存清理只能作用于新 cache namespace，不能删除不可重建的旧 asset。先完成 schema、
+WAL/Version/Paste 和 cacheless recovery，再暴露 UI。
 
 ### 25.5 QuickQanava 变成第二份 graph 状态
 
@@ -2191,14 +2231,15 @@ transfer package 显式列出可转移内容。
 - [ ] DRT/Post 专属调整不能出现在中间 Color Grade。
 - [ ] 一个 Color Grade 支持多个 Mask，组合只有 Union。
 - [ ] `color_range` 和 `luminance_range` 是 Mask 的两个直接预留字段。
-- [ ] Brush/Radial/Linear Gradient 的简单辅助范围由 QSG 直接绘制。
+- [ ] 已有 Mask 编辑的 QSG 只显示控件，无影响区域高亮；创建引导遵循 NM7 决策。
 - [ ] 实际蒙版调整通过统一接口产生 Interactive/Quality 结果。
 - [ ] 调色参数输入时不显示 mask editing overlay。
 - [ ] node topology 修改直接请求 Quality render。
 - [ ] node、Mask 和参数操作都能生成准确 history row 并 Undo/Redo。
 - [ ] 每个 Version 对应自己的 DAG，root/new default Version 对应三节点文档。
 - [ ] Adjustment Transfer 只创建 Paste Version，不再创建新的 pipeline merge commit。
-- [ ] Mask raster asset 不可变，stroke Undo/Redo 不依赖被覆盖文件。
+- [ ] Brush source 参数化，Undo/Redo 是可逆命令与重放，不生成每 stroke R8。
+- [ ] 每 Grade 一个当前 Mix R8 槽；项目路径/保留/清理策略与 cacheless recovery 验收通过。
 - [ ] CUDA、OpenCL、Metal 不使用 CPU 或其他 backend 替代路径。
 - [ ] 旧项目 metadata 在打开入口拒绝；当前格式坏图真实失败；产品路径不使用 stage 镜像。
 - [ ] Windows/macOS package 可加载 QuickQanava QML module 和全部新 panel。


### PR DESCRIPTION
## Summary

- Add a canonical Brush stroke model (paint/erase modes, shared sample bodies) with validation and JSON round-trip.
- Persist strokes and `placement_translation` on `ColorGradeNodeModel` via revision-gated commands: append, insert, remove, and set translation.
- Lock parameterized Brush source identity at format version 1 and raster algorithm version 1; characterize asset-key vs stroke-only JSON shapes.
- Add brush raster encoding helpers: dab coverage, R8 quantization, canonical raster extent (4096 cap), feather texel scaling, and packed R8 bilinear sampling.
- Mix stroke payloads into mask result content keys so parameterized edits invalidate cached results.
- Preserve legacy raster-only Brush JSON when no parameterized payload is present.
- Document NM7 mask creation, command replay, and project cache planning.

## Testing

- `ctest --test-dir build/debug -R 'BrushParameterizedSourceTest\.|BrushSourceFormatBoundaryTest\.' --output-on-failure`
- `BrushParameterizedSourceTest`: stroke JSON round-trip without raster files; append keeps existing stroke sample bodies; invalid commands leave the mask unchanged; translation is a no-copy metadata update; insert/remove preserve remaining bodies; unsupported algorithm version rejected.
- `BrushSourceFormatBoundaryTest`: published format constants; legacy asset-key brush JSON omits stroke fields; malformed stroke fields rejected; dab coverage and R8 bilinear sampling match native rules; canonical extent caps long edge at 4096.
- Editor brush UI and live raster replay: Not run (model/encoding layer only).
- Full `ctest --test-dir build/debug`: Not run.