### PR TITLE
feat(editor): add QSG mask overlay controls to EditorOverlayItem

### DIFF
--- a/alcedo_studio/src/include/ui/alcedo_main/app_theme.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/app_theme.hpp
@@ -171,6 +171,18 @@ class AppTheme final : public QObject {
   Q_PROPERTY(int graphPortHitSize READ graphPortHitSize CONSTANT)
   Q_PROPERTY(int graphEdgeWidth READ graphEdgeWidth CONSTANT)
   Q_PROPERTY(int graphSelectionOutlineWidth READ graphSelectionOutlineWidth CONSTANT)
+  // Mask overlay: two-layer control stroke, no coverage-area color. Sizes are
+  // logical pixels and stay constant at any zoom or DPR.
+  Q_PROPERTY(QColor maskOverlayControlColor READ maskOverlayControlColor NOTIFY ThemeChanged)
+  Q_PROPERTY(QColor maskOverlayControlOutlineColor READ maskOverlayControlOutlineColor NOTIFY
+                 ThemeChanged)
+  Q_PROPERTY(QColor maskOverlayInactiveColor READ maskOverlayInactiveColor NOTIFY ThemeChanged)
+  Q_PROPERTY(int maskOverlayHandleRadius READ maskOverlayHandleRadius CONSTANT)
+  Q_PROPERTY(qreal maskOverlayHandleOutlineWidth READ maskOverlayHandleOutlineWidth CONSTANT)
+  Q_PROPERTY(qreal maskOverlayStrokeWidth READ maskOverlayStrokeWidth CONSTANT)
+  Q_PROPERTY(qreal maskOverlayAntialiasWidth READ maskOverlayAntialiasWidth CONSTANT)
+  Q_PROPERTY(int maskOverlayHandleHitRadius READ maskOverlayHandleHitRadius CONSTANT)
+  Q_PROPERTY(int maskOverlayRotateHandleOffset READ maskOverlayRotateHandleOffset CONSTANT)
 
  public:
   enum class FontRole : int {
@@ -343,6 +355,15 @@ class AppTheme final : public QObject {
   auto graphPortHitSize() const -> int;
   auto graphEdgeWidth() const -> int;
   auto graphSelectionOutlineWidth() const -> int;
+  auto maskOverlayControlColor() const -> QColor;
+  auto maskOverlayControlOutlineColor() const -> QColor;
+  auto maskOverlayInactiveColor() const -> QColor;
+  auto maskOverlayHandleRadius() const -> int;
+  auto maskOverlayHandleOutlineWidth() const -> qreal;
+  auto maskOverlayStrokeWidth() const -> qreal;
+  auto maskOverlayAntialiasWidth() const -> qreal;
+  auto maskOverlayHandleHitRadius() const -> int;
+  auto maskOverlayRotateHandleOffset() const -> int;
 
   auto currentThemeIndex() const -> int;
   void setCurrentThemeIndex(int index);

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_geometry.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_geometry.hpp
@@ -1,0 +1,171 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <QColor>
+#include <QPointF>
+#include <QRectF>
+
+namespace alcedo {
+
+/// Draw radius of a Mask handle disc, in logical pixels. Constant at any zoom/DPR.
+inline constexpr float kMaskOverlayHandleRadiusLogicalPx = 5.0f;
+/// Two-layer handle outline width, in logical pixels.
+inline constexpr float kMaskOverlayHandleOutlineWidthLogicalPx = 1.2f;
+/// Connector and cursor stroke width, in logical pixels.
+inline constexpr float kMaskOverlayStrokeWidthLogicalPx = 1.5f;
+/// Premultiplied edge-alpha fringe width, in logical pixels.
+inline constexpr float kMaskOverlayAntialiasWidthLogicalPx = 1.0f;
+/// Pointer hit radius for Mask handles, in logical pixels. Matches @ref kMaskHandleHitRadiusLogicalPx.
+inline constexpr float kMaskOverlayHandleHitRadiusLogicalPx = 12.0f;
+/// Rotation/direction handle offset from the mapped origin, in logical pixels.
+inline constexpr float kMaskOverlayRotateHandleOffsetLogicalPx = 24.0f;
+/// Maximum chord deviation when tessellating a Radial creation outline, in logical pixels.
+inline constexpr float kMaskOverlayMaxChordDeviationLogicalPx = 0.25f;
+/// Upper bound on Radial outline vertices after adaptive subdivision.
+inline constexpr int kMaskOverlayMaxEllipseVertices = 256;
+
+/**
+ * @brief Published Mask overlay mode. Creating may emit temporary path/outline guides.
+ *
+ * Existing editing never emits coverage fill, heatmap, or settled Brush path geometry.
+ */
+enum class MaskOverlayMode : std::uint8_t {
+  Hidden   = 0,
+  Existing = 1,
+  Creating = 2,
+};
+
+/** @brief Source kind whose controls are shown. None when the overlay is hidden. */
+enum class MaskOverlaySourceKind : std::uint8_t {
+  None            = 0,
+  Brush           = 1,
+  Radial          = 2,
+  LinearGradient  = 3,
+};
+
+/** @brief Finite selected-source handle identity. Not a per-dab proxy. */
+enum class MaskOverlayHandleId : std::uint8_t {
+  None                 = 0,
+  BrushMove            = 1,
+  RadialCenter         = 2,
+  RadialMajor          = 3,
+  RadialMinor          = 4,
+  RadialRotate         = 5,
+  RadialInnerFeather   = 6,
+  RadialOuterFeather   = 7,
+  LinearOrigin         = 8,
+  LinearDirection      = 9,
+  LinearStartBoundary  = 10,
+  LinearEndBoundary    = 11,
+};
+
+/** @brief One handle disc in item/logical coordinates. */
+struct MaskOverlayHandle {
+  MaskOverlayHandleId id = MaskOverlayHandleId::None;
+  QPointF             item{};
+};
+
+/**
+ * @brief Theme-resolved Mask overlay metrics and colors.
+ *
+ * @p control_fill / @p control_outline are the two-layer handle stroke.
+ * @p inactive tints temporary creation guides. There is no coverage-area color.
+ */
+struct MaskOverlayStyle {
+  QColor control_fill    = QColor(0xE0, 0xE0, 0xE0);
+  QColor control_outline = QColor(0x0C, 0x0C, 0x0C);
+  QColor inactive        = QColor(0x7A, 0x7A, 0x7A);
+  float  handle_radius_logical_px          = kMaskOverlayHandleRadiusLogicalPx;
+  float  handle_outline_width_logical_px   = kMaskOverlayHandleOutlineWidthLogicalPx;
+  float  stroke_width_logical_px           = kMaskOverlayStrokeWidthLogicalPx;
+  float  antialias_width_logical_px        = kMaskOverlayAntialiasWidthLogicalPx;
+  float  hit_radius_logical_px             = kMaskOverlayHandleHitRadiusLogicalPx;
+  float  rotate_handle_offset_logical_px   = kMaskOverlayRotateHandleOffsetLogicalPx;
+};
+
+/**
+ * @brief GUI-thread Mask overlay publication. Item coordinates only.
+ *
+ * Built from current input and read-only mapped control positions. The scene
+ * graph copies this derived geometry; it must not lock the pipeline, read worker
+ * state, or perform cache I/O.
+ *
+ * An empty @p clip_rect disables clipping. Degenerate mapped controls yield empty
+ * triangle lists rather than NaN vertices.
+ */
+struct MaskOverlayDisplay {
+  MaskOverlayMode       mode         = MaskOverlayMode::Hidden;
+  MaskOverlaySourceKind source_kind  = MaskOverlaySourceKind::None;
+  std::vector<MaskOverlayHandle> handles;
+  std::vector<std::pair<QPointF, QPointF>> connectors;
+  bool    cursor_visible = false;
+  QPointF cursor_center{};
+  float   cursor_radius_logical_px = 0.0f;
+  std::vector<QPointF> creation_path;
+  std::vector<QPointF> creation_outline;
+  std::vector<std::pair<QPointF, QPointF>> creation_guides;
+  QRectF clip_rect{};
+};
+
+/**
+ * @brief Premultiplied vertex for QSGVertexColorMaterial.
+ *
+ * RGB channels are already multiplied by alpha in 0..255. Coordinates are item/
+ * logical pixels.
+ */
+struct MaskOverlayVertex {
+  float        x = 0.0f;
+  float        y = 0.0f;
+  std::uint8_t r = 0;
+  std::uint8_t g = 0;
+  std::uint8_t b = 0;
+  std::uint8_t a = 0;
+};
+
+/**
+ * @brief Triangle lists for retained Mask overlay nodes.
+ *
+ * @p coverage_fill_vertex_count and @p settled_stroke_path_vertex_count stay
+ * zero: coverage feedback is the photograph, not QSG fill.
+ */
+struct MaskOverlaySceneGeometry {
+  std::vector<MaskOverlayVertex> handle_fill;
+  std::vector<MaskOverlayVertex> handle_outline;
+  std::vector<MaskOverlayVertex> connectors;
+  std::vector<MaskOverlayVertex> cursor;
+  std::vector<MaskOverlayVertex> creation_guides;
+  int handle_count                       = 0;
+  int coverage_fill_vertex_count         = 0;
+  int settled_stroke_path_vertex_count   = 0;
+};
+
+/**
+ * @brief Alcedo-theme defaults matching @c AppTheme index 0 Mask overlay tokens.
+ *
+ * Tests may call this without constructing @c AppTheme. Production QML binds
+ * live theme colors onto @ref EditorOverlayItem.
+ */
+[[nodiscard]] auto DefaultMaskOverlayStyle() -> MaskOverlayStyle;
+
+/**
+ * @brief Build triangle lists from a published Mask overlay display.
+ *
+ * @param display Item-space controls and optional creation guides.
+ * @param style Logical sizes and theme colors. Handle/stroke widths stay in
+ *        logical pixels; they are not scaled by zoom or DPR.
+ * @return Triangle lists. Hidden or fully clipped displays are empty.
+ *
+ * Thread: GUI. Pure; no scene-graph, pipeline, or I/O access.
+ */
+[[nodiscard]] auto BuildMaskOverlaySceneGeometry(const MaskOverlayDisplay& display,
+                                                 const MaskOverlayStyle& style)
+    -> MaskOverlaySceneGeometry;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
@@ -1,0 +1,117 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <vector>
+
+#include <QPointF>
+#include <QRectF>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "ui/edit_viewer/mask_edit_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_geometry.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Map a normalized ReferenceSpace point to item coordinates.
+ *
+ * @return Empty when @p mapping is invalid or the mapped point is not finite.
+ */
+[[nodiscard]] auto MapNormalizedMaskPointToItem(const MaskEditViewMapping& mapping,
+                                                Vector2 normalized) -> std::optional<QPointF>;
+
+/**
+ * @brief Normalized Radial boundary point at @p rho and angle @p theta_radians.
+ *
+ * Inverse of the native Radial evaluator's local (u, v) frame:
+ * @c u = rho * cos(theta), @c v = rho * sin(theta).
+ */
+[[nodiscard]] auto RadialNormalizedPoint(const RadialMaskSource& source, float rho,
+                                         float theta_radians) -> Vector2;
+
+/**
+ * @brief Tessellate a Radial iso-@p rho curve into item-space vertices.
+ *
+ * Subdivides until projected chord error is at most
+ * @ref kMaskOverlayMaxChordDeviationLogicalPx or @ref kMaskOverlayMaxEllipseVertices
+ * is reached. Degenerate or unmappable curves return an empty polyline.
+ *
+ * @param mapping Current viewer mapping.
+ * @param source Radial parameters in normalized ReferenceSpace.
+ * @param rho Evaluator rho (1 = radius, inner/outer feather boundaries differ).
+ * @param clip Drop vertices whose item position lies outside @p clip expanded by
+ *        one handle radius. Empty @p clip disables clipping.
+ */
+[[nodiscard]] auto TessellateRadialBoundaryItemPolyline(const MaskEditViewMapping& mapping,
+                                                        const RadialMaskSource& source, float rho,
+                                                        const QRectF& clip) -> std::vector<QPointF>;
+
+/**
+ * @brief Existing Brush: Move handle at @p placement_translation. No stroke path.
+ */
+[[nodiscard]] auto MakeBrushExistingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                                   Vector2 placement_translation,
+                                                   const QRectF& clip) -> MaskOverlayDisplay;
+
+/**
+ * @brief Existing Radial: center, axes, rotation, and distinct feather handles.
+ *
+ * Connectors only. No ellipse fill and no iso-rho outline.
+ */
+[[nodiscard]] auto MakeRadialExistingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                                    const RadialMaskSource& source,
+                                                    const MaskOverlayStyle& style,
+                                                    const QRectF& clip) -> MaskOverlayDisplay;
+
+/**
+ * @brief Existing Linear Gradient: origin, direction, and transition boundaries.
+ *
+ * Finite connectors only. No filled coverage band.
+ */
+[[nodiscard]] auto MakeLinearExistingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                                    const LinearGradientMaskSource& source,
+                                                    const MaskOverlayStyle& style,
+                                                    const QRectF& clip) -> MaskOverlayDisplay;
+
+/**
+ * @brief Initial Brush drawing: cursor plus a temporary path through @p item_path.
+ *
+ * @p item_path must already be the canonical sample sequence mapped to item space.
+ * This function does not resample pointer events. No area fill.
+ */
+[[nodiscard]] auto MakeBrushCreatingOverlayDisplay(const std::vector<QPointF>& item_path,
+                                                   QPointF cursor_item,
+                                                   float cursor_radius_logical_px,
+                                                   const QRectF& clip) -> MaskOverlayDisplay;
+
+/**
+ * @brief Initial Radial drawing: existing handles plus a temporary outline at rho = 1.
+ */
+[[nodiscard]] auto MakeRadialCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                                    const RadialMaskSource& source,
+                                                    const MaskOverlayStyle& style,
+                                                    const QRectF& clip) -> MaskOverlayDisplay;
+
+/**
+ * @brief Initial Linear drawing: existing handles plus finite locus guides.
+ */
+[[nodiscard]] auto MakeLinearCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                                    const LinearGradientMaskSource& source,
+                                                    const MaskOverlayStyle& style,
+                                                    const QRectF& clip) -> MaskOverlayDisplay;
+
+/**
+ * @brief Item-space length of a ReferenceSpace radius around @p center_reference.
+ *
+ * Maps @p center_reference and a point one @p radius_reference_px along +X.
+ * Empty when either map fails.
+ */
+[[nodiscard]] auto MapReferenceRadiusToItem(const MaskEditViewMapping& mapping,
+                                            Vector2 center_reference, float radius_reference_px)
+    -> std::optional<float>;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/ui/editor_rhi/editor_overlay_item.hpp
+++ b/alcedo_studio/src/include/ui/editor_rhi/editor_overlay_item.hpp
@@ -4,18 +4,20 @@
 
 #pragma once
 
+#include <QColor>
 #include <QPointF>
 #include <QQuickItem>
 
 #include <vector>
 
 #include "ui/edit_viewer/edit_viewer_overlay_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_geometry.hpp"
 
 namespace alcedo::editor_rhi {
 
 class EditorInteractionController;
 
-// Pure geometry description used by both the QSG item and golden tests.
+// Pure geometry description used by both the QSG item and overlay tests.
 // Vertices are in item/logical coordinates (not physical pixels).
 // All stroke content is triangle lists so D3D11 (no reliable lineWidth) matches
 // OpenGL and the legacy QPainter overlay appearance.
@@ -54,8 +56,9 @@ struct OverlaySceneGeometry {
 auto BuildOverlaySceneGeometry(const CropOverlayWidgetGeometry& geometry,
                                bool crop_tool_visible) -> OverlaySceneGeometry;
 
-// QQuickItem that renders crop mask/grid/handles and detail-ROI bounds as
-// retained QSGGeometryNode content. Photograph pixels stay in EditorViewportItem.
+// QQuickItem that renders crop mask/grid/handles, detail-ROI bounds, and Mask
+// controls as retained QSGGeometryNode content. Photograph pixels stay in
+// EditorViewportItem. The overlay accepts no pointer grab.
 class EditorOverlayItem : public QQuickItem {
   Q_OBJECT
   Q_PROPERTY(EditorInteractionController* interaction READ interaction WRITE setInteraction NOTIFY
@@ -65,6 +68,22 @@ class EditorOverlayItem : public QQuickItem {
   // Diagnostics for tests: rebuilds coalesce; paint updates vertices in place.
   Q_PROPERTY(int geometryRebuildCount READ geometryRebuildCount NOTIFY GeometryRevisionChanged)
   Q_PROPERTY(int paintNodeCreateCount READ paintNodeCreateCount NOTIFY GeometryRevisionChanged)
+  Q_PROPERTY(int maskPaintNodeCreateCount READ maskPaintNodeCreateCount NOTIFY
+                 MaskOverlayRevisionChanged)
+  Q_PROPERTY(QColor maskOverlayControlColor READ maskOverlayControlColor WRITE
+                 setMaskOverlayControlColor NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(QColor maskOverlayControlOutlineColor READ maskOverlayControlOutlineColor WRITE
+                 setMaskOverlayControlOutlineColor NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(QColor maskOverlayInactiveColor READ maskOverlayInactiveColor WRITE
+                 setMaskOverlayInactiveColor NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(qreal maskOverlayHandleRadius READ maskOverlayHandleRadius WRITE
+                 setMaskOverlayHandleRadius NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(qreal maskOverlayHandleOutlineWidth READ maskOverlayHandleOutlineWidth WRITE
+                 setMaskOverlayHandleOutlineWidth NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(qreal maskOverlayStrokeWidth READ maskOverlayStrokeWidth WRITE
+                 setMaskOverlayStrokeWidth NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(qreal maskOverlayAntialiasWidth READ maskOverlayAntialiasWidth WRITE
+                 setMaskOverlayAntialiasWidth NOTIFY MaskOverlayStyleChanged)
 
  public:
   explicit EditorOverlayItem(QQuickItem* parent = nullptr);
@@ -76,11 +95,60 @@ class EditorOverlayItem : public QQuickItem {
   [[nodiscard]] auto geometryRevision() const -> int { return geometry_revision_; }
   [[nodiscard]] auto geometryRebuildCount() const -> int { return geometry_rebuild_count_; }
   [[nodiscard]] auto paintNodeCreateCount() const -> int { return paint_node_create_count_; }
+  [[nodiscard]] auto maskPaintNodeCreateCount() const -> int {
+    return mask_paint_node_create_count_;
+  }
 
-  // Test access: last built scene geometry after a sync.
+  [[nodiscard]] auto maskOverlayControlColor() const -> QColor {
+    return mask_style_.control_fill;
+  }
+  void setMaskOverlayControlColor(const QColor& color);
+  [[nodiscard]] auto maskOverlayControlOutlineColor() const -> QColor {
+    return mask_style_.control_outline;
+  }
+  void setMaskOverlayControlOutlineColor(const QColor& color);
+  [[nodiscard]] auto maskOverlayInactiveColor() const -> QColor { return mask_style_.inactive; }
+  void setMaskOverlayInactiveColor(const QColor& color);
+  [[nodiscard]] auto maskOverlayHandleRadius() const -> qreal {
+    return static_cast<qreal>(mask_style_.handle_radius_logical_px);
+  }
+  void setMaskOverlayHandleRadius(qreal radius);
+  [[nodiscard]] auto maskOverlayHandleOutlineWidth() const -> qreal {
+    return static_cast<qreal>(mask_style_.handle_outline_width_logical_px);
+  }
+  void setMaskOverlayHandleOutlineWidth(qreal width);
+  [[nodiscard]] auto maskOverlayStrokeWidth() const -> qreal {
+    return static_cast<qreal>(mask_style_.stroke_width_logical_px);
+  }
+  void setMaskOverlayStrokeWidth(qreal width);
+  [[nodiscard]] auto maskOverlayAntialiasWidth() const -> qreal {
+    return static_cast<qreal>(mask_style_.antialias_width_logical_px);
+  }
+  void setMaskOverlayAntialiasWidth(qreal width);
+
+  // Test access: last built crop scene geometry after a sync.
   [[nodiscard]] auto lastSceneGeometry() const -> const OverlaySceneGeometry& {
     return last_scene_geometry_;
   }
+
+  /**
+   * @brief Publish mapped Mask controls for the next scene-graph frame.
+   *
+   * @param display Item-space handles and optional creation guides. Hidden
+   *        clears Mask overlay nodes. Does not lock the pipeline or read
+   *        document/cache state.
+   *
+   * Thread: GUI. Schedules @c update(). @c updatePaintNode copies the derived
+   * triangles while Qt blocks the GUI thread.
+   */
+  void setMaskOverlayDisplay(MaskOverlayDisplay display);
+  [[nodiscard]] auto maskOverlayDisplay() const -> const MaskOverlayDisplay& {
+    return mask_display_;
+  }
+  [[nodiscard]] auto lastMaskSceneGeometry() const -> const MaskOverlaySceneGeometry& {
+    return last_mask_scene_geometry_;
+  }
+  [[nodiscard]] auto maskOverlayStyle() const -> const MaskOverlayStyle& { return mask_style_; }
 
   // Force a rebuild from the current interaction snapshot (also used by tests).
   Q_INVOKABLE void refreshFromInteraction();
@@ -88,6 +156,8 @@ class EditorOverlayItem : public QQuickItem {
  signals:
   void InteractionChanged();
   void GeometryRevisionChanged();
+  void MaskOverlayRevisionChanged();
+  void MaskOverlayStyleChanged();
 
  protected:
   auto updatePaintNode(QSGNode* old_node, UpdatePaintNodeData* data) -> QSGNode* override;
@@ -97,14 +167,19 @@ class EditorOverlayItem : public QQuickItem {
   struct OverlayRootNode;
   void scheduleRebuildFromInteraction();
   void rebuildSceneGeometry();
+  void rebuildMaskSceneGeometry();
   void bindInteraction(EditorInteractionController* controller);
   void onInteractionOverlayChanged();
 
   EditorInteractionController* interaction_ = nullptr;
   OverlaySceneGeometry last_scene_geometry_{};
+  MaskOverlayDisplay mask_display_{};
+  MaskOverlayStyle mask_style_ = DefaultMaskOverlayStyle();
+  MaskOverlaySceneGeometry last_mask_scene_geometry_{};
   int geometry_revision_ = 0;
   int geometry_rebuild_count_ = 0;
   int paint_node_create_count_ = 0;
+  int mask_paint_node_create_count_ = 0;
   bool geometry_dirty_ = true;
   bool rebuild_scheduled_ = false;
 };

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -19,6 +19,8 @@ def_library(EditorViewerLogic
         "${ALCEDO_UI_ROOT}/edit_viewer/edit_viewer_overlay_geometry.cpp"
         "${ALCEDO_UI_ROOT}/edit_viewer/viewport_mapper.cpp"
         "${ALCEDO_UI_ROOT}/edit_viewer/mask_edit_geometry.cpp"
+        "${ALCEDO_UI_ROOT}/edit_viewer/mask_overlay_geometry.cpp"
+        "${ALCEDO_UI_ROOT}/edit_viewer/mask_overlay_layout.cpp"
         "${ALCEDO_UI_ROOT}/edit_viewer/crop_geometry.cpp"
         "${ALCEDO_UI_ROOT}/edit_viewer/view_transform_controller.cpp"
         "${ALCEDO_UI_ROOT}/edit_viewer/crop_interaction_controller.cpp"
@@ -26,6 +28,8 @@ def_library(EditorViewerLogic
         "${ALCEDO_INCLUDE_ROOT}/ui/edit_viewer/viewer_state.hpp"
         "${ALCEDO_INCLUDE_ROOT}/ui/edit_viewer/viewport_mapper.hpp"
         "${ALCEDO_INCLUDE_ROOT}/ui/edit_viewer/mask_edit_geometry.hpp"
+        "${ALCEDO_INCLUDE_ROOT}/ui/edit_viewer/mask_overlay_geometry.hpp"
+        "${ALCEDO_INCLUDE_ROOT}/ui/edit_viewer/mask_overlay_layout.hpp"
         "${ALCEDO_INCLUDE_ROOT}/ui/edit_viewer/crop_geometry.hpp"
         "${ALCEDO_INCLUDE_ROOT}/ui/edit_viewer/view_transform_controller.hpp"
         "${ALCEDO_INCLUDE_ROOT}/ui/edit_viewer/crop_interaction_controller.hpp"
@@ -34,6 +38,7 @@ def_library(EditorViewerLogic
         Qt6::Core
         Qt6::Gui
         opencv_core
+        EditMaskStore
 )
 
 def_library(BackgroundTaskController

--- a/alcedo_studio/src/ui/alcedo_main/DESIGN.md
+++ b/alcedo_studio/src/ui/alcedo_main/DESIGN.md
@@ -408,6 +408,31 @@ invisible QuickQanava selection delegate, so the default blue animated
 selection item never renders. Do not set `selectionDelegate` to null in QML;
 null resets the QuickQanava default instead of disabling it.
 
+### Editor viewport Mask overlay
+
+Retained QSG Mask controls sit on `EditorOverlayItem` above the photograph. They
+use a two-layer high-contrast stroke. Existing-mask editing never paints a
+coverage fill, heatmap, or completed Brush path; the Interactive photograph
+supplies coverage feedback. Temporary cursor, outline, and path guides are
+allowed only during initial drawing.
+
+Handle and stroke widths are logical pixels and stay constant at any zoom or
+DPR. Image-space Brush cursor radius is transformed through the shared
+ReferenceSpace mapping. Do not add a coverage-area color. Do not use Material
+controls, badges, pills, or status dots on this overlay.
+
+| Token | Value | Use |
+| --- | --- | --- |
+| `maskOverlayControlColor` | `textColor` | Selected handle fill and connector stroke |
+| `maskOverlayControlOutlineColor` | `bgCanvasColor` | Handle outline |
+| `maskOverlayInactiveColor` | `textMutedColor` | Temporary initial-creation guides |
+| `maskOverlayHandleRadius` | 5 | Handle disc radius (logical px) |
+| `maskOverlayHandleOutlineWidth` | 1.2 | Handle outline width (logical px) |
+| `maskOverlayStrokeWidth` | 1.5 | Connector and cursor stroke (logical px) |
+| `maskOverlayAntialiasWidth` | 1.0 | Premultiplied edge-alpha fringe (logical px) |
+| `maskOverlayHandleHitRadius` | 12 | Pointer hit radius (logical px) |
+| `maskOverlayRotateHandleOffset` | 24 | Rotation/direction handle offset (logical px) |
+
 ### Color Grade node content
 
 A Color Grade node shows only:

--- a/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
@@ -1012,6 +1012,24 @@ auto AppTheme::graphEdgeWidth() const -> int { return 2; }
 
 auto AppTheme::graphSelectionOutlineWidth() const -> int { return 1; }
 
+auto AppTheme::maskOverlayControlColor() const -> QColor { return textColor(); }
+
+auto AppTheme::maskOverlayControlOutlineColor() const -> QColor { return bgCanvasColor(); }
+
+auto AppTheme::maskOverlayInactiveColor() const -> QColor { return textMutedColor(); }
+
+auto AppTheme::maskOverlayHandleRadius() const -> int { return 5; }
+
+auto AppTheme::maskOverlayHandleOutlineWidth() const -> qreal { return 1.2; }
+
+auto AppTheme::maskOverlayStrokeWidth() const -> qreal { return 1.5; }
+
+auto AppTheme::maskOverlayAntialiasWidth() const -> qreal { return 1.0; }
+
+auto AppTheme::maskOverlayHandleHitRadius() const -> int { return 12; }
+
+auto AppTheme::maskOverlayRotateHandleOffset() const -> int { return 24; }
+
 auto AppTheme::scopePlotBorderColor() const -> QColor {
   return Blend(bgBaseColor(), textMutedColor(), 0.42);
 }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
@@ -218,6 +218,13 @@ Item {
                         anchors.fill: parent
                         visible: root.hasImage
                         interaction: editorInteraction
+                        maskOverlayControlColor: appTheme.maskOverlayControlColor
+                        maskOverlayControlOutlineColor: appTheme.maskOverlayControlOutlineColor
+                        maskOverlayInactiveColor: appTheme.maskOverlayInactiveColor
+                        maskOverlayHandleRadius: appTheme.maskOverlayHandleRadius
+                        maskOverlayHandleOutlineWidth: appTheme.maskOverlayHandleOutlineWidth
+                        maskOverlayStrokeWidth: appTheme.maskOverlayStrokeWidth
+                        maskOverlayAntialiasWidth: appTheme.maskOverlayAntialiasWidth
                         // Overlay must sit above the photograph and receive no
                         // exclusive mouse grab — handlers below own input.
                         z: 2

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_geometry.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_geometry.cpp
@@ -1,0 +1,317 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "ui/edit_viewer/mask_overlay_geometry.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+
+namespace alcedo {
+namespace {
+
+constexpr int kDiscSegments = 20;
+constexpr int kCapSegments  = 10;
+constexpr float kMinLength  = 1.0e-6f;
+
+[[nodiscard]] auto IsFinitePoint(const QPointF& point) -> bool {
+  return std::isfinite(point.x()) && std::isfinite(point.y());
+}
+
+[[nodiscard]] auto Premultiply(const QColor& color, float alpha_scale) -> MaskOverlayVertex {
+  const float clamped = std::clamp(alpha_scale, 0.0f, 1.0f) * static_cast<float>(color.alphaF());
+  MaskOverlayVertex vertex;
+  vertex.r = static_cast<std::uint8_t>(
+      std::lround(static_cast<float>(color.red()) * clamped));
+  vertex.g = static_cast<std::uint8_t>(
+      std::lround(static_cast<float>(color.green()) * clamped));
+  vertex.b = static_cast<std::uint8_t>(
+      std::lround(static_cast<float>(color.blue()) * clamped));
+  vertex.a = static_cast<std::uint8_t>(std::lround(clamped * 255.0f));
+  return vertex;
+}
+
+[[nodiscard]] auto MakeVertex(const QPointF& point, const QColor& color, float alpha_scale)
+    -> MaskOverlayVertex {
+  MaskOverlayVertex vertex = Premultiply(color, alpha_scale);
+  vertex.x                 = static_cast<float>(point.x());
+  vertex.y                 = static_cast<float>(point.y());
+  return vertex;
+}
+
+void AppendTriangle(std::vector<MaskOverlayVertex>& triangles, const QPointF& a, const QPointF& b,
+                    const QPointF& c, const QColor& color, float alpha_a, float alpha_b,
+                    float alpha_c) {
+  if (!IsFinitePoint(a) || !IsFinitePoint(b) || !IsFinitePoint(c)) {
+    return;
+  }
+  triangles.push_back(MakeVertex(a, color, alpha_a));
+  triangles.push_back(MakeVertex(b, color, alpha_b));
+  triangles.push_back(MakeVertex(c, color, alpha_c));
+}
+
+void AppendTriangle(std::vector<MaskOverlayVertex>& triangles, const QPointF& a, const QPointF& b,
+                    const QPointF& c, const QColor& color) {
+  AppendTriangle(triangles, a, b, c, color, 1.0f, 1.0f, 1.0f);
+}
+
+[[nodiscard]] auto ExpandedClip(const QRectF& clip, float pad) -> QRectF {
+  if (!clip.isValid() || clip.isEmpty()) {
+    return {};
+  }
+  return clip.adjusted(-static_cast<qreal>(pad), -static_cast<qreal>(pad),
+                       static_cast<qreal>(pad), static_cast<qreal>(pad));
+}
+
+[[nodiscard]] auto PointInsideClip(const QPointF& point, const QRectF& clip) -> bool {
+  if (!clip.isValid() || clip.isEmpty()) {
+    return true;
+  }
+  return clip.contains(point);
+}
+
+// Liang–Barsky clip of segment a→b against an axis-aligned rectangle.
+[[nodiscard]] auto ClipSegment(const QPointF& a, const QPointF& b, const QRectF& clip)
+    -> std::optional<std::pair<QPointF, QPointF>> {
+  if (!clip.isValid() || clip.isEmpty()) {
+    if (!IsFinitePoint(a) || !IsFinitePoint(b)) {
+      return std::nullopt;
+    }
+    return std::make_pair(a, b);
+  }
+  const double dx = b.x() - a.x();
+  const double dy = b.y() - a.y();
+  double t0       = 0.0;
+  double t1       = 1.0;
+  const double p[4] = {-dx, dx, -dy, dy};
+  const double q[4] = {a.x() - clip.left(), clip.right() - a.x(), a.y() - clip.top(),
+                       clip.bottom() - a.y()};
+  for (int i = 0; i < 4; ++i) {
+    if (std::abs(p[i]) < 1.0e-12) {
+      if (q[i] < 0.0) {
+        return std::nullopt;
+      }
+      continue;
+    }
+    const double t = q[i] / p[i];
+    if (p[i] < 0.0) {
+      t0 = std::max(t0, t);
+    } else {
+      t1 = std::min(t1, t);
+    }
+    if (t0 > t1) {
+      return std::nullopt;
+    }
+  }
+  return std::make_pair(QPointF(a.x() + t0 * dx, a.y() + t0 * dy),
+                        QPointF(a.x() + t1 * dx, a.y() + t1 * dy));
+}
+
+[[nodiscard]] auto PerpUnit(const QPointF& a, const QPointF& b) -> QPointF {
+  const double dx  = b.x() - a.x();
+  const double dy  = b.y() - a.y();
+  const double len = std::hypot(dx, dy);
+  if (len < kMinLength) {
+    return {1.0, 0.0};
+  }
+  return {-dy / len, dx / len};
+}
+
+void AppendStrokeCoreAndFringe(std::vector<MaskOverlayVertex>& triangles, const QPointF& a,
+                               const QPointF& b, float width, float aa, const QColor& color) {
+  const QPointF n    = PerpUnit(a, b);
+  const double half  = static_cast<double>(width) * 0.5;
+  const double outer = half + static_cast<double>(std::max(aa, 0.0f));
+  const QPointF c0(a.x() + n.x() * half, a.y() + n.y() * half);
+  const QPointF c1(a.x() - n.x() * half, a.y() - n.y() * half);
+  const QPointF c2(b.x() - n.x() * half, b.y() - n.y() * half);
+  const QPointF c3(b.x() + n.x() * half, b.y() + n.y() * half);
+  AppendTriangle(triangles, c0, c1, c2, color);
+  AppendTriangle(triangles, c0, c2, c3, color);
+  if (aa > 0.0f) {
+    const QPointF o0(a.x() + n.x() * outer, a.y() + n.y() * outer);
+    const QPointF o1(b.x() + n.x() * outer, b.y() + n.y() * outer);
+    const QPointF o2(a.x() - n.x() * outer, a.y() - n.y() * outer);
+    const QPointF o3(b.x() - n.x() * outer, b.y() - n.y() * outer);
+    AppendTriangle(triangles, c0, o0, o1, color, 1.0f, 0.0f, 0.0f);
+    AppendTriangle(triangles, c0, o1, c3, color, 1.0f, 0.0f, 1.0f);
+    AppendTriangle(triangles, c1, c2, o3, color, 1.0f, 1.0f, 0.0f);
+    AppendTriangle(triangles, c1, o3, o2, color, 1.0f, 0.0f, 0.0f);
+  }
+}
+
+void AppendRoundCap(std::vector<MaskOverlayVertex>& triangles, const QPointF& center,
+                    const QPointF& along, float radius, float aa, const QColor& color) {
+  const double len = std::hypot(along.x(), along.y());
+  if (len < kMinLength || radius <= 0.0f) {
+    return;
+  }
+  const QPointF dir = {along.x() / len, along.y() / len};
+  const QPointF n   = {-dir.y(), dir.x()};
+  const double start = std::atan2(-n.y(), -n.x());
+  constexpr double kPi = 3.14159265358979323846;
+  for (int i = 0; i < kCapSegments; ++i) {
+    const double a0 = start + (kPi * static_cast<double>(i) / kCapSegments);
+    const double a1 = start + (kPi * static_cast<double>(i + 1) / kCapSegments);
+    const QPointF p0(center.x() + std::cos(a0) * radius, center.y() + std::sin(a0) * radius);
+    const QPointF p1(center.x() + std::cos(a1) * radius, center.y() + std::sin(a1) * radius);
+    AppendTriangle(triangles, center, p0, p1, color);
+    if (aa > 0.0f) {
+      const float outer = radius + aa;
+      const QPointF q0(center.x() + std::cos(a0) * outer, center.y() + std::sin(a0) * outer);
+      const QPointF q1(center.x() + std::cos(a1) * outer, center.y() + std::sin(a1) * outer);
+      AppendTriangle(triangles, p0, q0, q1, color, 1.0f, 0.0f, 0.0f);
+      AppendTriangle(triangles, p0, q1, p1, color, 1.0f, 0.0f, 1.0f);
+    }
+  }
+}
+
+void AppendClippedStroke(std::vector<MaskOverlayVertex>& triangles, const QPointF& a,
+                         const QPointF& b, float width, float aa, const QColor& color,
+                         const QRectF& clip, bool round_caps) {
+  const auto clipped = ClipSegment(a, b, ExpandedClip(clip, width * 0.5f + aa));
+  if (!clipped) {
+    return;
+  }
+  AppendStrokeCoreAndFringe(triangles, clipped->first, clipped->second, width, aa, color);
+  if (round_caps) {
+    const QPointF ab = clipped->second - clipped->first;
+    AppendRoundCap(triangles, clipped->first, clipped->first - clipped->second, width * 0.5f, aa,
+                   color);
+    AppendRoundCap(triangles, clipped->second, ab, width * 0.5f, aa, color);
+  }
+}
+
+void AppendPolylineStroke(std::vector<MaskOverlayVertex>& triangles,
+                          const std::vector<QPointF>& points, bool closed, float width, float aa,
+                          const QColor& color, const QRectF& clip) {
+  if (points.size() < 2) {
+    return;
+  }
+  const std::size_t count = closed ? points.size() : points.size() - 1;
+  for (std::size_t i = 0; i < count; ++i) {
+    AppendClippedStroke(triangles, points[i], points[(i + 1) % points.size()], width, aa, color,
+                        clip, /*round_caps=*/false);
+  }
+}
+
+void AppendFilledDisc(std::vector<MaskOverlayVertex>& triangles, const QPointF& center,
+                      float radius, float aa, const QColor& color, const QRectF& clip) {
+  if (radius <= 0.0f || !IsFinitePoint(center) ||
+      !PointInsideClip(center, ExpandedClip(clip, radius + aa))) {
+    return;
+  }
+  for (int i = 0; i < kDiscSegments; ++i) {
+    const float a0 =
+        (static_cast<float>(i) / static_cast<float>(kDiscSegments)) * 6.28318530718f;
+    const float a1 =
+        (static_cast<float>(i + 1) / static_cast<float>(kDiscSegments)) * 6.28318530718f;
+    const QPointF p0(center.x() + std::cos(a0) * radius, center.y() + std::sin(a0) * radius);
+    const QPointF p1(center.x() + std::cos(a1) * radius, center.y() + std::sin(a1) * radius);
+    AppendTriangle(triangles, center, p0, p1, color);
+    if (aa > 0.0f) {
+      const float outer = radius + aa;
+      const QPointF q0(center.x() + std::cos(a0) * outer, center.y() + std::sin(a0) * outer);
+      const QPointF q1(center.x() + std::cos(a1) * outer, center.y() + std::sin(a1) * outer);
+      AppendTriangle(triangles, p0, q0, q1, color, 1.0f, 0.0f, 0.0f);
+      AppendTriangle(triangles, p0, q1, p1, color, 1.0f, 0.0f, 1.0f);
+    }
+  }
+}
+
+void AppendRing(std::vector<MaskOverlayVertex>& triangles, const QPointF& center, float inner_r,
+                float outer_r, float aa, const QColor& color, const QRectF& clip) {
+  if (outer_r <= inner_r || !IsFinitePoint(center) ||
+      !PointInsideClip(center, ExpandedClip(clip, outer_r + aa))) {
+    return;
+  }
+  for (int i = 0; i < kDiscSegments; ++i) {
+    const float a0 =
+        (static_cast<float>(i) / static_cast<float>(kDiscSegments)) * 6.28318530718f;
+    const float a1 =
+        (static_cast<float>(i + 1) / static_cast<float>(kDiscSegments)) * 6.28318530718f;
+    const QPointF o0(center.x() + std::cos(a0) * outer_r, center.y() + std::sin(a0) * outer_r);
+    const QPointF o1(center.x() + std::cos(a1) * outer_r, center.y() + std::sin(a1) * outer_r);
+    const QPointF i0(center.x() + std::cos(a0) * inner_r, center.y() + std::sin(a0) * inner_r);
+    const QPointF i1(center.x() + std::cos(a1) * inner_r, center.y() + std::sin(a1) * inner_r);
+    AppendTriangle(triangles, o0, i0, i1, color);
+    AppendTriangle(triangles, o0, i1, o1, color);
+    if (aa > 0.0f) {
+      const float fringe = outer_r + aa;
+      const QPointF f0(center.x() + std::cos(a0) * fringe, center.y() + std::sin(a0) * fringe);
+      const QPointF f1(center.x() + std::cos(a1) * fringe, center.y() + std::sin(a1) * fringe);
+      AppendTriangle(triangles, o0, f0, f1, color, 1.0f, 0.0f, 0.0f);
+      AppendTriangle(triangles, o0, f1, o1, color, 1.0f, 0.0f, 1.0f);
+    }
+  }
+}
+
+void AppendHollowCircle(std::vector<MaskOverlayVertex>& triangles, const QPointF& center,
+                        float radius, float width, float aa, const QColor& color,
+                        const QRectF& clip) {
+  if (radius <= 0.0f) {
+    return;
+  }
+  const float half  = width * 0.5f;
+  const float inner = std::max(0.0f, radius - half);
+  const float outer = radius + half;
+  AppendRing(triangles, center, inner, outer, aa, color, clip);
+}
+
+}  // namespace
+
+auto DefaultMaskOverlayStyle() -> MaskOverlayStyle { return {}; }
+
+auto BuildMaskOverlaySceneGeometry(const MaskOverlayDisplay& display, const MaskOverlayStyle& style)
+    -> MaskOverlaySceneGeometry {
+  MaskOverlaySceneGeometry scene;
+  scene.coverage_fill_vertex_count       = 0;
+  scene.settled_stroke_path_vertex_count = 0;
+  if (display.mode == MaskOverlayMode::Hidden ||
+      display.source_kind == MaskOverlaySourceKind::None) {
+    return scene;
+  }
+
+  const float handle_r = style.handle_radius_logical_px;
+  const float outline  = style.handle_outline_width_logical_px;
+  const float stroke_w = style.stroke_width_logical_px;
+  const float aa       = style.antialias_width_logical_px;
+  const QRectF& clip   = display.clip_rect;
+
+  for (const auto& handle : display.handles) {
+    if (handle.id == MaskOverlayHandleId::None || !IsFinitePoint(handle.item)) {
+      continue;
+    }
+    AppendRing(scene.handle_outline, handle.item, handle_r, handle_r + outline, aa,
+               style.control_outline, clip);
+    AppendFilledDisc(scene.handle_fill, handle.item, handle_r, 0.0f, style.control_fill, clip);
+    ++scene.handle_count;
+  }
+
+  for (const auto& segment : display.connectors) {
+    AppendClippedStroke(scene.connectors, segment.first, segment.second, stroke_w, aa,
+                        style.control_fill, clip, /*round_caps=*/true);
+  }
+
+  if (display.cursor_visible && display.cursor_radius_logical_px > 0.0f &&
+      IsFinitePoint(display.cursor_center)) {
+    AppendHollowCircle(scene.cursor, display.cursor_center, display.cursor_radius_logical_px,
+                       stroke_w, aa, style.control_fill, clip);
+  }
+
+  if (display.mode == MaskOverlayMode::Creating) {
+    AppendPolylineStroke(scene.creation_guides, display.creation_path, /*closed=*/false, stroke_w,
+                         aa, style.inactive, clip);
+    AppendPolylineStroke(scene.creation_guides, display.creation_outline, /*closed=*/true, stroke_w,
+                         aa, style.inactive, clip);
+    for (const auto& segment : display.creation_guides) {
+      AppendClippedStroke(scene.creation_guides, segment.first, segment.second, stroke_w, aa,
+                          style.inactive, clip, /*round_caps=*/false);
+    }
+  }
+
+  return scene;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
@@ -1,0 +1,411 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "ui/edit_viewer/mask_overlay_layout.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace alcedo {
+namespace {
+
+constexpr float kPi          = 3.14159265358979323846f;
+constexpr float kMinRadius   = 1.0e-5f;
+constexpr float kHandleMerge = 2.0f;
+
+[[nodiscard]] auto IsFiniteVector(Vector2 point) -> bool {
+  return std::isfinite(point.x) && std::isfinite(point.y);
+}
+
+[[nodiscard]] auto WidgetClip(const MaskEditViewMapping& mapping) -> QRectF {
+  if (mapping.widget.widget_width <= 0 || mapping.widget.widget_height <= 0) {
+    return {};
+  }
+  return QRectF(0.0, 0.0, mapping.widget.widget_width, mapping.widget.widget_height);
+}
+
+[[nodiscard]] auto EffectiveClip(const MaskEditViewMapping& mapping, const QRectF& clip) -> QRectF {
+  if (clip.isValid() && !clip.isEmpty()) {
+    return clip;
+  }
+  return WidgetClip(mapping);
+}
+
+[[nodiscard]] auto ItemDistance(const QPointF& a, const QPointF& b) -> float {
+  return static_cast<float>(std::hypot(a.x() - b.x(), a.y() - b.y()));
+}
+
+void AppendHandle(MaskOverlayDisplay& display, MaskOverlayHandleId id, const QPointF& item,
+                  const QPointF& origin, float merge_px) {
+  if (id != MaskOverlayHandleId::RadialCenter && id != MaskOverlayHandleId::LinearOrigin &&
+      id != MaskOverlayHandleId::BrushMove && ItemDistance(item, origin) < merge_px) {
+    return;
+  }
+  for (const auto& existing : display.handles) {
+    if (ItemDistance(existing.item, item) < merge_px) {
+      return;
+    }
+  }
+  display.handles.push_back(MaskOverlayHandle{id, item});
+}
+
+void AppendConnector(MaskOverlayDisplay& display, const QPointF& a, const QPointF& b) {
+  if (ItemDistance(a, b) < kMinRadius) {
+    return;
+  }
+  display.connectors.emplace_back(a, b);
+}
+
+[[nodiscard]] auto MapRho(const MaskEditViewMapping& mapping, const RadialMaskSource& source,
+                          float rho, float theta) -> std::optional<QPointF> {
+  return MapNormalizedMaskPointToItem(mapping, RadialNormalizedPoint(source, rho, theta));
+}
+
+[[nodiscard]] auto InnerRho(const RadialMaskSource& source) -> float {
+  return std::max(0.0f, 1.0f - source.inner_feather);
+}
+
+[[nodiscard]] auto OuterRho(const RadialMaskSource& source) -> float {
+  return 1.0f + std::max(0.0f, source.outer_feather);
+}
+
+[[nodiscard]] auto OffsetAlongItem(const QPointF& origin, const QPointF& along, float offset_px)
+    -> std::optional<QPointF> {
+  const QPointF delta = along - origin;
+  const float len     = ItemDistance(along, origin);
+  if (len < kMinRadius) {
+    return std::nullopt;
+  }
+  const float scale = offset_px / len;
+  return QPointF(origin.x() + delta.x() * static_cast<qreal>(scale),
+                 origin.y() + delta.y() * static_cast<qreal>(scale));
+}
+
+[[nodiscard]] auto LinearNormal(const LinearGradientMaskSource& source) -> Vector2 {
+  const float length = std::hypot(source.normal_x, source.normal_y);
+  if (!std::isfinite(length) || length < kMinRadius) {
+    return {0.0f, 1.0f};
+  }
+  return {source.normal_x / length, source.normal_y / length};
+}
+
+[[nodiscard]] auto LinearLocus(const LinearGradientMaskSource& source, float signed_distance)
+    -> Vector2 {
+  const Vector2 n = LinearNormal(source);
+  return Vector2{source.origin_x + n.x * signed_distance, source.origin_y + n.y * signed_distance};
+}
+
+[[nodiscard]] auto PerpNormalized(Vector2 n) -> Vector2 { return {-n.y, n.x}; }
+
+void PopulateRadialHandles(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
+                           const RadialMaskSource& source, const MaskOverlayStyle& style,
+                           const QRectF& clip) {
+  const auto center = MapNormalizedMaskPointToItem(
+      mapping, Vector2{source.center_x, source.center_y});
+  if (!center) {
+    return;
+  }
+  display.handles.push_back(MaskOverlayHandle{MaskOverlayHandleId::RadialCenter, *center});
+
+  const auto major = MapRho(mapping, source, 1.0f, 0.0f);
+  const auto minor = MapRho(mapping, source, 1.0f, kPi * 0.5f);
+  if (major) {
+    AppendHandle(display, MaskOverlayHandleId::RadialMajor, *major, *center, kHandleMerge);
+    AppendConnector(display, *center, *major);
+    if (const auto rotate =
+            OffsetAlongItem(*center, *major, style.rotate_handle_offset_logical_px)) {
+      if (clip.isEmpty() || clip.contains(*rotate)) {
+        AppendHandle(display, MaskOverlayHandleId::RadialRotate, *rotate, *center, kHandleMerge);
+        AppendConnector(display, *major, *rotate);
+      }
+    }
+  }
+  if (minor) {
+    AppendHandle(display, MaskOverlayHandleId::RadialMinor, *minor, *center, kHandleMerge);
+    AppendConnector(display, *center, *minor);
+  }
+
+  const float inner = InnerRho(source);
+  const float outer = OuterRho(source);
+  if (std::fabs(inner - 1.0f) > 1.0e-3f && inner > kMinRadius) {
+    if (const auto inner_item = MapRho(mapping, source, inner, 0.0f)) {
+      AppendHandle(display, MaskOverlayHandleId::RadialInnerFeather, *inner_item, *center,
+                   kHandleMerge);
+      AppendConnector(display, *center, *inner_item);
+    }
+  }
+  if (std::fabs(outer - 1.0f) > 1.0e-3f) {
+    if (const auto outer_item = MapRho(mapping, source, outer, 0.0f)) {
+      AppendHandle(display, MaskOverlayHandleId::RadialOuterFeather, *outer_item, *center,
+                   kHandleMerge);
+      AppendConnector(display, *center, *outer_item);
+    }
+  }
+}
+
+void PopulateLinearHandles(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
+                           const LinearGradientMaskSource& source, const MaskOverlayStyle& style,
+                           const QRectF& clip) {
+  const auto origin = MapNormalizedMaskPointToItem(
+      mapping, Vector2{source.origin_x, source.origin_y});
+  if (!origin) {
+    return;
+  }
+  display.handles.push_back(MaskOverlayHandle{MaskOverlayHandleId::LinearOrigin, *origin});
+
+  const float half = std::max(source.transition_distance, kMinRadius) * 0.5f;
+  const auto start = MapNormalizedMaskPointToItem(mapping, LinearLocus(source, -half));
+  const auto end   = MapNormalizedMaskPointToItem(mapping, LinearLocus(source, half));
+  if (start) {
+    AppendHandle(display, MaskOverlayHandleId::LinearStartBoundary, *start, *origin, kHandleMerge);
+    AppendConnector(display, *origin, *start);
+  }
+  if (end) {
+    AppendHandle(display, MaskOverlayHandleId::LinearEndBoundary, *end, *origin, kHandleMerge);
+    AppendConnector(display, *origin, *end);
+    if (const auto direction =
+            OffsetAlongItem(*origin, *end, style.rotate_handle_offset_logical_px)) {
+      if (clip.isEmpty() || clip.contains(*direction)) {
+        AppendHandle(display, MaskOverlayHandleId::LinearDirection, *direction, *origin,
+                     kHandleMerge);
+        AppendConnector(display, *end, *direction);
+      }
+    }
+  }
+}
+
+[[nodiscard]] auto FiniteRadii(const RadialMaskSource& source) -> bool {
+  return std::isfinite(source.major_radius) && std::isfinite(source.minor_radius) &&
+         source.major_radius > kMinRadius && source.minor_radius > kMinRadius &&
+         std::isfinite(source.center_x) && std::isfinite(source.center_y) &&
+         std::isfinite(source.rotation);
+}
+
+}  // namespace
+
+auto MapNormalizedMaskPointToItem(const MaskEditViewMapping& mapping, Vector2 normalized)
+    -> std::optional<QPointF> {
+  if (!MaskEditGeometry::IsValid(mapping) || !IsFiniteVector(normalized)) {
+    return std::nullopt;
+  }
+  const Vector2 reference = MaskEditGeometry::ReferencePixelsFromNormalized(
+      normalized, mapping.geometry.full_reference_extent);
+  return MaskEditGeometry::MapReferenceToItem(mapping, reference);
+}
+
+auto RadialNormalizedPoint(const RadialMaskSource& source, float rho, float theta_radians)
+    -> Vector2 {
+  const float c = std::cos(source.rotation);
+  const float s = std::sin(source.rotation);
+  const float u = rho * std::cos(theta_radians);
+  const float v = rho * std::sin(theta_radians);
+  const float dx = c * (u * source.major_radius) - s * (v * source.minor_radius);
+  const float dy = s * (u * source.major_radius) + c * (v * source.minor_radius);
+  return Vector2{source.center_x + dx, source.center_y + dy};
+}
+
+auto TessellateRadialBoundaryItemPolyline(const MaskEditViewMapping& mapping,
+                                          const RadialMaskSource& source, float rho,
+                                          const QRectF& clip) -> std::vector<QPointF> {
+  (void)clip;
+  if (!FiniteRadii(source) || !std::isfinite(rho) || rho < 0.0f) {
+    return {};
+  }
+
+  auto map_theta = [&](float theta) -> std::optional<QPointF> {
+    return MapRho(mapping, source, rho, theta);
+  };
+  auto wrap_mid = [](float a, float b) -> float {
+    if (b < a) {
+      return std::fmod(0.5f * (a + b + 2.0f * kPi), 2.0f * kPi);
+    }
+    return 0.5f * (a + b);
+  };
+  auto chord_error = [&](float t0, float t1, const QPointF& p0, const QPointF& p1) -> float {
+    const auto true_item = map_theta(wrap_mid(t0, t1));
+    if (!true_item) {
+      return 0.0f;
+    }
+    const QPointF chord(0.5 * (p0.x() + p1.x()), 0.5 * (p0.y() + p1.y()));
+    return ItemDistance(*true_item, chord);
+  };
+
+  constexpr int kSeed = 32;
+  std::vector<float> thetas;
+  std::vector<QPointF> points;
+  thetas.reserve(kSeed);
+  points.reserve(kSeed);
+  for (int i = 0; i < kSeed; ++i) {
+    const float theta = (static_cast<float>(i) / static_cast<float>(kSeed)) * (2.0f * kPi);
+    const auto item   = map_theta(theta);
+    if (!item) {
+      return {};
+    }
+    thetas.push_back(theta);
+    points.push_back(*item);
+  }
+
+  bool grew = true;
+  while (grew && static_cast<int>(points.size()) < kMaskOverlayMaxEllipseVertices) {
+    grew = false;
+    std::vector<float> next_thetas;
+    std::vector<QPointF> next_points;
+    next_thetas.reserve(points.size() * 2);
+    next_points.reserve(points.size() * 2);
+    for (std::size_t i = 0; i < points.size(); ++i) {
+      next_thetas.push_back(thetas[i]);
+      next_points.push_back(points[i]);
+      const std::size_t j = (i + 1) % points.size();
+      if (static_cast<int>(next_points.size()) >= kMaskOverlayMaxEllipseVertices) {
+        continue;
+      }
+      if (chord_error(thetas[i], thetas[j], points[i], points[j]) <=
+          kMaskOverlayMaxChordDeviationLogicalPx) {
+        continue;
+      }
+      const float mid_theta = wrap_mid(thetas[i], thetas[j]);
+      const auto mid_item   = map_theta(mid_theta);
+      if (!mid_item) {
+        continue;
+      }
+      next_thetas.push_back(mid_theta);
+      next_points.push_back(*mid_item);
+      grew = true;
+    }
+    thetas.swap(next_thetas);
+    points.swap(next_points);
+  }
+
+  if (points.size() < 3) {
+    return {};
+  }
+  return points;
+}
+
+auto MakeBrushExistingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                     Vector2 placement_translation, const QRectF& clip)
+    -> MaskOverlayDisplay {
+  MaskOverlayDisplay display;
+  display.mode        = MaskOverlayMode::Existing;
+  display.source_kind = MaskOverlaySourceKind::Brush;
+  display.clip_rect   = EffectiveClip(mapping, clip);
+  const auto item     = MaskEditGeometry::MapReferenceToItem(mapping, placement_translation);
+  if (!item) {
+    display.mode        = MaskOverlayMode::Hidden;
+    display.source_kind = MaskOverlaySourceKind::None;
+    return display;
+  }
+  display.handles.push_back(MaskOverlayHandle{MaskOverlayHandleId::BrushMove, *item});
+  return display;
+}
+
+auto MakeRadialExistingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                      const RadialMaskSource& source, const MaskOverlayStyle& style,
+                                      const QRectF& clip) -> MaskOverlayDisplay {
+  MaskOverlayDisplay display;
+  if (!FiniteRadii(source)) {
+    return display;
+  }
+  display.mode        = MaskOverlayMode::Existing;
+  display.source_kind = MaskOverlaySourceKind::Radial;
+  display.clip_rect   = EffectiveClip(mapping, clip);
+  PopulateRadialHandles(display, mapping, source, style, display.clip_rect);
+  if (display.handles.empty()) {
+    display.mode        = MaskOverlayMode::Hidden;
+    display.source_kind = MaskOverlaySourceKind::None;
+  }
+  return display;
+}
+
+auto MakeLinearExistingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                      const LinearGradientMaskSource& source,
+                                      const MaskOverlayStyle& style, const QRectF& clip)
+    -> MaskOverlayDisplay {
+  MaskOverlayDisplay display;
+  if (!std::isfinite(source.origin_x) || !std::isfinite(source.origin_y) ||
+      !std::isfinite(source.transition_distance)) {
+    return display;
+  }
+  display.mode        = MaskOverlayMode::Existing;
+  display.source_kind = MaskOverlaySourceKind::LinearGradient;
+  display.clip_rect   = EffectiveClip(mapping, clip);
+  PopulateLinearHandles(display, mapping, source, style, display.clip_rect);
+  if (display.handles.empty()) {
+    display.mode        = MaskOverlayMode::Hidden;
+    display.source_kind = MaskOverlaySourceKind::None;
+  }
+  return display;
+}
+
+auto MakeBrushCreatingOverlayDisplay(const std::vector<QPointF>& item_path, QPointF cursor_item,
+                                     float cursor_radius_logical_px, const QRectF& clip)
+    -> MaskOverlayDisplay {
+  MaskOverlayDisplay display;
+  display.mode                     = MaskOverlayMode::Creating;
+  display.source_kind              = MaskOverlaySourceKind::Brush;
+  display.clip_rect                = clip;
+  display.creation_path            = item_path;
+  display.cursor_visible           = std::isfinite(cursor_item.x()) && std::isfinite(cursor_item.y()) &&
+                           cursor_radius_logical_px > 0.0f;
+  display.cursor_center            = cursor_item;
+  display.cursor_radius_logical_px = cursor_radius_logical_px;
+  return display;
+}
+
+auto MakeRadialCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                      const RadialMaskSource& source, const MaskOverlayStyle& style,
+                                      const QRectF& clip) -> MaskOverlayDisplay {
+  auto display          = MakeRadialExistingOverlayDisplay(mapping, source, style, clip);
+  if (display.mode == MaskOverlayMode::Hidden) {
+    return display;
+  }
+  display.mode             = MaskOverlayMode::Creating;
+  display.creation_outline = TessellateRadialBoundaryItemPolyline(mapping, source, 1.0f,
+                                                                  display.clip_rect);
+  return display;
+}
+
+auto MakeLinearCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
+                                      const LinearGradientMaskSource& source,
+                                      const MaskOverlayStyle& style, const QRectF& clip)
+    -> MaskOverlayDisplay {
+  auto display = MakeLinearExistingOverlayDisplay(mapping, source, style, clip);
+  if (display.mode == MaskOverlayMode::Hidden) {
+    return display;
+  }
+  display.mode = MaskOverlayMode::Creating;
+  const Vector2 n    = LinearNormal(source);
+  const Vector2 perp = PerpNormalized(n);
+  const float half   = std::max(source.transition_distance, kMinRadius) * 0.5f;
+  const float span   = 0.35f;
+  const float loci[] = {-half, 0.0f, half};
+  for (float signed_distance : loci) {
+    const Vector2 locus = LinearLocus(source, signed_distance);
+    const Vector2 a{locus.x + perp.x * span, locus.y + perp.y * span};
+    const Vector2 b{locus.x - perp.x * span, locus.y - perp.y * span};
+    const auto item_a = MapNormalizedMaskPointToItem(mapping, a);
+    const auto item_b = MapNormalizedMaskPointToItem(mapping, b);
+    if (item_a && item_b) {
+      display.creation_guides.emplace_back(*item_a, *item_b);
+    }
+  }
+  return display;
+}
+
+auto MapReferenceRadiusToItem(const MaskEditViewMapping& mapping, Vector2 center_reference,
+                              float radius_reference_px) -> std::optional<float> {
+  if (!std::isfinite(radius_reference_px) || radius_reference_px <= 0.0f) {
+    return std::nullopt;
+  }
+  const auto center = MaskEditGeometry::MapReferenceToItem(mapping, center_reference);
+  const auto edge   = MaskEditGeometry::MapReferenceToItem(
+      mapping, Vector2{center_reference.x + radius_reference_px, center_reference.y});
+  if (!center || !edge) {
+    return std::nullopt;
+  }
+  return ItemDistance(*center, *edge);
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/ui/editor_rhi/editor_overlay_item.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_overlay_item.cpp
@@ -7,6 +7,9 @@
 #include "ui/editor_rhi/editor_interaction_controller.hpp"
 
 #include <QMetaObject>
+#include <QSGGeometry>
+#include <QSGGeometryNode>
+#include <QSGNode>
 #include <QSGVertexColorMaterial>
 
 #include <algorithm>
@@ -14,6 +17,7 @@
 #include <utility>
 
 #include "ui/edit_viewer/crop_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_geometry.hpp"
 
 namespace alcedo::editor_rhi {
 namespace {
@@ -304,6 +308,48 @@ void UpsertTriangleNode(QSGNode* root, QSGGeometryNode*& slot, const std::vector
   slot->markDirty(QSGNode::DirtyGeometry);
 }
 
+void FillPremultipliedGeometry(QSGGeometry* geometry,
+                               const std::vector<alcedo::MaskOverlayVertex>& points) {
+  geometry->allocate(static_cast<int>(points.size()));
+  geometry->setDrawingMode(QSGGeometry::DrawTriangles);
+  auto* vertices = geometry->vertexDataAsColoredPoint2D();
+  for (size_t i = 0; i < points.size(); ++i) {
+    vertices[i].set(points[i].x, points[i].y, points[i].r, points[i].g, points[i].b, points[i].a);
+  }
+  geometry->markVertexDataDirty();
+}
+
+void UpsertPremultipliedTriangleNode(QSGNode* root, QSGGeometryNode*& slot,
+                                     const std::vector<alcedo::MaskOverlayVertex>& points,
+                                     int& create_count) {
+  if (points.empty()) {
+    if (slot) {
+      slot->setFlag(QSGNode::OwnedByParent, false);
+      root->removeChildNode(slot);
+      delete slot;
+      slot = nullptr;
+    }
+    return;
+  }
+
+  if (!slot) {
+    slot = new QSGGeometryNode;
+    auto* geometry = new QSGGeometry(QSGGeometry::defaultAttributes_ColoredPoint2D(),
+                                     static_cast<int>(points.size()));
+    geometry->setDrawingMode(QSGGeometry::DrawTriangles);
+    slot->setGeometry(geometry);
+    slot->setFlag(QSGNode::OwnsGeometry);
+    auto* material = new QSGVertexColorMaterial;
+    slot->setMaterial(material);
+    slot->setFlag(QSGNode::OwnsMaterial);
+    root->appendChildNode(slot);
+    ++create_count;
+  }
+
+  FillPremultipliedGeometry(slot->geometry(), points);
+  slot->markDirty(QSGNode::DirtyGeometry);
+}
+
 }  // namespace
 
 auto BuildOverlaySceneGeometry(const CropOverlayWidgetGeometry& geometry, bool crop_tool_visible)
@@ -391,6 +437,11 @@ struct EditorOverlayItem::OverlayRootNode : public QSGNode {
   QSGGeometryNode* handle_outline_node = nullptr;
   QSGGeometryNode* handle_fill_node = nullptr;
   QSGGeometryNode* detail_roi_node = nullptr;
+  QSGGeometryNode* mask_handle_outline_node = nullptr;
+  QSGGeometryNode* mask_handle_fill_node = nullptr;
+  QSGGeometryNode* mask_connector_node = nullptr;
+  QSGGeometryNode* mask_cursor_node = nullptr;
+  QSGGeometryNode* mask_creation_guide_node = nullptr;
 };
 
 EditorOverlayItem::EditorOverlayItem(QQuickItem* parent) : QQuickItem(parent) {
@@ -412,6 +463,7 @@ auto EditorOverlayItem::cropVisible() const -> bool { return last_scene_geometry
 
 void EditorOverlayItem::refreshFromInteraction() {
   rebuildSceneGeometry();
+  rebuildMaskSceneGeometry();
   ++geometry_revision_;
   ++geometry_rebuild_count_;
   geometry_dirty_ = true;
@@ -478,6 +530,99 @@ void EditorOverlayItem::rebuildSceneGeometry() {
                                                    interaction_->cropOverlayVisible());
 }
 
+void EditorOverlayItem::rebuildMaskSceneGeometry() {
+  last_mask_scene_geometry_ = BuildMaskOverlaySceneGeometry(mask_display_, mask_style_);
+}
+
+void EditorOverlayItem::setMaskOverlayDisplay(MaskOverlayDisplay display) {
+  mask_display_ = std::move(display);
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayRevisionChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayControlColor(const QColor& color) {
+  if (mask_style_.control_fill == color) {
+    return;
+  }
+  mask_style_.control_fill = color;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayControlOutlineColor(const QColor& color) {
+  if (mask_style_.control_outline == color) {
+    return;
+  }
+  mask_style_.control_outline = color;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayInactiveColor(const QColor& color) {
+  if (mask_style_.inactive == color) {
+    return;
+  }
+  mask_style_.inactive = color;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayHandleRadius(qreal radius) {
+  const float value = static_cast<float>(radius);
+  if (mask_style_.handle_radius_logical_px == value) {
+    return;
+  }
+  mask_style_.handle_radius_logical_px = value;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayHandleOutlineWidth(qreal width) {
+  const float value = static_cast<float>(width);
+  if (mask_style_.handle_outline_width_logical_px == value) {
+    return;
+  }
+  mask_style_.handle_outline_width_logical_px = value;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayStrokeWidth(qreal width) {
+  const float value = static_cast<float>(width);
+  if (mask_style_.stroke_width_logical_px == value) {
+    return;
+  }
+  mask_style_.stroke_width_logical_px = value;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayAntialiasWidth(qreal width) {
+  const float value = static_cast<float>(width);
+  if (mask_style_.antialias_width_logical_px == value) {
+    return;
+  }
+  mask_style_.antialias_width_logical_px = value;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
 auto EditorOverlayItem::updatePaintNode(QSGNode* old_node, UpdatePaintNodeData*) -> QSGNode* {
   auto* root = static_cast<OverlayRootNode*>(old_node);
   if (!root) {
@@ -515,7 +660,20 @@ auto EditorOverlayItem::updatePaintNode(QSGNode* old_node, UpdatePaintNodeData*)
   UpsertTriangleNode(root, root->detail_roi_node, scene.detail_roi_triangles,
                      QColor(120, 200, 255, 200), creates);
 
+  int mask_creates = 0;
+  const auto& mask_scene = last_mask_scene_geometry_;
+  UpsertPremultipliedTriangleNode(root, root->mask_handle_outline_node, mask_scene.handle_outline,
+                                  mask_creates);
+  UpsertPremultipliedTriangleNode(root, root->mask_handle_fill_node, mask_scene.handle_fill,
+                                  mask_creates);
+  UpsertPremultipliedTriangleNode(root, root->mask_connector_node, mask_scene.connectors,
+                                  mask_creates);
+  UpsertPremultipliedTriangleNode(root, root->mask_cursor_node, mask_scene.cursor, mask_creates);
+  UpsertPremultipliedTriangleNode(root, root->mask_creation_guide_node, mask_scene.creation_guides,
+                                  mask_creates);
+
   paint_node_create_count_ += creates;
+  mask_paint_node_create_count_ += mask_creates;
   return root;
 }
 

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -1226,6 +1226,31 @@ alcedo_ui_gtest_discover_tests(MaskEditGeometryTest
     PROPERTIES LABELS "mask_edit;interaction")
 alcedo_register_test_target(MaskEditGeometryTest ui)
 
+add_executable(MaskOverlayControlTest
+    ${ALCEDO_TEST_ROOT}/ui/mask_overlay_control_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
+)
+target_include_directories(MaskOverlayControlTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR}
+)
+target_link_libraries(MaskOverlayControlTest
+    PRIVATE
+        EditorRhiViewport
+        AppTheme
+        EditGeometry
+        GTest::gtest
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Test
+        Qt6::Quick
+        Qt6::Widgets
+)
+alcedo_ui_gtest_discover_tests(MaskOverlayControlTest
+    TEST_PREFIX "MaskOverlayControlTest."
+    PROPERTIES LABELS "mask_overlay;editor_rhi")
+alcedo_register_test_target(MaskOverlayControlTest ui)
+
 
 # Real-project regression: replay production Main.qml Copy/Paste and verify
 # that a reopened target publishes the saved Tone values to its QML models.

--- a/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
+++ b/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
@@ -1,0 +1,449 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+#include <QColor>
+#include <QCoreApplication>
+#include <QImage>
+#include <QPointF>
+#include <QQuickWindow>
+#include <QSignalSpy>
+#include <QTest>
+#include <QVector2D>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "ui/alcedo_main/app_theme.hpp"
+#include "ui/edit_viewer/mask_edit_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_layout.hpp"
+#include "ui/editor_rhi/editor_overlay_item.hpp"
+
+namespace alcedo {
+namespace {
+
+[[nodiscard]] auto MakeMapping(int widget_w, int widget_h, int image_w, int image_h, float zoom,
+                               QVector2D pan, float dpr) -> MaskEditViewMapping {
+  MaskEditViewMapping mapping;
+  mapping.widget      = {widget_w, widget_h, dpr};
+  mapping.photograph  = {image_w, image_h};
+  mapping.zoom        = zoom;
+  mapping.pan         = pan;
+  mapping.geometry    = MaskEditGeometry::MakeIdentityPhotographGeometry(
+      Extent2D{static_cast<std::uint32_t>(image_w), static_cast<std::uint32_t>(image_h)});
+  return mapping;
+}
+
+[[nodiscard]] auto SampleRadial() -> RadialMaskSource {
+  RadialMaskSource source;
+  source.center_x      = 0.50f;
+  source.center_y      = 0.50f;
+  source.major_radius  = 0.28f;
+  source.minor_radius  = 0.18f;
+  source.rotation      = 0.35f;
+  source.inner_feather = 0.25f;
+  source.outer_feather = 0.20f;
+  return source;
+}
+
+[[nodiscard]] auto SampleLinear() -> LinearGradientMaskSource {
+  LinearGradientMaskSource source;
+  source.origin_x            = 0.50f;
+  source.origin_y            = 0.50f;
+  source.normal_x            = 0.0f;
+  source.normal_y            = 1.0f;
+  source.transition_distance = 0.30f;
+  return source;
+}
+
+// Independent inverse of the native Radial evaluator (not the overlay layout helper).
+[[nodiscard]] auto IndependentRadialNormalized(const RadialMaskSource& source, float rho,
+                                               float theta) -> Vector2 {
+  const float c  = std::cos(source.rotation);
+  const float s  = std::sin(source.rotation);
+  const float u  = rho * std::cos(theta);
+  const float v  = rho * std::sin(theta);
+  const float dx = c * (u * source.major_radius) - s * (v * source.minor_radius);
+  const float dy = s * (u * source.major_radius) + c * (v * source.minor_radius);
+  return Vector2{source.center_x + dx, source.center_y + dy};
+}
+
+[[nodiscard]] auto IndependentRadialTheta(const RadialMaskSource& source, Vector2 normalized)
+    -> float {
+  const float c  = std::cos(source.rotation);
+  const float s  = std::sin(source.rotation);
+  const float dx = normalized.x - source.center_x;
+  const float dy = normalized.y - source.center_y;
+  const float u  = (c * dx + s * dy) / std::max(source.major_radius, 1.0e-6f);
+  const float v  = (-s * dx + c * dy) / std::max(source.minor_radius, 1.0e-6f);
+  return std::atan2(v, u);
+}
+
+[[nodiscard]] auto IndependentItemToNormalized(const MaskEditViewMapping& mapping,
+                                               const QPointF& item) -> Vector2 {
+  const auto sample = MaskEditGeometry::MapItemToReference(mapping, item, true);
+  EXPECT_TRUE(sample.has_value());
+  return sample ? sample->normalized : Vector2{};
+}
+
+[[nodiscard]] auto IndependentMapNormalized(const MaskEditViewMapping& mapping, Vector2 normalized)
+    -> QPointF {
+  const Vector2 reference = MaskEditGeometry::ReferencePixelsFromNormalized(
+      normalized, mapping.geometry.full_reference_extent);
+  const auto item = MaskEditGeometry::MapReferenceToItem(mapping, reference);
+  EXPECT_TRUE(item.has_value());
+  return item.value_or(QPointF());
+}
+
+[[nodiscard]] auto PointInTriangle(const QPointF& p, const QPointF& a, const QPointF& b,
+                                   const QPointF& c) -> bool {
+  const auto cross = [](const QPointF& o, const QPointF& u, const QPointF& v) {
+    return (u.x() - o.x()) * (v.y() - o.y()) - (u.y() - o.y()) * (v.x() - o.x());
+  };
+  const double c1      = cross(a, b, p);
+  const double c2      = cross(b, c, p);
+  const double c3      = cross(c, a, p);
+  const bool   has_neg = (c1 < 0) || (c2 < 0) || (c3 < 0);
+  const bool   has_pos = (c1 > 0) || (c2 > 0) || (c3 > 0);
+  return !(has_neg && has_pos);
+}
+
+[[nodiscard]] auto VerticesCoverPoint(const std::vector<MaskOverlayVertex>& vertices,
+                                      const QPointF& point) -> bool {
+  for (std::size_t i = 0; i + 2 < vertices.size(); i += 3) {
+    if (PointInTriangle(point, QPointF(vertices[i].x, vertices[i].y),
+                        QPointF(vertices[i + 1].x, vertices[i + 1].y),
+                        QPointF(vertices[i + 2].x, vertices[i + 2].y))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+[[nodiscard]] auto OverlayCoversPoint(const MaskOverlaySceneGeometry& scene, const QPointF& point)
+    -> bool {
+  return VerticesCoverPoint(scene.handle_fill, point) ||
+         VerticesCoverPoint(scene.handle_outline, point) ||
+         VerticesCoverPoint(scene.connectors, point) || VerticesCoverPoint(scene.cursor, point) ||
+         VerticesCoverPoint(scene.creation_guides, point);
+}
+
+[[nodiscard]] auto MaxDistanceFrom(const std::vector<MaskOverlayVertex>& vertices,
+                                   const QPointF& origin) -> float {
+  float best = 0.0f;
+  for (const auto& vertex : vertices) {
+    best = std::max(best, static_cast<float>(std::hypot(vertex.x - origin.x(), vertex.y - origin.y())));
+  }
+  return best;
+}
+
+[[nodiscard]] auto HandleById(const MaskOverlayDisplay& display, MaskOverlayHandleId id)
+    -> const MaskOverlayHandle* {
+  for (const auto& handle : display.handles) {
+    if (handle.id == id) {
+      return &handle;
+    }
+  }
+  return nullptr;
+}
+
+struct OverlayWindow {
+  QQuickWindow                    window;
+  editor_rhi::EditorOverlayItem*  overlay = nullptr;
+
+  OverlayWindow() {
+    window.setColor(QColor(32, 48, 64));
+    window.resize(400, 300);
+    overlay = new editor_rhi::EditorOverlayItem(window.contentItem());
+    overlay->setWidth(400);
+    overlay->setHeight(300);
+    overlay->setVisible(true);
+    window.show();
+    const bool exposed = QTest::qWaitForWindowExposed(&window);
+    EXPECT_TRUE(exposed);
+  }
+
+  void Present() {
+    overlay->update();
+    window.update();
+    QSignalSpy spy(&window, &QQuickWindow::frameSwapped);
+    if (!spy.wait(1500)) {
+      QTest::qWait(80);
+    }
+    QCoreApplication::processEvents();
+  }
+};
+
+}  // namespace
+
+TEST(MaskOverlayControlTest, ExistingMaskEditHasControlsAndNoCoverageFill) {
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto style   = DefaultMaskOverlayStyle();
+  const auto radial  = MakeRadialExistingOverlayDisplay(mapping, SampleRadial(), style, {});
+  const auto linear  = MakeLinearExistingOverlayDisplay(mapping, SampleLinear(), style, {});
+  const auto brush =
+      MakeBrushExistingOverlayDisplay(mapping, Vector2{200.0f, 150.0f}, {});
+
+  EXPECT_EQ(radial.mode, MaskOverlayMode::Existing);
+  EXPECT_EQ(linear.mode, MaskOverlayMode::Existing);
+  EXPECT_EQ(brush.mode, MaskOverlayMode::Existing);
+  EXPECT_GE(radial.handles.size(), 3u);
+  EXPECT_NE(HandleById(radial, MaskOverlayHandleId::RadialCenter), nullptr);
+  EXPECT_NE(HandleById(linear, MaskOverlayHandleId::LinearOrigin), nullptr);
+  EXPECT_NE(HandleById(brush, MaskOverlayHandleId::BrushMove), nullptr);
+  EXPECT_TRUE(radial.creation_path.empty());
+  EXPECT_TRUE(radial.creation_outline.empty());
+  EXPECT_TRUE(brush.creation_path.empty());
+
+  const auto radial_scene = BuildMaskOverlaySceneGeometry(radial, style);
+  const auto linear_scene = BuildMaskOverlaySceneGeometry(linear, style);
+  const auto brush_scene  = BuildMaskOverlaySceneGeometry(brush, style);
+  EXPECT_EQ(radial_scene.coverage_fill_vertex_count, 0);
+  EXPECT_EQ(radial_scene.settled_stroke_path_vertex_count, 0);
+  EXPECT_TRUE(radial_scene.creation_guides.empty());
+  EXPECT_GT(radial_scene.handle_count, 0);
+  EXPECT_FALSE(radial_scene.handle_fill.empty());
+  EXPECT_TRUE(brush_scene.creation_guides.empty());
+  EXPECT_EQ(linear_scene.coverage_fill_vertex_count, 0);
+
+  const auto interior = IndependentMapNormalized(
+      mapping, IndependentRadialNormalized(SampleRadial(), 0.40f, 1.05f));
+  EXPECT_FALSE(OverlayCoversPoint(radial_scene, interior))
+      << "existing Radial overlay filled coverage at " << interior.x() << "," << interior.y();
+
+  OverlayWindow host;
+  host.overlay->setMaskOverlayDisplay(radial);
+  host.Present();
+  const QImage grab = host.window.grabWindow();
+  ASSERT_FALSE(grab.isNull());
+  ASSERT_GT(grab.width(), 0);
+  const qreal dpr = host.window.devicePixelRatio();
+  const int px    = std::clamp(static_cast<int>(std::lround(interior.x() * dpr)), 0, grab.width() - 1);
+  const int py    = std::clamp(static_cast<int>(std::lround(interior.y() * dpr)), 0, grab.height() - 1);
+  const QColor sample = grab.pixelColor(px, py);
+  const QColor clear  = host.window.color();
+  EXPECT_LT(std::abs(sample.red() - clear.red()), 40);
+  EXPECT_LT(std::abs(sample.green() - clear.green()), 40);
+  EXPECT_LT(std::abs(sample.blue() - clear.blue()), 40)
+      << "grabbed (" << sample.red() << "," << sample.green() << "," << sample.blue()
+      << ") at interior; expected window color without Mask coverage tint";
+
+  const auto* center = HandleById(radial, MaskOverlayHandleId::RadialCenter);
+  ASSERT_NE(center, nullptr);
+  const int hx = std::clamp(static_cast<int>(std::lround(center->item.x() * dpr)), 0,
+                            grab.width() - 1);
+  const int hy = std::clamp(static_cast<int>(std::lround(center->item.y() * dpr)), 0,
+                            grab.height() - 1);
+  const QColor handle_pixel = grab.pixelColor(hx, hy);
+  EXPECT_GT(handle_pixel.red() + handle_pixel.green() + handle_pixel.blue(), 80);
+}
+
+TEST(MaskOverlayControlTest, MaskControlsUpdateWhileRenderIsHeld) {
+  std::atomic<bool> render_busy{true};
+  std::thread renderer([&] {
+    while (render_busy.load(std::memory_order_relaxed)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  });
+
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto style   = DefaultMaskOverlayStyle();
+  auto display       = MakeRadialExistingOverlayDisplay(mapping, SampleRadial(), style, {});
+  ASSERT_FALSE(display.handles.empty());
+  const QPointF before = display.handles.front().item;
+  for (auto& handle : display.handles) {
+    handle.item += QPointF(18.0, 0.0);
+  }
+
+  editor_rhi::EditorOverlayItem overlay;
+  overlay.setMaskOverlayDisplay(display);
+  const auto& scene = overlay.lastMaskSceneGeometry();
+  EXPECT_GT(scene.handle_count, 0);
+  EXPECT_EQ(scene.coverage_fill_vertex_count, 0);
+  bool moved = false;
+  for (const auto& vertex : scene.handle_fill) {
+    if (std::abs(vertex.x - static_cast<float>(before.x() + 18.0)) < 8.0f) {
+      moved = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(moved);
+
+  render_busy.store(false, std::memory_order_relaxed);
+  renderer.join();
+}
+
+TEST(MaskOverlayControlTest, MaskOverlayReusesNodesForMovement) {
+  OverlayWindow host;
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  auto display =
+      MakeRadialExistingOverlayDisplay(mapping, SampleRadial(), DefaultMaskOverlayStyle(), {});
+  host.overlay->setMaskOverlayDisplay(display);
+  host.Present();
+  const int creates_after_first = host.overlay->maskPaintNodeCreateCount();
+  ASSERT_GT(creates_after_first, 0);
+
+  for (auto& handle : display.handles) {
+    handle.item += QPointF(10.0, 6.0);
+  }
+  host.overlay->setMaskOverlayDisplay(display);
+  host.Present();
+  EXPECT_EQ(host.overlay->maskPaintNodeCreateCount(), creates_after_first);
+  EXPECT_GT(host.overlay->lastMaskSceneGeometry().handle_count, 0);
+}
+
+TEST(MaskOverlayControlTest, MaskControlsRecreateAfterSceneInvalidation) {
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto display =
+      MakeLinearExistingOverlayDisplay(mapping, SampleLinear(), DefaultMaskOverlayStyle(), {});
+  int handles_before = 0;
+  int vertices_before = 0;
+  {
+    OverlayWindow first;
+    first.overlay->setMaskOverlayDisplay(display);
+    first.Present();
+    handles_before  = first.overlay->lastMaskSceneGeometry().handle_count;
+    vertices_before = static_cast<int>(first.overlay->lastMaskSceneGeometry().handle_fill.size());
+    ASSERT_GT(first.overlay->maskPaintNodeCreateCount(), 0);
+    ASSERT_GT(handles_before, 0);
+  }
+
+  OverlayWindow second;
+  second.overlay->setMaskOverlayDisplay(display);
+  second.Present();
+  EXPECT_GT(second.overlay->maskPaintNodeCreateCount(), 0);
+  EXPECT_EQ(second.overlay->lastMaskSceneGeometry().handle_count, handles_before);
+  EXPECT_EQ(static_cast<int>(second.overlay->lastMaskSceneGeometry().handle_fill.size()),
+            vertices_before);
+  EXPECT_EQ(second.overlay->lastMaskSceneGeometry().coverage_fill_vertex_count, 0);
+}
+
+TEST(MaskOverlayControlTest, MaskControlsKeepLogicalSizeAndThemeColors) {
+  auto& theme = ui::AppTheme::Instance();
+  theme.setCurrentThemeIndex(0);
+  EXPECT_EQ(theme.maskOverlayHandleRadius(),
+            static_cast<int>(kMaskOverlayHandleRadiusLogicalPx));
+  EXPECT_NEAR(theme.maskOverlayHandleOutlineWidth(),
+              static_cast<qreal>(kMaskOverlayHandleOutlineWidthLogicalPx), 1.0e-6);
+  EXPECT_EQ(theme.maskOverlayHandleHitRadius(),
+            static_cast<int>(kMaskHandleHitRadiusLogicalPx));
+  EXPECT_EQ(theme.maskOverlayControlColor(), theme.textColor());
+  EXPECT_EQ(theme.maskOverlayControlOutlineColor(), theme.bgCanvasColor());
+  EXPECT_EQ(theme.maskOverlayInactiveColor(), theme.textMutedColor());
+
+  MaskOverlayStyle style = DefaultMaskOverlayStyle();
+  style.control_fill     = theme.maskOverlayControlColor();
+  style.control_outline  = theme.maskOverlayControlOutlineColor();
+  style.inactive         = theme.maskOverlayInactiveColor();
+
+  const auto fit = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto zoomed =
+      MakeMapping(400, 300, 400, 300, 2.0f, QVector2D(0, 0), 1.25f);
+  const auto fit_display =
+      MakeRadialExistingOverlayDisplay(fit, SampleRadial(), style, {});
+  const auto zoom_display =
+      MakeRadialExistingOverlayDisplay(zoomed, SampleRadial(), style, {});
+  const auto* fit_center  = HandleById(fit_display, MaskOverlayHandleId::RadialCenter);
+  const auto* zoom_center = HandleById(zoom_display, MaskOverlayHandleId::RadialCenter);
+  ASSERT_NE(fit_center, nullptr);
+  ASSERT_NE(zoom_center, nullptr);
+
+  MaskOverlayDisplay fit_handle_only;
+  fit_handle_only.mode        = MaskOverlayMode::Existing;
+  fit_handle_only.source_kind = MaskOverlaySourceKind::Radial;
+  fit_handle_only.handles.push_back(*fit_center);
+  MaskOverlayDisplay zoom_handle_only = fit_handle_only;
+  zoom_handle_only.handles.front().item = zoom_center->item;
+
+  const auto fit_scene  = BuildMaskOverlaySceneGeometry(fit_handle_only, style);
+  const auto zoom_scene = BuildMaskOverlaySceneGeometry(zoom_handle_only, style);
+  const float fit_span  = MaxDistanceFrom(fit_scene.handle_fill, fit_center->item);
+  const float zoom_span = MaxDistanceFrom(zoom_scene.handle_fill, zoom_center->item);
+  EXPECT_NEAR(fit_span, zoom_span, 0.75f);
+  EXPECT_NEAR(fit_span, style.handle_radius_logical_px, 0.75f);
+
+  ASSERT_FALSE(fit_scene.handle_fill.empty());
+  const float alpha = static_cast<float>(style.control_fill.alphaF());
+  EXPECT_NEAR(fit_scene.handle_fill.front().r, style.control_fill.red() * alpha, 2.0);
+  EXPECT_NEAR(fit_scene.handle_fill.front().g, style.control_fill.green() * alpha, 2.0);
+  EXPECT_NEAR(fit_scene.handle_fill.front().b, style.control_fill.blue() * alpha, 2.0);
+
+  const auto cursor_fit = MapReferenceRadiusToItem(fit, Vector2{200.0f, 150.0f}, 40.0f);
+  const auto cursor_zoom = MapReferenceRadiusToItem(zoomed, Vector2{200.0f, 150.0f}, 40.0f);
+  ASSERT_TRUE(cursor_fit.has_value());
+  ASSERT_TRUE(cursor_zoom.has_value());
+  EXPECT_GT(*cursor_zoom, *cursor_fit);
+}
+
+TEST(MaskOverlayControlTest, DegenerateRadialProducesEmptyGeometry) {
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  RadialMaskSource source;
+  source.major_radius = 0.0f;
+  source.minor_radius = 0.0f;
+  const auto display =
+      MakeRadialExistingOverlayDisplay(mapping, source, DefaultMaskOverlayStyle(), {});
+  EXPECT_EQ(display.mode, MaskOverlayMode::Hidden);
+  const auto scene = BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle());
+  EXPECT_EQ(scene.handle_count, 0);
+  EXPECT_TRUE(scene.handle_fill.empty());
+}
+
+TEST(MaskOverlayControlTest, RadialCreationOutlineStaysWithinChordTolerance) {
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto source  = SampleRadial();
+  const auto outline = TessellateRadialBoundaryItemPolyline(mapping, source, 1.0f, {});
+  ASSERT_GE(outline.size(), 3u);
+  float max_error = 0.0f;
+  constexpr float kPi = 3.14159265358979323846f;
+  for (std::size_t i = 0; i < outline.size(); ++i) {
+    const QPointF a = outline[i];
+    const QPointF b = outline[(i + 1) % outline.size()];
+    const QPointF chord(0.5 * (a.x() + b.x()), 0.5 * (a.y() + b.y()));
+    const float t0 = IndependentRadialTheta(source, IndependentItemToNormalized(mapping, a));
+    const float t1 = IndependentRadialTheta(source, IndependentItemToNormalized(mapping, b));
+    float dt       = t1 - t0;
+    while (dt > kPi) {
+      dt -= 2.0f * kPi;
+    }
+    while (dt < -kPi) {
+      dt += 2.0f * kPi;
+    }
+    const QPointF truth = IndependentMapNormalized(
+        mapping, IndependentRadialNormalized(source, 1.0f, t0 + 0.5f * dt));
+    max_error = std::max(
+        max_error, static_cast<float>(std::hypot(truth.x() - chord.x(), truth.y() - chord.y())));
+  }
+  EXPECT_LE(max_error, kMaskOverlayMaxChordDeviationLogicalPx + 0.05f);
+
+  const auto creating =
+      MakeRadialCreatingOverlayDisplay(mapping, source, DefaultMaskOverlayStyle(), {});
+  EXPECT_EQ(creating.mode, MaskOverlayMode::Creating);
+  EXPECT_FALSE(creating.creation_outline.empty());
+  const auto scene = BuildMaskOverlaySceneGeometry(creating, DefaultMaskOverlayStyle());
+  EXPECT_EQ(scene.coverage_fill_vertex_count, 0);
+  EXPECT_FALSE(scene.creation_guides.empty());
+}
+
+TEST(MaskOverlayControlTest, HiddenDisplayClearsMaskOverlayNodes) {
+  OverlayWindow host;
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  host.overlay->setMaskOverlayDisplay(
+      MakeBrushExistingOverlayDisplay(mapping, Vector2{200.0f, 150.0f}, {}));
+  host.Present();
+  EXPECT_GT(host.overlay->lastMaskSceneGeometry().handle_count, 0);
+  host.overlay->setMaskOverlayDisplay(MaskOverlayDisplay{});
+  host.Present();
+  EXPECT_EQ(host.overlay->lastMaskSceneGeometry().handle_count, 0);
+  EXPECT_TRUE(host.overlay->lastMaskSceneGeometry().handle_fill.empty());
+}
+
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
@@ -6,8 +6,8 @@ Status: NM7.2 parameterized Brush source and Grade owner operations landed; NM7.
 stroke/placement history, WAL/Version/Paste remapping, and the Section 8.1 project/schema
 version gate landed. NM7.4 host canonical rasterization, spatial index, and regional Mix
 replay landed. Raster-only Brush JSON is rejected. NM7.5 shared ReferenceSpace mapping and
-Brush placement landed. NM7.6+ QSG, viewer creation, Interactive Mix, and cache service remain
-planned.
+Brush placement landed. NM7.6 control-only retained QSG Mask overlay landed. NM7.7+ viewer
+creation, Interactive Mix, and cache service remain planned.
 
 Parent: [NM7 execution plan](phase_nm7_viewer_mask_creation_plan.md).
 This document defines NM7's revised algorithm, data ownership and storage behavior. It replaces

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,10 +2,11 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.5 complete; NM7.6–NM7.14 planned. This document records the NM7.1 source
+Status: NM7.1–NM7.6 complete; NM7.7–NM7.14 planned. This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
-project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, and NM7.5
-shared ReferenceSpace mapping with Brush placement. Remaining sub-phases are unimplemented.
+project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
+shared ReferenceSpace mapping with Brush placement, and NM7.6 control-only retained QSG.
+Remaining sub-phases are unimplemented.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -984,6 +985,60 @@ triangle strokes and explicit antialiasing; preserve crop/ROI layer behavior and
 
 **Exit:** real accelerated window captures show no mask-area tint while dragging an existing Mask;
 no live pipeline lock or raster I/O inside Qt synchronization.
+
+##### Phase NM7.6 completion record (2026-09-08)
+
+**Status:** complete — retained QSG Mask controls (handles, connectors, Brush cursor, initial-creation
+guides) with zero coverage-fill geometry; AppTheme/DESIGN tokens; crop/ROI overlay unchanged.
+
+**Primary success call chain:**
+
+```text
+GUI publishes MaskOverlayDisplay (item-space handles from MaskOverlayLayout + MaskEditGeometry)
+  -> EditorOverlayItem::setMaskOverlayDisplay
+  -> BuildMaskOverlaySceneGeometry (triangle lists, premultiplied AA fringes)
+  -> update()
+  -> updatePaintNode(oldNode) reuses QSGGeometryNode children
+  -> Qt Quick frame (controls only; photograph remains EditorViewportItem)
+```
+
+**Primary failure call chain:**
+
+```text
+Hidden display, degenerate Radial radii, or unmappable controls
+  -> empty MaskOverlaySceneGeometry (coverage_fill_vertex_count stays 0)
+  -> UpsertPremultipliedTriangleNode removes stale child nodes
+  -> no pipeline lock, MaskStore I/O, or document mutation
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `ExistingMaskEditHasControlsAndNoCoverageFill` | `MaskOverlayControlTest` | PASS |
+| `MaskControlsUpdateWhileRenderIsHeld` | `MaskOverlayControlTest` | PASS |
+| `MaskOverlayReusesNodesForMovement` | `MaskOverlayControlTest` | PASS |
+| `MaskControlsRecreateAfterSceneInvalidation` | `MaskOverlayControlTest` | PASS |
+| `MaskControlsKeepLogicalSizeAndThemeColors` | `MaskOverlayControlTest` | PASS |
+| Degenerate Radial yields empty geometry | `MaskOverlayControlTest` | PASS |
+| Radial creation outline chord error | `MaskOverlayControlTest` | PASS |
+| Hidden display clears Mask nodes | `MaskOverlayControlTest` | PASS |
+| Existing mapping / crop draft routing | `MaskEditGeometryTest`, `BrushPlacementMappingTest`, `EditorGeometryOverlayDraftRoutingTest` | PASS |
+
+Commands:
+`cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"`
+`cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target MaskOverlayControlTest`
+`ctest --test-dir build/debug --output-on-failure -R "MaskOverlayControlTest"`
+`ctest --test-dir build/debug --output-on-failure -R "MaskEditGeometryTest|EditorGeometryOverlayDraftRoutingTest|BrushPlacementMappingTest"`
+
+Suite totals: `8/8` `MaskOverlayControlTest` PASS; `7/7` related mapping/overlay tests PASS.
+Date / working tree on `feature/mask-qsg-controls` (base `e01bafdb`) / Windows MSVC `win_debug` / Qt 6.9.3 (`D:/misc/Qt/6.9.3/msvc2022_64`) / CUDA Toolkit 12.8. Window grabs used Qt `offscreen` QPA scene graph, not a native desktop GPU surface.
+
+**Checklist / exit condition:** required tests PASS. Existing Brush/Radial/Linear displays emit handles and connectors with `coverage_fill_vertex_count == 0`. Offscreen `grabWindow` of an existing Radial interior matches the window color (no Mask-area tint). Overlay geometry rebuilds from the published display while a dummy render thread stays busy. `updatePaintNode` reuses Mask child nodes on movement and reconstructs them on a new window from current display state. Handle draw radius is constant across zoom/DPR; Brush cursor radius scales with the mapping. Theme tokens match DESIGN.md.
+
+**LOC note (grill-code-review):** `mask_overlay_geometry.hpp` 155 / `.cpp` 287, `mask_overlay_layout.hpp` 101 / `.cpp` 372, `editor_overlay_item.hpp` 165 / `.cpp` 612, `mask_overlay_control_test.cpp` 402. Layout owns evaluator-inverse handle placement; geometry owns triangle tessellation. Overlay item only copies published triangles onto retained nodes. No split required.
+
+**Residual gaps:** NM7.7 Radial/Linear creation and existing-mask movement UI (controller + Interactive pixels). NM7.8 accumulating Brush paint/erase UI. Session does not yet publish live Mask overlay display (still NM7.9). Accessible handle proxies are NM7.11. Offscreen QPA grabs are not a packaged D3D11/Metal desktop capture (NM7.14). Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.7 — Complete analytic creation and movement
 


### PR DESCRIPTION
## Summary

- Add retained QSG mask overlay rendering on `EditorOverlayItem` for Brush, Radial, and Linear Gradient controls (handles, connectors, and creation guides only).
- Introduce `mask_overlay_geometry` and `mask_overlay_layout` to map ReferenceSpace controls to item coordinates and build premultiplied triangle-list scene geometry.
- Enforce overlay policy: two-layer theme stroke, logical-pixel sizes invariant to zoom/DPR, no coverage fill or settled Brush path (the Interactive photograph supplies mask feedback).
- Expose mask overlay AppTheme tokens, document them in `DESIGN.md`, and bind colors/sizes from `EditorWorkspace.qml`.
- Publish overlay state via `setMaskOverlayDisplay` on the GUI thread without pipeline locks or cache I/O; update NM7 mask-creation plan docs.

## Testing

- `ctest --test-dir build/debug -R MaskOverlayControlTest --output-on-failure` — 8 tests covering existing/creating displays, no coverage fill, render-busy updates, QSG node reuse vs. recreation, theme token mapping, zoom/DPR-invariant handle size, degenerate Radial geometry, radial outline chord tolerance, and hidden-display cleanup.
- `ExistingMaskEditHasControlsAndNoCoverageFill` — window grab confirms interior mask region stays untinted while handle pixels render.
- Manual editor mask creation/editing in the running app — Not run (overlay display publication from interaction is not wired in this change).