### PR TITLE
feat(edit): add regional brush mask replay and grade coverage

### DIFF
--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -40,6 +40,12 @@ def_library(EditMaskStore
         ${ALCEDO_SRC_ROOT}/edit/mask/mask_model.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_stroke.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_raster_encoding.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/brush_source_geometry.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/brush_canonical_sampler.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/brush_spatial_index.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/brush_rasterizer.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/brush_signed_distance.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/grade_mask_coverage.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/active_raster_mask.cpp
     PUBLIC_DEPS EditGeometry JSON
     PRIVATE_DEPS xxHash

--- a/alcedo_studio/src/edit/mask/brush_canonical_sampler.cpp
+++ b/alcedo_studio/src/edit/mask/brush_canonical_sampler.cpp
@@ -1,0 +1,137 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_canonical_sampler.hpp"
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace alcedo {
+namespace {
+
+[[noreturn]] void FailSampler(std::string_view message) {
+  throw std::runtime_error(std::string{message});
+}
+
+void RequireFinitePoint(Vector2 point, std::string_view name) {
+  if (!std::isfinite(point.x) || !std::isfinite(point.y)) {
+    FailSampler(std::string{name} + " must be finite");
+  }
+}
+
+void RequireMode(BrushStrokeMode mode) {
+  if (mode != BrushStrokeMode::Paint && mode != BrushStrokeMode::Erase) {
+    FailSampler("brush stroke mode must be paint or erase");
+  }
+}
+
+auto ValidatedSample(float local_x, float local_y, float radius, float strength, float hardness)
+    -> BrushCanonicalSample {
+  BrushCanonicalSample sample{local_x, local_y, radius, strength, hardness};
+  try {
+    ValidateBrushCanonicalSample(sample);
+  } catch (const std::invalid_argument& ex) {
+    FailSampler(ex.what());
+  }
+  return sample;
+}
+
+}  // namespace
+
+void BrushCanonicalSampler::RequireOpen() const {
+  if (!open_) {
+    FailSampler("brush stroke is not open");
+  }
+}
+
+void BrushCanonicalSampler::Emit(const BrushCanonicalSample& sample) {
+  samples_.push_back(sample);
+}
+
+void BrushCanonicalSampler::WalkTo(Vector2 local) {
+  const float dx     = local.x - last_local_.x;
+  const float dy     = local.y - last_local_.y;
+  const float length = std::hypot(dx, dy);
+  if (!(length > 0.0f)) {
+    last_local_ = local;
+    return;
+  }
+  const float spacing = radius_ * kBrushDabSpacingRadiusFraction;
+  float       next    = spacing - remainder_;
+  while (next <= length) {
+    const float t = next / length;
+    Emit(ValidatedSample(last_local_.x + dx * t, last_local_.y + dy * t, radius_, strength_,
+                         hardness_));
+    next += spacing;
+  }
+  remainder_  = length - (next - spacing);
+  last_local_ = local;
+}
+
+void BrushCanonicalSampler::BeginStroke(BrushStrokeMode mode, Vector2 reference,
+                                        Vector2 translation, float radius, float strength,
+                                        float hardness) {
+  if (open_) {
+    FailSampler("brush stroke is already open");
+  }
+  RequireMode(mode);
+  RequireFinitePoint(reference, "reference");
+  RequireFinitePoint(translation, "placement_translation");
+  const Vector2 local{reference.x - translation.x, reference.y - translation.y};
+  const auto    first = ValidatedSample(local.x, local.y, radius, strength, hardness);
+  mode_               = mode;
+  translation_        = translation;
+  last_local_         = local;
+  remainder_          = 0.0f;
+  radius_             = radius;
+  strength_           = strength;
+  hardness_           = hardness;
+  samples_.clear();
+  open_ = true;
+  Emit(first);
+}
+
+void BrushCanonicalSampler::SetSampleParameters(float radius, float strength, float hardness) {
+  RequireOpen();
+  const auto sample = ValidatedSample(last_local_.x, last_local_.y, radius, strength, hardness);
+  if (radius_ == radius && strength_ == strength && hardness_ == hardness) {
+    return;
+  }
+  radius_    = radius;
+  strength_  = strength;
+  hardness_  = hardness;
+  remainder_ = 0.0f;
+  Emit(sample);
+}
+
+void BrushCanonicalSampler::AppendReference(Vector2 reference) {
+  RequireOpen();
+  RequireFinitePoint(reference, "reference");
+  WalkTo({reference.x - translation_.x, reference.y - translation_.y});
+}
+
+auto BrushCanonicalSampler::FinishStroke() -> std::vector<BrushCanonicalSample> {
+  RequireOpen();
+  if (samples_.empty()) {
+    FailSampler("open brush stroke has no samples");
+  }
+  const auto& last = samples_.back();
+  if (last.local_x != last_local_.x || last.local_y != last_local_.y) {
+    Emit(ValidatedSample(last_local_.x, last_local_.y, radius_, strength_, hardness_));
+  }
+  open_ = false;
+  remainder_ = 0.0f;
+  return std::move(samples_);
+}
+
+void BrushCanonicalSampler::CancelStroke() {
+  open_      = false;
+  remainder_ = 0.0f;
+  samples_.clear();
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/mask/brush_rasterizer.cpp
+++ b/alcedo_studio/src/edit/mask/brush_rasterizer.cpp
@@ -1,0 +1,128 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_rasterizer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+
+namespace alcedo {
+namespace {
+
+[[noreturn]] void FailRaster(std::string_view message) {
+  throw std::runtime_error(std::string{message});
+}
+
+void RequireAlgorithm(const BrushMaskSource& source) {
+  if (source.raster_algorithm_version != kBrushRasterAlgorithmVersion) {
+    FailRaster("unsupported brush raster_algorithm_version");
+  }
+  if (source.source_format_version != kBrushSourceFormatVersion) {
+    FailRaster("unsupported brush source_format_version");
+  }
+}
+
+}  // namespace
+
+void BrushRasterizer::RequireGeometry() const {
+  if (raster_.Empty() || pixels_.size() !=
+                             static_cast<std::size_t>(raster_.width) *
+                                 static_cast<std::size_t>(raster_.height)) {
+    FailRaster("brush rasterizer geometry is unset");
+  }
+}
+
+void BrushRasterizer::SetGeometry(Extent2D raster, Extent2D full_reference) {
+  if (raster.Empty() || full_reference.Empty()) {
+    FailRaster("brush rasterizer requires positive raster and full-reference extents");
+  }
+  raster_          = raster;
+  full_reference_  = full_reference;
+  pixels_.assign(static_cast<std::size_t>(raster.width) * raster.height, 0);
+}
+
+void BrushRasterizer::ClearToZero() {
+  RequireGeometry();
+  std::fill(pixels_.begin(), pixels_.end(), 0);
+}
+
+void BrushRasterizer::StampDab(const BrushCanonicalSample& sample, Vector2 translation,
+                               BrushStrokeMode mode, RectI clip) {
+  const auto support =
+      IntersectTexelRect(BrushDabOutputTexelSupport(sample, translation, raster_, full_reference_),
+                         clip);
+  if (RectIEmpty(support)) {
+    return;
+  }
+  const float world_x = sample.local_x + translation.x;
+  const float world_y = sample.local_y + translation.y;
+  for (std::int32_t y = support.y; y < support.Y1(); ++y) {
+    for (std::int32_t x = support.x; x < support.X1(); ++x) {
+      const auto center = CanonicalBrushTexelReferenceCenter(static_cast<std::uint32_t>(x),
+                                                             static_cast<std::uint32_t>(y), raster_,
+                                                             full_reference_);
+      const float distance = std::hypot(center.x - world_x, center.y - world_y);
+      const auto  dab =
+          QuantizeMaskCoverageToR8(BrushDabCoverage(distance, sample.radius, sample.strength,
+                                                    sample.hardness));
+      const auto index = PackedR8Index(static_cast<std::uint32_t>(x), static_cast<std::uint32_t>(y),
+                                       raster_);
+      pixels_[index]   = mode == BrushStrokeMode::Erase ? EraseBrushR8(pixels_[index], dab)
+                                                        : PaintBrushR8(pixels_[index], dab);
+    }
+  }
+}
+
+void BrushRasterizer::ReplayRegion(const BrushMaskSource& source, const BrushSpatialIndex& index,
+                                   RectI dirty) {
+  RequireGeometry();
+  RequireAlgorithm(source);
+  if (index.Raster() != raster_ || index.FullReference() != full_reference_) {
+    FailRaster("spatial index geometry does not match the rasterizer");
+  }
+  const auto region = ClipTexelRect(dirty, raster_);
+  if (RectIEmpty(region)) {
+    return;
+  }
+  for (std::int32_t y = region.y; y < region.Y1(); ++y) {
+    for (std::int32_t x = region.x; x < region.X1(); ++x) {
+      const auto px = static_cast<std::uint32_t>(x);
+      const auto py = static_cast<std::uint32_t>(y);
+      pixels_[PackedR8Index(px, py, raster_)] = 0;
+    }
+  }
+  const auto spans = index.QueryOutput(region, source.placement_translation);
+  for (const auto& span : spans) {
+    if (span.stroke_index >= source.strokes.size()) {
+      FailRaster("spatial index stroke is outside the source");
+    }
+    const auto& stroke = source.strokes[span.stroke_index];
+    if (stroke.id != span.stroke_id) {
+      FailRaster("spatial index StrokeId does not match the source");
+    }
+    const auto samples = BrushStrokeSamples(stroke);
+    if (span.sample_end > samples.size() || span.sample_begin >= span.sample_end) {
+      FailRaster("spatial index sample span is outside the stroke");
+    }
+    for (auto sample_index = span.sample_begin; sample_index < span.sample_end; ++sample_index) {
+      StampDab(samples[sample_index], source.placement_translation, stroke.mode, region);
+    }
+  }
+}
+
+void BrushRasterizer::RasterizeFull(const BrushMaskSource& source) {
+  RequireGeometry();
+  BrushSpatialIndex index;
+  index.Rebuild(source, raster_, full_reference_);
+  ClearToZero();
+  ReplayRegion(source, index, FullTexelRect(raster_));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/mask/brush_signed_distance.cpp
+++ b/alcedo_studio/src/edit/mask/brush_signed_distance.cpp
@@ -1,0 +1,167 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_signed_distance.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr float kSignedDistanceInfinite = 1.0e20f;
+
+[[noreturn]] void FailFeather(std::string_view message) {
+  throw std::runtime_error(std::string{message});
+}
+
+auto FinishEffective(float value, bool invert, float opacity) -> std::uint8_t {
+  if (invert) {
+    value = 1.0f - value;
+  }
+  return QuantizeMaskCoverageToR8(std::clamp(value * opacity, 0.0f, 1.0f));
+}
+
+}  // namespace
+
+void BrushSignedDistanceFeather::EnsureScratch(std::uint32_t width, std::uint32_t height) {
+  const auto count = static_cast<std::size_t>(width) * height;
+  width_           = width;
+  height_          = height;
+  horizontal_.assign(count, kSignedDistanceInfinite);
+  inside_.assign(count, kSignedDistanceInfinite);
+  outside_.assign(count, kSignedDistanceInfinite);
+  sites_.assign(count, 0);
+  boundaries_.assign(count, 0.0f);
+}
+
+void BrushSignedDistanceFeather::BandHorizontal(std::span<const std::uint8_t> source,
+                                                bool want_inside) {
+  auto& destination = want_inside ? inside_ : outside_;
+  for (std::uint32_t y = 0; y < height_; ++y) {
+    int nearest = -1;
+    for (std::uint32_t x = 0; x < width_; ++x) {
+      const auto  index  = PackedR8Index(x, y, {width_, height_});
+      const bool  inside = source[index] >= 128;
+      if (inside == want_inside) {
+        nearest = static_cast<int>(x);
+      }
+      const float dx          = static_cast<float>(static_cast<int>(x) - nearest);
+      horizontal_[index]      = nearest < 0 ? kSignedDistanceInfinite : dx * dx;
+    }
+    nearest = static_cast<int>(width_);
+    for (int x = static_cast<int>(width_) - 1; x >= 0; --x) {
+      const auto  index  = PackedR8Index(static_cast<std::uint32_t>(x), y, {width_, height_});
+      const bool  inside = source[index] >= 128;
+      if (inside == want_inside) {
+        nearest = x;
+      }
+      if (nearest < static_cast<int>(width_)) {
+        const float dx     = static_cast<float>(x - nearest);
+        horizontal_[index] = std::min(horizontal_[index], dx * dx);
+      }
+    }
+  }
+  BandVertical(destination);
+}
+
+void BrushSignedDistanceFeather::BandVertical(std::span<float> squared_distance) {
+  for (std::uint32_t x = 0; x < width_; ++x) {
+    const auto site_base     = static_cast<std::size_t>(x) * height_;
+    const auto boundary_base = site_base;
+    int        count         = 0;
+    for (std::uint32_t y = 0; y < height_; ++y) {
+      const float f = horizontal_[PackedR8Index(x, y, {width_, height_})];
+      if (f >= 1.0e19f) {
+        continue;
+      }
+      float boundary = -1.0e20f;
+      while (count > 0) {
+        const int   previous   = sites_[site_base + static_cast<std::size_t>(count - 1)];
+        const float previous_f =
+            horizontal_[PackedR8Index(x, static_cast<std::uint32_t>(previous), {width_, height_})];
+        boundary = ((f + static_cast<float>(y * y)) -
+                    (previous_f + static_cast<float>(previous * previous))) /
+                   (2.0f * (static_cast<float>(y) - static_cast<float>(previous)));
+        if (boundary > boundaries_[boundary_base + static_cast<std::size_t>(count - 1)]) {
+          break;
+        }
+        --count;
+      }
+      sites_[site_base + static_cast<std::size_t>(count)] = static_cast<int>(y);
+      boundaries_[boundary_base + static_cast<std::size_t>(count)] =
+          count == 0 ? -1.0e20f : boundary;
+      ++count;
+    }
+    if (count == 0) {
+      for (std::uint32_t y = 0; y < height_; ++y) {
+        squared_distance[PackedR8Index(x, y, {width_, height_})] = kSignedDistanceInfinite;
+      }
+      continue;
+    }
+    int site_index = 0;
+    for (std::uint32_t y = 0; y < height_; ++y) {
+      while (site_index + 1 < count &&
+             boundaries_[boundary_base + static_cast<std::size_t>(site_index + 1)] <
+                 static_cast<float>(y)) {
+        ++site_index;
+      }
+      const int   site = sites_[site_base + static_cast<std::size_t>(site_index)];
+      const float dy   = static_cast<float>(static_cast<int>(y) - site);
+      squared_distance[PackedR8Index(x, y, {width_, height_})] =
+          horizontal_[PackedR8Index(x, static_cast<std::uint32_t>(site), {width_, height_})] +
+          dy * dy;
+    }
+  }
+}
+
+auto BrushSignedDistanceFeather::Apply(std::span<const std::uint8_t> source, Extent2D extent,
+                                       float radius_texels, bool invert, float opacity)
+    -> std::vector<std::uint8_t> {
+  if (extent.Empty()) {
+    FailFeather("signed-distance feather requires a positive extent");
+  }
+  if (source.size() != static_cast<std::size_t>(extent.width) * extent.height) {
+    FailFeather("signed-distance source must be tightly packed R8");
+  }
+  if (!std::isfinite(radius_texels) || radius_texels < 0.0f) {
+    FailFeather("feather radius_texels must be finite and nonnegative");
+  }
+  if (!std::isfinite(opacity) || opacity < 0.0f || opacity > 1.0f) {
+    FailFeather("opacity must stay in [0, 1]");
+  }
+  EnsureScratch(extent.width, extent.height);
+  BandHorizontal(source, true);
+  BandHorizontal(source, false);
+  std::vector<std::uint8_t> output(source.size());
+  for (std::uint32_t y = 0; y < height_; ++y) {
+    for (std::uint32_t x = 0; x < width_; ++x) {
+      const auto  index    = PackedR8Index(x, y, extent);
+      const float coverage = CoverageFromMaskR8(source[index]);
+      const bool  inside   = coverage >= 0.5f;
+      float       signed_distance;
+      if (coverage > 0.0f && coverage < 1.0f) {
+        signed_distance = coverage - 0.5f;
+      } else {
+        const float exact = std::sqrt(inside ? outside_[index] : inside_[index]);
+        const float to_boundary = std::max(exact - 0.5f, 0.0f);
+        signed_distance         = inside ? to_boundary : -to_boundary;
+      }
+      float value = radius_texels <= 0.0f
+                        ? (signed_distance >= 0.0f ? 1.0f : 0.0f)
+                        : std::clamp(0.5f + signed_distance / (2.0f * radius_texels), 0.0f, 1.0f);
+      value       = value * value * (3.0f - 2.0f * value);
+      output[index] = FinishEffective(value, invert, opacity);
+    }
+  }
+  return output;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/mask/brush_source_geometry.cpp
+++ b/alcedo_studio/src/edit/mask/brush_source_geometry.cpp
@@ -1,0 +1,206 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_source_geometry.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include "edit/mask/active_raster_mask.hpp"
+
+namespace alcedo {
+namespace {
+
+[[noreturn]] void FailGeometry(std::string_view message) {
+  throw std::invalid_argument(std::string{message});
+}
+
+void RequirePositiveExtent(Extent2D extent, std::string_view name) {
+  if (extent.Empty()) {
+    FailGeometry(std::string{name} + " must be positive");
+  }
+}
+
+void RequireFiniteTranslation(Vector2 translation) {
+  if (!std::isfinite(translation.x) || !std::isfinite(translation.y)) {
+    FailGeometry("placement_translation must be finite");
+  }
+}
+
+auto DabSupport(const BrushCanonicalSample& sample, Vector2 translation, Extent2D raster,
+                Extent2D full_reference) -> RectI {
+  ValidateBrushCanonicalSample(sample);
+  RequirePositiveExtent(raster, "raster");
+  RequirePositiveExtent(full_reference, "full_reference");
+  RequireFiniteTranslation(translation);
+  const float scale_x = static_cast<float>(raster.width) / static_cast<float>(full_reference.width);
+  const float scale_y =
+      static_cast<float>(raster.height) / static_cast<float>(full_reference.height);
+  const float world_x = sample.local_x + translation.x;
+  const float world_y = sample.local_y + translation.y;
+  const auto  x0 =
+      static_cast<std::int32_t>(std::floor((world_x - sample.radius) * scale_x - 0.5f));
+  const auto y0 =
+      static_cast<std::int32_t>(std::floor((world_y - sample.radius) * scale_y - 0.5f));
+  const auto x1 =
+      static_cast<std::int32_t>(std::floor((world_x + sample.radius) * scale_x - 0.5f)) + 1;
+  const auto y1 =
+      static_cast<std::int32_t>(std::floor((world_y + sample.radius) * scale_y - 0.5f)) + 1;
+  return ClipRasterDirtyRectangle({x0, y0, x1 - x0, y1 - y0}, raster);
+}
+
+}  // namespace
+
+auto PackedR8Index(std::uint32_t x, std::uint32_t y, Extent2D extent) -> std::size_t {
+  RequirePositiveExtent(extent, "extent");
+  if (x >= extent.width || y >= extent.height) {
+    FailGeometry("texel is outside the packed R8 raster");
+  }
+  return static_cast<std::size_t>(y) * extent.width + x;
+}
+
+auto FullTexelRect(Extent2D extent) -> RectI {
+  if (extent.Empty()) {
+    return {};
+  }
+  return {0, 0, static_cast<std::int32_t>(extent.width), static_cast<std::int32_t>(extent.height)};
+}
+
+auto ClipTexelRect(RectI rect, Extent2D extent) -> RectI {
+  return ClipRasterDirtyRectangle(rect, extent);
+}
+
+auto UnionTexelRect(RectI a, RectI b) -> RectI {
+  if (RectIEmpty(a)) {
+    return b;
+  }
+  if (RectIEmpty(b)) {
+    return a;
+  }
+  const auto x0 = std::min(a.x, b.x);
+  const auto y0 = std::min(a.y, b.y);
+  const auto x1 = std::max(a.X1(), b.X1());
+  const auto y1 = std::max(a.Y1(), b.Y1());
+  return {x0, y0, x1 - x0, y1 - y0};
+}
+
+auto IntersectTexelRect(RectI a, RectI b) -> RectI {
+  if (RectIEmpty(a) || RectIEmpty(b)) {
+    return {};
+  }
+  const auto x0 = std::max(a.x, b.x);
+  const auto y0 = std::max(a.y, b.y);
+  const auto x1 = std::min(a.X1(), b.X1());
+  const auto y1 = std::min(a.Y1(), b.Y1());
+  return x1 > x0 && y1 > y0 ? RectI{x0, y0, x1 - x0, y1 - y0} : RectI{};
+}
+
+auto BrushDabOutputTexelSupport(const BrushCanonicalSample& sample, Vector2 translation,
+                                Extent2D raster, Extent2D full_reference) -> RectI {
+  return DabSupport(sample, translation, raster, full_reference);
+}
+
+auto BrushDabLocalTexelSupport(const BrushCanonicalSample& sample, Extent2D raster,
+                               Extent2D full_reference) -> RectI {
+  return DabSupport(sample, {}, raster, full_reference);
+}
+
+auto BrushStrokeOutputTexelSupport(const BrushStroke& stroke, Vector2 translation, Extent2D raster,
+                                   Extent2D full_reference) -> RectI {
+  RectI support{};
+  for (const auto& sample : BrushStrokeSamples(stroke)) {
+    support = UnionTexelRect(
+        support, DabSupport(sample, translation, raster, full_reference));
+  }
+  return support;
+}
+
+auto BrushSourceOutputTexelSupport(const BrushMaskSource& source, Extent2D raster,
+                                   Extent2D full_reference) -> RectI {
+  RectI support{};
+  for (const auto& stroke : source.strokes) {
+    support = UnionTexelRect(
+        support, BrushStrokeOutputTexelSupport(stroke, source.placement_translation, raster,
+                                               full_reference));
+  }
+  return support;
+}
+
+auto BrushOutputTexelsToLocal(RectI output_texels, Vector2 translation, Extent2D raster,
+                              Extent2D full_reference) -> RectI {
+  RequirePositiveExtent(raster, "raster");
+  RequirePositiveExtent(full_reference, "full_reference");
+  RequireFiniteTranslation(translation);
+  const auto clipped = ClipRasterDirtyRectangle(output_texels, raster);
+  if (RectIEmpty(clipped)) {
+    return {};
+  }
+  const float inv_scale_x =
+      static_cast<float>(full_reference.width) / static_cast<float>(raster.width);
+  const float inv_scale_y =
+      static_cast<float>(full_reference.height) / static_cast<float>(raster.height);
+  const float ref_x0     = static_cast<float>(clipped.x) * inv_scale_x;
+  const float ref_y0     = static_cast<float>(clipped.y) * inv_scale_y;
+  const float ref_x1     = static_cast<float>(clipped.X1()) * inv_scale_x;
+  const float ref_y1     = static_cast<float>(clipped.Y1()) * inv_scale_y;
+  const float local_x0   = ref_x0 - translation.x;
+  const float local_y0   = ref_y0 - translation.y;
+  const float local_x1   = ref_x1 - translation.x;
+  const float local_y1   = ref_y1 - translation.y;
+  const auto scale_x =
+      static_cast<float>(raster.width) / static_cast<float>(full_reference.width);
+  const auto scale_y =
+      static_cast<float>(raster.height) / static_cast<float>(full_reference.height);
+  const auto  x0      = static_cast<std::int32_t>(std::floor(local_x0 * scale_x));
+  const auto  y0      = static_cast<std::int32_t>(std::floor(local_y0 * scale_y));
+  const auto  x1      = static_cast<std::int32_t>(std::ceil(local_x1 * scale_x));
+  const auto  y1      = static_cast<std::int32_t>(std::ceil(local_y1 * scale_y));
+  return ClipRasterDirtyRectangle({x0, y0, x1 - x0, y1 - y0}, raster);
+}
+
+auto EffectiveMaskTexelSupport(const MaskModel& mask, Extent2D raster, Extent2D full_reference)
+    -> RectI {
+  RequirePositiveExtent(raster, "raster");
+  RequirePositiveExtent(full_reference, "full_reference");
+  if (!mask.enabled) {
+    return {};
+  }
+  if (mask.invert) {
+    return FullTexelRect(raster);
+  }
+  if (const auto* brush = std::get_if<BrushMaskSource>(&mask.source)) {
+    if (brush->feather_radius > 0.0f) {
+      return FullTexelRect(raster);
+    }
+    return BrushSourceOutputTexelSupport(*brush, raster, full_reference);
+  }
+  if (std::holds_alternative<LinearGradientMaskSource>(mask.source)) {
+    return FullTexelRect(raster);
+  }
+  const auto& radial = std::get<RadialMaskSource>(mask.source);
+  const float outer  = 1.0f + radial.outer_feather;
+  const float c      = std::cos(radial.rotation);
+  const float s      = std::sin(radial.rotation);
+  const float x_ext  = outer * std::hypot(radial.major_radius * c, radial.minor_radius * s);
+  const float y_ext  = outer * std::hypot(radial.major_radius * s, radial.minor_radius * c);
+  const float nx0    = radial.center_x - x_ext;
+  const float ny0    = radial.center_y - y_ext;
+  const float nx1    = radial.center_x + x_ext;
+  const float ny1    = radial.center_y + y_ext;
+  const auto  x0 =
+      static_cast<std::int32_t>(std::floor(nx0 * static_cast<float>(raster.width) - 0.5f));
+  const auto y0 =
+      static_cast<std::int32_t>(std::floor(ny0 * static_cast<float>(raster.height) - 0.5f));
+  const auto x1 =
+      static_cast<std::int32_t>(std::floor(nx1 * static_cast<float>(raster.width) - 0.5f)) + 1;
+  const auto y1 =
+      static_cast<std::int32_t>(std::floor(ny1 * static_cast<float>(raster.height) - 0.5f)) + 1;
+  return ClipRasterDirtyRectangle({x0, y0, x1 - x0, y1 - y0}, raster);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/mask/brush_spatial_index.cpp
+++ b/alcedo_studio/src/edit/mask/brush_spatial_index.cpp
@@ -1,0 +1,140 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_spatial_index.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#include "edit/mask/brush_source_geometry.hpp"
+
+namespace alcedo {
+namespace {
+
+[[noreturn]] void FailIndex(std::string_view message) {
+  throw std::runtime_error(std::string{message});
+}
+
+}  // namespace
+
+BrushSpatialIndex::BrushSpatialIndex(std::uint32_t tile_texels) : tile_texels_(tile_texels) {
+  if (tile_texels_ == 0) {
+    FailIndex("spatial index tile size must be positive");
+  }
+}
+
+void BrushSpatialIndex::Clear() {
+  raster_            = {};
+  full_reference_    = {};
+  tiles_x_           = 0;
+  tiles_y_           = 0;
+  spans_.clear();
+  tile_span_indices_.clear();
+}
+
+void BrushSpatialIndex::Rebuild(const BrushMaskSource& source, Extent2D raster,
+                                Extent2D full_reference) {
+  if (raster.Empty() || full_reference.Empty()) {
+    FailIndex("spatial index requires positive raster and full-reference extents");
+  }
+  if (source.raster_algorithm_version != kBrushRasterAlgorithmVersion) {
+    FailIndex("unsupported brush raster_algorithm_version");
+  }
+  ValidateBrushStrokeList(source.strokes);
+  Clear();
+  raster_         = raster;
+  full_reference_ = full_reference;
+  tiles_x_        = (raster.width + tile_texels_ - 1) / tile_texels_;
+  tiles_y_        = (raster.height + tile_texels_ - 1) / tile_texels_;
+  tile_span_indices_.assign(static_cast<std::size_t>(tiles_x_) * tiles_y_, {});
+  for (std::size_t stroke_index = 0; stroke_index < source.strokes.size(); ++stroke_index) {
+    const auto& stroke  = source.strokes[stroke_index];
+    const auto  samples = BrushStrokeSamples(stroke);
+    for (std::size_t sample_index = 0; sample_index < samples.size(); ++sample_index) {
+      const auto local_bounds =
+          BrushDabLocalTexelSupport(samples[sample_index], raster, full_reference);
+      if (RectIEmpty(local_bounds)) {
+        continue;
+      }
+      const auto span_index = spans_.size();
+      spans_.push_back(BrushIndexedSpan{stroke.id, stroke_index, sample_index, sample_index + 1,
+                                        local_bounds});
+      const auto tile_x0 = static_cast<std::uint32_t>(local_bounds.x) / tile_texels_;
+      const auto tile_y0 = static_cast<std::uint32_t>(local_bounds.y) / tile_texels_;
+      const auto tile_x1 =
+          (static_cast<std::uint32_t>(local_bounds.X1() - 1) / tile_texels_) + 1;
+      const auto tile_y1 =
+          (static_cast<std::uint32_t>(local_bounds.Y1() - 1) / tile_texels_) + 1;
+      for (auto ty = tile_y0; ty < tile_y1 && ty < tiles_y_; ++ty) {
+        for (auto tx = tile_x0; tx < tile_x1 && tx < tiles_x_; ++tx) {
+          tile_span_indices_[TileIndex(tx, ty)].push_back(span_index);
+        }
+      }
+    }
+  }
+}
+
+auto BrushSpatialIndex::TileIndex(std::uint32_t tile_x, std::uint32_t tile_y) const -> std::size_t {
+  return static_cast<std::size_t>(tile_y) * tiles_x_ + tile_x;
+}
+
+auto BrushSpatialIndex::UniqueSpansIn(RectI local_texels) const -> std::vector<BrushIndexedSpan> {
+  const auto query = ClipTexelRect(local_texels, raster_);
+  if (RectIEmpty(query) || tiles_x_ == 0 || tiles_y_ == 0) {
+    return {};
+  }
+  const auto tile_x0 = static_cast<std::uint32_t>(query.x) / tile_texels_;
+  const auto tile_y0 = static_cast<std::uint32_t>(query.y) / tile_texels_;
+  const auto tile_x1 = (static_cast<std::uint32_t>(query.X1() - 1) / tile_texels_) + 1;
+  const auto tile_y1 = (static_cast<std::uint32_t>(query.Y1() - 1) / tile_texels_) + 1;
+  std::vector<std::size_t> ids;
+  for (auto ty = tile_y0; ty < tile_y1 && ty < tiles_y_; ++ty) {
+    for (auto tx = tile_x0; tx < tile_x1 && tx < tiles_x_; ++tx) {
+      const auto& tile = tile_span_indices_[TileIndex(tx, ty)];
+      ids.insert(ids.end(), tile.begin(), tile.end());
+    }
+  }
+  std::sort(ids.begin(), ids.end());
+  ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+  std::vector<BrushIndexedSpan> result;
+  result.reserve(ids.size());
+  for (const auto id : ids) {
+    const auto& span = spans_[id];
+    if (!RectIEmpty(IntersectTexelRect(span.local_bounds, query))) {
+      result.push_back(span);
+    }
+  }
+  std::sort(result.begin(), result.end(), [](const BrushIndexedSpan& a, const BrushIndexedSpan& b) {
+    if (a.stroke_index != b.stroke_index) {
+      return a.stroke_index < b.stroke_index;
+    }
+    return a.sample_begin < b.sample_begin;
+  });
+  return result;
+}
+
+auto BrushSpatialIndex::QueryLocal(RectI local_texels) const -> std::vector<BrushIndexedSpan> {
+  if (raster_.Empty()) {
+    return {};
+  }
+  return UniqueSpansIn(local_texels);
+}
+
+auto BrushSpatialIndex::QueryOutput(RectI output_texels, Vector2 translation) const
+    -> std::vector<BrushIndexedSpan> {
+  if (raster_.Empty()) {
+    FailIndex("spatial index has not been rebuilt");
+  }
+  try {
+    return UniqueSpansIn(BrushOutputTexelsToLocal(output_texels, translation, raster_,
+                                                  full_reference_));
+  } catch (const std::invalid_argument& ex) {
+    FailIndex(ex.what());
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/mask/grade_mask_coverage.cpp
+++ b/alcedo_studio/src/edit/mask/grade_mask_coverage.cpp
@@ -1,0 +1,253 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/grade_mask_coverage.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr float kAnalyticEpsilon = 1.0e-6f;
+
+[[noreturn]] void FailCoverage(std::string_view message) {
+  throw std::runtime_error(std::string{message});
+}
+
+auto AnyEnabled(std::span<const MaskModel> masks) -> bool {
+  return std::any_of(masks.begin(), masks.end(),
+                     [](const MaskModel& mask) { return mask.enabled; });
+}
+
+auto NeedsFullFeather(const MaskModel& mask) -> bool {
+  const auto* brush = std::get_if<BrushMaskSource>(&mask.source);
+  return brush != nullptr && mask.enabled && brush->feather_radius > 0.0f;
+}
+
+auto ApplyInvertOpacity(float coverage, bool invert, float opacity) -> std::uint8_t {
+  if (invert) {
+    coverage = 1.0f - coverage;
+  }
+  return QuantizeMaskCoverageToR8(std::clamp(coverage * opacity, 0.0f, 1.0f));
+}
+
+void UnionMaxInto(std::span<std::uint8_t> mix, std::span<const std::uint8_t> scratch, RectI region,
+                  Extent2D raster) {
+  for (std::int32_t y = region.y; y < region.Y1(); ++y) {
+    for (std::int32_t x = region.x; x < region.X1(); ++x) {
+      const auto index =
+          PackedR8Index(static_cast<std::uint32_t>(x), static_cast<std::uint32_t>(y), raster);
+      mix[index] = mix[index] > scratch[index] ? mix[index] : scratch[index];
+    }
+  }
+}
+
+auto CopyRegion(std::span<const std::uint8_t> pixels, RectI region, Extent2D raster)
+    -> std::vector<std::uint8_t> {
+  std::vector<std::uint8_t> bytes(static_cast<std::size_t>(region.width) *
+                                  static_cast<std::size_t>(region.height));
+  std::size_t i = 0;
+  for (std::int32_t y = region.y; y < region.Y1(); ++y) {
+    for (std::int32_t x = region.x; x < region.X1(); ++x) {
+      const auto px = static_cast<std::uint32_t>(x);
+      const auto py = static_cast<std::uint32_t>(y);
+      bytes[i++]    = pixels[PackedR8Index(px, py, raster)];
+    }
+  }
+  return bytes;
+}
+
+void RestoreRegion(std::span<std::uint8_t> pixels, RectI region, Extent2D raster,
+                   std::span<const std::uint8_t> bytes) {
+  std::size_t i = 0;
+  for (std::int32_t y = region.y; y < region.Y1(); ++y) {
+    for (std::int32_t x = region.x; x < region.X1(); ++x) {
+      pixels[PackedR8Index(static_cast<std::uint32_t>(x), static_cast<std::uint32_t>(y), raster)] =
+          bytes[i++];
+    }
+  }
+}
+
+}  // namespace
+
+void GradeMaskCoverage::RequireGeometry() const {
+  if (raster_.Empty() || mix_.size() != static_cast<std::size_t>(raster_.width) * raster_.height) {
+    FailCoverage("grade mask coverage geometry is unset");
+  }
+}
+
+void GradeMaskCoverage::FillMix(std::uint8_t value) {
+  std::fill(mix_.begin(), mix_.end(), value);
+}
+
+void GradeMaskCoverage::SetGeometry(Extent2D raster, Extent2D full_reference,
+                                    std::uint32_t tile_texels) {
+  if (tile_texels == 0) {
+    FailCoverage("spatial index tile size must be positive");
+  }
+  rasterizer_.SetGeometry(raster, full_reference);
+  raster_          = raster;
+  full_reference_  = full_reference;
+  tile_texels_     = tile_texels;
+  mix_.assign(static_cast<std::size_t>(raster.width) * raster.height, 0);
+  scratch_.assign(mix_.size(), 0);
+  brush_indices_.clear();
+}
+
+void GradeMaskCoverage::BindBrushSource(const MaskId& mask_id, const BrushMaskSource& source) {
+  RequireGeometry();
+  BrushSpatialIndex index(tile_texels_);
+  index.Rebuild(source, raster_, full_reference_);
+  brush_indices_.insert_or_assign(mask_id, std::move(index));
+}
+
+void GradeMaskCoverage::UnbindMask(const MaskId& mask_id) { brush_indices_.erase(mask_id); }
+
+auto GradeMaskCoverage::BrushIndex(const MaskId& mask_id) const -> const BrushSpatialIndex* {
+  const auto found = brush_indices_.find(mask_id);
+  return found == brush_indices_.end() ? nullptr : &found->second;
+}
+
+auto GradeMaskCoverage::AnalyticCoverage(const MaskModel& mask, std::uint32_t x,
+                                         std::uint32_t y) const -> float {
+  const auto center =
+      CanonicalBrushTexelReferenceCenter(x, y, raster_, full_reference_);
+  const float nx = center.x / static_cast<float>(full_reference_.width);
+  const float ny = center.y / static_cast<float>(full_reference_.height);
+  if (const auto* radial = std::get_if<RadialMaskSource>(&mask.source)) {
+    const float c      = std::cos(radial->rotation);
+    const float s      = std::sin(radial->rotation);
+    const float dx     = nx - radial->center_x;
+    const float dy     = ny - radial->center_y;
+    const float rx     = (c * dx + s * dy) / std::max(radial->major_radius, kAnalyticEpsilon);
+    const float ry     = (-s * dx + c * dy) / std::max(radial->minor_radius, kAnalyticEpsilon);
+    const float rho    = std::sqrt(rx * rx + ry * ry);
+    const float inner  = std::max(0.0f, 1.0f - radial->inner_feather);
+    const float outer  = 1.0f + radial->outer_feather;
+    return 1.0f - std::clamp((rho - inner) / std::max(outer - inner, kAnalyticEpsilon), 0.0f, 1.0f);
+  }
+  const auto& linear        = std::get<LinearGradientMaskSource>(mask.source);
+  const float normal_length = std::hypot(linear.normal_x, linear.normal_y);
+  const float normal_x      = linear.normal_x / std::max(normal_length, kAnalyticEpsilon);
+  const float normal_y      = linear.normal_y / std::max(normal_length, kAnalyticEpsilon);
+  const float distance      = (nx - linear.origin_x) * normal_x + (ny - linear.origin_y) * normal_y;
+  const float t =
+      std::clamp(distance / std::max(linear.transition_distance, kAnalyticEpsilon) + 0.5f, 0.0f,
+                 1.0f);
+  return linear.start_value + (linear.end_value - linear.start_value) * t;
+}
+
+void GradeMaskCoverage::WriteEffectiveAnalytic(const MaskModel& mask, RectI region,
+                                               std::span<std::uint8_t> dest) {
+  for (std::int32_t y = region.y; y < region.Y1(); ++y) {
+    for (std::int32_t x = region.x; x < region.X1(); ++x) {
+      const auto index =
+          PackedR8Index(static_cast<std::uint32_t>(x), static_cast<std::uint32_t>(y), raster_);
+      dest[index] = ApplyInvertOpacity(
+          AnalyticCoverage(mask, static_cast<std::uint32_t>(x), static_cast<std::uint32_t>(y)),
+          mask.invert, mask.opacity);
+    }
+  }
+}
+
+void GradeMaskCoverage::WriteEffectiveBrush(const MaskModel& mask, const BrushMaskSource& brush,
+                                            RectI region, std::span<std::uint8_t> dest) {
+  const auto* index = BrushIndex(mask.id);
+  if (index == nullptr) {
+    FailCoverage("brush spatial index is not bound for the Mask");
+  }
+  const bool feathered = brush.feather_radius > 0.0f;
+  if (feathered) {
+    rasterizer_.ClearToZero();
+    rasterizer_.ReplayRegion(brush, *index, FullTexelRect(raster_));
+    const auto radius_texels = BrushFeatherRadiusToSourceTexels(
+        brush.feather_radius, raster_, CanonicalBrushReferenceBounds(), full_reference_);
+    const auto feathered_pixels =
+        feather_.Apply(rasterizer_.Pixels(), raster_, radius_texels, mask.invert, mask.opacity);
+    for (std::int32_t y = region.y; y < region.Y1(); ++y) {
+      for (std::int32_t x = region.x; x < region.X1(); ++x) {
+        const auto i =
+            PackedR8Index(static_cast<std::uint32_t>(x), static_cast<std::uint32_t>(y), raster_);
+        dest[i] = feathered_pixels[i];
+      }
+    }
+    return;
+  }
+  rasterizer_.ReplayRegion(brush, *index, region);
+  const auto source = rasterizer_.Pixels();
+  for (std::int32_t y = region.y; y < region.Y1(); ++y) {
+    for (std::int32_t x = region.x; x < region.X1(); ++x) {
+      const auto i =
+          PackedR8Index(static_cast<std::uint32_t>(x), static_cast<std::uint32_t>(y), raster_);
+      dest[i] = ApplyInvertOpacity(CoverageFromMaskR8(source[i]), mask.invert, mask.opacity);
+    }
+  }
+}
+
+void GradeMaskCoverage::ReplayClippedRegion(std::span<const MaskModel> masks, RectI dirty) {
+  const auto previous = CopyRegion(mix_, dirty, raster_);
+  try {
+    for (std::int32_t y = dirty.y; y < dirty.Y1(); ++y) {
+      for (std::int32_t x = dirty.x; x < dirty.X1(); ++x) {
+        mix_[PackedR8Index(static_cast<std::uint32_t>(x), static_cast<std::uint32_t>(y), raster_)] =
+            0;
+      }
+    }
+    for (const auto& mask : masks) {
+      if (!mask.enabled) {
+        continue;
+      }
+      std::fill(scratch_.begin(), scratch_.end(), 0);
+      if (const auto* brush = std::get_if<BrushMaskSource>(&mask.source)) {
+        WriteEffectiveBrush(mask, *brush, dirty, scratch_);
+      } else {
+        WriteEffectiveAnalytic(mask, dirty, scratch_);
+      }
+      UnionMaxInto(mix_, scratch_, dirty, raster_);
+    }
+  } catch (...) {
+    RestoreRegion(mix_, dirty, raster_, previous);
+    throw;
+  }
+}
+
+void GradeMaskCoverage::EvaluateFull(std::span<const MaskModel> masks) {
+  RequireGeometry();
+  ReplayRegion(masks, FullTexelRect(raster_));
+}
+
+void GradeMaskCoverage::ReplayRegion(std::span<const MaskModel> masks, RectI dirty) {
+  RequireGeometry();
+  if (masks.empty()) {
+    FillMix(255);
+    return;
+  }
+  if (!AnyEnabled(masks)) {
+    FillMix(0);
+    return;
+  }
+  auto region = ClipTexelRect(dirty, raster_);
+  for (const auto& mask : masks) {
+    if (NeedsFullFeather(mask)) {
+      region = FullTexelRect(raster_);
+      break;
+    }
+  }
+  if (RectIEmpty(region)) {
+    return;
+  }
+  ReplayClippedRegion(masks, region);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/brush_canonical_sampler.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_canonical_sampler.hpp
@@ -1,0 +1,92 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Converts ordered reference-pixel pointer events into canonical Brush samples.
+ *
+ * Owns the open-stroke remainder so dab spacing is independent of event batching.
+ * Samples are stored in local reference pixels (`reference - translation`). The first
+ * press is recorded as-is; drag thresholds are not applied here.
+ *
+ * Thread: serial owner worker. Not thread-safe. Cancel discards the open stroke
+ * without returning samples.
+ */
+class BrushCanonicalSampler {
+ public:
+  /**
+   * @brief Open a stroke and emit the press dab.
+   *
+   * @param mode Paint or erase.
+   * @param reference Press position in reference pixels.
+   * @param translation Current Brush placement; subtracted from every event.
+   * @param radius Positive dab radius in reference pixels.
+   * @param strength Coverage strength in `[0, 1]`.
+   * @param hardness Edge hardness in `[0, 1]`.
+   * @throws std::runtime_error when a stroke is already open or a value is invalid.
+   */
+  void BeginStroke(BrushStrokeMode mode, Vector2 reference, Vector2 translation, float radius,
+                   float strength, float hardness);
+
+  /**
+   * @brief Record a size/strength/hardness change at the current position.
+   *
+   * Emits a boundary sample so the change is not discarded across later events.
+   * Subsequent spacing uses the new radius. No-op when values are unchanged.
+   *
+   * @throws std::runtime_error when no stroke is open or the new values are invalid.
+   */
+  void SetSampleParameters(float radius, float strength, float hardness);
+
+  /**
+   * @brief Walk from the last local point to @p reference and emit interior dabs.
+   *
+   * Does not emit an extra dab at the event end. Arc-length remainder is kept for
+   * the next batch. Zero-length moves are ignored.
+   *
+   * @throws std::runtime_error when no stroke is open or @p reference is not finite.
+   */
+  void AppendReference(Vector2 reference);
+
+  /**
+   * @brief Seal the stroke, emitting the endpoint once if it is not already a dab.
+   *
+   * @return Ordered canonical samples. The sampler is then idle.
+   * @throws std::runtime_error when no stroke is open.
+   */
+  [[nodiscard]] auto FinishStroke() -> std::vector<BrushCanonicalSample>;
+
+  /**
+   * @brief Drop an unfinished stroke. Idle when already closed.
+   */
+  void CancelStroke();
+
+  [[nodiscard]] auto IsOpen() const -> bool { return open_; }
+  [[nodiscard]] auto Mode() const -> BrushStrokeMode { return mode_; }
+
+ private:
+  void RequireOpen() const;
+  void Emit(const BrushCanonicalSample& sample);
+  void WalkTo(Vector2 local);
+
+  bool            open_        = false;
+  BrushStrokeMode mode_        = BrushStrokeMode::Paint;
+  Vector2         translation_{};
+  Vector2         last_local_{};
+  float           remainder_   = 0.0f;
+  float           radius_      = 1.0f;
+  float           strength_    = 1.0f;
+  float           hardness_    = 1.0f;
+  std::vector<BrushCanonicalSample> samples_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/brush_rasterizer.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_rasterizer.hpp
@@ -1,0 +1,75 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/brush_spatial_index.hpp"
+#include "edit/mask/mask_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Owns one current Brush source R8 and stamps canonical dabs in evaluation order.
+ *
+ * Regional replay initializes the dirty rectangle to 0 and restamps intersecting
+ * spans. It does not keep a per-stroke raster checkpoint. Geometry is the canonical
+ * Brush grid from @ref CanonicalBrushRasterExtent; zoom and DPR must not be passed.
+ *
+ * Thread: serial owner worker. Not thread-safe.
+ */
+class BrushRasterizer {
+ public:
+  /**
+   * @brief Allocate a zeroed canonical raster.
+   *
+   * @throws std::runtime_error when @p raster or @p full_reference is empty.
+   */
+  void SetGeometry(Extent2D raster, Extent2D full_reference);
+
+  /**
+   * @brief Fill every texel with 0. No-op until @ref SetGeometry.
+   */
+  void ClearToZero();
+
+  /**
+   * @brief Rebuild the entire source from @p source, starting from 0.
+   *
+   * @throws std::runtime_error when geometry is unset, the algorithm version is not 1,
+   *         or a stroke is invalid.
+   */
+  void RasterizeFull(const BrushMaskSource& source);
+
+  /**
+   * @brief Rebuild @p dirty from b0 = 0 using ordered index spans of @p source.
+   *
+   * Texels outside @p dirty are left unchanged. An empty clipped dirty rectangle is
+   * a no-op.
+   *
+   * @throws std::runtime_error when geometry is unset, @p index was built for a
+   *         different raster, the algorithm version is not 1, or a span identity
+   *         does not match @p source.
+   */
+  void ReplayRegion(const BrushMaskSource& source, const BrushSpatialIndex& index, RectI dirty);
+
+  [[nodiscard]] auto Pixels() const -> std::span<const std::uint8_t> { return pixels_; }
+  [[nodiscard]] auto Raster() const -> Extent2D { return raster_; }
+  [[nodiscard]] auto FullReference() const -> Extent2D { return full_reference_; }
+  [[nodiscard]] auto Empty() const -> bool { return pixels_.empty(); }
+
+ private:
+  void RequireGeometry() const;
+  void StampDab(const BrushCanonicalSample& sample, Vector2 translation, BrushStrokeMode mode,
+                RectI clip);
+
+  Extent2D                  raster_{};
+  Extent2D                  full_reference_{};
+  std::vector<std::uint8_t> pixels_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/brush_signed_distance.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_signed_distance.hpp
@@ -1,0 +1,59 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Full-field signed-distance Brush feather matching the native Mask pass.
+ *
+ * Separable Euclidean distance is computed over the entire source. This is not a
+ * local tile update: a small R8 dab dirty rectangle is not the feather domain.
+ * Scratch buffers are reused for the next call and are not per-stroke caches.
+ *
+ * Thread: serial owner worker. Not thread-safe.
+ */
+class BrushSignedDistanceFeather {
+ public:
+  /**
+   * @brief Feather packed R8 @p source onto a same-extent R8 result.
+   *
+   * Compose uses coverage in `(0, 1)` as `coverage - 0.5`, otherwise the exact
+   * distance to the opposite binary band minus 0.5. Smoothstep, invert, opacity,
+   * and round-half-up follow the native Mask pass.
+   *
+   * @param source Tightly packed R8, size `extent.width * extent.height`.
+   * @param extent Positive source/output extent.
+   * @param radius_texels Nonnegative finite source-texel feather radius.
+   * @param invert Applied after feather and before opacity.
+   * @param opacity Multiplier in `[0, 1]` after invert.
+   * @return New packed R8 buffer. @p source is not mutated.
+   * @throws std::runtime_error when extents, byte count, or parameters are invalid.
+   */
+  [[nodiscard]] auto Apply(std::span<const std::uint8_t> source, Extent2D extent,
+                           float radius_texels, bool invert, float opacity)
+      -> std::vector<std::uint8_t>;
+
+ private:
+  void EnsureScratch(std::uint32_t width, std::uint32_t height);
+  void BandHorizontal(std::span<const std::uint8_t> source, bool want_inside);
+  void BandVertical(std::span<float> squared_distance);
+
+  std::uint32_t      width_  = 0;
+  std::uint32_t      height_ = 0;
+  std::vector<float> horizontal_;
+  std::vector<float> inside_;
+  std::vector<float> outside_;
+  std::vector<int>   sites_;
+  std::vector<float> boundaries_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/brush_source_geometry.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_source_geometry.hpp
@@ -1,0 +1,112 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_stroke.hpp"
+#include "edit/mask/mask_model.hpp"
+
+namespace alcedo {
+
+/// Default spatial-index tile size in canonical raster texels. Pixel values do not depend on it.
+inline constexpr std::uint32_t kDefaultBrushSpatialIndexTileTexels = 64;
+
+/**
+ * @brief True when @p rect has no texels (non-positive width or height).
+ */
+[[nodiscard]] inline auto RectIEmpty(RectI rect) -> bool {
+  return rect.width <= 0 || rect.height <= 0;
+}
+
+/**
+ * @brief Tightly packed row-major R8 index for @p x, @p y in @p extent.
+ *
+ * @throws std::invalid_argument when @p extent is empty or the texel is outside it.
+ */
+[[nodiscard]] auto PackedR8Index(std::uint32_t x, std::uint32_t y, Extent2D extent) -> std::size_t;
+
+/**
+ * @brief Integer rectangle covering the entire raster, or empty when @p extent is empty.
+ */
+[[nodiscard]] auto FullTexelRect(Extent2D extent) -> RectI;
+
+/**
+ * @brief Clip @p rect to packed-R8 texel bounds. Empty when the intersection has no samples.
+ */
+[[nodiscard]] auto ClipTexelRect(RectI rect, Extent2D extent) -> RectI;
+
+/**
+ * @brief Bounding union of two texel rectangles. An empty operand is ignored.
+ */
+[[nodiscard]] auto UnionTexelRect(RectI a, RectI b) -> RectI;
+
+/**
+ * @brief Intersection of two texel rectangles. Empty when they do not overlap.
+ */
+[[nodiscard]] auto IntersectTexelRect(RectI a, RectI b) -> RectI;
+
+/**
+ * @brief Axis-aligned texel support of one dab after @p translation, clipped to @p raster.
+ *
+ * Uses the reference-pixel disk of @p sample.radius around the translated center.
+ * Conservative AABB; stamping still tests Euclidean distance per texel.
+ *
+ * @throws std::invalid_argument when extents are empty or @p sample fails encoding rules.
+ */
+[[nodiscard]] auto BrushDabOutputTexelSupport(const BrushCanonicalSample& sample,
+                                              Vector2 translation, Extent2D raster,
+                                              Extent2D full_reference) -> RectI;
+
+/**
+ * @brief Dab support in local (untranslated) canonical texels.
+ */
+[[nodiscard]] auto BrushDabLocalTexelSupport(const BrushCanonicalSample& sample, Extent2D raster,
+                                             Extent2D full_reference) -> RectI;
+
+/**
+ * @brief Union of dab supports for one stroke in output texels.
+ */
+[[nodiscard]] auto BrushStrokeOutputTexelSupport(const BrushStroke& stroke, Vector2 translation,
+                                                 Extent2D raster, Extent2D full_reference)
+    -> RectI;
+
+/**
+ * @brief Union of every dab in @p source after placement, clipped to @p raster.
+ *
+ * Does not expand for source feather or Mask invert. Those belong to effective coverage.
+ *
+ * @throws std::invalid_argument when extents are empty.
+ */
+[[nodiscard]] auto BrushSourceOutputTexelSupport(const BrushMaskSource& source, Extent2D raster,
+                                                 Extent2D full_reference) -> RectI;
+
+/**
+ * @brief Convert an output-texel query into local-texel space by subtracting placement.
+ *
+ * Corners are mapped through reference pixels and outward-rounded so a sub-texel
+ * translation cannot drop a contributing dab.
+ *
+ * @throws std::invalid_argument when extents are empty or @p translation is not finite.
+ */
+[[nodiscard]] auto BrushOutputTexelsToLocal(RectI output_texels, Vector2 translation,
+                                            Extent2D raster, Extent2D full_reference) -> RectI;
+
+/**
+ * @brief Effective Mix support of one Mask, including invert and Brush feather expansion.
+ *
+ * Disabled Masks have empty support. Invert, Linear Gradient, and Brush feather > 0
+ * use the full raster. Radial uses the outer-ellipse AABB. Brush without feather uses
+ * dab supports.
+ *
+ * @throws std::invalid_argument when extents are empty.
+ */
+[[nodiscard]] auto EffectiveMaskTexelSupport(const MaskModel& mask, Extent2D raster,
+                                             Extent2D full_reference) -> RectI;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/brush_spatial_index.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_spatial_index.hpp
@@ -1,0 +1,105 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/brush_stroke.hpp"
+#include "edit/mask/mask_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief One indexed sample span: identities, evaluation range, and local texel bounds.
+ *
+ * Does not store sample coordinates, R8 pixels, or history. Rebuildable from the
+ * parameterized Brush source.
+ */
+struct BrushIndexedSpan {
+  StrokeId    stroke_id;
+  std::size_t stroke_index = 0;
+  std::size_t sample_begin = 0;
+  std::size_t sample_end   = 0;
+  RectI       local_bounds{};
+};
+
+/**
+ * @brief Uniform-tile index of Brush sample spans in local canonical texels.
+ *
+ * Placement is applied at query time so a translation does not rebuild spans.
+ * Tile size affects only which tiles are visited, not dab pixels.
+ *
+ * Thread: serial owner worker. Not thread-safe.
+ */
+class BrushSpatialIndex {
+ public:
+  /**
+   * @brief Construct an empty index.
+   *
+   * @param tile_texels Positive tile size in canonical texels. Default is
+   *        @ref kDefaultBrushSpatialIndexTileTexels.
+   * @throws std::runtime_error when @p tile_texels is zero.
+   */
+  explicit BrushSpatialIndex(std::uint32_t tile_texels = kDefaultBrushSpatialIndexTileTexels);
+
+  /**
+   * @brief Replace spans from @p source. Translation is not baked into stored bounds.
+   *
+   * @throws std::runtime_error when extents are empty, the algorithm version is not 1,
+   *         or a stroke is invalid.
+   */
+  void Rebuild(const BrushMaskSource& source, Extent2D raster, Extent2D full_reference);
+
+  /**
+   * @brief Drop all spans and geometry. Tile size is kept.
+   */
+  void Clear();
+
+  [[nodiscard]] auto TileTexels() const -> std::uint32_t { return tile_texels_; }
+  [[nodiscard]] auto Raster() const -> Extent2D { return raster_; }
+  [[nodiscard]] auto FullReference() const -> Extent2D { return full_reference_; }
+  [[nodiscard]] auto Empty() const -> bool { return spans_.empty(); }
+
+  /**
+   * @brief All stored spans in evaluation order. For tests and rebuild inspection.
+   */
+  [[nodiscard]] auto Spans() const -> std::span<const BrushIndexedSpan> { return spans_; }
+
+  /**
+   * @brief Spans whose local bounds intersect @p local_texels, in stroke/sample order.
+   *
+   * Each span appears once even when it overlaps several tiles. Empty query yields
+   * an empty list, not an error.
+   */
+  [[nodiscard]] auto QueryLocal(RectI local_texels) const -> std::vector<BrushIndexedSpan>;
+
+  /**
+   * @brief Query in output texels by inverse-translating @p output_texels into local space.
+   *
+   * @throws std::runtime_error when geometry has not been rebuilt or @p translation is
+   *         not finite.
+   */
+  [[nodiscard]] auto QueryOutput(RectI output_texels, Vector2 translation) const
+      -> std::vector<BrushIndexedSpan>;
+
+ private:
+  auto TileIndex(std::uint32_t tile_x, std::uint32_t tile_y) const -> std::size_t;
+  auto UniqueSpansIn(RectI local_texels) const -> std::vector<BrushIndexedSpan>;
+
+  std::uint32_t                    tile_texels_ = kDefaultBrushSpatialIndexTileTexels;
+  Extent2D                         raster_{};
+  Extent2D                         full_reference_{};
+  std::uint32_t                    tiles_x_ = 0;
+  std::uint32_t                    tiles_y_ = 0;
+  std::vector<BrushIndexedSpan>    spans_;
+  std::vector<std::vector<std::size_t>> tile_span_indices_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/grade_mask_coverage.hpp
+++ b/alcedo_studio/src/include/edit/mask/grade_mask_coverage.hpp
@@ -1,0 +1,99 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <span>
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/brush_rasterizer.hpp"
+#include "edit/mask/brush_signed_distance.hpp"
+#include "edit/mask/brush_spatial_index.hpp"
+#include "edit/mask/mask_id.hpp"
+#include "edit/mask/mask_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Current Grade Mix coverage R8 from parameterized sources, without raster history.
+ *
+ * Owns one Mix buffer, derived Brush spatial indices, and transient source/feather
+ * scratch. Empty Mask lists write 255; a nonempty list with no enabled Mask writes 0;
+ * otherwise enabled Masks combine by per-pixel maximum after feather, invert, and
+ * opacity. Regional replay rebuilds the dirty rectangle from that defined base.
+ *
+ * Thread: serial owner worker. Not thread-safe.
+ */
+class GradeMaskCoverage {
+ public:
+  /**
+   * @brief Allocate a zeroed Mix raster on the canonical Brush grid.
+   *
+   * @throws std::runtime_error when @p raster or @p full_reference is empty.
+   */
+  void SetGeometry(Extent2D raster, Extent2D full_reference,
+                   std::uint32_t tile_texels = kDefaultBrushSpatialIndexTileTexels);
+
+  /**
+   * @brief Rebuild the local-space spatial index for @p mask_id from @p source.
+   *
+   * Translation is not stored in the index. Call after stroke insert/remove, not
+   * after placement-only edits.
+   *
+   * @throws std::runtime_error when geometry is unset or @p source cannot be indexed.
+   */
+  void BindBrushSource(const MaskId& mask_id, const BrushMaskSource& source);
+
+  /**
+   * @brief Drop the spatial index for @p mask_id. Missing ids are ignored.
+   */
+  void UnbindMask(const MaskId& mask_id);
+
+  /**
+   * @brief Evaluate every Mask into the Mix buffer from the defined base.
+   *
+   * @throws std::runtime_error when geometry is unset, a Brush is unbound, or
+   *         evaluation fails.
+   */
+  void EvaluateFull(std::span<const MaskModel> masks);
+
+  /**
+   * @brief Rebuild Mix in @p dirty from the defined base using surviving sources.
+   *
+   * Empty lists and all-disabled lists fill the entire raster (those bases are
+   * global). Brush feather > 0 still runs a complete signed-distance pass; the
+   * Mix write is then the full raster.
+   *
+   * @throws std::runtime_error when geometry is unset or a Brush index is missing.
+   */
+  void ReplayRegion(std::span<const MaskModel> masks, RectI dirty);
+
+  [[nodiscard]] auto Pixels() const -> std::span<const std::uint8_t> { return mix_; }
+  [[nodiscard]] auto Raster() const -> Extent2D { return raster_; }
+  [[nodiscard]] auto FullReference() const -> Extent2D { return full_reference_; }
+  [[nodiscard]] auto BrushIndex(const MaskId& mask_id) const -> const BrushSpatialIndex*;
+
+ private:
+  void RequireGeometry() const;
+  void FillMix(std::uint8_t value);
+  void ReplayClippedRegion(std::span<const MaskModel> masks, RectI dirty);
+  void WriteEffectiveBrush(const MaskModel& mask, const BrushMaskSource& brush, RectI region,
+                           std::span<std::uint8_t> dest);
+  void WriteEffectiveAnalytic(const MaskModel& mask, RectI region, std::span<std::uint8_t> dest);
+  auto AnalyticCoverage(const MaskModel& mask, std::uint32_t x, std::uint32_t y) const -> float;
+
+  Extent2D                         raster_{};
+  Extent2D                         full_reference_{};
+  std::uint32_t                    tile_texels_ = kDefaultBrushSpatialIndexTileTexels;
+  std::vector<std::uint8_t>        mix_;
+  std::vector<std::uint8_t>        scratch_;
+  BrushRasterizer                  rasterizer_;
+  BrushSignedDistanceFeather       feather_;
+  std::map<MaskId, BrushSpatialIndex> brush_indices_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -331,6 +331,35 @@ gtest_discover_tests(BrushParameterizedSourceTest
   PROPERTIES LABELS "ci_core_flow;edit;mask")
 alcedo_register_test_target(BrushParameterizedSourceTest edit)
 
+# Canonical Brush sampling, spatial index, and regional Mix replay without raster history.
+add_executable(BrushCanonicalSamplerTest
+  ${ALCEDO_TEST_ROOT}/edit/mask/brush_canonical_sampler_test.cpp)
+target_include_directories(BrushCanonicalSamplerTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(BrushCanonicalSamplerTest PRIVATE GTest::gtest_main EditMaskStore)
+gtest_discover_tests(BrushCanonicalSamplerTest
+  TEST_PREFIX "BrushCanonicalSamplerTest."
+  PROPERTIES LABELS "ci_core_flow;edit;mask")
+alcedo_register_test_target(BrushCanonicalSamplerTest edit)
+
+add_executable(BrushSpatialIndexTest
+  ${ALCEDO_TEST_ROOT}/edit/mask/brush_spatial_index_test.cpp)
+target_include_directories(BrushSpatialIndexTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(BrushSpatialIndexTest PRIVATE GTest::gtest_main EditMaskStore)
+gtest_discover_tests(BrushSpatialIndexTest
+  TEST_PREFIX "BrushSpatialIndexTest."
+  PROPERTIES LABELS "ci_core_flow;edit;mask")
+alcedo_register_test_target(BrushSpatialIndexTest edit)
+
+add_executable(BrushRegionalReplayTest
+  ${ALCEDO_TEST_ROOT}/edit/mask/brush_regional_replay_test.cpp)
+target_include_directories(BrushRegionalReplayTest
+  PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_ROOT}/edit/graph ${ALCEDO_TEST_ROOT}/edit/mask)
+target_link_libraries(BrushRegionalReplayTest PRIVATE GTest::gtest_main EditGraph)
+gtest_discover_tests(BrushRegionalReplayTest
+  TEST_PREFIX "BrushRegionalReplayTest."
+  PROPERTIES LABELS "ci_core_flow;edit;mask")
+alcedo_register_test_target(BrushRegionalReplayTest edit)
+
 # Host GraphImageCache retention: LRU budget vs live writes, injected allocation failure.
 add_executable(GraphImageCacheRetentionTest
   ${ALCEDO_TEST_ROOT}/edit/runtime/graph_image_cache_retention_test.cpp)

--- a/alcedo_studio/tests/edit/mask/brush_canonical_sampler_test.cpp
+++ b/alcedo_studio/tests/edit/mask/brush_canonical_sampler_test.cpp
@@ -1,0 +1,83 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_canonical_sampler.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_stroke.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <vector>
+
+namespace alcedo {
+namespace {
+
+auto SamplePath(const std::vector<Vector2>& points, Vector2 translation, float radius)
+    -> std::vector<BrushCanonicalSample> {
+  BrushCanonicalSampler sampler;
+  sampler.BeginStroke(BrushStrokeMode::Paint, points.front(), translation, radius, 1.0f, 1.0f);
+  for (std::size_t i = 1; i < points.size(); ++i) {
+    sampler.AppendReference(points[i]);
+  }
+  return sampler.FinishStroke();
+}
+
+TEST(BrushCanonicalSampler, BeginEmitsPressAndFinishAddsEndpointOnce) {
+  BrushCanonicalSampler sampler;
+  sampler.BeginStroke(BrushStrokeMode::Paint, {4.0f, 6.0f}, {1.0f, 2.0f}, 8.0f, 1.0f, 1.0f);
+  const auto click = sampler.FinishStroke();
+  ASSERT_EQ(click.size(), 1u);
+  EXPECT_FLOAT_EQ(click.front().local_x, 3.0f);
+  EXPECT_FLOAT_EQ(click.front().local_y, 4.0f);
+  EXPECT_FALSE(sampler.IsOpen());
+}
+
+TEST(BrushCanonicalSampler, EventBatchesKeepRemainderAndMatchDenseColinearPath) {
+  const Vector2 start{10.0f, 12.0f};
+  const Vector2 end{30.0f, 12.0f};
+  const float   radius = 8.0f;
+  std::vector<Vector2> sparse{start, end};
+  std::vector<Vector2> grouped{start, {16.0f, 12.0f}, {22.0f, 12.0f}, end};
+  std::vector<Vector2> dense{start};
+  for (int i = 1; i <= 40; ++i) {
+    dense.push_back({start.x + static_cast<float>(i) * 0.5f, start.y});
+  }
+  const auto a = SamplePath(sparse, {}, radius);
+  const auto b = SamplePath(grouped, {}, radius);
+  const auto c = SamplePath(dense, {}, radius);
+  ASSERT_GE(a.size(), 2u);
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(a, c);
+  EXPECT_FLOAT_EQ(a.front().local_x, start.x);
+  EXPECT_FLOAT_EQ(a.back().local_x, end.x);
+}
+
+TEST(BrushCanonicalSampler, ParameterBoundaryKeepsSizeChangeAtCurrentPoint) {
+  BrushCanonicalSampler sampler;
+  sampler.BeginStroke(BrushStrokeMode::Erase, {0.0f, 0.0f}, {}, 8.0f, 1.0f, 1.0f);
+  sampler.SetSampleParameters(4.0f, 0.5f, 0.25f);
+  sampler.AppendReference({20.0f, 0.0f});
+  const auto samples = sampler.FinishStroke();
+  ASSERT_GE(samples.size(), 2u);
+  EXPECT_FLOAT_EQ(samples[1].radius, 4.0f);
+  EXPECT_FLOAT_EQ(samples[1].strength, 0.5f);
+  EXPECT_FLOAT_EQ(samples[1].hardness, 0.25f);
+  EXPECT_EQ(sampler.Mode(), BrushStrokeMode::Erase);
+}
+
+TEST(BrushCanonicalSampler, CancelAndInvalidInputLeaveNoOpenStroke) {
+  BrushCanonicalSampler sampler;
+  EXPECT_THROW(sampler.AppendReference({1.0f, 1.0f}), std::runtime_error);
+  sampler.BeginStroke(BrushStrokeMode::Paint, {0.0f, 0.0f}, {}, 4.0f, 1.0f, 1.0f);
+  EXPECT_THROW(sampler.BeginStroke(BrushStrokeMode::Paint, {1.0f, 1.0f}, {}, 4.0f, 1.0f, 1.0f),
+               std::runtime_error);
+  sampler.CancelStroke();
+  EXPECT_FALSE(sampler.IsOpen());
+  EXPECT_THROW(sampler.BeginStroke(BrushStrokeMode::Paint, {0.0f, 0.0f}, {}, 0.0f, 1.0f, 1.0f),
+               std::runtime_error);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/mask/brush_regional_replay_test.cpp
+++ b/alcedo_studio/tests/edit/mask/brush_regional_replay_test.cpp
@@ -1,0 +1,287 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "brush_replay_oracle.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/mask/brush_canonical_sampler.hpp"
+#include "edit/mask/brush_mask_commands.hpp"
+#include "edit/mask/brush_rasterizer.hpp"
+#include "edit/mask/brush_signed_distance.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/brush_spatial_index.hpp"
+#include "edit/mask/grade_mask_coverage.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "grade_owned_mask_support.hpp"
+
+#include <gtest/gtest.h>
+
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace alcedo {
+namespace {
+
+constexpr Extent2D kRaster{96, 64};
+constexpr Extent2D kFull{96, 64};
+constexpr std::uint32_t kTile = 16;
+
+void ExpectR8Equal(const std::vector<std::uint8_t>& actual,
+                   const std::vector<std::uint8_t>& expected, Extent2D extent) {
+  ASSERT_EQ(actual.size(), expected.size());
+  for (std::uint32_t y = 0; y < extent.height; ++y) {
+    for (std::uint32_t x = 0; x < extent.width; ++x) {
+      const auto i = PackedR8Index(x, y, extent);
+      ASSERT_EQ(actual[i], expected[i]) << "texel " << x << "," << y;
+    }
+  }
+}
+
+auto PaintStroke(std::string_view id, std::vector<BrushCanonicalSample> samples) -> BrushStroke {
+  return MakeBrushStroke(StrokeId{std::string{id}}, BrushStrokeMode::Paint, std::move(samples));
+}
+
+auto EraseStroke(std::string_view id, std::vector<BrushCanonicalSample> samples) -> BrushStroke {
+  return MakeBrushStroke(StrokeId{std::string{id}}, BrushStrokeMode::Erase, std::move(samples));
+}
+
+auto MakeBrush(std::vector<BrushStroke> strokes, Vector2 translation = {}, float feather = 0.0f)
+    -> BrushMaskSource {
+  BrushMaskSource source;
+  source.strokes               = std::move(strokes);
+  source.placement_translation = translation;
+  source.feather_radius        = feather;
+  return source;
+}
+
+auto MakeBrushMask(MaskId id, BrushMaskSource source, bool invert = false, float opacity = 1.0f)
+    -> MaskModel {
+  MaskModel mask;
+  mask.id      = std::move(id);
+  mask.invert  = invert;
+  mask.opacity = opacity;
+  mask.source  = std::move(source);
+  return mask;
+}
+
+TEST(BrushRegionalReplay, RegionalBrushReplayMatchesFullEvaluation) {
+  auto source = MakeBrush({
+      PaintStroke("paint.a", {{12.0f, 10.0f, 6.0f, 1.0f, 1.0f},
+                              {18.0f, 12.0f, 6.0f, 0.75f, 0.5f}}),
+      EraseStroke("erase.b", {{16.0f, 11.0f, 4.0f, 1.0f, 1.0f}}),
+      PaintStroke("paint.c", {{70.0f, 50.0f, 5.0f, 1.0f, 1.0f}}),
+  });
+  BrushSpatialIndex index(kTile);
+  index.Rebuild(source, kRaster, kFull);
+  BrushRasterizer rasterizer;
+  rasterizer.SetGeometry(kRaster, kFull);
+  const auto dirty = BrushSourceOutputTexelSupport(source, kRaster, kFull);
+  rasterizer.ReplayRegion(source, index, dirty);
+  ExpectR8Equal(std::vector<std::uint8_t>(rasterizer.Pixels().begin(), rasterizer.Pixels().end()),
+                brush_replay_oracle::BrushSourceR8(source, kRaster, kFull), kRaster);
+
+  const auto center = CanonicalBrushTexelReferenceCenter(12, 10, kRaster, kFull);
+  EXPECT_NEAR(center.x, 12.5f, 1.0e-5f);
+  EXPECT_NEAR(center.y, 10.5f, 1.0e-5f);
+  const auto distant = PackedR8Index(70, 50, kRaster);
+  EXPECT_EQ(rasterizer.Pixels()[distant], 255);
+
+  BrushRasterizer full;
+  full.SetGeometry(kRaster, kFull);
+  full.RasterizeFull(source);
+  ExpectR8Equal(std::vector<std::uint8_t>(full.Pixels().begin(), full.Pixels().end()),
+                std::vector<std::uint8_t>(rasterizer.Pixels().begin(), rasterizer.Pixels().end()),
+                kRaster);
+
+  const auto before_move = BrushSourceOutputTexelSupport(source, kRaster, kFull);
+  source.placement_translation = {8.0f, -4.0f};
+  const auto after_move = BrushSourceOutputTexelSupport(source, kRaster, kFull);
+  rasterizer.ReplayRegion(source, index, UnionTexelRect(before_move, after_move));
+  ExpectR8Equal(std::vector<std::uint8_t>(rasterizer.Pixels().begin(), rasterizer.Pixels().end()),
+                brush_replay_oracle::BrushSourceR8(source, kRaster, kFull), kRaster);
+}
+
+TEST(BrushRegionalReplay, EraseUndoRestoresEarlierPaint) {
+  auto      grade = ColorGradeNodeModel::MakeClean(NodeId{"grade.primary"});
+  MaskModel mask;
+  mask.id     = MaskId{"mask.brush"};
+  mask.source = BrushMaskSource{};
+  grade->AddMask(std::move(mask), 0);
+  const auto paint =
+      PaintStroke("paint", {{20.0f, 16.0f, 8.0f, 1.0f, 1.0f}, {28.0f, 18.0f, 8.0f, 1.0f, 1.0f}});
+  const auto erase = EraseStroke("erase", {{24.0f, 17.0f, 6.0f, 1.0f, 1.0f}});
+  const auto id    = MaskId{"mask.brush"};
+  grade->AppendBrushStroke({grade->Id(), id, paint, grade->MaskContentRevision(id)});
+  BrushMaskSource painted = std::get<BrushMaskSource>(grade->FindMask(id)->source);
+  GradeMaskCoverage coverage;
+  coverage.SetGeometry(kRaster, kFull, kTile);
+  coverage.BindBrushSource(id, painted);
+  coverage.EvaluateFull(grade->Masks());
+  const auto paint_pixels =
+      std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end());
+
+  grade->AppendBrushStroke({grade->Id(), id, erase, grade->MaskContentRevision(id)});
+  auto erased = std::get<BrushMaskSource>(grade->FindMask(id)->source);
+  coverage.BindBrushSource(id, erased);
+  const auto erase_support = BrushSourceOutputTexelSupport(erased, kRaster, kFull);
+  coverage.ReplayRegion(grade->Masks(), erase_support);
+  ExpectR8Equal(std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end()),
+                brush_replay_oracle::GradeMixR8(grade->Masks(), kRaster, kFull), kRaster);
+
+  const auto erase_only_support = BrushStrokeOutputTexelSupport(
+      erase, erased.placement_translation, kRaster, kFull);
+  grade->RemoveBrushStroke({grade->Id(), id, StrokeId{"erase"}, grade->MaskContentRevision(id)});
+  auto restored = std::get<BrushMaskSource>(grade->FindMask(id)->source);
+  coverage.BindBrushSource(id, restored);
+  coverage.ReplayRegion(grade->Masks(), erase_only_support);
+  ExpectR8Equal(std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end()),
+                paint_pixels, kRaster);
+  ExpectR8Equal(paint_pixels, brush_replay_oracle::GradeMixR8(grade->Masks(), kRaster, kFull),
+                kRaster);
+
+  EXPECT_EQ(PaintBrushR8(30, 200), 200);
+  EXPECT_EQ(PaintBrushR8(90, 200), 200);
+  EXPECT_NE(30, 90);
+}
+
+TEST(BrushRegionalReplay, RemovingUnionMaximumPreservesOtherMasks) {
+  RadialMaskSource radial;
+  radial.center_x     = 0.35f;
+  radial.center_y     = 0.40f;
+  radial.major_radius = 0.45f;
+  radial.minor_radius = 0.40f;
+  auto radial_mask    = grade_mask_test::MakeRadialMask(MaskId{"mask.radial"}, radial);
+  auto brush_source   = MakeBrush({PaintStroke("hot", {{32.0f, 24.0f, 10.0f, 1.0f, 1.0f}})});
+  auto brush_mask     = MakeBrushMask(MaskId{"mask.brush"}, brush_source);
+  std::vector<MaskModel> both{radial_mask, brush_mask};
+  GradeMaskCoverage coverage;
+  coverage.SetGeometry(kRaster, kFull, kTile);
+  coverage.BindBrushSource(brush_mask.id, brush_source);
+  coverage.EvaluateFull(both);
+  ExpectR8Equal(std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end()),
+                brush_replay_oracle::GradeMixR8(both, kRaster, kFull), kRaster);
+
+  const auto brush_support = EffectiveMaskTexelSupport(brush_mask, kRaster, kFull);
+  std::vector<MaskModel> remaining{radial_mask};
+  coverage.UnbindMask(brush_mask.id);
+  coverage.ReplayRegion(remaining, brush_support);
+  const auto expected = brush_replay_oracle::GradeMixR8(remaining, kRaster, kFull);
+  ExpectR8Equal(std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end()),
+                expected, kRaster);
+
+  const auto overlap = PackedR8Index(32, 24, kRaster);
+  EXPECT_GT(expected[overlap], 0);
+  EXPECT_EQ(std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end())[overlap],
+            expected[overlap]);
+  const auto unioned = brush_replay_oracle::GradeMixR8(both, kRaster, kFull);
+  EXPECT_GE(unioned[overlap], expected[overlap]);
+}
+
+TEST(BrushRegionalReplay, BrushEventGroupingPreservesCanonicalPixels) {
+  const Vector2 start{14.0f, 20.0f};
+  const Vector2 end{54.0f, 20.0f};
+  const float   radius = 8.0f;
+  auto sample = [&](const std::vector<Vector2>& points) {
+    BrushCanonicalSampler sampler;
+    sampler.BeginStroke(BrushStrokeMode::Paint, points.front(), {}, radius, 1.0f, 0.5f);
+    for (std::size_t i = 1; i < points.size(); ++i) {
+      sampler.AppendReference(points[i]);
+    }
+    return sampler.FinishStroke();
+  };
+  std::vector<Vector2> sparse{start, end};
+  std::vector<Vector2> grouped{start, {24.0f, 20.0f}, {40.0f, 20.0f}, end};
+  std::vector<Vector2> dense{start};
+  for (int i = 1; i <= 80; ++i) {
+    dense.push_back({start.x + static_cast<float>(i) * 0.5f, start.y});
+  }
+  const auto sparse_samples  = sample(sparse);
+  const auto grouped_samples = sample(grouped);
+  const auto dense_samples   = sample(dense);
+  EXPECT_EQ(sparse_samples, grouped_samples);
+  EXPECT_EQ(sparse_samples, dense_samples);
+
+  auto source = MakeBrush({PaintStroke("grouped", sparse_samples)});
+  BrushSpatialIndex index(kTile);
+  index.Rebuild(source, kRaster, kFull);
+  BrushRasterizer rasterizer;
+  rasterizer.SetGeometry(kRaster, kFull);
+  rasterizer.ReplayRegion(source, index, BrushSourceOutputTexelSupport(source, kRaster, kFull));
+  ExpectR8Equal(std::vector<std::uint8_t>(rasterizer.Pixels().begin(), rasterizer.Pixels().end()),
+                brush_replay_oracle::BrushSourceR8(source, kRaster, kFull), kRaster);
+}
+
+TEST(BrushRegionalReplay, FeatherRebuildMatchesCompleteDistanceEvaluation) {
+  auto source = MakeBrush({PaintStroke("soft", {{22.0f, 18.0f, 7.0f, 1.0f, 0.35f},
+                                               {30.0f, 20.0f, 7.0f, 1.0f, 0.35f}})},
+                          {}, 4.0f);
+  auto mask   = MakeBrushMask(MaskId{"mask.brush"}, source);
+  GradeMaskCoverage coverage;
+  coverage.SetGeometry(kRaster, kFull, kTile);
+  coverage.BindBrushSource(mask.id, source);
+  const auto source_dirty = BrushSourceOutputTexelSupport(source, kRaster, kFull);
+  EXPECT_FALSE(RectIEmpty(source_dirty));
+  EXPECT_LT(source_dirty.width * source_dirty.height,
+            static_cast<int>(kRaster.width * kRaster.height));
+  coverage.ReplayRegion(std::span<const MaskModel>(&mask, 1), source_dirty);
+  ExpectR8Equal(std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end()),
+                brush_replay_oracle::GradeMixR8(std::span<const MaskModel>(&mask, 1), kRaster,
+                                                kFull),
+                kRaster);
+
+  BrushRasterizer rasterizer;
+  rasterizer.SetGeometry(kRaster, kFull);
+  BrushSpatialIndex index(kTile);
+  index.Rebuild(source, kRaster, kFull);
+  rasterizer.ReplayRegion(source, index, source_dirty);
+  const auto radius_texels = BrushFeatherRadiusToSourceTexels(
+      source.feather_radius, kRaster, CanonicalBrushReferenceBounds(), kFull);
+  BrushSignedDistanceFeather feather;
+  const auto dt = feather.Apply(rasterizer.Pixels(), kRaster, radius_texels, false, 1.0f);
+  const auto exact = brush_replay_oracle::ExactSignedDistanceFeather(
+      brush_replay_oracle::BrushSourceR8(source, kRaster, kFull), kRaster, radius_texels, false,
+      1.0f);
+  ExpectR8Equal(dt, exact, kRaster);
+}
+
+TEST(BrushRegionalReplay, EmptyAndDisabledListsUseDefinedCoverageBase) {
+  GradeMaskCoverage coverage;
+  coverage.SetGeometry(kRaster, kFull, kTile);
+  coverage.EvaluateFull({});
+  auto all_one = std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end());
+  EXPECT_EQ(all_one, brush_replay_oracle::GradeMixR8({}, kRaster, kFull));
+  EXPECT_EQ(all_one.front(), 255);
+
+  auto disabled = MakeBrushMask(MaskId{"mask.brush"},
+                                MakeBrush({PaintStroke("p", {{8.0f, 8.0f, 4.0f, 1.0f, 1.0f}})}));
+  disabled.enabled = false;
+  coverage.BindBrushSource(disabled.id, std::get<BrushMaskSource>(disabled.source));
+  coverage.EvaluateFull(std::span<const MaskModel>(&disabled, 1));
+  auto all_zero = std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end());
+  EXPECT_EQ(all_zero, brush_replay_oracle::GradeMixR8(std::span<const MaskModel>(&disabled, 1),
+                                                     kRaster, kFull));
+  EXPECT_EQ(all_zero.front(), 0);
+}
+
+TEST(BrushRegionalReplay, MissingBrushIndexAndUnsupportedAlgorithmFailWithoutPartialMix) {
+  GradeMaskCoverage coverage;
+  coverage.SetGeometry(kRaster, kFull, kTile);
+  coverage.EvaluateFull({});
+  auto before = std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end());
+  auto mask   = MakeBrushMask(
+      MaskId{"mask.brush"}, MakeBrush({PaintStroke("p", {{8.0f, 8.0f, 4.0f, 1.0f, 1.0f}})}));
+  EXPECT_THROW(coverage.EvaluateFull(std::span<const MaskModel>(&mask, 1)), std::runtime_error);
+  ExpectR8Equal(std::vector<std::uint8_t>(coverage.Pixels().begin(), coverage.Pixels().end()),
+                before, kRaster);
+  auto source = std::get<BrushMaskSource>(mask.source);
+  source.raster_algorithm_version = 99;
+  BrushSpatialIndex index(kTile);
+  EXPECT_THROW(index.Rebuild(source, kRaster, kFull), std::runtime_error);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/mask/brush_replay_oracle.hpp
+++ b/alcedo_studio/tests/edit/mask/brush_replay_oracle.hpp
@@ -1,0 +1,190 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <variant>
+#include <vector>
+
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/mask_model.hpp"
+
+namespace alcedo::brush_replay_oracle {
+
+inline constexpr float kAnalyticEpsilon = 1.0e-6f;
+
+inline auto MakeZeroR8(Extent2D extent) -> std::vector<std::uint8_t> {
+  return std::vector<std::uint8_t>(static_cast<std::size_t>(extent.width) * extent.height, 0);
+}
+
+inline auto CombineDab(std::uint8_t previous, std::uint8_t dab, BrushStrokeMode mode)
+    -> std::uint8_t {
+  return mode == BrushStrokeMode::Erase ? EraseBrushR8(previous, dab) : PaintBrushR8(previous, dab);
+}
+
+/**
+ * @brief Independent full Brush source R8. Walks every sample at every texel.
+ *
+ * Does not use the spatial index or regional rasterizer.
+ */
+inline auto BrushSourceR8(const BrushMaskSource& source, Extent2D raster, Extent2D full_reference)
+    -> std::vector<std::uint8_t> {
+  auto pixels = MakeZeroR8(raster);
+  for (const auto& stroke : source.strokes) {
+    for (const auto& sample : BrushStrokeSamples(stroke)) {
+      const float world_x = sample.local_x + source.placement_translation.x;
+      const float world_y = sample.local_y + source.placement_translation.y;
+      for (std::uint32_t y = 0; y < raster.height; ++y) {
+        for (std::uint32_t x = 0; x < raster.width; ++x) {
+          const auto  center = CanonicalBrushTexelReferenceCenter(x, y, raster, full_reference);
+          const float distance = std::hypot(center.x - world_x, center.y - world_y);
+          const auto  dab      = QuantizeMaskCoverageToR8(
+              BrushDabCoverage(distance, sample.radius, sample.strength, sample.hardness));
+          const auto index = PackedR8Index(x, y, raster);
+          pixels[index]    = CombineDab(pixels[index], dab, stroke.mode);
+        }
+      }
+    }
+  }
+  return pixels;
+}
+
+/**
+ * @brief Exhaustive signed-distance feather. Independent of the separable DT.
+ */
+inline auto ExactSignedDistanceFeather(std::span<const std::uint8_t> source, Extent2D extent,
+                                       float radius_texels, bool invert, float opacity)
+    -> std::vector<std::uint8_t> {
+  std::vector<std::uint8_t> output(source.size());
+  for (std::uint32_t y = 0; y < extent.height; ++y) {
+    for (std::uint32_t x = 0; x < extent.width; ++x) {
+      const auto  index    = PackedR8Index(x, y, extent);
+      const float coverage = CoverageFromMaskR8(source[index]);
+      const bool  inside   = coverage >= 0.5f;
+      float       signed_distance;
+      if (coverage > 0.0f && coverage < 1.0f) {
+        signed_distance = coverage - 0.5f;
+      } else {
+        float nearest_squared = (std::numeric_limits<float>::max)();
+        for (std::uint32_t ty = 0; ty < extent.height; ++ty) {
+          for (std::uint32_t tx = 0; tx < extent.width; ++tx) {
+            const auto t_index = PackedR8Index(tx, ty, extent);
+            if ((source[t_index] >= 128) == inside) {
+              continue;
+            }
+            const float dx  = static_cast<float>(x) - static_cast<float>(tx);
+            const float dy  = static_cast<float>(y) - static_cast<float>(ty);
+            nearest_squared = std::min(nearest_squared, dx * dx + dy * dy);
+          }
+        }
+        const float exact       = std::sqrt(nearest_squared);
+        const float to_boundary = std::max(exact - 0.5f, 0.0f);
+        signed_distance         = inside ? to_boundary : -to_boundary;
+      }
+      float value = radius_texels <= 0.0f
+                        ? (signed_distance >= 0.0f ? 1.0f : 0.0f)
+                        : std::clamp(0.5f + signed_distance / (2.0f * radius_texels), 0.0f, 1.0f);
+      value       = value * value * (3.0f - 2.0f * value);
+      if (invert) {
+        value = 1.0f - value;
+      }
+      output[index] = QuantizeMaskCoverageToR8(std::clamp(value * opacity, 0.0f, 1.0f));
+    }
+  }
+  return output;
+}
+
+inline auto AnalyticCoverage(const MaskModel& mask, std::uint32_t x, std::uint32_t y,
+                             Extent2D raster, Extent2D full_reference) -> float {
+  const auto  center = CanonicalBrushTexelReferenceCenter(x, y, raster, full_reference);
+  const float nx     = center.x / static_cast<float>(full_reference.width);
+  const float ny     = center.y / static_cast<float>(full_reference.height);
+  if (const auto* radial = std::get_if<RadialMaskSource>(&mask.source)) {
+    const float c     = std::cos(radial->rotation);
+    const float s     = std::sin(radial->rotation);
+    const float dx    = nx - radial->center_x;
+    const float dy    = ny - radial->center_y;
+    const float rx    = (c * dx + s * dy) / std::max(radial->major_radius, kAnalyticEpsilon);
+    const float ry    = (-s * dx + c * dy) / std::max(radial->minor_radius, kAnalyticEpsilon);
+    const float rho   = std::sqrt(rx * rx + ry * ry);
+    const float inner = std::max(0.0f, 1.0f - radial->inner_feather);
+    const float outer = 1.0f + radial->outer_feather;
+    return 1.0f - std::clamp((rho - inner) / std::max(outer - inner, kAnalyticEpsilon), 0.0f, 1.0f);
+  }
+  const auto& linear        = std::get<LinearGradientMaskSource>(mask.source);
+  const float normal_length = std::hypot(linear.normal_x, linear.normal_y);
+  const float normal_x      = linear.normal_x / std::max(normal_length, kAnalyticEpsilon);
+  const float normal_y      = linear.normal_y / std::max(normal_length, kAnalyticEpsilon);
+  const float distance      = (nx - linear.origin_x) * normal_x + (ny - linear.origin_y) * normal_y;
+  const float t =
+      std::clamp(distance / std::max(linear.transition_distance, kAnalyticEpsilon) + 0.5f, 0.0f,
+                 1.0f);
+  return linear.start_value + (linear.end_value - linear.start_value) * t;
+}
+
+inline auto EffectiveMaskR8(const MaskModel& mask, Extent2D raster, Extent2D full_reference)
+    -> std::vector<std::uint8_t> {
+  auto pixels = MakeZeroR8(raster);
+  if (!mask.enabled) {
+    return pixels;
+  }
+  if (const auto* brush = std::get_if<BrushMaskSource>(&mask.source)) {
+    auto source = BrushSourceR8(*brush, raster, full_reference);
+    if (brush->feather_radius > 0.0f) {
+      const auto radius_texels = BrushFeatherRadiusToSourceTexels(
+          brush->feather_radius, raster, CanonicalBrushReferenceBounds(), full_reference);
+      return ExactSignedDistanceFeather(source, raster, radius_texels, mask.invert, mask.opacity);
+    }
+    for (std::size_t i = 0; i < source.size(); ++i) {
+      float coverage = CoverageFromMaskR8(source[i]);
+      if (mask.invert) {
+        coverage = 1.0f - coverage;
+      }
+      pixels[i] = QuantizeMaskCoverageToR8(std::clamp(coverage * mask.opacity, 0.0f, 1.0f));
+    }
+    return pixels;
+  }
+  for (std::uint32_t y = 0; y < raster.height; ++y) {
+    for (std::uint32_t x = 0; x < raster.width; ++x) {
+      float coverage = AnalyticCoverage(mask, x, y, raster, full_reference);
+      if (mask.invert) {
+        coverage = 1.0f - coverage;
+      }
+      pixels[PackedR8Index(x, y, raster)] =
+          QuantizeMaskCoverageToR8(std::clamp(coverage * mask.opacity, 0.0f, 1.0f));
+    }
+  }
+  return pixels;
+}
+
+inline auto GradeMixR8(std::span<const MaskModel> masks, Extent2D raster, Extent2D full_reference)
+    -> std::vector<std::uint8_t> {
+  if (masks.empty()) {
+    return std::vector<std::uint8_t>(static_cast<std::size_t>(raster.width) * raster.height, 255);
+  }
+  auto       mix         = MakeZeroR8(raster);
+  bool       any_enabled = false;
+  for (const auto& mask : masks) {
+    if (!mask.enabled) {
+      continue;
+    }
+    any_enabled     = true;
+    const auto one  = EffectiveMaskR8(mask, raster, full_reference);
+    for (std::size_t i = 0; i < mix.size(); ++i) {
+      mix[i] = mix[i] > one[i] ? mix[i] : one[i];
+    }
+  }
+  if (!any_enabled) {
+    return mix;
+  }
+  return mix;
+}
+
+}  // namespace alcedo::brush_replay_oracle

--- a/alcedo_studio/tests/edit/mask/brush_spatial_index_test.cpp
+++ b/alcedo_studio/tests/edit/mask/brush_spatial_index_test.cpp
@@ -1,0 +1,76 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/brush_spatial_index.hpp"
+#include "edit/mask/brush_stroke.hpp"
+#include "edit/mask/mask_model.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+namespace alcedo {
+namespace {
+
+auto MakeSource(std::vector<BrushStroke> strokes, Vector2 translation = {}) -> BrushMaskSource {
+  BrushMaskSource source;
+  source.strokes               = std::move(strokes);
+  source.placement_translation = translation;
+  return source;
+}
+
+TEST(BrushSpatialIndex, WindingStrokeDoesNotMarkInteriorTiles) {
+  const Extent2D raster{80, 80};
+  const Extent2D full{80, 80};
+  BrushSpatialIndex index(16);
+  const auto stroke = MakeBrushStroke(
+      StrokeId{"u"}, BrushStrokeMode::Paint,
+      {{8.0f, 8.0f, 3.0f, 1.0f, 1.0f},
+       {8.0f, 72.0f, 3.0f, 1.0f, 1.0f},
+       {72.0f, 72.0f, 3.0f, 1.0f, 1.0f}});
+  index.Rebuild(MakeSource({stroke}), raster, full);
+  ASSERT_EQ(index.Spans().size(), 3u);
+  for (const auto& span : index.Spans()) {
+    EXPECT_FALSE(span.stroke_id.Empty());
+    EXPECT_EQ(span.sample_end, span.sample_begin + 1);
+    EXPECT_FALSE(RectIEmpty(span.local_bounds));
+  }
+  const auto interior = index.QueryLocal({32, 8, 16, 16});
+  EXPECT_TRUE(interior.empty());
+  const auto corner = index.QueryLocal({0, 0, 16, 16});
+  ASSERT_EQ(corner.size(), 1u);
+  EXPECT_EQ(corner.front().sample_begin, 0u);
+}
+
+TEST(BrushSpatialIndex, TranslationQueryUsesLocalIndexWithoutRebuild) {
+  const Extent2D raster{64, 32};
+  const Extent2D full{64, 32};
+  BrushSpatialIndex index(16);
+  const auto stroke = MakeBrushStroke(StrokeId{"a"}, BrushStrokeMode::Paint,
+                                      {{8.0f, 8.0f, 4.0f, 1.0f, 1.0f}});
+  index.Rebuild(MakeSource({stroke}), raster, full);
+  const auto local = index.QueryLocal({0, 0, 16, 16});
+  ASSERT_EQ(local.size(), 1u);
+  const Vector2 translation{16.0f, 0.0f};
+  const auto moved = index.QueryOutput({16, 0, 16, 16}, translation);
+  ASSERT_EQ(moved.size(), 1u);
+  EXPECT_EQ(moved.front().stroke_id, local.front().stroke_id);
+  EXPECT_EQ(moved.front().local_bounds, local.front().local_bounds);
+  const auto unmoved = index.QueryOutput({0, 0, 16, 16}, translation);
+  EXPECT_TRUE(unmoved.empty());
+}
+
+TEST(BrushSpatialIndex, RejectsZeroTileSizeAndUnsupportedAlgorithm) {
+  EXPECT_THROW(BrushSpatialIndex{0}, std::runtime_error);
+  BrushSpatialIndex index(8);
+  BrushMaskSource   source;
+  source.raster_algorithm_version = 2;
+  source.strokes                  = {MakeBrushStroke(StrokeId{"a"}, BrushStrokeMode::Paint,
+                                                     {{4.0f, 4.0f, 2.0f, 1.0f, 1.0f}})};
+  EXPECT_THROW(index.Rebuild(source, {16, 16}, {16, 16}), std::runtime_error);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
@@ -2,7 +2,11 @@
 
 Date: 2026-09-08
 
-Status: NM7.2 parameterized Brush source and Grade owner operations landed; NM7.3 typed stroke/placement history, WAL/Version/Paste remapping, and the Section 8.1 project/schema version gate landed. Raster-only Brush JSON is rejected. NM7.4+ regional replay and cache service remain planned.
+Status: NM7.2 parameterized Brush source and Grade owner operations landed; NM7.3 typed
+stroke/placement history, WAL/Version/Paste remapping, and the Section 8.1 project/schema
+version gate landed. NM7.4 host canonical rasterization, spatial index, and regional Mix
+replay landed. Raster-only Brush JSON is rejected. NM7.5+ mapping, viewer, Interactive Mix,
+and cache service remain planned.
 
 Parent: [NM7 execution plan](phase_nm7_viewer_mask_creation_plan.md).
 This document defines NM7's revised algorithm, data ownership and storage behavior. It replaces

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,9 +2,10 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.3 complete; NM7.4–NM7.14 planned. This document records the NM7.1 source
-audit, NM7.2 parameterized Brush owner operations, and NM7.3 typed stroke history plus the
-project/schema cutover. Remaining sub-phases are unimplemented.
+Status: NM7.1–NM7.4 complete; NM7.5–NM7.14 planned. This document records the NM7.1 source
+audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
+project/schema cutover, and NM7.4 canonical rasterization with regional Mix replay.
+Remaining sub-phases are unimplemented.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -831,6 +832,61 @@ recomputed source → effective coverage → current Grade result.
 
 **Exit:** independent full-evaluation oracle passes paint/erase/overlap/translate/Undo/Redo; index
 uses only IDs/spans/bounds. The simplified prototype is not a substitute for these production tests.
+
+##### Phase NM7.4 completion record (2026-09-08)
+
+**Status:** complete — host canonical Brush rasterization, local-space spatial index, regional
+source replay, full-required signed-distance feather, and Grade Mix union without raster history.
+
+**Primary success call chain:**
+
+```text
+reversible Brush/analytic mutation (Append/Remove stroke or SetBrushTranslation)
+  -> BrushSourceOutputTexelSupport / EffectiveMaskTexelSupport (old union new)
+  -> BrushSpatialIndex::QueryOutput (StrokeId + sample spans + local bounds)
+  -> BrushRasterizer::ReplayRegion (b0 = 0 in dirty texels; paint max / erase min)
+  -> BrushSignedDistanceFeather::Apply when feather_radius > 0 (complete field)
+  -> GradeMaskCoverage Mix: empty list 255, all-disabled 0, else max(effective)
+```
+
+**Primary failure call chain:**
+
+```text
+unbound Brush index, unsupported algorithm version, or invalid sample encoding
+  -> throw before Mix commit
+  -> previous Mix region restored from the dirty-rectangle backup
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `RegionalBrushReplayMatchesFullEvaluation` | `BrushRegionalReplayTest` | PASS |
+| `EraseUndoRestoresEarlierPaint` | `BrushRegionalReplayTest` | PASS |
+| `RemovingUnionMaximumPreservesOtherMasks` | `BrushRegionalReplayTest` | PASS |
+| `BrushEventGroupingPreservesCanonicalPixels` | `BrushRegionalReplayTest` | PASS |
+| `FeatherRebuildMatchesCompleteDistanceEvaluation` | `BrushRegionalReplayTest` | PASS |
+| Dense/grouped pointer events keep remainder | `BrushCanonicalSamplerTest` | PASS |
+| Winding stroke index does not mark interior tiles | `BrushSpatialIndexTest` | PASS |
+| Translation query does not rebuild local spans | `BrushSpatialIndexTest` | PASS |
+| Missing index leaves Mix unchanged | `BrushRegionalReplayTest` | PASS |
+| Existing parameterized Brush JSON/owner tests | `BrushParameterizedSourceTest`, `BrushSourceFormatBoundaryTest` | PASS |
+
+Commands:
+`cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target BrushCanonicalSamplerTest --target BrushSpatialIndexTest --target BrushRegionalReplayTest`
+`ctest --test-dir build/debug --output-on-failure -R "BrushCanonicalSamplerTest|BrushSpatialIndexTest|BrushRegionalReplayTest"`
+`ctest --test-dir build/debug --output-on-failure -R "BrushParameterizedSourceTest|BrushSourceFormatBoundaryTest"`
+
+Suite totals: `14/14` NM7.4 binaries PASS; `19/19` existing Brush source tests PASS.
+Date / working tree on `feature/brush-command-replay` (base `54975ddb`) / Windows MSVC `win_debug` / Qt 6.9.3 / CUDA Toolkit 12.8 (host Mix only; no GPU tests in this phase).
+
+Independent oracle: `alcedo_studio/tests/edit/mask/brush_replay_oracle.hpp` (per-texel dab walk and exhaustive signed distance). Production uses the spatial index, regional stamp, and separable Euclidean distance.
+
+**Checklist / exit condition:** all required tests PASS; index stores StrokeId, sample spans, and local bounds only; Mix/source R8 is current coverage, not a per-stroke checkpoint.
+
+**LOC note (grill-code-review):** `brush_source_geometry.hpp` 112 / `.cpp` 206, `brush_canonical_sampler.hpp` 92 / `.cpp` 137, `brush_spatial_index.hpp` 105 / `.cpp` 140, `brush_rasterizer.hpp` 75 / `.cpp` 128, `brush_signed_distance.hpp` 59 / `.cpp` 167, `grade_mask_coverage.hpp` 99 / `.cpp` 253, `brush_replay_oracle.hpp` 190, `brush_regional_replay_test.cpp` 287. No split required.
+
+**Residual gaps:** host Mix is not yet the Interactive/Quality native Mask pass (NM7.9) or the project Mix-cache slot (NM7.10). Shared ReferenceSpace pointer mapping is NM7.5. Native evaluation still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.5 — Implement shared mapping and parameterized movement
 


### PR DESCRIPTION
## Summary

- Add `BrushCanonicalSampler` to turn reference paths into deterministically spaced canonical dab samples (paint/erase, parameter boundaries, cancel).
- Add brush source geometry helpers for dab texel support, output/local coordinate transforms, and effective mask dirty bounds.
- Add tile-based `BrushSpatialIndex` so regional replay can query only dabs intersecting a dirty rectangle without rebuilding the full raster.
- Add `BrushRasterizer` for paint/erase dab stamping and dirty-rectangle replay from indexed stroke samples.
- Add `BrushSignedDistanceFeather` for feathered brush masks via signed-distance expansion.
- Add `GradeMaskCoverage` to evaluate and regionally replay the grade mix R8 from brush, radial, and linear masks (union-max combine, invert/opacity, defined empty/disabled bases).
- Wire the new mask modules into `EditMaskStore` and add oracle-backed unit tests.
- Update NM7 roadmap docs to record NM7.4 canonical rasterization, spatial index, and regional mix replay as landed.

## Testing

- `ctest --test-dir build/debug -R BrushCanonicalSamplerTest --output-on-failure` — begin/finish endpoint sampling, colinear event batching, parameter-boundary dab emission, cancel and invalid-input rejection.
- `ctest --test-dir build/debug -R BrushSpatialIndexTest --output-on-failure` — winding strokes do not over-index interior tiles, translation queries use local index without rebuild, zero tile size and unsupported algorithm versions fail.
- `ctest --test-dir build/debug -R BrushRegionalReplayTest --output-on-failure` — regional brush replay matches full rasterization and oracle pixels; erase undo restores prior paint; removing one mask preserves union-max with remaining masks; input grouping preserves canonical pixels; feathered regional rebuild matches full signed-distance evaluation; empty/disabled mask lists use defined coverage bases; missing brush index and unsupported algorithm versions fail without partial mix mutation.
- Full edit test suite: Not run.