### PR TITLE
feat(edit): serial Interactive Grade Mix for NM7.10

### DIFF
--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1220,6 +1220,12 @@ auto EditorSessionService::mask_creation_commands_pending() const -> bool {
   return !pending_mask_commands_.empty();
 }
 
+auto EditorSessionService::PeekPendingMaskCommands() const
+    -> std::vector<EditorMaskCreationCommand> {
+  std::scoped_lock lock(mask_command_mutex_);
+  return pending_mask_commands_;
+}
+
 auto EditorSessionService::PeekPendingInput() const -> EditorPendingInputView {
   return pending_input_.Peek();
 }

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -47,6 +47,7 @@ def_library(EditMaskStore
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_rasterizer.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_signed_distance.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/grade_mask_coverage.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/parameterized_brush_raster.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/active_raster_mask.cpp
     PUBLIC_DEPS EditGeometry JSON
     PRIVATE_DEPS xxHash

--- a/alcedo_studio/src/edit/mask/parameterized_brush_raster.cpp
+++ b/alcedo_studio/src/edit/mask/parameterized_brush_raster.cpp
@@ -1,0 +1,47 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/parameterized_brush_raster.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_rasterizer.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+
+namespace alcedo {
+
+auto RasterizeParameterizedBrushSource(const BrushMaskSource& source, Extent2D full_reference)
+    -> ParameterizedBrushRaster {
+  const auto raster = CanonicalBrushRasterExtent(full_reference);
+  BrushRasterizer rasterizer;
+  rasterizer.SetGeometry(raster, full_reference);
+  rasterizer.RasterizeFull(source);
+  ParameterizedBrushRaster result;
+  result.descriptor.extent           = raster;
+  result.descriptor.reference_bounds = CanonicalBrushReferenceBounds();
+  const auto pixels                  = rasterizer.Pixels();
+  result.pixels.assign(pixels.begin(), pixels.end());
+  return result;
+}
+
+auto MakeParameterizedBrushActiveRaster(const NodeId& owner_node_id, const MaskId& mask_id,
+                                        const BrushMaskSource& source, Extent2D full_reference,
+                                        std::uint64_t content_revision,
+                                        std::uint64_t session_generation)
+    -> ActiveRasterMaskInput {
+  auto raster = RasterizeParameterizedBrushSource(source, full_reference);
+  ActiveRasterMaskInput input;
+  input.owner_node_id      = owner_node_id;
+  input.mask_id            = mask_id;
+  input.session_generation = session_generation;
+  input.content_revision   = content_revision == 0 ? 1 : content_revision;
+  input.descriptor         = raster.descriptor;
+  input.dirty_rectangle    = FullTexelRect(raster.descriptor.extent);
+  input.pixels = std::make_shared<const std::vector<std::uint8_t>>(std::move(raster.pixels));
+  return input;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
@@ -313,6 +313,13 @@ auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
   } else if (const auto* brush = std::get_if<BrushMaskSource>(&mask_model.source)) {
     const auto* active = FindActiveRasterMaskInput(active_raster_masks, compiled_grade.node_id,
                                                    compiled_source.mask_id);
+    ActiveRasterMaskInput parameterized_replay;
+    if (active == nullptr && BrushUsesParameterizedReplay(*brush)) {
+      parameterized_replay = ParameterizedBrushActiveRasterForGrade(
+          document, compiled_grade.node_id, compiled_source.mask_id, *brush,
+          plan.geometry.full_reference_extent);
+      active = &parameterized_replay;
+    }
     const auto encode_coverage = [&](auto& source, const MaskAssetDescriptor& raster_descriptor,
                                      bool raster_bytes_changed) {
       result.mip_level_count = static_cast<std::uint32_t>(source.MipLevelCount());
@@ -450,10 +457,6 @@ auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
     } else {
       if (store == nullptr)
         throw std::invalid_argument("ExecuteCudaMask: raster mask needs MaskStore");
-      if (!brush->asset_key.has_value() || brush->asset_key->Empty()) {
-        MaskFillZeroKernel<<<(render_pixels + block - 1) / block, block, 0, context.Stream()>>>(
-            static_cast<std::uint8_t*>(output.Texture().DevicePointer()), render_pixels);
-      } else {
       const auto asset  = store->Load(*brush->asset_key);
       const bool cached = workspace.MaskTextures().Contains(asset->key);
       auto       source = workspace.MaskTextures().Acquire(asset->key, asset->descriptor.extent);
@@ -462,7 +465,6 @@ auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
         upload_full(source, asset->pixels);
       }
       encode_coverage(source, asset->descriptor, !cached);
-      }
     }
   } else {
     throw std::runtime_error("ExecuteCudaMask: compiled mask does not match document");

--- a/alcedo_studio/src/edit/runtime/metal/metal_mask_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_mask_pass.mm
@@ -434,6 +434,13 @@ auto ExecuteMetalMask(MetalRenderDevice& device, const ExecutionPlan& plan,
 
   const auto* active = FindActiveRasterMaskInput(active_raster_masks, compiled_grade.node_id,
                                                  compiled_source.mask_id);
+  ActiveRasterMaskInput parameterized_replay;
+  if (active == nullptr && BrushUsesParameterizedReplay(*brush)) {
+    parameterized_replay = ParameterizedBrushActiveRasterForGrade(
+        document, compiled_grade.node_id, compiled_source.mask_id, *brush,
+        plan.geometry.full_reference_extent);
+    active = &parameterized_replay;
+  }
   const auto encode_coverage = [&](auto& source, const MaskAssetDescriptor& raster_descriptor,
                                    bool raster_bytes_changed, const MaskAssetKey* persistent_key) {
     result.mip_level_count = static_cast<std::uint32_t>(source.MipLevelCount());
@@ -537,10 +544,6 @@ auto ExecuteMetalMask(MetalRenderDevice& device, const ExecutionPlan& plan,
 
   if (store == nullptr) {
     throw std::invalid_argument("ExecuteMetalMask: raster mask needs MaskStore");
-  }
-  if (!brush->asset_key.has_value() || brush->asset_key->Empty()) {
-    EncodeFillZero(device, output.Texture());
-    return result;
   }
   const auto asset  = store->Load(*brush->asset_key);
   const bool cached = workspace.MaskTextures().Contains(asset->key);

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_mask_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_mask_pass.cpp
@@ -460,6 +460,13 @@ auto ExecuteOpenClMask(OpenClRenderDevice& device, const ExecutionPlan& plan,
 
   const auto* active = FindActiveRasterMaskInput(active_raster_masks, compiled_grade.node_id,
                                                  compiled_source.mask_id);
+  ActiveRasterMaskInput parameterized_replay;
+  if (active == nullptr && BrushUsesParameterizedReplay(*brush)) {
+    parameterized_replay = ParameterizedBrushActiveRasterForGrade(
+        document, compiled_grade.node_id, compiled_source.mask_id, *brush,
+        plan.geometry.full_reference_extent);
+    active = &parameterized_replay;
+  }
   const auto encode_coverage = [&](auto& source, const MaskAssetDescriptor& raster_descriptor,
                                    bool raster_bytes_changed, const MaskAssetKey* persistent_key) {
     result.mip_level_count = static_cast<std::uint32_t>(source.MipLevelCount());
@@ -560,10 +567,6 @@ auto ExecuteOpenClMask(OpenClRenderDevice& device, const ExecutionPlan& plan,
 
   if (store == nullptr) {
     throw std::invalid_argument("ExecuteOpenClMask: raster mask needs MaskStore");
-  }
-  if (!brush->asset_key.has_value() || brush->asset_key->Empty()) {
-    EncodeFillZero(device, output.Texture());
-    return result;
   }
   const auto asset = store->Load(*brush->asset_key);
   if (asset == nullptr || asset->descriptor.extent.Empty()) {

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
@@ -299,6 +300,17 @@ class IEditorSessionBackend {
    * synchronize this read with their Mask command queue.
    */
   [[nodiscard]] virtual auto mask_creation_commands_pending() const -> bool { return false; }
+  /**
+   * @brief Copy of queued Mask-creation commands. Empty when none are waiting.
+   *
+   * Synchronized with the Mask command queue. Latest non-ordered Append samples
+   * with the same pointer identity are already coalesced. Does not take the
+   * render lock or mutate the live Grade.
+   */
+  [[nodiscard]] virtual auto PeekPendingMaskCommands() const
+      -> std::vector<EditorMaskCreationCommand> {
+    return {};
+  }
   [[nodiscard]] virtual auto mask_creation_node_id() const -> NodeId { return {}; }
   [[nodiscard]] virtual auto mask_creation_mask_id() const -> MaskId { return {}; }
   [[nodiscard]] virtual auto mask_creation_source() const -> std::optional<MaskSource> {
@@ -495,6 +507,8 @@ class EditorSessionService final : public IEditorSessionBackend {
       -> EditorSessionResult override;
   auto EnqueueMaskCreation(EditorMaskCreationCommand command) -> EditorSessionResult override;
   [[nodiscard]] auto mask_creation_commands_pending() const -> bool override;
+  [[nodiscard]] auto PeekPendingMaskCommands() const
+      -> std::vector<EditorMaskCreationCommand> override;
   [[nodiscard]] auto mask_creation_node_id() const -> NodeId override {
     return mask_creation_.node_id();
   }

--- a/alcedo_studio/src/include/edit/mask/parameterized_brush_raster.hpp
+++ b/alcedo_studio/src/include/edit/mask/parameterized_brush_raster.hpp
@@ -1,0 +1,70 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/mask/active_raster_mask.hpp"
+#include "edit/mask/mask_asset.hpp"
+#include "edit/mask/mask_id.hpp"
+#include "edit/mask/mask_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Canonical-grid R8 produced from a parameterized Brush source.
+ *
+ * Extent is @ref CanonicalBrushRasterExtent of @p full_reference. Bounds are
+ * full-frame. Pixels are tightly packed. This is request/scratch raster data,
+ * not a MaskStore asset or a history entry.
+ */
+struct ParameterizedBrushRaster {
+  MaskAssetDescriptor       descriptor{};
+  std::vector<std::uint8_t> pixels;
+};
+
+/**
+ * @brief Rasterize @p source onto the canonical Brush grid for native Mix.
+ *
+ * Empty strokes write zeros. Placement is applied during dab stamping; samples
+ * are not rewritten. Zoom, DPR, and Interactive output size must not be passed
+ * as @p full_reference.
+ *
+ * @param source Parameterized Brush. Algorithm versions must be 1.
+ * @param full_reference Developed full-frame extent in reference pixels.
+ * @return Canonical descriptor and packed R8.
+ * @throws std::runtime_error when extents are empty or the algorithm version is
+ *         not 1, or a stroke fails rasterization.
+ *
+ * Thread: serial owner or native Mask pass on the render thread. Not thread-safe
+ * across one rasterizer, but this function uses a local rasterizer.
+ */
+[[nodiscard]] auto RasterizeParameterizedBrushSource(const BrushMaskSource& source,
+                                                     Extent2D full_reference)
+    -> ParameterizedBrushRaster;
+
+/**
+ * @brief Request-owned Active raster from a parameterized Brush replay.
+ *
+ * @p pixels stay immutable for the lifetime of the returned input. Dirty
+ * rectangle is the full canonical raster so the first upload is complete.
+ * @p content_revision is the consume/owner Mask revision used to reject stale
+ * GPU uploads. @p session_generation isolates authoring sessions; default 1 is
+ * the live Interactive Mix slot.
+ *
+ * @throws std::runtime_error from @ref RasterizeParameterizedBrushSource.
+ */
+[[nodiscard]] auto MakeParameterizedBrushActiveRaster(const NodeId& owner_node_id,
+                                                      const MaskId& mask_id,
+                                                      const BrushMaskSource& source,
+                                                      Extent2D full_reference,
+                                                      std::uint64_t content_revision,
+                                                      std::uint64_t session_generation = 1)
+    -> ActiveRasterMaskInput;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -288,19 +288,18 @@ class BasicRenderWorkspace {
 
  private:
   /**
-   * @brief Drop published images that this frame cannot reuse.
+   * @brief Drop published images this Interactive frame cannot display.
    *
-   * Revision mismatches are always dropped. Interactive frames also drop results
-   * whose representation identity no longer matches (crop, viewport, decode).
-   * QualityBase keeps revision-current Interactive results even when this frame's
-   * extent differs.
+   * Interactive drops results whose representation identity no longer matches
+   * (crop, viewport, decode). A newer required revision alone does not drop
+   * last-good Mix, Union, or Grade: a failed encode must keep the prior published
+   * result until a successful publish replaces it. QualityBase keeps published
+   * Interactive results even when this frame's extent differs.
    */
   void DropUnusablePublishedImages() {
     images_.DropStalePublished([this](const GraphValueId& id, RuntimeRevision revision,
                                       const ResultRepresentation& published) {
-      if (!invalidation_.HasCurrentRevision(id, revision)) {
-        return false;
-      }
+      (void)revision;
       if (persistence_scope_ == ResultPersistenceScope::SensorDevelopOnly) {
         return true;
       }

--- a/alcedo_studio/src/include/edit/runtime/compiled_grade_mask.hpp
+++ b/alcedo_studio/src/include/edit/runtime/compiled_grade_mask.hpp
@@ -10,6 +10,7 @@
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/mask/mask_model.hpp"
+#include "edit/mask/parameterized_brush_raster.hpp"
 #include "edit/runtime/execution_plan.hpp"
 
 namespace alcedo {
@@ -52,6 +53,35 @@ inline auto RequireMaskStack(const CompiledGradeNode& compiled) -> const Compile
     throw std::runtime_error("compiled Color Grade has no Mask stack");
   }
   return *compiled.mask_stack;
+}
+
+/**
+ * @brief True when native Brush evaluation must replay parameterized strokes.
+ *
+ * Persistent MaskStore assets are used only when the Brush has an asset key and
+ * no parameterized payload. Empty parameterized Brushes replay as zeros.
+ */
+inline auto BrushUsesParameterizedReplay(const BrushMaskSource& brush) -> bool {
+  return BrushSourceHasParameterizedPayload(brush) || !brush.asset_key.has_value() ||
+         brush.asset_key->Empty();
+}
+
+/**
+ * @brief Request-owned canonical Brush raster tagged with the live Mask revision.
+ *
+ * @p content_revision is @ref ColorGradeNodeModel::MaskContentRevision, or 1 when
+ * unset. Used by native Mask passes when the PipelineApplyRequest has no active
+ * raster override. Throws when rasterization fails.
+ */
+inline auto ParameterizedBrushActiveRasterForGrade(const PipelineDocument& document,
+                                                   const NodeId& grade_id, const MaskId& mask_id,
+                                                   const BrushMaskSource& brush,
+                                                   Extent2D full_reference)
+    -> ActiveRasterMaskInput {
+  const auto* grade =
+      dynamic_cast<const ColorGradeNodeModel*>(document.Graph().FindNode(grade_id));
+  const auto revision = grade == nullptr ? 1 : grade->MaskContentRevision(mask_id);
+  return MakeParameterizedBrushActiveRaster(grade_id, mask_id, brush, full_reference, revision);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_mask_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_mask_pass.hpp
@@ -26,11 +26,12 @@ struct CudaMaskResult {
 /**
  * @brief Evaluate @p compiled_source into its effective GraphValueId (RenderSpace R8).
  *
- * Persistent Brush textures are keyed by MaskAssetKey and are never patched. Active Brush
- * pixels use a separate session-generation texture and dirty-rectangle upload. Changing
- * only feather radius reuses signed distance when the raster bytes are unchanged. Feather
- * (when present), invert, and opacity run in that order. No CPU image processing fallback
- * is used.
+ * Persistent Brush textures are keyed by MaskAssetKey and are never patched. Parameterized
+ * Brushes replay onto a request-owned canonical R8 and upload through the active-raster
+ * cache, not MaskStore. Active Brush pixels use a separate session-generation texture and
+ * dirty-rectangle upload. Changing only feather radius reuses signed distance when the
+ * raster bytes are unchanged. Feather (when present), invert, and opacity run in that
+ * order. No CPU image processing fallback is used.
  */
 [[nodiscard]] auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
                                    const PipelineDocument& document,

--- a/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
+++ b/alcedo_studio/src/include/edit/runtime/graph_image_cache.hpp
@@ -183,7 +183,9 @@ class GraphImageCache {
    * Only values allowed by @p persistence become the current published result.
    * Other recorded writes stay unpublished until @ref DiscardUnpublished.
    * @ref ResultPersistenceScope::AllCurrentResults also drops unrecorded slots,
-   * matching the previous publish-then-clear behavior.
+   * matching the previous publish-then-clear behavior. A recorded write whose
+   * revision is older than the currently published result is dropped without
+   * replacing that result, so a delayed older submission cannot regress Mix.
    */
   void PublishSuccessfulSubmission(std::uint64_t submission_id,
                                    ResultPersistenceScope persistence =
@@ -195,6 +197,11 @@ class GraphImageCache {
       if (!slot.has_revision || slot.last_writer != submission_id ||
           !PersistsGraphValue(persistence, id, sensor_linear)) {
         ++it;
+        continue;
+      }
+      if (const auto* published = FindPublished(id);
+          published != nullptr && published->revision > slot.revision) {
+        it = write_slots_.erase(it);
         continue;
       }
       PublishedResult published;

--- a/alcedo_studio/src/include/edit/runtime/metal/metal_mask_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/metal/metal_mask_pass.hpp
@@ -31,7 +31,9 @@ struct MetalMaskResult {
  * @brief Evaluate @p compiled_source into its effective GraphValueId (RenderSpace R8).
  *
  * Raster source textures and mip levels live in workspace MaskTextureCache or the separate
- * active-raster cache. Persistent assets are never patched. Signed-distance intermediates are
+ * active-raster cache. Parameterized Brushes replay onto a request-owned canonical R8
+ * through the active-raster cache instead of MaskStore. Persistent assets are never
+ * patched. Signed-distance intermediates are
  * destroyed after the recorded command buffer completes. The signed-distance result is stored
  * by Mask content key so a feather-radius edit can reuse it. Feather (when present),
  * invert, and opacity run in that order. Failures throw; there is no CPU substitute.

--- a/alcedo_studio/src/include/edit/runtime/opencl/opencl_mask_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/opencl/opencl_mask_pass.hpp
@@ -30,7 +30,9 @@ struct OpenClMaskResult {
  * @brief Evaluate @p compiled_grade's analytic or raster mask into a RenderSpace R8 image.
  *
  * Raster source levels are owned by the workspace mask cache. Persistent assets are never
- * patched. Active Brush pixels use a separate session-generation texture. Feathering uses an
+ * patched. Parameterized Brushes replay onto a request-owned canonical R8 through the
+ * active-raster cache instead of MaskStore. Active Brush pixels use a separate
+ * session-generation texture. Feathering uses an
  * exact signed Euclidean distance field whose node-buffer metadata omits the feather radius, so
  * changing only that radius reuses the distance result. The function only enqueues OpenCL
  * work; failures throw and no CPU or alternate-backend substitute is used.

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -424,6 +424,19 @@ gtest_discover_tests(EditorSerialFrameConsumptionTest
     PROPERTIES LABELS "ci_core_flow;editor_session")
 alcedo_register_test_target(EditorSerialFrameConsumptionTest app ci_core)
 
+add_executable(EditorSerialMaskInteractiveTest
+    ${ALCEDO_TEST_ROOT}/app/editor_serial_mask_interactive_test.cpp)
+target_include_directories(EditorSerialMaskInteractiveTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_DIR}
+    PRIVATE ${ALCEDO_TEST_ROOT}/edit/graph)
+target_link_libraries(EditorSerialMaskInteractiveTest
+    PRIVATE EditorSessionService EditorSessionCommandQueue EditGraph EditHistory xxHash JSON
+            ${ALCEDO_TEST_OPENCV_MIN_DEPS} GTest::gtest_main)
+gtest_discover_tests(EditorSerialMaskInteractiveTest
+    TEST_PREFIX "EditorSerialMaskInteractiveTest."
+    PROPERTIES LABELS "ci_core_flow;editor_session")
+alcedo_register_test_target(EditorSerialMaskInteractiveTest app ci_core)
+
 add_executable(EditorSessionServiceFacadeTest ${ALCEDO_TEST_ROOT}/app/editor_session_service_facade_test.cpp)
 target_include_directories(EditorSessionServiceFacadeTest PUBLIC ${ALCEDO_INCLUDE_DIR})
 target_link_libraries(EditorSessionServiceFacadeTest

--- a/alcedo_studio/tests/app/editor_serial_mask_interactive_test.cpp
+++ b/alcedo_studio/tests/app/editor_serial_mask_interactive_test.cpp
@@ -1,0 +1,278 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/editor_mask_creation_controller.hpp"
+#include "app/editor_monotonic_clock.hpp"
+#include "app/editor_render_coordinator.hpp"
+#include "app/editor_render_intent.hpp"
+#include "app/editor_session_bootstrap.hpp"
+#include "app/editor_session_ports.hpp"
+#include "app/editor_session_service.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/history/commit_graph.hpp"
+#include "edit/history/mini_git_working_history.hpp"
+#include "edit/history/pipeline_edit_batch.hpp"
+#include "edit/mask/analytic_mask_edit.hpp"
+#include "edit/mask/brush_placement.hpp"
+#include "edit/mask/mask_id.hpp"
+#include "grade_owned_mask_support.hpp"
+#include "support/editor_session_command_queue_test_support.hpp"
+#include "support/latch_blocked_pipeline_scheduler_port.hpp"
+#include "support/manual_monotonic_clock.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace alcedo {
+namespace {
+
+const MaskId kMask{"mask.brush"};
+constexpr MaskPointerIdentity kPointer{1, 0, 1};
+
+class ManualEditorClock final : public IEditorMonotonicClock {
+ public:
+  test::ManualMonotonicClock clock;
+
+  [[nodiscard]] auto NowNs() const -> std::int64_t override { return clock.now_ns(); }
+};
+
+class DocumentBackedHistoryPort final : public test::FakeEditorHistoryPort {
+ public:
+  DocumentBackedHistoryPort()
+      : graph_(std::make_shared<CommitGraph>(CommitGraph::CreateEmpty(17))),
+        journal_(std::make_shared<MiniGitJournal>()),
+        history_(graph_, journal_) {
+    document = CreateDefaultPipelineDocument();
+    grade_mask_test::AddParameterizedBrushMask(
+        document, kMask, {grade_mask_test::MakePaintStroke("stroke.1", 8.0f, 6.0f, 3.0f)});
+  }
+
+  auto WithLockedLiveDocument(const EditorHistoryGuardHandle&, const LockedMaskDocumentOp& op,
+                              std::string* error) -> bool override {
+    if (!op) {
+      if (error != nullptr) {
+        *error = "Locked Mask document operation is empty";
+      }
+      return false;
+    }
+    const LockedMaskSettle settle = [](const PipelineEditBatch&, std::string*) { return true; };
+    return op(document, history_, settle, error);
+  }
+
+  PipelineDocument document;
+
+ private:
+  std::shared_ptr<CommitGraph>      graph_;
+  std::shared_ptr<MiniGitJournal>   journal_;
+  MiniGitWorkingHistory             history_;
+};
+
+class SerialMaskInteractiveTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    history_          = std::make_shared<DocumentBackedHistoryPort>();
+    pipeline_         = std::make_shared<test::FakeEditorPipelinePort>();
+    tasks_            = std::make_shared<test::FakeEditorTaskPort>();
+    journal_          = std::make_shared<test::FakeEditorJournalPort>();
+    checkpoint_store_ = std::make_shared<test::FakeEditorCheckpointStore>();
+    latch_            = std::make_shared<test::LatchBlockedPipelineSchedulerPort>();
+    clock_            = std::make_shared<ManualEditorClock>();
+    runtime_          = EditorSessionRuntime::CreateWithPorts(
+        pipeline_, history_, tasks_, journal_, latch_, checkpoint_store_);
+    service_ = runtime_->service.get();
+    service_->SetMonotonicClock(clock_);
+    service_->SetPresentationSinkId(1);
+    service_->SetPresentationSize(640, 480);
+  }
+
+  void CompleteInflightAndDrain() {
+    for (int i = 0; i < 16; ++i) {
+      service_->DrainCommandQueueForTests();
+      if (latch_->running()) {
+        latch_->Complete(true);
+        continue;
+      }
+      if (!runtime_->coordinator->has_inflight() &&
+          !service_->serial_frame_admission().HoldsOwnership()) {
+        return;
+      }
+    }
+  }
+
+  void OpenInteractive() {
+    (void)service_->Open(10, 20);
+    CompleteInflightAndDrain();
+    ASSERT_EQ(service_->state(), EditorSessionState::Interactive);
+    ASSERT_FALSE(latch_->running());
+    ASSERT_FALSE(runtime_->coordinator->has_inflight());
+  }
+
+  void ConsumeQueued() {
+    service_->DrainCommandQueueForTests();
+    if (!runtime_->coordinator->has_inflight() &&
+        !service_->serial_frame_admission().HoldsOwnership()) {
+      service_->TryConsumePendingInput();
+    }
+  }
+
+  [[nodiscard]] auto GradeId() const -> NodeId {
+    return history_->document.PrimaryGrade()->Id();
+  }
+
+  [[nodiscard]] auto LiveTranslation() const -> Vector2 {
+    return history_->document.PrimaryGrade()->BrushPlacementTranslation(kMask);
+  }
+
+  [[nodiscard]] auto SampleAt(Vector2 reference) const -> MaskCreationSample {
+    MaskCreationSample sample;
+    sample.normalized        = {reference.x / 16.0f, reference.y / 12.0f};
+    sample.reference_pixels  = reference;
+    sample.inside_photograph = true;
+    return sample;
+  }
+
+  auto Enqueue(EditorMaskCreationCommand command) -> EditorSessionResult {
+    const auto result = service_->EnqueueMaskCreation(std::move(command));
+    EXPECT_EQ(result.kind, EditorSessionResultKind::Accepted);
+    return result;
+  }
+
+  void EnqueueSelectAndArmMove() {
+    EditorMaskCreationCommand select;
+    select.kind    = EditorMaskCreationCommandKind::SelectMask;
+    select.node_id = GradeId();
+    select.mask_id = kMask;
+    Enqueue(select);
+
+    EditorMaskCreationCommand tool;
+    tool.kind       = EditorMaskCreationCommandKind::SetBrushTool;
+    tool.brush_tool = EditorBrushTool::Move;
+    Enqueue(tool);
+
+    EditorMaskCreationCommand begin;
+    begin.kind       = EditorMaskCreationCommandKind::BeginMove;
+    begin.node_id    = GradeId();
+    begin.mask_id    = kMask;
+    begin.handle     = AnalyticMaskHandle::BrushMove;
+    begin.brush_tool = EditorBrushTool::Move;
+    begin.identity   = kPointer;
+    begin.sample     = SampleAt({8.0f, 6.0f});
+    Enqueue(begin);
+  }
+
+  void EnqueueAppend(Vector2 reference) {
+    EditorMaskCreationCommand append;
+    append.kind     = EditorMaskCreationCommandKind::Append;
+    append.node_id  = GradeId();
+    append.mask_id  = kMask;
+    append.identity = kPointer;
+    append.sample   = SampleAt(reference);
+    Enqueue(append);
+  }
+
+  [[nodiscard]] auto PendingAppendCount() const -> std::size_t {
+    const auto pending = service_->PeekPendingMaskCommands();
+    return static_cast<std::size_t>(
+        std::count_if(pending.begin(), pending.end(), [](const EditorMaskCreationCommand& command) {
+          return command.kind == EditorMaskCreationCommandKind::Append;
+        }));
+  }
+
+  [[nodiscard]] auto LastPendingAppend() const -> std::optional<EditorMaskCreationCommand> {
+    const auto pending = service_->PeekPendingMaskCommands();
+    for (auto it = pending.rbegin(); it != pending.rend(); ++it) {
+      if (it->kind == EditorMaskCreationCommandKind::Append) {
+        return *it;
+      }
+    }
+    return std::nullopt;
+  }
+
+  std::shared_ptr<DocumentBackedHistoryPort>                   history_;
+  std::shared_ptr<test::FakeEditorPipelinePort>                pipeline_;
+  std::shared_ptr<test::FakeEditorTaskPort>                    tasks_;
+  std::shared_ptr<test::FakeEditorJournalPort>                 journal_;
+  std::shared_ptr<test::FakeEditorCheckpointStore>             checkpoint_store_;
+  std::shared_ptr<test::LatchBlockedPipelineSchedulerPort>     latch_;
+  std::shared_ptr<ManualEditorClock>                           clock_;
+  std::unique_ptr<EditorSessionRuntime>                        runtime_;
+  EditorSessionService*                                        service_ = nullptr;
+};
+
+TEST_F(SerialMaskInteractiveTest, MaskMoveNeverMutatesSourceDuringRender) {
+  OpenInteractive();
+  clock_->clock.set_ns(0);
+  EnqueueSelectAndArmMove();
+  EnqueueAppend({12.0f, 6.0f});
+  ConsumeQueued();
+  ASSERT_TRUE(latch_->running());
+  ASSERT_TRUE(service_->serial_frame_admission().HoldsOwnership());
+  const auto first = BrushPlacementForReferenceDrag({0.0f, 0.0f}, {8.0f, 6.0f}, {12.0f, 6.0f});
+  EXPECT_EQ(LiveTranslation(), first);
+
+  EnqueueAppend({16.0f, 6.0f});
+  EnqueueAppend({20.0f, 6.0f});
+  service_->DrainCommandQueueForTests();
+  EXPECT_TRUE(latch_->running());
+  EXPECT_EQ(LiveTranslation(), first);
+  EXPECT_TRUE(service_->mask_creation_commands_pending());
+  EXPECT_EQ(PendingAppendCount(), 1U);
+  const auto coalesced = LastPendingAppend();
+  ASSERT_TRUE(coalesced.has_value());
+  EXPECT_EQ(coalesced->sample.reference_pixels.x, 20.0f);
+  EXPECT_EQ(coalesced->sample.reference_pixels.y, 6.0f);
+  EXPECT_FALSE(coalesced->ordered_append);
+
+  latch_->Complete(true);
+  service_->DrainCommandQueueForTests();
+  EXPECT_EQ(LiveTranslation(), first);
+  clock_->clock.set_ns(16'000'000);
+  ConsumeQueued();
+  ASSERT_TRUE(latch_->running());
+  const auto latest = BrushPlacementForReferenceDrag({0.0f, 0.0f}, {8.0f, 6.0f}, {20.0f, 6.0f});
+  EXPECT_EQ(LiveTranslation(), latest);
+  EXPECT_FALSE(service_->mask_creation_commands_pending());
+}
+
+TEST_F(SerialMaskInteractiveTest, LatestMoveValueSurvivesRelease) {
+  OpenInteractive();
+  EnqueueSelectAndArmMove();
+  EnqueueAppend({10.0f, 6.0f});
+  EnqueueAppend({14.0f, 7.0f});
+  EnqueueAppend({18.0f, 8.0f});
+  EditorMaskCreationCommand finish;
+  finish.kind    = EditorMaskCreationCommandKind::Finish;
+  finish.node_id = GradeId();
+  finish.mask_id = kMask;
+  Enqueue(finish);
+
+  const auto pending = service_->PeekPendingMaskCommands();
+  ASSERT_EQ(PendingAppendCount(), 1U);
+  const auto coalesced = LastPendingAppend();
+  ASSERT_TRUE(coalesced.has_value());
+  EXPECT_EQ(coalesced->sample.reference_pixels.x, 18.0f);
+  EXPECT_EQ(coalesced->sample.reference_pixels.y, 8.0f);
+  EXPECT_FALSE(coalesced->ordered_append);
+  EXPECT_EQ(pending.back().kind, EditorMaskCreationCommandKind::Finish);
+
+  ConsumeQueued();
+  ASSERT_TRUE(latch_->running());
+  ASSERT_FALSE(latch_->scheduled().empty());
+  EXPECT_EQ(latch_->scheduled().back().intent.quality, EditorRenderQuality::Quality);
+  const auto latest = BrushPlacementForReferenceDrag({0.0f, 0.0f}, {8.0f, 6.0f}, {18.0f, 8.0f});
+  EXPECT_EQ(LiveTranslation(), latest);
+  EXPECT_FALSE(service_->mask_creation_commands_pending());
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -481,7 +481,8 @@ if(ALCEDO_CUDA_ENABLED)
 
   add_executable(GpuDagCudaMaskTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_mask_test.cpp
-    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_multi_mask_resource_test.cpp)
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_multi_mask_resource_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_parameterized_grade_mix_test.cpp)
   target_include_directories(GpuDagCudaMaskTest PUBLIC ${ALCEDO_INCLUDE_DIR})
   target_link_libraries(GpuDagCudaMaskTest PRIVATE GTest::gtest_main EditRuntimeCuda EditInput)
   gtest_discover_tests(GpuDagCudaMaskTest TEST_PREFIX "GpuDagCudaMaskTest."

--- a/alcedo_studio/tests/edit/runtime/cuda_parameterized_grade_mix_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_parameterized_grade_mix_test.cpp
@@ -1,0 +1,205 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <variant>
+#include <vector>
+
+#include "../graph/grade_owned_mask_support.hpp"
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/mask/brush_placement.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/grade_mask_coverage.hpp"
+#include "edit/mask/mask_id.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+#include "edit/runtime/result_persistence.hpp"
+#include "gpu/transient_allocation_policy.hpp"
+#include "multi_mask_runtime_test_support.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+class CudaParameterizedGradeMixFixture : public ::testing::Test {
+ protected:
+  static const MaskId kMask;
+  static constexpr std::uint32_t kWidth  = 16;
+  static constexpr std::uint32_t kHeight = 12;
+
+  void SetUp() override {
+    if (!HasCudaDevice()) {
+      GTEST_SKIP() << "No CUDA device available.";
+    }
+    prepared_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(kWidth, kHeight),
+                                              gpu_dag_test::FullSensor(kWidth, kHeight));
+    document_ = CreateDefaultPipelineDocument();
+    gpu_dag_test::EnsureTestCameraProfile(document_);
+    grade_mask_test::AddParameterizedBrushMask(
+        document_, kMask, {grade_mask_test::MakePaintStroke("stroke.1", 8.0f, 6.0f, 3.0f)});
+    Compile();
+  }
+
+  void Compile() {
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), {});
+    ASSERT_NE(plan_.FirstGrade(), nullptr);
+    ASSERT_TRUE(plan_.FirstGrade()->mask_stack.has_value());
+  }
+
+  void ExecuteInteractive() {
+    ASSERT_EQ(device_.Execute(plan_, prepared_, document_, nullptr, true,
+                              TransientAllocationPolicy::SessionPacked),
+              plan_.display_output);
+    device_.WaitIdle();
+  }
+
+  void ExecuteQualityBase() {
+    ASSERT_EQ(device_.Execute(plan_, prepared_, document_, nullptr, true,
+                              TransientAllocationPolicy::SessionPacked, {},
+                              ResultPersistenceScope::SensorDevelopOnly),
+              plan_.display_output);
+    device_.WaitIdle();
+    device_.Workspace().Images().DiscardUnpublished();
+  }
+
+  [[nodiscard]] auto MixId() const -> GraphValueId { return plan_.FirstGrade()->mask_output; }
+
+  auto DownloadMix() -> std::vector<std::uint8_t> {
+    auto* lease = device_.Workspace().Images().Find(MixId());
+    EXPECT_NE(lease, nullptr);
+    if (lease == nullptr) {
+      return {};
+    }
+    std::vector<std::uint8_t> pixels(lease->Texture().Bytes());
+    device_.Workspace().Device().DownloadTexture2D(
+        lease->Texture(),
+        std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()), pixels.size()),
+        device_.CommandContext());
+    return pixels;
+  }
+
+  void MoveBrush(Vector2 after) {
+    auto* grade = document_.PrimaryGrade();
+    ASSERT_NE(grade, nullptr);
+    const auto before = grade->BrushPlacementTranslation(kMask);
+    grade->SetBrushTranslation(MakeBrushTranslationCommand(
+        grade->Id(), kMask, before, after, grade->MaskContentRevision(kMask)));
+  }
+
+  auto HostMixPixels() -> std::vector<std::uint8_t> {
+    const auto full   = plan_.geometry.full_reference_extent;
+    const auto raster = CanonicalBrushRasterExtent(full);
+    GradeMaskCoverage coverage;
+    coverage.SetGeometry(raster, full);
+    const auto* mask = document_.PrimaryGrade()->FindMask(kMask);
+    EXPECT_NE(mask, nullptr);
+    if (mask == nullptr) {
+      return {};
+    }
+    const auto* brush = std::get_if<BrushMaskSource>(&mask->source);
+    EXPECT_NE(brush, nullptr);
+    if (brush == nullptr) {
+      return {};
+    }
+    coverage.BindBrushSource(kMask, *brush);
+    coverage.EvaluateFull(document_.PrimaryGrade()->Masks());
+    const auto pixels = coverage.Pixels();
+    return {pixels.begin(), pixels.end()};
+  }
+
+  void ExpectOneGradeMixSlot() {
+    EXPECT_EQ(device_.Workspace().MaskTextures().EntryCount(), 0U);
+    EXPECT_LE(device_.Workspace().ActiveRasterTextures().EntryCount(), 1U);
+    EXPECT_NE(device_.Workspace().Images().Find(MixId()), nullptr);
+    EXPECT_NE(device_.Workspace().Images().PublishedRevision(MixId()), 0U);
+  }
+
+  PreparedRawInput prepared_;
+  PipelineDocument document_;
+  ExecutionPlan    plan_;
+  CudaRenderDevice device_;
+};
+
+const MaskId CudaParameterizedGradeMixFixture::kMask{"mask.brush"};
+
+TEST_F(CudaParameterizedGradeMixFixture, CurrentGradeCoverageHasOneRetainedResult) {
+  ExecuteInteractive();
+  ExpectOneGradeMixSlot();
+  const auto published_after_first = device_.Workspace().Images().PublishedCount();
+  const auto first_mix             = DownloadMix();
+  const auto first_revision        = device_.Workspace().Images().PublishedRevision(MixId());
+  ASSERT_EQ(plan_.geometry.render_extent, CanonicalBrushRasterExtent(plan_.geometry.full_reference_extent));
+  multi_mask_test::ExpectR8WithinTolerance(first_mix, HostMixPixels());
+
+  MoveBrush({4.0f, 0.0f});
+  ExecuteInteractive();
+  ExpectOneGradeMixSlot();
+  const auto second_mix = DownloadMix();
+  EXPECT_NE(second_mix, first_mix);
+  EXPECT_NE(device_.Workspace().Images().PublishedRevision(MixId()), first_revision);
+  EXPECT_EQ(device_.Workspace().Images().PublishedCount(), published_after_first);
+  multi_mask_test::ExpectR8WithinTolerance(second_mix, HostMixPixels());
+
+  MoveBrush({8.0f, 2.0f});
+  ExecuteInteractive();
+  ExpectOneGradeMixSlot();
+  EXPECT_NE(DownloadMix(), second_mix);
+  EXPECT_EQ(device_.Workspace().Images().PublishedCount(), published_after_first);
+  multi_mask_test::ExpectR8WithinTolerance(DownloadMix(), HostMixPixels());
+}
+
+TEST_F(CudaParameterizedGradeMixFixture, QualityMaskEvaluationDoesNotOverwriteInteractiveCache) {
+  ExecuteInteractive();
+  ExpectOneGradeMixSlot();
+  const auto mix_revision = device_.Workspace().Images().PublishedRevision(MixId());
+  const auto mix_resource = device_.Workspace().Images().Find(MixId())->Texture().ResourceId();
+  const auto mix_pixels   = DownloadMix();
+  const auto published    = device_.Workspace().Images().PublishedCount();
+
+  device_.ResetPassStats();
+  ExecuteQualityBase();
+  EXPECT_GT(device_.PassStats().result_policy_bypass, 0U);
+  EXPECT_EQ(device_.Workspace().Images().PublishedRevision(MixId()), mix_revision);
+  EXPECT_EQ(device_.Workspace().Images().Find(MixId())->Texture().ResourceId(), mix_resource);
+  EXPECT_EQ(device_.Workspace().Images().PublishedCount(), published);
+  EXPECT_EQ(DownloadMix(), mix_pixels);
+  ExpectOneGradeMixSlot();
+}
+
+TEST_F(CudaParameterizedGradeMixFixture, RebuiltMaskMatchesCacheHitPixels) {
+  ExecuteInteractive();
+  const auto first = DownloadMix();
+  ASSERT_FALSE(first.empty());
+  ASSERT_EQ(plan_.geometry.render_extent, CanonicalBrushRasterExtent(plan_.geometry.full_reference_extent));
+  multi_mask_test::ExpectR8WithinTolerance(first, HostMixPixels());
+
+  device_.ResetPassStats();
+  ExecuteInteractive();
+  EXPECT_GT(device_.PassStats().mask_union_skip, 0U);
+  EXPECT_EQ(DownloadMix(), first);
+
+  device_.Workspace().Images().DropPublished(MixId());
+  device_.ResetPassStats();
+  ExecuteInteractive();
+  EXPECT_GT(device_.PassStats().mask_union_execute, 0U);
+  EXPECT_EQ(DownloadMix(), first);
+  multi_mask_test::ExpectR8WithinTolerance(DownloadMix(), HostMixPixels());
+  ExpectOneGradeMixSlot();
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/runtime/graph_image_cache_retention_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_image_cache_retention_test.cpp
@@ -320,9 +320,7 @@ TEST(GraphImageCacheRetention, ExtraLeaseKeepsDisplayedTextureAfterStalePublishD
 auto KeepPublishedForInteractive(HostRetentionHarness& harness, const GraphValueId& id,
                                  RuntimeRevision revision, const ResultRepresentation& published)
     -> bool {
-  if (!harness.invalidation.HasCurrentRevision(id, revision)) {
-    return false;
-  }
+  (void)revision;
   const auto needed = harness.invalidation.MakeImageRepresentation(
       id, published.extent, published.format, published.source_detail);
   return RepresentationSatisfies(published, needed);
@@ -337,6 +335,33 @@ void PublishWithFrameIdentity(HostRetentionHarness& harness, const GraphValueId&
   harness.cache.RecordUnpublished(id, required, needed, 1);
   harness.cache.PublishSuccessfulSubmission(1, ResultPersistenceScope::AllCurrentResults,
                                             harness.Sensor());
+}
+
+TEST(GraphImageCacheRetention, LastGoodGradeSurvivesExposureRevisionWhenFrameIdentityMatches) {
+  HostRetentionHarness     harness;
+  constexpr TextureRequest kRgba{8, 8, TextureFormat::Rgba32f};
+  PublishWithFrameIdentity(harness, harness.Sensor(), kRgba);
+  PublishWithFrameIdentity(harness, harness.Geometry(), kRgba);
+  PublishWithFrameIdentity(harness, harness.Grade(), kRgba);
+  const auto grade_handle = harness.cache.Find(harness.Grade())->Handle();
+  const auto grade_rev    = harness.cache.PublishedRevision(harness.Grade());
+
+  auto* exposure = dynamic_cast<ExposureModel*>(
+      harness.document.PrimaryGrade()->FindAdjustmentByType(type_ids::Exposure()));
+  ASSERT_NE(exposure, nullptr);
+  exposure->SetValue(0.5f);
+  harness.invalidation.CollectAndPropagate(harness.plan, harness.document, harness.prepared, {});
+  ASSERT_NE(harness.invalidation.RequiredRevision(harness.Grade()), grade_rev);
+
+  harness.cache.DropStalePublished([&](const GraphValueId& id, RuntimeRevision revision,
+                                       const ResultRepresentation& published) {
+    return KeepPublishedForInteractive(harness, id, revision, published);
+  });
+
+  ASSERT_NE(harness.cache.Find(harness.Grade()), nullptr);
+  EXPECT_EQ(harness.cache.Find(harness.Grade())->Handle(), grade_handle);
+  EXPECT_EQ(harness.cache.PublishedRevision(harness.Grade()), grade_rev);
+  EXPECT_FALSE(harness.invalidation.HasCurrentRevision(harness.Grade(), grade_rev));
 }
 
 TEST(GraphImageCacheRetention, CropMismatchesFrameIdentityDropsGeometryAndFreesOldExtent) {

--- a/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/graph_image_cache_test.cpp
@@ -244,5 +244,30 @@ TEST_F(CudaWorkspaceFixture, SharedInputSurvivesBothBranchReaders) {
   EXPECT_EQ(workspace.Textures().EntryCount(), 1U);
 }
 
+TEST_F(CudaWorkspaceFixture, DelayedOldFrameCannotReplaceNewMaskPosition) {
+  CudaRenderDevice device;
+  auto&            workspace = device.Workspace();
+  const GraphValueId mix{NodeId{"grade.primary"}, PortId{"mask.union"}};
+  constexpr RuntimeRevision newer = 20;
+  constexpr RuntimeRevision older = 10;
+  PublishWrite(device, mix, newer);
+  const auto resource_new = workspace.Images().Find(mix)->Texture().ResourceId();
+  ASSERT_EQ(workspace.Images().PublishedRevision(mix), newer);
+  EXPECT_EQ(workspace.Images().PublishedCount(), 1U);
+
+  device.BeginRender();
+  (void)workspace.AcquireImageForWrite(mix, {kWidth, kHeight, TextureFormat::Rgba32f});
+  workspace.Images().RecordUnpublished(mix, older, ImageRepr(),
+                                       device.CommandContext().SubmissionId());
+  device.EndRender();
+  device.PublishResults();
+  device.WaitIdle();
+
+  EXPECT_EQ(workspace.Images().PublishedRevision(mix), newer);
+  EXPECT_EQ(workspace.Images().Find(mix)->Texture().ResourceId(), resource_new);
+  EXPECT_EQ(workspace.Images().PublishedCount(), 1U);
+  EXPECT_EQ(workspace.Images().UnpublishedCount(), 0U);
+}
+
 }  // namespace
 }  // namespace alcedo

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,15 +2,16 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.9 complete; NM7.10–NM7.15 planned. This document records the NM7.1 source
+Status: NM7.1–NM7.10 complete; NM7.11–NM7.15 planned. This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
 shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
 NM7.7 Radial/Linear creation plus existing-mask movement, NM7.8 parameter-mask
-controls, drawer selection/deletion, and crop-style Gradient, and NM7.9 accumulating
-Brush paint/erase/move with typed stroke history. Some former NM7.11 UI wiring
+controls, drawer selection/deletion, and crop-style Gradient, NM7.9 accumulating
+Brush paint/erase/move with typed stroke history, and NM7.10 serial Interactive Mix
+with one current Grade coverage result. Some former NM7.11 UI wiring
 (now NM7.12) was brought forward for Radial/Gradient testing. This is partial
-wiring of the full UI phase. NM7.10–NM7.15 acceptance remains outstanding.
+wiring of the full UI phase. NM7.11–NM7.15 acceptance remains outstanding.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -1521,6 +1522,93 @@ presentation → next consume. Release seals → durable command → Quality.
 `QualityMaskEvaluationDoesNotOverwriteInteractiveCache`, `RebuiltMaskMatchesCacheHitPixels`.
 
 **Exit:** actual end-to-end native request path works; a control redraw alone does not pass.
+
+##### Phase NM7.10 completion record (2026-09-10)
+
+**Status:** complete — serial consume plus native parameterized Mix; one current Grade coverage
+result; failed encodes keep last-good Mix
+
+**Primary success call chain:**
+
+```text
+EnqueueMaskCreation (coalesce latest placement; ordered_append keeps samples)
+  -> TryConsumePendingInput (blocked while inflight / 16 ms Interactive pacing)
+  -> WithLockedLiveDocument / ApplyMaskCreationCommand
+  -> RouteMaskCreationRender (Interactive or SettledMaskEdit)
+  -> PlanExecutor MaskEvaluate
+  -> parameterized canonical replay -> ActiveRasterTextures (not MaskStore)
+  -> feather scratch / Union -> mask.union published (one Grade Mix)
+  -> Grade Mix photograph
+```
+
+**Primary failure call chain:**
+
+```text
+inflight or 16 ms pacing
+  -> consume skipped; live Brush placement unchanged; queued Append remains
+missing MaskStore asset_key / injected upload failure
+  -> CancelRender discards unpublished writes
+  -> DropUnusablePublishedImages keeps last-good Mix when frame identity matches
+  -> PublishedRevision stays at the prior successful Mix
+delayed older Mix write
+  -> PublishSuccessfulSubmission drops the write when published revision is newer
+QualityBase (SensorDevelopOnly)
+  -> Mix is not published; DiscardUnpublished leaves Interactive Mix
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MaskMoveNeverMutatesSourceDuringRender` | `EditorSerialMaskInteractiveTest` | PASS |
+| `LatestMoveValueSurvivesRelease` | `EditorSerialMaskInteractiveTest` | PASS |
+| `CurrentGradeCoverageHasOneRetainedResult` | `GpuDagCudaMaskTest` | PASS |
+| `DelayedOldFrameCannotReplaceNewMaskPosition` | `GpuDagCudaWorkspaceTest` | PASS |
+| `QualityMaskEvaluationDoesNotOverwriteInteractiveCache` | `GpuDagCudaMaskTest` | PASS |
+| `RebuiltMaskMatchesCacheHitPixels` | `GpuDagCudaMaskTest` | PASS |
+| `MaskFailurePublishesNoSourceUnionOrGradeWrites` | `GpuDagCudaMaskTest` | PASS |
+| `MaskUploadFailureKeepsPriorPublishedResults` | `GpuDagCudaMaskTest`, `GpuDagOpenClGradeTest` | PASS |
+| `LastGoodGradeSurvivesExposureRevisionWhenFrameIdentityMatches` | `GraphImageCacheRetentionTest` | PASS |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target GpuDagCudaMaskTest --target GpuDagCudaWorkspaceTest --target EditorSerialMaskInteractiveTest --target GraphImageCacheRetentionTest --target GpuDagOpenClGradeTest
+ctest --test-dir build/debug --output-on-failure -R "EditorSerialMaskInteractiveTest|GpuDagCudaMaskTest|GpuDagCudaWorkspaceTest.CudaWorkspaceFixture.DelayedOldFrameCannotReplaceNewMaskPosition|GraphImageCacheRetentionTest|GpuDagOpenClGradeTest.OpenClMultiMaskResourceFixture.MaskUploadFailureKeepsPriorPublishedResults"
+```
+
+Suite totals: required names `6/6` PASS; `GpuDagCudaMaskTest` `31/31` PASS;
+`GraphImageCacheRetentionTest` `16/16` PASS; OpenCL `MaskUploadFailureKeepsPriorPublishedResults`
+PASS. Date / working tree on `feature/serial-interactive-grade-mix` (base `34ffdebf`) / Windows
+MSVC `win_debug` / CUDA for native Mix pixels. OpenCL/Metal Mask passes synthesize the same
+request-owned canonical replay; Metal was not executed on this host. Host Mix oracle is
+`GradeMaskCoverage` with `ExpectR8WithinTolerance` (1 code) when canonical raster equals the
+16×12 render extent. QualityBase tests call `DiscardUnpublished` after
+`ResultPersistenceScope::SensorDevelopOnly`, matching product cleanup so unpublished QualityBase
+writes cannot shadow Interactive Mix.
+
+**Checklist / exit condition:** required tests PASS. Native CUDA request path evaluates
+parameterized Brush Mix without `MaskStore` or per-source `MaskTextureCache`. Latest placement
+Append coalesces; `ordered_append` samples are not coalesced. Inflight consume does not mutate
+the live source. One published Grade Mix slot is retained across moves. A delayed older Mix
+write cannot replace a newer published revision. QualityBase does not overwrite Interactive Mix.
+Rebuilding Mix after dropping the published slot matches the prior pixels. Failed Mask encode
+keeps last-good Mix/Union/Grade. A QSG control redraw is not the acceptance path.
+
+**LOC note (grill-code-review):** `parameterized_brush_raster.hpp` 69 / `.cpp` 47;
+`compiled_grade_mask.hpp` 87; `cuda_mask_pass.cu` 580; `opencl_mask_pass.cpp` 690;
+`metal_mask_pass.mm` 670; `graph_image_cache.hpp` 450; `basic_render_workspace.hpp` 330;
+`editor_session_service.hpp` 676 / `.cpp` 2028 (Peek is a mutex copy of the Mask queue; Mix
+rules stay in PlanExecutor / GraphImageCache). `cuda_parameterized_grade_mix_test.cpp` 205;
+`editor_serial_mask_interactive_test.cpp` 278. Session cpp was already above 1000 lines;
+this slice did not add a second Mix owner there.
+
+**Remaining gaps:** project Mix-cache files, keep/delete-on-close, and Clear are NM7.11.
+Mask Adjustment Stack remaining chrome and the 260/320/460 theme matrix are NM7.12.
+Open-operation cancel on `MappingChanged` is NM7.13. Native Mask still loads `MaskStore` when
+an in-memory `asset_key` is present (legacy raster tests). Ordinary adjustment Mask writes still
+fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned. Packaged viewer/performance
+qualification is NM7.14–NM7.15. Metal parameterized Mix was not executed on this Windows host.
 
 ### NM7.11 — Add project-owned cache storage and maintenance
 


### PR DESCRIPTION
## Summary
- Evaluate parameterized Brush Mix on the native CUDA/OpenCL/Metal request path with one current Grade coverage result, without MaskStore on that path.
- Keep last-good Mix when a later encode fails, and reject delayed older Mix publishes so a stale frame cannot regress coverage.
- Serial consume coalesces latest placement while leaving ordered Brush samples intact; QualityBase still does not overwrite Interactive Mix.

## Test plan
- [ ] `EditorSerialMaskInteractiveTest`: `MaskMoveNeverMutatesSourceDuringRender`, `LatestMoveValueSurvivesRelease`
- [ ] `GpuDagCudaMaskTest` including parameterized Mix and `MaskFailurePublishesNoSourceUnionOrGradeWrites` / `MaskUploadFailureKeepsPriorPublishedResults`
- [ ] `GpuDagCudaWorkspaceTest.CudaWorkspaceFixture.DelayedOldFrameCannotReplaceNewMaskPosition`
- [ ] `GraphImageCacheRetentionTest.LastGoodGradeSurvivesExposureRevisionWhenFrameIdentityMatches`
- [ ] OpenCL `MaskUploadFailureKeepsPriorPublishedResults`

Made with [Cursor](https://cursor.com)