### PR TITLE
Accumulate Brush paint, erase, and move on one Mask

### DIFF
--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -444,7 +444,9 @@ target_link_libraries(PipelineMgmtService PRIVATE PipelineHistoryApplier EditorA
 def_library(EditorMaskCreationController
     SOURCES
         "${ALCEDO_APP_ROOT}/editor_mask_creation_controller.cpp"
+        "${ALCEDO_APP_ROOT}/brush_mask_input.cpp"
         "${ALCEDO_INCLUDE_ROOT}/app/editor_mask_creation_controller.hpp"
+        "${ALCEDO_INCLUDE_ROOT}/app/brush_mask_input.hpp"
     PUBLIC_DEPS EditGraph PipelineHistoryApplier
 )
 

--- a/alcedo_studio/src/app/brush_mask_input.cpp
+++ b/alcedo_studio/src/app/brush_mask_input.cpp
@@ -1,0 +1,60 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/brush_mask_input.hpp"
+
+#include <utility>
+#include <vector>
+
+namespace alcedo {
+
+void BrushMaskInput::SetStrokeParameters(float radius, float strength, float hardness) {
+  if (sampler_.IsOpen()) {
+    sampler_.SetSampleParameters(radius, strength, hardness);
+  } else {
+    BrushCanonicalSample probe{0.0f, 0.0f, radius, strength, hardness};
+    ValidateBrushCanonicalSample(probe);
+  }
+  radius_   = radius;
+  strength_ = strength;
+  hardness_ = hardness;
+}
+
+void BrushMaskInput::SetStrokeMode(BrushStrokeMode mode) {
+  if (sampler_.IsOpen()) {
+    return;
+  }
+  mode_ = mode;
+}
+
+void BrushMaskInput::Begin(StrokeId id, Vector2 reference, Vector2 translation) {
+  sampler_.BeginStroke(mode_, reference, translation, radius_, strength_, hardness_);
+  stroke_id_ = std::move(id);
+}
+
+void BrushMaskInput::Append(Vector2 reference) { sampler_.AppendReference(reference); }
+
+auto BrushMaskInput::Finish() -> BrushStroke {
+  const auto id      = stroke_id_;
+  const auto mode    = sampler_.Mode();
+  auto       samples = sampler_.FinishStroke();
+  stroke_id_         = StrokeId{};
+  return MakeBrushStroke(id, mode, std::move(samples));
+}
+
+void BrushMaskInput::Cancel() {
+  sampler_.CancelStroke();
+  stroke_id_ = StrokeId{};
+}
+
+auto BrushMaskInput::DraftStroke() const -> std::optional<BrushStroke> {
+  const auto samples = sampler_.DraftSamples();
+  if (samples.empty() || stroke_id_.Empty()) {
+    return std::nullopt;
+  }
+  return MakeBrushStroke(stroke_id_, sampler_.Mode(),
+                         std::vector<BrushCanonicalSample>(samples.begin(), samples.end()));
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/app/editor_mask_creation_controller.cpp
+++ b/alcedo_studio/src/app/editor_mask_creation_controller.cpp
@@ -5,17 +5,19 @@
 #include "app/editor_mask_creation_controller.hpp"
 
 #include <cmath>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "app/pipeline_document_history.hpp"
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/i_node_model.hpp"
+#include "edit/mask/brush_placement.hpp"
+#include "edit/mask/brush_stroke.hpp"
 #include "edit/mask/mask_list_selection.hpp"
-
-#include <vector>
 
 namespace alcedo {
 namespace {
@@ -39,6 +41,8 @@ namespace {
     case AnalyticMaskHandle::LinearStartBoundary:
     case AnalyticMaskHandle::LinearEndBoundary:
       return kind == MaskSourceKind::LinearGradient;
+    case AnalyticMaskHandle::BrushMove:
+      return kind == MaskSourceKind::Brush;
     case AnalyticMaskHandle::None:
       return false;
   }
@@ -46,7 +50,30 @@ namespace {
 }
 
 [[nodiscard]] auto CreationDisplayName(MaskSourceKind kind) -> std::string {
-  return kind == MaskSourceKind::Radial ? std::string{"Radial"} : std::string{"Linear Gradient"};
+  switch (kind) {
+    case MaskSourceKind::Brush:
+      return "Brush";
+    case MaskSourceKind::Radial:
+      return "Radial";
+    case MaskSourceKind::LinearGradient:
+      return "Linear Gradient";
+  }
+  return "Mask";
+}
+
+[[nodiscard]] auto CollectBrushMaskIds(const ColorGradeNodeModel& grade) -> std::vector<MaskId> {
+  std::vector<MaskId> ids;
+  ids.reserve(grade.MaskCount());
+  for (std::size_t i = 0; i < grade.MaskCount(); ++i) {
+    if (GetMaskSourceKind(grade.MaskAt(i).source) == MaskSourceKind::Brush) {
+      ids.push_back(grade.MaskAt(i).id);
+    }
+  }
+  return ids;
+}
+
+[[nodiscard]] auto IsBrushPaintTool(EditorBrushTool tool) -> bool {
+  return tool == EditorBrushTool::Paint || tool == EditorBrushTool::Erase;
 }
 
 [[nodiscard]] auto SourceFromJson(const nlohmann::json& source, const MaskId& mask_id)
@@ -139,8 +166,12 @@ auto EditorMaskCreationController::IdentityMatches(const MaskPointerIdentity& id
 
 auto EditorMaskCreationController::AllocateMaskId() const -> MaskId {
   const auto* grade = Grade();
-  const char* prefix =
-      kind_ == MaskSourceKind::Radial ? "mask.radial." : "mask.linear.";
+  const char* prefix = "mask.radial.";
+  if (kind_ == MaskSourceKind::LinearGradient) {
+    prefix = "mask.linear.";
+  } else if (kind_ == MaskSourceKind::Brush) {
+    prefix = "mask.brush.";
+  }
   for (std::uint32_t i = 1; i < 1000000; ++i) {
     MaskId id{std::string{prefix} + std::to_string(i)};
     if (grade != nullptr && grade->FindMask(id) == nullptr) {
@@ -219,15 +250,19 @@ void EditorMaskCreationController::RestoreLive() {
   try {
     if (inserted_ && !mask_id_.Empty() && grade->FindMask(mask_id_) != nullptr) {
       grade->RemoveMask(mask_id_);
-    } else if (!creating_ && !mask_id_.Empty() && !before_source_.is_null() &&
-               grade->FindMask(mask_id_) != nullptr) {
-      grade->ReplaceMaskSource(mask_id_, SourceFromJson(before_source_, mask_id_));
+    } else if (!creating_ && !mask_id_.Empty() && grade->FindMask(mask_id_) != nullptr) {
+      if (kind_ == MaskSourceKind::Brush) {
+        (void)ApplyLiveSource(committed_brush_);
+      } else if (!before_source_.is_null()) {
+        grade->ReplaceMaskSource(mask_id_, SourceFromJson(before_source_, mask_id_));
+      }
     }
   } catch (const std::exception&) {
   }
 }
 
 void EditorMaskCreationController::ClearOpenOperation() {
+  brush_input_.Cancel();
   open_               = false;
   terminated_         = true;
   handle_             = AnalyticMaskHandle::None;
@@ -238,15 +273,18 @@ void EditorMaskCreationController::ClearOpenOperation() {
 
 void EditorMaskCreationController::ResetMode() {
   ClearOpenOperation();
-  state_         = EditorMaskCreationState::Inactive;
-  creating_      = false;
-  inserted_      = false;
-  mask_id_       = MaskId{};
-  node_id_       = NodeId{};
-  kind_          = MaskSourceKind::Radial;
-  before_source_ = nullptr;
-  session_       = {};
-  terminated_    = false;
+  state_              = EditorMaskCreationState::Inactive;
+  creating_           = false;
+  inserted_           = false;
+  mask_id_            = MaskId{};
+  node_id_            = NodeId{};
+  kind_               = MaskSourceKind::Radial;
+  before_source_      = nullptr;
+  session_            = {};
+  terminated_         = false;
+  brush_tool_         = EditorBrushTool::Idle;
+  committed_brush_    = {};
+  before_translation_ = {};
 }
 
 void EditorMaskCreationController::RequestInteractive(EditorMaskCreationResult& result) {
@@ -257,7 +295,7 @@ void EditorMaskCreationController::RequestInteractive(EditorMaskCreationResult& 
 }
 
 auto EditorMaskCreationController::OverlayIsCreating() const -> bool {
-  return creating_ && open_;
+  return (creating_ && open_) || brush_input_.IsOpen();
 }
 
 auto EditorMaskCreationController::CurrentSource() const -> std::optional<MaskSource> {
@@ -276,21 +314,64 @@ auto EditorMaskCreationController::CurrentSource() const -> std::optional<MaskSo
 }
 
 auto EditorMaskCreationController::BeginCreation(MaskSourceKind kind, const NodeId& grade_id,
-                                                 EditorSessionIdentity session)
+                                                 EditorSessionIdentity session, MaskId resume_mask)
     -> EditorMaskCreationResult {
   if (open_) {
     return Reject("finish or cancel the open Mask operation before changing tools");
   }
-  if (kind != MaskSourceKind::Radial && kind != MaskSourceKind::LinearGradient) {
-    return Reject("analytic creation supports Radial and Linear Gradient");
+  if (kind != MaskSourceKind::Radial && kind != MaskSourceKind::LinearGradient &&
+      kind != MaskSourceKind::Brush) {
+    return Reject("creation supports Brush, Radial, and Linear Gradient");
   }
   if (document_ == nullptr || history_ == nullptr) {
     return Reject("Mask creation controller is not bound to a document");
   }
   node_id_ = grade_id;
-  if (Grade() == nullptr) {
+  auto* grade = Grade();
+  if (grade == nullptr) {
     node_id_ = NodeId{};
     return Reject("creation target is not a Color Grade");
+  }
+  if (kind == MaskSourceKind::Brush) {
+    const auto brushes = CollectBrushMaskIds(*grade);
+    MaskId     target  = resume_mask;
+    if (brushes.empty()) {
+      target = MaskId{};
+    } else if (brushes.size() == 1 && target.Empty()) {
+      target = brushes.front();
+    } else if (brushes.size() > 1) {
+      bool named = false;
+      for (const auto& id : brushes) {
+        if (id == target) {
+          named = true;
+          break;
+        }
+      }
+      if (!named) {
+        return Reject("select an existing Brush before painting");
+      }
+    }
+    kind_          = MaskSourceKind::Brush;
+    session_       = session;
+    handle_        = AnalyticMaskHandle::None;
+    draft_source_.reset();
+    terminated_    = false;
+    brush_tool_    = EditorBrushTool::Paint;
+    committed_brush_ = {};
+    if (target.Empty()) {
+      mask_id_       = MaskId{};
+      inserted_      = false;
+      creating_      = true;
+      before_source_ = nullptr;
+      state_         = EditorMaskCreationState::Creating;
+      return Ok();
+    }
+    const auto loaded = SelectMask(grade_id, target, session);
+    if (!loaded.accepted) {
+      return loaded;
+    }
+    brush_tool_ = EditorBrushTool::Paint;
+    return loaded;
   }
   kind_          = kind;
   session_       = session;
@@ -301,6 +382,7 @@ auto EditorMaskCreationController::BeginCreation(MaskSourceKind kind, const Node
   before_source_ = nullptr;
   draft_source_.reset();
   terminated_    = false;
+  brush_tool_    = EditorBrushTool::Idle;
   state_         = EditorMaskCreationState::Creating;
   return Ok();
 }
@@ -338,6 +420,11 @@ auto EditorMaskCreationController::SelectMask(const NodeId& grade_id, const Mask
   before_source_ = MaskModelToJson(*mask).at("source");
   draft_source_  = mask->source;
   terminated_    = false;
+  brush_tool_    = EditorBrushTool::Idle;
+  committed_brush_ = {};
+  if (const auto* brush = std::get_if<BrushMaskSource>(&mask->source)) {
+    committed_brush_ = *brush;
+  }
   state_         = EditorMaskCreationState::Selected;
   auto result    = Ok();
   result.mask_id = mask_id_;
@@ -428,6 +515,21 @@ auto EditorMaskCreationController::BeginMaskInput(MaskCreationSample sample,
   if (state_ == EditorMaskCreationState::Settling) {
     return Reject("Mask tool is unavailable until settle is acknowledged");
   }
+  if (kind_ == MaskSourceKind::Brush && IsBrushPaintTool(brush_tool_)) {
+    const bool armed =
+        (state_ == EditorMaskCreationState::Creating && !open_) ||
+        (state_ == EditorMaskCreationState::Selected && !open_ && !mask_id_.Empty());
+    if (!armed) {
+      return Reject("BeginMaskInput requires an armed Brush paint or erase tool");
+    }
+    if (!FiniteSample(sample) || !sample.inside_photograph) {
+      return Reject("Mask press must lie inside the photograph");
+    }
+    pointer_                = identity;
+    press_normalized_       = sample.normalized;
+    press_reference_pixels_ = sample.reference_pixels;
+    return BeginBrushStroke(sample);
+  }
   if (state_ != EditorMaskCreationState::Creating || open_) {
     return Reject("BeginMaskInput requires an armed creation tool");
   }
@@ -463,6 +565,11 @@ auto EditorMaskCreationController::BeginMaskMove(AnalyticMaskHandle handle,
   if (!HandleMatchesKind(handle, kind_)) {
     return Reject("handle does not match the selected Mask kind");
   }
+  if (kind_ == MaskSourceKind::Brush) {
+    if (brush_tool_ != EditorBrushTool::Move || handle != AnalyticMaskHandle::BrushMove) {
+      return Reject("Brush move requires Move mode");
+    }
+  }
   if (!FiniteSample(sample) || !sample.inside_photograph) {
     return Reject("Mask press must lie inside the photograph");
   }
@@ -485,6 +592,11 @@ auto EditorMaskCreationController::BeginMaskMove(AnalyticMaskHandle handle,
     unwrapped_rotation_ = radial->rotation;
   } else {
     unwrapped_rotation_ = 0.0f;
+  }
+  if (const auto* brush = std::get_if<BrushMaskSource>(&mask->source)) {
+    committed_brush_        = *brush;
+    before_translation_     = brush->placement_translation;
+    press_reference_pixels_ = sample.reference_pixels;
   }
   open_        = true;
   terminated_  = false;
@@ -561,6 +673,12 @@ auto EditorMaskCreationController::AppendMaskInput(MaskCreationSample sample,
   }
   if (creating_) {
     return UpdateCreation(sample);
+  }
+  if (kind_ == MaskSourceKind::Brush && brush_input_.IsOpen()) {
+    return UpdateBrushPaint(sample);
+  }
+  if (kind_ == MaskSourceKind::Brush && handle_ == AnalyticMaskHandle::BrushMove) {
+    return UpdateBrushMove(sample);
   }
   return UpdateExisting(sample);
 }
@@ -673,6 +791,12 @@ auto EditorMaskCreationController::FinishMaskInput() -> EditorMaskCreationResult
     state_ = EditorMaskCreationState::Creating;
     return Ok();
   }
+  if (kind_ == MaskSourceKind::Brush && brush_input_.IsOpen()) {
+    return FinishBrushStroke();
+  }
+  if (kind_ == MaskSourceKind::Brush && handle_ == AnalyticMaskHandle::BrushMove) {
+    return PublishSetTranslation();
+  }
   if (creating_ && inserted_) {
     return PublishAddMask();
   }
@@ -724,6 +848,282 @@ auto EditorMaskCreationController::CancelCreationMode() -> EditorMaskCreationRes
   auto result = CancelMaskInput();
   ResetMode();
   result.mask_id = MaskId{};
+  return result;
+}
+
+auto EditorMaskCreationController::SetBrushTool(EditorBrushTool tool) -> EditorMaskCreationResult {
+  if (open_) {
+    return Reject("finish or cancel the open Mask operation before changing the Brush tool");
+  }
+  if (tool != EditorBrushTool::Idle && kind_ != MaskSourceKind::Brush) {
+    return Reject("Brush tools require a Brush Mask");
+  }
+  if (tool == EditorBrushTool::Move && (creating_ || mask_id_.Empty())) {
+    return Reject("Brush move requires an existing Brush");
+  }
+  brush_tool_ = tool;
+  if (IsBrushPaintTool(tool)) {
+    brush_input_.SetStrokeMode(BrushStrokeModeFromTool());
+  }
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  return result;
+}
+
+auto EditorMaskCreationController::SetBrushStrokeParameters(float radius, float strength,
+                                                            float hardness)
+    -> EditorMaskCreationResult {
+  try {
+    brush_input_.SetStrokeParameters(radius, strength, hardness);
+  } catch (const std::exception& ex) {
+    return Reject(ex.what());
+  }
+  if (!brush_input_.IsOpen()) {
+    auto result    = Ok();
+    result.mask_id = mask_id_;
+    return result;
+  }
+  if (!ApplyLiveBrushDraft()) {
+    return Reject("Brush parameter update was rejected");
+  }
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  RequestInteractive(result);
+  return result;
+}
+
+auto EditorMaskCreationController::BrushStrokeModeFromTool() const -> BrushStrokeMode {
+  return brush_tool_ == EditorBrushTool::Erase ? BrushStrokeMode::Erase : BrushStrokeMode::Paint;
+}
+
+auto EditorMaskCreationController::AllocateStrokeId() const -> StrokeId {
+  for (std::uint32_t i = 1; i < 1000000; ++i) {
+    StrokeId id{std::string{"stroke."} + std::to_string(i)};
+    if (FindBrushStrokeIndex(committed_brush_.strokes, id) == committed_brush_.strokes.size()) {
+      return id;
+    }
+  }
+  return StrokeId{};
+}
+
+auto EditorMaskCreationController::ComposeDraftBrush() const -> BrushMaskSource {
+  auto brush = committed_brush_;
+  if (auto draft = brush_input_.DraftStroke()) {
+    const auto index = FindBrushStrokeIndex(brush.strokes, draft->id);
+    if (index != brush.strokes.size()) {
+      brush.strokes.erase(brush.strokes.begin() + static_cast<std::ptrdiff_t>(index));
+    }
+    brush.strokes.push_back(std::move(*draft));
+  }
+  return brush;
+}
+
+auto EditorMaskCreationController::ApplyLiveBrushDraft() -> bool {
+  const MaskSource source{ComposeDraftBrush()};
+  if (creating_ && !inserted_) {
+    return InsertProvisional(source);
+  }
+  return ApplyLiveSource(source);
+}
+
+auto EditorMaskCreationController::BeginBrushStroke(const MaskCreationSample& sample)
+    -> EditorMaskCreationResult {
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return Reject("creation target is not a Color Grade");
+  }
+  Vector2 translation{};
+  if (!mask_id_.Empty()) {
+    const auto* mask = grade->FindMask(mask_id_);
+    if (mask == nullptr) {
+      return Reject("Mask is missing");
+    }
+    const auto* brush = std::get_if<BrushMaskSource>(&mask->source);
+    if (brush == nullptr) {
+      return Reject("selected Mask is not a Brush");
+    }
+    committed_brush_ = *brush;
+    before_source_   = MaskModelToJson(*mask).at("source");
+    translation      = brush->placement_translation;
+  } else {
+    committed_brush_ = {};
+    before_source_   = nullptr;
+  }
+  const auto stroke_id = AllocateStrokeId();
+  if (stroke_id.Empty()) {
+    return Reject("Brush StrokeId allocation failed");
+  }
+  try {
+    brush_input_.SetStrokeMode(BrushStrokeModeFromTool());
+    brush_input_.Begin(stroke_id, sample.reference_pixels, translation);
+  } catch (const std::exception& ex) {
+    return Reject(ex.what());
+  }
+  handle_     = AnalyticMaskHandle::None;
+  open_       = true;
+  terminated_ = false;
+  state_      = EditorMaskCreationState::Painting;
+  if (!ApplyLiveBrushDraft()) {
+    brush_input_.Cancel();
+    open_ = false;
+    return Reject("provisional Brush stroke was rejected");
+  }
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  RequestInteractive(result);
+  return result;
+}
+
+auto EditorMaskCreationController::UpdateBrushPaint(const MaskCreationSample& sample)
+    -> EditorMaskCreationResult {
+  try {
+    brush_input_.Append(sample.reference_pixels);
+  } catch (const std::exception& ex) {
+    return Reject(ex.what());
+  }
+  if (!ApplyLiveBrushDraft()) {
+    return Reject("provisional Brush source was rejected");
+  }
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  RequestInteractive(result);
+  return result;
+}
+
+auto EditorMaskCreationController::UpdateBrushMove(const MaskCreationSample& sample)
+    -> EditorMaskCreationResult {
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return Reject("selection target is not a Color Grade");
+  }
+  if (grade->FindMask(mask_id_) == nullptr) {
+    return Reject("Mask is missing");
+  }
+  const auto after = BrushPlacementForReferenceDrag(before_translation_, press_reference_pixels_,
+                                                    sample.reference_pixels);
+  const auto current = grade->BrushPlacementTranslation(mask_id_);
+  if (current == after) {
+    auto result    = Ok();
+    result.mask_id = mask_id_;
+    return result;
+  }
+  try {
+    grade->SetBrushTranslation(MakeBrushTranslationCommand(
+        node_id_, mask_id_, current, after, grade->MaskContentRevision(mask_id_)));
+  } catch (const std::exception& ex) {
+    return Reject(ex.what());
+  }
+  draft_source_ = grade->FindMask(mask_id_)->source;
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  RequestInteractive(result);
+  return result;
+}
+
+auto EditorMaskCreationController::FinishBrushStroke() -> EditorMaskCreationResult {
+  BrushStroke stroke;
+  try {
+    stroke = brush_input_.Finish();
+  } catch (const std::exception& ex) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject(ex.what());
+  }
+  auto brush = committed_brush_;
+  const auto index = FindBrushStrokeIndex(brush.strokes, stroke.id);
+  if (index == brush.strokes.size()) {
+    brush.strokes.push_back(stroke);
+  } else {
+    brush.strokes[index] = stroke;
+  }
+  if (!ApplyLiveSource(brush)) {
+    RestoreLive();
+    inserted_ = false;
+    state_    = EditorMaskCreationState::Failed;
+    return Reject("Brush stroke source was rejected at settle");
+  }
+  if (creating_ && inserted_) {
+    return PublishAddMask();
+  }
+  return PublishAppendStroke(std::move(stroke));
+}
+
+auto EditorMaskCreationController::PublishAppendStroke(BrushStroke stroke)
+    -> EditorMaskCreationResult {
+  if (history_ == nullptr) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject("AppendBrushStroke settle is missing history");
+  }
+  const auto batch = MakeAppendBrushStrokeBatch(node_id_, mask_id_, std::move(stroke));
+  std::string settle_error;
+  if (!PublishSettledBatch(batch, &settle_error)) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject(settle_error.empty() ? std::string{"AppendBrushStroke history publish failed"}
+                                       : settle_error);
+  }
+  ClearOpenOperation();
+  creating_ = false;
+  inserted_ = false;
+  if (Grade() != nullptr) {
+    if (const auto* mask = Grade()->FindMask(mask_id_)) {
+      if (const auto* brush = std::get_if<BrushMaskSource>(&mask->source)) {
+        committed_brush_ = *brush;
+      }
+      before_source_ = MaskModelToJson(*mask).at("source");
+      draft_source_  = mask->source;
+    }
+  }
+  state_                   = EditorMaskCreationState::Settling;
+  auto result              = Ok();
+  result.mask_id           = mask_id_;
+  result.committed         = true;
+  result.quality_requested = true;
+  return result;
+}
+
+auto EditorMaskCreationController::PublishSetTranslation() -> EditorMaskCreationResult {
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject("SetBrushTranslation settle is missing the Grade");
+  }
+  Vector2 after{};
+  try {
+    after = grade->BrushPlacementTranslation(mask_id_);
+  } catch (const std::exception& ex) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject(ex.what());
+  }
+  if (after == before_translation_) {
+    ClearOpenOperation();
+    state_ = EditorMaskCreationState::Selected;
+    return Ok();
+  }
+  const auto batch = MakeSetBrushTranslationBatch(node_id_, mask_id_, before_translation_, after);
+  std::string settle_error;
+  if (!PublishSettledBatch(batch, &settle_error)) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject(settle_error.empty() ? std::string{"SetBrushTranslation history publish failed"}
+                                       : settle_error);
+  }
+  ClearOpenOperation();
+  if (const auto* mask = grade->FindMask(mask_id_)) {
+    if (const auto* brush = std::get_if<BrushMaskSource>(&mask->source)) {
+      committed_brush_ = *brush;
+    }
+    before_source_ = MaskModelToJson(*mask).at("source");
+    draft_source_  = mask->source;
+  }
+  state_                   = EditorMaskCreationState::Settling;
+  auto result              = Ok();
+  result.mask_id           = mask_id_;
+  result.committed         = true;
+  result.quality_requested = true;
   return result;
 }
 

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1196,7 +1196,8 @@ auto EditorSessionService::EnqueueMaskCreation(EditorMaskCreationCommand command
     if (command.kind == EditorMaskCreationCommandKind::Append && !pending_mask_commands_.empty()) {
       auto& back = pending_mask_commands_.back();
       if (back.kind == EditorMaskCreationCommandKind::Append &&
-          SameMaskPointer(back.identity, command.identity)) {
+          SameMaskPointer(back.identity, command.identity) && !back.ordered_append &&
+          !command.ordered_append) {
         back = std::move(command);
       } else {
         pending_mask_commands_.push_back(std::move(command));
@@ -1266,14 +1267,42 @@ auto EditorSessionService::ApplyMaskCreationCommand(const EditorMaskCreationComm
   const auto identity = lifecycle_.identity();
   switch (command.kind) {
     case EditorMaskCreationCommandKind::BeginCreation:
-      return mask_creation_.BeginCreation(command.source_kind, command.node_id, identity);
+      return mask_creation_.BeginCreation(command.source_kind, command.node_id, identity,
+                                          command.mask_id);
     case EditorMaskCreationCommandKind::SelectMask:
       return mask_creation_.SelectMask(command.node_id, command.mask_id, identity);
     case EditorMaskCreationCommandKind::BeginInput:
+      if (command.brush_radius > 0.0f) {
+        const auto parameters = mask_creation_.SetBrushStrokeParameters(
+            command.brush_radius, command.brush_strength, command.brush_hardness);
+        if (!parameters.accepted) {
+          return parameters;
+        }
+      }
+      if (command.brush_tool == EditorBrushTool::Paint ||
+          command.brush_tool == EditorBrushTool::Erase) {
+        const auto tool = mask_creation_.SetBrushTool(command.brush_tool);
+        if (!tool.accepted) {
+          return tool;
+        }
+      }
       return mask_creation_.BeginMaskInput(command.sample, command.identity);
     case EditorMaskCreationCommandKind::BeginMove:
+      if (command.brush_tool == EditorBrushTool::Move) {
+        const auto tool = mask_creation_.SetBrushTool(EditorBrushTool::Move);
+        if (!tool.accepted) {
+          return tool;
+        }
+      }
       return mask_creation_.BeginMaskMove(command.handle, command.sample, command.identity);
     case EditorMaskCreationCommandKind::Append:
+      if (command.brush_radius > 0.0f) {
+        const auto parameters = mask_creation_.SetBrushStrokeParameters(
+            command.brush_radius, command.brush_strength, command.brush_hardness);
+        if (!parameters.accepted) {
+          return parameters;
+        }
+      }
       return mask_creation_.AppendMaskInput(command.sample, command.identity);
     case EditorMaskCreationCommandKind::Finish:
       return mask_creation_.FinishMaskInput();
@@ -1285,6 +1314,11 @@ auto EditorSessionService::ApplyMaskCreationCommand(const EditorMaskCreationComm
       return mask_creation_.CancelCreationMode();
     case EditorMaskCreationCommandKind::RemoveMask:
       return mask_creation_.RemoveMask(command.node_id, command.mask_id);
+    case EditorMaskCreationCommandKind::SetBrushTool:
+      return mask_creation_.SetBrushTool(command.brush_tool);
+    case EditorMaskCreationCommandKind::SetBrushStrokeParameters:
+      return mask_creation_.SetBrushStrokeParameters(
+          command.brush_radius, command.brush_strength, command.brush_hardness);
   }
   EditorMaskCreationResult rejected;
   rejected.error = "unknown Mask creation command";

--- a/alcedo_studio/src/edit/mask/brush_canonical_sampler.cpp
+++ b/alcedo_studio/src/edit/mask/brush_canonical_sampler.cpp
@@ -134,4 +134,11 @@ void BrushCanonicalSampler::CancelStroke() {
   samples_.clear();
 }
 
+auto BrushCanonicalSampler::DraftSamples() const -> std::span<const BrushCanonicalSample> {
+  if (!open_) {
+    return {};
+  }
+  return samples_;
+}
+
 }  // namespace alcedo

--- a/alcedo_studio/src/include/app/brush_mask_input.hpp
+++ b/alcedo_studio/src/include/app/brush_mask_input.hpp
@@ -1,0 +1,96 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <optional>
+#include <span>
+
+#include "edit/geometry/types.hpp"
+#include "edit/mask/brush_canonical_sampler.hpp"
+#include "edit/mask/brush_stroke.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Open-stroke sampler plus the size/strength/hardness used for new dabs.
+ *
+ * Owns remainder and the draft sample body for one paint or erase sequence. The
+ * creation controller commits that body through AddMask or AppendBrushStroke.
+ * Movement does not use this type. Thread: document-owning thread. Not thread-safe.
+ */
+class BrushMaskInput {
+ public:
+  /**
+   * @brief Store radius/strength/hardness for the next dab or open-stroke boundary.
+   *
+   * When a stroke is open, emits a parameter-boundary sample at the current point.
+   *
+   * @throws std::runtime_error when a value fails canonical sample rules.
+   */
+  void SetStrokeParameters(float radius, float strength, float hardness);
+
+  /**
+   * @brief Paint or erase for the next @ref Begin. Ignored while a stroke is open.
+   */
+  void SetStrokeMode(BrushStrokeMode mode);
+
+  /**
+   * @brief Open a stroke at the press, emitting the first dab.
+   *
+   * @param id Stable StrokeId for this sequence. Must be unique on the target Brush.
+   * @param reference Press in world reference pixels.
+   * @param translation Current Brush placement; subtracted from every event.
+   * @throws std::runtime_error when a stroke is already open or an input is invalid.
+   */
+  void Begin(StrokeId id, Vector2 reference, Vector2 translation);
+
+  /**
+   * @brief Walk to @p reference and emit interior dabs. Does not emit an event-end dab.
+   *
+   * @throws std::runtime_error when no stroke is open or @p reference is not finite.
+   */
+  void Append(Vector2 reference);
+
+  /**
+   * @brief Seal the stroke, emitting the endpoint once when it is not already a dab.
+   *
+   * @return Stroke sharing one immutable sample body. The session is then idle.
+   * @throws std::runtime_error when no stroke is open.
+   */
+  [[nodiscard]] auto Finish() -> BrushStroke;
+
+  /**
+   * @brief Drop an unfinished stroke. Idle when already closed.
+   */
+  void Cancel();
+
+  /**
+   * @brief Open-stroke samples as a BrushStroke for live Mix. Empty when idle.
+   *
+   * Copies the draft vector into a new shared body. Committed strokes are not
+   * included. Valid independently of later sampler mutations.
+   */
+  [[nodiscard]] auto DraftStroke() const -> std::optional<BrushStroke>;
+
+  [[nodiscard]] auto IsOpen() const -> bool { return sampler_.IsOpen(); }
+  [[nodiscard]] auto stroke_id() const -> const StrokeId& { return stroke_id_; }
+  [[nodiscard]] auto mode() const -> BrushStrokeMode { return mode_; }
+  [[nodiscard]] auto radius() const -> float { return radius_; }
+  [[nodiscard]] auto strength() const -> float { return strength_; }
+  [[nodiscard]] auto hardness() const -> float { return hardness_; }
+  [[nodiscard]] auto DraftSamples() const -> std::span<const BrushCanonicalSample> {
+    return sampler_.DraftSamples();
+  }
+
+ private:
+  BrushCanonicalSampler sampler_;
+  StrokeId              stroke_id_;
+  BrushStrokeMode       mode_      = BrushStrokeMode::Paint;
+  float                 radius_    = 1.0f;
+  float                 strength_  = 1.0f;
+  float                 hardness_  = 1.0f;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
+++ b/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 
+#include "app/brush_mask_input.hpp"
 #include "app/editor_session_types.hpp"
 #include "edit/geometry/types.hpp"
 #include "edit/graph/graph_ids.hpp"
@@ -16,6 +17,7 @@
 #include "edit/history/mini_git_working_history.hpp"
 #include "edit/history/pipeline_edit_batch.hpp"
 #include "edit/mask/analytic_mask_edit.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
 #include "edit/mask/mask_id.hpp"
 #include "edit/mask/mask_model.hpp"
 #include "json.hpp"
@@ -33,6 +35,19 @@ enum class EditorMaskCreationState : std::uint8_t {
   Painting = 4,
   Settling = 5,
   Failed   = 6,
+};
+
+/**
+ * @brief Explicit Brush interaction. Paint and erase append strokes; Move does not.
+ *
+ * Drawer selection leaves this Idle so a handle drag cannot paint. The header Brush
+ * action arms Paint. Erase and Move are set through @ref SetBrushTool.
+ */
+enum class EditorBrushTool : std::uint8_t {
+  Idle  = 0,
+  Paint = 1,
+  Erase = 2,
+  Move  = 3,
 };
 
 /**
@@ -80,7 +95,8 @@ struct EditorMaskCreationResult {
  * @brief Queued Mask-creation operation for the session owner thread.
  *
  * GUI mapping produces these; the serial consumer applies them under the live
- * pipeline lock. Latest Append samples with the same pointer identity coalesce.
+ * pipeline lock. Latest analytic or Brush-move Append samples with the same
+ * pointer identity coalesce. Brush paint/erase Append sets @p ordered_append.
  */
 enum class EditorMaskCreationCommandKind : std::uint8_t {
   BeginCreation = 0,
@@ -93,6 +109,8 @@ enum class EditorMaskCreationCommandKind : std::uint8_t {
   FinishMode,
   CancelMode,
   RemoveMask,
+  SetBrushTool,
+  SetBrushStrokeParameters,
 };
 
 struct EditorMaskCreationCommand {
@@ -103,16 +121,24 @@ struct EditorMaskCreationCommand {
   MaskCreationSample            sample{};
   MaskPointerIdentity           identity{};
   AnalyticMaskHandle            handle = AnalyticMaskHandle::None;
+  EditorBrushTool               brush_tool      = EditorBrushTool::Idle;
+  float                         brush_radius    = 0.0f;
+  float                         brush_strength  = 1.0f;
+  float                         brush_hardness  = 1.0f;
+  bool                          ordered_append  = false;
 };
 
 /**
- * @brief Application owner of Radial/Linear creation and existing-mask movement.
+ * @brief Application owner of Mask creation, Brush strokes, and existing-mask movement.
  *
- * Owns mode, active handle, and captured identities. Does not own the live
- * @ref PipelineDocument, Grade selection, or Mix raster. Provisional source
- * fields are written through the Grade owner before release so Interactive Mix
- * can update; one NM4 AddMask or ReplaceMaskSource commit is published on
- * settle. Escape restores the live Grade and publishes no commit.
+ * Owns mode, active handle, Brush tool settings, and captured identities. Does
+ * not own the live @ref PipelineDocument, Grade selection, or Mix raster.
+ * Provisional Grade fields are written before release so Interactive Mix can
+ * update. First Brush release publishes AddMask; later strokes publish
+ * AppendBrushStroke; Brush moves publish SetBrushTranslation. Analytic settle
+ * stays AddMask or ReplaceMaskSource. Escape restores the live Grade and
+ * publishes no commit. New Brush work never calls MaskStore::Put or
+ * ReplaceMaskAsset.
  *
  * Thread: document-owning thread. Does not take the pipeline lock, perform
  * cache I/O, or build QSG geometry.
@@ -152,13 +178,15 @@ class EditorMaskCreationController {
   void DetachClosedDocument();
 
   /**
-   * @brief Arm Radial or Linear creation on @p grade_id without document mutation.
+   * @brief Arm Radial, Linear, or Brush creation on @p grade_id without a commit.
    *
-   * Brush is rejected until accumulating-stroke UI exists. An open operation must
+   * Brush with no existing Mask stays Creating until the first valid stroke.
+   * One existing Brush is resumed. Several existing Brushes require @p resume_mask
+   * to name one of them; the document is not flattened. An open operation must
    * be finished or cancelled first.
    */
-  auto BeginCreation(MaskSourceKind kind, const NodeId& grade_id, EditorSessionIdentity session)
-      -> EditorMaskCreationResult;
+  auto BeginCreation(MaskSourceKind kind, const NodeId& grade_id, EditorSessionIdentity session,
+                     MaskId resume_mask = {}) -> EditorMaskCreationResult;
 
   /**
    * @brief Select an existing Brush, Radial, or Linear Mask. Load-only; no Mix or commit.
@@ -167,6 +195,23 @@ class EditorMaskCreationController {
    * for later movement.
    */
   auto SelectMask(const NodeId& grade_id, const MaskId& mask_id, EditorSessionIdentity session)
+      -> EditorMaskCreationResult;
+
+  /**
+   * @brief Arm Paint, Erase, or Move on the selected or creating Brush.
+   *
+   * Rejected while a stroke or move is open. Move requires an existing Brush.
+   */
+  auto SetBrushTool(EditorBrushTool tool) -> EditorMaskCreationResult;
+
+  /**
+   * @brief Size/strength/hardness for subsequent dabs, including an open stroke.
+   *
+   * Mid-stroke changes emit a parameter-boundary sample. Mask opacity is not
+   * Brush strength. Radius is in reference pixels; strength and hardness stay
+   * in `[0, 1]`.
+   */
+  auto SetBrushStrokeParameters(float radius, float strength, float hardness)
       -> EditorMaskCreationResult;
 
   /**
@@ -232,6 +277,9 @@ class EditorMaskCreationController {
    */
   [[nodiscard]] auto HasOpenOperation() const -> bool { return open_; }
   [[nodiscard]] auto OverlayIsCreating() const -> bool;
+  [[nodiscard]] auto brush_tool() const -> EditorBrushTool { return brush_tool_; }
+  [[nodiscard]] auto brush_radius() const -> float { return brush_input_.radius(); }
+  [[nodiscard]] auto brush_strength() const -> float { return brush_input_.strength(); }
   /**
    * @brief Live or draft source for overlay layout. Empty when Inactive/hidden.
    */
@@ -259,6 +307,16 @@ class EditorMaskCreationController {
   void              RequestInteractive(EditorMaskCreationResult& result);
   auto              UpdateCreation(const MaskCreationSample& sample) -> EditorMaskCreationResult;
   auto              UpdateExisting(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto              BeginBrushStroke(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto              UpdateBrushPaint(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto              UpdateBrushMove(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto              FinishBrushStroke() -> EditorMaskCreationResult;
+  auto              PublishAppendStroke(BrushStroke stroke) -> EditorMaskCreationResult;
+  auto              PublishSetTranslation() -> EditorMaskCreationResult;
+  auto              ApplyLiveBrushDraft() -> bool;
+  [[nodiscard]] auto AllocateStrokeId() const -> StrokeId;
+  [[nodiscard]] auto ComposeDraftBrush() const -> BrushMaskSource;
+  [[nodiscard]] auto BrushStrokeModeFromTool() const -> BrushStrokeMode;
 
   PipelineDocument* document_                                          = nullptr;
   MiniGitWorkingHistory*                                      history_ = nullptr;
@@ -281,6 +339,11 @@ class EditorMaskCreationController {
   bool                      terminated_    = false;
   std::optional<MaskSource> draft_source_;
   MaskId                    last_removed_mask_id_;
+  EditorBrushTool           brush_tool_ = EditorBrushTool::Idle;
+  BrushMaskInput            brush_input_;
+  BrushMaskSource           committed_brush_{};
+  Vector2                   press_reference_pixels_{};
+  Vector2                   before_translation_{};
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/analytic_mask_edit.hpp
+++ b/alcedo_studio/src/include/edit/mask/analytic_mask_edit.hpp
@@ -39,6 +39,7 @@ enum class AnalyticMaskHandle : std::uint8_t {
   LinearDirection      = 8,
   LinearStartBoundary  = 9,
   LinearEndBoundary    = 10,
+  BrushMove            = 11,
 };
 
 /**

--- a/alcedo_studio/src/include/edit/mask/brush_canonical_sampler.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_canonical_sampler.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <span>
 #include <vector>
 
 #include "edit/geometry/types.hpp"
@@ -69,6 +70,13 @@ class BrushCanonicalSampler {
    * @brief Drop an unfinished stroke. Idle when already closed.
    */
   void CancelStroke();
+
+  /**
+   * @brief Samples emitted so far on the open stroke, excluding a pending endpoint.
+   *
+   * Empty when idle. Does not copy the vector. Valid until the next mutating call.
+   */
+  [[nodiscard]] auto DraftSamples() const -> std::span<const BrushCanonicalSample>;
 
   [[nodiscard]] auto IsOpen() const -> bool { return open_; }
   [[nodiscard]] auto Mode() const -> BrushStrokeMode { return mode_; }

--- a/alcedo_studio/src/include/edit/mask/brush_placement.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_placement.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 
 #include "edit/geometry/types.hpp"
@@ -12,6 +13,20 @@
 #include "edit/mask/mask_id.hpp"
 
 namespace alcedo {
+
+/**
+ * @brief Initial dab radius: 2% diameter of the shorter full-reference edge.
+ *
+ * Strength and hardness stay at 1. Empty extents yield radius 1 so a later
+ * validator can still reject a missing photograph instead of dividing by zero.
+ */
+[[nodiscard]] inline auto DefaultBrushRadiusReferencePixels(Extent2D full_reference) -> float {
+  const auto shorter = (std::min)(full_reference.width, full_reference.height);
+  if (shorter == 0) {
+    return 1.0f;
+  }
+  return 0.01f * static_cast<float>(shorter);
+}
 
 /**
  * @brief Convert a world ReferenceSpace pixel to Brush-local coordinates.

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
@@ -6,10 +6,12 @@
 
 #include <QObject>
 #include <QPointer>
+#include <QPointF>
 #include <QRectF>
 #include <QString>
 #include <cstdint>
 #include <optional>
+#include <vector>
 
 #include "app/editor_mask_creation_controller.hpp"
 #include "edit/mask/mask_model.hpp"
@@ -47,6 +49,9 @@ class EditorMaskCreationAdapter : public QObject {
   Q_PROPERTY(qreal minorRadiusPercent READ minor_radius_percent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal rotationDegrees READ rotation_degrees NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal transitionPercent READ transition_percent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushRadius READ brush_radius NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushStrengthPercent READ brush_strength_percent NOTIFY maskCreationChanged)
+  Q_PROPERTY(QString brushTool READ brush_tool_name NOTIFY maskCreationChanged)
 
  public:
   enum class EditMode : std::uint8_t {
@@ -72,11 +77,20 @@ class EditorMaskCreationAdapter : public QObject {
   [[nodiscard]] auto minor_radius_percent() const -> qreal;
   [[nodiscard]] auto rotation_degrees() const -> qreal;
   [[nodiscard]] auto transition_percent() const -> qreal;
+  [[nodiscard]] auto brush_radius() const -> qreal { return static_cast<qreal>(brush_radius_); }
+  [[nodiscard]] auto brush_strength_percent() const -> qreal {
+    return static_cast<qreal>(brush_strength_) * 100.0;
+  }
+  [[nodiscard]] auto brush_tool_name() const -> QString;
 
   Q_INVOKABLE void   bindInteractionItem(QObject* interaction);
   Q_INVOKABLE void   bindOverlayItem(QObject* overlay);
   Q_INVOKABLE void   beginRadial();
   Q_INVOKABLE void   beginLinear();
+  Q_INVOKABLE void   beginBrush();
+  Q_INVOKABLE void   setBrushTool(const QString& tool);
+  Q_INVOKABLE void   setBrushRadius(qreal radius);
+  Q_INVOKABLE void   setBrushStrengthPercent(qreal percent);
   Q_INVOKABLE void   cancel();
   Q_INVOKABLE void   hideBody();
   Q_INVOKABLE void   finishBody();
@@ -116,6 +130,10 @@ class EditorMaskCreationAdapter : public QObject {
 
  private:
   void               BeginTool(MaskSourceKind kind, const QString& tool_kind);
+  void               BeginBrushTool();
+  [[nodiscard]] auto ResolveBrushResumeMask(const NodeId& grade_id) const -> MaskId;
+  [[nodiscard]] auto BrushRadiusLogicalPx(const MaskCreationSample& sample) const -> float;
+  void               EnqueueBrushSettings(EditorMaskCreationCommand& command) const;
   void               ResetLocal();
   void               PublishOverlay();
   void               HideOverlay();
@@ -149,11 +167,18 @@ class EditorMaskCreationAdapter : public QObject {
   bool                                              open_        = false;
   MaskPointerIdentity                               pointer_{};
   Vector2                                           press_normalized_{};
+  Vector2                                           press_reference_pixels_{};
+  Vector2                                           brush_placement_before_{};
   std::optional<MaskSource>                         overlay_source_;
   MaskOverlayDisplay                                overlay_display_{};
   AnalyticMaskHandle                                active_handle_    = AnalyticMaskHandle::None;
   MaskOverlayHandleId                               hovered_handle_   = MaskOverlayHandleId::None;
   std::uint64_t                                     next_sequence_id_ = 1;
+  EditorBrushTool                                   brush_tool_       = EditorBrushTool::Idle;
+  float                                             brush_radius_     = 0.0f;
+  float                                             brush_strength_   = 1.0f;
+  float                                             brush_hardness_   = 1.0f;
+  std::vector<QPointF>                              brush_item_path_;
 };
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
@@ -5,6 +5,7 @@
 #include "ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp"
 
 #include <QDebug>
+#include <QLineF>
 #include <QPointF>
 #include <Qt>
 #include <algorithm>
@@ -16,9 +17,11 @@
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/mask/analytic_mask_edit.hpp"
+#include "edit/mask/brush_placement.hpp"
 #include "ui/alcedo_main/album_backend/editor_node_controller.hpp"
 #include "ui/alcedo_main/album_backend/editor_session_controller.hpp"
 #include "ui/edit_viewer/mask_edit_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_geometry.hpp"
 #include "ui/edit_viewer/mask_overlay_layout.hpp"
 #include "ui/editor_rhi/editor_interaction_controller.hpp"
 #include "ui/editor_rhi/editor_overlay_item.hpp"
@@ -50,6 +53,8 @@ constexpr float    kPi = 3.14159265358979323846f;
       return AnalyticMaskHandle::LinearStartBoundary;
     case MaskOverlayHandleId::LinearEndBoundary:
       return AnalyticMaskHandle::LinearEndBoundary;
+    case MaskOverlayHandleId::BrushMove:
+      return AnalyticMaskHandle::BrushMove;
     default:
       return AnalyticMaskHandle::None;
   }
@@ -77,6 +82,8 @@ constexpr float    kPi = 3.14159265358979323846f;
       return MaskOverlayHandleId::LinearStartBoundary;
     case AnalyticMaskHandle::LinearEndBoundary:
       return MaskOverlayHandleId::LinearEndBoundary;
+    case AnalyticMaskHandle::BrushMove:
+      return MaskOverlayHandleId::BrushMove;
     default:
       return MaskOverlayHandleId::None;
   }
@@ -120,8 +127,15 @@ EditorMaskCreationAdapter::~EditorMaskCreationAdapter() {
 }
 
 auto EditorMaskCreationAdapter::owns_left_button() const -> bool {
-  return edit_mode_ == EditMode::Creating ||
-         (edit_mode_ == EditMode::Editing && IsAnalyticKind(source_kind_));
+  if (edit_mode_ == EditMode::Creating) {
+    return true;
+  }
+  if (edit_mode_ == EditMode::Editing && IsAnalyticKind(source_kind_)) {
+    return true;
+  }
+  return source_kind_ == MaskSourceKind::Brush &&
+         (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase ||
+          brush_tool_ == EditorBrushTool::Move);
 }
 
 auto EditorMaskCreationAdapter::body_visible() const -> bool { return active(); }
@@ -207,6 +221,194 @@ void EditorMaskCreationAdapter::beginLinear() {
   BeginTool(MaskSourceKind::LinearGradient, QStringLiteral("linear"));
 }
 
+void EditorMaskCreationAdapter::beginBrush() { BeginBrushTool(); }
+
+auto EditorMaskCreationAdapter::brush_tool_name() const -> QString {
+  switch (brush_tool_) {
+    case EditorBrushTool::Paint:
+      return QStringLiteral("paint");
+    case EditorBrushTool::Erase:
+      return QStringLiteral("erase");
+    case EditorBrushTool::Move:
+      return QStringLiteral("move");
+    case EditorBrushTool::Idle:
+      return QString();
+  }
+  return QString();
+}
+
+void EditorMaskCreationAdapter::EnqueueBrushSettings(EditorMaskCreationCommand& command) const {
+  command.brush_tool     = brush_tool_;
+  command.brush_radius   = brush_radius_;
+  command.brush_strength = brush_strength_;
+  command.brush_hardness = brush_hardness_;
+}
+
+auto EditorMaskCreationAdapter::ResolveBrushResumeMask(const NodeId& grade_id) const -> MaskId {
+  if (session_ == nullptr || grade_id.Empty()) {
+    return {};
+  }
+  const auto* document = session_->pipeline_document();
+  if (document == nullptr) {
+    return {};
+  }
+  const auto* grade =
+      dynamic_cast<const ColorGradeNodeModel*>(document->Graph().FindNode(grade_id));
+  if (grade == nullptr) {
+    return {};
+  }
+  std::vector<MaskId> brushes;
+  for (std::size_t i = 0; i < grade->MaskCount(); ++i) {
+    if (GetMaskSourceKind(grade->MaskAt(i).source) == MaskSourceKind::Brush) {
+      brushes.push_back(grade->MaskAt(i).id);
+    }
+  }
+  if (brushes.empty()) {
+    return {};
+  }
+  if (brushes.size() == 1) {
+    return brushes.front();
+  }
+  const auto selected = MaskIdFromQString(selected_mask_id_);
+  for (const auto& id : brushes) {
+    if (id == selected) {
+      return selected;
+    }
+  }
+  return {};
+}
+
+auto EditorMaskCreationAdapter::BrushRadiusLogicalPx(const MaskCreationSample& sample) const
+    -> float {
+  if (interaction_ == nullptr || brush_radius_ <= 0.0f) {
+    return kMaskOverlayHandleRadiusLogicalPx * 2.0f;
+  }
+  const auto mapping = interaction_->maskEditViewMapping();
+  const auto center  = MaskEditGeometry::MapReferenceToItem(mapping, sample.reference_pixels);
+  const auto edge    = MaskEditGeometry::MapReferenceToItem(
+      mapping, Vector2{sample.reference_pixels.x + brush_radius_, sample.reference_pixels.y});
+  if (!center || !edge) {
+    return kMaskOverlayHandleRadiusLogicalPx * 2.0f;
+  }
+  return static_cast<float>(QLineF(*center, *edge).length());
+}
+
+void EditorMaskCreationAdapter::BeginBrushTool() {
+  const NodeId grade = CurrentGradeId();
+  if (!CanAuthorMasksFor(grade)) {
+    return;
+  }
+  if (open_) {
+    EditorMaskCreationCommand cancel;
+    cancel.kind    = EditorMaskCreationCommandKind::Cancel;
+    cancel.node_id = edit_node_id_;
+    cancel.mask_id = MaskIdFromQString(selected_mask_id_);
+    (void)Enqueue(cancel);
+  }
+  if (interaction_ != nullptr) {
+    const auto extent = interaction_->maskEditViewMapping().geometry.full_reference_extent;
+    if (brush_radius_ <= 0.0f && !extent.Empty()) {
+      brush_radius_ = DefaultBrushRadiusReferencePixels(extent);
+    }
+  }
+  const auto resume = ResolveBrushResumeMask(grade);
+  EditorMaskCreationCommand command;
+  command.kind        = EditorMaskCreationCommandKind::BeginCreation;
+  command.source_kind = MaskSourceKind::Brush;
+  command.node_id     = grade;
+  command.mask_id     = resume;
+  command.brush_tool  = EditorBrushTool::Paint;
+  EnqueueBrushSettings(command);
+  if (command.node_id.Empty() || !Enqueue(command)) {
+    return;
+  }
+  source_kind_      = MaskSourceKind::Brush;
+  tool_kind_        = QStringLiteral("brush");
+  edit_node_id_     = grade;
+  edit_mode_        = EditMode::Creating;
+  brush_tool_       = EditorBrushTool::Paint;
+  selected_mask_id_ = MaskIdToQString(resume);
+  open_             = false;
+  brush_item_path_.clear();
+  overlay_source_.reset();
+  overlay_display_ = {};
+  hovered_handle_  = MaskOverlayHandleId::None;
+  active_handle_   = AnalyticMaskHandle::None;
+  if (!resume.Empty() && session_ != nullptr) {
+    const auto* document = session_->pipeline_document();
+    const auto* grade_model =
+        document == nullptr
+            ? nullptr
+            : dynamic_cast<const ColorGradeNodeModel*>(document->Graph().FindNode(grade));
+    const auto* mask = grade_model == nullptr ? nullptr : grade_model->FindMask(resume);
+    if (mask != nullptr) {
+      overlay_source_ = mask->source;
+    }
+  }
+  HideOverlay();
+  PublishDisplayedGeometry();
+  if (overlay_source_.has_value()) {
+    PublishOverlay();
+  }
+  emit maskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::setBrushTool(const QString& tool) {
+  EditorBrushTool next = EditorBrushTool::Idle;
+  if (tool == QLatin1String("paint")) {
+    next = EditorBrushTool::Paint;
+  } else if (tool == QLatin1String("erase")) {
+    next = EditorBrushTool::Erase;
+  } else if (tool == QLatin1String("move")) {
+    next = EditorBrushTool::Move;
+  } else {
+    return;
+  }
+  if (!CanAuthorMasks() || source_kind_ != MaskSourceKind::Brush) {
+    return;
+  }
+  EditorMaskCreationCommand command;
+  command.kind       = EditorMaskCreationCommandKind::SetBrushTool;
+  command.node_id    = edit_node_id_;
+  command.mask_id    = MaskIdFromQString(selected_mask_id_);
+  command.brush_tool = next;
+  if (!Enqueue(command)) {
+    return;
+  }
+  brush_tool_ = next;
+  if (next == EditorBrushTool::Move) {
+    edit_mode_ = EditMode::Editing;
+  } else {
+    edit_mode_ = EditMode::Creating;
+  }
+  emit maskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::setBrushRadius(qreal radius) {
+  if (!(radius > 0.0)) {
+    return;
+  }
+  brush_radius_ = static_cast<float>(radius);
+  EditorMaskCreationCommand command;
+  command.kind = EditorMaskCreationCommandKind::SetBrushStrokeParameters;
+  command.node_id = edit_node_id_;
+  command.mask_id = MaskIdFromQString(selected_mask_id_);
+  EnqueueBrushSettings(command);
+  (void)Enqueue(command);
+  emit maskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::setBrushStrengthPercent(qreal percent) {
+  brush_strength_ = std::clamp(static_cast<float>(percent) / 100.0f, 0.0f, 1.0f);
+  EditorMaskCreationCommand command;
+  command.kind = EditorMaskCreationCommandKind::SetBrushStrokeParameters;
+  command.node_id = edit_node_id_;
+  command.mask_id = MaskIdFromQString(selected_mask_id_);
+  EnqueueBrushSettings(command);
+  (void)Enqueue(command);
+  emit maskCreationChanged();
+}
+
 void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& tool_kind) {
   const NodeId grade = CurrentGradeId();
   qWarning()
@@ -241,6 +443,8 @@ void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& to
   edit_mode_    = EditMode::Creating;
   selected_mask_id_.clear();
   open_ = false;
+  brush_tool_      = EditorBrushTool::Idle;
+  brush_item_path_.clear();
   overlay_source_.reset();
   overlay_display_ = {};
   hovered_handle_  = MaskOverlayHandleId::None;
@@ -436,6 +640,8 @@ void EditorMaskCreationAdapter::ResetLocal() {
   overlay_display_ = {};
   hovered_handle_  = MaskOverlayHandleId::None;
   active_handle_   = AnalyticMaskHandle::None;
+  brush_tool_      = EditorBrushTool::Idle;
+  brush_item_path_.clear();
   HideOverlay();
   if (changed) {
     emit maskCreationChanged();
@@ -593,7 +799,19 @@ void EditorMaskCreationAdapter::PublishOverlay() {
                   ? MakeLinearCreatingOverlayDisplay(mapping, *linear, style, clip)
                   : MakeLinearExistingOverlayDisplay(mapping, *linear, style, clip);
   } else if (const auto* brush = std::get_if<BrushMaskSource>(&*overlay_source_)) {
-    display = MakeBrushExistingOverlayDisplay(mapping, brush->placement_translation, clip);
+    if (open_ && (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {
+      QPointF cursor;
+      if (!brush_item_path_.empty()) {
+        cursor = brush_item_path_.back();
+      }
+      MaskCreationSample cursor_sample;
+      cursor_sample.reference_pixels = press_reference_pixels_;
+      display = MakeBrushCreatingOverlayDisplay(brush_item_path_, cursor,
+                                                BrushRadiusLogicalPx(cursor_sample), clip);
+      (void)brush;
+    } else {
+      display = MakeBrushExistingOverlayDisplay(mapping, brush->placement_translation, clip);
+    }
   }
   display.hovered_handle = hovered_handle_;
   display.active_handle  = OverlayHandleFromAnalytic(active_handle_);
@@ -800,11 +1018,31 @@ void EditorMaskCreationAdapter::EnqueueAppendSample(const MaskCreationSample& sa
   command.identity = pointer_;
   command.node_id  = edit_node_id_;
   command.mask_id  = MaskIdFromQString(selected_mask_id_);
+  if (source_kind_ == MaskSourceKind::Brush &&
+      (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {
+    command.ordered_append = true;
+    EnqueueBrushSettings(command);
+  }
   (void)Enqueue(command);
-  if (creating()) {
+  if (source_kind_ == MaskSourceKind::Brush &&
+      (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {
+    if (interaction_ != nullptr) {
+      if (const auto item =
+              MaskEditGeometry::MapReferenceToItem(interaction_->maskEditViewMapping(),
+                                                   sample.reference_pixels)) {
+        brush_item_path_.push_back(*item);
+      }
+    }
+  } else if (creating()) {
     overlay_source_ = source_kind_ == MaskSourceKind::Radial
                           ? MaskSource{RadialFromCenterOut(press_normalized_, sample.normalized)}
                           : MaskSource{LinearFromEndpoints(press_normalized_, sample.normalized)};
+  } else if (source_kind_ == MaskSourceKind::Brush &&
+             active_handle_ == AnalyticMaskHandle::BrushMove) {
+    if (auto* brush = overlay_source_ ? std::get_if<BrushMaskSource>(&*overlay_source_) : nullptr) {
+      brush->placement_translation = BrushPlacementForReferenceDrag(
+          brush_placement_before_, press_reference_pixels_, sample.reference_pixels);
+    }
   } else if (overlay_source_.has_value() && active_handle_ != AnalyticMaskHandle::None) {
     float unwrapped = 0.0f;
     if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
@@ -832,10 +1070,63 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
   pointer_.device_id   = 1;
   pointer_.point_id    = 1;
   pointer_.sequence_id = next_sequence_id_++;
+  press_normalized_       = sample->normalized;
+  press_reference_pixels_ = sample->reference_pixels;
 
-  const auto hit       = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
-                                                  OverlayStyle().hit_radius_logical_px);
-  const auto handle    = AnalyticHandleFromOverlay(hit);
+  const auto hit    = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
+                                               OverlayStyle().hit_radius_logical_px);
+  const auto handle = AnalyticHandleFromOverlay(hit);
+  if (source_kind_ == MaskSourceKind::Brush && brush_tool_ == EditorBrushTool::Move &&
+      handle == AnalyticMaskHandle::BrushMove) {
+    if (const auto* brush =
+            overlay_source_ ? std::get_if<BrushMaskSource>(&*overlay_source_) : nullptr) {
+      brush_placement_before_ = brush->placement_translation;
+    }
+    EditorMaskCreationCommand move;
+    move.kind       = EditorMaskCreationCommandKind::BeginMove;
+    move.handle     = AnalyticMaskHandle::BrushMove;
+    move.sample     = *sample;
+    move.identity   = pointer_;
+    move.node_id    = edit_node_id_;
+    move.mask_id    = MaskIdFromQString(selected_mask_id_);
+    move.brush_tool = EditorBrushTool::Move;
+    if (Enqueue(move)) {
+      active_handle_ = AnalyticMaskHandle::BrushMove;
+      open_          = true;
+      edit_mode_     = EditMode::Editing;
+      emit maskCreationChanged();
+      return true;
+    }
+    return true;
+  }
+  if (source_kind_ == MaskSourceKind::Brush &&
+      (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {
+    EditorMaskCreationCommand input;
+    input.kind     = EditorMaskCreationCommandKind::BeginInput;
+    input.sample   = *sample;
+    input.identity = pointer_;
+    input.node_id  = edit_node_id_;
+    input.mask_id  = MaskIdFromQString(selected_mask_id_);
+    EnqueueBrushSettings(input);
+    if (!Enqueue(input)) {
+      return true;
+    }
+    active_handle_ = AnalyticMaskHandle::None;
+    open_          = true;
+    brush_item_path_.clear();
+    if (interaction_ != nullptr) {
+      if (const auto item = MaskEditGeometry::MapReferenceToItem(
+              interaction_->maskEditViewMapping(), sample->reference_pixels)) {
+        brush_item_path_.push_back(*item);
+      }
+    }
+    if (!overlay_source_.has_value()) {
+      overlay_source_ = BrushMaskSource{};
+    }
+    PublishOverlay();
+    emit maskCreationChanged();
+    return true;
+  }
   if (handle != AnalyticMaskHandle::None && edit_mode_ == EditMode::Editing &&
       IsAnalyticKind(source_kind_)) {
     EditorMaskCreationCommand select;
@@ -934,9 +1225,15 @@ auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> b
   finish.identity = pointer_;
   (void)Enqueue(finish);
   open_          = false;
-  edit_mode_     = overlay_source_.has_value() ? EditMode::Editing : EditMode::Creating;
   active_handle_ = AnalyticMaskHandle::None;
-  if (edit_mode_ == EditMode::Editing && selected_mask_id_.isEmpty() && session_ != nullptr) {
+  brush_item_path_.clear();
+  if (source_kind_ == MaskSourceKind::Brush &&
+      (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {
+    edit_mode_ = EditMode::Creating;
+  } else {
+    edit_mode_ = overlay_source_.has_value() ? EditMode::Editing : EditMode::Creating;
+  }
+  if (selected_mask_id_.isEmpty() && session_ != nullptr) {
     selected_mask_id_ = MaskIdToQString(session_->mask_creation_mask_id());
   }
   PublishOverlay();

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentHeader.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorAdjustmentHeader.qml
@@ -4,9 +4,8 @@ import QtQuick.Layouts
 
 // Selected-node name, image-owned EXIF tokens, and Mask tool buttons under the
 // scope slot. Node switching does not reread EXIF; the session publishes the
-// four tokens when the open image identity changes. Radial / Gradient arm
-// analytic creation on the selected Color Grade. Brush remains disabled until
-// accumulating-stroke UI exists.
+// four tokens when the open image identity changes. Brush / Radial / Gradient
+// arm creation on the selected Color Grade.
 Item {
     id: root
     objectName: "editorAdjustmentHeader"
@@ -130,9 +129,13 @@ Item {
                 spacing: 0
 
                 IconActionButton {
+                    id: brushButton
                     objectName: "editorAdjustmentHeaderBrushButton"
                     compact: true
-                    enabled: false
+                    enabled: root.controlsEnabled
+                             && root.selectedNodeKind === "colorGrade"
+                    selected: root.maskCreation
+                              && String(root.maskCreation.toolKind || "") === "brush"
                     iconSrc: "qrc:/mask_icons/brush.svg"
                     actionName: qsTr("Brush")
                     iconColorDefault: root.colIcon
@@ -141,6 +144,13 @@ Item {
                     fillHover: appTheme.buttonHoveredFillColor
                     fillPressed: appTheme.buttonPressedFillColor
                     fillSelected: appTheme.buttonSelectedFillColor
+                    onClicked: {
+                        if (root.maskCreation && brushButton.selected) {
+                            root.maskCreation.finishBody()
+                        } else if (root.maskCreation) {
+                            root.maskCreation.beginBrush()
+                        }
+                    }
                 }
 
                 IconActionButton {

--- a/alcedo_studio/tests/edit/mask/brush_canonical_sampler_test.cpp
+++ b/alcedo_studio/tests/edit/mask/brush_canonical_sampler_test.cpp
@@ -67,6 +67,19 @@ TEST(BrushCanonicalSampler, ParameterBoundaryKeepsSizeChangeAtCurrentPoint) {
   EXPECT_EQ(sampler.Mode(), BrushStrokeMode::Erase);
 }
 
+TEST(BrushCanonicalSampler, DraftSamplesExposeOpenStrokeWithoutSealing) {
+  BrushCanonicalSampler sampler;
+  sampler.BeginStroke(BrushStrokeMode::Paint, {4.0f, 6.0f}, {}, 8.0f, 1.0f, 1.0f);
+  const auto draft = sampler.DraftSamples();
+  ASSERT_EQ(draft.size(), 1u);
+  EXPECT_FLOAT_EQ(draft.front().local_x, 4.0f);
+  sampler.AppendReference({12.0f, 6.0f});
+  EXPECT_GE(sampler.DraftSamples().size(), 1u);
+  const auto finished = sampler.FinishStroke();
+  EXPECT_TRUE(sampler.DraftSamples().empty());
+  EXPECT_GE(finished.size(), 2u);
+}
+
 TEST(BrushCanonicalSampler, CancelAndInvalidInputLeaveNoOpenStroke) {
   BrushCanonicalSampler sampler;
   EXPECT_THROW(sampler.AppendReference({1.0f, 1.0f}), std::runtime_error);

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -1274,6 +1274,29 @@ alcedo_ui_gtest_discover_tests(AnalyticMaskCreationTest
     PROPERTIES LABELS "mask_creation;interaction")
 alcedo_register_test_target(AnalyticMaskCreationTest ui)
 
+add_executable(AccumulatingBrushCreationTest
+    ${ALCEDO_TEST_ROOT}/ui/accumulating_brush_creation_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/ui_test_main.cpp
+)
+target_include_directories(AccumulatingBrushCreationTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR} ${ALCEDO_TEST_ROOT}/edit/graph ${ALCEDO_TEST_ROOT}/edit/mask
+)
+target_link_libraries(AccumulatingBrushCreationTest
+    PRIVATE
+        EditorMaskCreationController
+        EditorViewerLogic
+        EditGraph
+        GTest::gtest
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Test
+)
+alcedo_ui_gtest_discover_tests(AccumulatingBrushCreationTest
+    TEST_PREFIX "AccumulatingBrushCreationTest."
+    PROPERTIES LABELS "mask_creation;interaction")
+alcedo_register_test_target(AccumulatingBrushCreationTest ui)
+
 # Real-project regression: replay production Main.qml Copy/Paste and verify
 # that a reopened target publishes the saved Tone values to its QML models.
 add_executable(EditorAdjustmentTransferRealProjectE2eTest

--- a/alcedo_studio/tests/ui/accumulating_brush_creation_test.cpp
+++ b/alcedo_studio/tests/ui/accumulating_brush_creation_test.cpp
@@ -1,0 +1,403 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <QPointF>
+#include <QRectF>
+#include <QVector2D>
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "app/editor_mask_creation_controller.hpp"
+#include "app/pipeline_history_applier.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/history/commit_graph.hpp"
+#include "edit/history/edit_commit.hpp"
+#include "edit/history/mini_git_working_history.hpp"
+#include "edit/history/pipeline_edit_batch.hpp"
+#include "edit/mask/brush_placement.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_stroke.hpp"
+#include "edit/mask/grade_mask_coverage.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "grade_owned_mask_support.hpp"
+#include "ui/edit_viewer/mask_edit_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_geometry.hpp"
+#include "ui/edit_viewer/mask_overlay_layout.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr Extent2D kRaster{64, 32};
+constexpr float    kRadius = 8.0f;
+
+[[nodiscard]] auto MakeMapping() -> MaskEditViewMapping {
+  MaskEditViewMapping mapping;
+  mapping.widget     = {200, 100, 1.0f};
+  mapping.photograph = {static_cast<int>(kRaster.width), static_cast<int>(kRaster.height)};
+  mapping.zoom       = 1.25f;
+  mapping.pan        = QVector2D(4.0f, -3.0f);
+  mapping.geometry   = MaskEditGeometry::MakeIdentityPhotographGeometry(kRaster);
+  return mapping;
+}
+
+[[nodiscard]] auto SampleOf(const MaskEditViewMapping& mapping, QPointF item, bool allow_outside)
+    -> MaskCreationSample {
+  const auto mapped = MaskEditGeometry::MapItemToReference(mapping, item, allow_outside);
+  EXPECT_TRUE(mapped.has_value());
+  MaskCreationSample sample;
+  sample.normalized        = mapped->normalized;
+  sample.reference_pixels  = mapped->reference_pixels;
+  sample.inside_photograph = mapped->inside_photograph;
+  return sample;
+}
+
+[[nodiscard]] auto ItemOf(const MaskEditViewMapping& mapping, Vector2 normalized) -> QPointF {
+  const auto item = MapNormalizedMaskPointToItem(mapping, normalized);
+  EXPECT_TRUE(item.has_value());
+  return item.value_or(QPointF());
+}
+
+[[nodiscard]] auto CopyMix(const GradeMaskCoverage& mix) -> std::vector<std::uint8_t> {
+  const auto pixels = mix.Pixels();
+  return {pixels.begin(), pixels.end()};
+}
+
+[[nodiscard]] auto OverlayFillCount(const MaskOverlayDisplay& display) -> int {
+  return BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle())
+      .coverage_fill_vertex_count;
+}
+
+[[nodiscard]] auto BatchFromCommit(const EditCommit& commit) -> PipelineEditBatch {
+  return PipelineEditBatch::FromJSON(commit.GetPayloadJSON());
+}
+
+[[nodiscard]] auto LiveBrush(const PipelineDocument& document, const MaskId& id)
+    -> const BrushMaskSource* {
+  const auto* mask = document.PrimaryGrade()->FindMask(id);
+  if (mask == nullptr) {
+    return nullptr;
+  }
+  return std::get_if<BrushMaskSource>(&mask->source);
+}
+
+struct BrushCreationHarness {
+  BrushCreationHarness()
+      : graph(std::make_shared<CommitGraph>(CommitGraph::CreateEmpty(17))),
+        journal(std::make_shared<MiniGitJournal>()),
+        history(graph, journal) {
+    document = CreateDefaultPipelineDocument();
+    mix.SetGeometry(kRaster, kRaster);
+    controller.Bind(document, history);
+    controller.SetInteractivePreview([this]() {
+      ++preview_count;
+      EvaluateMix();
+      last_mix = CopyMix(mix);
+    });
+    (void)controller.SetBrushStrokeParameters(kRadius, 1.0f, 1.0f);
+  }
+
+  void EvaluateMix() {
+    for (const auto& mask : document.PrimaryGrade()->Masks()) {
+      if (const auto* brush = std::get_if<BrushMaskSource>(&mask.source)) {
+        mix.BindBrushSource(mask.id, *brush);
+      }
+    }
+    mix.EvaluateFull(document.PrimaryGrade()->Masks());
+  }
+
+  auto ArmPaint() -> EditorMaskCreationResult {
+    return controller.BeginCreation(MaskSourceKind::Brush, document.PrimaryGrade()->Id(), session);
+  }
+
+  auto PaintStroke(Vector2 from_normalized, Vector2 to_normalized, MaskPointerIdentity identity)
+      -> EditorMaskCreationResult {
+    const auto press  = SampleOf(mapping, ItemOf(mapping, from_normalized), false);
+    const auto move   = SampleOf(mapping, ItemOf(mapping, to_normalized), true);
+    EXPECT_TRUE(controller.BeginMaskInput(press, identity).accepted);
+    EXPECT_TRUE(controller.AppendMaskInput(move, identity).accepted);
+    return controller.FinishMaskInput();
+  }
+
+  auto AcknowledgePaint() -> bool {
+    const auto id = controller.selected_mask_id();
+    return controller.SelectMask(document.PrimaryGrade()->Id(), id, session).accepted &&
+           controller.SetBrushTool(EditorBrushTool::Paint).accepted;
+  }
+
+  std::shared_ptr<CommitGraph>    graph;
+  std::shared_ptr<MiniGitJournal> journal;
+  MiniGitWorkingHistory           history;
+  PipelineDocument                document;
+  EditorMaskCreationController    controller;
+  GradeMaskCoverage               mix;
+  std::vector<std::uint8_t>       last_mix;
+  int                             preview_count = 0;
+  MaskEditViewMapping             mapping       = MakeMapping();
+  EditorSessionIdentity           session{17, 4};
+  MaskPointerIdentity             pointer{3, 1, 9};
+};
+
+}  // namespace
+
+TEST(AccumulatingBrushCreationTest, MultipleStrokesUseOneBrushMask) {
+  BrushCreationHarness harness;
+  ASSERT_TRUE(harness.ArmPaint().accepted);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
+
+  const auto first = harness.PaintStroke({0.20f, 0.40f}, {0.28f, 0.42f}, harness.pointer);
+  ASSERT_TRUE(first.accepted);
+  EXPECT_TRUE(first.committed);
+  ASSERT_EQ(harness.document.PrimaryGrade()->MaskCount(), 1u);
+  const auto mask_id = first.mask_id;
+  const auto* brush  = LiveBrush(harness.document, mask_id);
+  ASSERT_NE(brush, nullptr);
+  EXPECT_EQ(brush->strokes.size(), 1u);
+  EXPECT_FALSE(brush->asset_key.has_value());
+
+  ASSERT_TRUE(harness.AcknowledgePaint());
+  MaskPointerIdentity second_pointer{3, 1, 10};
+  const auto second = harness.PaintStroke({0.55f, 0.60f}, {0.62f, 0.58f}, second_pointer);
+  ASSERT_TRUE(second.accepted);
+  EXPECT_TRUE(second.committed);
+  EXPECT_EQ(second.mask_id, mask_id);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 1u);
+  brush = LiveBrush(harness.document, mask_id);
+  ASSERT_NE(brush, nullptr);
+  ASSERT_EQ(brush->strokes.size(), 2u);
+  EXPECT_NE(brush->strokes.front().id, brush->strokes.back().id);
+  EXPECT_EQ(brush->strokes.front().mode, BrushStrokeMode::Paint);
+  EXPECT_EQ(brush->strokes.back().mode, BrushStrokeMode::Paint);
+
+  const auto display =
+      MakeBrushExistingOverlayDisplay(harness.mapping, brush->placement_translation, QRectF());
+  EXPECT_EQ(OverlayFillCount(display), 0);
+  EXPECT_FALSE(display.handles.empty());
+}
+
+TEST(AccumulatingBrushCreationTest, SizeAndStrengthChangesPersistInStrokeSamples) {
+  BrushCreationHarness harness;
+  ASSERT_TRUE(harness.ArmPaint().accepted);
+  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.25f, 0.40f}), false);
+  ASSERT_TRUE(harness.controller.BeginMaskInput(press, harness.pointer).accepted);
+  ASSERT_TRUE(harness.controller.SetBrushStrokeParameters(4.0f, 0.5f, 1.0f).accepted);
+  const auto move =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.45f, 0.40f}), true);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(move, harness.pointer).accepted);
+  const auto finish = harness.controller.FinishMaskInput();
+  ASSERT_TRUE(finish.accepted);
+  const auto* brush = LiveBrush(harness.document, finish.mask_id);
+  ASSERT_NE(brush, nullptr);
+  ASSERT_EQ(brush->strokes.size(), 1u);
+  const auto samples = BrushStrokeSamples(brush->strokes.front());
+  ASSERT_GE(samples.size(), 2u);
+  EXPECT_FLOAT_EQ(samples.front().radius, kRadius);
+  EXPECT_FLOAT_EQ(samples.front().strength, 1.0f);
+  bool saw_boundary = false;
+  for (const auto& sample : samples) {
+    if (sample.radius == 4.0f && sample.strength == 0.5f) {
+      saw_boundary = true;
+    }
+  }
+  EXPECT_TRUE(saw_boundary);
+}
+
+TEST(AccumulatingBrushCreationTest, MovingExistingBrushUpdatesInteractivePixels) {
+  BrushCreationHarness harness;
+  auto mask = grade_mask_test::MakeParameterizedBrushMask(
+      MaskId{"mask.brush"},
+      {MakeBrushStroke(StrokeId{"stroke.1"}, BrushStrokeMode::Paint,
+                       {{16.0f, 12.0f, kRadius, 1.0f, 1.0f}})});
+  harness.document.PrimaryGrade()->AddMask(std::move(mask), 0);
+  harness.EvaluateMix();
+  const auto mix_before  = CopyMix(harness.mix);
+  const auto head_before = harness.history.working_head();
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.brush"},
+                              harness.session)
+                  .accepted);
+  ASSERT_TRUE(harness.controller.SetBrushTool(EditorBrushTool::Move).accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{16.0f / 64.0f, 12.0f / 32.0f}),
+               false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::BrushMove, press, harness.pointer)
+                  .accepted);
+  const auto moved =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{40.0f / 64.0f, 20.0f / 32.0f}),
+               true);
+  const auto preview = harness.controller.AppendMaskInput(moved, harness.pointer);
+  ASSERT_TRUE(preview.accepted);
+  EXPECT_TRUE(preview.interactive_preview);
+  EXPECT_FALSE(preview.committed);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  EXPECT_GE(harness.preview_count, 1);
+  EXPECT_NE(harness.last_mix, mix_before);
+  const auto* live = LiveBrush(harness.document, MaskId{"mask.brush"});
+  ASSERT_NE(live, nullptr);
+  EXPECT_NE(live->placement_translation.x, 0.0f);
+  EXPECT_EQ(live->strokes.size(), 1u);
+
+  const auto finish = harness.controller.FinishMaskInput();
+  ASSERT_TRUE(finish.accepted);
+  EXPECT_TRUE(finish.committed);
+  ASSERT_TRUE(harness.history.working_head().has_value());
+  const auto* commit =
+      harness.history.graph()->FindCommit(*harness.history.working_head());
+  ASSERT_NE(commit, nullptr);
+  const auto batch = BatchFromCommit(*commit);
+  EXPECT_EQ(batch.operation_kind, PipelineEditOperationKind::SetBrushTranslation);
+}
+
+TEST(AccumulatingBrushCreationTest, BrushMoveDoesNotAppendStroke) {
+  BrushCreationHarness harness;
+  const auto original = MakeBrushStroke(StrokeId{"stroke.keep"}, BrushStrokeMode::Paint,
+                                        {{10.0f, 8.0f, kRadius, 1.0f, 1.0f}});
+  harness.document.PrimaryGrade()->AddMask(
+      grade_mask_test::MakeParameterizedBrushMask(MaskId{"mask.brush"}, {original}), 0);
+  const auto before_body = harness.document.PrimaryGrade()->BrushStrokes(MaskId{"mask.brush"}).front();
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), MaskId{"mask.brush"},
+                              harness.session)
+                  .accepted);
+  ASSERT_TRUE(harness.controller.SetBrushTool(EditorBrushTool::Move).accepted);
+  const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.20f, 0.30f}), false);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskMove(AnalyticMaskHandle::BrushMove, press, harness.pointer)
+                  .accepted);
+  const auto moved = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.35f, 0.40f}), true);
+  ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
+  ASSERT_TRUE(harness.controller.FinishMaskInput().accepted);
+  const auto strokes = harness.document.PrimaryGrade()->BrushStrokes(MaskId{"mask.brush"});
+  ASSERT_EQ(strokes.size(), 1u);
+  EXPECT_EQ(strokes.front().id, StrokeId{"stroke.keep"});
+  EXPECT_TRUE(BrushStrokesShareSampleBody(before_body, strokes.front()));
+}
+
+TEST(AccumulatingBrushCreationTest, UndoLastStrokePreservesEarlierStrokes) {
+  BrushCreationHarness harness;
+  ASSERT_TRUE(harness.ArmPaint().accepted);
+  const auto first = harness.PaintStroke({0.20f, 0.40f}, {0.30f, 0.42f}, harness.pointer);
+  ASSERT_TRUE(first.accepted);
+  const auto mask_id = first.mask_id;
+  const auto first_id =
+      LiveBrush(harness.document, mask_id)->strokes.front().id;
+  ASSERT_TRUE(harness.AcknowledgePaint());
+  MaskPointerIdentity second_pointer{3, 1, 11};
+  ASSERT_TRUE(harness.controller.SetBrushTool(EditorBrushTool::Erase).accepted);
+  const auto second = harness.PaintStroke({0.22f, 0.41f}, {0.28f, 0.41f}, second_pointer);
+  ASSERT_TRUE(second.accepted);
+  ASSERT_EQ(LiveBrush(harness.document, mask_id)->strokes.size(), 2u);
+  EXPECT_EQ(LiveBrush(harness.document, mask_id)->strokes.back().mode, BrushStrokeMode::Erase);
+
+  const auto undone = harness.history.Undo();
+  ASSERT_TRUE(undone.moved) << undone.error;
+  ASSERT_TRUE(undone.selected_commit.has_value());
+  std::string error;
+  ASSERT_TRUE(ApplyPipelineEditBatch(harness.document, BatchFromCommit(*undone.selected_commit),
+                                     PipelineEditApplyDirection::Inverse, &error))
+      << error;
+  const auto* restored = LiveBrush(harness.document, mask_id);
+  ASSERT_NE(restored, nullptr);
+  ASSERT_EQ(restored->strokes.size(), 1u);
+  EXPECT_EQ(restored->strokes.front().id, first_id);
+  EXPECT_EQ(harness.document.PrimaryGrade()->FindMask(mask_id)->id, mask_id);
+
+  const auto redone = harness.history.Redo();
+  ASSERT_TRUE(redone.moved) << redone.error;
+  ASSERT_TRUE(redone.selected_commit.has_value());
+  ASSERT_TRUE(ApplyPipelineEditBatch(harness.document, BatchFromCommit(*redone.selected_commit),
+                                     PipelineEditApplyDirection::Forward, &error))
+      << error;
+  const auto* replayed = LiveBrush(harness.document, mask_id);
+  ASSERT_NE(replayed, nullptr);
+  ASSERT_EQ(replayed->strokes.size(), 2u);
+  EXPECT_EQ(replayed->strokes.front().id, first_id);
+  EXPECT_EQ(replayed->strokes.back().mode, BrushStrokeMode::Erase);
+}
+
+TEST(AccumulatingBrushCreationTest, BrushReleaseCreatesNoHistoricalRasterFile) {
+  BrushCreationHarness harness;
+  ASSERT_TRUE(harness.ArmPaint().accepted);
+  const auto finish = harness.PaintStroke({0.40f, 0.50f}, {0.48f, 0.52f}, harness.pointer);
+  ASSERT_TRUE(finish.accepted);
+  EXPECT_TRUE(finish.committed);
+  const auto* brush = LiveBrush(harness.document, finish.mask_id);
+  ASSERT_NE(brush, nullptr);
+  EXPECT_FALSE(brush->asset_key.has_value());
+  EXPECT_TRUE(brush->descriptor.extent.Empty());
+  ASSERT_TRUE(harness.history.working_head().has_value());
+  const auto* commit =
+      harness.history.graph()->FindCommit(*harness.history.working_head());
+  ASSERT_NE(commit, nullptr);
+  const auto payload = commit->GetPayloadJSON();
+  const auto batch = PipelineEditBatch::FromJSON(payload);
+  EXPECT_EQ(batch.operation_kind, PipelineEditOperationKind::AddMask);
+  const auto dumped = payload.dump();
+  EXPECT_EQ(dumped.find("asset_key"), std::string::npos);
+  EXPECT_EQ(dumped.find("ReplaceMaskAsset"), std::string::npos);
+  EXPECT_NE(dumped.find("strokes"), std::string::npos);
+}
+
+TEST(AccumulatingBrushCreationTest, HeaderBrushResumesSingleExistingBrush) {
+  BrushCreationHarness harness;
+  harness.document.PrimaryGrade()->AddMask(
+      grade_mask_test::MakeParameterizedBrushMask(
+          MaskId{"mask.existing"},
+          {MakeBrushStroke(StrokeId{"stroke.keep"}, BrushStrokeMode::Paint,
+                           {{8.0f, 8.0f, kRadius, 1.0f, 1.0f}})}),
+      0);
+  ASSERT_TRUE(harness.ArmPaint().accepted);
+  EXPECT_EQ(harness.controller.selected_mask_id(), MaskId{"mask.existing"});
+  EXPECT_EQ(harness.controller.brush_tool(), EditorBrushTool::Paint);
+  const auto second = harness.PaintStroke({0.50f, 0.50f}, {0.58f, 0.52f}, harness.pointer);
+  ASSERT_TRUE(second.accepted);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 1u);
+  EXPECT_EQ(second.mask_id, MaskId{"mask.existing"});
+  EXPECT_EQ(LiveBrush(harness.document, MaskId{"mask.existing"})->strokes.size(), 2u);
+}
+
+TEST(AccumulatingBrushCreationTest, HeaderBrushWithMultipleExistingBrushesRequiresSelection) {
+  BrushCreationHarness harness;
+  harness.document.PrimaryGrade()->AddMask(
+      grade_mask_test::MakeParameterizedBrushMask(MaskId{"mask.a"}), 0);
+  harness.document.PrimaryGrade()->AddMask(
+      grade_mask_test::MakeParameterizedBrushMask(MaskId{"mask.b"}), 1);
+  const auto rejected = harness.ArmPaint();
+  EXPECT_FALSE(rejected.accepted);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 2u);
+  ASSERT_TRUE(harness.controller
+                  .BeginCreation(MaskSourceKind::Brush, harness.document.PrimaryGrade()->Id(),
+                                 harness.session, MaskId{"mask.b"})
+                  .accepted);
+  EXPECT_EQ(harness.controller.selected_mask_id(), MaskId{"mask.b"});
+}
+
+TEST(AccumulatingBrushCreationTest, DefaultBrushRadiusIsTwoPercentDiameterOfShorterEdge) {
+  EXPECT_FLOAT_EQ(DefaultBrushRadiusReferencePixels(kRaster), 0.32f);
+}
+
+TEST(AccumulatingBrushCreationTest, CancelledFirstStrokeLeavesGradeUnchanged) {
+  BrushCreationHarness harness;
+  const auto           head_before = harness.history.working_head();
+  ASSERT_TRUE(harness.ArmPaint().accepted);
+  const auto press =
+      SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.30f, 0.40f}), false);
+  ASSERT_TRUE(harness.controller.BeginMaskInput(press, harness.pointer).accepted);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 1u);
+  ASSERT_TRUE(harness.controller.CancelMaskInput().accepted);
+  EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+  EXPECT_TRUE(harness.controller.selected_mask_id().Empty());
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
@@ -67,6 +67,7 @@ class FakeMaskCreation final : public QObject {
 
   Q_INVOKABLE void beginRadial() { Open(QStringLiteral("radial"), true); }
   Q_INVOKABLE void beginLinear() { Open(QStringLiteral("linear"), true); }
+  Q_INVOKABLE void beginBrush() { Open(QStringLiteral("brush"), true); }
   Q_INVOKABLE void cancel() { Close(); }
   Q_INVOKABLE void hideBody() { finishBody(); }
   Q_INVOKABLE void finishBody() {

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,14 +2,15 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.8 complete; NM7.9–NM7.15 planned. This document records the NM7.1 source
+Status: NM7.1–NM7.9 complete; NM7.10–NM7.15 planned. This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
 shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
-NM7.7 Radial/Linear creation plus existing-mask movement, and NM7.8 parameter-mask
-controls, drawer selection/deletion, and crop-style Gradient. Some former NM7.11 UI
-wiring (now NM7.12) was brought forward for Radial/Gradient testing. This is partial
-wiring of the full UI phase. NM7.9–NM7.15 acceptance remains outstanding.
+NM7.7 Radial/Linear creation plus existing-mask movement, NM7.8 parameter-mask
+controls, drawer selection/deletion, and crop-style Gradient, and NM7.9 accumulating
+Brush paint/erase/move with typed stroke history. Some former NM7.11 UI wiring
+(now NM7.12) was brought forward for Radial/Gradient testing. This is partial
+wiring of the full UI phase. NM7.10–NM7.15 acceptance remains outstanding.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -1415,6 +1416,89 @@ release → corresponding single typed command → Quality.
 `UndoLastStrokePreservesEarlierStrokes`, `BrushReleaseCreatesNoHistoricalRasterFile`.
 
 **Exit:** paint/erase/move/Undo/Redo work after deleting caches, with stable MaskId and StrokeIds.
+
+##### Phase NM7.9 completion record (2026-09-10)
+
+**Status:** complete — one accumulating Brush per Grade for header-created work; paint/erase
+append canonical strokes; Move sets placement without rewriting samples; first release is
+AddMask, later strokes are AppendBrushStroke, moves are SetBrushTranslation.
+
+**Primary success call chain:**
+
+```text
+header beginBrush / BeginCreation(Brush)
+  -> BeginMaskInput (first dab; Paint or Erase)
+  -> BrushMaskInput + ColorGradeNodeModel AddMask (provisional first stroke)
+     or ReplaceMaskSource (draft on an existing Brush)
+  -> Interactive GradeMaskCoverage::EvaluateFull
+  -> FinishMaskInput
+  -> MakeAddMaskBatch (first stroke) or MakeAppendBrushStrokeBatch
+  -> history AppendEdit / PublishAppliedTypedBatch (document already at after)
+  -> Quality requested
+
+SetBrushTool(Move) + BeginMaskMove(BrushMove)
+  -> SetBrushTranslation live (canonical samples unchanged)
+  -> Interactive GradeMaskCoverage::EvaluateFull
+  -> MakeSetBrushTranslationBatch(before, after)
+  -> history AppendEdit / PublishAppliedTypedBatch
+  -> Quality requested
+```
+
+**Primary failure call chain:**
+
+```text
+Escape / cancel of an unfinished first stroke
+  -> RestoreLive RemoveMask of the provisional Brush
+  -> history head unchanged; Grade Mask list empty
+
+several existing Brushes and header BeginCreation without a named Brush
+  -> reject "select an existing Brush before painting"
+  -> document unchanged
+
+Brush Move
+  -> no AppendBrushStroke; sample bodies stay shared
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MultipleStrokesUseOneBrushMask` | `AccumulatingBrushCreationTest` | PASS |
+| `SizeAndStrengthChangesPersistInStrokeSamples` | `AccumulatingBrushCreationTest` | PASS |
+| `MovingExistingBrushUpdatesInteractivePixels` | `AccumulatingBrushCreationTest` | PASS |
+| `BrushMoveDoesNotAppendStroke` | `AccumulatingBrushCreationTest` | PASS |
+| `UndoLastStrokePreservesEarlierStrokes` (Undo + Redo) | `AccumulatingBrushCreationTest` | PASS |
+| `BrushReleaseCreatesNoHistoricalRasterFile` | `AccumulatingBrushCreationTest` | PASS |
+| `HeaderBrushResumesSingleExistingBrush` | `AccumulatingBrushCreationTest` | PASS |
+| `HeaderBrushWithMultipleExistingBrushesRequiresSelection` | `AccumulatingBrushCreationTest` | PASS |
+| `DefaultBrushRadiusIsTwoPercentDiameterOfShorterEdge` | `AccumulatingBrushCreationTest` | PASS |
+| `CancelledFirstStrokeLeavesGradeUnchanged` | `AccumulatingBrushCreationTest` | PASS |
+| `DraftSamplesExposeOpenStrokeWithoutSealing` | `BrushCanonicalSamplerTest` | PASS |
+| Analytic creation/movement and header Mask buttons | `AnalyticMaskCreationTest`, `EditorAdjustmentHeaderQmlTest` | PASS |
+
+Commands:
+`cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target AccumulatingBrushCreationTest --target BrushCanonicalSamplerTest --target AnalyticMaskCreationTest --target EditorAdjustmentHeaderQmlTest`
+`ctest --test-dir build/debug --output-on-failure -R "AccumulatingBrushCreationTest|BrushCanonicalSamplerTest|AnalyticMaskCreationTest|EditorAdjustmentHeaderQmlTest"`
+
+Suite totals: `47/47` PASS. Date / working tree on `feature/accumulating-brush-paint-erase-move` (base `0e890073`) / Windows MSVC `win_debug`. Interactive Mix in these tests is host `GradeMaskCoverage`; no GPU Mask pass in this phase. Ordered paint/erase Append is not coalesced (`ordered_append`); analytic and Brush-move Append still coalesce.
+
+**Checklist / exit condition:** required tests PASS. Paint and erase accumulate on one MaskId with stable StrokeIds. Size/strength boundaries persist in the sample body. Move updates Mix R8 before history and does not append a stroke. Undo of the last stroke keeps earlier strokes; Redo restores the erased stroke. First-stroke release JSON has no `asset_key` or `ReplaceMaskAsset`. Header resume of a single existing Brush and rejection when several Brushes exist without a named target are covered. No project Mix-cache files existed to delete (that storage is NM7.11); `BrushReleaseCreatesNoHistoricalRasterFile` shows the owner path does not write raster history.
+
+**LOC note (grill-code-review):** `editor_mask_creation_controller.cpp` 1069 / `.hpp` 318,
+`brush_mask_input.cpp` 49 / `.hpp` 82, `editor_mask_creation_adapter.cpp` 1159 / `.hpp` 168,
+`accumulating_brush_creation_test.cpp` 367, `brush_canonical_sampler.hpp` 86 / `.cpp` 126.
+`BrushMaskInput` owns the open-stroke sampler and dab settings. The controller still orchestrates
+analytic creation plus Brush paint/erase/move above the 1000-line mark; a later split should be a
+second owner (Brush vs analytic), not a method-file split. The adapter remains the QML command
+bridge and overlay publisher; Brush overlay geometry stays in `mask_overlay_layout`.
+
+**Remaining gaps:** native serial Interactive Mix and one Grade R8 slot are NM7.10. Project
+Mix-cache slot, keep/delete-on-close, and Clear are NM7.11. Mask Adjustment Stack paint/erase/
+size/strength/Move chrome and the 260/320/460 theme matrix are NM7.12. Open-operation cancel on
+`MappingChanged` is NM7.13. Header `beginBrush` is wired; the Mask page does not yet expose Brush
+tool settings. Native Mask still loads `MaskStore` when an in-memory `asset_key` is present.
+Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain
+planned.
 
 ### NM7.10 — Integrate serial Interactive evaluation and one current Grade R8
 


### PR DESCRIPTION
## Summary
- Accumulate paint and erase strokes on one Brush Mask per Grade, with header resume of a single existing Brush and an explicit selection requirement when several Brushes already exist.
- Publish AddMask for the first stroke, AppendBrushStroke for later strokes, and SetBrushTranslation for Move, without MaskStore or ReplaceMaskAsset raster history.
- Keep move input separate from paint, persist size/strength boundaries in canonical samples, and record NM7.9 completion in the viewer Mask creation plan.

## Test plan
- [x] `AccumulatingBrushCreationTest` required cases: multiple strokes, size/strength samples, Interactive move, move does not append, Undo/Redo, no historical raster
- [x] Header resume / multi-Brush selection, default 2% diameter radius, cancelled first stroke
- [x] `BrushCanonicalSamplerTest`, `AnalyticMaskCreationTest`, `EditorAdjustmentHeaderQmlTest`
- [ ] In-app: header Brush paint/erase, Move handle, Escape cancel, Undo/Redo of the last stroke

Made with [Cursor](https://cursor.com)