### PR TITLE
feat(editor): add parameter mask controls and selection overlay

### DIFF
--- a/alcedo_studio/src/app/editor_mask_creation_controller.cpp
+++ b/alcedo_studio/src/app/editor_mask_creation_controller.cpp
@@ -13,6 +13,9 @@
 #include "app/pipeline_document_history.hpp"
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/i_node_model.hpp"
+#include "edit/mask/mask_list_selection.hpp"
+
+#include <vector>
 
 namespace alcedo {
 namespace {
@@ -322,8 +325,9 @@ auto EditorMaskCreationController::SelectMask(const NodeId& grade_id, const Mask
     return Reject("Mask is missing");
   }
   const auto kind = GetMaskSourceKind(mask->source);
-  if (kind != MaskSourceKind::Radial && kind != MaskSourceKind::LinearGradient) {
-    return Reject("analytic movement supports Radial and Linear Gradient");
+  if (kind != MaskSourceKind::Brush && kind != MaskSourceKind::Radial &&
+      kind != MaskSourceKind::LinearGradient) {
+    return Reject("Mask source kind is not selectable");
   }
   kind_          = kind;
   session_       = session;
@@ -337,6 +341,84 @@ auto EditorMaskCreationController::SelectMask(const NodeId& grade_id, const Mask
   state_         = EditorMaskCreationState::Selected;
   auto result    = Ok();
   result.mask_id = mask_id_;
+  return result;
+}
+
+auto EditorMaskCreationController::RemoveMask(const NodeId& grade_id, const MaskId& mask_id)
+    -> EditorMaskCreationResult {
+  if (document_ == nullptr || history_ == nullptr) {
+    return Reject("Mask creation controller is not bound to a document");
+  }
+  if (grade_id.Empty() || mask_id.Empty()) {
+    return Reject("RemoveMask requires a Color Grade and Mask identity");
+  }
+  if (open_ && mask_id_ == mask_id) {
+    if (inserted_ && creating_) {
+      return CancelMaskInput();
+    }
+    const auto cancelled = CancelMaskInput();
+    if (!cancelled.accepted) {
+      return cancelled;
+    }
+  }
+  node_id_    = grade_id;
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    node_id_ = NodeId{};
+    return Reject("removal target is not a Color Grade");
+  }
+  std::vector<MaskId> ordered;
+  ordered.reserve(grade->MaskCount());
+  std::optional<std::uint32_t> index;
+  for (std::size_t i = 0; i < grade->MaskCount(); ++i) {
+    const auto& mask = grade->MaskAt(i);
+    ordered.push_back(mask.id);
+    if (mask.id == mask_id) {
+      index = static_cast<std::uint32_t>(i);
+    }
+  }
+  if (!index.has_value()) {
+    return Reject("Mask is missing");
+  }
+  const auto next_selection = MaskIdAfterDeletion(ordered, mask_id, mask_id_);
+  const auto stored        = MaskModelToJson(grade->MaskAt(*index));
+  const auto batch         = MakeRemoveMaskBatch(grade_id, mask_id, stored, *index);
+  try {
+    grade->RemoveMask(mask_id);
+  } catch (const std::exception& ex) {
+    return Reject(ex.what());
+  }
+  std::string settle_error;
+  if (!PublishSettledBatch(batch, &settle_error)) {
+    try {
+      grade->AddMask(MaskModelFromJson(stored), *index);
+    } catch (const std::exception&) {
+    }
+    return Reject(settle_error.empty() ? std::string{"RemoveMask history publish failed"}
+                                        : settle_error);
+  }
+  last_removed_mask_id_ = mask_id;
+  if (next_selection.Empty()) {
+    mask_id_       = MaskId{};
+    draft_source_.reset();
+    before_source_ = nullptr;
+    creating_      = false;
+    handle_        = AnalyticMaskHandle::None;
+    state_         = EditorMaskCreationState::Inactive;
+  } else if (next_selection != mask_id_) {
+    const auto loaded = SelectMask(grade_id, next_selection, session_);
+    if (!loaded.accepted) {
+      mask_id_       = MaskId{};
+      draft_source_.reset();
+      before_source_ = nullptr;
+      state_         = EditorMaskCreationState::Inactive;
+    }
+  }
+  auto result              = Ok();
+  result.mask_id           = mask_id_;
+  result.committed         = true;
+  result.quality_requested = true;
+  RequestInteractive(result);
   return result;
 }
 

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1150,7 +1150,8 @@ namespace {
 [[nodiscard]] auto MaskCommandIsTerminal(EditorMaskCreationCommandKind kind) -> bool {
   return kind == EditorMaskCreationCommandKind::Finish ||
          kind == EditorMaskCreationCommandKind::Cancel ||
-         kind == EditorMaskCreationCommandKind::CancelMode;
+         kind == EditorMaskCreationCommandKind::CancelMode ||
+         kind == EditorMaskCreationCommandKind::RemoveMask;
 }
 
 }  // namespace
@@ -1165,6 +1166,20 @@ auto EditorSessionService::EnqueueMaskCreation(EditorMaskCreationCommand command
   }
   {
     std::scoped_lock lock(mask_command_mutex_);
+    if (command.kind == EditorMaskCreationCommandKind::RemoveMask && !command.mask_id.Empty()) {
+      pending_mask_commands_.erase(
+          std::remove_if(pending_mask_commands_.begin(), pending_mask_commands_.end(),
+                           [&command](const EditorMaskCreationCommand& pending) {
+                             if (pending.mask_id != command.mask_id) {
+                               return false;
+                             }
+                             return pending.kind == EditorMaskCreationCommandKind::Append ||
+                                    pending.kind == EditorMaskCreationCommandKind::BeginMove ||
+                                    pending.kind == EditorMaskCreationCommandKind::Finish ||
+                                    pending.kind == EditorMaskCreationCommandKind::BeginInput;
+                           }),
+          pending_mask_commands_.end());
+    }
     if (command.kind == EditorMaskCreationCommandKind::Append && !pending_mask_commands_.empty()) {
       auto& back = pending_mask_commands_.back();
       if (back.kind == EditorMaskCreationCommandKind::Append &&
@@ -1248,6 +1263,8 @@ auto EditorSessionService::ApplyMaskCreationCommand(const EditorMaskCreationComm
       return mask_creation_.CancelMaskInput();
     case EditorMaskCreationCommandKind::CancelMode:
       return mask_creation_.CancelCreationMode();
+    case EditorMaskCreationCommandKind::RemoveMask:
+      return mask_creation_.RemoveMask(command.node_id, command.mask_id);
   }
   EditorMaskCreationResult rejected;
   rejected.error = "unknown Mask creation command";

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -64,9 +64,8 @@ EditorSessionService::EditorSessionService(Dependencies dependencies)
       navigation_(lifecycle_, save_service_, render_, dependencies_.journal.get(),
                   dependencies_.checkpoint_store.get(), dependencies_.history.get(),
                   &navigation_state_) {
-  navigation_.SetOwnerPoster([this](std::function<void()> task) {
-    command_queue_.PostCompletion(std::move(task));
-  });
+  navigation_.SetOwnerPoster(
+      [this](std::function<void()> task) { command_queue_.PostCompletion(std::move(task)); });
   navigation_.SetCompletionNotifier([this](const NavigationCompletion& completion) {
     EditorSessionCompletion posted;
     posted.kind                 = EditorSessionCompletionKind::NavigationFinished;
@@ -120,8 +119,8 @@ auto EditorSessionService::SubmitCommand(EditorSessionCommand command, CommandRe
             rejected.operation_id = queued.operation.command_id;
             rejected.state        = lifecycle_.state();
             rejected.identity     = lifecycle_.identity();
-            rejected.message      = decision.reason.empty() ? "Editor command rejected by policy"
-                                                            : decision.reason;
+            rejected.message =
+                decision.reason.empty() ? "Editor command rejected by policy" : decision.reason;
             *reduced_result = Emit(std::move(rejected));
             EndPublication();
             reducing_command_     = previous_reducing;
@@ -491,9 +490,9 @@ auto EditorSessionService::Open(sl_element_id_t element_id, image_id_t image_id)
 auto EditorSessionService::CheckoutVersion(const version_ref_id_t& version_id)
     -> EditorSessionResult {
   if (!reducing_command_) {
-    if (auto deferred = DeferIfLiveOwnershipHeld(
-            [this, version_id] { return CheckoutVersion(version_id); },
-            "Checkout queued behind in-flight frame")) {
+    if (auto deferred =
+            DeferIfLiveOwnershipHeld([this, version_id] { return CheckoutVersion(version_id); },
+                                     "Checkout queued behind in-flight frame")) {
       return *deferred;
     }
     EditorSessionCommand command;
@@ -523,7 +522,7 @@ auto EditorSessionService::active_version_id() const -> version_ref_id_t {
   std::string      error;
   version_ref_id_t version_id;
   if (!dependencies_.history->ReadActiveVersionId(lifecycle_.history_guard(), &version_id,
-                                                   &error)) {
+                                                  &error)) {
     return {};
   }
   return version_id;
@@ -542,9 +541,9 @@ auto EditorSessionService::adjustment_snapshot() const -> EditorRenderAdjustment
   }
   EditorRenderAdjustmentSnapshot snapshot;
   std::string                    error;
-  auto& history = *dependencies_.history;
-  if (!const_cast<IEditorHistoryPort&>(history).ReadAdjustmentSnapshot(
-          lifecycle_.history_guard(), &snapshot, &error)) {
+  auto&                          history = *dependencies_.history;
+  if (!const_cast<IEditorHistoryPort&>(history).ReadAdjustmentSnapshot(lifecycle_.history_guard(),
+                                                                       &snapshot, &error)) {
     return {};
   }
   return snapshot;
@@ -557,8 +556,8 @@ auto EditorSessionService::panel_projection() const -> EditorPanelProjection {
   EditorPanelProjection projection;
   std::string           error;
   auto&                 history = *dependencies_.history;
-  if (!const_cast<IEditorHistoryPort&>(history).ReadPanelProjection(
-          lifecycle_.history_guard(), &projection, &error)) {
+  if (!const_cast<IEditorHistoryPort&>(history).ReadPanelProjection(lifecycle_.history_guard(),
+                                                                    &projection, &error)) {
     return {};
   }
   projection.session_generation = lifecycle_.active_image_load_request().value;
@@ -693,9 +692,9 @@ auto EditorSessionService::PasteAdjustments(const AdjustmentTransferPackage& pac
   }
   AdjustmentPasteResult paste_result;
   std::string           error;
-  if (!dependencies_.history->PasteLiveRootRelativeVersion(
-          lifecycle_.history_guard(), package, std::move(version_display_name), &paste_result,
-          &error)) {
+  if (!dependencies_.history->PasteLiveRootRelativeVersion(lifecycle_.history_guard(), package,
+                                                           std::move(version_display_name),
+                                                           &paste_result, &error)) {
     return Reject(error.empty() ? "Editor Paste failed" : std::move(error));
   }
 
@@ -710,7 +709,6 @@ auto EditorSessionService::PasteAdjustments(const AdjustmentTransferPackage& pac
   }
   return started;
 }
-
 
 auto EditorSessionService::StartHistoryCheckpoint(std::string success_message, bool route_render)
     -> EditorSessionResult {
@@ -734,9 +732,8 @@ auto EditorSessionService::StartHistoryCheckpointSave() -> EditorSessionResult {
   const auto identity = lifecycle_.identity();
   if (dependencies_.journal) {
     std::string finalize_error;
-    if (!dependencies_.journal->FinalizeEdit(identity.element_id,
-                                             lifecycle_.active_image_load_request().value,
-                                             &finalize_error)) {
+    if (!dependencies_.journal->FinalizeEdit(
+            identity.element_id, lifecycle_.active_image_load_request().value, &finalize_error)) {
       return Reject(finalize_error.empty() ? "Editor command could not be finalized"
                                            : std::move(finalize_error));
     }
@@ -754,10 +751,10 @@ auto EditorSessionService::StartHistoryCheckpointSave() -> EditorSessionResult {
   }
 
   SaveCheckpointRequest request;
-  request.element_id         = identity.element_id;
-  request.operation_id       = current_operation_id_;
+  request.element_id            = identity.element_id;
+  request.operation_id          = current_operation_id_;
   request.image_load_request_id = lifecycle_.active_image_load_request();
-  request.capture            = std::move(capture);
+  request.capture               = std::move(capture);
   if (request.capture->has_journal_range()) {
     request.last_journal_sequence = request.capture->last_journal_sequence;
   }
@@ -889,8 +886,8 @@ void EditorSessionService::HandleSaveCheckpointCompletion(
   published.task_id  = completion.task_id;
   if (marker.route_render) {
     EditorRenderCommand command;
-    command.reason =
-        dependencies_.history->LastPublishedRenderReason().value_or(EditorRenderReason::InitialFrame);
+    command.reason = dependencies_.history->LastPublishedRenderReason().value_or(
+        EditorRenderReason::InitialFrame);
     command.operation_id = current_operation_id_;
     render_.RouteInitialRender(command, lifecycle_.identity(),
                                lifecycle_.active_image_load_request());
@@ -1105,8 +1102,7 @@ auto EditorSessionService::EnqueueAdjustmentInput(EditorAdjustmentPatch patch)
   const auto identity = lifecycle_.identity();
   const auto admitted = pending_input_.AdmitFieldChange(identity, patch);
   if (!admitted.accepted) {
-    return Reject(admitted.error.empty() ? "Queued adjustment input was rejected"
-                                         : admitted.error);
+    return Reject(admitted.error.empty() ? "Queued adjustment input was rejected" : admitted.error);
   }
   RequestPendingInputConsume();
   EditorSessionResult result;
@@ -1150,6 +1146,7 @@ namespace {
 [[nodiscard]] auto MaskCommandIsTerminal(EditorMaskCreationCommandKind kind) -> bool {
   return kind == EditorMaskCreationCommandKind::Finish ||
          kind == EditorMaskCreationCommandKind::Cancel ||
+         kind == EditorMaskCreationCommandKind::FinishMode ||
          kind == EditorMaskCreationCommandKind::CancelMode ||
          kind == EditorMaskCreationCommandKind::RemoveMask;
 }
@@ -1169,15 +1166,16 @@ auto EditorSessionService::EnqueueMaskCreation(EditorMaskCreationCommand command
     if (command.kind == EditorMaskCreationCommandKind::RemoveMask && !command.mask_id.Empty()) {
       pending_mask_commands_.erase(
           std::remove_if(pending_mask_commands_.begin(), pending_mask_commands_.end(),
-                           [&command](const EditorMaskCreationCommand& pending) {
-                             if (pending.mask_id != command.mask_id) {
-                               return false;
-                             }
-                             return pending.kind == EditorMaskCreationCommandKind::Append ||
-                                    pending.kind == EditorMaskCreationCommandKind::BeginMove ||
-                                    pending.kind == EditorMaskCreationCommandKind::Finish ||
-                                    pending.kind == EditorMaskCreationCommandKind::BeginInput;
-                           }),
+                         [&command](const EditorMaskCreationCommand& pending) {
+                           if (pending.mask_id != command.mask_id) {
+                             return false;
+                           }
+                           return pending.kind == EditorMaskCreationCommandKind::Append ||
+                                  pending.kind == EditorMaskCreationCommandKind::BeginMove ||
+                                  pending.kind == EditorMaskCreationCommandKind::Finish ||
+                                  pending.kind == EditorMaskCreationCommandKind::FinishMode ||
+                                  pending.kind == EditorMaskCreationCommandKind::BeginInput;
+                         }),
           pending_mask_commands_.end());
     }
     if (command.kind == EditorMaskCreationCommandKind::Append && !pending_mask_commands_.empty()) {
@@ -1228,7 +1226,7 @@ void EditorSessionService::AbortMaskCreation() {
     return;
   }
   std::string error;
-  const auto guard = lifecycle_.history_guard();
+  const auto  guard = lifecycle_.history_guard();
   (void)dependencies_.history->WithLockedLiveDocument(
       guard,
       [this](PipelineDocument& document, MiniGitWorkingHistory& history,
@@ -1261,6 +1259,8 @@ auto EditorSessionService::ApplyMaskCreationCommand(const EditorMaskCreationComm
       return mask_creation_.FinishMaskInput();
     case EditorMaskCreationCommandKind::Cancel:
       return mask_creation_.CancelMaskInput();
+    case EditorMaskCreationCommandKind::FinishMode:
+      return mask_creation_.FinishCreationMode();
     case EditorMaskCreationCommandKind::CancelMode:
       return mask_creation_.CancelCreationMode();
     case EditorMaskCreationCommandKind::RemoveMask:
@@ -1285,13 +1285,12 @@ auto EditorSessionService::RouteMaskCreationRender(bool interactive_preview, boo
     return result;
   }
   EditorRenderCommand render_command;
-  render_command.reason                    = quality_requested ? EditorRenderReason::SettledMaskEdit
-                                                               : EditorRenderReason::InteractiveAdjustment;
-  render_command.live_parameters_applied   = true;
-  render_command.operation_id              = current_operation_id_;
-  const auto request_id =
-      render_.RouteInitialRender(render_command, lifecycle_.identity(),
-                                 lifecycle_.active_image_load_request());
+  render_command.reason                  = quality_requested ? EditorRenderReason::SettledMaskEdit
+                                                             : EditorRenderReason::InteractiveAdjustment;
+  render_command.live_parameters_applied = true;
+  render_command.operation_id            = current_operation_id_;
+  const auto request_id = render_.RouteInitialRender(render_command, lifecycle_.identity(),
+                                                     lifecycle_.active_image_load_request());
   if (request_id == 0) {
     serial_admission_.AbortCycle();
   } else {
@@ -1305,8 +1304,8 @@ auto EditorSessionService::RouteMaskCreationRender(bool interactive_preview, boo
   result.state             = lifecycle_.state();
   result.identity          = lifecycle_.identity();
   result.render_request_id = request_id;
-  result.message           = quality_requested ? "Settled Mask render routed"
-                                               : "Interactive Mask render routed";
+  result.message =
+      quality_requested ? "Settled Mask render routed" : "Interactive Mask render routed";
   return result;
 }
 
@@ -1337,11 +1336,11 @@ void EditorSessionService::ConsumePendingMaskCommands() {
     serial_admission_.AbortCycle();
     return;
   }
-  bool interactive_preview = false;
-  bool quality_requested   = false;
-  bool committed           = false;
+  bool        interactive_preview = false;
+  bool        quality_requested   = false;
+  bool        committed           = false;
   std::string error;
-  const auto applied = dependencies_.history->WithLockedLiveDocument(
+  const auto  applied = dependencies_.history->WithLockedLiveDocument(
       lifecycle_.history_guard(),
       [this, &batch, &interactive_preview, &quality_requested, &committed](
           PipelineDocument& document, MiniGitWorkingHistory& history,
@@ -1353,8 +1352,8 @@ void EditorSessionService::ConsumePendingMaskCommands() {
           auto result = ApplyMaskCreationCommand(command);
           if (!result.accepted) {
             if (op_error != nullptr) {
-              *op_error = result.error.empty() ? "Mask creation command was rejected"
-                                               : result.error;
+              *op_error =
+                  result.error.empty() ? "Mask creation command was rejected" : result.error;
             }
             if (mask_creation_.HasOpenOperation()) {
               (void)mask_creation_.CancelMaskInput();
@@ -1367,7 +1366,7 @@ void EditorSessionService::ConsumePendingMaskCommands() {
           if (command.kind == EditorMaskCreationCommandKind::Finish && result.committed &&
               !result.mask_id.Empty()) {
             (void)mask_creation_.SelectMask(mask_creation_.node_id(), result.mask_id,
-                                            lifecycle_.identity());
+                                             lifecycle_.identity());
           }
         }
         return true;
@@ -1438,8 +1437,7 @@ void EditorSessionService::TryConsumePendingInput() {
   if (peek.sequences.empty()) {
     return;
   }
-  const bool interactive =
-      peek.sequences.front().seal == EditorPendingInputBoundaryKind::None;
+  const bool interactive = peek.sequences.front().seal == EditorPendingInputBoundaryKind::None;
   if (!serial_admission_.TryBeginCycle(interactive)) {
     return;
   }
@@ -1459,8 +1457,8 @@ void EditorSessionService::TryConsumePendingInput() {
 
 auto EditorSessionService::ConsumeTakenSequence(const EditorPendingSequence& sequence)
     -> EditorSessionResult {
-  const auto guard = lifecycle_.history_guard();
-  const auto ident = lifecycle_.identity();
+  const auto guard   = lifecycle_.history_guard();
+  const auto ident   = lifecycle_.identity();
   auto       outcome = edit_.HandlePendingSequence(sequence, guard, ident);
   if (outcome.kind == EditorEditOutcome::Kind::Rejected ||
       outcome.kind == EditorEditOutcome::Kind::Failed) {
@@ -1534,7 +1532,7 @@ void EditorSessionService::FinishSerialFrameIfNeeded(const EditorRenderResult& r
 }
 
 auto EditorSessionService::DeferIfLiveOwnershipHeld(std::function<EditorSessionResult()> retry,
-                                                    std::string message)
+                                                    std::string                          message)
     -> std::optional<EditorSessionResult> {
   if (!serial_admission_.HoldsOwnership() || !retry) {
     return std::nullopt;
@@ -1628,7 +1626,7 @@ auto EditorSessionService::CommitAdjustment(std::string patch_key) -> EditorSess
 auto EditorSessionService::Undo() -> EditorSessionResult {
   if (!reducing_command_) {
     if (auto deferred = DeferIfLiveOwnershipHeld([this] { return Undo(); },
-                                                "Undo queued behind in-flight frame")) {
+                                                 "Undo queued behind in-flight frame")) {
       return *deferred;
     }
     EditorSessionCommand command;
@@ -1667,7 +1665,7 @@ auto EditorSessionService::Undo() -> EditorSessionResult {
 auto EditorSessionService::Redo() -> EditorSessionResult {
   if (!reducing_command_) {
     if (auto deferred = DeferIfLiveOwnershipHeld([this] { return Redo(); },
-                                                "Redo queued behind in-flight frame")) {
+                                                 "Redo queued behind in-flight frame")) {
       return *deferred;
     }
     EditorSessionCommand command;
@@ -1922,14 +1920,13 @@ auto EditorSessionService::RequestViewChange(EditorRenderReason                 
     });
   }
   EditorRenderCommand command;
-  command.operation_id = current_operation_id_;
-  command.reason       = reason;
-  command.view_region  = std::move(region);
-  const auto view_identity  = lifecycle_.identity();
-  const auto view_state     = lifecycle_.state();
-  const auto load_request   = lifecycle_.active_image_load_request();
-  const auto event =
-      render_.RouteViewChange(command, view_identity, load_request, view_state);
+  command.operation_id     = current_operation_id_;
+  command.reason           = reason;
+  command.view_region      = std::move(region);
+  const auto view_identity = lifecycle_.identity();
+  const auto view_state    = lifecycle_.state();
+  const auto load_request  = lifecycle_.active_image_load_request();
+  const auto event = render_.RouteViewChange(command, view_identity, load_request, view_state);
   EditorSessionResult result;
   result.state    = event.state;
   result.identity = event.identity;
@@ -2000,28 +1997,26 @@ void EditorSessionService::SetBackgroundActionRestrictions(
 
 auto EditorSessionService::BuildActionInputs() -> EditorActionInputs {
   EditorActionInputs inputs;
-  inputs.session_state = lifecycle_.state();
-  inputs.has_image     = lifecycle_.has_image();
-  inputs.package_available = package_available_;
-  inputs.background_blocks_select_image = background_restrictions_.blocks_select_image;
-  inputs.background_blocks_paste        = background_restrictions_.blocks_paste;
-  inputs.background_blocks_checkout     = background_restrictions_.blocks_checkout;
-  inputs.background_blocks_workspace    = background_restrictions_.blocks_workspace;
+  inputs.session_state                   = lifecycle_.state();
+  inputs.has_image                       = lifecycle_.has_image();
+  inputs.package_available               = package_available_;
+  inputs.background_blocks_select_image  = background_restrictions_.blocks_select_image;
+  inputs.background_blocks_paste         = background_restrictions_.blocks_paste;
+  inputs.background_blocks_checkout      = background_restrictions_.blocks_checkout;
+  inputs.background_blocks_workspace     = background_restrictions_.blocks_workspace;
   // A second selection may queue/replace while a switch save or acquire is
   // already in flight (CQ1 pending_next_target). Allow SelectImage as soon as
   // navigation owns a pending action, not only after a target was queued.
-  inputs.can_replace_unstarted_selection =
-      navigation_state_.pending_action.has_value() ||
-      navigation_state_.pending_next_target.has_value();
-  inputs.recovery_allows_retry =
-      navigation_.has_pending_recovery() &&
-      lifecycle_.state() == EditorSessionState::RetainedImageFailure;
+  inputs.can_replace_unstarted_selection = navigation_state_.pending_action.has_value() ||
+                                           navigation_state_.pending_next_target.has_value();
+  inputs.recovery_allows_retry = navigation_.has_pending_recovery() &&
+                                 lifecycle_.state() == EditorSessionState::RetainedImageFailure;
   inputs.recovery_allows_discard_continue = inputs.recovery_allows_retry;
   inputs.recovery_allows_cancel           = inputs.recovery_allows_retry;
 
   if (dependencies_.history && lifecycle_.has_history_guard()) {
-    std::string error;
-  EditorHistorySnapshot snapshot;
+    std::string           error;
+    EditorHistorySnapshot snapshot;
     if (dependencies_.history->ReadHistorySnapshot(lifecycle_.history_guard(), &snapshot, &error)) {
       inputs.can_undo = snapshot.can_undo;
       inputs.can_redo = snapshot.can_redo;
@@ -2046,7 +2041,7 @@ void EditorSessionService::PublishActionAvailabilityIfChanged() {
 void EditorSessionService::AcquireLease(EditorOperationLeaseKind kind, std::uint64_t command_id,
                                         sl_element_id_t element_id, image_id_t image_id,
                                         ImageLoadRequestId image_load_request,
-                                        std::string blocking_reason) {
+                                        std::string        blocking_reason) {
   EditorOperationLease lease;
   lease.operation.command_id = command_id;
   lease.kind                 = kind;
@@ -2068,14 +2063,13 @@ void EditorSessionService::ReleaseLeaseByCommandId(std::uint64_t command_id) {
 }
 
 void EditorSessionService::ReleaseLeasesByKind(EditorOperationLeaseKind kind) {
-  std::erase_if(active_leases_, [kind](const EditorOperationLease& lease) {
-    return lease.kind == kind;
-  });
+  std::erase_if(active_leases_,
+                [kind](const EditorOperationLease& lease) { return lease.kind == kind; });
 }
 
-void EditorSessionService::SetPendingPresentationTarget(sl_element_id_t element_id,
-                                                      image_id_t       image_id,
-                                                      ImageLoadRequestId image_load_request) {
+void EditorSessionService::SetPendingPresentationTarget(sl_element_id_t    element_id,
+                                                        image_id_t         image_id,
+                                                        ImageLoadRequestId image_load_request) {
   pending_presentation_target_ =
       EditorPendingPresentationTarget{element_id, image_id, image_load_request};
 }

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1163,6 +1163,21 @@ auto EditorSessionService::EnqueueMaskCreation(EditorMaskCreationCommand command
   }
   {
     std::scoped_lock lock(mask_command_mutex_);
+    if (command.kind == EditorMaskCreationCommandKind::CancelMode && command.mask_id.Empty()) {
+      pending_mask_commands_.erase(
+          std::remove_if(pending_mask_commands_.begin(), pending_mask_commands_.end(),
+                         [&command](const EditorMaskCreationCommand& pending) {
+                           if (pending.node_id != command.node_id) {
+                             return false;
+                           }
+                           return pending.kind == EditorMaskCreationCommandKind::BeginCreation ||
+                                  pending.kind == EditorMaskCreationCommandKind::BeginInput ||
+                                  pending.kind == EditorMaskCreationCommandKind::Append ||
+                                  pending.kind == EditorMaskCreationCommandKind::Finish ||
+                                  pending.kind == EditorMaskCreationCommandKind::Cancel;
+                         }),
+          pending_mask_commands_.end());
+    }
     if (command.kind == EditorMaskCreationCommandKind::RemoveMask && !command.mask_id.Empty()) {
       pending_mask_commands_.erase(
           std::remove_if(pending_mask_commands_.begin(), pending_mask_commands_.end(),
@@ -1197,6 +1212,11 @@ auto EditorSessionService::EnqueueMaskCreation(EditorMaskCreationCommand command
   result.identity = lifecycle_.identity();
   result.message  = "Mask creation queued";
   return result;
+}
+
+auto EditorSessionService::mask_creation_commands_pending() const -> bool {
+  std::scoped_lock lock(mask_command_mutex_);
+  return !pending_mask_commands_.empty();
 }
 
 auto EditorSessionService::PeekPendingInput() const -> EditorPendingInputView {

--- a/alcedo_studio/src/edit/mask/analytic_mask_edit.cpp
+++ b/alcedo_studio/src/edit/mask/analytic_mask_edit.cpp
@@ -97,8 +97,8 @@ auto RadialFromCenterOut(Vector2 center_normalized, Vector2 current_normalized)
   source.center_y     = center_normalized.y;
   source.major_radius = std::fabs(current_normalized.x - center_normalized.x);
   source.minor_radius = std::fabs(current_normalized.y - center_normalized.y);
-  source.rotation     = 0.0f;
-  source.inner_feather = 0.0f;
+  source.rotation      = 0.0f;
+  source.inner_feather = kAnalyticCreationDefaultInnerFeather;
   source.outer_feather = 0.0f;
   return source;
 }

--- a/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
+++ b/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
@@ -91,6 +91,7 @@ enum class EditorMaskCreationCommandKind : std::uint8_t {
   Finish,
   Cancel,
   CancelMode,
+  RemoveMask,
 };
 
 struct EditorMaskCreationCommand {
@@ -159,10 +160,21 @@ class EditorMaskCreationController {
                      EditorSessionIdentity session) -> EditorMaskCreationResult;
 
   /**
-   * @brief Select an existing Radial or Linear Mask. Load-only; no Mix or commit.
+   * @brief Select an existing Brush, Radial, or Linear Mask. Load-only; no Mix or commit.
+   *
+   * Brush selection does not arm paint or movement. Analytic kinds load handles
+   * for later movement.
    */
   auto SelectMask(const NodeId& grade_id, const MaskId& mask_id,
                   EditorSessionIdentity session) -> EditorMaskCreationResult;
+
+  /**
+   * @brief Remove @p mask_id from @p grade_id with one typed history operation.
+   *
+   * Cancels an unfinished operation on that Mask first. Other Masks' open
+   * edits are left alone. Failed publish leaves the committed Mask in place.
+   */
+  auto RemoveMask(const NodeId& grade_id, const MaskId& mask_id) -> EditorMaskCreationResult;
 
   /**
    * @brief Start a creation drag at @p sample.
@@ -223,6 +235,7 @@ class EditorMaskCreationController {
    * @brief Live or draft source for overlay layout. Empty when Inactive/hidden.
    */
   [[nodiscard]] auto CurrentSource() const -> std::optional<MaskSource>;
+  [[nodiscard]] auto last_removed_mask_id() const -> const MaskId& { return last_removed_mask_id_; }
 
  private:
   auto Reject(std::string error) const -> EditorMaskCreationResult;
@@ -266,6 +279,7 @@ class EditorMaskCreationController {
   bool                     inserted_      = false;
   bool                     terminated_    = false;
   std::optional<MaskSource> draft_source_;
+  MaskId                   last_removed_mask_id_;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
+++ b/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
@@ -26,13 +26,13 @@ namespace alcedo {
  * @brief Master Mask-creation states. One controller owns the current state.
  */
 enum class EditorMaskCreationState : std::uint8_t {
-  Inactive  = 0,
-  Selected  = 1,
-  Creating  = 2,
-  Editing   = 3,
-  Painting  = 4,
-  Settling  = 5,
-  Failed    = 6,
+  Inactive = 0,
+  Selected = 1,
+  Creating = 2,
+  Editing  = 3,
+  Painting = 4,
+  Settling = 5,
+  Failed   = 6,
 };
 
 /**
@@ -68,12 +68,12 @@ struct MaskPointerIdentity {
  * @p committed / @p quality_requested are set only by a successful settle.
  */
 struct EditorMaskCreationResult {
-  bool          accepted              = false;
-  bool          interactive_preview   = false;
-  bool          committed             = false;
-  bool          quality_requested     = false;
-  std::string   error;
-  MaskId        mask_id;
+  bool        accepted            = false;
+  bool        interactive_preview = false;
+  bool        committed           = false;
+  bool        quality_requested   = false;
+  std::string error;
+  MaskId      mask_id;
 };
 
 /**
@@ -90,6 +90,7 @@ enum class EditorMaskCreationCommandKind : std::uint8_t {
   Append,
   Finish,
   Cancel,
+  FinishMode,
   CancelMode,
   RemoveMask,
 };
@@ -156,8 +157,8 @@ class EditorMaskCreationController {
    * Brush is rejected until accumulating-stroke UI exists. An open operation must
    * be finished or cancelled first.
    */
-  auto BeginCreation(MaskSourceKind kind, const NodeId& grade_id,
-                     EditorSessionIdentity session) -> EditorMaskCreationResult;
+  auto BeginCreation(MaskSourceKind kind, const NodeId& grade_id, EditorSessionIdentity session)
+      -> EditorMaskCreationResult;
 
   /**
    * @brief Select an existing Brush, Radial, or Linear Mask. Load-only; no Mix or commit.
@@ -165,8 +166,8 @@ class EditorMaskCreationController {
    * Brush selection does not arm paint or movement. Analytic kinds load handles
    * for later movement.
    */
-  auto SelectMask(const NodeId& grade_id, const MaskId& mask_id,
-                  EditorSessionIdentity session) -> EditorMaskCreationResult;
+  auto SelectMask(const NodeId& grade_id, const MaskId& mask_id, EditorSessionIdentity session)
+      -> EditorMaskCreationResult;
 
   /**
    * @brief Remove @p mask_id from @p grade_id with one typed history operation.
@@ -202,22 +203,22 @@ class EditorMaskCreationController {
    *
    * Degenerate creation and unchanged placement publish neither a commit nor Quality.
    */
-  auto FinishMaskInput() -> EditorMaskCreationResult;
+  auto               FinishMaskInput() -> EditorMaskCreationResult;
 
   /**
    * @brief Restore the live Grade to the captured before-state. Zero commits.
    */
-  auto CancelMaskInput() -> EditorMaskCreationResult;
+  auto               CancelMaskInput() -> EditorMaskCreationResult;
 
   /**
    * @brief Leave creation mode. Seals a valid open operation once, then clears mode.
    */
-  auto FinishCreationMode() -> EditorMaskCreationResult;
+  auto               FinishCreationMode() -> EditorMaskCreationResult;
 
   /**
    * @brief Cancel any open operation and leave creation mode. Zero new commits.
    */
-  auto CancelCreationMode() -> EditorMaskCreationResult;
+  auto               CancelCreationMode() -> EditorMaskCreationResult;
 
   [[nodiscard]] auto state() const -> EditorMaskCreationState { return state_; }
   [[nodiscard]] auto source_kind() const -> MaskSourceKind { return kind_; }
@@ -238,8 +239,8 @@ class EditorMaskCreationController {
   [[nodiscard]] auto last_removed_mask_id() const -> const MaskId& { return last_removed_mask_id_; }
 
  private:
-  auto Reject(std::string error) const -> EditorMaskCreationResult;
-  auto Ok() const -> EditorMaskCreationResult;
+  auto               Reject(std::string error) const -> EditorMaskCreationResult;
+  auto               Ok() const -> EditorMaskCreationResult;
   [[nodiscard]] auto Grade() -> ColorGradeNodeModel*;
   [[nodiscard]] auto Grade() const -> const ColorGradeNodeModel*;
   [[nodiscard]] auto IdentityMatches(const MaskPointerIdentity& identity) const -> bool;
@@ -247,39 +248,39 @@ class EditorMaskCreationController {
   [[nodiscard]] auto MakeCreationMask(const MaskSource& source) const -> MaskModel;
   [[nodiscard]] auto LiveSourceJson() const -> nlohmann::json;
   [[nodiscard]] auto SourcesEqual(const nlohmann::json& a, const nlohmann::json& b) const -> bool;
-  auto ApplyLiveSource(const MaskSource& source) -> bool;
-  auto InsertProvisional(const MaskSource& source) -> bool;
-  void RestoreLive();
-  void ClearOpenOperation();
-  void ResetMode();
-  auto PublishAddMask() -> EditorMaskCreationResult;
-  auto PublishReplaceSource() -> EditorMaskCreationResult;
-  auto PublishSettledBatch(const PipelineEditBatch& batch, std::string* error) -> bool;
-  void RequestInteractive(EditorMaskCreationResult& result);
-  auto UpdateCreation(const MaskCreationSample& sample) -> EditorMaskCreationResult;
-  auto UpdateExisting(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto               ApplyLiveSource(const MaskSource& source) -> bool;
+  auto               InsertProvisional(const MaskSource& source) -> bool;
+  void               RestoreLive();
+  void               ClearOpenOperation();
+  void               ResetMode();
+  auto               PublishAddMask() -> EditorMaskCreationResult;
+  auto               PublishReplaceSource() -> EditorMaskCreationResult;
+  auto              PublishSettledBatch(const PipelineEditBatch& batch, std::string* error) -> bool;
+  void              RequestInteractive(EditorMaskCreationResult& result);
+  auto              UpdateCreation(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto              UpdateExisting(const MaskCreationSample& sample) -> EditorMaskCreationResult;
 
-  PipelineDocument*        document_ = nullptr;
-  MiniGitWorkingHistory*   history_  = nullptr;
-  std::function<void()>    interactive_preview_;
+  PipelineDocument* document_                                          = nullptr;
+  MiniGitWorkingHistory*                                      history_ = nullptr;
+  std::function<void()>                                       interactive_preview_;
   std::function<bool(const PipelineEditBatch&, std::string*)> settle_publisher_;
-  EditorMaskCreationState  state_    = EditorMaskCreationState::Inactive;
-  MaskSourceKind           kind_     = MaskSourceKind::Radial;
-  EditorSessionIdentity    session_{};
-  NodeId                   node_id_;
-  MaskId                   mask_id_;
-  AnalyticMaskHandle       handle_ = AnalyticMaskHandle::None;
-  MaskPointerIdentity      pointer_{};
-  Vector2                  press_normalized_{};
-  float                    unwrapped_rotation_ = 0.0f;
-  nlohmann::json           before_source_;
-  std::uint32_t            display_index_ = 0;
-  bool                     open_          = false;
-  bool                     creating_      = false;
-  bool                     inserted_      = false;
-  bool                     terminated_    = false;
+  EditorMaskCreationState   state_ = EditorMaskCreationState::Inactive;
+  MaskSourceKind            kind_  = MaskSourceKind::Radial;
+  EditorSessionIdentity     session_{};
+  NodeId                    node_id_;
+  MaskId                    mask_id_;
+  AnalyticMaskHandle        handle_ = AnalyticMaskHandle::None;
+  MaskPointerIdentity       pointer_{};
+  Vector2                   press_normalized_{};
+  float                     unwrapped_rotation_ = 0.0f;
+  nlohmann::json            before_source_;
+  std::uint32_t             display_index_ = 0;
+  bool                      open_          = false;
+  bool                      creating_      = false;
+  bool                      inserted_      = false;
+  bool                      terminated_    = false;
   std::optional<MaskSource> draft_source_;
-  MaskId                   last_removed_mask_id_;
+  MaskId                    last_removed_mask_id_;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -291,6 +291,10 @@ class IEditorSessionBackend {
   }
   [[nodiscard]] virtual auto mask_creation_node_id() const -> NodeId { return {}; }
   [[nodiscard]] virtual auto mask_creation_mask_id() const -> MaskId { return {}; }
+  [[nodiscard]] virtual auto mask_creation_source() const -> std::optional<MaskSource> {
+    return std::nullopt;
+  }
+  [[nodiscard]] virtual auto mask_creation_last_removed_mask_id() const -> MaskId { return {}; }
   /**
    * @brief Inspect queued change descriptions. Empty when the backend has none.
    *
@@ -489,6 +493,12 @@ class EditorSessionService final : public IEditorSessionBackend {
   }
   [[nodiscard]] auto mask_creation_mask_id() const -> MaskId override {
     return mask_creation_.selected_mask_id();
+  }
+  [[nodiscard]] auto mask_creation_source() const -> std::optional<MaskSource> override {
+    return mask_creation_.CurrentSource();
+  }
+  [[nodiscard]] auto mask_creation_last_removed_mask_id() const -> MaskId override {
+    return mask_creation_.last_removed_mask_id();
   }
   auto SetAdjustmentProjectionNode(const NodeId& node_id) -> EditorSessionResult override;
   [[nodiscard]] auto PeekPendingInput() const -> EditorPendingInputView override;

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -15,18 +15,18 @@
 #include "app/adjustment_transfer_types.hpp"
 #include "app/editor_action_policy.hpp"
 #include "app/editor_mask_creation_controller.hpp"
-#include "app/editor_pending_input.hpp"
 #include "app/editor_panel_projection.hpp"
-#include "app/editor_serial_frame_admission.hpp"
-#include "app/editor_session_request_ids.hpp"
+#include "app/editor_pending_input.hpp"
 #include "app/editor_render_intent.hpp"
 #include "app/editor_save_checkpoint_service.hpp"
+#include "app/editor_serial_frame_admission.hpp"
 #include "app/editor_session_command_queue.hpp"
 #include "app/editor_session_edit_controller.hpp"
 #include "app/editor_session_lifecycle.hpp"
 #include "app/editor_session_navigation_controller.hpp"
 #include "app/editor_session_ports.hpp"
 #include "app/editor_session_render_controller.hpp"
+#include "app/editor_session_request_ids.hpp"
 #include "app/editor_session_types.hpp"
 
 namespace alcedo {
@@ -44,8 +44,8 @@ struct EditorBackgroundActionRestrictions {
 
 /// Presentation target queued with the active image-load operation.
 struct EditorPendingPresentationTarget {
-  sl_element_id_t    element_id         = 0;
-  image_id_t         image_id           = 0;
+  sl_element_id_t    element_id = 0;
+  image_id_t         image_id   = 0;
   ImageLoadRequestId image_load_request{};
 };
 
@@ -94,10 +94,12 @@ class IEditorSessionBackend {
   [[nodiscard]] virtual auto history_snapshot() -> EditorHistorySnapshot { return {}; }
   /// Live PipelineDocument for the Nodes-page projection. Null when the backend
   /// has no loaded image document. Default fakes return nullptr.
-  [[nodiscard]] virtual auto pipeline_document() const -> const PipelineDocument* { return nullptr; }
+  [[nodiscard]] virtual auto pipeline_document() const -> const PipelineDocument* {
+    return nullptr;
+  }
 
   /// Optional: notified after state/identity changes from async results.
-  virtual void               SetChangeNotifier(ChangeNotifier notifier) {
+  virtual void SetChangeNotifier(ChangeNotifier notifier) {
     change_notifier_ = std::move(notifier);
   }
 
@@ -254,10 +256,10 @@ class IEditorSessionBackend {
    */
   virtual auto EnqueueAdjustmentInput(EditorAdjustmentPatch /*patch*/) -> EditorSessionResult {
     EditorSessionResult result;
-    result.kind    = EditorSessionResultKind::Rejected;
-    result.state   = state();
+    result.kind     = EditorSessionResultKind::Rejected;
+    result.state    = state();
     result.identity = identity();
-    result.message = "Queued adjustment input is not supported by this backend";
+    result.message  = "Queued adjustment input is not supported by this backend";
     return result;
   }
   /**
@@ -289,6 +291,14 @@ class IEditorSessionBackend {
     result.message  = "Queued Mask creation is not supported by this backend";
     return result;
   }
+  /**
+   * @brief True while queued Mask commands have not reached the session owner.
+   *
+   * UI adapters use this owner read to avoid replacing a just-requested local
+   * selection or removal with the previous owner state. Implementations must
+   * synchronize this read with their Mask command queue.
+   */
+  [[nodiscard]] virtual auto mask_creation_commands_pending() const -> bool { return false; }
   [[nodiscard]] virtual auto mask_creation_node_id() const -> NodeId { return {}; }
   [[nodiscard]] virtual auto mask_creation_mask_id() const -> MaskId { return {}; }
   [[nodiscard]] virtual auto mask_creation_source() const -> std::optional<MaskSource> {
@@ -308,9 +318,9 @@ class IEditorSessionBackend {
    * session owner thread. Does not take the render lock from a GUI input
    * callback.
    */
-  virtual void TryConsumePendingInput() {}
-  virtual void SetAdmissionDeadlineHandler(std::function<void(std::int64_t /*delay_ns*/)> /*handler*/) {
-  }
+  virtual void               TryConsumePendingInput() {}
+  virtual void               SetAdmissionDeadlineHandler(
+                    std::function<void(std::int64_t /*delay_ns*/)> /*handler*/) {}
   /// Rename a Color Grade as a metadata-only history change. Default backends reject.
   virtual auto RenameColorGrade(const NodeId& /*node_id*/, std::string /*display_name*/)
       -> EditorSessionResult {
@@ -340,12 +350,8 @@ class IEditorSessionBackend {
     return result;
   }
   [[nodiscard]] virtual auto render_busy() const -> bool { return false; }
-  [[nodiscard]] virtual auto action_availability() const -> EditorActionAvailability {
-    return {};
-  }
-  [[nodiscard]] virtual auto active_image_load_request() const -> ImageLoadRequestId {
-    return {};
-  }
+  [[nodiscard]] virtual auto action_availability() const -> EditorActionAvailability { return {}; }
+  [[nodiscard]] virtual auto active_image_load_request() const -> ImageLoadRequestId { return {}; }
   [[nodiscard]] virtual auto pending_presentation_target() const
       -> std::optional<EditorPendingPresentationTarget> {
     return std::nullopt;
@@ -488,6 +494,7 @@ class EditorSessionService final : public IEditorSessionBackend {
   auto EnqueuePendingInputBoundary(EditorPendingInputBoundaryKind kind)
       -> EditorSessionResult override;
   auto EnqueueMaskCreation(EditorMaskCreationCommand command) -> EditorSessionResult override;
+  [[nodiscard]] auto mask_creation_commands_pending() const -> bool override;
   [[nodiscard]] auto mask_creation_node_id() const -> NodeId override {
     return mask_creation_.node_id();
   }
@@ -554,22 +561,22 @@ class EditorSessionService final : public IEditorSessionBackend {
   void HandleSaveCheckpointCompletion(const EditorSessionCompletion& completion);
   void PublishActionAvailabilityIfChanged();
   [[nodiscard]] auto BuildActionInputs() -> EditorActionInputs;
-  void AcquireLease(EditorOperationLeaseKind kind, std::uint64_t command_id,
-                    sl_element_id_t element_id, image_id_t image_id,
-                    ImageLoadRequestId image_load_request, std::string blocking_reason = {});
-  void ReleaseLeaseByCommandId(std::uint64_t command_id);
-  void ReleaseLeasesByKind(EditorOperationLeaseKind kind);
-  void SetPendingPresentationTarget(sl_element_id_t element_id, image_id_t image_id,
-                                    ImageLoadRequestId image_load_request);
-  void ClearPendingPresentationTarget();
+  void               AcquireLease(EditorOperationLeaseKind kind, std::uint64_t command_id,
+                                  sl_element_id_t element_id, image_id_t image_id,
+                                  ImageLoadRequestId image_load_request, std::string blocking_reason = {});
+  void               ReleaseLeaseByCommandId(std::uint64_t command_id);
+  void               ReleaseLeasesByKind(EditorOperationLeaseKind kind);
+  void               SetPendingPresentationTarget(sl_element_id_t element_id, image_id_t image_id,
+                                                  ImageLoadRequestId image_load_request);
+  void               ClearPendingPresentationTarget();
 
   /// Publish a result to the observer and change-notifier. The only state the
   /// facade owns is the result history and observer registration.
-  auto Emit(EditorSessionResult result) -> EditorSessionResult;
-  auto Reject(std::string message) -> EditorSessionResult;
+  auto               Emit(EditorSessionResult result) -> EditorSessionResult;
+  auto               Reject(std::string message) -> EditorSessionResult;
   /// Transition lifecycle to Failed and emit a Failed result. Used when a
   /// navigation or save failure requires the session to enter the Failed state.
-  auto Fail(std::string message) -> EditorSessionResult;
+  auto               Fail(std::string message) -> EditorSessionResult;
   auto FinishVersionNavigation(const NavigationOutcome& outcome) -> EditorSessionResult;
   /// Persist a graph mutation through the same journal/materialization path as
   /// ordinary editor saves. The terminal outcome is delivered as a typed
@@ -622,33 +629,33 @@ class EditorSessionService final : public IEditorSessionBackend {
     std::string success_message;
   };
 
-  Dependencies                            dependencies_;
-  EditorSessionCommandQueue               command_queue_;
-  EditorSessionNavigationState            navigation_state_;
-  EditorSessionLifecycle                  lifecycle_;
-  EditorSaveCheckpointService             save_service_;
-  EditorSessionRenderController           render_;
-  EditorSessionEditController             edit_;
-  EditorSessionNavigationController       navigation_;
-  EditorPendingInputQueue                 pending_input_;
-  EditorSerialFrameAdmission              serial_admission_;
-  EditorMaskCreationController            mask_creation_;
-  std::vector<EditorMaskCreationCommand>  pending_mask_commands_;
-  mutable std::mutex                      mask_command_mutex_;
-  bool                                    reducing_command_     = false;
-  std::uint64_t                           current_operation_id_ = 0;
-  std::size_t                             publication_depth_    = 0;
-  bool                                    publication_dirty_    = false;
-  std::vector<EditorSessionResult>        results_;
-  mutable std::mutex                      results_mutex_;
-  std::optional<PendingHistoryCheckpoint>          pending_history_checkpoint_;
-  std::vector<EditorOperationLease>       active_leases_;
-  EditorActionAvailability                published_availability_{};
-  ActionAvailabilityObserver              action_availability_observer_;
+  Dependencies                                   dependencies_;
+  EditorSessionCommandQueue                      command_queue_;
+  EditorSessionNavigationState                   navigation_state_;
+  EditorSessionLifecycle                         lifecycle_;
+  EditorSaveCheckpointService                    save_service_;
+  EditorSessionRenderController                  render_;
+  EditorSessionEditController                    edit_;
+  EditorSessionNavigationController              navigation_;
+  EditorPendingInputQueue                        pending_input_;
+  EditorSerialFrameAdmission                     serial_admission_;
+  EditorMaskCreationController                   mask_creation_;
+  std::vector<EditorMaskCreationCommand>         pending_mask_commands_;
+  mutable std::mutex                             mask_command_mutex_;
+  bool                                           reducing_command_     = false;
+  std::uint64_t                                  current_operation_id_ = 0;
+  std::size_t                                    publication_depth_    = 0;
+  bool                                           publication_dirty_    = false;
+  std::vector<EditorSessionResult>               results_;
+  mutable std::mutex                             results_mutex_;
+  std::optional<PendingHistoryCheckpoint>        pending_history_checkpoint_;
+  std::vector<EditorOperationLease>              active_leases_;
+  EditorActionAvailability                       published_availability_{};
+  ActionAvailabilityObserver                     action_availability_observer_;
   std::optional<EditorPendingPresentationTarget> pending_presentation_target_;
-  bool                                    package_available_ = false;
-  EditorBackgroundActionRestrictions      background_restrictions_{};
-  std::atomic<std::uint64_t>              history_revision_{0};
+  bool                                           package_available_ = false;
+  EditorBackgroundActionRestrictions             background_restrictions_{};
+  std::atomic<std::uint64_t>                     history_revision_{0};
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/analytic_mask_edit.hpp
+++ b/alcedo_studio/src/include/edit/mask/analytic_mask_edit.hpp
@@ -16,6 +16,10 @@ namespace alcedo {
 inline constexpr float kAnalyticMaskEpsilon = 1.0e-6f;
 /// Minimum positive Radial radii before a center-out drag becomes a Mask.
 inline constexpr float kAnalyticCreationMinRadius = 1.0e-5f;
+/// Default inner feather for center-out Radial creation. The full-strength
+/// boundary starts at rho = 1 - kAnalyticCreationDefaultInnerFeather, so a new
+/// Radial Mask fades out over the outer half of its radii instead of a hard edge.
+inline constexpr float kAnalyticCreationDefaultInnerFeather = 0.5f;
 
 /**
  * @brief Finite analytic handle identity. Not a per-texel or per-dab proxy.
@@ -71,7 +75,9 @@ enum class AnalyticMaskHandle : std::uint8_t {
 /**
  * @brief Center-out Radial: press is the center, drag sets positive x/y radii.
  *
- * Rotation and feathers stay 0. Radii are absolute normalized deltas, never swapped.
+ * Rotation and outer feather stay 0. Inner feather defaults to
+ * @ref kAnalyticCreationDefaultInnerFeather so a new Radial Mask is feathered,
+ * not hard-edged. Radii are absolute normalized deltas, never swapped.
  */
 [[nodiscard]] auto RadialFromCenterOut(Vector2 center_normalized, Vector2 current_normalized)
     -> RadialMaskSource;

--- a/alcedo_studio/src/include/edit/mask/mask_list_selection.hpp
+++ b/alcedo_studio/src/include/edit/mask/mask_list_selection.hpp
@@ -1,0 +1,62 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <span>
+
+#include "edit/mask/mask_id.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Next selected Mask after deleting @p deleted from @p ordered_ids.
+ *
+ * Display order is the Grade Mask list. Deleting a Mask that is not selected
+ * keeps @p selected. Deleting the selected Mask chooses the next row at the
+ * same index, otherwise the previous row, otherwise none.
+ *
+ * Thread: any. Pure.
+ */
+[[nodiscard]] inline auto MaskIdAfterDeletion(std::span<const MaskId> ordered_ids,
+                                                const MaskId& deleted, const MaskId& selected)
+    -> MaskId {
+  if (deleted.Empty() || deleted != selected) {
+    return selected;
+  }
+  std::size_t index = ordered_ids.size();
+  for (std::size_t i = 0; i < ordered_ids.size(); ++i) {
+    if (ordered_ids[i] == deleted) {
+      index = i;
+      break;
+    }
+  }
+  if (index >= ordered_ids.size()) {
+    return {};
+  }
+  if (index + 1 < ordered_ids.size()) {
+    return ordered_ids[index + 1];
+  }
+  if (index > 0) {
+    return ordered_ids[index - 1];
+  }
+  return {};
+}
+
+/**
+ * @brief Selection after Undo restores @p restored.
+ *
+ * Selects the restored Mask only when the current selection is empty. A valid
+ * current selection is preserved.
+ */
+[[nodiscard]] inline auto MaskIdAfterUndoRestore(const MaskId& restored, const MaskId& selected)
+    -> MaskId {
+  if (selected.Empty()) {
+    return restored;
+  }
+  return selected;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
@@ -79,6 +79,8 @@ class AlcedoQanGraph : public QObject {
   Q_PROPERTY(bool keyboardConnectActive READ keyboard_connect_active NOTIFY KeyboardConnectChanged)
   Q_PROPERTY(QString keyboardConnectSourceId READ keyboard_connect_source_id_string NOTIFY
                  KeyboardConnectChanged)
+  Q_PROPERTY(QString selectedMaskId READ selected_mask_id_string WRITE set_selected_mask_id NOTIFY
+                 SelectedMaskChanged)
 
  public:
   explicit AlcedoQanGraph(QObject* parent = nullptr);
@@ -291,10 +293,13 @@ class AlcedoQanGraph : public QObject {
    * Does not write PipelineDocument, history, or start a photo render.
    */
   Q_INVOKABLE void cancelKeyboardConnect();
+  Q_INVOKABLE void setSelectedMaskId(const QString& mask_id);
   [[nodiscard]] auto keyboard_connect_active() const -> bool {
     return !keyboard_connect_source_id_.Empty();
   }
   [[nodiscard]] auto keyboard_connect_source_id_string() const -> QString;
+  [[nodiscard]] auto selected_mask_id_string() const -> QString { return selected_mask_id_; }
+  void               set_selected_mask_id(const QString& mask_id);
 
  signals:
   void GraphChanged();
@@ -318,6 +323,9 @@ class AlcedoQanGraph : public QObject {
    * photo render.
    */
   void NodeDrawerOpenChanged(const QString& nodeId, bool open);
+  void SelectedMaskChanged();
+  void MaskRowSelected(const QString& nodeId, const QString& maskId);
+  void MaskRowDeleteRequested(const QString& nodeId, const QString& maskId);
 
  protected:
   /**
@@ -419,6 +427,8 @@ class AlcedoQanGraph : public QObject {
 
  private slots:
   void OnDrawerOpenChanged();
+  void OnMaskSelected(const QString& node_id, const QString& mask_id);
+  void OnMaskDeleteRequested(const QString& node_id, const QString& mask_id);
 
  private:
   void DestroyMappedPrimitives();
@@ -491,6 +501,7 @@ class AlcedoQanGraph : public QObject {
   std::vector<QMetaObject::Connection>              drawer_connections_;
   NodeId                                            product_selected_node_id_;
   NodeId                                            keyboard_connect_source_id_;
+  QString                                           selected_mask_id_;
 };
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/alcedo_qan_graph.hpp
@@ -294,6 +294,34 @@ class AlcedoQanGraph : public QObject {
    */
   Q_INVOKABLE void cancelKeyboardConnect();
   Q_INVOKABLE void setSelectedMaskId(const QString& mask_id);
+  /**
+   * @brief Forward a Mask-row press from a Color Grade delegate.
+   *
+   * @p item is the live node visual (or a descendant). The NodeId is resolved
+   * from the adapter identity map so drawer-copied strings cannot drop the
+   * owner. Emits @c MaskRowSelected.
+   */
+  Q_INVOKABLE void notifyMaskRowSelected(QObject* item, const QString& mask_id);
+  /**
+   * @brief Forward a Mask-row delete press from a Color Grade delegate.
+   * @see notifyMaskRowSelected
+   */
+  Q_INVOKABLE void notifyMaskRowDeleteRequested(QObject* item, const QString& mask_id);
+  /**
+   * @brief MaskId under a NodeItem-local point, or empty when the point is not
+   *        on a Mask row (name row, header, and empty canvas return empty).
+   */
+  Q_INVOKABLE QString maskIdAtItemPosition(QObject* node_item, qreal x, qreal y) const;
+  /**
+   * @brief True when the NodeItem-local point is on a Mask-row delete control.
+   */
+  Q_INVOKABLE bool maskDeleteContainsItemPosition(QObject* node_item, qreal x, qreal y) const;
+  /**
+   * @brief Write a Mask-row press diagnostic. Visible at warning so the log
+   *        file flushes immediately while isolating this click path.
+   */
+  Q_INVOKABLE void logMaskRow(const QString& where, const QString& node_id, const QString& mask_id,
+                              bool right_button) const;
   [[nodiscard]] auto keyboard_connect_active() const -> bool {
     return !keyboard_connect_source_id_.Empty();
   }
@@ -323,9 +351,12 @@ class AlcedoQanGraph : public QObject {
    * photo render.
    */
   void NodeDrawerOpenChanged(const QString& nodeId, bool open);
+  void nodeDrawerOpenChanged(const QString& nodeId, bool open);
   void SelectedMaskChanged();
   void MaskRowSelected(const QString& nodeId, const QString& maskId);
+  void maskRowSelected(const QString& nodeId, const QString& maskId);
   void MaskRowDeleteRequested(const QString& nodeId, const QString& maskId);
+  void maskRowDeleteRequested(const QString& nodeId, const QString& maskId);
 
  protected:
   /**
@@ -418,12 +449,19 @@ class AlcedoQanGraph : public QObject {
   void ClearDrawerConnections();
   void BindDrawerSignals();
   void BindDrawerSignal(QQuickItem* item, const NodeId& node_id);
+  [[nodiscard]] auto NodeIdStringForItem(QObject* item) const -> QString;
   void ConfigureGraphPolicy();
   void ConfigureConnector();
   void ApplyConnectablePolicy();
   void OnGraphDestroyed();
   void OnConnectorRequestEdgeCreation(qan::Node* src, QObject* dst, qan::PortItem* src_port,
                                       qan::PortItem* dst_port);
+  void OnGraphNodeClicked(qan::Node* node, QPointF pos);
+  void OnGraphNodeRightClicked(qan::Node* node, QPointF pos);
+  void HandleNodeItemPress(qan::Node* node, QPointF local_pos, bool right_button);
+  [[nodiscard]] auto MaskRowAt(QQuickItem* node_item, QPointF local_pos) const -> QQuickItem*;
+  [[nodiscard]] auto MaskDeleteButtonContains(QQuickItem* row, const QPointF& scene_pos) const
+      -> bool;
 
  private slots:
   void OnDrawerOpenChanged();

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
@@ -34,15 +34,19 @@ class EditorSessionController;
  */
 class EditorMaskCreationAdapter : public QObject {
   Q_OBJECT
-  Q_PROPERTY(bool active READ active NOTIFY MaskCreationChanged)
-  Q_PROPERTY(bool creating READ creating NOTIFY MaskCreationChanged)
-  Q_PROPERTY(bool ownsLeftButton READ owns_left_button NOTIFY MaskCreationChanged)
-  Q_PROPERTY(bool bodyVisible READ body_visible NOTIFY MaskCreationChanged)
-  Q_PROPERTY(bool maskControlsActive READ mask_controls_active NOTIFY MaskCreationChanged)
-  Q_PROPERTY(QString toolKind READ tool_kind NOTIFY MaskCreationChanged)
-  Q_PROPERTY(QString selectedMaskId READ selected_mask_id NOTIFY MaskCreationChanged)
-  Q_PROPERTY(qreal innerFeatherPercent READ inner_feather_percent NOTIFY MaskCreationChanged)
-  Q_PROPERTY(qreal outerFeatherPercent READ outer_feather_percent NOTIFY MaskCreationChanged)
+  Q_PROPERTY(bool active READ active NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool creating READ creating NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool ownsLeftButton READ owns_left_button NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool bodyVisible READ body_visible NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool maskControlsActive READ mask_controls_active NOTIFY maskCreationChanged)
+  Q_PROPERTY(QString toolKind READ tool_kind NOTIFY maskCreationChanged)
+  Q_PROPERTY(QString selectedMaskId READ selected_mask_id NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal innerFeatherPercent READ inner_feather_percent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal outerFeatherPercent READ outer_feather_percent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal majorRadiusPercent READ major_radius_percent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal minorRadiusPercent READ minor_radius_percent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal rotationDegrees READ rotation_degrees NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal transitionPercent READ transition_percent NOTIFY maskCreationChanged)
 
  public:
   explicit EditorMaskCreationAdapter(EditorSessionController* session, QObject* parent = nullptr);
@@ -57,49 +61,62 @@ class EditorMaskCreationAdapter : public QObject {
   [[nodiscard]] auto selected_mask_id() const -> QString { return selected_mask_id_; }
   [[nodiscard]] auto inner_feather_percent() const -> qreal;
   [[nodiscard]] auto outer_feather_percent() const -> qreal;
+  [[nodiscard]] auto major_radius_percent() const -> qreal;
+  [[nodiscard]] auto minor_radius_percent() const -> qreal;
+  [[nodiscard]] auto rotation_degrees() const -> qreal;
+  [[nodiscard]] auto transition_percent() const -> qreal;
 
-  Q_INVOKABLE void bindInteractionItem(QObject* interaction);
-  Q_INVOKABLE void bindOverlayItem(QObject* overlay);
-  Q_INVOKABLE void beginRadial();
-  Q_INVOKABLE void beginLinear();
-  Q_INVOKABLE void cancel();
-  Q_INVOKABLE void hideBody();
-  Q_INVOKABLE void finishBody();
-  Q_INVOKABLE void selectMask(const QString& node_id, const QString& mask_id);
-  Q_INVOKABLE void removeMask(const QString& node_id, const QString& mask_id);
-  Q_INVOKABLE void removeSelectedMask();
-  Q_INVOKABLE void handleHover(qreal x, qreal y);
-  Q_INVOKABLE void beginInnerFeather();
-  Q_INVOKABLE void beginOuterFeather();
-  Q_INVOKABLE void updateInnerFeather(qreal percent);
-  Q_INVOKABLE void updateOuterFeather(qreal percent);
-  Q_INVOKABLE void finishFeather();
-  Q_INVOKABLE bool handlePress(qreal x, qreal y, int button);
-  Q_INVOKABLE bool handleMove(qreal x, qreal y, int buttons);
-  Q_INVOKABLE bool handleRelease(qreal x, qreal y, int button);
+  Q_INVOKABLE void   bindInteractionItem(QObject* interaction);
+  Q_INVOKABLE void   bindOverlayItem(QObject* overlay);
+  Q_INVOKABLE void   beginRadial();
+  Q_INVOKABLE void   beginLinear();
+  Q_INVOKABLE void   cancel();
+  Q_INVOKABLE void   hideBody();
+  Q_INVOKABLE void   finishBody();
+  Q_INVOKABLE void   selectMask(const QString& node_id, const QString& mask_id);
+  Q_INVOKABLE void   removeMask(const QString& node_id, const QString& mask_id);
+  Q_INVOKABLE void   removeSelectedMask();
+  Q_INVOKABLE void   handleHover(qreal x, qreal y);
+  Q_INVOKABLE void   beginInnerFeather();
+  Q_INVOKABLE void   beginOuterFeather();
+  Q_INVOKABLE void   updateInnerFeather(qreal percent);
+  Q_INVOKABLE void   updateOuterFeather(qreal percent);
+  Q_INVOKABLE void   beginMajorRadius();
+  Q_INVOKABLE void   updateMajorRadius(qreal percent);
+  Q_INVOKABLE void   beginMinorRadius();
+  Q_INVOKABLE void   updateMinorRadius(qreal percent);
+  Q_INVOKABLE void   beginRotation();
+  Q_INVOKABLE void   updateRotation(qreal degrees);
+  Q_INVOKABLE void   beginTransition();
+  Q_INVOKABLE void   updateTransition(qreal percent);
+  Q_INVOKABLE void   finishAnalyticControl();
+  Q_INVOKABLE bool   handlePress(qreal x, qreal y, int button);
+  Q_INVOKABLE bool   handleMove(qreal x, qreal y, int buttons);
+  Q_INVOKABLE bool   handleRelease(qreal x, qreal y, int button);
 
-  void OnImageClosed();
+  void               OnImageClosed();
   /**
    * @brief Copy owner selection/source after consume, Undo, or session rebind.
    *
    * Open pointer/numeric edits keep GUI-predicted overlay fields. Empty
    * selection after Undo selects the restored Mask only when it is present.
    */
-  void SyncFromSession();
+  void               SyncFromSession();
 
  signals:
-  void MaskCreationChanged();
+  void maskCreationChanged();
 
  private:
-  void BeginTool(MaskSourceKind kind, const QString& tool_kind);
-  void ResetLocal();
-  void PublishOverlay();
-  void HideOverlay();
-  void PublishDisplayedGeometry();
-  void ApplyOwnerSource(const MaskId& mask_id, const MaskSource& source);
-  void BeginFeatherMove(AnalyticMaskHandle handle);
-  void UpdateFeatherPercent(AnalyticMaskHandle handle, qreal percent);
-  void EnqueueAppendSample(const MaskCreationSample& sample);
+  void               BeginTool(MaskSourceKind kind, const QString& tool_kind);
+  void               ResetLocal();
+  void               PublishOverlay();
+  void               HideOverlay();
+  void               PublishDisplayedGeometry();
+  void               ApplyOwnerSource(const MaskId& mask_id, const MaskSource& source);
+  void               BeginAnalyticMove(AnalyticMaskHandle handle);
+  void               UpdateFeatherPercent(AnalyticMaskHandle handle, qreal percent);
+  void               UpdateRadialRadiusPercent(AnalyticMaskHandle handle, qreal percent);
+  void               EnqueueAppendSample(const MaskCreationSample& sample);
   [[nodiscard]] auto CurrentGradeId() const -> NodeId;
   [[nodiscard]] auto CanAuthorMasks() const -> bool;
   [[nodiscard]] auto DocumentContainsMask(const MaskId& mask_id) const -> bool;
@@ -109,7 +126,7 @@ class EditorMaskCreationAdapter : public QObject {
   [[nodiscard]] auto OverlayClip() const -> QRectF;
   [[nodiscard]] auto OverlayStyle() const -> MaskOverlayStyle;
   [[nodiscard]] auto Enqueue(EditorMaskCreationCommand command) -> bool;
-  void ConnectInteraction(editor_rhi::EditorInteractionController* interaction);
+  void               ConnectInteraction(editor_rhi::EditorInteractionController* interaction);
 
   QPointer<EditorSessionController>                 session_;
   QPointer<editor_rhi::EditorInteractionController> interaction_;
@@ -126,8 +143,8 @@ class EditorMaskCreationAdapter : public QObject {
   Vector2                                           press_normalized_{};
   std::optional<MaskSource>                         overlay_source_;
   MaskOverlayDisplay                                overlay_display_{};
-  AnalyticMaskHandle                                active_handle_ = AnalyticMaskHandle::None;
-  MaskOverlayHandleId                               hovered_handle_ = MaskOverlayHandleId::None;
+  AnalyticMaskHandle                                active_handle_    = AnalyticMaskHandle::None;
+  MaskOverlayHandleId                               hovered_handle_   = MaskOverlayHandleId::None;
   std::uint64_t                                     next_sequence_id_ = 1;
 };
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
@@ -26,17 +26,23 @@ class EditorNodeController;
 class EditorSessionController;
 
 /**
- * @brief QML adapter for Radial/Linear Mask creation and existing-mask movement.
+ * @brief QML adapter for Radial/Linear Mask creation and existing-mask editing.
  *
  * Maps item pointers, publishes control-only overlay geometry, and queues
- * owner-thread Mask commands. Does not take the pipeline lock.
+ * owner-thread Mask commands. Does not take the pipeline lock. Selection is
+ * load-only: it does not create a Mask, history, or photo render.
  */
 class EditorMaskCreationAdapter : public QObject {
   Q_OBJECT
   Q_PROPERTY(bool active READ active NOTIFY MaskCreationChanged)
   Q_PROPERTY(bool creating READ creating NOTIFY MaskCreationChanged)
   Q_PROPERTY(bool ownsLeftButton READ owns_left_button NOTIFY MaskCreationChanged)
+  Q_PROPERTY(bool bodyVisible READ body_visible NOTIFY MaskCreationChanged)
+  Q_PROPERTY(bool maskControlsActive READ mask_controls_active NOTIFY MaskCreationChanged)
   Q_PROPERTY(QString toolKind READ tool_kind NOTIFY MaskCreationChanged)
+  Q_PROPERTY(QString selectedMaskId READ selected_mask_id NOTIFY MaskCreationChanged)
+  Q_PROPERTY(qreal innerFeatherPercent READ inner_feather_percent NOTIFY MaskCreationChanged)
+  Q_PROPERTY(qreal outerFeatherPercent READ outer_feather_percent NOTIFY MaskCreationChanged)
 
  public:
   explicit EditorMaskCreationAdapter(EditorSessionController* session, QObject* parent = nullptr);
@@ -44,19 +50,42 @@ class EditorMaskCreationAdapter : public QObject {
 
   [[nodiscard]] auto active() const -> bool { return !tool_kind_.isEmpty(); }
   [[nodiscard]] auto creating() const -> bool { return creating_; }
-  [[nodiscard]] auto owns_left_button() const -> bool { return active(); }
+  [[nodiscard]] auto owns_left_button() const -> bool;
+  [[nodiscard]] auto body_visible() const -> bool;
+  [[nodiscard]] auto mask_controls_active() const -> bool;
   [[nodiscard]] auto tool_kind() const -> QString { return tool_kind_; }
+  [[nodiscard]] auto selected_mask_id() const -> QString { return selected_mask_id_; }
+  [[nodiscard]] auto inner_feather_percent() const -> qreal;
+  [[nodiscard]] auto outer_feather_percent() const -> qreal;
 
   Q_INVOKABLE void bindInteractionItem(QObject* interaction);
   Q_INVOKABLE void bindOverlayItem(QObject* overlay);
   Q_INVOKABLE void beginRadial();
   Q_INVOKABLE void beginLinear();
   Q_INVOKABLE void cancel();
+  Q_INVOKABLE void hideBody();
+  Q_INVOKABLE void finishBody();
+  Q_INVOKABLE void selectMask(const QString& node_id, const QString& mask_id);
+  Q_INVOKABLE void removeMask(const QString& node_id, const QString& mask_id);
+  Q_INVOKABLE void removeSelectedMask();
+  Q_INVOKABLE void handleHover(qreal x, qreal y);
+  Q_INVOKABLE void beginInnerFeather();
+  Q_INVOKABLE void beginOuterFeather();
+  Q_INVOKABLE void updateInnerFeather(qreal percent);
+  Q_INVOKABLE void updateOuterFeather(qreal percent);
+  Q_INVOKABLE void finishFeather();
   Q_INVOKABLE bool handlePress(qreal x, qreal y, int button);
   Q_INVOKABLE bool handleMove(qreal x, qreal y, int buttons);
   Q_INVOKABLE bool handleRelease(qreal x, qreal y, int button);
 
   void OnImageClosed();
+  /**
+   * @brief Copy owner selection/source after consume, Undo, or session rebind.
+   *
+   * Open pointer/numeric edits keep GUI-predicted overlay fields. Empty
+   * selection after Undo selects the restored Mask only when it is present.
+   */
+  void SyncFromSession();
 
  signals:
   void MaskCreationChanged();
@@ -66,10 +95,17 @@ class EditorMaskCreationAdapter : public QObject {
   void ResetLocal();
   void PublishOverlay();
   void HideOverlay();
+  void PublishDisplayedGeometry();
+  void ApplyOwnerSource(const MaskId& mask_id, const MaskSource& source);
+  void BeginFeatherMove(AnalyticMaskHandle handle);
+  void UpdateFeatherPercent(AnalyticMaskHandle handle, qreal percent);
+  void EnqueueAppendSample(const MaskCreationSample& sample);
   [[nodiscard]] auto CurrentGradeId() const -> NodeId;
   [[nodiscard]] auto CanAuthorMasks() const -> bool;
+  [[nodiscard]] auto DocumentContainsMask(const MaskId& mask_id) const -> bool;
   [[nodiscard]] auto MakeSample(qreal x, qreal y, bool allow_outside) const
       -> std::optional<MaskCreationSample>;
+  [[nodiscard]] auto MakeNormalizedSample(Vector2 normalized) const -> MaskCreationSample;
   [[nodiscard]] auto OverlayClip() const -> QRectF;
   [[nodiscard]] auto OverlayStyle() const -> MaskOverlayStyle;
   [[nodiscard]] auto Enqueue(EditorMaskCreationCommand command) -> bool;
@@ -80,15 +116,18 @@ class EditorMaskCreationAdapter : public QObject {
   QPointer<editor_rhi::EditorOverlayItem>           overlay_;
   QMetaObject::Connection                           view_change_connection_;
   QString                                           tool_kind_;
+  QString                                           selected_mask_id_;
   MaskSourceKind                                    source_kind_ = MaskSourceKind::Radial;
   bool                                              creating_    = false;
   bool                                              open_        = false;
   bool                                              selected_    = false;
+  bool                                              body_open_   = false;
   MaskPointerIdentity                               pointer_{};
   Vector2                                           press_normalized_{};
   std::optional<MaskSource>                         overlay_source_;
   MaskOverlayDisplay                                overlay_display_{};
   AnalyticMaskHandle                                active_handle_ = AnalyticMaskHandle::None;
+  MaskOverlayHandleId                               hovered_handle_ = MaskOverlayHandleId::None;
   std::uint64_t                                     next_sequence_id_ = 1;
 };
 

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
@@ -49,16 +49,23 @@ class EditorMaskCreationAdapter : public QObject {
   Q_PROPERTY(qreal transitionPercent READ transition_percent NOTIFY maskCreationChanged)
 
  public:
+  enum class EditMode : std::uint8_t {
+    Inactive = 0,
+    Creating,
+    Editing,
+  };
+
   explicit EditorMaskCreationAdapter(EditorSessionController* session, QObject* parent = nullptr);
   ~EditorMaskCreationAdapter() override;
 
-  [[nodiscard]] auto active() const -> bool { return !tool_kind_.isEmpty(); }
-  [[nodiscard]] auto creating() const -> bool { return creating_; }
+  [[nodiscard]] auto active() const -> bool { return edit_mode_ != EditMode::Inactive; }
+  [[nodiscard]] auto creating() const -> bool { return edit_mode_ == EditMode::Creating; }
   [[nodiscard]] auto owns_left_button() const -> bool;
   [[nodiscard]] auto body_visible() const -> bool;
   [[nodiscard]] auto mask_controls_active() const -> bool;
   [[nodiscard]] auto tool_kind() const -> QString { return tool_kind_; }
   [[nodiscard]] auto selected_mask_id() const -> QString { return selected_mask_id_; }
+  [[nodiscard]] auto edit_node_id() const -> const NodeId& { return edit_node_id_; }
   [[nodiscard]] auto inner_feather_percent() const -> qreal;
   [[nodiscard]] auto outer_feather_percent() const -> qreal;
   [[nodiscard]] auto major_radius_percent() const -> qreal;
@@ -76,6 +83,7 @@ class EditorMaskCreationAdapter : public QObject {
   Q_INVOKABLE void   selectMask(const QString& node_id, const QString& mask_id);
   Q_INVOKABLE void   removeMask(const QString& node_id, const QString& mask_id);
   Q_INVOKABLE void   removeSelectedMask();
+  Q_INVOKABLE void   deleteActiveMask();
   Q_INVOKABLE void   handleHover(qreal x, qreal y);
   Q_INVOKABLE void   beginInnerFeather();
   Q_INVOKABLE void   beginOuterFeather();
@@ -119,6 +127,7 @@ class EditorMaskCreationAdapter : public QObject {
   void               EnqueueAppendSample(const MaskCreationSample& sample);
   [[nodiscard]] auto CurrentGradeId() const -> NodeId;
   [[nodiscard]] auto CanAuthorMasks() const -> bool;
+  [[nodiscard]] auto CanAuthorMasksFor(const NodeId& grade_id) const -> bool;
   [[nodiscard]] auto DocumentContainsMask(const MaskId& mask_id) const -> bool;
   [[nodiscard]] auto MakeSample(qreal x, qreal y, bool allow_outside) const
       -> std::optional<MaskCreationSample>;
@@ -134,11 +143,10 @@ class EditorMaskCreationAdapter : public QObject {
   QMetaObject::Connection                           view_change_connection_;
   QString                                           tool_kind_;
   QString                                           selected_mask_id_;
+  NodeId                                            edit_node_id_;
   MaskSourceKind                                    source_kind_ = MaskSourceKind::Radial;
-  bool                                              creating_    = false;
+  EditMode                                          edit_mode_   = EditMode::Inactive;
   bool                                              open_        = false;
-  bool                                              selected_    = false;
-  bool                                              body_open_   = false;
   MaskPointerIdentity                               pointer_{};
   Vector2                                           press_normalized_{};
   std::optional<MaskSource>                         overlay_source_;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -238,7 +238,9 @@ class EditorNodeController : public QObject {
  signals:
   void EditorSessionChanged();
   void SnapshotChanged();
+  void snapshotChanged();
   void SelectionChanged();
+  void selectionChanged();
   void lastErrorChanged();
   void CommandStateChanged();
   void ActionAvailabilityChanged();

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_controller.hpp
@@ -289,6 +289,11 @@ class EditorNodeController : public QObject {
   /// not nested inside a GraphView key or menu handler.
   void               QueueProjectionApply();
   void               ApplyBoundGraphIfCurrent();
+  /// Fill missing backbone positions, push nodes below grown predecessors, then
+  /// push stored positions and drawer state to the adapter. Runs after a
+  /// projection apply and on every layout-store change (drawer folds, drags) so
+  /// a taller node never leaves its drawer rows under the next card.
+  void               ApplyLayoutToAdapter();
   void               SyncLayoutKey();
   void               PersistSavedSelection();
   void               ApplyLiveSelectionToAdapter();
@@ -308,6 +313,7 @@ class EditorNodeController : public QObject {
   QMetaObject::Connection                             history_connection_;
   QMetaObject::Connection                             availability_connection_;
   QMetaObject::Connection                             graph_adapter_connection_;
+  QMetaObject::Connection                             layout_store_connection_;
   EditorNodeGraphSnapshot                             snapshot_{};
   bool                                                has_snapshot_ = false;
   NodeId                                              selected_node_id_;
@@ -315,6 +321,7 @@ class EditorNodeController : public QObject {
   NodeId                                              selection_restore_node_id_;
   bool                                                command_active_          = false;
   bool                                                projection_apply_queued_ = false;
+  bool                                                applying_layout_         = false;
   quint64                                             session_generation_      = 0;
   quint64                                             observed_history_revision_ = 0;
   quint64                                             projection_revision_     = 0;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_layout_store.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_node_layout_store.hpp
@@ -174,6 +174,20 @@ class EditorNodeLayoutStore : public QObject {
   void AssignStagingPosition(const NodeId& node_id, const EditorNodeGraphSnapshot& snapshot);
 
   /**
+   * @brief Push nodes down when a predecessor's current height would cover them.
+   *
+   * Walks @p snapshot in backbone order. A node whose stored y sits above the
+   * previous node's footprint (stored y + current height + vertical gap) is
+   * shifted down to that footprint. Heights come from DefaultHeight with the
+   * snapshot's Mask counts and the stored drawer state, so Mask additions and
+   * drawer folds move following nodes out of the way instead of letting later
+   * siblings paint over the drawer rows. The shift is push-down-only: extra
+   * user spacing is preserved, and nodes on a different column (x ranges do
+   * not intersect) are never constrained. Existing stored x values are kept.
+   */
+  void ResolveVerticalOverlaps(const EditorNodeGraphSnapshot& snapshot);
+
+  /**
    * @brief QML entry that copies defaults from an EditorNodeController snapshot.
    * @param controller EditorNodeController, or ignored when the type does not match.
    */
@@ -192,6 +206,15 @@ class EditorNodeLayoutStore : public QObject {
 
  signals:
   void LayoutChanged();
+  /**
+   * @brief Emitted only when a stored value that changes a node's height
+   *        (currently the drawer open flag) is written.
+   *
+   * Position and view writes do not raise this: an explicit SetNodePosition
+   * (user drag) stays authoritative and must not be rewritten by overlap
+   * resolution. Mask-count changes arrive through projection applies instead.
+   */
+  void NodeHeightChanged();
 
  private:
   [[nodiscard]] auto      MutableCurrent() -> EditorNodeLayoutValue&;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "app/adjustment_transfer_types.hpp"
@@ -24,6 +25,7 @@
 #include "app/editor_session_types.hpp"
 #include "edit/graph/graph_ids.hpp"
 #include "edit/mask/mask_id.hpp"
+#include "edit/mask/mask_model.hpp"
 #include "ui/alcedo_main/album_backend/editor_action_availability_model.hpp"
 #include "ui/alcedo_main/album_backend/editor_adjustment_submitter.hpp"
 #include "ui/alcedo_main/album_backend/editor_history_operation_publisher.hpp"
@@ -303,6 +305,9 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   }
   auto EnqueueMaskCreation(alcedo::EditorMaskCreationCommand command) -> bool;
   [[nodiscard]] auto mask_creation_mask_id() const -> alcedo::MaskId;
+  [[nodiscard]] auto mask_creation_node_id() const -> alcedo::NodeId;
+  [[nodiscard]] auto mask_creation_source() const -> std::optional<alcedo::MaskSource>;
+  [[nodiscard]] auto mask_creation_last_removed_mask_id() const -> alcedo::MaskId;
 
   // Production pipeline entry: resolves the bound viewport through the scope tap.
   // Returns null when unbound or the object is not an EditorViewportItem.

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -107,8 +107,8 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   // Left tool rail page: empty string = collapsed; "history", "versions", or
   // "nodes" = expanded. Survives workspace round-trips within the process
   // (not persisted across application restart).
-  Q_PROPERTY(QString editorToolPanelPage READ editor_tool_panel_page WRITE set_editor_tool_panel_page
-                 NOTIFY DesktopUiChanged)
+  Q_PROPERTY(QString editorToolPanelPage READ editor_tool_panel_page WRITE
+                 set_editor_tool_panel_page NOTIFY DesktopUiChanged)
   Q_PROPERTY(bool presentationViewportBound READ presentation_viewport_bound NOTIFY
                  PresentationBindingChanged)
   Q_PROPERTY(EditorScopeController* scopeController READ scope_controller CONSTANT)
@@ -144,46 +144,46 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
                           QObject*                       parent = nullptr);
   ~EditorSessionController() override;
 
-  void                  SetSessionBackend(alcedo::IEditorSessionBackend* session_backend);
-  void                  SetInteractionPolicy(InteractionPolicyController* interaction_policy);
-  void                  SetCopiedPackageAvailable(bool available);
+  void                     SetSessionBackend(alcedo::IEditorSessionBackend* session_backend);
+  void                     SetInteractionPolicy(InteractionPolicyController* interaction_policy);
+  void                     SetCopiedPackageAvailable(bool available);
   /// Album catalog used to mirror ODT HDR EOTF into the library HDR badge.
-  void                  SetAlbumCatalog(IAlbumCatalog* album_catalog);
+  void                     SetAlbumCatalog(IAlbumCatalog* album_catalog);
 
   /// Called when the injected backend reports an async state/identity change
   /// (render presented, save finished, etc.). Mirrors backend into QML properties.
-  void                  OnBackendChanged();
+  void                     OnBackendChanged();
 
-  [[nodiscard]] bool    active() const;
-  [[nodiscard]] bool    has_image() const;
-  [[nodiscard]] bool    has_pending_recovery() const;
-  [[nodiscard]] uint    element_id() const;
-  [[nodiscard]] uint    image_id() const;
-  [[nodiscard]] uint    last_element_id() const { return last_element_id_; }
-  [[nodiscard]] uint    last_image_id() const { return last_image_id_; }
-  [[nodiscard]] QString viewport_identity_key() const;
-  [[nodiscard]] auto    session_state() const -> alcedo::EditorSessionState;
-  [[nodiscard]] QString session_state_name() const;
-  [[nodiscard]] bool    filmstrip_collapsed() const { return filmstrip_collapsed_; }
-  [[nodiscard]] double  filmstrip_expanded_height() const { return filmstrip_expanded_height_; }
-  [[nodiscard]] double  filmstrip_scroll_position() const { return filmstrip_scroll_position_; }
-  [[nodiscard]] QString active_adjustment_panel() const { return active_adjustment_panel_; }
-  [[nodiscard]] QString exif_line_text() const { return exif_line_text_; }
-  [[nodiscard]] QString exif_shutter_text() const { return exif_shutter_text_; }
-  [[nodiscard]] QString exif_iso_text() const { return exif_iso_text_; }
-  [[nodiscard]] QString exif_aperture_text() const { return exif_aperture_text_; }
-  [[nodiscard]] QString exif_focal_text() const { return exif_focal_text_; }
-  [[nodiscard]] QString editor_tool_panel_page() const { return editor_tool_panel_page_; }
+  [[nodiscard]] bool       active() const;
+  [[nodiscard]] bool       has_image() const;
+  [[nodiscard]] bool       has_pending_recovery() const;
+  [[nodiscard]] uint       element_id() const;
+  [[nodiscard]] uint       image_id() const;
+  [[nodiscard]] uint       last_element_id() const { return last_element_id_; }
+  [[nodiscard]] uint       last_image_id() const { return last_image_id_; }
+  [[nodiscard]] QString    viewport_identity_key() const;
+  [[nodiscard]] auto       session_state() const -> alcedo::EditorSessionState;
+  [[nodiscard]] QString    session_state_name() const;
+  [[nodiscard]] bool       filmstrip_collapsed() const { return filmstrip_collapsed_; }
+  [[nodiscard]] double     filmstrip_expanded_height() const { return filmstrip_expanded_height_; }
+  [[nodiscard]] double     filmstrip_scroll_position() const { return filmstrip_scroll_position_; }
+  [[nodiscard]] QString    active_adjustment_panel() const { return active_adjustment_panel_; }
+  [[nodiscard]] QString    exif_line_text() const { return exif_line_text_; }
+  [[nodiscard]] QString    exif_shutter_text() const { return exif_shutter_text_; }
+  [[nodiscard]] QString    exif_iso_text() const { return exif_iso_text_; }
+  [[nodiscard]] QString    exif_aperture_text() const { return exif_aperture_text_; }
+  [[nodiscard]] QString    exif_focal_text() const { return exif_focal_text_; }
+  [[nodiscard]] QString    editor_tool_panel_page() const { return editor_tool_panel_page_; }
   [[nodiscard]] qulonglong session_generation() const;
   [[nodiscard]] qulonglong history_revision() const;
   [[nodiscard]] QString    active_version_id() const;
   [[nodiscard]] auto       pipeline_document() const -> const alcedo::PipelineDocument*;
   // Phase 6C-7: load panel state from the backend adjustment snapshot.
-  [[nodiscard]] auto    adjustment_snapshot() const -> QVariantMap;
-  [[nodiscard]] auto    history_snapshot() const -> alcedo::EditorHistorySnapshot;
-  [[nodiscard]] auto    actions() -> EditorActionAvailabilityModel* { return &actions_; }
+  [[nodiscard]] auto       adjustment_snapshot() const -> QVariantMap;
+  [[nodiscard]] auto       history_snapshot() const -> alcedo::EditorHistorySnapshot;
+  [[nodiscard]] auto       actions() -> EditorActionAvailabilityModel* { return &actions_; }
 
-  [[nodiscard]] bool    presentation_viewport_bound() const {
+  [[nodiscard]] bool       presentation_viewport_bound() const {
     return presentation_viewport_ != nullptr;
   }
   // Phase 5D: true when the coordinator has in-flight/pending render work.
@@ -210,13 +210,13 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   // the session accepted the write for later owner processing, not that live
   // parameters or history were updated.
   Q_INVOKABLE bool   submitPatch(QString fieldKey, QString paramsJson, bool settled) override;
-  auto               submitWrite(QString fieldKey, alcedo::EditorParameterWrite write,
-                                 bool settled) -> bool override;
+  auto               submitWrite(QString fieldKey, alcedo::EditorParameterWrite write, bool settled)
+      -> bool override;
   /// Queue a node-switch seal so later writes start a new sequence. Old
   /// sequence ids keep their captured target. No live mutation.
-  Q_INVOKABLE bool   enqueueNodeSwitchBoundary();
+  Q_INVOKABLE bool enqueueNodeSwitchBoundary();
   /// Bind the Nodes-page selection owner used to stamp submit targets.
-  void               BindNodeSelectionSource(EditorNodeController* nodes);
+  void             BindNodeSelectionSource(EditorNodeController* nodes);
   /**
    * @brief Install the Image-owner EXIF reader used by the adjustment header.
    *
@@ -224,7 +224,7 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
    * selection. The reader copies Image::exif_display_ and must not parse EXIF
    * JSON. Throw or missing images yield an em-dash EXIF line.
    */
-  void SetImageExifReader(std::function<alcedo::EditorImageExifDisplay(uint)> reader);
+  void             SetImageExifReader(std::function<alcedo::EditorImageExifDisplay(uint)> reader);
   /// Reproject panels for the selected node without rendering or committing.
   void ApplySelectedAdjustmentNode(const alcedo::NodeId& node_id, alcedo::EditorNodeKind kind);
   [[nodiscard]] auto PeekPendingInput() const -> alcedo::EditorPendingInputView;
@@ -249,7 +249,7 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   Q_INVOKABLE void   Shutdown();
 
   /** Route a metadata-only Color Grade rename through the active session backend. */
-  auto SubmitRenameColorGrade(const alcedo::NodeId& node_id, std::string display_name)
+  auto               SubmitRenameColorGrade(const alcedo::NodeId& node_id, std::string display_name)
       -> alcedo::EditorSessionResult;
   /** Route one net topology delta through the active session backend. */
   auto SubmitNodeGraphTopologyEdit(const alcedo::NodeGraphTopologyChange& change)
@@ -303,11 +303,12 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   [[nodiscard]] auto session_backend() const -> alcedo::IEditorSessionBackend* {
     return session_backend_;
   }
-  auto EnqueueMaskCreation(alcedo::EditorMaskCreationCommand command) -> bool;
+  auto               EnqueueMaskCreation(alcedo::EditorMaskCreationCommand command) -> bool;
   [[nodiscard]] auto mask_creation_mask_id() const -> alcedo::MaskId;
   [[nodiscard]] auto mask_creation_node_id() const -> alcedo::NodeId;
   [[nodiscard]] auto mask_creation_source() const -> std::optional<alcedo::MaskSource>;
   [[nodiscard]] auto mask_creation_last_removed_mask_id() const -> alcedo::MaskId;
+  [[nodiscard]] auto mask_creation_commands_pending() const -> bool;
 
   // Production pipeline entry: resolves the bound viewport through the scope tap.
   // Returns null when unbound or the object is not an EditorViewportItem.
@@ -363,8 +364,9 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
                                      const QString&                     selected_id = {});
   /// Correlate an async backend result observer delivery to a pending action.
   void OnBackendSessionResult(const alcedo::EditorSessionResult& result);
-  void                     BindAdmissionDeadline();
-  void                     SetActiveAdjustmentPanel(const QString& panel, bool request_view);
+  void BindAdmissionDeadline();
+  void SetActiveAdjustmentPanel(const QString& panel, bool request_view);
+  void SyncMaskAdjustmentPanel();
   [[nodiscard]] static auto       NormalizeAdjustmentPanel(const QString& panel) -> QString;
   [[nodiscard]] static auto       NormalizeToolPanelPage(const QString& page) -> QString;
 
@@ -392,29 +394,32 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   /// When true, OnBackendChanged still refreshes the cached snapshot map but
   /// does not emit AdjustmentSnapshotChanged. Kept so a later owner completion
   /// can suppress panel reload while a pointer drag is still on the stack.
-  bool                            suppress_snapshot_publish_ = false;
+  bool                            suppress_snapshot_publish_     = false;
   // Phase 7A R2: last history revision observed from the backend. OnBackendChanged
   // emits HistoryChanged only when the backend's history_revision advances, so
   // render/preview/task notifications no longer trigger a history projection.
-  std::uint64_t                   last_history_revision_     = 0;
+  std::uint64_t                   last_history_revision_         = 0;
   /// Last panel projection session_generation applied to adjustment_snapshot_.
   /// A matching generation merges changed fields; a new generation replaces.
   std::uint64_t                   last_applied_panel_generation_ = 0;
 
-  QString                                        active_adjustment_panel_ = QStringLiteral("tone");
-  QString                                        editor_tool_panel_page_;
+  QString                         active_adjustment_panel_       = QStringLiteral("tone");
+  QString                         panel_before_mask_edit_        = QStringLiteral("tone");
+  bool                            mask_edit_was_active_          = false;
+  bool                            mask_panel_transition_         = false;
+  QString                         editor_tool_panel_page_;
   std::function<alcedo::EditorImageExifDisplay(uint)> image_exif_reader_;
-  uint                                           exif_image_id_          = 0;
-  qulonglong                                     exif_session_generation_ = 0;
-  QString exif_line_text_     = QString::fromUtf8("\xE2\x80\x94");
-  QString exif_shutter_text_  = QString::fromUtf8("\xE2\x80\x94");
-  QString exif_iso_text_      = QString::fromUtf8("\xE2\x80\x94");
-  QString exif_aperture_text_ = QString::fromUtf8("\xE2\x80\x94");
-  QString exif_focal_text_    = QString::fromUtf8("\xE2\x80\x94");
-  QPointer<QObject>                              presentation_viewport_;
-  QPointer<QObject>                              interaction_controller_;
-  QMetaObject::Connection                        interaction_view_change_connection_;
-  QMetaObject::Connection                        interaction_policy_connection_;
+  uint                                                exif_image_id_           = 0;
+  qulonglong                                          exif_session_generation_ = 0;
+  QString                 exif_line_text_     = QString::fromUtf8("\xE2\x80\x94");
+  QString                 exif_shutter_text_  = QString::fromUtf8("\xE2\x80\x94");
+  QString                 exif_iso_text_      = QString::fromUtf8("\xE2\x80\x94");
+  QString                 exif_aperture_text_ = QString::fromUtf8("\xE2\x80\x94");
+  QString                 exif_focal_text_    = QString::fromUtf8("\xE2\x80\x94");
+  QPointer<QObject>       presentation_viewport_;
+  QPointer<QObject>       interaction_controller_;
+  QMetaObject::Connection interaction_view_change_connection_;
+  QMetaObject::Connection interaction_policy_connection_;
   mutable std::unique_ptr<EditorScopeController> scope_controller_;
   std::unique_ptr<EditorMaskCreationAdapter>     mask_creation_;
   QTimer*                                        admission_deadline_timer_ = nullptr;

--- a/alcedo_studio/src/include/ui/alcedo_main/app_theme.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/app_theme.hpp
@@ -183,6 +183,12 @@ class AppTheme final : public QObject {
   Q_PROPERTY(qreal maskOverlayAntialiasWidth READ maskOverlayAntialiasWidth CONSTANT)
   Q_PROPERTY(int maskOverlayHandleHitRadius READ maskOverlayHandleHitRadius CONSTANT)
   Q_PROPERTY(int maskOverlayRotateHandleOffset READ maskOverlayRotateHandleOffset CONSTANT)
+  Q_PROPERTY(qreal maskOverlayGuideOuterWidth READ maskOverlayGuideOuterWidth CONSTANT)
+  Q_PROPERTY(qreal maskOverlayGuideInnerWidth READ maskOverlayGuideInnerWidth CONSTANT)
+  Q_PROPERTY(qreal maskOverlayGripOuterWidth READ maskOverlayGripOuterWidth CONSTANT)
+  Q_PROPERTY(qreal maskOverlayGripInnerWidth READ maskOverlayGripInnerWidth CONSTANT)
+  Q_PROPERTY(qreal maskOverlayGripSpanT0 READ maskOverlayGripSpanT0 CONSTANT)
+  Q_PROPERTY(qreal maskOverlayGripSpanT1 READ maskOverlayGripSpanT1 CONSTANT)
 
  public:
   enum class FontRole : int {
@@ -364,6 +370,12 @@ class AppTheme final : public QObject {
   auto maskOverlayAntialiasWidth() const -> qreal;
   auto maskOverlayHandleHitRadius() const -> int;
   auto maskOverlayRotateHandleOffset() const -> int;
+  auto maskOverlayGuideOuterWidth() const -> qreal;
+  auto maskOverlayGuideInnerWidth() const -> qreal;
+  auto maskOverlayGripOuterWidth() const -> qreal;
+  auto maskOverlayGripInnerWidth() const -> qreal;
+  auto maskOverlayGripSpanT0() const -> qreal;
+  auto maskOverlayGripSpanT1() const -> qreal;
 
   auto currentThemeIndex() const -> int;
   void setCurrentThemeIndex(int index);

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_edit_geometry.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_edit_geometry.hpp
@@ -10,6 +10,7 @@
 #include <QPointF>
 #include <QVector2D>
 
+#include "edit/geometry/render_request.hpp"
 #include "edit/geometry/resolved_render_geometry.hpp"
 #include "edit/geometry/types.hpp"
 #include "ui/edit_viewer/viewport_mapper.hpp"
@@ -106,6 +107,19 @@ class MaskEditGeometry {
    * identity. Empty @p extent yields empty extents so @ref IsValid is false.
    */
   [[nodiscard]] static auto MakeIdentityPhotographGeometry(Extent2D extent)
+      -> ResolvedRenderGeometry;
+
+  /**
+   * @brief Resolved photograph geometry from document crop, rotation, and expand-to-fit.
+   *
+   * @p full_reference is uncropped ReferenceSpace. Identity crop and zero rotation
+   * return @ref MakeIdentityPhotographGeometry. Empty @p full_reference yields
+   * empty extents so @ref IsValid is false.
+   *
+   * Thread: GUI. Pure; does not lock the pipeline.
+   */
+  [[nodiscard]] static auto MakeDocumentPhotographGeometry(Extent2D full_reference,
+                                                            const ImageGeometryParams& image)
       -> ResolvedRenderGeometry;
 
   /**

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_geometry.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_geometry.hpp
@@ -42,6 +42,10 @@ inline constexpr float kMaskOverlayGripSpanT1 = 0.62f;
 inline constexpr float kMaskOverlayMaxChordDeviationLogicalPx = 0.25f;
 /// Upper bound on Radial outline vertices after adaptive subdivision.
 inline constexpr int kMaskOverlayMaxEllipseVertices = 256;
+/// Dash on-length for feather-boundary contours, in logical pixels.
+inline constexpr float kMaskOverlayDashLengthLogicalPx = 6.0f;
+/// Dash off-length for feather-boundary contours, in logical pixels.
+inline constexpr float kMaskOverlayDashGapLogicalPx = 4.0f;
 
 /**
  * @brief Published Mask overlay mode. Creating may emit temporary path/outline guides.
@@ -128,6 +132,18 @@ struct MaskOverlayStyle {
 };
 
 /**
+ * @brief One closed Radial iso-rho contour in item/logical coordinates.
+ *
+ * @p dashed marks feather boundaries (inner/outer); the base rho = 1 ellipse is
+ * solid. Dashed contours use @ref kMaskOverlayDashLengthLogicalPx and
+ * @ref kMaskOverlayDashGapLogicalPx with a continuous arc-length phase.
+ */
+struct MaskOverlayContour {
+  std::vector<QPointF> points;
+  bool                 dashed = false;
+};
+
+/**
  * @brief GUI-thread Mask overlay publication. Item coordinates only.
  *
  * Built from current input and read-only mapped control positions. The scene
@@ -149,7 +165,7 @@ struct MaskOverlayDisplay {
   std::vector<QPointF> creation_outline;
   std::vector<std::pair<QPointF, QPointF>> creation_guides;
   /// Selected Radial iso-rho contours. Closed polylines; coincident rhos appear once.
-  std::vector<std::vector<QPointF>> selected_contours;
+  std::vector<MaskOverlayContour> selected_contours;
   /// Selected Gradient loci and other open analytic guides. Not a closed polygon.
   std::vector<MaskOverlayGuide> selected_guides;
   /// Short Geometry-crop edge grips on visible Gradient guides.

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_geometry.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_geometry.hpp
@@ -26,7 +26,19 @@ inline constexpr float kMaskOverlayAntialiasWidthLogicalPx = 1.0f;
 inline constexpr float kMaskOverlayHandleHitRadiusLogicalPx = 12.0f;
 /// Rotation/direction handle offset from the mapped origin, in logical pixels.
 inline constexpr float kMaskOverlayRotateHandleOffsetLogicalPx = 24.0f;
-/// Maximum chord deviation when tessellating a Radial creation outline, in logical pixels.
+/// Geometry-crop outer stroke for selected analytic guides, in logical pixels.
+inline constexpr float kMaskOverlayGuideOuterWidthLogicalPx = 3.0f;
+/// Geometry-crop inner stroke for selected analytic guides, in logical pixels.
+inline constexpr float kMaskOverlayGuideInnerWidthLogicalPx = 1.2f;
+/// Geometry-crop outer edge-grip width, in logical pixels.
+inline constexpr float kMaskOverlayGripOuterWidthLogicalPx = 5.0f;
+/// Geometry-crop inner edge-grip width, in logical pixels.
+inline constexpr float kMaskOverlayGripInnerWidthLogicalPx = 2.4f;
+/// Start of the short edge grip along a visible guide, in [0, 1].
+inline constexpr float kMaskOverlayGripSpanT0 = 0.38f;
+/// End of the short edge grip along a visible guide, in [0, 1].
+inline constexpr float kMaskOverlayGripSpanT1 = 0.62f;
+/// Maximum chord deviation when tessellating a Radial iso-rho contour, in logical pixels.
 inline constexpr float kMaskOverlayMaxChordDeviationLogicalPx = 0.25f;
 /// Upper bound on Radial outline vertices after adaptive subdivision.
 inline constexpr int kMaskOverlayMaxEllipseVertices = 256;
@@ -66,10 +78,29 @@ enum class MaskOverlayHandleId : std::uint8_t {
   LinearEndBoundary    = 11,
 };
 
-/** @brief One handle disc in item/logical coordinates. */
+/** @brief Disc is a filled radius/origin control. Ring is a feather control. */
+enum class MaskOverlayHandleShape : std::uint8_t {
+  Disc = 0,
+  Ring = 1,
+};
+
+/** @brief One handle in item/logical coordinates. */
 struct MaskOverlayHandle {
+  MaskOverlayHandleId    id    = MaskOverlayHandleId::None;
+  QPointF                item{};
+  MaskOverlayHandleShape shape = MaskOverlayHandleShape::Disc;
+};
+
+/**
+ * @brief One open guide segment in item/logical coordinates.
+ *
+ * Gradient loci and Radial contours use open or closed polylines. These
+ * segments are never joined into a closed polygon.
+ */
+struct MaskOverlayGuide {
   MaskOverlayHandleId id = MaskOverlayHandleId::None;
-  QPointF             item{};
+  QPointF             a{};
+  QPointF             b{};
 };
 
 /**
@@ -88,6 +119,12 @@ struct MaskOverlayStyle {
   float  antialias_width_logical_px        = kMaskOverlayAntialiasWidthLogicalPx;
   float  hit_radius_logical_px             = kMaskOverlayHandleHitRadiusLogicalPx;
   float  rotate_handle_offset_logical_px   = kMaskOverlayRotateHandleOffsetLogicalPx;
+  float  guide_outer_width_logical_px      = kMaskOverlayGuideOuterWidthLogicalPx;
+  float  guide_inner_width_logical_px      = kMaskOverlayGuideInnerWidthLogicalPx;
+  float  grip_outer_width_logical_px       = kMaskOverlayGripOuterWidthLogicalPx;
+  float  grip_inner_width_logical_px       = kMaskOverlayGripInnerWidthLogicalPx;
+  float  grip_span_t0                     = kMaskOverlayGripSpanT0;
+  float  grip_span_t1                     = kMaskOverlayGripSpanT1;
 };
 
 /**
@@ -111,6 +148,14 @@ struct MaskOverlayDisplay {
   std::vector<QPointF> creation_path;
   std::vector<QPointF> creation_outline;
   std::vector<std::pair<QPointF, QPointF>> creation_guides;
+  /// Selected Radial iso-rho contours. Closed polylines; coincident rhos appear once.
+  std::vector<std::vector<QPointF>> selected_contours;
+  /// Selected Gradient loci and other open analytic guides. Not a closed polygon.
+  std::vector<MaskOverlayGuide> selected_guides;
+  /// Short Geometry-crop edge grips on visible Gradient guides.
+  std::vector<std::pair<QPointF, QPointF>> edge_grips;
+  MaskOverlayHandleId hovered_handle = MaskOverlayHandleId::None;
+  MaskOverlayHandleId active_handle  = MaskOverlayHandleId::None;
   QRectF clip_rect{};
 };
 
@@ -141,7 +186,11 @@ struct MaskOverlaySceneGeometry {
   std::vector<MaskOverlayVertex> connectors;
   std::vector<MaskOverlayVertex> cursor;
   std::vector<MaskOverlayVertex> creation_guides;
+  std::vector<MaskOverlayVertex> selected_guides;
+  std::vector<MaskOverlayVertex> edge_grips;
   int handle_count                       = 0;
+  int selected_guide_segment_count      = 0;
+  int closed_polygon_edge_count         = 0;
   int coverage_fill_vertex_count         = 0;
   int settled_stroke_path_vertex_count   = 0;
 };

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
@@ -82,8 +82,8 @@ namespace alcedo {
 /**
  * @brief Existing Radial: center, axes, rotation, feather handles, and iso-rho lines.
  *
- * Shows the base ellipse and distinct inner/outer feather contours. Coincident
- * rhos are drawn once. No ellipse fill.
+ * Shows the base ellipse (solid) and distinct inner/outer feather contours
+ * (dashed). Coincident rhos are drawn once. No ellipse fill.
  */
 [[nodiscard]] auto MakeRadialExistingOverlayDisplay(const MaskEditViewMapping& mapping,
                                                     const RadialMaskSource&    source,

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
@@ -58,9 +58,10 @@ namespace alcedo {
                                                    const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
- * @brief Existing Radial: center, axes, rotation, and distinct feather handles.
+ * @brief Existing Radial: center, axes, rotation, feather handles, and iso-rho lines.
  *
- * Connectors only. No ellipse fill and no iso-rho outline.
+ * Shows the base ellipse and distinct inner/outer feather contours. Coincident
+ * rhos are drawn once. No ellipse fill.
  */
 [[nodiscard]] auto MakeRadialExistingOverlayDisplay(const MaskEditViewMapping& mapping,
                                                     const RadialMaskSource& source,
@@ -68,9 +69,10 @@ namespace alcedo {
                                                     const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
- * @brief Existing Linear Gradient: origin, direction, and transition boundaries.
+ * @brief Existing Linear Gradient: origin, direction, and three parallel loci.
  *
- * Finite connectors only. No filled coverage band.
+ * Guides are clipped to the photograph with Geometry crop-style dual strokes
+ * and short edge grips. Ends are not joined into a kite or closed polygon.
  */
 [[nodiscard]] auto MakeLinearExistingOverlayDisplay(const MaskEditViewMapping& mapping,
                                                     const LinearGradientMaskSource& source,
@@ -89,7 +91,7 @@ namespace alcedo {
                                                    const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
- * @brief Initial Radial drawing: existing handles plus a temporary outline at rho = 1.
+ * @brief Initial Radial drawing: selected contours and handles while the drag is open.
  */
 [[nodiscard]] auto MakeRadialCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
                                                     const RadialMaskSource& source,
@@ -97,7 +99,7 @@ namespace alcedo {
                                                     const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
- * @brief Initial Linear drawing: existing handles plus finite locus guides.
+ * @brief Initial Linear drawing: three photograph-clipped loci plus handles.
  */
 [[nodiscard]] auto MakeLinearCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
                                                     const LinearGradientMaskSource& source,
@@ -107,6 +109,14 @@ namespace alcedo {
 [[nodiscard]] auto HitTestMaskOverlayHandle(const MaskOverlayDisplay& display, QPointF item,
                                            float hit_radius_logical_px)
     -> MaskOverlayHandleId;
+
+/**
+ * @brief Axis-aligned photograph rectangle in item coordinates.
+ *
+ * Maps photograph UV (0,0) and (1,1) through the current view. Empty when mapping
+ * is invalid.
+ */
+[[nodiscard]] auto PhotographItemRect(const MaskEditViewMapping& mapping) -> QRectF;
 
 /**
  * @brief Item-space length of a ReferenceSpace radius around @p center_reference.

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <vector>
-
 #include <QPointF>
 #include <QRectF>
+#include <vector>
 
 #include "edit/geometry/types.hpp"
 #include "edit/mask/mask_model.hpp"
@@ -34,6 +33,29 @@ namespace alcedo {
                                          float theta_radians) -> Vector2;
 
 /**
+ * @brief Map the item-space perpendicular foot on one Linear Gradient locus.
+ *
+ * The evaluator normal is a covector under a non-square photograph transform.
+ * This helper keeps the visible control axis perpendicular to the mapped guide
+ * while the returned point remains on the exact normalized-space locus.
+ */
+[[nodiscard]] auto MapLinearLocusNormalPointToItem(const MaskEditViewMapping&      mapping,
+                                                   const LinearGradientMaskSource& source,
+                                                   float signed_distance) -> std::optional<QPointF>;
+
+/**
+ * @brief Convert an item-space direction control point to an evaluator normal sample.
+ *
+ * This is the inverse interaction mapping for
+ * @ref MapLinearLocusNormalPointToItem. The returned normalized point is one
+ * unit normal from the source origin and can be passed to
+ * @c UpdateLinearDirection.
+ */
+[[nodiscard]] auto MapItemPointToLinearDirectionSample(const MaskEditViewMapping&      mapping,
+                                                       const LinearGradientMaskSource& source,
+                                                       QPointF item) -> std::optional<Vector2>;
+
+/**
  * @brief Tessellate a Radial iso-@p rho curve into item-space vertices.
  *
  * Subdivides until projected chord error is at most
@@ -54,7 +76,7 @@ namespace alcedo {
  * @brief Existing Brush: Move handle at @p placement_translation. No stroke path.
  */
 [[nodiscard]] auto MakeBrushExistingOverlayDisplay(const MaskEditViewMapping& mapping,
-                                                   Vector2 placement_translation,
+                                                   Vector2                    placement_translation,
                                                    const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
@@ -64,8 +86,8 @@ namespace alcedo {
  * rhos are drawn once. No ellipse fill.
  */
 [[nodiscard]] auto MakeRadialExistingOverlayDisplay(const MaskEditViewMapping& mapping,
-                                                    const RadialMaskSource& source,
-                                                    const MaskOverlayStyle& style,
+                                                    const RadialMaskSource&    source,
+                                                    const MaskOverlayStyle&    style,
                                                     const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
@@ -74,9 +96,9 @@ namespace alcedo {
  * Guides are clipped to the photograph with Geometry crop-style dual strokes
  * and short edge grips. Ends are not joined into a kite or closed polygon.
  */
-[[nodiscard]] auto MakeLinearExistingOverlayDisplay(const MaskEditViewMapping& mapping,
+[[nodiscard]] auto MakeLinearExistingOverlayDisplay(const MaskEditViewMapping&      mapping,
                                                     const LinearGradientMaskSource& source,
-                                                    const MaskOverlayStyle& style,
+                                                    const MaskOverlayStyle&         style,
                                                     const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
@@ -86,29 +108,28 @@ namespace alcedo {
  * This function does not resample pointer events. No area fill.
  */
 [[nodiscard]] auto MakeBrushCreatingOverlayDisplay(const std::vector<QPointF>& item_path,
-                                                   QPointF cursor_item,
-                                                   float cursor_radius_logical_px,
+                                                   QPointF                     cursor_item,
+                                                   float         cursor_radius_logical_px,
                                                    const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
  * @brief Initial Radial drawing: selected contours and handles while the drag is open.
  */
 [[nodiscard]] auto MakeRadialCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
-                                                    const RadialMaskSource& source,
-                                                    const MaskOverlayStyle& style,
+                                                    const RadialMaskSource&    source,
+                                                    const MaskOverlayStyle&    style,
                                                     const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
  * @brief Initial Linear drawing: three photograph-clipped loci plus handles.
  */
-[[nodiscard]] auto MakeLinearCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
+[[nodiscard]] auto MakeLinearCreatingOverlayDisplay(const MaskEditViewMapping&      mapping,
                                                     const LinearGradientMaskSource& source,
-                                                    const MaskOverlayStyle& style,
+                                                    const MaskOverlayStyle&         style,
                                                     const QRectF& clip) -> MaskOverlayDisplay;
 
 [[nodiscard]] auto HitTestMaskOverlayHandle(const MaskOverlayDisplay& display, QPointF item,
-                                           float hit_radius_logical_px)
-    -> MaskOverlayHandleId;
+                                            float hit_radius_logical_px) -> MaskOverlayHandleId;
 
 /**
  * @brief Axis-aligned photograph rectangle in item coordinates.

--- a/alcedo_studio/src/include/ui/editor_rhi/editor_overlay_item.hpp
+++ b/alcedo_studio/src/include/ui/editor_rhi/editor_overlay_item.hpp
@@ -84,6 +84,14 @@ class EditorOverlayItem : public QQuickItem {
                  setMaskOverlayStrokeWidth NOTIFY MaskOverlayStyleChanged)
   Q_PROPERTY(qreal maskOverlayAntialiasWidth READ maskOverlayAntialiasWidth WRITE
                  setMaskOverlayAntialiasWidth NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(qreal maskOverlayGuideOuterWidth READ maskOverlayGuideOuterWidth WRITE
+                 setMaskOverlayGuideOuterWidth NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(qreal maskOverlayGuideInnerWidth READ maskOverlayGuideInnerWidth WRITE
+                 setMaskOverlayGuideInnerWidth NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(qreal maskOverlayGripOuterWidth READ maskOverlayGripOuterWidth WRITE
+                 setMaskOverlayGripOuterWidth NOTIFY MaskOverlayStyleChanged)
+  Q_PROPERTY(qreal maskOverlayGripInnerWidth READ maskOverlayGripInnerWidth WRITE
+                 setMaskOverlayGripInnerWidth NOTIFY MaskOverlayStyleChanged)
 
  public:
   explicit EditorOverlayItem(QQuickItem* parent = nullptr);
@@ -125,6 +133,22 @@ class EditorOverlayItem : public QQuickItem {
     return static_cast<qreal>(mask_style_.antialias_width_logical_px);
   }
   void setMaskOverlayAntialiasWidth(qreal width);
+  [[nodiscard]] auto maskOverlayGuideOuterWidth() const -> qreal {
+    return static_cast<qreal>(mask_style_.guide_outer_width_logical_px);
+  }
+  void setMaskOverlayGuideOuterWidth(qreal width);
+  [[nodiscard]] auto maskOverlayGuideInnerWidth() const -> qreal {
+    return static_cast<qreal>(mask_style_.guide_inner_width_logical_px);
+  }
+  void setMaskOverlayGuideInnerWidth(qreal width);
+  [[nodiscard]] auto maskOverlayGripOuterWidth() const -> qreal {
+    return static_cast<qreal>(mask_style_.grip_outer_width_logical_px);
+  }
+  void setMaskOverlayGripOuterWidth(qreal width);
+  [[nodiscard]] auto maskOverlayGripInnerWidth() const -> qreal {
+    return static_cast<qreal>(mask_style_.grip_inner_width_logical_px);
+  }
+  void setMaskOverlayGripInnerWidth(qreal width);
 
   // Test access: last built crop scene geometry after a sync.
   [[nodiscard]] auto lastSceneGeometry() const -> const OverlaySceneGeometry& {

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -39,6 +39,7 @@ def_library(EditorViewerLogic
         Qt6::Gui
         opencv_core
         EditMaskStore
+        EditGeometry
 )
 
 def_library(BackgroundTaskController

--- a/alcedo_studio/src/ui/alcedo_main/DESIGN.md
+++ b/alcedo_studio/src/ui/alcedo_main/DESIGN.md
@@ -414,8 +414,8 @@ Retained QSG Mask controls sit on `EditorOverlayItem` above the photograph. They
 use a two-layer high-contrast stroke. Existing-mask editing never paints a
 coverage fill, heatmap, or completed Brush path; the Interactive photograph
 supplies coverage feedback. Temporary Brush cursor/path guides are allowed during initial
-drawing. The planned NM7.8 revision requires selected Radial base ellipse and inner/outer
-feather boundary lines during creation and later editing. Selected Gradient uses three parallel
+drawing. Selected Radial shows the base ellipse and inner/outer feather boundary
+lines during creation and later editing. Selected Gradient uses three parallel
 lines with Geometry crop-style dual high-contrast strokes and short edge grips, without a kite,
 closed polygon or crop dimming. Radius/feather and direction controls must be independently
 reachable. Unselected analytic masks do not retain editing guides.
@@ -424,6 +424,14 @@ Handle and stroke widths are logical pixels and stay constant at any zoom or
 DPR. Image-space Brush cursor radius is transformed through the shared
 ReferenceSpace mapping. Do not add a coverage-area color. Do not use Material
 controls, badges, pills, or status dots on this overlay.
+
+Selected Radial shows the base ellipse plus inner and outer feather boundary
+lines from the evaluator inverse. Coincident rhos are drawn once. A collapsed
+inner contour is omitted rather than producing invalid geometry. Feather
+handles are rings; radius handles are discs. Selected Gradient uses three
+photograph-clipped parallel loci with Geometry crop-style dual strokes and
+short edge grips. Ends are not joined into a kite, diamond, or closed
+polygon. Crop overlay dimming is not reused.
 
 | Token | Value | Use |
 | --- | --- | --- |
@@ -436,6 +444,12 @@ controls, badges, pills, or status dots on this overlay.
 | `maskOverlayAntialiasWidth` | 1.0 | Premultiplied edge-alpha fringe (logical px) |
 | `maskOverlayHandleHitRadius` | 12 | Pointer hit radius (logical px) |
 | `maskOverlayRotateHandleOffset` | 24 | Rotation/direction handle offset (logical px) |
+| `maskOverlayGuideOuterWidth` | 3.0 | Geometry-crop outer guide stroke (logical px) |
+| `maskOverlayGuideInnerWidth` | 1.2 | Geometry-crop inner guide stroke (logical px) |
+| `maskOverlayGripOuterWidth` | 5.0 | Geometry-crop outer edge-grip width (logical px) |
+| `maskOverlayGripInnerWidth` | 2.4 | Geometry-crop inner edge-grip width (logical px) |
+| `maskOverlayGripSpanT0` | 0.38 | Start of the short edge grip along a visible guide |
+| `maskOverlayGripSpanT1` | 0.62 | End of the short edge grip along a visible guide |
 
 ### Color Grade node content
 
@@ -484,13 +498,14 @@ of painting square corners over the card.
 The open state is UI layout state. A drawer change does not modify the pipeline,
 create history, or start photo rendering. An empty open drawer has no Mask rows.
 
-Each Mask row is flat. It shows only the approved source-type icon and localized
-type name. Do not show the Mask name, opacity, enabled value, invert value, ranges, or identity.
-The planned NM7.8 revision adds stable NodeId/MaskId selection and a compact per-row delete
-`IconActionButton`. Selecting loads the existing Mask into the temporary Masks body and viewer
-without creating a mask or history. Use existing monochrome selection tokens and preserve scroll.
-Delete must not propagate into row selection or graph Grade deletion. Parameter editors stay in
-the Masks body. This supersedes the earlier read-only row rule.
+Each Mask row is flat. It shows the approved source-type icon, localized type
+name, and a compact per-row delete `IconActionButton`. Do not show the Mask
+name, opacity, enabled value, invert value, ranges, or identity. Selection
+uses stable NodeId/MaskId and loads the existing Mask into the temporary Masks
+body and viewer without creating a mask or history. Bind highlight to session
+selection with existing monochrome selection tokens and preserve scroll. Do
+not rebuild the list on click. Delete must not propagate into row selection or
+graph Grade deletion. Parameter editors stay in the Masks body.
 
 | Model kind | UI label | Icon |
 | --- | --- | --- |

--- a/alcedo_studio/src/ui/alcedo_main/DESIGN.md
+++ b/alcedo_studio/src/ui/alcedo_main/DESIGN.md
@@ -405,8 +405,10 @@ forwarding a dock move — anchor placement after creation or a drawer fold
 changing the host height — leaves edges visually detached from their ports.
 Node selection paints only the card outline: the adapter installs an
 invisible QuickQanava selection delegate, so the default blue animated
-selection item never renders. Do not set `selectionDelegate` to null in QML;
-null resets the QuickQanava default instead of disabling it.
+selection item never renders. That delegate is still a full-size `z: 1` child
+of the node; the card uses `z: 2` and the port dock uses `z: 3` so Mask rows
+and ports stay the pointer target. Do not set `selectionDelegate` to null in
+QML; null resets the QuickQanava default instead of disabling it.
 
 ### Editor viewport Mask overlay
 
@@ -419,6 +421,16 @@ lines during creation and later editing. Selected Gradient uses three parallel
 lines with Geometry crop-style dual high-contrast strokes and short edge grips, without a kite,
 closed polygon or crop dimming. Radius/feather and direction controls must be independently
 reachable. Unselected analytic masks do not retain editing guides.
+
+Mask editing has three mutually exclusive states: inactive, creating, and
+editing an existing Mask. The header creation buttons and a Mask row selection
+both enter this state machine and immediately open the transient Mask page.
+`Enter` and `Escape` finish the edit, hide the overlay, and return to the prior
+adjustment page. Selecting any node-parameter adjustment page also finishes the
+Mask edit before opening that page. `Delete` removes the selected Mask and exits;
+before a new Mask exists it exits the armed creation tool. These shortcuts are
+disabled when Mask editing ends, so the Nodes graph resumes ownership of
+`Delete` for Color Grade removal.
 
 Handle and stroke widths are logical pixels and stay constant at any zoom or
 DPR. Image-space Brush cursor radius is transformed through the shared

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
@@ -1306,6 +1306,8 @@ void AlcedoQanGraph::ApplyNodePresentation(qan::Node& qan_node, const EditorNode
   }
   item->setResizable(false);
   item->setProperty("nodeKind", NodeKindKey(node.node_kind));
+  item->setProperty("nodeId", ToQString(node.node_id.Value()));
+  item->setProperty("selectedMaskId", selected_mask_id_);
   item->setProperty("masks", MasksToVariant(node.masks));
 }
 
@@ -1530,11 +1532,19 @@ void AlcedoQanGraph::BindDrawerSignal(QQuickItem* item, const NodeId& /*node_id*
   }
   const auto* meta         = item->metaObject();
   const int   signal_index = meta->indexOfSignal("drawerOpenChanged()");
-  if (signal_index < 0) {
-    return;
+  if (signal_index >= 0) {
+    drawer_connections_.push_back(
+        QObject::connect(item, SIGNAL(drawerOpenChanged()), this, SLOT(OnDrawerOpenChanged())));
   }
-  drawer_connections_.push_back(
-      QObject::connect(item, SIGNAL(drawerOpenChanged()), this, SLOT(OnDrawerOpenChanged())));
+  if (meta->indexOfSignal("maskSelected(QString,QString)") >= 0) {
+    drawer_connections_.push_back(QObject::connect(item, SIGNAL(maskSelected(QString,QString)),
+                                                    this, SLOT(OnMaskSelected(QString,QString))));
+  }
+  if (meta->indexOfSignal("maskDeleteRequested(QString,QString)") >= 0) {
+    drawer_connections_.push_back(
+        QObject::connect(item, SIGNAL(maskDeleteRequested(QString,QString)), this,
+                         SLOT(OnMaskDeleteRequested(QString,QString))));
+  }
 }
 
 void AlcedoQanGraph::OnDrawerOpenChanged() {
@@ -1549,6 +1559,32 @@ void AlcedoQanGraph::OnDrawerOpenChanged() {
     emit NodeDrawerOpenChanged(ToQString(node_id.Value()), item->property("drawerOpen").toBool());
     return;
   }
+}
+
+void AlcedoQanGraph::OnMaskSelected(const QString& node_id, const QString& mask_id) {
+  emit MaskRowSelected(node_id, mask_id);
+}
+
+void AlcedoQanGraph::OnMaskDeleteRequested(const QString& node_id, const QString& mask_id) {
+  emit MaskRowDeleteRequested(node_id, mask_id);
+}
+
+void AlcedoQanGraph::set_selected_mask_id(const QString& mask_id) {
+  if (selected_mask_id_ == mask_id) {
+    return;
+  }
+  selected_mask_id_ = mask_id;
+  for (const auto& [node_id, node] : node_by_id_) {
+    if (node.isNull() || node->getItem() == nullptr) {
+      continue;
+    }
+    node->getItem()->setProperty("selectedMaskId", selected_mask_id_);
+  }
+  emit SelectedMaskChanged();
+}
+
+void AlcedoQanGraph::setSelectedMaskId(const QString& mask_id) {
+  set_selected_mask_id(mask_id);
 }
 
 void AlcedoQanGraph::BindDrawerSignals() {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/alcedo_qan_graph.cpp
@@ -11,6 +11,7 @@
 #include <QQmlComponent>
 #include <QQmlEngine>
 #include <QQuickItem>
+#include <QRectF>
 #include <QVariant>
 #include <QVariantMap>
 #include <algorithm>
@@ -81,6 +82,7 @@ void AlcedoQanGraph::set_graph(qan::Graph* graph) {
     return;
   }
   if (!graph_.isNull()) {
+    graph_->setProperty("alcedoQanGraph", QVariant());
     disconnect(graph_.data(), nullptr, this, nullptr);
   }
   rebuild_in_progress_ = true;
@@ -95,6 +97,7 @@ void AlcedoQanGraph::set_graph(qan::Graph* graph) {
   rebuild_in_progress_ = false;
   graph_               = graph;
   if (!graph_.isNull()) {
+    graph_->setProperty("alcedoQanGraph", QVariant::fromValue(this));
     connect(graph_.data(), &QObject::destroyed, this, &AlcedoQanGraph::OnGraphDestroyed);
     ConfigureGraphPolicy();
   }
@@ -1309,6 +1312,7 @@ void AlcedoQanGraph::ApplyNodePresentation(qan::Node& qan_node, const EditorNode
   item->setProperty("nodeId", ToQString(node.node_id.Value()));
   item->setProperty("selectedMaskId", selected_mask_id_);
   item->setProperty("masks", MasksToVariant(node.masks));
+  item->setProperty("graphAdapter", QVariant::fromValue(this));
 }
 
 auto AlcedoQanGraph::ComponentFor(EditorNodeKind kind) const -> QQmlComponent* {
@@ -1363,6 +1367,14 @@ void AlcedoQanGraph::ConfigureGraphPolicy() {
           Qt::UniqueConnection);
   connect(graph_.data(), &qan::Graph::connectorRequestEdgeCreation, this,
           &AlcedoQanGraph::OnConnectorRequestEdgeCreation, Qt::UniqueConnection);
+  const auto clicked =
+      connect(graph_.data(), &qan::Graph::nodeClicked, this, &AlcedoQanGraph::OnGraphNodeClicked,
+              Qt::UniqueConnection);
+  const auto right_clicked = connect(graph_.data(), &qan::Graph::nodeRightClicked, this,
+                                     &AlcedoQanGraph::OnGraphNodeRightClicked, Qt::UniqueConnection);
+  qWarning()
+      << "[MaskRow] graph signals connected clicked=" << static_cast<bool>(clicked)
+      << "rightClicked=" << static_cast<bool>(right_clicked) << "graph=" << graph_.data();
   ConfigureConnector();
 }
 
@@ -1526,24 +1538,140 @@ void AlcedoQanGraph::ClearDrawerConnections() {
   drawer_connections_.clear();
 }
 
+auto AlcedoQanGraph::NodeIdStringForItem(QObject* item) const -> QString {
+  auto* current = qobject_cast<QQuickItem*>(item);
+  while (current != nullptr) {
+    for (const auto& [node_id, node] : node_by_id_) {
+      if (!node.isNull() && node->getItem() == current) {
+        return ToQString(node_id.Value());
+      }
+    }
+    current = current->parentItem();
+  }
+  return {};
+}
+
+auto AlcedoQanGraph::MaskRowAt(QQuickItem* node_item, QPointF local_pos) const -> QQuickItem* {
+  if (node_item == nullptr) {
+    return nullptr;
+  }
+  const QPointF scene = node_item->mapToScene(local_pos);
+  const auto    rows =
+      node_item->findChildren<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  for (auto* row : rows) {
+    if (row == nullptr || !row->isVisible() || row->width() <= 0.0 || row->height() <= 0.0) {
+      continue;
+    }
+    const QPointF in_row = row->mapFromScene(scene);
+    if (!QRectF(QPointF(0.0, 0.0), row->size()).contains(in_row)) {
+      continue;
+    }
+    auto* body = row->parentItem();
+    while (body != nullptr &&
+           body->objectName() != QLatin1String("editorNodeMaskDrawerBody")) {
+      body = body->parentItem();
+    }
+    if (body != nullptr && body->clip()) {
+      const QPointF in_body = body->mapFromScene(scene);
+      if (!QRectF(QPointF(0.0, 0.0), body->size()).contains(in_body)) {
+        continue;
+      }
+    }
+    return row;
+  }
+  return nullptr;
+}
+
+auto AlcedoQanGraph::MaskDeleteButtonContains(QQuickItem* row, const QPointF& scene_pos) const
+    -> bool {
+  if (row == nullptr) {
+    return false;
+  }
+  auto* button = row->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRowDelete"));
+  if (button == nullptr || !button->isVisible()) {
+    return false;
+  }
+  const QPointF in_button = button->mapFromScene(scene_pos);
+  return QRectF(QPointF(0.0, 0.0), button->size()).contains(in_button);
+}
+
+auto AlcedoQanGraph::maskIdAtItemPosition(QObject* node_item, qreal x, qreal y) const -> QString {
+  auto* item = qobject_cast<QQuickItem*>(node_item);
+  auto* row  = MaskRowAt(item, QPointF(x, y));
+  return row == nullptr ? QString() : row->property("maskId").toString();
+}
+
+auto AlcedoQanGraph::maskDeleteContainsItemPosition(QObject* node_item, qreal x, qreal y) const
+    -> bool {
+  auto* item = qobject_cast<QQuickItem*>(node_item);
+  if (item == nullptr) {
+    return false;
+  }
+  auto* row = MaskRowAt(item, QPointF(x, y));
+  return MaskDeleteButtonContains(row, item->mapToScene(QPointF(x, y)));
+}
+
+void AlcedoQanGraph::logMaskRow(const QString& where, const QString& node_id, const QString& mask_id,
+                                bool right_button) const {
+  qWarning() << "[MaskRow]" << where << "node=" << node_id << "mask=" << mask_id
+             << "right=" << right_button;
+}
+
+void AlcedoQanGraph::HandleNodeItemPress(qan::Node* node, QPointF local_pos, bool right_button) {
+  if (node == nullptr || node->getItem() == nullptr) {
+    qWarning()
+        << "[MaskRow] HandleNodeItemPress abort no node/item right=" << right_button;
+    return;
+  }
+  auto* item = node->getItem();
+  auto* row  = MaskRowAt(item, local_pos);
+  if (row == nullptr) {
+    return;
+  }
+  const auto mask_id = row->property("maskId").toString();
+  const auto node_id = NodeIdStringForItem(item);
+  if (mask_id.isEmpty()) {
+    qWarning()
+        << "[MaskRow] HandleNodeItemPress empty maskId node=" << node_id;
+    return;
+  }
+  const bool on_delete = !right_button && MaskDeleteButtonContains(row, item->mapToScene(local_pos));
+  qWarning()
+      << "[MaskRow] HandleNodeItemPress hit node=" << node_id << "mask=" << mask_id
+      << "delete=" << on_delete << "right=" << right_button << "pos=" << local_pos;
+  if (on_delete) {
+    OnMaskDeleteRequested(node_id, mask_id);
+    return;
+  }
+  OnMaskSelected(node_id, mask_id);
+}
+
+void AlcedoQanGraph::OnGraphNodeClicked(qan::Node* node, QPointF pos) {
+  HandleNodeItemPress(node, pos, false);
+}
+
+void AlcedoQanGraph::OnGraphNodeRightClicked(qan::Node* node, QPointF pos) {
+  HandleNodeItemPress(node, pos, true);
+}
+
+void AlcedoQanGraph::notifyMaskRowSelected(QObject* item, const QString& mask_id) {
+  OnMaskSelected(NodeIdStringForItem(item), mask_id);
+}
+
+void AlcedoQanGraph::notifyMaskRowDeleteRequested(QObject* item, const QString& mask_id) {
+  OnMaskDeleteRequested(NodeIdStringForItem(item), mask_id);
+}
+
 void AlcedoQanGraph::BindDrawerSignal(QQuickItem* item, const NodeId& /*node_id*/) {
   if (item == nullptr) {
     return;
   }
+  item->setProperty("graphAdapter", QVariant::fromValue(this));
   const auto* meta         = item->metaObject();
   const int   signal_index = meta->indexOfSignal("drawerOpenChanged()");
   if (signal_index >= 0) {
     drawer_connections_.push_back(
         QObject::connect(item, SIGNAL(drawerOpenChanged()), this, SLOT(OnDrawerOpenChanged())));
-  }
-  if (meta->indexOfSignal("maskSelected(QString,QString)") >= 0) {
-    drawer_connections_.push_back(QObject::connect(item, SIGNAL(maskSelected(QString,QString)),
-                                                    this, SLOT(OnMaskSelected(QString,QString))));
-  }
-  if (meta->indexOfSignal("maskDeleteRequested(QString,QString)") >= 0) {
-    drawer_connections_.push_back(
-        QObject::connect(item, SIGNAL(maskDeleteRequested(QString,QString)), this,
-                         SLOT(OnMaskDeleteRequested(QString,QString))));
   }
 }
 
@@ -1557,16 +1685,21 @@ void AlcedoQanGraph::OnDrawerOpenChanged() {
       continue;
     }
     emit NodeDrawerOpenChanged(ToQString(node_id.Value()), item->property("drawerOpen").toBool());
+    emit nodeDrawerOpenChanged(ToQString(node_id.Value()), item->property("drawerOpen").toBool());
     return;
   }
 }
 
 void AlcedoQanGraph::OnMaskSelected(const QString& node_id, const QString& mask_id) {
+  qWarning() << "[MaskRow] emit maskRowSelected node=" << node_id << "mask=" << mask_id;
   emit MaskRowSelected(node_id, mask_id);
+  emit maskRowSelected(node_id, mask_id);
 }
 
 void AlcedoQanGraph::OnMaskDeleteRequested(const QString& node_id, const QString& mask_id) {
+  qWarning() << "[MaskRow] emit maskRowDeleteRequested node=" << node_id << "mask=" << mask_id;
   emit MaskRowDeleteRequested(node_id, mask_id);
+  emit maskRowDeleteRequested(node_id, mask_id);
 }
 
 void AlcedoQanGraph::set_selected_mask_id(const QString& mask_id) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
@@ -6,10 +6,18 @@
 
 #include <QPointF>
 #include <Qt>
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <variant>
 
+#include "edit/geometry/render_request.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
 #include "edit/mask/analytic_mask_edit.hpp"
 #include "ui/alcedo_main/album_backend/editor_node_controller.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_controller.hpp"
+#include "ui/edit_viewer/mask_edit_geometry.hpp"
 #include "ui/edit_viewer/mask_overlay_layout.hpp"
 #include "ui/editor_rhi/editor_interaction_controller.hpp"
 #include "ui/editor_rhi/editor_overlay_item.hpp"
@@ -44,6 +52,58 @@ namespace {
   }
 }
 
+[[nodiscard]] auto OverlayHandleFromAnalytic(AnalyticMaskHandle handle) -> MaskOverlayHandleId {
+  switch (handle) {
+    case AnalyticMaskHandle::RadialCenter:
+      return MaskOverlayHandleId::RadialCenter;
+    case AnalyticMaskHandle::RadialMajor:
+      return MaskOverlayHandleId::RadialMajor;
+    case AnalyticMaskHandle::RadialMinor:
+      return MaskOverlayHandleId::RadialMinor;
+    case AnalyticMaskHandle::RadialRotate:
+      return MaskOverlayHandleId::RadialRotate;
+    case AnalyticMaskHandle::RadialInnerFeather:
+      return MaskOverlayHandleId::RadialInnerFeather;
+    case AnalyticMaskHandle::RadialOuterFeather:
+      return MaskOverlayHandleId::RadialOuterFeather;
+    case AnalyticMaskHandle::LinearOrigin:
+      return MaskOverlayHandleId::LinearOrigin;
+    case AnalyticMaskHandle::LinearDirection:
+      return MaskOverlayHandleId::LinearDirection;
+    case AnalyticMaskHandle::LinearStartBoundary:
+      return MaskOverlayHandleId::LinearStartBoundary;
+    case AnalyticMaskHandle::LinearEndBoundary:
+      return MaskOverlayHandleId::LinearEndBoundary;
+    default:
+      return MaskOverlayHandleId::None;
+  }
+}
+
+[[nodiscard]] auto ToolKindFromSource(MaskSourceKind kind) -> QString {
+  switch (kind) {
+    case MaskSourceKind::Brush:
+      return QStringLiteral("brush");
+    case MaskSourceKind::Radial:
+      return QStringLiteral("radial");
+    case MaskSourceKind::LinearGradient:
+      return QStringLiteral("linear");
+  }
+  return QStringLiteral("radial");
+}
+
+[[nodiscard]] auto MaskIdFromQString(const QString& value) -> MaskId {
+  return MaskId{value.toStdString()};
+}
+
+[[nodiscard]] auto MaskIdToQString(const MaskId& id) -> QString {
+  const auto view = id.Value();
+  return QString::fromUtf8(view.data(), static_cast<int>(view.size()));
+}
+
+[[nodiscard]] auto IsAnalyticKind(MaskSourceKind kind) -> bool {
+  return kind == MaskSourceKind::Radial || kind == MaskSourceKind::LinearGradient;
+}
+
 }  // namespace
 
 EditorMaskCreationAdapter::EditorMaskCreationAdapter(EditorSessionController* session,
@@ -54,6 +114,28 @@ EditorMaskCreationAdapter::~EditorMaskCreationAdapter() {
   if (view_change_connection_) {
     QObject::disconnect(view_change_connection_);
   }
+}
+
+auto EditorMaskCreationAdapter::owns_left_button() const -> bool {
+  return creating_ || (selected_ && IsAnalyticKind(source_kind_));
+}
+
+auto EditorMaskCreationAdapter::body_visible() const -> bool {
+  return body_open_ && (creating_ || selected_ || !selected_mask_id_.isEmpty());
+}
+
+auto EditorMaskCreationAdapter::mask_controls_active() const -> bool {
+  return creating_ || selected_ || !selected_mask_id_.isEmpty() || body_open_;
+}
+
+auto EditorMaskCreationAdapter::inner_feather_percent() const -> qreal {
+  const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
+  return radial == nullptr ? 0.0 : static_cast<qreal>(radial->inner_feather) * 100.0;
+}
+
+auto EditorMaskCreationAdapter::outer_feather_percent() const -> qreal {
+  const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
+  return radial == nullptr ? 0.0 : static_cast<qreal>(std::max(0.0f, radial->outer_feather)) * 100.0;
 }
 
 void EditorMaskCreationAdapter::bindInteractionItem(QObject* interaction) {
@@ -67,6 +149,7 @@ void EditorMaskCreationAdapter::bindInteractionItem(QObject* interaction) {
   }
   interaction_ = typed;
   ConnectInteraction(typed);
+  PublishDisplayedGeometry();
 }
 
 void EditorMaskCreationAdapter::bindOverlayItem(QObject* overlay) {
@@ -101,7 +184,11 @@ void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& to
     return;
   }
   if (open_) {
-    (void)Enqueue(EditorMaskCreationCommand{EditorMaskCreationCommandKind::Cancel});
+    EditorMaskCreationCommand cancel;
+    cancel.kind     = EditorMaskCreationCommandKind::Cancel;
+    cancel.node_id  = CurrentGradeId();
+    cancel.mask_id  = MaskIdFromQString(selected_mask_id_);
+    (void)Enqueue(cancel);
   }
   EditorMaskCreationCommand command;
   command.kind        = EditorMaskCreationCommandKind::BeginCreation;
@@ -110,37 +197,181 @@ void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& to
   if (command.node_id.Empty() || !Enqueue(command)) {
     return;
   }
-  source_kind_     = kind;
-  tool_kind_       = tool_kind;
-  creating_        = true;
-  selected_        = false;
-  open_            = false;
+  source_kind_       = kind;
+  tool_kind_         = tool_kind;
+  creating_          = true;
+  selected_          = false;
+  selected_mask_id_.clear();
+  open_              = false;
+  body_open_         = true;
   overlay_source_.reset();
-  overlay_display_ = {};
+  overlay_display_   = {};
+  hovered_handle_    = MaskOverlayHandleId::None;
+  active_handle_     = AnalyticMaskHandle::None;
   HideOverlay();
+  PublishDisplayedGeometry();
   emit MaskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::cancel() {
-  if (!active()) {
+  if (!active() && !body_open_) {
     return;
   }
-  (void)Enqueue(EditorMaskCreationCommand{EditorMaskCreationCommandKind::CancelMode});
+  EditorMaskCreationCommand command;
+  command.kind    = EditorMaskCreationCommandKind::CancelMode;
+  command.node_id = CurrentGradeId();
+  command.mask_id = MaskIdFromQString(selected_mask_id_);
+  (void)Enqueue(command);
   ResetLocal();
+}
+
+void EditorMaskCreationAdapter::hideBody() {
+  if (!body_open_) {
+    return;
+  }
+  body_open_ = false;
+  emit MaskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::finishBody() {
+  if (open_) {
+    EditorMaskCreationCommand finish;
+    finish.kind     = EditorMaskCreationCommandKind::Finish;
+    finish.node_id  = CurrentGradeId();
+    finish.mask_id  = MaskIdFromQString(selected_mask_id_);
+    finish.identity = pointer_;
+    (void)Enqueue(finish);
+    open_ = false;
+  }
+  creating_  = false;
+  body_open_ = false;
+  emit MaskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::selectMask(const QString& node_id, const QString& mask_id) {
+  if (!CanAuthorMasks() || mask_id.isEmpty()) {
+    return;
+  }
+  NodeId grade{node_id.toStdString()};
+  if (grade.Empty()) {
+    grade = CurrentGradeId();
+  }
+  if (grade.Empty()) {
+    return;
+  }
+  if (open_) {
+    EditorMaskCreationCommand cancel;
+    cancel.kind    = EditorMaskCreationCommandKind::Cancel;
+    cancel.node_id = grade;
+    cancel.mask_id = MaskIdFromQString(selected_mask_id_);
+    (void)Enqueue(cancel);
+    open_ = false;
+  }
+  EditorMaskCreationCommand command;
+  command.kind    = EditorMaskCreationCommandKind::SelectMask;
+  command.node_id = grade;
+  command.mask_id = MaskIdFromQString(mask_id);
+  if (!Enqueue(command)) {
+    return;
+  }
+  selected_mask_id_ = mask_id;
+  selected_          = true;
+  creating_          = false;
+  open_              = false;
+  body_open_         = true;
+  emit MaskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::removeMask(const QString& node_id, const QString& mask_id) {
+  if (!CanAuthorMasks() || mask_id.isEmpty()) {
+    return;
+  }
+  NodeId grade{node_id.toStdString()};
+  if (grade.Empty()) {
+    grade = CurrentGradeId();
+  }
+  if (grade.Empty()) {
+    return;
+  }
+  EditorMaskCreationCommand command;
+  command.kind    = EditorMaskCreationCommandKind::RemoveMask;
+  command.node_id = grade;
+  command.mask_id = MaskIdFromQString(mask_id);
+  if (!Enqueue(command)) {
+    return;
+  }
+  if (selected_mask_id_ == mask_id) {
+    selected_        = false;
+    selected_mask_id_.clear();
+    overlay_source_.reset();
+    overlay_display_ = {};
+    HideOverlay();
+  }
+  emit MaskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::removeSelectedMask() {
+  if (selected_mask_id_.isEmpty()) {
+    return;
+  }
+  removeMask(QString{}, selected_mask_id_);
 }
 
 void EditorMaskCreationAdapter::OnImageClosed() {
   ResetLocal();
 }
 
+void EditorMaskCreationAdapter::SyncFromSession() {
+  PublishDisplayedGeometry();
+  if (open_ || session_ == nullptr) {
+    return;
+  }
+  const auto owner_id = session_->mask_creation_mask_id();
+  const auto source    = session_->mask_creation_source();
+  if (!owner_id.Empty() && source.has_value()) {
+    ApplyOwnerSource(owner_id, *source);
+    return;
+  }
+  if (selected_mask_id_.isEmpty()) {
+    const auto restored = session_->mask_creation_last_removed_mask_id();
+    if (!restored.Empty() && DocumentContainsMask(restored)) {
+      selectMask(QString{}, MaskIdToQString(restored));
+      return;
+    }
+  }
+  if (!selected_mask_id_.isEmpty() || creating_) {
+    return;
+  }
+  if (active() || body_open_) {
+    ResetLocal();
+  }
+}
+
+void EditorMaskCreationAdapter::ApplyOwnerSource(const MaskId& mask_id,
+                                                   const MaskSource& source) {
+  overlay_source_   = source;
+  source_kind_       = GetMaskSourceKind(source);
+  tool_kind_         = ToolKindFromSource(source_kind_);
+  selected_mask_id_ = MaskIdToQString(mask_id);
+  selected_          = true;
+  creating_          = false;
+  body_open_         = true;
+  PublishOverlay();
+  emit MaskCreationChanged();
+}
+
 void EditorMaskCreationAdapter::ResetLocal() {
-  const bool changed = active() || open_ || creating_ || selected_;
+  const bool changed = active() || open_ || creating_ || selected_ || body_open_;
   tool_kind_.clear();
-  creating_ = false;
-  open_     = false;
-  selected_ = false;
+  selected_mask_id_.clear();
+  creating_        = false;
+  open_            = false;
+  selected_        = false;
+  body_open_       = false;
   overlay_source_.reset();
   overlay_display_ = {};
+  hovered_handle_  = MaskOverlayHandleId::None;
+  active_handle_   = AnalyticMaskHandle::None;
   HideOverlay();
   if (changed) {
     emit MaskCreationChanged();
@@ -171,6 +402,19 @@ auto EditorMaskCreationAdapter::CanAuthorMasks() const -> bool {
   return true;
 }
 
+auto EditorMaskCreationAdapter::DocumentContainsMask(const MaskId& mask_id) const -> bool {
+  if (session_ == nullptr || mask_id.Empty()) {
+    return false;
+  }
+  const auto* document = session_->pipeline_document();
+  if (document == nullptr) {
+    return false;
+  }
+  const auto* node = document->Graph().FindNode(CurrentGradeId());
+  const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(node);
+  return grade != nullptr && grade->FindMask(mask_id) != nullptr;
+}
+
 auto EditorMaskCreationAdapter::MakeSample(qreal x, qreal y, bool allow_outside) const
     -> std::optional<MaskCreationSample> {
   if (interaction_ == nullptr) {
@@ -184,6 +428,21 @@ auto EditorMaskCreationAdapter::MakeSample(qreal x, qreal y, bool allow_outside)
   sample.normalized        = mapped->normalized;
   sample.reference_pixels  = mapped->reference_pixels;
   sample.inside_photograph = mapped->inside_photograph;
+  return sample;
+}
+
+auto EditorMaskCreationAdapter::MakeNormalizedSample(Vector2 normalized) const
+    -> MaskCreationSample {
+  MaskCreationSample sample;
+  sample.normalized        = normalized;
+  sample.inside_photograph = true;
+  if (interaction_ != nullptr) {
+    const auto mapping = interaction_->maskEditViewMapping();
+    if (!mapping.geometry.full_reference_extent.Empty()) {
+      sample.reference_pixels = MaskEditGeometry::ReferencePixelsFromNormalized(
+          normalized, mapping.geometry.full_reference_extent);
+    }
+  }
   return sample;
 }
 
@@ -212,11 +471,33 @@ void EditorMaskCreationAdapter::HideOverlay() {
   overlay_->setMaskOverlayDisplay(MaskOverlayDisplay{});
 }
 
+void EditorMaskCreationAdapter::PublishDisplayedGeometry() {
+  if (interaction_ == nullptr || session_ == nullptr) {
+    return;
+  }
+  const auto* document = session_->pipeline_document();
+  if (document == nullptr) {
+    return;
+  }
+  const int width  = interaction_->imageWidth();
+  const int height = interaction_->imageHeight();
+  if (width <= 0 || height <= 0) {
+    return;
+  }
+  ImageGeometryParams image;
+  image.crop_rect         = document->Geometry().CropRect();
+  image.rotation_degrees  = document->Geometry().RotationDegrees();
+  image.expand_to_fit     = document->Geometry().ExpandToFit();
+  interaction_->setDisplayedMaskGeometry(MaskEditGeometry::MakeDocumentPhotographGeometry(
+      Extent2D{static_cast<std::uint32_t>(width), static_cast<std::uint32_t>(height)}, image));
+}
+
 void EditorMaskCreationAdapter::PublishOverlay() {
   if (overlay_ == nullptr || interaction_ == nullptr || !overlay_source_.has_value()) {
     HideOverlay();
     return;
   }
+  PublishDisplayedGeometry();
   const auto mapping = interaction_->maskEditViewMapping();
   const auto style   = OverlayStyle();
   const auto clip    = OverlayClip();
@@ -228,9 +509,130 @@ void EditorMaskCreationAdapter::PublishOverlay() {
     display = (creating_ && open_)
                   ? MakeLinearCreatingOverlayDisplay(mapping, *linear, style, clip)
                   : MakeLinearExistingOverlayDisplay(mapping, *linear, style, clip);
+  } else if (const auto* brush = std::get_if<BrushMaskSource>(&*overlay_source_)) {
+    display = MakeBrushExistingOverlayDisplay(mapping, brush->placement_translation, clip);
   }
-  overlay_display_ = display;
+  display.hovered_handle = hovered_handle_;
+  display.active_handle  = OverlayHandleFromAnalytic(active_handle_);
+  overlay_display_       = display;
   overlay_->setMaskOverlayDisplay(std::move(display));
+}
+
+void EditorMaskCreationAdapter::handleHover(qreal x, qreal y) {
+  if (!owns_left_button() || overlay_display_.mode == MaskOverlayMode::Hidden) {
+    return;
+  }
+  const auto hit =
+      HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y), OverlayStyle().hit_radius_logical_px);
+  if (hit == hovered_handle_) {
+    return;
+  }
+  hovered_handle_ = hit;
+  PublishOverlay();
+}
+
+void EditorMaskCreationAdapter::BeginFeatherMove(AnalyticMaskHandle handle) {
+  const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
+  if (radial == nullptr || selected_mask_id_.isEmpty() || !CanAuthorMasks()) {
+    return;
+  }
+  const float rho = handle == AnalyticMaskHandle::RadialInnerFeather
+                        ? std::max(0.0f, 1.0f - radial->inner_feather)
+                        : 1.0f + std::max(0.0f, radial->outer_feather);
+  const auto sample = MakeNormalizedSample(RadialNormalizedPoint(*radial, rho, 0.0f));
+  pointer_.device_id   = 2;
+  pointer_.point_id    = 1;
+  pointer_.sequence_id = next_sequence_id_++;
+  EditorMaskCreationCommand select;
+  select.kind    = EditorMaskCreationCommandKind::SelectMask;
+  select.node_id = CurrentGradeId();
+  select.mask_id = MaskIdFromQString(selected_mask_id_);
+  (void)Enqueue(select);
+  EditorMaskCreationCommand move;
+  move.kind     = EditorMaskCreationCommandKind::BeginMove;
+  move.handle   = handle;
+  move.sample   = sample;
+  move.identity = pointer_;
+  move.node_id  = CurrentGradeId();
+  move.mask_id  = MaskIdFromQString(selected_mask_id_);
+  if (!Enqueue(move)) {
+    return;
+  }
+  active_handle_ = handle;
+  open_          = true;
+  creating_      = false;
+  emit MaskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::beginInnerFeather() {
+  BeginFeatherMove(AnalyticMaskHandle::RadialInnerFeather);
+}
+
+void EditorMaskCreationAdapter::beginOuterFeather() {
+  BeginFeatherMove(AnalyticMaskHandle::RadialOuterFeather);
+}
+
+void EditorMaskCreationAdapter::UpdateFeatherPercent(AnalyticMaskHandle handle, qreal percent) {
+  const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
+  if (radial == nullptr || !open_) {
+    return;
+  }
+  const float clamped = handle == AnalyticMaskHandle::RadialInnerFeather
+                             ? std::clamp(static_cast<float>(percent) / 100.0f, 0.0f, 1.0f)
+                             : std::max(0.0f, static_cast<float>(percent) / 100.0f);
+  const float rho =
+      handle == AnalyticMaskHandle::RadialInnerFeather ? std::max(0.0f, 1.0f - clamped)
+                                                        : 1.0f + clamped;
+  EnqueueAppendSample(MakeNormalizedSample(RadialNormalizedPoint(*radial, rho, 0.0f)));
+}
+
+void EditorMaskCreationAdapter::updateInnerFeather(qreal percent) {
+  UpdateFeatherPercent(AnalyticMaskHandle::RadialInnerFeather, percent);
+}
+
+void EditorMaskCreationAdapter::updateOuterFeather(qreal percent) {
+  UpdateFeatherPercent(AnalyticMaskHandle::RadialOuterFeather, percent);
+}
+
+void EditorMaskCreationAdapter::finishFeather() {
+  if (!open_) {
+    return;
+  }
+  EditorMaskCreationCommand finish;
+  finish.kind     = EditorMaskCreationCommandKind::Finish;
+  finish.node_id  = CurrentGradeId();
+  finish.mask_id  = MaskIdFromQString(selected_mask_id_);
+  finish.identity = pointer_;
+  (void)Enqueue(finish);
+  open_          = false;
+  active_handle_ = AnalyticMaskHandle::None;
+  PublishOverlay();
+  emit MaskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::EnqueueAppendSample(const MaskCreationSample& sample) {
+  EditorMaskCreationCommand command;
+  command.kind     = EditorMaskCreationCommandKind::Append;
+  command.sample   = sample;
+  command.identity = pointer_;
+  command.node_id  = CurrentGradeId();
+  command.mask_id  = MaskIdFromQString(selected_mask_id_);
+  (void)Enqueue(command);
+  if (creating_) {
+    overlay_source_ = source_kind_ == MaskSourceKind::Radial
+                           ? MaskSource{RadialFromCenterOut(press_normalized_, sample.normalized)}
+                           : MaskSource{LinearFromEndpoints(press_normalized_, sample.normalized)};
+  } else if (overlay_source_.has_value() && active_handle_ != AnalyticMaskHandle::None) {
+    float unwrapped = 0.0f;
+    if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
+      unwrapped = radial->rotation;
+    }
+    if (auto next = ApplyAnalyticMaskHandle(active_handle_, *overlay_source_, sample.normalized,
+                                             unwrapped)) {
+      overlay_source_ = std::move(*next);
+    }
+  }
+  PublishOverlay();
 }
 
 auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> bool {
@@ -248,14 +650,14 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
   pointer_.point_id    = 1;
   pointer_.sequence_id = next_sequence_id_++;
 
-  const auto hit = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
-                                            OverlayStyle().hit_radius_logical_px);
+  const auto hit    = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
+                                           OverlayStyle().hit_radius_logical_px);
   const auto handle = AnalyticHandleFromOverlay(hit);
-  if (handle != AnalyticMaskHandle::None && selected_ && session_ != nullptr) {
+  if (handle != AnalyticMaskHandle::None && selected_ && IsAnalyticKind(source_kind_)) {
     EditorMaskCreationCommand select;
     select.kind    = EditorMaskCreationCommandKind::SelectMask;
     select.node_id = CurrentGradeId();
-    select.mask_id = session_->mask_creation_mask_id();
+    select.mask_id = MaskIdFromQString(selected_mask_id_);
     if (!select.mask_id.Empty()) {
       (void)Enqueue(select);
       EditorMaskCreationCommand move;
@@ -263,6 +665,8 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
       move.handle   = handle;
       move.sample   = *sample;
       move.identity = pointer_;
+      move.node_id  = CurrentGradeId();
+      move.mask_id  = MaskIdFromQString(selected_mask_id_);
       if (Enqueue(move)) {
         press_normalized_ = sample->normalized;
         active_handle_    = handle;
@@ -275,19 +679,13 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
   }
 
   if (!creating_) {
-    EditorMaskCreationCommand begin;
-    begin.kind        = EditorMaskCreationCommandKind::BeginCreation;
-    begin.source_kind = source_kind_;
-    begin.node_id     = CurrentGradeId();
-    if (!Enqueue(begin)) {
-      return true;
-    }
-    creating_ = true;
+    return true;
   }
   EditorMaskCreationCommand input;
   input.kind     = EditorMaskCreationCommandKind::BeginInput;
   input.sample   = *sample;
   input.identity = pointer_;
+  input.node_id  = CurrentGradeId();
   if (!Enqueue(input)) {
     return true;
   }
@@ -311,26 +709,7 @@ auto EditorMaskCreationAdapter::handleMove(qreal x, qreal y, int /*buttons*/) ->
   if (!sample) {
     return true;
   }
-  EditorMaskCreationCommand command;
-  command.kind     = EditorMaskCreationCommandKind::Append;
-  command.sample   = *sample;
-  command.identity = pointer_;
-  (void)Enqueue(command);
-  if (creating_) {
-    overlay_source_ = source_kind_ == MaskSourceKind::Radial
-                          ? MaskSource{RadialFromCenterOut(press_normalized_, sample->normalized)}
-                          : MaskSource{LinearFromEndpoints(press_normalized_, sample->normalized)};
-  } else if (overlay_source_.has_value() && active_handle_ != AnalyticMaskHandle::None) {
-    float unwrapped = 0.0f;
-    if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
-      unwrapped = radial->rotation;
-    }
-    if (auto next = ApplyAnalyticMaskHandle(active_handle_, *overlay_source_, sample->normalized,
-                                            unwrapped)) {
-      overlay_source_ = std::move(*next);
-    }
-  }
-  PublishOverlay();
+  EnqueueAppendSample(*sample);
   return true;
 }
 
@@ -340,22 +719,21 @@ auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> b
   }
   const auto sample = MakeSample(x, y, true);
   if (sample) {
-    EditorMaskCreationCommand append;
-    append.kind     = EditorMaskCreationCommandKind::Append;
-    append.sample   = *sample;
-    append.identity = pointer_;
-    (void)Enqueue(append);
-    if (creating_) {
-      overlay_source_ =
-          source_kind_ == MaskSourceKind::Radial
-              ? MaskSource{RadialFromCenterOut(press_normalized_, sample->normalized)}
-              : MaskSource{LinearFromEndpoints(press_normalized_, sample->normalized)};
-    }
+    EnqueueAppendSample(*sample);
   }
-  (void)Enqueue(EditorMaskCreationCommand{EditorMaskCreationCommandKind::Finish});
-  open_     = false;
-  creating_ = false;
-  selected_ = overlay_source_.has_value();
+  EditorMaskCreationCommand finish;
+  finish.kind     = EditorMaskCreationCommandKind::Finish;
+  finish.node_id  = CurrentGradeId();
+  finish.mask_id  = MaskIdFromQString(selected_mask_id_);
+  finish.identity = pointer_;
+  (void)Enqueue(finish);
+  open_          = false;
+  creating_      = false;
+  selected_      = overlay_source_.has_value();
+  active_handle_ = AnalyticMaskHandle::None;
+  if (selected_ && selected_mask_id_.isEmpty() && session_ != nullptr) {
+    selected_mask_id_ = MaskIdToQString(session_->mask_creation_mask_id());
+  }
   PublishOverlay();
   emit MaskCreationChanged();
   return true;

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
@@ -25,6 +25,8 @@
 namespace alcedo::ui {
 namespace {
 
+constexpr float    kPi = 3.14159265358979323846f;
+
 [[nodiscard]] auto AnalyticHandleFromOverlay(MaskOverlayHandleId id) -> AnalyticMaskHandle {
   switch (id) {
     case MaskOverlayHandleId::RadialCenter:
@@ -107,7 +109,7 @@ namespace {
 }  // namespace
 
 EditorMaskCreationAdapter::EditorMaskCreationAdapter(EditorSessionController* session,
-                                                     QObject* parent)
+                                                     QObject*                 parent)
     : QObject(parent), session_(session) {}
 
 EditorMaskCreationAdapter::~EditorMaskCreationAdapter() {
@@ -135,7 +137,36 @@ auto EditorMaskCreationAdapter::inner_feather_percent() const -> qreal {
 
 auto EditorMaskCreationAdapter::outer_feather_percent() const -> qreal {
   const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
-  return radial == nullptr ? 0.0 : static_cast<qreal>(std::max(0.0f, radial->outer_feather)) * 100.0;
+  return radial == nullptr ? 0.0
+                           : static_cast<qreal>(std::max(0.0f, radial->outer_feather)) * 100.0;
+}
+
+auto EditorMaskCreationAdapter::major_radius_percent() const -> qreal {
+  const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
+  return radial == nullptr ? 0.0 : static_cast<qreal>(radial->major_radius) * 100.0;
+}
+
+auto EditorMaskCreationAdapter::minor_radius_percent() const -> qreal {
+  const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
+  return radial == nullptr ? 0.0 : static_cast<qreal>(radial->minor_radius) * 100.0;
+}
+
+auto EditorMaskCreationAdapter::rotation_degrees() const -> qreal {
+  if (const auto* radial =
+          overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr) {
+    return static_cast<qreal>(radial->rotation) * 180.0 / kPi;
+  }
+  if (const auto* linear =
+          overlay_source_ ? std::get_if<LinearGradientMaskSource>(&*overlay_source_) : nullptr) {
+    return static_cast<qreal>(std::atan2(linear->normal_y, linear->normal_x)) * 180.0 / kPi;
+  }
+  return 0.0;
+}
+
+auto EditorMaskCreationAdapter::transition_percent() const -> qreal {
+  const auto* linear =
+      overlay_source_ ? std::get_if<LinearGradientMaskSource>(&*overlay_source_) : nullptr;
+  return linear == nullptr ? 0.0 : static_cast<qreal>(linear->transition_distance) * 100.0;
 }
 
 void EditorMaskCreationAdapter::bindInteractionItem(QObject* interaction) {
@@ -163,8 +194,7 @@ void EditorMaskCreationAdapter::ConnectInteraction(
     return;
   }
   view_change_connection_ = connect(
-      interaction, &editor_rhi::EditorInteractionController::viewChangeReported, this,
-      [this](int) {
+      interaction, &editor_rhi::EditorInteractionController::viewChangeReported, this, [this](int) {
         if (open_) {
           cancel();
         }
@@ -185,9 +215,9 @@ void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& to
   }
   if (open_) {
     EditorMaskCreationCommand cancel;
-    cancel.kind     = EditorMaskCreationCommandKind::Cancel;
-    cancel.node_id  = CurrentGradeId();
-    cancel.mask_id  = MaskIdFromQString(selected_mask_id_);
+    cancel.kind    = EditorMaskCreationCommandKind::Cancel;
+    cancel.node_id = CurrentGradeId();
+    cancel.mask_id = MaskIdFromQString(selected_mask_id_);
     (void)Enqueue(cancel);
   }
   EditorMaskCreationCommand command;
@@ -197,20 +227,20 @@ void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& to
   if (command.node_id.Empty() || !Enqueue(command)) {
     return;
   }
-  source_kind_       = kind;
-  tool_kind_         = tool_kind;
-  creating_          = true;
-  selected_          = false;
+  source_kind_ = kind;
+  tool_kind_   = tool_kind;
+  creating_    = true;
+  selected_    = false;
   selected_mask_id_.clear();
-  open_              = false;
-  body_open_         = true;
+  open_      = false;
+  body_open_ = true;
   overlay_source_.reset();
-  overlay_display_   = {};
-  hovered_handle_    = MaskOverlayHandleId::None;
-  active_handle_     = AnalyticMaskHandle::None;
+  overlay_display_ = {};
+  hovered_handle_  = MaskOverlayHandleId::None;
+  active_handle_   = AnalyticMaskHandle::None;
   HideOverlay();
   PublishDisplayedGeometry();
-  emit MaskCreationChanged();
+  emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::cancel() {
@@ -225,27 +255,19 @@ void EditorMaskCreationAdapter::cancel() {
   ResetLocal();
 }
 
-void EditorMaskCreationAdapter::hideBody() {
-  if (!body_open_) {
-    return;
-  }
-  body_open_ = false;
-  emit MaskCreationChanged();
-}
+void EditorMaskCreationAdapter::hideBody() { finishBody(); }
 
 void EditorMaskCreationAdapter::finishBody() {
-  if (open_) {
-    EditorMaskCreationCommand finish;
-    finish.kind     = EditorMaskCreationCommandKind::Finish;
-    finish.node_id  = CurrentGradeId();
-    finish.mask_id  = MaskIdFromQString(selected_mask_id_);
-    finish.identity = pointer_;
-    (void)Enqueue(finish);
-    open_ = false;
+  if (!active() && !body_open_) {
+    return;
   }
-  creating_  = false;
-  body_open_ = false;
-  emit MaskCreationChanged();
+  EditorMaskCreationCommand finish;
+  finish.kind     = EditorMaskCreationCommandKind::FinishMode;
+  finish.node_id  = CurrentGradeId();
+  finish.mask_id  = MaskIdFromQString(selected_mask_id_);
+  finish.identity = pointer_;
+  (void)Enqueue(finish);
+  ResetLocal();
 }
 
 void EditorMaskCreationAdapter::selectMask(const QString& node_id, const QString& mask_id) {
@@ -275,11 +297,11 @@ void EditorMaskCreationAdapter::selectMask(const QString& node_id, const QString
     return;
   }
   selected_mask_id_ = mask_id;
-  selected_          = true;
-  creating_          = false;
-  open_              = false;
-  body_open_         = true;
-  emit MaskCreationChanged();
+  selected_         = true;
+  creating_         = false;
+  open_             = false;
+  body_open_        = true;
+  emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::removeMask(const QString& node_id, const QString& mask_id) {
@@ -301,13 +323,13 @@ void EditorMaskCreationAdapter::removeMask(const QString& node_id, const QString
     return;
   }
   if (selected_mask_id_ == mask_id) {
-    selected_        = false;
+    selected_ = false;
     selected_mask_id_.clear();
     overlay_source_.reset();
     overlay_display_ = {};
     HideOverlay();
   }
-  emit MaskCreationChanged();
+  emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::removeSelectedMask() {
@@ -317,9 +339,7 @@ void EditorMaskCreationAdapter::removeSelectedMask() {
   removeMask(QString{}, selected_mask_id_);
 }
 
-void EditorMaskCreationAdapter::OnImageClosed() {
-  ResetLocal();
-}
+void EditorMaskCreationAdapter::OnImageClosed() { ResetLocal(); }
 
 void EditorMaskCreationAdapter::SyncFromSession() {
   PublishDisplayedGeometry();
@@ -327,7 +347,7 @@ void EditorMaskCreationAdapter::SyncFromSession() {
     return;
   }
   const auto owner_id = session_->mask_creation_mask_id();
-  const auto source    = session_->mask_creation_source();
+  const auto source   = session_->mask_creation_source();
   if (!owner_id.Empty() && source.has_value()) {
     ApplyOwnerSource(owner_id, *source);
     return;
@@ -347,34 +367,33 @@ void EditorMaskCreationAdapter::SyncFromSession() {
   }
 }
 
-void EditorMaskCreationAdapter::ApplyOwnerSource(const MaskId& mask_id,
-                                                   const MaskSource& source) {
+void EditorMaskCreationAdapter::ApplyOwnerSource(const MaskId& mask_id, const MaskSource& source) {
   overlay_source_   = source;
-  source_kind_       = GetMaskSourceKind(source);
-  tool_kind_         = ToolKindFromSource(source_kind_);
+  source_kind_      = GetMaskSourceKind(source);
+  tool_kind_        = ToolKindFromSource(source_kind_);
   selected_mask_id_ = MaskIdToQString(mask_id);
-  selected_          = true;
-  creating_          = false;
-  body_open_         = true;
+  selected_         = true;
+  creating_         = false;
+  body_open_        = true;
   PublishOverlay();
-  emit MaskCreationChanged();
+  emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::ResetLocal() {
   const bool changed = active() || open_ || creating_ || selected_ || body_open_;
   tool_kind_.clear();
   selected_mask_id_.clear();
-  creating_        = false;
-  open_            = false;
-  selected_        = false;
-  body_open_       = false;
+  creating_  = false;
+  open_      = false;
+  selected_  = false;
+  body_open_ = false;
   overlay_source_.reset();
   overlay_display_ = {};
   hovered_handle_  = MaskOverlayHandleId::None;
   active_handle_   = AnalyticMaskHandle::None;
   HideOverlay();
   if (changed) {
-    emit MaskCreationChanged();
+    emit maskCreationChanged();
   }
 }
 
@@ -410,7 +429,7 @@ auto EditorMaskCreationAdapter::DocumentContainsMask(const MaskId& mask_id) cons
   if (document == nullptr) {
     return false;
   }
-  const auto* node = document->Graph().FindNode(CurrentGradeId());
+  const auto* node  = document->Graph().FindNode(CurrentGradeId());
   const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(node);
   return grade != nullptr && grade->FindMask(mask_id) != nullptr;
 }
@@ -485,9 +504,9 @@ void EditorMaskCreationAdapter::PublishDisplayedGeometry() {
     return;
   }
   ImageGeometryParams image;
-  image.crop_rect         = document->Geometry().CropRect();
-  image.rotation_degrees  = document->Geometry().RotationDegrees();
-  image.expand_to_fit     = document->Geometry().ExpandToFit();
+  image.crop_rect        = document->Geometry().CropRect();
+  image.rotation_degrees = document->Geometry().RotationDegrees();
+  image.expand_to_fit    = document->Geometry().ExpandToFit();
   interaction_->setDisplayedMaskGeometry(MaskEditGeometry::MakeDocumentPhotographGeometry(
       Extent2D{static_cast<std::uint32_t>(width), static_cast<std::uint32_t>(height)}, image));
 }
@@ -498,13 +517,14 @@ void EditorMaskCreationAdapter::PublishOverlay() {
     return;
   }
   PublishDisplayedGeometry();
-  const auto mapping = interaction_->maskEditViewMapping();
-  const auto style   = OverlayStyle();
-  const auto clip    = OverlayClip();
+  const auto         mapping = interaction_->maskEditViewMapping();
+  const auto         style   = OverlayStyle();
+  const auto         clip    = OverlayClip();
   MaskOverlayDisplay display;
   if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
-    display = (creating_ && open_) ? MakeRadialCreatingOverlayDisplay(mapping, *radial, style, clip)
-                                   : MakeRadialExistingOverlayDisplay(mapping, *radial, style, clip);
+    display = (creating_ && open_)
+                  ? MakeRadialCreatingOverlayDisplay(mapping, *radial, style, clip)
+                  : MakeRadialExistingOverlayDisplay(mapping, *radial, style, clip);
   } else if (const auto* linear = std::get_if<LinearGradientMaskSource>(&*overlay_source_)) {
     display = (creating_ && open_)
                   ? MakeLinearCreatingOverlayDisplay(mapping, *linear, style, clip)
@@ -522,8 +542,8 @@ void EditorMaskCreationAdapter::handleHover(qreal x, qreal y) {
   if (!owns_left_button() || overlay_display_.mode == MaskOverlayMode::Hidden) {
     return;
   }
-  const auto hit =
-      HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y), OverlayStyle().hit_radius_logical_px);
+  const auto hit = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
+                                            OverlayStyle().hit_radius_logical_px);
   if (hit == hovered_handle_) {
     return;
   }
@@ -531,15 +551,41 @@ void EditorMaskCreationAdapter::handleHover(qreal x, qreal y) {
   PublishOverlay();
 }
 
-void EditorMaskCreationAdapter::BeginFeatherMove(AnalyticMaskHandle handle) {
-  const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
-  if (radial == nullptr || selected_mask_id_.isEmpty() || !CanAuthorMasks()) {
+void EditorMaskCreationAdapter::BeginAnalyticMove(AnalyticMaskHandle handle) {
+  if (!overlay_source_.has_value() || selected_mask_id_.isEmpty() || !CanAuthorMasks()) {
     return;
   }
-  const float rho = handle == AnalyticMaskHandle::RadialInnerFeather
-                        ? std::max(0.0f, 1.0f - radial->inner_feather)
-                        : 1.0f + std::max(0.0f, radial->outer_feather);
-  const auto sample = MakeNormalizedSample(RadialNormalizedPoint(*radial, rho, 0.0f));
+  Vector2 normalized;
+  if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
+    float rho   = 1.0f;
+    float theta = 0.0f;
+    if (handle == AnalyticMaskHandle::RadialMinor) {
+      theta = kPi * 0.5f;
+    } else if (handle == AnalyticMaskHandle::RadialInnerFeather) {
+      rho = std::max(0.0f, 1.0f - radial->inner_feather);
+    } else if (handle == AnalyticMaskHandle::RadialOuterFeather) {
+      rho = 1.0f + std::max(0.0f, radial->outer_feather);
+    }
+    normalized = RadialNormalizedPoint(*radial, rho, theta);
+  } else if (const auto* linear = std::get_if<LinearGradientMaskSource>(&*overlay_source_)) {
+    if (handle != AnalyticMaskHandle::LinearDirection &&
+        handle != AnalyticMaskHandle::LinearStartBoundary &&
+        handle != AnalyticMaskHandle::LinearEndBoundary) {
+      return;
+    }
+    const float length = std::hypot(linear->normal_x, linear->normal_y);
+    if (length <= kAnalyticMaskEpsilon) {
+      return;
+    }
+    const float distance = handle == AnalyticMaskHandle::LinearDirection
+                               ? std::max(0.1f, linear->transition_distance)
+                               : 0.5f * linear->transition_distance;
+    normalized           = Vector2{linear->origin_x + distance * linear->normal_x / length,
+                         linear->origin_y + distance * linear->normal_y / length};
+  } else {
+    return;
+  }
+  const auto sample    = MakeNormalizedSample(normalized);
   pointer_.device_id   = 2;
   pointer_.point_id    = 1;
   pointer_.sequence_id = next_sequence_id_++;
@@ -561,15 +607,15 @@ void EditorMaskCreationAdapter::BeginFeatherMove(AnalyticMaskHandle handle) {
   active_handle_ = handle;
   open_          = true;
   creating_      = false;
-  emit MaskCreationChanged();
+  emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::beginInnerFeather() {
-  BeginFeatherMove(AnalyticMaskHandle::RadialInnerFeather);
+  BeginAnalyticMove(AnalyticMaskHandle::RadialInnerFeather);
 }
 
 void EditorMaskCreationAdapter::beginOuterFeather() {
-  BeginFeatherMove(AnalyticMaskHandle::RadialOuterFeather);
+  BeginAnalyticMove(AnalyticMaskHandle::RadialOuterFeather);
 }
 
 void EditorMaskCreationAdapter::UpdateFeatherPercent(AnalyticMaskHandle handle, qreal percent) {
@@ -578,11 +624,11 @@ void EditorMaskCreationAdapter::UpdateFeatherPercent(AnalyticMaskHandle handle, 
     return;
   }
   const float clamped = handle == AnalyticMaskHandle::RadialInnerFeather
-                             ? std::clamp(static_cast<float>(percent) / 100.0f, 0.0f, 1.0f)
-                             : std::max(0.0f, static_cast<float>(percent) / 100.0f);
-  const float rho =
-      handle == AnalyticMaskHandle::RadialInnerFeather ? std::max(0.0f, 1.0f - clamped)
-                                                        : 1.0f + clamped;
+                            ? std::clamp(static_cast<float>(percent) / 100.0f, 0.0f, 1.0f)
+                            : std::max(0.0f, static_cast<float>(percent) / 100.0f);
+  const float rho     = handle == AnalyticMaskHandle::RadialInnerFeather
+                            ? std::max(0.0f, 1.0f - clamped)
+                            : 1.0f + clamped;
   EnqueueAppendSample(MakeNormalizedSample(RadialNormalizedPoint(*radial, rho, 0.0f)));
 }
 
@@ -594,7 +640,81 @@ void EditorMaskCreationAdapter::updateOuterFeather(qreal percent) {
   UpdateFeatherPercent(AnalyticMaskHandle::RadialOuterFeather, percent);
 }
 
-void EditorMaskCreationAdapter::finishFeather() {
+void EditorMaskCreationAdapter::beginMajorRadius() {
+  BeginAnalyticMove(AnalyticMaskHandle::RadialMajor);
+}
+
+void EditorMaskCreationAdapter::beginMinorRadius() {
+  BeginAnalyticMove(AnalyticMaskHandle::RadialMinor);
+}
+
+void EditorMaskCreationAdapter::UpdateRadialRadiusPercent(AnalyticMaskHandle handle,
+                                                          qreal              percent) {
+  const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
+  if (radial == nullptr || !open_) {
+    return;
+  }
+  RadialMaskSource next = *radial;
+  const float radius = std::max(kAnalyticCreationMinRadius, static_cast<float>(percent) / 100.0f);
+  if (handle == AnalyticMaskHandle::RadialMajor) {
+    next.major_radius = radius;
+    EnqueueAppendSample(MakeNormalizedSample(RadialNormalizedPoint(next, 1.0f, 0.0f)));
+  } else if (handle == AnalyticMaskHandle::RadialMinor) {
+    next.minor_radius = radius;
+    EnqueueAppendSample(MakeNormalizedSample(RadialNormalizedPoint(next, 1.0f, kPi * 0.5f)));
+  }
+}
+
+void EditorMaskCreationAdapter::updateMajorRadius(qreal percent) {
+  UpdateRadialRadiusPercent(AnalyticMaskHandle::RadialMajor, percent);
+}
+
+void EditorMaskCreationAdapter::updateMinorRadius(qreal percent) {
+  UpdateRadialRadiusPercent(AnalyticMaskHandle::RadialMinor, percent);
+}
+
+void EditorMaskCreationAdapter::beginRotation() {
+  BeginAnalyticMove(source_kind_ == MaskSourceKind::Radial ? AnalyticMaskHandle::RadialRotate
+                                                           : AnalyticMaskHandle::LinearDirection);
+}
+
+void EditorMaskCreationAdapter::updateRotation(qreal degrees) {
+  if (!overlay_source_.has_value() || !open_) {
+    return;
+  }
+  const float radians = static_cast<float>(degrees) * kPi / 180.0f;
+  if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
+    const float radius = std::max(radial->major_radius, kAnalyticCreationMinRadius);
+    EnqueueAppendSample(
+        MakeNormalizedSample(Vector2{radial->center_x + radius * std::cos(radians),
+                                     radial->center_y + radius * std::sin(radians)}));
+  } else if (const auto* linear = std::get_if<LinearGradientMaskSource>(&*overlay_source_)) {
+    EnqueueAppendSample(MakeNormalizedSample(
+        Vector2{linear->origin_x + std::cos(radians), linear->origin_y + std::sin(radians)}));
+  }
+}
+
+void EditorMaskCreationAdapter::beginTransition() {
+  BeginAnalyticMove(AnalyticMaskHandle::LinearEndBoundary);
+}
+
+void EditorMaskCreationAdapter::updateTransition(qreal percent) {
+  const auto* linear =
+      overlay_source_ ? std::get_if<LinearGradientMaskSource>(&*overlay_source_) : nullptr;
+  if (linear == nullptr || !open_) {
+    return;
+  }
+  const float length = std::hypot(linear->normal_x, linear->normal_y);
+  if (length <= kAnalyticMaskEpsilon) {
+    return;
+  }
+  const float half = std::max(0.0f, static_cast<float>(percent) / 200.0f);
+  EnqueueAppendSample(
+      MakeNormalizedSample(Vector2{linear->origin_x + half * linear->normal_x / length,
+                                   linear->origin_y + half * linear->normal_y / length}));
+}
+
+void EditorMaskCreationAdapter::finishAnalyticControl() {
   if (!open_) {
     return;
   }
@@ -607,7 +727,7 @@ void EditorMaskCreationAdapter::finishFeather() {
   open_          = false;
   active_handle_ = AnalyticMaskHandle::None;
   PublishOverlay();
-  emit MaskCreationChanged();
+  emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::EnqueueAppendSample(const MaskCreationSample& sample) {
@@ -620,15 +740,15 @@ void EditorMaskCreationAdapter::EnqueueAppendSample(const MaskCreationSample& sa
   (void)Enqueue(command);
   if (creating_) {
     overlay_source_ = source_kind_ == MaskSourceKind::Radial
-                           ? MaskSource{RadialFromCenterOut(press_normalized_, sample.normalized)}
-                           : MaskSource{LinearFromEndpoints(press_normalized_, sample.normalized)};
+                          ? MaskSource{RadialFromCenterOut(press_normalized_, sample.normalized)}
+                          : MaskSource{LinearFromEndpoints(press_normalized_, sample.normalized)};
   } else if (overlay_source_.has_value() && active_handle_ != AnalyticMaskHandle::None) {
     float unwrapped = 0.0f;
     if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
       unwrapped = radial->rotation;
     }
     if (auto next = ApplyAnalyticMaskHandle(active_handle_, *overlay_source_, sample.normalized,
-                                             unwrapped)) {
+                                            unwrapped)) {
       overlay_source_ = std::move(*next);
     }
   }
@@ -650,9 +770,9 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
   pointer_.point_id    = 1;
   pointer_.sequence_id = next_sequence_id_++;
 
-  const auto hit    = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
-                                           OverlayStyle().hit_radius_logical_px);
-  const auto handle = AnalyticHandleFromOverlay(hit);
+  const auto hit       = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
+                                                  OverlayStyle().hit_radius_logical_px);
+  const auto handle    = AnalyticHandleFromOverlay(hit);
   if (handle != AnalyticMaskHandle::None && selected_ && IsAnalyticKind(source_kind_)) {
     EditorMaskCreationCommand select;
     select.kind    = EditorMaskCreationCommandKind::SelectMask;
@@ -672,7 +792,7 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
         active_handle_    = handle;
         open_             = true;
         creating_         = false;
-        emit MaskCreationChanged();
+        emit maskCreationChanged();
         return true;
       }
     }
@@ -697,7 +817,7 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
                           ? MaskSource{RadialFromCenterOut(sample->normalized, sample->normalized)}
                           : MaskSource{LinearFromEndpoints(sample->normalized, sample->normalized)};
   PublishOverlay();
-  emit MaskCreationChanged();
+  emit maskCreationChanged();
   return true;
 }
 
@@ -705,9 +825,21 @@ auto EditorMaskCreationAdapter::handleMove(qreal x, qreal y, int /*buttons*/) ->
   if (!open_) {
     return owns_left_button();
   }
-  const auto sample = MakeSample(x, y, true);
+  auto sample = MakeSample(x, y, true);
   if (!sample) {
     return true;
+  }
+  if (active_handle_ == AnalyticMaskHandle::LinearDirection) {
+    const auto* linear =
+        overlay_source_ ? std::get_if<LinearGradientMaskSource>(&*overlay_source_) : nullptr;
+    if (linear != nullptr && interaction_ != nullptr) {
+      const auto normalized = MapItemPointToLinearDirectionSample(
+          interaction_->maskEditViewMapping(), *linear, QPointF(x, y));
+      if (!normalized) {
+        return true;
+      }
+      sample = MakeNormalizedSample(*normalized);
+    }
   }
   EnqueueAppendSample(*sample);
   return true;
@@ -717,7 +849,18 @@ auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> b
   if (!open_ || button != static_cast<int>(Qt::LeftButton)) {
     return owns_left_button() && button == static_cast<int>(Qt::LeftButton);
   }
-  const auto sample = MakeSample(x, y, true);
+  auto sample = MakeSample(x, y, true);
+  if (sample && active_handle_ == AnalyticMaskHandle::LinearDirection) {
+    const auto* linear =
+        overlay_source_ ? std::get_if<LinearGradientMaskSource>(&*overlay_source_) : nullptr;
+    if (linear != nullptr && interaction_ != nullptr) {
+      const auto normalized = MapItemPointToLinearDirectionSample(
+          interaction_->maskEditViewMapping(), *linear, QPointF(x, y));
+      if (normalized) {
+        sample = MakeNormalizedSample(*normalized);
+      }
+    }
+  }
   if (sample) {
     EnqueueAppendSample(*sample);
   }
@@ -735,7 +878,7 @@ auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> b
     selected_mask_id_ = MaskIdToQString(session_->mask_creation_mask_id());
   }
   PublishOverlay();
-  emit MaskCreationChanged();
+  emit maskCreationChanged();
   return true;
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
@@ -4,6 +4,7 @@
 
 #include "ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp"
 
+#include <QDebug>
 #include <QPointF>
 #include <Qt>
 #include <algorithm>
@@ -119,16 +120,13 @@ EditorMaskCreationAdapter::~EditorMaskCreationAdapter() {
 }
 
 auto EditorMaskCreationAdapter::owns_left_button() const -> bool {
-  return creating_ || (selected_ && IsAnalyticKind(source_kind_));
+  return edit_mode_ == EditMode::Creating ||
+         (edit_mode_ == EditMode::Editing && IsAnalyticKind(source_kind_));
 }
 
-auto EditorMaskCreationAdapter::body_visible() const -> bool {
-  return body_open_ && (creating_ || selected_ || !selected_mask_id_.isEmpty());
-}
+auto EditorMaskCreationAdapter::body_visible() const -> bool { return active(); }
 
-auto EditorMaskCreationAdapter::mask_controls_active() const -> bool {
-  return creating_ || selected_ || !selected_mask_id_.isEmpty() || body_open_;
-}
+auto EditorMaskCreationAdapter::mask_controls_active() const -> bool { return active(); }
 
 auto EditorMaskCreationAdapter::inner_feather_percent() const -> qreal {
   const auto* radial = overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr;
@@ -210,30 +208,39 @@ void EditorMaskCreationAdapter::beginLinear() {
 }
 
 void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& tool_kind) {
-  if (!CanAuthorMasks()) {
+  const NodeId grade = CurrentGradeId();
+  qWarning()
+      << "[MaskRow] BeginTool kind=" << tool_kind
+      << "grade=" << QString::fromStdString(std::string(grade.Value()))
+      << "canEdit=" << (session_ && session_->can_edit()) << "active=" << active()
+      << "open=" << open_;
+  if (!CanAuthorMasksFor(grade)) {
+    qWarning() << "[MaskRow] BeginTool abort CanAuthorMasksFor";
     return;
   }
   if (open_) {
     EditorMaskCreationCommand cancel;
     cancel.kind    = EditorMaskCreationCommandKind::Cancel;
-    cancel.node_id = CurrentGradeId();
+    cancel.node_id = edit_node_id_;
     cancel.mask_id = MaskIdFromQString(selected_mask_id_);
     (void)Enqueue(cancel);
   }
   EditorMaskCreationCommand command;
   command.kind        = EditorMaskCreationCommandKind::BeginCreation;
   command.source_kind = kind;
-  command.node_id     = CurrentGradeId();
+  command.node_id     = grade;
   if (command.node_id.Empty() || !Enqueue(command)) {
+    qWarning() << "[MaskRow] BeginTool abort Enqueue emptyNode="
+                                       << command.node_id.Empty();
     return;
   }
-  source_kind_ = kind;
-  tool_kind_   = tool_kind;
-  creating_    = true;
-  selected_    = false;
+  qWarning() << "[MaskRow] BeginTool queued Creating";
+  source_kind_  = kind;
+  tool_kind_    = tool_kind;
+  edit_node_id_ = grade;
+  edit_mode_    = EditMode::Creating;
   selected_mask_id_.clear();
-  open_      = false;
-  body_open_ = true;
+  open_ = false;
   overlay_source_.reset();
   overlay_display_ = {};
   hovered_handle_  = MaskOverlayHandleId::None;
@@ -244,12 +251,12 @@ void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& to
 }
 
 void EditorMaskCreationAdapter::cancel() {
-  if (!active() && !body_open_) {
+  if (!active()) {
     return;
   }
   EditorMaskCreationCommand command;
   command.kind    = EditorMaskCreationCommandKind::CancelMode;
-  command.node_id = CurrentGradeId();
+  command.node_id = edit_node_id_;
   command.mask_id = MaskIdFromQString(selected_mask_id_);
   (void)Enqueue(command);
   ResetLocal();
@@ -258,12 +265,12 @@ void EditorMaskCreationAdapter::cancel() {
 void EditorMaskCreationAdapter::hideBody() { finishBody(); }
 
 void EditorMaskCreationAdapter::finishBody() {
-  if (!active() && !body_open_) {
+  if (!active()) {
     return;
   }
   EditorMaskCreationCommand finish;
   finish.kind     = EditorMaskCreationCommandKind::FinishMode;
-  finish.node_id  = CurrentGradeId();
+  finish.node_id  = edit_node_id_;
   finish.mask_id  = MaskIdFromQString(selected_mask_id_);
   finish.identity = pointer_;
   (void)Enqueue(finish);
@@ -271,20 +278,34 @@ void EditorMaskCreationAdapter::finishBody() {
 }
 
 void EditorMaskCreationAdapter::selectMask(const QString& node_id, const QString& mask_id) {
-  if (!CanAuthorMasks() || mask_id.isEmpty()) {
+  qWarning()
+      << "[MaskRow] selectMask enter node=" << node_id << "mask=" << mask_id
+      << "active=" << active() << "creating=" << creating() << "open=" << open_
+      << "selected=" << selected_mask_id_ << "canEdit=" << (session_ && session_->can_edit())
+      << "sessionState=" << (session_ ? session_->session_state_name() : QString());
+  if (mask_id.isEmpty()) {
+    qWarning() << "[MaskRow] selectMask abort empty maskId";
     return;
   }
   NodeId grade{node_id.toStdString()};
   if (grade.Empty()) {
-    grade = CurrentGradeId();
+    grade = active() ? edit_node_id_ : CurrentGradeId();
+    qWarning()
+        << "[MaskRow] selectMask filled empty node from"
+        << (active() ? "editNode" : "currentGrade")
+        << QString::fromStdString(std::string(grade.Value()));
   }
-  if (grade.Empty()) {
+  if (!CanAuthorMasksFor(grade)) {
+    qWarning()
+        << "[MaskRow] selectMask abort CanAuthorMasksFor grade="
+        << QString::fromStdString(std::string(grade.Value()))
+        << "canEdit=" << (session_ && session_->can_edit());
     return;
   }
   if (open_) {
     EditorMaskCreationCommand cancel;
     cancel.kind    = EditorMaskCreationCommandKind::Cancel;
-    cancel.node_id = grade;
+    cancel.node_id = edit_node_id_;
     cancel.mask_id = MaskIdFromQString(selected_mask_id_);
     (void)Enqueue(cancel);
     open_ = false;
@@ -294,25 +315,32 @@ void EditorMaskCreationAdapter::selectMask(const QString& node_id, const QString
   command.node_id = grade;
   command.mask_id = MaskIdFromQString(mask_id);
   if (!Enqueue(command)) {
+    qWarning() << "[MaskRow] selectMask abort Enqueue";
     return;
   }
   selected_mask_id_ = mask_id;
-  selected_         = true;
-  creating_         = false;
+  edit_node_id_     = grade;
+  edit_mode_        = EditMode::Editing;
   open_             = false;
-  body_open_        = true;
+  qWarning()
+      << "[MaskRow] selectMask queued Editing maskControlsActive=" << mask_controls_active();
   emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::removeMask(const QString& node_id, const QString& mask_id) {
-  if (!CanAuthorMasks() || mask_id.isEmpty()) {
+  qWarning()
+      << "[MaskRow] removeMask enter node=" << node_id << "mask=" << mask_id
+      << "canEdit=" << (session_ && session_->can_edit());
+  if (mask_id.isEmpty()) {
+    qWarning() << "[MaskRow] removeMask abort empty maskId";
     return;
   }
   NodeId grade{node_id.toStdString()};
   if (grade.Empty()) {
-    grade = CurrentGradeId();
+    grade = active() ? edit_node_id_ : CurrentGradeId();
   }
-  if (grade.Empty()) {
+  if (!CanAuthorMasksFor(grade)) {
+    qWarning() << "[MaskRow] removeMask abort CanAuthorMasksFor";
     return;
   }
   EditorMaskCreationCommand command;
@@ -320,14 +348,21 @@ void EditorMaskCreationAdapter::removeMask(const QString& node_id, const QString
   command.node_id = grade;
   command.mask_id = MaskIdFromQString(mask_id);
   if (!Enqueue(command)) {
+    qWarning() << "[MaskRow] removeMask abort Enqueue";
     return;
   }
+  qWarning() << "[MaskRow] removeMask queued";
   if (selected_mask_id_ == mask_id) {
-    selected_ = false;
     selected_mask_id_.clear();
     overlay_source_.reset();
     overlay_display_ = {};
     HideOverlay();
+    EditorMaskCreationCommand finish;
+    finish.kind    = EditorMaskCreationCommandKind::FinishMode;
+    finish.node_id = grade;
+    (void)Enqueue(finish);
+    ResetLocal();
+    return;
   }
   emit maskCreationChanged();
 }
@@ -339,16 +374,32 @@ void EditorMaskCreationAdapter::removeSelectedMask() {
   removeMask(QString{}, selected_mask_id_);
 }
 
+void EditorMaskCreationAdapter::deleteActiveMask() {
+  if (!active()) {
+    return;
+  }
+  if (selected_mask_id_.isEmpty() && session_ != nullptr) {
+    selected_mask_id_ = MaskIdToQString(session_->mask_creation_mask_id());
+  }
+  if (selected_mask_id_.isEmpty()) {
+    cancel();
+    return;
+  }
+  removeMask(QString{}, selected_mask_id_);
+}
+
 void EditorMaskCreationAdapter::OnImageClosed() { ResetLocal(); }
 
 void EditorMaskCreationAdapter::SyncFromSession() {
   PublishDisplayedGeometry();
-  if (open_ || session_ == nullptr) {
+  if (open_ || session_ == nullptr || session_->mask_creation_commands_pending()) {
     return;
   }
-  const auto owner_id = session_->mask_creation_mask_id();
-  const auto source   = session_->mask_creation_source();
+  const auto owner_node = session_->mask_creation_node_id();
+  const auto owner_id   = session_->mask_creation_mask_id();
+  const auto source     = session_->mask_creation_source();
   if (!owner_id.Empty() && source.has_value()) {
+    edit_node_id_ = owner_node;
     ApplyOwnerSource(owner_id, *source);
     return;
   }
@@ -359,11 +410,8 @@ void EditorMaskCreationAdapter::SyncFromSession() {
       return;
     }
   }
-  if (!selected_mask_id_.isEmpty() || creating_) {
+  if (!selected_mask_id_.isEmpty() || active()) {
     return;
-  }
-  if (active() || body_open_) {
-    ResetLocal();
   }
 }
 
@@ -372,21 +420,18 @@ void EditorMaskCreationAdapter::ApplyOwnerSource(const MaskId& mask_id, const Ma
   source_kind_      = GetMaskSourceKind(source);
   tool_kind_        = ToolKindFromSource(source_kind_);
   selected_mask_id_ = MaskIdToQString(mask_id);
-  selected_         = true;
-  creating_         = false;
-  body_open_        = true;
+  edit_mode_        = EditMode::Editing;
   PublishOverlay();
   emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::ResetLocal() {
-  const bool changed = active() || open_ || creating_ || selected_ || body_open_;
+  const bool changed = active() || open_;
   tool_kind_.clear();
   selected_mask_id_.clear();
-  creating_  = false;
-  open_      = false;
-  selected_  = false;
-  body_open_ = false;
+  edit_node_id_ = {};
+  edit_mode_    = EditMode::Inactive;
+  open_         = false;
   overlay_source_.reset();
   overlay_display_ = {};
   hovered_handle_  = MaskOverlayHandleId::None;
@@ -409,16 +454,23 @@ auto EditorMaskCreationAdapter::CurrentGradeId() const -> NodeId {
 }
 
 auto EditorMaskCreationAdapter::CanAuthorMasks() const -> bool {
-  if (session_ == nullptr || !session_->can_edit()) {
+  return CanAuthorMasksFor(active() ? edit_node_id_ : CurrentGradeId());
+}
+
+auto EditorMaskCreationAdapter::CanAuthorMasksFor(const NodeId& grade_id) const -> bool {
+  if (session_ == nullptr || !session_->can_edit() || grade_id.Empty()) {
     return false;
   }
-  if (CurrentGradeId().Empty()) {
-    return false;
+  if (auto* nodes = session_->node_selection_source()) {
+    for (const auto& node : nodes->ActiveNodes()) {
+      if (node.node_id == grade_id && node.node_kind == EditorNodeKind::ColorGrade) {
+        return true;
+      }
+    }
   }
-  if (interaction_ != nullptr && interaction_->cropOverlayVisible()) {
-    return false;
-  }
-  return true;
+  const auto* document = session_->pipeline_document();
+  return document != nullptr &&
+         dynamic_cast<const ColorGradeNodeModel*>(document->Graph().FindNode(grade_id)) != nullptr;
 }
 
 auto EditorMaskCreationAdapter::DocumentContainsMask(const MaskId& mask_id) const -> bool {
@@ -429,7 +481,7 @@ auto EditorMaskCreationAdapter::DocumentContainsMask(const MaskId& mask_id) cons
   if (document == nullptr) {
     return false;
   }
-  const auto* node  = document->Graph().FindNode(CurrentGradeId());
+  const auto* node  = document->Graph().FindNode(edit_node_id_);
   const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(node);
   return grade != nullptr && grade->FindMask(mask_id) != nullptr;
 }
@@ -480,7 +532,18 @@ auto EditorMaskCreationAdapter::OverlayStyle() const -> MaskOverlayStyle {
 }
 
 auto EditorMaskCreationAdapter::Enqueue(EditorMaskCreationCommand command) -> bool {
-  return session_ != nullptr && session_->EnqueueMaskCreation(std::move(command));
+  if (session_ == nullptr) {
+    qWarning() << "[MaskRow] Enqueue abort no session kind=" << static_cast<int>(command.kind);
+    return false;
+  }
+  const auto kind = command.kind;
+  const bool ok   = session_->EnqueueMaskCreation(std::move(command));
+  if (!ok) {
+    qWarning()
+        << "[MaskRow] Enqueue rejected kind=" << static_cast<int>(kind)
+        << "canEdit=" << session_->can_edit() << "state=" << session_->session_state_name();
+  }
+  return ok;
 }
 
 void EditorMaskCreationAdapter::HideOverlay() {
@@ -522,11 +585,11 @@ void EditorMaskCreationAdapter::PublishOverlay() {
   const auto         clip    = OverlayClip();
   MaskOverlayDisplay display;
   if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
-    display = (creating_ && open_)
+    display = (creating() && open_)
                   ? MakeRadialCreatingOverlayDisplay(mapping, *radial, style, clip)
                   : MakeRadialExistingOverlayDisplay(mapping, *radial, style, clip);
   } else if (const auto* linear = std::get_if<LinearGradientMaskSource>(&*overlay_source_)) {
-    display = (creating_ && open_)
+    display = (creating() && open_)
                   ? MakeLinearCreatingOverlayDisplay(mapping, *linear, style, clip)
                   : MakeLinearExistingOverlayDisplay(mapping, *linear, style, clip);
   } else if (const auto* brush = std::get_if<BrushMaskSource>(&*overlay_source_)) {
@@ -591,7 +654,7 @@ void EditorMaskCreationAdapter::BeginAnalyticMove(AnalyticMaskHandle handle) {
   pointer_.sequence_id = next_sequence_id_++;
   EditorMaskCreationCommand select;
   select.kind    = EditorMaskCreationCommandKind::SelectMask;
-  select.node_id = CurrentGradeId();
+  select.node_id = edit_node_id_;
   select.mask_id = MaskIdFromQString(selected_mask_id_);
   (void)Enqueue(select);
   EditorMaskCreationCommand move;
@@ -599,14 +662,14 @@ void EditorMaskCreationAdapter::BeginAnalyticMove(AnalyticMaskHandle handle) {
   move.handle   = handle;
   move.sample   = sample;
   move.identity = pointer_;
-  move.node_id  = CurrentGradeId();
+  move.node_id  = edit_node_id_;
   move.mask_id  = MaskIdFromQString(selected_mask_id_);
   if (!Enqueue(move)) {
     return;
   }
   active_handle_ = handle;
   open_          = true;
-  creating_      = false;
+  edit_mode_     = EditMode::Editing;
   emit maskCreationChanged();
 }
 
@@ -720,7 +783,7 @@ void EditorMaskCreationAdapter::finishAnalyticControl() {
   }
   EditorMaskCreationCommand finish;
   finish.kind     = EditorMaskCreationCommandKind::Finish;
-  finish.node_id  = CurrentGradeId();
+  finish.node_id  = edit_node_id_;
   finish.mask_id  = MaskIdFromQString(selected_mask_id_);
   finish.identity = pointer_;
   (void)Enqueue(finish);
@@ -735,10 +798,10 @@ void EditorMaskCreationAdapter::EnqueueAppendSample(const MaskCreationSample& sa
   command.kind     = EditorMaskCreationCommandKind::Append;
   command.sample   = sample;
   command.identity = pointer_;
-  command.node_id  = CurrentGradeId();
+  command.node_id  = edit_node_id_;
   command.mask_id  = MaskIdFromQString(selected_mask_id_);
   (void)Enqueue(command);
-  if (creating_) {
+  if (creating()) {
     overlay_source_ = source_kind_ == MaskSourceKind::Radial
                           ? MaskSource{RadialFromCenterOut(press_normalized_, sample.normalized)}
                           : MaskSource{LinearFromEndpoints(press_normalized_, sample.normalized)};
@@ -773,10 +836,11 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
   const auto hit       = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
                                                   OverlayStyle().hit_radius_logical_px);
   const auto handle    = AnalyticHandleFromOverlay(hit);
-  if (handle != AnalyticMaskHandle::None && selected_ && IsAnalyticKind(source_kind_)) {
+  if (handle != AnalyticMaskHandle::None && edit_mode_ == EditMode::Editing &&
+      IsAnalyticKind(source_kind_)) {
     EditorMaskCreationCommand select;
     select.kind    = EditorMaskCreationCommandKind::SelectMask;
-    select.node_id = CurrentGradeId();
+    select.node_id = edit_node_id_;
     select.mask_id = MaskIdFromQString(selected_mask_id_);
     if (!select.mask_id.Empty()) {
       (void)Enqueue(select);
@@ -785,34 +849,33 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
       move.handle   = handle;
       move.sample   = *sample;
       move.identity = pointer_;
-      move.node_id  = CurrentGradeId();
+      move.node_id  = edit_node_id_;
       move.mask_id  = MaskIdFromQString(selected_mask_id_);
       if (Enqueue(move)) {
         press_normalized_ = sample->normalized;
         active_handle_    = handle;
         open_             = true;
-        creating_         = false;
+        edit_mode_        = EditMode::Editing;
         emit maskCreationChanged();
         return true;
       }
     }
   }
 
-  if (!creating_) {
+  if (!creating()) {
     return true;
   }
   EditorMaskCreationCommand input;
   input.kind     = EditorMaskCreationCommandKind::BeginInput;
   input.sample   = *sample;
   input.identity = pointer_;
-  input.node_id  = CurrentGradeId();
+  input.node_id  = edit_node_id_;
   if (!Enqueue(input)) {
     return true;
   }
   press_normalized_ = sample->normalized;
   active_handle_    = AnalyticMaskHandle::None;
   open_             = true;
-  selected_         = false;
   overlay_source_   = source_kind_ == MaskSourceKind::Radial
                           ? MaskSource{RadialFromCenterOut(sample->normalized, sample->normalized)}
                           : MaskSource{LinearFromEndpoints(sample->normalized, sample->normalized)};
@@ -866,15 +929,14 @@ auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> b
   }
   EditorMaskCreationCommand finish;
   finish.kind     = EditorMaskCreationCommandKind::Finish;
-  finish.node_id  = CurrentGradeId();
+  finish.node_id  = edit_node_id_;
   finish.mask_id  = MaskIdFromQString(selected_mask_id_);
   finish.identity = pointer_;
   (void)Enqueue(finish);
   open_          = false;
-  creating_      = false;
-  selected_      = overlay_source_.has_value();
+  edit_mode_     = overlay_source_.has_value() ? EditMode::Editing : EditMode::Creating;
   active_handle_ = AnalyticMaskHandle::None;
-  if (selected_ && selected_mask_id_.isEmpty() && session_ != nullptr) {
+  if (edit_mode_ == EditMode::Editing && selected_mask_id_.isEmpty() && session_ != nullptr) {
     selected_mask_id_ = MaskIdToQString(session_->mask_creation_mask_id());
   }
   PublishOverlay();

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -140,6 +140,7 @@ void EditorNodeController::SetLayoutIdentity(quint64 element_id, quint64 image_i
     }
   }
   emit SnapshotChanged();
+  emit snapshotChanged();
 }
 
 auto EditorNodeController::BoundSessionGeneration() const -> std::optional<std::uint64_t> {
@@ -171,7 +172,9 @@ void EditorNodeController::ClearSnapshot() {
   snapshot_image_id_            = 0;
   snapshot_version_id_.clear();
   emit SnapshotChanged();
+  emit snapshotChanged();
   emit SelectionChanged();
+  emit selectionChanged();
   emit ActionAvailabilityChanged();
 }
 
@@ -443,7 +446,9 @@ auto EditorNodeController::PublishSnapshot(EditorNodeGraphSnapshot snapshot) -> 
   SyncSessionAdjustmentNode(false);
   SetLastError({});
   emit SnapshotChanged();
+  emit snapshotChanged();
   emit SelectionChanged();
+  emit selectionChanged();
   emit ActionAvailabilityChanged();
   QueueProjectionApply();
   return true;
@@ -665,6 +670,7 @@ bool EditorNodeController::refreshFromSession() {
     ClearSnapshot();
     SetLastError({});
     emit SnapshotChanged();
+    emit snapshotChanged();
     return false;
   }
   return PublishDocument(*document, static_cast<std::uint64_t>(session_->session_generation()));
@@ -805,6 +811,7 @@ void EditorNodeController::selectNode(const QString& node_id) {
   ApplyLiveSelectionToAdapter();
   SyncSessionAdjustmentNode(true);
   emit SelectionChanged();
+  emit selectionChanged();
   emit ActionAvailabilityChanged();
 }
 
@@ -931,6 +938,7 @@ bool EditorNodeController::deleteColorGrade(const QString& node_id) {
     ApplyLiveSelectionToAdapter();
     SyncSessionAdjustmentNode(false);
     emit SelectionChanged();
+    emit selectionChanged();
     emit ActionAvailabilityChanged();
   }
   return MaybeSubmitDraft();
@@ -1138,6 +1146,7 @@ auto EditorNodeController::MaybeSubmitDraft() -> bool {
     SetLastError({});
   }
   emit SnapshotChanged();
+  emit snapshotChanged();
   emit ActionAvailabilityChanged();
   return true;
 }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_controller.cpp
@@ -498,6 +498,32 @@ bool EditorNodeController::applyToGraph(QObject* adapter) {
   return true;
 }
 
+void EditorNodeController::ApplyLayoutToAdapter() {
+  auto* layout = layout_store_.data();
+  if (layout == nullptr || graph_adapter_ == nullptr || !HasActiveGraph() || applying_layout_) {
+    return;
+  }
+  applying_layout_ = true;
+  const auto finish = qScopeGuard([this] { applying_layout_ = false; });
+  if (draft_ != nullptr) {
+    const auto view =
+        draft_->CurrentSnapshot(session_generation_, projection_revision_, topology_revision_);
+    layout->EnsureDefaultPositions(view);
+    layout->ResolveVerticalOverlaps(view);
+  } else {
+    layout->EnsureDefaultPositions(snapshot_);
+    layout->ResolveVerticalOverlaps(snapshot_);
+  }
+  for (const auto& node : ActiveNodes()) {
+    const auto id = NodeIdToQString(node.node_id);
+    if (layout->hasNodePosition(id)) {
+      const auto pos = layout->nodePosition(id);
+      graph_adapter_->setNodePosition(id, pos.x(), pos.y());
+    }
+    graph_adapter_->setDrawerOpen(id, layout->drawerOpen(id));
+  }
+}
+
 auto EditorNodeController::graph_adapter_object() const -> QObject* {
   return graph_adapter_.data();
 }
@@ -534,7 +560,16 @@ void EditorNodeController::set_layout_store(QObject* store) {
   if (layout_store_.data() == layout) {
     return;
   }
-  layout_store_ = layout;
+  if (layout_store_ != nullptr) {
+    disconnect(layout_store_.data(), nullptr, this, nullptr);
+  }
+  layout_store_connection_ = {};
+  layout_store_            = layout;
+  if (layout_store_ != nullptr) {
+    layout_store_connection_ =
+        connect(layout_store_.data(), &EditorNodeLayoutStore::NodeHeightChanged, this,
+                &EditorNodeController::ApplyLayoutToAdapter);
+  }
   emit LayoutStoreChanged();
   SyncLayoutKey();
 }
@@ -587,21 +622,7 @@ void EditorNodeController::ApplyBoundGraph() {
     return;
   }
   ++completed_projection_apply_count_;
-  auto* layout = layout_store_.data();
-  if (layout != nullptr) {
-    layout->EnsureDefaultPositions(draft_ == nullptr ? snapshot_
-                                                     : draft_->CurrentSnapshot(session_generation_,
-                                                                               projection_revision_,
-                                                                               topology_revision_));
-    for (const auto& node : ActiveNodes()) {
-      const auto id = NodeIdToQString(node.node_id);
-      if (layout->hasNodePosition(id)) {
-        const auto pos = layout->nodePosition(id);
-        graph_adapter_->setNodePosition(id, pos.x(), pos.y());
-      }
-      graph_adapter_->setDrawerOpen(id, layout->drawerOpen(id));
-    }
-  }
+  ApplyLayoutToAdapter();
   ApplyLiveSelectionToAdapter();
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_layout_store.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_node_layout_store.cpp
@@ -225,6 +225,7 @@ void EditorNodeLayoutStore::SetDrawerOpen(const NodeId& node_id, bool open) {
   }
   value.drawer_open[node_id] = open;
   emit LayoutChanged();
+  emit NodeHeightChanged();
 }
 
 auto EditorNodeLayoutStore::DefaultHeight(EditorNodeKind kind, int mask_count,
@@ -288,6 +289,36 @@ void EditorNodeLayoutStore::AssignStagingPosition(const NodeId&                 
   }
   value.node_positions[node_id] = QPointF(column_x, staging_y);
   emit LayoutChanged();
+}
+
+void EditorNodeLayoutStore::ResolveVerticalOverlaps(const EditorNodeGraphSnapshot& snapshot) {
+  auto& value   = MutableCurrent();
+  bool  wrote   = false;
+  bool  have_previous = false;
+  qreal previous_bottom = 0;
+  qreal previous_x      = 0;
+  for (const auto& node : snapshot.nodes) {
+    auto it = value.node_positions.find(node.node_id);
+    if (it == value.node_positions.end()) {
+      continue;
+    }
+    QPointF position = it->second;
+    if (have_previous &&
+        std::fabs(position.x() - previous_x) < static_cast<qreal>(metrics_.node_width) &&
+        position.y() < previous_bottom) {
+      position.setY(previous_bottom);
+      it->second = position;
+      wrote      = true;
+    }
+    const qreal height = DefaultHeight(node.node_kind, static_cast<int>(node.masks.size()),
+                                       DrawerOpen(node.node_id));
+    previous_bottom = position.y() + height + static_cast<qreal>(metrics_.vertical_gap);
+    previous_x      = position.x();
+    have_previous   = true;
+  }
+  if (wrote) {
+    emit LayoutChanged();
+  }
 }
 
 void EditorNodeLayoutStore::ensureDefaultsFrom(QObject* controller) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -13,8 +13,8 @@
 #include <exception>
 
 #include "app/editor_adjustment_context.hpp"
-#include "app/editor_parameter_write.hpp"
 #include "app/editor_panel_projection.hpp"
+#include "app/editor_parameter_write.hpp"
 #include "app/editor_render_intent.hpp"
 #include "app/editor_session_ports.hpp"
 #include "app/editor_session_service.hpp"
@@ -116,8 +116,7 @@ void EditorSessionController::BindAdmissionDeadline() {
       });
       return;
     }
-    const int delay_ms =
-        static_cast<int>((delay_ns + 999999) / 1000000);
+    const int delay_ms = static_cast<int>((delay_ns + 999999) / 1000000);
     timer->start(std::max(1, delay_ms));
   });
 }
@@ -390,7 +389,7 @@ void EditorSessionController::RefreshImageExifDisplay() {
   if (image_id_ == exif_image_id_ && session_generation_ == exif_session_generation_) {
     return;
   }
-  exif_image_id_          = image_id_;
+  exif_image_id_           = image_id_;
   exif_session_generation_ = session_generation_;
   alcedo::EditorImageExifDisplay display;
   if (image_id_ != 0 && image_exif_reader_) {
@@ -404,12 +403,14 @@ void EditorSessionController::RefreshImageExifDisplay() {
 }
 
 void EditorSessionController::ApplyExifRowText(const alcedo::EditorExifRowText& text) {
-  const auto shutter  = QString::fromUtf8(text.shutter.data(), static_cast<int>(text.shutter.size()));
-  const auto iso      = QString::fromUtf8(text.iso.data(), static_cast<int>(text.iso.size()));
-  const auto aperture = QString::fromUtf8(text.aperture.data(), static_cast<int>(text.aperture.size()));
-  const auto focal    = QString::fromUtf8(text.focal.data(), static_cast<int>(text.focal.size()));
+  const auto shutter =
+      QString::fromUtf8(text.shutter.data(), static_cast<int>(text.shutter.size()));
+  const auto iso = QString::fromUtf8(text.iso.data(), static_cast<int>(text.iso.size()));
+  const auto aperture =
+      QString::fromUtf8(text.aperture.data(), static_cast<int>(text.aperture.size()));
+  const auto focal     = QString::fromUtf8(text.focal.data(), static_cast<int>(text.focal.size()));
   const auto line_utf8 = alcedo::FormatEditorImageExifLine(text);
-  const auto line = QString::fromUtf8(line_utf8.data(), static_cast<int>(line_utf8.size()));
+  const auto line      = QString::fromUtf8(line_utf8.data(), static_cast<int>(line_utf8.size()));
   if (exif_line_text_ == line && exif_shutter_text_ == shutter && exif_iso_text_ == iso &&
       exif_aperture_text_ == aperture && exif_focal_text_ == focal) {
     return;
@@ -1335,13 +1336,13 @@ auto EditorSessionController::mask_creation_source() const -> std::optional<alce
 
 auto EditorSessionController::mask_creation_last_removed_mask_id() const -> alcedo::MaskId {
   return session_backend_ ? session_backend_->mask_creation_last_removed_mask_id()
-                            : alcedo::MaskId{};
+                          : alcedo::MaskId{};
 }
 
 void EditorSessionController::SetImageExifReader(
     std::function<alcedo::EditorImageExifDisplay(uint)> reader) {
-  image_exif_reader_     = std::move(reader);
-  exif_image_id_         = 0;
+  image_exif_reader_       = std::move(reader);
+  exif_image_id_           = 0;
   exif_session_generation_ = 0;
   RefreshImageExifDisplay();
 }
@@ -1368,8 +1369,7 @@ void EditorSessionController::ApplySelectedAdjustmentNode(const alcedo::NodeId& 
 }
 
 auto EditorSessionController::PeekPendingInput() const -> alcedo::EditorPendingInputView {
-  return session_backend_ ? session_backend_->PeekPendingInput()
-                          : alcedo::EditorPendingInputView{};
+  return session_backend_ ? session_backend_->PeekPendingInput() : alcedo::EditorPendingInputView{};
 }
 
 void EditorSessionController::set_filmstrip_collapsed(bool collapsed) {
@@ -1436,10 +1436,12 @@ auto EditorSessionController::NormalizeAdjustmentPanel(const QString& panel) -> 
   if (key == QLatin1String("raw") || key == QLatin1String("rawdecode")) {
     return QStringLiteral("raw");
   }
+  if (key == QLatin1String("masks") || key == QLatin1String("mask")) {
+    return QStringLiteral("masks");
+  }
   if (key == QLatin1String("detail")) {
     return QStringLiteral("detail");
   }
-  // The Masks body overlays the six navbar pages. It is not a persisted panel.
   return QStringLiteral("tone");
 }
 
@@ -1464,9 +1466,8 @@ auto EditorSessionController::history_revision() const -> qulonglong {
 }
 
 auto EditorSessionController::active_version_id() const -> QString {
-  return session_backend_
-             ? QString::fromStdString(session_backend_->active_version_id().ToString())
-             : QString{};
+  return session_backend_ ? QString::fromStdString(session_backend_->active_version_id().ToString())
+                          : QString{};
 }
 
 auto EditorSessionController::pipeline_document() const -> const alcedo::PipelineDocument* {
@@ -1518,6 +1519,9 @@ void EditorSessionController::LoadDesktopUiPrefs() {
 }
 
 void EditorSessionController::SaveDesktopUiPrefs() const {
+  if (active_adjustment_panel_ == QLatin1String("masks")) {
+    return;
+  }
   QSettings settings;
   settings.setValue(QLatin1String(kActiveAdjustmentPanelKey), active_adjustment_panel_);
   settings.sync();

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -54,6 +54,8 @@ EditorSessionController::EditorSessionController(alcedo::IEditorSessionBackend* 
           &EditorSessionController::ActionAvailabilityChanged);
   scope_controller_ = std::make_unique<EditorScopeController>(this);
   mask_creation_    = std::make_unique<EditorMaskCreationAdapter>(this);
+  connect(mask_creation_.get(), &EditorMaskCreationAdapter::maskCreationChanged, this,
+          &EditorSessionController::SyncMaskAdjustmentPanel);
   connect(scope_controller_.get(), &EditorScopeController::FrameRequested, this, [this]() {
     if (!session_backend_ || !has_image() ||
         session_backend_->state() != alcedo::EditorSessionState::Interactive) {
@@ -1339,6 +1341,10 @@ auto EditorSessionController::mask_creation_last_removed_mask_id() const -> alce
                           : alcedo::MaskId{};
 }
 
+auto EditorSessionController::mask_creation_commands_pending() const -> bool {
+  return session_backend_ && session_backend_->mask_creation_commands_pending();
+}
+
 void EditorSessionController::SetImageExifReader(
     std::function<alcedo::EditorImageExifDisplay(uint)> reader) {
   image_exif_reader_       = std::move(reader);
@@ -1349,6 +1355,13 @@ void EditorSessionController::SetImageExifReader(
 
 void EditorSessionController::ApplySelectedAdjustmentNode(const alcedo::NodeId&  node_id,
                                                           alcedo::EditorNodeKind kind) {
+  if (mask_creation_ && mask_creation_->mask_controls_active() &&
+      node_id != mask_creation_->edit_node_id()) {
+    mask_panel_transition_ = true;
+    mask_creation_->finishBody();
+    mask_panel_transition_ = false;
+    SetActiveAdjustmentPanel(panel_before_mask_edit_, true);
+  }
   if (session_backend_ != nullptr) {
     (void)session_backend_->SetAdjustmentProjectionNode(node_id);
   }
@@ -1475,10 +1488,42 @@ auto EditorSessionController::pipeline_document() const -> const alcedo::Pipelin
 }
 
 void EditorSessionController::set_active_adjustment_panel(const QString& panel) {
+  const QString normalized = NormalizeAdjustmentPanel(panel);
+  if (normalized == QLatin1String("masks") &&
+      (!mask_creation_ || !mask_creation_->mask_controls_active())) {
+    return;
+  }
+  if (normalized != QLatin1String("masks") && mask_creation_ &&
+      mask_creation_->mask_controls_active()) {
+    mask_panel_transition_ = true;
+    mask_creation_->finishBody();
+    mask_panel_transition_ = false;
+  }
   // Publish Geometry exit while Develop still owns any pending crop submission.
-  SetActiveAdjustmentPanel(panel, true);
+  SetActiveAdjustmentPanel(normalized, true);
   if (node_controller_) {
     node_controller_->SelectNodeForAdjustmentPanel(active_adjustment_panel_);
+  }
+}
+
+void EditorSessionController::SyncMaskAdjustmentPanel() {
+  const bool mask_active = mask_creation_ && mask_creation_->mask_controls_active();
+  if (mask_active == mask_edit_was_active_) {
+    return;
+  }
+  mask_edit_was_active_ = mask_active;
+  if (mask_active) {
+    if (active_adjustment_panel_ != QLatin1String("masks")) {
+      panel_before_mask_edit_ = active_adjustment_panel_;
+      SetActiveAdjustmentPanel(QStringLiteral("masks"), true);
+    }
+    return;
+  }
+  if (!mask_panel_transition_ && active_adjustment_panel_ == QLatin1String("masks")) {
+    SetActiveAdjustmentPanel(panel_before_mask_edit_, true);
+    if (node_controller_) {
+      node_controller_->SelectNodeForAdjustmentPanel(active_adjustment_panel_);
+    }
   }
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -293,8 +293,12 @@ void EditorSessionController::OnBackendChanged() {
     }
   }
   SyncViewportDisplayConfig();
-  if (mask_creation_ && !has_image()) {
-    mask_creation_->OnImageClosed();
+  if (mask_creation_) {
+    if (!has_image()) {
+      mask_creation_->OnImageClosed();
+    } else {
+      mask_creation_->SyncFromSession();
+    }
   }
   emit       StateChanged();
   // Phase 7A R2: emit the dedicated history signal only when the backend's
@@ -1321,6 +1325,19 @@ auto EditorSessionController::mask_creation_mask_id() const -> alcedo::MaskId {
   return session_backend_ ? session_backend_->mask_creation_mask_id() : alcedo::MaskId{};
 }
 
+auto EditorSessionController::mask_creation_node_id() const -> alcedo::NodeId {
+  return session_backend_ ? session_backend_->mask_creation_node_id() : alcedo::NodeId{};
+}
+
+auto EditorSessionController::mask_creation_source() const -> std::optional<alcedo::MaskSource> {
+  return session_backend_ ? session_backend_->mask_creation_source() : std::nullopt;
+}
+
+auto EditorSessionController::mask_creation_last_removed_mask_id() const -> alcedo::MaskId {
+  return session_backend_ ? session_backend_->mask_creation_last_removed_mask_id()
+                            : alcedo::MaskId{};
+}
+
 void EditorSessionController::SetImageExifReader(
     std::function<alcedo::EditorImageExifDisplay(uint)> reader) {
   image_exif_reader_     = std::move(reader);
@@ -1422,9 +1439,7 @@ auto EditorSessionController::NormalizeAdjustmentPanel(const QString& panel) -> 
   if (key == QLatin1String("detail")) {
     return QStringLiteral("detail");
   }
-  if (key == QLatin1String("masks") || key == QLatin1String("mask")) {
-    return QStringLiteral("masks");
-  }
+  // The Masks body overlays the six navbar pages. It is not a persisted panel.
   return QStringLiteral("tone");
 }
 

--- a/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/app_theme.cpp
@@ -1030,6 +1030,18 @@ auto AppTheme::maskOverlayHandleHitRadius() const -> int { return 12; }
 
 auto AppTheme::maskOverlayRotateHandleOffset() const -> int { return 24; }
 
+auto AppTheme::maskOverlayGuideOuterWidth() const -> qreal { return 3.0; }
+
+auto AppTheme::maskOverlayGuideInnerWidth() const -> qreal { return 1.2; }
+
+auto AppTheme::maskOverlayGripOuterWidth() const -> qreal { return 5.0; }
+
+auto AppTheme::maskOverlayGripInnerWidth() const -> qreal { return 2.4; }
+
+auto AppTheme::maskOverlayGripSpanT0() const -> qreal { return 0.38; }
+
+auto AppTheme::maskOverlayGripSpanT1() const -> qreal { return 0.62; }
+
 auto AppTheme::scopePlotBorderColor() const -> QColor {
   return Blend(bgBaseColor(), textMutedColor(), 0.42);
 }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentHeader.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentHeader.qml
@@ -19,7 +19,6 @@ Item {
     property string isoText: "\u2014"
     property var maskCreation: null
     property string selectedNodeKind: ""
-    property bool cropOverlayVisible: false
     property bool controlsEnabled: true
 
     readonly property color colText: theme ? theme.colText : appTheme.textColor
@@ -150,7 +149,6 @@ Item {
                     compact: true
                     enabled: root.controlsEnabled
                              && root.selectedNodeKind === "colorGrade"
-                             && !root.cropOverlayVisible
                     selected: root.maskCreation
                               && String(root.maskCreation.toolKind || "") === "radial"
                     iconSrc: "qrc:/mask_icons/radial.svg"
@@ -163,7 +161,7 @@ Item {
                     fillSelected: appTheme.buttonSelectedFillColor
                     onClicked: {
                         if (root.maskCreation && radialButton.selected) {
-                            root.maskCreation.cancel()
+                            root.maskCreation.finishBody()
                         } else if (root.maskCreation) {
                             root.maskCreation.beginRadial()
                         }
@@ -176,7 +174,6 @@ Item {
                     compact: true
                     enabled: root.controlsEnabled
                              && root.selectedNodeKind === "colorGrade"
-                             && !root.cropOverlayVisible
                     selected: root.maskCreation
                               && String(root.maskCreation.toolKind || "") === "linear"
                     iconSrc: "qrc:/mask_icons/gradient.svg"
@@ -189,7 +186,7 @@ Item {
                     fillSelected: appTheme.buttonSelectedFillColor
                     onClicked: {
                         if (root.maskCreation && gradientButton.selected) {
-                            root.maskCreation.cancel()
+                            root.maskCreation.finishBody()
                         } else if (root.maskCreation) {
                             root.maskCreation.beginLinear()
                         }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
@@ -153,13 +153,15 @@ Item {
             return
         if (panel === "masks" && !root.maskPanelAvailable)
             return
-        if (root.activePanel === "masks" && panel !== "masks" && root.maskCreation)
+        // Leaving any panel while a Mask draw or edit is open settles it;
+        // finishBody is a no-op when the Mask tool is idle.
+        if (panel !== root.activePanel && root.maskCreation)
             root.maskCreation.finishBody()
         editorSession.activeAdjustmentPanel = panel
     }
 
     function confirmMaskEditAndReturn() {
-        if (root.activePanel !== "masks" || !root.maskCreation)
+        if (!root.maskCreation || !root.maskCreation.maskControlsActive)
             return false
         root.maskCreation.finishBody()
         return true

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
@@ -109,8 +109,6 @@ Item {
     }
 
     property int lastAppliedRevision: -1
-    property string panelBeforeMaskEdit: "tone"
-
     EditorLutCatalogModel {
         id: lutModel
         objectName: "adjustmentStackLutModel"
@@ -153,10 +151,6 @@ Item {
             return
         if (panel === "masks" && !root.maskPanelAvailable)
             return
-        // Leaving any panel while a Mask draw or edit is open settles it;
-        // finishBody is a no-op when the Mask tool is idle.
-        if (panel !== root.activePanel && root.maskCreation)
-            root.maskCreation.finishBody()
         editorSession.activeAdjustmentPanel = panel
     }
 
@@ -245,9 +239,6 @@ Item {
                 selectedNodeKind: root.nodeController
                                   ? String(root.nodeController.selectedNodeKind || "")
                                   : ""
-                cropOverlayVisible: root.interaction
-                                    ? !!root.interaction.cropOverlayVisible
-                                    : false
                 controlsEnabled: root.controlsEnabled
             }
 
@@ -355,21 +346,6 @@ Item {
         target: root.editorSession
         function onAdjustmentSnapshotChanged() {
             root.loadFromSnapshot(root.editorSession ? root.editorSession.adjustmentSnapshot : null)
-        }
-    }
-    Connections {
-        target: root.maskCreation
-        function onMaskCreationChanged() {
-            if (!root.editorSession)
-                return
-            if (root.maskCreation && root.maskCreation.bodyVisible) {
-                if (root.activePanel !== "masks") {
-                    root.panelBeforeMaskEdit = root.activePanel
-                    root.editorSession.activeAdjustmentPanel = "masks"
-                }
-            } else if (root.activePanel === "masks") {
-                root.editorSession.activeAdjustmentPanel = root.panelBeforeMaskEdit
-            }
         }
     }
     onEditorSessionChanged: {

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
@@ -36,6 +36,7 @@ Item {
     readonly property int panelRadius: theme ? theme.panelRadius : 12
     readonly property int controlRadius: theme ? theme.controlRadius : 10
 
+    readonly property var maskCreation: editorSession ? editorSession.maskCreation : null
     readonly property string activePanel: editorSession
                                           ? String(editorSession.activeAdjustmentPanel || "tone")
                                           : "tone"
@@ -142,6 +143,8 @@ Item {
     function selectPanel(panel) {
         if (!editorSession)
             return
+        if (root.maskCreation && root.maskCreation.bodyVisible)
+            root.maskCreation.hideBody()
         editorSession.activeAdjustmentPanel = panel
     }
 
@@ -242,72 +245,89 @@ Item {
                 onActivated: key => root.selectPanel(key)
             }
 
-            StackLayout {
-                id: panelStack
-                objectName: "editorAdjustmentPanelStack"
+            Item {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                currentIndex: {
-                    switch (root.activePanel) {
-                    case "look": return 1
-                    case "lut": return 2
-                    case "display": return 3
-                    case "geometry": return 4
-                    case "raw": return 5
-                    default: return 0
+
+                StackLayout {
+                    id: panelStack
+                    objectName: "editorAdjustmentPanelStack"
+                    anchors.fill: parent
+                    currentIndex: {
+                        switch (root.activePanel) {
+                        case "look": return 1
+                        case "lut": return 2
+                        case "display": return 3
+                        case "geometry": return 4
+                        case "raw": return 5
+                        default: return 0
+                        }
+                    }
+
+                    EditorTonePanel {
+                        id: tonePanel
+                        objectName: "editorAdjustmentPanel_tone"
+                        theme: root.theme
+                        editorSession: root.editorSession
+                        controlsEnabled: root.controlsEnabled
+                    }
+
+                    EditorLookPanel {
+                        id: lookPanel
+                        objectName: "editorAdjustmentPanel_look"
+                        theme: root.theme
+                        editorSession: root.editorSession
+                        controlsEnabled: root.controlsEnabled
+                        lutModel: lutModel
+                    }
+
+                    LUTPanel {
+                        id: lutPanel
+                        objectName: "editorAdjustmentPanel_lut"
+                        theme: root.theme
+                        editorSession: root.editorSession
+                        lutModel: lutModel
+                        controlsEnabled: root.controlsEnabled
+                    }
+
+                    EditorDisplayTransformPanel {
+                        id: displayPanel
+                        objectName: "editorAdjustmentPanel_display"
+                        theme: root.theme
+                        editorSession: root.editorSession
+                        controlsEnabled: root.controlsEnabled
+                    }
+
+                    EditorGeometryPanel {
+                        id: geometryPanel
+                        objectName: "editorAdjustmentPanel_geometry"
+                        theme: root.theme
+                        editorSession: root.editorSession
+                        interaction: root.interaction
+                        controlsEnabled: root.controlsEnabled
+                        panelActive: root.activePanel === "geometry"
+                    }
+
+                    EditorRawDecodePanel {
+                        id: rawPanel
+                        objectName: "editorAdjustmentPanel_raw"
+                        theme: root.theme
+                        editorSession: root.editorSession
+                        controlsEnabled: root.controlsEnabled
                     }
                 }
 
-                EditorTonePanel {
-                    id: tonePanel
-                    objectName: "editorAdjustmentPanel_tone"
+                EditorMasksContextPanel {
+                    id: masksPanel
+                    objectName: "editorAdjustmentPanel_masksOverlay"
+                    anchors.fill: parent
+                    visible: root.maskCreation && root.maskCreation.bodyVisible
                     theme: root.theme
                     editorSession: root.editorSession
+                    nodeController: root.nodeController
+                    maskCreation: root.maskCreation
                     controlsEnabled: root.controlsEnabled
-                }
-
-                EditorLookPanel {
-                    id: lookPanel
-                    objectName: "editorAdjustmentPanel_look"
-                    theme: root.theme
-                    editorSession: root.editorSession
-                    controlsEnabled: root.controlsEnabled
-                    lutModel: lutModel
-                }
-
-                LUTPanel {
-                    id: lutPanel
-                    objectName: "editorAdjustmentPanel_lut"
-                    theme: root.theme
-                    editorSession: root.editorSession
-                    lutModel: lutModel
-                    controlsEnabled: root.controlsEnabled
-                }
-
-                EditorDisplayTransformPanel {
-                    id: displayPanel
-                    objectName: "editorAdjustmentPanel_display"
-                    theme: root.theme
-                    editorSession: root.editorSession
-                    controlsEnabled: root.controlsEnabled
-                }
-
-                EditorGeometryPanel {
-                    id: geometryPanel
-                    objectName: "editorAdjustmentPanel_geometry"
-                    theme: root.theme
-                    editorSession: root.editorSession
-                    interaction: root.interaction
-                    controlsEnabled: root.controlsEnabled
-                    panelActive: root.activePanel === "geometry"
-                }
-
-                EditorRawDecodePanel {
-                    id: rawPanel
-                    objectName: "editorAdjustmentPanel_raw"
-                    theme: root.theme
-                    editorSession: root.editorSession
-                    controlsEnabled: root.controlsEnabled
+                    z: 1
                 }
             }
         }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentStack.qml
@@ -37,6 +37,8 @@ Item {
     readonly property int controlRadius: theme ? theme.controlRadius : 10
 
     readonly property var maskCreation: editorSession ? editorSession.maskCreation : null
+    readonly property bool maskPanelAvailable: root.maskCreation
+                                               && root.maskCreation.maskControlsActive
     readonly property string activePanel: editorSession
                                           ? String(editorSession.activeAdjustmentPanel || "tone")
                                           : "tone"
@@ -54,7 +56,10 @@ Item {
         { key: "geometry", icon: "qrc:/panel_icons/crop.svg",
           label: qsTr("Geometry"), itemObjectName: "editorAdjustmentNav_geometry" },
         { key: "raw", icon: "qrc:/panel_icons/aperture.svg",
-          label: qsTr("RAW Decode"), itemObjectName: "editorAdjustmentNav_raw" }
+          label: qsTr("RAW Decode"), itemObjectName: "editorAdjustmentNav_raw" },
+        { key: "masks", icon: "qrc:/panel_icons/masks.svg",
+          label: qsTr("Mask"), itemObjectName: "editorAdjustmentNav_masks",
+          enabled: root.maskPanelAvailable }
     ]
 
     readonly property int preferredPanelWidth: appTheme.editorSidePanelWidth
@@ -104,6 +109,7 @@ Item {
     }
 
     property int lastAppliedRevision: -1
+    property string panelBeforeMaskEdit: "tone"
 
     EditorLutCatalogModel {
         id: lutModel
@@ -129,6 +135,8 @@ Item {
             geometryPanel.loadFromSnapshot(snapshot)
         if (typeof rawPanel.loadFromSnapshot === "function")
             rawPanel.loadFromSnapshot(snapshot)
+        if (typeof masksPanel.loadFromSnapshot === "function")
+            masksPanel.loadFromSnapshot(snapshot)
     }
 
     function scheduleLoadFromSession() {
@@ -143,9 +151,18 @@ Item {
     function selectPanel(panel) {
         if (!editorSession)
             return
-        if (root.maskCreation && root.maskCreation.bodyVisible)
-            root.maskCreation.hideBody()
+        if (panel === "masks" && !root.maskPanelAvailable)
+            return
+        if (root.activePanel === "masks" && panel !== "masks" && root.maskCreation)
+            root.maskCreation.finishBody()
         editorSession.activeAdjustmentPanel = panel
+    }
+
+    function confirmMaskEditAndReturn() {
+        if (root.activePanel !== "masks" || !root.maskCreation)
+            return false
+        root.maskCreation.finishBody()
+        return true
     }
 
     function confirmGeometryAndReturnToTone() {
@@ -165,6 +182,7 @@ Item {
         case "display": return qsTr("Display Transform")
         case "geometry": return qsTr("Geometry")
         case "raw": return qsTr("RAW Decode")
+        case "masks": return qsTr("Mask")
         default: return qsTr("Tone")
         }
     }
@@ -260,6 +278,7 @@ Item {
                         case "display": return 3
                         case "geometry": return 4
                         case "raw": return 5
+                        case "masks": return 6
                         default: return 0
                         }
                     }
@@ -315,19 +334,16 @@ Item {
                         editorSession: root.editorSession
                         controlsEnabled: root.controlsEnabled
                     }
-                }
 
-                EditorMasksContextPanel {
-                    id: masksPanel
-                    objectName: "editorAdjustmentPanel_masksOverlay"
-                    anchors.fill: parent
-                    visible: root.maskCreation && root.maskCreation.bodyVisible
-                    theme: root.theme
-                    editorSession: root.editorSession
-                    nodeController: root.nodeController
-                    maskCreation: root.maskCreation
-                    controlsEnabled: root.controlsEnabled
-                    z: 1
+                    EditorMasksContextPanel {
+                        id: masksPanel
+                        objectName: "editorAdjustmentPanel_masks"
+                        theme: root.theme
+                        editorSession: root.editorSession
+                        nodeController: root.nodeController
+                        maskCreation: root.maskCreation
+                        controlsEnabled: root.controlsEnabled && root.maskPanelAvailable
+                    }
                 }
             }
         }
@@ -337,6 +353,21 @@ Item {
         target: root.editorSession
         function onAdjustmentSnapshotChanged() {
             root.loadFromSnapshot(root.editorSession ? root.editorSession.adjustmentSnapshot : null)
+        }
+    }
+    Connections {
+        target: root.maskCreation
+        function onMaskCreationChanged() {
+            if (!root.editorSession)
+                return
+            if (root.maskCreation && root.maskCreation.bodyVisible) {
+                if (root.activePanel !== "masks") {
+                    root.panelBeforeMaskEdit = root.activePanel
+                    root.editorSession.activeAdjustmentPanel = "masks"
+                }
+            } else if (root.activePanel === "masks") {
+                root.editorSession.activeAdjustmentPanel = root.panelBeforeMaskEdit
+            }
         }
     }
     onEditorSessionChanged: {

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorEndpointNodeDelegate.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorEndpointNodeDelegate.qml
@@ -34,6 +34,7 @@ Qan.NodeItem {
     Rectangle {
         id: card
         objectName: "editorEndpointNodeCard"
+        z: 2
         anchors.fill: parent
         radius: appTheme.controlRadiusSmall
         color: appTheme.cardSurfaceColor

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
@@ -91,10 +91,10 @@ Item {
                 from: 0.1; to: 100; stepSize: 0.1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
                 externalValue: root.maskCreation ? root.maskCreation.majorRadiusPercent : 0
-                onBegin: root.maskCreation.beginMajorRadius()
+                onBegin: function () { root.maskCreation.beginMajorRadius() }
                 onUpdate: function (v) { root.maskCreation.updateMajorRadius(v) }
-                onFinish: root.maskCreation.finishAnalyticControl()
-                onReset: {
+                onFinish: function () { root.maskCreation.finishAnalyticControl() }
+                onReset: function () {
                     root.maskCreation.beginMajorRadius()
                     root.maskCreation.updateMajorRadius(50)
                     root.maskCreation.finishAnalyticControl()
@@ -117,10 +117,10 @@ Item {
                 from: 0.1; to: 100; stepSize: 0.1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
                 externalValue: root.maskCreation ? root.maskCreation.minorRadiusPercent : 0
-                onBegin: root.maskCreation.beginMinorRadius()
+                onBegin: function () { root.maskCreation.beginMinorRadius() }
                 onUpdate: function (v) { root.maskCreation.updateMinorRadius(v) }
-                onFinish: root.maskCreation.finishAnalyticControl()
-                onReset: {
+                onFinish: function () { root.maskCreation.finishAnalyticControl() }
+                onReset: function () {
                     root.maskCreation.beginMinorRadius()
                     root.maskCreation.updateMinorRadius(50)
                     root.maskCreation.finishAnalyticControl()
@@ -143,10 +143,10 @@ Item {
                 from: -180; to: 180; stepSize: 0.5; pointerGain: 1
                 rowHeight: 28; handleSize: 18
                 externalValue: root.maskCreation ? root.maskCreation.rotationDegrees : 0
-                onBegin: root.maskCreation.beginRotation()
+                onBegin: function () { root.maskCreation.beginRotation() }
                 onUpdate: function (v) { root.maskCreation.updateRotation(v) }
-                onFinish: root.maskCreation.finishAnalyticControl()
-                onReset: {
+                onFinish: function () { root.maskCreation.finishAnalyticControl() }
+                onReset: function () {
                     root.maskCreation.beginRotation()
                     root.maskCreation.updateRotation(0)
                     root.maskCreation.finishAnalyticControl()
@@ -169,10 +169,10 @@ Item {
                 from: 0; to: 100; stepSize: 1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
                 externalValue: root.maskCreation ? root.maskCreation.innerFeatherPercent : 0
-                onBegin: root.maskCreation.beginInnerFeather()
+                onBegin: function () { root.maskCreation.beginInnerFeather() }
                 onUpdate: function (v) { root.maskCreation.updateInnerFeather(v) }
-                onFinish: root.maskCreation.finishAnalyticControl()
-                onReset: {
+                onFinish: function () { root.maskCreation.finishAnalyticControl() }
+                onReset: function () {
                     root.maskCreation.beginInnerFeather()
                     root.maskCreation.updateInnerFeather(0)
                     root.maskCreation.finishAnalyticControl()
@@ -195,10 +195,10 @@ Item {
                 rowHeight: 28; handleSize: 18
                 externalValue: root.maskCreation
                                ? Math.min(400, root.maskCreation.outerFeatherPercent) : 0
-                onBegin: root.maskCreation.beginOuterFeather()
+                onBegin: function () { root.maskCreation.beginOuterFeather() }
                 onUpdate: function (v) { root.maskCreation.updateOuterFeather(v) }
-                onFinish: root.maskCreation.finishAnalyticControl()
-                onReset: {
+                onFinish: function () { root.maskCreation.finishAnalyticControl() }
+                onReset: function () {
                     root.maskCreation.beginOuterFeather()
                     root.maskCreation.updateOuterFeather(0)
                     root.maskCreation.finishAnalyticControl()
@@ -220,10 +220,10 @@ Item {
                 from: 0.1; to: 200; stepSize: 0.1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
                 externalValue: root.maskCreation ? root.maskCreation.transitionPercent : 0
-                onBegin: root.maskCreation.beginTransition()
+                onBegin: function () { root.maskCreation.beginTransition() }
                 onUpdate: function (v) { root.maskCreation.updateTransition(v) }
-                onFinish: root.maskCreation.finishAnalyticControl()
-                onReset: {
+                onFinish: function () { root.maskCreation.finishAnalyticControl() }
+                onReset: function () {
                     root.maskCreation.beginTransition()
                     root.maskCreation.updateTransition(20)
                     root.maskCreation.finishAnalyticControl()

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
@@ -2,9 +2,9 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-// Temporary Color Grade Masks body. Overlays the ordinary six-tab stack
-// without writing "masks" into QSettings. Radial inner/outer values are
-// percent of the base radius. Selection/load is adapter-owned.
+// Parameter editor for the Mask selected in the Node drawer or created from
+// the adjustment header. The Node drawer is the only Mask list/management
+// surface; this page owns only source-specific controls for the exact MaskId.
 Item {
     id: root
     objectName: "editorAdjustmentPanel_masks"
@@ -17,205 +17,227 @@ Item {
 
     readonly property color colText: theme ? theme.colText : appTheme.textColor
     readonly property color colMuted: theme ? theme.colTextMuted : appTheme.textMutedColor
-    readonly property var masks: {
-        if (!root.nodeController)
-            return []
-        return root.nodeController.selectedNodeMasks || []
-    }
-    readonly property bool radialSelected: root.maskCreation
-            && String(root.maskCreation.toolKind || "") === "radial"
-            && String(root.maskCreation.selectedMaskId || "").length > 0
+    readonly property string selectedMaskId: root.maskCreation
+                                               ? String(root.maskCreation.selectedMaskId || "")
+                                               : ""
+    readonly property string sourceKind: root.maskCreation
+                                           ? String(root.maskCreation.toolKind || "")
+                                           : ""
+    readonly property bool radialSelected: root.controlsEnabled
+                                            && root.selectedMaskId.length > 0
+                                            && root.sourceKind === "radial"
+    readonly property bool gradientSelected: root.controlsEnabled
+                                              && root.selectedMaskId.length > 0
+                                              && root.sourceKind === "linear"
+    readonly property bool analyticSelected: root.radialSelected || root.gradientSelected
 
     function loadFromSnapshot(snapshot) {
         void snapshot
     }
 
-    ColumnLayout {
+    component ParameterLabel: Label {
+        Layout.fillWidth: true
+        color: root.colText
+        font.pixelSize: appTheme.fontSizeCaption
+        Accessible.role: Accessible.StaticText
+        Accessible.name: text
+    }
+
+    component ParameterValue: Label {
+        Layout.fillWidth: true
+        color: root.colMuted
+        font.family: appTheme.dataFontFamily
+        font.pixelSize: appTheme.fontSizeCaption
+    }
+
+    Flickable {
         anchors.fill: parent
-        spacing: appTheme.spaceSm
+        contentWidth: width
+        contentHeight: content.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
 
-        Label {
-            Layout.fillWidth: true
-            text: qsTr("Masks")
-            color: root.colText
-            font.pixelSize: appTheme.fontSizeTitle
-            font.weight: appTheme.fontWeightHeading
-        }
-
-        Label {
-            objectName: "editorMasksContextEmpty"
-            Layout.fillWidth: true
-            visible: root.masks.length === 0
-            wrapMode: Text.WordWrap
-            text: qsTr("This Color Grade has no Masks.")
-            color: root.colMuted
-            font.pixelSize: appTheme.fontSizeCaption
-        }
-
-        Repeater {
-            model: root.masks
-            delegate: EditorNodeMaskTypeRow {
-                required property var modelData
-                Layout.fillWidth: true
-                sourceKind: String(modelData.sourceKind || "")
-                maskId: String(modelData.maskId || "")
-                selected: root.maskCreation
-                          && maskId === String(root.maskCreation.selectedMaskId || "")
-                onClicked: {
-                    if (root.maskCreation)
-                        root.maskCreation.selectMask("", maskId)
-                }
-                onDeleteClicked: {
-                    if (root.maskCreation)
-                        root.maskCreation.removeMask("", maskId)
-                }
-            }
-        }
-
-        Label {
-            objectName: "editorMasksInnerFeatherLabel"
-            Layout.fillWidth: true
-            visible: root.radialSelected
-            text: qsTr("Inner feather")
-            color: root.colText
-            font.pixelSize: appTheme.fontSizeCaption
-            Accessible.role: Accessible.StaticText
-            Accessible.name: qsTr("Inner feather")
-        }
-
-        EditorMonoSlider {
-            id: innerFeatherSlider
-            objectName: "editorMasksInnerFeatherSlider"
-            Layout.fillWidth: true
-            visible: root.radialSelected
-            enabled: root.controlsEnabled && root.radialSelected
-            from: 0
-            to: 100
-            stepSize: 1
-            pointerGain: 1
-            rowHeight: 28
-            handleSize: 18
-            externalValue: root.maskCreation ? root.maskCreation.innerFeatherPercent : 0
-            onBegin: {
-                if (root.maskCreation)
-                    root.maskCreation.beginInnerFeather()
-            }
-            onUpdate: function (v) {
-                if (root.maskCreation)
-                    root.maskCreation.updateInnerFeather(v)
-            }
-            onFinish: {
-                if (root.maskCreation)
-                    root.maskCreation.finishFeather()
-            }
-            onReset: {
-                if (root.maskCreation) {
-                    root.maskCreation.beginInnerFeather()
-                    root.maskCreation.updateInnerFeather(0)
-                    root.maskCreation.finishFeather()
-                }
-            }
-        }
-
-        Label {
-            objectName: "editorMasksInnerFeatherValue"
-            Layout.fillWidth: true
-            visible: root.radialSelected
-            text: qsTr("%1 percent").arg(
-                      Math.round(root.maskCreation ? root.maskCreation.innerFeatherPercent : 0))
-            color: root.colMuted
-            font.pixelSize: appTheme.fontSizeCaption
-        }
-
-        Label {
-            objectName: "editorMasksOuterFeatherLabel"
-            Layout.fillWidth: true
-            visible: root.radialSelected
-            text: qsTr("Outer feather")
-            color: root.colText
-            font.pixelSize: appTheme.fontSizeCaption
-            Accessible.role: Accessible.StaticText
-            Accessible.name: qsTr("Outer feather")
-        }
-
-        EditorMonoSlider {
-            id: outerFeatherSlider
-            objectName: "editorMasksOuterFeatherSlider"
-            Layout.fillWidth: true
-            visible: root.radialSelected
-            enabled: root.controlsEnabled && root.radialSelected
-            from: 0
-            to: 400
-            stepSize: 1
-            pointerGain: 1
-            rowHeight: 28
-            handleSize: 18
-            externalValue: {
-                if (!root.maskCreation)
-                    return 0
-                return Math.min(400, root.maskCreation.outerFeatherPercent)
-            }
-            onBegin: {
-                if (root.maskCreation)
-                    root.maskCreation.beginOuterFeather()
-            }
-            onUpdate: function (v) {
-                if (root.maskCreation)
-                    root.maskCreation.updateOuterFeather(v)
-            }
-            onFinish: {
-                if (root.maskCreation)
-                    root.maskCreation.finishFeather()
-            }
-            onReset: {
-                if (root.maskCreation) {
-                    root.maskCreation.beginOuterFeather()
-                    root.maskCreation.updateOuterFeather(0)
-                    root.maskCreation.finishFeather()
-                }
-            }
-        }
-
-        Label {
-            objectName: "editorMasksOuterFeatherValue"
-            Layout.fillWidth: true
-            visible: root.radialSelected
-            text: qsTr("%1 percent").arg(
-                      Math.round(root.maskCreation ? root.maskCreation.outerFeatherPercent : 0))
-            color: root.colMuted
-            font.pixelSize: appTheme.fontSizeCaption
-        }
-
-        RowLayout {
-            Layout.fillWidth: true
+        ColumnLayout {
+            id: content
+            width: parent.width
             spacing: appTheme.spaceSm
 
-            DialogActionButton {
-                objectName: "editorMasksDoneButton"
+            Label {
                 Layout.fillWidth: true
-                buttonWidth: 0
-                text: qsTr("Done")
-                kind: "accent"
-                enabled: root.controlsEnabled
-                onClicked: {
-                    if (root.maskCreation)
-                        root.maskCreation.finishBody()
-                }
+                text: qsTr("Mask")
+                color: root.colText
+                font.pixelSize: appTheme.fontSizeTitle
+                font.weight: appTheme.fontWeightHeading
             }
 
-            DialogActionButton {
-                objectName: "editorMasksCancelButton"
+            Label {
+                objectName: "editorMasksContextEmpty"
                 Layout.fillWidth: true
-                buttonWidth: 0
-                text: qsTr("Cancel")
-                enabled: root.controlsEnabled
-                onClicked: {
-                    if (root.maskCreation)
-                        root.maskCreation.cancel()
+                visible: !root.analyticSelected
+                wrapMode: Text.WordWrap
+                text: root.maskCreation && root.maskCreation.creating
+                      ? qsTr("Draw on the photograph to create the Mask.")
+                      : qsTr("Select a Mask in the Node drawer or choose a Mask tool.")
+                color: root.colMuted
+                font.pixelSize: appTheme.fontSizeCaption
+            }
+
+            ParameterLabel { visible: root.radialSelected; text: qsTr("Horizontal radius") }
+            EditorMonoSlider {
+                objectName: "editorMasksMajorRadiusSlider"
+                Layout.fillWidth: true
+                visible: root.radialSelected
+                enabled: root.radialSelected
+                from: 0.1; to: 100; stepSize: 0.1; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                externalValue: root.maskCreation ? root.maskCreation.majorRadiusPercent : 0
+                onBegin: root.maskCreation.beginMajorRadius()
+                onUpdate: function (v) { root.maskCreation.updateMajorRadius(v) }
+                onFinish: root.maskCreation.finishAnalyticControl()
+                onReset: {
+                    root.maskCreation.beginMajorRadius()
+                    root.maskCreation.updateMajorRadius(50)
+                    root.maskCreation.finishAnalyticControl()
                 }
             }
+            ParameterValue {
+                objectName: "editorMasksMajorRadiusValue"
+                visible: root.radialSelected
+                text: qsTr("%1 percent").arg(Number(root.maskCreation
+                                                     ? root.maskCreation.majorRadiusPercent : 0)
+                                              .toFixed(1))
+            }
+
+            ParameterLabel { visible: root.radialSelected; text: qsTr("Vertical radius") }
+            EditorMonoSlider {
+                objectName: "editorMasksMinorRadiusSlider"
+                Layout.fillWidth: true
+                visible: root.radialSelected
+                enabled: root.radialSelected
+                from: 0.1; to: 100; stepSize: 0.1; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                externalValue: root.maskCreation ? root.maskCreation.minorRadiusPercent : 0
+                onBegin: root.maskCreation.beginMinorRadius()
+                onUpdate: function (v) { root.maskCreation.updateMinorRadius(v) }
+                onFinish: root.maskCreation.finishAnalyticControl()
+                onReset: {
+                    root.maskCreation.beginMinorRadius()
+                    root.maskCreation.updateMinorRadius(50)
+                    root.maskCreation.finishAnalyticControl()
+                }
+            }
+            ParameterValue {
+                objectName: "editorMasksMinorRadiusValue"
+                visible: root.radialSelected
+                text: qsTr("%1 percent").arg(Number(root.maskCreation
+                                                     ? root.maskCreation.minorRadiusPercent : 0)
+                                              .toFixed(1))
+            }
+
+            ParameterLabel { visible: root.analyticSelected; text: qsTr("Rotation") }
+            EditorMonoSlider {
+                objectName: "editorMasksRotationSlider"
+                Layout.fillWidth: true
+                visible: root.analyticSelected
+                enabled: root.analyticSelected
+                from: -180; to: 180; stepSize: 0.5; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                externalValue: root.maskCreation ? root.maskCreation.rotationDegrees : 0
+                onBegin: root.maskCreation.beginRotation()
+                onUpdate: function (v) { root.maskCreation.updateRotation(v) }
+                onFinish: root.maskCreation.finishAnalyticControl()
+                onReset: {
+                    root.maskCreation.beginRotation()
+                    root.maskCreation.updateRotation(0)
+                    root.maskCreation.finishAnalyticControl()
+                }
+            }
+            ParameterValue {
+                objectName: "editorMasksRotationValue"
+                visible: root.analyticSelected
+                text: qsTr("%1 degrees").arg(Number(root.maskCreation
+                                                     ? root.maskCreation.rotationDegrees : 0)
+                                              .toFixed(1))
+            }
+
+            ParameterLabel { visible: root.radialSelected; text: qsTr("Inner feather") }
+            EditorMonoSlider {
+                objectName: "editorMasksInnerFeatherSlider"
+                Layout.fillWidth: true
+                visible: root.radialSelected
+                enabled: root.radialSelected
+                from: 0; to: 100; stepSize: 1; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                externalValue: root.maskCreation ? root.maskCreation.innerFeatherPercent : 0
+                onBegin: root.maskCreation.beginInnerFeather()
+                onUpdate: function (v) { root.maskCreation.updateInnerFeather(v) }
+                onFinish: root.maskCreation.finishAnalyticControl()
+                onReset: {
+                    root.maskCreation.beginInnerFeather()
+                    root.maskCreation.updateInnerFeather(0)
+                    root.maskCreation.finishAnalyticControl()
+                }
+            }
+            ParameterValue {
+                objectName: "editorMasksInnerFeatherValue"
+                visible: root.radialSelected
+                text: qsTr("%1 percent").arg(Math.round(root.maskCreation
+                                                        ? root.maskCreation.innerFeatherPercent : 0))
+            }
+
+            ParameterLabel { visible: root.radialSelected; text: qsTr("Outer feather") }
+            EditorMonoSlider {
+                objectName: "editorMasksOuterFeatherSlider"
+                Layout.fillWidth: true
+                visible: root.radialSelected
+                enabled: root.radialSelected
+                from: 0; to: 400; stepSize: 1; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                externalValue: root.maskCreation
+                               ? Math.min(400, root.maskCreation.outerFeatherPercent) : 0
+                onBegin: root.maskCreation.beginOuterFeather()
+                onUpdate: function (v) { root.maskCreation.updateOuterFeather(v) }
+                onFinish: root.maskCreation.finishAnalyticControl()
+                onReset: {
+                    root.maskCreation.beginOuterFeather()
+                    root.maskCreation.updateOuterFeather(0)
+                    root.maskCreation.finishAnalyticControl()
+                }
+            }
+            ParameterValue {
+                objectName: "editorMasksOuterFeatherValue"
+                visible: root.radialSelected
+                text: qsTr("%1 percent").arg(Math.round(root.maskCreation
+                                                        ? root.maskCreation.outerFeatherPercent : 0))
+            }
+
+            ParameterLabel { visible: root.gradientSelected; text: qsTr("Transition width") }
+            EditorMonoSlider {
+                objectName: "editorMasksTransitionSlider"
+                Layout.fillWidth: true
+                visible: root.gradientSelected
+                enabled: root.gradientSelected
+                from: 0.1; to: 200; stepSize: 0.1; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                externalValue: root.maskCreation ? root.maskCreation.transitionPercent : 0
+                onBegin: root.maskCreation.beginTransition()
+                onUpdate: function (v) { root.maskCreation.updateTransition(v) }
+                onFinish: root.maskCreation.finishAnalyticControl()
+                onReset: {
+                    root.maskCreation.beginTransition()
+                    root.maskCreation.updateTransition(20)
+                    root.maskCreation.finishAnalyticControl()
+                }
+            }
+            ParameterValue {
+                objectName: "editorMasksTransitionValue"
+                visible: root.gradientSelected
+                text: qsTr("%1 percent").arg(Number(root.maskCreation
+                                                     ? root.maskCreation.transitionPercent : 0)
+                                              .toFixed(1))
+            }
+
+            Item { Layout.fillHeight: true }
         }
-
-        Item { Layout.fillHeight: true }
     }
 }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
@@ -2,8 +2,9 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-// Color Grade Mask context. Identifies Masks on the selected node without
-// viewer authoring controls.
+// Temporary Color Grade Masks body. Overlays the ordinary six-tab stack
+// without writing "masks" into QSettings. Radial inner/outer values are
+// percent of the base radius. Selection/load is adapter-owned.
 Item {
     id: root
     objectName: "editorAdjustmentPanel_masks"
@@ -11,6 +12,7 @@ Item {
     property var theme: null
     property var editorSession: null
     property var nodeController: null
+    property var maskCreation: null
     property bool controlsEnabled: true
 
     readonly property color colText: theme ? theme.colText : appTheme.textColor
@@ -20,9 +22,11 @@ Item {
             return []
         return root.nodeController.selectedNodeMasks || []
     }
+    readonly property bool radialSelected: root.maskCreation
+            && String(root.maskCreation.toolKind || "") === "radial"
+            && String(root.maskCreation.selectedMaskId || "").length > 0
 
     function loadFromSnapshot(snapshot) {
-        // Mask identity is selection-owned. Snapshot values are not submitted.
         void snapshot
     }
 
@@ -55,6 +59,160 @@ Item {
                 Layout.fillWidth: true
                 sourceKind: String(modelData.sourceKind || "")
                 maskId: String(modelData.maskId || "")
+                selected: root.maskCreation
+                          && maskId === String(root.maskCreation.selectedMaskId || "")
+                onClicked: {
+                    if (root.maskCreation)
+                        root.maskCreation.selectMask("", maskId)
+                }
+                onDeleteClicked: {
+                    if (root.maskCreation)
+                        root.maskCreation.removeMask("", maskId)
+                }
+            }
+        }
+
+        Label {
+            objectName: "editorMasksInnerFeatherLabel"
+            Layout.fillWidth: true
+            visible: root.radialSelected
+            text: qsTr("Inner feather")
+            color: root.colText
+            font.pixelSize: appTheme.fontSizeCaption
+            Accessible.role: Accessible.StaticText
+            Accessible.name: qsTr("Inner feather")
+        }
+
+        EditorMonoSlider {
+            id: innerFeatherSlider
+            objectName: "editorMasksInnerFeatherSlider"
+            Layout.fillWidth: true
+            visible: root.radialSelected
+            enabled: root.controlsEnabled && root.radialSelected
+            from: 0
+            to: 100
+            stepSize: 1
+            pointerGain: 1
+            rowHeight: 28
+            handleSize: 18
+            externalValue: root.maskCreation ? root.maskCreation.innerFeatherPercent : 0
+            onBegin: {
+                if (root.maskCreation)
+                    root.maskCreation.beginInnerFeather()
+            }
+            onUpdate: function (v) {
+                if (root.maskCreation)
+                    root.maskCreation.updateInnerFeather(v)
+            }
+            onFinish: {
+                if (root.maskCreation)
+                    root.maskCreation.finishFeather()
+            }
+            onReset: {
+                if (root.maskCreation) {
+                    root.maskCreation.beginInnerFeather()
+                    root.maskCreation.updateInnerFeather(0)
+                    root.maskCreation.finishFeather()
+                }
+            }
+        }
+
+        Label {
+            objectName: "editorMasksInnerFeatherValue"
+            Layout.fillWidth: true
+            visible: root.radialSelected
+            text: qsTr("%1 percent").arg(
+                      Math.round(root.maskCreation ? root.maskCreation.innerFeatherPercent : 0))
+            color: root.colMuted
+            font.pixelSize: appTheme.fontSizeCaption
+        }
+
+        Label {
+            objectName: "editorMasksOuterFeatherLabel"
+            Layout.fillWidth: true
+            visible: root.radialSelected
+            text: qsTr("Outer feather")
+            color: root.colText
+            font.pixelSize: appTheme.fontSizeCaption
+            Accessible.role: Accessible.StaticText
+            Accessible.name: qsTr("Outer feather")
+        }
+
+        EditorMonoSlider {
+            id: outerFeatherSlider
+            objectName: "editorMasksOuterFeatherSlider"
+            Layout.fillWidth: true
+            visible: root.radialSelected
+            enabled: root.controlsEnabled && root.radialSelected
+            from: 0
+            to: 400
+            stepSize: 1
+            pointerGain: 1
+            rowHeight: 28
+            handleSize: 18
+            externalValue: {
+                if (!root.maskCreation)
+                    return 0
+                return Math.min(400, root.maskCreation.outerFeatherPercent)
+            }
+            onBegin: {
+                if (root.maskCreation)
+                    root.maskCreation.beginOuterFeather()
+            }
+            onUpdate: function (v) {
+                if (root.maskCreation)
+                    root.maskCreation.updateOuterFeather(v)
+            }
+            onFinish: {
+                if (root.maskCreation)
+                    root.maskCreation.finishFeather()
+            }
+            onReset: {
+                if (root.maskCreation) {
+                    root.maskCreation.beginOuterFeather()
+                    root.maskCreation.updateOuterFeather(0)
+                    root.maskCreation.finishFeather()
+                }
+            }
+        }
+
+        Label {
+            objectName: "editorMasksOuterFeatherValue"
+            Layout.fillWidth: true
+            visible: root.radialSelected
+            text: qsTr("%1 percent").arg(
+                      Math.round(root.maskCreation ? root.maskCreation.outerFeatherPercent : 0))
+            color: root.colMuted
+            font.pixelSize: appTheme.fontSizeCaption
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: appTheme.spaceSm
+
+            DialogActionButton {
+                objectName: "editorMasksDoneButton"
+                Layout.fillWidth: true
+                buttonWidth: 0
+                text: qsTr("Done")
+                kind: "accent"
+                enabled: root.controlsEnabled
+                onClicked: {
+                    if (root.maskCreation)
+                        root.maskCreation.finishBody()
+                }
+            }
+
+            DialogActionButton {
+                objectName: "editorMasksCancelButton"
+                Layout.fillWidth: true
+                buttonWidth: 0
+                text: qsTr("Cancel")
+                enabled: root.controlsEnabled
+                onClicked: {
+                    if (root.maskCreation)
+                        root.maskCreation.cancel()
+                }
             }
         }
 

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeDelegate.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeDelegate.qml
@@ -11,8 +11,13 @@ Qan.NodeItem {
     objectName: "qan::NodeItem"
 
     property string nodeKind: "colorGrade"
+    property string nodeId: ""
     property var masks: []
+    property string selectedMaskId: ""
     property bool drawerOpen: true
+
+    signal maskSelected(string nodeId, string maskId)
+    signal maskDeleteRequested(string nodeId, string maskId)
 
     readonly property string displayName: node ? node.label : ""
 
@@ -86,11 +91,19 @@ Qan.NodeItem {
             EditorNodeMaskDrawer {
                 id: maskDrawer
                 width: parent.width
+                nodeId: root.nodeId
                 masks: root.masks
+                selectedMaskId: root.selectedMaskId
                 expanded: root.drawerOpen
                 surfaceColor: appTheme.graphMaskDrawerSurfaceColor
                 onToggled: function (open) {
                     root.drawerOpen = open
+                }
+                onMaskSelected: function (nodeId, maskId) {
+                    root.maskSelected(nodeId, maskId)
+                }
+                onMaskDeleteRequested: function (nodeId, maskId) {
+                    root.maskDeleteRequested(nodeId, maskId)
                 }
             }
         }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeDelegate.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeDelegate.qml
@@ -15,6 +15,12 @@ Qan.NodeItem {
     property var masks: []
     property string selectedMaskId: ""
     property bool drawerOpen: true
+    property var graphAdapter: null
+    readonly property var resolvedAdapter: {
+        if (root.graphAdapter)
+            return root.graphAdapter
+        return (root.graph && root.graph.alcedoQanGraph) ? root.graph.alcedoQanGraph : null
+    }
 
     signal maskSelected(string nodeId, string maskId)
     signal maskDeleteRequested(string nodeId, string maskId)
@@ -39,6 +45,9 @@ Qan.NodeItem {
     Rectangle {
         id: card
         objectName: "editorNodeCard"
+        // QuickQanava parents an invisible selection item at z=1 that covers the
+        // whole node. Keep the card above it so Mask rows receive pointer input.
+        z: 2
         anchors.fill: parent
         radius: appTheme.controlRadiusSmall
         color: appTheme.cardSurfaceColor
@@ -100,10 +109,12 @@ Qan.NodeItem {
                     root.drawerOpen = open
                 }
                 onMaskSelected: function (nodeId, maskId) {
-                    root.maskSelected(nodeId, maskId)
+                    if (root.resolvedAdapter)
+                        root.resolvedAdapter.notifyMaskRowSelected(root, maskId)
                 }
                 onMaskDeleteRequested: function (nodeId, maskId) {
-                    root.maskDeleteRequested(nodeId, maskId)
+                    if (root.resolvedAdapter)
+                        root.resolvedAdapter.notifyMaskRowDeleteRequested(root, maskId)
                 }
             }
         }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskDrawer.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskDrawer.qml
@@ -31,7 +31,9 @@ Item {
             return 0
         }
         const count = root.masks.length !== undefined ? root.masks.length : 0
-        return count * appTheme.graphMaskRowHeight
+        return count > 0
+                ? count * appTheme.graphMaskRowHeight + appTheme.spaceXs
+                : 0
     }
     readonly property real bodyHeight: Math.max(0, bodyContentHeight) * foldProgress
 
@@ -201,6 +203,7 @@ Item {
                 id: headerMouse
                 anchors.fill: parent
                 hoverEnabled: true
+                preventStealing: true
                 focus: false
                 cursorShape: Qt.PointingHandCursor
                 onClicked: root.toggle()
@@ -229,13 +232,14 @@ Item {
                     model: root.masks
 
                     EditorNodeMaskTypeRow {
+                        id: maskTypeRow
                         width: maskList.width
                         sourceKind: modelData.sourceKind !== undefined ? String(modelData.sourceKind) : ""
                         maskId: modelData.maskId !== undefined ? String(modelData.maskId) : ""
                         selected: root.selectedMaskId.length > 0
                                   && maskId === root.selectedMaskId
-                        onClicked: root.maskSelected(root.nodeId, maskId)
-                        onDeleteClicked: root.maskDeleteRequested(root.nodeId, maskId)
+                        onClicked: root.maskSelected(root.nodeId, maskTypeRow.maskId)
+                        onDeleteClicked: root.maskDeleteRequested(root.nodeId, maskTypeRow.maskId)
                     }
                 }
             }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskDrawer.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskDrawer.qml
@@ -12,6 +12,8 @@ Item {
     objectName: "editorNodeMaskDrawer"
 
     property var masks: []
+    property string nodeId: ""
+    property string selectedMaskId: ""
     property bool expanded: true
     property color textColor: appTheme.textColor
     property color mutedColor: appTheme.textMutedColor
@@ -39,6 +41,8 @@ Item {
     clip: true
 
     signal toggled(bool expanded)
+    signal maskSelected(string nodeId, string maskId)
+    signal maskDeleteRequested(string nodeId, string maskId)
 
     function toggle() {
         root.expanded = !root.expanded
@@ -228,6 +232,10 @@ Item {
                         width: maskList.width
                         sourceKind: modelData.sourceKind !== undefined ? String(modelData.sourceKind) : ""
                         maskId: modelData.maskId !== undefined ? String(modelData.maskId) : ""
+                        selected: root.selectedMaskId.length > 0
+                                  && maskId === root.selectedMaskId
+                        onClicked: root.maskSelected(root.nodeId, maskId)
+                        onDeleteClicked: root.maskDeleteRequested(root.nodeId, maskId)
                     }
                 }
             }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskTypeRow.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskTypeRow.qml
@@ -3,15 +3,19 @@ import QtQuick.Controls
 import QtQuick.Controls.impl
 import QtQuick.Layouts
 
-// One read-only Mask source-type row inside a Color Grade drawer.
-// Shows only the approved type icon and localized type name. MaskId stays on
-// the projection for later selection; it is never UI text.
+// One Mask source-type row inside a Color Grade drawer. Selection is
+// NodeId/MaskId owned; click does not rebuild the list. Delete is a compact
+// IconActionButton and does not propagate into row selection.
 Item {
     id: root
     objectName: "editorNodeMaskTypeRow"
 
     property string sourceKind: ""
     property string maskId: ""
+    property bool selected: false
+
+    signal clicked
+    signal deleteClicked
 
     readonly property string typeLabel: {
         if (root.sourceKind === "linearGradient") {
@@ -40,18 +44,40 @@ Item {
     }
 
     implicitWidth: appTheme.graphNodeWidth
-    implicitHeight: Math.max(appTheme.graphMaskRowHeight, typeName.implicitHeight + appTheme.spaceXs)
+    implicitHeight: appTheme.graphMaskRowHeight
     height: implicitHeight
-    activeFocusOnTab: false
+    activeFocusOnTab: true
 
-    Accessible.role: Accessible.StaticText
+    Accessible.role: Accessible.Button
     Accessible.name: root.typeLabel
     Accessible.ignored: !root.visible || root.typeLabel.length === 0
+    Accessible.onPressAction: root.clicked()
+
+    Keys.onPressed: function (event) {
+        if (event.key === Qt.Key_Space || event.key === Qt.Key_Return
+                || event.key === Qt.Key_Enter) {
+            root.clicked()
+            event.accepted = true
+        } else if (event.key === Qt.Key_Delete || event.key === Qt.Key_Backspace) {
+            root.deleteClicked()
+            event.accepted = true
+        }
+    }
+
+    Rectangle {
+        objectName: "editorNodeMaskTypeRowWash"
+        anchors.fill: parent
+        anchors.leftMargin: appTheme.graphSelectionOutlineWidth
+        anchors.rightMargin: appTheme.graphSelectionOutlineWidth
+        color: root.selected ? appTheme.selectedTintColor
+                            : (rowMouse.containsMouse || root.activeFocus
+                               ? appTheme.hoverColor : "transparent")
+    }
 
     RowLayout {
         anchors.fill: parent
         anchors.leftMargin: appTheme.spaceSm
-        anchors.rightMargin: appTheme.spaceSm
+        anchors.rightMargin: appTheme.spaceXs
         spacing: appTheme.spaceSm
 
         ColorImage {
@@ -84,5 +110,29 @@ Item {
             wrapMode: Text.NoWrap
             Accessible.ignored: true
         }
+
+        IconActionButton {
+            id: deleteButton
+            objectName: "editorNodeMaskTypeRowDelete"
+            compact: true
+            width: appTheme.graphMaskRowHeight
+            height: appTheme.graphMaskRowHeight
+            Layout.preferredWidth: appTheme.graphMaskRowHeight
+            Layout.preferredHeight: appTheme.graphMaskRowHeight
+            Layout.alignment: Qt.AlignVCenter
+            iconSrc: "qrc:/panel_icons/trash.svg"
+            actionName: qsTr("Delete %1").arg(root.typeLabel)
+            focusOnPointerPress: false
+            onClicked: root.deleteClicked()
+        }
+    }
+
+    MouseArea {
+        id: rowMouse
+        anchors.fill: parent
+        anchors.rightMargin: appTheme.graphMaskRowHeight
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onClicked: root.clicked()
     }
 }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskTypeRow.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskTypeRow.qml
@@ -110,28 +110,40 @@ Item {
             Accessible.ignored: true
         }
 
-        IconActionButton {
-            id: deleteButton
-            objectName: "editorNodeMaskTypeRowDelete"
-            compact: true
-            width: appTheme.graphMaskRowHeight
-            height: appTheme.graphMaskRowHeight
+        Item {
             Layout.preferredWidth: appTheme.graphMaskRowHeight
             Layout.preferredHeight: appTheme.graphMaskRowHeight
             Layout.alignment: Qt.AlignVCenter
-            iconSrc: "qrc:/panel_icons/trash.svg"
-            actionName: qsTr("Delete %1").arg(root.typeLabel)
-            focusOnPointerPress: false
-            onClicked: root.deleteClicked()
+
+            IconActionButton {
+                id: deleteButton
+                objectName: "editorNodeMaskTypeRowDelete"
+                anchors.fill: parent
+                compact: true
+                stretchInLayout: true
+                iconSrc: "qrc:/panel_icons/trash.svg"
+                actionName: qsTr("Delete %1").arg(root.typeLabel)
+                focusOnPointerPress: false
+                onClicked: root.deleteClicked()
+            }
         }
     }
 
     MouseArea {
         id: rowMouse
         anchors.fill: parent
-        anchors.rightMargin: appTheme.graphMaskRowHeight
+        anchors.rightMargin: appTheme.graphMaskRowHeight + appTheme.spaceXs
         hoverEnabled: true
+        preventStealing: true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
         cursorShape: Qt.PointingHandCursor
-        onClicked: root.clicked()
+        // NodeItem::mousePressEvent accepts the whole card and emits
+        // nodeClicked / nodeRightClicked. When this MouseArea is the pick
+        // target, consume both buttons so the Color Grade menu does not open
+        // on a Mask row. Select on press; the graph also hit-tests rows.
+        onPressed: function (mouse) {
+            mouse.accepted = true
+            root.clicked()
+        }
     }
 }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskTypeRow.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodeMaskTypeRow.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Controls.impl
 import QtQuick.Layouts
 
@@ -97,7 +96,7 @@ Item {
             visible: root.iconSrc.toString().length > 0
         }
 
-        Label {
+        Text {
             id: typeName
             objectName: "editorNodeMaskTypeLabel"
             Layout.fillWidth: true

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodePortDock.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodePortDock.qml
@@ -18,7 +18,8 @@ RowLayout {
     property int dockType: -1
 
     spacing: 0
-    z: 1.5
+    // Above the node card (z=2) and the invisible QuickQanava selection item (z=1).
+    z: 3
 
     onXChanged: if (hostNodeItem) hostNodeItem.updatePortsEdges()
     onYChanged: if (hostNodeItem) hostNodeItem.updatePortsEdges()

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
@@ -17,6 +17,8 @@ Item {
     property var nodeController: null
     property var nodeLayoutStore: null
 
+    readonly property var maskCreation: root.editorSession ? root.editorSession.maskCreation : null
+
     property bool renameVisible: false
     property string renameNodeId: ""
     property string renameOriginalName: ""
@@ -135,6 +137,8 @@ Item {
             return
         }
         root.nodeController.graphAdapter = qanAdapter
+        if (root.maskCreation)
+            qanAdapter.selectedMaskId = String(root.maskCreation.selectedMaskId || "")
     }
 
     function detachAdapter() {
@@ -202,7 +206,14 @@ Item {
         } else if (id === "nodes.renameColorGrade") {
             root.beginRename()
         } else if (id === "nodes.deleteColorGrade") {
-            root.deleteSelectedColorGrade()
+            if (root.renameVisible) {
+                return
+            }
+            if (root.maskCreation && root.maskCreation.maskControlsActive) {
+                root.maskCreation.removeSelectedMask()
+            } else {
+                root.deleteSelectedColorGrade()
+            }
         } else if (id === "nodes.beginConnect") {
             root.startKeyboardConnect()
         } else if (id === "nodes.completeConnect") {
@@ -250,6 +261,24 @@ Item {
         }
         function onGraphChanged() {
             root.attachAdapter()
+        }
+        function onMaskRowSelected(nodeId, maskId) {
+            if (root.maskCreation)
+                root.maskCreation.selectMask(nodeId, maskId)
+        }
+        function onMaskRowDeleteRequested(nodeId, maskId) {
+            if (root.maskCreation)
+                root.maskCreation.removeMask(nodeId, maskId)
+        }
+    }
+
+    Connections {
+        target: root.maskCreation
+        function onMaskCreationChanged() {
+            if (qanAdapter)
+                qanAdapter.selectedMaskId = root.maskCreation
+                        ? String(root.maskCreation.selectedMaskId || "")
+                        : ""
         }
     }
 

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
@@ -154,19 +154,73 @@ Item {
     }
 
     function selectMaskFromDrawer(nodeId, maskId) {
-        if (!root.maskCreation || String(maskId).length === 0
-                || !root.selectDrawerOwner(nodeId)) {
+        if (qanAdapter) {
+            qanAdapter.logMaskRow("selectMaskFromDrawer", String(nodeId || ""),
+                                  String(maskId || ""), false)
+        }
+        if (!root.maskCreation || String(maskId).length === 0) {
+            if (qanAdapter) {
+                qanAdapter.logMaskRow("selectMaskFromDrawer-abort",
+                                      String(nodeId || ""), String(maskId || ""),
+                                      false)
+            }
             return
         }
+        root.selectDrawerOwner(nodeId)
         root.maskCreation.selectMask(nodeId, maskId)
     }
 
     function removeMaskFromDrawer(nodeId, maskId) {
-        if (!root.maskCreation || String(maskId).length === 0
-                || !root.selectDrawerOwner(nodeId)) {
+        if (qanAdapter) {
+            qanAdapter.logMaskRow("removeMaskFromDrawer", String(nodeId || ""),
+                                  String(maskId || ""), false)
+        }
+        if (!root.maskCreation || String(maskId).length === 0) {
+            if (qanAdapter) {
+                qanAdapter.logMaskRow("removeMaskFromDrawer-abort",
+                                      String(nodeId || ""), String(maskId || ""),
+                                      false)
+            }
             return
         }
+        root.selectDrawerOwner(nodeId)
         root.maskCreation.removeMask(nodeId, maskId)
+    }
+
+    // NodeItem owns the press for the whole card. GraphView.nodeClicked is the
+    // same path as a working right-click skip, and the same style of call as
+    // beginRadial: a QML handler invoking maskCreation directly.
+    function handleGraphNodePress(node, position, rightButton) {
+        if (!root.nodeController || !qanAdapter || !node) {
+            if (qanAdapter) {
+                qanAdapter.logMaskRow("graph-press-missing", "", "", rightButton)
+            }
+            return false
+        }
+        const id = qanAdapter.liveNodeId(node)
+        if (id.length > 0) {
+            root.nodeController.selectNode(id)
+        }
+        if (!node.item || position === undefined || position === null) {
+            qanAdapter.logMaskRow("graph-press-no-pos", id, "", rightButton)
+            return false
+        }
+        const maskId = String(qanAdapter.maskIdAtItemPosition(
+                                  node.item, position.x, position.y) || "")
+        const onDelete = !rightButton
+                && qanAdapter.maskDeleteContainsItemPosition(
+                       node.item, position.x, position.y)
+        qanAdapter.logMaskRow(onDelete ? "graph-press-delete" : "graph-press",
+                              id, maskId, rightButton)
+        if (maskId.length === 0) {
+            return false
+        }
+        if (onDelete) {
+            root.removeMaskFromDrawer(id, maskId)
+        } else {
+            root.selectMaskFromDrawer(id, maskId)
+        }
+        return true
     }
 
     function detachAdapter() {
@@ -237,16 +291,12 @@ Item {
             if (root.renameVisible) {
                 return
             }
-            // Mask-scoped Delete wins over node deletion while a Mask draw or
-            // Mask selection is active.
-            if (root.maskCreation && root.maskCreation.creating) {
-                root.maskCreation.cancel()
-            } else if (root.maskCreation
-                       && String(root.maskCreation.selectedMaskId || "").length > 0) {
-                root.maskCreation.removeSelectedMask()
-            } else {
-                root.deleteSelectedColorGrade()
+            // Leave the event unaccepted while transient Mask editing owns
+            // Delete; EditorWorkspace's scoped Shortcut handles it exactly once.
+            if (root.maskCreation && root.maskCreation.maskControlsActive) {
+                return
             }
+            root.deleteSelectedColorGrade()
         } else if (id === "nodes.beginConnect") {
             root.startKeyboardConnect()
         } else if (id === "nodes.completeConnect") {
@@ -556,16 +606,24 @@ Item {
                 }
 
                 onNavigated: root.captureView()
-                onNodeClicked: function (node) {
-                    if (!root.nodeController || !qanAdapter) {
+                onNodeClicked: function (node, pos) {
+                    if (qanAdapter) {
+                        qanAdapter.logMaskRow("graphView-nodeClicked",
+                                              node ? qanAdapter.liveNodeId(node) : "",
+                                              "", false)
+                    }
+                    root.handleGraphNodePress(node, pos, false)
+                }
+                onNodeRightClicked: function (node, pos) {
+                    if (qanAdapter) {
+                        qanAdapter.logMaskRow("graphView-nodeRightClicked",
+                                              node ? qanAdapter.liveNodeId(node) : "",
+                                              "", true)
+                    }
+                    const onMaskRow = root.handleGraphNodePress(node, pos, true)
+                    if (onMaskRow) {
                         return
                     }
-                    const id = qanAdapter.liveNodeId(node)
-                    if (id.length > 0) {
-                        root.nodeController.selectNode(id)
-                    }
-                }
-                onNodeRightClicked: function (node, position) {
                     if (!root.nodeController || !qanAdapter || !node || !node.item) {
                         return
                     }
@@ -573,9 +631,7 @@ Item {
                     if (id.length === 0) {
                         return
                     }
-                    root.nodeController.selectNode(id)
-                    const menuPosition = node.item.mapToItem(canvasHost,
-                                                              position.x, position.y)
+                    const menuPosition = node.item.mapToItem(canvasHost, pos.x, pos.y)
                     nodeMenu.openAt(menuPosition.x, menuPosition.y)
                 }
                 onRightClicked: function () {

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
@@ -141,6 +141,34 @@ Item {
             qanAdapter.selectedMaskId = String(root.maskCreation.selectedMaskId || "")
     }
 
+    function selectDrawerOwner(nodeId) {
+        if (!root.nodeController || String(nodeId).length === 0) {
+            return false
+        }
+
+        // The row's MouseArea owns this click, so Qan.NodeItem does not receive
+        // it and cannot select the Color Grade for us. Select the owning Grade
+        // first because mask authoring is intentionally scoped to that node.
+        root.nodeController.selectNode(nodeId)
+        return String(root.nodeController.selectedNodeId || "") === String(nodeId)
+    }
+
+    function selectMaskFromDrawer(nodeId, maskId) {
+        if (!root.maskCreation || String(maskId).length === 0
+                || !root.selectDrawerOwner(nodeId)) {
+            return
+        }
+        root.maskCreation.selectMask(nodeId, maskId)
+    }
+
+    function removeMaskFromDrawer(nodeId, maskId) {
+        if (!root.maskCreation || String(maskId).length === 0
+                || !root.selectDrawerOwner(nodeId)) {
+            return
+        }
+        root.maskCreation.removeMask(nodeId, maskId)
+    }
+
     function detachAdapter() {
         if (root.nodeController) {
             root.nodeController.graphAdapter = null
@@ -263,12 +291,10 @@ Item {
             root.attachAdapter()
         }
         function onMaskRowSelected(nodeId, maskId) {
-            if (root.maskCreation)
-                root.maskCreation.selectMask(nodeId, maskId)
+            root.selectMaskFromDrawer(nodeId, maskId)
         }
         function onMaskRowDeleteRequested(nodeId, maskId) {
-            if (root.maskCreation)
-                root.maskCreation.removeMask(nodeId, maskId)
+            root.removeMaskFromDrawer(nodeId, maskId)
         }
     }
 

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorNodesPanel.qml
@@ -237,7 +237,12 @@ Item {
             if (root.renameVisible) {
                 return
             }
-            if (root.maskCreation && root.maskCreation.maskControlsActive) {
+            // Mask-scoped Delete wins over node deletion while a Mask draw or
+            // Mask selection is active.
+            if (root.maskCreation && root.maskCreation.creating) {
+                root.maskCreation.cancel()
+            } else if (root.maskCreation
+                       && String(root.maskCreation.selectedMaskId || "").length > 0) {
                 root.maskCreation.removeSelectedMask()
             } else {
                 root.deleteSelectedColorGrade()

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
@@ -234,6 +234,10 @@ Item {
                         maskOverlayHandleOutlineWidth: appTheme.maskOverlayHandleOutlineWidth
                         maskOverlayStrokeWidth: appTheme.maskOverlayStrokeWidth
                         maskOverlayAntialiasWidth: appTheme.maskOverlayAntialiasWidth
+                        maskOverlayGuideOuterWidth: appTheme.maskOverlayGuideOuterWidth
+                        maskOverlayGuideInnerWidth: appTheme.maskOverlayGuideInnerWidth
+                        maskOverlayGripOuterWidth: appTheme.maskOverlayGripOuterWidth
+                        maskOverlayGripInnerWidth: appTheme.maskOverlayGripInnerWidth
                         // Overlay must sit above the photograph and receive no
                         // exclusive mouse grab — handlers below own input.
                         z: 2
@@ -342,6 +346,8 @@ Item {
                         onPointChanged: {
                             if (viewportHover.hovered) {
                                 editorInteraction.handleHoverMove(point.position.x, point.position.y)
+                                if (root.maskCreation)
+                                    root.maskCreation.handleHover(point.position.x, point.position.y)
                             }
                         }
                     }
@@ -562,6 +568,11 @@ Item {
                             if (event.key === Qt.Key_0 || event.key === Qt.Key_Home) {
                                 editorInteraction.resetView()
                                 event.accepted = true
+                            } else if (event.key === Qt.Key_Delete) {
+                                if (root.maskCreation && root.maskCreation.maskControlsActive) {
+                                    root.maskCreation.removeSelectedMask()
+                                    event.accepted = true
+                                }
                             } else if (event.key === Qt.Key_1) {
                                 // 1:1 (actual pixels). Pro-editor convention.
                                 editorInteraction.zoomToActualPixels()

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
@@ -569,7 +569,15 @@ Item {
                                 editorInteraction.resetView()
                                 event.accepted = true
                             } else if (event.key === Qt.Key_Delete) {
-                                if (root.maskCreation && root.maskCreation.maskControlsActive) {
+                                // Mask-scoped Delete: cancel an open draw, else
+                                // remove the selected Mask. Only while the Mask
+                                // tool owns the session.
+                                if (root.maskCreation && root.maskCreation.creating) {
+                                    root.maskCreation.cancel()
+                                    event.accepted = true
+                                } else if (root.maskCreation
+                                           && String(root.maskCreation.selectedMaskId
+                                                     || "").length > 0) {
                                     root.maskCreation.removeSelectedMask()
                                     event.accepted = true
                                 }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
@@ -568,29 +568,11 @@ Item {
                             if (event.key === Qt.Key_0 || event.key === Qt.Key_Home) {
                                 editorInteraction.resetView()
                                 event.accepted = true
-                            } else if (event.key === Qt.Key_Delete) {
-                                // Mask-scoped Delete: cancel an open draw, else
-                                // remove the selected Mask. Only while the Mask
-                                // tool owns the session.
-                                if (root.maskCreation && root.maskCreation.creating) {
-                                    root.maskCreation.cancel()
-                                    event.accepted = true
-                                } else if (root.maskCreation
-                                           && String(root.maskCreation.selectedMaskId
-                                                     || "").length > 0) {
-                                    root.maskCreation.removeSelectedMask()
-                                    event.accepted = true
-                                }
                             } else if (event.key === Qt.Key_1) {
                                 // 1:1 (actual pixels). Pro-editor convention.
                                 editorInteraction.zoomToActualPixels()
                                 event.accepted = true
                             } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                if (typeof adjustmentStack.confirmMaskEditAndReturn === "function"
-                                        && adjustmentStack.confirmMaskEditAndReturn()) {
-                                    event.accepted = true
-                                    return
-                                }
                                 // Geometry confirm: bake draft crop and return to Tone.
                                 if (typeof adjustmentStack.confirmGeometryAndReturnToTone === "function"
                                         && adjustmentStack.confirmGeometryAndReturnToTone()) {
@@ -786,8 +768,29 @@ Item {
 
     Shortcut {
         sequences: [ "Escape" ]
-        enabled: root.editorControlsEnabled && root.maskOwnsLeftButton && root.maskCreation
-        onActivated: root.maskCreation.cancel()
+        enabled: root.editorControlsEnabled && root.maskCreation
+                 && root.maskCreation.maskControlsActive
+        onActivated: root.maskCreation.finishBody()
+    }
+
+    // Mask editing shortcuts live at workspace scope so the viewport, Nodes
+    // graph, and right-side controls all produce the same outcome. They are
+    // disabled immediately after the transient Mask mode finishes.
+    Shortcut {
+        sequences: [ "Delete" ]
+        enabled: root.editorControlsEnabled && root.maskCreation
+                 && root.maskCreation.maskControlsActive
+        onActivated: root.maskCreation.deleteActiveMask()
+    }
+
+    Shortcut {
+        sequences: [ "Return", "Enter" ]
+        enabled: root.editorControlsEnabled && root.maskCreation
+                 && root.maskCreation.maskControlsActive
+        onActivated: {
+            if (typeof adjustmentStack.confirmMaskEditAndReturn === "function")
+                adjustmentStack.confirmMaskEditAndReturn()
+        }
     }
 
     // Geometry confirm (legacy Enter / numpad Enter). Lives on the workspace so

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
@@ -578,6 +578,11 @@ Item {
                                 editorInteraction.zoomToActualPixels()
                                 event.accepted = true
                             } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                                if (typeof adjustmentStack.confirmMaskEditAndReturn === "function"
+                                        && adjustmentStack.confirmMaskEditAndReturn()) {
+                                    event.accepted = true
+                                    return
+                                }
                                 // Geometry confirm: bake draft crop and return to Tone.
                                 if (typeof adjustmentStack.confirmGeometryAndReturnToTone === "function"
                                         && adjustmentStack.confirmGeometryAndReturnToTone()) {

--- a/alcedo_studio/src/ui/alcedo_main/qml/SlidingIconNav.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/SlidingIconNav.qml
@@ -116,7 +116,7 @@ Rectangle {
                 objectName: String(entry.itemObjectName || "")
                 visible: itemIndex < root.items.length
                 compact: true
-                enabled: root.controlsEnabled
+                enabled: root.controlsEnabled && entry.enabled !== false
                 selected: root.currentKey === String(entry.key || "")
                 showHoverFill: false
                 showFocusRing: false
@@ -139,6 +139,7 @@ Rectangle {
             NavButton { itemIndex: 3 }
             NavButton { itemIndex: 4 }
             NavButton { itemIndex: 5 }
+            NavButton { itemIndex: 6 }
         }
     }
 }

--- a/alcedo_studio/src/ui/edit_viewer/mask_edit_geometry.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_edit_geometry.cpp
@@ -8,6 +8,9 @@
 #include <stdexcept>
 #include <utility>
 
+#include "edit/geometry/render_geometry_resolver.hpp"
+#include "edit/geometry/source_geometry.hpp"
+
 namespace alcedo {
 namespace {
 
@@ -107,6 +110,24 @@ auto MaskEditGeometry::MakeIdentityPhotographGeometry(Extent2D extent) -> Resolv
   geometry.render_to_reference    = Matrix3x3::Identity();
   geometry.render_to_decoded      = Matrix3x3::Identity();
   return geometry;
+}
+
+auto MaskEditGeometry::MakeDocumentPhotographGeometry(Extent2D full_reference,
+                                                       const ImageGeometryParams& image)
+    -> ResolvedRenderGeometry {
+  if (full_reference.Empty()) {
+    return {};
+  }
+  const bool identity_crop =
+      std::fabs(image.crop_rect.x) < 1.0e-6f && std::fabs(image.crop_rect.y) < 1.0e-6f &&
+      std::fabs(image.crop_rect.w - 1.0f) < 1.0e-6f &&
+      std::fabs(image.crop_rect.h - 1.0f) < 1.0e-6f &&
+      std::fabs(image.rotation_degrees) < 1.0e-4f;
+  if (identity_crop) {
+    return MakeIdentityPhotographGeometry(full_reference);
+  }
+  return ResolveRenderGeometry(MakeSourceGeometry(full_reference, full_reference), image, {},
+                                {}, {});
 }
 
 auto MaskEditGeometry::IsValid(const MaskEditViewMapping& mapping) -> bool {

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_geometry.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_geometry.cpp
@@ -197,6 +197,48 @@ void AppendPolylineStroke(std::vector<MaskOverlayVertex>& triangles,
   }
 }
 
+// Dashes follow the polyline arc length, so the dash phase stays continuous
+// across the adaptive tessellation vertices instead of restarting per segment.
+void AppendDashedPolylineStroke(std::vector<MaskOverlayVertex>& triangles,
+                                const std::vector<QPointF>& points, bool closed, float width,
+                                float aa, const QColor& color, const QRectF& clip, float dash_len,
+                                float gap_len) {
+  if (points.size() < 2 || dash_len <= 0.0f || gap_len < 0.0f) {
+    return;
+  }
+  const std::size_t count = closed ? points.size() : points.size() - 1;
+  double            phase = 0.0;
+  bool              draw  = true;
+  for (std::size_t i = 0; i < count; ++i) {
+    const QPointF& a  = points[i];
+    const QPointF& b  = points[(i + 1) % points.size()];
+    const double   dx = b.x() - a.x();
+    const double   dy = b.y() - a.y();
+    const double   len = std::hypot(dx, dy);
+    if (len < kMinLength) {
+      continue;
+    }
+    const double ux = dx / len;
+    const double uy = dy / len;
+    double       t  = 0.0;
+    while (t < len - 1.0e-9) {
+      const double period = draw ? static_cast<double>(dash_len) : static_cast<double>(gap_len);
+      const double step   = std::min(len - t, period - phase);
+      if (draw && step > 1.0e-9) {
+        const QPointF p0(a.x() + ux * t, a.y() + uy * t);
+        const QPointF p1(a.x() + ux * (t + step), a.y() + uy * (t + step));
+        AppendClippedStroke(triangles, p0, p1, width, aa, color, clip, /*round_caps=*/false);
+      }
+      t += step;
+      phase += step;
+      if (phase >= period - 1.0e-9) {
+        phase = 0.0;
+        draw  = !draw;
+      }
+    }
+  }
+}
+
 void AppendFilledDisc(std::vector<MaskOverlayVertex>& triangles, const QPointF& center,
                       float radius, float aa, const QColor& color, const QRectF& clip) {
   if (radius <= 0.0f || !IsFinitePoint(center) ||
@@ -340,12 +382,22 @@ auto BuildMaskOverlaySceneGeometry(const MaskOverlayDisplay& display, const Mask
   };
 
   for (const auto& contour : display.selected_contours) {
-    if (contour.size() < 2) {
+    if (contour.points.size() < 2) {
       continue;
     }
-    const std::size_t count = contour.size();
+    const std::size_t count = contour.points.size();
+    if (contour.dashed) {
+      AppendDashedPolylineStroke(scene.selected_guides, contour.points, /*closed=*/true,
+                                 guide_outer, aa, style.control_fill, clip,
+                                 kMaskOverlayDashLengthLogicalPx, kMaskOverlayDashGapLogicalPx);
+      AppendDashedPolylineStroke(scene.selected_guides, contour.points, /*closed=*/true,
+                                 guide_inner, aa, style.control_outline, clip,
+                                 kMaskOverlayDashLengthLogicalPx, kMaskOverlayDashGapLogicalPx);
+      scene.selected_guide_segment_count += static_cast<int>(count);
+      continue;
+    }
     for (std::size_t i = 0; i < count; ++i) {
-      append_dual(scene.selected_guides, contour[i], contour[(i + 1) % contour.size()],
+      append_dual(scene.selected_guides, contour.points[i], contour.points[(i + 1) % count],
                   guide_outer, guide_inner);
       ++scene.selected_guide_segment_count;
     }

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_geometry.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_geometry.cpp
@@ -14,6 +14,7 @@ namespace {
 constexpr int kDiscSegments = 20;
 constexpr int kCapSegments  = 10;
 constexpr float kMinLength  = 1.0e-6f;
+constexpr float kHoverHandleScale = 1.25f;
 
 [[nodiscard]] auto IsFinitePoint(const QPointF& point) -> bool {
   return std::isfinite(point.x()) && std::isfinite(point.y());
@@ -277,15 +278,34 @@ auto BuildMaskOverlaySceneGeometry(const MaskOverlayDisplay& display, const Mask
   const float outline  = style.handle_outline_width_logical_px;
   const float stroke_w = style.stroke_width_logical_px;
   const float aa       = style.antialias_width_logical_px;
+  const float guide_outer = style.guide_outer_width_logical_px;
+  const float guide_inner = style.guide_inner_width_logical_px;
+  const float grip_outer  = style.grip_outer_width_logical_px;
+  const float grip_inner  = style.grip_inner_width_logical_px;
   const QRectF& clip   = display.clip_rect;
+
+  const auto handle_radius = [&](MaskOverlayHandleId id) {
+    if (id == display.hovered_handle || id == display.active_handle) {
+      return handle_r * kHoverHandleScale;
+    }
+    return handle_r;
+  };
 
   for (const auto& handle : display.handles) {
     if (handle.id == MaskOverlayHandleId::None || !IsFinitePoint(handle.item)) {
       continue;
     }
-    AppendRing(scene.handle_outline, handle.item, handle_r, handle_r + outline, aa,
-               style.control_outline, clip);
-    AppendFilledDisc(scene.handle_fill, handle.item, handle_r, 0.0f, style.control_fill, clip);
+    const float radius = handle_radius(handle.id);
+    if (handle.shape == MaskOverlayHandleShape::Ring) {
+      AppendHollowCircle(scene.handle_outline, handle.item, radius + outline * 0.5f, outline, aa,
+                         style.control_outline, clip);
+      AppendHollowCircle(scene.handle_fill, handle.item, radius, outline, aa, style.control_fill,
+                         clip);
+    } else {
+      AppendRing(scene.handle_outline, handle.item, radius, radius + outline, aa,
+                 style.control_outline, clip);
+      AppendFilledDisc(scene.handle_fill, handle.item, radius, 0.0f, style.control_fill, clip);
+    }
     ++scene.handle_count;
   }
 
@@ -310,6 +330,36 @@ auto BuildMaskOverlaySceneGeometry(const MaskOverlayDisplay& display, const Mask
                           style.inactive, clip, /*round_caps=*/false);
     }
   }
+
+  auto append_dual = [&](std::vector<MaskOverlayVertex>& triangles, const QPointF& a,
+                          const QPointF& b, float outer_w, float inner_w) {
+    AppendClippedStroke(triangles, a, b, outer_w, aa, style.control_fill, clip,
+                        /*round_caps=*/false);
+    AppendClippedStroke(triangles, a, b, inner_w, aa, style.control_outline, clip,
+                        /*round_caps=*/false);
+  };
+
+  for (const auto& contour : display.selected_contours) {
+    if (contour.size() < 2) {
+      continue;
+    }
+    const std::size_t count = contour.size();
+    for (std::size_t i = 0; i < count; ++i) {
+      append_dual(scene.selected_guides, contour[i], contour[(i + 1) % contour.size()],
+                  guide_outer, guide_inner);
+      ++scene.selected_guide_segment_count;
+    }
+  }
+  for (const auto& guide : display.selected_guides) {
+    append_dual(scene.selected_guides, guide.a, guide.b, guide_outer, guide_inner);
+    ++scene.selected_guide_segment_count;
+  }
+  for (const auto& grip : display.edge_grips) {
+    append_dual(scene.edge_grips, grip.first, grip.second, grip_outer, grip_inner);
+  }
+  scene.closed_polygon_edge_count         = 0;
+  scene.coverage_fill_vertex_count       = 0;
+  scene.settled_stroke_path_vertex_count = 0;
 
   return scene;
 }

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
@@ -203,7 +203,8 @@ void PopulateRadialHandles(MaskOverlayDisplay& display, const MaskEditViewMappin
 }
 
 void AppendRadialContour(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
-                         const RadialMaskSource& source, float rho, const QRectF& clip) {
+                         const RadialMaskSource& source, float rho, bool dashed,
+                         const QRectF& clip) {
   if (!std::isfinite(rho) || rho < kMinRadius) {
     return;
   }
@@ -211,7 +212,7 @@ void AppendRadialContour(MaskOverlayDisplay& display, const MaskEditViewMapping&
   if (polyline.size() < 3) {
     return;
   }
-  display.selected_contours.push_back(std::move(polyline));
+  display.selected_contours.push_back(MaskOverlayContour{std::move(polyline), dashed});
 }
 
 void PopulateRadialContours(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
@@ -231,7 +232,9 @@ void PopulateRadialContours(MaskOverlayDisplay& display, const MaskEditViewMappi
       continue;
     }
     published.push_back(rho);
-    AppendRadialContour(display, mapping, source, rho, clip);
+    // Feather boundaries are dashed; the base rho = 1 ellipse stays solid.
+    AppendRadialContour(display, mapping, source, rho, std::fabs(rho - 1.0f) > kRhoCoincide,
+                        clip);
   }
 }
 

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
@@ -6,14 +6,20 @@
 
 #include <algorithm>
 #include <cmath>
+#include <optional>
 #include <utility>
+
+#include "ui/edit_viewer/crop_geometry.hpp"
+#include "ui/edit_viewer/viewport_mapper.hpp"
 
 namespace alcedo {
 namespace {
 
-constexpr float kPi          = 3.14159265358979323846f;
-constexpr float kMinRadius   = 1.0e-5f;
-constexpr float kHandleMerge = 2.0f;
+constexpr float kPi           = 3.14159265358979323846f;
+constexpr float kMinRadius    = 1.0e-5f;
+constexpr float kHandleMerge  = 2.0f;
+constexpr float kRhoCoincide  = 1.0e-3f;
+constexpr float kGuideSpan    = 8.0f;
 
 [[nodiscard]] auto IsFiniteVector(Vector2 point) -> bool {
   return std::isfinite(point.x) && std::isfinite(point.y);
@@ -38,7 +44,7 @@ constexpr float kHandleMerge = 2.0f;
 }
 
 void AppendHandle(MaskOverlayDisplay& display, MaskOverlayHandleId id, const QPointF& item,
-                  const QPointF& origin, float merge_px) {
+                  const QPointF& origin, float merge_px, MaskOverlayHandleShape shape) {
   if (id != MaskOverlayHandleId::RadialCenter && id != MaskOverlayHandleId::LinearOrigin &&
       id != MaskOverlayHandleId::BrushMove && ItemDistance(item, origin) < merge_px) {
     return;
@@ -48,7 +54,56 @@ void AppendHandle(MaskOverlayDisplay& display, MaskOverlayHandleId id, const QPo
       return;
     }
   }
-  display.handles.push_back(MaskOverlayHandle{id, item});
+  display.handles.push_back(MaskOverlayHandle{id, item, shape});
+}
+
+[[nodiscard]] auto DistanceToSegment(QPointF point, QPointF a, QPointF b) -> float {
+  const double dx = b.x() - a.x();
+  const double dy = b.y() - a.y();
+  const double len2 = dx * dx + dy * dy;
+  if (len2 < static_cast<double>(kMinRadius) * static_cast<double>(kMinRadius)) {
+    return ItemDistance(point, a);
+  }
+  double t = ((point.x() - a.x()) * dx + (point.y() - a.y()) * dy) / len2;
+  t        = std::clamp(t, 0.0, 1.0);
+  return ItemDistance(point, QPointF(a.x() + t * dx, a.y() + t * dy));
+}
+
+[[nodiscard]] auto ClipSegmentToRect(QPointF a, QPointF b, const QRectF& clip)
+    -> std::optional<std::pair<QPointF, QPointF>> {
+  if (!clip.isValid() || clip.isEmpty()) {
+    if (!std::isfinite(a.x()) || !std::isfinite(a.y()) || !std::isfinite(b.x()) ||
+        !std::isfinite(b.y())) {
+      return std::nullopt;
+    }
+    return std::make_pair(a, b);
+  }
+  const double dx = b.x() - a.x();
+  const double dy = b.y() - a.y();
+  double t0       = 0.0;
+  double t1       = 1.0;
+  const double p[4] = {-dx, dx, -dy, dy};
+  const double q[4] = {a.x() - clip.left(), clip.right() - a.x(), a.y() - clip.top(),
+                       clip.bottom() - a.y()};
+  for (int i = 0; i < 4; ++i) {
+    if (std::abs(p[i]) < 1.0e-12) {
+      if (q[i] < 0.0) {
+        return std::nullopt;
+      }
+      continue;
+    }
+    const double t = q[i] / p[i];
+    if (p[i] < 0.0) {
+      t0 = std::max(t0, t);
+    } else {
+      t1 = std::min(t1, t);
+    }
+    if (t0 > t1) {
+      return std::nullopt;
+    }
+  }
+  return std::make_pair(QPointF(a.x() + t0 * dx, a.y() + t0 * dy),
+                        QPointF(a.x() + t1 * dx, a.y() + t1 * dy));
 }
 
 void AppendConnector(MaskOverlayDisplay& display, const QPointF& a, const QPointF& b) {
@@ -107,41 +162,104 @@ void PopulateRadialHandles(MaskOverlayDisplay& display, const MaskEditViewMappin
   if (!center) {
     return;
   }
-  display.handles.push_back(MaskOverlayHandle{MaskOverlayHandleId::RadialCenter, *center});
+  display.handles.push_back(
+      MaskOverlayHandle{MaskOverlayHandleId::RadialCenter, *center, MaskOverlayHandleShape::Disc});
 
   const auto major = MapRho(mapping, source, 1.0f, 0.0f);
   const auto minor = MapRho(mapping, source, 1.0f, kPi * 0.5f);
   if (major) {
-    AppendHandle(display, MaskOverlayHandleId::RadialMajor, *major, *center, kHandleMerge);
+    AppendHandle(display, MaskOverlayHandleId::RadialMajor, *major, *center, kHandleMerge,
+                 MaskOverlayHandleShape::Disc);
     AppendConnector(display, *center, *major);
     if (const auto rotate =
             OffsetAlongItem(*center, *major, style.rotate_handle_offset_logical_px)) {
       if (clip.isEmpty() || clip.contains(*rotate)) {
-        AppendHandle(display, MaskOverlayHandleId::RadialRotate, *rotate, *center, kHandleMerge);
+        AppendHandle(display, MaskOverlayHandleId::RadialRotate, *rotate, *center, kHandleMerge,
+                     MaskOverlayHandleShape::Disc);
         AppendConnector(display, *major, *rotate);
       }
     }
   }
   if (minor) {
-    AppendHandle(display, MaskOverlayHandleId::RadialMinor, *minor, *center, kHandleMerge);
+    AppendHandle(display, MaskOverlayHandleId::RadialMinor, *minor, *center, kHandleMerge,
+                 MaskOverlayHandleShape::Disc);
     AppendConnector(display, *center, *minor);
   }
 
   const float inner = InnerRho(source);
   const float outer = OuterRho(source);
-  if (std::fabs(inner - 1.0f) > 1.0e-3f && inner > kMinRadius) {
+  if (inner > kMinRadius && std::fabs(inner - 1.0f) > kRhoCoincide) {
     if (const auto inner_item = MapRho(mapping, source, inner, 0.0f)) {
       AppendHandle(display, MaskOverlayHandleId::RadialInnerFeather, *inner_item, *center,
-                   kHandleMerge);
-      AppendConnector(display, *center, *inner_item);
+                   kHandleMerge, MaskOverlayHandleShape::Ring);
     }
   }
-  if (std::fabs(outer - 1.0f) > 1.0e-3f) {
+  if (std::fabs(outer - 1.0f) > kRhoCoincide) {
     if (const auto outer_item = MapRho(mapping, source, outer, 0.0f)) {
       AppendHandle(display, MaskOverlayHandleId::RadialOuterFeather, *outer_item, *center,
-                   kHandleMerge);
-      AppendConnector(display, *center, *outer_item);
+                   kHandleMerge, MaskOverlayHandleShape::Ring);
     }
+  }
+}
+
+void AppendRadialContour(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
+                         const RadialMaskSource& source, float rho, const QRectF& clip) {
+  if (!std::isfinite(rho) || rho < kMinRadius) {
+    return;
+  }
+  auto polyline = TessellateRadialBoundaryItemPolyline(mapping, source, rho, clip);
+  if (polyline.size() < 3) {
+    return;
+  }
+  display.selected_contours.push_back(std::move(polyline));
+}
+
+void PopulateRadialContours(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
+                           const RadialMaskSource& source, const QRectF& clip) {
+  const float rhos[] = {1.0f, InnerRho(source), OuterRho(source)};
+  std::vector<float> published;
+  published.reserve(3);
+  for (float rho : rhos) {
+    bool duplicate = false;
+    for (float existing : published) {
+      if (std::fabs(existing - rho) <= kRhoCoincide) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (duplicate) {
+      continue;
+    }
+    published.push_back(rho);
+    AppendRadialContour(display, mapping, source, rho, clip);
+  }
+}
+
+void AppendClippedGuide(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
+                         const LinearGradientMaskSource& source, float signed_distance,
+                         MaskOverlayHandleId id, const MaskOverlayStyle& style,
+                         const QRectF& photograph) {
+  const Vector2 n    = LinearNormal(source);
+  const Vector2 perp = PerpNormalized(n);
+  const Vector2 locus = LinearLocus(source, signed_distance);
+  const Vector2 a{locus.x + perp.x * kGuideSpan, locus.y + perp.y * kGuideSpan};
+  const Vector2 b{locus.x - perp.x * kGuideSpan, locus.y - perp.y * kGuideSpan};
+  const auto item_a = MapNormalizedMaskPointToItem(mapping, a);
+  const auto item_b = MapNormalizedMaskPointToItem(mapping, b);
+  if (!item_a || !item_b) {
+    return;
+  }
+  const auto clipped = ClipSegmentToRect(*item_a, *item_b, photograph);
+  if (!clipped) {
+    return;
+  }
+  display.selected_guides.push_back(MaskOverlayGuide{id, clipped->first, clipped->second});
+  const QPointF grip_a =
+      CropGeometry::LerpPoint(clipped->first, clipped->second, style.grip_span_t0);
+  const QPointF grip_b =
+      CropGeometry::LerpPoint(clipped->first, clipped->second, style.grip_span_t1);
+  if (ItemDistance(grip_a, grip_b) >= kMinRadius) {
+    display.edge_grips.emplace_back(grip_a, grip_b);
   }
 }
 
@@ -153,27 +271,37 @@ void PopulateLinearHandles(MaskOverlayDisplay& display, const MaskEditViewMappin
   if (!origin) {
     return;
   }
-  display.handles.push_back(MaskOverlayHandle{MaskOverlayHandleId::LinearOrigin, *origin});
+  display.handles.push_back(
+      MaskOverlayHandle{MaskOverlayHandleId::LinearOrigin, *origin, MaskOverlayHandleShape::Disc});
 
   const float half = std::max(source.transition_distance, kMinRadius) * 0.5f;
   const auto start = MapNormalizedMaskPointToItem(mapping, LinearLocus(source, -half));
   const auto end   = MapNormalizedMaskPointToItem(mapping, LinearLocus(source, half));
   if (start) {
-    AppendHandle(display, MaskOverlayHandleId::LinearStartBoundary, *start, *origin, kHandleMerge);
-    AppendConnector(display, *origin, *start);
+    AppendHandle(display, MaskOverlayHandleId::LinearStartBoundary, *start, *origin, kHandleMerge,
+                 MaskOverlayHandleShape::Disc);
   }
   if (end) {
-    AppendHandle(display, MaskOverlayHandleId::LinearEndBoundary, *end, *origin, kHandleMerge);
-    AppendConnector(display, *origin, *end);
+    AppendHandle(display, MaskOverlayHandleId::LinearEndBoundary, *end, *origin, kHandleMerge,
+                 MaskOverlayHandleShape::Disc);
     if (const auto direction =
             OffsetAlongItem(*origin, *end, style.rotate_handle_offset_logical_px)) {
       if (clip.isEmpty() || clip.contains(*direction)) {
         AppendHandle(display, MaskOverlayHandleId::LinearDirection, *direction, *origin,
-                     kHandleMerge);
+                     kHandleMerge, MaskOverlayHandleShape::Disc);
         AppendConnector(display, *end, *direction);
       }
     }
   }
+
+  const QRectF photograph = PhotographItemRect(mapping);
+  const QRectF guide_clip = photograph.isEmpty() ? clip : photograph;
+  AppendClippedGuide(display, mapping, source, -half, MaskOverlayHandleId::LinearStartBoundary,
+                     style, guide_clip);
+  AppendClippedGuide(display, mapping, source, 0.0f, MaskOverlayHandleId::LinearOrigin, style,
+                     guide_clip);
+  AppendClippedGuide(display, mapping, source, half, MaskOverlayHandleId::LinearEndBoundary, style,
+                     guide_clip);
 }
 
 [[nodiscard]] auto FiniteRadii(const RadialMaskSource& source) -> bool {
@@ -312,6 +440,7 @@ auto MakeRadialExistingOverlayDisplay(const MaskEditViewMapping& mapping,
   display.source_kind = MaskOverlaySourceKind::Radial;
   display.clip_rect   = EffectiveClip(mapping, clip);
   PopulateRadialHandles(display, mapping, source, style, display.clip_rect);
+  PopulateRadialContours(display, mapping, source, display.clip_rect);
   if (display.handles.empty()) {
     display.mode        = MaskOverlayMode::Hidden;
     display.source_kind = MaskOverlaySourceKind::None;
@@ -357,13 +486,11 @@ auto MakeBrushCreatingOverlayDisplay(const std::vector<QPointF>& item_path, QPoi
 auto MakeRadialCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
                                       const RadialMaskSource& source, const MaskOverlayStyle& style,
                                       const QRectF& clip) -> MaskOverlayDisplay {
-  auto display          = MakeRadialExistingOverlayDisplay(mapping, source, style, clip);
+  auto display = MakeRadialExistingOverlayDisplay(mapping, source, style, clip);
   if (display.mode == MaskOverlayMode::Hidden) {
     return display;
   }
-  display.mode             = MaskOverlayMode::Creating;
-  display.creation_outline = TessellateRadialBoundaryItemPolyline(mapping, source, 1.0f,
-                                                                  display.clip_rect);
+  display.mode = MaskOverlayMode::Creating;
   return display;
 }
 
@@ -376,22 +503,21 @@ auto MakeLinearCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
     return display;
   }
   display.mode = MaskOverlayMode::Creating;
-  const Vector2 n    = LinearNormal(source);
-  const Vector2 perp = PerpNormalized(n);
-  const float half   = std::max(source.transition_distance, kMinRadius) * 0.5f;
-  const float span   = 0.35f;
-  const float loci[] = {-half, 0.0f, half};
-  for (float signed_distance : loci) {
-    const Vector2 locus = LinearLocus(source, signed_distance);
-    const Vector2 a{locus.x + perp.x * span, locus.y + perp.y * span};
-    const Vector2 b{locus.x - perp.x * span, locus.y - perp.y * span};
-    const auto item_a = MapNormalizedMaskPointToItem(mapping, a);
-    const auto item_b = MapNormalizedMaskPointToItem(mapping, b);
-    if (item_a && item_b) {
-      display.creation_guides.emplace_back(*item_a, *item_b);
-    }
-  }
   return display;
+}
+
+auto PhotographItemRect(const MaskEditViewMapping& mapping) -> QRectF {
+  if (!MaskEditGeometry::IsValid(mapping)) {
+    return {};
+  }
+  const auto top_left = ViewportMapper::ImageUvToWidgetPoint(
+      QPointF(0.0, 0.0), mapping.widget, mapping.photograph, mapping.zoom, mapping.pan, false);
+  const auto bottom_right = ViewportMapper::ImageUvToWidgetPoint(
+      QPointF(1.0, 1.0), mapping.widget, mapping.photograph, mapping.zoom, mapping.pan, false);
+  if (!top_left || !bottom_right) {
+    return {};
+  }
+  return QRectF(*top_left, *bottom_right).normalized();
 }
 
 auto MapReferenceRadiusToItem(const MaskEditViewMapping& mapping, Vector2 center_reference,
@@ -425,6 +551,19 @@ auto HitTestMaskOverlayHandle(const MaskOverlayDisplay& display, QPointF item,
     if (distance <= best) {
       best = distance;
       hit  = handle.id;
+    }
+  }
+  if (hit != MaskOverlayHandleId::None) {
+    return hit;
+  }
+  for (const auto& guide : display.selected_guides) {
+    if (guide.id == MaskOverlayHandleId::None) {
+      continue;
+    }
+    const float distance = DistanceToSegment(item, guide.a, guide.b);
+    if (distance <= best) {
+      best = distance;
+      hit  = guide.id;
     }
   }
   return hit;

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
@@ -15,11 +15,11 @@
 namespace alcedo {
 namespace {
 
-constexpr float kPi           = 3.14159265358979323846f;
-constexpr float kMinRadius    = 1.0e-5f;
-constexpr float kHandleMerge  = 2.0f;
-constexpr float kRhoCoincide  = 1.0e-3f;
-constexpr float kGuideSpan    = 8.0f;
+constexpr float    kPi          = 3.14159265358979323846f;
+constexpr float    kMinRadius   = 1.0e-5f;
+constexpr float    kHandleMerge = 2.0f;
+constexpr float    kRhoCoincide = 1.0e-3f;
+constexpr float    kGuideSpan   = 8.0f;
 
 [[nodiscard]] auto IsFiniteVector(Vector2 point) -> bool {
   return std::isfinite(point.x) && std::isfinite(point.y);
@@ -58,8 +58,8 @@ void AppendHandle(MaskOverlayDisplay& display, MaskOverlayHandleId id, const QPo
 }
 
 [[nodiscard]] auto DistanceToSegment(QPointF point, QPointF a, QPointF b) -> float {
-  const double dx = b.x() - a.x();
-  const double dy = b.y() - a.y();
+  const double dx   = b.x() - a.x();
+  const double dy   = b.y() - a.y();
   const double len2 = dx * dx + dy * dy;
   if (len2 < static_cast<double>(kMinRadius) * static_cast<double>(kMinRadius)) {
     return ItemDistance(point, a);
@@ -78,10 +78,10 @@ void AppendHandle(MaskOverlayDisplay& display, MaskOverlayHandleId id, const QPo
     }
     return std::make_pair(a, b);
   }
-  const double dx = b.x() - a.x();
-  const double dy = b.y() - a.y();
-  double t0       = 0.0;
-  double t1       = 1.0;
+  const double dx   = b.x() - a.x();
+  const double dy   = b.y() - a.y();
+  double       t0   = 0.0;
+  double       t1   = 1.0;
   const double p[4] = {-dx, dx, -dy, dy};
   const double q[4] = {a.x() - clip.left(), clip.right() - a.x(), a.y() - clip.top(),
                        clip.bottom() - a.y()};
@@ -129,7 +129,7 @@ void AppendConnector(MaskOverlayDisplay& display, const QPointF& a, const QPoint
 [[nodiscard]] auto OffsetAlongItem(const QPointF& origin, const QPointF& along, float offset_px)
     -> std::optional<QPointF> {
   const QPointF delta = along - origin;
-  const float len     = ItemDistance(along, origin);
+  const float   len   = ItemDistance(along, origin);
   if (len < kMinRadius) {
     return std::nullopt;
   }
@@ -157,8 +157,8 @@ void AppendConnector(MaskOverlayDisplay& display, const QPointF& a, const QPoint
 void PopulateRadialHandles(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
                            const RadialMaskSource& source, const MaskOverlayStyle& style,
                            const QRectF& clip) {
-  const auto center = MapNormalizedMaskPointToItem(
-      mapping, Vector2{source.center_x, source.center_y});
+  const auto center =
+      MapNormalizedMaskPointToItem(mapping, Vector2{source.center_x, source.center_y});
   if (!center) {
     return;
   }
@@ -215,8 +215,8 @@ void AppendRadialContour(MaskOverlayDisplay& display, const MaskEditViewMapping&
 }
 
 void PopulateRadialContours(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
-                           const RadialMaskSource& source, const QRectF& clip) {
-  const float rhos[] = {1.0f, InnerRho(source), OuterRho(source)};
+                            const RadialMaskSource& source, const QRectF& clip) {
+  const float        rhos[] = {1.0f, InnerRho(source), OuterRho(source)};
   std::vector<float> published;
   published.reserve(3);
   for (float rho : rhos) {
@@ -236,16 +236,16 @@ void PopulateRadialContours(MaskOverlayDisplay& display, const MaskEditViewMappi
 }
 
 void AppendClippedGuide(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
-                         const LinearGradientMaskSource& source, float signed_distance,
-                         MaskOverlayHandleId id, const MaskOverlayStyle& style,
-                         const QRectF& photograph) {
-  const Vector2 n    = LinearNormal(source);
-  const Vector2 perp = PerpNormalized(n);
+                        const LinearGradientMaskSource& source, float signed_distance,
+                        MaskOverlayHandleId id, const MaskOverlayStyle& style,
+                        const QRectF& photograph) {
+  const Vector2 n     = LinearNormal(source);
+  const Vector2 perp  = PerpNormalized(n);
   const Vector2 locus = LinearLocus(source, signed_distance);
   const Vector2 a{locus.x + perp.x * kGuideSpan, locus.y + perp.y * kGuideSpan};
   const Vector2 b{locus.x - perp.x * kGuideSpan, locus.y - perp.y * kGuideSpan};
-  const auto item_a = MapNormalizedMaskPointToItem(mapping, a);
-  const auto item_b = MapNormalizedMaskPointToItem(mapping, b);
+  const auto    item_a = MapNormalizedMaskPointToItem(mapping, a);
+  const auto    item_b = MapNormalizedMaskPointToItem(mapping, b);
   if (!item_a || !item_b) {
     return;
   }
@@ -266,17 +266,17 @@ void AppendClippedGuide(MaskOverlayDisplay& display, const MaskEditViewMapping& 
 void PopulateLinearHandles(MaskOverlayDisplay& display, const MaskEditViewMapping& mapping,
                            const LinearGradientMaskSource& source, const MaskOverlayStyle& style,
                            const QRectF& clip) {
-  const auto origin = MapNormalizedMaskPointToItem(
-      mapping, Vector2{source.origin_x, source.origin_y});
+  const auto origin =
+      MapNormalizedMaskPointToItem(mapping, Vector2{source.origin_x, source.origin_y});
   if (!origin) {
     return;
   }
   display.handles.push_back(
       MaskOverlayHandle{MaskOverlayHandleId::LinearOrigin, *origin, MaskOverlayHandleShape::Disc});
 
-  const float half = std::max(source.transition_distance, kMinRadius) * 0.5f;
-  const auto start = MapNormalizedMaskPointToItem(mapping, LinearLocus(source, -half));
-  const auto end   = MapNormalizedMaskPointToItem(mapping, LinearLocus(source, half));
+  const float half  = std::max(source.transition_distance, kMinRadius) * 0.5f;
+  const auto  start = MapLinearLocusNormalPointToItem(mapping, source, -half);
+  const auto  end   = MapLinearLocusNormalPointToItem(mapping, source, half);
   if (start) {
     AppendHandle(display, MaskOverlayHandleId::LinearStartBoundary, *start, *origin, kHandleMerge,
                  MaskOverlayHandleShape::Disc);
@@ -284,8 +284,8 @@ void PopulateLinearHandles(MaskOverlayDisplay& display, const MaskEditViewMappin
   if (end) {
     AppendHandle(display, MaskOverlayHandleId::LinearEndBoundary, *end, *origin, kHandleMerge,
                  MaskOverlayHandleShape::Disc);
-    if (const auto direction =
-            OffsetAlongItem(*origin, *end, style.rotate_handle_offset_logical_px)) {
+    if (const auto direction = OffsetAlongItem(
+            *origin, *end, ItemDistance(*origin, *end) + style.rotate_handle_offset_logical_px)) {
       if (clip.isEmpty() || clip.contains(*direction)) {
         AppendHandle(display, MaskOverlayHandleId::LinearDirection, *direction, *origin,
                      kHandleMerge, MaskOverlayHandleShape::Disc);
@@ -323,12 +323,70 @@ auto MapNormalizedMaskPointToItem(const MaskEditViewMapping& mapping, Vector2 no
   return MaskEditGeometry::MapReferenceToItem(mapping, reference);
 }
 
+auto MapLinearLocusNormalPointToItem(const MaskEditViewMapping&      mapping,
+                                     const LinearGradientMaskSource& source, float signed_distance)
+    -> std::optional<QPointF> {
+  if (!std::isfinite(signed_distance)) {
+    return std::nullopt;
+  }
+  const Vector2 origin{source.origin_x, source.origin_y};
+  const Vector2 normal      = LinearNormal(source);
+  const Vector2 tangent     = PerpNormalized(normal);
+  const auto    item_origin = MapNormalizedMaskPointToItem(mapping, origin);
+  const auto    item_normal =
+      MapNormalizedMaskPointToItem(mapping, Vector2{origin.x + normal.x, origin.y + normal.y});
+  const auto item_tangent =
+      MapNormalizedMaskPointToItem(mapping, Vector2{origin.x + tangent.x, origin.y + tangent.y});
+  if (!item_origin || !item_normal || !item_tangent) {
+    return std::nullopt;
+  }
+  const QPointF mapped_normal          = *item_normal - *item_origin;
+  const QPointF mapped_tangent         = *item_tangent - *item_origin;
+  const double  tangent_length_squared = QPointF::dotProduct(mapped_tangent, mapped_tangent);
+  if (!std::isfinite(tangent_length_squared) || tangent_length_squared <= kMinRadius) {
+    return std::nullopt;
+  }
+  const double tangent_offset = -static_cast<double>(signed_distance) *
+                                QPointF::dotProduct(mapped_normal, mapped_tangent) /
+                                tangent_length_squared;
+  return MapNormalizedMaskPointToItem(
+      mapping,
+      Vector2{
+          origin.x + normal.x * signed_distance + tangent.x * static_cast<float>(tangent_offset),
+          origin.y + normal.y * signed_distance + tangent.y * static_cast<float>(tangent_offset)});
+}
+
+auto MapItemPointToLinearDirectionSample(const MaskEditViewMapping&      mapping,
+                                         const LinearGradientMaskSource& source, QPointF item)
+    -> std::optional<Vector2> {
+  if (!std::isfinite(item.x()) || !std::isfinite(item.y())) {
+    return std::nullopt;
+  }
+  const Vector2 origin{source.origin_x, source.origin_y};
+  const auto    item_origin = MapNormalizedMaskPointToItem(mapping, origin);
+  const auto    item_x = MapNormalizedMaskPointToItem(mapping, Vector2{origin.x + 1.0f, origin.y});
+  const auto    item_y = MapNormalizedMaskPointToItem(mapping, Vector2{origin.x, origin.y + 1.0f});
+  if (!item_origin || !item_x || !item_y) {
+    return std::nullopt;
+  }
+  const QPointF direction = item - *item_origin;
+  const QPointF mapped_x  = *item_x - *item_origin;
+  const QPointF mapped_y  = *item_y - *item_origin;
+  const float   nx        = static_cast<float>(QPointF::dotProduct(mapped_x, direction));
+  const float   ny        = static_cast<float>(QPointF::dotProduct(mapped_y, direction));
+  const float   length    = std::hypot(nx, ny);
+  if (!std::isfinite(length) || length <= kMinRadius) {
+    return std::nullopt;
+  }
+  return Vector2{origin.x + nx / length, origin.y + ny / length};
+}
+
 auto RadialNormalizedPoint(const RadialMaskSource& source, float rho, float theta_radians)
     -> Vector2 {
-  const float c = std::cos(source.rotation);
-  const float s = std::sin(source.rotation);
-  const float u = rho * std::cos(theta_radians);
-  const float v = rho * std::sin(theta_radians);
+  const float c  = std::cos(source.rotation);
+  const float s  = std::sin(source.rotation);
+  const float u  = rho * std::cos(theta_radians);
+  const float v  = rho * std::sin(theta_radians);
   const float dx = c * (u * source.major_radius) - s * (v * source.minor_radius);
   const float dy = s * (u * source.major_radius) + c * (v * source.minor_radius);
   return Vector2{source.center_x + dx, source.center_y + dy};
@@ -360,14 +418,14 @@ auto TessellateRadialBoundaryItemPolyline(const MaskEditViewMapping& mapping,
     return ItemDistance(*true_item, chord);
   };
 
-  constexpr int kSeed = 32;
-  std::vector<float> thetas;
+  constexpr int        kSeed = 32;
+  std::vector<float>   thetas;
   std::vector<QPointF> points;
   thetas.reserve(kSeed);
   points.reserve(kSeed);
   for (int i = 0; i < kSeed; ++i) {
     const float theta = (static_cast<float>(i) / static_cast<float>(kSeed)) * (2.0f * kPi);
-    const auto item   = map_theta(theta);
+    const auto  item  = map_theta(theta);
     if (!item) {
       return {};
     }
@@ -378,7 +436,7 @@ auto TessellateRadialBoundaryItemPolyline(const MaskEditViewMapping& mapping,
   bool grew = true;
   while (grew && static_cast<int>(points.size()) < kMaskOverlayMaxEllipseVertices) {
     grew = false;
-    std::vector<float> next_thetas;
+    std::vector<float>   next_thetas;
     std::vector<QPointF> next_points;
     next_thetas.reserve(points.size() * 2);
     next_points.reserve(points.size() * 2);
@@ -394,7 +452,7 @@ auto TessellateRadialBoundaryItemPolyline(const MaskEditViewMapping& mapping,
         continue;
       }
       const float mid_theta = wrap_mid(thetas[i], thetas[j]);
-      const auto mid_item   = map_theta(mid_theta);
+      const auto  mid_item  = map_theta(mid_theta);
       if (!mid_item) {
         continue;
       }
@@ -448,7 +506,7 @@ auto MakeRadialExistingOverlayDisplay(const MaskEditViewMapping& mapping,
   return display;
 }
 
-auto MakeLinearExistingOverlayDisplay(const MaskEditViewMapping& mapping,
+auto MakeLinearExistingOverlayDisplay(const MaskEditViewMapping&      mapping,
                                       const LinearGradientMaskSource& source,
                                       const MaskOverlayStyle& style, const QRectF& clip)
     -> MaskOverlayDisplay {
@@ -472,11 +530,11 @@ auto MakeBrushCreatingOverlayDisplay(const std::vector<QPointF>& item_path, QPoi
                                      float cursor_radius_logical_px, const QRectF& clip)
     -> MaskOverlayDisplay {
   MaskOverlayDisplay display;
-  display.mode                     = MaskOverlayMode::Creating;
-  display.source_kind              = MaskOverlaySourceKind::Brush;
-  display.clip_rect                = clip;
-  display.creation_path            = item_path;
-  display.cursor_visible           = std::isfinite(cursor_item.x()) && std::isfinite(cursor_item.y()) &&
+  display.mode           = MaskOverlayMode::Creating;
+  display.source_kind    = MaskOverlaySourceKind::Brush;
+  display.clip_rect      = clip;
+  display.creation_path  = item_path;
+  display.cursor_visible = std::isfinite(cursor_item.x()) && std::isfinite(cursor_item.y()) &&
                            cursor_radius_logical_px > 0.0f;
   display.cursor_center            = cursor_item;
   display.cursor_radius_logical_px = cursor_radius_logical_px;
@@ -494,7 +552,7 @@ auto MakeRadialCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
   return display;
 }
 
-auto MakeLinearCreatingOverlayDisplay(const MaskEditViewMapping& mapping,
+auto MakeLinearCreatingOverlayDisplay(const MaskEditViewMapping&      mapping,
                                       const LinearGradientMaskSource& source,
                                       const MaskOverlayStyle& style, const QRectF& clip)
     -> MaskOverlayDisplay {
@@ -540,7 +598,7 @@ auto HitTestMaskOverlayHandle(const MaskOverlayDisplay& display, QPointF item,
       !std::isfinite(item.x()) || !std::isfinite(item.y())) {
     return MaskOverlayHandleId::None;
   }
-  MaskOverlayHandleId hit = MaskOverlayHandleId::None;
+  MaskOverlayHandleId hit  = MaskOverlayHandleId::None;
   float               best = hit_radius_logical_px;
   for (const auto& handle : display.handles) {
     if (handle.id == MaskOverlayHandleId::None || !std::isfinite(handle.item.x()) ||

--- a/alcedo_studio/src/ui/editor_rhi/editor_interaction_controller.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_interaction_controller.cpp
@@ -664,15 +664,11 @@ void EditorInteractionController::setDisplayedMaskGeometry(const ResolvedRenderG
 
 auto EditorInteractionController::maskEditViewMapping() const -> MaskEditViewMapping {
   MaskEditViewMapping mapping;
-  mapping.widget       = widgetInfo();
-  mapping.photograph   = imageInfo();
-  mapping.geometry     = displayed_mask_geometry_;
-  if (mapping.geometry.full_reference_extent.Empty() && mapping.photograph.image_width > 0 &&
-      mapping.photograph.image_height > 0) {
-    mapping.geometry = MaskEditGeometry::MakeIdentityPhotographGeometry(Extent2D{
-        static_cast<std::uint32_t>(mapping.photograph.image_width),
-        static_cast<std::uint32_t>(mapping.photograph.image_height)});
-  }
+  mapping.widget = widgetInfo();
+  // Crop overlay keeps uncropped source in image_info_. Mask mapping uses the
+  // displayed photograph (render-reference size when the viewport has one).
+  mapping.photograph = interactionImageInfo();
+  mapping.geometry   = displayed_mask_geometry_;
   mapping.presentation = presentation_mode_;
   const auto view     = viewer_state_.GetViewTransform();
   mapping.zoom        = view.zoom;

--- a/alcedo_studio/src/ui/editor_rhi/editor_overlay_item.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_overlay_item.cpp
@@ -442,6 +442,8 @@ struct EditorOverlayItem::OverlayRootNode : public QSGNode {
   QSGGeometryNode* mask_connector_node = nullptr;
   QSGGeometryNode* mask_cursor_node = nullptr;
   QSGGeometryNode* mask_creation_guide_node = nullptr;
+  QSGGeometryNode* mask_selected_guide_node = nullptr;
+  QSGGeometryNode* mask_edge_grip_node = nullptr;
 };
 
 EditorOverlayItem::EditorOverlayItem(QQuickItem* parent) : QQuickItem(parent) {
@@ -623,6 +625,54 @@ void EditorOverlayItem::setMaskOverlayAntialiasWidth(qreal width) {
   update();
 }
 
+void EditorOverlayItem::setMaskOverlayGuideOuterWidth(qreal width) {
+  const float value = static_cast<float>(width);
+  if (mask_style_.guide_outer_width_logical_px == value) {
+    return;
+  }
+  mask_style_.guide_outer_width_logical_px = value;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayGuideInnerWidth(qreal width) {
+  const float value = static_cast<float>(width);
+  if (mask_style_.guide_inner_width_logical_px == value) {
+    return;
+  }
+  mask_style_.guide_inner_width_logical_px = value;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayGripOuterWidth(qreal width) {
+  const float value = static_cast<float>(width);
+  if (mask_style_.grip_outer_width_logical_px == value) {
+    return;
+  }
+  mask_style_.grip_outer_width_logical_px = value;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
+void EditorOverlayItem::setMaskOverlayGripInnerWidth(qreal width) {
+  const float value = static_cast<float>(width);
+  if (mask_style_.grip_inner_width_logical_px == value) {
+    return;
+  }
+  mask_style_.grip_inner_width_logical_px = value;
+  rebuildMaskSceneGeometry();
+  geometry_dirty_ = true;
+  emit MaskOverlayStyleChanged();
+  update();
+}
+
 auto EditorOverlayItem::updatePaintNode(QSGNode* old_node, UpdatePaintNodeData*) -> QSGNode* {
   auto* root = static_cast<OverlayRootNode*>(old_node);
   if (!root) {
@@ -670,6 +720,10 @@ auto EditorOverlayItem::updatePaintNode(QSGNode* old_node, UpdatePaintNodeData*)
                                   mask_creates);
   UpsertPremultipliedTriangleNode(root, root->mask_cursor_node, mask_scene.cursor, mask_creates);
   UpsertPremultipliedTriangleNode(root, root->mask_creation_guide_node, mask_scene.creation_guides,
+                                  mask_creates);
+  UpsertPremultipliedTriangleNode(root, root->mask_selected_guide_node, mask_scene.selected_guides,
+                                  mask_creates);
+  UpsertPremultipliedTriangleNode(root, root->mask_edge_grip_node, mask_scene.edge_grips,
                                   mask_creates);
 
   paint_node_create_count_ += creates;

--- a/alcedo_studio/tests/edit/mask/analytic_mask_edit_test.cpp
+++ b/alcedo_studio/tests/edit/mask/analytic_mask_edit_test.cpp
@@ -19,6 +19,8 @@ TEST(AnalyticMaskEditTest, CenterOutRadiiStayPositiveAndUnswapped) {
   EXPECT_FLOAT_EQ(left_up.major_radius, 0.15f);
   EXPECT_FLOAT_EQ(left_up.minor_radius, 0.15f);
   EXPECT_FLOAT_EQ(left_up.rotation, 0.0f);
+  EXPECT_FLOAT_EQ(left_up.inner_feather, kAnalyticCreationDefaultInnerFeather);
+  EXPECT_FLOAT_EQ(left_up.outer_feather, 0.0f);
   EXPECT_FALSE(RadialCreationIsValid(RadialFromCenterOut(center, center)));
 
   RadialMaskSource tall;

--- a/alcedo_studio/tests/ui/analytic_mask_creation_test.cpp
+++ b/alcedo_studio/tests/ui/analytic_mask_creation_test.cpp
@@ -4,6 +4,9 @@
 
 #include <gtest/gtest.h>
 
+#include <QPointF>
+#include <QRectF>
+#include <QVector2D>
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -11,10 +14,6 @@
 #include <optional>
 #include <span>
 #include <vector>
-
-#include <QPointF>
-#include <QRectF>
-#include <QVector2D>
 
 #include "app/editor_mask_creation_controller.hpp"
 #include "app/pipeline_history_applier.hpp"
@@ -39,7 +38,6 @@ namespace alcedo {
 namespace {
 
 constexpr Extent2D kRaster{64, 32};
-constexpr float    kPi = 3.14159265358979323846f;
 
 [[nodiscard]] auto MakeMapping() -> MaskEditViewMapping {
   MaskEditViewMapping mapping;
@@ -70,11 +68,11 @@ constexpr float    kPi = 3.14159265358979323846f;
 
 // Independent native Radial coverage from the NM7 plan equations. Not overlay layout.
 [[nodiscard]] auto IndependentRadialCoverage(const RadialMaskSource& source, Vector2 q) -> float {
-  const float c     = std::cos(source.rotation);
-  const float s     = std::sin(source.rotation);
-  const float u     = (c * (q.x - source.center_x) + s * (q.y - source.center_y)) /
+  const float c = std::cos(source.rotation);
+  const float s = std::sin(source.rotation);
+  const float u = (c * (q.x - source.center_x) + s * (q.y - source.center_y)) /
                   std::max(source.major_radius, 1.0e-6f);
-  const float v     = (-s * (q.x - source.center_x) + c * (q.y - source.center_y)) /
+  const float v = (-s * (q.x - source.center_x) + c * (q.y - source.center_y)) /
                   std::max(source.minor_radius, 1.0e-6f);
   const float rho   = std::sqrt(u * u + v * v);
   const float inner = std::max(0.0f, 1.0f - source.inner_feather);
@@ -88,8 +86,7 @@ constexpr float    kPi = 3.14159265358979323846f;
   const float nx     = source.normal_x / std::max(length, 1.0e-6f);
   const float ny     = source.normal_y / std::max(length, 1.0e-6f);
   const float d      = (q.x - source.origin_x) * nx + (q.y - source.origin_y) * ny;
-  const float t =
-      std::clamp(d / std::max(source.transition_distance, 1.0e-6f) + 0.5f, 0.0f, 1.0f);
+  const float t = std::clamp(d / std::max(source.transition_distance, 1.0e-6f) + 0.5f, 0.0f, 1.0f);
   return source.start_value + (source.end_value - source.start_value) * t;
 }
 
@@ -114,7 +111,7 @@ void ExpectMixMatchesIndependent(const GradeMaskCoverage& mix, const MaskModel& 
   std::int32_t  max_err    = 0;
   for (std::uint32_t y = 0; y < kRaster.height; y += 4) {
     for (std::uint32_t x = 0; x < kRaster.width; x += 4) {
-      const Vector2 q     = TexelNormalized(x, y);
+      const Vector2 q        = TexelNormalized(x, y);
       float         coverage = 0.0f;
       if (const auto* radial = std::get_if<RadialMaskSource>(&mask.source)) {
         coverage = IndependentRadialCoverage(*radial, q);
@@ -125,8 +122,8 @@ void ExpectMixMatchesIndependent(const GradeMaskCoverage& mix, const MaskModel& 
         coverage = 1.0f - coverage;
       }
       const auto expected = IndependentR8(std::clamp(coverage * mask.opacity, 0.0f, 1.0f));
-      const auto err      = std::abs(static_cast<int>(MixAt(mix, x, y)) - static_cast<int>(expected));
-      max_err             = std::max(max_err, err);
+      const auto err = std::abs(static_cast<int>(MixAt(mix, x, y)) - static_cast<int>(expected));
+      max_err        = std::max(max_err, err);
       if (err > 1) {
         ++mismatches;
       }
@@ -155,21 +152,22 @@ struct AnalyticCreationHarness {
     });
   }
 
-  std::shared_ptr<CommitGraph>           graph;
-  std::shared_ptr<MiniGitJournal>        journal;
-  MiniGitWorkingHistory                  history;
-  PipelineDocument                       document;
-  EditorMaskCreationController           controller;
-  GradeMaskCoverage                      mix;
-  std::vector<std::uint8_t>              last_mix;
-  int                                    preview_count = 0;
-  MaskEditViewMapping                    mapping       = MakeMapping();
-  EditorSessionIdentity                  session{17, 4};
-  MaskPointerIdentity                    pointer{3, 1, 9};
+  std::shared_ptr<CommitGraph>    graph;
+  std::shared_ptr<MiniGitJournal> journal;
+  MiniGitWorkingHistory           history;
+  PipelineDocument                document;
+  EditorMaskCreationController    controller;
+  GradeMaskCoverage               mix;
+  std::vector<std::uint8_t>       last_mix;
+  int                             preview_count = 0;
+  MaskEditViewMapping             mapping       = MakeMapping();
+  EditorSessionIdentity           session{17, 4};
+  MaskPointerIdentity             pointer{3, 1, 9};
 };
 
 [[nodiscard]] auto OverlayFillCount(const MaskOverlayDisplay& display) -> int {
-  return BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle()).coverage_fill_vertex_count;
+  return BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle())
+      .coverage_fill_vertex_count;
 }
 
 [[nodiscard]] auto BatchFromCommit(const EditCommit& commit) -> PipelineEditBatch {
@@ -188,17 +186,18 @@ TEST(AnalyticMaskCreationTest, ExistingRadialMoveUpdatesInteractivePixelsBeforeR
   radial.rotation     = 0.40f;
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
   harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
-  const auto mix_before = CopyMix(harness.mix);
+  const auto mix_before  = CopyMix(harness.mix);
   const auto head_before = harness.history.working_head();
 
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
-  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
-  ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+          .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.28f, 0.62f}), true);
   const auto preview = harness.controller.AppendMaskInput(moved, harness.pointer);
@@ -221,8 +220,8 @@ TEST(AnalyticMaskCreationTest, ExistingRadialMoveUpdatesInteractivePixelsBeforeR
   ExpectMixMatchesIndependent(harness.mix,
                               *harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"}));
 
-  const auto display = MakeRadialExistingOverlayDisplay(
-      harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
+  const auto display =
+      MakeRadialExistingOverlayDisplay(harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
   EXPECT_EQ(OverlayFillCount(display), 0);
   EXPECT_FALSE(display.handles.empty());
 
@@ -233,8 +232,44 @@ TEST(AnalyticMaskCreationTest, ExistingRadialMoveUpdatesInteractivePixelsBeforeR
   EXPECT_NE(harness.history.working_head(), head_before);
 }
 
-TEST(AnalyticMaskCreationTest, ExistingGradientMovePreservesDirectionAndUpdatesInteractivePixels) {
+TEST(AnalyticMaskCreationTest, FinishModeSettlesOnceAndLeavesMaskEditingInactive) {
   AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.center_x     = 0.5f;
+  radial.center_y     = 0.5f;
+  radial.major_radius = 0.22f;
+  radial.minor_radius = 0.16f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.72f, 0.5f}), false);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialMajor, press, harness.pointer)
+          .accepted);
+  const auto moved = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.80f, 0.5f}), true);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
+  const auto head_before = harness.history.working_head();
+
+  const auto finish      = harness.controller.FinishCreationMode();
+  EXPECT_TRUE(finish.accepted);
+  EXPECT_TRUE(finish.committed);
+  EXPECT_TRUE(finish.quality_requested);
+  EXPECT_EQ(harness.controller.state(), EditorMaskCreationState::Inactive);
+  EXPECT_NE(harness.history.working_head(), head_before);
+  const auto settled_head = harness.history.working_head();
+
+  const auto duplicate    = harness.controller.FinishCreationMode();
+  EXPECT_TRUE(duplicate.accepted);
+  EXPECT_FALSE(duplicate.committed);
+  EXPECT_FALSE(duplicate.quality_requested);
+  EXPECT_EQ(harness.history.working_head(), settled_head);
+}
+
+TEST(AnalyticMaskCreationTest, ExistingGradientMovePreservesDirectionAndUpdatesInteractivePixels) {
+  AnalyticCreationHarness  harness;
   LinearGradientMaskSource linear;
   linear.origin_x            = 0.50f;
   linear.origin_y            = 0.50f;
@@ -246,14 +281,15 @@ TEST(AnalyticMaskCreationTest, ExistingGradientMovePreservesDirectionAndUpdatesI
   const auto mix_before  = CopyMix(harness.mix);
   const auto head_before = harness.history.working_head();
 
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.linear"},
-                              harness.session)
-                  .accepted);
-  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
-  ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::LinearOrigin, press, harness.pointer)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.linear"}, harness.session)
+          .accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::LinearOrigin, press, harness.pointer)
+          .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.70f, 0.50f}), true);
   const auto preview = harness.controller.AppendMaskInput(moved, harness.pointer);
@@ -274,8 +310,8 @@ TEST(AnalyticMaskCreationTest, ExistingGradientMovePreservesDirectionAndUpdatesI
   ExpectMixMatchesIndependent(harness.mix,
                               *harness.document.PrimaryGrade()->FindMask(MaskId{"mask.linear"}));
 
-  const auto display = MakeLinearExistingOverlayDisplay(
-      harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
+  const auto display =
+      MakeLinearExistingOverlayDisplay(harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
   EXPECT_EQ(OverlayFillCount(display), 0);
   EXPECT_FALSE(display.handles.empty());
 
@@ -296,14 +332,14 @@ TEST(AnalyticMaskCreationTest, RadialFeatherControlsMatchEvaluator) {
   radial.inner_feather = 0.10f;
   radial.outer_feather = 0.05f;
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
 
   const Vector2 inner_q{radial.center_x + std::cos(radial.rotation) * radial.major_radius * 0.55f,
                         radial.center_y + std::sin(radial.rotation) * radial.major_radius * 0.55f};
-  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, inner_q), false);
+  const auto    press = SampleOf(harness.mapping, ItemOf(harness.mapping, inner_q), false);
   ASSERT_TRUE(harness.controller
                   .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, press, harness.pointer)
                   .accepted);
@@ -313,11 +349,11 @@ TEST(AnalyticMaskCreationTest, RadialFeatherControlsMatchEvaluator) {
                         radial.center_y + std::sin(radial.rotation) * radial.major_radius * 1.35f};
   MaskPointerIdentity outer_pointer = harness.pointer;
   ASSERT_TRUE(harness.controller.FinishMaskInput().accepted);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
-  const auto outer_press = SampleOf(harness.mapping, ItemOf(harness.mapping, outer_q), false);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
+  const auto outer_press    = SampleOf(harness.mapping, ItemOf(harness.mapping, outer_q), false);
   outer_pointer.sequence_id = 10;
   ASSERT_TRUE(harness.controller
                   .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer)
@@ -337,8 +373,8 @@ TEST(AnalyticMaskCreationTest, RadialFeatherControlsMatchEvaluator) {
 
   const auto inner_rho = RadialRho(*live, TexelNormalized(kRaster.width / 2, kRaster.height / 2));
   ASSERT_TRUE(inner_rho.has_value());
-  const float expected_center = IndependentRadialCoverage(*live, TexelNormalized(
-                                                                     kRaster.width / 2, kRaster.height / 2));
+  const float expected_center =
+      IndependentRadialCoverage(*live, TexelNormalized(kRaster.width / 2, kRaster.height / 2));
   EXPECT_NEAR(CoverageFromMaskR8(MixAt(harness.mix, kRaster.width / 2, kRaster.height / 2)),
               expected_center, 1.0f / 255.0f + 1.0e-6f);
 }
@@ -388,16 +424,15 @@ TEST(AnalyticMaskCreationTest, EscapeRestoresAnalyticSourceWithoutCommit) {
   const auto mix_before  = CopyMix(harness.mix);
   const auto head_before = harness.history.working_head();
 
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
-  const auto press =
-      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{radial.center_x, radial.center_y}),
-               false);
-  ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
+  const auto press = SampleOf(
+      harness.mapping, ItemOf(harness.mapping, Vector2{radial.center_x, radial.center_y}), false);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+          .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.22f, 0.30f}), true);
   ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).interactive_preview);
@@ -426,8 +461,7 @@ TEST(AnalyticMaskCreationTest, ValidRadialCreationCommitsOnceAndKeepsControlOnly
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.45f, 0.40f}), false);
   ASSERT_TRUE(harness.controller.BeginMaskInput(press, harness.pointer).accepted);
-  const auto drag =
-      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.62f, 0.58f}), true);
+  const auto drag = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.62f, 0.58f}), true);
   const auto preview = harness.controller.AppendMaskInput(drag, harness.pointer);
   ASSERT_TRUE(preview.accepted);
   EXPECT_TRUE(preview.interactive_preview);
@@ -438,8 +472,8 @@ TEST(AnalyticMaskCreationTest, ValidRadialCreationCommitsOnceAndKeepsControlOnly
   const auto* live = std::get_if<RadialMaskSource>(
       &harness.document.PrimaryGrade()->FindMask(preview.mask_id)->source);
   ASSERT_NE(live, nullptr);
-  const auto display = MakeRadialCreatingOverlayDisplay(
-      harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
+  const auto display =
+      MakeRadialCreatingOverlayDisplay(harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
   EXPECT_EQ(OverlayFillCount(display), 0);
   EXPECT_TRUE(display.creation_outline.empty());
   EXPECT_FALSE(display.selected_contours.empty());
@@ -463,28 +497,27 @@ TEST(AnalyticMaskCreationTest, RadialFeatherControlsPreserveCenterRadiiAndRotati
   radial.inner_feather = 0.12f;
   radial.outer_feather = 0.08f;
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
   const auto inner_q = RadialNormalizedPoint(radial, 0.55f, 0.0f);
-  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, inner_q), false);
+  const auto press   = SampleOf(harness.mapping, ItemOf(harness.mapping, inner_q), false);
   ASSERT_TRUE(harness.controller
                   .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, press, harness.pointer)
                   .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(press, harness.pointer).accepted);
   ASSERT_TRUE(harness.controller.FinishMaskInput().accepted);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
-  const auto outer_q = RadialNormalizedPoint(radial, 1.40f, 0.0f);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
+  const auto          outer_q       = RadialNormalizedPoint(radial, 1.40f, 0.0f);
   MaskPointerIdentity outer_pointer = harness.pointer;
-  outer_pointer.sequence_id          = 11;
+  outer_pointer.sequence_id         = 11;
   const auto outer_press = SampleOf(harness.mapping, ItemOf(harness.mapping, outer_q), false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press,
-                                  outer_pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer)
                   .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(outer_press, outer_pointer).accepted);
   const auto* live = std::get_if<RadialMaskSource>(
@@ -512,13 +545,12 @@ TEST(AnalyticMaskCreationTest, RadialFeatherDragUpdatesInteractivePixelsBeforeRe
   harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
   const auto mix_before  = CopyMix(harness.mix);
   const auto head_before = harness.history.working_head();
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
   const auto press = SampleOf(
-      harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 1.45f, 0.0f)),
-      false);
+      harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 1.45f, 0.0f)), false);
   ASSERT_TRUE(harness.controller
                   .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, press, harness.pointer)
                   .accepted);
@@ -541,9 +573,8 @@ TEST(AnalyticMaskCreationTest, NodeDrawerSelectionLoadsExistingMaskWithoutCreati
   const auto head_before    = harness.history.working_head();
   const auto preview_before = harness.preview_count;
   const auto count_before   = harness.document.PrimaryGrade()->MaskCount();
-  const auto loaded =
-      harness.controller.SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                                     harness.session);
+  const auto loaded         = harness.controller.SelectMask(harness.document.PrimaryGrade()->Id(),
+                                                            MaskId{"mask.radial"}, harness.session);
   ASSERT_TRUE(loaded.accepted);
   EXPECT_FALSE(loaded.committed);
   EXPECT_FALSE(loaded.interactive_preview);
@@ -552,14 +583,13 @@ TEST(AnalyticMaskCreationTest, NodeDrawerSelectionLoadsExistingMaskWithoutCreati
   EXPECT_EQ(harness.preview_count, preview_before);
   EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), count_before);
   EXPECT_EQ(harness.controller.selected_mask_id(), MaskId{"mask.radial"});
-  const auto display = MakeRadialExistingOverlayDisplay(
-      harness.mapping, radial, DefaultMaskOverlayStyle(), QRectF());
+  const auto display = MakeRadialExistingOverlayDisplay(harness.mapping, radial,
+                                                        DefaultMaskOverlayStyle(), QRectF());
   EXPECT_FALSE(display.handles.empty());
   EXPECT_EQ(OverlayFillCount(display), 0);
 
-  const auto brush_loaded =
-      harness.controller.SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.brush"},
-                                     harness.session);
+  const auto brush_loaded = harness.controller.SelectMask(harness.document.PrimaryGrade()->Id(),
+                                                          MaskId{"mask.brush"}, harness.session);
   ASSERT_TRUE(brush_loaded.accepted);
   EXPECT_FALSE(brush_loaded.committed);
   EXPECT_FALSE(brush_loaded.interactive_preview);
@@ -577,19 +607,19 @@ TEST(AnalyticMaskCreationTest, SelectedMaskCanBeEditedAfterWorkspaceReentry) {
   radial.major_radius = 0.20f;
   radial.minor_radius = 0.16f;
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
-  ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+          .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.33f, 0.58f}), true);
   ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
@@ -611,10 +641,10 @@ TEST(AnalyticMaskCreationTest, NodeDrawerDeleteRemovesExactMaskAndUndoRestoresSo
   second.minor_radius = 0.12f;
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.first"}, first);
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.second"}, second);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.first"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.first"}, harness.session)
+          .accepted);
   const auto removed =
       harness.controller.RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.first"});
   ASSERT_TRUE(removed.accepted);
@@ -629,7 +659,7 @@ TEST(AnalyticMaskCreationTest, NodeDrawerDeleteRemovesExactMaskAndUndoRestoresSo
   ASSERT_TRUE(undone.selected_commit.has_value());
   std::string error;
   ASSERT_TRUE(ApplyPipelineEditBatch(harness.document, BatchFromCommit(*undone.selected_commit),
-                                      PipelineEditApplyDirection::Inverse, &error))
+                                     PipelineEditApplyDirection::Inverse, &error))
       << error;
   const auto* restored = harness.document.PrimaryGrade()->FindMask(MaskId{"mask.first"});
   ASSERT_NE(restored, nullptr);
@@ -645,14 +675,13 @@ TEST(AnalyticMaskCreationTest, DeletingLastMaskRestoresFullGradeCoverage) {
   RadialMaskSource        radial;
   radial.major_radius = 0.20f;
   radial.minor_radius = 0.14f;
-  auto& mask =
-      grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.last"}, radial);
+  auto& mask   = grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.last"}, radial);
   mask.enabled = false;
   harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
   EXPECT_EQ(MixAt(harness.mix, 1, 1), 0);
-  ASSERT_TRUE(harness.controller
-                  .RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.last"})
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller.RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.last"})
+          .accepted);
   EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
   harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
   EXPECT_EQ(MixAt(harness.mix, 1, 1), 255);
@@ -665,13 +694,13 @@ TEST(AnalyticMaskCreationTest, DeletingUnselectedMaskPreservesSelection) {
   radial.minor_radius = 0.14f;
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.keep"}, radial);
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.other"}, radial);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.keep"},
-                              harness.session)
-                  .accepted);
-  ASSERT_TRUE(harness.controller
-                  .RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.other"})
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.keep"}, harness.session)
+          .accepted);
+  ASSERT_TRUE(
+      harness.controller.RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.other"})
+          .accepted);
   EXPECT_EQ(harness.controller.selected_mask_id(), MaskId{"mask.keep"});
   EXPECT_NE(harness.document.PrimaryGrade()->FindMask(MaskId{"mask.keep"}), nullptr);
 }
@@ -690,28 +719,28 @@ TEST(AnalyticMaskCreationTest, DeletingMaskRejectsQueuedEditsAndDelayedFrames) {
   keep.minor_radius = 0.10f;
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.moving"}, moving);
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.keep"}, keep);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.moving"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.moving"}, harness.session)
+          .accepted);
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
-  ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+          .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.70f, 0.40f}), true);
   ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
   const auto delayed = harness.last_mix;
-  ASSERT_TRUE(harness.controller
-                  .RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.moving"})
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller.RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.moving"})
+          .accepted);
   EXPECT_FALSE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
   EXPECT_EQ(harness.document.PrimaryGrade()->FindMask(MaskId{"mask.moving"}), nullptr);
   harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
   EXPECT_NE(CopyMix(harness.mix), delayed);
-  ExpectMixMatchesIndependent(harness.mix, *harness.document.PrimaryGrade()->FindMask(
-                                                 MaskId{"mask.keep"}));
+  ExpectMixMatchesIndependent(harness.mix,
+                              *harness.document.PrimaryGrade()->FindMask(MaskId{"mask.keep"}));
 }
 
 TEST(AnalyticMaskCreationTest, MaskDeleteWithViewerFocusDoesNotDeleteGrade) {
@@ -728,7 +757,7 @@ TEST(AnalyticMaskCreationTest, MaskDeleteWithViewerFocusDoesNotDeleteGrade) {
 }
 
 TEST(AnalyticMaskCreationTest, GradientBoundaryDragPreservesOriginAndChangesTransition) {
-  AnalyticCreationHarness harness;
+  AnalyticCreationHarness  harness;
   LinearGradientMaskSource linear;
   linear.origin_x            = 0.50f;
   linear.origin_y            = 0.50f;
@@ -736,10 +765,10 @@ TEST(AnalyticMaskCreationTest, GradientBoundaryDragPreservesOriginAndChangesTran
   linear.normal_y            = 1.0f;
   linear.transition_distance = 0.24f;
   grade_mask_test::AddLinearGradientMask(harness.document, MaskId{"mask.linear"}, linear);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.linear"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.linear"}, harness.session)
+          .accepted);
   const Vector2 end{linear.origin_x, linear.origin_y + 0.40f};
   const auto    press = SampleOf(harness.mapping, ItemOf(harness.mapping, end), false);
   ASSERT_TRUE(harness.controller
@@ -758,20 +787,20 @@ TEST(AnalyticMaskCreationTest, AnalyticControlCancelRestoresSourceWithoutHistory
   AnalyticCreationHarness harness;
   RadialMaskSource        radial;
   radial.center_x     = 0.50f;
-  radial.center_y      = 0.50f;
-  radial.major_radius  = 0.22f;
-  radial.minor_radius  = 0.16f;
+  radial.center_y     = 0.50f;
+  radial.major_radius = 0.22f;
+  radial.minor_radius = 0.16f;
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
   const auto head_before = harness.history.working_head();
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
-  ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+          .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.30f, 0.60f}), true);
   ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
@@ -794,31 +823,28 @@ TEST(AnalyticMaskCreationTest, CoincidentRadialBoundariesKeepFeatherControlsReac
   radial.inner_feather = 0.0f;
   radial.outer_feather = 0.0f;
   grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
   const auto inner_press = SampleOf(
-      harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 0.70f, 0.0f)),
-      false);
-  ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, inner_press,
-                                  harness.pointer)
-                  .accepted);
+      harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 0.70f, 0.0f)), false);
+  ASSERT_TRUE(
+      harness.controller
+          .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, inner_press, harness.pointer)
+          .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(inner_press, harness.pointer).accepted);
   ASSERT_TRUE(harness.controller.FinishMaskInput().accepted);
-  ASSERT_TRUE(harness.controller
-                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
-                              harness.session)
-                  .accepted);
+  ASSERT_TRUE(
+      harness.controller
+          .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"}, harness.session)
+          .accepted);
   MaskPointerIdentity outer_pointer = harness.pointer;
-  outer_pointer.sequence_id          = 12;
-  const auto outer_press = SampleOf(
-      harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 1.35f, 0.0f)),
-      false);
+  outer_pointer.sequence_id         = 12;
+  const auto outer_press            = SampleOf(
+      harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 1.35f, 0.0f)), false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press,
-                                  outer_pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer)
                   .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(outer_press, outer_pointer).accepted);
   const auto* live = std::get_if<RadialMaskSource>(

--- a/alcedo_studio/tests/ui/analytic_mask_creation_test.cpp
+++ b/alcedo_studio/tests/ui/analytic_mask_creation_test.cpp
@@ -17,15 +17,18 @@
 #include <QVector2D>
 
 #include "app/editor_mask_creation_controller.hpp"
-#include "app/pipeline_document_history.hpp"
+#include "app/pipeline_history_applier.hpp"
 #include "edit/geometry/types.hpp"
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/history/commit_graph.hpp"
+#include "edit/history/edit_commit.hpp"
 #include "edit/history/mini_git_working_history.hpp"
+#include "edit/history/pipeline_edit_batch.hpp"
 #include "edit/mask/analytic_mask_edit.hpp"
 #include "edit/mask/brush_raster_encoding.hpp"
 #include "edit/mask/grade_mask_coverage.hpp"
+#include "edit/mask/mask_list_selection.hpp"
 #include "edit/mask/mask_model.hpp"
 #include "grade_owned_mask_support.hpp"
 #include "ui/edit_viewer/mask_edit_geometry.hpp"
@@ -167,6 +170,10 @@ struct AnalyticCreationHarness {
 
 [[nodiscard]] auto OverlayFillCount(const MaskOverlayDisplay& display) -> int {
   return BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle()).coverage_fill_vertex_count;
+}
+
+[[nodiscard]] auto BatchFromCommit(const EditCommit& commit) -> PipelineEditBatch {
+  return PipelineEditBatch::FromJSON(commit.GetPayloadJSON());
 }
 
 }  // namespace
@@ -434,7 +441,8 @@ TEST(AnalyticMaskCreationTest, ValidRadialCreationCommitsOnceAndKeepsControlOnly
   const auto display = MakeRadialCreatingOverlayDisplay(
       harness.mapping, *live, DefaultMaskOverlayStyle(), QRectF());
   EXPECT_EQ(OverlayFillCount(display), 0);
-  EXPECT_FALSE(display.creation_outline.empty());
+  EXPECT_TRUE(display.creation_outline.empty());
+  EXPECT_FALSE(display.selected_contours.empty());
 
   const auto finish = harness.controller.FinishMaskInput();
   ASSERT_TRUE(finish.accepted);
@@ -442,6 +450,396 @@ TEST(AnalyticMaskCreationTest, ValidRadialCreationCommitsOnceAndKeepsControlOnly
   EXPECT_TRUE(finish.quality_requested);
   EXPECT_NE(harness.history.working_head(), head_before);
   EXPECT_FALSE(harness.controller.FinishMaskInput().committed);
+}
+
+TEST(AnalyticMaskCreationTest, RadialFeatherControlsPreserveCenterRadiiAndRotation) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.center_x      = 0.48f;
+  radial.center_y      = 0.52f;
+  radial.major_radius  = 0.24f;
+  radial.minor_radius  = 0.17f;
+  radial.rotation      = 0.55f;
+  radial.inner_feather = 0.12f;
+  radial.outer_feather = 0.08f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  const auto inner_q = RadialNormalizedPoint(radial, 0.55f, 0.0f);
+  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, inner_q), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, press, harness.pointer)
+                  .accepted);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(press, harness.pointer).accepted);
+  ASSERT_TRUE(harness.controller.FinishMaskInput().accepted);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  const auto outer_q = RadialNormalizedPoint(radial, 1.40f, 0.0f);
+  MaskPointerIdentity outer_pointer = harness.pointer;
+  outer_pointer.sequence_id          = 11;
+  const auto outer_press = SampleOf(harness.mapping, ItemOf(harness.mapping, outer_q), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press,
+                                  outer_pointer)
+                  .accepted);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(outer_press, outer_pointer).accepted);
+  const auto* live = std::get_if<RadialMaskSource>(
+      &harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"})->source);
+  ASSERT_NE(live, nullptr);
+  EXPECT_FLOAT_EQ(live->center_x, radial.center_x);
+  EXPECT_FLOAT_EQ(live->center_y, radial.center_y);
+  EXPECT_FLOAT_EQ(live->major_radius, radial.major_radius);
+  EXPECT_FLOAT_EQ(live->minor_radius, radial.minor_radius);
+  EXPECT_NEAR(live->rotation, radial.rotation, 1.0e-5f);
+  EXPECT_GT(live->inner_feather, radial.inner_feather);
+  EXPECT_GT(live->outer_feather, radial.outer_feather);
+}
+
+TEST(AnalyticMaskCreationTest, RadialFeatherDragUpdatesInteractivePixelsBeforeRelease) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.center_x      = 0.50f;
+  radial.center_y      = 0.50f;
+  radial.major_radius  = 0.22f;
+  radial.minor_radius  = 0.16f;
+  radial.inner_feather = 0.10f;
+  radial.outer_feather = 0.05f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
+  const auto mix_before  = CopyMix(harness.mix);
+  const auto head_before = harness.history.working_head();
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  const auto press = SampleOf(
+      harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 1.45f, 0.0f)),
+      false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, press, harness.pointer)
+                  .accepted);
+  const auto preview = harness.controller.AppendMaskInput(press, harness.pointer);
+  ASSERT_TRUE(preview.accepted);
+  EXPECT_TRUE(preview.interactive_preview);
+  EXPECT_FALSE(preview.committed);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  EXPECT_GE(harness.preview_count, 1);
+  EXPECT_NE(harness.last_mix, mix_before);
+}
+
+TEST(AnalyticMaskCreationTest, NodeDrawerSelectionLoadsExistingMaskWithoutCreatingOrRendering) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.major_radius = 0.20f;
+  radial.minor_radius = 0.16f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  grade_mask_test::AddParameterizedBrushMask(harness.document, MaskId{"mask.brush"});
+  const auto head_before    = harness.history.working_head();
+  const auto preview_before = harness.preview_count;
+  const auto count_before   = harness.document.PrimaryGrade()->MaskCount();
+  const auto loaded =
+      harness.controller.SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                                     harness.session);
+  ASSERT_TRUE(loaded.accepted);
+  EXPECT_FALSE(loaded.committed);
+  EXPECT_FALSE(loaded.interactive_preview);
+  EXPECT_FALSE(loaded.quality_requested);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  EXPECT_EQ(harness.preview_count, preview_before);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), count_before);
+  EXPECT_EQ(harness.controller.selected_mask_id(), MaskId{"mask.radial"});
+  const auto display = MakeRadialExistingOverlayDisplay(
+      harness.mapping, radial, DefaultMaskOverlayStyle(), QRectF());
+  EXPECT_FALSE(display.handles.empty());
+  EXPECT_EQ(OverlayFillCount(display), 0);
+
+  const auto brush_loaded =
+      harness.controller.SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.brush"},
+                                     harness.session);
+  ASSERT_TRUE(brush_loaded.accepted);
+  EXPECT_FALSE(brush_loaded.committed);
+  EXPECT_FALSE(brush_loaded.interactive_preview);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  EXPECT_EQ(harness.preview_count, preview_before);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), count_before);
+  EXPECT_EQ(harness.controller.selected_mask_id(), MaskId{"mask.brush"});
+}
+
+TEST(AnalyticMaskCreationTest, SelectedMaskCanBeEditedAfterWorkspaceReentry) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.center_x     = 0.50f;
+  radial.center_y     = 0.50f;
+  radial.major_radius = 0.20f;
+  radial.minor_radius = 0.16f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+                  .accepted);
+  const auto moved =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.33f, 0.58f}), true);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
+  const auto finish = harness.controller.FinishMaskInput();
+  ASSERT_TRUE(finish.accepted);
+  EXPECT_TRUE(finish.committed);
+  EXPECT_EQ(harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"})->id,
+            MaskId{"mask.radial"});
+}
+
+TEST(AnalyticMaskCreationTest, NodeDrawerDeleteRemovesExactMaskAndUndoRestoresSource) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        first;
+  first.major_radius = 0.18f;
+  first.minor_radius = 0.14f;
+  RadialMaskSource second;
+  second.center_x     = 0.62f;
+  second.major_radius = 0.15f;
+  second.minor_radius = 0.12f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.first"}, first);
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.second"}, second);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.first"},
+                              harness.session)
+                  .accepted);
+  const auto removed =
+      harness.controller.RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.first"});
+  ASSERT_TRUE(removed.accepted);
+  EXPECT_TRUE(removed.committed);
+  EXPECT_EQ(harness.document.PrimaryGrade()->FindMask(MaskId{"mask.first"}), nullptr);
+  EXPECT_NE(harness.document.PrimaryGrade()->FindMask(MaskId{"mask.second"}), nullptr);
+  EXPECT_EQ(harness.controller.selected_mask_id(), MaskId{"mask.second"});
+  EXPECT_EQ(harness.controller.last_removed_mask_id(), MaskId{"mask.first"});
+
+  const auto undone = harness.history.Undo();
+  ASSERT_TRUE(undone.moved) << undone.error;
+  ASSERT_TRUE(undone.selected_commit.has_value());
+  std::string error;
+  ASSERT_TRUE(ApplyPipelineEditBatch(harness.document, BatchFromCommit(*undone.selected_commit),
+                                      PipelineEditApplyDirection::Inverse, &error))
+      << error;
+  const auto* restored = harness.document.PrimaryGrade()->FindMask(MaskId{"mask.first"});
+  ASSERT_NE(restored, nullptr);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 2u);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskAt(0).id, MaskId{"mask.first"});
+  const auto* live = std::get_if<RadialMaskSource>(&restored->source);
+  ASSERT_NE(live, nullptr);
+  EXPECT_FLOAT_EQ(live->major_radius, first.major_radius);
+}
+
+TEST(AnalyticMaskCreationTest, DeletingLastMaskRestoresFullGradeCoverage) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.major_radius = 0.20f;
+  radial.minor_radius = 0.14f;
+  auto& mask =
+      grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.last"}, radial);
+  mask.enabled = false;
+  harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
+  EXPECT_EQ(MixAt(harness.mix, 1, 1), 0);
+  ASSERT_TRUE(harness.controller
+                  .RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.last"})
+                  .accepted);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
+  harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
+  EXPECT_EQ(MixAt(harness.mix, 1, 1), 255);
+}
+
+TEST(AnalyticMaskCreationTest, DeletingUnselectedMaskPreservesSelection) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.major_radius = 0.18f;
+  radial.minor_radius = 0.14f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.keep"}, radial);
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.other"}, radial);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.keep"},
+                              harness.session)
+                  .accepted);
+  ASSERT_TRUE(harness.controller
+                  .RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.other"})
+                  .accepted);
+  EXPECT_EQ(harness.controller.selected_mask_id(), MaskId{"mask.keep"});
+  EXPECT_NE(harness.document.PrimaryGrade()->FindMask(MaskId{"mask.keep"}), nullptr);
+}
+
+TEST(AnalyticMaskCreationTest, DeletingMaskRejectsQueuedEditsAndDelayedFrames) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        moving;
+  moving.center_x     = 0.50f;
+  moving.center_y     = 0.50f;
+  moving.major_radius = 0.20f;
+  moving.minor_radius = 0.16f;
+  RadialMaskSource keep;
+  keep.center_x     = 0.20f;
+  keep.center_y     = 0.20f;
+  keep.major_radius = 0.12f;
+  keep.minor_radius = 0.10f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.moving"}, moving);
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.keep"}, keep);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.moving"},
+                              harness.session)
+                  .accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+                  .accepted);
+  const auto moved =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.70f, 0.40f}), true);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
+  const auto delayed = harness.last_mix;
+  ASSERT_TRUE(harness.controller
+                  .RemoveMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.moving"})
+                  .accepted);
+  EXPECT_FALSE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
+  EXPECT_EQ(harness.document.PrimaryGrade()->FindMask(MaskId{"mask.moving"}), nullptr);
+  harness.mix.EvaluateFull(harness.document.PrimaryGrade()->Masks());
+  EXPECT_NE(CopyMix(harness.mix), delayed);
+  ExpectMixMatchesIndependent(harness.mix, *harness.document.PrimaryGrade()->FindMask(
+                                                 MaskId{"mask.keep"}));
+}
+
+TEST(AnalyticMaskCreationTest, MaskDeleteWithViewerFocusDoesNotDeleteGrade) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.major_radius = 0.18f;
+  radial.minor_radius = 0.12f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  const auto grade_id = harness.document.PrimaryGrade()->Id();
+  ASSERT_TRUE(harness.controller.RemoveMask(grade_id, MaskId{"mask.radial"}).accepted);
+  EXPECT_NE(harness.document.PrimaryGrade(), nullptr);
+  EXPECT_EQ(harness.document.PrimaryGrade()->Id(), grade_id);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
+}
+
+TEST(AnalyticMaskCreationTest, GradientBoundaryDragPreservesOriginAndChangesTransition) {
+  AnalyticCreationHarness harness;
+  LinearGradientMaskSource linear;
+  linear.origin_x            = 0.50f;
+  linear.origin_y            = 0.50f;
+  linear.normal_x            = 0.0f;
+  linear.normal_y            = 1.0f;
+  linear.transition_distance = 0.24f;
+  grade_mask_test::AddLinearGradientMask(harness.document, MaskId{"mask.linear"}, linear);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.linear"},
+                              harness.session)
+                  .accepted);
+  const Vector2 end{linear.origin_x, linear.origin_y + 0.40f};
+  const auto    press = SampleOf(harness.mapping, ItemOf(harness.mapping, end), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::LinearEndBoundary, press, harness.pointer)
+                  .accepted);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(press, harness.pointer).accepted);
+  const auto* live = std::get_if<LinearGradientMaskSource>(
+      &harness.document.PrimaryGrade()->FindMask(MaskId{"mask.linear"})->source);
+  ASSERT_NE(live, nullptr);
+  EXPECT_NEAR(live->origin_x, linear.origin_x, 1.0e-5f);
+  EXPECT_NEAR(live->origin_y, linear.origin_y, 1.0e-5f);
+  EXPECT_GT(live->transition_distance, linear.transition_distance);
+}
+
+TEST(AnalyticMaskCreationTest, AnalyticControlCancelRestoresSourceWithoutHistory) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.center_x     = 0.50f;
+  radial.center_y      = 0.50f;
+  radial.major_radius  = 0.22f;
+  radial.minor_radius  = 0.16f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  const auto head_before = harness.history.working_head();
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+                  .accepted);
+  const auto moved =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.30f, 0.60f}), true);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
+  ASSERT_TRUE(harness.controller.CancelMaskInput().accepted);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  const auto* live = std::get_if<RadialMaskSource>(
+      &harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"})->source);
+  ASSERT_NE(live, nullptr);
+  EXPECT_FLOAT_EQ(live->center_x, radial.center_x);
+  EXPECT_FLOAT_EQ(live->center_y, radial.center_y);
+}
+
+TEST(AnalyticMaskCreationTest, CoincidentRadialBoundariesKeepFeatherControlsReachable) {
+  AnalyticCreationHarness harness;
+  RadialMaskSource        radial;
+  radial.center_x      = 0.50f;
+  radial.center_y      = 0.50f;
+  radial.major_radius  = 0.22f;
+  radial.minor_radius  = 0.16f;
+  radial.inner_feather = 0.0f;
+  radial.outer_feather = 0.0f;
+  grade_mask_test::AddRadialMask(harness.document, MaskId{"mask.radial"}, radial);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  const auto inner_press = SampleOf(
+      harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 0.70f, 0.0f)),
+      false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, inner_press,
+                                  harness.pointer)
+                  .accepted);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(inner_press, harness.pointer).accepted);
+  ASSERT_TRUE(harness.controller.FinishMaskInput().accepted);
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.radial"},
+                              harness.session)
+                  .accepted);
+  MaskPointerIdentity outer_pointer = harness.pointer;
+  outer_pointer.sequence_id          = 12;
+  const auto outer_press = SampleOf(
+      harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 1.35f, 0.0f)),
+      false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press,
+                                  outer_pointer)
+                  .accepted);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(outer_press, outer_pointer).accepted);
+  const auto* live = std::get_if<RadialMaskSource>(
+      &harness.document.PrimaryGrade()->FindMask(MaskId{"mask.radial"})->source);
+  ASSERT_NE(live, nullptr);
+  EXPECT_FLOAT_EQ(live->center_x, radial.center_x);
+  EXPECT_FLOAT_EQ(live->center_y, radial.center_y);
+  EXPECT_GT(live->inner_feather, 0.0f);
+  EXPECT_GT(live->outer_feather, 0.0f);
+}
+
+TEST(AnalyticMaskCreationTest, MaskListDeletionChoosesNextThenPrevious) {
+  const MaskId first{"mask.a"};
+  const MaskId second{"mask.b"};
+  const MaskId third{"mask.c"};
+  const MaskId ids[] = {first, second, third};
+  EXPECT_EQ(MaskIdAfterDeletion(ids, first, first), second);
+  EXPECT_EQ(MaskIdAfterDeletion(ids, third, third), second);
+  EXPECT_EQ(MaskIdAfterDeletion(ids, second, first), first);
+  EXPECT_EQ(MaskIdAfterUndoRestore(first, MaskId{}), first);
+  EXPECT_EQ(MaskIdAfterUndoRestore(first, second), second);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
@@ -23,7 +23,6 @@
 #include <QUrl>
 #include <QVariantList>
 #include <QVariantMap>
-
 #include <filesystem>
 #include <memory>
 #include <mutex>
@@ -38,6 +37,84 @@ namespace {
 
 constexpr auto kEmDash = "\xE2\x80\x94";
 
+class FakeMaskCreation final : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(bool bodyVisible READ bodyVisible NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool maskControlsActive READ maskControlsActive NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool creating READ creating NOTIFY maskCreationChanged)
+  Q_PROPERTY(QString toolKind READ toolKind NOTIFY maskCreationChanged)
+  Q_PROPERTY(QString selectedMaskId READ selectedMaskId NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal majorRadiusPercent READ majorRadiusPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal minorRadiusPercent READ minorRadiusPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal rotationDegrees READ rotationDegrees NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal innerFeatherPercent READ innerFeatherPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal outerFeatherPercent READ outerFeatherPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal transitionPercent READ transitionPercent NOTIFY maskCreationChanged)
+
+ public:
+  auto             bodyVisible() const -> bool { return active_; }
+  auto             maskControlsActive() const -> bool { return active_; }
+  auto             creating() const -> bool { return creating_; }
+  auto             toolKind() const -> QString { return tool_kind_; }
+  auto             selectedMaskId() const -> QString { return selected_mask_id_; }
+  auto             majorRadiusPercent() const -> qreal { return 28.0; }
+  auto             minorRadiusPercent() const -> qreal { return 18.0; }
+  auto             rotationDegrees() const -> qreal { return 20.0; }
+  auto             innerFeatherPercent() const -> qreal { return 25.0; }
+  auto             outerFeatherPercent() const -> qreal { return 20.0; }
+  auto             transitionPercent() const -> qreal { return 30.0; }
+  auto             finishCount() const -> int { return finish_count_; }
+
+  Q_INVOKABLE void beginRadial() { Open(QStringLiteral("radial"), true); }
+  Q_INVOKABLE void beginLinear() { Open(QStringLiteral("linear"), true); }
+  Q_INVOKABLE void cancel() { Close(); }
+  Q_INVOKABLE void hideBody() { finishBody(); }
+  Q_INVOKABLE void finishBody() {
+    ++finish_count_;
+    Close();
+  }
+  Q_INVOKABLE void beginMajorRadius() {}
+  Q_INVOKABLE void updateMajorRadius(qreal) {}
+  Q_INVOKABLE void beginMinorRadius() {}
+  Q_INVOKABLE void updateMinorRadius(qreal) {}
+  Q_INVOKABLE void beginRotation() {}
+  Q_INVOKABLE void updateRotation(qreal) {}
+  Q_INVOKABLE void beginInnerFeather() {}
+  Q_INVOKABLE void updateInnerFeather(qreal) {}
+  Q_INVOKABLE void beginOuterFeather() {}
+  Q_INVOKABLE void updateOuterFeather(qreal) {}
+  Q_INVOKABLE void beginTransition() {}
+  Q_INVOKABLE void updateTransition(qreal) {}
+  Q_INVOKABLE void finishAnalyticControl() {}
+
+  void             SelectExisting(const QString& kind) { Open(kind, false); }
+
+ signals:
+  void maskCreationChanged();
+
+ private:
+  void Open(const QString& kind, bool creating) {
+    active_           = true;
+    creating_         = creating;
+    tool_kind_        = kind;
+    selected_mask_id_ = creating ? QString{} : QStringLiteral("mask.selected");
+    emit maskCreationChanged();
+  }
+  void Close() {
+    active_   = false;
+    creating_ = false;
+    tool_kind_.clear();
+    selected_mask_id_.clear();
+    emit maskCreationChanged();
+  }
+
+  bool    active_   = false;
+  bool    creating_ = false;
+  QString tool_kind_;
+  QString selected_mask_id_;
+  int     finish_count_ = 0;
+};
+
 class HeaderSession final : public QObject, public IEditorAdjustmentSubmitter {
   Q_OBJECT
   Q_PROPERTY(
@@ -50,8 +127,10 @@ class HeaderSession final : public QObject, public IEditorAdjustmentSubmitter {
   Q_PROPERTY(QString exifIsoText READ exifIsoText NOTIFY ImageExifChanged)
   Q_PROPERTY(QString exifApertureText READ exifApertureText NOTIFY ImageExifChanged)
   Q_PROPERTY(QString exifFocalText READ exifFocalText NOTIFY ImageExifChanged)
+  Q_PROPERTY(QObject* maskCreation READ maskCreation CONSTANT)
 
  public:
+  explicit HeaderSession(QObject* mask_creation = nullptr) : mask_creation_(mask_creation) {}
   auto adjustmentSnapshot() const -> QVariantMap { return snapshot_; }
   auto snapshotRevision() const -> quint64 { return revision_; }
   auto activeAdjustmentPanel() const -> QString { return panel_; }
@@ -67,15 +146,16 @@ class HeaderSession final : public QObject, public IEditorAdjustmentSubmitter {
   auto exifIsoText() const -> QString { return iso_; }
   auto exifApertureText() const -> QString { return aperture_; }
   auto exifFocalText() const -> QString { return focal_; }
+  auto maskCreation() const -> QObject* { return mask_creation_; }
 
   void setExif(const QString& shutter, const QString& iso, const QString& aperture,
-              const QString& focal) {
-    shutter_  = shutter;
-    iso_      = iso;
-    aperture_ = aperture;
-    focal_    = focal;
+               const QString& focal) {
+    shutter_           = shutter;
+    iso_               = iso;
+    aperture_          = aperture;
+    focal_             = focal;
     const QString dash = QString::fromUtf8(kEmDash);
-    QStringList parts;
+    QStringList   parts;
     for (const auto& token : {focal, aperture, shutter, iso}) {
       if (!token.isEmpty() && token != dash) {
         parts.push_back(token);
@@ -116,22 +196,23 @@ class HeaderSession final : public QObject, public IEditorAdjustmentSubmitter {
 
  private:
   QVariantMap snapshot_;
-  quint64     revision_     = 0;
-  QString     panel_        = QStringLiteral("tone");
-  QString     line_         = QString::fromUtf8(kEmDash);
-  QString     shutter_      = QString::fromUtf8(kEmDash);
-  QString     iso_          = QString::fromUtf8(kEmDash);
-  QString     aperture_     = QString::fromUtf8(kEmDash);
-  QString     focal_        = QString::fromUtf8(kEmDash);
-  int         submit_count_ = 0;
+  quint64     revision_      = 0;
+  QString     panel_         = QStringLiteral("tone");
+  QString     line_          = QString::fromUtf8(kEmDash);
+  QString     shutter_       = QString::fromUtf8(kEmDash);
+  QString     iso_           = QString::fromUtf8(kEmDash);
+  QString     aperture_      = QString::fromUtf8(kEmDash);
+  QString     focal_         = QString::fromUtf8(kEmDash);
+  int         submit_count_  = 0;
+  QObject*    mask_creation_ = nullptr;
 };
 
 class FakeNodeController final : public QObject {
   Q_OBJECT
   Q_PROPERTY(QString selectedNodeName READ selectedNodeName NOTIFY SelectionChanged)
   Q_PROPERTY(QString selectedNodeKind READ selectedNodeKind NOTIFY SelectionChanged)
-  Q_PROPERTY(QStringList supportedAdjustmentPanels READ supportedAdjustmentPanels NOTIFY
-                 SelectionChanged)
+  Q_PROPERTY(
+      QStringList supportedAdjustmentPanels READ supportedAdjustmentPanels NOTIFY SelectionChanged)
   Q_PROPERTY(QVariantList selectedNodeMasks READ selectedNodeMasks NOTIFY SelectionChanged)
 
  public:
@@ -151,8 +232,8 @@ class FakeNodeController final : public QObject {
   void SelectionChanged();
 
  private:
-  QString      name_ = QStringLiteral("Color Grade");
-  QString      kind_ = QStringLiteral("colorGrade");
+  QString      name_   = QStringLiteral("Color Grade");
+  QString      kind_   = QStringLiteral("colorGrade");
   QStringList  panels_ = {QStringLiteral("tone"), QStringLiteral("look"), QStringLiteral("lut"),
                           QStringLiteral("masks")};
   QVariantList masks_;
@@ -161,7 +242,8 @@ class FakeNodeController final : public QObject {
 class FakeLutCatalogModel final : public QObject {
   Q_OBJECT
   Q_PROPERTY(QVariantList entries READ entries NOTIFY entriesChanged)
-  Q_PROPERTY(QString selectedPath READ selectedPath WRITE setSelectedPath NOTIFY selectedPathChanged)
+  Q_PROPERTY(
+      QString selectedPath READ selectedPath WRITE setSelectedPath NOTIFY selectedPathChanged)
   Q_PROPERTY(int selectedIndex READ selectedIndex NOTIFY selectedPathChanged)
 
  public:
@@ -237,7 +319,8 @@ class StackHarness {
     engine_.rootContext()->setContextProperty(QStringLiteral("appTheme"), &AppTheme::Instance());
 
     QQmlComponent component(
-        &engine_, QUrl::fromLocalFile(QmlDirectory() + QStringLiteral("/EditorAdjustmentStack.qml")));
+        &engine_,
+        QUrl::fromLocalFile(QmlDirectory() + QStringLiteral("/EditorAdjustmentStack.qml")));
     if (component.isError()) {
       errors_ = component.errors();
       return;
@@ -285,8 +368,8 @@ class StackHarness {
 
 void ExpectNavPresent(const StackHarness& harness) {
   for (const auto& panel : {QStringLiteral("tone"), QStringLiteral("look"), QStringLiteral("lut"),
-                             QStringLiteral("display"), QStringLiteral("geometry"),
-                             QStringLiteral("raw")}) {
+                            QStringLiteral("display"), QStringLiteral("geometry"),
+                            QStringLiteral("raw"), QStringLiteral("masks")}) {
     ASSERT_NE(harness.find(QStringLiteral("editorAdjustmentNav_") + panel), nullptr)
         << panel.toStdString();
   }
@@ -311,8 +394,7 @@ void ExpectMaskToolButtons(const StackHarness& harness) {
   ASSERT_NE(brush, nullptr);
   ASSERT_NE(radial, nullptr);
   ASSERT_NE(gradient, nullptr);
-  EXPECT_EQ(brush->property("iconSrc").toUrl(),
-            QUrl(QStringLiteral("qrc:/mask_icons/brush.svg")));
+  EXPECT_EQ(brush->property("iconSrc").toUrl(), QUrl(QStringLiteral("qrc:/mask_icons/brush.svg")));
   EXPECT_EQ(radial->property("iconSrc").toUrl(),
             QUrl(QStringLiteral("qrc:/mask_icons/radial.svg")));
   EXPECT_EQ(gradient->property("iconSrc").toUrl(),
@@ -331,7 +413,8 @@ void ExpectExifAboveNameRow(const StackHarness& harness) {
 }
 
 void ExpectFourEqualExifTokens(const StackHarness& harness, const QString& focal,
-                               const QString& aperture, const QString& shutter, const QString& iso) {
+                               const QString& aperture, const QString& shutter,
+                               const QString& iso) {
   auto* focal_item    = harness.find(QStringLiteral("editorAdjustmentHeaderFocal"));
   auto* aperture_item = harness.find(QStringLiteral("editorAdjustmentHeaderAperture"));
   auto* shutter_item  = harness.find(QStringLiteral("editorAdjustmentHeaderShutter"));
@@ -372,19 +455,19 @@ void ExpectNameThenMaskTools(const StackHarness& harness) {
   ASSERT_NE(radial, nullptr);
   ASSERT_NE(gradient, nullptr);
   EXPECT_EQ(harness.find(QStringLiteral("editorAdjustmentHeaderDivider")), nullptr);
-  const qreal name_right     = name->mapToItem(root, QPointF(name->width(), 0)).x();
-  const qreal brush_left     = brush->mapToItem(root, QPointF(0, 0)).x();
-  const qreal brush_right    = brush->mapToItem(root, QPointF(brush->width(), 0)).x();
-  const qreal radial_left    = radial->mapToItem(root, QPointF(0, 0)).x();
-  const qreal radial_right   = radial->mapToItem(root, QPointF(radial->width(), 0)).x();
-  const qreal gradient_left  = gradient->mapToItem(root, QPointF(0, 0)).x();
+  const qreal name_right    = name->mapToItem(root, QPointF(name->width(), 0)).x();
+  const qreal brush_left    = brush->mapToItem(root, QPointF(0, 0)).x();
+  const qreal brush_right   = brush->mapToItem(root, QPointF(brush->width(), 0)).x();
+  const qreal radial_left   = radial->mapToItem(root, QPointF(0, 0)).x();
+  const qreal radial_right  = radial->mapToItem(root, QPointF(radial->width(), 0)).x();
+  const qreal gradient_left = gradient->mapToItem(root, QPointF(0, 0)).x();
   EXPECT_LE(name_right, brush_left + 0.5);
   EXPECT_LE(brush_right, radial_left + 0.5);
   EXPECT_LE(radial_right, gradient_left + 0.5);
 }
 
 TEST(EditorAdjustmentHeaderQmlTest, HeaderAtMinPreferredAndMaxWidthKeepsNameAndExifAboveNav) {
-  HeaderSession     session;
+  HeaderSession      session;
   FakeNodeController nodes;
   session.setExif(QStringLiteral("1/250s"), QStringLiteral("ISO 100"), QStringLiteral("f2.8"),
                   QStringLiteral("50mm"));
@@ -415,7 +498,7 @@ TEST(EditorAdjustmentHeaderQmlTest, HeaderAtMinPreferredAndMaxWidthKeepsNameAndE
 TEST(EditorAdjustmentHeaderQmlTest, LongNodeNameElidesAndKeepsFullAccessibleName) {
   HeaderSession      session;
   FakeNodeController nodes;
-  const QString long_name =
+  const QString      long_name =
       QStringLiteral("Color Grade with an extremely long display name for elision");
   nodes.setSelection(long_name, QStringLiteral("colorGrade"),
                      {QStringLiteral("tone"), QStringLiteral("look")});
@@ -436,8 +519,8 @@ TEST(EditorAdjustmentHeaderQmlTest, MissingExifShowsEmDashOnFourTokens) {
   FakeNodeController nodes;
   StackHarness       harness(&session, &nodes, 320);
   ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
-  const QString dash = QString::fromUtf8(kEmDash);
-  auto* header = harness.find(QStringLiteral("editorAdjustmentHeader"));
+  const QString dash   = QString::fromUtf8(kEmDash);
+  auto*         header = harness.find(QStringLiteral("editorAdjustmentHeader"));
   ASSERT_NE(header, nullptr);
   EXPECT_EQ(header->property("focalText").toString(), dash);
   EXPECT_EQ(header->property("apertureText").toString(), dash);
@@ -475,9 +558,9 @@ TEST(EditorAdjustmentHeaderQmlTest, BothThemesMapHeaderInkToAppThemeTokens) {
                      {QStringLiteral("raw"), QStringLiteral("geometry")});
   StackHarness harness(&session, &nodes, 320);
   ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
-  auto& theme = AppTheme::Instance();
-  const int original = theme.currentThemeIndex();
-  const auto themes  = theme.availableThemes();
+  auto&      theme    = AppTheme::Instance();
+  const int  original = theme.currentThemeIndex();
+  const auto themes   = theme.availableThemes();
   ASSERT_GE(themes.size(), 2);
 
   auto* name  = harness.find(QStringLiteral("editorAdjustmentHeaderNodeName"));
@@ -497,7 +580,7 @@ TEST(EditorAdjustmentHeaderQmlTest, BothThemesMapHeaderInkToAppThemeTokens) {
 TEST(EditorAdjustmentHeaderQmlTest, ReduceMotionAndTitleSizeKeepHeaderAboveNav) {
   HeaderSession      session;
   FakeNodeController nodes;
-  const QString long_name = QStringLiteral("Second Color Grade with wrapped title text");
+  const QString      long_name = QStringLiteral("Second Color Grade with wrapped title text");
   nodes.setSelection(long_name, QStringLiteral("colorGrade"),
                      {QStringLiteral("tone"), QStringLiteral("look"), QStringLiteral("lut")});
   AppTheme::Instance().setReduceMotion(true);
@@ -529,6 +612,67 @@ TEST(EditorAdjustmentHeaderQmlTest, NavbarKeepsAllPagesWhenSelectedNodeKindChang
                                         Q_ARG(QVariant, QVariant(QStringLiteral("geometry")))));
   ProcessEvents(20);
   EXPECT_EQ(session.activeAdjustmentPanel(), QStringLiteral("geometry"));
+}
+
+TEST(EditorAdjustmentHeaderQmlTest, MaskPageActivatesOnlyForSelectedOrCreatingMask) {
+  FakeMaskCreation   mask_creation;
+  HeaderSession      session(&mask_creation);
+  FakeNodeController nodes;
+  StackHarness       harness(&session, &nodes, 320);
+  ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
+  auto* nav   = harness.find(QStringLiteral("editorAdjustmentNav_masks"));
+  auto* panel = harness.find(QStringLiteral("editorAdjustmentPanel_masks"));
+  ASSERT_NE(nav, nullptr);
+  ASSERT_NE(panel, nullptr);
+  EXPECT_FALSE(nav->isEnabled());
+  EXPECT_EQ(harness.find(QStringLiteral("editorMasksDoneButton")), nullptr);
+  EXPECT_EQ(harness.find(QStringLiteral("editorMasksCancelButton")), nullptr);
+
+  mask_creation.beginRadial();
+  ProcessEvents(20);
+  EXPECT_TRUE(nav->isEnabled());
+  EXPECT_EQ(session.activeAdjustmentPanel(), QStringLiteral("masks"));
+  auto* radius = harness.find(QStringLiteral("editorMasksMajorRadiusSlider"));
+  ASSERT_NE(radius, nullptr);
+  EXPECT_FALSE(radius->isVisible());
+
+  mask_creation.SelectExisting(QStringLiteral("radial"));
+  ProcessEvents(20);
+  EXPECT_TRUE(radius->isVisible());
+  EXPECT_NE(harness.find(QStringLiteral("editorMasksMinorRadiusSlider")), nullptr);
+  EXPECT_NE(harness.find(QStringLiteral("editorMasksRotationSlider")), nullptr);
+  EXPECT_NE(harness.find(QStringLiteral("editorMasksInnerFeatherSlider")), nullptr);
+  EXPECT_NE(harness.find(QStringLiteral("editorMasksOuterFeatherSlider")), nullptr);
+
+  ASSERT_TRUE(QMetaObject::invokeMethod(harness.root(), "selectPanel",
+                                        Q_ARG(QVariant, QVariant(QStringLiteral("look")))));
+  ProcessEvents(20);
+  EXPECT_EQ(mask_creation.finishCount(), 1);
+  EXPECT_EQ(session.activeAdjustmentPanel(), QStringLiteral("look"));
+  EXPECT_FALSE(nav->isEnabled());
+}
+
+TEST(EditorAdjustmentHeaderQmlTest, EnterEquivalentFinishesMaskEditAndRestoresPanel) {
+  FakeMaskCreation   mask_creation;
+  HeaderSession      session(&mask_creation);
+  FakeNodeController nodes;
+  session.setActiveAdjustmentPanel(QStringLiteral("lut"));
+  StackHarness harness(&session, &nodes, 320);
+  ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
+  mask_creation.SelectExisting(QStringLiteral("linear"));
+  ProcessEvents(20);
+  EXPECT_EQ(session.activeAdjustmentPanel(), QStringLiteral("masks"));
+  auto* transition = harness.find(QStringLiteral("editorMasksTransitionSlider"));
+  ASSERT_NE(transition, nullptr);
+  EXPECT_TRUE(transition->isVisible());
+
+  QVariant returned;
+  ASSERT_TRUE(QMetaObject::invokeMethod(harness.root(), "confirmMaskEditAndReturn",
+                                        Q_RETURN_ARG(QVariant, returned)));
+  ProcessEvents(20);
+  EXPECT_TRUE(returned.toBool());
+  EXPECT_EQ(mask_creation.finishCount(), 1);
+  EXPECT_EQ(session.activeAdjustmentPanel(), QStringLiteral("lut"));
 }
 
 TEST(EditorAdjustmentHeaderQmlTest, GeometryPanelStatesWholeImageScope) {
@@ -587,7 +731,7 @@ TEST(EditorAdjustmentHeaderQmlTest, LutSelectionAndScrollSurviveStackLoadWithout
     ProcessEvents(20);
   }
   const qreal y_before = list->property("contentY").toReal();
-  const int   submits   = session.submitCount();
+  const int   submits  = session.submitCount();
 
   QVariantMap lut_entry;
   lut_entry.insert(QStringLiteral("path"), QStringLiteral("D:/fake/lut_12.cube"));

--- a/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
@@ -35,7 +35,7 @@
 namespace alcedo::ui::test {
 namespace {
 
-constexpr auto kEmDash = "\xE2\x80\x94";
+constexpr auto         kEmDash = "\xE2\x80\x94";
 
 class FakeMaskCreation final : public QObject {
   Q_OBJECT
@@ -130,11 +130,41 @@ class HeaderSession final : public QObject, public IEditorAdjustmentSubmitter {
   Q_PROPERTY(QObject* maskCreation READ maskCreation CONSTANT)
 
  public:
-  explicit HeaderSession(QObject* mask_creation = nullptr) : mask_creation_(mask_creation) {}
+  explicit HeaderSession(QObject* mask_creation = nullptr) : mask_creation_(mask_creation) {
+    auto* mask = qobject_cast<FakeMaskCreation*>(mask_creation_);
+    if (mask == nullptr) {
+      return;
+    }
+    connect(mask, &FakeMaskCreation::maskCreationChanged, this, [this, mask] {
+      const bool active = mask->maskControlsActive();
+      if (active == mask_edit_was_active_) {
+        return;
+      }
+      mask_edit_was_active_ = active;
+      if (active) {
+        if (panel_ != QLatin1String("masks")) {
+          panel_before_mask_edit_ = panel_;
+          SetPanel(QStringLiteral("masks"));
+        }
+      } else if (!mask_panel_transition_ && panel_ == QLatin1String("masks")) {
+        SetPanel(panel_before_mask_edit_);
+      }
+    });
+  }
   auto adjustmentSnapshot() const -> QVariantMap { return snapshot_; }
   auto snapshotRevision() const -> quint64 { return revision_; }
   auto activeAdjustmentPanel() const -> QString { return panel_; }
   void setActiveAdjustmentPanel(const QString& panel) {
+    auto* mask = qobject_cast<FakeMaskCreation*>(mask_creation_);
+    if (panel != QLatin1String("masks") && mask != nullptr && mask->maskControlsActive()) {
+      mask_panel_transition_ = true;
+      mask->finishBody();
+      mask_panel_transition_ = false;
+    }
+    SetPanel(panel);
+  }
+
+  void SetPanel(const QString& panel) {
     if (panel_ == panel) {
       return;
     }
@@ -196,15 +226,18 @@ class HeaderSession final : public QObject, public IEditorAdjustmentSubmitter {
 
  private:
   QVariantMap snapshot_;
-  quint64     revision_      = 0;
-  QString     panel_         = QStringLiteral("tone");
-  QString     line_          = QString::fromUtf8(kEmDash);
-  QString     shutter_       = QString::fromUtf8(kEmDash);
-  QString     iso_           = QString::fromUtf8(kEmDash);
-  QString     aperture_      = QString::fromUtf8(kEmDash);
-  QString     focal_         = QString::fromUtf8(kEmDash);
-  int         submit_count_  = 0;
-  QObject*    mask_creation_ = nullptr;
+  quint64     revision_               = 0;
+  QString     panel_                  = QStringLiteral("tone");
+  QString     line_                   = QString::fromUtf8(kEmDash);
+  QString     shutter_                = QString::fromUtf8(kEmDash);
+  QString     iso_                    = QString::fromUtf8(kEmDash);
+  QString     aperture_               = QString::fromUtf8(kEmDash);
+  QString     focal_                  = QString::fromUtf8(kEmDash);
+  int         submit_count_           = 0;
+  QObject*    mask_creation_          = nullptr;
+  QString     panel_before_mask_edit_ = QStringLiteral("tone");
+  bool        mask_edit_was_active_   = false;
+  bool        mask_panel_transition_  = false;
 };
 
 class FakeNodeController final : public QObject {

--- a/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
+++ b/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
@@ -380,6 +380,14 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
 
   void SetBlockVersionOps(bool block) { block_version_ops_ = block; }
   void SetFailNodeCommands(bool fail) { fail_node_commands_ = fail; }
+  void AddMaskToPrimaryGrade(MaskModel mask) {
+    auto* grade = document_->PrimaryGrade();
+    if (grade == nullptr) {
+      return;
+    }
+    grade->AddMask(std::move(mask), grade->Masks().size());
+    NotifyHistoryChange();
+  }
 
  private:
   auto Accepted(const char* message) const -> EditorSessionResult {

--- a/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
+++ b/alcedo_studio/tests/ui/editor_history_versions_rail_qml_harness.hpp
@@ -22,6 +22,7 @@
 #include <QUrl>
 #include <QVariantList>
 #include <QVariantMap>
+#include <QuickQanava>
 #include <algorithm>
 #include <filesystem>
 #include <functional>
@@ -40,8 +41,6 @@
 #include "ui/alcedo_main/album_backend/editor_session_controller.hpp"
 #include "ui/alcedo_main/app_theme.hpp"
 
-#include <QuickQanava>
-
 namespace alcedo::ui::test {
 namespace rail_harness {
 
@@ -59,31 +58,31 @@ inline auto MakeVersion(const Hash128& id, std::string name, const head_commit_h
   return version;
 }
 
-inline auto MakeCommit(const Hash128& id, std::string field_key, std::string before_value_json,
-                       std::string after_value_json,
-                       const head_commit_hash_t&     first_parent  = std::nullopt,
-                       EditorHistoryTimelinePosition position =
-                           EditorHistoryTimelinePosition::Applied) -> EditorHistoryCommit {
+inline auto MakeCommit(
+    const Hash128& id, std::string field_key, std::string before_value_json,
+    std::string after_value_json, const head_commit_hash_t& first_parent = std::nullopt,
+    EditorHistoryTimelinePosition position = EditorHistoryTimelinePosition::Applied)
+    -> EditorHistoryCommit {
   EditorHistoryCommit commit;
-  commit.commit_hash        = id;
-  commit.first_parent_hash  = first_parent;
-  commit.created_at_ns      = id.low64();
-  commit.field_key          = std::move(field_key);
-  commit.before_value_json  = std::move(before_value_json);
-  commit.after_value_json   = std::move(after_value_json);
-  commit.before_enabled     = true;
-  commit.after_enabled      = true;
-  commit.position           = position;
+  commit.commit_hash       = id;
+  commit.first_parent_hash = first_parent;
+  commit.created_at_ns     = id.low64();
+  commit.field_key         = std::move(field_key);
+  commit.before_value_json = std::move(before_value_json);
+  commit.after_value_json  = std::move(after_value_json);
+  commit.before_enabled    = true;
+  commit.after_enabled     = true;
+  commit.position          = position;
   return commit;
 }
 
 class RecordingEditorSessionBackend final : public IEditorSessionBackend {
  public:
   RecordingEditorSessionBackend() {
-    const auto first_version   = StableId(1);
-    const auto second_version  = StableId(2);
-    const auto first_commit    = StableId(11);
-    const auto second_commit   = StableId(12);
+    const auto first_version    = StableId(1);
+    const auto second_version   = StableId(2);
+    const auto first_commit     = StableId(11);
+    const auto second_commit    = StableId(12);
 
     snapshot_.active_version_id = first_version;
     snapshot_.active_head       = second_commit;
@@ -110,7 +109,7 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
   [[nodiscard]] auto last_error() const -> std::string override { return last_error_; }
   [[nodiscard]] auto action_availability() const -> alcedo::EditorActionAvailability override {
     alcedo::EditorActionAvailability availability;
-    auto allow = [&](alcedo::EditorAction action, bool enabled) {
+    auto                             allow = [&](alcedo::EditorAction action, bool enabled) {
       availability.decisions[static_cast<std::size_t>(action)].allowed = enabled;
     };
     allow(alcedo::EditorAction::Undo, snapshot_.can_undo);
@@ -180,7 +179,7 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
   auto BranchFromCommit(const commit_hash_t& commit_id, std::string display_name)
       -> EditorSessionResult override {
     last_branch_name_ = display_name;
-    const auto id = StableId(next_version_id_++);
+    const auto id     = StableId(next_version_id_++);
     for (auto& version : snapshot_.versions) version.active = false;
     snapshot_.versions.push_back(MakeVersion(id, std::move(display_name), commit_id, true));
     snapshot_.active_version_id = id;
@@ -264,6 +263,32 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
     return Accepted("View changed");
   }
 
+  auto EnqueueMaskCreation(EditorMaskCreationCommand command) -> EditorSessionResult override {
+    mask_commands_pending_ = true;
+    mask_commands_.push_back(std::move(command));
+    return Accepted("Mask command queued");
+  }
+
+  [[nodiscard]] auto mask_creation_commands_pending() const -> bool override {
+    return mask_commands_pending_;
+  }
+
+  [[nodiscard]] auto mask_creation_node_id() const -> NodeId override {
+    return selected_mask_node_id_;
+  }
+
+  [[nodiscard]] auto mask_creation_mask_id() const -> MaskId override { return selected_mask_id_; }
+
+  [[nodiscard]] auto mask_creation_source() const -> std::optional<MaskSource> override {
+    if (selected_mask_node_id_.Empty() || selected_mask_id_.Empty()) {
+      return std::nullopt;
+    }
+    const auto* node  = document_->Graph().FindNode(selected_mask_node_id_);
+    const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(node);
+    const auto* mask  = grade == nullptr ? nullptr : grade->FindMask(selected_mask_id_);
+    return mask == nullptr ? std::nullopt : std::optional<MaskSource>{mask->source};
+  }
+
   auto RenameColorGrade(const NodeId& node_id, std::string display_name)
       -> EditorSessionResult override {
     if (fail_node_commands_) return Rejected("mini-Git journal append failed");
@@ -277,8 +302,8 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
 
   auto EditNodeGraph(NodeGraphTopologyChange change) -> EditorSessionResult override {
     if (fail_node_commands_) return Rejected("mini-Git journal append failed");
-    const auto errors = ApplyNodeGraphTopologyChange(*document_, change,
-                                                     PipelineEditApplyDirection::Forward);
+    const auto errors =
+        ApplyNodeGraphTopologyChange(*document_, change, PipelineEditApplyDirection::Forward);
     if (!errors.empty()) return Rejected(errors.front().message.c_str());
     last_topology_change_ = std::move(change);
     ++edit_node_graph_count_;
@@ -319,16 +344,17 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
     last_move_head_commit_ = commit_id;
     snapshot_.active_head  = commit_id;
     for (auto& commit : snapshot_.commits) {
-      commit.position = (commit.commit_hash == commit_id)
-                            ? EditorHistoryTimelinePosition::Current
-                            : EditorHistoryTimelinePosition::Applied;
+      commit.position = (commit.commit_hash == commit_id) ? EditorHistoryTimelinePosition::Current
+                                                          : EditorHistoryTimelinePosition::Applied;
     }
     NotifyHistoryChange();
     return Accepted("Head moved");
   }
 
   [[nodiscard]] auto history_snapshot() -> EditorHistorySnapshot override { return snapshot_; }
-  [[nodiscard]] auto history_revision() const -> std::uint64_t override { return history_revision_; }
+  [[nodiscard]] auto history_revision() const -> std::uint64_t override {
+    return history_revision_;
+  }
   [[nodiscard]] auto active_version_id() const -> version_ref_id_t override {
     return snapshot_.active_version_id;
   }
@@ -365,6 +391,9 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
     return last_topology_change_;
   }
   [[nodiscard]] auto last_renamed_node_id() const -> NodeId { return last_renamed_node_id_; }
+  [[nodiscard]] auto mask_commands() const -> const std::vector<EditorMaskCreationCommand>& {
+    return mask_commands_;
+  }
 
   void SetRecovery(bool pending, std::string error = {}) {
     recovery_pending_ = pending;
@@ -386,6 +415,32 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
       return;
     }
     grade->AddMask(std::move(mask), grade->Masks().size());
+    NotifyHistoryChange();
+  }
+
+  void CompleteMaskCommands() {
+    for (const auto& command : mask_commands_) {
+      if (command.kind == EditorMaskCreationCommandKind::SelectMask) {
+        selected_mask_node_id_ = command.node_id;
+        selected_mask_id_      = command.mask_id;
+      } else if (command.kind == EditorMaskCreationCommandKind::RemoveMask) {
+        auto* node  = document_->Graph().FindNode(command.node_id);
+        auto* grade = dynamic_cast<ColorGradeNodeModel*>(node);
+        if (grade != nullptr && grade->FindMask(command.mask_id) != nullptr) {
+          grade->RemoveMask(command.mask_id);
+        }
+        if (selected_mask_id_ == command.mask_id) {
+          selected_mask_node_id_ = {};
+          selected_mask_id_      = {};
+        }
+      } else if (command.kind == EditorMaskCreationCommandKind::FinishMode ||
+                 command.kind == EditorMaskCreationCommandKind::CancelMode) {
+        selected_mask_node_id_ = {};
+        selected_mask_id_      = {};
+      }
+    }
+    mask_commands_.clear();
+    mask_commands_pending_ = false;
     NotifyHistoryChange();
   }
 
@@ -414,46 +469,50 @@ class RecordingEditorSessionBackend final : public IEditorSessionBackend {
     NotifyChange();
   }
 
-  std::uint64_t         history_revision_            = 0;
+  std::uint64_t                     history_revision_ = 0;
 
-  EditorSessionState    state_     = EditorSessionState::Interactive;
-  bool                  has_image_ = true;
-  EditorSessionIdentity identity_{1, 2};
-  EditorHistorySnapshot snapshot_;
+  EditorSessionState                state_            = EditorSessionState::Interactive;
+  bool                              has_image_        = true;
+  EditorSessionIdentity             identity_{1, 2};
+  EditorHistorySnapshot             snapshot_;
   std::shared_ptr<PipelineDocument> document_ =
       std::make_shared<PipelineDocument>(CreateDefaultPipelineDocument());
-  std::uint64_t         next_version_id_ = 20;
-  Hash128               last_checkout_id_;
-  Hash128               last_created_id_;
-  Hash128               last_rename_id_;
-  Hash128               last_removed_id_;
-  Hash128               last_move_head_commit_;
-  Hash128               last_branch_commit_;
-  std::string           last_branch_name_;
-  int                   checkout_count_              = 0;
-  int                   create_count_                = 0;
-  int                   rename_count_                = 0;
-  int                   remove_count_                = 0;
-  int                   move_head_count_             = 0;
-  int                   branch_count_                = 0;
-  int                   undo_count_                  = 0;
-  int                   redo_count_                  = 0;
-  int                   paste_count_                 = 0;
-  bool                  recovery_pending_            = false;
-  std::string           last_error_;
-  int                   retry_save_count_      = 0;
-  int                   discard_count_         = 0;
-  int                   cancel_recovery_count_ = 0;
-  bool                  block_version_ops_     = false;
-  bool                  fail_node_commands_    = false;
-  int                   blocked_create_count_  = 0;
-  int                   blocked_rename_count_  = 0;
-  int                   patch_count_           = 0;
-  int                   view_change_count_     = 0;
-  int                   rename_grade_count_    = 0;
-  int                   edit_node_graph_count_ = 0;
-  NodeGraphTopologyChange last_topology_change_{};
-  NodeId                last_renamed_node_id_;
+  std::uint64_t                          next_version_id_ = 20;
+  Hash128                                last_checkout_id_;
+  Hash128                                last_created_id_;
+  Hash128                                last_rename_id_;
+  Hash128                                last_removed_id_;
+  Hash128                                last_move_head_commit_;
+  std::vector<EditorMaskCreationCommand> mask_commands_;
+  NodeId                                 selected_mask_node_id_;
+  MaskId                                 selected_mask_id_;
+  bool                                   mask_commands_pending_ = false;
+  Hash128                                last_branch_commit_;
+  std::string                            last_branch_name_;
+  int                                    checkout_count_   = 0;
+  int                                    create_count_     = 0;
+  int                                    rename_count_     = 0;
+  int                                    remove_count_     = 0;
+  int                                    move_head_count_  = 0;
+  int                                    branch_count_     = 0;
+  int                                    undo_count_       = 0;
+  int                                    redo_count_       = 0;
+  int                                    paste_count_      = 0;
+  bool                                   recovery_pending_ = false;
+  std::string                            last_error_;
+  int                                    retry_save_count_      = 0;
+  int                                    discard_count_         = 0;
+  int                                    cancel_recovery_count_ = 0;
+  bool                                   block_version_ops_     = false;
+  bool                                   fail_node_commands_    = false;
+  int                                    blocked_create_count_  = 0;
+  int                                    blocked_rename_count_  = 0;
+  int                                    patch_count_           = 0;
+  int                                    view_change_count_     = 0;
+  int                                    rename_grade_count_    = 0;
+  int                                    edit_node_graph_count_ = 0;
+  NodeGraphTopologyChange                last_topology_change_{};
+  NodeId                                 last_renamed_node_id_;
 };
 
 class RecordingInteractionPolicy final : public QObject {
@@ -471,7 +530,7 @@ class RecordingAdjustmentTransfer final : public QObject {
   Q_PROPERTY(bool packageAvailable READ packageAvailable CONSTANT)
 
  public:
-  [[nodiscard]] auto packageAvailable() const -> bool { return true; }
+  [[nodiscard]] auto      packageAvailable() const -> bool { return true; }
 
   Q_INVOKABLE QVariantMap PasteIntoEditor(QObject*) {
     ++paste_count_;
@@ -485,7 +544,7 @@ class RecordingAdjustmentTransfer final : public QObject {
   int paste_count_ = 0;
 };
 
-inline constexpr char kHarnessQml[] = R"(
+inline constexpr char kHarnessQml[]         = R"(
 import QtQuick
 import QtQuick.Controls
 
@@ -540,7 +599,7 @@ ApplicationWindow {
 }
 )";
 
-inline auto QmlDirectory() -> QString {
+inline auto           QmlDirectory() -> QString {
   return QString::fromStdString(
       (std::filesystem::path(ALCEDO_TEST_SRC_DIR) / "ui" / "alcedo_main" / "qml").string());
 }
@@ -610,7 +669,8 @@ class RailQmlFixture : public ::testing::Test {
     engine_.rootContext()->setContextProperty(QStringLiteral("interactionPolicyFake"), &policy_);
     engine_.rootContext()->setContextProperty(QStringLiteral("adjustmentTransferFake"), &transfer_);
     engine_.rootContext()->setContextProperty(QStringLiteral("railSourceUrl"), RailUrl());
-    engine_.rootContext()->setContextProperty(QStringLiteral("recoverySourceUrl"), RecoveryBarUrl());
+    engine_.rootContext()->setContextProperty(QStringLiteral("recoverySourceUrl"),
+                                              RecoveryBarUrl());
     QObject::connect(&engine_, &QQmlEngine::warnings, [this](const QList<QQmlError>& warnings) {
       for (const auto& warning : warnings) warnings_.push_back(warning.toString());
     });

--- a/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
@@ -27,6 +27,7 @@
 #include <QQuickItem>
 #include <QQuickStyle>
 #include <QQuickWindow>
+#include <QSignalSpy>
 #include <QSize>
 #include <QStringList>
 #include <QUrl>
@@ -923,6 +924,93 @@ TEST_F(EditorNodeDelegateQml, CompactMaskIconsKeepSourceSizeForListedDevicePixel
     EXPECT_EQ(icon->property("sourceSize").toSize().width(), source) << dpr;
     EXPECT_EQ(icon->property("status").toInt(), 1) << dpr;
   }
+}
+
+TEST_F(EditorNodeDelegateQml, MaskRowSelectionHighlightDoesNotRebuildList) {
+  ui::AlcedoQanGraph adapter;
+  auto               document = CreateDefaultPipelineDocument();
+  auto*              grade    = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  grade->AddMask(MakeMask(MaskId{"mask.gradient"}, LinearGradientMaskSource{}), 0);
+  grade->AddMask(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}), 1);
+  grade->AddMask(MakeMask(MaskId{"mask.brush"}, BrushMaskSource{}), 2);
+  ApplyDocument(&adapter, std::move(document));
+
+  auto* item = adapter.NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(item, nullptr);
+  ASSERT_TRUE(WaitFor([&] { return MaskRows(item).size() == 3; }));
+  const auto rows_before = MaskRows(item);
+  ASSERT_EQ(rows_before.size(), 3);
+  QPointer<QQuickItem> first  = rows_before.at(0);
+  QPointer<QQuickItem> second = rows_before.at(1);
+  QPointer<QQuickItem> third = rows_before.at(2);
+  EXPECT_EQ(item->property("nodeId").toString(), QStringLiteral("grade.primary"));
+  EXPECT_FALSE(first->property("selected").toBool());
+
+  adapter.setSelectedMaskId(QStringLiteral("mask.radial"));
+  ASSERT_TRUE(WaitFor([&] { return second && second->property("selected").toBool(); }));
+  const auto rows_after = MaskRows(item);
+  ASSERT_EQ(rows_after.size(), 3);
+  EXPECT_EQ(rows_after.at(0), first.data());
+  EXPECT_EQ(rows_after.at(1), second.data());
+  EXPECT_EQ(rows_after.at(2), third.data());
+  EXPECT_FALSE(first->property("selected").toBool());
+  EXPECT_TRUE(second->property("selected").toBool());
+  EXPECT_FALSE(third->property("selected").toBool());
+
+  QSignalSpy selected_spy(&adapter, &ui::AlcedoQanGraph::MaskRowSelected);
+  ASSERT_TRUE(QMetaObject::invokeMethod(first.data(), "clicked", Qt::DirectConnection));
+  ASSERT_TRUE(WaitFor([&] { return selected_spy.count() == 1; }));
+  ASSERT_EQ(selected_spy.count(), 1);
+  EXPECT_EQ(selected_spy.at(0).at(0).toString(), QStringLiteral("grade.primary"));
+  EXPECT_EQ(selected_spy.at(0).at(1).toString(), QStringLiteral("mask.gradient"));
+}
+
+TEST_F(EditorNodeDelegateQml, MaskRowDeleteRequestsExactMaskIdAndLeavesGrade) {
+  ui::AlcedoQanGraph adapter;
+  auto               document = CreateDefaultPipelineDocument();
+  auto*              grade    = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  grade->AddMask(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}), 0);
+  grade->AddMask(MakeMask(MaskId{"mask.brush"}, BrushMaskSource{}), 1);
+  ApplyDocument(&adapter, std::move(document));
+
+  auto* item = adapter.NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(item, nullptr);
+  ASSERT_TRUE(WaitFor([&] { return MaskRows(item).size() == 2; }));
+  const auto rows = MaskRows(item);
+  ASSERT_EQ(rows.size(), 2);
+  auto* delete_button = FindDescendant(rows.at(0), QStringLiteral("editorNodeMaskTypeRowDelete"));
+  ASSERT_NE(delete_button, nullptr);
+  EXPECT_EQ(delete_button->property("actionName").toString(), QStringLiteral("Delete Radial"));
+
+  QSignalSpy delete_spy(&adapter, &ui::AlcedoQanGraph::MaskRowDeleteRequested);
+  ASSERT_TRUE(QMetaObject::invokeMethod(delete_button, "clicked", Qt::DirectConnection));
+  ASSERT_TRUE(WaitFor([&] { return delete_spy.count() == 1; }));
+  ASSERT_EQ(delete_spy.count(), 1);
+  EXPECT_EQ(delete_spy.at(0).at(0).toString(), QStringLiteral("grade.primary"));
+  EXPECT_EQ(delete_spy.at(0).at(1).toString(), QStringLiteral("mask.radial"));
+  EXPECT_NE(adapter.NodeFor(NodeId{"grade.primary"}), nullptr);
+  EXPECT_EQ(MaskRows(item).size(), 2);
+
+  QSignalSpy brush_delete_spy(&adapter, &ui::AlcedoQanGraph::MaskRowDeleteRequested);
+  auto* brush_delete = FindDescendant(rows.at(1), QStringLiteral("editorNodeMaskTypeRowDelete"));
+  ASSERT_NE(brush_delete, nullptr);
+  EXPECT_EQ(brush_delete->property("actionName").toString(), QStringLiteral("Delete Brush"));
+  ASSERT_TRUE(QMetaObject::invokeMethod(brush_delete, "clicked", Qt::DirectConnection));
+  ASSERT_TRUE(WaitFor([&] { return brush_delete_spy.count() == 1; }));
+  EXPECT_EQ(brush_delete_spy.at(0).at(1).toString(), QStringLiteral("mask.brush"));
+  EXPECT_NE(adapter.NodeFor(NodeId{"grade.primary"}), nullptr);
+
+  const auto workspace = ReadQmlFile("EditorWorkspace.qml");
+  const auto nodes     = ReadQmlFile("EditorNodesPanel.qml");
+  ASSERT_FALSE(workspace.isEmpty());
+  ASSERT_FALSE(nodes.isEmpty());
+  EXPECT_NE(workspace.indexOf(QStringLiteral("maskControlsActive")), -1);
+  EXPECT_NE(workspace.indexOf(QStringLiteral("removeSelectedMask")), -1);
+  EXPECT_NE(nodes.indexOf(QStringLiteral("maskControlsActive")), -1);
+  EXPECT_NE(nodes.indexOf(QStringLiteral("removeSelectedMask")), -1);
+  EXPECT_NE(nodes.indexOf(QStringLiteral("deleteSelectedColorGrade")), -1);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
@@ -1011,9 +1011,14 @@ TEST_F(EditorNodeDelegateQml, MaskRowDeleteRequestsExactMaskIdAndLeavesGrade) {
   const auto nodes     = ReadQmlFile("EditorNodesPanel.qml");
   ASSERT_FALSE(workspace.isEmpty());
   ASSERT_FALSE(nodes.isEmpty());
-  EXPECT_NE(workspace.indexOf(QStringLiteral("maskControlsActive")), -1);
+  // Delete is Mask-scoped only while a draw is open or a Mask is selected:
+  // an open draw cancels, a selected Mask is removed, and only otherwise does
+  // the Nodes panel fall through to deleting the selected Color Grade.
+  EXPECT_NE(workspace.indexOf(QStringLiteral("maskCreation.creating")), -1);
+  EXPECT_NE(workspace.indexOf(QStringLiteral("selectedMaskId")), -1);
   EXPECT_NE(workspace.indexOf(QStringLiteral("removeSelectedMask")), -1);
-  EXPECT_NE(nodes.indexOf(QStringLiteral("maskControlsActive")), -1);
+  EXPECT_NE(nodes.indexOf(QStringLiteral("maskCreation.creating")), -1);
+  EXPECT_NE(nodes.indexOf(QStringLiteral("selectedMaskId")), -1);
   EXPECT_NE(nodes.indexOf(QStringLiteral("removeSelectedMask")), -1);
   EXPECT_NE(nodes.indexOf(QStringLiteral("deleteSelectedColorGrade")), -1);
 }

--- a/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
@@ -11,6 +11,7 @@
 #include <QEvent>
 #include <QEventLoop>
 #include <QFile>
+#include <QFont>
 #include <QList>
 #include <QMetaObject>
 #include <QMetaType>
@@ -23,7 +24,6 @@
 #include <QQmlError>
 #include <QQmlExtensionPlugin>
 #include <QQmlProperty>
-#include <QFont>
 #include <QQuickItem>
 #include <QQuickStyle>
 #include <QQuickWindow>
@@ -534,14 +534,13 @@ TEST_F(EditorNodeDelegateQml, EdgeEndpointsStayGluedToPortsThroughFirstOpenBurst
     if (src == nullptr || dst == nullptr || item->getHidden()) {
       return false;
     }
-    const QRectF src_br = src->mapRectToItem(container, src->boundingRect());
-    const QRectF dst_br = dst->mapRectToItem(container, dst->boundingRect());
-    const QPointF p1    = item->mapToItem(container, item->getP1());
-    const QPointF p2    = item->mapToItem(container, item->getP2());
+    const QRectF  src_br = src->mapRectToItem(container, src->boundingRect());
+    const QRectF  dst_br = dst->mapRectToItem(container, dst->boundingRect());
+    const QPointF p1     = item->mapToItem(container, item->getP1());
+    const QPointF p2     = item->mapToItem(container, item->getP2());
     return std::abs(p1.x() - src_br.center().x()) < 1.0 &&
            std::abs(p1.y() - src_br.bottom()) < 1.0 &&
-           std::abs(p2.x() - dst_br.center().x()) < 1.0 &&
-           std::abs(p2.y() - dst_br.top()) < 1.0;
+           std::abs(p2.x() - dst_br.center().x()) < 1.0 && std::abs(p2.y() - dst_br.top()) < 1.0;
   };
 
   ASSERT_TRUE(WaitFor([&] { return glued(incoming) && glued(outgoing); }))
@@ -651,6 +650,13 @@ TEST_F(EditorNodeDelegateQml, ProductionNodeQmlHasNoMaterialImportOrEffectChrome
     EXPECT_FALSE(source.contains(QStringLiteral("gradient:"))) << file;
   }
 
+  const char* style_independent_files[] = {"EditorNodeMaskTypeRow.qml"};
+  for (const auto* file : style_independent_files) {
+    const auto source = ReadQmlFile(file);
+    ASSERT_FALSE(source.isEmpty()) << file;
+    EXPECT_FALSE(source.contains(QStringLiteral("import QtQuick.Controls\n"))) << file;
+  }
+
   ui::AlcedoQanGraph adapter;
   ApplyDefault(&adapter);
   auto* port = FindDescendant(adapter.OutputPortFor(NodeId{"develop"}, PortId{"image"}),
@@ -683,7 +689,7 @@ TEST_F(EditorNodeDelegateQml, PortSquareIsHollowGreenOutlineAcrossThemes) {
 
 TEST_F(EditorNodeDelegateQml, BackboneEdgeStrokeMatchesGraphEdgeTokens) {
   ui::AlcedoQanGraph adapter;
-  const auto           snapshot = ApplyDefault(&adapter);
+  const auto         snapshot = ApplyDefault(&adapter);
   ASSERT_FALSE(snapshot.edges.empty());
 
   for (const auto& edge : snapshot.edges) {
@@ -725,8 +731,8 @@ TEST_F(EditorNodeDelegateQml, MaskDrawerWellIsInsetInsideVisibleCardBorder) {
   const auto border_width = QQmlProperty::read(card, QStringLiteral("border.width")).toDouble();
   EXPECT_NEAR(well->mapToItem(card, QPointF(0, 0)).x(), border_width, 0.5);
   EXPECT_NEAR(well->width(), card->width() - 2.0 * border_width, 0.5);
-  EXPECT_NEAR(well->mapToItem(card, QPointF(0, well->height())).y(),
-              card->height() - border_width, 0.5)
+  EXPECT_NEAR(well->mapToItem(card, QPointF(0, well->height())).y(), card->height() - border_width,
+              0.5)
       << "well leaves the card border visible along the bottom edge";
 }
 
@@ -766,8 +772,7 @@ TEST_F(EditorNodeDelegateQml, MaskDrawerHeaderWashKeepsCardBorderVisibleOnHover)
   }));
   EXPECT_NEAR(wash->property("bottomLeftRadius").toDouble(), well_radius, 0.01);
   EXPECT_NEAR(wash->property("bottomRightRadius").toDouble(), well_radius, 0.01);
-  EXPECT_LE(wash->mapToItem(drawer, QPointF(0, wash->height())).y(),
-            drawer->height() - inset + 0.5)
+  EXPECT_LE(wash->mapToItem(drawer, QPointF(0, wash->height())).y(), drawer->height() - inset + 0.5)
       << "hover wash must not paint over the card border row";
 }
 
@@ -813,12 +818,12 @@ TEST_F(EditorNodeDelegateQml, NameRowGrowsWithLargeTitleFontWithoutChangingCardW
 TEST_F(EditorNodeDelegateQml, SelectedAndUnselectedOutlinesUseThemeTokensInBothThemes) {
   ui::AlcedoQanGraph adapter;
   ApplyDefault(&adapter);
-  auto* grade_item    = adapter.NodeFor(NodeId{"grade.primary"})->getItem();
-  auto* develop_item  = adapter.NodeFor(NodeId{"develop"})->getItem();
-  auto* drt_item      = adapter.NodeFor(NodeId{"drt"})->getItem();
-  auto* grade_card    = FindDescendant(grade_item, QStringLiteral("editorNodeCard"));
-  auto* develop_card  = FindDescendant(develop_item, QStringLiteral("editorEndpointNodeCard"));
-  auto* drt_card      = FindDescendant(drt_item, QStringLiteral("editorEndpointNodeCard"));
+  auto* grade_item   = adapter.NodeFor(NodeId{"grade.primary"})->getItem();
+  auto* develop_item = adapter.NodeFor(NodeId{"develop"})->getItem();
+  auto* drt_item     = adapter.NodeFor(NodeId{"drt"})->getItem();
+  auto* grade_card   = FindDescendant(grade_item, QStringLiteral("editorNodeCard"));
+  auto* develop_card = FindDescendant(develop_item, QStringLiteral("editorEndpointNodeCard"));
+  auto* drt_card     = FindDescendant(drt_item, QStringLiteral("editorEndpointNodeCard"));
   ASSERT_NE(grade_card, nullptr);
   ASSERT_NE(develop_card, nullptr);
   ASSERT_NE(drt_card, nullptr);
@@ -943,7 +948,7 @@ TEST_F(EditorNodeDelegateQml, MaskRowSelectionHighlightDoesNotRebuildList) {
   ASSERT_EQ(rows_before.size(), 3);
   QPointer<QQuickItem> first  = rows_before.at(0);
   QPointer<QQuickItem> second = rows_before.at(1);
-  QPointer<QQuickItem> third = rows_before.at(2);
+  QPointer<QQuickItem> third  = rows_before.at(2);
   EXPECT_EQ(item->property("nodeId").toString(), QStringLiteral("grade.primary"));
   EXPECT_FALSE(first->property("selected").toBool());
 

--- a/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_delegate_qml_test.cpp
@@ -30,6 +30,7 @@
 #include <QSignalSpy>
 #include <QSize>
 #include <QStringList>
+#include <QTest>
 #include <QUrl>
 #include <QuickQanava>
 #include <algorithm>
@@ -971,6 +972,97 @@ TEST_F(EditorNodeDelegateQml, MaskRowSelectionHighlightDoesNotRebuildList) {
   EXPECT_EQ(selected_spy.at(0).at(1).toString(), QStringLiteral("mask.gradient"));
 }
 
+TEST_F(EditorNodeDelegateQml, PointerClickSelectsAndDeletesMaskRowAboveSelectionOverlay) {
+  ui::AlcedoQanGraph adapter;
+  auto               document = CreateDefaultPipelineDocument();
+  document.PrimaryGrade()->AddMask(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}), 0);
+  ApplyDocument(&adapter, std::move(document));
+
+  auto* item = adapter.NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(item, nullptr);
+  ASSERT_TRUE(WaitFor([&] { return MaskRows(item).size() == 1; }));
+  adapter.ApplyProductSelection(NodeId{"grade.primary"});
+
+  auto* node_item = qobject_cast<qan::NodeItem*>(item);
+  ASSERT_NE(node_item, nullptr);
+  auto* selection = node_item->getSelectionItem();
+  auto* card      = FindDescendant(item, QStringLiteral("editorNodeCard"));
+  ASSERT_NE(selection, nullptr);
+  ASSERT_NE(card, nullptr);
+  EXPECT_GT(card->z(), selection->z());
+
+  auto* window = harness_->window();
+  ASSERT_NE(window, nullptr);
+  auto* row = MaskRows(item).front();
+  QSignalSpy selected_spy(&adapter, &ui::AlcedoQanGraph::MaskRowSelected);
+  QTest::mouseClick(window, Qt::LeftButton, Qt::NoModifier,
+                    row->mapToScene(QPointF(row->width() / 4.0, row->height() / 2.0)).toPoint());
+  ASSERT_TRUE(WaitFor([&] { return selected_spy.count() >= 1; }));
+  EXPECT_EQ(selected_spy.at(0).at(0).toString(), QStringLiteral("grade.primary"));
+  EXPECT_EQ(selected_spy.at(0).at(1).toString(), QStringLiteral("mask.radial"));
+
+  auto* delete_button = FindDescendant(row, QStringLiteral("editorNodeMaskTypeRowDelete"));
+  ASSERT_NE(delete_button, nullptr);
+  QSignalSpy delete_spy(&adapter, &ui::AlcedoQanGraph::MaskRowDeleteRequested);
+  QTest::mouseClick(
+      window, Qt::LeftButton, Qt::NoModifier,
+      delete_button->mapToScene(QPointF(delete_button->width() / 2.0, delete_button->height() / 2.0))
+          .toPoint());
+  ASSERT_TRUE(WaitFor([&] { return delete_spy.count() >= 1; }));
+  EXPECT_EQ(delete_spy.at(0).at(0).toString(), QStringLiteral("grade.primary"));
+  EXPECT_EQ(delete_spy.at(0).at(1).toString(), QStringLiteral("mask.radial"));
+}
+
+TEST_F(EditorNodeDelegateQml, MaskRowPressResolvesOwnerFromLiveItemWhenNodeIdPropertyIsEmpty) {
+  ui::AlcedoQanGraph adapter;
+  auto               document = CreateDefaultPipelineDocument();
+  document.PrimaryGrade()->AddMask(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}), 0);
+  ApplyDocument(&adapter, std::move(document));
+
+  auto* item = adapter.NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(item, nullptr);
+  ASSERT_TRUE(WaitFor([&] { return MaskRows(item).size() == 1; }));
+  EXPECT_EQ(item->property("graphAdapter").value<ui::AlcedoQanGraph*>(), &adapter);
+
+  item->setProperty("nodeId", QString());
+  QSignalSpy selected_spy(&adapter, &ui::AlcedoQanGraph::MaskRowSelected);
+  adapter.notifyMaskRowSelected(item, QStringLiteral("mask.radial"));
+  ASSERT_EQ(selected_spy.count(), 1);
+  EXPECT_EQ(selected_spy.at(0).at(0).toString(), QStringLiteral("grade.primary"));
+  EXPECT_EQ(selected_spy.at(0).at(1).toString(), QStringLiteral("mask.radial"));
+
+  auto* window = harness_->window();
+  ASSERT_NE(window, nullptr);
+  auto* row = MaskRows(item).front();
+  QTest::mousePress(window, Qt::LeftButton, Qt::NoModifier,
+                    row->mapToScene(QPointF(row->width() / 4.0, row->height() / 2.0)).toPoint());
+  ASSERT_TRUE(WaitFor([&] { return selected_spy.count() >= 2; }));
+  EXPECT_EQ(selected_spy.at(1).at(0).toString(), QStringLiteral("grade.primary"));
+  EXPECT_EQ(selected_spy.at(1).at(1).toString(), QStringLiteral("mask.radial"));
+  QTest::mouseRelease(window, Qt::LeftButton, Qt::NoModifier,
+                      row->mapToScene(QPointF(row->width() / 4.0, row->height() / 2.0)).toPoint());
+}
+
+TEST_F(EditorNodeDelegateQml, RightClickOnMaskRowSelectsMaskThroughNodeItemPress) {
+  ui::AlcedoQanGraph adapter;
+  auto               document = CreateDefaultPipelineDocument();
+  document.PrimaryGrade()->AddMask(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}), 0);
+  ApplyDocument(&adapter, std::move(document));
+
+  auto* item = adapter.NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(item, nullptr);
+  ASSERT_TRUE(WaitFor([&] { return MaskRows(item).size() == 1; }));
+  auto* window = harness_->window();
+  ASSERT_NE(window, nullptr);
+  auto* row = MaskRows(item).front();
+  QSignalSpy selected_spy(&adapter, &ui::AlcedoQanGraph::MaskRowSelected);
+  QTest::mouseClick(window, Qt::RightButton, Qt::NoModifier,
+                    row->mapToScene(QPointF(row->width() / 4.0, row->height() / 2.0)).toPoint());
+  ASSERT_TRUE(WaitFor([&] { return selected_spy.count() >= 1; }));
+  EXPECT_EQ(selected_spy.at(0).at(0).toString(), QStringLiteral("grade.primary"));
+  EXPECT_EQ(selected_spy.at(0).at(1).toString(), QStringLiteral("mask.radial"));
+}
+
 TEST_F(EditorNodeDelegateQml, MaskRowDeleteRequestsExactMaskIdAndLeavesGrade) {
   ui::AlcedoQanGraph adapter;
   auto               document = CreateDefaultPipelineDocument();
@@ -1011,15 +1103,12 @@ TEST_F(EditorNodeDelegateQml, MaskRowDeleteRequestsExactMaskIdAndLeavesGrade) {
   const auto nodes     = ReadQmlFile("EditorNodesPanel.qml");
   ASSERT_FALSE(workspace.isEmpty());
   ASSERT_FALSE(nodes.isEmpty());
-  // Delete is Mask-scoped only while a draw is open or a Mask is selected:
-  // an open draw cancels, a selected Mask is removed, and only otherwise does
-  // the Nodes panel fall through to deleting the selected Color Grade.
-  EXPECT_NE(workspace.indexOf(QStringLiteral("maskCreation.creating")), -1);
-  EXPECT_NE(workspace.indexOf(QStringLiteral("selectedMaskId")), -1);
-  EXPECT_NE(workspace.indexOf(QStringLiteral("removeSelectedMask")), -1);
-  EXPECT_NE(nodes.indexOf(QStringLiteral("maskCreation.creating")), -1);
-  EXPECT_NE(nodes.indexOf(QStringLiteral("selectedMaskId")), -1);
-  EXPECT_NE(nodes.indexOf(QStringLiteral("removeSelectedMask")), -1);
+  // Workspace scope owns Mask Delete while the transient Mask editor is open;
+  // the Nodes graph leaves that event unaccepted and resumes Grade deletion
+  // after Mask controls close.
+  EXPECT_NE(workspace.indexOf(QStringLiteral("maskCreation.maskControlsActive")), -1);
+  EXPECT_NE(workspace.indexOf(QStringLiteral("deleteActiveMask")), -1);
+  EXPECT_NE(nodes.indexOf(QStringLiteral("maskCreation.maskControlsActive")), -1);
   EXPECT_NE(nodes.indexOf(QStringLiteral("deleteSelectedColorGrade")), -1);
 }
 

--- a/alcedo_studio/tests/ui/editor_node_layout_store_test.cpp
+++ b/alcedo_studio/tests/ui/editor_node_layout_store_test.cpp
@@ -7,14 +7,20 @@
 #include <gtest/gtest.h>
 
 #include "app/editor_node_graph_projection.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
+#include "edit/mask/mask_model.hpp"
 #include "ui/alcedo_main/app_theme.hpp"
 
 namespace {
 
 using alcedo::CreateDefaultPipelineDocument;
 using alcedo::EditorNodeGraphProjection;
+using alcedo::EditorNodeKind;
+using alcedo::MaskId;
+using alcedo::MaskModel;
 using alcedo::NodeId;
+using alcedo::RadialMaskSource;
 using alcedo::ui::EditorNodeLayoutMetrics;
 using alcedo::ui::EditorNodeLayoutStore;
 using alcedo::ui::NodeIdToQString;
@@ -146,6 +152,110 @@ TEST(EditorNodeLayoutStore, AssignStagingPositionStacksLaterDraftsDownwardOnTheS
   EXPECT_DOUBLE_EQ(a->x(), static_cast<qreal>(metrics.origin_x));
   EXPECT_DOUBLE_EQ(b->x(), a->x());
   EXPECT_GT(b->y(), a->y());
+}
+
+TEST(EditorNodeLayoutStore, ResolveVerticalOverlapsKeepsInitialLayoutUntouched) {
+  EditorNodeLayoutStore store(MakeMetrics());
+  store.activate("p", 1, 2, "v");
+  const auto snapshot = EditorNodeGraphProjection::Build(CreateDefaultPipelineDocument(), 1, 1, 1);
+  store.EnsureDefaultPositions(snapshot);
+  const auto develop = store.NodePosition(NodeId{"develop"});
+  const auto primary = store.NodePosition(NodeId{"grade.primary"});
+  const auto drt     = store.NodePosition(NodeId{"drt"});
+
+  store.ResolveVerticalOverlaps(snapshot);
+
+  EXPECT_EQ(store.NodePosition(NodeId{"develop"}), develop);
+  EXPECT_EQ(store.NodePosition(NodeId{"grade.primary"}), primary);
+  EXPECT_EQ(store.NodePosition(NodeId{"drt"}), drt);
+}
+
+TEST(EditorNodeLayoutStore, ResolveVerticalOverlapsPushesNodesBelowGrownPredecessor) {
+  const auto            metrics = MakeMetrics();
+  EditorNodeLayoutStore store(metrics);
+  store.activate("p", 1, 2, "v");
+  auto document = CreateDefaultPipelineDocument();
+  store.EnsureDefaultPositions(EditorNodeGraphProjection::Build(document, 1, 1, 1));
+  const auto drt_before = store.NodePosition(NodeId{"drt"});
+  ASSERT_TRUE(drt_before.has_value());
+
+  auto* grade = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  for (const char* id : {"mask.one", "mask.two", "mask.three"}) {
+    MaskModel mask;
+    mask.id           = MaskId{id};
+    mask.display_name = id;
+    mask.source       = RadialMaskSource{};
+    grade->AddMask(std::move(mask), grade->Masks().size());
+  }
+  const auto grown = EditorNodeGraphProjection::Build(document, 1, 2, 1);
+
+  store.ResolveVerticalOverlaps(grown);
+
+  const auto primary = store.NodePosition(NodeId{"grade.primary"});
+  const auto drt     = store.NodePosition(NodeId{"drt"});
+  ASSERT_TRUE(primary.has_value());
+  ASSERT_TRUE(drt.has_value());
+  const qreal grown_height = store.DefaultHeight(EditorNodeKind::ColorGrade, 3, true);
+  EXPECT_DOUBLE_EQ(drt->y(), primary->y() + grown_height + metrics.vertical_gap);
+  EXPECT_GT(drt->y(), drt_before->y());
+}
+
+TEST(EditorNodeLayoutStore, ResolveVerticalOverlapsLeavesSpacedAndOffsetNodesAlone) {
+  const auto            metrics = MakeMetrics();
+  EditorNodeLayoutStore store(metrics);
+  store.activate("p", 1, 2, "v");
+  auto document = CreateDefaultPipelineDocument();
+  store.EnsureDefaultPositions(EditorNodeGraphProjection::Build(document, 1, 1, 1));
+
+  auto* grade = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  MaskModel mask;
+  mask.id           = MaskId{"mask.one"};
+  mask.display_name = "mask.one";
+  mask.source       = RadialMaskSource{};
+  grade->AddMask(std::move(mask), 0);
+  const auto grown = EditorNodeGraphProjection::Build(document, 1, 2, 1);
+
+  // A node dragged to another column never overlaps the drawer rows, so the
+  // reflow must not move it even when its predecessor grows past its y.
+  store.SetNodePosition(NodeId{"drt"}, QPointF(metrics.origin_x + metrics.node_width + 40,
+                                               metrics.origin_y));
+  store.ResolveVerticalOverlaps(grown);
+  EXPECT_EQ(store.NodePosition(NodeId{"drt"}),
+            QPointF(metrics.origin_x + metrics.node_width + 40, metrics.origin_y));
+
+  // A node the user placed far below the flow keeps its extra spacing.
+  store.SetNodePosition(NodeId{"drt"}, QPointF(metrics.origin_x, 2000));
+  store.ResolveVerticalOverlaps(grown);
+  EXPECT_EQ(store.NodePosition(NodeId{"drt"}), QPointF(metrics.origin_x, 2000));
+}
+
+TEST(EditorNodeLayoutStore, ResolveVerticalOverlapsUsesClosedDrawerHeight) {
+  const auto            metrics = MakeMetrics();
+  EditorNodeLayoutStore store(metrics);
+  store.activate("p", 1, 2, "v");
+  auto document = CreateDefaultPipelineDocument();
+  auto* grade   = document.PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  for (const char* id : {"mask.one", "mask.two", "mask.three"}) {
+    MaskModel mask;
+    mask.id           = MaskId{id};
+    mask.display_name = id;
+    mask.source       = RadialMaskSource{};
+    grade->AddMask(std::move(mask), grade->Masks().size());
+  }
+  const auto grown = EditorNodeGraphProjection::Build(document, 1, 2, 1);
+  store.EnsureDefaultPositions(grown);
+  store.SetDrawerOpen(NodeId{"grade.primary"}, false);
+  const auto drt_before = store.NodePosition(NodeId{"drt"});
+  ASSERT_TRUE(drt_before.has_value());
+
+  store.ResolveVerticalOverlaps(grown);
+
+  // The closed drawer keeps the grade compact, so the stored drt position
+  // still clears it and must not move.
+  EXPECT_EQ(store.NodePosition(NodeId{"drt"}), drt_before);
 }
 
 TEST(EditorNodeLayoutStore, DefaultConstructorReadsMetricsFromAppTheme) {

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -281,20 +281,23 @@ TEST_F(EditorNodesPanelQmlTest, TwoVersionsKeepSeparateLayoutValues) {
   QTRY_VERIFY_WITH_TIMEOUT(nodes->has_snapshot(), 2000);
 
   const QString first_version = nodes->version_id();
-  store->SetNodePosition(NodeId{"grade.primary"}, QPointF(15, 25));
+  // Custom positions sit below the default backbone stack: overlap resolution
+  // treats any y inside a predecessor's footprint as illegal and pushes the
+  // node down, which would destroy the stored value this test round-trips.
+  store->SetNodePosition(NodeId{"grade.primary"}, QPointF(15, 400));
   store->SetDrawerOpen(NodeId{"grade.primary"}, false);
 
   backend_.CheckoutVersion(rail_harness::StableId(2));
   ProcessEvents();
   QTRY_VERIFY_WITH_TIMEOUT(nodes->version_id() != first_version, 2000);
-  EXPECT_NE(store->NodePosition(NodeId{"grade.primary"}), QPointF(15, 25));
+  EXPECT_NE(store->NodePosition(NodeId{"grade.primary"}), QPointF(15, 400));
   EXPECT_TRUE(store->DrawerOpen(NodeId{"grade.primary"}));
-  store->SetNodePosition(NodeId{"grade.primary"}, QPointF(70, 80));
+  store->SetNodePosition(NodeId{"grade.primary"}, QPointF(70, 460));
 
   backend_.CheckoutVersion(rail_harness::StableId(1));
   ProcessEvents();
   QTRY_VERIFY_WITH_TIMEOUT(nodes->version_id() == first_version, 2000);
-  EXPECT_EQ(store->NodePosition(NodeId{"grade.primary"}), QPointF(15, 25));
+  EXPECT_EQ(store->NodePosition(NodeId{"grade.primary"}), QPointF(15, 400));
   EXPECT_FALSE(store->DrawerOpen(NodeId{"grade.primary"}));
 }
 
@@ -668,6 +671,42 @@ TEST_F(EditorNodesPanelQmlTest, MaskRowSelectionSelectsItsOwningColorGrade) {
   Click(window_, row, QPointF(row->width() / 4.0, row->height() / 2.0));
 
   EXPECT_EQ(nodes->selected_node_id(), NodeId{"grade.primary"});
+}
+
+TEST_F(EditorNodesPanelQmlTest, MaskGrowthShiftsFollowingNodesDownKeepingRowsClickable) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  OpenNodesPage();
+  QTRY_VERIFY_WITH_TIMEOUT(Adapter() != nullptr, 2000);
+  auto* adapter = Adapter();
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"drt"}) != nullptr, 2000);
+  auto* grade_item = adapter->NodeFor(NodeId{"grade.primary"})->getItem();
+  auto* drt_item   = adapter->NodeFor(NodeId{"drt"})->getItem();
+  ASSERT_NE(grade_item, nullptr);
+  ASSERT_NE(drt_item, nullptr);
+  const qreal grade_height_without_masks = grade_item->height();
+  ASSERT_GT(drt_item->y(), grade_item->y());
+
+  // Masks arrive after the initial layout, mirroring a Mask creation settle.
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.one"}, RadialMaskSource{}));
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.two"}, RadialMaskSource{}));
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.three"}, RadialMaskSource{}));
+
+  const qreal row_height = AppTheme::Instance().graphMaskRowHeight();
+  QTRY_VERIFY_WITH_TIMEOUT(grade_item->height() >= grade_height_without_masks + 3 * row_height - 0.5,
+                           2000);
+  QTRY_VERIFY_WITH_TIMEOUT(
+      grade_item->findChildren<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")).size() == 3,
+      2000);
+
+  // The following node must move below the grown drawer instead of covering it.
+  EXPECT_GE(drt_item->y(), grade_item->y() + grade_item->height());
+
+  const auto rows = grade_item->findChildren<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  QSignalSpy selected_spy(adapter, &AlcedoQanGraph::MaskRowSelected);
+  Click(window_, rows.constLast());
+  EXPECT_GE(selected_spy.count(), 1);
 }
 
 TEST_F(EditorNodesPanelQmlTest, OrdinaryDraftEditsDoNotReplaceQanTopology) {

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -35,6 +35,14 @@ using rail_harness::Click;
 using rail_harness::ProcessEvents;
 using rail_harness::RailQmlFixture;
 
+auto MakeMask(MaskId id, MaskSource source) -> MaskModel {
+  MaskModel mask;
+  mask.id           = std::move(id);
+  mask.display_name = "Mask";
+  mask.source       = std::move(source);
+  return mask;
+}
+
 auto AttachedName(QObject* object) -> QString {
   if (object == nullptr) {
     return {};
@@ -634,6 +642,31 @@ TEST_F(EditorNodesPanelQmlTest, OpenPageAppliesCommittedProjectionOnce) {
   ProcessEvents();
   EXPECT_EQ(nodes->completed_projection_apply_count(), 1);
   EXPECT_EQ(adapter->topology_replace_count(), 1);
+  EXPECT_EQ(nodes->selected_node_id(), NodeId{"grade.primary"});
+}
+
+TEST_F(EditorNodesPanelQmlTest, MaskRowSelectionSelectsItsOwningColorGrade) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}));
+  OpenNodesPage();
+  QTRY_VERIFY_WITH_TIMEOUT(Adapter() != nullptr, 2000);
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+
+  nodes->selectDevelop();
+  ASSERT_EQ(nodes->selected_node_id(), NodeId{"develop"});
+
+  auto* grade_item = adapter->NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(grade_item, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(
+      grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")) != nullptr, 2000);
+  auto* row =
+      grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  Click(window_, row, QPointF(row->width() / 4.0, row->height() / 2.0));
+
   EXPECT_EQ(nodes->selected_node_id(), NodeId{"grade.primary"});
 }
 

--- a/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_nodes_panel_qml_test.cpp
@@ -90,10 +90,10 @@ void CollectAccessiblePhrases(QObject* object, QStringList* phrases) {
 
 class NodesPanelTextExpander final : public QTranslator {
  public:
-  bool isEmpty() const override { return false; }
+  bool    isEmpty() const override { return false; }
 
   QString translate(const char* /*context*/, const char* source, const char*, int) const override {
-    const auto text = QString::fromUtf8(source);
+    const auto               text  = QString::fromUtf8(source);
     static const QStringList owned = {
         QStringLiteral("Nodes"),
         QStringLiteral("Add Color Grade"),
@@ -651,6 +651,8 @@ TEST_F(EditorNodesPanelQmlTest, OpenPageAppliesCommittedProjectionOnce) {
 TEST_F(EditorNodesPanelQmlTest, MaskRowSelectionSelectsItsOwningColorGrade) {
   ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
   backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}));
+  controller_.set_active_adjustment_panel(QStringLiteral("geometry"));
+  ASSERT_EQ(controller_.active_adjustment_panel(), QStringLiteral("geometry"));
   OpenNodesPage();
   QTRY_VERIFY_WITH_TIMEOUT(Adapter() != nullptr, 2000);
   auto* nodes   = Controller();
@@ -666,11 +668,235 @@ TEST_F(EditorNodesPanelQmlTest, MaskRowSelectionSelectsItsOwningColorGrade) {
   ASSERT_NE(grade_item, nullptr);
   QTRY_VERIFY_WITH_TIMEOUT(
       grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")) != nullptr, 2000);
-  auto* row =
-      grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  auto* row = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
   Click(window_, row, QPointF(row->width() / 4.0, row->height() / 2.0));
 
   EXPECT_EQ(nodes->selected_node_id(), NodeId{"grade.primary"});
+  ASSERT_NE(controller_.mask_creation(), nullptr);
+  EXPECT_EQ(controller_.mask_creation()->selected_mask_id(), QStringLiteral("mask.radial"));
+  EXPECT_EQ(controller_.active_adjustment_panel(), QStringLiteral("masks"));
+  ASSERT_TRUE(backend_.mask_creation_commands_pending());
+  ASSERT_FALSE(backend_.mask_commands().empty());
+  EXPECT_EQ(backend_.mask_commands().back().kind, EditorMaskCreationCommandKind::SelectMask);
+  EXPECT_EQ(backend_.mask_commands().back().node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(backend_.mask_commands().back().mask_id, MaskId{"mask.radial"});
+
+  // A normal backend publication can arrive before the queued Mask command is
+  // consumed. It must not restore the previous empty owner selection.
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.other"}, RadialMaskSource{}));
+  ProcessEvents();
+  EXPECT_EQ(controller_.mask_creation()->selected_mask_id(), QStringLiteral("mask.radial"));
+
+  backend_.CompleteMaskCommands();
+  ProcessEvents();
+  EXPECT_EQ(controller_.mask_creation()->selected_mask_id(), QStringLiteral("mask.radial"));
+  EXPECT_EQ(controller_.mask_creation()->tool_kind(), QStringLiteral("radial"));
+
+  controller_.set_active_adjustment_panel(QStringLiteral("look"));
+  EXPECT_EQ(controller_.active_adjustment_panel(), QStringLiteral("look"));
+  EXPECT_FALSE(controller_.mask_creation()->mask_controls_active());
+  EXPECT_TRUE(controller_.mask_creation()->selected_mask_id().isEmpty());
+  ASSERT_TRUE(backend_.mask_creation_commands_pending());
+  ASSERT_FALSE(backend_.mask_commands().empty());
+  EXPECT_EQ(backend_.mask_commands().back().kind, EditorMaskCreationCommandKind::FinishMode);
+}
+
+TEST_F(EditorNodesPanelQmlTest, MaskRowClickOnSelectedGradeQueuesSelectMask) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}));
+  OpenNodesPage();
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  ASSERT_EQ(nodes->selected_node_id(), NodeId{"grade.primary"});
+
+  auto* grade_item = adapter->NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(grade_item, nullptr);
+  auto* node_item = qobject_cast<qan::NodeItem*>(grade_item);
+  ASSERT_NE(node_item, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(node_item->getSelectionItem() != nullptr, 2000);
+  auto* card = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeCard"));
+  ASSERT_NE(card, nullptr);
+  EXPECT_GT(card->z(), node_item->getSelectionItem()->z());
+  QTRY_VERIFY_WITH_TIMEOUT(
+      grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")) != nullptr, 2000);
+  auto* row = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  Click(window_, row, QPointF(row->width() / 4.0, row->height() / 2.0));
+
+  ASSERT_NE(controller_.mask_creation(), nullptr);
+  EXPECT_EQ(controller_.mask_creation()->selected_mask_id(), QStringLiteral("mask.radial"));
+  EXPECT_EQ(controller_.active_adjustment_panel(), QStringLiteral("masks"));
+  ASSERT_TRUE(backend_.mask_creation_commands_pending());
+  ASSERT_FALSE(backend_.mask_commands().empty());
+  EXPECT_EQ(backend_.mask_commands().back().kind, EditorMaskCreationCommandKind::SelectMask);
+  EXPECT_EQ(backend_.mask_commands().back().node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(backend_.mask_commands().back().mask_id, MaskId{"mask.radial"});
+}
+
+TEST_F(EditorNodesPanelQmlTest, MaskRowPressQueuesSelectMaskWhenNodeIdPropertyIsEmpty) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}));
+  OpenNodesPage();
+  auto* nodes   = Controller();
+  auto* adapter = Adapter();
+  ASSERT_NE(nodes, nullptr);
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  ASSERT_EQ(nodes->selected_node_id(), NodeId{"grade.primary"});
+
+  auto* grade_item = adapter->NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(grade_item, nullptr);
+  EXPECT_EQ(grade_item->property("graphAdapter").value<AlcedoQanGraph*>(), adapter);
+  QTRY_VERIFY_WITH_TIMEOUT(
+      grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")) != nullptr, 2000);
+  auto* row = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  grade_item->setProperty("nodeId", QString());
+  QTest::mousePress(window_, Qt::LeftButton, Qt::NoModifier,
+                    row->mapToScene(QPointF(row->width() / 4.0, row->height() / 2.0)).toPoint());
+  ProcessEvents();
+  QTest::mouseRelease(window_, Qt::LeftButton, Qt::NoModifier,
+                      row->mapToScene(QPointF(row->width() / 4.0, row->height() / 2.0)).toPoint());
+  ProcessEvents();
+
+  ASSERT_NE(controller_.mask_creation(), nullptr);
+  EXPECT_EQ(controller_.mask_creation()->selected_mask_id(), QStringLiteral("mask.radial"));
+  EXPECT_EQ(controller_.active_adjustment_panel(), QStringLiteral("masks"));
+  ASSERT_TRUE(backend_.mask_creation_commands_pending());
+  ASSERT_FALSE(backend_.mask_commands().empty());
+  EXPECT_EQ(backend_.mask_commands().back().kind, EditorMaskCreationCommandKind::SelectMask);
+  EXPECT_EQ(backend_.mask_commands().back().node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(backend_.mask_commands().back().mask_id, MaskId{"mask.radial"});
+}
+
+TEST_F(EditorNodesPanelQmlTest, RightClickOnMaskRowSelectsMaskAndDoesNotOpenNodeMenu) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}));
+  OpenNodesPage();
+  auto* adapter = Adapter();
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  auto* grade_item = adapter->NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(grade_item, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(
+      grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")) != nullptr, 2000);
+  auto* row = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  auto* menu = Find(QStringLiteral("editorNodesNodeMenu"));
+  ASSERT_NE(menu, nullptr);
+
+  QTest::mouseClick(window_, Qt::RightButton, Qt::NoModifier,
+                    row->mapToScene(QPointF(row->width() / 4.0, row->height() / 2.0)).toPoint());
+  ProcessEvents();
+
+  ASSERT_NE(controller_.mask_creation(), nullptr);
+  EXPECT_EQ(controller_.mask_creation()->selected_mask_id(), QStringLiteral("mask.radial"));
+  EXPECT_EQ(controller_.active_adjustment_panel(), QStringLiteral("masks"));
+  EXPECT_FALSE(menu->property("opened").toBool());
+  EXPECT_FALSE(menu->isVisible());
+}
+
+TEST_F(EditorNodesPanelQmlTest,
+       MaskRowDeleteButtonQueuesExactOwnerAndDoesNotRestoreStaleSelection) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}));
+  OpenNodesPage();
+  auto* adapter = Adapter();
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  auto* grade_item = adapter->NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(grade_item, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(
+      grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")) != nullptr, 2000);
+  auto* row = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  Click(window_, row, QPointF(row->width() / 4.0, row->height() / 2.0));
+  backend_.CompleteMaskCommands();
+  ProcessEvents();
+  ASSERT_EQ(controller_.mask_creation()->selected_mask_id(), QStringLiteral("mask.radial"));
+
+  row = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  ASSERT_NE(row, nullptr);
+  auto* delete_button = row->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRowDelete"));
+  ASSERT_NE(delete_button, nullptr);
+  Click(window_, delete_button);
+
+  ASSERT_TRUE(backend_.mask_creation_commands_pending());
+  ASSERT_EQ(backend_.mask_commands().size(), 2U);
+  EXPECT_EQ(backend_.mask_commands().front().kind, EditorMaskCreationCommandKind::RemoveMask);
+  EXPECT_EQ(backend_.mask_commands().front().node_id, NodeId{"grade.primary"});
+  EXPECT_EQ(backend_.mask_commands().front().mask_id, MaskId{"mask.radial"});
+  EXPECT_EQ(backend_.mask_commands().back().kind, EditorMaskCreationCommandKind::FinishMode);
+  EXPECT_TRUE(controller_.mask_creation()->selected_mask_id().isEmpty());
+  EXPECT_FALSE(controller_.mask_creation()->mask_controls_active());
+  EXPECT_EQ(controller_.active_adjustment_panel(), QStringLiteral("tone"));
+
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.later"}, RadialMaskSource{}));
+  ProcessEvents();
+  EXPECT_TRUE(controller_.mask_creation()->selected_mask_id().isEmpty());
+
+  backend_.CompleteMaskCommands();
+  ProcessEvents();
+  const auto* grade = backend_.pipeline_document()->PrimaryGrade();
+  ASSERT_NE(grade, nullptr);
+  EXPECT_EQ(grade->FindMask(MaskId{"mask.radial"}), nullptr);
+}
+
+TEST_F(EditorNodesPanelQmlTest, EscapeFinishesMaskEditAndReturnsToPriorAdjustmentPanel) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}));
+  controller_.set_active_adjustment_panel(QStringLiteral("lut"));
+  OpenNodesPage();
+  auto* adapter = Adapter();
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  auto* grade_item = adapter->NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(grade_item, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(
+      grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")) != nullptr, 2000);
+  auto* row = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  Click(window_, row, QPointF(row->width() / 4.0, row->height() / 2.0));
+  backend_.CompleteMaskCommands();
+  ProcessEvents();
+  ASSERT_EQ(controller_.active_adjustment_panel(), QStringLiteral("masks"));
+  ASSERT_TRUE(controller_.mask_creation()->mask_controls_active());
+
+  QTest::keyClick(window_, Qt::Key_Escape);
+  ProcessEvents();
+
+  EXPECT_EQ(controller_.active_adjustment_panel(), QStringLiteral("lut"));
+  EXPECT_FALSE(controller_.mask_creation()->mask_controls_active());
+  EXPECT_TRUE(controller_.mask_creation()->selected_mask_id().isEmpty());
+  ASSERT_TRUE(backend_.mask_creation_commands_pending());
+  ASSERT_FALSE(backend_.mask_commands().empty());
+  EXPECT_EQ(backend_.mask_commands().back().kind, EditorMaskCreationCommandKind::FinishMode);
+}
+
+TEST_F(EditorNodesPanelQmlTest, MaskDeleteButtonAndLastRowStayInsideDrawerWithBottomInset) {
+  ASSERT_NE(window_, nullptr) << warnings_.join('\n').toStdString();
+  backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.radial"}, RadialMaskSource{}));
+  OpenNodesPage();
+  auto* adapter = Adapter();
+  ASSERT_NE(adapter, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
+  auto* grade_item = adapter->NodeFor(NodeId{"grade.primary"})->getItem();
+  ASSERT_NE(grade_item, nullptr);
+  QTRY_VERIFY_WITH_TIMEOUT(
+      grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")) != nullptr, 2000);
+  auto* drawer = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskDrawer"));
+  auto* row    = grade_item->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow"));
+  ASSERT_NE(drawer, nullptr);
+  ASSERT_NE(row, nullptr);
+  auto* delete_button = row->findChild<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRowDelete"));
+  ASSERT_NE(delete_button, nullptr);
+
+  const QPointF button_top_left = row->mapFromItem(delete_button, QPointF{});
+  EXPECT_GE(button_top_left.x(), 0.0);
+  EXPECT_GE(button_top_left.y(), 0.0);
+  EXPECT_LE(button_top_left.x() + delete_button->width(), row->width());
+  EXPECT_LE(button_top_left.y() + delete_button->height(), row->height());
+
+  const QPointF row_bottom = drawer->mapFromItem(row, QPointF(0.0, row->height()));
+  EXPECT_GE(drawer->height() - row_bottom.y(), AppTheme::Instance().spaceXs());
 }
 
 TEST_F(EditorNodesPanelQmlTest, MaskGrowthShiftsFollowingNodesDownKeepingRowsClickable) {
@@ -694,8 +920,8 @@ TEST_F(EditorNodesPanelQmlTest, MaskGrowthShiftsFollowingNodesDownKeepingRowsCli
   backend_.AddMaskToPrimaryGrade(MakeMask(MaskId{"mask.three"}, RadialMaskSource{}));
 
   const qreal row_height = AppTheme::Instance().graphMaskRowHeight();
-  QTRY_VERIFY_WITH_TIMEOUT(grade_item->height() >= grade_height_without_masks + 3 * row_height - 0.5,
-                           2000);
+  QTRY_VERIFY_WITH_TIMEOUT(
+      grade_item->height() >= grade_height_without_masks + 3 * row_height - 0.5, 2000);
   QTRY_VERIFY_WITH_TIMEOUT(
       grade_item->findChildren<QQuickItem*>(QStringLiteral("editorNodeMaskTypeRow")).size() == 3,
       2000);
@@ -1075,7 +1301,7 @@ TEST_F(EditorNodesPanelQmlTest, AddColorGradeShowsPendingWithoutReplacingQanTopo
   ASSERT_NE(nodes, nullptr);
   ASSERT_NE(adapter, nullptr);
   QTRY_VERIFY_WITH_TIMEOUT(adapter->NodeFor(NodeId{"grade.primary"}) != nullptr, 2000);
-  const auto replace_count = adapter->topology_replace_count();
+  const auto    replace_count = adapter->topology_replace_count();
   QElapsedTimer timer;
   timer.start();
   ASSERT_TRUE(nodes->addCleanColorGrade());

--- a/alcedo_studio/tests/ui/editor_real_raw_gpu_e2e_test.cpp
+++ b/alcedo_studio/tests/ui/editor_real_raw_gpu_e2e_test.cpp
@@ -393,7 +393,7 @@ TEST_F(EditorRealRawGpuE2eTest, RealRawGpuFramesRemainReadyAcrossSustainedImageS
       const auto pending = host.editor_session_service()->PeekPendingInput();
       const auto* exposure = alcedo::FindPendingField(pending, "exposure");
       ASSERT_NE(exposure, nullptr);
-      EXPECT_NE(exposure->params_json.find("0.30"), std::string::npos);
+      EXPECT_EQ(alcedo::PendingScalarValue(*exposure), 0.30f);
       EXPECT_EQ(viewport->presentedFrameCount(), composed_before_drag)
           << "queued input must not apply or render until the owner consumes it";
     }

--- a/alcedo_studio/tests/ui/mask_edit_geometry_test.cpp
+++ b/alcedo_studio/tests/ui/mask_edit_geometry_test.cpp
@@ -269,4 +269,46 @@ TEST(MaskEditGeometryTest, HandleHitRadiusStaysLogicalAcrossZoom) {
                                    *zoomed_handle));
 }
 
+TEST(MaskEditGeometryTest, CroppedRotatedPhotographUsesResolvedGeometryNotIdentity) {
+  ImageGeometryParams image;
+  image.crop_rect        = NormalizedRect{0.10f, 0.15f, 0.55f, 0.60f};
+  image.rotation_degrees = 18.0f;
+  image.expand_to_fit    = true;
+  const Extent2D full{400, 300};
+  const auto    resolved = MaskEditGeometry::MakeDocumentPhotographGeometry(full, image);
+  const auto    identity = MaskEditGeometry::MakeIdentityPhotographGeometry(full);
+  EXPECT_NE(resolved.render_extent.width, identity.render_extent.width);
+  EXPECT_NE(resolved.render_to_reference.m[0], identity.render_to_reference.m[0]);
+
+  MaskEditViewMapping mapping;
+  mapping.widget     = {400, 300, 1.0f};
+  mapping.photograph = {static_cast<int>(resolved.edit_extent.width),
+                         static_cast<int>(resolved.edit_extent.height)};
+  mapping.zoom       = 1.0f;
+  mapping.geometry   = resolved;
+  ASSERT_TRUE(MaskEditGeometry::IsValid(mapping));
+  auto identity_mapping     = mapping;
+  identity_mapping.geometry = identity;
+  identity_mapping.photograph = {400, 300};
+  const QPointF item(200.0, 150.0);
+  const auto    cropped = MaskEditGeometry::MapItemToReference(mapping, item, true);
+  const auto    uncropped = MaskEditGeometry::MapItemToReference(identity_mapping, item, true);
+  ASSERT_TRUE(cropped.has_value());
+  ASSERT_TRUE(uncropped.has_value());
+  EXPECT_GT(std::hypot(cropped->normalized.x - uncropped->normalized.x,
+                         cropped->normalized.y - uncropped->normalized.y),
+            1.0e-3f);
+
+  editor_rhi::EditorInteractionController controller;
+  controller.setViewportMetrics(400, 300, 1.0);
+  controller.setImageSize(400, 300);
+  controller.setDisplayedMaskGeometry(resolved);
+  controller.setRenderReferenceSize(static_cast<int>(resolved.edit_extent.width),
+                                     static_cast<int>(resolved.edit_extent.height));
+  const auto published = controller.maskEditViewMapping();
+  EXPECT_EQ(published.photograph.image_width, static_cast<int>(resolved.edit_extent.width));
+  EXPECT_EQ(published.photograph.image_height, static_cast<int>(resolved.edit_extent.height));
+  EXPECT_NE(published.geometry.render_to_reference.m[0], identity.render_to_reference.m[0]);
+}
+
 }  // namespace alcedo

--- a/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
+++ b/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
@@ -478,12 +478,47 @@ TEST(MaskOverlayControlTest, CoincidentRadialBoundariesKeepFeatherControlsReacha
   source.outer_feather     = 0.0f;
   const auto display =
       MakeRadialExistingOverlayDisplay(mapping, source, DefaultMaskOverlayStyle(), {});
-  EXPECT_EQ(display.selected_contours.size(), 1u);
+  ASSERT_EQ(display.selected_contours.size(), 1u);
+  EXPECT_FALSE(display.selected_contours.front().dashed);
   EXPECT_EQ(HandleById(display, MaskOverlayHandleId::RadialInnerFeather), nullptr);
   EXPECT_EQ(HandleById(display, MaskOverlayHandleId::RadialOuterFeather), nullptr);
   EXPECT_NE(HandleById(display, MaskOverlayHandleId::RadialMajor), nullptr);
   const auto scene = BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle());
   EXPECT_EQ(scene.closed_polygon_edge_count, 0);
+  EXPECT_GT(scene.selected_guide_segment_count, 0);
+}
+
+TEST(MaskOverlayControlTest, RadialFeatherContoursRenderDashedWithArcLengthGaps) {
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto source  = SampleRadial();
+  const auto display =
+      MakeRadialExistingOverlayDisplay(mapping, source, DefaultMaskOverlayStyle(), {});
+  ASSERT_EQ(display.selected_contours.size(), 3u);
+  std::size_t dashed_count = 0;
+  for (const auto& contour : display.selected_contours) {
+    dashed_count += contour.dashed ? 1u : 0u;
+  }
+  EXPECT_EQ(dashed_count, 2u);
+
+  // Densely sample the inner feather ellipse: a dashed stroke must leave some
+  // samples in gaps while others land on dash segments.
+  const auto scene          = BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle());
+  const float inner_rho     = 1.0f - source.inner_feather;
+  int         covered_count = 0;
+  int         gap_count     = 0;
+  constexpr float kTwoPi    = 6.28318530718f;
+  for (int i = 0; i < 720; ++i) {
+    const float   theta = (static_cast<float>(i) / 720.0f) * kTwoPi;
+    const QPointF sample =
+        IndependentMapNormalized(mapping, IndependentRadialNormalized(source, inner_rho, theta));
+    if (VerticesCoverPoint(scene.selected_guides, sample)) {
+      ++covered_count;
+    } else {
+      ++gap_count;
+    }
+  }
+  EXPECT_GT(covered_count, 0);
+  EXPECT_GT(gap_count, 0);
   EXPECT_GT(scene.selected_guide_segment_count, 0);
 }
 

--- a/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
+++ b/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
@@ -4,13 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <atomic>
-#include <chrono>
-#include <cmath>
-#include <thread>
-#include <vector>
-
 #include <QColor>
 #include <QCoreApplication>
 #include <QImage>
@@ -19,6 +12,12 @@
 #include <QSignalSpy>
 #include <QTest>
 #include <QVector2D>
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <thread>
+#include <vector>
 
 #include "edit/geometry/types.hpp"
 #include "edit/mask/mask_model.hpp"
@@ -34,11 +33,11 @@ namespace {
 [[nodiscard]] auto MakeMapping(int widget_w, int widget_h, int image_w, int image_h, float zoom,
                                QVector2D pan, float dpr) -> MaskEditViewMapping {
   MaskEditViewMapping mapping;
-  mapping.widget      = {widget_w, widget_h, dpr};
-  mapping.photograph  = {image_w, image_h};
-  mapping.zoom        = zoom;
-  mapping.pan         = pan;
-  mapping.geometry    = MaskEditGeometry::MakeIdentityPhotographGeometry(
+  mapping.widget     = {widget_w, widget_h, dpr};
+  mapping.photograph = {image_w, image_h};
+  mapping.zoom       = zoom;
+  mapping.pan        = pan;
+  mapping.geometry   = MaskEditGeometry::MakeIdentityPhotographGeometry(
       Extent2D{static_cast<std::uint32_t>(image_w), static_cast<std::uint32_t>(image_h)});
   return mapping;
 }
@@ -89,7 +88,7 @@ namespace {
 }
 
 [[nodiscard]] auto IndependentItemToNormalized(const MaskEditViewMapping& mapping,
-                                               const QPointF& item) -> Vector2 {
+                                               const QPointF&             item) -> Vector2 {
   const auto sample = MaskEditGeometry::MapItemToReference(mapping, item, true);
   EXPECT_TRUE(sample.has_value());
   return sample ? sample->normalized : Vector2{};
@@ -118,7 +117,7 @@ namespace {
 }
 
 [[nodiscard]] auto VerticesCoverPoint(const std::vector<MaskOverlayVertex>& vertices,
-                                      const QPointF& point) -> bool {
+                                      const QPointF&                        point) -> bool {
   for (std::size_t i = 0; i + 2 < vertices.size(); i += 3) {
     if (PointInTriangle(point, QPointF(vertices[i].x, vertices[i].y),
                         QPointF(vertices[i + 1].x, vertices[i + 1].y),
@@ -140,10 +139,11 @@ namespace {
 }
 
 [[nodiscard]] auto MaxDistanceFrom(const std::vector<MaskOverlayVertex>& vertices,
-                                   const QPointF& origin) -> float {
+                                   const QPointF&                        origin) -> float {
   float best = 0.0f;
   for (const auto& vertex : vertices) {
-    best = std::max(best, static_cast<float>(std::hypot(vertex.x - origin.x(), vertex.y - origin.y())));
+    best = std::max(best,
+                    static_cast<float>(std::hypot(vertex.x - origin.x(), vertex.y - origin.y())));
   }
   return best;
 }
@@ -159,8 +159,8 @@ namespace {
 }
 
 struct OverlayWindow {
-  QQuickWindow                    window;
-  editor_rhi::EditorOverlayItem*  overlay = nullptr;
+  QQuickWindow                   window;
+  editor_rhi::EditorOverlayItem* overlay = nullptr;
 
   OverlayWindow() {
     window.setColor(QColor(32, 48, 64));
@@ -192,8 +192,7 @@ TEST(MaskOverlayControlTest, ExistingMaskEditHasControlsAndNoCoverageFill) {
   const auto style   = DefaultMaskOverlayStyle();
   const auto radial  = MakeRadialExistingOverlayDisplay(mapping, SampleRadial(), style, {});
   const auto linear  = MakeLinearExistingOverlayDisplay(mapping, SampleLinear(), style, {});
-  const auto brush =
-      MakeBrushExistingOverlayDisplay(mapping, Vector2{200.0f, 150.0f}, {});
+  const auto brush   = MakeBrushExistingOverlayDisplay(mapping, Vector2{200.0f, 150.0f}, {});
 
   EXPECT_EQ(radial.mode, MaskOverlayMode::Existing);
   EXPECT_EQ(linear.mode, MaskOverlayMode::Existing);
@@ -217,8 +216,8 @@ TEST(MaskOverlayControlTest, ExistingMaskEditHasControlsAndNoCoverageFill) {
   EXPECT_TRUE(brush_scene.creation_guides.empty());
   EXPECT_EQ(linear_scene.coverage_fill_vertex_count, 0);
 
-  const auto interior = IndependentMapNormalized(
-      mapping, IndependentRadialNormalized(SampleRadial(), 0.40f, 1.05f));
+  const auto interior =
+      IndependentMapNormalized(mapping, IndependentRadialNormalized(SampleRadial(), 0.40f, 1.05f));
   EXPECT_FALSE(OverlayCoversPoint(radial_scene, interior))
       << "existing Radial overlay filled coverage at " << interior.x() << "," << interior.y();
 
@@ -229,8 +228,9 @@ TEST(MaskOverlayControlTest, ExistingMaskEditHasControlsAndNoCoverageFill) {
   ASSERT_FALSE(grab.isNull());
   ASSERT_GT(grab.width(), 0);
   const qreal dpr = host.window.devicePixelRatio();
-  const int px    = std::clamp(static_cast<int>(std::lround(interior.x() * dpr)), 0, grab.width() - 1);
-  const int py    = std::clamp(static_cast<int>(std::lround(interior.y() * dpr)), 0, grab.height() - 1);
+  const int px = std::clamp(static_cast<int>(std::lround(interior.x() * dpr)), 0, grab.width() - 1);
+  const int py =
+      std::clamp(static_cast<int>(std::lround(interior.y() * dpr)), 0, grab.height() - 1);
   const QColor sample = grab.pixelColor(px, py);
   const QColor clear  = host.window.color();
   EXPECT_LT(std::abs(sample.red() - clear.red()), 40);
@@ -241,25 +241,25 @@ TEST(MaskOverlayControlTest, ExistingMaskEditHasControlsAndNoCoverageFill) {
 
   const auto* center = HandleById(radial, MaskOverlayHandleId::RadialCenter);
   ASSERT_NE(center, nullptr);
-  const int hx = std::clamp(static_cast<int>(std::lround(center->item.x() * dpr)), 0,
-                            grab.width() - 1);
-  const int hy = std::clamp(static_cast<int>(std::lround(center->item.y() * dpr)), 0,
-                            grab.height() - 1);
+  const int hx =
+      std::clamp(static_cast<int>(std::lround(center->item.x() * dpr)), 0, grab.width() - 1);
+  const int hy =
+      std::clamp(static_cast<int>(std::lround(center->item.y() * dpr)), 0, grab.height() - 1);
   const QColor handle_pixel = grab.pixelColor(hx, hy);
   EXPECT_GT(handle_pixel.red() + handle_pixel.green() + handle_pixel.blue(), 80);
 }
 
 TEST(MaskOverlayControlTest, MaskControlsUpdateWhileRenderIsHeld) {
   std::atomic<bool> render_busy{true};
-  std::thread renderer([&] {
+  std::thread       renderer([&] {
     while (render_busy.load(std::memory_order_relaxed)) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
   });
 
-  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
-  const auto style   = DefaultMaskOverlayStyle();
-  auto display       = MakeRadialExistingOverlayDisplay(mapping, SampleRadial(), style, {});
+  const auto        mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto        style   = DefaultMaskOverlayStyle();
+  auto              display = MakeRadialExistingOverlayDisplay(mapping, SampleRadial(), style, {});
   ASSERT_FALSE(display.handles.empty());
   const QPointF before = display.handles.front().item;
   for (auto& handle : display.handles) {
@@ -286,8 +286,8 @@ TEST(MaskOverlayControlTest, MaskControlsUpdateWhileRenderIsHeld) {
 
 TEST(MaskOverlayControlTest, MaskOverlayReusesNodesForMovement) {
   OverlayWindow host;
-  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
-  auto display =
+  const auto    mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  auto          display =
       MakeRadialExistingOverlayDisplay(mapping, SampleRadial(), DefaultMaskOverlayStyle(), {});
   host.overlay->setMaskOverlayDisplay(display);
   host.Present();
@@ -307,7 +307,7 @@ TEST(MaskOverlayControlTest, MaskControlsRecreateAfterSceneInvalidation) {
   const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
   const auto display =
       MakeLinearExistingOverlayDisplay(mapping, SampleLinear(), DefaultMaskOverlayStyle(), {});
-  int handles_before = 0;
+  int handles_before  = 0;
   int vertices_before = 0;
   {
     OverlayWindow first;
@@ -332,30 +332,25 @@ TEST(MaskOverlayControlTest, MaskControlsRecreateAfterSceneInvalidation) {
 TEST(MaskOverlayControlTest, MaskControlsKeepLogicalSizeAndThemeColors) {
   auto& theme = ui::AppTheme::Instance();
   theme.setCurrentThemeIndex(0);
-  EXPECT_EQ(theme.maskOverlayHandleRadius(),
-            static_cast<int>(kMaskOverlayHandleRadiusLogicalPx));
+  EXPECT_EQ(theme.maskOverlayHandleRadius(), static_cast<int>(kMaskOverlayHandleRadiusLogicalPx));
   EXPECT_NEAR(theme.maskOverlayHandleOutlineWidth(),
               static_cast<qreal>(kMaskOverlayHandleOutlineWidthLogicalPx), 1.0e-6);
-  EXPECT_EQ(theme.maskOverlayHandleHitRadius(),
-            static_cast<int>(kMaskHandleHitRadiusLogicalPx));
+  EXPECT_EQ(theme.maskOverlayHandleHitRadius(), static_cast<int>(kMaskHandleHitRadiusLogicalPx));
   EXPECT_EQ(theme.maskOverlayControlColor(), theme.textColor());
   EXPECT_EQ(theme.maskOverlayControlOutlineColor(), theme.bgCanvasColor());
   EXPECT_EQ(theme.maskOverlayInactiveColor(), theme.textMutedColor());
 
-  MaskOverlayStyle style = DefaultMaskOverlayStyle();
-  style.control_fill     = theme.maskOverlayControlColor();
-  style.control_outline  = theme.maskOverlayControlOutlineColor();
-  style.inactive         = theme.maskOverlayInactiveColor();
+  MaskOverlayStyle style   = DefaultMaskOverlayStyle();
+  style.control_fill       = theme.maskOverlayControlColor();
+  style.control_outline    = theme.maskOverlayControlOutlineColor();
+  style.inactive           = theme.maskOverlayInactiveColor();
 
-  const auto fit = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
-  const auto zoomed =
-      MakeMapping(400, 300, 400, 300, 2.0f, QVector2D(0, 0), 1.25f);
-  const auto fit_display =
-      MakeRadialExistingOverlayDisplay(fit, SampleRadial(), style, {});
-  const auto zoom_display =
-      MakeRadialExistingOverlayDisplay(zoomed, SampleRadial(), style, {});
-  const auto* fit_center  = HandleById(fit_display, MaskOverlayHandleId::RadialCenter);
-  const auto* zoom_center = HandleById(zoom_display, MaskOverlayHandleId::RadialCenter);
+  const auto  fit          = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto  zoomed       = MakeMapping(400, 300, 400, 300, 2.0f, QVector2D(0, 0), 1.25f);
+  const auto  fit_display  = MakeRadialExistingOverlayDisplay(fit, SampleRadial(), style, {});
+  const auto  zoom_display = MakeRadialExistingOverlayDisplay(zoomed, SampleRadial(), style, {});
+  const auto* fit_center   = HandleById(fit_display, MaskOverlayHandleId::RadialCenter);
+  const auto* zoom_center  = HandleById(zoom_display, MaskOverlayHandleId::RadialCenter);
   ASSERT_NE(fit_center, nullptr);
   ASSERT_NE(zoom_center, nullptr);
 
@@ -363,12 +358,12 @@ TEST(MaskOverlayControlTest, MaskControlsKeepLogicalSizeAndThemeColors) {
   fit_handle_only.mode        = MaskOverlayMode::Existing;
   fit_handle_only.source_kind = MaskOverlaySourceKind::Radial;
   fit_handle_only.handles.push_back(*fit_center);
-  MaskOverlayDisplay zoom_handle_only = fit_handle_only;
+  MaskOverlayDisplay zoom_handle_only   = fit_handle_only;
   zoom_handle_only.handles.front().item = zoom_center->item;
 
-  const auto fit_scene  = BuildMaskOverlaySceneGeometry(fit_handle_only, style);
-  const auto zoom_scene = BuildMaskOverlaySceneGeometry(zoom_handle_only, style);
-  const float fit_span  = MaxDistanceFrom(fit_scene.handle_fill, fit_center->item);
+  const auto  fit_scene                 = BuildMaskOverlaySceneGeometry(fit_handle_only, style);
+  const auto  zoom_scene                = BuildMaskOverlaySceneGeometry(zoom_handle_only, style);
+  const float fit_span                  = MaxDistanceFrom(fit_scene.handle_fill, fit_center->item);
   const float zoom_span = MaxDistanceFrom(zoom_scene.handle_fill, zoom_center->item);
   EXPECT_NEAR(fit_span, zoom_span, 0.75f);
   EXPECT_NEAR(fit_span, style.handle_radius_logical_px, 0.75f);
@@ -379,7 +374,7 @@ TEST(MaskOverlayControlTest, MaskControlsKeepLogicalSizeAndThemeColors) {
   EXPECT_NEAR(fit_scene.handle_fill.front().g, style.control_fill.green() * alpha, 2.0);
   EXPECT_NEAR(fit_scene.handle_fill.front().b, style.control_fill.blue() * alpha, 2.0);
 
-  const auto cursor_fit = MapReferenceRadiusToItem(fit, Vector2{200.0f, 150.0f}, 40.0f);
+  const auto cursor_fit  = MapReferenceRadiusToItem(fit, Vector2{200.0f, 150.0f}, 40.0f);
   const auto cursor_zoom = MapReferenceRadiusToItem(zoomed, Vector2{200.0f, 150.0f}, 40.0f);
   ASSERT_TRUE(cursor_fit.has_value());
   ASSERT_TRUE(cursor_zoom.has_value());
@@ -387,7 +382,7 @@ TEST(MaskOverlayControlTest, MaskControlsKeepLogicalSizeAndThemeColors) {
 }
 
 TEST(MaskOverlayControlTest, DegenerateRadialProducesEmptyGeometry) {
-  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto       mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
   RadialMaskSource source;
   source.major_radius = 0.0f;
   source.minor_radius = 0.0f;
@@ -404,15 +399,15 @@ TEST(MaskOverlayControlTest, RadialCreationOutlineStaysWithinChordTolerance) {
   const auto source  = SampleRadial();
   const auto outline = TessellateRadialBoundaryItemPolyline(mapping, source, 1.0f, {});
   ASSERT_GE(outline.size(), 3u);
-  float max_error = 0.0f;
-  constexpr float kPi = 3.14159265358979323846f;
+  float           max_error = 0.0f;
+  constexpr float kPi       = 3.14159265358979323846f;
   for (std::size_t i = 0; i < outline.size(); ++i) {
     const QPointF a = outline[i];
     const QPointF b = outline[(i + 1) % outline.size()];
     const QPointF chord(0.5 * (a.x() + b.x()), 0.5 * (a.y() + b.y()));
-    const float t0 = IndependentRadialTheta(source, IndependentItemToNormalized(mapping, a));
-    const float t1 = IndependentRadialTheta(source, IndependentItemToNormalized(mapping, b));
-    float dt       = t1 - t0;
+    const float   t0 = IndependentRadialTheta(source, IndependentItemToNormalized(mapping, a));
+    const float   t1 = IndependentRadialTheta(source, IndependentItemToNormalized(mapping, b));
+    float         dt = t1 - t0;
     while (dt > kPi) {
       dt -= 2.0f * kPi;
     }
@@ -438,7 +433,7 @@ TEST(MaskOverlayControlTest, RadialCreationOutlineStaysWithinChordTolerance) {
 
 TEST(MaskOverlayControlTest, HiddenDisplayClearsMaskOverlayNodes) {
   OverlayWindow host;
-  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto    mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
   host.overlay->setMaskOverlayDisplay(
       MakeBrushExistingOverlayDisplay(mapping, Vector2{200.0f, 150.0f}, {}));
   host.Present();
@@ -471,16 +466,16 @@ TEST(MaskOverlayControlTest, RadialSelectionShowsEllipseAndBothFeatherBoundaries
   EXPECT_GT(scene.selected_guide_segment_count, 0);
   EXPECT_EQ(scene.coverage_fill_vertex_count, 0);
   EXPECT_EQ(scene.closed_polygon_edge_count, 0);
-  const auto interior = IndependentMapNormalized(
-      mapping, IndependentRadialNormalized(source, 0.40f, 1.05f));
+  const auto interior =
+      IndependentMapNormalized(mapping, IndependentRadialNormalized(source, 0.40f, 1.05f));
   EXPECT_FALSE(OverlayCoversPoint(scene, interior));
 }
 
 TEST(MaskOverlayControlTest, CoincidentRadialBoundariesKeepFeatherControlsReachable) {
-  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
-  RadialMaskSource source = SampleRadial();
-  source.inner_feather = 0.0f;
-  source.outer_feather = 0.0f;
+  const auto       mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  RadialMaskSource source  = SampleRadial();
+  source.inner_feather     = 0.0f;
+  source.outer_feather     = 0.0f;
   const auto display =
       MakeRadialExistingOverlayDisplay(mapping, source, DefaultMaskOverlayStyle(), {});
   EXPECT_EQ(display.selected_contours.size(), 1u);
@@ -507,9 +502,9 @@ TEST(MaskOverlayControlTest, GradientGuidesUseThreeParallelLinesWithoutClosedPol
     EXPECT_GT(length, 1.0e-3);
     return QPointF(d.x() / length, d.y() / length);
   };
-  const QPointF d0 = unit(display.selected_guides[0].b - display.selected_guides[0].a);
-  const QPointF d1 = unit(display.selected_guides[1].b - display.selected_guides[1].a);
-  const QPointF d2 = unit(display.selected_guides[2].b - display.selected_guides[2].a);
+  const QPointF d0    = unit(display.selected_guides[0].b - display.selected_guides[0].a);
+  const QPointF d1    = unit(display.selected_guides[1].b - display.selected_guides[1].a);
+  const QPointF d2    = unit(display.selected_guides[2].b - display.selected_guides[2].a);
   const auto    cross = [](const QPointF& a, const QPointF& b) {
     return a.x() * b.y() - a.y() * b.x();
   };
@@ -522,6 +517,35 @@ TEST(MaskOverlayControlTest, GradientGuidesUseThreeParallelLinesWithoutClosedPol
   EXPECT_EQ(scene.selected_guide_segment_count, 3);
   EXPECT_FALSE(scene.edge_grips.empty());
   EXPECT_TRUE(display.creation_guides.empty());
+}
+
+TEST(MaskOverlayControlTest, GradientControlAxisIsPerpendicularAfterNonSquareMapping) {
+  const auto mapping = MakeMapping(600, 400, 1200, 400, 1.0f, QVector2D(0, 0), 1.5f);
+  auto       source  = SampleLinear();
+  source.normal_x    = 0.6f;
+  source.normal_y    = 0.8f;
+  const auto display =
+      MakeLinearExistingOverlayDisplay(mapping, source, DefaultMaskOverlayStyle(), {});
+  ASSERT_EQ(display.selected_guides.size(), 3u);
+  const auto* origin    = HandleById(display, MaskOverlayHandleId::LinearOrigin);
+  const auto* boundary  = HandleById(display, MaskOverlayHandleId::LinearEndBoundary);
+  const auto* direction = HandleById(display, MaskOverlayHandleId::LinearDirection);
+  ASSERT_NE(origin, nullptr);
+  ASSERT_NE(boundary, nullptr);
+  ASSERT_NE(direction, nullptr);
+
+  const QPointF guide       = display.selected_guides[1].b - display.selected_guides[1].a;
+  const QPointF axis        = boundary->item - origin->item;
+  const double  denominator = std::hypot(guide.x(), guide.y()) * std::hypot(axis.x(), axis.y());
+  ASSERT_GT(denominator, 1.0e-3);
+  EXPECT_NEAR(QPointF::dotProduct(guide, axis) / denominator, 0.0, 1.0e-5);
+
+  const auto normalized = MapItemPointToLinearDirectionSample(mapping, source, direction->item);
+  ASSERT_TRUE(normalized.has_value());
+  const float dx = normalized->x - source.origin_x;
+  const float dy = normalized->y - source.origin_y;
+  EXPECT_NEAR(dx, source.normal_x, 1.0e-5f);
+  EXPECT_NEAR(dy, source.normal_y, 1.0e-5f);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
+++ b/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
@@ -134,7 +134,9 @@ namespace {
   return VerticesCoverPoint(scene.handle_fill, point) ||
          VerticesCoverPoint(scene.handle_outline, point) ||
          VerticesCoverPoint(scene.connectors, point) || VerticesCoverPoint(scene.cursor, point) ||
-         VerticesCoverPoint(scene.creation_guides, point);
+         VerticesCoverPoint(scene.creation_guides, point) ||
+         VerticesCoverPoint(scene.selected_guides, point) ||
+         VerticesCoverPoint(scene.edge_grips, point);
 }
 
 [[nodiscard]] auto MaxDistanceFrom(const std::vector<MaskOverlayVertex>& vertices,
@@ -427,10 +429,11 @@ TEST(MaskOverlayControlTest, RadialCreationOutlineStaysWithinChordTolerance) {
   const auto creating =
       MakeRadialCreatingOverlayDisplay(mapping, source, DefaultMaskOverlayStyle(), {});
   EXPECT_EQ(creating.mode, MaskOverlayMode::Creating);
-  EXPECT_FALSE(creating.creation_outline.empty());
+  EXPECT_TRUE(creating.creation_outline.empty());
+  EXPECT_FALSE(creating.selected_contours.empty());
   const auto scene = BuildMaskOverlaySceneGeometry(creating, DefaultMaskOverlayStyle());
   EXPECT_EQ(scene.coverage_fill_vertex_count, 0);
-  EXPECT_FALSE(scene.creation_guides.empty());
+  EXPECT_FALSE(scene.selected_guides.empty());
 }
 
 TEST(MaskOverlayControlTest, HiddenDisplayClearsMaskOverlayNodes) {
@@ -444,6 +447,81 @@ TEST(MaskOverlayControlTest, HiddenDisplayClearsMaskOverlayNodes) {
   host.Present();
   EXPECT_EQ(host.overlay->lastMaskSceneGeometry().handle_count, 0);
   EXPECT_TRUE(host.overlay->lastMaskSceneGeometry().handle_fill.empty());
+}
+
+TEST(MaskOverlayControlTest, RadialSelectionShowsEllipseAndBothFeatherBoundaries) {
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto source  = SampleRadial();
+  const auto display =
+      MakeRadialExistingOverlayDisplay(mapping, source, DefaultMaskOverlayStyle(), {});
+  EXPECT_EQ(display.selected_contours.size(), 3u);
+  EXPECT_NE(HandleById(display, MaskOverlayHandleId::RadialMajor), nullptr);
+  EXPECT_NE(HandleById(display, MaskOverlayHandleId::RadialInnerFeather), nullptr);
+  EXPECT_NE(HandleById(display, MaskOverlayHandleId::RadialOuterFeather), nullptr);
+  const auto* inner = HandleById(display, MaskOverlayHandleId::RadialInnerFeather);
+  const auto* outer = HandleById(display, MaskOverlayHandleId::RadialOuterFeather);
+  ASSERT_NE(inner, nullptr);
+  ASSERT_NE(outer, nullptr);
+  EXPECT_EQ(inner->shape, MaskOverlayHandleShape::Ring);
+  EXPECT_EQ(outer->shape, MaskOverlayHandleShape::Ring);
+  EXPECT_EQ(HandleById(display, MaskOverlayHandleId::RadialMajor)->shape,
+            MaskOverlayHandleShape::Disc);
+
+  const auto scene = BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle());
+  EXPECT_GT(scene.selected_guide_segment_count, 0);
+  EXPECT_EQ(scene.coverage_fill_vertex_count, 0);
+  EXPECT_EQ(scene.closed_polygon_edge_count, 0);
+  const auto interior = IndependentMapNormalized(
+      mapping, IndependentRadialNormalized(source, 0.40f, 1.05f));
+  EXPECT_FALSE(OverlayCoversPoint(scene, interior));
+}
+
+TEST(MaskOverlayControlTest, CoincidentRadialBoundariesKeepFeatherControlsReachable) {
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  RadialMaskSource source = SampleRadial();
+  source.inner_feather = 0.0f;
+  source.outer_feather = 0.0f;
+  const auto display =
+      MakeRadialExistingOverlayDisplay(mapping, source, DefaultMaskOverlayStyle(), {});
+  EXPECT_EQ(display.selected_contours.size(), 1u);
+  EXPECT_EQ(HandleById(display, MaskOverlayHandleId::RadialInnerFeather), nullptr);
+  EXPECT_EQ(HandleById(display, MaskOverlayHandleId::RadialOuterFeather), nullptr);
+  EXPECT_NE(HandleById(display, MaskOverlayHandleId::RadialMajor), nullptr);
+  const auto scene = BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle());
+  EXPECT_EQ(scene.closed_polygon_edge_count, 0);
+  EXPECT_GT(scene.selected_guide_segment_count, 0);
+}
+
+TEST(MaskOverlayControlTest, GradientGuidesUseThreeParallelLinesWithoutClosedPolygon) {
+  const auto mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  const auto display =
+      MakeLinearExistingOverlayDisplay(mapping, SampleLinear(), DefaultMaskOverlayStyle(), {});
+  ASSERT_EQ(display.selected_guides.size(), 3u);
+  EXPECT_EQ(display.edge_grips.size(), 3u);
+  EXPECT_EQ(display.selected_guides[0].id, MaskOverlayHandleId::LinearStartBoundary);
+  EXPECT_EQ(display.selected_guides[1].id, MaskOverlayHandleId::LinearOrigin);
+  EXPECT_EQ(display.selected_guides[2].id, MaskOverlayHandleId::LinearEndBoundary);
+
+  const auto unit = [](const QPointF& d) {
+    const auto length = std::hypot(d.x(), d.y());
+    EXPECT_GT(length, 1.0e-3);
+    return QPointF(d.x() / length, d.y() / length);
+  };
+  const QPointF d0 = unit(display.selected_guides[0].b - display.selected_guides[0].a);
+  const QPointF d1 = unit(display.selected_guides[1].b - display.selected_guides[1].a);
+  const QPointF d2 = unit(display.selected_guides[2].b - display.selected_guides[2].a);
+  const auto    cross = [](const QPointF& a, const QPointF& b) {
+    return a.x() * b.y() - a.y() * b.x();
+  };
+  EXPECT_NEAR(cross(d0, d1), 0.0, 0.05);
+  EXPECT_NEAR(cross(d1, d2), 0.0, 0.05);
+
+  const auto scene = BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle());
+  EXPECT_EQ(scene.closed_polygon_edge_count, 0);
+  EXPECT_EQ(scene.coverage_fill_vertex_count, 0);
+  EXPECT_EQ(scene.selected_guide_segment_count, 3);
+  EXPECT_FALSE(scene.edge_grips.empty());
+  EXPECT_TRUE(display.creation_guides.empty());
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/ui/workspace_shell_test.cpp
+++ b/alcedo_studio/tests/ui/workspace_shell_test.cpp
@@ -1099,7 +1099,7 @@ TEST_F(WorkspaceShellTests, ProductionFirstFramePathWritesAndSubmitsRealFrameDat
   const auto pending = loaded->host.editor_session_service()->PeekPendingInput();
   const auto* exposure = alcedo::FindPendingField(pending, "exposure");
   ASSERT_NE(exposure, nullptr);
-  EXPECT_NE(exposure->params_json.find("0.30"), std::string::npos);
+  EXPECT_EQ(alcedo::PendingScalarValue(*exposure), 0.30f);
   EXPECT_EQ(composed_before_drag, viewport->presentedFrameCount())
       << "queued input must not apply or render until the owner consumes it";
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,13 +2,14 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.7 complete; NM7.8–NM7.15 planned. This document records the NM7.1 source
+Status: NM7.1–NM7.8 complete; NM7.9–NM7.15 planned. This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
 shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
-and NM7.7 Radial/Linear creation plus existing-mask movement. Some former NM7.11 UI wiring (now NM7.12) was brought forward for Radial/Gradient testing.
-This is partial wiring, not completion of the full UI phase. New NM7.8 addresses the usability
-gaps found in that testing; NM7.8–NM7.15 acceptance remains outstanding.
+NM7.7 Radial/Linear creation plus existing-mask movement, and NM7.8 parameter-mask
+controls, drawer selection/deletion, and crop-style Gradient. Some former NM7.11 UI
+wiring (now NM7.12) was brought forward for Radial/Gradient testing. This is partial
+wiring of the full UI phase. NM7.9–NM7.15 acceptance remains outstanding.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -1152,7 +1153,7 @@ EditorAdjustmentHeader beginRadial/beginLinear
 
 ### NM7.8 — Improve parameter-mask controls and existing-mask editing
 
-**Status:** planned. Builds on NM7.7 and the early UI wiring; does not repeat owner-path
+**Status:** complete. Builds on NM7.7 and the early UI wiring; does not repeat owner-path
 implementation or wait for Brush accumulation and project cache settings.
 
 **Purpose:** make Radial feather/range editable and visible, allow selection/deletion and
@@ -1240,6 +1241,84 @@ lines and crop-style Gradient grips without coverage fill. Independent Section 6
 sampled coverage within 1 R8 code. Prove exact history counts, stable IDs/scroll and actual photo
 updates before release; control redraw alone does not pass. Record the executed native backend
 and any remaining platform qualification explicitly.
+
+##### Phase NM7.8 completion record (2026-09-09)
+
+**Status:** complete — selected Radial range/feather lines, crop-style Gradient guides,
+Node Mask drawer select/re-edit/delete, and document Geometry mapping publication.
+
+**Primary success call chain:**
+
+```text
+drawer click / Masks body row
+  -> EditorMaskCreationAdapter::selectMask
+  -> Enqueue SelectMask
+  -> EditorMaskCreationController::SelectMask (load-only; zero Mix / history)
+  -> overlay from live Grade source; Masks body fields
+
+handle or Inner/Outer feather slider
+  -> BeginMove / Append
+  -> ReplaceMaskSource live
+  -> Interactive Mix (host GradeMaskCoverage)
+  -> Finish
+  -> one ReplaceMaskSource commit
+  -> Quality
+
+delete icon / Delete with Mask controls focused
+  -> cancel target op + drop queued Append/BeginMove/Finish/BeginInput
+  -> MakeRemoveMaskBatch
+  -> selection next-then-previous; overlay/list update
+  -> remaining Mix; Grade node retained
+```
+
+**Primary failure call chain:**
+
+```text
+degenerate creation or Escape
+  -> RestoreLive; history head unchanged
+
+failed RemoveMask publish
+  -> re-insert stored Mask at the same index; committed Mask remains
+
+Delete with Mask controls focused
+  -> removeSelectedMask; Grade delete shortcut is not taken
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `RadialSelectionShowsEllipseAndBothFeatherBoundaries` | `MaskOverlayControlTest` | PASS |
+| `RadialFeatherControlsPreserveCenterRadiiAndRotation` | `AnalyticMaskCreationTest` | PASS |
+| `RadialFeatherDragUpdatesInteractivePixelsBeforeRelease` | `AnalyticMaskCreationTest` | PASS |
+| `CoincidentRadialBoundariesKeepFeatherControlsReachable` | `MaskOverlayControlTest`, `AnalyticMaskCreationTest` | PASS |
+| `NodeDrawerSelectionLoadsExistingMaskWithoutCreatingOrRendering` | `AnalyticMaskCreationTest` | PASS |
+| `SelectedMaskCanBeEditedAfterWorkspaceReentry` | `AnalyticMaskCreationTest` | PASS |
+| `NodeDrawerDeleteRemovesExactMaskAndUndoRestoresSource` | `AnalyticMaskCreationTest` | PASS |
+| `DeletingLastMaskRestoresFullGradeCoverage` | `AnalyticMaskCreationTest` | PASS |
+| `DeletingUnselectedMaskPreservesSelection` | `AnalyticMaskCreationTest` | PASS |
+| `DeletingMaskRejectsQueuedEditsAndDelayedFrames` | `AnalyticMaskCreationTest` | PASS |
+| `MaskDeleteWithViewerFocusDoesNotDeleteGrade` | `AnalyticMaskCreationTest` | PASS |
+| `GradientGuidesUseThreeParallelLinesWithoutClosedPolygon` | `MaskOverlayControlTest` | PASS |
+| `GradientBoundaryDragPreservesOriginAndChangesTransition` | `AnalyticMaskCreationTest` | PASS |
+| `AnalyticControlCancelRestoresSourceWithoutHistory` | `AnalyticMaskCreationTest` | PASS |
+| Drawer select highlight without list rebuild; delete icon emits exact MaskId | `EditorNodeDelegateQmlTest` | PASS |
+| Cropped/rotated photograph uses resolved geometry, not identity | `MaskEditGeometryTest` | PASS |
+| Independent Section 6 formulas vs Mix within 1 R8 | `AnalyticMaskCreationTest` | PASS |
+| Overlay `coverage_fill_vertex_count == 0`; no closed Gradient polygon | `MaskOverlayControlTest` | PASS |
+
+Commands:
+`cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target MaskOverlayControlTest --target AnalyticMaskCreationTest --target MaskEditGeometryTest --target EditorNodeDelegateQmlTest --target AlbumBackendLib`
+`ctest --test-dir build/debug --output-on-failure -R "MaskOverlayControlTest|AnalyticMaskCreationTest|MaskEditGeometryTest|EditorNodeDelegateQmlTest"`
+
+Suite totals: `56/56` PASS (`EditorNodeDelegateQmlTest` 21, `MaskEditGeometryTest` 5, `MaskOverlayControlTest` 11, `AnalyticMaskCreationTest` 19).
+Date / working tree on `feature/parameter-mask-controls` / Windows MSVC `win_debug` / Qt 6.9.3 (`D:/misc/Qt/6.9.3/msvc2022_64`) / CUDA Toolkit 12.8. Interactive Mix is host `GradeMaskCoverage` using the native analytic equations; no GPU Mask pass in this phase.
+
+**Checklist / exit condition:** required named tests PASS. Radial selected overlay shows base ellipse plus inner/outer feather lines (rings vs discs); coincident zero-feather contours are drawn once and Inner/Outer remain reachable through `BeginMaskMove` after settle. Drawer selection is load-only. Delete uses typed `RemoveMaskChange`, restores source/ID/index on Undo, chooses next then previous, and does not delete the Grade. Gradient guides are three photograph-clipped parallel loci with edge grips, not a kite. Feather/center/origin edits update Mix before `AppendEdit`. Cropped/rotated mapping uses `MakeDocumentPhotographGeometry` plus displayed photograph size (`interactionImageInfo`), not an unpublished identity transform.
+
+**LOC note (grill-code-review):** `editor_mask_creation_adapter.cpp` 682, `mask_overlay_layout.cpp` 524, `analytic_mask_creation_test.cpp` 785, `EditorMasksContextPanel.qml` 203, `mask_list_selection.hpp` 55. Overlay layout owns selected contours/guides; the adapter routes QML; the controller owns select/delete/settle; `MaskIdAfterDeletion` / `MaskIdAfterUndoRestore` stay pure. No split required.
+
+**Residual gaps:** NM7.9 accumulating Brush paint/erase UI. Live pipeline `ResolvedRenderGeometry` from the Interactive/Quality frame (including Interactive `max_edge`) remains NM7.10. Project Mix-cache slot is NM7.11. Remaining Brush/cache UI, accessibility qualification, and Masks-body width/theme matrix at 260/320/460 px are NM7.12. Open-operation cancel on `MappingChanged` is NM7.13. No single workspace e2e with two Grades was executed. Overlay evidence is geometry/QSG assertions, not PNG captures. Failed `RemoveMask` history publish re-inserts in production but was not driven by a failing history port. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.9 — Complete accumulating Brush creation, erase and movement
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -124,7 +124,7 @@ User decisions received on 2026-09-08:
 | Existing Mask movement | Brush/Radial/Gradient update real Interactive pixels during drag, Quality after release | NM7.5, NM7.7–NM7.10 |
 | QSG existing-mask display | Controls only, no affected-area fill or completed Brush path | NM7.6 |
 | Initial creation guides | Working interpretation: temporary cursor/outline/path guides are allowed only during initial drawing, never area-fill highlighting; clarification requested | NM7.6 |
-| Editing body | Temporary Masks body; preserve six adjustment tabs; analytic test wiring brought forward | NM7.8, NM7.12 |
+| Editing body | Seventh Mask parameter page in the Adjustment Stack; disabled until Mask creation or selection; Node drawer remains the sole Mask list | NM7.8, NM7.12 |
 | Project storage | User-selected cache root, per-project Keep/DeleteOnProjectClose and Clear actions | NM7.11–NM7.12 |
 
 Size and strength are explicit user controls. Automatic pen-pressure modulation was not requested;
@@ -152,7 +152,7 @@ explicit version gate described in the companion design, not silently converted 
    and Brush strokes plus supported Brush/Mask controls.
 3. Expose existing Mask opacity, enabled, invert, rename and delete through focused owner calls.
 4. Provide immediate retained QSG assistance, real Interactive preview, and settled Quality.
-5. Support pointer release, Done/Enter, Escape/Cancel, keyboard editing, interruption, and stale
+5. Support pointer release, Enter or panel-switch confirmation, Escape cancellation, keyboard editing, interruption, and stale
    asynchronous work rejection with precise one-operation/one-commit behavior.
 6. Restore correct mask selection and values after Undo/Redo, checkout, re-entry, and image change.
 7. Parameterize Brush paths and add reversible commands plus exact regional replay.
@@ -212,13 +212,15 @@ absolute write per field. Parameterized strokes are not present in production JS
 
 [NM6.7 completion](phase_nm6_node_aware_adjustments_plan.md#nm67--build-node-nameexif-header-and-capability-filtered-panels)
 and [DESIGN.md](../../../../../alcedo_studio/src/ui/alcedo_main/DESIGN.md) supersede the older
-capability-filtered navbar and vertical EXIF layout: six tabs remain, EXIF occupies one row, and
-Mask tool actions sit beside the node name. NM7 must preserve those landed choices.
+capability-filtered navbar and vertical EXIF layout: EXIF occupies one row, and Mask tool actions
+sit beside the node name. NM7 must preserve those landed choices.
 
-The temporary Masks body approved in Section 2 makes the older master Masks panel reachable
-without adding a seventh tab. Store the previous ordinary panel key as session presentation state,
-restore it on Done/Cancel, and never submit edits just because a body opens or closes. This routing
-choice was approved on 2026-09-08 and is reflected in master Section 18.1.
+The 2026-09-09 correction adds Mask as a seventh Adjustment Stack page. It is disabled until a
+header creation action or Node drawer Mask selection enters Mask editing. The Node drawer is the
+only Mask list; the page contains source-specific parameter controls and does not repeat management
+rows. Store the previous ordinary panel key as session presentation state. Enter or selecting a
+different adjustment page confirms and exits Mask editing, while Escape cancels. There are no
+explicit Done/Cancel actions and the transient Mask page is not persisted as the ordinary panel.
 
 ## 4. Official Qt documentation and drawing decisions
 
@@ -324,8 +326,8 @@ Mask; first Brush release commits AddMask with its first canonical stroke, later
 AppendBrushStroke on the same MaskId. An analytic drag commits its final source fields; a Brush
 move commits before/after translation, without rewriting any sample coordinates.
 
-Done after release only exits mode. Cancel rolls back unfinished commands and replays affected
-regions; earlier completed strokes remain. No-op creation or unchanged placement creates no
+Enter or selecting another adjustment page after release only exits mode. Escape rolls back
+unfinished commands and replays affected regions; earlier completed strokes remain. No-op creation or unchanged placement creates no
 commit. A release equal to the last provisional value still seals the actual earlier change.
 
 Undo removes/restores the relevant command data using NM4; deterministic evaluation updates the
@@ -495,9 +497,9 @@ before-values stay with history; they are not copied into another session model.
 | Choose a creation tool | Resolve exact Grade; arm Creating; no AddMask/history/render until valid input |
 | Select an existing Mask | Load owner data, selected row and overlay; pure selection makes no photo render |
 | Valid press / move | Editing or Painting; immediate overlay; queue focused input for Interactive |
-| Release / Enter / Done with a valid open operation | Seal once, enter Settling, publish one commit and request Quality |
-| Escape / Cancel | Cancel unfinished input, restore before-state/remove provisional addition, zero commits; exit mode |
-| Enter / Done after a released operation | Leave mode without a duplicate commit |
+| Release with a valid open operation | Seal once, enter Settling, publish one commit and request Quality |
+| Escape | Cancel unfinished input, restore before-state/remove provisional addition, zero commits; exit mode |
+| Enter or select another adjustment page after a released operation | Leave mode without a duplicate commit and restore/select the requested ordinary page |
 | New press while Settling | Keep the tool visibly unavailable for a new stroke until acknowledgement; preserve GUI responsiveness and never silently accept then drop a press |
 | Unexpected grab loss, touch cancellation, window deactivation or workspace hiding | Cancel open operation before disabling/destroying its input adapter; do not fabricate release |
 | Switch to another Mask/tool | Settle a valid current operation, then retarget; abandon an unstarted/degenerate creation |
@@ -526,24 +528,23 @@ Version/sequence identity. A late result must release its resources even when pr
 
 ## 9. UI, accessibility and integration behavior
 
-Implement Section 2's approved routing, preserving the landed header and six-tab product decision.
-The approved temporary body reuses `EditorMasksContextPanel.qml` as the actual Masks editor and
-loads through the adjustment shell; it is not a hidden unused QML module or a separate window.
+Implement Section 2's approved routing. `EditorMasksContextPanel.qml` is the seventh Adjustment
+Stack parameter page; it is not a floating overlay, hidden unused module, or second Mask manager.
 
 The Node Mask drawer exposes selectable compact type rows and a per-row delete action.
-Selection targets exact NodeId/MaskId and opens the existing source in the temporary Masks body;
+Selection targets exact NodeId/MaskId and opens the existing source in the Mask parameter page;
 it never calls a header creation action. Delete must not propagate into row or graph actions.
-The Masks-body list exposes type icon, Mask name, selection, and supported commands. Selected-row controls
-edit name, enabled, invert, opacity and source-specific values plus an explicit Brush Move action. Use exact IDs, stable row updates,
-and a panel-level `selectedMaskId` binding. No list rebuild or forced scroll containment on click.
+The Node drawer alone exposes type, selection, deletion, and supported management commands. The
+Mask parameter page edits source-specific values plus the controls implemented by its phase. Use
+exact IDs, stable row updates, and a panel-level `selectedMaskId` binding. No list rebuild or forced
+scroll containment on click.
 After deletion select the next row at the old position, otherwise previous, otherwise no selection.
 Undo restores IDs; select a restored mask only according to an explicit current-session selection
 rule, never by a reused index. Selection-only restore stays load-only.
 
-The compact viewer creation bar contains separate source-kind and name text plus Done/Cancel.
-Use existing shared actions and `cardSurfaceColor`, `cardBorderColor`, `panelRadius`, spacing,
-font and icon tokens. Place it in a reserved viewer edge area; if it would cover an active primary
-handle, relocate the bar within that area without moving the photo or changing coordinates.
+Do not add explicit Done/Cancel actions in the viewer or parameter page. Enter confirms and returns
+to the previous ordinary page; selecting any other enabled adjustment page confirms and opens that
+page. Escape remains the cancellation route.
 
 Use existing approved Brush/Radial/Gradient SVGs, including their documented 2 px exception.
 Define required Mask colors/handle geometry/hit-area/antialias widths as AppTheme semantic tokens
@@ -552,7 +553,7 @@ master's `maskOverlayControlColor`, `maskOverlayControlOutlineColor`, `maskOverl
 
 QSG nodes are not accessible controls. Expose lightweight accessible proxies for the selected
 source's finite set of handles, or equivalent named numeric controls plus handle selection. Do
-not create a proxy for every dab. Tab reaches the list, selected controls and Done/Cancel; arrows
+not create a proxy for every dab. Tab reaches the selected controls; arrows
 move the focused handle, with a named numeric alternative for precision. Proposed step is one
 ReferenceSpace pixel, Shift ten; rotations and feather widths use explicitly labelled units.
 Text-input Delete/Escape/Enter must first obey text editing/rename semantics; graph Delete must
@@ -1176,8 +1177,8 @@ controls in the actual workspace.
    later edits update that same MaskId. Selection creates no mask, history or photo render.
    Bind highlight to session selection and preserve scroll; do not rebuild the list on click.
    Restore controls on re-entry, session rebind and Undo/Redo using the load-only route. Keep
-   compact type labels and parameter editors in the temporary Masks body. Brush rows support
-   selection/deletion here; new paint/erase controls remain NM7.9.
+   compact type labels in the Node drawer and parameter editors in the Mask Adjustment Stack page.
+   Brush rows support selection/deletion here; new paint/erase controls remain NM7.9.
 3. **Deletion.** Add a compact per-row delete icon with pointer/keyboard access and a clear
    accessible name. Target the clicked row's exact mask, never its Grade or a reused index.
    Stop delete-event propagation. Cancel/restore unfinished edits for that target before removal,
@@ -1200,7 +1201,7 @@ controls in the actual workspace.
    begin/update/finish/cancel service and exact target identity. Update actual Interactive pixels
    before release, then one typed history operation and Quality on settle. Escape restores the
    original source without a commit. Read/edit through the existing owner without a mirrored
-   editable source. Preserve six tabs and prior-panel restoration. Fix any mapping publication
+   editable source. Preserve prior-panel restoration. Fix any mapping publication
    needed for these controls in this phase: cropped/rotated images must use actual resolved
    geometry, not a guessed identity transform. Remaining serial/cache integration is NM7.10.
 6. **VI.** Follow `alcedo-qml-ui`, reuse shared controls and AppTheme tokens. Update AppTheme
@@ -1318,7 +1319,83 @@ Date / working tree on `feature/parameter-mask-controls` / Windows MSVC `win_deb
 
 **LOC note (grill-code-review):** `editor_mask_creation_adapter.cpp` 682, `mask_overlay_layout.cpp` 524, `analytic_mask_creation_test.cpp` 785, `EditorMasksContextPanel.qml` 203, `mask_list_selection.hpp` 55. Overlay layout owns selected contours/guides; the adapter routes QML; the controller owns select/delete/settle; `MaskIdAfterDeletion` / `MaskIdAfterUndoRestore` stay pure. No split required.
 
-**Residual gaps:** NM7.9 accumulating Brush paint/erase UI. Live pipeline `ResolvedRenderGeometry` from the Interactive/Quality frame (including Interactive `max_edge`) remains NM7.10. Project Mix-cache slot is NM7.11. Remaining Brush/cache UI, accessibility qualification, and Masks-body width/theme matrix at 260/320/460 px are NM7.12. Open-operation cancel on `MappingChanged` is NM7.13. No single workspace e2e with two Grades was executed. Overlay evidence is geometry/QSG assertions, not PNG captures. Failed `RemoveMask` history publish re-inserts in production but was not driven by a failing history port. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
+**Residual gaps:** NM7.9 accumulating Brush paint/erase UI. Live pipeline `ResolvedRenderGeometry` from the Interactive/Quality frame (including Interactive `max_edge`) remains NM7.10. Project Mix-cache slot is NM7.11. Remaining Brush/cache UI, accessibility qualification, and Mask-page width/theme matrix at 260/320/460 px are NM7.12. Open-operation cancel on `MappingChanged` is NM7.13. No single workspace e2e with two Grades was executed. Overlay evidence is geometry/QSG assertions, not PNG captures. Failed `RemoveMask` history publish re-inserts in production but was not driven by a failing history port. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present. Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
+
+##### Phase NM7.8 correction record (2026-09-09)
+
+**Status:** complete — removed the second Mask list, made Mask a disabled-until-editing seventh
+Adjustment Stack page, added Enter/panel-switch confirmation, exposed Radial/Gradient parameters,
+and corrected Gradient control-axis geometry under non-square view mapping.
+
+**Primary success call chains:**
+
+```text
+header Mask action or Node drawer Mask row
+  -> EditorMaskCreationAdapter begin/select
+  -> maskCreationChanged
+  -> EditorAdjustmentStack stores the ordinary page and opens masks
+  -> EditorMasksContextPanel reads the selected live source
+
+Mask parameter slider
+  -> BeginAnalyticMove
+  -> AppendMaskInput
+  -> owner ReplaceMaskSource + Interactive pixels
+  -> finishAnalyticControl
+  -> FinishMaskInput + one history operation + Quality
+
+Enter or adjustment-page selection
+  -> EditorMaskCreationAdapter::finishBody
+  -> FinishMode
+  -> EditorMaskCreationController::FinishCreationMode
+  -> ResetMode
+  -> prior or requested ordinary page
+
+Gradient direction pointer
+  -> MapItemPointToLinearDirectionSample using the view transform transpose
+  -> evaluator-space normal
+  -> MapLinearLocusNormalPointToItem
+  -> item-space control axis perpendicular to all three guides
+
+Node drawer Mask-row pointer click
+  -> EditorNodeMaskTypeRow MouseArea
+  -> AlcedoQanGraph MaskRowSelected(nodeId, maskId)
+  -> EditorNodesPanel selects the owning Color Grade
+  -> EditorMaskCreationAdapter selects the exact Mask
+```
+
+**What was proven (macOS debug tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MaskPageActivatesOnlyForSelectedOrCreatingMask` | `EditorAdjustmentHeaderQmlTest` | PASS |
+| `EnterEquivalentFinishesMaskEditAndRestoresPanel` | `EditorAdjustmentHeaderQmlTest` | PASS |
+| `FinishModeSettlesOnceAndLeavesMaskEditingInactive` | `AnalyticMaskCreationTest` | PASS |
+| `GradientControlAxisIsPerpendicularAfterNonSquareMapping` | `MaskOverlayControlTest` | PASS |
+| Existing affected tests in the three binaries | 40 additional tests | PASS |
+| `MaskRowSelectionSelectsItsOwningColorGrade` | `EditorNodesPanelQmlTest` | PASS |
+| Node Mask row avoids style-controlled text and all Node QML avoids Material imports | `EditorNodeDelegateQmlTest` | PASS |
+
+Commands:
+`cmake --build --preset macos_debug_tests --target MaskOverlayControlTest EditorAdjustmentHeaderQmlTest AnalyticMaskCreationTest -j4`
+`ctest --test-dir build/macos-debug-tests --output-on-failure -R "MaskOverlayControlTest|EditorAdjustmentHeaderQmlTest|AnalyticMaskCreationTest"`
+
+Suite total: `44/44` PASS. A broader `WorkspaceShellTest` rebuild remains blocked by the unrelated
+existing use of removed `EditorPendingFieldChange::params_json` in `workspace_shell_test.cpp:1102`;
+the focused production-QML test loads the changed stack and Mask page successfully. The
+`alcedo_main` build compiled the changed QML cache and production sources, then the existing macOS
+test-preset link failed on missing generated `qml_register_types_Alcedo_Main()`.
+
+The Node drawer click correction was additionally verified with `EditorNodesPanelQmlTest` `34/34`
+PASS and `EditorNodeDelegateQmlTest` `21/21` PASS on macOS debug. The interactive Mask row uses
+QtQuick `Item` / `MouseArea` / `Text` plus the shared `IconActionButton`; it has no Material import
+and no style-controlled `Label` in its pointer path.
+
+**LOC note (grill-code-review):** `editor_mask_creation_adapter.cpp` 885,
+`mask_overlay_layout.cpp` 630, `EditorMasksContextPanel.qml` 243,
+`EditorAdjustmentStack.qml` 383, `analytic_mask_creation_test.cpp` 871,
+`editor_adjustment_header_qml_test.cpp` 751, `mask_overlay_control_test.cpp` 551. The adapter owns
+the QML command bridge, overlay layout owns view/evaluator geometry conversion, and the parameter
+page contains no Mask collection or duplicate owner state.
 
 ### NM7.9 — Complete accumulating Brush creation, erase and movement
 
@@ -1392,17 +1469,17 @@ Clear → maintenance boundary → stop old writer → delete only owned cache �
 NM7.7; NM7.8 owns analytic controls and drawer selection/deletion. Retain and verify those paths.
 The complete UI phase remains planned until its remaining work and acceptance pass.
 
-**Work:** finish Brush header/body routing; preserve six tabs and prior panel restoration;
+**Work:** finish Brush routing into the Mask Adjustment Stack page and preserve prior panel restoration;
 expose paint/erase/size/strength/Move and remaining source/Mask values. Add project
 cache section through app APIs with root chooser, policy and per-project usage/Clear. Existing
 cache settings are thumbnail-specific; keep the new project fields separate. Add keyboard/accessible
 controls, focus rules, theme/width/reduced-motion tests and QML registration.
 
-**Files/APIs:** header/stack/Masks body/node drawer/creation bar, `SettingDialog.qml`,
+**Files/APIs:** header/stack/Mask parameter page/node drawer, `SettingDialog.qml`,
 `CacheSettingsPanel.qml`, proposed `ProjectMaskCacheSettingsPanel.qml`, project adapter, AppTheme/DESIGN.
 
 **Primary chain:** UI action → exact project/Mask owner → validated operation → completion projection.
-**Tests:** `MaskModePreservesSixTabs`, `MaskSelectionDoesNotSubmitOrJumpScroll`,
+**Tests:** `MaskPageActivatesOnlyForSelectedOrCreatingMask`, `MaskSelectionDoesNotSubmitOrJumpScroll`,
 `KeyboardMaskMoveUsesSameInteractiveRoute`, `CacheSettingsTargetSelectedProjectOnly`,
 `ProjectClearExplainsThatBrushHistoryIsRetained`.
 
@@ -1483,10 +1560,10 @@ helpers to generate both sides of a comparison.
 | Parameter-mask UI | selected Radial range/feather lines; crop-style Gradient guides; drawer select/re-edit/delete | NM7.8 production QML input, IDs/history, before-release pixels and captures; no fill |
 | Movement | existing Brush/Radial/Gradient; old/new domains; repeated translation; press/move/release | Interactive pixels update before release; controls only, no coverage fill; one final commit |
 | Project cache | custom root, Clear, close cleanup, two projects, repeated Versions | Stable file count; delete-all-cache restores same history/coverage; no cross-project deletion |
-| Input | press under threshold, outside release, canceled grab, synthesized mouse, second touch, repeated Done | One source stream and exactly one terminal outcome; no duplicate commit |
+| Input | press under threshold, outside release, canceled grab, synthesized mouse, second touch, repeated Enter | One source stream and exactly one terminal outcome; no duplicate commit |
 | Ownership | held GPU/request reader, late callback, load/checkout during settle, new image with reused IDs | No simultaneous raster read/write or live mutation/render; no stale publication |
 | History | creation, later edit, delete, cancel, no-op, Undo/Redo, cache corruption, WAL failure | Exact commit counts/HEAD, canonical document values and replayed expected coverage with no prior cache |
-| UI | header/node entry, six tabs, stable rows, focus, renamed/missing target, two themes/reduced motion | Production QML load; load-only emits zero commands/renders; actual reachable control path |
+| UI | header/node entry, seven pages with Mask disabled outside editing, stable rows, focus, renamed/missing target, two themes/reduced motion | Production QML load; load-only emits zero commands/renders; actual reachable control path |
 | Persistence | reopen, two Versions, Paste, export | Same settled source-derived coverage; target RAW metadata retained; no overlay in exported pixels |
 
 For final RGB comparisons use existing pipeline fixture tolerances and record max/mean error plus
@@ -1562,7 +1639,7 @@ Global NM7 completion checklist:
 - [ ] Brush canonical input, parameterized strokes, one current Grade R8 slot, regional replay and reader ownership are proven.
 - [ ] Creation, each edit/stroke, cancellation and deletion have the specified history outcome.
 - [ ] Stale inputs, cache jobs and frames cannot cross image/Version/sequence boundaries.
-- [ ] UI entry points, accessibility, six-tab behavior and load-only selection restore are tested.
+- [ ] UI entry points, accessibility, disabled-until-editing Mask page and load-only selection restore are tested.
 - [ ] Native runtime, cacheless persistence/recovery and exported pixels pass the acceptance matrix.
 - [ ] One thousand strokes/Undo/Redo do not create per-step R8 files or pixel history.
 - [ ] Per-project paths, retain/close-cleanup/Clear and stale-writer rejection are qualified.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
@@ -4,7 +4,7 @@ Date: 2026-08-29
 
 Status: NM0, NM2, NM3, NM4, and NM5 complete; NM6.1–NM6.4, NM6.4P, and NM6.P complete
 per execution records; NM6.5–NM6.9 planned; NM1 status retained below;
-NM7–NM8 planned. NML was
+NM7.1–NM7.8 complete; NM7.9–NM7.15 and NM8 planned. NML was
 cancelled on 2026-08-30.
 
 2026-08-30 简化修订：每张图片只有一个 live document，领域函数原地修改，后台任务共用
@@ -21,16 +21,19 @@ QuickQanava boundary, and official documentation sources for NM5-NM8 are fixed b
 See the [NM5 execution plan](node_mask_editor/phase_nm5_nodes_panel_plan.md) for its sub-phases.
 
 2026-09-08 NM7 revised user direction: the
-[NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md) now has fourteen
+[NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md) now has fifteen
 sub-phases and a companion [algorithm/storage design](node_mask_editor/mask_command_replay_and_project_cache_plan.md).
 Brush paths are parameterized; NM4 records reversible stroke/placement commands. R8 is one
 current Grade Mix cache slot, never a per-stroke Undo asset. Project settings own its root and
 cleanup policy. Moving existing Brush/Radial/Gradient masks updates actual Interactive pixels;
 QSG displays controls without affected-area highlighting. Center-out Radial creation, adjustable
-Brush size/strength with paint/erase, and the temporary Masks body/six tabs remain approved.
+Brush size/strength with paint/erase remain approved. The 2026-09-09 correction makes Mask a
+seventh Adjustment Stack parameter page that is enabled only during Mask creation or selection;
+the Node drawer remains the sole Mask list.
 This supersedes the earlier immutable-raster-history requirement in Sections 8–12 and NM7.
 NM3/NM4 completion records remain historical evidence; their source/history/cache interfaces
-must be extended inside NM7 before exposing its UI. NM7 remains planned.
+must be extended inside NM7 before exposing its UI. NM7.1–NM7.8 are complete; NM7.9–NM7.15 remain
+planned.
 
 2026-09-05 NM6 design approval: NM5 is complete. The
 [NM6 execution plan](node_mask_editor/phase_nm6_node_aware_adjustments_plan.md) now defines
@@ -1085,7 +1088,7 @@ Each row shows only the approved source-type icon and localized type label:
 
 Do not show Mask name, opacity, enabled state, invert state, ranges, or identity in compact rows.
 The NM7.8 revision requires stable-ID selection and a compact per-row delete action, with
-parameter controls in the temporary Masks body. It supersedes the earlier read-only row rule.
+parameter controls in the Mask Adjustment Stack page. It supersedes the earlier read-only row rule.
 An empty open drawer has no Mask rows.
 
 Drawer state is local UI layout state. A fold creates no history and no render. The output port and
@@ -1433,18 +1436,21 @@ Use these interruption rules:
 
 ### 18.1 Masks panel
 
-2026-09-08 user decision: Masks is a temporary right-side editing body for the Color Grade
-context. The existing header Brush/Radial/Gradient actions and node Mask rows open it; the six
-ordinary adjustment tabs remain unchanged. Done/Cancel restores the previous ordinary body.
-Its controls do not become QuickQanava graph content.
+2026-09-09 user correction: Mask is the seventh right-side Adjustment Stack page for the Color
+Grade context. It is disabled until an existing header Brush/Radial/Gradient action or Node Mask
+row opens Mask editing. Enter confirms and returns to the previous ordinary page; choosing another
+adjustment page confirms and opens that page. Escape cancels. There are no explicit Done/Cancel
+actions, and the transient Mask page is not persisted as the ordinary panel. Its controls do not
+become QuickQanava graph content.
 
 The panel has this structure:
 
 1. A header shows `Masks`.
 2. The existing header actions enter Brush, Radial, or Linear Gradient creation. Brush resumes
    the selected Grade's current accumulating Brush Mask if present. It creates no extra row per stroke.
-3. A list shows the Masks that the selected Color Grade owns.
-4. The selected row exposes supported Mask controls, including opacity, rename, and delete.
+3. The Node drawer is the sole list and management surface for Masks owned by the selected Color
+   Grade; the Adjustment Stack page does not repeat those rows.
+4. The Mask page exposes supported source-specific controls for the selected Mask.
    Brush supports paint/erase and adjustable size/strength; these tool settings affect subsequent
    samples, while Mask opacity affects the entire accumulated raster. Multiple strokes on a Grade
    merge into the same current Brush raster and keep its MaskId. Each settled stroke remains
@@ -1460,18 +1466,13 @@ for one.
 After Mask add, delete, or reorder, update the owning node's Mask drawer rows. Update row identity,
 order, type, and label only. Do not add a Mask count. Do not rebuild the full graph.
 
-### 18.2 Viewer creation bar
+### 18.2 Mask editing state
 
-In creation mode, the viewer shows a compact creation bar. It shows the source kind, selected
-Mask name, Done, and Cancel. Each value has its own text element. Do not join values with a
-decorative separator.
-
-The bar uses `cardSurfaceColor`, `cardBorderColor`, and `panelRadius`. Done and Cancel use existing
-shared action components. Escape is equivalent to Cancel. Enter is equivalent to Done when the
-current source can settle.
-
-The creation bar does not cover a primary control point. It does not change the viewer coordinate
-space.
+Creation or selection enters the explicit Mask editing state and opens the Mask Adjustment Stack
+page. The viewer contains only the source controls and guides; it does not add a Done/Cancel bar.
+Enter confirms and restores the previous ordinary page. Selecting another enabled adjustment page
+confirms and switches directly to it. Escape cancels and restores the before-state. Leaving the
+state does not change viewer coordinates.
 
 ### 18.3 QSG overlay VI
 
@@ -1582,7 +1583,7 @@ AdjustmentSlider
 
 ```text
 Header action selects Radial
-  -> viewer creation mode and temporary Masks body
+  -> viewer creation mode and Mask Adjustment Stack page
   -> first valid input applies provisional AddMask(NodeId, MaskId, Radial params)
   -> pointer input mapped to ReferenceSpace
   -> provisional params shared by QSG + pipeline
@@ -1951,8 +1952,8 @@ parameterized source/history extensions, project cache ownership, and Interactiv
 would produce an edit that cannot restore or preview correctly.
 
 **Scope:** Follow the [NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md).
-Connect the header actions and node Mask rows to a temporary Masks editing body while preserving
-the six ordinary adjustment tabs. Add Brush paint/erase with adjustable size and strength; accumulate
+Connect the header actions and node Mask rows to the disabled-until-editing Mask Adjustment Stack
+page, keeping the Node drawer as the sole Mask list. Add Brush paint/erase with adjustable size and strength; accumulate
 all strokes for a Color Grade in one current Brush raster. Add center-out Radial creation, Linear
 Gradient creation, viewer input routing, `ReferenceSpace` mapping, QSG Mask-editing overlay, provisional raster dirty rectangle,
 settled parameter commands, project cache settings/cleanup, Escape cancellation, mode interruption, and stale-session fencing. Hide the overlay


### PR DESCRIPTION
## Summary

- Add load-only mask selection for Brush, Radial, and Linear Gradient masks through the session queue, `EditorMaskCreationAdapter`, and node graph mask rows.
- Add mask removal (`RemoveMask`) with a typed history batch, selection fallback via `MaskIdAfterDeletion`, and cleanup of pending queued edits for the deleted mask.
- Extend the analytic mask overlay to show selected Radial iso-rho contours and Linear Gradient loci with Geometry crop-style dual strokes, short edge grips, and distinct disc/ring handles for radius vs feather.
- Add radial inner/outer feather parameter controls in `EditorMasksContextPanel`, wired to interactive overlay and slider edits.
- Wire node drawer mask row selection and delete through `AlcedoQanGraph` without triggering photo render on selection alone.
- Add `MakeDocumentPhotographGeometry` so mask input respects cropped/rotated photograph geometry.
- Document new overlay guide/grip tokens in `DESIGN.md` and `AppTheme`.

## Testing

- `ctest --test-dir build/debug -R AnalyticMaskCreationTest --output-on-failure` — selection loads without commit/render, feather controls match evaluator, delete/undo restores source, deletion selection fallback, queued edit rejection
- `ctest --test-dir build/debug -R MaskOverlayControlTest --output-on-failure` — selected Radial shows ellipse and both feather boundaries, coincident boundaries keep feather controls reachable, Gradient guides use three parallel lines without closed polygon, controls update while render is held
- `ctest --test-dir build/debug -R MaskEditGeometryTest --output-on-failure` — cropped/rotated photograph uses resolved geometry, handle hit radius stays logical across zoom
- `ctest --test-dir build/debug -R EditorNodeDelegateQml --output-on-failure` — mask row selection highlight does not rebuild list, delete requests exact mask id and leaves grade intact
- Manual: select masks from node drawer and Masks context panel; verify overlay guides appear only for selected analytic masks; drag feather handles and sliders; delete masks and confirm selection moves to next/previous row
- Full `alcedo_main` interactive pass: Not run