### PR TITLE
feat(edit): add project-owned Mix cache storage

### DIFF
--- a/alcedo_studio/src/app/CMakeLists.txt
+++ b/alcedo_studio/src/app/CMakeLists.txt
@@ -258,12 +258,14 @@ def_library(ModelDownloadService
 def_library(ProjectService
     SOURCES
         "${ALCEDO_APP_ROOT}/project_service.cpp"
+        "${ALCEDO_APP_ROOT}/project_mask_cache_settings.cpp"
+        "${ALCEDO_APP_ROOT}/project_mask_cache_service.cpp"
         "${ALCEDO_APP_ROOT}/project_package_backend.cpp"
         "${ALCEDO_APP_ROOT}/project_package_service.cpp"
         "${ALCEDO_SRC_ROOT}/ui/alcedo_main/album_backend/path_utils.cpp"
     PUBLIC_DEPS FSService Storage ImagePoolService AlbumBrowseService SleeveFilterService
                 AiSidecarRuntimeService ModelDownloadService
-                StrConv JSON xxHash stduuid
+                StrConv JSON xxHash stduuid EditMaskStore
     PRIVATE_DEPS
         AppDiagnostics
         Qt6::Core

--- a/alcedo_studio/src/app/project_mask_cache_service.cpp
+++ b/alcedo_studio/src/app/project_mask_cache_service.cpp
@@ -1,0 +1,809 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/project_mask_cache_service.hpp"
+
+#include <xxhash.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstring>
+#include <fstream>
+#include <span>
+#include <stdexcept>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "edit/mask/mask_asset.hpp"
+#include "utils/string/convert.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace alcedo {
+namespace {
+
+constexpr std::array<char, 8> kMagic = {'A', 'L', 'C', 'R', '8', 'C', 'C', 'H'};
+constexpr std::uint32_t       kPackedR8FormatId = 1;
+std::atomic<std::uint64_t>    g_temp_sequence{0};
+
+auto ProcessIdText() -> std::string {
+#ifdef _WIN32
+  return std::to_string(static_cast<unsigned long>(::GetCurrentProcessId()));
+#else
+  return std::to_string(static_cast<long>(::getpid()));
+#endif
+}
+
+void AppendU32Le(std::vector<std::uint8_t>& out, std::uint32_t value) {
+  out.push_back(static_cast<std::uint8_t>(value));
+  out.push_back(static_cast<std::uint8_t>(value >> 8));
+  out.push_back(static_cast<std::uint8_t>(value >> 16));
+  out.push_back(static_cast<std::uint8_t>(value >> 24));
+}
+
+void AppendU64Le(std::vector<std::uint8_t>& out, std::uint64_t value) {
+  AppendU32Le(out, static_cast<std::uint32_t>(value));
+  AppendU32Le(out, static_cast<std::uint32_t>(value >> 32));
+}
+
+void AppendF32BitsLe(std::vector<std::uint8_t>& out, float value) {
+  std::uint32_t bits = 0;
+  std::memcpy(&bits, &value, sizeof(bits));
+  AppendU32Le(out, bits);
+}
+
+void AppendBytes(std::vector<std::uint8_t>& out, std::string_view text) {
+  AppendU32Le(out, static_cast<std::uint32_t>(text.size()));
+  out.insert(out.end(), text.begin(), text.end());
+}
+
+auto ReadU32Le(std::span<const std::uint8_t> bytes, std::size_t* offset) -> std::uint32_t {
+  if (*offset + 4 > bytes.size()) {
+    throw std::runtime_error("Project Mask cache file is truncated");
+  }
+  const auto value = static_cast<std::uint32_t>(bytes[*offset]) |
+                     (static_cast<std::uint32_t>(bytes[*offset + 1]) << 8) |
+                     (static_cast<std::uint32_t>(bytes[*offset + 2]) << 16) |
+                     (static_cast<std::uint32_t>(bytes[*offset + 3]) << 24);
+  *offset += 4;
+  return value;
+}
+
+auto ReadU64Le(std::span<const std::uint8_t> bytes, std::size_t* offset) -> std::uint64_t {
+  const auto lo = ReadU32Le(bytes, offset);
+  const auto hi = ReadU32Le(bytes, offset);
+  return static_cast<std::uint64_t>(lo) | (static_cast<std::uint64_t>(hi) << 32);
+}
+
+auto ReadF32Le(std::span<const std::uint8_t> bytes, std::size_t* offset) -> float {
+  const auto bits = ReadU32Le(bytes, offset);
+  float      value = 0;
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+auto ReadCountedString(std::span<const std::uint8_t> bytes, std::size_t* offset) -> std::string {
+  const auto size = ReadU32Le(bytes, offset);
+  if (size > 4096 || *offset + size > bytes.size()) {
+    throw std::runtime_error("Project Mask cache string field is invalid");
+  }
+  std::string text(reinterpret_cast<const char*>(bytes.data() + *offset), size);
+  *offset += size;
+  return text;
+}
+
+auto HexEncode(std::string_view text) -> std::string {
+  constexpr char digits[] = "0123456789abcdef";
+  std::string    encoded;
+  encoded.reserve(text.size() * 2);
+  for (const unsigned char byte : text) {
+    encoded.push_back(digits[byte >> 4]);
+    encoded.push_back(digits[byte & 0x0f]);
+  }
+  return encoded;
+}
+
+auto NormalizeChosenRoot(std::filesystem::path root) -> std::filesystem::path {
+  if (root.empty()) {
+    throw std::invalid_argument("Project Mask cache root must not be empty");
+  }
+  std::error_code error;
+  auto            absolute = std::filesystem::absolute(root, error);
+  if (error) {
+    throw std::invalid_argument("Project Mask cache root is not a usable path");
+  }
+  return absolute.lexically_normal();
+}
+
+auto PathText(const std::filesystem::path& path) -> std::string {
+  return conv::ToBytes(path.wstring());
+}
+
+auto AssignError(std::string* error, std::string message) -> bool {
+  if (error) {
+    *error = std::move(message);
+  }
+  return false;
+}
+
+auto FlushWrittenFile(std::ofstream& stream, const std::filesystem::path& path, std::string* error)
+    -> bool {
+  stream.flush();
+  if (!stream) {
+    return AssignError(error, "Project Mask cache temporary write did not complete");
+  }
+  stream.close();
+#ifdef _WIN32
+  const HANDLE handle = ::CreateFileW(
+      path.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle != INVALID_HANDLE_VALUE) {
+    ::FlushFileBuffers(handle);
+    ::CloseHandle(handle);
+  }
+#else
+  const int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd >= 0) {
+    ::fsync(fd);
+    ::close(fd);
+  }
+#endif
+  return true;
+}
+
+auto AtomicReplaceFile(const std::filesystem::path& source, const std::filesystem::path& destination,
+                       std::string* error) -> bool {
+#ifdef _WIN32
+  if (::ReplaceFileW(destination.wstring().c_str(), source.wstring().c_str(), nullptr,
+                     REPLACEFILE_WRITE_THROUGH, nullptr, nullptr)) {
+    return true;
+  }
+  if (::GetLastError() == ERROR_FILE_NOT_FOUND) {
+    if (::MoveFileExW(source.wstring().c_str(), destination.wstring().c_str(),
+                      MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+      return true;
+    }
+  }
+  return AssignError(error, "Project Mask cache atomic replace failed (Win32 error " +
+                                std::to_string(::GetLastError()) + ")");
+#else
+  std::error_code ec;
+  std::filesystem::rename(source, destination, ec);
+  if (ec) {
+    return AssignError(error, "Project Mask cache atomic replace failed: " + ec.message());
+  }
+  return true;
+#endif
+}
+
+auto EncodeRecord(std::string_view project_uuid, const ProjectMaskCacheRecord& record)
+    -> std::vector<std::uint8_t> {
+  std::vector<std::uint8_t> bytes;
+  bytes.reserve(128 + project_uuid.size() + record.identity.node_id.Value().size() +
+                record.recipe_fingerprint.size() + record.producer_id.size() + record.pixels.size());
+  bytes.insert(bytes.end(), kMagic.begin(), kMagic.end());
+  AppendU32Le(bytes, kProjectMaskCacheFormatVersion);
+  AppendU32Le(bytes, record.raster_algorithm_version);
+  AppendU32Le(bytes, kPackedR8FormatId);
+  AppendBytes(bytes, project_uuid);
+  AppendU32Le(bytes, record.identity.image_id);
+  AppendBytes(bytes, record.identity.node_id.Value());
+  AppendU32Le(bytes, record.output_extent.width);
+  AppendU32Le(bytes, record.output_extent.height);
+  AppendF32BitsLe(bytes, record.reference_bounds.x);
+  AppendF32BitsLe(bytes, record.reference_bounds.y);
+  AppendF32BitsLe(bytes, record.reference_bounds.w);
+  AppendF32BitsLe(bytes, record.reference_bounds.h);
+  AppendU32Le(bytes, record.source_grid.width);
+  AppendU32Le(bytes, record.source_grid.height);
+  AppendBytes(bytes, record.recipe_fingerprint);
+  AppendBytes(bytes, record.producer_id);
+  AppendU64Le(bytes, static_cast<std::uint64_t>(record.pixels.size()));
+  bytes.insert(bytes.end(), record.pixels.begin(), record.pixels.end());
+  const auto checksum = XXH3_64bits(bytes.data(), bytes.size());
+  AppendU64Le(bytes, checksum);
+  return bytes;
+}
+
+auto DecodeRecord(std::span<const std::uint8_t> bytes, std::string_view expected_uuid)
+    -> ProjectMaskCacheRecord {
+  if (bytes.size() < kMagic.size() + 16) {
+    throw std::runtime_error("Project Mask cache file is truncated");
+  }
+  if (std::memcmp(bytes.data(), kMagic.data(), kMagic.size()) != 0) {
+    throw std::runtime_error("Project Mask cache magic does not match");
+  }
+  const auto checksum_offset = bytes.size() - 8;
+  const auto stored_checksum = [&] {
+    std::size_t offset = checksum_offset;
+    return ReadU64Le(bytes, &offset);
+  }();
+  const auto computed = XXH3_64bits(bytes.data(), checksum_offset);
+  if (computed != stored_checksum) {
+    throw std::runtime_error("Project Mask cache checksum mismatch");
+  }
+  std::size_t offset = kMagic.size();
+  const auto  format = ReadU32Le(bytes, &offset);
+  if (format != kProjectMaskCacheFormatVersion) {
+    throw std::runtime_error("Project Mask cache format is unsupported");
+  }
+  ProjectMaskCacheRecord record;
+  record.raster_algorithm_version = ReadU32Le(bytes, &offset);
+  const auto packed_format        = ReadU32Le(bytes, &offset);
+  if (packed_format != kPackedR8FormatId) {
+    throw std::runtime_error("Project Mask cache pixel format is unsupported");
+  }
+  const auto uuid = ReadCountedString(bytes, &offset);
+  if (uuid != expected_uuid) {
+    throw std::runtime_error("Project Mask cache file belongs to another project");
+  }
+  record.identity.image_id = ReadU32Le(bytes, &offset);
+  record.identity.node_id  = NodeId{ReadCountedString(bytes, &offset)};
+  record.output_extent.width  = ReadU32Le(bytes, &offset);
+  record.output_extent.height = ReadU32Le(bytes, &offset);
+  record.reference_bounds.x   = ReadF32Le(bytes, &offset);
+  record.reference_bounds.y   = ReadF32Le(bytes, &offset);
+  record.reference_bounds.w   = ReadF32Le(bytes, &offset);
+  record.reference_bounds.h   = ReadF32Le(bytes, &offset);
+  record.source_grid.width    = ReadU32Le(bytes, &offset);
+  record.source_grid.height   = ReadU32Le(bytes, &offset);
+  record.recipe_fingerprint   = ReadCountedString(bytes, &offset);
+  record.producer_id          = ReadCountedString(bytes, &offset);
+  const auto pixel_bytes      = ReadU64Le(bytes, &offset);
+  if (offset + pixel_bytes != checksum_offset) {
+    throw std::runtime_error("Project Mask cache pixel payload size is invalid");
+  }
+  record.pixels.assign(bytes.begin() + static_cast<std::ptrdiff_t>(offset),
+                       bytes.begin() + static_cast<std::ptrdiff_t>(checksum_offset));
+  ValidateProjectMaskCacheRecord(record);
+  return record;
+}
+
+auto ReadEntireFile(const std::filesystem::path& path) -> std::vector<std::uint8_t> {
+  std::ifstream stream(path, std::ios::binary | std::ios::ate);
+  if (!stream) {
+    throw std::runtime_error("Project Mask cache file does not exist");
+  }
+  const auto size = static_cast<std::size_t>(stream.tellg());
+  stream.seekg(0);
+  std::vector<std::uint8_t> bytes(size);
+  stream.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(size));
+  if (!stream) {
+    throw std::runtime_error("Project Mask cache file is incomplete");
+  }
+  return bytes;
+}
+
+auto IsOwnedCacheFileName(const std::filesystem::path& path) -> bool {
+  return path.extension() == kProjectMaskCacheFileExtension;
+}
+
+auto IsOwnedTempFileName(std::string_view name) -> bool {
+  return name.find(".r8cache.tmp.") != std::string_view::npos;
+}
+
+auto RemovePath(const std::filesystem::path& path, std::string* error) -> bool {
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+  if (ec) {
+    return AssignError(error, "Failed to remove " + PathText(path) + ": " + ec.message());
+  }
+  return true;
+}
+
+}  // namespace
+
+void ValidateProjectMaskCacheRecord(const ProjectMaskCacheRecord& record) {
+  if (record.identity.node_id.Empty()) {
+    throw std::invalid_argument("Project Mask cache NodeId must not be empty");
+  }
+  if (record.recipe_fingerprint.empty()) {
+    throw std::invalid_argument("Project Mask cache recipe fingerprint must not be empty");
+  }
+  if (record.producer_id.empty()) {
+    throw std::invalid_argument("Project Mask cache producer id must not be empty");
+  }
+  if (record.raster_algorithm_version != kBrushRasterAlgorithmVersion) {
+    throw std::invalid_argument("Project Mask cache raster algorithm version is unsupported");
+  }
+  if (record.source_grid.Empty() || record.source_grid.width > kMaximumRasterMaskAxis ||
+      record.source_grid.height > kMaximumRasterMaskAxis) {
+    throw std::invalid_argument("Project Mask cache source grid axes must be in [1, 4096]");
+  }
+  MaskAssetDescriptor descriptor;
+  descriptor.extent           = record.output_extent;
+  descriptor.reference_bounds = record.reference_bounds;
+  ValidateMaskAssetPixels(descriptor, record.pixels);
+}
+
+ProjectMaskCacheReader::~ProjectMaskCacheReader() {
+  if (release_) {
+    release_();
+  }
+}
+
+ProjectMaskCacheReader::ProjectMaskCacheReader(ProjectMaskCacheReader&& other) noexcept
+    : record_(std::move(other.record_)), release_(std::move(other.release_)) {
+  other.release_ = nullptr;
+}
+
+auto ProjectMaskCacheReader::operator=(ProjectMaskCacheReader&& other) noexcept
+    -> ProjectMaskCacheReader& {
+  if (this == &other) {
+    return *this;
+  }
+  if (release_) {
+    release_();
+  }
+  record_        = std::move(other.record_);
+  release_       = std::move(other.release_);
+  other.release_ = nullptr;
+  return *this;
+}
+
+auto ProjectMaskCacheReader::Get() const -> const ProjectMaskCacheRecord& {
+  if (!record_) {
+    throw std::runtime_error("Project Mask cache reader is empty");
+  }
+  return *record_;
+}
+
+ProjectMaskCacheService::ProjectMaskCacheService(std::string project_uuid,
+                                                 std::filesystem::path chosen_root)
+    : project_uuid_(std::move(project_uuid)), chosen_root_(NormalizeChosenRoot(std::move(chosen_root))) {
+  (void)ProjectMaskCacheNamespaceDirectory(chosen_root_, project_uuid_);
+  writer_ = std::thread([this] { WriterLoop(); });
+}
+
+ProjectMaskCacheService::~ProjectMaskCacheService() { ShutdownWriter(); }
+
+auto ProjectMaskCacheService::ProjectUuid() const -> std::string {
+  std::lock_guard lock(mutex_);
+  return project_uuid_;
+}
+
+auto ProjectMaskCacheService::ChosenRoot() const -> std::filesystem::path {
+  std::lock_guard lock(mutex_);
+  return chosen_root_;
+}
+
+auto ProjectMaskCacheService::StorageGeneration() const -> std::uint64_t {
+  std::lock_guard lock(mutex_);
+  return generation_;
+}
+
+auto ProjectMaskCacheService::PrepareNamespace(const std::filesystem::path& chosen_root,
+                                               std::string_view project_uuid, std::string* error)
+    -> bool {
+  try {
+    const auto normalized = NormalizeChosenRoot(chosen_root);
+    const auto ns         = ProjectMaskCacheNamespaceDirectory(normalized, project_uuid);
+    std::error_code ec;
+    if (std::filesystem::exists(normalized, ec) && !std::filesystem::is_directory(normalized, ec)) {
+      return AssignError(error, "Project Mask cache root exists and is not a directory");
+    }
+    std::filesystem::create_directories(ns, ec);
+    if (ec) {
+      return AssignError(error, "Failed to create project Mask cache namespace: " + ec.message());
+    }
+    if (std::filesystem::is_symlink(ns)) {
+      return AssignError(error, "Project Mask cache namespace must not be a symbolic link");
+    }
+    return true;
+  } catch (const std::exception& exception) {
+    return AssignError(error, exception.what());
+  }
+}
+
+auto ProjectMaskCacheService::SlotKeyFrom(const ProjectMaskCacheSlotIdentity& identity) const
+    -> SlotKey {
+  return SlotKey{identity.image_id, std::string(identity.node_id.Value())};
+}
+
+auto ProjectMaskCacheService::SlotPath(const std::filesystem::path& chosen_root,
+                                       const ProjectMaskCacheSlotIdentity& identity) const
+    -> std::filesystem::path {
+  const auto ns = ProjectMaskCacheNamespaceDirectory(chosen_root, project_uuid_);
+  return ns / std::to_string(identity.image_id) /
+         (HexEncode(identity.node_id.Value()) + std::string(kProjectMaskCacheFileExtension));
+}
+
+auto ProjectMaskCacheService::PublishedSlotPath(const ProjectMaskCacheSlotIdentity& identity) const
+    -> std::filesystem::path {
+  std::lock_guard lock(mutex_);
+  return SlotPath(chosen_root_, identity);
+}
+
+auto ProjectMaskCacheService::EnqueueSettledWrite(ProjectMaskCacheRecord record, std::string* error)
+    -> bool {
+  try {
+    ValidateProjectMaskCacheRecord(record);
+  } catch (const std::exception& exception) {
+    return AssignError(error, exception.what());
+  }
+  std::lock_guard lock(mutex_);
+  if (maintenance_) {
+    return AssignError(error, "Project Mask cache is under maintenance");
+  }
+  if (!ChosenRootUsable(error)) {
+    has_dirty_slot_ = true;
+    last_error_     = error ? *error : last_error_;
+    return false;
+  }
+  const auto key      = SlotKeyFrom(record.identity);
+  pending_[key] = PendingWrite{std::move(record), generation_, chosen_root_};
+  has_dirty_slot_     = true;
+  cv_.notify_all();
+  return true;
+}
+
+auto ProjectMaskCacheService::FlushPendingWrites(std::string* error) -> bool {
+  std::unique_lock lock(mutex_);
+  cv_.notify_all();
+  cv_.wait(lock, [this] { return pending_.empty() && inflight_writes_ == 0; });
+  if (!last_error_.empty() && has_dirty_slot_) {
+    return AssignError(error, last_error_);
+  }
+  return true;
+}
+
+auto ProjectMaskCacheService::TryAcquireReader(const ProjectMaskCacheSlotIdentity& identity,
+                                               std::string_view expected_fingerprint,
+                                               std::string_view expected_producer,
+                                               std::string* error) -> std::optional<ProjectMaskCacheReader> {
+  std::filesystem::path path;
+  {
+    std::unique_lock lock(mutex_);
+    if (maintenance_) {
+      if (error) {
+        error->clear();
+      }
+      return std::nullopt;
+    }
+    if (!ChosenRootUsable(error)) {
+      return std::nullopt;
+    }
+    path = SlotPath(chosen_root_, identity);
+    ++reader_count_;
+  }
+
+  struct CountGuard {
+    ProjectMaskCacheService* service;
+    ~CountGuard() {
+      if (service) {
+        service->ReleaseReader();
+      }
+    }
+  } guard{this};
+
+  std::error_code exists_error;
+  if (!std::filesystem::exists(path, exists_error) || exists_error) {
+    if (error) {
+      error->clear();
+    }
+    return std::nullopt;
+  }
+  if (std::filesystem::is_symlink(path)) {
+    if (error) {
+      error->clear();
+    }
+    return std::nullopt;
+  }
+
+  try {
+    const auto bytes  = ReadEntireFile(path);
+    auto       record = DecodeRecord(bytes, project_uuid_);
+    if (record.identity.image_id != identity.image_id ||
+        record.identity.node_id.Value() != identity.node_id.Value() ||
+        record.recipe_fingerprint != expected_fingerprint ||
+        record.producer_id != expected_producer) {
+      if (error) {
+        error->clear();
+      }
+      return std::nullopt;
+    }
+    ProjectMaskCacheReader reader;
+    reader.record_  = std::make_shared<const ProjectMaskCacheRecord>(std::move(record));
+    reader.release_ = [this] { ReleaseReader(); };
+    guard.service   = nullptr;
+    return reader;
+  } catch (const std::exception&) {
+    if (error) {
+      error->clear();
+    }
+    return std::nullopt;
+  }
+}
+
+auto ProjectMaskCacheService::ClearOwnedCache(std::string* error) -> bool {
+  std::filesystem::path root;
+  {
+    std::unique_lock lock(mutex_);
+    maintenance_ = true;
+    ++generation_;
+    pending_.clear();
+    cv_.notify_all();
+    cv_.wait(lock, [this] { return inflight_writes_ == 0 && reader_count_ == 0; });
+    root = chosen_root_;
+  }
+  std::string delete_error;
+  const bool  deleted = DeleteNamespaceFiles(root, &delete_error);
+  {
+    std::lock_guard lock(mutex_);
+    maintenance_    = false;
+    has_dirty_slot_ = false;
+    if (deleted) {
+      last_error_.clear();
+    } else {
+      last_error_ = delete_error;
+    }
+    cv_.notify_all();
+  }
+  if (!deleted) {
+    return AssignError(error, delete_error);
+  }
+  return true;
+}
+
+auto ProjectMaskCacheService::PublishChosenRoot(const std::filesystem::path& new_root,
+                                                std::string* error) -> bool {
+  try {
+    const auto normalized = NormalizeChosenRoot(new_root);
+    std::unique_lock lock(mutex_);
+    maintenance_ = true;
+    ++generation_;
+    pending_.clear();
+    cv_.notify_all();
+    cv_.wait(lock, [this] { return inflight_writes_ == 0; });
+    chosen_root_    = normalized;
+    maintenance_    = false;
+    has_dirty_slot_ = false;
+    last_error_.clear();
+    cv_.notify_all();
+    return true;
+  } catch (const std::exception& exception) {
+    return AssignError(error, exception.what());
+  }
+}
+
+auto ProjectMaskCacheService::DeleteOwnedNamespace(const std::filesystem::path& chosen_root,
+                                                   std::string* error) -> bool {
+  return DeleteNamespaceFiles(chosen_root, error);
+}
+
+auto ProjectMaskCacheService::FenceWrites(std::string* error) -> bool {
+  (void)error;
+  std::unique_lock lock(mutex_);
+  ++generation_;
+  pending_.clear();
+  cv_.notify_all();
+  cv_.wait(lock, [this] { return inflight_writes_ == 0; });
+  return true;
+}
+
+auto ProjectMaskCacheService::Usage() const -> ProjectMaskCacheUsage {
+  std::lock_guard lock(mutex_);
+  ProjectMaskCacheUsage usage;
+  usage.pending_write_count = pending_.size();
+  usage.has_dirty_slot      = has_dirty_slot_;
+  usage.last_error          = last_error_;
+  ScanUsage(&usage);
+  return usage;
+}
+
+auto ProjectMaskCacheService::CountPublishedSlots() const -> std::size_t {
+  return Usage().published_file_count;
+}
+
+void ProjectMaskCacheService::SetPublishHookForTesting(
+    std::function<bool(const std::filesystem::path&, const std::filesystem::path&)> hook) {
+  std::lock_guard lock(mutex_);
+  publish_hook_ = std::move(hook);
+}
+
+void ProjectMaskCacheService::ShutdownWriter() {
+  {
+    std::lock_guard lock(mutex_);
+    stop_writer_ = true;
+    cv_.notify_all();
+  }
+  if (writer_.joinable()) {
+    writer_.join();
+  }
+}
+
+void ProjectMaskCacheService::ReleaseReader() {
+  std::lock_guard lock(mutex_);
+  if (reader_count_ > 0) {
+    --reader_count_;
+  }
+  cv_.notify_all();
+}
+
+auto ProjectMaskCacheService::ChosenRootUsable(std::string* error) const -> bool {
+  std::error_code ec;
+  if (std::filesystem::exists(chosen_root_, ec) && !std::filesystem::is_directory(chosen_root_, ec)) {
+    return AssignError(error, "Configured project Mask cache root is not a directory");
+  }
+  return true;
+}
+
+void ProjectMaskCacheService::ScanUsage(ProjectMaskCacheUsage* usage) const {
+  std::error_code ec;
+  const auto      ns = ProjectMaskCacheNamespaceDirectory(chosen_root_, project_uuid_);
+  if (!std::filesystem::exists(ns, ec) || !std::filesystem::is_directory(ns, ec)) {
+    return;
+  }
+  const auto options = std::filesystem::directory_options::skip_permission_denied;
+  for (const auto& entry : std::filesystem::recursive_directory_iterator(ns, options, ec)) {
+    if (ec) {
+      break;
+    }
+    if (entry.is_symlink()) {
+      continue;
+    }
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    if (!IsOwnedCacheFileName(entry.path())) {
+      continue;
+    }
+    usage->published_file_count += 1;
+    usage->published_byte_count += static_cast<std::size_t>(entry.file_size(ec));
+  }
+}
+
+auto ProjectMaskCacheService::DeleteNamespaceFiles(const std::filesystem::path& chosen_root,
+                                                   std::string* error) -> bool {
+  std::error_code ec;
+  const auto      ns = ProjectMaskCacheNamespaceDirectory(chosen_root, project_uuid_);
+  if (!std::filesystem::exists(ns, ec)) {
+    return true;
+  }
+  if (std::filesystem::is_symlink(ns)) {
+    return RemovePath(ns, error);
+  }
+  if (!std::filesystem::is_directory(ns, ec)) {
+    return AssignError(error, "Project Mask cache namespace is not a directory");
+  }
+  std::vector<std::filesystem::path> files;
+  std::vector<std::filesystem::path> directories;
+  const auto options = std::filesystem::directory_options::skip_permission_denied;
+  for (const auto& entry : std::filesystem::recursive_directory_iterator(ns, options, ec)) {
+    if (ec) {
+      return AssignError(error, "Failed to enumerate project Mask cache: " + ec.message());
+    }
+    if (entry.is_symlink()) {
+      continue;
+    }
+    if (entry.is_directory()) {
+      directories.push_back(entry.path());
+      continue;
+    }
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    const auto name = entry.path().filename().string();
+    if (IsOwnedTempFileName(name) || IsOwnedCacheFileName(entry.path())) {
+      files.push_back(entry.path());
+    }
+  }
+  for (const auto& file : files) {
+    if (!RemovePath(file, error)) {
+      return false;
+    }
+  }
+  std::sort(directories.begin(), directories.end(),
+            [](const std::filesystem::path& lhs, const std::filesystem::path& rhs) {
+              return PathText(lhs).size() > PathText(rhs).size();
+            });
+  for (const auto& directory : directories) {
+    std::filesystem::remove(directory, ec);
+  }
+  std::filesystem::remove(ns, ec);
+  return true;
+}
+
+auto ProjectMaskCacheService::WriteOne(const PendingWrite& pending, std::string* error) -> bool {
+  if (!PrepareNamespace(pending.chosen_root, project_uuid_, error)) {
+    return false;
+  }
+  const auto destination = SlotPath(pending.chosen_root, pending.record.identity);
+  std::error_code ec;
+  std::filesystem::create_directories(destination.parent_path(), ec);
+  if (ec) {
+    return AssignError(error, "Failed to create Mix-cache slot directory: " + ec.message());
+  }
+  auto temporary = destination;
+  temporary += ".tmp." + ProcessIdText() + "." + std::to_string(++g_temp_sequence);
+  try {
+    const auto bytes = EncodeRecord(project_uuid_, pending.record);
+    std::ofstream stream(temporary, std::ios::binary | std::ios::trunc);
+    if (!stream) {
+      return AssignError(error, "Project Mask cache could not open a temporary file");
+    }
+    stream.write(reinterpret_cast<const char*>(bytes.data()),
+                 static_cast<std::streamsize>(bytes.size()));
+    if (!FlushWrittenFile(stream, temporary, error)) {
+      std::filesystem::remove(temporary, ec);
+      return false;
+    }
+    std::function<bool(const std::filesystem::path&, const std::filesystem::path&)> hook;
+    {
+      std::lock_guard lock(mutex_);
+      if (pending.generation != generation_) {
+        std::filesystem::remove(temporary, ec);
+        return AssignError(error, "Project Mask cache write was fenced");
+      }
+      hook = publish_hook_;
+    }
+    if (hook && !hook(temporary, destination)) {
+      std::filesystem::remove(temporary, ec);
+      return AssignError(error, "Project Mask cache publish hook rejected the write");
+    }
+    {
+      std::lock_guard lock(mutex_);
+      if (pending.generation != generation_) {
+        std::filesystem::remove(temporary, ec);
+        return AssignError(error, "Project Mask cache write was fenced");
+      }
+    }
+    if (!AtomicReplaceFile(temporary, destination, error)) {
+      std::filesystem::remove(temporary, ec);
+      return false;
+    }
+    return true;
+  } catch (const std::exception& exception) {
+    std::filesystem::remove(temporary, ec);
+    return AssignError(error, exception.what());
+  }
+}
+
+void ProjectMaskCacheService::WriterLoop() {
+  for (;;) {
+    PendingWrite pending;
+    bool         has_work = false;
+    {
+      std::unique_lock lock(mutex_);
+      cv_.wait(lock, [this] { return stop_writer_ || !pending_.empty(); });
+      if (stop_writer_ && pending_.empty()) {
+        return;
+      }
+      if (!pending_.empty()) {
+        pending = std::move(pending_.begin()->second);
+        pending_.erase(pending_.begin());
+        ++inflight_writes_;
+        has_work = true;
+      }
+    }
+    if (!has_work) {
+      continue;
+    }
+    std::string write_error;
+    const bool  ok = WriteOne(pending, &write_error);
+    {
+      std::lock_guard lock(mutex_);
+      --inflight_writes_;
+      if (ok) {
+        if (pending_.empty()) {
+          has_dirty_slot_ = false;
+          last_error_.clear();
+        }
+      } else {
+        has_dirty_slot_ = true;
+        last_error_     = write_error;
+      }
+      cv_.notify_all();
+    }
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/app/project_mask_cache_settings.cpp
+++ b/alcedo_studio/src/app/project_mask_cache_settings.cpp
@@ -1,0 +1,177 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "app/project_mask_cache_settings.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+#include "utils/string/convert.hpp"
+
+namespace alcedo {
+namespace {
+
+constexpr auto kMetadataKey     = "mask_cache";
+constexpr auto kRootPathKey     = "root_path";
+constexpr auto kRetentionKey    = "retention";
+constexpr auto kRevisionKey     = "settings_revision";
+constexpr auto kPreviousRootsKey = "previous_roots";
+constexpr auto kClosePendingKey = "close_cleanup_pending";
+constexpr auto kKeepToken       = "keep";
+constexpr auto kDeleteOnCloseToken = "delete_on_project_close";
+
+auto PathToStored(const std::filesystem::path& path) -> std::string {
+  return conv::ToBytes(path.wstring());
+}
+
+auto StoredToPath(const std::string& stored) -> std::filesystem::path {
+  return std::filesystem::path(conv::FromBytes(stored));
+}
+
+auto RetentionToken(ProjectMaskCacheRetention retention) -> std::string_view {
+  switch (retention) {
+    case ProjectMaskCacheRetention::Keep:
+      return kKeepToken;
+    case ProjectMaskCacheRetention::DeleteOnProjectClose:
+      return kDeleteOnCloseToken;
+  }
+  throw std::invalid_argument("Unknown project Mask cache retention");
+}
+
+auto RetentionFromToken(std::string_view token) -> ProjectMaskCacheRetention {
+  if (token == kKeepToken) {
+    return ProjectMaskCacheRetention::Keep;
+  }
+  if (token == kDeleteOnCloseToken) {
+    return ProjectMaskCacheRetention::DeleteOnProjectClose;
+  }
+  throw std::invalid_argument("Unknown project Mask cache retention '" + std::string(token) + "'");
+}
+
+auto MetadataParent(const std::filesystem::path& meta_path) -> std::filesystem::path {
+  auto parent = meta_path.parent_path();
+  if (parent.empty()) {
+    return std::filesystem::current_path();
+  }
+  return parent;
+}
+
+auto StoreChosenRoot(const std::filesystem::path& chosen_root,
+                     const std::filesystem::path& meta_path) -> std::string {
+  if (chosen_root.empty()) {
+    return {};
+  }
+  const auto default_root = DefaultProjectMaskCacheChosenRoot(meta_path);
+  std::error_code error;
+  const auto      absolute_root = std::filesystem::absolute(chosen_root, error);
+  if (error) {
+    return PathToStored(chosen_root);
+  }
+  const auto normalized = absolute_root.lexically_normal();
+  if (normalized == std::filesystem::absolute(default_root).lexically_normal()) {
+    return {};
+  }
+  const auto relative = normalized.lexically_relative(
+      std::filesystem::absolute(default_root).lexically_normal());
+  const auto relative_text = relative.generic_wstring();
+  if (relative.empty() || relative.has_root_name() || relative.has_root_directory() ||
+      relative_text.starts_with(L"..")) {
+    return PathToStored(normalized);
+  }
+  return PathToStored(relative);
+}
+
+}  // namespace
+
+auto DefaultProjectMaskCacheChosenRoot(const std::filesystem::path& meta_path)
+    -> std::filesystem::path {
+  return MetadataParent(meta_path);
+}
+
+auto ResolveProjectMaskCacheChosenRoot(const ProjectMaskCacheSettings& settings,
+                                       const std::filesystem::path& meta_path)
+    -> std::filesystem::path {
+  if (settings.chosen_root.empty()) {
+    return DefaultProjectMaskCacheChosenRoot(meta_path);
+  }
+  if (settings.chosen_root.is_absolute()) {
+    return settings.chosen_root.lexically_normal();
+  }
+  return (DefaultProjectMaskCacheChosenRoot(meta_path) / settings.chosen_root).lexically_normal();
+}
+
+auto ProjectMaskCacheNamespaceDirectory(const std::filesystem::path& chosen_root,
+                                        std::string_view project_uuid) -> std::filesystem::path {
+  if (chosen_root.empty()) {
+    throw std::invalid_argument("Project Mask cache root must not be empty");
+  }
+  if (project_uuid.empty() || project_uuid.find('/') != std::string_view::npos ||
+      project_uuid.find('\\') != std::string_view::npos || project_uuid == "." ||
+      project_uuid == ".." || project_uuid.find("..") != std::string_view::npos) {
+    throw std::invalid_argument("Project Mask cache UUID is not a safe directory name");
+  }
+  return chosen_root / kProjectMaskCacheDirectoryName / std::filesystem::path(project_uuid);
+}
+
+void ApplyProjectMaskCacheSettingsToMetadata(nlohmann::json& metadata,
+                                             const ProjectMaskCacheSettings& settings,
+                                             const std::filesystem::path& meta_path) {
+  nlohmann::json body;
+  body[kRootPathKey]      = StoreChosenRoot(settings.chosen_root, meta_path);
+  body[kRetentionKey]     = std::string(RetentionToken(settings.retention));
+  body[kRevisionKey]      = settings.settings_revision;
+  body[kClosePendingKey]  = settings.close_cleanup_pending;
+  nlohmann::json previous = nlohmann::json::array();
+  for (const auto& root : settings.previous_roots) {
+    previous.push_back(PathToStored(root));
+  }
+  body[kPreviousRootsKey] = std::move(previous);
+  metadata[kMetadataKey]  = std::move(body);
+}
+
+auto ReadProjectMaskCacheSettingsFromMetadata(const nlohmann::json& metadata,
+                                              const std::filesystem::path& meta_path)
+    -> ProjectMaskCacheSettings {
+  ProjectMaskCacheSettings settings;
+  if (!metadata.contains(kMetadataKey) || !metadata.at(kMetadataKey).is_object()) {
+    settings.chosen_root = DefaultProjectMaskCacheChosenRoot(meta_path);
+    return settings;
+  }
+  const auto& body = metadata.at(kMetadataKey);
+  if (body.contains(kRootPathKey) && body.at(kRootPathKey).is_string()) {
+    const auto stored = StoredToPath(body.at(kRootPathKey).get<std::string>());
+    if (stored.empty()) {
+      settings.chosen_root = DefaultProjectMaskCacheChosenRoot(meta_path);
+    } else if (stored.is_absolute()) {
+      settings.chosen_root = stored;
+    } else {
+      settings.chosen_root = stored;
+    }
+  } else {
+    settings.chosen_root = DefaultProjectMaskCacheChosenRoot(meta_path);
+  }
+  if (body.contains(kRetentionKey) && body.at(kRetentionKey).is_string()) {
+    settings.retention = RetentionFromToken(body.at(kRetentionKey).get<std::string>());
+  }
+  if (body.contains(kRevisionKey) && body.at(kRevisionKey).is_number_unsigned()) {
+    settings.settings_revision = body.at(kRevisionKey).get<std::uint64_t>();
+  }
+  if (body.contains(kClosePendingKey) && body.at(kClosePendingKey).is_boolean()) {
+    settings.close_cleanup_pending = body.at(kClosePendingKey).get<bool>();
+  }
+  if (body.contains(kPreviousRootsKey) && body.at(kPreviousRootsKey).is_array()) {
+    for (const auto& entry : body.at(kPreviousRootsKey)) {
+      if (!entry.is_string()) {
+        continue;
+      }
+      auto path = StoredToPath(entry.get<std::string>());
+      if (!path.empty()) {
+        settings.previous_roots.push_back(std::move(path));
+      }
+    }
+  }
+  return settings;
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/app/project_service.cpp
+++ b/alcedo_studio/src/app/project_service.cpp
@@ -436,6 +436,8 @@ ProjectService::ProjectService(const std::filesystem::path& db_path,
     package_service_ = std::make_shared<ProjectPackageService>();
 
     project_uuid_    = GenerateProjectUUID();
+    mask_cache_settings_.chosen_root = DefaultProjectMaskCacheChosenRoot(meta_path_);
+    RecreateMaskCacheService();
   };
 
   switch (open_mode) {
@@ -462,6 +464,7 @@ ProjectService::ProjectService(const std::filesystem::path& db_path,
 }
 
 ProjectService::~ProjectService() {
+  mask_cache_service_.reset();
   package_service_.reset();
   std::shared_ptr<AiSidecarRuntimeService> runtime;
   {
@@ -498,6 +501,7 @@ void ProjectService::SaveProject(const std::filesystem::path& meta_path) {
   metadata["start_id"]            = sleeve_service_->GetCurrentID();
   metadata["image_pool_start_id"] = pool_service_->GetCurrentID();
   metadata["data_summary"]        = ComputeProjectDataSummary(*storage_);
+  ApplyProjectMaskCacheSettingsToMetadata(metadata, mask_cache_settings_, meta_path_);
 
   std::ofstream file(meta_path_);
   if (!file.is_open()) {
@@ -508,6 +512,7 @@ void ProjectService::SaveProject(const std::filesystem::path& meta_path) {
 }
 
 void ProjectService::LoadProject(const std::filesystem::path& meta_path) {
+  mask_cache_service_.reset();
   std::shared_ptr<AiSidecarRuntimeService> previous_runtime;
   {
     std::lock_guard lock(ai_sidecar_runtime_mutex_);
@@ -629,6 +634,9 @@ void ProjectService::LoadProject(const std::filesystem::path& meta_path) {
   RegisterSemanticSearchProvider();
   browse_service_  = std::make_shared<AlbumBrowseService>(sleeve_service_, filter_service_);
   package_service_ = std::make_shared<ProjectPackageService>();
+  mask_cache_settings_ = ReadProjectMaskCacheSettingsFromMetadata(metadata, meta_path_);
+  RecreateMaskCacheService();
+  FinishPendingMaskCacheCleanup();
 }
 
 void ProjectService::RecreateSleeveService(sl_element_id_t start_id) {
@@ -654,4 +662,162 @@ auto ProjectService::GetAiSidecarRuntimeService() const
   }
   return ai_sidecar_runtime_service_;
 }
+
+void ProjectService::RecreateMaskCacheService() {
+  mask_cache_service_.reset();
+  const auto root = ResolveProjectMaskCacheChosenRoot(mask_cache_settings_, meta_path_);
+  mask_cache_service_ = std::make_unique<ProjectMaskCacheService>(project_uuid_, root);
+}
+
+auto ProjectService::PersistCurrentMetadata(std::string* error) -> bool {
+  try {
+    SaveProject(meta_path_);
+    return true;
+  } catch (const std::exception& exception) {
+    if (error) {
+      *error = exception.what();
+    }
+    return false;
+  }
+}
+
+void ProjectService::FinishPendingMaskCacheCleanup() {
+  if (!mask_cache_settings_.close_cleanup_pending || !mask_cache_service_) {
+    return;
+  }
+  std::string ignored;
+  if (mask_cache_service_->ClearOwnedCache(&ignored)) {
+    mask_cache_settings_.close_cleanup_pending = false;
+    (void)PersistCurrentMetadata(nullptr);
+  }
+}
+
+auto ProjectService::GetMaskCacheSettings() const -> ProjectMaskCacheSettings {
+  return mask_cache_settings_;
+}
+
+auto ProjectService::GetMaskCacheService() -> ProjectMaskCacheService* {
+  return mask_cache_service_.get();
+}
+
+auto ProjectService::GetMaskCacheService() const -> const ProjectMaskCacheService* {
+  return mask_cache_service_.get();
+}
+
+auto ProjectService::SetMaskCacheRoot(std::filesystem::path chosen_root,
+                                      std::uint64_t expected_revision, std::string* error) -> bool {
+  if (expected_revision != mask_cache_settings_.settings_revision) {
+    if (error) {
+      *error = "Project Mask cache settings revision does not match";
+    }
+    return false;
+  }
+  if (!mask_cache_service_) {
+    RecreateMaskCacheService();
+  }
+  if (chosen_root.empty()) {
+    chosen_root = DefaultProjectMaskCacheChosenRoot(meta_path_);
+  }
+  std::error_code absolute_error;
+  auto            resolved = std::filesystem::absolute(chosen_root, absolute_error);
+  if (absolute_error) {
+    if (error) {
+      *error = "Project Mask cache root is not a usable path";
+    }
+    return false;
+  }
+  resolved = resolved.lexically_normal();
+  if (!ProjectMaskCacheService::PrepareNamespace(resolved, project_uuid_, error)) {
+    return false;
+  }
+  const auto previous_root =
+      ResolveProjectMaskCacheChosenRoot(mask_cache_settings_, meta_path_);
+  const auto previous_settings = mask_cache_settings_;
+  mask_cache_settings_.chosen_root       = resolved;
+  mask_cache_settings_.settings_revision = expected_revision + 1;
+  if (!PersistCurrentMetadata(error)) {
+    mask_cache_settings_ = previous_settings;
+    return false;
+  }
+  if (!mask_cache_service_->PublishChosenRoot(resolved, error)) {
+    mask_cache_settings_ = previous_settings;
+    (void)PersistCurrentMetadata(nullptr);
+    return false;
+  }
+  if (previous_root != resolved) {
+    std::string cleanup_error;
+    if (!mask_cache_service_->DeleteOwnedNamespace(previous_root, &cleanup_error)) {
+      mask_cache_settings_.previous_roots.push_back(previous_root);
+      (void)PersistCurrentMetadata(nullptr);
+      if (error) {
+        *error = cleanup_error;
+      }
+      return false;
+    }
+  }
+  return true;
+}
+
+auto ProjectService::SetMaskCacheRetention(ProjectMaskCacheRetention retention,
+                                           std::uint64_t expected_revision, std::string* error)
+    -> bool {
+  if (expected_revision != mask_cache_settings_.settings_revision) {
+    if (error) {
+      *error = "Project Mask cache settings revision does not match";
+    }
+    return false;
+  }
+  const auto previous_settings             = mask_cache_settings_;
+  mask_cache_settings_.retention           = retention;
+  mask_cache_settings_.settings_revision   = expected_revision + 1;
+  if (!PersistCurrentMetadata(error)) {
+    mask_cache_settings_ = previous_settings;
+    return false;
+  }
+  return true;
+}
+
+auto ProjectService::ClearMaskCache(std::string* error) -> bool {
+  if (!mask_cache_service_) {
+    RecreateMaskCacheService();
+  }
+  return mask_cache_service_->ClearOwnedCache(error);
+}
+
+auto ProjectService::FlushMaskCacheWrites(std::string* error) -> bool {
+  if (!mask_cache_service_) {
+    return true;
+  }
+  return mask_cache_service_->FlushPendingWrites(error);
+}
+
+auto ProjectService::CloseAfterSuccessfulSave(std::string* error) -> bool {
+  if (mask_cache_settings_.retention != ProjectMaskCacheRetention::DeleteOnProjectClose) {
+    return FlushMaskCacheWrites(error);
+  }
+  mask_cache_settings_.close_cleanup_pending = true;
+  if (!PersistCurrentMetadata(error)) {
+    return false;
+  }
+  std::string cleanup_error;
+  const bool  cleaned = ClearMaskCache(&cleanup_error);
+  if (cleaned) {
+    mask_cache_settings_.close_cleanup_pending = false;
+    (void)PersistCurrentMetadata(nullptr);
+    return true;
+  }
+  if (error) {
+    *error = cleanup_error;
+  }
+  return false;
+}
+
+auto ProjectService::ApplyMaskCacheRemovalChoice(ProjectMaskCacheRemovalChoice choice,
+                                                 std::string* error) -> bool {
+  if (choice == ProjectMaskCacheRemovalChoice::KeepFiles) {
+    return true;
+  }
+  return ClearMaskCache(error);
+}
+
 };  // namespace alcedo

--- a/alcedo_studio/src/include/app/project_mask_cache_service.hpp
+++ b/alcedo_studio/src/include/app/project_mask_cache_service.hpp
@@ -1,0 +1,258 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "app/project_mask_cache_settings.hpp"
+#include "edit/geometry/types.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "type/type.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Stable Mix-cache slot: one published file per image and Color Grade.
+ *
+ * Filenames use this identity, never stroke, commit, Version, or content hash.
+ */
+struct ProjectMaskCacheSlotIdentity {
+  sl_element_id_t image_id = 0;
+  NodeId          node_id;
+};
+
+/**
+ * @brief One settled Grade Mix coverage payload plus identity for disk writeback.
+ *
+ * @p recipe_fingerprint and @p producer_id are caller-owned reopen checks. The
+ * service stores and verifies them; it does not compute coverage.
+ */
+struct ProjectMaskCacheRecord {
+  ProjectMaskCacheSlotIdentity identity;
+  Extent2D                     output_extent{};
+  NormalizedRect               reference_bounds{};
+  Extent2D                     source_grid{};
+  std::string                  recipe_fingerprint;
+  std::string                  producer_id;
+  std::uint32_t                raster_algorithm_version = kBrushRasterAlgorithmVersion;
+  std::vector<std::uint8_t>    pixels;
+};
+
+struct ProjectMaskCacheUsage {
+  std::size_t published_file_count = 0;
+  std::size_t published_byte_count = 0;
+  std::size_t pending_write_count  = 0;
+  bool        has_dirty_slot       = false;
+  std::string last_error;
+};
+
+/**
+ * @brief In-memory Mix-cache pixels plus a reader fence for Clear/close.
+ *
+ * Copies pixels out of the file so a later atomic replace does not mutate a
+ * live reader. Must be released before the owning service destructor.
+ */
+class ProjectMaskCacheReader {
+ public:
+  ProjectMaskCacheReader() = default;
+  ~ProjectMaskCacheReader();
+  ProjectMaskCacheReader(ProjectMaskCacheReader&& other) noexcept;
+  auto operator=(ProjectMaskCacheReader&& other) noexcept -> ProjectMaskCacheReader&;
+  ProjectMaskCacheReader(const ProjectMaskCacheReader&)            = delete;
+  auto operator=(const ProjectMaskCacheReader&) -> ProjectMaskCacheReader& = delete;
+
+  [[nodiscard]] auto HasRecord() const -> bool { return static_cast<bool>(record_); }
+  [[nodiscard]] auto Get() const -> const ProjectMaskCacheRecord&;
+
+ private:
+  friend class ProjectMaskCacheService;
+  std::shared_ptr<const ProjectMaskCacheRecord> record_;
+  std::function<void()>                         release_;
+};
+
+/**
+ * @brief Disposable current Mix R8 slot writer for one project UUID.
+ *
+ * Coalesces pending writes for the same slot, atomically replaces one file, and
+ * fences work with a storage generation so Clear and root changes cannot be
+ * undone by an older writer. Parameter/history files are never opened.
+ *
+ * @threadsafe Enqueue, Flush, Clear, ChangeChosenRoot, and TryAcquireReader may
+ *             run concurrently. The owner thread still owns ProjectService settings.
+ */
+class ProjectMaskCacheService {
+ public:
+  /**
+   * @brief Bind this writer to @p project_uuid under @p chosen_root.
+   *
+   * Does not create directories until the first write. Does not use the process
+   * temp directory as a substitute root.
+   *
+   * @throws std::invalid_argument when @p project_uuid or @p chosen_root is invalid.
+   */
+  ProjectMaskCacheService(std::string project_uuid, std::filesystem::path chosen_root);
+  ~ProjectMaskCacheService();
+
+  ProjectMaskCacheService(const ProjectMaskCacheService&)            = delete;
+  auto operator=(const ProjectMaskCacheService&) -> ProjectMaskCacheService& = delete;
+  ProjectMaskCacheService(ProjectMaskCacheService&&)                 = delete;
+  auto operator=(ProjectMaskCacheService&&) -> ProjectMaskCacheService&      = delete;
+
+  [[nodiscard]] auto ProjectUuid() const -> std::string;
+  [[nodiscard]] auto ChosenRoot() const -> std::filesystem::path;
+  [[nodiscard]] auto StorageGeneration() const -> std::uint64_t;
+
+  /**
+   * @brief Create `<root>/alcedo-mask-cache/<uuid>` when it does not exist.
+   *
+   * @return false when the path cannot be used as a directory. @p error names the
+   *         real filesystem failure. Never substitutes another root.
+   */
+  [[nodiscard]] static auto PrepareNamespace(const std::filesystem::path& chosen_root,
+                                             std::string_view project_uuid, std::string* error)
+      -> bool;
+
+  /**
+   * @brief Queue the latest settled Mix for @p record.identity, replacing any
+   *        not-yet-started write for that slot.
+   *
+   * Does not write on the caller thread. A later Flush, save, or idle write
+   * publishes at most one file per slot. Failure keeps the slot dirty.
+   */
+  auto EnqueueSettledWrite(ProjectMaskCacheRecord record, std::string* error) -> bool;
+
+  /**
+   * @brief Block until queued writes have been attempted and in-flight work ends.
+   *
+   * @return false when any slot in this flush failed. Last-good published files
+   *         stay in place; pending dirty slots remain dirty.
+   */
+  auto FlushPendingWrites(std::string* error) -> bool;
+
+  /**
+   * @brief Load one published slot when identity, fingerprint, producer, and checksum match.
+   *
+   * Missing files and checksum mismatches are cache misses (`nullopt` with an
+   * empty @p error). An unusable configured root sets @p error and returns
+   * `nullopt` without reading another directory.
+   */
+  [[nodiscard]] auto TryAcquireReader(const ProjectMaskCacheSlotIdentity& identity,
+                                      std::string_view expected_fingerprint,
+                                      std::string_view expected_producer, std::string* error)
+      -> std::optional<ProjectMaskCacheReader>;
+
+  /**
+   * @brief Stop writers, wait for readers, and delete only this project's Mix-cache files.
+   *
+   * Does not delete `.r8mask` assets, other project UUID directories, or files
+   * outside the dedicated namespace. Does not enqueue a rebuild write.
+   */
+  auto ClearOwnedCache(std::string* error) -> bool;
+
+  /**
+   * @brief Fence current jobs, then publish @p new_root for later writes.
+   *
+   * Does not persist project metadata. The owner must save settings first.
+   * Old-generation jobs refuse to write into the new root. Does not copy files.
+   */
+  auto PublishChosenRoot(const std::filesystem::path& new_root, std::string* error) -> bool;
+
+  /**
+   * @brief Delete this UUID's namespace under @p chosen_root after a successful root change.
+   *
+   * On failure, @p error describes the residual path. Callers must keep that
+   * path in @ref ProjectMaskCacheSettings::previous_roots.
+   */
+  auto DeleteOwnedNamespace(const std::filesystem::path& chosen_root, std::string* error) -> bool;
+
+  /**
+   * @brief Increment storage generation, drop coalesced pending writes, wait for in-flight work.
+   */
+  auto FenceWrites(std::string* error) -> bool;
+
+  [[nodiscard]] auto Usage() const -> ProjectMaskCacheUsage;
+  [[nodiscard]] auto PublishedSlotPath(const ProjectMaskCacheSlotIdentity& identity) const
+      -> std::filesystem::path;
+  [[nodiscard]] auto CountPublishedSlots() const -> std::size_t;
+
+  /**
+   * @brief Test hook after the temporary file is closed and before atomic replace.
+   *
+   * Return false to fail the replace. The hook must not call Clear on this
+   * instance. Pass an empty function to clear. Not used by product rendering.
+   */
+  void SetPublishHookForTesting(
+      std::function<bool(const std::filesystem::path& temporary,
+                         const std::filesystem::path& destination)>
+          hook);
+
+  void ShutdownWriter();
+
+ private:
+  struct SlotKey {
+    sl_element_id_t image_id = 0;
+    std::string     node_id;
+
+    friend auto operator<(const SlotKey& lhs, const SlotKey& rhs) -> bool {
+      if (lhs.image_id != rhs.image_id) {
+        return lhs.image_id < rhs.image_id;
+      }
+      return lhs.node_id < rhs.node_id;
+    }
+  };
+
+  struct PendingWrite {
+    ProjectMaskCacheRecord  record;
+    std::uint64_t           generation = 0;
+    std::filesystem::path   chosen_root;
+  };
+
+  auto SlotKeyFrom(const ProjectMaskCacheSlotIdentity& identity) const -> SlotKey;
+  auto SlotPath(const std::filesystem::path& chosen_root,
+                const ProjectMaskCacheSlotIdentity& identity) const -> std::filesystem::path;
+  void WriterLoop();
+  auto WriteOne(const PendingWrite& pending, std::string* error) -> bool;
+  auto DeleteNamespaceFiles(const std::filesystem::path& chosen_root, std::string* error) -> bool;
+  auto ScanUsage(ProjectMaskCacheUsage* usage) const -> void;
+  auto ChosenRootUsable(std::string* error) const -> bool;
+  void ReleaseReader();
+
+  std::string           project_uuid_;
+  std::filesystem::path chosen_root_;
+
+  mutable std::mutex      mutex_;
+  std::condition_variable cv_;
+  std::uint64_t           generation_     = 1;
+  std::uint32_t           inflight_writes_ = 0;
+  std::uint32_t           reader_count_    = 0;
+  bool                    stop_writer_     = false;
+  bool                    maintenance_     = false;
+  bool                    has_dirty_slot_  = false;
+  std::string             last_error_;
+  std::map<SlotKey, PendingWrite> pending_;
+  std::function<bool(const std::filesystem::path&, const std::filesystem::path&)> publish_hook_;
+  std::thread writer_;
+};
+
+/**
+ * @brief Validate Mix-cache record identity, fingerprint, producer, and packed R8 size.
+ *
+ * @throws std::invalid_argument when a field is empty, non-finite, or oversized.
+ */
+void ValidateProjectMaskCacheRecord(const ProjectMaskCacheRecord& record);
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/project_mask_cache_settings.hpp
+++ b/alcedo_studio/src/include/app/project_mask_cache_settings.hpp
@@ -1,0 +1,94 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <json.hpp>
+
+namespace alcedo {
+
+/// Directory name under the user-selected root that owns every project UUID namespace.
+inline constexpr std::string_view kProjectMaskCacheDirectoryName = "alcedo-mask-cache";
+/// Published Mix-cache file suffix. Distinct from persistent `.r8mask` assets.
+inline constexpr std::string_view kProjectMaskCacheFileExtension = ".r8cache";
+
+enum class ProjectMaskCacheRetention : std::uint8_t {
+  Keep = 0,
+  DeleteOnProjectClose = 1,
+};
+
+enum class ProjectMaskCacheRemovalChoice : std::uint8_t {
+  KeepFiles = 0,
+  DeleteFiles = 1,
+};
+
+/**
+ * @brief Per-project Mix-cache location and close policy owned by ProjectService.
+ *
+ * Settings are project metadata, not photo history. An empty @ref chosen_root
+ * means the persistent metadata directory. @ref previous_roots records namespaces
+ * whose cleanup failed after a successful root change so they stay manageable.
+ */
+struct ProjectMaskCacheSettings {
+  std::filesystem::path              chosen_root;
+  ProjectMaskCacheRetention          retention = ProjectMaskCacheRetention::Keep;
+  std::uint64_t                      settings_revision = 0;
+  std::vector<std::filesystem::path> previous_roots;
+  bool                               close_cleanup_pending = false;
+};
+
+/**
+ * @brief Default user-selected root: the directory that contains @p meta_path.
+ *
+ * @pre @p meta_path is the persistent project metadata file.
+ */
+[[nodiscard]] auto DefaultProjectMaskCacheChosenRoot(const std::filesystem::path& meta_path)
+    -> std::filesystem::path;
+
+/**
+ * @brief Resolve @p settings.chosen_root against @p meta_path.
+ *
+ * Relative stored roots are interpreted from the metadata directory. Absolute
+ * roots are returned as stored. Does not create directories or substitute temp.
+ */
+[[nodiscard]] auto ResolveProjectMaskCacheChosenRoot(const ProjectMaskCacheSettings& settings,
+                                                     const std::filesystem::path& meta_path)
+    -> std::filesystem::path;
+
+/**
+ * @brief Dedicated namespace `<chosen-root>/alcedo-mask-cache/<project-uuid>`.
+ *
+ * @throws std::invalid_argument when @p project_uuid is empty or contains a path
+ *         separator or parent traversal.
+ */
+[[nodiscard]] auto ProjectMaskCacheNamespaceDirectory(const std::filesystem::path& chosen_root,
+                                                      std::string_view project_uuid)
+    -> std::filesystem::path;
+
+/**
+ * @brief Write @p settings under `mask_cache` in reconstructed project metadata.
+ *
+ * Empty roots persist as an empty string so Save cannot drop the key. Paths are
+ * stored relative to the metadata directory when they lie inside it.
+ */
+void ApplyProjectMaskCacheSettingsToMetadata(nlohmann::json& metadata,
+                                             const ProjectMaskCacheSettings& settings,
+                                             const std::filesystem::path& meta_path);
+
+/**
+ * @brief Read `mask_cache` from @p metadata. Missing keys yield defaults.
+ *
+ * Does not migrate thumbnail cache keys. Unknown retention values throw.
+ */
+[[nodiscard]] auto ReadProjectMaskCacheSettingsFromMetadata(const nlohmann::json& metadata,
+                                                            const std::filesystem::path& meta_path)
+    -> ProjectMaskCacheSettings;
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/app/project_service.hpp
+++ b/alcedo_studio/src/include/app/project_service.hpp
@@ -11,6 +11,7 @@
 
 #include "app/album_browse_service.hpp"
 #include "app/ai_sidecar_runtime_service.hpp"
+#include "app/project_mask_cache_service.hpp"
 #include "app/sleeve_service.hpp"
 #include "app/sleeve_filter_service.hpp"
 #include "image_pool_service.hpp"
@@ -55,13 +56,74 @@ class ProjectService {
   auto GetMetaPath() const -> const std::filesystem::path& { return meta_path_; }
   auto GetProjectUUID() const -> const std::string& { return project_uuid_; }
 
+  /**
+   * @brief Current Mix-cache root, retention, and leftover-cleanup state.
+   *
+   * Empty @ref ProjectMaskCacheSettings::chosen_root is resolved against this
+   * project's metadata directory. Not part of photo history.
+   */
+  [[nodiscard]] auto GetMaskCacheSettings() const -> ProjectMaskCacheSettings;
+
+  [[nodiscard]] auto GetMaskCacheService() -> ProjectMaskCacheService*;
+  [[nodiscard]] auto GetMaskCacheService() const -> const ProjectMaskCacheService*;
+
+  /**
+   * @brief Validate @p chosen_root, persist it, then publish it to the cache writer.
+   *
+   * @param chosen_root User-selected root, or empty for the metadata directory.
+   * @param expected_revision Must match the current settings revision.
+   * @param error Receives the real filesystem or revision failure. Unchanged on success.
+   * @return false when the previous root and files are retained.
+   */
+  auto SetMaskCacheRoot(std::filesystem::path chosen_root, std::uint64_t expected_revision,
+                        std::string* error) -> bool;
+
+  /**
+   * @brief Persist Keep vs DeleteOnProjectClose. Does not add a photo Version.
+   */
+  auto SetMaskCacheRetention(ProjectMaskCacheRetention retention, std::uint64_t expected_revision,
+                             std::string* error) -> bool;
+
+  /**
+   * @brief Delete this project's Mix-cache files. Stroke history and RAW stay on disk.
+   */
+  auto ClearMaskCache(std::string* error) -> bool;
+
+  /**
+   * @brief Flush coalesced Mix-cache writes at a save boundary.
+   *
+   * Parameter save must already have succeeded or be independent of this call.
+   * A cache I/O failure does not rewrite project metadata or history.
+   */
+  auto FlushMaskCacheWrites(std::string* error) -> bool;
+
+  /**
+   * @brief After a successful parameter/WAL save, apply DeleteOnProjectClose if set.
+   *
+   * Waits for Mix-cache readers and writers. Cleanup failure does not mark the
+   * parameter save as failed.
+   */
+  auto CloseAfterSuccessfulSave(std::string* error) -> bool;
+
+  /**
+   * @brief Explicit project-removal cache choice. Removing a recent-list row is
+   *        not authorization to delete files; pass KeepFiles for that path.
+   */
+  auto ApplyMaskCacheRemovalChoice(ProjectMaskCacheRemovalChoice choice, std::string* error)
+      -> bool;
+
  private:
   void                                  RecreateSleeveService(sl_element_id_t start_id);
   void                                  RegisterSemanticSearchProvider();
+  void                                  RecreateMaskCacheService();
+  auto                                  PersistCurrentMetadata(std::string* error) -> bool;
+  void                                  FinishPendingMaskCacheCleanup();
 
   std::filesystem::path                 db_path_;
   std::filesystem::path                 meta_path_;
   std::string                           project_uuid_;
+  ProjectMaskCacheSettings              mask_cache_settings_;
+  std::unique_ptr<ProjectMaskCacheService> mask_cache_service_;
   std::shared_ptr<Storage>       storage_;
   std::shared_ptr<SleeveServiceImpl>    sleeve_service_;
   // TODO: Add ImagePoolService and store its start_id into the metadata

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/application_module_host.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/application_module_host.cpp
@@ -481,6 +481,11 @@ void ApplicationModuleHost::ShutdownModules() {
       if (project_->handler().PersistCurrentProjectState()) {
         QString ignored_error;
         (void)project_->handler().PackageCurrentProjectFiles(&ignored_error);
+        auto project_service = project_->handler().project();
+        if (project_service) {
+          std::string cache_close_error;
+          (void)project_service->CloseAfterSuccessfulSave(&cache_close_error);
+        }
       }
       album_util::CleanupWorkspaceDirectory(project_->handler().workspace_dir());
     }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/project_handler.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/project_handler.cpp
@@ -8,6 +8,7 @@
 #include <QPointer>
 
 #include <stdexcept>
+#include <string>
 #include <thread>
 
 #include "app/project_package_service.hpp"
@@ -100,6 +101,8 @@ bool ProjectHandler::InitializeServices(const std::filesystem::path& dbPath,
         old_project->GetSleeveService()->Sync();
         old_project->GetImagePoolService()->SyncWithStorage();
         old_project->SaveProject(old_meta);
+        std::string cache_close_error;
+        (void)old_project->CloseAfterSuccessfulSave(&cache_close_error);
 
         if (!old_package.empty()) {
           auto package_service = old_project->GetProjectPackageService();
@@ -279,6 +282,8 @@ bool ProjectHandler::PersistCurrentProjectState() {
       if (!meta_path_.empty()) {
         project_->SaveProject(meta_path_);
       }
+      std::string cache_error;
+      (void)project_->FlushMaskCacheWrites(&cache_error);
     }
     return true;
   } catch (...) {

--- a/alcedo_studio/tests/app/CMakeLists.txt
+++ b/alcedo_studio/tests/app/CMakeLists.txt
@@ -545,6 +545,19 @@ gtest_discover_tests(ProjectServiceTest TEST_PREFIX "ProjectServiceTest."
   PROPERTIES LABELS "ci_core_flow")
 alcedo_register_test_target(ProjectServiceTest app ci_core)
 
+add_executable(ProjectMaskCacheServiceTest
+    ${ALCEDO_TEST_ROOT}/app/project_mask_cache_service_test.cpp)
+target_include_directories(ProjectMaskCacheServiceTest PUBLIC ${ALCEDO_INCLUDE_DIR})
+target_link_libraries(ProjectMaskCacheServiceTest
+    PRIVATE
+      ProjectService
+      GTest::gtest
+      Qt6::Core
+)
+gtest_discover_tests(ProjectMaskCacheServiceTest TEST_PREFIX "ProjectMaskCacheServiceTest."
+  PROPERTIES LABELS "ci_core_flow;edit;mask")
+alcedo_register_test_target(ProjectMaskCacheServiceTest app ci_core)
+
 add_executable(AiSidecarFakeRuntime ${ALCEDO_TEST_ROOT}/app/ai_sidecar_fake_runtime_main.cpp)
 alcedo_register_test_target(AiSidecarFakeRuntime app)
 

--- a/alcedo_studio/tests/app/project_mask_cache_service_test.cpp
+++ b/alcedo_studio/tests/app/project_mask_cache_service_test.cpp
@@ -1,0 +1,345 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QString>
+#include <json.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "app/project_mask_cache_service.hpp"
+#include "app/project_package_service.hpp"
+#include "app/project_service.hpp"
+#include "edit/graph/graph_ids.hpp"
+
+namespace alcedo {
+namespace {
+
+auto TestRoot(std::string_view name) -> std::filesystem::path {
+  auto              root = std::filesystem::path{"build/tmp/project_mask_cache"} / std::string(name);
+  std::error_code   ignored;
+  std::filesystem::remove_all(root, ignored);
+  std::filesystem::create_directories(root);
+  return root;
+}
+
+auto WriteText(const std::filesystem::path& path, std::string_view text) -> void {
+  std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(stream) << path;
+  stream << text;
+}
+
+auto ReadText(const std::filesystem::path& path) -> std::string {
+  std::ifstream stream(path, std::ios::binary);
+  return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+auto MakeRecord(sl_element_id_t image_id, std::string node_id, std::uint8_t fill,
+                std::string fingerprint) -> ProjectMaskCacheRecord {
+  ProjectMaskCacheRecord record;
+  record.identity.image_id     = image_id;
+  record.identity.node_id      = NodeId{std::move(node_id)};
+  record.output_extent         = {2, 2};
+  record.reference_bounds      = {0.0f, 0.0f, 1.0f, 1.0f};
+  record.source_grid           = {2, 2};
+  record.recipe_fingerprint    = std::move(fingerprint);
+  record.producer_id           = "host-test";
+  record.pixels                = {fill, fill, fill, fill};
+  return record;
+}
+
+constexpr auto kStrokeHistory = R"({"strokes":[{"id":"stroke.1","x":8.0,"y":12.0}]})";
+
+}  // namespace
+
+TEST(ProjectMaskCacheServiceTest, ProjectMaskCacheSettingsSurviveSaveAndReopen) {
+  const auto root       = TestRoot("settings_reopen");
+  const auto db_path    = root / "project.db";
+  const auto meta_path  = root / "project.json";
+  const auto cache_root = std::filesystem::path{"build/tmp/project_mask_cache"} /
+                          "settings_reopen_external_root";
+  std::error_code ignored;
+  std::filesystem::remove_all(cache_root, ignored);
+  std::filesystem::create_directories(cache_root);
+  std::string uuid;
+  std::uint64_t revision = 0;
+  {
+    ProjectService project(db_path, meta_path, ProjectOpenMode::kCreateNew);
+    uuid = project.GetProjectUUID();
+    project.SaveProject(meta_path);
+    std::string error;
+    ASSERT_TRUE(project.SetMaskCacheRoot(cache_root, 0, &error)) << error;
+    revision = project.GetMaskCacheSettings().settings_revision;
+    ASSERT_TRUE(project.SetMaskCacheRetention(ProjectMaskCacheRetention::DeleteOnProjectClose,
+                                              revision, &error))
+        << error;
+    revision = project.GetMaskCacheSettings().settings_revision;
+    ASSERT_TRUE(project.FlushMaskCacheWrites(&error)) << error;
+  }
+
+  {
+    QString pack_error;
+    const auto packed = root / "project.alcd";
+    ASSERT_TRUE(ProjectPackageService{}.WritePackedProject(packed, meta_path, db_path, &pack_error))
+        << pack_error.toStdString();
+  }
+
+  {
+    ProjectService project(db_path, meta_path, ProjectOpenMode::kLoadExisting);
+    EXPECT_EQ(project.GetProjectUUID(), uuid);
+    const auto settings = project.GetMaskCacheSettings();
+    EXPECT_EQ(ResolveProjectMaskCacheChosenRoot(settings, meta_path),
+              std::filesystem::absolute(cache_root).lexically_normal());
+    EXPECT_EQ(settings.retention, ProjectMaskCacheRetention::DeleteOnProjectClose);
+    EXPECT_EQ(settings.settings_revision, revision);
+    EXPECT_FALSE(settings.close_cleanup_pending);
+  }
+
+  const auto unpack_dir = root / "unpacked";
+  std::filesystem::create_directories(unpack_dir);
+  std::filesystem::path unpacked_db;
+  std::filesystem::path unpacked_meta;
+  QString               unpack_error;
+  ASSERT_TRUE(ProjectPackageService{}.UnpackProjectToWorkspace(
+      root / "project.alcd", unpack_dir, QStringLiteral("reopen_pack"), &unpacked_db, &unpacked_meta,
+      &unpack_error))
+      << unpack_error.toStdString();
+  {
+    ProjectService project(unpacked_db, unpacked_meta, ProjectOpenMode::kLoadExisting);
+    EXPECT_EQ(project.GetProjectUUID(), uuid);
+    const auto settings = project.GetMaskCacheSettings();
+    EXPECT_EQ(settings.retention, ProjectMaskCacheRetention::DeleteOnProjectClose);
+    EXPECT_EQ(ResolveProjectMaskCacheChosenRoot(settings, unpacked_meta),
+              std::filesystem::absolute(cache_root).lexically_normal());
+  }
+}
+
+TEST(ProjectMaskCacheServiceTest, ThousandStrokesKeepOneRasterSlot) {
+  const auto root = TestRoot("thousand_strokes");
+  const auto uuid = "11111111-1111-1111-1111-111111111111";
+  ProjectMaskCacheService service(uuid, root);
+  const auto identity = ProjectMaskCacheSlotIdentity{7, NodeId{"grade.primary"}};
+  std::string error;
+  for (int i = 0; i < 1000; ++i) {
+    auto record = MakeRecord(identity.image_id, "grade.primary", static_cast<std::uint8_t>(i % 250),
+                             "fp-" + std::to_string(i));
+    ASSERT_TRUE(service.EnqueueSettledWrite(std::move(record), &error)) << error;
+  }
+  ASSERT_TRUE(service.FlushPendingWrites(&error)) << error;
+  EXPECT_EQ(service.CountPublishedSlots(), 1u);
+  const auto reader = service.TryAcquireReader(identity, "fp-999", "host-test", &error);
+  ASSERT_TRUE(reader.has_value());
+  EXPECT_EQ(reader->Get().pixels, (std::vector<std::uint8_t>{249, 249, 249, 249}));
+  const auto ns = ProjectMaskCacheNamespaceDirectory(root, uuid);
+  std::size_t cache_files = 0;
+  for (const auto& entry : std::filesystem::recursive_directory_iterator(ns)) {
+    if (entry.is_regular_file() && entry.path().extension() == kProjectMaskCacheFileExtension) {
+      ++cache_files;
+    }
+  }
+  EXPECT_EQ(cache_files, 1u);
+}
+
+TEST(ProjectMaskCacheServiceTest, CacheClearCannotDeleteAnotherProjectsFiles) {
+  const auto root   = TestRoot("clear_isolation");
+  const auto uuid_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const auto uuid_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  ProjectMaskCacheService service_a(uuid_a, root);
+  ProjectMaskCacheService service_b(uuid_b, root);
+  std::string             error;
+  ASSERT_TRUE(service_a.EnqueueSettledWrite(MakeRecord(1, "grade.primary", 11, "fp-a"), &error))
+      << error;
+  ASSERT_TRUE(service_b.EnqueueSettledWrite(MakeRecord(1, "grade.primary", 22, "fp-b"), &error))
+      << error;
+  ASSERT_TRUE(service_a.FlushPendingWrites(&error)) << error;
+  ASSERT_TRUE(service_b.FlushPendingWrites(&error)) << error;
+
+  const auto foreign_mask = root / "legacy.r8mask";
+  WriteText(foreign_mask, "ALCR8MSK-not-cache");
+  const auto owned_mask =
+      ProjectMaskCacheNamespaceDirectory(root, uuid_a) / "1" / "legacy.r8mask";
+  WriteText(owned_mask, "ALCR8MSK-inside-namespace");
+  const auto outside = root / "outside-secret.bin";
+  WriteText(outside, "do-not-delete");
+  const auto escape_link = ProjectMaskCacheNamespaceDirectory(root, uuid_a) / "escape.lnk";
+  std::error_code link_error;
+  std::filesystem::create_symlink(outside, escape_link, link_error);
+
+  ASSERT_TRUE(service_a.ClearOwnedCache(&error)) << error;
+  EXPECT_EQ(service_a.CountPublishedSlots(), 0u);
+  EXPECT_EQ(service_b.CountPublishedSlots(), 1u);
+  EXPECT_TRUE(std::filesystem::exists(foreign_mask));
+  EXPECT_TRUE(std::filesystem::exists(owned_mask));
+  EXPECT_TRUE(std::filesystem::exists(outside));
+  EXPECT_EQ(ReadText(outside), "do-not-delete");
+  const auto b_reader =
+      service_b.TryAcquireReader({1, NodeId{"grade.primary"}}, "fp-b", "host-test", &error);
+  ASSERT_TRUE(b_reader.has_value());
+  EXPECT_EQ(b_reader->Get().pixels[0], 22);
+}
+
+TEST(ProjectMaskCacheServiceTest, OldWriterCannotRecreateClearedCache) {
+  const auto root = TestRoot("old_writer");
+  const auto uuid = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+  ProjectMaskCacheService service(uuid, root);
+  const auto identity = ProjectMaskCacheSlotIdentity{3, NodeId{"grade.primary"}};
+  const auto gen      = service.StorageGeneration();
+  std::mutex              mutex;
+  std::condition_variable ready;
+  bool                    entered = false;
+  service.SetPublishHookForTesting([&](const std::filesystem::path&, const std::filesystem::path&) {
+    {
+      std::lock_guard lock(mutex);
+      entered = true;
+      ready.notify_all();
+    }
+    while (service.StorageGeneration() == gen) {
+      std::this_thread::yield();
+    }
+    return true;
+  });
+  std::string error;
+  ASSERT_TRUE(service.EnqueueSettledWrite(MakeRecord(3, "grade.primary", 33, "fp-old"), &error))
+      << error;
+  {
+    std::unique_lock lock(mutex);
+    ASSERT_TRUE(ready.wait_for(lock, std::chrono::seconds(5), [&] { return entered; }))
+        << "writer never reached the publish hook";
+  }
+  ASSERT_TRUE(service.ClearOwnedCache(&error)) << error;
+  EXPECT_EQ(service.CountPublishedSlots(), 0u);
+  EXPECT_FALSE(std::filesystem::exists(service.PublishedSlotPath(identity)));
+  service.SetPublishHookForTesting({});
+  std::this_thread::yield();
+  EXPECT_EQ(service.CountPublishedSlots(), 0u);
+}
+
+TEST(ProjectMaskCacheServiceTest, RootChangeFailurePreservesOldSetting) {
+  const auto root      = TestRoot("root_change_failure");
+  const auto db_path   = root / "project.db";
+  const auto meta_path = root / "project.json";
+  const auto cache_a   = root / "cache-a";
+  std::filesystem::create_directories(cache_a);
+  ProjectService project(db_path, meta_path, ProjectOpenMode::kCreateNew);
+  project.SaveProject(meta_path);
+  std::string error;
+  ASSERT_TRUE(project.SetMaskCacheRoot(cache_a, 0, &error)) << error;
+  auto* cache = project.GetMaskCacheService();
+  ASSERT_NE(cache, nullptr);
+  ASSERT_TRUE(cache->EnqueueSettledWrite(MakeRecord(4, "grade.primary", 44, "fp-a"), &error))
+      << error;
+  ASSERT_TRUE(cache->FlushPendingWrites(&error)) << error;
+  const auto published = cache->PublishedSlotPath({4, NodeId{"grade.primary"}});
+  ASSERT_TRUE(std::filesystem::exists(published));
+
+  const auto blocker = root / "not-a-directory";
+  WriteText(blocker, "file");
+  const auto bad_root = blocker / "cache-b";
+  const auto before   = project.GetMaskCacheSettings();
+  EXPECT_FALSE(project.SetMaskCacheRoot(bad_root, before.settings_revision, &error));
+  EXPECT_FALSE(error.empty());
+  const auto after = project.GetMaskCacheSettings();
+  EXPECT_EQ(after.settings_revision, before.settings_revision);
+  EXPECT_EQ(ResolveProjectMaskCacheChosenRoot(after, meta_path),
+            std::filesystem::absolute(cache_a).lexically_normal());
+  EXPECT_TRUE(std::filesystem::exists(published));
+  EXPECT_EQ(project.GetMaskCacheService()->CountPublishedSlots(), 1u);
+}
+
+TEST(ProjectMaskCacheServiceTest, CacheWriteFailureDoesNotLoseStrokeHistory) {
+  const auto root      = TestRoot("write_failure_history");
+  const auto db_path   = root / "project.db";
+  const auto meta_path = root / "project.json";
+  const auto strokes   = root / "strokes.json";
+  WriteText(strokes, kStrokeHistory);
+  ProjectService project(db_path, meta_path, ProjectOpenMode::kCreateNew);
+  project.SaveProject(meta_path);
+  auto* cache = project.GetMaskCacheService();
+  ASSERT_NE(cache, nullptr);
+  cache->SetPublishHookForTesting(
+      [](const std::filesystem::path&, const std::filesystem::path&) { return false; });
+  std::string error;
+  ASSERT_TRUE(cache->EnqueueSettledWrite(MakeRecord(5, "grade.primary", 55, "fp-fail"), &error))
+      << error;
+  EXPECT_FALSE(cache->FlushPendingWrites(&error));
+  EXPECT_FALSE(error.empty());
+  EXPECT_EQ(ReadText(strokes), kStrokeHistory);
+  EXPECT_TRUE(std::filesystem::exists(meta_path));
+  std::ifstream meta(meta_path);
+  nlohmann::json metadata;
+  meta >> metadata;
+  EXPECT_EQ(metadata.at("project_uuid").get<std::string>(), project.GetProjectUUID());
+  EXPECT_TRUE(metadata.contains("mask_cache"));
+  EXPECT_TRUE(cache->Usage().has_dirty_slot);
+  EXPECT_EQ(cache->CountPublishedSlots(), 0u);
+  EXPECT_EQ(ReadText(strokes), kStrokeHistory);
+}
+
+TEST(ProjectMaskCacheServiceTest, CloseCleanupRunsAfterParameterSaveAndReadersFinish) {
+  const auto root      = TestRoot("close_cleanup");
+  const auto db_path   = root / "project.db";
+  const auto meta_path = root / "project.json";
+  const auto strokes   = root / "strokes.json";
+  WriteText(strokes, kStrokeHistory);
+  ProjectService project(db_path, meta_path, ProjectOpenMode::kCreateNew);
+  project.SaveProject(meta_path);
+  std::string error;
+  ASSERT_TRUE(project.SetMaskCacheRetention(ProjectMaskCacheRetention::DeleteOnProjectClose, 0,
+                                            &error))
+      << error;
+  auto* cache = project.GetMaskCacheService();
+  ASSERT_NE(cache, nullptr);
+  const auto identity = ProjectMaskCacheSlotIdentity{9, NodeId{"grade.primary"}};
+  ASSERT_TRUE(cache->EnqueueSettledWrite(MakeRecord(9, "grade.primary", 99, "fp-close"), &error))
+      << error;
+  ASSERT_TRUE(cache->FlushPendingWrites(&error)) << error;
+  const auto published = cache->PublishedSlotPath(identity);
+  ASSERT_TRUE(std::filesystem::exists(published));
+  auto reader = cache->TryAcquireReader(identity, "fp-close", "host-test", &error);
+  ASSERT_TRUE(reader.has_value());
+  const auto generation = cache->StorageGeneration();
+  std::string close_error;
+  std::atomic<bool> close_done{false};
+  std::thread closer([&] {
+    (void)project.CloseAfterSuccessfulSave(&close_error);
+    close_done = true;
+  });
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (cache->StorageGeneration() == generation) {
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline) << "close did not fence writers";
+    std::this_thread::yield();
+  }
+  EXPECT_FALSE(close_done.load());
+  EXPECT_TRUE(std::filesystem::exists(published));
+  EXPECT_EQ(ReadText(strokes), kStrokeHistory);
+  reader.reset();
+  closer.join();
+  EXPECT_TRUE(close_error.empty()) << close_error;
+  EXPECT_FALSE(std::filesystem::exists(published));
+  EXPECT_EQ(cache->CountPublishedSlots(), 0u);
+  EXPECT_EQ(ReadText(strokes), kStrokeHistory);
+  EXPECT_EQ(project.GetMaskCacheSettings().retention,
+            ProjectMaskCacheRetention::DeleteOnProjectClose);
+  EXPECT_FALSE(project.GetMaskCacheSettings().close_cleanup_pending);
+}
+
+}  // namespace alcedo
+
+int main(int argc, char** argv) {
+  QCoreApplication application(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,16 +2,17 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.10 complete; NM7.11–NM7.15 planned. This document records the NM7.1 source
+Status: NM7.1–NM7.11 complete; NM7.12–NM7.15 planned. This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
 shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
 NM7.7 Radial/Linear creation plus existing-mask movement, NM7.8 parameter-mask
 controls, drawer selection/deletion, and crop-style Gradient, NM7.9 accumulating
-Brush paint/erase/move with typed stroke history, and NM7.10 serial Interactive Mix
-with one current Grade coverage result. Some former NM7.11 UI wiring
-(now NM7.12) was brought forward for Radial/Gradient testing. This is partial
-wiring of the full UI phase. NM7.11–NM7.15 acceptance remains outstanding.
+Brush paint/erase/move with typed stroke history, NM7.10 serial Interactive Mix
+with one current Grade coverage result, and NM7.11 project Mix-cache storage plus
+Keep/DeleteOnProjectClose cleanup. Some former NM7.11 UI wiring (now NM7.12) was
+brought forward for Radial/Gradient testing. This is partial wiring of the full UI
+phase. NM7.12–NM7.15 acceptance remains outstanding.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -1632,6 +1633,68 @@ Clear → maintenance boundary → stop old writer → delete only owned cache �
 `CloseCleanupRunsAfterParameterSaveAndReadersFinish`.
 
 **Exit:** new cache namespace can be completely removed without losing any supported edit/Version.
+
+##### Phase NM7.11 completion record (2026-09-10)
+
+**Status:** complete — project Mix-cache settings, one-slot writeback, Clear, root change, and close cleanup
+
+**Primary success call chain:**
+
+```text
+SetMaskCacheRoot / SetMaskCacheRetention
+  -> PrepareNamespace (no temp substitution)
+  -> SaveProject writes mask_cache in metadata JSON
+  -> ProjectMaskCacheService::PublishChosenRoot / EnqueueSettledWrite
+  -> coalesced writer -> temp file + checksum -> atomic replace
+     <chosen-root>/alcedo-mask-cache/<ProjectUUID>/<ImageId>/<hex(NodeId)>.r8cache
+PersistCurrentProjectState / CloseAfterSuccessfulSave(Keep)
+  -> FlushPendingWrites
+DeleteOnProjectClose after parameter save
+  -> close_cleanup_pending persisted
+  -> wait readers/writers -> delete owned .r8cache only
+```
+
+**Primary failure call chain:**
+
+```text
+unusable new root or settings-revision mismatch
+  -> no metadata write of the new root; previous files retained
+publish hook / I/O failure
+  -> temp removed; last-good slot kept; dirty retained; stroke JSON/history untouched
+Clear / generation bump while a writer is in-flight
+  -> old generation refuses atomic replace; cleared namespace stays empty
+unavailable configured root
+  -> error string; no process-temp fallback
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `ProjectMaskCacheSettingsSurviveSaveAndReopen` | `ProjectMaskCacheServiceTest` | PASS |
+| `ThousandStrokesKeepOneRasterSlot` | `ProjectMaskCacheServiceTest` | PASS |
+| `CacheClearCannotDeleteAnotherProjectsFiles` | `ProjectMaskCacheServiceTest` | PASS |
+| `OldWriterCannotRecreateClearedCache` | `ProjectMaskCacheServiceTest` | PASS |
+| `RootChangeFailurePreservesOldSetting` | `ProjectMaskCacheServiceTest` | PASS |
+| `CacheWriteFailureDoesNotLoseStrokeHistory` | `ProjectMaskCacheServiceTest` | PASS |
+| `CloseCleanupRunsAfterParameterSaveAndReadersFinish` | `ProjectMaskCacheServiceTest` | PASS |
+| Existing UUID save/load (metadata still round-trips) | `ProjectServiceTest` | PASS `6/6` |
+
+Commands:
+
+```text
+cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target ProjectMaskCacheServiceTest
+ctest --test-dir build/debug --output-on-failure -R "ProjectMaskCacheSettingsSurviveSaveAndReopen|ThousandStrokesKeepOneRasterSlot|CacheClearCannotDeleteAnotherProjectsFiles|OldWriterCannotRecreateClearedCache|RootChangeFailurePreservesOldSetting|CacheWriteFailureDoesNotLoseStrokeHistory|CloseCleanupRunsAfterParameterSaveAndReadersFinish"
+ctest --test-dir build/debug --output-on-failure -R "ProjectServiceTest."
+```
+
+Suite totals: required names `7/7` PASS; `ProjectMaskCacheServiceTest` `7/7` PASS; `ProjectServiceTest` `6/6` PASS. Date / working tree on `feature/project-mask-cache` / Windows MSVC `win_debug`. Packages still contain only metadata JSON plus the DuckDB file (no `.r8cache`). `.r8mask` files are not deleted by Clear.
+
+**Checklist / exit condition:** required tests PASS. Settings survive Save, Load, and packed reopen. One thousand coalesced writes leave one published slot. Clear of project A leaves project B and `.r8mask` files. A fenced in-flight writer cannot recreate a cleared slot. Failed root change keeps the previous setting and files. Failed cache publish leaves stroke JSON and project metadata intact. DeleteOnProjectClose waits for a held reader, then removes only the Mix-cache namespace after the parameter save.
+
+**LOC note (grill-code-review):** `project_mask_cache_service.hpp` 226 / `.cpp` 745; `project_mask_cache_settings.hpp` 80 / `.cpp` 159; `project_service.hpp` 118 / `.cpp` 742; `project_mask_cache_service_test.cpp` 319. The cache writer owns generation, coalesced pending slots, and namespace deletion. ProjectService owns metadata keys, revision, and close-cleanup persistence. No file crossed 1000 lines.
+
+**Residual gaps:** the serial Interactive Mix owner (GraphImageCache / PlanExecutor) does not yet call `EnqueueSettledWrite`; save/close flush the cache writer, but a settled native Mix is not copied onto disk until that enqueue exists. Mask Adjustment Stack cache UI, root chooser, and Clear copy are NM7.12. Open-operation cancel and project-switch fencing of in-flight cache jobs beyond the current close/switch hooks are NM7.13. Native Mix rebuild after a cacheless reopen is NM7.14. `RemoveRecentProject` still only edits the recent list (KeepFiles). Ordinary adjustment Mask writes still fail with the existing “until NM3” text. NM6.8–NM6.9 remain planned.
 
 ### NM7.12 — Wire Mask editing and project cache UI
 


### PR DESCRIPTION
## Summary
- Add a project-owned Mix-cache writer with one stable `.r8cache` slot per image and Color Grade, plus Keep/DeleteOnProjectClose, Clear, and root-change fencing.
- Persist cache settings through `ProjectService` metadata so save/reopen and packed projects keep the policy without storing raster history.
- Flush on save and run close cleanup after a successful parameter save; failed writes and Clear leave stroke history intact.

## Test plan
- [x] `ProjectMaskCacheServiceTest` required cases (`ProjectMaskCacheSettingsSurviveSaveAndReopen`, `ThousandStrokesKeepOneRasterSlot`, `CacheClearCannotDeleteAnotherProjectsFiles`, `OldWriterCannotRecreateClearedCache`, `RootChangeFailurePreservesOldSetting`, `CacheWriteFailureDoesNotLoseStrokeHistory`, `CloseCleanupRunsAfterParameterSaveAndReadersFinish`)
- [x] `ProjectServiceTest` UUID save/load still passes
- [ ] Confirm Settings UI is still out of scope (NM7.12) and native Mix enqueue remains a follow-on
