### PR TITLE
feat(editor): add analytic mask creation and handle movement

### DIFF
--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -441,6 +441,13 @@ def_library(PipelineHistoryApplier
 
 target_link_libraries(PipelineMgmtService PRIVATE PipelineHistoryApplier EditorAdjustmentPipeline)
 
+def_library(EditorMaskCreationController
+    SOURCES
+        "${ALCEDO_APP_ROOT}/editor_mask_creation_controller.cpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/editor_mask_creation_controller.hpp"
+    PUBLIC_DEPS EditGraph PipelineHistoryApplier
+)
+
 def_library(EditorPendingInput
     SOURCES
         "${ALCEDO_APP_ROOT}/editor_pending_input.cpp"

--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -485,7 +485,7 @@ def_library(EditorSessionService
                  EditHistory EditorMiniGitMaterializer EditorSaveCheckpointService EditorSessionLifecycle
                  EditorSessionNavigationController EditorSessionRenderController
                  EditorSessionEditController EditorSessionCommandQueue EditorActionPolicy
-                 EditorSerialFrameAdmission
+                 EditorSerialFrameAdmission EditorMaskCreationController
 )
 
 # Facade consumers (tests/UI) include session headers that pull metal_image.hpp

--- a/alcedo_studio/src/app/editor_mask_creation_controller.cpp
+++ b/alcedo_studio/src/app/editor_mask_creation_controller.cpp
@@ -1,0 +1,611 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_mask_creation_controller.hpp"
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "app/pipeline_document_history.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/i_node_model.hpp"
+
+namespace alcedo {
+namespace {
+
+[[nodiscard]] auto FiniteSample(const MaskCreationSample& sample) -> bool {
+  return std::isfinite(sample.normalized.x) && std::isfinite(sample.normalized.y) &&
+         std::isfinite(sample.reference_pixels.x) && std::isfinite(sample.reference_pixels.y);
+}
+
+[[nodiscard]] auto HandleMatchesKind(AnalyticMaskHandle handle, MaskSourceKind kind) -> bool {
+  switch (handle) {
+    case AnalyticMaskHandle::RadialCenter:
+    case AnalyticMaskHandle::RadialMajor:
+    case AnalyticMaskHandle::RadialMinor:
+    case AnalyticMaskHandle::RadialRotate:
+    case AnalyticMaskHandle::RadialInnerFeather:
+    case AnalyticMaskHandle::RadialOuterFeather:
+      return kind == MaskSourceKind::Radial;
+    case AnalyticMaskHandle::LinearOrigin:
+    case AnalyticMaskHandle::LinearDirection:
+    case AnalyticMaskHandle::LinearStartBoundary:
+    case AnalyticMaskHandle::LinearEndBoundary:
+      return kind == MaskSourceKind::LinearGradient;
+    case AnalyticMaskHandle::None:
+      return false;
+  }
+  return false;
+}
+
+[[nodiscard]] auto CreationDisplayName(MaskSourceKind kind) -> std::string {
+  return kind == MaskSourceKind::Radial ? std::string{"Radial"} : std::string{"Linear Gradient"};
+}
+
+[[nodiscard]] auto SourceFromJson(const nlohmann::json& source, const MaskId& mask_id)
+    -> MaskSource {
+  auto mask = MaskModelFromJson({{"id", std::string{mask_id.Value()}},
+                                 {"display_name", ""},
+                                 {"enabled", true},
+                                 {"opacity", 1.0},
+                                 {"invert", false},
+                                 {"source", source},
+                                 {"color_range", nullptr},
+                                 {"luminance_range", nullptr}});
+  return std::move(mask.source);
+}
+
+[[nodiscard]] auto CreationSourceValid(const MaskSource& source) -> bool {
+  if (const auto* radial = std::get_if<RadialMaskSource>(&source)) {
+    return RadialCreationIsValid(*radial);
+  }
+  if (const auto* linear = std::get_if<LinearGradientMaskSource>(&source)) {
+    return LinearCreationIsValid(*linear);
+  }
+  return false;
+}
+
+}  // namespace
+
+void EditorMaskCreationController::Bind(PipelineDocument& document,
+                                        MiniGitWorkingHistory& history) {
+  if (open_) {
+    throw std::runtime_error("cannot rebind the Mask creation controller during an open operation");
+  }
+  document_ = &document;
+  history_  = &history;
+}
+
+void EditorMaskCreationController::SetInteractivePreview(std::function<void()> preview) {
+  interactive_preview_ = std::move(preview);
+}
+
+auto EditorMaskCreationController::Reject(std::string error) const -> EditorMaskCreationResult {
+  EditorMaskCreationResult result;
+  result.error   = std::move(error);
+  result.mask_id = mask_id_;
+  return result;
+}
+
+auto EditorMaskCreationController::Ok() const -> EditorMaskCreationResult {
+  EditorMaskCreationResult result;
+  result.accepted = true;
+  result.mask_id  = mask_id_;
+  return result;
+}
+
+auto EditorMaskCreationController::Grade() -> ColorGradeNodeModel* {
+  if (document_ == nullptr || node_id_.Empty()) {
+    return nullptr;
+  }
+  return dynamic_cast<ColorGradeNodeModel*>(document_->Graph().FindNode(node_id_));
+}
+
+auto EditorMaskCreationController::Grade() const -> const ColorGradeNodeModel* {
+  if (document_ == nullptr || node_id_.Empty()) {
+    return nullptr;
+  }
+  return dynamic_cast<const ColorGradeNodeModel*>(document_->Graph().FindNode(node_id_));
+}
+
+auto EditorMaskCreationController::IdentityMatches(const MaskPointerIdentity& identity) const
+    -> bool {
+  return identity.device_id == pointer_.device_id && identity.point_id == pointer_.point_id &&
+         identity.sequence_id == pointer_.sequence_id;
+}
+
+auto EditorMaskCreationController::AllocateMaskId() const -> MaskId {
+  const auto* grade = Grade();
+  const char* prefix =
+      kind_ == MaskSourceKind::Radial ? "mask.radial." : "mask.linear.";
+  for (std::uint32_t i = 1; i < 1000000; ++i) {
+    MaskId id{std::string{prefix} + std::to_string(i)};
+    if (grade != nullptr && grade->FindMask(id) == nullptr) {
+      return id;
+    }
+  }
+  return MaskId{};
+}
+
+auto EditorMaskCreationController::MakeCreationMask(const MaskSource& source) const -> MaskModel {
+  MaskModel mask;
+  mask.id           = mask_id_;
+  mask.display_name = CreationDisplayName(kind_);
+  mask.source       = source;
+  return mask;
+}
+
+auto EditorMaskCreationController::LiveSourceJson() const -> nlohmann::json {
+  const auto* grade = Grade();
+  if (grade == nullptr) {
+    return nullptr;
+  }
+  const auto* mask = grade->FindMask(mask_id_);
+  if (mask == nullptr) {
+    return nullptr;
+  }
+  return MaskModelToJson(*mask).at("source");
+}
+
+auto EditorMaskCreationController::SourcesEqual(const nlohmann::json& a,
+                                                const nlohmann::json& b) const -> bool {
+  return a == b;
+}
+
+auto EditorMaskCreationController::ApplyLiveSource(const MaskSource& source) -> bool {
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return false;
+  }
+  try {
+    grade->ReplaceMaskSource(mask_id_, source);
+    draft_source_ = source;
+    return true;
+  } catch (const std::exception&) {
+    return false;
+  }
+}
+
+auto EditorMaskCreationController::InsertProvisional(const MaskSource& source) -> bool {
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return false;
+  }
+  mask_id_ = AllocateMaskId();
+  if (mask_id_.Empty()) {
+    return false;
+  }
+  try {
+    auto mask         = MakeCreationMask(source);
+    display_index_    = static_cast<std::uint32_t>(grade->MaskCount());
+    grade->AddMask(std::move(mask), display_index_);
+    inserted_         = true;
+    draft_source_     = source;
+    return true;
+  } catch (const std::exception&) {
+    mask_id_ = MaskId{};
+    return false;
+  }
+}
+
+void EditorMaskCreationController::RestoreLive() {
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return;
+  }
+  try {
+    if (inserted_ && !mask_id_.Empty() && grade->FindMask(mask_id_) != nullptr) {
+      grade->RemoveMask(mask_id_);
+    } else if (!creating_ && !mask_id_.Empty() && !before_source_.is_null() &&
+               grade->FindMask(mask_id_) != nullptr) {
+      grade->ReplaceMaskSource(mask_id_, SourceFromJson(before_source_, mask_id_));
+    }
+  } catch (const std::exception&) {
+  }
+}
+
+void EditorMaskCreationController::ClearOpenOperation() {
+  open_               = false;
+  terminated_         = true;
+  handle_             = AnalyticMaskHandle::None;
+  pointer_            = {};
+  unwrapped_rotation_ = 0.0f;
+  draft_source_.reset();
+}
+
+void EditorMaskCreationController::ResetMode() {
+  ClearOpenOperation();
+  state_         = EditorMaskCreationState::Inactive;
+  creating_      = false;
+  inserted_      = false;
+  mask_id_       = MaskId{};
+  node_id_       = NodeId{};
+  kind_          = MaskSourceKind::Radial;
+  before_source_ = nullptr;
+  session_       = {};
+  terminated_    = false;
+}
+
+void EditorMaskCreationController::RequestInteractive(EditorMaskCreationResult& result) {
+  if (interactive_preview_) {
+    interactive_preview_();
+  }
+  result.interactive_preview = true;
+}
+
+auto EditorMaskCreationController::OverlayIsCreating() const -> bool {
+  return creating_ && open_;
+}
+
+auto EditorMaskCreationController::CurrentSource() const -> std::optional<MaskSource> {
+  if (draft_source_.has_value()) {
+    return draft_source_;
+  }
+  const auto* grade = Grade();
+  if (grade == nullptr || mask_id_.Empty()) {
+    return std::nullopt;
+  }
+  const auto* mask = grade->FindMask(mask_id_);
+  if (mask == nullptr) {
+    return std::nullopt;
+  }
+  return mask->source;
+}
+
+auto EditorMaskCreationController::BeginCreation(MaskSourceKind kind, const NodeId& grade_id,
+                                                 EditorSessionIdentity session)
+    -> EditorMaskCreationResult {
+  if (open_) {
+    return Reject("finish or cancel the open Mask operation before changing tools");
+  }
+  if (kind != MaskSourceKind::Radial && kind != MaskSourceKind::LinearGradient) {
+    return Reject("analytic creation supports Radial and Linear Gradient");
+  }
+  if (document_ == nullptr || history_ == nullptr) {
+    return Reject("Mask creation controller is not bound to a document");
+  }
+  node_id_ = grade_id;
+  if (Grade() == nullptr) {
+    node_id_ = NodeId{};
+    return Reject("creation target is not a Color Grade");
+  }
+  kind_          = kind;
+  session_       = session;
+  mask_id_       = MaskId{};
+  inserted_      = false;
+  creating_      = true;
+  handle_        = AnalyticMaskHandle::None;
+  before_source_ = nullptr;
+  draft_source_.reset();
+  terminated_    = false;
+  state_         = EditorMaskCreationState::Creating;
+  return Ok();
+}
+
+auto EditorMaskCreationController::SelectMask(const NodeId& grade_id, const MaskId& mask_id,
+                                              EditorSessionIdentity session)
+    -> EditorMaskCreationResult {
+  if (open_) {
+    return Reject("finish or cancel the open Mask operation before changing selection");
+  }
+  if (document_ == nullptr || history_ == nullptr) {
+    return Reject("Mask creation controller is not bound to a document");
+  }
+  node_id_ = grade_id;
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    node_id_ = NodeId{};
+    return Reject("selection target is not a Color Grade");
+  }
+  const auto* mask = grade->FindMask(mask_id);
+  if (mask == nullptr) {
+    return Reject("Mask is missing");
+  }
+  const auto kind = GetMaskSourceKind(mask->source);
+  if (kind != MaskSourceKind::Radial && kind != MaskSourceKind::LinearGradient) {
+    return Reject("analytic movement supports Radial and Linear Gradient");
+  }
+  kind_          = kind;
+  session_       = session;
+  mask_id_       = mask_id;
+  creating_      = false;
+  inserted_      = false;
+  handle_        = AnalyticMaskHandle::None;
+  before_source_ = MaskModelToJson(*mask).at("source");
+  draft_source_  = mask->source;
+  terminated_    = false;
+  state_         = EditorMaskCreationState::Selected;
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  return result;
+}
+
+auto EditorMaskCreationController::BeginMaskInput(MaskCreationSample sample,
+                                                  MaskPointerIdentity identity)
+    -> EditorMaskCreationResult {
+  if (state_ == EditorMaskCreationState::Settling) {
+    return Reject("Mask tool is unavailable until settle is acknowledged");
+  }
+  if (state_ != EditorMaskCreationState::Creating || open_) {
+    return Reject("BeginMaskInput requires an armed creation tool");
+  }
+  if (!FiniteSample(sample) || !sample.inside_photograph) {
+    return Reject("Mask press must lie inside the photograph");
+  }
+  pointer_            = identity;
+  press_normalized_   = sample.normalized;
+  handle_             = AnalyticMaskHandle::None;
+  inserted_           = false;
+  mask_id_            = MaskId{};
+  before_source_      = nullptr;
+  unwrapped_rotation_ = 0.0f;
+  draft_source_       = kind_ == MaskSourceKind::Radial
+                            ? MaskSource{RadialFromCenterOut(sample.normalized, sample.normalized)}
+                            : MaskSource{LinearFromEndpoints(sample.normalized, sample.normalized)};
+  open_               = true;
+  terminated_         = false;
+  state_              = EditorMaskCreationState::Editing;
+  return Ok();
+}
+
+auto EditorMaskCreationController::BeginMaskMove(AnalyticMaskHandle handle,
+                                                 MaskCreationSample sample,
+                                                 MaskPointerIdentity identity)
+    -> EditorMaskCreationResult {
+  if (state_ == EditorMaskCreationState::Settling) {
+    return Reject("Mask tool is unavailable until settle is acknowledged");
+  }
+  if (state_ != EditorMaskCreationState::Selected || open_) {
+    return Reject("BeginMaskMove requires a selected existing Mask");
+  }
+  if (!HandleMatchesKind(handle, kind_)) {
+    return Reject("handle does not match the selected Mask kind");
+  }
+  if (!FiniteSample(sample) || !sample.inside_photograph) {
+    return Reject("Mask press must lie inside the photograph");
+  }
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return Reject("selection target is not a Color Grade");
+  }
+  const auto* mask = grade->FindMask(mask_id_);
+  if (mask == nullptr) {
+    return Reject("Mask is missing");
+  }
+  pointer_          = identity;
+  press_normalized_ = sample.normalized;
+  handle_           = handle;
+  creating_         = false;
+  inserted_         = false;
+  before_source_    = MaskModelToJson(*mask).at("source");
+  draft_source_     = mask->source;
+  if (const auto* radial = std::get_if<RadialMaskSource>(&mask->source)) {
+    unwrapped_rotation_ = radial->rotation;
+  } else {
+    unwrapped_rotation_ = 0.0f;
+  }
+  open_        = true;
+  terminated_  = false;
+  state_       = EditorMaskCreationState::Editing;
+  auto result  = Ok();
+  result.mask_id = mask_id_;
+  return result;
+}
+
+auto EditorMaskCreationController::UpdateCreation(const MaskCreationSample& sample)
+    -> EditorMaskCreationResult {
+  MaskSource next;
+  if (kind_ == MaskSourceKind::Radial) {
+    next = RadialFromCenterOut(press_normalized_, sample.normalized);
+  } else {
+    next = LinearFromEndpoints(press_normalized_, sample.normalized);
+  }
+  draft_source_ = next;
+  if (!CreationSourceValid(next)) {
+    return Ok();
+  }
+  if (!inserted_) {
+    if (!InsertProvisional(next)) {
+      return Reject("provisional Mask insertion failed");
+    }
+  } else if (!ApplyLiveSource(next)) {
+    return Reject("provisional Mask source was rejected");
+  }
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  RequestInteractive(result);
+  return result;
+}
+
+auto EditorMaskCreationController::UpdateExisting(const MaskCreationSample& sample)
+    -> EditorMaskCreationResult {
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return Reject("selection target is not a Color Grade");
+  }
+  const auto* mask = grade->FindMask(mask_id_);
+  if (mask == nullptr) {
+    return Reject("Mask is missing");
+  }
+  auto next = ApplyAnalyticMaskHandle(handle_, mask->source, sample.normalized, unwrapped_rotation_);
+  if (!next) {
+    return Reject("analytic handle update is not valid");
+  }
+  if (*next == mask->source) {
+    auto result    = Ok();
+    result.mask_id = mask_id_;
+    return result;
+  }
+  if (!ApplyLiveSource(*next)) {
+    return Reject("analytic source update was rejected");
+  }
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  RequestInteractive(result);
+  return result;
+}
+
+auto EditorMaskCreationController::AppendMaskInput(MaskCreationSample sample,
+                                                   MaskPointerIdentity identity)
+    -> EditorMaskCreationResult {
+  if (!open_ || terminated_) {
+    return Reject("no open Mask input sequence");
+  }
+  if (!IdentityMatches(identity)) {
+    return Reject("pointer identity does not match the captured sequence");
+  }
+  if (!FiniteSample(sample)) {
+    return Reject("Mask sample is not finite");
+  }
+  if (creating_) {
+    return UpdateCreation(sample);
+  }
+  return UpdateExisting(sample);
+}
+
+auto EditorMaskCreationController::PublishAddMask() -> EditorMaskCreationResult {
+  auto* grade = Grade();
+  if (grade == nullptr || history_ == nullptr) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject("AddMask settle is missing the Grade or history");
+  }
+  const auto* mask = grade->FindMask(mask_id_);
+  if (mask == nullptr) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject("provisional Mask is missing at settle");
+  }
+  const auto batch =
+      MakeAddMaskBatch(node_id_, mask_id_, MaskModelToJson(*mask), display_index_);
+  const auto append = history_->AppendEdit(batch);
+  if (!append.committed) {
+    RestoreLive();
+    inserted_ = false;
+    state_    = EditorMaskCreationState::Failed;
+    return Reject(append.error.empty() ? std::string{"AddMask history publish failed"}
+                                       : append.error);
+  }
+  ClearOpenOperation();
+  creating_      = false;
+  inserted_      = false;
+  before_source_ = MaskModelToJson(*mask).at("source");
+  draft_source_  = mask->source;
+  state_         = EditorMaskCreationState::Settling;
+  auto result    = Ok();
+  result.mask_id           = mask_id_;
+  result.committed         = true;
+  result.quality_requested = true;
+  return result;
+}
+
+auto EditorMaskCreationController::PublishReplaceSource() -> EditorMaskCreationResult {
+  const auto after = LiveSourceJson();
+  if (after.is_null()) {
+    state_ = EditorMaskCreationState::Failed;
+    return Reject("Mask source is missing at settle");
+  }
+  if (SourcesEqual(before_source_, after)) {
+    ClearOpenOperation();
+    state_ = EditorMaskCreationState::Selected;
+    return Ok();
+  }
+  if (history_ == nullptr) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject("ReplaceMaskSource settle is missing history");
+  }
+  const auto batch = MakeReplaceMaskSourceBatch(node_id_, mask_id_, before_source_, after);
+  const auto append = history_->AppendEdit(batch);
+  if (!append.committed) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject(append.error.empty() ? std::string{"ReplaceMaskSource history publish failed"}
+                                       : append.error);
+  }
+  ClearOpenOperation();
+  before_source_ = after;
+  if (Grade() != nullptr) {
+    if (const auto* mask = Grade()->FindMask(mask_id_)) {
+      draft_source_ = mask->source;
+    }
+  }
+  state_      = EditorMaskCreationState::Settling;
+  auto result = Ok();
+  result.mask_id           = mask_id_;
+  result.committed         = true;
+  result.quality_requested = true;
+  return result;
+}
+
+auto EditorMaskCreationController::FinishMaskInput() -> EditorMaskCreationResult {
+  if (!open_) {
+    auto result = Ok();
+    result.mask_id = mask_id_;
+    return result;
+  }
+  if (creating_ && !inserted_) {
+    ClearOpenOperation();
+    draft_source_.reset();
+    state_ = EditorMaskCreationState::Creating;
+    return Ok();
+  }
+  if (creating_ && inserted_) {
+    return PublishAddMask();
+  }
+  return PublishReplaceSource();
+}
+
+auto EditorMaskCreationController::CancelMaskInput() -> EditorMaskCreationResult {
+  if (open_) {
+    RestoreLive();
+  }
+  const auto id = mask_id_;
+  ClearOpenOperation();
+  if (creating_) {
+    inserted_      = false;
+    mask_id_       = MaskId{};
+    draft_source_.reset();
+    before_source_ = nullptr;
+    state_         = EditorMaskCreationState::Inactive;
+  } else {
+    state_ = EditorMaskCreationState::Selected;
+    if (Grade() != nullptr && Grade()->FindMask(id) != nullptr) {
+      mask_id_       = id;
+      before_source_ = MaskModelToJson(*Grade()->FindMask(id)).at("source");
+      draft_source_  = Grade()->FindMask(id)->source;
+    }
+  }
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  return result;
+}
+
+auto EditorMaskCreationController::FinishCreationMode() -> EditorMaskCreationResult {
+  auto result = open_ ? FinishMaskInput() : Ok();
+  if (!result.accepted && open_) {
+    return result;
+  }
+  const bool committed         = result.committed;
+  const bool quality_requested = result.quality_requested;
+  const auto mask_id           = result.mask_id;
+  ResetMode();
+  result                   = Ok();
+  result.committed         = committed;
+  result.quality_requested = quality_requested;
+  result.mask_id           = mask_id;
+  return result;
+}
+
+auto EditorMaskCreationController::CancelCreationMode() -> EditorMaskCreationResult {
+  auto result = CancelMaskInput();
+  ResetMode();
+  result.mask_id = MaskId{};
+  return result;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/app/editor_mask_creation_controller.cpp
+++ b/alcedo_studio/src/app/editor_mask_creation_controller.cpp
@@ -73,6 +73,9 @@ namespace {
 
 void EditorMaskCreationController::Bind(PipelineDocument& document,
                                         MiniGitWorkingHistory& history) {
+  if (document_ == &document && history_ == &history) {
+    return;
+  }
   if (open_) {
     throw std::runtime_error("cannot rebind the Mask creation controller during an open operation");
   }
@@ -82,6 +85,19 @@ void EditorMaskCreationController::Bind(PipelineDocument& document,
 
 void EditorMaskCreationController::SetInteractivePreview(std::function<void()> preview) {
   interactive_preview_ = std::move(preview);
+}
+
+void EditorMaskCreationController::SetSettlePublisher(
+    std::function<bool(const PipelineEditBatch&, std::string*)> publish) {
+  settle_publisher_ = std::move(publish);
+}
+
+void EditorMaskCreationController::DetachClosedDocument() {
+  interactive_preview_ = {};
+  settle_publisher_    = {};
+  document_            = nullptr;
+  history_             = nullptr;
+  ResetMode();
 }
 
 auto EditorMaskCreationController::Reject(std::string error) const -> EditorMaskCreationResult {
@@ -467,6 +483,27 @@ auto EditorMaskCreationController::AppendMaskInput(MaskCreationSample sample,
   return UpdateExisting(sample);
 }
 
+auto EditorMaskCreationController::PublishSettledBatch(const PipelineEditBatch& batch,
+                                                       std::string* error) -> bool {
+  if (settle_publisher_) {
+    return settle_publisher_(batch, error);
+  }
+  if (history_ == nullptr) {
+    if (error != nullptr) {
+      *error = "Mask creation controller is not bound to history";
+    }
+    return false;
+  }
+  const auto append = history_->AppendEdit(batch);
+  if (append.committed) {
+    return true;
+  }
+  if (error != nullptr) {
+    *error = append.error;
+  }
+  return false;
+}
+
 auto EditorMaskCreationController::PublishAddMask() -> EditorMaskCreationResult {
   auto* grade = Grade();
   if (grade == nullptr || history_ == nullptr) {
@@ -482,13 +519,13 @@ auto EditorMaskCreationController::PublishAddMask() -> EditorMaskCreationResult 
   }
   const auto batch =
       MakeAddMaskBatch(node_id_, mask_id_, MaskModelToJson(*mask), display_index_);
-  const auto append = history_->AppendEdit(batch);
-  if (!append.committed) {
+  std::string settle_error;
+  if (!PublishSettledBatch(batch, &settle_error)) {
     RestoreLive();
     inserted_ = false;
     state_    = EditorMaskCreationState::Failed;
-    return Reject(append.error.empty() ? std::string{"AddMask history publish failed"}
-                                       : append.error);
+    return Reject(settle_error.empty() ? std::string{"AddMask history publish failed"}
+                                       : settle_error);
   }
   ClearOpenOperation();
   creating_      = false;
@@ -520,12 +557,12 @@ auto EditorMaskCreationController::PublishReplaceSource() -> EditorMaskCreationR
     return Reject("ReplaceMaskSource settle is missing history");
   }
   const auto batch = MakeReplaceMaskSourceBatch(node_id_, mask_id_, before_source_, after);
-  const auto append = history_->AppendEdit(batch);
-  if (!append.committed) {
+  std::string settle_error;
+  if (!PublishSettledBatch(batch, &settle_error)) {
     RestoreLive();
     state_ = EditorMaskCreationState::Failed;
-    return Reject(append.error.empty() ? std::string{"ReplaceMaskSource history publish failed"}
-                                       : append.error);
+    return Reject(settle_error.empty() ? std::string{"ReplaceMaskSource history publish failed"}
+                                       : settle_error);
   }
   ClearOpenOperation();
   before_source_ = after;

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -5,6 +5,7 @@
 #include "app/editor_session_service.hpp"
 
 #include <algorithm>
+#include <iterator>
 #include <mutex>
 #include <utility>
 
@@ -14,6 +15,8 @@
 #include "app/editor_session_lifecycle.hpp"
 #include "app/editor_session_navigation_controller.hpp"
 #include "app/editor_session_render_controller.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/history/mini_git_working_history.hpp"
 
 namespace alcedo {
 
@@ -424,6 +427,7 @@ auto EditorSessionService::Open(sl_element_id_t element_id, image_id_t image_id)
       return Open(queued.element_id, queued.image_id);
     });
   }
+  AbortMaskCreation();
   const auto outcome = navigation_.RequestOpenOrSwitch(element_id, image_id, false);
   if (outcome.rejected) {
     return Reject(outcome.message);
@@ -912,6 +916,7 @@ auto EditorSessionService::Switch(sl_element_id_t element_id, image_id_t image_i
       return Switch(queued.element_id, queued.image_id);
     });
   }
+  AbortMaskCreation();
   const auto outcome = navigation_.RequestOpenOrSwitch(element_id, image_id, true);
   if (outcome.rejected) {
     return Reject(outcome.message);
@@ -996,6 +1001,7 @@ auto EditorSessionService::Close(bool persist_changes) -> EditorSessionResult {
       return Close(queued.persist_changes);
     });
   }
+  AbortMaskCreation();
   const auto outcome = navigation_.RequestClose(persist_changes);
   if (outcome.rejected) {
     return Reject(outcome.message);
@@ -1134,6 +1140,52 @@ auto EditorSessionService::EnqueuePendingInputBoundary(EditorPendingInputBoundar
   return result;
 }
 
+namespace {
+
+[[nodiscard]] auto SameMaskPointer(const MaskPointerIdentity& a, const MaskPointerIdentity& b)
+    -> bool {
+  return a.device_id == b.device_id && a.point_id == b.point_id && a.sequence_id == b.sequence_id;
+}
+
+[[nodiscard]] auto MaskCommandIsTerminal(EditorMaskCreationCommandKind kind) -> bool {
+  return kind == EditorMaskCreationCommandKind::Finish ||
+         kind == EditorMaskCreationCommandKind::Cancel ||
+         kind == EditorMaskCreationCommandKind::CancelMode;
+}
+
+}  // namespace
+
+auto EditorSessionService::EnqueueMaskCreation(EditorMaskCreationCommand command)
+    -> EditorSessionResult {
+  if (lifecycle_.state() != EditorSessionState::Interactive) {
+    return Reject("Queued Mask creation requires an interactive session");
+  }
+  if (!lifecycle_.has_image()) {
+    return Reject("Queued Mask creation requires an open image");
+  }
+  {
+    std::scoped_lock lock(mask_command_mutex_);
+    if (command.kind == EditorMaskCreationCommandKind::Append && !pending_mask_commands_.empty()) {
+      auto& back = pending_mask_commands_.back();
+      if (back.kind == EditorMaskCreationCommandKind::Append &&
+          SameMaskPointer(back.identity, command.identity)) {
+        back = std::move(command);
+      } else {
+        pending_mask_commands_.push_back(std::move(command));
+      }
+    } else {
+      pending_mask_commands_.push_back(std::move(command));
+    }
+  }
+  RequestPendingInputConsume();
+  EditorSessionResult result;
+  result.kind     = EditorSessionResultKind::Accepted;
+  result.state    = lifecycle_.state();
+  result.identity = lifecycle_.identity();
+  result.message  = "Mask creation queued";
+  return result;
+}
+
 auto EditorSessionService::PeekPendingInput() const -> EditorPendingInputView {
   return pending_input_.Peek();
 }
@@ -1145,6 +1197,181 @@ void EditorSessionService::SetAdmissionDeadlineHandler(
 
 void EditorSessionService::SetMonotonicClock(std::shared_ptr<IEditorMonotonicClock> clock) {
   serial_admission_.SetClock(std::move(clock));
+}
+
+void EditorSessionService::AbortMaskCreation() {
+  {
+    std::scoped_lock lock(mask_command_mutex_);
+    pending_mask_commands_.clear();
+  }
+  if (mask_creation_.state() == EditorMaskCreationState::Inactive) {
+    mask_creation_.DetachClosedDocument();
+    return;
+  }
+  if (!dependencies_.history || !lifecycle_.has_history_guard()) {
+    mask_creation_.DetachClosedDocument();
+    return;
+  }
+  std::string error;
+  const auto guard = lifecycle_.history_guard();
+  (void)dependencies_.history->WithLockedLiveDocument(
+      guard,
+      [this](PipelineDocument& document, MiniGitWorkingHistory& history,
+             const IEditorHistoryPort::LockedMaskSettle& settle, std::string*) {
+        mask_creation_.Bind(document, history);
+        mask_creation_.SetSettlePublisher(settle);
+        mask_creation_.SetInteractivePreview({});
+        (void)mask_creation_.CancelCreationMode();
+        return true;
+      },
+      &error);
+  mask_creation_.DetachClosedDocument();
+}
+
+auto EditorSessionService::ApplyMaskCreationCommand(const EditorMaskCreationCommand& command)
+    -> EditorMaskCreationResult {
+  const auto identity = lifecycle_.identity();
+  switch (command.kind) {
+    case EditorMaskCreationCommandKind::BeginCreation:
+      return mask_creation_.BeginCreation(command.source_kind, command.node_id, identity);
+    case EditorMaskCreationCommandKind::SelectMask:
+      return mask_creation_.SelectMask(command.node_id, command.mask_id, identity);
+    case EditorMaskCreationCommandKind::BeginInput:
+      return mask_creation_.BeginMaskInput(command.sample, command.identity);
+    case EditorMaskCreationCommandKind::BeginMove:
+      return mask_creation_.BeginMaskMove(command.handle, command.sample, command.identity);
+    case EditorMaskCreationCommandKind::Append:
+      return mask_creation_.AppendMaskInput(command.sample, command.identity);
+    case EditorMaskCreationCommandKind::Finish:
+      return mask_creation_.FinishMaskInput();
+    case EditorMaskCreationCommandKind::Cancel:
+      return mask_creation_.CancelMaskInput();
+    case EditorMaskCreationCommandKind::CancelMode:
+      return mask_creation_.CancelCreationMode();
+  }
+  EditorMaskCreationResult rejected;
+  rejected.error = "unknown Mask creation command";
+  return rejected;
+}
+
+auto EditorSessionService::RouteMaskCreationRender(bool interactive_preview, bool quality_requested,
+                                                   bool committed) -> EditorSessionResult {
+  if (!quality_requested && !interactive_preview) {
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Accepted;
+    result.state    = lifecycle_.state();
+    result.identity = lifecycle_.identity();
+    result.message  = "Mask creation applied";
+    if (committed) {
+      BumpHistoryRevision();
+    }
+    return result;
+  }
+  EditorRenderCommand render_command;
+  render_command.reason                    = quality_requested ? EditorRenderReason::SettledMaskEdit
+                                                               : EditorRenderReason::InteractiveAdjustment;
+  render_command.live_parameters_applied   = true;
+  render_command.operation_id              = current_operation_id_;
+  const auto request_id =
+      render_.RouteInitialRender(render_command, lifecycle_.identity(),
+                                 lifecycle_.active_image_load_request());
+  if (request_id == 0) {
+    serial_admission_.AbortCycle();
+  } else {
+    serial_admission_.NoteScheduledRequest(request_id);
+  }
+  if (committed) {
+    BumpHistoryRevision();
+  }
+  EditorSessionResult result;
+  result.kind              = EditorSessionResultKind::RenderRouted;
+  result.state             = lifecycle_.state();
+  result.identity          = lifecycle_.identity();
+  result.render_request_id = request_id;
+  result.message           = quality_requested ? "Settled Mask render routed"
+                                               : "Interactive Mask render routed";
+  return result;
+}
+
+void EditorSessionService::ConsumePendingMaskCommands() {
+  std::vector<EditorMaskCreationCommand> batch;
+  {
+    std::scoped_lock lock(mask_command_mutex_);
+    batch.swap(pending_mask_commands_);
+  }
+  if (batch.empty()) {
+    return;
+  }
+  bool interactive = true;
+  for (const auto& command : batch) {
+    if (MaskCommandIsTerminal(command.kind)) {
+      interactive = false;
+      break;
+    }
+  }
+  if (!serial_admission_.TryBeginCycle(interactive)) {
+    std::scoped_lock lock(mask_command_mutex_);
+    pending_mask_commands_.insert(pending_mask_commands_.begin(),
+                                  std::make_move_iterator(batch.begin()),
+                                  std::make_move_iterator(batch.end()));
+    return;
+  }
+  if (!dependencies_.history || !lifecycle_.has_history_guard()) {
+    serial_admission_.AbortCycle();
+    return;
+  }
+  bool interactive_preview = false;
+  bool quality_requested   = false;
+  bool committed           = false;
+  std::string error;
+  const auto applied = dependencies_.history->WithLockedLiveDocument(
+      lifecycle_.history_guard(),
+      [this, &batch, &interactive_preview, &quality_requested, &committed](
+          PipelineDocument& document, MiniGitWorkingHistory& history,
+          const IEditorHistoryPort::LockedMaskSettle& settle, std::string* op_error) {
+        mask_creation_.Bind(document, history);
+        mask_creation_.SetSettlePublisher(settle);
+        mask_creation_.SetInteractivePreview({});
+        for (const auto& command : batch) {
+          auto result = ApplyMaskCreationCommand(command);
+          if (!result.accepted) {
+            if (op_error != nullptr) {
+              *op_error = result.error.empty() ? "Mask creation command was rejected"
+                                               : result.error;
+            }
+            if (mask_creation_.HasOpenOperation()) {
+              (void)mask_creation_.CancelMaskInput();
+            }
+            return false;
+          }
+          interactive_preview = interactive_preview || result.interactive_preview;
+          quality_requested   = quality_requested || result.quality_requested;
+          committed           = committed || result.committed;
+          if (command.kind == EditorMaskCreationCommandKind::Finish && result.committed &&
+              !result.mask_id.Empty()) {
+            (void)mask_creation_.SelectMask(mask_creation_.node_id(), result.mask_id,
+                                            lifecycle_.identity());
+          }
+        }
+        return true;
+      },
+      &error);
+  if (!applied) {
+    serial_admission_.AbortCycle();
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Rejected;
+    result.state    = lifecycle_.state();
+    result.identity = lifecycle_.identity();
+    result.message  = error.empty() ? "Mask creation consume failed" : std::move(error);
+    (void)Emit(std::move(result));
+    RequestPendingInputConsume();
+    return;
+  }
+  const auto routed = RouteMaskCreationRender(interactive_preview, quality_requested, committed);
+  if (routed.kind == EditorSessionResultKind::Accepted) {
+    serial_admission_.AbortCycle();
+  }
+  (void)Emit(routed);
 }
 
 void EditorSessionService::RequestPendingInputConsume() {
@@ -1176,6 +1403,15 @@ void EditorSessionService::TryConsumePendingInput() {
     if (work) {
       work();
     }
+    return;
+  }
+  bool has_mask_commands = false;
+  {
+    std::scoped_lock lock(mask_command_mutex_);
+    has_mask_commands = !pending_mask_commands_.empty();
+  }
+  if (has_mask_commands) {
+    ConsumePendingMaskCommands();
     return;
   }
   if (!pending_input_.HasConsumableWork()) {

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -40,6 +40,7 @@ def_library(EditMaskStore
         ${ALCEDO_SRC_ROOT}/edit/mask/mask_model.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_stroke.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_raster_encoding.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/analytic_mask_edit.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_source_geometry.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_canonical_sampler.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_spatial_index.cpp

--- a/alcedo_studio/src/edit/mask/analytic_mask_edit.cpp
+++ b/alcedo_studio/src/edit/mask/analytic_mask_edit.cpp
@@ -1,0 +1,310 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/analytic_mask_edit.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <variant>
+
+namespace alcedo {
+namespace {
+
+constexpr float kPi = 3.14159265358979323846f;
+
+[[nodiscard]] auto IsFinite(Vector2 point) -> bool {
+  return std::isfinite(point.x) && std::isfinite(point.y);
+}
+
+[[nodiscard]] auto IsFiniteRadial(const RadialMaskSource& source) -> bool {
+  return std::isfinite(source.center_x) && std::isfinite(source.center_y) &&
+         std::isfinite(source.major_radius) && std::isfinite(source.minor_radius) &&
+         std::isfinite(source.rotation) && std::isfinite(source.inner_feather) &&
+         std::isfinite(source.outer_feather);
+}
+
+[[nodiscard]] auto IsFiniteLinear(const LinearGradientMaskSource& source) -> bool {
+  return std::isfinite(source.origin_x) && std::isfinite(source.origin_y) &&
+         std::isfinite(source.normal_x) && std::isfinite(source.normal_y) &&
+         std::isfinite(source.transition_distance) && std::isfinite(source.start_value) &&
+         std::isfinite(source.end_value);
+}
+
+[[nodiscard]] auto LinearNormalLength(const LinearGradientMaskSource& source) -> float {
+  return std::hypot(source.normal_x, source.normal_y);
+}
+
+[[nodiscard]] auto UnwrapRadians(float previous, float candidate) -> float {
+  float delta = candidate - previous;
+  while (delta > kPi) {
+    delta -= 2.0f * kPi;
+  }
+  while (delta < -kPi) {
+    delta += 2.0f * kPi;
+  }
+  return previous + delta;
+}
+
+}  // namespace
+
+auto RadialLocalAxes(const RadialMaskSource& source, Vector2 normalized) -> std::optional<Vector2> {
+  if (!IsFiniteRadial(source) || !IsFinite(normalized)) {
+    return std::nullopt;
+  }
+  const float c  = std::cos(source.rotation);
+  const float s  = std::sin(source.rotation);
+  const float dx = normalized.x - source.center_x;
+  const float dy = normalized.y - source.center_y;
+  if (!std::isfinite(dx) || !std::isfinite(dy) || !std::isfinite(c) || !std::isfinite(s)) {
+    return std::nullopt;
+  }
+  return Vector2{c * dx + s * dy, -s * dx + c * dy};
+}
+
+auto RadialRho(const RadialMaskSource& source, Vector2 normalized) -> std::optional<float> {
+  const auto local = RadialLocalAxes(source, normalized);
+  if (!local) {
+    return std::nullopt;
+  }
+  const float u =
+      local->x / std::max(source.major_radius, kAnalyticMaskEpsilon);
+  const float v =
+      local->y / std::max(source.minor_radius, kAnalyticMaskEpsilon);
+  const float rho = std::sqrt(u * u + v * v);
+  if (!std::isfinite(rho)) {
+    return std::nullopt;
+  }
+  return rho;
+}
+
+auto RadialCreationIsValid(const RadialMaskSource& source) -> bool {
+  return IsFiniteRadial(source) && source.major_radius > kAnalyticCreationMinRadius &&
+         source.minor_radius > kAnalyticCreationMinRadius && source.major_radius >= 0.0f &&
+         source.minor_radius >= 0.0f && source.inner_feather >= 0.0f &&
+         source.outer_feather >= 0.0f;
+}
+
+auto LinearCreationIsValid(const LinearGradientMaskSource& source) -> bool {
+  return IsFiniteLinear(source) && LinearNormalLength(source) > kAnalyticMaskEpsilon &&
+         source.transition_distance >= 0.0f;
+}
+
+auto RadialFromCenterOut(Vector2 center_normalized, Vector2 current_normalized)
+    -> RadialMaskSource {
+  RadialMaskSource source;
+  source.center_x     = center_normalized.x;
+  source.center_y     = center_normalized.y;
+  source.major_radius = std::fabs(current_normalized.x - center_normalized.x);
+  source.minor_radius = std::fabs(current_normalized.y - center_normalized.y);
+  source.rotation     = 0.0f;
+  source.inner_feather = 0.0f;
+  source.outer_feather = 0.0f;
+  return source;
+}
+
+auto LinearFromEndpoints(Vector2 a_normalized, Vector2 b_normalized)
+    -> LinearGradientMaskSource {
+  LinearGradientMaskSource source;
+  source.origin_x            = 0.5f * (a_normalized.x + b_normalized.x);
+  source.origin_y            = 0.5f * (a_normalized.y + b_normalized.y);
+  const float dx             = b_normalized.x - a_normalized.x;
+  const float dy             = b_normalized.y - a_normalized.y;
+  const float length         = std::hypot(dx, dy);
+  source.transition_distance = length;
+  source.start_value         = 1.0f;
+  source.end_value           = 0.0f;
+  if (length > kAnalyticMaskEpsilon && std::isfinite(length)) {
+    source.normal_x = dx / length;
+    source.normal_y = dy / length;
+  } else {
+    source.normal_x = 0.0f;
+    source.normal_y = 0.0f;
+  }
+  return source;
+}
+
+auto TranslateRadialCenter(RadialMaskSource source, Vector2 center_normalized)
+    -> RadialMaskSource {
+  source.center_x = center_normalized.x;
+  source.center_y = center_normalized.y;
+  return source;
+}
+
+auto TranslateLinearOrigin(LinearGradientMaskSource source, Vector2 origin_normalized)
+    -> LinearGradientMaskSource {
+  source.origin_x = origin_normalized.x;
+  source.origin_y = origin_normalized.y;
+  return source;
+}
+
+auto UpdateRadialMajorRadius(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<RadialMaskSource> {
+  const auto local = RadialLocalAxes(source, normalized);
+  if (!local) {
+    return std::nullopt;
+  }
+  RadialMaskSource next = source;
+  next.major_radius     = std::fabs(local->x);
+  return next;
+}
+
+auto UpdateRadialMinorRadius(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<RadialMaskSource> {
+  const auto local = RadialLocalAxes(source, normalized);
+  if (!local) {
+    return std::nullopt;
+  }
+  RadialMaskSource next = source;
+  next.minor_radius     = std::fabs(local->y);
+  return next;
+}
+
+auto UpdateRadialRotation(const RadialMaskSource& source, Vector2 normalized,
+                          float& unwrapped_rotation) -> std::optional<RadialMaskSource> {
+  if (!IsFiniteRadial(source) || !IsFinite(normalized)) {
+    return std::nullopt;
+  }
+  const float dx = normalized.x - source.center_x;
+  const float dy = normalized.y - source.center_y;
+  if (!std::isfinite(dx) || !std::isfinite(dy) || std::hypot(dx, dy) <= kAnalyticMaskEpsilon) {
+    return std::nullopt;
+  }
+  const float wrapped = std::atan2(dy, dx);
+  if (!std::isfinite(wrapped)) {
+    return std::nullopt;
+  }
+  unwrapped_rotation        = UnwrapRadians(unwrapped_rotation, wrapped);
+  RadialMaskSource next     = source;
+  next.rotation             = unwrapped_rotation;
+  return next;
+}
+
+auto UpdateRadialInnerFeather(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<RadialMaskSource> {
+  const auto rho = RadialRho(source, normalized);
+  if (!rho) {
+    return std::nullopt;
+  }
+  RadialMaskSource next = source;
+  next.inner_feather    = std::clamp(1.0f - *rho, 0.0f, 1.0f);
+  return next;
+}
+
+auto UpdateRadialOuterFeather(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<RadialMaskSource> {
+  const auto rho = RadialRho(source, normalized);
+  if (!rho) {
+    return std::nullopt;
+  }
+  RadialMaskSource next = source;
+  next.outer_feather    = std::max(0.0f, *rho - 1.0f);
+  return next;
+}
+
+auto UpdateLinearDirection(const LinearGradientMaskSource& source, Vector2 normalized)
+    -> std::optional<LinearGradientMaskSource> {
+  if (!IsFiniteLinear(source) || !IsFinite(normalized)) {
+    return std::nullopt;
+  }
+  const float dx     = normalized.x - source.origin_x;
+  const float dy     = normalized.y - source.origin_y;
+  const float length = std::hypot(dx, dy);
+  if (!std::isfinite(length) || length <= kAnalyticMaskEpsilon) {
+    return std::nullopt;
+  }
+  LinearGradientMaskSource next = source;
+  next.normal_x                 = dx / length;
+  next.normal_y                 = dy / length;
+  return next;
+}
+
+auto UpdateLinearTransitionFromBoundary(const LinearGradientMaskSource& source,
+                                        Vector2 normalized)
+    -> std::optional<LinearGradientMaskSource> {
+  if (!IsFiniteLinear(source) || !IsFinite(normalized)) {
+    return std::nullopt;
+  }
+  const float length = LinearNormalLength(source);
+  if (length <= kAnalyticMaskEpsilon) {
+    return std::nullopt;
+  }
+  const float nx = source.normal_x / length;
+  const float ny = source.normal_y / length;
+  const float d  = (normalized.x - source.origin_x) * nx + (normalized.y - source.origin_y) * ny;
+  if (!std::isfinite(d)) {
+    return std::nullopt;
+  }
+  LinearGradientMaskSource next = source;
+  next.transition_distance      = 2.0f * std::fabs(d);
+  return next;
+}
+
+auto ApplyAnalyticMaskHandle(AnalyticMaskHandle handle, const MaskSource& source,
+                             Vector2 normalized, float& unwrapped_rotation)
+    -> std::optional<MaskSource> {
+  if (handle == AnalyticMaskHandle::None) {
+    return std::nullopt;
+  }
+  if (const auto* radial = std::get_if<RadialMaskSource>(&source)) {
+    switch (handle) {
+      case AnalyticMaskHandle::RadialCenter:
+        if (!IsFinite(normalized)) {
+          return std::nullopt;
+        }
+        return TranslateRadialCenter(*radial, normalized);
+      case AnalyticMaskHandle::RadialMajor:
+        if (const auto next = UpdateRadialMajorRadius(*radial, normalized)) {
+          return *next;
+        }
+        return std::nullopt;
+      case AnalyticMaskHandle::RadialMinor:
+        if (const auto next = UpdateRadialMinorRadius(*radial, normalized)) {
+          return *next;
+        }
+        return std::nullopt;
+      case AnalyticMaskHandle::RadialRotate:
+        if (const auto next = UpdateRadialRotation(*radial, normalized, unwrapped_rotation)) {
+          return *next;
+        }
+        return std::nullopt;
+      case AnalyticMaskHandle::RadialInnerFeather:
+        if (const auto next = UpdateRadialInnerFeather(*radial, normalized)) {
+          return *next;
+        }
+        return std::nullopt;
+      case AnalyticMaskHandle::RadialOuterFeather:
+        if (const auto next = UpdateRadialOuterFeather(*radial, normalized)) {
+          return *next;
+        }
+        return std::nullopt;
+      default:
+        return std::nullopt;
+    }
+  }
+  if (const auto* linear = std::get_if<LinearGradientMaskSource>(&source)) {
+    switch (handle) {
+      case AnalyticMaskHandle::LinearOrigin:
+        if (!IsFinite(normalized)) {
+          return std::nullopt;
+        }
+        return TranslateLinearOrigin(*linear, normalized);
+      case AnalyticMaskHandle::LinearDirection:
+        if (const auto next = UpdateLinearDirection(*linear, normalized)) {
+          return *next;
+        }
+        return std::nullopt;
+      case AnalyticMaskHandle::LinearStartBoundary:
+      case AnalyticMaskHandle::LinearEndBoundary:
+        if (const auto next = UpdateLinearTransitionFromBoundary(*linear, normalized)) {
+          return *next;
+        }
+        return std::nullopt;
+      default:
+        return std::nullopt;
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
+++ b/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
@@ -14,6 +14,7 @@
 #include "edit/graph/graph_ids.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/history/mini_git_working_history.hpp"
+#include "edit/history/pipeline_edit_batch.hpp"
 #include "edit/mask/analytic_mask_edit.hpp"
 #include "edit/mask/mask_id.hpp"
 #include "edit/mask/mask_model.hpp"
@@ -76,6 +77,33 @@ struct EditorMaskCreationResult {
 };
 
 /**
+ * @brief Queued Mask-creation operation for the session owner thread.
+ *
+ * GUI mapping produces these; the serial consumer applies them under the live
+ * pipeline lock. Latest Append samples with the same pointer identity coalesce.
+ */
+enum class EditorMaskCreationCommandKind : std::uint8_t {
+  BeginCreation = 0,
+  SelectMask,
+  BeginInput,
+  BeginMove,
+  Append,
+  Finish,
+  Cancel,
+  CancelMode,
+};
+
+struct EditorMaskCreationCommand {
+  EditorMaskCreationCommandKind kind        = EditorMaskCreationCommandKind::BeginCreation;
+  MaskSourceKind                source_kind = MaskSourceKind::Radial;
+  NodeId                        node_id;
+  MaskId                        mask_id;
+  MaskCreationSample            sample{};
+  MaskPointerIdentity           identity{};
+  AnalyticMaskHandle            handle = AnalyticMaskHandle::None;
+};
+
+/**
  * @brief Application owner of Radial/Linear creation and existing-mask movement.
  *
  * Owns mode, active handle, and captured identities. Does not own the live
@@ -104,6 +132,22 @@ class EditorMaskCreationController {
    * commit history. Empty clears the callback.
    */
   void SetInteractivePreview(std::function<void()> preview);
+
+  /**
+   * @brief Optional settle publisher used instead of @c MiniGitWorkingHistory::AppendEdit.
+   *
+   * Production supplies a locked @c PublishAppliedTypedBatch with the live document
+   * already at after-values. Empty keeps the test AppendEdit path.
+   */
+  void SetSettlePublisher(std::function<bool(const PipelineEditBatch&, std::string*)> publish);
+
+  /**
+   * @brief Drop document/history pointers after cancel or image close.
+   *
+   * Does not restore Grade fields. Callers must Cancel first when an operation
+   * is still open and the document is still alive.
+   */
+  void DetachClosedDocument();
 
   /**
    * @brief Arm Radial or Linear creation on @p grade_id without document mutation.
@@ -173,6 +217,7 @@ class EditorMaskCreationController {
    *
    * Existing-mask edits are false. Armed creation without a press is false.
    */
+  [[nodiscard]] auto HasOpenOperation() const -> bool { return open_; }
   [[nodiscard]] auto OverlayIsCreating() const -> bool;
   /**
    * @brief Live or draft source for overlay layout. Empty when Inactive/hidden.
@@ -196,6 +241,7 @@ class EditorMaskCreationController {
   void ResetMode();
   auto PublishAddMask() -> EditorMaskCreationResult;
   auto PublishReplaceSource() -> EditorMaskCreationResult;
+  auto PublishSettledBatch(const PipelineEditBatch& batch, std::string* error) -> bool;
   void RequestInteractive(EditorMaskCreationResult& result);
   auto UpdateCreation(const MaskCreationSample& sample) -> EditorMaskCreationResult;
   auto UpdateExisting(const MaskCreationSample& sample) -> EditorMaskCreationResult;
@@ -203,6 +249,7 @@ class EditorMaskCreationController {
   PipelineDocument*        document_ = nullptr;
   MiniGitWorkingHistory*   history_  = nullptr;
   std::function<void()>    interactive_preview_;
+  std::function<bool(const PipelineEditBatch&, std::string*)> settle_publisher_;
   EditorMaskCreationState  state_    = EditorMaskCreationState::Inactive;
   MaskSourceKind           kind_     = MaskSourceKind::Radial;
   EditorSessionIdentity    session_{};

--- a/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
+++ b/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
@@ -1,0 +1,224 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "app/editor_session_types.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/history/mini_git_working_history.hpp"
+#include "edit/mask/analytic_mask_edit.hpp"
+#include "edit/mask/mask_id.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "json.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Master Mask-creation states. One controller owns the current state.
+ */
+enum class EditorMaskCreationState : std::uint8_t {
+  Inactive  = 0,
+  Selected  = 1,
+  Creating  = 2,
+  Editing   = 3,
+  Painting  = 4,
+  Settling  = 5,
+  Failed    = 6,
+};
+
+/**
+ * @brief One pointer sample already mapped into Mask ReferenceSpace.
+ *
+ * Mapping is the UI/item boundary (@c MaskEditGeometry). This service does not
+ * reapply crop, zoom, or DPR. Pointer samples have no extra half-pixel offset.
+ * @p inside_photograph is the press gate; captured drags may set it false.
+ */
+struct MaskCreationSample {
+  Vector2 normalized{};
+  Vector2 reference_pixels{};
+  bool    inside_photograph = false;
+};
+
+/**
+ * @brief Captured pointer identity for one input sequence.
+ *
+ * Admission is not a history commit. Samples with a mismatched identity after
+ * press are ignored.
+ */
+struct MaskPointerIdentity {
+  std::uint64_t device_id   = 0;
+  std::uint32_t point_id    = 0;
+  std::uint64_t sequence_id = 0;
+};
+
+/**
+ * @brief Result of one creation-controller admission.
+ *
+ * @p accepted means the call was consumed by the state machine. @p interactive_preview
+ * is true when live Grade source fields changed and the Interactive callback ran.
+ * @p committed / @p quality_requested are set only by a successful settle.
+ */
+struct EditorMaskCreationResult {
+  bool          accepted              = false;
+  bool          interactive_preview   = false;
+  bool          committed             = false;
+  bool          quality_requested     = false;
+  std::string   error;
+  MaskId        mask_id;
+};
+
+/**
+ * @brief Application owner of Radial/Linear creation and existing-mask movement.
+ *
+ * Owns mode, active handle, and captured identities. Does not own the live
+ * @ref PipelineDocument, Grade selection, or Mix raster. Provisional source
+ * fields are written through the Grade owner before release so Interactive Mix
+ * can update; one NM4 AddMask or ReplaceMaskSource commit is published on
+ * settle. Escape restores the live Grade and publishes no commit.
+ *
+ * Thread: document-owning thread. Does not take the pipeline lock, perform
+ * cache I/O, or build QSG geometry.
+ */
+class EditorMaskCreationController {
+ public:
+  /**
+   * @brief Bind the live document and history journal for subsequent calls.
+   *
+   * @p document and @p history are not owned. Callers keep them alive for every
+   * operation. Rebinding while an operation is open is rejected.
+   */
+  void Bind(PipelineDocument& document, MiniGitWorkingHistory& history);
+
+  /**
+   * @brief Called after live Grade source fields become visible, before return.
+   *
+   * Used to evaluate Interactive Mix. Must not lock the pipeline, throw, or
+   * commit history. Empty clears the callback.
+   */
+  void SetInteractivePreview(std::function<void()> preview);
+
+  /**
+   * @brief Arm Radial or Linear creation on @p grade_id without document mutation.
+   *
+   * Brush is rejected until accumulating-stroke UI exists. An open operation must
+   * be finished or cancelled first.
+   */
+  auto BeginCreation(MaskSourceKind kind, const NodeId& grade_id,
+                     EditorSessionIdentity session) -> EditorMaskCreationResult;
+
+  /**
+   * @brief Select an existing Radial or Linear Mask. Load-only; no Mix or commit.
+   */
+  auto SelectMask(const NodeId& grade_id, const MaskId& mask_id,
+                  EditorSessionIdentity session) -> EditorMaskCreationResult;
+
+  /**
+   * @brief Start a creation drag at @p sample.
+   *
+   * Press outside the photograph is rejected. Degenerate zero-area input stays
+   * transient until a later valid sample.
+   */
+  auto BeginMaskInput(MaskCreationSample sample, MaskPointerIdentity identity)
+      -> EditorMaskCreationResult;
+
+  /**
+   * @brief Start an existing-mask handle drag. Shape fields stay fixed for center/origin.
+   */
+  auto BeginMaskMove(AnalyticMaskHandle handle, MaskCreationSample sample,
+                     MaskPointerIdentity identity) -> EditorMaskCreationResult;
+
+  /**
+   * @brief Continue the captured sequence. Applies provisional fields and Interactive.
+   */
+  auto AppendMaskInput(MaskCreationSample sample, MaskPointerIdentity identity)
+      -> EditorMaskCreationResult;
+
+  /**
+   * @brief Seal the open operation once. Valid work publishes one commit and Quality.
+   *
+   * Degenerate creation and unchanged placement publish neither a commit nor Quality.
+   */
+  auto FinishMaskInput() -> EditorMaskCreationResult;
+
+  /**
+   * @brief Restore the live Grade to the captured before-state. Zero commits.
+   */
+  auto CancelMaskInput() -> EditorMaskCreationResult;
+
+  /**
+   * @brief Leave creation mode. Seals a valid open operation once, then clears mode.
+   */
+  auto FinishCreationMode() -> EditorMaskCreationResult;
+
+  /**
+   * @brief Cancel any open operation and leave creation mode. Zero new commits.
+   */
+  auto CancelCreationMode() -> EditorMaskCreationResult;
+
+  [[nodiscard]] auto state() const -> EditorMaskCreationState { return state_; }
+  [[nodiscard]] auto source_kind() const -> MaskSourceKind { return kind_; }
+  [[nodiscard]] auto selected_mask_id() const -> const MaskId& { return mask_id_; }
+  [[nodiscard]] auto active_handle() const -> AnalyticMaskHandle { return handle_; }
+  [[nodiscard]] auto node_id() const -> const NodeId& { return node_id_; }
+  /**
+   * @brief True while an initial Radial/Linear drawing sequence is open.
+   *
+   * Existing-mask edits are false. Armed creation without a press is false.
+   */
+  [[nodiscard]] auto OverlayIsCreating() const -> bool;
+  /**
+   * @brief Live or draft source for overlay layout. Empty when Inactive/hidden.
+   */
+  [[nodiscard]] auto CurrentSource() const -> std::optional<MaskSource>;
+
+ private:
+  auto Reject(std::string error) const -> EditorMaskCreationResult;
+  auto Ok() const -> EditorMaskCreationResult;
+  [[nodiscard]] auto Grade() -> ColorGradeNodeModel*;
+  [[nodiscard]] auto Grade() const -> const ColorGradeNodeModel*;
+  [[nodiscard]] auto IdentityMatches(const MaskPointerIdentity& identity) const -> bool;
+  [[nodiscard]] auto AllocateMaskId() const -> MaskId;
+  [[nodiscard]] auto MakeCreationMask(const MaskSource& source) const -> MaskModel;
+  [[nodiscard]] auto LiveSourceJson() const -> nlohmann::json;
+  [[nodiscard]] auto SourcesEqual(const nlohmann::json& a, const nlohmann::json& b) const -> bool;
+  auto ApplyLiveSource(const MaskSource& source) -> bool;
+  auto InsertProvisional(const MaskSource& source) -> bool;
+  void RestoreLive();
+  void ClearOpenOperation();
+  void ResetMode();
+  auto PublishAddMask() -> EditorMaskCreationResult;
+  auto PublishReplaceSource() -> EditorMaskCreationResult;
+  void RequestInteractive(EditorMaskCreationResult& result);
+  auto UpdateCreation(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto UpdateExisting(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+
+  PipelineDocument*        document_ = nullptr;
+  MiniGitWorkingHistory*   history_  = nullptr;
+  std::function<void()>    interactive_preview_;
+  EditorMaskCreationState  state_    = EditorMaskCreationState::Inactive;
+  MaskSourceKind           kind_     = MaskSourceKind::Radial;
+  EditorSessionIdentity    session_{};
+  NodeId                   node_id_;
+  MaskId                   mask_id_;
+  AnalyticMaskHandle       handle_ = AnalyticMaskHandle::None;
+  MaskPointerIdentity      pointer_{};
+  Vector2                  press_normalized_{};
+  float                    unwrapped_rotation_ = 0.0f;
+  nlohmann::json           before_source_;
+  std::uint32_t            display_index_ = 0;
+  bool                     open_          = false;
+  bool                     creating_      = false;
+  bool                     inserted_      = false;
+  bool                     terminated_    = false;
+  std::optional<MaskSource> draft_source_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_session_ports.hpp
+++ b/alcedo_studio/src/include/app/editor_session_ports.hpp
@@ -25,6 +25,7 @@
 namespace alcedo {
 
 class Hash128;
+class MiniGitWorkingHistory;
 class PipelineDocument;
 struct EditorMiniGitSaveCapture;
 struct EditorAdjustmentPatch;
@@ -114,6 +115,29 @@ class IEditorHistoryPort {
     if (error != nullptr) *error = "Color Grade rename is not supported by this history port";
     return false;
   }
+
+  using LockedMaskSettle =
+      std::function<bool(const PipelineEditBatch& batch, std::string* error)>;
+  using LockedMaskDocumentOp =
+      std::function<bool(PipelineDocument& document, MiniGitWorkingHistory& history,
+                         const LockedMaskSettle& settle, std::string* error)>;
+
+  /**
+   * @brief Run @p op while holding the live pipeline render lock.
+   *
+   * @p settle publishes a typed batch whose live document already holds after
+   * values. Default fakes reject. Must not be called from a GUI pointer callback
+   * that still needs the GUI thread for present.
+   */
+  virtual auto WithLockedLiveDocument(const EditorHistoryGuardHandle& /*guard*/,
+                                      const LockedMaskDocumentOp& /*op*/, std::string* error)
+      -> bool {
+    if (error != nullptr) {
+      *error = "Locked live document access is not supported by this history port";
+    }
+    return false;
+  }
+
   virtual auto Undo(const EditorHistoryGuardHandle& guard, std::string* error) -> bool = 0;
   virtual auto Redo(const EditorHistoryGuardHandle& guard, std::string* error) -> bool = 0;
   /// Render reason published by the last successful history mutation. Default

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -14,6 +14,7 @@
 
 #include "app/adjustment_transfer_types.hpp"
 #include "app/editor_action_policy.hpp"
+#include "app/editor_mask_creation_controller.hpp"
 #include "app/editor_pending_input.hpp"
 #include "app/editor_panel_projection.hpp"
 #include "app/editor_serial_frame_admission.hpp"
@@ -273,6 +274,23 @@ class IEditorSessionBackend {
     result.message  = "Queued adjustment input is not supported by this backend";
     return result;
   }
+
+  /**
+   * @brief Queue one Mask-creation command for owner-thread consume.
+   *
+   * Does not take the render lock or mutate the live Grade. Latest Append
+   * samples with the same pointer identity coalesce. Default backends reject.
+   */
+  virtual auto EnqueueMaskCreation(EditorMaskCreationCommand /*command*/) -> EditorSessionResult {
+    EditorSessionResult result;
+    result.kind     = EditorSessionResultKind::Rejected;
+    result.state    = state();
+    result.identity = identity();
+    result.message  = "Queued Mask creation is not supported by this backend";
+    return result;
+  }
+  [[nodiscard]] virtual auto mask_creation_node_id() const -> NodeId { return {}; }
+  [[nodiscard]] virtual auto mask_creation_mask_id() const -> MaskId { return {}; }
   /**
    * @brief Inspect queued change descriptions. Empty when the backend has none.
    *
@@ -465,6 +483,13 @@ class EditorSessionService final : public IEditorSessionBackend {
   auto EnqueueAdjustmentInput(EditorAdjustmentPatch patch) -> EditorSessionResult override;
   auto EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind kind)
       -> EditorSessionResult override;
+  auto EnqueueMaskCreation(EditorMaskCreationCommand command) -> EditorSessionResult override;
+  [[nodiscard]] auto mask_creation_node_id() const -> NodeId override {
+    return mask_creation_.node_id();
+  }
+  [[nodiscard]] auto mask_creation_mask_id() const -> MaskId override {
+    return mask_creation_.selected_mask_id();
+  }
   auto SetAdjustmentProjectionNode(const NodeId& node_id) -> EditorSessionResult override;
   [[nodiscard]] auto PeekPendingInput() const -> EditorPendingInputView override;
   void               TryConsumePendingInput() override;
@@ -572,6 +597,12 @@ class EditorSessionService final : public IEditorSessionBackend {
   auto DeferIfLiveOwnershipHeld(std::function<EditorSessionResult()> retry, std::string message)
       -> std::optional<EditorSessionResult>;
   auto ConsumeTakenSequence(const EditorPendingSequence& sequence) -> EditorSessionResult;
+  void AbortMaskCreation();
+  void ConsumePendingMaskCommands();
+  auto ApplyMaskCreationCommand(const EditorMaskCreationCommand& command)
+      -> EditorMaskCreationResult;
+  auto RouteMaskCreationRender(bool interactive_preview, bool quality_requested, bool committed)
+      -> EditorSessionResult;
 
   /// Queue-owned publish flavor for one in-flight history save checkpoint.
   /// Set by StartHistoryCheckpoint and consumed by the matching
@@ -591,6 +622,9 @@ class EditorSessionService final : public IEditorSessionBackend {
   EditorSessionNavigationController       navigation_;
   EditorPendingInputQueue                 pending_input_;
   EditorSerialFrameAdmission              serial_admission_;
+  EditorMaskCreationController            mask_creation_;
+  std::vector<EditorMaskCreationCommand>  pending_mask_commands_;
+  mutable std::mutex                      mask_command_mutex_;
   bool                                    reducing_command_     = false;
   std::uint64_t                           current_operation_id_ = 0;
   std::size_t                             publication_depth_    = 0;

--- a/alcedo_studio/src/include/edit/mask/analytic_mask_edit.hpp
+++ b/alcedo_studio/src/include/edit/mask/analytic_mask_edit.hpp
@@ -1,0 +1,179 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/mask_model.hpp"
+
+namespace alcedo {
+
+/// Evaluator epsilon shared with host Mix / native analytic shaders.
+inline constexpr float kAnalyticMaskEpsilon = 1.0e-6f;
+/// Minimum positive Radial radii before a center-out drag becomes a Mask.
+inline constexpr float kAnalyticCreationMinRadius = 1.0e-5f;
+
+/**
+ * @brief Finite analytic handle identity. Not a per-texel or per-dab proxy.
+ *
+ * Overlay hit testing maps pointer discs onto these ids. Creation drags do not
+ * use a handle: Radial is center-out from the press, Linear uses two endpoints.
+ */
+enum class AnalyticMaskHandle : std::uint8_t {
+  None                 = 0,
+  RadialCenter         = 1,
+  RadialMajor          = 2,
+  RadialMinor          = 3,
+  RadialRotate         = 4,
+  RadialInnerFeather   = 5,
+  RadialOuterFeather   = 6,
+  LinearOrigin         = 7,
+  LinearDirection      = 8,
+  LinearStartBoundary  = 9,
+  LinearEndBoundary    = 10,
+};
+
+/**
+ * @brief Rotated local coordinates of @p normalized relative to @p source.
+ *
+ * @p local.x = cos(r)*dx + sin(r)*dy, @p local.y = -sin(r)*dx + cos(r)*dy.
+ * These are @c u * major_radius and @c v * minor_radius in the native evaluator.
+ * Does not divide by radii, so axis identity stays stable when a numeric radius
+ * crosses the other axis.
+ *
+ * @return Empty when any input is not finite.
+ */
+[[nodiscard]] auto RadialLocalAxes(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<Vector2>;
+
+/**
+ * @brief Evaluator rho of @p normalized for @p source.
+ *
+ * @return Empty when radii or coordinates are not finite.
+ */
+[[nodiscard]] auto RadialRho(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<float>;
+
+/**
+ * @brief True when both Radial radii exceed @ref kAnalyticCreationMinRadius.
+ */
+[[nodiscard]] auto RadialCreationIsValid(const RadialMaskSource& source) -> bool;
+
+/**
+ * @brief True when the Linear normal has length above the source validator minimum.
+ */
+[[nodiscard]] auto LinearCreationIsValid(const LinearGradientMaskSource& source) -> bool;
+
+/**
+ * @brief Center-out Radial: press is the center, drag sets positive x/y radii.
+ *
+ * Rotation and feathers stay 0. Radii are absolute normalized deltas, never swapped.
+ */
+[[nodiscard]] auto RadialFromCenterOut(Vector2 center_normalized, Vector2 current_normalized)
+    -> RadialMaskSource;
+
+/**
+ * @brief Linear from press @p a to current @p b in normalized ReferenceSpace.
+ *
+ * @c origin = (a+b)/2, @c normal = normalize(b-a), @c transition_distance = |b-a|,
+ * @c start_value = 1, @c end_value = 0. Degenerate @p a==@p b yields a zero normal.
+ */
+[[nodiscard]] auto LinearFromEndpoints(Vector2 a_normalized, Vector2 b_normalized)
+    -> LinearGradientMaskSource;
+
+/**
+ * @brief Move Radial center. Radii, rotation, and feathers are unchanged.
+ */
+[[nodiscard]] auto TranslateRadialCenter(RadialMaskSource source, Vector2 center_normalized)
+    -> RadialMaskSource;
+
+/**
+ * @brief Move Linear origin. Direction, width, and end values are unchanged.
+ */
+[[nodiscard]] auto TranslateLinearOrigin(LinearGradientMaskSource source, Vector2 origin_normalized)
+    -> LinearGradientMaskSource;
+
+/**
+ * @brief Set major_radius from the local x-axis component of @p normalized.
+ *
+ * Uses absolute local x so dragging across the center does not swap axis identity
+ * with the minor handle. Minor radius, rotation, center, and feathers stay fixed.
+ *
+ * @return Empty when the local frame cannot be formed.
+ */
+[[nodiscard]] auto UpdateRadialMajorRadius(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<RadialMaskSource>;
+
+/**
+ * @brief Set minor_radius from the local y-axis component of @p normalized.
+ */
+[[nodiscard]] auto UpdateRadialMinorRadius(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<RadialMaskSource>;
+
+/**
+ * @brief Set rotation from the normalized-space angle of @p normalized about center.
+ *
+ * @p unwrapped_rotation is the continuous angle from the previous sample. It is
+ * updated in place so wrapping across ±π does not jump by 2π.
+ *
+ * @return Empty when @p normalized is not finite or coincides with the center.
+ */
+[[nodiscard]] auto UpdateRadialRotation(const RadialMaskSource& source, Vector2 normalized,
+                                        float& unwrapped_rotation)
+    -> std::optional<RadialMaskSource>;
+
+/**
+ * @brief Set inner_feather from evaluator rho at @p normalized. Radii stay fixed.
+ *
+ * @c inner_feather = clamp(1 - rho, 0, 1).
+ */
+[[nodiscard]] auto UpdateRadialInnerFeather(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<RadialMaskSource>;
+
+/**
+ * @brief Set outer_feather from evaluator rho at @p normalized. Radii stay fixed.
+ *
+ * @c outer_feather = max(0, rho - 1).
+ */
+[[nodiscard]] auto UpdateRadialOuterFeather(const RadialMaskSource& source, Vector2 normalized)
+    -> std::optional<RadialMaskSource>;
+
+/**
+ * @brief Set Linear normal to the direction from origin to @p normalized.
+ *
+ * Origin and transition_distance stay fixed. Empty when the direction is degenerate.
+ */
+[[nodiscard]] auto UpdateLinearDirection(const LinearGradientMaskSource& source,
+                                         Vector2 normalized)
+    -> std::optional<LinearGradientMaskSource>;
+
+/**
+ * @brief Set transition_distance to twice the projected distance from origin.
+ *
+ * Origin and normal stay fixed. Both start and end boundaries stay symmetric.
+ * Empty when the stored normal is degenerate.
+ */
+[[nodiscard]] auto UpdateLinearTransitionFromBoundary(const LinearGradientMaskSource& source,
+                                                      Vector2 normalized)
+    -> std::optional<LinearGradientMaskSource>;
+
+/**
+ * @brief Apply one existing-mask handle drag in normalized ReferenceSpace.
+ *
+ * Creation drags must use @ref RadialFromCenterOut or @ref LinearFromEndpoints.
+ *
+ * @param handle Selected control. @c None is rejected.
+ * @param source Current source. Kind must match @p handle.
+ * @param normalized Pointer in normalized ReferenceSpace. Off-image values are allowed.
+ * @param unwrapped_rotation In/out continuous rotation for @c RadialRotate.
+ * @return Updated source, or empty when the handle/kind/sample is invalid.
+ */
+[[nodiscard]] auto ApplyAnalyticMaskHandle(AnalyticMaskHandle handle, const MaskSource& source,
+                                           Vector2 normalized, float& unwrapped_rotation)
+    -> std::optional<MaskSource>;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_history_mutation.hpp
@@ -107,6 +107,15 @@ class EditorHistoryMutation {
                               const alcedo::NodeId& node_id, std::uint64_t session_generation,
                               std::string* error) -> bool;
 
+  /**
+   * @brief Run @p op under the live pipeline render lock.
+   *
+   * @p settle publishes typed batches whose live document already holds after values.
+   */
+  auto WithLockedLiveDocument(const alcedo::EditorHistoryGuardHandle& guard,
+                              const alcedo::IEditorHistoryPort::LockedMaskDocumentOp& op,
+                              std::string* error) -> bool;
+
  private:
   EditorHistoryState& state_;
 };

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
@@ -1,0 +1,95 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+#include <QRectF>
+#include <QString>
+#include <cstdint>
+#include <optional>
+
+#include "app/editor_mask_creation_controller.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "ui/edit_viewer/mask_overlay_geometry.hpp"
+
+namespace alcedo::editor_rhi {
+class EditorInteractionController;
+class EditorOverlayItem;
+}  // namespace alcedo::editor_rhi
+
+namespace alcedo::ui {
+
+class EditorNodeController;
+class EditorSessionController;
+
+/**
+ * @brief QML adapter for Radial/Linear Mask creation and existing-mask movement.
+ *
+ * Maps item pointers, publishes control-only overlay geometry, and queues
+ * owner-thread Mask commands. Does not take the pipeline lock.
+ */
+class EditorMaskCreationAdapter : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(bool active READ active NOTIFY MaskCreationChanged)
+  Q_PROPERTY(bool creating READ creating NOTIFY MaskCreationChanged)
+  Q_PROPERTY(bool ownsLeftButton READ owns_left_button NOTIFY MaskCreationChanged)
+  Q_PROPERTY(QString toolKind READ tool_kind NOTIFY MaskCreationChanged)
+
+ public:
+  explicit EditorMaskCreationAdapter(EditorSessionController* session, QObject* parent = nullptr);
+  ~EditorMaskCreationAdapter() override;
+
+  [[nodiscard]] auto active() const -> bool { return !tool_kind_.isEmpty(); }
+  [[nodiscard]] auto creating() const -> bool { return creating_; }
+  [[nodiscard]] auto owns_left_button() const -> bool { return active(); }
+  [[nodiscard]] auto tool_kind() const -> QString { return tool_kind_; }
+
+  Q_INVOKABLE void bindInteractionItem(QObject* interaction);
+  Q_INVOKABLE void bindOverlayItem(QObject* overlay);
+  Q_INVOKABLE void beginRadial();
+  Q_INVOKABLE void beginLinear();
+  Q_INVOKABLE void cancel();
+  Q_INVOKABLE bool handlePress(qreal x, qreal y, int button);
+  Q_INVOKABLE bool handleMove(qreal x, qreal y, int buttons);
+  Q_INVOKABLE bool handleRelease(qreal x, qreal y, int button);
+
+  void OnImageClosed();
+
+ signals:
+  void MaskCreationChanged();
+
+ private:
+  void BeginTool(MaskSourceKind kind, const QString& tool_kind);
+  void ResetLocal();
+  void PublishOverlay();
+  void HideOverlay();
+  [[nodiscard]] auto CurrentGradeId() const -> NodeId;
+  [[nodiscard]] auto CanAuthorMasks() const -> bool;
+  [[nodiscard]] auto MakeSample(qreal x, qreal y, bool allow_outside) const
+      -> std::optional<MaskCreationSample>;
+  [[nodiscard]] auto OverlayClip() const -> QRectF;
+  [[nodiscard]] auto OverlayStyle() const -> MaskOverlayStyle;
+  [[nodiscard]] auto Enqueue(EditorMaskCreationCommand command) -> bool;
+  void ConnectInteraction(editor_rhi::EditorInteractionController* interaction);
+
+  QPointer<EditorSessionController>                 session_;
+  QPointer<editor_rhi::EditorInteractionController> interaction_;
+  QPointer<editor_rhi::EditorOverlayItem>           overlay_;
+  QMetaObject::Connection                           view_change_connection_;
+  QString                                           tool_kind_;
+  MaskSourceKind                                    source_kind_ = MaskSourceKind::Radial;
+  bool                                              creating_    = false;
+  bool                                              open_        = false;
+  bool                                              selected_    = false;
+  MaskPointerIdentity                               pointer_{};
+  Vector2                                           press_normalized_{};
+  std::optional<MaskSource>                         overlay_source_;
+  MaskOverlayDisplay                                overlay_display_{};
+  AnalyticMaskHandle                                active_handle_ = AnalyticMaskHandle::None;
+  std::uint64_t                                     next_sequence_id_ = 1;
+};
+
+}  // namespace alcedo::ui

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -23,9 +23,12 @@
 #include "app/editor_pending_input.hpp"
 #include "app/editor_session_types.hpp"
 #include "edit/graph/graph_ids.hpp"
+#include "edit/mask/mask_id.hpp"
 #include "ui/alcedo_main/album_backend/editor_action_availability_model.hpp"
 #include "ui/alcedo_main/album_backend/editor_adjustment_submitter.hpp"
 #include "ui/alcedo_main/album_backend/editor_history_operation_publisher.hpp"
+#include "ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp"
+#include "ui/alcedo_main/album_backend/editor_node_controller.hpp"
 #include "ui/alcedo_main/album_backend/editor_scope_controller.hpp"
 
 namespace alcedo {
@@ -38,7 +41,6 @@ struct NodeGraphTopologyChange;
 namespace alcedo::ui {
 class IAlbumCatalog;
 class InteractionPolicyController;
-class EditorNodeController;
 }  // namespace alcedo::ui
 
 namespace alcedo::ui {
@@ -108,6 +110,7 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   Q_PROPERTY(bool presentationViewportBound READ presentation_viewport_bound NOTIFY
                  PresentationBindingChanged)
   Q_PROPERTY(EditorScopeController* scopeController READ scope_controller CONSTANT)
+  Q_PROPERTY(EditorMaskCreationAdapter* maskCreation READ mask_creation CONSTANT)
   // Phase 5D: the render coordinator has in-flight or pending work for this
   // session. QML binds a busy indicator to it. Reflects backend render_busy()
   // (coordinator diagnostics); transitions fire StateChanged via the backend
@@ -289,6 +292,17 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   [[nodiscard]] auto scope_controller() const -> EditorScopeController* {
     return scope_controller_.get();
   }
+  [[nodiscard]] auto mask_creation() const -> EditorMaskCreationAdapter* {
+    return mask_creation_.get();
+  }
+  [[nodiscard]] auto node_selection_source() const -> EditorNodeController* {
+    return node_controller_;
+  }
+  [[nodiscard]] auto session_backend() const -> alcedo::IEditorSessionBackend* {
+    return session_backend_;
+  }
+  auto EnqueueMaskCreation(alcedo::EditorMaskCreationCommand command) -> bool;
+  [[nodiscard]] auto mask_creation_mask_id() const -> alcedo::MaskId;
 
   // Production pipeline entry: resolves the bound viewport through the scope tap.
   // Returns null when unbound or the object is not an EditorViewportItem.
@@ -397,6 +411,7 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   QMetaObject::Connection                        interaction_view_change_connection_;
   QMetaObject::Connection                        interaction_policy_connection_;
   mutable std::unique_ptr<EditorScopeController> scope_controller_;
+  std::unique_ptr<EditorMaskCreationAdapter>     mask_creation_;
   QTimer*                                        admission_deadline_timer_ = nullptr;
 };
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_history_port.hpp
@@ -138,6 +138,9 @@ class EditorSessionHistoryPort final : public alcedo::IEditorHistoryPort {
   auto SetPanelProjectionNode(const alcedo::EditorHistoryGuardHandle& guard,
                               const alcedo::NodeId& node_id, std::uint64_t session_generation,
                               std::string* error) -> bool override;
+  auto WithLockedLiveDocument(const alcedo::EditorHistoryGuardHandle& guard,
+                              const alcedo::IEditorHistoryPort::LockedMaskDocumentOp& op,
+                              std::string* error) -> bool override;
   auto CaptureSaveCheckpoint(const alcedo::EditorHistoryGuardHandle& guard, std::string* error)
       -> std::shared_ptr<const alcedo::EditorMiniGitSaveCapture> override;
   auto DiscardMaterializedJournalThrough(const alcedo::EditorHistoryGuardHandle& guard,

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
@@ -104,6 +104,10 @@ namespace alcedo {
                                                     const MaskOverlayStyle& style,
                                                     const QRectF& clip) -> MaskOverlayDisplay;
 
+[[nodiscard]] auto HitTestMaskOverlayHandle(const MaskOverlayDisplay& display, QPointF item,
+                                           float hit_radius_logical_px)
+    -> MaskOverlayHandleId;
+
 /**
  * @brief Item-space length of a ReferenceSpace radius around @p center_reference.
  *

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -77,6 +77,8 @@ add_library(AlbumBackendLib STATIC
     "${ALCEDO_UI_SHELL_ROOT}/album_backend/import_export.cpp"
     "${ALCEDO_UI_SHELL_ROOT}/album_backend/nikon_he_recovery_controller.cpp"
     "${ALCEDO_UI_SHELL_ROOT}/album_backend/editor_session_controller.cpp"
+    "${ALCEDO_UI_SHELL_ROOT}/album_backend/editor_mask_creation_adapter.cpp"
+    "${ALCEDO_INCLUDE_ROOT}/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp"
     "${ALCEDO_UI_SHELL_ROOT}/album_backend/editor_panel_presentation.cpp"
     "${ALCEDO_UI_SHELL_ROOT}/album_backend/editor_scope_controller.cpp"
     "${ALCEDO_UI_SHELL_ROOT}/album_backend/editor_scope_item.cpp"
@@ -217,6 +219,7 @@ target_link_libraries(AlbumBackendLib
         PipelineMgmtService
         AdjustmentTransferService
         EditorSessionService
+        EditorMaskCreationController
         EditorAdjustmentPipeline
         EditorPipelineCommandService
         EditorPanelProjection

--- a/alcedo_studio/src/ui/alcedo_main/DESIGN.md
+++ b/alcedo_studio/src/ui/alcedo_main/DESIGN.md
@@ -413,8 +413,12 @@ null resets the QuickQanava default instead of disabling it.
 Retained QSG Mask controls sit on `EditorOverlayItem` above the photograph. They
 use a two-layer high-contrast stroke. Existing-mask editing never paints a
 coverage fill, heatmap, or completed Brush path; the Interactive photograph
-supplies coverage feedback. Temporary cursor, outline, and path guides are
-allowed only during initial drawing.
+supplies coverage feedback. Temporary Brush cursor/path guides are allowed during initial
+drawing. The planned NM7.8 revision requires selected Radial base ellipse and inner/outer
+feather boundary lines during creation and later editing. Selected Gradient uses three parallel
+lines with Geometry crop-style dual high-contrast strokes and short edge grips, without a kite,
+closed polygon or crop dimming. Radius/feather and direction controls must be independently
+reachable. Unselected analytic masks do not retain editing guides.
 
 Handle and stroke widths are logical pixels and stay constant at any zoom or
 DPR. Image-space Brush cursor radius is transformed through the shared
@@ -481,8 +485,12 @@ The open state is UI layout state. A drawer change does not modify the pipeline,
 create history, or start photo rendering. An empty open drawer has no Mask rows.
 
 Each Mask row is flat. It shows only the approved source-type icon and localized
-type name. Do not show the Mask name, opacity, enabled value, invert value,
-ranges, identity, selection, or actions.
+type name. Do not show the Mask name, opacity, enabled value, invert value, ranges, or identity.
+The planned NM7.8 revision adds stable NodeId/MaskId selection and a compact per-row delete
+`IconActionButton`. Selecting loads the existing Mask into the temporary Masks body and viewer
+without creating a mask or history. Use existing monochrome selection tokens and preserve scroll.
+Delete must not propagate into row selection or graph Grade deletion. Parameter editors stay in
+the Masks body. This supersedes the earlier read-only row rule.
 
 | Model kind | UI label | Icon |
 | --- | --- | --- |

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_history_mutation.cpp
@@ -1109,4 +1109,30 @@ auto EditorHistoryMutation::SetPanelProjectionNode(const alcedo::EditorHistoryGu
   }
 }
 
+auto EditorHistoryMutation::WithLockedLiveDocument(
+    const alcedo::EditorHistoryGuardHandle& guard,
+    const alcedo::IEditorHistoryPort::LockedMaskDocumentOp& op, std::string* error) -> bool {
+  if (!op) {
+    if (error) *error = "Locked Mask document operation is empty";
+    return false;
+  }
+  auto state = state_.EnsureWorkingState(guard.element_id, error);
+  if (!state) return false;
+  if (!state->pipeline_guard || !state->pipeline_guard->commit_graph_ || !state->history) {
+    if (error) *error = "Editor history graph is unavailable";
+    return false;
+  }
+  if (!state->pipeline_guard->pipeline_ || !state->pipeline_guard->document_) {
+    if (error) *error = "Live pipeline document is unavailable";
+    return false;
+  }
+  auto render_lock = LockLivePipeline(*state->pipeline_guard->pipeline_);
+  alcedo::IEditorHistoryPort::LockedMaskSettle settle =
+      [this, state](const alcedo::PipelineEditBatch& batch, std::string* settle_error) {
+        return PublishAppliedTypedBatch(*state, state_, batch, true, state->mask_store,
+                                        settle_error);
+      };
+  return op(*state->pipeline_guard->document_, *state->history, settle, error);
+}
+
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
@@ -1,0 +1,364 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp"
+
+#include <QPointF>
+#include <Qt>
+
+#include "edit/mask/analytic_mask_edit.hpp"
+#include "ui/alcedo_main/album_backend/editor_node_controller.hpp"
+#include "ui/alcedo_main/album_backend/editor_session_controller.hpp"
+#include "ui/edit_viewer/mask_overlay_layout.hpp"
+#include "ui/editor_rhi/editor_interaction_controller.hpp"
+#include "ui/editor_rhi/editor_overlay_item.hpp"
+
+namespace alcedo::ui {
+namespace {
+
+[[nodiscard]] auto AnalyticHandleFromOverlay(MaskOverlayHandleId id) -> AnalyticMaskHandle {
+  switch (id) {
+    case MaskOverlayHandleId::RadialCenter:
+      return AnalyticMaskHandle::RadialCenter;
+    case MaskOverlayHandleId::RadialMajor:
+      return AnalyticMaskHandle::RadialMajor;
+    case MaskOverlayHandleId::RadialMinor:
+      return AnalyticMaskHandle::RadialMinor;
+    case MaskOverlayHandleId::RadialRotate:
+      return AnalyticMaskHandle::RadialRotate;
+    case MaskOverlayHandleId::RadialInnerFeather:
+      return AnalyticMaskHandle::RadialInnerFeather;
+    case MaskOverlayHandleId::RadialOuterFeather:
+      return AnalyticMaskHandle::RadialOuterFeather;
+    case MaskOverlayHandleId::LinearOrigin:
+      return AnalyticMaskHandle::LinearOrigin;
+    case MaskOverlayHandleId::LinearDirection:
+      return AnalyticMaskHandle::LinearDirection;
+    case MaskOverlayHandleId::LinearStartBoundary:
+      return AnalyticMaskHandle::LinearStartBoundary;
+    case MaskOverlayHandleId::LinearEndBoundary:
+      return AnalyticMaskHandle::LinearEndBoundary;
+    default:
+      return AnalyticMaskHandle::None;
+  }
+}
+
+}  // namespace
+
+EditorMaskCreationAdapter::EditorMaskCreationAdapter(EditorSessionController* session,
+                                                     QObject* parent)
+    : QObject(parent), session_(session) {}
+
+EditorMaskCreationAdapter::~EditorMaskCreationAdapter() {
+  if (view_change_connection_) {
+    QObject::disconnect(view_change_connection_);
+  }
+}
+
+void EditorMaskCreationAdapter::bindInteractionItem(QObject* interaction) {
+  auto* typed = qobject_cast<editor_rhi::EditorInteractionController*>(interaction);
+  if (interaction_ == typed) {
+    return;
+  }
+  if (view_change_connection_) {
+    QObject::disconnect(view_change_connection_);
+    view_change_connection_ = {};
+  }
+  interaction_ = typed;
+  ConnectInteraction(typed);
+}
+
+void EditorMaskCreationAdapter::bindOverlayItem(QObject* overlay) {
+  overlay_ = qobject_cast<editor_rhi::EditorOverlayItem*>(overlay);
+  PublishOverlay();
+}
+
+void EditorMaskCreationAdapter::ConnectInteraction(
+    editor_rhi::EditorInteractionController* interaction) {
+  if (interaction == nullptr) {
+    return;
+  }
+  view_change_connection_ = connect(
+      interaction, &editor_rhi::EditorInteractionController::viewChangeReported, this,
+      [this](int) {
+        if (open_) {
+          cancel();
+        }
+      });
+}
+
+void EditorMaskCreationAdapter::beginRadial() {
+  BeginTool(MaskSourceKind::Radial, QStringLiteral("radial"));
+}
+
+void EditorMaskCreationAdapter::beginLinear() {
+  BeginTool(MaskSourceKind::LinearGradient, QStringLiteral("linear"));
+}
+
+void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& tool_kind) {
+  if (!CanAuthorMasks()) {
+    return;
+  }
+  if (open_) {
+    (void)Enqueue(EditorMaskCreationCommand{EditorMaskCreationCommandKind::Cancel});
+  }
+  EditorMaskCreationCommand command;
+  command.kind        = EditorMaskCreationCommandKind::BeginCreation;
+  command.source_kind = kind;
+  command.node_id     = CurrentGradeId();
+  if (command.node_id.Empty() || !Enqueue(command)) {
+    return;
+  }
+  source_kind_     = kind;
+  tool_kind_       = tool_kind;
+  creating_        = true;
+  selected_        = false;
+  open_            = false;
+  overlay_source_.reset();
+  overlay_display_ = {};
+  HideOverlay();
+  emit MaskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::cancel() {
+  if (!active()) {
+    return;
+  }
+  (void)Enqueue(EditorMaskCreationCommand{EditorMaskCreationCommandKind::CancelMode});
+  ResetLocal();
+}
+
+void EditorMaskCreationAdapter::OnImageClosed() {
+  ResetLocal();
+}
+
+void EditorMaskCreationAdapter::ResetLocal() {
+  const bool changed = active() || open_ || creating_ || selected_;
+  tool_kind_.clear();
+  creating_ = false;
+  open_     = false;
+  selected_ = false;
+  overlay_source_.reset();
+  overlay_display_ = {};
+  HideOverlay();
+  if (changed) {
+    emit MaskCreationChanged();
+  }
+}
+
+auto EditorMaskCreationAdapter::CurrentGradeId() const -> NodeId {
+  if (session_ == nullptr) {
+    return {};
+  }
+  auto* nodes = session_->node_selection_source();
+  if (nodes == nullptr || nodes->selected_node_kind() != QLatin1String("colorGrade")) {
+    return {};
+  }
+  return nodes->selected_node_id();
+}
+
+auto EditorMaskCreationAdapter::CanAuthorMasks() const -> bool {
+  if (session_ == nullptr || !session_->can_edit()) {
+    return false;
+  }
+  if (CurrentGradeId().Empty()) {
+    return false;
+  }
+  if (interaction_ != nullptr && interaction_->cropOverlayVisible()) {
+    return false;
+  }
+  return true;
+}
+
+auto EditorMaskCreationAdapter::MakeSample(qreal x, qreal y, bool allow_outside) const
+    -> std::optional<MaskCreationSample> {
+  if (interaction_ == nullptr) {
+    return std::nullopt;
+  }
+  const auto mapped = interaction_->MapItemToMaskReference(x, y, allow_outside);
+  if (!mapped) {
+    return std::nullopt;
+  }
+  MaskCreationSample sample;
+  sample.normalized        = mapped->normalized;
+  sample.reference_pixels  = mapped->reference_pixels;
+  sample.inside_photograph = mapped->inside_photograph;
+  return sample;
+}
+
+auto EditorMaskCreationAdapter::OverlayClip() const -> QRectF {
+  if (interaction_ == nullptr) {
+    return {};
+  }
+  return QRectF(0.0, 0.0, interaction_->viewportWidth(), interaction_->viewportHeight());
+}
+
+auto EditorMaskCreationAdapter::OverlayStyle() const -> MaskOverlayStyle {
+  if (overlay_ != nullptr) {
+    return overlay_->maskOverlayStyle();
+  }
+  return DefaultMaskOverlayStyle();
+}
+
+auto EditorMaskCreationAdapter::Enqueue(EditorMaskCreationCommand command) -> bool {
+  return session_ != nullptr && session_->EnqueueMaskCreation(std::move(command));
+}
+
+void EditorMaskCreationAdapter::HideOverlay() {
+  if (overlay_ == nullptr) {
+    return;
+  }
+  overlay_->setMaskOverlayDisplay(MaskOverlayDisplay{});
+}
+
+void EditorMaskCreationAdapter::PublishOverlay() {
+  if (overlay_ == nullptr || interaction_ == nullptr || !overlay_source_.has_value()) {
+    HideOverlay();
+    return;
+  }
+  const auto mapping = interaction_->maskEditViewMapping();
+  const auto style   = OverlayStyle();
+  const auto clip    = OverlayClip();
+  MaskOverlayDisplay display;
+  if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
+    display = (creating_ && open_) ? MakeRadialCreatingOverlayDisplay(mapping, *radial, style, clip)
+                                   : MakeRadialExistingOverlayDisplay(mapping, *radial, style, clip);
+  } else if (const auto* linear = std::get_if<LinearGradientMaskSource>(&*overlay_source_)) {
+    display = (creating_ && open_)
+                  ? MakeLinearCreatingOverlayDisplay(mapping, *linear, style, clip)
+                  : MakeLinearExistingOverlayDisplay(mapping, *linear, style, clip);
+  }
+  overlay_display_ = display;
+  overlay_->setMaskOverlayDisplay(std::move(display));
+}
+
+auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> bool {
+  if (!owns_left_button() || button != static_cast<int>(Qt::LeftButton)) {
+    return false;
+  }
+  if (!CanAuthorMasks() || interaction_ == nullptr) {
+    return true;
+  }
+  const auto sample = MakeSample(x, y, false);
+  if (!sample || !sample->inside_photograph) {
+    return true;
+  }
+  pointer_.device_id   = 1;
+  pointer_.point_id    = 1;
+  pointer_.sequence_id = next_sequence_id_++;
+
+  const auto hit = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
+                                            OverlayStyle().hit_radius_logical_px);
+  const auto handle = AnalyticHandleFromOverlay(hit);
+  if (handle != AnalyticMaskHandle::None && selected_ && session_ != nullptr) {
+    EditorMaskCreationCommand select;
+    select.kind    = EditorMaskCreationCommandKind::SelectMask;
+    select.node_id = CurrentGradeId();
+    select.mask_id = session_->mask_creation_mask_id();
+    if (!select.mask_id.Empty()) {
+      (void)Enqueue(select);
+      EditorMaskCreationCommand move;
+      move.kind     = EditorMaskCreationCommandKind::BeginMove;
+      move.handle   = handle;
+      move.sample   = *sample;
+      move.identity = pointer_;
+      if (Enqueue(move)) {
+        press_normalized_ = sample->normalized;
+        active_handle_    = handle;
+        open_             = true;
+        creating_         = false;
+        emit MaskCreationChanged();
+        return true;
+      }
+    }
+  }
+
+  if (!creating_) {
+    EditorMaskCreationCommand begin;
+    begin.kind        = EditorMaskCreationCommandKind::BeginCreation;
+    begin.source_kind = source_kind_;
+    begin.node_id     = CurrentGradeId();
+    if (!Enqueue(begin)) {
+      return true;
+    }
+    creating_ = true;
+  }
+  EditorMaskCreationCommand input;
+  input.kind     = EditorMaskCreationCommandKind::BeginInput;
+  input.sample   = *sample;
+  input.identity = pointer_;
+  if (!Enqueue(input)) {
+    return true;
+  }
+  press_normalized_ = sample->normalized;
+  active_handle_    = AnalyticMaskHandle::None;
+  open_             = true;
+  selected_         = false;
+  overlay_source_   = source_kind_ == MaskSourceKind::Radial
+                          ? MaskSource{RadialFromCenterOut(sample->normalized, sample->normalized)}
+                          : MaskSource{LinearFromEndpoints(sample->normalized, sample->normalized)};
+  PublishOverlay();
+  emit MaskCreationChanged();
+  return true;
+}
+
+auto EditorMaskCreationAdapter::handleMove(qreal x, qreal y, int /*buttons*/) -> bool {
+  if (!open_) {
+    return owns_left_button();
+  }
+  const auto sample = MakeSample(x, y, true);
+  if (!sample) {
+    return true;
+  }
+  EditorMaskCreationCommand command;
+  command.kind     = EditorMaskCreationCommandKind::Append;
+  command.sample   = *sample;
+  command.identity = pointer_;
+  (void)Enqueue(command);
+  if (creating_) {
+    overlay_source_ = source_kind_ == MaskSourceKind::Radial
+                          ? MaskSource{RadialFromCenterOut(press_normalized_, sample->normalized)}
+                          : MaskSource{LinearFromEndpoints(press_normalized_, sample->normalized)};
+  } else if (overlay_source_.has_value() && active_handle_ != AnalyticMaskHandle::None) {
+    float unwrapped = 0.0f;
+    if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
+      unwrapped = radial->rotation;
+    }
+    if (auto next = ApplyAnalyticMaskHandle(active_handle_, *overlay_source_, sample->normalized,
+                                            unwrapped)) {
+      overlay_source_ = std::move(*next);
+    }
+  }
+  PublishOverlay();
+  return true;
+}
+
+auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> bool {
+  if (!open_ || button != static_cast<int>(Qt::LeftButton)) {
+    return owns_left_button() && button == static_cast<int>(Qt::LeftButton);
+  }
+  const auto sample = MakeSample(x, y, true);
+  if (sample) {
+    EditorMaskCreationCommand append;
+    append.kind     = EditorMaskCreationCommandKind::Append;
+    append.sample   = *sample;
+    append.identity = pointer_;
+    (void)Enqueue(append);
+    if (creating_) {
+      overlay_source_ =
+          source_kind_ == MaskSourceKind::Radial
+              ? MaskSource{RadialFromCenterOut(press_normalized_, sample->normalized)}
+              : MaskSource{LinearFromEndpoints(press_normalized_, sample->normalized)};
+    }
+  }
+  (void)Enqueue(EditorMaskCreationCommand{EditorMaskCreationCommandKind::Finish});
+  open_     = false;
+  creating_ = false;
+  selected_ = overlay_source_.has_value();
+  PublishOverlay();
+  emit MaskCreationChanged();
+  return true;
+}
+
+}  // namespace alcedo::ui

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -53,6 +53,7 @@ EditorSessionController::EditorSessionController(alcedo::IEditorSessionBackend* 
   connect(&actions_, &EditorActionAvailabilityModel::AvailabilityChanged, this,
           &EditorSessionController::ActionAvailabilityChanged);
   scope_controller_ = std::make_unique<EditorScopeController>(this);
+  mask_creation_    = std::make_unique<EditorMaskCreationAdapter>(this);
   connect(scope_controller_.get(), &EditorScopeController::FrameRequested, this, [this]() {
     if (!session_backend_ || !has_image() ||
         session_backend_->state() != alcedo::EditorSessionState::Interactive) {
@@ -292,6 +293,9 @@ void EditorSessionController::OnBackendChanged() {
     }
   }
   SyncViewportDisplayConfig();
+  if (mask_creation_ && !has_image()) {
+    mask_creation_->OnImageClosed();
+  }
   emit       StateChanged();
   // Phase 7A R2: emit the dedicated history signal only when the backend's
   // monotonic history_revision advances. Render-busy, frame-ready, preview,
@@ -1003,6 +1007,9 @@ void EditorSessionController::bindInteractionController(QObject* interactionCont
   interaction_controller_ = interactionController;
 
   auto* interaction = qobject_cast<editor_rhi::EditorInteractionController*>(interactionController);
+  if (mask_creation_) {
+    mask_creation_->bindInteractionItem(interaction);
+  }
   if (!interaction) {
     return;
   }
@@ -1298,6 +1305,20 @@ bool EditorSessionController::enqueueNodeSwitchBoundary() {
 
 void EditorSessionController::BindNodeSelectionSource(EditorNodeController* nodes) {
   node_controller_ = nodes;
+}
+
+auto EditorSessionController::EnqueueMaskCreation(alcedo::EditorMaskCreationCommand command)
+    -> bool {
+  if (session_backend_ == nullptr || !can_edit()) {
+    return false;
+  }
+  const auto result = session_backend_->EnqueueMaskCreation(std::move(command));
+  return result.kind != alcedo::EditorSessionResultKind::Rejected &&
+         result.kind != alcedo::EditorSessionResultKind::Failed;
+}
+
+auto EditorSessionController::mask_creation_mask_id() const -> alcedo::MaskId {
+  return session_backend_ ? session_backend_->mask_creation_mask_id() : alcedo::MaskId{};
 }
 
 void EditorSessionController::SetImageExifReader(

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_history_port.cpp
@@ -261,6 +261,12 @@ auto EditorSessionHistoryPort::SetPanelProjectionNode(const alcedo::EditorHistor
   return mutation_->SetPanelProjectionNode(guard, node_id, session_generation, error);
 }
 
+auto EditorSessionHistoryPort::WithLockedLiveDocument(
+    const alcedo::EditorHistoryGuardHandle& guard,
+    const alcedo::IEditorHistoryPort::LockedMaskDocumentOp& op, std::string* error) -> bool {
+  return mutation_->WithLockedLiveDocument(guard, op, error);
+}
+
 auto EditorSessionHistoryPort::CaptureSaveCheckpoint(const alcedo::EditorHistoryGuardHandle& guard,
                                                      std::string* error)
     -> std::shared_ptr<const alcedo::EditorMiniGitSaveCapture> {

--- a/alcedo_studio/src/ui/alcedo_main/application_module_qml_types.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/application_module_qml_types.cpp
@@ -8,6 +8,7 @@
 
 #include "app/ai_provider_profile.hpp"
 #include "ui/alcedo_main/album_backend/application_module_host.hpp"
+#include "ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp"
 #include "ui/alcedo_main/shortcut_registry.hpp"
 
 namespace alcedo::ui {
@@ -48,6 +49,8 @@ void RegisterApplicationModuleTypes() {
       "Alcedo.Main", 1, 0, "AdjustmentTransferController", "Owned by ApplicationModuleHost");
   qmlRegisterUncreatableType<EditorSessionController>(
       "Alcedo.Main", 1, 0, "EditorSessionController", "Owned by ApplicationModuleHost");
+  qmlRegisterUncreatableType<EditorMaskCreationAdapter>(
+      "Alcedo.Main", 1, 0, "EditorMaskCreationAdapter", "Owned by EditorSessionController");
   qmlRegisterUncreatableType<EditorScopeController>("Alcedo.Main", 1, 0, "EditorScopeController",
                                                     "Owned by EditorSessionController");
   qmlRegisterUncreatableType<WorkspaceRouter>("Alcedo.Main", 1, 0, "WorkspaceRouter",

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentHeader.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentHeader.qml
@@ -2,10 +2,11 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-// Selected-node name, image-owned EXIF tokens, and reserved Mask tool buttons
-// under the scope slot. Node switching does not reread EXIF; the session
-// publishes the four tokens when the open image identity changes. Brush / Radial /
-// Gradient actions are NM7 authoring placeholders: icons only, no command.
+// Selected-node name, image-owned EXIF tokens, and Mask tool buttons under the
+// scope slot. Node switching does not reread EXIF; the session publishes the
+// four tokens when the open image identity changes. Radial / Gradient arm
+// analytic creation on the selected Color Grade. Brush remains disabled until
+// accumulating-stroke UI exists.
 Item {
     id: root
     objectName: "editorAdjustmentHeader"
@@ -16,6 +17,10 @@ Item {
     property string apertureText: "\u2014"
     property string shutterText: "\u2014"
     property string isoText: "\u2014"
+    property var maskCreation: null
+    property string selectedNodeKind: ""
+    property bool cropOverlayVisible: false
+    property bool controlsEnabled: true
 
     readonly property color colText: theme ? theme.colText : appTheme.textColor
     readonly property color colIcon: appTheme.iconColor
@@ -128,6 +133,7 @@ Item {
                 IconActionButton {
                     objectName: "editorAdjustmentHeaderBrushButton"
                     compact: true
+                    enabled: false
                     iconSrc: "qrc:/mask_icons/brush.svg"
                     actionName: qsTr("Brush")
                     iconColorDefault: root.colIcon
@@ -139,8 +145,14 @@ Item {
                 }
 
                 IconActionButton {
+                    id: radialButton
                     objectName: "editorAdjustmentHeaderRadialButton"
                     compact: true
+                    enabled: root.controlsEnabled
+                             && root.selectedNodeKind === "colorGrade"
+                             && !root.cropOverlayVisible
+                    selected: root.maskCreation
+                              && String(root.maskCreation.toolKind || "") === "radial"
                     iconSrc: "qrc:/mask_icons/radial.svg"
                     actionName: qsTr("Radial")
                     iconColorDefault: root.colIcon
@@ -149,11 +161,24 @@ Item {
                     fillHover: appTheme.buttonHoveredFillColor
                     fillPressed: appTheme.buttonPressedFillColor
                     fillSelected: appTheme.buttonSelectedFillColor
+                    onClicked: {
+                        if (root.maskCreation && radialButton.selected) {
+                            root.maskCreation.cancel()
+                        } else if (root.maskCreation) {
+                            root.maskCreation.beginRadial()
+                        }
+                    }
                 }
 
                 IconActionButton {
+                    id: gradientButton
                     objectName: "editorAdjustmentHeaderGradientButton"
                     compact: true
+                    enabled: root.controlsEnabled
+                             && root.selectedNodeKind === "colorGrade"
+                             && !root.cropOverlayVisible
+                    selected: root.maskCreation
+                              && String(root.maskCreation.toolKind || "") === "linear"
                     iconSrc: "qrc:/mask_icons/gradient.svg"
                     actionName: qsTr("Gradient")
                     iconColorDefault: root.colIcon
@@ -162,6 +187,13 @@ Item {
                     fillHover: appTheme.buttonHoveredFillColor
                     fillPressed: appTheme.buttonPressedFillColor
                     fillSelected: appTheme.buttonSelectedFillColor
+                    onClicked: {
+                        if (root.maskCreation && gradientButton.selected) {
+                            root.maskCreation.cancel()
+                        } else if (root.maskCreation) {
+                            root.maskCreation.beginLinear()
+                        }
+                    }
                 }
             }
         }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
@@ -218,6 +218,14 @@ Item {
                 isoText: root.editorSession
                          ? String(root.editorSession.exifIsoText || "\u2014")
                          : "\u2014"
+                maskCreation: root.editorSession ? root.editorSession.maskCreation : null
+                selectedNodeKind: root.nodeController
+                                  ? String(root.nodeController.selectedNodeKind || "")
+                                  : ""
+                cropOverlayVisible: root.interaction
+                                    ? !!root.interaction.cropOverlayVisible
+                                    : false
+                controlsEnabled: root.controlsEnabled
             }
 
             SlidingIconNav {

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
@@ -47,6 +47,15 @@ Item {
                                                      && editorSession
                                                      && editorSession.actions
                                                      && editorSession.actions.canEdit)
+    readonly property var maskCreation: editorSession ? editorSession.maskCreation : null
+    readonly property bool maskOwnsLeftButton: !!(maskCreation && maskCreation.ownsLeftButton)
+
+    function bindMaskOverlay() {
+        if (maskCreation && editorOverlayItem)
+            maskCreation.bindOverlayItem(editorOverlayItem)
+    }
+
+    onMaskCreationChanged: bindMaskOverlay()
     readonly property var renderDiagnostics: editorSession ? editorSession.renderDiagnostics : ({})
     readonly property string inflightRenderReason: renderDiagnostics.inflightReason || ""
     readonly property bool adjustmentRenderBusy: editorSession
@@ -228,6 +237,7 @@ Item {
                         // Overlay must sit above the photograph and receive no
                         // exclusive mouse grab — handlers below own input.
                         z: 2
+                        Component.onCompleted: root.bindMaskOverlay()
                     }
 
                     // Spinner / status remain ordinary QML (not baked into the RHI pass).
@@ -346,24 +356,46 @@ Item {
                         acceptedButtons: Qt.LeftButton | Qt.MiddleButton
                         property int _activeButton: Qt.LeftButton
                         property bool _pressed: false
+                        property bool _maskStream: false
                         onActiveChanged: {
                             if (active) {
                                 _pressed = true
                                 _activeButton = (point.pressedButtons & Qt.MiddleButton)
                                         ? Qt.MiddleButton : Qt.LeftButton
-                                editorInteraction.handlePress(
-                                            point.position.x, point.position.y, _activeButton)
+                                if (_activeButton === Qt.LeftButton
+                                        && root.maskOwnsLeftButton
+                                        && root.maskCreation
+                                        && root.maskCreation.handlePress(
+                                               point.position.x, point.position.y, _activeButton)) {
+                                    _maskStream = true
+                                } else {
+                                    _maskStream = false
+                                    editorInteraction.handlePress(
+                                                point.position.x, point.position.y, _activeButton)
+                                }
                             } else if (_pressed) {
-                                editorInteraction.handleRelease(
-                                            point.position.x, point.position.y, _activeButton)
+                                if (_maskStream && root.maskCreation) {
+                                    root.maskCreation.handleRelease(
+                                                point.position.x, point.position.y, _activeButton)
+                                } else {
+                                    editorInteraction.handleRelease(
+                                                point.position.x, point.position.y, _activeButton)
+                                }
                                 _pressed = false
+                                _maskStream = false
                             }
                         }
                         onPointChanged: {
                             if (active) {
-                                editorInteraction.handleMove(
-                                            point.position.x, point.position.y,
-                                            point.pressedButtons)
+                                if (_maskStream && root.maskCreation) {
+                                    root.maskCreation.handleMove(
+                                                point.position.x, point.position.y,
+                                                point.pressedButtons)
+                                } else {
+                                    editorInteraction.handleMove(
+                                                point.position.x, point.position.y,
+                                                point.pressedButtons)
+                                }
                             }
                         }
                     }
@@ -389,7 +421,9 @@ Item {
                         id: viewportPanDrag
                         enabled: root.editorControlsEnabled
                         acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.TouchScreen | PointerDevice.Stylus
-                        acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+                        acceptedButtons: root.maskOwnsLeftButton
+                                         ? Qt.MiddleButton
+                                         : (Qt.LeftButton | Qt.MiddleButton)
                         target: null
                         property bool _forwardingDrag: false
                         property int _activeButton: Qt.LeftButton
@@ -724,6 +758,12 @@ Item {
             objectName: "editorSaveRecoveryBar"
             editorSession: root.editorSession
         }
+    }
+
+    Shortcut {
+        sequences: [ "Escape" ]
+        enabled: root.editorControlsEnabled && root.maskOwnsLeftButton && root.maskCreation
+        onActivated: root.maskCreation.cancel()
     }
 
     // Geometry confirm (legacy Enter / numpad Enter). Lives on the workspace so

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
@@ -408,4 +408,26 @@ auto MapReferenceRadiusToItem(const MaskEditViewMapping& mapping, Vector2 center
   return ItemDistance(*center, *edge);
 }
 
+auto HitTestMaskOverlayHandle(const MaskOverlayDisplay& display, QPointF item,
+                              float hit_radius_logical_px) -> MaskOverlayHandleId {
+  if (display.mode == MaskOverlayMode::Hidden || hit_radius_logical_px <= 0.0f ||
+      !std::isfinite(item.x()) || !std::isfinite(item.y())) {
+    return MaskOverlayHandleId::None;
+  }
+  MaskOverlayHandleId hit = MaskOverlayHandleId::None;
+  float               best = hit_radius_logical_px;
+  for (const auto& handle : display.handles) {
+    if (handle.id == MaskOverlayHandleId::None || !std::isfinite(handle.item.x()) ||
+        !std::isfinite(handle.item.y())) {
+      continue;
+    }
+    const float distance = ItemDistance(item, handle.item);
+    if (distance <= best) {
+      best = distance;
+      hit  = handle.id;
+    }
+  }
+  return hit;
+}
+
 }  // namespace alcedo

--- a/alcedo_studio/src/ui/editor_rhi/editor_interaction_controller.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_interaction_controller.cpp
@@ -664,9 +664,15 @@ void EditorInteractionController::setDisplayedMaskGeometry(const ResolvedRenderG
 
 auto EditorInteractionController::maskEditViewMapping() const -> MaskEditViewMapping {
   MaskEditViewMapping mapping;
-  mapping.widget      = widgetInfo();
-  mapping.photograph  = imageInfo();
-  mapping.geometry    = displayed_mask_geometry_;
+  mapping.widget       = widgetInfo();
+  mapping.photograph   = imageInfo();
+  mapping.geometry     = displayed_mask_geometry_;
+  if (mapping.geometry.full_reference_extent.Empty() && mapping.photograph.image_width > 0 &&
+      mapping.photograph.image_height > 0) {
+    mapping.geometry = MaskEditGeometry::MakeIdentityPhotographGeometry(Extent2D{
+        static_cast<std::uint32_t>(mapping.photograph.image_width),
+        static_cast<std::uint32_t>(mapping.photograph.image_height)});
+  }
   mapping.presentation = presentation_mode_;
   const auto view     = viewer_state_.GetViewTransform();
   mapping.zoom        = view.zoom;

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -360,6 +360,15 @@ gtest_discover_tests(BrushRegionalReplayTest
   PROPERTIES LABELS "ci_core_flow;edit;mask")
 alcedo_register_test_target(BrushRegionalReplayTest edit)
 
+add_executable(AnalyticMaskEditTest
+  ${ALCEDO_TEST_ROOT}/edit/mask/analytic_mask_edit_test.cpp)
+target_include_directories(AnalyticMaskEditTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(AnalyticMaskEditTest PRIVATE GTest::gtest_main EditMaskStore)
+gtest_discover_tests(AnalyticMaskEditTest
+  TEST_PREFIX "AnalyticMaskEditTest."
+  PROPERTIES LABELS "ci_core_flow;edit;mask")
+alcedo_register_test_target(AnalyticMaskEditTest edit)
+
 add_executable(BrushPlacementMappingTest
   ${ALCEDO_TEST_ROOT}/edit/mask/brush_placement_mapping_test.cpp)
 target_include_directories(BrushPlacementMappingTest

--- a/alcedo_studio/tests/edit/mask/analytic_mask_edit_test.cpp
+++ b/alcedo_studio/tests/edit/mask/analytic_mask_edit_test.cpp
@@ -1,0 +1,68 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/analytic_mask_edit.hpp"
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+namespace alcedo {
+namespace {
+
+TEST(AnalyticMaskEditTest, CenterOutRadiiStayPositiveAndUnswapped) {
+  const Vector2 center{0.40f, 0.55f};
+  const auto    left_up = RadialFromCenterOut(center, Vector2{0.25f, 0.70f});
+  EXPECT_FLOAT_EQ(left_up.center_x, 0.40f);
+  EXPECT_FLOAT_EQ(left_up.center_y, 0.55f);
+  EXPECT_FLOAT_EQ(left_up.major_radius, 0.15f);
+  EXPECT_FLOAT_EQ(left_up.minor_radius, 0.15f);
+  EXPECT_FLOAT_EQ(left_up.rotation, 0.0f);
+  EXPECT_FALSE(RadialCreationIsValid(RadialFromCenterOut(center, center)));
+
+  RadialMaskSource tall;
+  tall.center_x     = 0.50f;
+  tall.center_y     = 0.50f;
+  tall.major_radius = 0.20f;
+  tall.minor_radius = 0.08f;
+  const auto across = UpdateRadialMajorRadius(tall, Vector2{0.50f - 0.05f, 0.50f});
+  ASSERT_TRUE(across.has_value());
+  EXPECT_FLOAT_EQ(across->major_radius, 0.05f);
+  EXPECT_FLOAT_EQ(across->minor_radius, 0.08f);
+  EXPECT_EQ(across->center_x, tall.center_x);
+}
+
+TEST(AnalyticMaskEditTest, LinearEndpointsSetOriginNormalAndWidth) {
+  const auto source = LinearFromEndpoints(Vector2{0.20f, 0.25f}, Vector2{0.80f, 0.25f});
+  EXPECT_FLOAT_EQ(source.origin_x, 0.50f);
+  EXPECT_FLOAT_EQ(source.origin_y, 0.25f);
+  EXPECT_FLOAT_EQ(source.normal_x, 1.0f);
+  EXPECT_FLOAT_EQ(source.normal_y, 0.0f);
+  EXPECT_FLOAT_EQ(source.transition_distance, 0.60f);
+  EXPECT_FLOAT_EQ(source.start_value, 1.0f);
+  EXPECT_FLOAT_EQ(source.end_value, 0.0f);
+  EXPECT_TRUE(LinearCreationIsValid(source));
+  EXPECT_FALSE(LinearCreationIsValid(LinearFromEndpoints(Vector2{0.3f, 0.3f}, Vector2{0.3f, 0.3f})));
+}
+
+TEST(AnalyticMaskEditTest, RotationUnwrapsAcrossPi) {
+  RadialMaskSource source;
+  source.center_x     = 0.50f;
+  source.center_y     = 0.50f;
+  source.major_radius = 0.20f;
+  source.minor_radius = 0.10f;
+  float unwrapped     = 3.0f;
+  source.rotation     = unwrapped;
+  const float wrapped = -3.0f;
+  const auto  next    = UpdateRadialRotation(
+      source, Vector2{0.50f + std::cos(wrapped) * 0.2f, 0.50f + std::sin(wrapped) * 0.2f},
+      unwrapped);
+  ASSERT_TRUE(next.has_value());
+  EXPECT_NEAR(unwrapped, 3.0f + (wrapped - 3.0f + 2.0f * 3.14159265358979323846f), 1.0e-4f);
+  EXPECT_FLOAT_EQ(next->rotation, unwrapped);
+  EXPECT_GT(unwrapped, 3.0f);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -1251,6 +1251,28 @@ alcedo_ui_gtest_discover_tests(MaskOverlayControlTest
     PROPERTIES LABELS "mask_overlay;editor_rhi")
 alcedo_register_test_target(MaskOverlayControlTest ui)
 
+add_executable(AnalyticMaskCreationTest
+    ${ALCEDO_TEST_ROOT}/ui/analytic_mask_creation_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/ui_test_main.cpp
+)
+target_include_directories(AnalyticMaskCreationTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR} ${ALCEDO_TEST_ROOT}/edit/graph
+)
+target_link_libraries(AnalyticMaskCreationTest
+    PRIVATE
+        EditorMaskCreationController
+        EditorViewerLogic
+        EditGraph
+        GTest::gtest
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Test
+)
+alcedo_ui_gtest_discover_tests(AnalyticMaskCreationTest
+    TEST_PREFIX "AnalyticMaskCreationTest."
+    PROPERTIES LABELS "mask_creation;interaction")
+alcedo_register_test_target(AnalyticMaskCreationTest ui)
 
 # Real-project regression: replay production Main.qml Copy/Paste and verify
 # that a reopened target publishes the saved Tone values to its QML models.

--- a/alcedo_studio/tests/ui/analytic_mask_creation_test.cpp
+++ b/alcedo_studio/tests/ui/analytic_mask_creation_test.cpp
@@ -1,0 +1,447 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <memory>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include <QPointF>
+#include <QRectF>
+#include <QVector2D>
+
+#include "app/editor_mask_creation_controller.hpp"
+#include "app/pipeline_document_history.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/history/commit_graph.hpp"
+#include "edit/history/mini_git_working_history.hpp"
+#include "edit/mask/analytic_mask_edit.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/grade_mask_coverage.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "grade_owned_mask_support.hpp"
+#include "ui/edit_viewer/mask_edit_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_layout.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr Extent2D kRaster{64, 32};
+constexpr float    kPi = 3.14159265358979323846f;
+
+[[nodiscard]] auto MakeMapping() -> MaskEditViewMapping {
+  MaskEditViewMapping mapping;
+  mapping.widget     = {200, 100, 1.0f};
+  mapping.photograph = {static_cast<int>(kRaster.width), static_cast<int>(kRaster.height)};
+  mapping.zoom       = 1.25f;
+  mapping.pan        = QVector2D(4.0f, -3.0f);
+  mapping.geometry   = MaskEditGeometry::MakeIdentityPhotographGeometry(kRaster);
+  return mapping;
+}
+
+[[nodiscard]] auto SampleOf(const MaskEditViewMapping& mapping, QPointF item, bool allow_outside)
+    -> MaskCreationSample {
+  const auto mapped = MaskEditGeometry::MapItemToReference(mapping, item, allow_outside);
+  EXPECT_TRUE(mapped.has_value());
+  MaskCreationSample sample;
+  sample.normalized        = mapped->normalized;
+  sample.reference_pixels  = mapped->reference_pixels;
+  sample.inside_photograph = mapped->inside_photograph;
+  return sample;
+}
+
+[[nodiscard]] auto ItemOf(const MaskEditViewMapping& mapping, Vector2 normalized) -> QPointF {
+  const auto item = MapNormalizedMaskPointToItem(mapping, normalized);
+  EXPECT_TRUE(item.has_value());
+  return item.value_or(QPointF());
+}
+
+// Independent native Radial coverage from the NM7 plan equations. Not overlay layout.
+[[nodiscard]] auto IndependentRadialCoverage(const RadialMaskSource& source, Vector2 q) -> float {
+  const float c     = std::cos(source.rotation);
+  const float s     = std::sin(source.rotation);
+  const float u     = (c * (q.x - source.center_x) + s * (q.y - source.center_y)) /
+                  std::max(source.major_radius, 1.0e-6f);
+  const float v     = (-s * (q.x - source.center_x) + c * (q.y - source.center_y)) /
+                  std::max(source.minor_radius, 1.0e-6f);
+  const float rho   = std::sqrt(u * u + v * v);
+  const float inner = std::max(0.0f, 1.0f - source.inner_feather);
+  const float outer = 1.0f + source.outer_feather;
+  return 1.0f - std::clamp((rho - inner) / std::max(outer - inner, 1.0e-6f), 0.0f, 1.0f);
+}
+
+[[nodiscard]] auto IndependentLinearCoverage(const LinearGradientMaskSource& source, Vector2 q)
+    -> float {
+  const float length = std::hypot(source.normal_x, source.normal_y);
+  const float nx     = source.normal_x / std::max(length, 1.0e-6f);
+  const float ny     = source.normal_y / std::max(length, 1.0e-6f);
+  const float d      = (q.x - source.origin_x) * nx + (q.y - source.origin_y) * ny;
+  const float t =
+      std::clamp(d / std::max(source.transition_distance, 1.0e-6f) + 0.5f, 0.0f, 1.0f);
+  return source.start_value + (source.end_value - source.start_value) * t;
+}
+
+[[nodiscard]] auto IndependentR8(float coverage) -> std::uint8_t {
+  return static_cast<std::uint8_t>(std::clamp(coverage * 255.0f + 0.5f, 0.0f, 255.0f));
+}
+
+[[nodiscard]] auto TexelNormalized(std::uint32_t x, std::uint32_t y) -> Vector2 {
+  const auto center = CanonicalBrushTexelReferenceCenter(x, y, kRaster, kRaster);
+  return {center.x / static_cast<float>(kRaster.width),
+          center.y / static_cast<float>(kRaster.height)};
+}
+
+[[nodiscard]] auto MixAt(const GradeMaskCoverage& mix, std::uint32_t x, std::uint32_t y)
+    -> std::uint8_t {
+  return mix.Pixels()[PackedR8Index(x, y, kRaster)];
+}
+
+void ExpectMixMatchesIndependent(const GradeMaskCoverage& mix, const MaskModel& mask) {
+  ASSERT_EQ(mix.Pixels().size(), static_cast<std::size_t>(kRaster.width) * kRaster.height);
+  std::uint32_t mismatches = 0;
+  std::int32_t  max_err    = 0;
+  for (std::uint32_t y = 0; y < kRaster.height; y += 4) {
+    for (std::uint32_t x = 0; x < kRaster.width; x += 4) {
+      const Vector2 q     = TexelNormalized(x, y);
+      float         coverage = 0.0f;
+      if (const auto* radial = std::get_if<RadialMaskSource>(&mask.source)) {
+        coverage = IndependentRadialCoverage(*radial, q);
+      } else {
+        coverage = IndependentLinearCoverage(std::get<LinearGradientMaskSource>(mask.source), q);
+      }
+      if (mask.invert) {
+        coverage = 1.0f - coverage;
+      }
+      const auto expected = IndependentR8(std::clamp(coverage * mask.opacity, 0.0f, 1.0f));
+      const auto err      = std::abs(static_cast<int>(MixAt(mix, x, y)) - static_cast<int>(expected));
+      max_err             = std::max(max_err, err);
+      if (err > 1) {
+        ++mismatches;
+      }
+    }
+  }
+  EXPECT_EQ(mismatches, 0u) << "max R8 error " << max_err;
+}
+
+[[nodiscard]] auto CopyMix(const GradeMaskCoverage& mix) -> std::vector<std::uint8_t> {
+  const auto pixels = mix.Pixels();
+  return {pixels.begin(), pixels.end()};
+}
+
+struct AnalyticCreationHarness {
+  AnalyticCreationHarness()
+      : graph(std::make_shared<CommitGraph>(CommitGraph::CreateEmpty(17))),
+        journal(std::make_shared<MiniGitJournal>()),
+        history(graph, journal) {
+    document = CreateDefaultPipelineDocument();
+    mix.SetGeometry(kRaster, kRaster);
+    controller.Bind(document, history);
+    controller.SetInteractivePreview([this]() {
+      ++preview_count;
+      mix.EvaluateFull(document.PrimaryGrade()->Masks());
+      last_mix = CopyMix(mix);
+    });
+  }
+
+  std::shared_ptr<CommitGraph>           graph;
+  std::shared_ptr<MiniGitJournal>        journal;
+  MiniGitWorkingHistory                  history;
+  PipelineDocument                       document;
+  EditorMaskCreationController           controller;
+  GradeMaskCoverage                      mix;
+  std::vector<std::uint8_t>              last_mix;
+  int                                    preview_count = 0;
+  MaskEditViewMapping                    mapping       = MakeMapping();
+  EditorSessionIdentity                  session{17, 4};
+  MaskPointerIdentity                    pointer{3, 1, 9};
+};
+
+[[nodiscard]] auto OverlayFillCount(const MaskOverlayDisplay& display) -> int {
+  return BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle()).coverage_fill_vertex_count;
+}
+
+}  // namespace
+
+TEST(AnalyticMaskCreationTest, ExistingRadialMoveUpdatesInteractivePixelsBeforeRelease) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.center_x     = 0.50f;
+  radial.center_y     = 0.50f;
+  radial.major_radius = 0.22f;
+  radial.minor_radius = 0.16f;
+  radial.rotation     = 0.40f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
+  const auto mix_before = CopyMix(harness.mix);
+  const auto head_before = harness.history.working_head();
+
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+                  .accepted);
+  const auto moved =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.28f, 0.62f}), true);
+  const auto preview = harness.controller.AppendMaskInput(moved, harness.pointer);
+  ASSERT_TRUE(preview.accepted);
+  EXPECT_TRUE(preview.interactive_preview);
+  EXPECT_FALSE(preview.committed);
+  EXPECT_FALSE(preview.quality_requested);
+  EXPECT_GE(harness.preview_count, 1);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  EXPECT_NE(harness.last_mix, mix_before);
+
+  const auto* live = std::get_if<RadialMaskSource>(
+      &harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"})->source);
+  ASSERT_NE(live, nullptr);
+  EXPECT_NEAR(live->center_x, 0.28f, 1.0e-2f);
+  EXPECT_NEAR(live->center_y, 0.62f, 1.0e-2f);
+  EXPECT_FLOAT_EQ(live->major_radius, radial.major_radius);
+  EXPECT_FLOAT_EQ(live->minor_radius, radial.minor_radius);
+  EXPECT_FLOAT_EQ(live->rotation, radial.rotation);
+  ExpectMixMatchesIndependent(harness.mix,
+                              *harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"}));
+
+  const auto display = MakeRadialExistingOverlayDisplay(
+      harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
+  EXPECT_EQ(OverlayFillCount(display), 0);
+  EXPECT_FALSE(display.handles.empty());
+
+  const auto finish = harness.controller.FinishMaskInput();
+  ASSERT_TRUE(finish.accepted);
+  EXPECT_TRUE(finish.committed);
+  EXPECT_TRUE(finish.quality_requested);
+  EXPECT_NE(harness.history.working_head(), head_before);
+}
+
+TEST(AnalyticMaskCreationTest, ExistingGradientMovePreservesDirectionAndUpdatesInteractivePixels) {
+  AnalyticCreationHarness harness;
+  LinearGradientMaskSource linear;
+  linear.origin_x            = 0.50f;
+  linear.origin_y            = 0.50f;
+  linear.normal_x            = 1.0f;
+  linear.normal_y            = 0.0f;
+  linear.transition_distance = 0.40f;
+  grade_mask_test::AddLinearGradientMask(harness.document, MaskId{"mask.linear"}, linear);
+  harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
+  const auto mix_before  = CopyMix(harness.mix);
+  const auto head_before = harness.history.working_head();
+
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.linear"},
+                              harness.session)
+                  .accepted);
+  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::LinearOrigin, press, harness.pointer)
+                  .accepted);
+  const auto moved =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.70f, 0.50f}), true);
+  const auto preview = harness.controller.AppendMaskInput(moved, harness.pointer);
+  ASSERT_TRUE(preview.accepted);
+  EXPECT_TRUE(preview.interactive_preview);
+  EXPECT_FALSE(preview.committed);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  EXPECT_NE(harness.last_mix, mix_before);
+
+  const auto* live = std::get_if<LinearGradientMaskSource>(
+      &harness.document.PrimaryGrade()->FindMask(MaskId{"mask.linear"})->source);
+  ASSERT_NE(live, nullptr);
+  EXPECT_NEAR(live->origin_x, 0.70f, 1.0e-2f);
+  EXPECT_NEAR(live->origin_y, 0.50f, 1.0e-2f);
+  EXPECT_FLOAT_EQ(live->normal_x, linear.normal_x);
+  EXPECT_FLOAT_EQ(live->normal_y, linear.normal_y);
+  EXPECT_FLOAT_EQ(live->transition_distance, linear.transition_distance);
+  ExpectMixMatchesIndependent(harness.mix,
+                              *harness.document.PrimaryGrade()->FindMask(MaskId{"mask.linear"}));
+
+  const auto display = MakeLinearExistingOverlayDisplay(
+      harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
+  EXPECT_EQ(OverlayFillCount(display), 0);
+  EXPECT_FALSE(display.handles.empty());
+
+  const auto finish = harness.controller.FinishMaskInput();
+  ASSERT_TRUE(finish.accepted);
+  EXPECT_TRUE(finish.committed);
+  EXPECT_TRUE(finish.quality_requested);
+}
+
+TEST(AnalyticMaskCreationTest, RadialFeatherControlsMatchEvaluator) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.center_x      = 0.50f;
+  radial.center_y      = 0.50f;
+  radial.major_radius  = 0.24f;
+  radial.minor_radius  = 0.18f;
+  radial.rotation      = 0.30f;
+  radial.inner_feather = 0.10f;
+  radial.outer_feather = 0.05f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+
+  const Vector2 inner_q{radial.center_x + std::cos(radial.rotation) * radial.major_radius * 0.55f,
+                        radial.center_y + std::sin(radial.rotation) * radial.major_radius * 0.55f};
+  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, inner_q), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, press, harness.pointer)
+                  .accepted);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(press, harness.pointer).accepted);
+
+  const Vector2 outer_q{radial.center_x + std::cos(radial.rotation) * radial.major_radius * 1.35f,
+                        radial.center_y + std::sin(radial.rotation) * radial.major_radius * 1.35f};
+  MaskPointerIdentity outer_pointer = harness.pointer;
+  ASSERT_TRUE(harness.controller.FinishMaskInput().accepted);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  const auto outer_press = SampleOf(harness.mapping, ItemOf(harness.mapping, outer_q), false);
+  outer_pointer.sequence_id = 10;
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer)
+                  .accepted);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(outer_press, outer_pointer).accepted);
+
+  const auto* live = std::get_if<RadialMaskSource>(
+      &harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"})->source);
+  ASSERT_NE(live, nullptr);
+  EXPECT_FLOAT_EQ(live->major_radius, radial.major_radius);
+  EXPECT_FLOAT_EQ(live->minor_radius, radial.minor_radius);
+  EXPECT_NEAR(live->inner_feather, 0.45f, 0.08f);
+  EXPECT_NEAR(live->outer_feather, 0.35f, 0.08f);
+  harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
+  ExpectMixMatchesIndependent(harness.mix,
+                              *harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"}));
+
+  const auto inner_rho = RadialRho(*live, TexelNormalized(kRaster.width / 2, kRaster.height / 2));
+  ASSERT_TRUE(inner_rho.has_value());
+  const float expected_center = IndependentRadialCoverage(*live, TexelNormalized(
+                                                                     kRaster.width / 2, kRaster.height / 2));
+  EXPECT_NEAR(CoverageFromMaskR8(MixAt(harness.mix, kRaster.width / 2, kRaster.height / 2)),
+              expected_center, 1.0f / 255.0f + 1.0e-6f);
+}
+
+TEST(AnalyticMaskCreationTest, DegenerateAnalyticCreationCreatesNoCommit) {
+  AnalyticCreationHarness harness;
+  const auto              head_before = harness.history.working_head();
+  ASSERT_TRUE(harness.controller
+                  .BeginCreation(MaskSourceKind::Radial, harness.document.PrimaryGrade()->Id(),
+                                 harness.session)
+                  .accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
+  ASSERT_TRUE(harness.controller.BeginMaskInput(press, harness.pointer).accepted);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(press, harness.pointer).accepted);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
+  EXPECT_EQ(harness.preview_count, 0);
+
+  const auto finish = harness.controller.FinishMaskInput();
+  ASSERT_TRUE(finish.accepted);
+  EXPECT_FALSE(finish.committed);
+  EXPECT_FALSE(finish.quality_requested);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+
+  ASSERT_TRUE(harness.controller
+                  .BeginCreation(MaskSourceKind::LinearGradient,
+                                 harness.document.PrimaryGrade()->Id(), harness.session)
+                  .accepted);
+  MaskPointerIdentity linear_pointer = harness.pointer;
+  linear_pointer.sequence_id         = 11;
+  ASSERT_TRUE(harness.controller.BeginMaskInput(press, linear_pointer).accepted);
+  EXPECT_TRUE(harness.controller.FinishMaskInput().accepted);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+}
+
+TEST(AnalyticMaskCreationTest, EscapeRestoresAnalyticSourceWithoutCommit) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.center_x     = 0.42f;
+  radial.center_y     = 0.58f;
+  radial.major_radius = 0.20f;
+  radial.minor_radius = 0.14f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
+  const auto mix_before  = CopyMix(harness.mix);
+  const auto head_before = harness.history.working_head();
+
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{radial.center_x, radial.center_y}),
+               false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+                  .accepted);
+  const auto moved =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.22f, 0.30f}), true);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).interactive_preview);
+  EXPECT_NE(harness.last_mix, mix_before);
+
+  const auto cancel = harness.controller.CancelMaskInput();
+  ASSERT_TRUE(cancel.accepted);
+  EXPECT_FALSE(cancel.committed);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  const auto* restored = std::get_if<RadialMaskSource>(
+      &harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"})->source);
+  ASSERT_NE(restored, nullptr);
+  EXPECT_FLOAT_EQ(restored->center_x, radial.center_x);
+  EXPECT_FLOAT_EQ(restored->center_y, radial.center_y);
+  harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
+  EXPECT_EQ(CopyMix(harness.mix), mix_before);
+}
+
+TEST(AnalyticMaskCreationTest, ValidRadialCreationCommitsOnceAndKeepsControlOnlyOverlay) {
+  AnalyticCreationHarness harness;
+  const auto              head_before = harness.history.working_head();
+  ASSERT_TRUE(harness.controller
+                  .BeginCreation(MaskSourceKind::Radial, harness.document.PrimaryGrade()->Id(),
+                                 harness.session)
+                  .accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.45f, 0.40f}), false);
+  ASSERT_TRUE(harness.controller.BeginMaskInput(press, harness.pointer).accepted);
+  const auto drag =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.62f, 0.58f}), true);
+  const auto preview = harness.controller.AppendMaskInput(drag, harness.pointer);
+  ASSERT_TRUE(preview.accepted);
+  EXPECT_TRUE(preview.interactive_preview);
+  EXPECT_FALSE(preview.committed);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 1u);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  ASSERT_TRUE(harness.controller.OverlayIsCreating());
+  const auto* live = std::get_if<RadialMaskSource>(
+      &harness.document.PrimaryGrade()->FindMask(preview.mask_id)->source);
+  ASSERT_NE(live, nullptr);
+  const auto display = MakeRadialCreatingOverlayDisplay(
+      harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
+  EXPECT_EQ(OverlayFillCount(display), 0);
+  EXPECT_FALSE(display.creation_outline.empty());
+
+  const auto finish = harness.controller.FinishMaskInput();
+  ASSERT_TRUE(finish.accepted);
+  EXPECT_TRUE(finish.committed);
+  EXPECT_TRUE(finish.quality_requested);
+  EXPECT_NE(harness.history.working_head(), head_before);
+  EXPECT_FALSE(harness.controller.FinishMaskInput().committed);
+}
+
+}  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
@@ -7,8 +7,10 @@ stroke/placement history, WAL/Version/Paste remapping, and the Section 8.1 proje
 version gate landed. NM7.4 host canonical rasterization, spatial index, and regional Mix
 replay landed. Raster-only Brush JSON is rejected. NM7.5 shared ReferenceSpace mapping and
 Brush placement landed. NM7.6 control-only retained QSG Mask overlay landed. NM7.7 Radial
-and Linear creation plus existing-mask movement landed. NM7.8+ accumulating Brush UI,
-Interactive Mix, and cache service remain planned.
+and Linear creation plus existing-mask movement landed. Some former NM7.11 UI wiring was
+brought forward for testing. New NM7.8 parameter-mask controls and drawer selection/deletion
+remain planned. Brush UI, Interactive Mix and cache service are now NM7.9–NM7.11; remaining
+full UI is NM7.12 and final qualification ends at NM7.15.
 
 Parent: [NM7 execution plan](phase_nm7_viewer_mask_creation_plan.md).
 This document defines NM7's revised algorithm, data ownership and storage behavior. It replaces

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
@@ -6,8 +6,9 @@ Status: NM7.2 parameterized Brush source and Grade owner operations landed; NM7.
 stroke/placement history, WAL/Version/Paste remapping, and the Section 8.1 project/schema
 version gate landed. NM7.4 host canonical rasterization, spatial index, and regional Mix
 replay landed. Raster-only Brush JSON is rejected. NM7.5 shared ReferenceSpace mapping and
-Brush placement landed. NM7.6 control-only retained QSG Mask overlay landed. NM7.7+ viewer
-creation, Interactive Mix, and cache service remain planned.
+Brush placement landed. NM7.6 control-only retained QSG Mask overlay landed. NM7.7 Radial
+and Linear creation plus existing-mask movement landed. NM7.8+ accumulating Brush UI,
+Interactive Mix, and cache service remain planned.
 
 Parent: [NM7 execution plan](phase_nm7_viewer_mask_creation_plan.md).
 This document defines NM7's revised algorithm, data ownership and storage behavior. It replaces

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,11 +2,12 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.6 complete; NM7.7–NM7.14 planned. This document records the NM7.1 source
+Status: NM7.1–NM7.7 complete; NM7.8–NM7.14 planned. This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
-shared ReferenceSpace mapping with Brush placement, and NM7.6 control-only retained QSG.
-Remaining sub-phases are unimplemented.
+shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
+and NM7.7 Radial/Linear creation plus existing-mask movement. Remaining sub-phases are
+unimplemented.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -1058,6 +1059,63 @@ release to update the photographed result.
 `EscapeRestoresAnalyticSourceWithoutCommit`.
 
 **Exit:** both shapes move with actual native preview and control-only QSG on non-square images.
+
+##### Phase NM7.7 completion record (2026-09-08)
+
+**Status:** complete — Radial/Linear center-out creation, existing-mask movement, and handle
+edits apply provisional Grade source fields before release; one NM4 AddMask or
+ReplaceMaskSource commit on settle; Escape restores with zero commits.
+
+**Primary success call chain:**
+
+```text
+item/logical pointer (MaskEditGeometry::MapItemToReference)
+  -> EditorMaskCreationController::BeginMaskInput / BeginMaskMove / AppendMaskInput
+  -> RadialFromCenterOut / LinearFromEndpoints / ApplyAnalyticMaskHandle
+  -> ColorGradeNodeModel::AddMask (first valid creation) or ReplaceMaskSource
+  -> Interactive Mix callback (GradeMaskCoverage::EvaluateFull)
+  -> FinishMaskInput
+  -> MakeAddMaskBatch / MakeReplaceMaskSourceBatch
+  -> MiniGitWorkingHistory::AppendEdit
+  -> Quality requested (no second Apply; live already holds after values)
+```
+
+**Primary failure call chain:**
+
+```text
+degenerate zero-area creation, unchanged placement, or Escape/Cancel
+  -> no AddMask, or RestoreLive (RemoveMask / ReplaceMaskSource to before JSON)
+  -> history head unchanged; Grade source matches the captured before-state
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `ExistingRadialMoveUpdatesInteractivePixelsBeforeRelease` | `AnalyticMaskCreationTest` | PASS |
+| `ExistingGradientMovePreservesDirectionAndUpdatesInteractivePixels` | `AnalyticMaskCreationTest` | PASS |
+| `RadialFeatherControlsMatchEvaluator` | `AnalyticMaskCreationTest` | PASS |
+| `DegenerateAnalyticCreationCreatesNoCommit` | `AnalyticMaskCreationTest` | PASS |
+| `EscapeRestoresAnalyticSourceWithoutCommit` | `AnalyticMaskCreationTest` | PASS |
+| Valid Radial creation commits once; creating overlay has no coverage fill | `AnalyticMaskCreationTest` | PASS |
+| Center-out radii stay positive and unswapped | `AnalyticMaskEditTest` | PASS |
+| Linear endpoints set origin, unit normal, and width | `AnalyticMaskEditTest` | PASS |
+| Rotation unwraps across ±π | `AnalyticMaskEditTest` | PASS |
+| Existing mapping / overlay / Brush placement | `MaskEditGeometryTest`, `MaskOverlayControlTest`, `BrushPlacementMappingTest` | PASS |
+
+Commands:
+`cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target AnalyticMaskEditTest --target AnalyticMaskCreationTest`
+`ctest --test-dir build/debug --output-on-failure -R "AnalyticMaskEditTest|AnalyticMaskCreationTest"`
+`ctest --test-dir build/debug --output-on-failure -R "MaskOverlayControlTest|MaskEditGeometryTest|BrushPlacementMappingTest"`
+
+Suite totals: `9/9` NM7.7 binaries PASS; `14/14` related mapping/overlay tests PASS.
+Date / working tree on `feature/analytic-mask-creation-movement` (base `6eb68e4b`) / Windows MSVC `win_debug` / Qt 6.9.3 (`D:/misc/Qt/6.9.3/msvc2022_64`) / CUDA Toolkit 12.8. Interactive Mix is host `GradeMaskCoverage` using the native analytic equations; no GPU Mask pass in this phase.
+
+**Checklist / exit condition:** required tests PASS. Existing Radial/Linear center/origin drags update Mix R8 before `AppendEdit`. Shape fields other than center/origin stay fixed. Independent plan-equation coverage at sampled texels matches Mix within 1 R8 code. Degenerate creation and Escape publish no history. Existing and creating overlays on a non-square 64×32 photograph keep `coverage_fill_vertex_count == 0`.
+
+**LOC note (grill-code-review):** `analytic_mask_edit.hpp` 179 / `.cpp` 310, `editor_mask_creation_controller.hpp` 224 / `.cpp` 611, `analytic_mask_edit_test.cpp` 68, `analytic_mask_creation_test.cpp` 447. Geometry owns evaluator-inverse handle math; the controller owns mode, identities, provisional Grade writes, and settle/cancel. No split required.
+
+**Residual gaps:** NM7.8 accumulating Brush paint/erase UI. Session still does not publish live Mask overlay display or enqueue Interactive GPU frames (NM7.9). Project Mix-cache slot is NM7.10. Header/Masks-body wiring and accessible handles are NM7.11. Open-operation cancel on `MappingChanged` is NM7.12. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.8 — Complete accumulating Brush creation, erase and movement
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -1115,7 +1115,18 @@ Date / working tree on `feature/analytic-mask-creation-movement` (base `6eb68e4b
 
 **LOC note (grill-code-review):** `analytic_mask_edit.hpp` 179 / `.cpp` 310, `editor_mask_creation_controller.hpp` 224 / `.cpp` 611, `analytic_mask_edit_test.cpp` 68, `analytic_mask_creation_test.cpp` 447. Geometry owns evaluator-inverse handle math; the controller owns mode, identities, provisional Grade writes, and settle/cancel. No split required.
 
-**Residual gaps:** NM7.8 accumulating Brush paint/erase UI. Session still does not publish live Mask overlay display or enqueue Interactive GPU frames (NM7.9). Project Mix-cache slot is NM7.10. Header/Masks-body wiring and accessible handles are NM7.11. Open-operation cancel on `MappingChanged` is NM7.12. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
+**In-app test wiring (same branch, after owner-path completion):** Radial/Gradient header buttons, viewport left-button routing, control-only overlay, Escape, and session enqueue/consume are connected. Overlay uses local draft geometry plus identity photograph mapping when `ResolvedRenderGeometry` is unpublished. Interactive frames reuse `EditorRenderReason::InteractiveAdjustment` with `live_parameters_applied`; settle uses `SettledMaskEdit`.
+
+```text
+EditorAdjustmentHeader beginRadial/beginLinear
+  -> EditorMaskCreationAdapter (item → MaskCreationSample, QSG overlay)
+  -> EditorSessionService::EnqueueMaskCreation (coalesced Append)
+  -> TryConsumePendingInput / WithLockedLiveDocument
+  -> EditorMaskCreationController + PublishAppliedTypedBatch(document_already_at_after)
+  -> InteractiveAdjustment or SettledMaskEdit
+```
+
+**Residual gaps:** NM7.8 accumulating Brush paint/erase UI. Live `ResolvedRenderGeometry` publication into `setDisplayedMaskGeometry` remains NM7.9. Project Mix-cache slot is NM7.10. Accessible handle proxies and Masks-body list wiring remain NM7.11. Open-operation cancel on `MappingChanged` is NM7.12. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.8 — Complete accumulating Brush creation, erase and movement
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,12 +2,13 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.7 complete; NM7.8–NM7.14 planned. This document records the NM7.1 source
+Status: NM7.1–NM7.7 complete; NM7.8–NM7.15 planned. This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
 shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
-and NM7.7 Radial/Linear creation plus existing-mask movement. Remaining sub-phases are
-unimplemented.
+and NM7.7 Radial/Linear creation plus existing-mask movement. Some former NM7.11 UI wiring (now NM7.12) was brought forward for Radial/Gradient testing.
+This is partial wiring, not completion of the full UI phase. New NM7.8 addresses the usability
+gaps found in that testing; NM7.8–NM7.15 acceptance remains outstanding.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -27,8 +28,16 @@ highlighting. This revision supersedes the earlier per-stroke immutable-asset de
 
 Required algorithm/storage design:
 [Parameterized commands, regional replay and project cache](mask_command_replay_and_project_cache_plan.md).
-Read it before implementing NM7.2–NM7.14. It gives equations, inverse operations, replay bounds,
+Read it before implementing NM7.2–NM7.15. It gives equations, inverse operations, replay bounds,
 cache lifecycle, project settings, failure behavior and an initial executable algorithm experiment.
+
+2026-09-08 parameter-mask revision: retain NM7.1–NM7.7 completion records. Insert NM7.8
+for Radial feather/range controls, Node drawer selection/deletion, and Geometry crop-style
+Gradient controls. Former NM7.8–NM7.14 become NM7.9–NM7.15; forward references in historical
+records use the new numbering. Selected analytic boundary lines are required during later
+editing as well as creation; coverage fill remains prohibited. The reported Radial “半圆范围”
+is specified here as the radial/elliptical range contour and feather boundaries of the existing
+full-ellipse evaluator, without introducing a semicircle coverage algorithm.
 
 ## 1. Purpose and background for the executor
 
@@ -104,15 +113,18 @@ User decisions received on 2026-09-08:
 
 | Decision | Required behavior | Implementation dependency |
 | --- | --- | --- |
-| Brush operations | Paint/erase with size and strength controls | NM7.2, NM7.4, NM7.8 |
+| Brush operations | Paint/erase with size and strength controls | NM7.2, NM7.4, NM7.9 |
 | Persistent source | Parameterized ordered strokes; history stores reversible commands, not R8 revisions | NM7.2–NM7.3 |
-| Accumulation/cache | Same Grade's strokes accumulate in one Brush; one current final Grade Mix R8 cache slot | NM7.4, NM7.9–NM7.10 |
+| Accumulation/cache | Same Grade's strokes accumulate in one Brush; one current final Grade Mix R8 cache slot | NM7.4, NM7.10–NM7.11 |
 | Radial initial drag | Center outward | NM7.7 |
-| Existing Mask movement | Brush/Radial/Gradient update real Interactive pixels during drag, Quality after release | NM7.5, NM7.7–NM7.9 |
+| Radial feather/range | Explicit inner/outer feather controls and selected ellipse/boundary lines | NM7.8 |
+| Node Mask drawer | Select existing Mask, reopen its controls and delete with Undo/Redo | NM7.8 |
+| Gradient controls | Geometry crop-style dual strokes and edge grips on three parallel guides; no kite outline | NM7.8 |
+| Existing Mask movement | Brush/Radial/Gradient update real Interactive pixels during drag, Quality after release | NM7.5, NM7.7–NM7.10 |
 | QSG existing-mask display | Controls only, no affected-area fill or completed Brush path | NM7.6 |
 | Initial creation guides | Working interpretation: temporary cursor/outline/path guides are allowed only during initial drawing, never area-fill highlighting; clarification requested | NM7.6 |
-| Editing body | Temporary Masks body; preserve six adjustment tabs | NM7.11 |
-| Project storage | User-selected cache root, per-project Keep/DeleteOnProjectClose and Clear actions | NM7.10–NM7.11 |
+| Editing body | Temporary Masks body; preserve six adjustment tabs; analytic test wiring brought forward | NM7.8, NM7.12 |
+| Project storage | User-selected cache root, per-project Keep/DeleteOnProjectClose and Clear actions | NM7.11–NM7.12 |
 
 Size and strength are explicit user controls. Automatic pen-pressure modulation was not requested;
 this plan specifies manual size/strength, with stylus position accepted through the same input
@@ -246,7 +258,7 @@ These are Alcedo design choices derived from the documented lifecycle and curren
 - Use explicit edge-alpha triangle fringes for antialiasing and premultiplied color consistently.
   Do not assume `QQuickItem::antialiasing` automatically fixes custom geometry. Test control outlines, intersections, joins and caps for
   dark seams or doubled alpha. Feather
-  controls may show a handle/connector, not a highlighted feather band.
+  controls show selected analytic boundary lines and handles, without a filled feather band.
 - QSG coordinates and handle hit areas are logical pixels. Image-space radius is transformed;
   handle and outline widths remain constant in logical pixels at any zoom or DPR.
 - For a growing stroke under Qt 6.9, use bounded geometry chunks or exact allocations with full
@@ -381,9 +393,10 @@ coverage = 1-clamp((rho-inner)/max(outer-inner, evaluator_epsilon), 0, 1)
 ```
 
 Generate each boundary at its `rho` from the inverse equation, then apply the shared viewport
-mapping. Use these boundaries to locate radius/feather controls. Initial creation may display outline
-guides; editing an existing Mask shows the necessary handles/connectors without area highlighting
-or filled feather bands.
+mapping. During creation and while an existing Radial is selected, show the base ellipse
+`rho=1` and inner/outer feather boundaries with independent radius and feather handles.
+Coincident lines render once; `inner=0` reduces to the center without invalid geometry.
+Unselected masks do not retain editing guides. No area highlighting or filled feather bands.
 Rotation is stored in radians. It occurs in normalized coordinates; a rotated ellipse on a
 non-square image is not generally reproduced by QML rotation of a screen-space ellipse.
 
@@ -404,8 +417,11 @@ coverage = start_value + (end_value-start_value)*t
 ```
 
 The three mathematical guide loci are `d = -distance/2`, `d = 0`, and `d = +distance/2`.
-During initial creation, these lines may form guides; for an existing Mask use them to position
-finite direction/width controls without filling or highlighting the affected area. Map control points
+During creation and while an existing Gradient is selected, show all three parallel lines
+clipped to the visible photograph, using Geometry crop-style dual strokes and edge grips.
+Do not connect their ends into a diamond/kite or closed polygon. Center line translates,
+boundary grips change width at fixed center, and a separate direction control rotates.
+No coverage fill or crop outside-dimming. Map control points
 through the shared item transform. On a
 non-square image, a normalized normal is not directly a screen normal. Handle hit tests and edits
 must use the same mapping as evaluation.
@@ -513,7 +529,10 @@ Implement Section 2's approved routing, preserving the landed header and six-tab
 The approved temporary body reuses `EditorMasksContextPanel.qml` as the actual Masks editor and
 loads through the adjustment shell; it is not a hidden unused QML module or a separate window.
 
-The list exposes type icon, Mask name, selection, and supported commands. Selected-row controls
+The Node Mask drawer exposes selectable compact type rows and a per-row delete action.
+Selection targets exact NodeId/MaskId and opens the existing source in the temporary Masks body;
+it never calls a header creation action. Delete must not propagate into row or graph actions.
+The Masks-body list exposes type icon, Mask name, selection, and supported commands. Selected-row controls
 edit name, enabled, invert, opacity and source-specific values plus an explicit Brush Move action. Use exact IDs, stable row updates,
 and a panel-level `selectedMaskId` binding. No list rebuild or forced scroll containment on click.
 After deletion select the next row at the old position, otherwise previous, otherwise no selection.
@@ -552,8 +571,10 @@ transitions immediate, and input-following geometry is never animated behind the
 ## 10. Revised ordered implementation phases
 
 本次改变 NM3 source、NM4 history 与 runtime cache，因此先完成数据和重放能力，再开放 viewer。
-下面的 NM7.1–NM7.14 **替代上一版十二阶段拆分**；旧阶段没有本轮 production completion，
-不能把旧的 immutable asset 测试当作新格式验收。保持总体 NM1→NM6→NM7→NM8 顺序。
+保留已完成的 NM7.1–NM7.7，新增 NM7.8 参数蒙版改进；原 NM7.8–NM7.14
+顺延为 NM7.9–NM7.15。原 NM7.11（现 NM7.12）的部分 UI 已为测试提前接线，
+不代表该阶段全部完成。不能把旧的 immutable asset 测试当作新格式验收。
+保持总体 NM1→NM6→NM7→NM8 顺序。
 
 | Phase | Result | Dependency |
 | --- | --- | --- |
@@ -564,13 +585,14 @@ transitions immediate, and input-following geometry is never animated behind the
 | NM7.5 | Shared ReferenceSpace mapping, Brush placement and hit testing | NM7.4 |
 | NM7.6 | QSG control-only retained rendering | NM7.5 |
 | NM7.7 | Radial and Linear creation plus existing-mask movement | NM7.3, NM7.5–NM7.6 |
-| NM7.8 | Accumulating Brush creation, erase, tool settings and movement | NM7.4–NM7.6 |
-| NM7.9 | Serial Interactive replay and one current Grade R8 result | NM7.7–NM7.8 |
-| NM7.10 | Project-owned cache settings, writeback and cleanup service | NM7.3, NM7.9 |
-| NM7.11 | Production Mask controls and project storage UI | NM7.10 |
-| NM7.12 | Interruptions, late jobs and complete lifecycle | NM7.11 |
-| NM7.13 | Native pixel, persistence, cache bounds and recovery qualification | NM7.12 |
-| NM7.14 | Real viewer/package/performance qualification and NM8 handoff | NM7.13 |
+| NM7.8 | Parameter-mask controls, drawer selection/deletion and crop-style Gradient | NM7.7 |
+| NM7.9 | Accumulating Brush creation, erase, tool settings and movement | NM7.4–NM7.6 |
+| NM7.10 | Serial Interactive replay and one current Grade R8 result | NM7.7–NM7.9 |
+| NM7.11 | Project-owned cache settings, writeback and cleanup service | NM7.3, NM7.10 |
+| NM7.12 | Production Mask controls and project storage UI | NM7.11 |
+| NM7.13 | Interruptions, late jobs and complete lifecycle | NM7.12 |
+| NM7.14 | Native pixel, persistence, cache bounds and recovery qualification | NM7.13 |
+| NM7.15 | Real viewer/package/performance qualification and NM8 handoff | NM7.14 |
 
 Each phase records actual files/APIs, success and failure call chains, commands, executed test
 counts and remaining gaps. Branch names describe the result, e.g. `feature/brush-command-replay`
@@ -811,7 +833,7 @@ Suite totals: `219/219` PASS. Date / working tree on `feature/brush-stroke-histo
 
 **LOC note (grill-code-review):** After NM7.3 the batch codec was split NM6P-style (named module APIs, not a method-file split): `pipeline_edit_json.cpp` 453 (nested JSON collection), `pipeline_edit_change_validate.cpp` 353, `pipeline_edit_change_json.cpp` 581 (encode/decode), `pipeline_edit_batch.cpp` 423 (Make, Validate, CanonicalJSON, FromJSON, and projection). Headers: `pipeline_edit_batch.hpp` 464, `pipeline_edit_json.hpp` 88, `pipeline_edit_change.hpp` 56. Inverse/apply remains `pipeline_history_applier.cpp` 797. `pipeline_document_history.cpp` 593, `document_transfer.cpp` 625, `mask_model.cpp` 464, `parameterized_brush_history_persistence_test.cpp` 153, `pipeline_edit_batch_test.cpp` 735.
 
-**Residual gaps:** native Mask evaluation still loads `MaskStore` when in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned. NM7.4 regional replay is not started. Project Mix cache service is NM7.10. `ReplaceMaskAsset` remains in the typed batch surface but cannot validate parameterized or raster-only Brush JSON through the current source gate.
+**Residual gaps:** native Mask evaluation still loads `MaskStore` when in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned. NM7.4 regional replay is not started. Project Mix cache service is NM7.11. `ReplaceMaskAsset` remains in the typed batch surface but cannot validate parameterized or raster-only Brush JSON through the current source gate.
 
 ### NM7.4 — Implement deterministic Brush replay and spatial indexing
 
@@ -888,7 +910,7 @@ Independent oracle: `alcedo_studio/tests/edit/mask/brush_replay_oracle.hpp` (per
 
 **LOC note (grill-code-review):** `brush_source_geometry.hpp` 112 / `.cpp` 206, `brush_canonical_sampler.hpp` 92 / `.cpp` 137, `brush_spatial_index.hpp` 105 / `.cpp` 140, `brush_rasterizer.hpp` 75 / `.cpp` 128, `brush_signed_distance.hpp` 59 / `.cpp` 167, `grade_mask_coverage.hpp` 99 / `.cpp` 253, `brush_replay_oracle.hpp` 190, `brush_regional_replay_test.cpp` 287. No split required.
 
-**Residual gaps:** host Mix is not yet the Interactive/Quality native Mask pass (NM7.9) or the project Mix-cache slot (NM7.10). Shared ReferenceSpace pointer mapping is NM7.5. Native evaluation still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
+**Residual gaps:** host Mix is not yet the Interactive/Quality native Mask pass (NM7.10) or the project Mix-cache slot (NM7.11). Shared ReferenceSpace pointer mapping is NM7.5. Native evaluation still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.5 — Implement shared mapping and parameterized movement
 
@@ -966,7 +988,7 @@ Date / working tree on `feature/mask-reference-mapping` (base `dab6a8e5`) / Wind
 
 **LOC note (grill-code-review):** `mask_edit_geometry.hpp` 183 / `.cpp` 258, `brush_placement.hpp` 79, `mask_edit_geometry_test.cpp` 270, `brush_placement_mapping_test.cpp` 151, `editor_interaction_controller.cpp` 1027. Mapping math lives in `MaskEditGeometry`; the controller only stores displayed photograph geometry and routes. Do not add Mask business rules to the controller. No split required this phase.
 
-**Residual gaps:** QSG controls are NM7.6. Radial/Linear creation and existing-mask movement UI are NM7.7. Accumulating Brush paint/erase UI is NM7.8. Session does not yet publish live `ResolvedRenderGeometry` into `setDisplayedMaskGeometry` (NM7.9). Open-operation cancel on `MappingChanged` is NM7.12. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
+**Residual gaps:** QSG controls are NM7.6. Radial/Linear creation and existing-mask movement UI are NM7.7. Accumulating Brush paint/erase UI is NM7.9. Session does not yet publish live `ResolvedRenderGeometry` into `setDisplayedMaskGeometry` (NM7.10). Open-operation cancel on `MappingChanged` is NM7.13. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.6 — Implement retained QSG controls without affected-area highlighting
 
@@ -1039,7 +1061,7 @@ Date / working tree on `feature/mask-qsg-controls` (base `e01bafdb`) / Windows M
 
 **LOC note (grill-code-review):** `mask_overlay_geometry.hpp` 155 / `.cpp` 287, `mask_overlay_layout.hpp` 101 / `.cpp` 372, `editor_overlay_item.hpp` 165 / `.cpp` 612, `mask_overlay_control_test.cpp` 402. Layout owns evaluator-inverse handle placement; geometry owns triangle tessellation. Overlay item only copies published triangles onto retained nodes. No split required.
 
-**Residual gaps:** NM7.7 Radial/Linear creation and existing-mask movement UI (controller + Interactive pixels). NM7.8 accumulating Brush paint/erase UI. Session does not yet publish live Mask overlay display (still NM7.9). Accessible handle proxies are NM7.11. Offscreen QPA grabs are not a packaged D3D11/Metal desktop capture (NM7.14). Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
+**Residual gaps:** NM7.7 Radial/Linear creation and existing-mask movement UI (controller + Interactive pixels). NM7.9 accumulating Brush paint/erase UI. Session does not yet publish live Mask overlay display (still NM7.10). Accessible handle proxies are NM7.12. Offscreen QPA grabs are not a packaged D3D11/Metal desktop capture (NM7.15). Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.7 — Complete analytic creation and movement
 
@@ -1126,9 +1148,100 @@ EditorAdjustmentHeader beginRadial/beginLinear
   -> InteractiveAdjustment or SettledMaskEdit
 ```
 
-**Residual gaps:** NM7.8 accumulating Brush paint/erase UI. Live `ResolvedRenderGeometry` publication into `setDisplayedMaskGeometry` remains NM7.9. Project Mix-cache slot is NM7.10. Accessible handle proxies and Masks-body list wiring remain NM7.11. Open-operation cancel on `MappingChanged` is NM7.12. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
+**Residual gaps:** NM7.9 accumulating Brush paint/erase UI. Live `ResolvedRenderGeometry` publication into `setDisplayedMaskGeometry` remains NM7.10. Project Mix-cache slot is NM7.11. Radial feather/range presentation, drawer selection/deletion and Gradient restyling are NM7.8; remaining Brush/cache UI and accessibility qualification are NM7.12. Open-operation cancel on `MappingChanged` is NM7.13. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
-### NM7.8 — Complete accumulating Brush creation, erase and movement
+### NM7.8 — Improve parameter-mask controls and existing-mask editing
+
+**Status:** planned. Builds on NM7.7 and the early UI wiring; does not repeat owner-path
+implementation or wait for Brush accumulation and project cache settings.
+
+**Purpose:** make Radial feather/range editable and visible, allow selection/deletion and
+re-editing from the Node Mask drawer, and replace the Gradient kite with Geometry crop-style
+controls in the actual workspace.
+
+**Work / interaction specification:**
+
+1. **Radial feather and range.** Show the selected base ellipse and both feather boundaries
+   from Section 6.2 during creation and later editing, including after release. Provide separate
+   labelled Inner feather and Outer feather sliders/numeric controls plus independently
+   draggable contour handles. Display percentages of the base radius (`100 * stored value`)
+   and enforce the existing source validator limits. Feather changes preserve center, radii
+   and rotation. Distinguish radius and feather handles by position/shape and accessible names;
+   coincident zero-feather controls remain independently reachable through panel/keyboard.
+   Draw coincident contours once and handle a collapsed inner contour without invalid geometry.
+   Range and feather use lines only, with no coverage tint or filled band.
+2. **Node drawer selection.** Every existing Brush/Radial/Gradient row is selectable through
+   stable NodeId/MaskId. Selecting Radial/Gradient loads current fields and viewer handles;
+   later edits update that same MaskId. Selection creates no mask, history or photo render.
+   Bind highlight to session selection and preserve scroll; do not rebuild the list on click.
+   Restore controls on re-entry, session rebind and Undo/Redo using the load-only route. Keep
+   compact type labels and parameter editors in the temporary Masks body. Brush rows support
+   selection/deletion here; new paint/erase controls remain NM7.9.
+3. **Deletion.** Add a compact per-row delete icon with pointer/keyboard access and a clear
+   accessible name. Target the clicked row's exact mask, never its Grade or a reused index.
+   Stop delete-event propagation. Cancel/restore unfinished edits for that target before removal,
+   discard its queued updates and reject delayed results. Use the existing owner and typed
+   `RemoveMaskChange` path for one settled deletion and one history operation. Undo restores
+   source, ID and list position; Redo removes it again. Deleting a selected row chooses next,
+   otherwise previous, otherwise none; deleting another row preserves selection. Undo deletion
+   selects the restored mask only when selection is still empty, otherwise preserves the valid
+   current selection. Deleting the last mask restores full-image Grade coverage, including a
+   disabled last mask. Failed deletion preserves the committed mask and reports the real error.
+   Text-input Delete retains text semantics; Delete with Mask controls focused never deletes
+   the Grade. The cancel/delete boundary belongs here; broader lifecycle work remains NM7.13.
+4. **Gradient design.** Use the three parallel loci from Section 6.3, clipped to the photograph,
+   with Geometry crop overlay's two-layer high-contrast fine lines, short edge grips and
+   hover/active feedback. No kite, diamond, enclosing polygon, or crop dimming. Center line drag
+   translates; boundary grips change transition distance symmetrically around fixed origin;
+   a separate direction/rotation handle rotates. Keep stroke/hit sizes constant in logical px
+   across zoom/DPR. Do not change image crop settings or add another Gradient feather field.
+5. **Owner/input integration.** Pointer, numeric and keyboard controls share the existing
+   begin/update/finish/cancel service and exact target identity. Update actual Interactive pixels
+   before release, then one typed history operation and Quality on settle. Escape restores the
+   original source without a commit. Read/edit through the existing owner without a mirrored
+   editable source. Preserve six tabs and prior-panel restoration. Fix any mapping publication
+   needed for these controls in this phase: cropped/rotated images must use actual resolved
+   geometry, not a guessed identity transform. Remaining serial/cache integration is NM7.10.
+6. **VI.** Follow `alcedo-qml-ui`, reuse shared controls and AppTheme tokens. Update AppTheme
+   and DESIGN together if new values are needed. This revision supersedes the old creation-only
+   guide and read-only drawer restrictions. Keep no-fill coverage policy.
+
+**Files/APIs:** `EditorNodeMaskDrawer.qml`, `EditorNodeMaskTypeRow.qml`,
+`EditorMasksContextPanel.qml`, workspace/adjustment stack, existing creation adapter/controller;
+`EditorOverlayItem`, analytic geometry/hit testing, Grade Mask owner, pending input and typed
+history; AppTheme/DESIGN. Inspect and reuse focused APIs before extending them.
+
+**Primary chains:** drawer select → session selection → load existing source → selected QSG
+controls; handle/numeric edit → queued owner update → Interactive pixels → settle → one typed
+history operation → Quality. Delete → cancel target's unfinished input → owner removal and typed
+history → selection/list/overlay update → rendered remaining coverage.
+
+**Tests:** production QML input, owner/history tests and independent coverage calculations:
+`RadialSelectionShowsEllipseAndBothFeatherBoundaries`,
+`RadialFeatherControlsPreserveCenterRadiiAndRotation`,
+`RadialFeatherDragUpdatesInteractivePixelsBeforeRelease`,
+`CoincidentRadialBoundariesKeepFeatherControlsReachable`,
+`NodeDrawerSelectionLoadsExistingMaskWithoutCreatingOrRendering`,
+`SelectedMaskCanBeEditedAfterWorkspaceReentry`,
+`NodeDrawerDeleteRemovesExactMaskAndUndoRestoresSource`,
+`DeletingLastMaskRestoresFullGradeCoverage`,
+`DeletingUnselectedMaskPreservesSelection`,
+`DeletingMaskRejectsQueuedEditsAndDelayedFrames`,
+`MaskDeleteWithViewerFocusDoesNotDeleteGrade`,
+`GradientGuidesUseThreeParallelLinesWithoutClosedPolygon`,
+`GradientBoundaryDragPreservesOriginAndChangesTransition`,
+`AnalyticControlCancelRestoresSourceWithoutHistory`.
+
+**Exit:** actual workspace create → release → select another row → reselect → edit → Undo/Redo
+→ delete works with multiple Radial/Gradient masks on two Grades. Existing Brush rows can be
+selected/deleted without adding a Brush. Verify 260/320/460 px in both themes, non-square and
+cropped/rotated images, zoom/pan and DPR 1/1.25/1.5/2. Captures show selected radial range/feather
+lines and crop-style Gradient grips without coverage fill. Independent Section 6 formulas match
+sampled coverage within 1 R8 code. Prove exact history counts, stable IDs/scroll and actual photo
+updates before release; control redraw alone does not pass. Record the executed native backend
+and any remaining platform qualification explicitly.
+
+### NM7.9 — Complete accumulating Brush creation, erase and movement
 
 **Purpose:** multiple strokes remain editable data in one Brush, with one current Grade raster.
 
@@ -1147,7 +1260,7 @@ release → corresponding single typed command → Quality.
 
 **Exit:** paint/erase/move/Undo/Redo work after deleting caches, with stable MaskId and StrokeIds.
 
-### NM7.9 — Integrate serial Interactive evaluation and one current Grade R8
+### NM7.10 — Integrate serial Interactive evaluation and one current Grade R8
 
 **Purpose:** connect all provisional movement to real pixels while respecting NM6 reader ownership.
 
@@ -1169,7 +1282,7 @@ presentation → next consume. Release seals → durable command → Quality.
 
 **Exit:** actual end-to-end native request path works; a control redraw alone does not pass.
 
-### NM7.10 — Add project-owned cache storage and maintenance
+### NM7.11 — Add project-owned cache storage and maintenance
 
 **Purpose:** bounded, disposable R8 storage controlled per project.
 
@@ -1192,12 +1305,16 @@ Clear → maintenance boundary → stop old writer → delete only owned cache �
 
 **Exit:** new cache namespace can be completely removed without losing any supported edit/Version.
 
-### NM7.11 — Wire Mask editing and project cache UI
+### NM7.12 — Wire Mask editing and project cache UI
 
 **Purpose:** make the fully working capability reachable through approved surfaces.
 
-**Work:** connect header tools/node Mask rows to temporary Masks body; preserve six tabs and prior
-panel restoration; expose paint/erase/size/strength/Move and existing source/Mask values. Add project
+**Already brought forward:** Radial/Gradient header, viewport and session test wiring after
+NM7.7; NM7.8 owns analytic controls and drawer selection/deletion. Retain and verify those paths.
+The complete UI phase remains planned until its remaining work and acceptance pass.
+
+**Work:** finish Brush header/body routing; preserve six tabs and prior panel restoration;
+expose paint/erase/size/strength/Move and remaining source/Mask values. Add project
 cache section through app APIs with root chooser, policy and per-project usage/Clear. Existing
 cache settings are thumbnail-specific; keep the new project fields separate. Add keyboard/accessible
 controls, focus rules, theme/width/reduced-motion tests and QML registration.
@@ -1212,7 +1329,7 @@ controls, focus rules, theme/width/reduced-motion tests and QML registration.
 
 **Exit:** production QML at 260/320/460 px in both themes; no unregistered/unused-only implementation.
 
-### NM7.12 — Complete cancellation and project/session lifecycle
+### NM7.13 — Complete cancellation and project/session lifecycle
 
 **Purpose:** preserve state when operations terminate without a normal release.
 
@@ -1234,7 +1351,7 @@ operation → stale result rejection / old writer retirement.
 
 **Exit:** delayed native completion, write jobs and genuine Qt input all obey the same outcome.
 
-### NM7.13 — Qualify native pixels, bounded disk storage and recovery
+### NM7.14 — Qualify native pixels, bounded disk storage and recovery
 
 **Purpose:** verify source, command replay and disposable cache as one product path.
 
@@ -1253,7 +1370,7 @@ coverage → expected pixels independent of any previous cache.
 
 **Exit:** registered tests execute nonzero counts; actual file count/bytes and error cases recorded.
 
-### NM7.14 — Qualify real viewer, packages and performance
+### NM7.15 — Qualify real viewer, packages and performance
 
 **Purpose:** measure the requested Interactive editing and ensure it ships in installed builds.
 
@@ -1284,6 +1401,7 @@ helpers to generate both sides of a comparison.
 | Brush pixels | multiple strokes on one MaskId, size/strength changes, click, sparse/dense events, overlaps, duplicates, hard/soft edge, erase, zero changes | Exact R8 bytes for deterministic raster output; different event grouping gives same bytes |
 | Native runtime | CUDA/OpenCL/Metal, one/many Masks, two Grades, invert/opacity/feather, current-cache/fresh-replay | Existing NM3 numerical tolerances; record backend and runtime actually used |
 | Overlay | finite vertices, winding, clipping, alpha seams, constant handle widths, next available Qt frame | Geometry assertions plus accelerated window captures; contour deviation ≤ 0.25 logical px |
+| Parameter-mask UI | selected Radial range/feather lines; crop-style Gradient guides; drawer select/re-edit/delete | NM7.8 production QML input, IDs/history, before-release pixels and captures; no fill |
 | Movement | existing Brush/Radial/Gradient; old/new domains; repeated translation; press/move/release | Interactive pixels update before release; controls only, no coverage fill; one final commit |
 | Project cache | custom root, Clear, close cleanup, two projects, repeated Versions | Stable file count; delete-all-cache restores same history/coverage; no cross-project deletion |
 | Input | press under threshold, outside release, canceled grab, synthesized mouse, second touch, repeated Done | One source stream and exactly one terminal outcome; no duplicate commit |

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
@@ -1083,7 +1083,9 @@ Each row shows only the approved source-type icon and localized type label:
 | `MaskSourceKind::Radial` | `Radial` | `mask_icons/radial.svg` |
 | `MaskSourceKind::Brush` | `Brush` | `mask_icons/brush.svg` |
 
-Do not show Mask name, opacity, enabled state, invert state, ranges, identity, selection, or actions.
+Do not show Mask name, opacity, enabled state, invert state, ranges, or identity in compact rows.
+The NM7.8 revision requires stable-ID selection and a compact per-row delete action, with
+parameter controls in the temporary Masks body. It supersedes the earlier read-only row rule.
 An empty open drawer has no Mask rows.
 
 Drawer state is local UI layout state. A fold creates no history and no render. The output port and
@@ -1933,8 +1935,15 @@ current-result storage. Runtime/platform evidence is required; this design appro
 ### 21.8 Phase NM7 — Viewer Mask Creation
 
 2026-09-08 revision: NM7.2–NM7.4 extend the historical NM3/NM4 source/history interfaces before
-viewer integration; NM7.9–NM7.10 replace per-source/history raster retention with current project
+viewer integration; NM7.10–NM7.11 replace per-source/history raster retention with current project
 coverage cache. Historical NM3/NM4 asset tests do not qualify the new parameter format.
+
+Parameter-mask revision: NM7.1–NM7.7 remain complete. Some former NM7.11 UI wiring was
+brought forward for Radial/Gradient testing. New NM7.8 adds Radial feather controls and selected
+range contours, Node drawer selection/deletion and re-editing, and Gradient controls styled after
+Geometry crop lines/grips. Selected analytic guide lines are required; coverage fill remains
+prohibited. Former NM7.8–NM7.14 shift to NM7.9–NM7.15; remaining full UI is NM7.12.
+Follow the detailed phase for interaction and acceptance requirements.
 
 
 **Reason for this position:** Viewer creation needs the selected-node context, multi-Mask runtime,


### PR DESCRIPTION
## Summary

- Add `EditorMaskCreationController` to own Radial and Linear Gradient mask creation, existing-mask handle movement, and settle/cancel semantics on the document-owning thread.
- Add `analytic_mask_edit` helpers for center-out creation, handle updates (center/origin, radii, rotation with π unwrap, feather, linear direction/boundaries), and creation validity checks.
- During drag, write provisional mask sources through the Grade owner and trigger Interactive Mix preview; publish a single `AddMask` or `ReplaceMaskSource` history commit on release when the edit is valid and changed.
- Cancel restores the captured before-state with no history commit; degenerate zero-area creation inserts no mask and commits nothing.
- Wire `EditorMaskCreationController` into the app CMake graph; mark NM7.7 complete in the phase plan.

## Testing

- `AnalyticMaskEditTest` — radial center-out radii, linear endpoint origin/normal/width, and rotation unwrap across π.
- `AnalyticMaskCreationTest` — existing radial/linear moves update Interactive Mix before release and commit once on finish; radial feather handles match independent evaluator coverage.
- `AnalyticMaskCreationTest` — degenerate analytic creation leaves mask count and working head unchanged.
- `AnalyticMaskCreationTest` — cancel restores analytic source and Mix pixels without a history commit.
- `AnalyticMaskCreationTest` — valid radial creation commits once, requests quality, and keeps control-only overlay geometry (no coverage fill).
- Manual UI verification: Not run.