### PR TITLE
feat(editor): wire Mask field editing and project Mix cache UI (NM7.12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,15 @@ reserved for local state and ignored through their nested `.gitignore` files.
 
 ### Windows (MSVC + CUDA)
 
+**Build time allowance:** Start Windows configure/build/link timeout budgets at **10–20 minutes**
+per invocation (at least 10 minutes; prefer 20 minutes for CUDA builds, broad target sets, or
+relinking the application). Increase the budget for a clean build or when compiler/linker progress
+continues; 20 minutes is a starting allowance, not a hard upper limit. Do not terminate or restart
+a healthy build merely because a short tool wait returned no output. Keep the same process/session
+and poll it in short intervals so progress updates remain possible. Tool polling/yield intervals
+are separate from the build's total timeout. Treat a build as failed only on an actual error,
+process exit, or evidence of a stalled process, and put its logs under `build/tmp/`.
+
 ```bash
 # Configure (debug)
 cmd /c scripts\msvc_env.cmd --preset win_debug -DCMAKE_PREFIX_PATH="D:/Qt/6.9.3/msvc2022_64/lib/cmake"

--- a/alcedo_studio/src/app/editor_mask_creation_controller.cpp
+++ b/alcedo_studio/src/app/editor_mask_creation_controller.cpp
@@ -99,9 +99,64 @@ namespace {
   return false;
 }
 
+/// Field-edit keys: Mask fields settle through SetMaskField; the Brush feather
+/// is a source field and settles through ReplaceMaskSource.
+[[nodiscard]] auto MaskFieldEditKeyIsValid(std::string_view field_key, MaskSourceKind kind)
+    -> bool {
+  if (field_key == kMaskFieldBrushFeather) {
+    return kind == MaskSourceKind::Brush;
+  }
+  return field_key == kMaskFieldEnabled || field_key == kMaskFieldInvert ||
+         field_key == kMaskFieldOpacity || field_key == kMaskFieldDisplayName;
+}
+
+[[nodiscard]] auto MaskFieldAffectsPixels(std::string_view field_key) -> bool {
+  return field_key != kMaskFieldDisplayName;
+}
+
+[[nodiscard]] auto MaskFieldValueIsValid(std::string_view field_key, const nlohmann::json& value)
+    -> bool {
+  if (field_key == kMaskFieldEnabled || field_key == kMaskFieldInvert) {
+    return value.is_boolean();
+  }
+  if (field_key == kMaskFieldOpacity) {
+    return value.is_number() && std::isfinite(value.get<double>()) && value.get<double>() >= 0.0 &&
+           value.get<double>() <= 1.0;
+  }
+  if (field_key == kMaskFieldDisplayName) {
+    return value.is_string();
+  }
+  if (field_key == kMaskFieldBrushFeather) {
+    return value.is_number() && std::isfinite(value.get<double>()) && value.get<double>() >= 0.0;
+  }
+  return false;
+}
+
+[[nodiscard]] auto MaskFieldValueJson(const MaskModel& mask, std::string_view field_key)
+    -> nlohmann::json {
+  if (field_key == kMaskFieldEnabled) {
+    return mask.enabled;
+  }
+  if (field_key == kMaskFieldInvert) {
+    return mask.invert;
+  }
+  if (field_key == kMaskFieldOpacity) {
+    return mask.opacity;
+  }
+  if (field_key == kMaskFieldDisplayName) {
+    return mask.display_name;
+  }
+  if (field_key == kMaskFieldBrushFeather) {
+    if (const auto* brush = std::get_if<BrushMaskSource>(&mask.source)) {
+      return brush->feather_radius;
+    }
+  }
+  return nullptr;
+}
+
 }  // namespace
 
-void EditorMaskCreationController::Bind(PipelineDocument& document,
+void EditorMaskCreationController::Bind(PipelineDocument&      document,
                                         MiniGitWorkingHistory& history) {
   if (document_ == &document && history_ == &history) {
     return;
@@ -165,7 +220,7 @@ auto EditorMaskCreationController::IdentityMatches(const MaskPointerIdentity& id
 }
 
 auto EditorMaskCreationController::AllocateMaskId() const -> MaskId {
-  const auto* grade = Grade();
+  const auto* grade  = Grade();
   const char* prefix = "mask.radial.";
   if (kind_ == MaskSourceKind::LinearGradient) {
     prefix = "mask.linear.";
@@ -230,11 +285,11 @@ auto EditorMaskCreationController::InsertProvisional(const MaskSource& source) -
     return false;
   }
   try {
-    auto mask         = MakeCreationMask(source);
-    display_index_    = static_cast<std::uint32_t>(grade->MaskCount());
+    auto mask      = MakeCreationMask(source);
+    display_index_ = static_cast<std::uint32_t>(grade->MaskCount());
     grade->AddMask(std::move(mask), display_index_);
-    inserted_         = true;
-    draft_source_     = source;
+    inserted_     = true;
+    draft_source_ = source;
     return true;
   } catch (const std::exception&) {
     mask_id_ = MaskId{};
@@ -256,6 +311,9 @@ void EditorMaskCreationController::RestoreLive() {
       } else if (!before_source_.is_null()) {
         grade->ReplaceMaskSource(mask_id_, SourceFromJson(before_source_, mask_id_));
       }
+      if (!field_edit_key_.empty() && field_edit_key_ != kMaskFieldBrushFeather) {
+        (void)ApplyLiveMaskField(field_edit_key_, before_field_value_);
+      }
     }
   } catch (const std::exception&) {
   }
@@ -268,6 +326,8 @@ void EditorMaskCreationController::ClearOpenOperation() {
   handle_             = AnalyticMaskHandle::None;
   pointer_            = {};
   unwrapped_rotation_ = 0.0f;
+  field_edit_key_.clear();
+  before_field_value_ = nullptr;
   draft_source_.reset();
 }
 
@@ -326,7 +386,7 @@ auto EditorMaskCreationController::BeginCreation(MaskSourceKind kind, const Node
   if (document_ == nullptr || history_ == nullptr) {
     return Reject("Mask creation controller is not bound to a document");
   }
-  node_id_ = grade_id;
+  node_id_    = grade_id;
   auto* grade = Grade();
   if (grade == nullptr) {
     node_id_ = NodeId{};
@@ -351,12 +411,12 @@ auto EditorMaskCreationController::BeginCreation(MaskSourceKind kind, const Node
         return Reject("select an existing Brush before painting");
       }
     }
-    kind_          = MaskSourceKind::Brush;
-    session_       = session;
-    handle_        = AnalyticMaskHandle::None;
+    kind_    = MaskSourceKind::Brush;
+    session_ = session;
+    handle_  = AnalyticMaskHandle::None;
     draft_source_.reset();
-    terminated_    = false;
-    brush_tool_    = EditorBrushTool::Paint;
+    terminated_      = false;
+    brush_tool_      = EditorBrushTool::Paint;
     committed_brush_ = {};
     if (target.Empty()) {
       mask_id_       = MaskId{};
@@ -381,9 +441,9 @@ auto EditorMaskCreationController::BeginCreation(MaskSourceKind kind, const Node
   handle_        = AnalyticMaskHandle::None;
   before_source_ = nullptr;
   draft_source_.reset();
-  terminated_    = false;
-  brush_tool_    = EditorBrushTool::Idle;
-  state_         = EditorMaskCreationState::Creating;
+  terminated_ = false;
+  brush_tool_ = EditorBrushTool::Idle;
+  state_      = EditorMaskCreationState::Creating;
   return Ok();
 }
 
@@ -396,7 +456,7 @@ auto EditorMaskCreationController::SelectMask(const NodeId& grade_id, const Mask
   if (document_ == nullptr || history_ == nullptr) {
     return Reject("Mask creation controller is not bound to a document");
   }
-  node_id_ = grade_id;
+  node_id_    = grade_id;
   auto* grade = Grade();
   if (grade == nullptr) {
     node_id_ = NodeId{};
@@ -411,16 +471,16 @@ auto EditorMaskCreationController::SelectMask(const NodeId& grade_id, const Mask
       kind != MaskSourceKind::LinearGradient) {
     return Reject("Mask source kind is not selectable");
   }
-  kind_          = kind;
-  session_       = session;
-  mask_id_       = mask_id;
-  creating_      = false;
-  inserted_      = false;
-  handle_        = AnalyticMaskHandle::None;
-  before_source_ = MaskModelToJson(*mask).at("source");
-  draft_source_  = mask->source;
-  terminated_    = false;
-  brush_tool_    = EditorBrushTool::Idle;
+  kind_            = kind;
+  session_         = session;
+  mask_id_         = mask_id;
+  creating_        = false;
+  inserted_        = false;
+  handle_          = AnalyticMaskHandle::None;
+  before_source_   = MaskModelToJson(*mask).at("source");
+  draft_source_    = mask->source;
+  terminated_      = false;
+  brush_tool_      = EditorBrushTool::Idle;
   committed_brush_ = {};
   if (const auto* brush = std::get_if<BrushMaskSource>(&mask->source)) {
     committed_brush_ = *brush;
@@ -468,8 +528,8 @@ auto EditorMaskCreationController::RemoveMask(const NodeId& grade_id, const Mask
     return Reject("Mask is missing");
   }
   const auto next_selection = MaskIdAfterDeletion(ordered, mask_id, mask_id_);
-  const auto stored        = MaskModelToJson(grade->MaskAt(*index));
-  const auto batch         = MakeRemoveMaskBatch(grade_id, mask_id, stored, *index);
+  const auto stored         = MaskModelToJson(grade->MaskAt(*index));
+  const auto batch          = MakeRemoveMaskBatch(grade_id, mask_id, stored, *index);
   try {
     grade->RemoveMask(mask_id);
   } catch (const std::exception& ex) {
@@ -482,11 +542,11 @@ auto EditorMaskCreationController::RemoveMask(const NodeId& grade_id, const Mask
     } catch (const std::exception&) {
     }
     return Reject(settle_error.empty() ? std::string{"RemoveMask history publish failed"}
-                                        : settle_error);
+                                       : settle_error);
   }
   last_removed_mask_id_ = mask_id;
   if (next_selection.Empty()) {
-    mask_id_       = MaskId{};
+    mask_id_ = MaskId{};
     draft_source_.reset();
     before_source_ = nullptr;
     creating_      = false;
@@ -495,7 +555,7 @@ auto EditorMaskCreationController::RemoveMask(const NodeId& grade_id, const Mask
   } else if (next_selection != mask_id_) {
     const auto loaded = SelectMask(grade_id, next_selection, session_);
     if (!loaded.accepted) {
-      mask_id_       = MaskId{};
+      mask_id_ = MaskId{};
       draft_source_.reset();
       before_source_ = nullptr;
       state_         = EditorMaskCreationState::Inactive;
@@ -509,16 +569,226 @@ auto EditorMaskCreationController::RemoveMask(const NodeId& grade_id, const Mask
   return result;
 }
 
-auto EditorMaskCreationController::BeginMaskInput(MaskCreationSample sample,
+auto EditorMaskCreationController::BeginMaskFieldEdit(std::string field_key)
+    -> EditorMaskCreationResult {
+  if (open_) {
+    return Reject("finish or cancel the open Mask operation before editing Mask values");
+  }
+  if (state_ == EditorMaskCreationState::Settling) {
+    return Reject("Mask tool is unavailable until settle is acknowledged");
+  }
+  if (state_ != EditorMaskCreationState::Selected || mask_id_.Empty()) {
+    return Reject("Mask value edits require a selected existing Mask");
+  }
+  if (!MaskFieldEditKeyIsValid(field_key, kind_)) {
+    return Reject("Mask value key is not editable: " + field_key);
+  }
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return Reject("selection target is not a Color Grade");
+  }
+  const auto* mask = grade->FindMask(mask_id_);
+  if (mask == nullptr) {
+    return Reject("Mask is missing");
+  }
+  field_edit_key_     = std::move(field_key);
+  before_field_value_ = MaskFieldValueJson(*mask, field_edit_key_);
+  if (field_edit_key_ == kMaskFieldBrushFeather) {
+    before_source_   = MaskModelToJson(*mask).at("source");
+    committed_brush_ = *std::get_if<BrushMaskSource>(&mask->source);
+    draft_source_    = mask->source;
+  }
+  handle_        = AnalyticMaskHandle::None;
+  open_          = true;
+  terminated_    = false;
+  state_         = EditorMaskCreationState::Editing;
+  auto result    = Ok();
+  result.mask_id = mask_id_;
+  return result;
+}
+
+auto EditorMaskCreationController::ApplyLiveMaskField(const std::string&    field_key,
+                                                      const nlohmann::json& value) -> bool {
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return false;
+  }
+  auto* mask = grade->FindMask(mask_id_);
+  if (mask == nullptr) {
+    return false;
+  }
+  try {
+    if (field_key == kMaskFieldEnabled) {
+      grade->SetMaskEnabled(mask_id_, value.get<bool>());
+    } else if (field_key == kMaskFieldInvert) {
+      grade->SetMaskInvert(mask_id_, value.get<bool>());
+    } else if (field_key == kMaskFieldOpacity) {
+      grade->SetMaskOpacity(mask_id_, value.get<float>());
+    } else if (field_key == kMaskFieldDisplayName) {
+      mask->display_name = value.get<std::string>();
+    } else if (field_key == kMaskFieldBrushFeather) {
+      if (const auto* brush = std::get_if<BrushMaskSource>(&mask->source)) {
+        auto next           = *brush;
+        next.feather_radius = value.get<float>();
+        grade->ReplaceMaskSource(mask_id_, std::move(next));
+        draft_source_ = grade->FindMask(mask_id_)->source;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  } catch (const std::exception&) {
+    return false;
+  }
+  return true;
+}
+
+auto EditorMaskCreationController::ApplyMaskFieldValue(std::string    field_key,
+                                                       nlohmann::json after_value)
+    -> EditorMaskCreationResult {
+  if (open_) {
+    if (field_edit_key_.empty() || field_edit_key_ != field_key) {
+      return Reject("Mask value does not match the open Mask edit");
+    }
+    if (!MaskFieldValueIsValid(field_key, after_value)) {
+      return Reject("Mask value is invalid for '" + field_key + "'");
+    }
+    if (!ApplyLiveMaskField(field_key, after_value)) {
+      return Reject("Mask value apply was rejected");
+    }
+    auto result    = Ok();
+    result.mask_id = mask_id_;
+    if (MaskFieldAffectsPixels(field_key)) {
+      RequestInteractive(result);
+    }
+    return result;
+  }
+  if (state_ == EditorMaskCreationState::Settling) {
+    return Reject("Mask tool is unavailable until settle is acknowledged");
+  }
+  if (state_ != EditorMaskCreationState::Selected || mask_id_.Empty()) {
+    return Reject("Mask value edits require a selected existing Mask");
+  }
+  if (!MaskFieldEditKeyIsValid(field_key, kind_)) {
+    return Reject("Mask value key is not editable: " + field_key);
+  }
+  if (!MaskFieldValueIsValid(field_key, after_value)) {
+    return Reject("Mask value is invalid for '" + field_key + "'");
+  }
+  auto* grade = Grade();
+  if (grade == nullptr) {
+    return Reject("selection target is not a Color Grade");
+  }
+  const auto* mask = grade->FindMask(mask_id_);
+  if (mask == nullptr) {
+    return Reject("Mask is missing");
+  }
+  const auto before = MaskFieldValueJson(*mask, field_key);
+  if (before == after_value) {
+    auto result    = Ok();
+    result.mask_id = mask_id_;
+    return result;
+  }
+  const auto before_source = MaskModelToJson(*mask).at("source");
+  if (!ApplyLiveMaskField(field_key, after_value)) {
+    return Reject("Mask value apply was rejected");
+  }
+  PipelineEditBatch batch;
+  if (field_key == kMaskFieldBrushFeather) {
+    const auto after_source = LiveSourceJson();
+    if (after_source.is_null()) {
+      state_ = EditorMaskCreationState::Failed;
+      return Reject("Mask source is missing at settle");
+    }
+    batch = MakeReplaceMaskSourceBatch(node_id_, mask_id_, before_source, after_source);
+  } else {
+    batch = MakeSetMaskFieldBatch(node_id_, mask_id_, field_key, before, after_value);
+  }
+  std::string settle_error;
+  if (!PublishSettledBatch(batch, &settle_error)) {
+    (void)ApplyLiveMaskField(field_key, before);
+    state_ = EditorMaskCreationState::Failed;
+    return Reject(settle_error.empty() ? std::string{"Mask value history publish failed"}
+                                       : settle_error);
+  }
+  if (const auto* updated = grade->FindMask(mask_id_)) {
+    if (const auto* brush = std::get_if<BrushMaskSource>(&updated->source)) {
+      committed_brush_ = *brush;
+    }
+    before_source_ = MaskModelToJson(*updated).at("source");
+    draft_source_  = updated->source;
+  }
+  auto result              = Ok();
+  result.mask_id           = mask_id_;
+  result.committed         = true;
+  result.quality_requested = MaskFieldAffectsPixels(field_key);
+  return result;
+}
+
+auto EditorMaskCreationController::PublishMaskFieldEdit() -> EditorMaskCreationResult {
+  const auto field_key = field_edit_key_;
+  auto*      grade     = Grade();
+  if (grade == nullptr) {
+    state_ = EditorMaskCreationState::Failed;
+    return Reject("Mask value settle is missing the Grade");
+  }
+  const auto* mask = grade->FindMask(mask_id_);
+  if (mask == nullptr) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject("Mask is missing at value settle");
+  }
+  const auto after = MaskFieldValueJson(*mask, field_key);
+  if (after == before_field_value_) {
+    ClearOpenOperation();
+    state_ = EditorMaskCreationState::Selected;
+    return Ok();
+  }
+  PipelineEditBatch batch;
+  if (field_key == kMaskFieldBrushFeather) {
+    const auto after_source = LiveSourceJson();
+    if (after_source.is_null()) {
+      RestoreLive();
+      state_ = EditorMaskCreationState::Failed;
+      return Reject("Mask source is missing at value settle");
+    }
+    batch = MakeReplaceMaskSourceBatch(node_id_, mask_id_, before_source_, after_source);
+  } else {
+    batch = MakeSetMaskFieldBatch(node_id_, mask_id_, field_key, before_field_value_, after);
+  }
+  std::string settle_error;
+  if (!PublishSettledBatch(batch, &settle_error)) {
+    RestoreLive();
+    state_ = EditorMaskCreationState::Failed;
+    return Reject(settle_error.empty() ? std::string{"Mask value history publish failed"}
+                                       : settle_error);
+  }
+  ClearOpenOperation();
+  if (const auto* updated = grade->FindMask(mask_id_)) {
+    if (const auto* brush = std::get_if<BrushMaskSource>(&updated->source)) {
+      committed_brush_ = *brush;
+    }
+    before_source_ = MaskModelToJson(*updated).at("source");
+    draft_source_  = updated->source;
+  }
+  state_                   = EditorMaskCreationState::Settling;
+  auto result              = Ok();
+  result.mask_id           = mask_id_;
+  result.committed         = true;
+  result.quality_requested = MaskFieldAffectsPixels(field_key);
+  return result;
+}
+
+auto EditorMaskCreationController::BeginMaskInput(MaskCreationSample  sample,
                                                   MaskPointerIdentity identity)
     -> EditorMaskCreationResult {
   if (state_ == EditorMaskCreationState::Settling) {
     return Reject("Mask tool is unavailable until settle is acknowledged");
   }
   if (kind_ == MaskSourceKind::Brush && IsBrushPaintTool(brush_tool_)) {
-    const bool armed =
-        (state_ == EditorMaskCreationState::Creating && !open_) ||
-        (state_ == EditorMaskCreationState::Selected && !open_ && !mask_id_.Empty());
+    const bool armed = (state_ == EditorMaskCreationState::Creating && !open_) ||
+                       (state_ == EditorMaskCreationState::Selected && !open_ && !mask_id_.Empty());
     if (!armed) {
       return Reject("BeginMaskInput requires an armed Brush paint or erase tool");
     }
@@ -552,8 +822,8 @@ auto EditorMaskCreationController::BeginMaskInput(MaskCreationSample sample,
   return Ok();
 }
 
-auto EditorMaskCreationController::BeginMaskMove(AnalyticMaskHandle handle,
-                                                 MaskCreationSample sample,
+auto EditorMaskCreationController::BeginMaskMove(AnalyticMaskHandle  handle,
+                                                 MaskCreationSample  sample,
                                                  MaskPointerIdentity identity)
     -> EditorMaskCreationResult {
   if (state_ == EditorMaskCreationState::Settling) {
@@ -598,10 +868,10 @@ auto EditorMaskCreationController::BeginMaskMove(AnalyticMaskHandle handle,
     before_translation_     = brush->placement_translation;
     press_reference_pixels_ = sample.reference_pixels;
   }
-  open_        = true;
-  terminated_  = false;
-  state_       = EditorMaskCreationState::Editing;
-  auto result  = Ok();
+  open_          = true;
+  terminated_    = false;
+  state_         = EditorMaskCreationState::Editing;
+  auto result    = Ok();
   result.mask_id = mask_id_;
   return result;
 }
@@ -641,7 +911,8 @@ auto EditorMaskCreationController::UpdateExisting(const MaskCreationSample& samp
   if (mask == nullptr) {
     return Reject("Mask is missing");
   }
-  auto next = ApplyAnalyticMaskHandle(handle_, mask->source, sample.normalized, unwrapped_rotation_);
+  auto next =
+      ApplyAnalyticMaskHandle(handle_, mask->source, sample.normalized, unwrapped_rotation_);
   if (!next) {
     return Reject("analytic handle update is not valid");
   }
@@ -659,7 +930,7 @@ auto EditorMaskCreationController::UpdateExisting(const MaskCreationSample& samp
   return result;
 }
 
-auto EditorMaskCreationController::AppendMaskInput(MaskCreationSample sample,
+auto EditorMaskCreationController::AppendMaskInput(MaskCreationSample  sample,
                                                    MaskPointerIdentity identity)
     -> EditorMaskCreationResult {
   if (!open_ || terminated_) {
@@ -684,7 +955,7 @@ auto EditorMaskCreationController::AppendMaskInput(MaskCreationSample sample,
 }
 
 auto EditorMaskCreationController::PublishSettledBatch(const PipelineEditBatch& batch,
-                                                       std::string* error) -> bool {
+                                                       std::string*             error) -> bool {
   if (settle_publisher_) {
     return settle_publisher_(batch, error);
   }
@@ -717,8 +988,7 @@ auto EditorMaskCreationController::PublishAddMask() -> EditorMaskCreationResult 
     state_ = EditorMaskCreationState::Failed;
     return Reject("provisional Mask is missing at settle");
   }
-  const auto batch =
-      MakeAddMaskBatch(node_id_, mask_id_, MaskModelToJson(*mask), display_index_);
+  const auto  batch = MakeAddMaskBatch(node_id_, mask_id_, MaskModelToJson(*mask), display_index_);
   std::string settle_error;
   if (!PublishSettledBatch(batch, &settle_error)) {
     RestoreLive();
@@ -728,12 +998,12 @@ auto EditorMaskCreationController::PublishAddMask() -> EditorMaskCreationResult 
                                        : settle_error);
   }
   ClearOpenOperation();
-  creating_      = false;
-  inserted_      = false;
-  before_source_ = MaskModelToJson(*mask).at("source");
-  draft_source_  = mask->source;
-  state_         = EditorMaskCreationState::Settling;
-  auto result    = Ok();
+  creating_                = false;
+  inserted_                = false;
+  before_source_           = MaskModelToJson(*mask).at("source");
+  draft_source_            = mask->source;
+  state_                   = EditorMaskCreationState::Settling;
+  auto result              = Ok();
   result.mask_id           = mask_id_;
   result.committed         = true;
   result.quality_requested = true;
@@ -756,7 +1026,7 @@ auto EditorMaskCreationController::PublishReplaceSource() -> EditorMaskCreationR
     state_ = EditorMaskCreationState::Failed;
     return Reject("ReplaceMaskSource settle is missing history");
   }
-  const auto batch = MakeReplaceMaskSourceBatch(node_id_, mask_id_, before_source_, after);
+  const auto  batch = MakeReplaceMaskSourceBatch(node_id_, mask_id_, before_source_, after);
   std::string settle_error;
   if (!PublishSettledBatch(batch, &settle_error)) {
     RestoreLive();
@@ -771,8 +1041,8 @@ auto EditorMaskCreationController::PublishReplaceSource() -> EditorMaskCreationR
       draft_source_ = mask->source;
     }
   }
-  state_      = EditorMaskCreationState::Settling;
-  auto result = Ok();
+  state_                   = EditorMaskCreationState::Settling;
+  auto result              = Ok();
   result.mask_id           = mask_id_;
   result.committed         = true;
   result.quality_requested = true;
@@ -781,9 +1051,12 @@ auto EditorMaskCreationController::PublishReplaceSource() -> EditorMaskCreationR
 
 auto EditorMaskCreationController::FinishMaskInput() -> EditorMaskCreationResult {
   if (!open_) {
-    auto result = Ok();
+    auto result    = Ok();
     result.mask_id = mask_id_;
     return result;
+  }
+  if (!field_edit_key_.empty()) {
+    return PublishMaskFieldEdit();
   }
   if (creating_ && !inserted_) {
     ClearOpenOperation();
@@ -810,8 +1083,8 @@ auto EditorMaskCreationController::CancelMaskInput() -> EditorMaskCreationResult
   const auto id = mask_id_;
   ClearOpenOperation();
   if (creating_) {
-    inserted_      = false;
-    mask_id_       = MaskId{};
+    inserted_ = false;
+    mask_id_  = MaskId{};
     draft_source_.reset();
     before_source_ = nullptr;
     state_         = EditorMaskCreationState::Inactive;
@@ -999,8 +1272,8 @@ auto EditorMaskCreationController::UpdateBrushMove(const MaskCreationSample& sam
   if (grade->FindMask(mask_id_) == nullptr) {
     return Reject("Mask is missing");
   }
-  const auto after = BrushPlacementForReferenceDrag(before_translation_, press_reference_pixels_,
-                                                    sample.reference_pixels);
+  const auto after   = BrushPlacementForReferenceDrag(before_translation_, press_reference_pixels_,
+                                                      sample.reference_pixels);
   const auto current = grade->BrushPlacementTranslation(mask_id_);
   if (current == after) {
     auto result    = Ok();
@@ -1008,12 +1281,12 @@ auto EditorMaskCreationController::UpdateBrushMove(const MaskCreationSample& sam
     return result;
   }
   try {
-    grade->SetBrushTranslation(MakeBrushTranslationCommand(
-        node_id_, mask_id_, current, after, grade->MaskContentRevision(mask_id_)));
+    grade->SetBrushTranslation(MakeBrushTranslationCommand(node_id_, mask_id_, current, after,
+                                                           grade->MaskContentRevision(mask_id_)));
   } catch (const std::exception& ex) {
     return Reject(ex.what());
   }
-  draft_source_ = grade->FindMask(mask_id_)->source;
+  draft_source_  = grade->FindMask(mask_id_)->source;
   auto result    = Ok();
   result.mask_id = mask_id_;
   RequestInteractive(result);
@@ -1029,7 +1302,7 @@ auto EditorMaskCreationController::FinishBrushStroke() -> EditorMaskCreationResu
     state_ = EditorMaskCreationState::Failed;
     return Reject(ex.what());
   }
-  auto brush = committed_brush_;
+  auto       brush = committed_brush_;
   const auto index = FindBrushStrokeIndex(brush.strokes, stroke.id);
   if (index == brush.strokes.size()) {
     brush.strokes.push_back(stroke);
@@ -1055,7 +1328,7 @@ auto EditorMaskCreationController::PublishAppendStroke(BrushStroke stroke)
     state_ = EditorMaskCreationState::Failed;
     return Reject("AppendBrushStroke settle is missing history");
   }
-  const auto batch = MakeAppendBrushStrokeBatch(node_id_, mask_id_, std::move(stroke));
+  const auto  batch = MakeAppendBrushStrokeBatch(node_id_, mask_id_, std::move(stroke));
   std::string settle_error;
   if (!PublishSettledBatch(batch, &settle_error)) {
     RestoreLive();
@@ -1103,7 +1376,7 @@ auto EditorMaskCreationController::PublishSetTranslation() -> EditorMaskCreation
     state_ = EditorMaskCreationState::Selected;
     return Ok();
   }
-  const auto batch = MakeSetBrushTranslationBatch(node_id_, mask_id_, before_translation_, after);
+  const auto  batch = MakeSetBrushTranslationBatch(node_id_, mask_id_, before_translation_, after);
   std::string settle_error;
   if (!PublishSettledBatch(batch, &settle_error)) {
     RestoreLive();

--- a/alcedo_studio/src/app/editor_mask_creation_controller.cpp
+++ b/alcedo_studio/src/app/editor_mask_creation_controller.cpp
@@ -321,14 +321,15 @@ void EditorMaskCreationController::RestoreLive() {
 
 void EditorMaskCreationController::ClearOpenOperation() {
   brush_input_.Cancel();
-  open_               = false;
-  terminated_         = true;
-  handle_             = AnalyticMaskHandle::None;
-  pointer_            = {};
-  unwrapped_rotation_ = 0.0f;
+  open_                    = false;
+  terminated_              = true;
+  handle_                  = AnalyticMaskHandle::None;
+  pointer_                 = {};
+  unwrapped_rotation_      = 0.0f;
   field_edit_key_.clear();
-  before_field_value_ = nullptr;
+  before_field_value_      = nullptr;
   draft_source_.reset();
+  published_draft_samples_ = 0;
 }
 
 void EditorMaskCreationController::ResetMode() {
@@ -781,10 +782,15 @@ auto EditorMaskCreationController::PublishMaskFieldEdit() -> EditorMaskCreationR
 }
 
 auto EditorMaskCreationController::BeginMaskInput(MaskCreationSample  sample,
-                                                  MaskPointerIdentity identity)
+                                                  MaskPointerIdentity identity,
+                                                  MaskSourceKind      expected_source,
+                                                  float default_feather_reference_px)
     -> EditorMaskCreationResult {
   if (state_ == EditorMaskCreationState::Settling) {
     return Reject("Mask tool is unavailable until settle is acknowledged");
+  }
+  if (expected_source != kind_) {
+    return Reject("stale Mask tool dispatch does not match the armed source kind");
   }
   if (kind_ == MaskSourceKind::Brush && IsBrushPaintTool(brush_tool_)) {
     const bool armed = (state_ == EditorMaskCreationState::Creating && !open_) ||
@@ -792,13 +798,16 @@ auto EditorMaskCreationController::BeginMaskInput(MaskCreationSample  sample,
     if (!armed) {
       return Reject("BeginMaskInput requires an armed Brush paint or erase tool");
     }
+    if (brush_tool_ == EditorBrushTool::Erase && mask_id_.Empty()) {
+      return Reject("Brush erase requires an existing Brush");
+    }
     if (!FiniteSample(sample) || !sample.inside_photograph) {
       return Reject("Mask press must lie inside the photograph");
     }
     pointer_                = identity;
     press_normalized_       = sample.normalized;
     press_reference_pixels_ = sample.reference_pixels;
-    return BeginBrushStroke(sample);
+    return BeginBrushStroke(sample, default_feather_reference_px);
   }
   if (state_ != EditorMaskCreationState::Creating || open_) {
     return Reject("BeginMaskInput requires an armed creation tool");
@@ -824,10 +833,14 @@ auto EditorMaskCreationController::BeginMaskInput(MaskCreationSample  sample,
 
 auto EditorMaskCreationController::BeginMaskMove(AnalyticMaskHandle  handle,
                                                  MaskCreationSample  sample,
-                                                 MaskPointerIdentity identity)
+                                                 MaskPointerIdentity identity,
+                                                 MaskSourceKind      expected_source)
     -> EditorMaskCreationResult {
   if (state_ == EditorMaskCreationState::Settling) {
     return Reject("Mask tool is unavailable until settle is acknowledged");
+  }
+  if (expected_source != kind_) {
+    return Reject("stale Mask tool dispatch does not match the selected source kind");
   }
   if (state_ != EditorMaskCreationState::Selected || open_) {
     return Reject("BeginMaskMove requires a selected existing Mask");
@@ -879,10 +892,15 @@ auto EditorMaskCreationController::BeginMaskMove(AnalyticMaskHandle  handle,
 auto EditorMaskCreationController::UpdateCreation(const MaskCreationSample& sample)
     -> EditorMaskCreationResult {
   MaskSource next;
-  if (kind_ == MaskSourceKind::Radial) {
-    next = RadialFromCenterOut(press_normalized_, sample.normalized);
-  } else {
-    next = LinearFromEndpoints(press_normalized_, sample.normalized);
+  switch (kind_) {
+    case MaskSourceKind::Radial:
+      next = RadialFromCenterOut(press_normalized_, sample.normalized);
+      break;
+    case MaskSourceKind::LinearGradient:
+      next = LinearFromEndpoints(press_normalized_, sample.normalized);
+      break;
+    case MaskSourceKind::Brush:
+      return Reject("Brush input must route through the Brush stroke path");
   }
   draft_source_ = next;
   if (!CreationSourceValid(next)) {
@@ -942,14 +960,17 @@ auto EditorMaskCreationController::AppendMaskInput(MaskCreationSample  sample,
   if (!FiniteSample(sample)) {
     return Reject("Mask sample is not finite");
   }
-  if (creating_) {
-    return UpdateCreation(sample);
-  }
+  // Brush strokes keep `creating_` armed until PublishAddMask, so the open
+  // Brush input must win over the analytic creation path; otherwise the first
+  // stroke's appends would replace the live source with a Linear draft.
   if (kind_ == MaskSourceKind::Brush && brush_input_.IsOpen()) {
     return UpdateBrushPaint(sample);
   }
   if (kind_ == MaskSourceKind::Brush && handle_ == AnalyticMaskHandle::BrushMove) {
     return UpdateBrushMove(sample);
+  }
+  if (creating_) {
+    return UpdateCreation(sample);
   }
   return UpdateExisting(sample);
 }
@@ -1134,6 +1155,9 @@ auto EditorMaskCreationController::SetBrushTool(EditorBrushTool tool) -> EditorM
   if (tool == EditorBrushTool::Move && (creating_ || mask_id_.Empty())) {
     return Reject("Brush move requires an existing Brush");
   }
+  if (tool == EditorBrushTool::Erase && mask_id_.Empty()) {
+    return Reject("Brush erase requires an existing Brush");
+  }
   brush_tool_ = tool;
   if (IsBrushPaintTool(tool)) {
     brush_input_.SetStrokeMode(BrushStrokeModeFromTool());
@@ -1146,6 +1170,14 @@ auto EditorMaskCreationController::SetBrushTool(EditorBrushTool tool) -> EditorM
 auto EditorMaskCreationController::SetBrushStrokeParameters(float radius, float strength,
                                                             float hardness)
     -> EditorMaskCreationResult {
+  if (radius == brush_input_.radius() && strength == brush_input_.strength() &&
+      hardness == brush_input_.hardness()) {
+    // Queued appends re-send the current parameters; an unchanged set must not
+    // republish the draft or schedule a render.
+    auto result    = Ok();
+    result.mask_id = mask_id_;
+    return result;
+  }
   try {
     brush_input_.SetStrokeParameters(radius, strength, hardness);
   } catch (const std::exception& ex) {
@@ -1159,6 +1191,7 @@ auto EditorMaskCreationController::SetBrushStrokeParameters(float radius, float 
   if (!ApplyLiveBrushDraft()) {
     return Reject("Brush parameter update was rejected");
   }
+  published_draft_samples_ = brush_input_.DraftSamples().size();
   auto result    = Ok();
   result.mask_id = mask_id_;
   RequestInteractive(result);
@@ -1199,7 +1232,8 @@ auto EditorMaskCreationController::ApplyLiveBrushDraft() -> bool {
   return ApplyLiveSource(source);
 }
 
-auto EditorMaskCreationController::BeginBrushStroke(const MaskCreationSample& sample)
+auto EditorMaskCreationController::BeginBrushStroke(const MaskCreationSample& sample,
+                                                    float default_feather_reference_px)
     -> EditorMaskCreationResult {
   auto* grade = Grade();
   if (grade == nullptr) {
@@ -1220,7 +1254,10 @@ auto EditorMaskCreationController::BeginBrushStroke(const MaskCreationSample& sa
     translation      = brush->placement_translation;
   } else {
     committed_brush_ = {};
-    before_source_   = nullptr;
+    if (std::isfinite(default_feather_reference_px) && default_feather_reference_px > 0.0f) {
+      committed_brush_.feather_radius = default_feather_reference_px;
+    }
+    before_source_ = nullptr;
   }
   const auto stroke_id = AllocateStrokeId();
   if (stroke_id.Empty()) {
@@ -1241,6 +1278,7 @@ auto EditorMaskCreationController::BeginBrushStroke(const MaskCreationSample& sa
     open_ = false;
     return Reject("provisional Brush stroke was rejected");
   }
+  published_draft_samples_ = brush_input_.DraftSamples().size();
   auto result    = Ok();
   result.mask_id = mask_id_;
   RequestInteractive(result);
@@ -1254,9 +1292,18 @@ auto EditorMaskCreationController::UpdateBrushPaint(const MaskCreationSample& sa
   } catch (const std::exception& ex) {
     return Reject(ex.what());
   }
+  const auto draft_count = brush_input_.DraftSamples().size();
+  if (draft_count == published_draft_samples_) {
+    // The append emitted no new canonical dab: the live source is unchanged, so
+    // neither a republish nor an Interactive frame is needed.
+    auto result    = Ok();
+    result.mask_id = mask_id_;
+    return result;
+  }
   if (!ApplyLiveBrushDraft()) {
     return Reject("provisional Brush source was rejected");
   }
+  published_draft_samples_ = draft_count;
   auto result    = Ok();
   result.mask_id = mask_id_;
   RequestInteractive(result);
@@ -1301,6 +1348,31 @@ auto EditorMaskCreationController::FinishBrushStroke() -> EditorMaskCreationResu
     RestoreLive();
     state_ = EditorMaskCreationState::Failed;
     return Reject(ex.what());
+  }
+  const bool unchanged =
+      stroke.mode == BrushStrokeMode::Paint
+          ? !BrushStrokeHasCoverageEffect(stroke)
+          : !BrushEraseOverlapsPaint(stroke, committed_brush_);
+  if (unchanged) {
+    // Confirmed no-change stroke: restore the live draft and stay armed without
+    // producing a history commit.
+    const auto id = mask_id_;
+    RestoreLive();
+    ClearOpenOperation();
+    if (creating_) {
+      inserted_      = false;
+      mask_id_       = MaskId{};
+      before_source_ = nullptr;
+      state_         = EditorMaskCreationState::Creating;
+    } else {
+      state_ = EditorMaskCreationState::Selected;
+      if (Grade() != nullptr && Grade()->FindMask(id) != nullptr) {
+        mask_id_       = id;
+        before_source_ = MaskModelToJson(*Grade()->FindMask(id)).at("source");
+        draft_source_  = Grade()->FindMask(id)->source;
+      }
+    }
+    return Ok();
   }
   auto       brush = committed_brush_;
   const auto index = FindBrushStrokeIndex(brush.strokes, stroke.id);

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1296,7 +1296,8 @@ auto EditorSessionService::ApplyMaskCreationCommand(const EditorMaskCreationComm
           return tool;
         }
       }
-      return mask_creation_.BeginMaskInput(command.sample, command.identity);
+      return mask_creation_.BeginMaskInput(command.sample, command.identity, command.source_kind,
+                                           command.default_feather_reference_px);
     case EditorMaskCreationCommandKind::BeginMove:
       if (command.brush_tool == EditorBrushTool::Move) {
         const auto tool = mask_creation_.SetBrushTool(EditorBrushTool::Move);
@@ -1304,7 +1305,8 @@ auto EditorSessionService::ApplyMaskCreationCommand(const EditorMaskCreationComm
           return tool;
         }
       }
-      return mask_creation_.BeginMaskMove(command.handle, command.sample, command.identity);
+      return mask_creation_.BeginMaskMove(command.handle, command.sample, command.identity,
+                                          command.source_kind);
     case EditorMaskCreationCommandKind::Append:
       if (command.brush_radius > 0.0f) {
         const auto parameters = mask_creation_.SetBrushStrokeParameters(

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -260,6 +260,10 @@ void EditorSessionService::HandleRenderEvent(const EditorRenderEvent& event) {
     result.identity = lifecycle_.identity();
     BumpHistoryRevision();
   }
+  if (event.kind == EditorRenderEventKind::RenderReused) {
+    EmitQuiet(std::move(result));
+    return;
+  }
   Emit(std::move(result));
 }
 
@@ -346,6 +350,18 @@ auto EditorSessionService::Emit(EditorSessionResult result) -> EditorSessionResu
   } else {
     NotifyChange();
   }
+  return result;
+}
+
+auto EditorSessionService::EmitQuiet(EditorSessionResult result) -> EditorSessionResult {
+  if (result.operation_id == 0) {
+    result.operation_id = current_operation_id_;
+  }
+  {
+    std::scoped_lock lock(results_mutex_);
+    results_.push_back(result);
+  }
+  NotifyResult(result);
   return result;
 }
 
@@ -1915,13 +1931,16 @@ void EditorSessionService::SetPresentationSize(int width, int height) {
       accepted.state    = lifecycle_.state();
       accepted.identity = lifecycle_.identity();
       accepted.message  = "Presentation size updated";
-      NotifyChange();
+      // The presentation size is a render input consumed by the next render
+      // intent; no session-visible field moves, so per-frame resize bursts
+      // (panel fold, window drag) must not publish a change notification.
       return accepted;
     });
     return;
   }
   render_.SetPresentationSize(width, height);
-  NotifyChange();
+  // An enclosing command's own Emit publishes; the size itself is invisible
+  // to change observers.
 }
 
 void EditorSessionService::SetGeometryOverlayActive(bool active) {
@@ -2014,6 +2033,12 @@ auto EditorSessionService::RequestViewChange(EditorRenderReason                 
       result.kind    = EditorSessionResultKind::Rejected;
       result.message = event.message;
       break;
+  }
+  if (event.kind == EditorRenderEventKind::RenderReused) {
+    // A reused frame changes no session-visible state; deliver the result
+    // without a change notification so continuous view churn (panel fold,
+    // window resize, zoom/pan) does not run a full backend refresh per frame.
+    return EmitQuiet(std::move(result));
   }
   return Emit(std::move(result));
 }

--- a/alcedo_studio/src/app/editor_session_service.cpp
+++ b/alcedo_studio/src/app/editor_session_service.cpp
@@ -1174,7 +1174,9 @@ auto EditorSessionService::EnqueueMaskCreation(EditorMaskCreationCommand command
                                   pending.kind == EditorMaskCreationCommandKind::BeginInput ||
                                   pending.kind == EditorMaskCreationCommandKind::Append ||
                                   pending.kind == EditorMaskCreationCommandKind::Finish ||
-                                  pending.kind == EditorMaskCreationCommandKind::Cancel;
+                                  pending.kind == EditorMaskCreationCommandKind::Cancel ||
+                                  pending.kind == EditorMaskCreationCommandKind::BeginMaskField ||
+                                  pending.kind == EditorMaskCreationCommandKind::SetMaskField;
                          }),
           pending_mask_commands_.end());
     }
@@ -1189,7 +1191,9 @@ auto EditorSessionService::EnqueueMaskCreation(EditorMaskCreationCommand command
                                   pending.kind == EditorMaskCreationCommandKind::BeginMove ||
                                   pending.kind == EditorMaskCreationCommandKind::Finish ||
                                   pending.kind == EditorMaskCreationCommandKind::FinishMode ||
-                                  pending.kind == EditorMaskCreationCommandKind::BeginInput;
+                                  pending.kind == EditorMaskCreationCommandKind::BeginInput ||
+                                  pending.kind == EditorMaskCreationCommandKind::BeginMaskField ||
+                                  pending.kind == EditorMaskCreationCommandKind::SetMaskField;
                          }),
           pending_mask_commands_.end());
     }
@@ -1323,8 +1327,12 @@ auto EditorSessionService::ApplyMaskCreationCommand(const EditorMaskCreationComm
     case EditorMaskCreationCommandKind::SetBrushTool:
       return mask_creation_.SetBrushTool(command.brush_tool);
     case EditorMaskCreationCommandKind::SetBrushStrokeParameters:
-      return mask_creation_.SetBrushStrokeParameters(
-          command.brush_radius, command.brush_strength, command.brush_hardness);
+      return mask_creation_.SetBrushStrokeParameters(command.brush_radius, command.brush_strength,
+                                                     command.brush_hardness);
+    case EditorMaskCreationCommandKind::BeginMaskField:
+      return mask_creation_.BeginMaskFieldEdit(command.field_key);
+    case EditorMaskCreationCommandKind::SetMaskField:
+      return mask_creation_.ApplyMaskFieldValue(command.field_key, command.field_value);
   }
   EditorMaskCreationResult rejected;
   rejected.error = "unknown Mask creation command";

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -48,6 +48,7 @@ def_library(EditMaskStore
         ${ALCEDO_SRC_ROOT}/edit/mask/brush_signed_distance.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/grade_mask_coverage.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/parameterized_brush_raster.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/parameterized_brush_replay_cache.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/active_raster_mask.cpp
     PUBLIC_DEPS EditGeometry JSON
     PRIVATE_DEPS xxHash

--- a/alcedo_studio/src/edit/CMakeLists.txt
+++ b/alcedo_studio/src/edit/CMakeLists.txt
@@ -49,6 +49,7 @@ def_library(EditMaskStore
         ${ALCEDO_SRC_ROOT}/edit/mask/grade_mask_coverage.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/parameterized_brush_raster.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/parameterized_brush_replay_cache.cpp
+        ${ALCEDO_SRC_ROOT}/edit/mask/brush_coverage_update.cpp
         ${ALCEDO_SRC_ROOT}/edit/mask/active_raster_mask.cpp
     PUBLIC_DEPS EditGeometry JSON
     PRIVATE_DEPS xxHash
@@ -174,6 +175,7 @@ if(ALCEDO_CUDA_ENABLED)
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_neighbor_grade.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_local_tone_pass.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_mask_pass.cu
+            ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_brush_raster.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_plan_executor.cpp
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_product_renderer.cu
             ${ALCEDO_SRC_ROOT}/edit/runtime/cuda/cuda_primary_grade_pass.cu

--- a/alcedo_studio/src/edit/mask/brush_coverage_update.cpp
+++ b/alcedo_studio/src/edit/mask/brush_coverage_update.cpp
@@ -1,0 +1,203 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_coverage_update.hpp"
+
+#include <algorithm>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/brush_stroke.hpp"
+
+namespace alcedo {
+namespace {
+
+[[nodiscard]] auto SamplesEqual(std::span<const BrushCanonicalSample> lhs,
+                                std::span<const BrushCanonicalSample> rhs) -> bool {
+  return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
+}
+
+[[nodiscard]] auto SamplesArePrefix(std::span<const BrushCanonicalSample> prefix,
+                                    std::span<const BrushCanonicalSample> full) -> bool {
+  return prefix.size() <= full.size() &&
+         std::equal(prefix.begin(), prefix.end(), full.begin());
+}
+
+[[nodiscard]] auto StrokeIdentityMatches(const BrushStroke& lhs, const BrushStroke& rhs) -> bool {
+  return lhs.id == rhs.id && lhs.mode == rhs.mode;
+}
+
+[[nodiscard]] auto UnionNewSampleSupports(const BrushStroke& stroke, Vector2 translation,
+                                          std::size_t sample_begin, std::size_t sample_end,
+                                          Extent2D raster, Extent2D full_reference) -> RectI {
+  RectI       dirty{};
+  const auto  samples = BrushStrokeSamples(stroke);
+  const auto  end     = std::min(sample_end, samples.size());
+  for (auto i = sample_begin; i < end; ++i) {
+    dirty = UnionTexelRect(dirty, BrushDabOutputTexelSupport(samples[i], translation, raster,
+                                                             full_reference));
+  }
+  return ClipTexelRect(dirty, raster);
+}
+
+[[nodiscard]] auto ChangedStrokeDirty(const BrushMaskSource& previous, const BrushMaskSource& next,
+                                      Extent2D raster, Extent2D full_reference) -> RectI {
+  RectI      dirty{};
+  const auto common = std::min(previous.strokes.size(), next.strokes.size());
+  for (std::size_t i = 0; i < common; ++i) {
+    const auto& before = previous.strokes[i];
+    const auto& after  = next.strokes[i];
+    if (StrokeIdentityMatches(before, after) &&
+        SamplesEqual(BrushStrokeSamples(before), BrushStrokeSamples(after)) &&
+        previous.placement_translation == next.placement_translation) {
+      continue;
+    }
+    dirty = UnionTexelRect(
+        dirty, BrushStrokeOutputTexelSupport(before, previous.placement_translation, raster,
+                                             full_reference));
+    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(after, next.placement_translation,
+                                                                raster, full_reference));
+  }
+  for (std::size_t i = common; i < previous.strokes.size(); ++i) {
+    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(previous.strokes[i],
+                                                                previous.placement_translation,
+                                                                raster, full_reference));
+  }
+  for (std::size_t i = common; i < next.strokes.size(); ++i) {
+    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(next.strokes[i],
+                                                                next.placement_translation, raster,
+                                                                full_reference));
+  }
+  dirty = ClipTexelRect(dirty, raster);
+  if (RectIEmpty(dirty)) {
+    return ClipTexelRect(RectI{0, 0, 1, 1}, raster);
+  }
+  return dirty;
+}
+
+[[nodiscard]] auto OneTexelDirty(Extent2D raster) -> RectI {
+  return ClipTexelRect(RectI{0, 0, 1, 1}, raster);
+}
+
+}  // namespace
+
+auto DetectBrushCoverageUpdate(const BrushMaskSource* previous, Extent2D prev_raster,
+                               Extent2D prev_full_reference, const BrushMaskSource& next,
+                               Extent2D raster, Extent2D full_reference) -> BrushCoverageUpdate {
+  if (raster.Empty() || full_reference.Empty()) {
+    throw std::invalid_argument("DetectBrushCoverageUpdate: extents must be positive");
+  }
+  if (next.raster_algorithm_version != kBrushRasterAlgorithmVersion ||
+      next.source_format_version != kBrushSourceFormatVersion) {
+    throw std::runtime_error("DetectBrushCoverageUpdate: unsupported brush algorithm version");
+  }
+
+  BrushCoverageUpdate update;
+  if (previous == nullptr || prev_raster != raster || prev_full_reference != full_reference) {
+    update.kind  = BrushCoverageUpdateKind::ReplayDirty;
+    update.dirty = FullTexelRect(raster);
+    return update;
+  }
+  if (previous->raster_algorithm_version != next.raster_algorithm_version ||
+      previous->source_format_version != next.source_format_version) {
+    update.kind  = BrushCoverageUpdateKind::ReplayDirty;
+    update.dirty = FullTexelRect(raster);
+    return update;
+  }
+  if (previous->placement_translation != next.placement_translation) {
+    update.kind  = BrushCoverageUpdateKind::ReplayDirty;
+    update.dirty = ChangedStrokeDirty(*previous, next, raster, full_reference);
+    return update;
+  }
+
+  const auto n_prev = previous->strokes.size();
+  const auto n_next = next.strokes.size();
+  std::size_t equal = 0;
+  while (equal < n_prev && equal < n_next &&
+         StrokeIdentityMatches(previous->strokes[equal], next.strokes[equal]) &&
+         SamplesEqual(BrushStrokeSamples(previous->strokes[equal]),
+                      BrushStrokeSamples(next.strokes[equal]))) {
+    ++equal;
+  }
+
+  if (equal == n_prev && equal == n_next) {
+    update.kind  = BrushCoverageUpdateKind::Unchanged;
+    update.dirty = OneTexelDirty(raster);
+    return update;
+  }
+
+  if (equal == n_prev && n_next > n_prev) {
+    RectI dirty{};
+    for (auto i = n_prev; i < n_next; ++i) {
+      dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(next.strokes[i],
+                                                                  next.placement_translation,
+                                                                  raster, full_reference));
+    }
+    update.kind         = BrushCoverageUpdateKind::StampNewSamples;
+    update.stroke_index = n_prev;
+    update.stroke_end   = n_next;
+    update.sample_begin = 0;
+    update.dirty        = ClipTexelRect(dirty, raster);
+    if (RectIEmpty(update.dirty)) {
+      update.dirty = OneTexelDirty(raster);
+    }
+    return update;
+  }
+
+  if (equal + 1 == n_prev && n_prev <= n_next &&
+      StrokeIdentityMatches(previous->strokes[equal], next.strokes[equal])) {
+    const auto prev_samples = BrushStrokeSamples(previous->strokes[equal]);
+    const auto next_samples = BrushStrokeSamples(next.strokes[equal]);
+    if (SamplesArePrefix(prev_samples, next_samples) && prev_samples.size() < next_samples.size()) {
+      RectI dirty = UnionNewSampleSupports(next.strokes[equal], next.placement_translation,
+                                           prev_samples.size(), next_samples.size(), raster,
+                                           full_reference);
+      for (auto i = n_prev; i < n_next; ++i) {
+        dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(next.strokes[i],
+                                                                    next.placement_translation,
+                                                                    raster, full_reference));
+      }
+      update.kind         = BrushCoverageUpdateKind::StampNewSamples;
+      update.stroke_index = equal;
+      update.stroke_end   = n_next;
+      update.sample_begin = prev_samples.size();
+      update.dirty        = ClipTexelRect(dirty, raster);
+      if (RectIEmpty(update.dirty)) {
+        update.dirty = OneTexelDirty(raster);
+      }
+      return update;
+    }
+  }
+
+  update.kind  = BrushCoverageUpdateKind::ReplayDirty;
+  update.dirty = ChangedStrokeDirty(*previous, next, raster, full_reference);
+  return update;
+}
+
+auto BrushCoverageCommandJournal::Find(const NodeId& owner_node_id, const MaskId& mask_id) const
+    -> const Entry* {
+  const auto found = entries_.find({owner_node_id, mask_id});
+  if (found == entries_.end()) {
+    return nullptr;
+  }
+  return &found->second;
+}
+
+void BrushCoverageCommandJournal::Store(const NodeId& owner_node_id, const MaskId& mask_id,
+                                        BrushMaskSource source, Extent2D raster,
+                                        Extent2D full_reference) {
+  Entry entry;
+  entry.source          = std::move(source);
+  entry.raster          = raster;
+  entry.full_reference  = full_reference;
+  entries_[{owner_node_id, mask_id}] = std::move(entry);
+}
+
+void BrushCoverageCommandJournal::Clear() { entries_.clear(); }
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/mask/brush_rasterizer.cpp
+++ b/alcedo_studio/src/edit/mask/brush_rasterizer.cpp
@@ -12,6 +12,7 @@
 
 #include "edit/mask/brush_raster_encoding.hpp"
 #include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/brush_stroke.hpp"
 
 namespace alcedo {
 namespace {
@@ -80,6 +81,46 @@ void BrushRasterizer::StampDab(const BrushCanonicalSample& sample, Vector2 trans
       (*pixels_)[index] = mode == BrushStrokeMode::Erase ? EraseBrushR8((*pixels_)[index], dab)
                                                           : PaintBrushR8((*pixels_)[index], dab);
     }
+  }
+}
+
+void BrushRasterizer::StampOrderedSamples(std::span<const BrushCanonicalSample> samples,
+                                          Vector2 translation, BrushStrokeMode mode, RectI clip) {
+  RequireGeometry();
+  const auto region = ClipTexelRect(clip, raster_);
+  if (RectIEmpty(region)) {
+    return;
+  }
+  for (const auto& sample : samples) {
+    StampDab(sample, translation, mode, region);
+  }
+}
+
+void BrushRasterizer::ApplyCoverageUpdate(const BrushMaskSource& source,
+                                          const BrushSpatialIndex& index,
+                                          const BrushCoverageUpdate& update) {
+  RequireGeometry();
+  RequireAlgorithm(source);
+  if (update.kind == BrushCoverageUpdateKind::Unchanged) {
+    return;
+  }
+  if (update.kind == BrushCoverageUpdateKind::ReplayDirty) {
+    ReplayRegion(source, index, update.dirty);
+    return;
+  }
+  if (update.stroke_index >= source.strokes.size() || update.stroke_end > source.strokes.size() ||
+      update.stroke_index >= update.stroke_end) {
+    FailRaster("coverage stamp stroke range is outside the source");
+  }
+  for (auto stroke_index = update.stroke_index; stroke_index < update.stroke_end; ++stroke_index) {
+    const auto& stroke  = source.strokes[stroke_index];
+    const auto  samples = BrushStrokeSamples(stroke);
+    const auto  begin   = stroke_index == update.stroke_index ? update.sample_begin : 0;
+    if (begin > samples.size()) {
+      FailRaster("coverage stamp sample begin is outside the stroke");
+    }
+    StampOrderedSamples(samples.subspan(begin), source.placement_translation, stroke.mode,
+                        update.dirty);
   }
 }
 

--- a/alcedo_studio/src/edit/mask/brush_rasterizer.cpp
+++ b/alcedo_studio/src/edit/mask/brush_rasterizer.cpp
@@ -32,7 +32,7 @@ void RequireAlgorithm(const BrushMaskSource& source) {
 }  // namespace
 
 void BrushRasterizer::RequireGeometry() const {
-  if (raster_.Empty() || pixels_.size() !=
+  if (raster_.Empty() || pixels_->size() !=
                              static_cast<std::size_t>(raster_.width) *
                                  static_cast<std::size_t>(raster_.height)) {
     FailRaster("brush rasterizer geometry is unset");
@@ -45,12 +45,15 @@ void BrushRasterizer::SetGeometry(Extent2D raster, Extent2D full_reference) {
   }
   raster_          = raster;
   full_reference_  = full_reference;
-  pixels_.assign(static_cast<std::size_t>(raster.width) * raster.height, 0);
+  // Fresh storage: SharedPixels handles handed out for the previous geometry
+  // must keep the old bytes immutable.
+  pixels_ = std::make_shared<std::vector<std::uint8_t>>(
+      static_cast<std::size_t>(raster.width) * raster.height, 0);
 }
 
 void BrushRasterizer::ClearToZero() {
   RequireGeometry();
-  std::fill(pixels_.begin(), pixels_.end(), 0);
+  std::fill(pixels_->begin(), pixels_->end(), 0);
 }
 
 void BrushRasterizer::StampDab(const BrushCanonicalSample& sample, Vector2 translation,
@@ -74,8 +77,8 @@ void BrushRasterizer::StampDab(const BrushCanonicalSample& sample, Vector2 trans
                                                     sample.hardness));
       const auto index = PackedR8Index(static_cast<std::uint32_t>(x), static_cast<std::uint32_t>(y),
                                        raster_);
-      pixels_[index]   = mode == BrushStrokeMode::Erase ? EraseBrushR8(pixels_[index], dab)
-                                                        : PaintBrushR8(pixels_[index], dab);
+      (*pixels_)[index] = mode == BrushStrokeMode::Erase ? EraseBrushR8((*pixels_)[index], dab)
+                                                          : PaintBrushR8((*pixels_)[index], dab);
     }
   }
 }
@@ -95,7 +98,7 @@ void BrushRasterizer::ReplayRegion(const BrushMaskSource& source, const BrushSpa
     for (std::int32_t x = region.x; x < region.X1(); ++x) {
       const auto px = static_cast<std::uint32_t>(x);
       const auto py = static_cast<std::uint32_t>(y);
-      pixels_[PackedR8Index(px, py, raster_)] = 0;
+      (*pixels_)[PackedR8Index(px, py, raster_)] = 0;
     }
   }
   const auto spans = index.QueryOutput(region, source.placement_translation);

--- a/alcedo_studio/src/edit/mask/parameterized_brush_replay_cache.cpp
+++ b/alcedo_studio/src/edit/mask/parameterized_brush_replay_cache.cpp
@@ -1,0 +1,113 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/parameterized_brush_replay_cache.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/brush_stroke.hpp"
+
+namespace alcedo {
+namespace {
+
+/// Output-texels that differ between the previously replayed source and @p next.
+/// Stroke identity compares id, mode, and the shared sample-body pointer; a
+/// placement move dirties the same stroke under both translations.
+[[nodiscard]] auto BrushReplayDirtyTexels(const BrushMaskSource& previous,
+                                          const BrushMaskSource& next, Extent2D raster,
+                                          Extent2D full_reference) -> RectI {
+  RectI      dirty{};
+  const auto common = std::min(previous.strokes.size(), next.strokes.size());
+  for (std::size_t i = 0; i < common; ++i) {
+    const auto& before = previous.strokes[i];
+    const auto& after  = next.strokes[i];
+    const bool  same_stroke =
+        before.id == after.id && before.mode == after.mode &&
+        BrushStrokesShareSampleBody(before, after);
+    if (same_stroke && previous.placement_translation == next.placement_translation) {
+      continue;
+    }
+    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(before, previous.placement_translation,
+                                                              raster, full_reference));
+    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(after, next.placement_translation,
+                                                                raster, full_reference));
+  }
+  for (std::size_t i = common; i < previous.strokes.size(); ++i) {
+    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(previous.strokes[i],
+                                                                previous.placement_translation,
+                                                                raster, full_reference));
+  }
+  for (std::size_t i = common; i < next.strokes.size(); ++i) {
+    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(next.strokes[i],
+                                                                next.placement_translation, raster,
+                                                                full_reference));
+  }
+  return ClipTexelRect(dirty, raster);
+}
+
+}  // namespace
+
+auto ParameterizedBrushReplayCache::Replay(const NodeId& owner_node_id, const MaskId& mask_id,
+                                           const BrushMaskSource& source, Extent2D full_reference,
+                                           std::uint64_t content_revision,
+                                           std::uint64_t session_generation)
+    -> ActiveRasterMaskInput {
+  const auto raster = CanonicalBrushRasterExtent(full_reference);
+  auto&      entry  = entries_[{owner_node_id, mask_id}];
+  entry.lru_tick    = ++lru_clock_;
+
+  RectI dirty{};
+  if (!entry.valid || entry.raster != raster ||
+      entry.rasterizer.FullReference() != full_reference) {
+    entry.rasterizer.SetGeometry(raster, full_reference);
+    entry.rasterizer.RasterizeFull(source);
+    entry.index.Rebuild(source, raster, full_reference);
+    entry.source = source;
+    entry.raster = raster;
+    entry.valid  = true;
+    dirty        = FullTexelRect(raster);
+  } else {
+    dirty = BrushReplayDirtyTexels(entry.source, source, raster, full_reference);
+    if (!RectIEmpty(dirty)) {
+      entry.index.Rebuild(source, raster, full_reference);
+      entry.rasterizer.ReplayRegion(source, entry.index, dirty);
+      entry.source = source;
+    }
+  }
+  EvictOverflow();
+
+  ActiveRasterMaskInput input;
+  input.owner_node_id               = owner_node_id;
+  input.mask_id                     = mask_id;
+  input.session_generation          = session_generation;
+  input.content_revision            = content_revision == 0 ? 1 : content_revision;
+  input.descriptor.extent           = raster;
+  input.descriptor.reference_bounds = CanonicalBrushReferenceBounds();
+  // The upload contract requires a non-empty clipped rectangle even when the
+  // replay found no pixel change; one texel of identical data keeps it valid.
+  input.dirty_rectangle = RectIEmpty(dirty)
+                              ? ClipTexelRect(RectI{0, 0, 1, 1}, raster)
+                              : dirty;
+  input.pixels          = entry.rasterizer.SharedPixels();
+  return input;
+}
+
+void ParameterizedBrushReplayCache::Clear() { entries_.clear(); }
+
+void ParameterizedBrushReplayCache::EvictOverflow() {
+  while (entries_.size() > kMaxRetainedEntries) {
+    auto victim = entries_.end();
+    for (auto it = entries_.begin(); it != entries_.end(); ++it) {
+      if (victim == entries_.end() || it->second.lru_tick < victim->second.lru_tick) {
+        victim = it;
+      }
+    }
+    entries_.erase(victim);
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/mask/parameterized_brush_replay_cache.cpp
+++ b/alcedo_studio/src/edit/mask/parameterized_brush_replay_cache.cpp
@@ -4,52 +4,14 @@
 
 #include "edit/mask/parameterized_brush_replay_cache.hpp"
 
-#include <algorithm>
 #include <utility>
 
+#include "edit/mask/brush_coverage_update.hpp"
 #include "edit/mask/brush_raster_encoding.hpp"
 #include "edit/mask/brush_source_geometry.hpp"
 #include "edit/mask/brush_stroke.hpp"
 
 namespace alcedo {
-namespace {
-
-/// Output-texels that differ between the previously replayed source and @p next.
-/// Stroke identity compares id, mode, and the shared sample-body pointer; a
-/// placement move dirties the same stroke under both translations.
-[[nodiscard]] auto BrushReplayDirtyTexels(const BrushMaskSource& previous,
-                                          const BrushMaskSource& next, Extent2D raster,
-                                          Extent2D full_reference) -> RectI {
-  RectI      dirty{};
-  const auto common = std::min(previous.strokes.size(), next.strokes.size());
-  for (std::size_t i = 0; i < common; ++i) {
-    const auto& before = previous.strokes[i];
-    const auto& after  = next.strokes[i];
-    const bool  same_stroke =
-        before.id == after.id && before.mode == after.mode &&
-        BrushStrokesShareSampleBody(before, after);
-    if (same_stroke && previous.placement_translation == next.placement_translation) {
-      continue;
-    }
-    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(before, previous.placement_translation,
-                                                              raster, full_reference));
-    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(after, next.placement_translation,
-                                                                raster, full_reference));
-  }
-  for (std::size_t i = common; i < previous.strokes.size(); ++i) {
-    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(previous.strokes[i],
-                                                                previous.placement_translation,
-                                                                raster, full_reference));
-  }
-  for (std::size_t i = common; i < next.strokes.size(); ++i) {
-    dirty = UnionTexelRect(dirty, BrushStrokeOutputTexelSupport(next.strokes[i],
-                                                                next.placement_translation, raster,
-                                                                full_reference));
-  }
-  return ClipTexelRect(dirty, raster);
-}
-
-}  // namespace
 
 auto ParameterizedBrushReplayCache::Replay(const NodeId& owner_node_id, const MaskId& mask_id,
                                            const BrushMaskSource& source, Extent2D full_reference,
@@ -71,10 +33,12 @@ auto ParameterizedBrushReplayCache::Replay(const NodeId& owner_node_id, const Ma
     entry.valid  = true;
     dirty        = FullTexelRect(raster);
   } else {
-    dirty = BrushReplayDirtyTexels(entry.source, source, raster, full_reference);
-    if (!RectIEmpty(dirty)) {
+    const auto update = DetectBrushCoverageUpdate(&entry.source, entry.raster, full_reference,
+                                                  source, raster, full_reference);
+    dirty             = update.dirty;
+    if (update.kind != BrushCoverageUpdateKind::Unchanged) {
       entry.index.Rebuild(source, raster, full_reference);
-      entry.rasterizer.ReplayRegion(source, entry.index, dirty);
+      entry.rasterizer.ApplyCoverageUpdate(source, entry.index, update);
       entry.source = source;
     }
   }

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_brush_raster.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_brush_raster.cu
@@ -1,0 +1,193 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/runtime/cuda/cuda_brush_raster.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/brush_spatial_index.hpp"
+#include "edit/mask/brush_stroke.hpp"
+
+namespace alcedo {
+namespace {
+
+[[noreturn]] void FailCudaBrush(std::string_view message) {
+  throw std::runtime_error(std::string{message});
+}
+
+__device__ auto DeviceDabCoverage(float distance, float radius, float strength, float hardness)
+    -> float {
+  if (hardness >= 1.0f) {
+    return distance <= radius ? strength : 0.0f;
+  }
+  const float inner = hardness * radius;
+  if (distance <= inner) {
+    return strength;
+  }
+  if (distance >= radius) {
+    return 0.0f;
+  }
+  const float span = radius - inner;
+  return strength * (1.0f - (distance - inner) / span);
+}
+
+__global__ void FillR8RectKernel(std::uint8_t* pixels, int width, int height, int x0, int y0,
+                                 int rect_w, int rect_h, std::uint8_t value) {
+  const int x = x0 + static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  const int y = y0 + static_cast<int>(blockIdx.y * blockDim.y + threadIdx.y);
+  if (x < x0 || y < y0 || x >= x0 + rect_w || y >= y0 + rect_h || x >= width || y >= height) {
+    return;
+  }
+  pixels[y * width + x] = value;
+}
+
+__global__ void StampDabKernel(std::uint8_t* pixels, int width, int height, int x0, int y0,
+                               int rect_w, int rect_h, float world_x, float world_y, float radius,
+                               float strength, float hardness, float full_w, float full_h,
+                               int erase) {
+  const int x = x0 + static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  const int y = y0 + static_cast<int>(blockIdx.y * blockDim.y + threadIdx.y);
+  if (x < x0 || y < y0 || x >= x0 + rect_w || y >= y0 + rect_h || x >= width || y >= height) {
+    return;
+  }
+  const float cx = (static_cast<float>(x) + 0.5f) * full_w / static_cast<float>(width);
+  const float cy = (static_cast<float>(y) + 0.5f) * full_h / static_cast<float>(height);
+  const float coverage =
+      DeviceDabCoverage(hypotf(cx - world_x, cy - world_y), radius, strength, hardness);
+  const float scaled = fminf(fmaxf(coverage * 255.0f + 0.5f, 0.0f), 255.0f);
+  const auto  dab    = static_cast<std::uint8_t>(scaled);
+  const int   index  = y * width + x;
+  const auto  previous = pixels[index];
+  pixels[index] =
+      erase != 0 ? (previous < static_cast<std::uint8_t>(255u - dab)
+                        ? previous
+                        : static_cast<std::uint8_t>(255u - dab))
+                 : (previous > dab ? previous : dab);
+}
+
+void LaunchFill(std::uint8_t* pixels, Extent2D extent, RectI rect, std::uint8_t value,
+                cudaStream_t stream) {
+  if (RectIEmpty(rect)) {
+    return;
+  }
+  const dim3 block(16, 16);
+  const dim3 grid((static_cast<unsigned>(rect.width) + 15u) / 16u,
+                  (static_cast<unsigned>(rect.height) + 15u) / 16u);
+  FillR8RectKernel<<<grid, block, 0, stream>>>(
+      pixels, static_cast<int>(extent.width), static_cast<int>(extent.height), rect.x, rect.y,
+      rect.width, rect.height, value);
+}
+
+void LaunchStamp(std::uint8_t* pixels, Extent2D raster, Extent2D full_reference, RectI clip,
+                 const BrushCanonicalSample& sample, Vector2 translation, BrushStrokeMode mode,
+                 cudaStream_t stream) {
+  const auto support = IntersectTexelRect(
+      BrushDabOutputTexelSupport(sample, translation, raster, full_reference), clip);
+  if (RectIEmpty(support)) {
+    return;
+  }
+  const dim3 block(16, 16);
+  const dim3 grid((static_cast<unsigned>(support.width) + 15u) / 16u,
+                  (static_cast<unsigned>(support.height) + 15u) / 16u);
+  StampDabKernel<<<grid, block, 0, stream>>>(
+      pixels, static_cast<int>(raster.width), static_cast<int>(raster.height), support.x, support.y,
+      support.width, support.height, sample.local_x + translation.x,
+      sample.local_y + translation.y, sample.radius, sample.strength, sample.hardness,
+      static_cast<float>(full_reference.width), static_cast<float>(full_reference.height),
+      mode == BrushStrokeMode::Erase ? 1 : 0);
+}
+
+void StampRange(std::uint8_t* pixels, Extent2D raster, Extent2D full_reference,
+                const BrushMaskSource& source, const BrushCoverageUpdate& update,
+                cudaStream_t stream) {
+  if (update.stroke_index >= source.strokes.size() || update.stroke_end > source.strokes.size() ||
+      update.stroke_index >= update.stroke_end) {
+    FailCudaBrush("ApplyParameterizedBrushCuda: stamp stroke range is outside the source");
+  }
+  const auto clip = ClipTexelRect(update.dirty, raster);
+  for (auto stroke_index = update.stroke_index; stroke_index < update.stroke_end; ++stroke_index) {
+    const auto& stroke  = source.strokes[stroke_index];
+    const auto  samples = BrushStrokeSamples(stroke);
+    const auto  begin   = stroke_index == update.stroke_index ? update.sample_begin : 0;
+    if (begin > samples.size()) {
+      FailCudaBrush("ApplyParameterizedBrushCuda: stamp sample begin is outside the stroke");
+    }
+    for (auto i = begin; i < samples.size(); ++i) {
+      LaunchStamp(pixels, raster, full_reference, clip, samples[i], source.placement_translation,
+                  stroke.mode, stream);
+    }
+  }
+}
+
+void ReplayDirty(std::uint8_t* pixels, Extent2D raster, Extent2D full_reference,
+                 const BrushMaskSource& source, RectI dirty, cudaStream_t stream) {
+  const auto region = ClipTexelRect(dirty, raster);
+  if (RectIEmpty(region)) {
+    return;
+  }
+  LaunchFill(pixels, raster, region, 0, stream);
+  BrushSpatialIndex index;
+  index.Rebuild(source, raster, full_reference);
+  const auto spans = index.QueryOutput(region, source.placement_translation);
+  for (const auto& span : spans) {
+    if (span.stroke_index >= source.strokes.size()) {
+      FailCudaBrush("ApplyParameterizedBrushCuda: spatial index stroke is outside the source");
+    }
+    const auto& stroke = source.strokes[span.stroke_index];
+    if (stroke.id != span.stroke_id) {
+      FailCudaBrush("ApplyParameterizedBrushCuda: spatial index StrokeId does not match");
+    }
+    const auto samples = BrushStrokeSamples(stroke);
+    if (span.sample_end > samples.size() || span.sample_begin >= span.sample_end) {
+      FailCudaBrush("ApplyParameterizedBrushCuda: spatial index sample span is outside the stroke");
+    }
+    for (auto i = span.sample_begin; i < span.sample_end; ++i) {
+      LaunchStamp(pixels, raster, full_reference, region, samples[i], source.placement_translation,
+                  stroke.mode, stream);
+    }
+  }
+}
+
+}  // namespace
+
+void ApplyParameterizedBrushCuda(CudaRenderDevice& device, CudaBackend::Texture2D& dest,
+                                 const BrushMaskSource& source, Extent2D full_reference,
+                                 const BrushCoverageUpdate& update, bool texture_uninitialized) {
+  if (dest.Format() != TextureFormat::R8 || dest.DevicePointer() == nullptr || dest.Width() == 0 ||
+      dest.Height() == 0) {
+    FailCudaBrush("ApplyParameterizedBrushCuda: destination must be a non-empty R8 texture");
+  }
+  if (full_reference.Empty()) {
+    throw std::invalid_argument("ApplyParameterizedBrushCuda: full_reference must be positive");
+  }
+  if (source.raster_algorithm_version != kBrushRasterAlgorithmVersion ||
+      source.source_format_version != kBrushSourceFormatVersion) {
+    FailCudaBrush("ApplyParameterizedBrushCuda: unsupported brush algorithm version");
+  }
+  const Extent2D raster{dest.Width(), dest.Height()};
+  auto*          pixels = static_cast<std::uint8_t*>(dest.DevicePointer());
+  const auto     stream = device.CommandContext().Stream();
+  if (texture_uninitialized || update.kind == BrushCoverageUpdateKind::ReplayDirty) {
+    auto replay = update;
+    if (texture_uninitialized) {
+      replay.kind  = BrushCoverageUpdateKind::ReplayDirty;
+      replay.dirty = FullTexelRect(raster);
+    }
+    ReplayDirty(pixels, raster, full_reference, source, replay.dirty, stream);
+  } else if (update.kind == BrushCoverageUpdateKind::StampNewSamples) {
+    StampRange(pixels, raster, full_reference, source, update, stream);
+  }
+  if (::cudaGetLastError() != cudaSuccess) {
+    FailCudaBrush("ApplyParameterizedBrushCuda: CUDA kernel launch failed");
+  }
+}
+
+}  // namespace alcedo

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
@@ -17,9 +17,12 @@
 #include "edit/geometry/texture_sampling_plan.hpp"
 #include "edit/graph/active_raster_mask_validation.hpp"
 #include "edit/mask/active_raster_mask.hpp"
+#include "edit/mask/brush_coverage_update.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
 #include "edit/mask/mask_model.hpp"
 #include "edit/runtime/compiled_grade_mask.hpp"
 #include "edit/runtime/compiled_mask_stack.hpp"
+#include "edit/runtime/cuda/cuda_brush_raster.hpp"
 #include "edit/runtime/cuda/cuda_mask_pass.hpp"
 
 namespace alcedo {
@@ -313,22 +316,18 @@ auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
   } else if (const auto* brush = std::get_if<BrushMaskSource>(&mask_model.source)) {
     const auto* active = FindActiveRasterMaskInput(active_raster_masks, compiled_grade.node_id,
                                                    compiled_source.mask_id);
-    ActiveRasterMaskInput parameterized_replay;
-    if (active == nullptr && BrushUsesParameterizedReplay(*brush)) {
-      parameterized_replay = ParameterizedBrushActiveRasterForGrade(
-          document, compiled_grade.node_id, compiled_source.mask_id, *brush,
-          plan.geometry.full_reference_extent, workspace.BrushReplay());
-      active = &parameterized_replay;
-    }
     const auto encode_coverage = [&](auto& source, const MaskAssetDescriptor& raster_descriptor,
-                                     bool raster_bytes_changed) {
+                                     bool raster_bytes_changed, bool generate_mips) {
       result.mip_level_count = static_cast<std::uint32_t>(source.MipLevelCount());
       const auto sampling    = MakeRasterMaskSamplingPlan(
           plan.geometry, raster_descriptor.reference_bounds, raster_descriptor.extent);
       if (brush->feather_radius <= 0.0f) {
-        const auto selected_level = std::min<std::size_t>(
-            static_cast<std::size_t>(std::max(std::floor(sampling.mip_level), 0.0f)),
-            source.MipLevelCount() - 1);
+        const auto selected_level =
+            generate_mips
+                ? std::min<std::size_t>(
+                      static_cast<std::size_t>(std::max(std::floor(sampling.mip_level), 0.0f)),
+                      source.MipLevelCount() - 1)
+                : std::size_t{0};
         auto& sampled_texture = source.Texture(selected_level);
         RasterSampleKernel<<<(render_pixels + block - 1) / block, block, 0, context.Stream()>>>(
             static_cast<const std::uint8_t*>(sampled_texture.DevicePointer()),
@@ -423,10 +422,49 @@ auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
           std::span<const std::byte>(reinterpret_cast<const std::byte*>(pixels.data()),
                                      pixels.size()),
           context);
-      GenerateMipChain(source, context);
+      if (brush->feather_radius <= 0.0f) {
+        GenerateMipChain(source, context);
+      }
     };
 
-    if (active != nullptr) {
+    if (active == nullptr && BrushUsesParameterizedReplay(*brush)) {
+      const auto raster = CanonicalBrushRasterExtent(plan.geometry.full_reference_extent);
+      auto&      cache  = workspace.ActiveRasterTextures();
+      const ActiveRasterTextureKey tex_key{compiled_grade.node_id, compiled_source.mask_id, 1};
+      cache.EraseIdleIf([&](const ActiveRasterTextureKey& key) {
+        return key.owner_node_id == tex_key.owner_node_id && key.mask_id == tex_key.mask_id &&
+               key.session_generation != tex_key.session_generation;
+      });
+      auto source_tex                     = cache.Acquire(tex_key, raster);
+      result.active_texture_resource_id   = source_tex.Texture().ResourceId();
+      MaskAssetDescriptor descriptor;
+      descriptor.extent                   = raster;
+      descriptor.reference_bounds         = CanonicalBrushReferenceBounds();
+      const auto* recorded =
+          workspace.BrushCommands().Find(compiled_grade.node_id, compiled_source.mask_id);
+      const bool uninitialized = !cache.PixelsUploaded(tex_key);
+      const auto update        = DetectBrushCoverageUpdate(
+          recorded == nullptr ? nullptr : &recorded->source,
+          recorded == nullptr ? Extent2D{} : recorded->raster,
+          recorded == nullptr ? Extent2D{} : recorded->full_reference, *brush, raster,
+          plan.geometry.full_reference_extent);
+      const bool raster_bytes_changed =
+          uninitialized || update.kind != BrushCoverageUpdateKind::Unchanged;
+      if (raster_bytes_changed) {
+        ApplyParameterizedBrushCuda(device, source_tex.Texture(), *brush,
+                                    plan.geometry.full_reference_extent, update, uninitialized);
+      }
+      const auto* grade = dynamic_cast<const ColorGradeNodeModel*>(
+          document.Graph().FindNode(compiled_grade.node_id));
+      auto revision = grade == nullptr ? 1 : grade->MaskContentRevision(compiled_source.mask_id);
+      if (revision == 0) {
+        revision = 1;
+      }
+      cache.SetUploadedPixels(tex_key, revision);
+      workspace.BrushCommands().Store(compiled_grade.node_id, compiled_source.mask_id, *brush,
+                                      raster, plan.geometry.full_reference_extent);
+      encode_coverage(source_tex, descriptor, raster_bytes_changed, false);
+    } else if (active != nullptr) {
       auto& cache = workspace.ActiveRasterTextures();
       const ActiveRasterTextureKey tex_key{compiled_grade.node_id, compiled_source.mask_id,
                                            active->session_generation};
@@ -449,11 +487,14 @@ auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
         const auto bytes =
             CopyPackedR8Rectangle(*active->pixels, active->descriptor.extent, dirty);
         workspace.Device().UploadR8TextureRect(source.Texture(), dirty, bytes, context);
-        GenerateMipChain(source, context);
+        if (brush->feather_radius <= 0.0f) {
+          GenerateMipChain(source, context);
+        }
         cache.SetUploadedPixels(tex_key, active->content_revision);
         raster_bytes_changed = true;
       }
-      encode_coverage(source, active->descriptor, raster_bytes_changed);
+      encode_coverage(source, active->descriptor, raster_bytes_changed,
+                      brush->feather_radius <= 0.0f);
     } else {
       if (store == nullptr)
         throw std::invalid_argument("ExecuteCudaMask: raster mask needs MaskStore");
@@ -464,7 +505,7 @@ auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
       if (!cached) {
         upload_full(source, asset->pixels);
       }
-      encode_coverage(source, asset->descriptor, !cached);
+      encode_coverage(source, asset->descriptor, !cached, brush->feather_radius <= 0.0f);
     }
   } else {
     throw std::runtime_error("ExecuteCudaMask: compiled mask does not match document");

--- a/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
+++ b/alcedo_studio/src/edit/runtime/cuda/cuda_mask_pass.cu
@@ -317,7 +317,7 @@ auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
     if (active == nullptr && BrushUsesParameterizedReplay(*brush)) {
       parameterized_replay = ParameterizedBrushActiveRasterForGrade(
           document, compiled_grade.node_id, compiled_source.mask_id, *brush,
-          plan.geometry.full_reference_extent);
+          plan.geometry.full_reference_extent, workspace.BrushReplay());
       active = &parameterized_replay;
     }
     const auto encode_coverage = [&](auto& source, const MaskAssetDescriptor& raster_descriptor,

--- a/alcedo_studio/src/edit/runtime/metal/metal_mask_pass.mm
+++ b/alcedo_studio/src/edit/runtime/metal/metal_mask_pass.mm
@@ -438,7 +438,7 @@ auto ExecuteMetalMask(MetalRenderDevice& device, const ExecutionPlan& plan,
   if (active == nullptr && BrushUsesParameterizedReplay(*brush)) {
     parameterized_replay = ParameterizedBrushActiveRasterForGrade(
         document, compiled_grade.node_id, compiled_source.mask_id, *brush,
-        plan.geometry.full_reference_extent);
+        plan.geometry.full_reference_extent, workspace.BrushReplay());
     active = &parameterized_replay;
   }
   const auto encode_coverage = [&](auto& source, const MaskAssetDescriptor& raster_descriptor,

--- a/alcedo_studio/src/edit/runtime/opencl/opencl_mask_pass.cpp
+++ b/alcedo_studio/src/edit/runtime/opencl/opencl_mask_pass.cpp
@@ -464,7 +464,7 @@ auto ExecuteOpenClMask(OpenClRenderDevice& device, const ExecutionPlan& plan,
   if (active == nullptr && BrushUsesParameterizedReplay(*brush)) {
     parameterized_replay = ParameterizedBrushActiveRasterForGrade(
         document, compiled_grade.node_id, compiled_source.mask_id, *brush,
-        plan.geometry.full_reference_extent);
+        plan.geometry.full_reference_extent, workspace.BrushReplay());
     active = &parameterized_replay;
   }
   const auto encode_coverage = [&](auto& source, const MaskAssetDescriptor& raster_descriptor,

--- a/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
+++ b/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
@@ -138,6 +138,10 @@ struct EditorMaskCreationCommand {
   float                         brush_radius   = 0.0f;
   float                         brush_strength = 1.0f;
   float                         brush_hardness = 1.0f;
+  /// BeginInput only: source feather for a newly created Brush, in reference
+  /// pixels. Existing Brushes keep their stored feather; zero leaves the
+  /// source default unchanged.
+  float                         default_feather_reference_px = 0.0f;
   bool                          ordered_append = false;
   /**
    * @brief Mask-level value edit target.
@@ -267,16 +271,24 @@ class EditorMaskCreationController {
    * @brief Start a creation drag at @p sample.
    *
    * Press outside the photograph is rejected. Degenerate zero-area input stays
-   * transient until a later valid sample.
+   * transient until a later valid sample. @p expected_source must equal the
+   * armed kind so a stale queued dispatch cannot drive the wrong Mask type.
+   * @p default_feather_reference_px is applied only when a new Brush Mask is
+   * created by this stroke.
    */
-  auto BeginMaskInput(MaskCreationSample sample, MaskPointerIdentity identity)
+  auto BeginMaskInput(MaskCreationSample sample, MaskPointerIdentity identity,
+                      MaskSourceKind expected_source, float default_feather_reference_px = 0.0f)
       -> EditorMaskCreationResult;
 
   /**
    * @brief Start an existing-mask handle drag. Shape fields stay fixed for center/origin.
+   *
+   * @p expected_source must equal the selected Mask kind; a mismatch rejects
+   * the stale dispatch without opening an operation.
    */
   auto BeginMaskMove(AnalyticMaskHandle handle, MaskCreationSample sample,
-                     MaskPointerIdentity identity) -> EditorMaskCreationResult;
+                     MaskPointerIdentity identity, MaskSourceKind expected_source)
+      -> EditorMaskCreationResult;
 
   /**
    * @brief Continue the captured sequence. Applies provisional fields and Interactive.
@@ -348,7 +360,8 @@ class EditorMaskCreationController {
   void RequestInteractive(EditorMaskCreationResult& result);
   auto UpdateCreation(const MaskCreationSample& sample) -> EditorMaskCreationResult;
   auto UpdateExisting(const MaskCreationSample& sample) -> EditorMaskCreationResult;
-  auto BeginBrushStroke(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto BeginBrushStroke(const MaskCreationSample& sample, float default_feather_reference_px)
+      -> EditorMaskCreationResult;
   auto UpdateBrushPaint(const MaskCreationSample& sample) -> EditorMaskCreationResult;
   auto UpdateBrushMove(const MaskCreationSample& sample) -> EditorMaskCreationResult;
   auto FinishBrushStroke() -> EditorMaskCreationResult;
@@ -389,6 +402,9 @@ class EditorMaskCreationController {
   Vector2                   before_translation_{};
   std::string               field_edit_key_;
   nlohmann::json            before_field_value_;
+  /// Draft-sample count already republished into the live Brush source; appends
+  /// that emit no new canonical dab skip the live-source republish.
+  std::size_t               published_draft_samples_ = 0;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
+++ b/alcedo_studio/src/include/app/editor_mask_creation_controller.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "app/brush_mask_input.hpp"
 #include "app/editor_session_types.hpp"
@@ -111,7 +112,19 @@ enum class EditorMaskCreationCommandKind : std::uint8_t {
   RemoveMask,
   SetBrushTool,
   SetBrushStrokeParameters,
+  BeginMaskField,
+  SetMaskField,
 };
+
+/// Mask value keys used by BeginMaskField / SetMaskField commands. The first
+/// four are Mask fields committed through SetMaskField; `brush.feather`
+/// rewrites the Brush source feather (reference pixels) and settles through
+/// ReplaceMaskSource.
+inline constexpr std::string_view kMaskFieldEnabled      = "enabled";
+inline constexpr std::string_view kMaskFieldInvert       = "invert";
+inline constexpr std::string_view kMaskFieldOpacity      = "opacity";
+inline constexpr std::string_view kMaskFieldDisplayName  = "display_name";
+inline constexpr std::string_view kMaskFieldBrushFeather = "brush.feather";
 
 struct EditorMaskCreationCommand {
   EditorMaskCreationCommandKind kind        = EditorMaskCreationCommandKind::BeginCreation;
@@ -120,12 +133,20 @@ struct EditorMaskCreationCommand {
   MaskId                        mask_id;
   MaskCreationSample            sample{};
   MaskPointerIdentity           identity{};
-  AnalyticMaskHandle            handle = AnalyticMaskHandle::None;
-  EditorBrushTool               brush_tool      = EditorBrushTool::Idle;
-  float                         brush_radius    = 0.0f;
-  float                         brush_strength  = 1.0f;
-  float                         brush_hardness  = 1.0f;
-  bool                          ordered_append  = false;
+  AnalyticMaskHandle            handle         = AnalyticMaskHandle::None;
+  EditorBrushTool               brush_tool     = EditorBrushTool::Idle;
+  float                         brush_radius   = 0.0f;
+  float                         brush_strength = 1.0f;
+  float                         brush_hardness = 1.0f;
+  bool                          ordered_append = false;
+  /**
+   * @brief Mask-level value edit target.
+   *
+   * `enabled`, `invert`, `opacity`, and `display_name` settle as SetMaskField;
+   * `brush.feather` rewrites the Brush source and settles as ReplaceMaskSource.
+   */
+  std::string                   field_key;
+  nlohmann::json                field_value;
 };
 
 /**
@@ -223,6 +244,26 @@ class EditorMaskCreationController {
   auto RemoveMask(const NodeId& grade_id, const MaskId& mask_id) -> EditorMaskCreationResult;
 
   /**
+   * @brief Open a Mask value edit on the selected Mask.
+   *
+   * Valid keys: `enabled`, `invert`, `opacity`, `display_name`, and
+   * `brush.feather` (Brush source feather, reference pixels). The live value is
+   * captured for Finish/Cancel. Requires a selected existing Mask with no open
+   * operation.
+   */
+  auto BeginMaskFieldEdit(std::string field_key) -> EditorMaskCreationResult;
+
+  /**
+   * @brief Apply @p after_value for @p field_key.
+   *
+   * While a matching field edit is open this updates the live Grade and runs
+   * Interactive without committing. With no open field edit it performs one
+   * atomic live apply plus settle commit; equal values commit nothing.
+   */
+  auto ApplyMaskFieldValue(std::string field_key, nlohmann::json after_value)
+      -> EditorMaskCreationResult;
+
+  /**
    * @brief Start a creation drag at @p sample.
    *
    * Press outside the photograph is rejected. Degenerate zero-area input stays
@@ -303,24 +344,26 @@ class EditorMaskCreationController {
   void               ResetMode();
   auto               PublishAddMask() -> EditorMaskCreationResult;
   auto               PublishReplaceSource() -> EditorMaskCreationResult;
-  auto              PublishSettledBatch(const PipelineEditBatch& batch, std::string* error) -> bool;
-  void              RequestInteractive(EditorMaskCreationResult& result);
-  auto              UpdateCreation(const MaskCreationSample& sample) -> EditorMaskCreationResult;
-  auto              UpdateExisting(const MaskCreationSample& sample) -> EditorMaskCreationResult;
-  auto              BeginBrushStroke(const MaskCreationSample& sample) -> EditorMaskCreationResult;
-  auto              UpdateBrushPaint(const MaskCreationSample& sample) -> EditorMaskCreationResult;
-  auto              UpdateBrushMove(const MaskCreationSample& sample) -> EditorMaskCreationResult;
-  auto              FinishBrushStroke() -> EditorMaskCreationResult;
-  auto              PublishAppendStroke(BrushStroke stroke) -> EditorMaskCreationResult;
-  auto              PublishSetTranslation() -> EditorMaskCreationResult;
-  auto              ApplyLiveBrushDraft() -> bool;
-  [[nodiscard]] auto AllocateStrokeId() const -> StrokeId;
-  [[nodiscard]] auto ComposeDraftBrush() const -> BrushMaskSource;
-  [[nodiscard]] auto BrushStrokeModeFromTool() const -> BrushStrokeMode;
+  auto PublishSettledBatch(const PipelineEditBatch& batch, std::string* error) -> bool;
+  void RequestInteractive(EditorMaskCreationResult& result);
+  auto UpdateCreation(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto UpdateExisting(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto BeginBrushStroke(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto UpdateBrushPaint(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto UpdateBrushMove(const MaskCreationSample& sample) -> EditorMaskCreationResult;
+  auto FinishBrushStroke() -> EditorMaskCreationResult;
+  auto PublishAppendStroke(BrushStroke stroke) -> EditorMaskCreationResult;
+  auto PublishSetTranslation() -> EditorMaskCreationResult;
+  auto PublishMaskFieldEdit() -> EditorMaskCreationResult;
+  auto ApplyLiveMaskField(const std::string& field_key, const nlohmann::json& value) -> bool;
+  auto ApplyLiveBrushDraft() -> bool;
+  [[nodiscard]] auto     AllocateStrokeId() const -> StrokeId;
+  [[nodiscard]] auto     ComposeDraftBrush() const -> BrushMaskSource;
+  [[nodiscard]] auto     BrushStrokeModeFromTool() const -> BrushStrokeMode;
 
-  PipelineDocument* document_                                          = nullptr;
-  MiniGitWorkingHistory*                                      history_ = nullptr;
-  std::function<void()>                                       interactive_preview_;
+  PipelineDocument*      document_ = nullptr;
+  MiniGitWorkingHistory* history_  = nullptr;
+  std::function<void()>  interactive_preview_;
   std::function<bool(const PipelineEditBatch&, std::string*)> settle_publisher_;
   EditorMaskCreationState   state_ = EditorMaskCreationState::Inactive;
   MaskSourceKind            kind_  = MaskSourceKind::Radial;
@@ -344,6 +387,8 @@ class EditorMaskCreationController {
   BrushMaskSource           committed_brush_{};
   Vector2                   press_reference_pixels_{};
   Vector2                   before_translation_{};
+  std::string               field_edit_key_;
+  nlohmann::json            before_field_value_;
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -599,6 +599,11 @@ class EditorSessionService final : public IEditorSessionBackend {
   /// Publish a result to the observer and change-notifier. The only state the
   /// facade owns is the result history and observer registration.
   auto               Emit(EditorSessionResult result) -> EditorSessionResult;
+  /// Record and deliver a result without marking the publication dirty. Use
+  /// for render outcomes that change no session-visible state (frame reuse on
+  /// continuous view churn): every field OnBackendChanged reads is unchanged,
+  /// so a full change notification per frame is pure cost.
+  auto               EmitQuiet(EditorSessionResult result) -> EditorSessionResult;
   auto               Reject(std::string message) -> EditorSessionResult;
   /// Transition lifecycle to Failed and emit a Failed result. Used when a
   /// navigation or save failure requires the session to enter the Failed state.

--- a/alcedo_studio/src/include/app/editor_session_service.hpp
+++ b/alcedo_studio/src/include/app/editor_session_service.hpp
@@ -313,6 +313,15 @@ class IEditorSessionBackend {
   }
   [[nodiscard]] virtual auto mask_creation_node_id() const -> NodeId { return {}; }
   [[nodiscard]] virtual auto mask_creation_mask_id() const -> MaskId { return {}; }
+  /**
+   * @brief Owner-side Mask-creation state machine value.
+   *
+   * UI adapters compare this with their local armed state so a rejected tool
+   * arming cannot leave a stale armed kind waiting for the next press.
+   */
+  [[nodiscard]] virtual auto mask_creation_state() const -> EditorMaskCreationState {
+    return EditorMaskCreationState::Inactive;
+  }
   [[nodiscard]] virtual auto mask_creation_source() const -> std::optional<MaskSource> {
     return std::nullopt;
   }
@@ -514,6 +523,9 @@ class EditorSessionService final : public IEditorSessionBackend {
   }
   [[nodiscard]] auto mask_creation_mask_id() const -> MaskId override {
     return mask_creation_.selected_mask_id();
+  }
+  [[nodiscard]] auto mask_creation_state() const -> EditorMaskCreationState override {
+    return mask_creation_.state();
   }
   [[nodiscard]] auto mask_creation_source() const -> std::optional<MaskSource> override {
     return mask_creation_.CurrentSource();

--- a/alcedo_studio/src/include/edit/mask/brush_coverage_update.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_coverage_update.hpp
@@ -1,0 +1,89 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <utility>
+
+#include "edit/geometry/types.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/mask/mask_id.hpp"
+#include "edit/mask/mask_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief How the next parameterized Brush source differs from the last stamped source.
+ *
+ * @c StampNewSamples means existing pixels stay; only the named sample range is
+ * applied in evaluation order. @c ReplayDirty zeros @c dirty and restamps every
+ * contributing dab. @c Unchanged means no pixel work.
+ */
+enum class BrushCoverageUpdateKind {
+  Unchanged,
+  StampNewSamples,
+  ReplayDirty,
+};
+
+/**
+ * @brief Incremental Brush raster work for one source replacement.
+ *
+ * @p dirty is in canonical output texels, clipped to @p raster. Stamp ranges use
+ * the incoming source's stroke list.
+ */
+struct BrushCoverageUpdate {
+  BrushCoverageUpdateKind kind         = BrushCoverageUpdateKind::ReplayDirty;
+  /// First incoming stroke to stamp for @c StampNewSamples.
+  std::size_t             stroke_index = 0;
+  /// Exclusive end stroke index for @c StampNewSamples (incoming source).
+  std::size_t             stroke_end   = 0;
+  /// Sample begin on @c stroke_index only; later strokes stamp from 0.
+  std::size_t             sample_begin = 0;
+  RectI                   dirty{};
+};
+
+/**
+ * @brief Classify @p next against the last stamped @p previous.
+ *
+ * @p previous null, geometry mismatch, placement change, removals, and unordered
+ * sample edits produce @c ReplayDirty. A shared-prefix growth of the last stroke
+ * or appended trailing strokes produce @c StampNewSamples. Equal stroke lists and
+ * placement produce @c Unchanged (feather is not coverage). @c dirty is a
+ * one-texel rectangle so host-upload callers still have a valid patch region.
+ *
+ * @throws std::invalid_argument when extents are empty.
+ * @throws std::runtime_error when @p next uses an unsupported algorithm version.
+ */
+[[nodiscard]] auto DetectBrushCoverageUpdate(const BrushMaskSource* previous, Extent2D prev_raster,
+                                             Extent2D prev_full_reference,
+                                             const BrushMaskSource& next, Extent2D raster,
+                                             Extent2D full_reference) -> BrushCoverageUpdate;
+
+/**
+ * @brief Last stamped parameterized Brush command per (Grade, Mask).
+ *
+ * Stores the source (shared sample bodies) and geometry, not pixels. Cleared with
+ * the render workspace session. Thread: serial native Mask pass. Not thread-safe.
+ */
+class BrushCoverageCommandJournal {
+ public:
+  struct Entry {
+    BrushMaskSource source{};
+    Extent2D        raster{};
+    Extent2D        full_reference{};
+  };
+
+  [[nodiscard]] auto Find(const NodeId& owner_node_id, const MaskId& mask_id) const
+      -> const Entry*;
+  void Store(const NodeId& owner_node_id, const MaskId& mask_id, BrushMaskSource source,
+             Extent2D raster, Extent2D full_reference);
+  void Clear();
+
+ private:
+  std::map<std::pair<NodeId, MaskId>, Entry> entries_;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/brush_placement.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_placement.hpp
@@ -5,12 +5,15 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 
 #include "edit/geometry/types.hpp"
 #include "edit/graph/graph_ids.hpp"
 #include "edit/mask/brush_mask_commands.hpp"
+#include "edit/mask/brush_stroke.hpp"
 #include "edit/mask/mask_id.hpp"
+#include "edit/mask/mask_model.hpp"
 
 namespace alcedo {
 
@@ -26,6 +29,19 @@ namespace alcedo {
     return 1.0f;
   }
   return 0.01f * static_cast<float>(shorter);
+}
+
+/**
+ * @brief Default source feather for a newly created Brush: 0.5% of the shorter
+ * full-reference edge, in reference pixels. Existing Brushes keep their stored
+ * feather; this value is applied only at first-stroke creation.
+ */
+[[nodiscard]] inline auto DefaultBrushFeatherReferencePixels(Extent2D full_reference) -> float {
+  const auto shorter = (std::min)(full_reference.width, full_reference.height);
+  if (shorter == 0) {
+    return 0.0f;
+  }
+  return 0.005f * static_cast<float>(shorter);
 }
 
 /**
@@ -89,6 +105,69 @@ namespace alcedo {
   command.after               = after;
   command.expected_revision   = expected_revision;
   return command;
+}
+
+/**
+ * @brief True when every dab in @p stroke carries no positive strength.
+ *
+ * A Paint stroke with only zero-strength samples cannot change coverage, so a
+ * settle may skip its history commit.
+ */
+[[nodiscard]] inline auto BrushStrokeHasCoverageEffect(const BrushStroke& stroke) -> bool {
+  if (stroke.samples == nullptr) {
+    return false;
+  }
+  for (const auto& sample : *stroke.samples) {
+    if (sample.strength > 0.0f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief True when @p erase can overlap positive Paint coverage in @p committed.
+ *
+ * Both sides are compared in world reference pixels (local plus the current
+ * placement translation). A disc test on dab centers and radii is
+ * conservative: overlapping erase/paint discs may still erase nothing when
+ * earlier Erase strokes already removed the coverage there. That is a valid
+ * commit; the no-change skip only needs the disjoint case.
+ */
+[[nodiscard]] inline auto BrushEraseOverlapsPaint(const BrushStroke& erase,
+                                                  const BrushMaskSource& committed) -> bool {
+  if (erase.samples == nullptr) {
+    return false;
+  }
+  const auto overlap = [&erase](const BrushStroke& paint) {
+    if (paint.mode != BrushStrokeMode::Paint || paint.samples == nullptr) {
+      return false;
+    }
+    for (const auto& e : *erase.samples) {
+      if (!(e.strength > 0.0f)) {
+        continue;
+      }
+      for (const auto& p : *paint.samples) {
+        if (!(p.strength > 0.0f)) {
+          continue;
+        }
+        const float dx       = e.local_x - p.local_x;
+        const float dy       = e.local_y - p.local_y;
+        const float reach    = e.radius + p.radius;
+        const float distance = std::sqrt(dx * dx + dy * dy);
+        if (distance < reach) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+  for (const auto& paint : committed.strokes) {
+    if (overlap(paint)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/brush_rasterizer.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_rasterizer.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "edit/geometry/types.hpp"
+#include "edit/mask/brush_coverage_update.hpp"
 #include "edit/mask/brush_spatial_index.hpp"
 #include "edit/mask/mask_model.hpp"
 
@@ -57,6 +58,24 @@ class BrushRasterizer {
    *         does not match @p source.
    */
   void ReplayRegion(const BrushMaskSource& source, const BrushSpatialIndex& index, RectI dirty);
+
+  /**
+   * @brief Stamp @p samples in order onto existing pixels. Does not zero any texel.
+   *
+   * Empty @p samples is a no-op. @p clip limits which texels may change.
+   *
+   * @throws std::runtime_error when geometry is unset.
+   */
+  void StampOrderedSamples(std::span<const BrushCanonicalSample> samples, Vector2 translation,
+                           BrushStrokeMode mode, RectI clip);
+
+  /**
+   * @brief Apply a classified coverage update. @c StampNewSamples does not zero texels.
+   *
+   * @c ReplayDirty uses @p index over @c dirty. @c Unchanged is a no-op.
+   */
+  void ApplyCoverageUpdate(const BrushMaskSource& source, const BrushSpatialIndex& index,
+                           const BrushCoverageUpdate& update);
 
   [[nodiscard]] auto Pixels() const -> std::span<const std::uint8_t> { return *pixels_; }
   /**

--- a/alcedo_studio/src/include/edit/mask/brush_rasterizer.hpp
+++ b/alcedo_studio/src/include/edit/mask/brush_rasterizer.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <span>
 #include <vector>
 
@@ -57,19 +58,29 @@ class BrushRasterizer {
    */
   void ReplayRegion(const BrushMaskSource& source, const BrushSpatialIndex& index, RectI dirty);
 
-  [[nodiscard]] auto Pixels() const -> std::span<const std::uint8_t> { return pixels_; }
+  [[nodiscard]] auto Pixels() const -> std::span<const std::uint8_t> { return *pixels_; }
+  /**
+   * @brief Shared handle to the retained pixel buffer.
+   *
+   * The rasterizer keeps mutating it; later replay writes are visible through
+   * the handle. Consumers treat the pointee as immutable during a render.
+   */
+  [[nodiscard]] auto SharedPixels() const -> std::shared_ptr<const std::vector<std::uint8_t>> {
+    return pixels_;
+  }
   [[nodiscard]] auto Raster() const -> Extent2D { return raster_; }
   [[nodiscard]] auto FullReference() const -> Extent2D { return full_reference_; }
-  [[nodiscard]] auto Empty() const -> bool { return pixels_.empty(); }
+  [[nodiscard]] auto Empty() const -> bool { return pixels_->empty(); }
 
  private:
   void RequireGeometry() const;
   void StampDab(const BrushCanonicalSample& sample, Vector2 translation, BrushStrokeMode mode,
                 RectI clip);
 
-  Extent2D                  raster_{};
-  Extent2D                  full_reference_{};
-  std::vector<std::uint8_t> pixels_;
+  Extent2D                                  raster_{};
+  Extent2D                                  full_reference_{};
+  std::shared_ptr<std::vector<std::uint8_t>> pixels_ =
+      std::make_shared<std::vector<std::uint8_t>>();
 };
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/mask/parameterized_brush_replay_cache.hpp
+++ b/alcedo_studio/src/include/edit/mask/parameterized_brush_replay_cache.hpp
@@ -1,0 +1,90 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "edit/geometry/types.hpp"
+#include "edit/graph/graph_ids.hpp"
+#include "edit/mask/active_raster_mask.hpp"
+#include "edit/mask/brush_rasterizer.hpp"
+#include "edit/mask/brush_spatial_index.hpp"
+#include "edit/mask/mask_id.hpp"
+#include "edit/mask/mask_model.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Workspace-retained canonical Brush rasters with regional replay.
+ *
+ * One entry per (Grade, Mask) keeps the rasterized R8 and the source that
+ * produced it. A @ref Replay call diffs the incoming source against the entry:
+ * unchanged pixels return without rasterizing, an appended or regrown stroke
+ * replays only its output-texel support, and a placement move replays the union
+ * of the old and new coverage bounds. Geometry changes, reordered or removed
+ * strokes, and body replacements restart the affected texels through
+ * @ref BrushRasterizer::ReplayRegion — never a weaker path.
+ *
+ * Entries own shared sample bodies through the stored source copy; retaining a
+ * bounded number of entries bounds host memory. Cleared with the workspace
+ * session. Thread: serial owner worker. Not thread-safe.
+ */
+class ParameterizedBrushReplayCache {
+ public:
+  /// Upper bound on retained canonical rasters; the least-recently-used entry
+  /// beyond it is evicted and rasters restart on its next replay.
+  static constexpr std::size_t kMaxRetainedEntries = 4;
+
+  /**
+   * @brief Canonical R8 input for ( @p owner_node_id, @p mask_id ).
+   *
+   * The returned pixels stay valid until the next call for the same key or
+   * @ref Clear. @p dirty_rectangle names the texels that differ from the
+   * previously returned raster for this key, clipped to the descriptor extent;
+   * it is never empty so the upload contract holds even when only the revision
+   * advanced.
+   *
+   * @param content_revision Live Mask revision used by the texture cache to
+   *        reject stale uploads; 0 maps to 1.
+   * @param session_generation Authoring-session isolation; default 1 is the
+   *        live Interactive Mix slot.
+   * @throws std::runtime_error when extents are empty, the algorithm version is
+   *         not 1, or a stroke fails rasterization.
+   */
+  [[nodiscard]] auto Replay(const NodeId& owner_node_id, const MaskId& mask_id,
+                            const BrushMaskSource& source, Extent2D full_reference,
+                            std::uint64_t content_revision,
+                            std::uint64_t session_generation = 1) -> ActiveRasterMaskInput;
+
+  /** @brief Drop every retained raster, index, and source copy. */
+  void Clear();
+
+  [[nodiscard]] auto EntryCount() const -> std::size_t { return entries_.size(); }
+
+ private:
+  struct Entry {
+    /// Canonical R8 rasterizer owning the retained pixel buffer.
+    BrushRasterizer   rasterizer;
+    /// Local-texel span index rebuilt whenever the source changes.
+    BrushSpatialIndex index;
+    /// Last replayed source; shares immutable sample bodies with the caller.
+    BrushMaskSource   source{};
+    /// Canonical raster extent used by @ref rasterizer.
+    Extent2D          raster{};
+    bool              valid = false;
+    std::uint64_t     lru_tick = 0;
+  };
+
+  void EvictOverflow();
+
+  std::map<std::pair<NodeId, MaskId>, Entry> entries_;
+  std::uint64_t                              lru_clock_ = 0;
+};
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -10,6 +10,7 @@
 #include <span>
 #include <stdexcept>
 
+#include "edit/mask/parameterized_brush_replay_cache.hpp"
 #include "edit/runtime/graph_image_cache.hpp"
 #include "edit/runtime/mask_texture_cache.hpp"
 #include "edit/runtime/node_result_cache.hpp"
@@ -66,6 +67,13 @@ class BasicRenderWorkspace {
   [[nodiscard]] auto ActiveRasterTextures() const -> const ActiveRasterTextureCache<Backend>& {
     return active_raster_textures_;
   }
+  /**
+   * @brief Retained canonical Brush rasters replayed regionally per render.
+   *
+   * Native Mask passes feed it the document source instead of a full
+   * re-rasterization; unchanged entries return shared pixels untouched.
+   */
+  [[nodiscard]] auto BrushReplay() -> ParameterizedBrushReplayCache& { return brush_replay_; }
   [[nodiscard]] auto Values() -> NodeResultCache<Backend>& { return values_; }
   [[nodiscard]] auto Images() -> GraphImageCache<Backend>& { return images_; }
   [[nodiscard]] auto Images() const -> const GraphImageCache<Backend>& { return images_; }
@@ -263,6 +271,7 @@ class BasicRenderWorkspace {
     validity_prepared_ = false;
     mask_textures_.Clear();
     active_raster_textures_.Clear();
+    brush_replay_.Clear();
     textures_.ReleaseUnleased();
     transients_.ReleaseDeviceMemory();
     parameters_.Clear();
@@ -315,6 +324,7 @@ class BasicRenderWorkspace {
   TexturePool<Backend>          textures_;
   MaskTextureCache<Backend>         mask_textures_;
   ActiveRasterTextureCache<Backend> active_raster_textures_;
+  ParameterizedBrushReplayCache     brush_replay_{};
   NodeResultCache<Backend>       values_{};
   GraphImageCache<Backend>       images_{};
   RuntimeInvalidationState       invalidation_{};

--- a/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
+++ b/alcedo_studio/src/include/edit/runtime/basic_render_workspace.hpp
@@ -10,6 +10,7 @@
 #include <span>
 #include <stdexcept>
 
+#include "edit/mask/brush_coverage_update.hpp"
 #include "edit/mask/parameterized_brush_replay_cache.hpp"
 #include "edit/runtime/graph_image_cache.hpp"
 #include "edit/runtime/mask_texture_cache.hpp"
@@ -74,6 +75,13 @@ class BasicRenderWorkspace {
    * re-rasterization; unchanged entries return shared pixels untouched.
    */
   [[nodiscard]] auto BrushReplay() -> ParameterizedBrushReplayCache& { return brush_replay_; }
+  /**
+   * @brief Last stamped parameterized Brush commands (no pixels).
+   *
+   * CUDA source raster uses this to stamp only new dabs. OpenCL/Metal host replay
+   * does not read it.
+   */
+  [[nodiscard]] auto BrushCommands() -> BrushCoverageCommandJournal& { return brush_commands_; }
   [[nodiscard]] auto Values() -> NodeResultCache<Backend>& { return values_; }
   [[nodiscard]] auto Images() -> GraphImageCache<Backend>& { return images_; }
   [[nodiscard]] auto Images() const -> const GraphImageCache<Backend>& { return images_; }
@@ -272,6 +280,7 @@ class BasicRenderWorkspace {
     mask_textures_.Clear();
     active_raster_textures_.Clear();
     brush_replay_.Clear();
+    brush_commands_.Clear();
     textures_.ReleaseUnleased();
     transients_.ReleaseDeviceMemory();
     parameters_.Clear();
@@ -325,6 +334,7 @@ class BasicRenderWorkspace {
   MaskTextureCache<Backend>         mask_textures_;
   ActiveRasterTextureCache<Backend> active_raster_textures_;
   ParameterizedBrushReplayCache     brush_replay_{};
+  BrushCoverageCommandJournal       brush_commands_{};
   NodeResultCache<Backend>       values_{};
   GraphImageCache<Backend>       images_{};
   RuntimeInvalidationState       invalidation_{};

--- a/alcedo_studio/src/include/edit/runtime/compiled_grade_mask.hpp
+++ b/alcedo_studio/src/include/edit/runtime/compiled_grade_mask.hpp
@@ -10,6 +10,7 @@
 #include "edit/graph/color_grade_node_model.hpp"
 #include "edit/graph/pipeline_document.hpp"
 #include "edit/mask/mask_model.hpp"
+#include "edit/mask/parameterized_brush_replay_cache.hpp"
 #include "edit/mask/parameterized_brush_raster.hpp"
 #include "edit/runtime/execution_plan.hpp"
 
@@ -69,19 +70,21 @@ inline auto BrushUsesParameterizedReplay(const BrushMaskSource& brush) -> bool {
 /**
  * @brief Request-owned canonical Brush raster tagged with the live Mask revision.
  *
- * @p content_revision is @ref ColorGradeNodeModel::MaskContentRevision, or 1 when
- * unset. Used by native Mask passes when the PipelineApplyRequest has no active
- * raster override. Throws when rasterization fails.
+ * Replays through the workspace-retained @p replay cache so an unchanged or
+ * locally grown source does not re-rasterize the full canvas. Used by native
+ * Mask passes when the PipelineApplyRequest has no active raster override.
+ * Throws when rasterization fails.
  */
 inline auto ParameterizedBrushActiveRasterForGrade(const PipelineDocument& document,
                                                    const NodeId& grade_id, const MaskId& mask_id,
                                                    const BrushMaskSource& brush,
-                                                   Extent2D full_reference)
+                                                   Extent2D full_reference,
+                                                   ParameterizedBrushReplayCache& replay)
     -> ActiveRasterMaskInput {
   const auto* grade =
       dynamic_cast<const ColorGradeNodeModel*>(document.Graph().FindNode(grade_id));
   const auto revision = grade == nullptr ? 1 : grade->MaskContentRevision(mask_id);
-  return MakeParameterizedBrushActiveRaster(grade_id, mask_id, brush, full_reference, revision);
+  return replay.Replay(grade_id, mask_id, brush, full_reference, revision);
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_brush_raster.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_brush_raster.hpp
@@ -1,0 +1,32 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#pragma once
+
+#include "edit/mask/brush_coverage_update.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "edit/runtime/cuda/cuda_backend.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+
+namespace alcedo {
+
+/**
+ * @brief Stamp or regionally replay a parameterized Brush onto an existing GPU R8.
+ *
+ * CPU owns commands. This writes canonical coverage texels in evaluation order:
+ * paint is max, erase is min(previous, 255-dab). @c StampNewSamples does not zero
+ * texels. @c ReplayDirty zeros @c update.dirty then restamps intersecting dabs.
+ * Uninitialized textures must pass @p texture_uninitialized true so the first
+ * write starts from zeros. There is no CPU raster substitute.
+ *
+ * @throws std::runtime_error on unsupported algorithm versions or CUDA launch
+ *         failure, or std::invalid_argument on empty geometry.
+ *
+ * Thread: CUDA Mask pass on the render thread. Uses @p device's current stream.
+ */
+void ApplyParameterizedBrushCuda(CudaRenderDevice& device, CudaBackend::Texture2D& dest,
+                                 const BrushMaskSource& source, Extent2D full_reference,
+                                 const BrushCoverageUpdate& update, bool texture_uninitialized);
+
+}  // namespace alcedo

--- a/alcedo_studio/src/include/edit/runtime/cuda/cuda_mask_pass.hpp
+++ b/alcedo_studio/src/include/edit/runtime/cuda/cuda_mask_pass.hpp
@@ -27,11 +27,12 @@ struct CudaMaskResult {
  * @brief Evaluate @p compiled_source into its effective GraphValueId (RenderSpace R8).
  *
  * Persistent Brush textures are keyed by MaskAssetKey and are never patched. Parameterized
- * Brushes replay onto a request-owned canonical R8 and upload through the active-raster
- * cache, not MaskStore. Active Brush pixels use a separate session-generation texture and
- * dirty-rectangle upload. Changing only feather radius reuses signed distance when the
- * raster bytes are unchanged. Feather (when present), invert, and opacity run in that
- * order. No CPU image processing fallback is used.
+ * Brushes stamp canonical coverage on the GPU active-raster texture from stroke commands.
+ * There is no host R8 replay on this CUDA authoring path. Injected active Brush pixels still
+ * upload through the active-raster cache. Changing only feather radius reuses signed distance
+ * when the raster bytes are unchanged. Feather (when present), invert, and opacity run in that
+ * order. Soft-edge authoring does not fill unused R8 mips. No CPU image processing fallback is
+ * used.
  */
 [[nodiscard]] auto ExecuteCudaMask(CudaRenderDevice& device, const ExecutionPlan& plan,
                                    const PipelineDocument& document,

--- a/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
+++ b/alcedo_studio/src/include/edit/runtime/detail/renderer.inl.hpp
@@ -168,7 +168,11 @@ auto Renderer<Backend>::Render(const std::shared_ptr<ImageBuffer>& input,
 
   try {
     if (request.sink != nullptr) {
-      FramePresenter<Backend>::Present(*render_device, output_id, *request.sink, request.submission,
+      // Attach the exact resolved geometry so viewer-side Mask mapping uses the
+      // frame being presented instead of a separately derived document mapping.
+      FrameCompletionSubmission presented = request.submission;
+      presented.geometry                  = plan.geometry;
+      FramePresenter<Backend>::Present(*render_device, output_id, *request.sink, presented,
                                        display_config);
     }
     if (request.require_host_output) {

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
@@ -15,6 +15,7 @@
 
 #include "app/editor_mask_creation_controller.hpp"
 #include "edit/mask/mask_model.hpp"
+#include "ui/edit_viewer/mask_edit_geometry.hpp"
 #include "ui/edit_viewer/mask_overlay_geometry.hpp"
 
 namespace alcedo::editor_rhi {
@@ -49,8 +50,8 @@ class EditorMaskCreationAdapter : public QObject {
   Q_PROPERTY(qreal minorRadiusPercent READ minor_radius_percent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal rotationDegrees READ rotation_degrees NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal transitionPercent READ transition_percent NOTIFY maskCreationChanged)
-  Q_PROPERTY(qreal brushRadius READ brush_radius NOTIFY maskCreationChanged)
-  Q_PROPERTY(qreal brushRadiusPercent READ brush_radius_percent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushDiameter READ brush_diameter NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushDiameterPercent READ brush_diameter_percent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal brushStrengthPercent READ brush_strength_percent NOTIFY maskCreationChanged)
   Q_PROPERTY(QString brushTool READ brush_tool_name NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal brushFeatherPercent READ brush_feather_percent NOTIFY maskCreationChanged)
@@ -85,13 +86,15 @@ class EditorMaskCreationAdapter : public QObject {
   [[nodiscard]] auto rotation_degrees() const -> qreal;
   [[nodiscard]] auto transition_percent() const -> qreal;
   [[nodiscard]] auto brush_radius() const -> qreal { return static_cast<qreal>(brush_radius_); }
+  /// Brush dab diameter in reference pixels (2 * radius).
+  [[nodiscard]] auto brush_diameter() const -> qreal { return 2.0 * static_cast<qreal>(brush_radius_); }
   /**
-   * @brief Brush radius as a percent of the shorter full-reference edge.
+   * @brief Brush dab diameter as a percent of the shorter full-reference edge.
    *
-   * Reference extents are read from the bound interaction mapping. Zero when no
-   * extent is published.
+   * The panel slider edits diameter, not radius. Reference extents are read
+   * from the bound interaction mapping. Zero when no extent is published.
    */
-  [[nodiscard]] auto brush_radius_percent() const -> qreal;
+  [[nodiscard]] auto brush_diameter_percent() const -> qreal;
   [[nodiscard]] auto brush_strength_percent() const -> qreal {
     return static_cast<qreal>(brush_strength_) * 100.0;
   }
@@ -116,7 +119,8 @@ class EditorMaskCreationAdapter : public QObject {
   Q_INVOKABLE void   beginBrush();
   Q_INVOKABLE void   setBrushTool(const QString& tool);
   Q_INVOKABLE void   setBrushRadius(qreal radius);
-  Q_INVOKABLE void   setBrushRadiusPercent(qreal percent);
+  /// Set the dab diameter as a percent of the shorter full-reference edge.
+  Q_INVOKABLE void   setBrushDiameterPercent(qreal percent);
   Q_INVOKABLE void   setBrushStrengthPercent(qreal percent);
   Q_INVOKABLE void   setMaskEnabled(bool enabled);
   Q_INVOKABLE void   setMaskInvert(bool invert);
@@ -168,12 +172,14 @@ class EditorMaskCreationAdapter : public QObject {
   void               BeginTool(MaskSourceKind kind, const QString& tool_kind);
   void               BeginBrushTool();
   [[nodiscard]] auto ResolveBrushResumeMask(const NodeId& grade_id) const -> MaskId;
-  [[nodiscard]] auto BrushRadiusLogicalPx(const MaskCreationSample& sample) const -> float;
+  /// Item-space dab radius at the current mapping. Affine, so position-free.
+  [[nodiscard]] auto BrushRadiusLogicalPx() const -> float;
   void               EnqueueBrushSettings(EditorMaskCreationCommand& command) const;
   void               ResetLocal();
   void               PublishOverlay();
   void               HideOverlay();
-  void               PublishDisplayedGeometry();
+  /// Cancel the open op when the press-time mapping no longer matches.
+  auto               CancelIfMappingChanged() -> bool;
   void               ApplyOwnerSource(const MaskId& mask_id, const MaskSource& source);
   void               BeginAnalyticMove(AnalyticMaskHandle handle);
   void               UpdateFeatherPercent(AnalyticMaskHandle handle, qreal percent);
@@ -221,6 +227,12 @@ class EditorMaskCreationAdapter : public QObject {
   float                                             brush_strength_   = 1.0f;
   float                                             brush_hardness_   = 1.0f;
   std::vector<QPointF>                              brush_item_path_;
+  /// Mapping snapshot taken when the open pointer op started. A presented-frame
+  /// or view change that alters it cancels the op before the next sample.
+  std::optional<MaskEditMappingIdentity>            press_mapping_identity_;
+  /// Last hover point in item space; drives the armed-Brush cursor ring.
+  QPointF                                           hover_item_{};
+  bool                                              hover_valid_ = false;
   Vector2                                           nudge_base_normalized_{};
   Vector2                                           nudge_base_reference_{};
   Vector2                                           nudge_offset_{};

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
@@ -212,6 +212,13 @@ class EditorMaskCreationAdapter : public QObject {
   QPointer<editor_rhi::EditorInteractionController> interaction_;
   QPointer<editor_rhi::EditorOverlayItem>           overlay_;
   QMetaObject::Connection                           view_change_connection_;
+  /// overlayGeometryChanged → PublishOverlay. Mask chrome is item-space, so
+  /// view churn (panel fold, window resize, zoom/pan) remaps it through this
+  /// signal instead of relying on backend NotifyChange storms.
+  QMetaObject::Connection                           overlay_geometry_connection_;
+  /// Mapping inputs of the last PublishOverlay; compared against the live
+  /// maskEditMappingIdentity so identical geometry never republishes.
+  MaskEditMappingIdentity                           published_mapping_identity_{};
   QString                                           tool_kind_;
   QString                                           selected_mask_id_;
   NodeId                                            edit_node_id_;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
@@ -132,6 +132,13 @@ class EditorMaskCreationAdapter : public QObject {
   Q_INVOKABLE bool   beginMaskNudge();
   Q_INVOKABLE void   nudgeMaskBy(qreal dx_px, qreal dy_px);
   Q_INVOKABLE void   cancel();
+  /**
+   * @brief Cancel the open canvas pointer sequence and keep the armed tool.
+   *
+   * Use for grab loss / handler cancellation. Does not enqueue CancelMode.
+   * No-op when no pointer sequence is open or the open op is a panel control.
+   */
+  Q_INVOKABLE void   cancelOpenPointerInput();
   Q_INVOKABLE void   hideBody();
   Q_INVOKABLE void   finishBody();
   Q_INVOKABLE void   selectMask(const QString& node_id, const QString& mask_id);

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <QObject>
-#include <QPointer>
 #include <QPointF>
+#include <QPointer>
 #include <QRectF>
 #include <QString>
 #include <cstdint>
@@ -50,8 +50,15 @@ class EditorMaskCreationAdapter : public QObject {
   Q_PROPERTY(qreal rotationDegrees READ rotation_degrees NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal transitionPercent READ transition_percent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal brushRadius READ brush_radius NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushRadiusPercent READ brush_radius_percent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal brushStrengthPercent READ brush_strength_percent NOTIFY maskCreationChanged)
   Q_PROPERTY(QString brushTool READ brush_tool_name NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushFeatherPercent READ brush_feather_percent NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool maskEnabled READ mask_enabled NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool maskInvert READ mask_invert NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal maskOpacityPercent READ mask_opacity_percent NOTIFY maskCreationChanged)
+  Q_PROPERTY(QString maskName READ mask_name NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool maskNudgeAvailable READ mask_nudge_available NOTIFY maskCreationChanged)
 
  public:
   enum class EditMode : std::uint8_t {
@@ -78,10 +85,29 @@ class EditorMaskCreationAdapter : public QObject {
   [[nodiscard]] auto rotation_degrees() const -> qreal;
   [[nodiscard]] auto transition_percent() const -> qreal;
   [[nodiscard]] auto brush_radius() const -> qreal { return static_cast<qreal>(brush_radius_); }
+  /**
+   * @brief Brush radius as a percent of the shorter full-reference edge.
+   *
+   * Reference extents are read from the bound interaction mapping. Zero when no
+   * extent is published.
+   */
+  [[nodiscard]] auto brush_radius_percent() const -> qreal;
   [[nodiscard]] auto brush_strength_percent() const -> qreal {
     return static_cast<qreal>(brush_strength_) * 100.0;
   }
   [[nodiscard]] auto brush_tool_name() const -> QString;
+  [[nodiscard]] auto brush_feather_percent() const -> qreal;
+  [[nodiscard]] auto mask_enabled() const -> bool;
+  [[nodiscard]] auto mask_invert() const -> bool;
+  [[nodiscard]] auto mask_opacity_percent() const -> qreal;
+  [[nodiscard]] auto mask_name() const -> QString;
+  /**
+   * @brief True when the selected Mask has a keyboard-movable position.
+   *
+   * Brush placement nudges require Move mode; Radial center and Linear origin
+   * are always movable while selected.
+   */
+  [[nodiscard]] auto mask_nudge_available() const -> bool;
 
   Q_INVOKABLE void   bindInteractionItem(QObject* interaction);
   Q_INVOKABLE void   bindOverlayItem(QObject* overlay);
@@ -90,7 +116,17 @@ class EditorMaskCreationAdapter : public QObject {
   Q_INVOKABLE void   beginBrush();
   Q_INVOKABLE void   setBrushTool(const QString& tool);
   Q_INVOKABLE void   setBrushRadius(qreal radius);
+  Q_INVOKABLE void   setBrushRadiusPercent(qreal percent);
   Q_INVOKABLE void   setBrushStrengthPercent(qreal percent);
+  Q_INVOKABLE void   setMaskEnabled(bool enabled);
+  Q_INVOKABLE void   setMaskInvert(bool invert);
+  Q_INVOKABLE void   setMaskName(const QString& name);
+  Q_INVOKABLE void   beginMaskOpacity();
+  Q_INVOKABLE void   updateMaskOpacity(qreal percent);
+  Q_INVOKABLE void   beginBrushFeather();
+  Q_INVOKABLE void   updateBrushFeatherPercent(qreal percent);
+  Q_INVOKABLE bool   beginMaskNudge();
+  Q_INVOKABLE void   nudgeMaskBy(qreal dx_px, qreal dy_px);
   Q_INVOKABLE void   cancel();
   Q_INVOKABLE void   hideBody();
   Q_INVOKABLE void   finishBody();
@@ -143,6 +179,10 @@ class EditorMaskCreationAdapter : public QObject {
   void               UpdateFeatherPercent(AnalyticMaskHandle handle, qreal percent);
   void               UpdateRadialRadiusPercent(AnalyticMaskHandle handle, qreal percent);
   void               EnqueueAppendSample(const MaskCreationSample& sample);
+  void               EnqueueMaskField(std::string_view field_key, nlohmann::json value);
+  void               BeginMaskField(std::string_view field_key);
+  [[nodiscard]] auto SelectedMask() const -> const MaskModel*;
+  [[nodiscard]] auto ReferenceShorterEdgePx() const -> float;
   [[nodiscard]] auto CurrentGradeId() const -> NodeId;
   [[nodiscard]] auto CanAuthorMasks() const -> bool;
   [[nodiscard]] auto CanAuthorMasksFor(const NodeId& grade_id) const -> bool;
@@ -162,9 +202,11 @@ class EditorMaskCreationAdapter : public QObject {
   QString                                           tool_kind_;
   QString                                           selected_mask_id_;
   NodeId                                            edit_node_id_;
-  MaskSourceKind                                    source_kind_ = MaskSourceKind::Radial;
-  EditMode                                          edit_mode_   = EditMode::Inactive;
-  bool                                              open_        = false;
+  MaskSourceKind                                    source_kind_    = MaskSourceKind::Radial;
+  EditMode                                          edit_mode_      = EditMode::Inactive;
+  bool                                              open_           = false;
+  /// Open op belongs to a panel control (slider/keyboard), not a canvas drag.
+  bool                                              open_via_panel_ = false;
   MaskPointerIdentity                               pointer_{};
   Vector2                                           press_normalized_{};
   Vector2                                           press_reference_pixels_{};
@@ -179,6 +221,9 @@ class EditorMaskCreationAdapter : public QObject {
   float                                             brush_strength_   = 1.0f;
   float                                             brush_hardness_   = 1.0f;
   std::vector<QPointF>                              brush_item_path_;
+  Vector2                                           nudge_base_normalized_{};
+  Vector2                                           nudge_base_reference_{};
+  Vector2                                           nudge_offset_{};
 };
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/editor_session_controller.hpp
@@ -306,6 +306,7 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   auto               EnqueueMaskCreation(alcedo::EditorMaskCreationCommand command) -> bool;
   [[nodiscard]] auto mask_creation_mask_id() const -> alcedo::MaskId;
   [[nodiscard]] auto mask_creation_node_id() const -> alcedo::NodeId;
+  [[nodiscard]] auto mask_creation_state() const -> alcedo::EditorMaskCreationState;
   [[nodiscard]] auto mask_creation_source() const -> std::optional<alcedo::MaskSource>;
   [[nodiscard]] auto mask_creation_last_removed_mask_id() const -> alcedo::MaskId;
   [[nodiscard]] auto mask_creation_commands_pending() const -> bool;
@@ -420,6 +421,7 @@ class EditorSessionController final : public QObject, public IEditorAdjustmentSu
   QPointer<QObject>       interaction_controller_;
   QMetaObject::Connection interaction_view_change_connection_;
   QMetaObject::Connection interaction_policy_connection_;
+  QMetaObject::Connection presented_geometry_connection_;
   mutable std::unique_ptr<EditorScopeController> scope_controller_;
   std::unique_ptr<EditorMaskCreationAdapter>     mask_creation_;
   QTimer*                                        admission_deadline_timer_ = nullptr;

--- a/alcedo_studio/src/include/ui/alcedo_main/album_backend/project_module.hpp
+++ b/alcedo_studio/src/include/ui/alcedo_main/album_backend/project_module.hpp
@@ -7,6 +7,7 @@
 #include <QObject>
 #include <QString>
 #include <QVariantList>
+#include <QVariantMap>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
@@ -14,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "app/semantic_generation_service.hpp"
 #include "edit/pipeline/pipeline_accelerator.hpp"
 #include "ui/alcedo_main/album_backend/project_handler.hpp"
 #include "ui/alcedo_main/album_backend/ui_status_sink.hpp"
 #include "ui/alcedo_main/i18n.hpp"
-#include "app/semantic_generation_service.hpp"
 
 namespace alcedo::ui {
 
@@ -26,14 +27,14 @@ namespace alcedo::ui {
 /// are behavior seams, not a service bag: project code can ask the composition
 /// root to perform one lifecycle operation without acquiring sibling modules.
 struct ProjectLifecycleHooks {
-  std::function<QString()> project_switch_block_reason;
-  std::function<void()> finalize_editor_session;
-  std::function<void()> clear_project_ui_state;
-  std::function<void()> project_opened;
+  std::function<QString()>            project_switch_block_reason;
+  std::function<void()>               finalize_editor_session;
+  std::function<void()>               clear_project_ui_state;
+  std::function<void()>               project_opened;
   std::function<bool(const QString&)> should_keep_semantic_model_data;
-  std::function<void()> refresh_semantic_state;
-  std::function<bool()> export_inflight;
-  std::function<void()> refresh_translations;
+  std::function<void()>               refresh_semantic_state;
+  std::function<bool()>               export_inflight;
+  std::function<void()>               refresh_translations;
 };
 
 /// Project lifecycle module: open/create/save, accelerator preference, recent
@@ -57,12 +58,13 @@ class ProjectModule final : public QObject, public IUiStatusSink {
   Q_PROPERTY(QString taskStatus READ TaskStatus NOTIFY TaskStateChanged)
   Q_PROPERTY(int taskProgress READ TaskProgress NOTIFY TaskStateChanged)
   Q_PROPERTY(bool taskCancelVisible READ TaskCancelVisible NOTIFY TaskStateChanged)
+  Q_PROPERTY(QVariantMap maskCacheState READ MaskCacheState NOTIFY MaskCacheStateChanged)
 
  public:
   explicit ProjectModule(QObject* parent = nullptr);
   ~ProjectModule() override = default;
 
-  void SetLifecycleHooks(ProjectLifecycleHooks hooks);
+  void               SetLifecycleHooks(ProjectLifecycleHooks hooks);
 
   // ── Core accessors ─────────────────────────────────────────────────────
   [[nodiscard]] auto handler() -> ProjectHandler& { return handler_; }
@@ -70,7 +72,7 @@ class ProjectModule final : public QObject, public IUiStatusSink {
   [[nodiscard]] auto accelerator_preference() const -> AcceleratorBackendPreference {
     return accelerator_preference_;
   }
-  void SetRuntimeAcceleratorPreference(AcceleratorBackendPreference preference);
+  void         SetRuntimeAcceleratorPreference(AcceleratorBackendPreference preference);
   // ── Q_PROPERTY getters ─────────────────────────────────────────────────
   bool         ServiceReady() const { return service_ready_; }
   QString      ServiceMessage() const { return service_message_text_.Render(); }
@@ -91,37 +93,45 @@ class ProjectModule final : public QObject, public IUiStatusSink {
   bool    TaskCancelVisible() const { return task_cancel_visible_; }
 
   // ── IUiStatusSink ──────────────────────────────────────────────────────
-  void SetServiceMessage(const i18n::LocalizedText& message) override;
-  void SetTaskState(const i18n::LocalizedText& status, int progress,
-                    bool cancelVisible) override;
+  void    SetServiceMessage(const i18n::LocalizedText& message) override;
+  void SetTaskState(const i18n::LocalizedText& status, int progress, bool cancelVisible) override;
   void ScheduleIdleTaskStateReset(int delayMs) override;
 
   void SetServiceState(bool ready, const i18n::LocalizedText& message);
   void SetServiceMessageForCurrentProject(const i18n::LocalizedText& message);
 
   // ── Project lifecycle Q_INVOKABLE ──────────────────────────────────────
-  Q_INVOKABLE bool PromptAndLoadProject();
-  Q_INVOKABLE bool PromptAndCreateProject();
-  Q_INVOKABLE bool SetAcceleratorBackend(const QString& backendKey);
-  Q_INVOKABLE void StartAcceleratorPreparation();
-  Q_INVOKABLE void AcknowledgeAcceleratorWarning();
-  Q_INVOKABLE bool LoadProject(const QString& metaFileUrlOrPath);
-  Q_INVOKABLE bool CreateProjectInFolder(const QString& folderUrlOrPath);
-  Q_INVOKABLE bool CreateProjectInFolderNamed(const QString& folderUrlOrPath,
-                                              const QString& projectName);
-  Q_INVOKABLE bool SaveProject();
+  Q_INVOKABLE bool   PromptAndLoadProject();
+  Q_INVOKABLE bool   PromptAndCreateProject();
+  Q_INVOKABLE bool   SetAcceleratorBackend(const QString& backendKey);
+  Q_INVOKABLE void   StartAcceleratorPreparation();
+  Q_INVOKABLE void   AcknowledgeAcceleratorWarning();
+  Q_INVOKABLE bool   LoadProject(const QString& metaFileUrlOrPath);
+  Q_INVOKABLE bool   CreateProjectInFolder(const QString& folderUrlOrPath);
+  Q_INVOKABLE bool   CreateProjectInFolderNamed(const QString& folderUrlOrPath,
+                                                const QString& projectName);
+  Q_INVOKABLE bool   SaveProject();
+
+  // ── Project Mask cache settings (Settings > Cache) ─────────────────────
+  // Project-scoped Mix-cache location/retention/usage. Not photo history and
+  // separate from the thumbnail disk cache surfaced by LibraryModule.
+  [[nodiscard]] auto MaskCacheState() const -> QVariantMap;
+  Q_INVOKABLE bool   ApplyMaskCacheRoot(const QString& chosenRoot);
+  Q_INVOKABLE bool   ApplyMaskCacheRetention(const QString& retentionKey);
+  Q_INVOKABLE bool   ClearMaskCache();
+  Q_INVOKABLE void   RefreshMaskCacheState();
 
   // ── Internals used by ProjectHandler / host ────────────────────────────
-  void InitializeAcceleratorSettings();
-  void RefreshTranslations();
-  void LoadRecentProjectsFromSettings();
-  void RegisterRecentProject(const std::filesystem::path& projectPath);
-  void RemoveRecentProject(const std::filesystem::path& projectPath);
-  void NotifyProjectLoadStateChanged();
-  void HandleProjectOpened();
-  void ClearProjectUiState();
+  void               InitializeAcceleratorSettings();
+  void               RefreshTranslations();
+  void               LoadRecentProjectsFromSettings();
+  void               RegisterRecentProject(const std::filesystem::path& projectPath);
+  void               RemoveRecentProject(const std::filesystem::path& projectPath);
+  void               NotifyProjectLoadStateChanged();
+  void               HandleProjectOpened();
+  void               ClearProjectUiState();
   [[nodiscard]] auto ProjectSwitchBlockReason() const -> QString;
-  void              FinalizeEditorSession();
+  void               FinalizeEditorSession();
   [[nodiscard]] bool ShouldKeepSemanticModelData(const QString& profileId) const;
 
  signals:
@@ -133,22 +143,23 @@ class ProjectModule final : public QObject, public IUiStatusSink {
   void ProjectChanged();
   void projectChanged();
   void ProjectLoadStateChanged();
+  void MaskCacheStateChanged();
 
  private:
-  void StartOpenClPreparationIfNeeded();
-  void SetAcceleratorPreparationState(bool preparing, const i18n::LocalizedText& status);
-  void RebuildAcceleratorOptions();
-  bool IsAcceleratorWarningAcknowledged() const;
-  void PersistAcceleratorWarningAcknowledgement() const;
-  void PersistRecentProjects() const;
+  void           StartOpenClPreparationIfNeeded();
+  void           SetAcceleratorPreparationState(bool preparing, const i18n::LocalizedText& status);
+  void           RebuildAcceleratorOptions();
+  bool           IsAcceleratorWarningAcknowledged() const;
+  void           PersistAcceleratorWarningAcknowledgement() const;
+  void           PersistRecentProjects() const;
 
   ProjectHandler handler_;
 
-  ProjectLifecycleHooks lifecycle_hooks_{};
+  ProjectLifecycleHooks        lifecycle_hooks_{};
 
-  i18n::LocalizedText service_message_text_{};
-  bool                service_ready_ = false;
-  QVariantList        recent_projects_{};
+  i18n::LocalizedText          service_message_text_{};
+  bool                         service_ready_ = false;
+  QVariantList                 recent_projects_{};
   AcceleratorBackendPreference accelerator_preference_ = AcceleratorBackendPreference::Auto;
   QString                      accelerator_backend_key_{};
   QString                      accelerator_warning_id_{};
@@ -163,6 +174,7 @@ class ProjectModule final : public QObject, public IUiStatusSink {
   i18n::LocalizedText          task_status_text_{};
   int                          task_progress_       = 0;
   bool                         task_cancel_visible_ = false;
+  QString                      mask_cache_apply_error_{};
 };
 
 }  // namespace alcedo::ui

--- a/alcedo_studio/src/include/ui/edit_viewer/frame_sink.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/frame_sink.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 
 #include "edit/frame_presentation_types.hpp"
+#include "edit/geometry/resolved_render_geometry.hpp"
 #include "edit/operators/utils/color_utils.hpp"
 
 namespace alcedo {
@@ -63,6 +64,14 @@ enum class FramePresentationMode {
 struct FrameCompletionSubmission {
   FramePreviewMetadata  metadata{};
   FramePresentationMode mode = FramePresentationMode::FullFrame;
+  /**
+   * @brief Exact @c ResolveRenderGeometry result of the presented frame.
+   *
+   * Stamped by the renderer so Mask pointer mapping, overlays, and pixels use
+   * the same displayed-photograph geometry the frame was produced with. Empty
+   * extents mean no geometry was attached (analysis-only or legacy frames).
+   */
+  ResolvedRenderGeometry geometry{};
 };
 
 enum class FramePixelFormat {

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_edit_geometry.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_edit_geometry.hpp
@@ -64,9 +64,9 @@ struct MaskReferenceSample {
 /**
  * @brief Snapshot of mapping inputs used to cancel an open Mask operation.
  *
- * Viewport resize, DPR change, view transform, presentation, RoiFrame ROI, or
- * displayed-photograph geometry changes must cancel unfinished Mask input before
- * the new mapping is used.
+ * Widget resize, DPR, zoom/pan, presentation, or a different full-reference
+ * image cancel unfinished Mask input. Quality vs Interactive render extent is
+ * compared through the composed item→reference mapping, not raw field equality.
  */
 struct MaskEditMappingIdentity {
   int                   widget_width        = 0;
@@ -139,6 +139,11 @@ class MaskEditGeometry {
 
   /**
    * @brief True when unfinished Mask input must be cancelled before using @p after.
+   *
+   * Compares the composed item→ReferenceSpace mapping, not raw identity fields.
+   * Quality and Interactive frames of the same view (different render extent with
+   * a compensating @c render_to_reference) keep the stroke open. Widget resize,
+   * DPR, zoom/pan, presentation mode, or a different full-reference image cancel.
    */
   [[nodiscard]] static auto MappingChanged(const MaskEditMappingIdentity& before,
                                            const MaskEditMappingIdentity& after) -> bool;

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_geometry.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_geometry.hpp
@@ -82,10 +82,15 @@ enum class MaskOverlayHandleId : std::uint8_t {
   LinearEndBoundary    = 11,
 };
 
-/** @brief Disc is a filled radius/origin control. Ring is a feather control. */
+/**
+ * @brief Disc is a filled radius/origin control. Ring is a feather control.
+ * CornerTick is a short Brush Move frame anchor: two segments along the frame
+ * edges meeting at the corner point.
+ */
 enum class MaskOverlayHandleShape : std::uint8_t {
-  Disc = 0,
-  Ring = 1,
+  Disc       = 0,
+  Ring       = 1,
+  CornerTick = 2,
 };
 
 /** @brief One handle in item/logical coordinates. */
@@ -161,6 +166,12 @@ struct MaskOverlayDisplay {
   bool    cursor_visible = false;
   QPointF cursor_center{};
   float   cursor_radius_logical_px = 0.0f;
+  /// Erase preview: the cursor outline renders dashed instead of solid.
+  bool    cursor_dashed = false;
+  /// Brush Move affordance: translated coverage bounds (paint supports plus
+  /// feather) mapped to item/logical space as a, possibly rotated, quad. The
+  /// four CornerTick handles anchor it; inside/frame hits resolve to BrushMove.
+  bool move_frame_visible = false;
   std::vector<QPointF> creation_path;
   std::vector<QPointF> creation_outline;
   std::vector<std::pair<QPointF, QPointF>> creation_guides;

--- a/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
+++ b/alcedo_studio/src/include/ui/edit_viewer/mask_overlay_layout.hpp
@@ -80,6 +80,28 @@ namespace alcedo {
                                                    const QRectF& clip) -> MaskOverlayDisplay;
 
 /**
+ * @brief Existing Brush in Move mode: translated coverage bounds as a frame.
+ *
+ * The quad is the AABB of positive-strength Paint dab supports (each dab's
+ * reference-pixel disc bounding box), expanded by @p source.feather_radius,
+ * then mapped corner-by-corner so rotation stays faithful. CornerTick handles
+ * anchor the four corners; pressing inside the frame or on an edge begins
+ * BrushMove. A Brush with no painted coverage falls back to the single Move
+ * handle at @c placement_translation.
+ */
+[[nodiscard]] auto MakeBrushMoveOverlayDisplay(const MaskEditViewMapping& mapping,
+                                               const BrushMaskSource&     source,
+                                               const QRectF& clip) -> MaskOverlayDisplay;
+
+/**
+ * @brief Translated Paint-dab support AABB of @p source in reference pixels.
+ *
+ * Empty @c RectF when no Paint dab carries positive strength. Feather is not
+ * included; callers expand as needed.
+ */
+[[nodiscard]] auto BrushPaintSupportReferenceBounds(const BrushMaskSource& source) -> QRectF;
+
+/**
  * @brief Existing Radial: center, axes, rotation, feather handles, and iso-rho lines.
  *
  * Shows the base ellipse (solid) and distinct inner/outer feather contours
@@ -110,7 +132,9 @@ namespace alcedo {
 [[nodiscard]] auto MakeBrushCreatingOverlayDisplay(const std::vector<QPointF>& item_path,
                                                    QPointF                     cursor_item,
                                                    float         cursor_radius_logical_px,
-                                                   const QRectF& clip) -> MaskOverlayDisplay;
+                                                   const QRectF& clip,
+                                                   bool          erase_cursor = false)
+    -> MaskOverlayDisplay;
 
 /**
  * @brief Initial Radial drawing: selected contours and handles while the drag is open.

--- a/alcedo_studio/src/include/ui/editor_rhi/editor_viewport_item.hpp
+++ b/alcedo_studio/src/include/ui/editor_rhi/editor_viewport_item.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <mutex>
 
+#include "edit/geometry/resolved_render_geometry.hpp"
 #include "ui/edit_viewer/frame_sink.hpp"
 #include "ui/editor_rhi/direct_present_queue.hpp"
 #include "ui/viewer/viewer_view_state.hpp"
@@ -142,6 +143,19 @@ class EditorViewportItem : public QQuickRhiItem {
     return adjustment_frame_request_count_.load(std::memory_order_acquire);
   }
 
+  /**
+   * @brief Resolved geometry of the latest presented render-reference frame.
+   *
+   * Written by @c DirectFrameSink on the GUI thread after a submission is
+   * accepted. Mask pointer mapping must use this instead of a separately
+   * derived document geometry so the mask always tracks the displayed pixels.
+   */
+  void               NotePresentedMaskGeometry(const ResolvedRenderGeometry& geometry,
+                                               qulonglong                    request_id);
+  [[nodiscard]] auto presentedMaskGeometry() const -> const ResolvedRenderGeometry& {
+    return presented_mask_geometry_;
+  }
+
   // Called by the application composition root before loading QML. The
   // registration is idempotent and also makes visible-window QML tests use the
   // same real type.
@@ -155,6 +169,8 @@ class EditorViewportItem : public QQuickRhiItem {
   void DisplayConfigChanged();
   // camelCase for QML handler onTargetSizeRequested.
   void targetSizeRequested(int width, int height);
+  /// Emitted after @ref NotePresentedMaskGeometry stores a newer frame geometry.
+  void PresentedMaskGeometryChanged();
 
  protected:
   auto createRenderer() -> QQuickRhiItemRenderer* override;
@@ -195,6 +211,9 @@ class EditorViewportItem : public QQuickRhiItem {
   std::atomic<std::uint64_t> adjustment_frame_request_count_{0};
   std::atomic<bool>          interactive_present_loop_{false};
   std::atomic<std::uint64_t> interactive_present_loop_tick_count_{0};
+  // GUI-thread only: geometry of the last accepted render-reference frame.
+  ResolvedRenderGeometry     presented_mask_geometry_{};
+  qulonglong                 presented_mask_request_id_ = 0;
   QQuickWindow*              attached_window_ = nullptr;
   QMetaObject::Connection    window_visibility_connection_;
   QMetaObject::Connection    window_screen_connection_;

--- a/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
+++ b/alcedo_studio/src/ui/alcedo_main/CMakeLists.txt
@@ -565,6 +565,7 @@ set(ALCEDO_MAIN_QML_FILES
     "${ALCEDO_UI_SHELL_ROOT}/qml/UpdateNotice.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/UpdatesSettingsPanel.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/CacheSettingsPanel.qml"
+    "${ALCEDO_UI_SHELL_ROOT}/qml/ProjectMaskCacheSettingsPanel.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/NikonHeRecoveryDialog.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/SemanticGenerationDialog.qml"
     "${ALCEDO_UI_SHELL_ROOT}/qml/AdvancedContentAnalysisDialog.qml"

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
@@ -4,13 +4,13 @@
 
 #include "ui/alcedo_main/album_backend/editor_mask_creation_adapter.hpp"
 
-#include <QDebug>
 #include <QLineF>
 #include <QPointF>
 #include <Qt>
 #include <algorithm>
 #include <cmath>
 #include <string>
+#include <string_view>
 #include <variant>
 
 #include "edit/geometry/render_request.hpp"
@@ -311,7 +311,7 @@ void EditorMaskCreationAdapter::BeginBrushTool() {
       brush_radius_ = DefaultBrushRadiusReferencePixels(extent);
     }
   }
-  const auto resume = ResolveBrushResumeMask(grade);
+  const auto                resume = ResolveBrushResumeMask(grade);
   EditorMaskCreationCommand command;
   command.kind        = EditorMaskCreationCommandKind::BeginCreation;
   command.source_kind = MaskSourceKind::Brush;
@@ -329,6 +329,7 @@ void EditorMaskCreationAdapter::BeginBrushTool() {
   brush_tool_       = EditorBrushTool::Paint;
   selected_mask_id_ = MaskIdToQString(resume);
   open_             = false;
+  open_via_panel_   = false;
   brush_item_path_.clear();
   overlay_source_.reset();
   overlay_display_ = {};
@@ -390,7 +391,7 @@ void EditorMaskCreationAdapter::setBrushRadius(qreal radius) {
   }
   brush_radius_ = static_cast<float>(radius);
   EditorMaskCreationCommand command;
-  command.kind = EditorMaskCreationCommandKind::SetBrushStrokeParameters;
+  command.kind    = EditorMaskCreationCommandKind::SetBrushStrokeParameters;
   command.node_id = edit_node_id_;
   command.mask_id = MaskIdFromQString(selected_mask_id_);
   EnqueueBrushSettings(command);
@@ -401,7 +402,7 @@ void EditorMaskCreationAdapter::setBrushRadius(qreal radius) {
 void EditorMaskCreationAdapter::setBrushStrengthPercent(qreal percent) {
   brush_strength_ = std::clamp(static_cast<float>(percent) / 100.0f, 0.0f, 1.0f);
   EditorMaskCreationCommand command;
-  command.kind = EditorMaskCreationCommandKind::SetBrushStrokeParameters;
+  command.kind    = EditorMaskCreationCommandKind::SetBrushStrokeParameters;
   command.node_id = edit_node_id_;
   command.mask_id = MaskIdFromQString(selected_mask_id_);
   EnqueueBrushSettings(command);
@@ -409,15 +410,245 @@ void EditorMaskCreationAdapter::setBrushStrengthPercent(qreal percent) {
   emit maskCreationChanged();
 }
 
+auto EditorMaskCreationAdapter::SelectedMask() const -> const MaskModel* {
+  if (session_ == nullptr || selected_mask_id_.isEmpty()) {
+    return nullptr;
+  }
+  const auto* document = session_->pipeline_document();
+  if (document == nullptr) {
+    return nullptr;
+  }
+  const auto* grade =
+      dynamic_cast<const ColorGradeNodeModel*>(document->Graph().FindNode(edit_node_id_));
+  if (grade == nullptr) {
+    return nullptr;
+  }
+  return grade->FindMask(MaskIdFromQString(selected_mask_id_));
+}
+
+auto EditorMaskCreationAdapter::ReferenceShorterEdgePx() const -> float {
+  if (interaction_ == nullptr) {
+    return 0.0f;
+  }
+  const auto& extent = interaction_->maskEditViewMapping().geometry.full_reference_extent;
+  if (extent.Empty()) {
+    return 0.0f;
+  }
+  return static_cast<float>(std::min(extent.width, extent.height));
+}
+
+auto EditorMaskCreationAdapter::brush_radius_percent() const -> qreal {
+  const float edge = ReferenceShorterEdgePx();
+  if (edge <= 0.0f) {
+    return 0.0;
+  }
+  return static_cast<qreal>(brush_radius_) * 100.0 / static_cast<qreal>(edge);
+}
+
+auto EditorMaskCreationAdapter::brush_feather_percent() const -> qreal {
+  const auto* mask  = SelectedMask();
+  const auto* brush = mask == nullptr ? nullptr : std::get_if<BrushMaskSource>(&mask->source);
+  const float edge  = ReferenceShorterEdgePx();
+  if (brush == nullptr || edge <= 0.0f) {
+    return 0.0;
+  }
+  return static_cast<qreal>(brush->feather_radius) * 100.0 / static_cast<qreal>(edge);
+}
+
+auto EditorMaskCreationAdapter::mask_enabled() const -> bool {
+  const auto* mask = SelectedMask();
+  return mask == nullptr || mask->enabled;
+}
+
+auto EditorMaskCreationAdapter::mask_invert() const -> bool {
+  const auto* mask = SelectedMask();
+  return mask != nullptr && mask->invert;
+}
+
+auto EditorMaskCreationAdapter::mask_opacity_percent() const -> qreal {
+  const auto* mask = SelectedMask();
+  return mask == nullptr ? 100.0 : static_cast<qreal>(mask->opacity) * 100.0;
+}
+
+auto EditorMaskCreationAdapter::mask_name() const -> QString {
+  const auto* mask = SelectedMask();
+  return mask == nullptr ? QString{} : QString::fromStdString(mask->display_name);
+}
+
+auto EditorMaskCreationAdapter::mask_nudge_available() const -> bool {
+  if (!overlay_source_.has_value() || selected_mask_id_.isEmpty()) {
+    return false;
+  }
+  if (source_kind_ == MaskSourceKind::Brush) {
+    return brush_tool_ == EditorBrushTool::Move;
+  }
+  return IsAnalyticKind(source_kind_);
+}
+
+void EditorMaskCreationAdapter::setBrushRadiusPercent(qreal percent) {
+  const float edge = ReferenceShorterEdgePx();
+  if (edge <= 0.0f || !(percent > 0.0)) {
+    return;
+  }
+  setBrushRadius(static_cast<qreal>(percent) * 0.01 * static_cast<qreal>(edge));
+}
+
+void EditorMaskCreationAdapter::EnqueueMaskField(std::string_view field_key, nlohmann::json value) {
+  if (selected_mask_id_.isEmpty() || !CanAuthorMasks()) {
+    return;
+  }
+  EditorMaskCreationCommand command;
+  command.kind        = EditorMaskCreationCommandKind::SetMaskField;
+  command.node_id     = edit_node_id_;
+  command.mask_id     = MaskIdFromQString(selected_mask_id_);
+  command.field_key   = std::string{field_key};
+  command.field_value = std::move(value);
+  (void)Enqueue(command);
+}
+
+void EditorMaskCreationAdapter::BeginMaskField(std::string_view field_key) {
+  if (selected_mask_id_.isEmpty() || !CanAuthorMasks() || open_) {
+    return;
+  }
+  EditorMaskCreationCommand command;
+  command.kind      = EditorMaskCreationCommandKind::BeginMaskField;
+  command.node_id   = edit_node_id_;
+  command.mask_id   = MaskIdFromQString(selected_mask_id_);
+  command.field_key = std::string{field_key};
+  if (!Enqueue(command)) {
+    return;
+  }
+  active_handle_  = AnalyticMaskHandle::None;
+  open_           = true;
+  open_via_panel_ = true;
+  edit_mode_      = EditMode::Editing;
+  emit maskCreationChanged();
+}
+
+void EditorMaskCreationAdapter::setMaskEnabled(bool enabled) {
+  EnqueueMaskField(kMaskFieldEnabled, enabled);
+}
+
+void EditorMaskCreationAdapter::setMaskInvert(bool invert) {
+  EnqueueMaskField(kMaskFieldInvert, invert);
+}
+
+void EditorMaskCreationAdapter::setMaskName(const QString& name) {
+  const QString trimmed = name.trimmed();
+  if (trimmed.isEmpty() || trimmed == mask_name()) {
+    return;
+  }
+  EnqueueMaskField(kMaskFieldDisplayName, trimmed.toStdString());
+}
+
+void EditorMaskCreationAdapter::beginMaskOpacity() { BeginMaskField(kMaskFieldOpacity); }
+
+void EditorMaskCreationAdapter::updateMaskOpacity(qreal percent) {
+  EnqueueMaskField(kMaskFieldOpacity, std::clamp(static_cast<float>(percent) / 100.0f, 0.0f, 1.0f));
+}
+
+void EditorMaskCreationAdapter::beginBrushFeather() { BeginMaskField(kMaskFieldBrushFeather); }
+
+void EditorMaskCreationAdapter::updateBrushFeatherPercent(qreal percent) {
+  const float edge = ReferenceShorterEdgePx();
+  if (edge <= 0.0f || !(percent >= 0.0)) {
+    return;
+  }
+  EnqueueMaskField(kMaskFieldBrushFeather, static_cast<float>(percent) * 0.01f * edge);
+}
+
+auto EditorMaskCreationAdapter::beginMaskNudge() -> bool {
+  if (open_ || !CanAuthorMasks() || selected_mask_id_.isEmpty() || interaction_ == nullptr ||
+      !overlay_source_.has_value()) {
+    return false;
+  }
+  AnalyticMaskHandle handle     = AnalyticMaskHandle::None;
+  Vector2            normalized = {0.5f, 0.5f};
+  if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
+    handle     = AnalyticMaskHandle::RadialCenter;
+    normalized = {radial->center_x, radial->center_y};
+  } else if (const auto* linear = std::get_if<LinearGradientMaskSource>(&*overlay_source_)) {
+    handle     = AnalyticMaskHandle::LinearOrigin;
+    normalized = {linear->origin_x, linear->origin_y};
+  } else if (const auto* brush = std::get_if<BrushMaskSource>(&*overlay_source_)) {
+    if (brush_tool_ != EditorBrushTool::Move) {
+      return false;
+    }
+    handle                  = AnalyticMaskHandle::BrushMove;
+    brush_placement_before_ = brush->placement_translation;
+  } else {
+    return false;
+  }
+  const auto& extent = interaction_->maskEditViewMapping().geometry.full_reference_extent;
+  if (extent.Empty()) {
+    return false;
+  }
+  const auto reference    = MaskEditGeometry::ReferencePixelsFromNormalized(normalized, extent);
+  pointer_.device_id      = 2;
+  pointer_.point_id       = 1;
+  pointer_.sequence_id    = next_sequence_id_++;
+  nudge_base_normalized_  = normalized;
+  nudge_base_reference_   = reference;
+  nudge_offset_           = {};
+  press_normalized_       = normalized;
+  press_reference_pixels_ = reference;
+
+  MaskCreationSample sample;
+  sample.normalized        = normalized;
+  sample.reference_pixels  = reference;
+  sample.inside_photograph = true;
+
+  EditorMaskCreationCommand select;
+  select.kind    = EditorMaskCreationCommandKind::SelectMask;
+  select.node_id = edit_node_id_;
+  select.mask_id = MaskIdFromQString(selected_mask_id_);
+  (void)Enqueue(select);
+
+  EditorMaskCreationCommand move;
+  move.kind     = EditorMaskCreationCommandKind::BeginMove;
+  move.handle   = handle;
+  move.sample   = sample;
+  move.identity = pointer_;
+  move.node_id  = edit_node_id_;
+  move.mask_id  = MaskIdFromQString(selected_mask_id_);
+  if (handle == AnalyticMaskHandle::BrushMove) {
+    move.brush_tool = EditorBrushTool::Move;
+  }
+  if (!Enqueue(move)) {
+    return false;
+  }
+  active_handle_  = handle;
+  open_           = true;
+  open_via_panel_ = true;
+  edit_mode_      = EditMode::Editing;
+  emit maskCreationChanged();
+  return true;
+}
+
+void EditorMaskCreationAdapter::nudgeMaskBy(qreal dx_px, qreal dy_px) {
+  if (!open_ || !open_via_panel_ || active_handle_ == AnalyticMaskHandle::None ||
+      interaction_ == nullptr) {
+    return;
+  }
+  const auto& extent = interaction_->maskEditViewMapping().geometry.full_reference_extent;
+  if (extent.Empty()) {
+    return;
+  }
+  nudge_offset_.x += static_cast<float>(dx_px);
+  nudge_offset_.y += static_cast<float>(dy_px);
+  MaskCreationSample sample;
+  sample.normalized =
+      Vector2{nudge_base_normalized_.x + nudge_offset_.x / static_cast<float>(extent.width),
+              nudge_base_normalized_.y + nudge_offset_.y / static_cast<float>(extent.height)};
+  sample.reference_pixels =
+      Vector2{nudge_base_reference_.x + nudge_offset_.x, nudge_base_reference_.y + nudge_offset_.y};
+  sample.inside_photograph = true;
+  EnqueueAppendSample(sample);
+}
+
 void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& tool_kind) {
   const NodeId grade = CurrentGradeId();
-  qWarning()
-      << "[MaskRow] BeginTool kind=" << tool_kind
-      << "grade=" << QString::fromStdString(std::string(grade.Value()))
-      << "canEdit=" << (session_ && session_->can_edit()) << "active=" << active()
-      << "open=" << open_;
   if (!CanAuthorMasksFor(grade)) {
-    qWarning() << "[MaskRow] BeginTool abort CanAuthorMasksFor";
     return;
   }
   if (open_) {
@@ -432,18 +663,16 @@ void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& to
   command.source_kind = kind;
   command.node_id     = grade;
   if (command.node_id.Empty() || !Enqueue(command)) {
-    qWarning() << "[MaskRow] BeginTool abort Enqueue emptyNode="
-                                       << command.node_id.Empty();
     return;
   }
-  qWarning() << "[MaskRow] BeginTool queued Creating";
   source_kind_  = kind;
   tool_kind_    = tool_kind;
   edit_node_id_ = grade;
   edit_mode_    = EditMode::Creating;
   selected_mask_id_.clear();
-  open_ = false;
-  brush_tool_      = EditorBrushTool::Idle;
+  open_           = false;
+  open_via_panel_ = false;
+  brush_tool_     = EditorBrushTool::Idle;
   brush_item_path_.clear();
   overlay_source_.reset();
   overlay_display_ = {};
@@ -482,28 +711,14 @@ void EditorMaskCreationAdapter::finishBody() {
 }
 
 void EditorMaskCreationAdapter::selectMask(const QString& node_id, const QString& mask_id) {
-  qWarning()
-      << "[MaskRow] selectMask enter node=" << node_id << "mask=" << mask_id
-      << "active=" << active() << "creating=" << creating() << "open=" << open_
-      << "selected=" << selected_mask_id_ << "canEdit=" << (session_ && session_->can_edit())
-      << "sessionState=" << (session_ ? session_->session_state_name() : QString());
   if (mask_id.isEmpty()) {
-    qWarning() << "[MaskRow] selectMask abort empty maskId";
     return;
   }
   NodeId grade{node_id.toStdString()};
   if (grade.Empty()) {
     grade = active() ? edit_node_id_ : CurrentGradeId();
-    qWarning()
-        << "[MaskRow] selectMask filled empty node from"
-        << (active() ? "editNode" : "currentGrade")
-        << QString::fromStdString(std::string(grade.Value()));
   }
   if (!CanAuthorMasksFor(grade)) {
-    qWarning()
-        << "[MaskRow] selectMask abort CanAuthorMasksFor grade="
-        << QString::fromStdString(std::string(grade.Value()))
-        << "canEdit=" << (session_ && session_->can_edit());
     return;
   }
   if (open_) {
@@ -519,24 +734,18 @@ void EditorMaskCreationAdapter::selectMask(const QString& node_id, const QString
   command.node_id = grade;
   command.mask_id = MaskIdFromQString(mask_id);
   if (!Enqueue(command)) {
-    qWarning() << "[MaskRow] selectMask abort Enqueue";
     return;
   }
   selected_mask_id_ = mask_id;
   edit_node_id_     = grade;
   edit_mode_        = EditMode::Editing;
   open_             = false;
-  qWarning()
-      << "[MaskRow] selectMask queued Editing maskControlsActive=" << mask_controls_active();
+  open_via_panel_   = false;
   emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::removeMask(const QString& node_id, const QString& mask_id) {
-  qWarning()
-      << "[MaskRow] removeMask enter node=" << node_id << "mask=" << mask_id
-      << "canEdit=" << (session_ && session_->can_edit());
   if (mask_id.isEmpty()) {
-    qWarning() << "[MaskRow] removeMask abort empty maskId";
     return;
   }
   NodeId grade{node_id.toStdString()};
@@ -544,7 +753,6 @@ void EditorMaskCreationAdapter::removeMask(const QString& node_id, const QString
     grade = active() ? edit_node_id_ : CurrentGradeId();
   }
   if (!CanAuthorMasksFor(grade)) {
-    qWarning() << "[MaskRow] removeMask abort CanAuthorMasksFor";
     return;
   }
   EditorMaskCreationCommand command;
@@ -552,10 +760,8 @@ void EditorMaskCreationAdapter::removeMask(const QString& node_id, const QString
   command.node_id = grade;
   command.mask_id = MaskIdFromQString(mask_id);
   if (!Enqueue(command)) {
-    qWarning() << "[MaskRow] removeMask abort Enqueue";
     return;
   }
-  qWarning() << "[MaskRow] removeMask queued";
   if (selected_mask_id_ == mask_id) {
     selected_mask_id_.clear();
     overlay_source_.reset();
@@ -633,9 +839,10 @@ void EditorMaskCreationAdapter::ResetLocal() {
   const bool changed = active() || open_;
   tool_kind_.clear();
   selected_mask_id_.clear();
-  edit_node_id_ = {};
-  edit_mode_    = EditMode::Inactive;
-  open_         = false;
+  edit_node_id_   = {};
+  edit_mode_      = EditMode::Inactive;
+  open_           = false;
+  open_via_panel_ = false;
   overlay_source_.reset();
   overlay_display_ = {};
   hovered_handle_  = MaskOverlayHandleId::None;
@@ -739,17 +946,9 @@ auto EditorMaskCreationAdapter::OverlayStyle() const -> MaskOverlayStyle {
 
 auto EditorMaskCreationAdapter::Enqueue(EditorMaskCreationCommand command) -> bool {
   if (session_ == nullptr) {
-    qWarning() << "[MaskRow] Enqueue abort no session kind=" << static_cast<int>(command.kind);
     return false;
   }
-  const auto kind = command.kind;
-  const bool ok   = session_->EnqueueMaskCreation(std::move(command));
-  if (!ok) {
-    qWarning()
-        << "[MaskRow] Enqueue rejected kind=" << static_cast<int>(kind)
-        << "canEdit=" << session_->can_edit() << "state=" << session_->session_state_name();
-  }
-  return ok;
+  return session_->EnqueueMaskCreation(std::move(command));
 }
 
 void EditorMaskCreationAdapter::HideOverlay() {
@@ -799,15 +998,16 @@ void EditorMaskCreationAdapter::PublishOverlay() {
                   ? MakeLinearCreatingOverlayDisplay(mapping, *linear, style, clip)
                   : MakeLinearExistingOverlayDisplay(mapping, *linear, style, clip);
   } else if (const auto* brush = std::get_if<BrushMaskSource>(&*overlay_source_)) {
-    if (open_ && (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {
+    if (open_ && !open_via_panel_ &&
+        (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {
       QPointF cursor;
       if (!brush_item_path_.empty()) {
         cursor = brush_item_path_.back();
       }
       MaskCreationSample cursor_sample;
       cursor_sample.reference_pixels = press_reference_pixels_;
-      display = MakeBrushCreatingOverlayDisplay(brush_item_path_, cursor,
-                                                BrushRadiusLogicalPx(cursor_sample), clip);
+      display                        = MakeBrushCreatingOverlayDisplay(brush_item_path_, cursor,
+                                                                       BrushRadiusLogicalPx(cursor_sample), clip);
       (void)brush;
     } else {
       display = MakeBrushExistingOverlayDisplay(mapping, brush->placement_translation, clip);
@@ -885,9 +1085,10 @@ void EditorMaskCreationAdapter::BeginAnalyticMove(AnalyticMaskHandle handle) {
   if (!Enqueue(move)) {
     return;
   }
-  active_handle_ = handle;
-  open_          = true;
-  edit_mode_     = EditMode::Editing;
+  active_handle_  = handle;
+  open_           = true;
+  open_via_panel_ = true;
+  edit_mode_      = EditMode::Editing;
   emit maskCreationChanged();
 }
 
@@ -1005,8 +1206,9 @@ void EditorMaskCreationAdapter::finishAnalyticControl() {
   finish.mask_id  = MaskIdFromQString(selected_mask_id_);
   finish.identity = pointer_;
   (void)Enqueue(finish);
-  open_          = false;
-  active_handle_ = AnalyticMaskHandle::None;
+  open_           = false;
+  open_via_panel_ = false;
+  active_handle_  = AnalyticMaskHandle::None;
   PublishOverlay();
   emit maskCreationChanged();
 }
@@ -1027,9 +1229,8 @@ void EditorMaskCreationAdapter::EnqueueAppendSample(const MaskCreationSample& sa
   if (source_kind_ == MaskSourceKind::Brush &&
       (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {
     if (interaction_ != nullptr) {
-      if (const auto item =
-              MaskEditGeometry::MapReferenceToItem(interaction_->maskEditViewMapping(),
-                                                   sample.reference_pixels)) {
+      if (const auto item = MaskEditGeometry::MapReferenceToItem(
+              interaction_->maskEditViewMapping(), sample.reference_pixels)) {
         brush_item_path_.push_back(*item);
       }
     }
@@ -1060,6 +1261,9 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
   if (!owns_left_button() || button != static_cast<int>(Qt::LeftButton)) {
     return false;
   }
+  if (open_) {
+    return true;
+  }
   if (!CanAuthorMasks() || interaction_ == nullptr) {
     return true;
   }
@@ -1067,15 +1271,15 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
   if (!sample || !sample->inside_photograph) {
     return true;
   }
-  pointer_.device_id   = 1;
-  pointer_.point_id    = 1;
-  pointer_.sequence_id = next_sequence_id_++;
+  pointer_.device_id      = 1;
+  pointer_.point_id       = 1;
+  pointer_.sequence_id    = next_sequence_id_++;
   press_normalized_       = sample->normalized;
   press_reference_pixels_ = sample->reference_pixels;
 
-  const auto hit    = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
-                                               OverlayStyle().hit_radius_logical_px);
-  const auto handle = AnalyticHandleFromOverlay(hit);
+  const auto hit          = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
+                                                     OverlayStyle().hit_radius_logical_px);
+  const auto handle       = AnalyticHandleFromOverlay(hit);
   if (source_kind_ == MaskSourceKind::Brush && brush_tool_ == EditorBrushTool::Move &&
       handle == AnalyticMaskHandle::BrushMove) {
     if (const auto* brush =
@@ -1091,9 +1295,10 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
     move.mask_id    = MaskIdFromQString(selected_mask_id_);
     move.brush_tool = EditorBrushTool::Move;
     if (Enqueue(move)) {
-      active_handle_ = AnalyticMaskHandle::BrushMove;
-      open_          = true;
-      edit_mode_     = EditMode::Editing;
+      active_handle_  = AnalyticMaskHandle::BrushMove;
+      open_           = true;
+      open_via_panel_ = false;
+      edit_mode_      = EditMode::Editing;
       emit maskCreationChanged();
       return true;
     }
@@ -1111,8 +1316,9 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
     if (!Enqueue(input)) {
       return true;
     }
-    active_handle_ = AnalyticMaskHandle::None;
-    open_          = true;
+    active_handle_  = AnalyticMaskHandle::None;
+    open_           = true;
+    open_via_panel_ = false;
     brush_item_path_.clear();
     if (interaction_ != nullptr) {
       if (const auto item = MaskEditGeometry::MapReferenceToItem(
@@ -1146,6 +1352,7 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
         press_normalized_ = sample->normalized;
         active_handle_    = handle;
         open_             = true;
+        open_via_panel_   = false;
         edit_mode_        = EditMode::Editing;
         emit maskCreationChanged();
         return true;
@@ -1167,6 +1374,7 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
   press_normalized_ = sample->normalized;
   active_handle_    = AnalyticMaskHandle::None;
   open_             = true;
+  open_via_panel_   = false;
   overlay_source_   = source_kind_ == MaskSourceKind::Radial
                           ? MaskSource{RadialFromCenterOut(sample->normalized, sample->normalized)}
                           : MaskSource{LinearFromEndpoints(sample->normalized, sample->normalized)};
@@ -1176,7 +1384,7 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
 }
 
 auto EditorMaskCreationAdapter::handleMove(qreal x, qreal y, int /*buttons*/) -> bool {
-  if (!open_) {
+  if (!open_ || open_via_panel_) {
     return owns_left_button();
   }
   auto sample = MakeSample(x, y, true);
@@ -1200,7 +1408,7 @@ auto EditorMaskCreationAdapter::handleMove(qreal x, qreal y, int /*buttons*/) ->
 }
 
 auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> bool {
-  if (!open_ || button != static_cast<int>(Qt::LeftButton)) {
+  if (!open_ || open_via_panel_ || button != static_cast<int>(Qt::LeftButton)) {
     return owns_left_button() && button == static_cast<int>(Qt::LeftButton);
   }
   auto sample = MakeSample(x, y, true);
@@ -1224,8 +1432,9 @@ auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> b
   finish.mask_id  = MaskIdFromQString(selected_mask_id_);
   finish.identity = pointer_;
   (void)Enqueue(finish);
-  open_          = false;
-  active_handle_ = AnalyticMaskHandle::None;
+  open_           = false;
+  open_via_panel_ = false;
+  active_handle_  = AnalyticMaskHandle::None;
   brush_item_path_.clear();
   if (source_kind_ == MaskSourceKind::Brush &&
       (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
@@ -124,6 +124,9 @@ EditorMaskCreationAdapter::~EditorMaskCreationAdapter() {
   if (view_change_connection_) {
     QObject::disconnect(view_change_connection_);
   }
+  if (overlay_geometry_connection_) {
+    QObject::disconnect(overlay_geometry_connection_);
+  }
 }
 
 auto EditorMaskCreationAdapter::owns_left_button() const -> bool {
@@ -190,6 +193,10 @@ void EditorMaskCreationAdapter::bindInteractionItem(QObject* interaction) {
     QObject::disconnect(view_change_connection_);
     view_change_connection_ = {};
   }
+  if (overlay_geometry_connection_) {
+    QObject::disconnect(overlay_geometry_connection_);
+    overlay_geometry_connection_ = {};
+  }
   interaction_ = typed;
   ConnectInteraction(typed);
   PublishOverlay();
@@ -211,6 +218,20 @@ void EditorMaskCreationAdapter::ConnectInteraction(
         // sequence when the composed item→reference mapping actually changed.
         if (open_ && !open_via_panel_) {
           (void)CancelIfMappingChanged();
+        }
+      });
+  overlay_geometry_connection_ = connect(
+      interaction, &editor_rhi::EditorInteractionController::overlayGeometryChanged, this, [this] {
+        // Mask chrome is item-space: a viewport/view change moves it even
+        // though the owner Mask did not. Republish the display so handles and
+        // contours track the letterbox without a backend NotifyChange.
+        if (interaction_ == nullptr ||
+            (edit_mode_ == EditMode::Inactive && !overlay_source_.has_value())) {
+          return;
+        }
+        const auto identity = interaction_->maskEditMappingIdentity();
+        if (identity != published_mapping_identity_) {
+          PublishOverlay();
         }
       });
 }
@@ -681,6 +702,7 @@ void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& to
   overlay_display_ = {};
   hovered_handle_  = MaskOverlayHandleId::None;
   active_handle_   = AnalyticMaskHandle::None;
+  published_mapping_identity_ = {};
   HideOverlay();
   emit maskCreationChanged();
 }
@@ -832,8 +854,18 @@ void EditorMaskCreationAdapter::SyncFromSession() {
   const auto owner_state = session_->mask_creation_state();
   const auto source      = session_->mask_creation_source();
   if (!owner_id.Empty() && source.has_value()) {
-    edit_node_id_ = owner_node;
-    ApplyOwnerSource(owner_id, *source);
+    // Backend change notifications also arrive for events that cannot move
+    // the owner mask. Re-applying an unchanged owner rebuilds the whole
+    // overlay display and emits maskCreationChanged every time, so only
+    // re-apply on a real owner/source change; pure view remapping is driven
+    // by the overlayGeometryChanged connection in ConnectInteraction.
+    const bool owner_changed = owner_node != edit_node_id_ ||
+                               MaskIdToQString(owner_id) != selected_mask_id_ ||
+                               !overlay_source_.has_value() || *overlay_source_ != *source;
+    if (owner_changed) {
+      edit_node_id_ = owner_node;
+      ApplyOwnerSource(owner_id, *source);
+    }
     return;
   }
   if (owner_state == EditorMaskCreationState::Inactive) {
@@ -878,6 +910,7 @@ void EditorMaskCreationAdapter::ResetLocal() {
   brush_tool_              = EditorBrushTool::Idle;
   brush_item_path_.clear();
   press_mapping_identity_  = std::nullopt;
+  published_mapping_identity_ = {};
   hover_valid_             = false;
   HideOverlay();
   if (changed) {
@@ -1000,6 +1033,7 @@ void EditorMaskCreationAdapter::PublishOverlay() {
     return;
   }
   const auto         mapping = interaction_->maskEditViewMapping();
+  published_mapping_identity_ = MaskEditGeometry::Identity(mapping);
   const auto         style   = OverlayStyle();
   const auto         clip    = OverlayClip();
   MaskOverlayDisplay display;

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
@@ -207,8 +207,10 @@ void EditorMaskCreationAdapter::ConnectInteraction(
   }
   view_change_connection_ = connect(
       interaction, &editor_rhi::EditorInteractionController::viewChangeReported, this, [this](int) {
-        if (open_) {
-          cancel();
+        // Pan/zoom must not disarm the Mask tool. Cancel only the open canvas
+        // sequence when the composed item→reference mapping actually changed.
+        if (open_ && !open_via_panel_) {
+          (void)CancelIfMappingChanged();
         }
       });
 }
@@ -693,6 +695,24 @@ void EditorMaskCreationAdapter::cancel() {
   command.mask_id = MaskIdFromQString(selected_mask_id_);
   (void)Enqueue(command);
   ResetLocal();
+}
+
+void EditorMaskCreationAdapter::cancelOpenPointerInput() {
+  if (!open_ || open_via_panel_) {
+    return;
+  }
+  EditorMaskCreationCommand cancel;
+  cancel.kind    = EditorMaskCreationCommandKind::Cancel;
+  cancel.node_id = edit_node_id_;
+  cancel.mask_id = MaskIdFromQString(selected_mask_id_);
+  (void)Enqueue(cancel);
+  open_                   = false;
+  open_via_panel_         = false;
+  active_handle_          = AnalyticMaskHandle::None;
+  press_mapping_identity_ = std::nullopt;
+  brush_item_path_.clear();
+  PublishOverlay();
+  emit maskCreationChanged();
 }
 
 void EditorMaskCreationAdapter::hideBody() { finishBody(); }

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp
@@ -192,7 +192,7 @@ void EditorMaskCreationAdapter::bindInteractionItem(QObject* interaction) {
   }
   interaction_ = typed;
   ConnectInteraction(typed);
-  PublishDisplayedGeometry();
+  PublishOverlay();
 }
 
 void EditorMaskCreationAdapter::bindOverlayItem(QObject* overlay) {
@@ -278,15 +278,15 @@ auto EditorMaskCreationAdapter::ResolveBrushResumeMask(const NodeId& grade_id) c
   return {};
 }
 
-auto EditorMaskCreationAdapter::BrushRadiusLogicalPx(const MaskCreationSample& sample) const
-    -> float {
+auto EditorMaskCreationAdapter::BrushRadiusLogicalPx() const -> float {
   if (interaction_ == nullptr || brush_radius_ <= 0.0f) {
     return kMaskOverlayHandleRadiusLogicalPx * 2.0f;
   }
   const auto mapping = interaction_->maskEditViewMapping();
-  const auto center  = MaskEditGeometry::MapReferenceToItem(mapping, sample.reference_pixels);
-  const auto edge    = MaskEditGeometry::MapReferenceToItem(
-      mapping, Vector2{sample.reference_pixels.x + brush_radius_, sample.reference_pixels.y});
+  // Reference->item is affine, so the dab radius is position-independent.
+  const auto center = MaskEditGeometry::MapReferenceToItem(mapping, Vector2{0.0f, 0.0f});
+  const auto edge =
+      MaskEditGeometry::MapReferenceToItem(mapping, Vector2{brush_radius_, 0.0f});
   if (!center || !edge) {
     return kMaskOverlayHandleRadiusLogicalPx * 2.0f;
   }
@@ -347,8 +347,7 @@ void EditorMaskCreationAdapter::BeginBrushTool() {
     }
   }
   HideOverlay();
-  PublishDisplayedGeometry();
-  if (overlay_source_.has_value()) {
+  if (overlay_source_.has_value() || hover_valid_) {
     PublishOverlay();
   }
   emit maskCreationChanged();
@@ -382,6 +381,7 @@ void EditorMaskCreationAdapter::setBrushTool(const QString& tool) {
   } else {
     edit_mode_ = EditMode::Creating;
   }
+  PublishOverlay();
   emit maskCreationChanged();
 }
 
@@ -396,6 +396,7 @@ void EditorMaskCreationAdapter::setBrushRadius(qreal radius) {
   command.mask_id = MaskIdFromQString(selected_mask_id_);
   EnqueueBrushSettings(command);
   (void)Enqueue(command);
+  PublishOverlay();
   emit maskCreationChanged();
 }
 
@@ -437,12 +438,12 @@ auto EditorMaskCreationAdapter::ReferenceShorterEdgePx() const -> float {
   return static_cast<float>(std::min(extent.width, extent.height));
 }
 
-auto EditorMaskCreationAdapter::brush_radius_percent() const -> qreal {
+auto EditorMaskCreationAdapter::brush_diameter_percent() const -> qreal {
   const float edge = ReferenceShorterEdgePx();
   if (edge <= 0.0f) {
     return 0.0;
   }
-  return static_cast<qreal>(brush_radius_) * 100.0 / static_cast<qreal>(edge);
+  return 2.0 * static_cast<qreal>(brush_radius_) * 100.0 / static_cast<qreal>(edge);
 }
 
 auto EditorMaskCreationAdapter::brush_feather_percent() const -> qreal {
@@ -485,12 +486,12 @@ auto EditorMaskCreationAdapter::mask_nudge_available() const -> bool {
   return IsAnalyticKind(source_kind_);
 }
 
-void EditorMaskCreationAdapter::setBrushRadiusPercent(qreal percent) {
+void EditorMaskCreationAdapter::setBrushDiameterPercent(qreal percent) {
   const float edge = ReferenceShorterEdgePx();
   if (edge <= 0.0f || !(percent > 0.0)) {
     return;
   }
-  setBrushRadius(static_cast<qreal>(percent) * 0.01 * static_cast<qreal>(edge));
+  setBrushRadius(static_cast<qreal>(percent) * 0.005 * static_cast<qreal>(edge));
 }
 
 void EditorMaskCreationAdapter::EnqueueMaskField(std::string_view field_key, nlohmann::json value) {
@@ -679,7 +680,6 @@ void EditorMaskCreationAdapter::BeginTool(MaskSourceKind kind, const QString& to
   hovered_handle_  = MaskOverlayHandleId::None;
   active_handle_   = AnalyticMaskHandle::None;
   HideOverlay();
-  PublishDisplayedGeometry();
   emit maskCreationChanged();
 }
 
@@ -801,16 +801,27 @@ void EditorMaskCreationAdapter::deleteActiveMask() {
 void EditorMaskCreationAdapter::OnImageClosed() { ResetLocal(); }
 
 void EditorMaskCreationAdapter::SyncFromSession() {
-  PublishDisplayedGeometry();
-  if (open_ || session_ == nullptr || session_->mask_creation_commands_pending()) {
+  if (session_ == nullptr) {
     return;
   }
-  const auto owner_node = session_->mask_creation_node_id();
-  const auto owner_id   = session_->mask_creation_mask_id();
-  const auto source     = session_->mask_creation_source();
+  if (open_ || session_->mask_creation_commands_pending()) {
+    return;
+  }
+  const auto owner_node  = session_->mask_creation_node_id();
+  const auto owner_id    = session_->mask_creation_mask_id();
+  const auto owner_state = session_->mask_creation_state();
+  const auto source      = session_->mask_creation_source();
   if (!owner_id.Empty() && source.has_value()) {
     edit_node_id_ = owner_node;
     ApplyOwnerSource(owner_id, *source);
+    return;
+  }
+  if (owner_state == EditorMaskCreationState::Inactive) {
+    // The owner rejected or dropped the armed tool after this adapter queued
+    // its arm; local state must not advertise a tool the owner will reject.
+    if (active() || open_) {
+      ResetLocal();
+    }
     return;
   }
   if (selected_mask_id_.isEmpty()) {
@@ -819,9 +830,6 @@ void EditorMaskCreationAdapter::SyncFromSession() {
       selectMask(QString{}, MaskIdToQString(restored));
       return;
     }
-  }
-  if (!selected_mask_id_.isEmpty() || active()) {
-    return;
   }
 }
 
@@ -839,16 +847,18 @@ void EditorMaskCreationAdapter::ResetLocal() {
   const bool changed = active() || open_;
   tool_kind_.clear();
   selected_mask_id_.clear();
-  edit_node_id_   = {};
-  edit_mode_      = EditMode::Inactive;
-  open_           = false;
-  open_via_panel_ = false;
+  edit_node_id_            = {};
+  edit_mode_               = EditMode::Inactive;
+  open_                    = false;
+  open_via_panel_          = false;
   overlay_source_.reset();
   overlay_display_ = {};
-  hovered_handle_  = MaskOverlayHandleId::None;
-  active_handle_   = AnalyticMaskHandle::None;
-  brush_tool_      = EditorBrushTool::Idle;
+  hovered_handle_          = MaskOverlayHandleId::None;
+  active_handle_           = AnalyticMaskHandle::None;
+  brush_tool_              = EditorBrushTool::Idle;
   brush_item_path_.clear();
+  press_mapping_identity_  = std::nullopt;
+  hover_valid_             = false;
   HideOverlay();
   if (changed) {
     emit maskCreationChanged();
@@ -948,6 +958,12 @@ auto EditorMaskCreationAdapter::Enqueue(EditorMaskCreationCommand command) -> bo
   if (session_ == nullptr) {
     return false;
   }
+  // Stamp the armed source kind on every dispatched command so the owner can
+  // reject a stale queued dispatch whose kind no longer matches the armed or
+  // selected Mask. BeginCreation carries its own target kind already.
+  if (command.kind != EditorMaskCreationCommandKind::BeginCreation) {
+    command.source_kind = source_kind_;
+  }
   return session_->EnqueueMaskCreation(std::move(command));
 }
 
@@ -958,74 +974,81 @@ void EditorMaskCreationAdapter::HideOverlay() {
   overlay_->setMaskOverlayDisplay(MaskOverlayDisplay{});
 }
 
-void EditorMaskCreationAdapter::PublishDisplayedGeometry() {
-  if (interaction_ == nullptr || session_ == nullptr) {
-    return;
-  }
-  const auto* document = session_->pipeline_document();
-  if (document == nullptr) {
-    return;
-  }
-  const int width  = interaction_->imageWidth();
-  const int height = interaction_->imageHeight();
-  if (width <= 0 || height <= 0) {
-    return;
-  }
-  ImageGeometryParams image;
-  image.crop_rect        = document->Geometry().CropRect();
-  image.rotation_degrees = document->Geometry().RotationDegrees();
-  image.expand_to_fit    = document->Geometry().ExpandToFit();
-  interaction_->setDisplayedMaskGeometry(MaskEditGeometry::MakeDocumentPhotographGeometry(
-      Extent2D{static_cast<std::uint32_t>(width), static_cast<std::uint32_t>(height)}, image));
-}
-
 void EditorMaskCreationAdapter::PublishOverlay() {
-  if (overlay_ == nullptr || interaction_ == nullptr || !overlay_source_.has_value()) {
+  if (overlay_ == nullptr || interaction_ == nullptr) {
     HideOverlay();
     return;
   }
-  PublishDisplayedGeometry();
   const auto         mapping = interaction_->maskEditViewMapping();
   const auto         style   = OverlayStyle();
   const auto         clip    = OverlayClip();
   MaskOverlayDisplay display;
-  if (const auto* radial = std::get_if<RadialMaskSource>(&*overlay_source_)) {
+  const bool         brush_paint_tool =
+      brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase;
+  if (const auto* radial =
+          overlay_source_ ? std::get_if<RadialMaskSource>(&*overlay_source_) : nullptr) {
     display = (creating() && open_)
                   ? MakeRadialCreatingOverlayDisplay(mapping, *radial, style, clip)
                   : MakeRadialExistingOverlayDisplay(mapping, *radial, style, clip);
-  } else if (const auto* linear = std::get_if<LinearGradientMaskSource>(&*overlay_source_)) {
+  } else if (const auto* linear =
+                 overlay_source_ ? std::get_if<LinearGradientMaskSource>(&*overlay_source_)
+                                 : nullptr) {
     display = (creating() && open_)
                   ? MakeLinearCreatingOverlayDisplay(mapping, *linear, style, clip)
                   : MakeLinearExistingOverlayDisplay(mapping, *linear, style, clip);
-  } else if (const auto* brush = std::get_if<BrushMaskSource>(&*overlay_source_)) {
-    if (open_ && !open_via_panel_ &&
-        (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {
-      QPointF cursor;
-      if (!brush_item_path_.empty()) {
-        cursor = brush_item_path_.back();
+  } else if (source_kind_ == MaskSourceKind::Brush) {
+    const auto* brush =
+        overlay_source_ ? std::get_if<BrushMaskSource>(&*overlay_source_) : nullptr;
+    if (open_ && !open_via_panel_ && brush_paint_tool) {
+      // Open stroke: temporary path through canonical samples plus the live
+      // cursor. The cursor follows the last sampled item point so a fast drag
+      // keeps the ring under the pen even between hover callbacks.
+      const QPointF cursor =
+          !brush_item_path_.empty() ? brush_item_path_.back() : hover_item_;
+      display = MakeBrushCreatingOverlayDisplay(brush_item_path_, cursor, BrushRadiusLogicalPx(),
+                                                clip, brush_tool_ == EditorBrushTool::Erase);
+    } else if (brush_paint_tool) {
+      // Armed Paint/Erase with no open stroke: a hollow (dashed for Erase)
+      // cursor ring follows the pointer; it is not a handle.
+      display = MakeBrushCreatingOverlayDisplay(
+          {}, hover_item_, BrushRadiusLogicalPx(), clip,
+          brush_tool_ == EditorBrushTool::Erase);
+      if (!hover_valid_) {
+        display.mode           = MaskOverlayMode::Hidden;
+        display.cursor_visible = false;
       }
-      MaskCreationSample cursor_sample;
-      cursor_sample.reference_pixels = press_reference_pixels_;
-      display                        = MakeBrushCreatingOverlayDisplay(brush_item_path_, cursor,
-                                                                       BrushRadiusLogicalPx(cursor_sample), clip);
-      (void)brush;
-    } else {
-      display = MakeBrushExistingOverlayDisplay(mapping, brush->placement_translation, clip);
+    } else if (brush != nullptr) {
+      display = MakeBrushMoveOverlayDisplay(mapping, *brush, clip);
     }
   }
-  display.hovered_handle = hovered_handle_;
-  display.active_handle  = OverlayHandleFromAnalytic(active_handle_);
-  overlay_display_       = display;
+  if (display.mode == MaskOverlayMode::Hidden || display.handles.empty()) {
+    display.hovered_handle = MaskOverlayHandleId::None;
+  } else {
+    display.hovered_handle = hovered_handle_;
+  }
+  display.active_handle = OverlayHandleFromAnalytic(active_handle_);
+  overlay_display_      = display;
   overlay_->setMaskOverlayDisplay(std::move(display));
 }
 
 void EditorMaskCreationAdapter::handleHover(qreal x, qreal y) {
-  if (!owns_left_button() || overlay_display_.mode == MaskOverlayMode::Hidden) {
+  if (!owns_left_button()) {
+    hover_valid_ = false;
+    return;
+  }
+  hover_item_  = QPointF(x, y);
+  hover_valid_ = true;
+  // An armed Brush paint/erase cursor follows the pointer even when no handles
+  // exist (e.g. before the first stroke creates the Mask).
+  const bool brush_cursor = source_kind_ == MaskSourceKind::Brush &&
+                            (brush_tool_ == EditorBrushTool::Paint ||
+                             brush_tool_ == EditorBrushTool::Erase);
+  if (overlay_display_.mode == MaskOverlayMode::Hidden && !brush_cursor) {
     return;
   }
   const auto hit = HitTestMaskOverlayHandle(overlay_display_, QPointF(x, y),
                                             OverlayStyle().hit_radius_logical_px);
-  if (hit == hovered_handle_) {
+  if (hit == hovered_handle_ && !brush_cursor) {
     return;
   }
   hovered_handle_ = hit;
@@ -1213,6 +1236,31 @@ void EditorMaskCreationAdapter::finishAnalyticControl() {
   emit maskCreationChanged();
 }
 
+auto EditorMaskCreationAdapter::CancelIfMappingChanged() -> bool {
+  if (!open_ || !press_mapping_identity_.has_value() || interaction_ == nullptr) {
+    return false;
+  }
+  if (!MaskEditGeometry::MappingChanged(*press_mapping_identity_,
+                                        interaction_->maskEditMappingIdentity())) {
+    return false;
+  }
+  // The presented-frame or view mapping changed mid-drag; queued samples would
+  // land in the new reference space against a press taken in the old one.
+  EditorMaskCreationCommand cancel;
+  cancel.kind    = EditorMaskCreationCommandKind::Cancel;
+  cancel.node_id = edit_node_id_;
+  cancel.mask_id = MaskIdFromQString(selected_mask_id_);
+  (void)Enqueue(cancel);
+  open_                    = false;
+  open_via_panel_          = false;
+  active_handle_           = AnalyticMaskHandle::None;
+  press_mapping_identity_  = std::nullopt;
+  brush_item_path_.clear();
+  PublishOverlay();
+  emit maskCreationChanged();
+  return true;
+}
+
 void EditorMaskCreationAdapter::EnqueueAppendSample(const MaskCreationSample& sample) {
   EditorMaskCreationCommand command;
   command.kind     = EditorMaskCreationCommandKind::Append;
@@ -1295,10 +1343,11 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
     move.mask_id    = MaskIdFromQString(selected_mask_id_);
     move.brush_tool = EditorBrushTool::Move;
     if (Enqueue(move)) {
-      active_handle_  = AnalyticMaskHandle::BrushMove;
-      open_           = true;
-      open_via_panel_ = false;
-      edit_mode_      = EditMode::Editing;
+      press_mapping_identity_ = interaction_->maskEditMappingIdentity();
+      active_handle_          = AnalyticMaskHandle::BrushMove;
+      open_                   = true;
+      open_via_panel_         = false;
+      edit_mode_              = EditMode::Editing;
       emit maskCreationChanged();
       return true;
     }
@@ -1312,13 +1361,18 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
     input.identity = pointer_;
     input.node_id  = edit_node_id_;
     input.mask_id  = MaskIdFromQString(selected_mask_id_);
+    if (const auto& extent = interaction_->maskEditViewMapping().geometry.full_reference_extent;
+        !extent.Empty()) {
+      input.default_feather_reference_px = DefaultBrushFeatherReferencePixels(extent);
+    }
     EnqueueBrushSettings(input);
     if (!Enqueue(input)) {
       return true;
     }
-    active_handle_  = AnalyticMaskHandle::None;
-    open_           = true;
-    open_via_panel_ = false;
+    press_mapping_identity_ = interaction_->maskEditMappingIdentity();
+    active_handle_          = AnalyticMaskHandle::None;
+    open_                   = true;
+    open_via_panel_         = false;
     brush_item_path_.clear();
     if (interaction_ != nullptr) {
       if (const auto item = MaskEditGeometry::MapReferenceToItem(
@@ -1349,11 +1403,12 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
       move.node_id  = edit_node_id_;
       move.mask_id  = MaskIdFromQString(selected_mask_id_);
       if (Enqueue(move)) {
-        press_normalized_ = sample->normalized;
-        active_handle_    = handle;
-        open_             = true;
-        open_via_panel_   = false;
-        edit_mode_        = EditMode::Editing;
+        press_normalized_       = sample->normalized;
+        press_mapping_identity_ = interaction_->maskEditMappingIdentity();
+        active_handle_          = handle;
+        open_                   = true;
+        open_via_panel_         = false;
+        edit_mode_              = EditMode::Editing;
         emit maskCreationChanged();
         return true;
       }
@@ -1371,10 +1426,11 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
   if (!Enqueue(input)) {
     return true;
   }
-  press_normalized_ = sample->normalized;
-  active_handle_    = AnalyticMaskHandle::None;
-  open_             = true;
-  open_via_panel_   = false;
+  press_normalized_       = sample->normalized;
+  press_mapping_identity_ = interaction_->maskEditMappingIdentity();
+  active_handle_          = AnalyticMaskHandle::None;
+  open_                   = true;
+  open_via_panel_         = false;
   overlay_source_   = source_kind_ == MaskSourceKind::Radial
                           ? MaskSource{RadialFromCenterOut(sample->normalized, sample->normalized)}
                           : MaskSource{LinearFromEndpoints(sample->normalized, sample->normalized)};
@@ -1386,6 +1442,9 @@ auto EditorMaskCreationAdapter::handlePress(qreal x, qreal y, int button) -> boo
 auto EditorMaskCreationAdapter::handleMove(qreal x, qreal y, int /*buttons*/) -> bool {
   if (!open_ || open_via_panel_) {
     return owns_left_button();
+  }
+  if (CancelIfMappingChanged()) {
+    return true;
   }
   auto sample = MakeSample(x, y, true);
   if (!sample) {
@@ -1411,6 +1470,9 @@ auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> b
   if (!open_ || open_via_panel_ || button != static_cast<int>(Qt::LeftButton)) {
     return owns_left_button() && button == static_cast<int>(Qt::LeftButton);
   }
+  if (CancelIfMappingChanged()) {
+    return true;
+  }
   auto sample = MakeSample(x, y, true);
   if (sample && active_handle_ == AnalyticMaskHandle::LinearDirection) {
     const auto* linear =
@@ -1432,9 +1494,10 @@ auto EditorMaskCreationAdapter::handleRelease(qreal x, qreal y, int button) -> b
   finish.mask_id  = MaskIdFromQString(selected_mask_id_);
   finish.identity = pointer_;
   (void)Enqueue(finish);
-  open_           = false;
-  open_via_panel_ = false;
-  active_handle_  = AnalyticMaskHandle::None;
+  open_                   = false;
+  open_via_panel_         = false;
+  active_handle_          = AnalyticMaskHandle::None;
+  press_mapping_identity_ = std::nullopt;
   brush_item_path_.clear();
   if (source_kind_ == MaskSourceKind::Brush &&
       (brush_tool_ == EditorBrushTool::Paint || brush_tool_ == EditorBrushTool::Erase)) {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/editor_session_controller.cpp
@@ -928,6 +928,10 @@ void EditorSessionController::bindPresentationViewport(QObject* viewportItem) {
   if (presentation_viewport_ == viewportItem) {
     return;
   }
+  if (presented_geometry_connection_) {
+    QObject::disconnect(presented_geometry_connection_);
+    presented_geometry_connection_ = {};
+  }
   presentation_viewport_ = viewportItem;
   if (auto* item = qobject_cast<editor_rhi::EditorViewportItem*>(viewportItem)) {
     if (scope_controller_) {
@@ -935,6 +939,20 @@ void EditorSessionController::bindPresentationViewport(QObject* viewportItem) {
     }
     SyncViewportIdentity();
     SyncViewportDisplayConfig();
+    // Forward the presented frame's resolved geometry to the interaction
+    // controller so Mask pointer mapping shares the displayed frame's
+    // reference space. The connection resolves the interaction controller at
+    // fire time; an unbound interaction simply skips the update.
+    presented_geometry_connection_ =
+        connect(item, &editor_rhi::EditorViewportItem::PresentedMaskGeometryChanged, this,
+                [this, item] {
+                  auto* interaction =
+                      qobject_cast<editor_rhi::EditorInteractionController*>(
+                          interaction_controller_.data());
+                  if (interaction != nullptr) {
+                    interaction->setDisplayedMaskGeometry(item->presentedMaskGeometry());
+                  }
+                });
     // Stamp a stable presentation sink identity for render intents (Phase 5A).
     // DirectFrameSink owns the short scene-graph startup wait when this binding
     // precedes QQuickRhiItem::synchronize().
@@ -1020,6 +1038,14 @@ void EditorSessionController::bindInteractionController(QObject* interactionCont
   if (!interaction) {
     return;
   }
+  // A frame may have been presented before this binding; push the stored
+  // presented-frame geometry so Mask mapping does not wait for the next frame.
+  if (auto* item = qobject_cast<editor_rhi::EditorViewportItem*>(presentation_viewport_.data())) {
+    const auto& geometry = item->presentedMaskGeometry();
+    if (!geometry.full_reference_extent.Empty()) {
+      interaction->setDisplayedMaskGeometry(geometry);
+    }
+  }
   // viewChangeReported follows viewStateChanged. QML has therefore already
   // updated DirectFrameSink with the matching ROI when this route reads it.
   interaction_view_change_connection_ =
@@ -1030,6 +1056,10 @@ void EditorSessionController::bindInteractionController(QObject* interactionCont
 void EditorSessionController::unbindPresentationViewport() {
   if (!presentation_viewport_) {
     return;
+  }
+  if (presented_geometry_connection_) {
+    QObject::disconnect(presented_geometry_connection_);
+    presented_geometry_connection_ = {};
   }
   if (auto* item = qobject_cast<editor_rhi::EditorViewportItem*>(presentation_viewport_.data())) {
     item->suspendPresentation();
@@ -1330,6 +1360,11 @@ auto EditorSessionController::mask_creation_mask_id() const -> alcedo::MaskId {
 
 auto EditorSessionController::mask_creation_node_id() const -> alcedo::NodeId {
   return session_backend_ ? session_backend_->mask_creation_node_id() : alcedo::NodeId{};
+}
+
+auto EditorSessionController::mask_creation_state() const -> alcedo::EditorMaskCreationState {
+  return session_backend_ ? session_backend_->mask_creation_state()
+                          : alcedo::EditorMaskCreationState::Inactive;
 }
 
 auto EditorSessionController::mask_creation_source() const -> std::optional<alcedo::MaskSource> {

--- a/alcedo_studio/src/ui/alcedo_main/album_backend/project_module.cpp
+++ b/alcedo_studio/src/ui/alcedo_main/album_backend/project_module.cpp
@@ -209,10 +209,7 @@ auto BuildRecentProjectEntry(const QString& normalizedPath, qint64 lastOpenedMs)
 
 }  // namespace
 
-
-
-ProjectModule::ProjectModule(QObject* parent)
-    : QObject(parent), handler_(*this) {
+ProjectModule::ProjectModule(QObject* parent) : QObject(parent), handler_(*this) {
   LoadRecentProjectsFromSettings();
   QObject::connect(&i18n::TranslationNotifier::Instance(),
                    &i18n::TranslationNotifier::LanguageChanged, this,
@@ -227,8 +224,7 @@ void ProjectModule::SetLifecycleHooks(ProjectLifecycleHooks hooks) {
   lifecycle_hooks_ = std::move(hooks);
 }
 
-void ProjectModule::SetRuntimeAcceleratorPreference(
-    const AcceleratorBackendPreference preference) {
+void ProjectModule::SetRuntimeAcceleratorPreference(const AcceleratorBackendPreference preference) {
   // The RHI backend selected by main.cpp is the process-wide source of truth.
   // QSettings is only the next-launch request and may differ when a command-line
   // override is active or when settings changed during the previous process.
@@ -249,12 +245,11 @@ void ProjectModule::SetServiceMessage(const i18n::LocalizedText& message) {
 void ProjectModule::NotifyProjectLoadStateChanged() { emit ProjectLoadStateChanged(); }
 
 void ProjectModule::SetAcceleratorPreparationState(bool                       preparing,
-                                                  const i18n::LocalizedText& status) {
+                                                   const i18n::LocalizedText& status) {
   accelerator_preparing_               = preparing;
   accelerator_preparation_status_text_ = status;
   emit AcceleratorPreparationStateChanged();
 }
-
 
 void ProjectModule::StartOpenClPreparationIfNeeded() {
   if (accelerator_prepare_started_ || accelerator_preparing_ ||
@@ -306,9 +301,7 @@ void ProjectModule::StartOpenClPreparationIfNeeded() {
 #endif
 }
 
-
 void ProjectModule::StartAcceleratorPreparation() { StartOpenClPreparationIfNeeded(); }
-
 
 void ProjectModule::InitializeAcceleratorSettings() {
   const QString stored_key = QSettings{}.value(QLatin1String(kAcceleratorBackendKey)).toString();
@@ -406,7 +399,6 @@ void ProjectModule::InitializeAcceleratorSettings() {
   QSettings{}.setValue(QLatin1String(kAcceleratorBackendKey), accelerator_backend_key_);
 }
 
-
 void ProjectModule::RebuildAcceleratorOptions() {
   QVariantList options;
 #if defined(__APPLE__)
@@ -430,7 +422,6 @@ void ProjectModule::RebuildAcceleratorOptions() {
   }
   accelerator_options_ = options;
 }
-
 
 bool ProjectModule::SetAcceleratorBackend(const QString& backendKey) {
   const auto preference = AcceleratorPreferenceFromKey(backendKey);
@@ -462,7 +453,6 @@ bool ProjectModule::SetAcceleratorBackend(const QString& backendKey) {
   return true;
 }
 
-
 void ProjectModule::AcknowledgeAcceleratorWarning() {
   if (accelerator_warning_id_.isEmpty()) {
     return;
@@ -471,13 +461,11 @@ void ProjectModule::AcknowledgeAcceleratorWarning() {
   emit AcceleratorStateChanged();
 }
 
-
 bool ProjectModule::IsAcceleratorWarningAcknowledged() const {
   return !accelerator_warning_id_.isEmpty() &&
          QSettings{}.value(QLatin1String(kAcceleratorWarningAcknowledgedKey)).toString() ==
              accelerator_warning_id_;
 }
-
 
 void ProjectModule::PersistAcceleratorWarningAcknowledgement() const {
   if (!accelerator_warning_id_.isEmpty()) {
@@ -485,7 +473,6 @@ void ProjectModule::PersistAcceleratorWarningAcknowledgement() const {
                          accelerator_warning_id_);
   }
 }
-
 
 bool ProjectModule::PromptAndLoadProject() {
   const QString start_dir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
@@ -497,7 +484,6 @@ bool ProjectModule::PromptAndLoadProject() {
   }
   return LoadProject(QUrl::fromLocalFile(selected_path).toString());
 }
-
 
 bool ProjectModule::PromptAndCreateProject() {
   const QString start_dir    = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
@@ -524,7 +510,6 @@ bool ProjectModule::PromptAndCreateProject() {
 
   return CreateProjectInFolderNamed(QUrl::fromLocalFile(selected_dir).toString(), project_name);
 }
-
 
 bool ProjectModule::LoadProject(const QString& metaFileUrlOrPath) {
   if (handler_.project_loading()) {
@@ -579,22 +564,20 @@ bool ProjectModule::LoadProject(const QString& metaFileUrlOrPath) {
     }
 
     return handler_.InitializeServices(unpacked_db_path, unpacked_meta_path,
-                                               ProjectOpenMode::kLoadExisting, project_path,
-                                               workspace_dir, project_path);
+                                       ProjectOpenMode::kLoadExisting, project_path, workspace_dir,
+                                       project_path);
   }
 
   SetServiceMessageForCurrentProject(PL_TEXT("Unsupported project format. Choose a .alcd file."));
   return false;
 }
 
-
 bool ProjectModule::CreateProjectInFolder(const QString& folderUrlOrPath) {
   return CreateProjectInFolderNamed(folderUrlOrPath, "album_editor_project");
 }
 
-
 bool ProjectModule::CreateProjectInFolderNamed(const QString& folderUrlOrPath,
-                                              const QString& projectName) {
+                                               const QString& projectName) {
   if (handler_.project_loading()) {
     SetServiceMessageForCurrentProject(PL_TEXT("A project load is already in progress."));
     return false;
@@ -638,7 +621,6 @@ bool ProjectModule::CreateProjectInFolderNamed(const QString& folderUrlOrPath,
   return started;
 }
 
-
 bool ProjectModule::SaveProject() {
   if (handler_.project_loading()) {
     SetServiceMessageForCurrentProject(PL_TEXT("Please wait until project loading finishes."));
@@ -679,17 +661,15 @@ bool ProjectModule::SaveProject() {
   SetServiceMessageForCurrentProject(
       handler_.package_path().empty()
           ? PL_TEXT("Project saved to %1", PathToQString(handler_.meta_path()))
-          : PL_TEXT("Project saved and packed to %1",
-                    PathToQString(handler_.package_path())));
+          : PL_TEXT("Project saved and packed to %1", PathToQString(handler_.package_path())));
   SetTaskState(handler_.package_path().empty() ? PL_TEXT("Project saved.")
-                                                       : PL_TEXT("Project saved and packed."),
+                                               : PL_TEXT("Project saved and packed."),
                100, false);
   ScheduleIdleTaskStateReset(1200);
   return true;
 }
 
 // ── Shared internal methods ─────────────────────────────────────────────────
-
 
 void ProjectModule::SetServiceState(bool ready, const i18n::LocalizedText& message) {
   if (service_ready_ == ready && service_message_text_.source_ == message.source_ &&
@@ -701,11 +681,9 @@ void ProjectModule::SetServiceState(bool ready, const i18n::LocalizedText& messa
   emit ServiceStateChanged();
 }
 
-
 void ProjectModule::SetServiceMessageForCurrentProject(const i18n::LocalizedText& message) {
   SetServiceState(handler_.project() != nullptr, message);
 }
-
 
 void ProjectModule::ScheduleIdleTaskStateReset(int delayMs) {
   QTimer::singleShot(std::max(delayMs, 0), this, [this]() {
@@ -716,15 +694,13 @@ void ProjectModule::ScheduleIdleTaskStateReset(int delayMs) {
   });
 }
 
-
 void ProjectModule::SetTaskState(const i18n::LocalizedText& status, int progress,
-                                bool cancelVisible) {
+                                 bool cancelVisible) {
   task_status_text_    = status;
   task_progress_       = std::clamp(progress, 0, 100);
   task_cancel_visible_ = cancelVisible;
   emit TaskStateChanged();
 }
-
 
 void ProjectModule::RefreshTranslations() {
   if (lifecycle_hooks_.refresh_translations) {
@@ -739,12 +715,126 @@ void ProjectModule::RefreshTranslations() {
 }
 
 void ProjectModule::HandleProjectOpened() {
+  mask_cache_apply_error_.clear();
+  emit MaskCacheStateChanged();
   if (lifecycle_hooks_.project_opened) {
     lifecycle_hooks_.project_opened();
   }
 }
 
+auto ProjectModule::MaskCacheState() const -> QVariantMap {
+  QVariantMap state;
+  const auto& project = handler_.project();
+  if (!project) {
+    state.insert(QStringLiteral("available"), false);
+    state.insert(QStringLiteral("applyError"), mask_cache_apply_error_);
+    return state;
+  }
+  const auto settings = project->GetMaskCacheSettings();
+  state.insert(QStringLiteral("available"), true);
+  state.insert(QStringLiteral("projectName"),
+               QFileInfo(PathToQString(handler_.meta_path())).completeBaseName());
+  state.insert(QStringLiteral("projectUuid"), QString::fromStdString(project->GetProjectUUID()));
+  state.insert(QStringLiteral("chosenRoot"), PathToQString(settings.chosen_root));
+  QString effective_root;
+  try {
+    effective_root = PathToQString(ProjectMaskCacheNamespaceDirectory(
+        ResolveProjectMaskCacheChosenRoot(settings, handler_.meta_path()),
+        project->GetProjectUUID()));
+  } catch (const std::exception&) {
+    effective_root.clear();
+  }
+  state.insert(QStringLiteral("effectiveRoot"), effective_root);
+  state.insert(QStringLiteral("retention"),
+               settings.retention == ProjectMaskCacheRetention::DeleteOnProjectClose
+                   ? QStringLiteral("deleteOnProjectClose")
+                   : QStringLiteral("keep"));
+  if (const auto* service = project->GetMaskCacheService()) {
+    const auto usage = service->Usage();
+    state.insert(QStringLiteral("fileCount"), static_cast<int>(usage.published_file_count));
+    state.insert(QStringLiteral("byteCount"), static_cast<qlonglong>(usage.published_byte_count));
+    state.insert(QStringLiteral("pendingWrites"), static_cast<int>(usage.pending_write_count));
+    state.insert(QStringLiteral("dirty"), usage.has_dirty_slot);
+    state.insert(QStringLiteral("lastError"), QString::fromStdString(usage.last_error));
+  }
+  state.insert(QStringLiteral("applyError"), mask_cache_apply_error_);
+  return state;
+}
+
+auto ProjectModule::ApplyMaskCacheRoot(const QString& chosenRoot) -> bool {
+  const auto& project = handler_.project();
+  if (!project) {
+    mask_cache_apply_error_ = QStringLiteral("no project is open");
+    emit MaskCacheStateChanged();
+    return false;
+  }
+  std::filesystem::path root;
+  if (!chosenRoot.trimmed().isEmpty()) {
+    const auto parsed = InputToPath(chosenRoot);
+    if (!parsed) {
+      mask_cache_apply_error_ = QStringLiteral("invalid cache folder");
+      emit MaskCacheStateChanged();
+      return false;
+    }
+    root = *parsed;
+  }
+  std::string error;
+  const auto  revision = project->GetMaskCacheSettings().settings_revision;
+  if (!project->SetMaskCacheRoot(std::move(root), revision, &error)) {
+    mask_cache_apply_error_ = QString::fromStdString(error);
+    emit MaskCacheStateChanged();
+    return false;
+  }
+  mask_cache_apply_error_.clear();
+  emit MaskCacheStateChanged();
+  return true;
+}
+
+auto ProjectModule::ApplyMaskCacheRetention(const QString& retentionKey) -> bool {
+  const auto& project = handler_.project();
+  if (!project) {
+    mask_cache_apply_error_ = QStringLiteral("no project is open");
+    emit MaskCacheStateChanged();
+    return false;
+  }
+  const auto  retention = retentionKey == QLatin1String("deleteOnProjectClose")
+                              ? ProjectMaskCacheRetention::DeleteOnProjectClose
+                              : ProjectMaskCacheRetention::Keep;
+  std::string error;
+  const auto  revision = project->GetMaskCacheSettings().settings_revision;
+  if (!project->SetMaskCacheRetention(retention, revision, &error)) {
+    mask_cache_apply_error_ = QString::fromStdString(error);
+    emit MaskCacheStateChanged();
+    return false;
+  }
+  mask_cache_apply_error_.clear();
+  emit MaskCacheStateChanged();
+  return true;
+}
+
+auto ProjectModule::ClearMaskCache() -> bool {
+  const auto& project = handler_.project();
+  if (!project) {
+    mask_cache_apply_error_ = QStringLiteral("no project is open");
+    emit MaskCacheStateChanged();
+    return false;
+  }
+  std::string error;
+  if (!project->ClearMaskCache(&error)) {
+    mask_cache_apply_error_ = QString::fromStdString(error);
+    emit MaskCacheStateChanged();
+    return false;
+  }
+  mask_cache_apply_error_.clear();
+  emit MaskCacheStateChanged();
+  return true;
+}
+
+void ProjectModule::RefreshMaskCacheState() { emit MaskCacheStateChanged(); }
+
 void ProjectModule::ClearProjectUiState() {
+  mask_cache_apply_error_.clear();
+  emit MaskCacheStateChanged();
   if (lifecycle_hooks_.clear_project_ui_state) {
     lifecycle_hooks_.clear_project_ui_state();
   }
@@ -766,7 +856,6 @@ bool ProjectModule::ShouldKeepSemanticModelData(const QString& profileId) const 
   return !lifecycle_hooks_.should_keep_semantic_model_data ||
          lifecycle_hooks_.should_keep_semantic_model_data(profileId);
 }
-
 
 void ProjectModule::LoadRecentProjectsFromSettings() {
   const QVariantList stored_entries = QSettings{}.value(QLatin1String(kRecentProjectsKey)).toList();
@@ -821,11 +910,9 @@ void ProjectModule::LoadRecentProjectsFromSettings() {
   }
 }
 
-
 void ProjectModule::PersistRecentProjects() const {
   QSettings{}.setValue(QLatin1String(kRecentProjectsKey), recent_projects_);
 }
-
 
 void ProjectModule::RegisterRecentProject(const std::filesystem::path& projectPath) {
   const QString normalized_path = NormalizeRecentProjectPath(projectPath);
@@ -858,7 +945,6 @@ void ProjectModule::RegisterRecentProject(const std::filesystem::path& projectPa
   emit RecentProjectsChanged();
 }
 
-
 void ProjectModule::RemoveRecentProject(const std::filesystem::path& projectPath) {
   const QString normalized_path = NormalizeRecentProjectPath(projectPath);
   if (normalized_path.isEmpty()) {
@@ -883,7 +969,6 @@ void ProjectModule::RemoveRecentProject(const std::filesystem::path& projectPath
   PersistRecentProjects();
   emit RecentProjectsChanged();
 }
-
 
 }  // namespace alcedo::ui
 

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
@@ -30,6 +30,10 @@ Item {
                                               && root.selectedMaskId.length > 0
                                               && root.sourceKind === "linear"
     readonly property bool analyticSelected: root.radialSelected || root.gradientSelected
+    readonly property bool brushSelected: root.controlsEnabled
+                                          && root.sourceKind === "brush"
+    readonly property bool maskSelected: root.controlsEnabled
+                                          && root.selectedMaskId.length > 0
 
     function loadFromSnapshot(snapshot) {
         void snapshot
@@ -51,11 +55,21 @@ Item {
     }
 
     Flickable {
+        id: maskScroll
+        objectName: "editorMasksScroll"
         anchors.fill: parent
         contentWidth: width
         contentHeight: content.implicitHeight
         clip: true
+        interactive: contentHeight > height
         boundsBehavior: Flickable.StopAtBounds
+
+        function beginInputLock() {
+            interactive = false
+        }
+        function endInputLock() {
+            interactive = contentHeight > height
+        }
 
         ColumnLayout {
             id: content
@@ -73,7 +87,7 @@ Item {
             Label {
                 objectName: "editorMasksContextEmpty"
                 Layout.fillWidth: true
-                visible: !root.analyticSelected
+                visible: !root.maskSelected
                 wrapMode: Text.WordWrap
                 text: root.maskCreation && root.maskCreation.creating
                       ? qsTr("Draw on the photograph to create the Mask.")
@@ -82,14 +96,276 @@ Item {
                 font.pixelSize: appTheme.fontSizeCaption
             }
 
+            // Mask fields for the selected Mask. Each edit settles as one
+            // typed SetMaskField; opacity drags stay Interactive until release.
+            ParameterLabel { visible: root.maskSelected; text: qsTr("Name") }
+            TextField {
+                id: maskNameField
+                objectName: "editorMasksNameField"
+                Layout.fillWidth: true
+                visible: root.maskSelected
+                enabled: root.maskSelected
+                color: root.colText
+                font.pixelSize: appTheme.fontSizeBody
+                selectByMouse: true
+                activeFocusOnTab: true
+                Accessible.role: Accessible.EditableText
+                Accessible.name: qsTr("Mask name")
+                background: Rectangle {
+                    radius: appTheme.controlRadiusSmall
+                    color: appTheme.bgBaseColor
+                    border.width: 1
+                    border.color: maskNameField.activeFocus ? appTheme.accentColor
+                                                            : appTheme.dividerColor
+                }
+                Component.onCompleted: {
+                    if (root.maskCreation)
+                        text = root.maskCreation.maskName
+                }
+                onEditingFinished: {
+                    if (root.maskCreation)
+                        root.maskCreation.setMaskName(text)
+                }
+                onActiveFocusChanged: {
+                    if (!activeFocus && root.maskCreation)
+                        text = root.maskCreation.maskName
+                }
+                Connections {
+                    target: root.maskCreation
+                    enabled: root.maskCreation !== null
+                    function onMaskCreationChanged() {
+                        if (!maskNameField.activeFocus && root.maskCreation)
+                            maskNameField.text = root.maskCreation.maskName
+                    }
+                }
+            }
+
+            ThemeCheckBox {
+                objectName: "editorMasksEnabledCheck"
+                Layout.fillWidth: true
+                visible: root.maskSelected
+                enabled: root.maskSelected
+                text: qsTr("Enabled")
+                checked: root.maskCreation ? root.maskCreation.maskEnabled : true
+                onToggled: function (checked) {
+                    if (root.maskCreation)
+                        root.maskCreation.setMaskEnabled(checked)
+                }
+            }
+            ThemeCheckBox {
+                objectName: "editorMasksInvertCheck"
+                Layout.fillWidth: true
+                visible: root.maskSelected
+                enabled: root.maskSelected
+                text: qsTr("Invert")
+                checked: root.maskCreation ? root.maskCreation.maskInvert : false
+                onToggled: function (checked) {
+                    if (root.maskCreation)
+                        root.maskCreation.setMaskInvert(checked)
+                }
+            }
+
+            ParameterLabel { visible: root.maskSelected; text: qsTr("Opacity") }
+            EditorMonoSlider {
+                objectName: "editorMasksOpacitySlider"
+                Layout.fillWidth: true
+                visible: root.maskSelected
+                enabled: root.maskSelected
+                accessibleName: qsTr("Mask opacity")
+                from: 0; to: 100; stepSize: 1; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                flickable: maskScroll
+                externalValue: root.maskCreation ? root.maskCreation.maskOpacityPercent : 100
+                onBegin: function () { root.maskCreation.beginMaskOpacity() }
+                onUpdate: function (v) { root.maskCreation.updateMaskOpacity(v) }
+                onFinish: function () { root.maskCreation.finishAnalyticControl() }
+                onReset: function () {
+                    root.maskCreation.beginMaskOpacity()
+                    root.maskCreation.updateMaskOpacity(100)
+                    root.maskCreation.finishAnalyticControl()
+                }
+            }
+            ParameterValue {
+                objectName: "editorMasksOpacityValue"
+                visible: root.maskSelected
+                text: qsTr("%1 percent").arg(Math.round(root.maskCreation
+                                                        ? root.maskCreation.maskOpacityPercent
+                                                        : 100))
+            }
+
+            // Position: arrows nudge the focused Mask position through the
+            // same queued translate-handle route a pointer drag uses.
+            ParameterLabel { visible: nudgeArea.visible; text: qsTr("Position") }
+            Item {
+                id: nudgeArea
+                objectName: "editorMasksNudgeArea"
+                Layout.fillWidth: true
+                implicitHeight: 28
+                visible: root.maskCreation
+                         ? root.maskCreation.maskNudgeAvailable : false
+                activeFocusOnTab: visible
+                Accessible.role: Accessible.Grouping
+                Accessible.name: qsTr("Mask position. Arrow keys move; Shift steps faster.")
+
+                property bool nudgeActive: false
+
+                Keys.onPressed: function (event) {
+                    if (!root.maskCreation || !visible)
+                        return
+                    var step = (event.modifiers & Qt.ShiftModifier) ? 10 : 1
+                    var dx = 0
+                    var dy = 0
+                    if (event.key === Qt.Key_Left)
+                        dx = -step
+                    else if (event.key === Qt.Key_Right)
+                        dx = step
+                    else if (event.key === Qt.Key_Up)
+                        dy = -step
+                    else if (event.key === Qt.Key_Down)
+                        dy = step
+                    else
+                        return
+                    if (!event.isAutoRepeat && !nudgeActive)
+                        nudgeActive = root.maskCreation.beginMaskNudge()
+                    if (nudgeActive)
+                        root.maskCreation.nudgeMaskBy(dx, dy)
+                    event.accepted = true
+                }
+                Keys.onReleased: function (event) {
+                    if (!root.maskCreation || !nudgeActive)
+                        return
+                    if (event.key === Qt.Key_Left || event.key === Qt.Key_Right
+                            || event.key === Qt.Key_Up || event.key === Qt.Key_Down) {
+                        if (!event.isAutoRepeat) {
+                            root.maskCreation.finishAnalyticControl()
+                            nudgeActive = false
+                            event.accepted = true
+                        }
+                    }
+                }
+
+                Rectangle {
+                    anchors.fill: parent
+                    radius: appTheme.controlRadiusSmall
+                    color: nudgeArea.activeFocus ? appTheme.hoverColor
+                                                 : appTheme.bgBaseColor
+                    border.width: 1
+                    border.color: nudgeArea.activeFocus ? appTheme.accentColor
+                                                        : appTheme.cardBorderColor
+                }
+                Label {
+                    anchors.centerIn: parent
+                    width: parent.width - appTheme.spaceSm * 2
+                    horizontalAlignment: Text.AlignHCenter
+                    text: qsTr("Arrow keys move · Shift ×10")
+                    color: root.colMuted
+                    font.pixelSize: appTheme.fontSizeCaption
+                    elide: Text.ElideRight
+                }
+            }
+
+            // Brush tool: Paint/Erase append strokes; Move drags the whole
+            // placement. Move needs an existing committed Brush Mask.
+            ParameterLabel { visible: root.brushSelected; text: qsTr("Tool") }
+            SegmentedCardSwitcher {
+                id: brushToolSegments
+                objectName: "editorMasksBrushToolSegments"
+                Layout.fillWidth: true
+                visible: root.brushSelected
+                enabled: root.brushSelected
+                entries: [
+                    { "label": qsTr("Paint"), "value": "paint" },
+                    { "label": qsTr("Erase"), "value": "erase" },
+                    { "label": qsTr("Move"), "value": "move",
+                      "enabled": root.maskSelected }
+                ]
+                currentValue: root.maskCreation ? String(root.maskCreation.brushTool) : ""
+                onSelected: function (index, value) {
+                    if (root.maskCreation)
+                        root.maskCreation.setBrushTool(value)
+                }
+            }
+
+            ParameterLabel { visible: root.brushSelected; text: qsTr("Brush size") }
+            EditorMonoSlider {
+                objectName: "editorMasksBrushSizeSlider"
+                Layout.fillWidth: true
+                visible: root.brushSelected
+                enabled: root.brushSelected
+                accessibleName: qsTr("Brush size")
+                from: 0.5; to: 50; stepSize: 0.1; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                flickable: maskScroll
+                externalValue: root.maskCreation ? root.maskCreation.brushRadiusPercent : 0
+                onUpdate: function (v) { root.maskCreation.setBrushRadiusPercent(v) }
+            }
+            ParameterValue {
+                objectName: "editorMasksBrushSizeValue"
+                visible: root.brushSelected
+                text: qsTr("%1 px").arg(Math.round(root.maskCreation
+                                                   ? root.maskCreation.brushRadius : 0))
+            }
+
+            ParameterLabel { visible: root.brushSelected; text: qsTr("Brush strength") }
+            EditorMonoSlider {
+                objectName: "editorMasksBrushStrengthSlider"
+                Layout.fillWidth: true
+                visible: root.brushSelected
+                enabled: root.brushSelected
+                accessibleName: qsTr("Brush strength")
+                from: 0; to: 100; stepSize: 1; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                flickable: maskScroll
+                externalValue: root.maskCreation ? root.maskCreation.brushStrengthPercent : 100
+                onUpdate: function (v) { root.maskCreation.setBrushStrengthPercent(v) }
+            }
+            ParameterValue {
+                objectName: "editorMasksBrushStrengthValue"
+                visible: root.brushSelected
+                text: qsTr("%1 percent").arg(Math.round(root.maskCreation
+                                                        ? root.maskCreation.brushStrengthPercent
+                                                        : 100))
+            }
+
+            ParameterLabel { visible: root.brushSelected && root.maskSelected
+                             ; text: qsTr("Brush feather") }
+            EditorMonoSlider {
+                objectName: "editorMasksBrushFeatherSlider"
+                Layout.fillWidth: true
+                visible: root.brushSelected && root.maskSelected
+                enabled: root.brushSelected && root.maskSelected
+                accessibleName: qsTr("Brush feather")
+                from: 0; to: 20; stepSize: 0.1; pointerGain: 1
+                rowHeight: 28; handleSize: 18
+                flickable: maskScroll
+                externalValue: root.maskCreation ? root.maskCreation.brushFeatherPercent : 0
+                onBegin: function () { root.maskCreation.beginBrushFeather() }
+                onUpdate: function (v) { root.maskCreation.updateBrushFeatherPercent(v) }
+                onFinish: function () { root.maskCreation.finishAnalyticControl() }
+                onReset: function () {
+                    root.maskCreation.beginBrushFeather()
+                    root.maskCreation.updateBrushFeatherPercent(0)
+                    root.maskCreation.finishAnalyticControl()
+                }
+            }
+            ParameterValue {
+                objectName: "editorMasksBrushFeatherValue"
+                visible: root.brushSelected && root.maskSelected
+                text: qsTr("%1 percent").arg(Number(root.maskCreation
+                                                    ? root.maskCreation.brushFeatherPercent : 0)
+                                             .toFixed(1))
+            }
+
             ParameterLabel { visible: root.radialSelected; text: qsTr("Horizontal radius") }
             EditorMonoSlider {
                 objectName: "editorMasksMajorRadiusSlider"
                 Layout.fillWidth: true
                 visible: root.radialSelected
                 enabled: root.radialSelected
+                accessibleName: qsTr("Mask horizontal radius")
                 from: 0.1; to: 100; stepSize: 0.1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
+                flickable: maskScroll
                 externalValue: root.maskCreation ? root.maskCreation.majorRadiusPercent : 0
                 onBegin: function () { root.maskCreation.beginMajorRadius() }
                 onUpdate: function (v) { root.maskCreation.updateMajorRadius(v) }
@@ -114,8 +390,10 @@ Item {
                 Layout.fillWidth: true
                 visible: root.radialSelected
                 enabled: root.radialSelected
+                accessibleName: qsTr("Mask vertical radius")
                 from: 0.1; to: 100; stepSize: 0.1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
+                flickable: maskScroll
                 externalValue: root.maskCreation ? root.maskCreation.minorRadiusPercent : 0
                 onBegin: function () { root.maskCreation.beginMinorRadius() }
                 onUpdate: function (v) { root.maskCreation.updateMinorRadius(v) }
@@ -140,8 +418,10 @@ Item {
                 Layout.fillWidth: true
                 visible: root.analyticSelected
                 enabled: root.analyticSelected
+                accessibleName: qsTr("Mask rotation")
                 from: -180; to: 180; stepSize: 0.5; pointerGain: 1
                 rowHeight: 28; handleSize: 18
+                flickable: maskScroll
                 externalValue: root.maskCreation ? root.maskCreation.rotationDegrees : 0
                 onBegin: function () { root.maskCreation.beginRotation() }
                 onUpdate: function (v) { root.maskCreation.updateRotation(v) }
@@ -166,8 +446,10 @@ Item {
                 Layout.fillWidth: true
                 visible: root.radialSelected
                 enabled: root.radialSelected
+                accessibleName: qsTr("Mask inner feather")
                 from: 0; to: 100; stepSize: 1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
+                flickable: maskScroll
                 externalValue: root.maskCreation ? root.maskCreation.innerFeatherPercent : 0
                 onBegin: function () { root.maskCreation.beginInnerFeather() }
                 onUpdate: function (v) { root.maskCreation.updateInnerFeather(v) }
@@ -191,8 +473,10 @@ Item {
                 Layout.fillWidth: true
                 visible: root.radialSelected
                 enabled: root.radialSelected
+                accessibleName: qsTr("Mask outer feather")
                 from: 0; to: 400; stepSize: 1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
+                flickable: maskScroll
                 externalValue: root.maskCreation
                                ? Math.min(400, root.maskCreation.outerFeatherPercent) : 0
                 onBegin: function () { root.maskCreation.beginOuterFeather() }
@@ -217,8 +501,10 @@ Item {
                 Layout.fillWidth: true
                 visible: root.gradientSelected
                 enabled: root.gradientSelected
+                accessibleName: qsTr("Mask transition width")
                 from: 0.1; to: 200; stepSize: 0.1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
+                flickable: maskScroll
                 externalValue: root.maskCreation ? root.maskCreation.transitionPercent : 0
                 onBegin: function () { root.maskCreation.beginTransition() }
                 onUpdate: function (v) { root.maskCreation.updateTransition(v) }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorMasksContextPanel.qml
@@ -275,7 +275,8 @@ Item {
                 enabled: root.brushSelected
                 entries: [
                     { "label": qsTr("Paint"), "value": "paint" },
-                    { "label": qsTr("Erase"), "value": "erase" },
+                    { "label": qsTr("Erase"), "value": "erase",
+                      "enabled": root.maskSelected },
                     { "label": qsTr("Move"), "value": "move",
                       "enabled": root.maskSelected }
                 ]
@@ -296,14 +297,14 @@ Item {
                 from: 0.5; to: 50; stepSize: 0.1; pointerGain: 1
                 rowHeight: 28; handleSize: 18
                 flickable: maskScroll
-                externalValue: root.maskCreation ? root.maskCreation.brushRadiusPercent : 0
-                onUpdate: function (v) { root.maskCreation.setBrushRadiusPercent(v) }
+                externalValue: root.maskCreation ? root.maskCreation.brushDiameterPercent : 0
+                onUpdate: function (v) { root.maskCreation.setBrushDiameterPercent(v) }
             }
             ParameterValue {
                 objectName: "editorMasksBrushSizeValue"
                 visible: root.brushSelected
                 text: qsTr("%1 px").arg(Math.round(root.maskCreation
-                                                   ? root.maskCreation.brushRadius : 0))
+                                                   ? root.maskCreation.brushDiameter : 0))
             }
 
             ParameterLabel { visible: root.brushSelected; text: qsTr("Brush strength") }

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorMonoSlider.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorMonoSlider.qml
@@ -14,6 +14,7 @@ Slider {
     property var onUpdate: function (v) {}
     property var onFinish: function () {}
     property var onReset: function () {}
+    property string accessibleName: ""
     property real externalValue: 0
     /// Full-track mouse travel maps to this fraction of the value range.
     property real pointerGain: 0.32
@@ -44,9 +45,46 @@ Slider {
     topPadding: 0
     bottomPadding: 0
     hoverEnabled: false
+    activeFocusOnTab: true
+    Accessible.role: Accessible.Slider
+    Accessible.name: mono.accessibleName
     Layout.fillWidth: true
     Layout.preferredHeight: mono.rowHeight
     implicitHeight: mono.rowHeight
+
+    function keyStep(event) {
+        var step = mono.stepSize > 0 ? mono.stepSize : (mono.to - mono.from) / 100
+        if (event.modifiers & Qt.ShiftModifier)
+            step *= 10
+        var delta = 0
+        if (event.key === Qt.Key_Left || event.key === Qt.Key_Down)
+            delta = -step
+        else if (event.key === Qt.Key_Right || event.key === Qt.Key_Up)
+            delta = step
+        if (delta === 0)
+            return false
+        var v = Math.max(mono.from, Math.min(mono.to, mono.value + delta))
+        mono.onBegin()
+        mono.value = v
+        mono.onUpdate(v)
+        mono.onFinish()
+        return true
+    }
+
+    Keys.priority: Keys.BeforeItem
+    Keys.onPressed: function (event) {
+        if (mono.enabled && mono.keyStep(event))
+            event.accepted = true
+    }
+
+    Accessible.onIncreaseAction: {
+        if (mono.enabled)
+            mono.keyStep({key: Qt.Key_Right, modifiers: Qt.NoModifier})
+    }
+    Accessible.onDecreaseAction: {
+        if (mono.enabled)
+            mono.keyStep({key: Qt.Key_Left, modifiers: Qt.NoModifier})
+    }
 
     Component.onCompleted: value = externalValue
 

--- a/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/EditorWorkspace.qml
@@ -355,53 +355,113 @@ Item {
                     // PointHandler records the true press position (no drag-distance
                     // threshold). DragHandler would only activate after the system
                     // drag distance, which lost crop-corner hit tests and click-zoom.
+                    // Mask left-button drawing stays on this handler: a second
+                    // DragHandler must not also write samples. Double-tap is
+                    // disabled while Mask owns the left button so its grab cannot
+                    // end the stream on the first press.
                     PointHandler {
                         id: viewportPointer
+                        objectName: "editorViewportPointer"
                         enabled: root.editorControlsEnabled
                         acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.TouchScreen | PointerDevice.Stylus
                         acceptedButtons: Qt.LeftButton | Qt.MiddleButton
                         property int _activeButton: Qt.LeftButton
                         property bool _pressed: false
                         property bool _maskStream: false
+                        property bool _canceled: false
+                        property real _lastX: 0
+                        property real _lastY: 0
+                        property bool _haveLastItemPos: false
+
+                        function rememberItemPos(x, y) {
+                            _lastX = x
+                            _lastY = y
+                            _haveLastItemPos = true
+                        }
+
+                        function finishX() {
+                            if (_haveLastItemPos && Math.abs(point.position.x) < 1e-6
+                                    && Math.abs(point.position.y) < 1e-6)
+                                return _lastX
+                            return point.position.x
+                        }
+
+                        function finishY() {
+                            if (_haveLastItemPos && Math.abs(point.position.x) < 1e-6
+                                    && Math.abs(point.position.y) < 1e-6)
+                                return _lastY
+                            return point.position.y
+                        }
+
+                        function beginMaskOrPan() {
+                            _activeButton = (point.pressedButtons & Qt.MiddleButton)
+                                    ? Qt.MiddleButton : Qt.LeftButton
+                            rememberItemPos(point.position.x, point.position.y)
+                            if (_activeButton === Qt.LeftButton
+                                    && root.maskOwnsLeftButton
+                                    && root.maskCreation
+                                    && root.maskCreation.handlePress(
+                                           point.position.x, point.position.y, _activeButton)) {
+                                _maskStream = true
+                            } else {
+                                _maskStream = false
+                                editorInteraction.handlePress(
+                                            point.position.x, point.position.y, _activeButton)
+                            }
+                        }
+
+                        function finishMaskOrPan() {
+                            var x = finishX()
+                            var y = finishY()
+                            if (_canceled && _maskStream && root.maskCreation
+                                    && typeof root.maskCreation.cancelOpenPointerInput === "function") {
+                                root.maskCreation.cancelOpenPointerInput()
+                            } else if (_maskStream && root.maskCreation) {
+                                root.maskCreation.handleRelease(x, y, _activeButton)
+                            } else {
+                                editorInteraction.handleRelease(x, y, _activeButton)
+                            }
+                            _pressed = false
+                            _maskStream = false
+                            _canceled = false
+                            _haveLastItemPos = false
+                        }
+
+                        onCanceled: {
+                            _canceled = true
+                        }
                         onActiveChanged: {
                             if (active) {
                                 _pressed = true
-                                _activeButton = (point.pressedButtons & Qt.MiddleButton)
-                                        ? Qt.MiddleButton : Qt.LeftButton
-                                if (_activeButton === Qt.LeftButton
-                                        && root.maskOwnsLeftButton
-                                        && root.maskCreation
-                                        && root.maskCreation.handlePress(
-                                               point.position.x, point.position.y, _activeButton)) {
-                                    _maskStream = true
-                                } else {
-                                    _maskStream = false
-                                    editorInteraction.handlePress(
-                                                point.position.x, point.position.y, _activeButton)
-                                }
+                                _canceled = false
+                                beginMaskOrPan()
                             } else if (_pressed) {
-                                if (_maskStream && root.maskCreation) {
-                                    root.maskCreation.handleRelease(
-                                                point.position.x, point.position.y, _activeButton)
-                                } else {
-                                    editorInteraction.handleRelease(
-                                                point.position.x, point.position.y, _activeButton)
-                                }
-                                _pressed = false
-                                _maskStream = false
+                                finishMaskOrPan()
                             }
                         }
                         onPointChanged: {
-                            if (active) {
-                                if (_maskStream && root.maskCreation) {
-                                    root.maskCreation.handleMove(
-                                                point.position.x, point.position.y,
-                                                point.pressedButtons)
-                                } else {
-                                    editorInteraction.handleMove(
-                                                point.position.x, point.position.y,
-                                                point.pressedButtons)
-                                }
+                            if (!active) {
+                                return
+                            }
+                            // pointChanged can run before activeChanged; start the
+                            // Mask stream here so the first move is not sent to pan.
+                            if (!_pressed) {
+                                _pressed = true
+                                _canceled = false
+                                beginMaskOrPan()
+                            }
+                            if (point.pressedButtons !== 0) {
+                                rememberItemPos(point.position.x, point.position.y)
+                            }
+                            if (_maskStream && root.maskCreation) {
+                                root.maskCreation.handleMove(
+                                            _haveLastItemPos ? _lastX : point.position.x,
+                                            _haveLastItemPos ? _lastY : point.position.y,
+                                            point.pressedButtons)
+                            } else {
+                                editorInteraction.handleMove(
+                                            point.position.x, point.position.y,
+                                            point.pressedButtons)
                             }
                         }
                     }
@@ -539,10 +599,13 @@ Item {
                     // of being held as a would-be double-tap. A clean double-click
                     // (two clicks without a drag) still fires onDoubleTapped and
                     // toggles the zoom; only drags are excluded, which is what
-                    // separates pan from double-click-zoom.
+                    // separates pan from double-click-zoom. Mask left-button
+                    // drawing disables this handler so it cannot take the grab
+                    // on the first press of a stroke.
                     TapHandler {
                         id: viewportDoubleTap
-                        enabled: root.editorControlsEnabled
+                        objectName: "editorViewportDoubleTap"
+                        enabled: root.editorControlsEnabled && !root.maskOwnsLeftButton
                         acceptedButtons: Qt.LeftButton
                         gesturePolicy: TapHandler.DragThreshold
                         onDoubleTapped: function (eventPoint) {

--- a/alcedo_studio/src/ui/alcedo_main/qml/ProjectMaskCacheSettingsPanel.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/ProjectMaskCacheSettingsPanel.qml
@@ -1,0 +1,442 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls.Basic
+import QtQuick.Dialogs
+import QtQuick.Layouts
+
+// Settings > Cache — project Mask (Mix) cache. The open project owns
+// disposable R8 coverage files under a dedicated namespace; this panel is
+// separate from the thumbnail disk cache. Pending fields apply through
+// ProjectModule (ProjectService facade); nothing touches storage directly.
+ColumnLayout {
+    id: panel
+    objectName: "projectMaskCacheSettingsPanel"
+
+    property var projectModule: null
+    property bool projectReady: false
+    property color textColor: appTheme.textColor
+    property color mutedTextColor: appTheme.textMutedColor
+    property color dividerColor: appTheme.dividerColor
+    property color dangerColor: appTheme.dangerColor
+    property string dataFontFamily: appTheme.dataFontFamily
+
+    property string pendingRoot: ""
+    property string pendingRetention: "keep"
+
+    signal messageRequested(string message)
+
+    readonly property var cacheState: projectModule ? projectModule.maskCacheState : ({})
+    readonly property bool hasProject: panel.projectReady
+                                       && panel.cacheState.available === true
+    readonly property bool rootPending: panel.pendingRoot
+                                        !== String(panel.cacheState.chosenRoot || "")
+    readonly property string applyErrorText: String(panel.cacheState.applyError || "")
+    readonly property string lastErrorText: String(panel.cacheState.lastError || "")
+
+    width: parent ? parent.width : implicitWidth
+    spacing: 20
+
+    function reloadPending() {
+        if (panel.projectModule)
+            panel.projectModule.RefreshMaskCacheState()
+        if (!panel.hasProject)
+            return
+        panel.pendingRoot = String(panel.cacheState.chosenRoot || "")
+        panel.pendingRetention = String(panel.cacheState.retention || "keep")
+    }
+
+    function applyPending() {
+        if (!panel.hasProject || !panel.projectModule)
+            return
+        if (panel.rootPending) {
+            if (!panel.projectModule.ApplyMaskCacheRoot(panel.pendingRoot)) {
+                panel.messageRequested(
+                            String(panel.projectModule.maskCacheState.applyError
+                                   || qsTr("Mask cache folder was not changed")))
+                return
+            }
+            panel.messageRequested(qsTr("Mask cache folder updated"))
+        }
+        if (panel.pendingRetention !== String(panel.cacheState.retention || "keep")) {
+            if (!panel.projectModule.ApplyMaskCacheRetention(panel.pendingRetention)) {
+                panel.messageRequested(
+                            String(panel.projectModule.maskCacheState.applyError
+                                   || qsTr("Mask cache retention was not changed")))
+                return
+            }
+        }
+        panel.projectModule.RefreshMaskCacheState()
+    }
+
+    function formatBytes(count) {
+        const value = Number(count || 0)
+        if (value < 1024)
+            return qsTr("%1 B").arg(value)
+        if (value < 1024 * 1024)
+            return qsTr("%1 KB").arg((value / 1024).toFixed(1))
+        if (value < 1024 * 1024 * 1024)
+            return qsTr("%1 MB").arg((value / (1024 * 1024)).toFixed(1))
+        return qsTr("%1 GB").arg((value / (1024 * 1024 * 1024)).toFixed(1))
+    }
+
+    function rootDisplayText() {
+        if (panel.pendingRoot.length > 0)
+            return panel.pendingRoot
+        return qsTr("Project metadata folder")
+    }
+
+    FolderDialog {
+        id: maskCacheFolderDialog
+        title: qsTr("Select Mask Cache Folder")
+        onAccepted: panel.pendingRoot = selectedFolder.toString()
+    }
+
+    QtObject {
+        id: retentionModel
+        property string label: ""
+        property bool enabled: panel.hasProject
+        readonly property var entries: [
+            { "label": qsTr("Keep cache files"), "value": "keep" },
+            { "label": qsTr("Delete on project close"), "value": "deleteOnProjectClose" }
+        ]
+        property int currentIndex: panel.pendingRetention === "deleteOnProjectClose" ? 1 : 0
+        function selectIndex(index) {
+            const item = entries[index]
+            if (item)
+                panel.pendingRetention = item.value
+        }
+    }
+
+    SettingsSection {
+        Layout.fillWidth: true
+        Layout.leftMargin: 34
+        Layout.rightMargin: 34
+        title: qsTr("Project Mask cache")
+        textColor: panel.textColor
+        mutedTextColor: panel.mutedTextColor
+        dividerColor: panel.dividerColor
+
+        Label {
+            Layout.fillWidth: true
+            text: qsTr("Disposable coverage cache for Mask results on this project's photos. "
+                       + "Brush strokes, Mask parameters, history, and RAW files are stored "
+                       + "with the project and are never kept here.")
+            color: panel.mutedTextColor
+            font.pixelSize: appTheme.fontSizeBody
+            wrapMode: Text.WordWrap
+        }
+
+        GridLayout {
+            Layout.fillWidth: true
+            columns: 3
+            columnSpacing: 12
+            rowSpacing: 12
+
+            CacheMetric {
+                Layout.fillWidth: true
+                label: qsTr("Project")
+                value: panel.hasProject ? String(panel.cacheState.projectName || "")
+                                        : qsTr("No project")
+            }
+
+            CacheMetric {
+                Layout.fillWidth: true
+                label: qsTr("Files")
+                value: panel.hasProject ? String(panel.cacheState.fileCount || 0) : "0"
+            }
+
+            CacheMetric {
+                Layout.fillWidth: true
+                label: qsTr("Size")
+                value: panel.hasProject ? panel.formatBytes(panel.cacheState.byteCount) : "0 B"
+            }
+        }
+
+        Label {
+            Layout.fillWidth: true
+            visible: panel.hasProject
+            text: qsTr("Project UUID: %1").arg(String(panel.cacheState.projectUuid || ""))
+            color: panel.mutedTextColor
+            font.family: panel.dataFontFamily
+            font.pixelSize: appTheme.fontSizeCaption
+            elide: Text.ElideMiddle
+        }
+
+        Label {
+            id: maskCacheStatusLabel
+            objectName: "maskCacheStatusLabel"
+            Layout.fillWidth: true
+            visible: panel.hasProject
+                     && (panel.cacheState.dirty === true
+                         || Number(panel.cacheState.pendingWrites || 0) > 0
+                         || panel.lastErrorText.length > 0
+                         || panel.applyErrorText.length > 0)
+            text: {
+                if (panel.applyErrorText.length > 0)
+                    return panel.applyErrorText
+                if (panel.lastErrorText.length > 0)
+                    return panel.lastErrorText
+                return qsTr("%1 pending write%2").arg(Number(panel.cacheState.pendingWrites || 0))
+                        .arg(Number(panel.cacheState.pendingWrites || 0) === 1 ? "" : "s")
+            }
+            color: (panel.applyErrorText.length > 0 || panel.lastErrorText.length > 0)
+                   ? panel.dangerColor : panel.mutedTextColor
+            font.pixelSize: appTheme.fontSizeBody
+            wrapMode: Text.WordWrap
+        }
+    }
+
+    SettingsSection {
+        Layout.fillWidth: true
+        Layout.leftMargin: 34
+        Layout.rightMargin: 34
+        title: qsTr("Storage")
+        textColor: panel.textColor
+        mutedTextColor: panel.mutedTextColor
+        dividerColor: panel.dividerColor
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 16
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: qsTr("Cache folder")
+                    color: panel.textColor
+                    font.pixelSize: 15
+                    font.weight: 600
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 36
+                    radius: appTheme.controlRadiusSmall
+                    color: appTheme.bgBaseColor
+                    border.width: 1
+                    border.color: appTheme.cardBorderColor
+
+                    Label {
+                        anchors.fill: parent
+                        anchors.leftMargin: appTheme.spaceSm
+                        anchors.rightMargin: appTheme.spaceSm
+                        text: panel.hasProject ? panel.rootDisplayText()
+                                               : qsTr("No project")
+                        elide: Text.ElideMiddle
+                        verticalAlignment: Text.AlignVCenter
+                        color: panel.textColor
+                        font.family: panel.dataFontFamily
+                        font.pixelSize: appTheme.fontSizeBody
+                    }
+                }
+
+                Label {
+                    Layout.fillWidth: true
+                    visible: panel.hasProject
+                             && String(panel.cacheState.effectiveRoot || "").length > 0
+                    text: String(panel.cacheState.effectiveRoot || "")
+                    elide: Text.ElideMiddle
+                    color: panel.mutedTextColor
+                    font.family: panel.dataFontFamily
+                    font.pixelSize: appTheme.fontSizeCaption
+                }
+            }
+
+            IconButton {
+                objectName: "maskCacheRootChooseButton"
+                buttonWidth: 36
+                buttonHeight: 36
+                buttonRadius: appTheme.controlRadiusSmall
+                iconSize: appTheme.iconOpticalSizeCompact
+                kind: "normal"
+                bordered: true
+                borderColor: appTheme.cardBorderColor
+                iconSrc: "qrc:/panel_icons/folder-open.svg"
+                tooltipText: qsTr("Select Mask Cache Folder")
+                enabled: panel.hasProject
+                Layout.alignment: Qt.AlignBottom
+                onClicked: maskCacheFolderDialog.open()
+            }
+
+            IconButton {
+                objectName: "maskCacheRootDefaultButton"
+                buttonWidth: 36
+                buttonHeight: 36
+                buttonRadius: appTheme.controlRadiusSmall
+                iconSize: appTheme.iconOpticalSizeCompact
+                kind: "normal"
+                bordered: true
+                borderColor: appTheme.cardBorderColor
+                iconSrc: "qrc:/panel_icons/reset.svg"
+                tooltipText: qsTr("Use the project metadata folder")
+                enabled: panel.hasProject && panel.pendingRoot.length > 0
+                Layout.alignment: Qt.AlignBottom
+                onClicked: panel.pendingRoot = ""
+            }
+        }
+
+        Label {
+            id: maskCacheRootWarning
+            objectName: "maskCacheRootWarning"
+            Layout.fillWidth: true
+            visible: panel.hasProject && panel.rootPending
+            text: qsTr("Applying moves new cache writes to this folder and deletes this "
+                       + "project's cache files under the previous folder.")
+            color: panel.dangerColor
+            font.pixelSize: appTheme.fontSizeBody
+            wrapMode: Text.WordWrap
+        }
+    }
+
+    SettingsSection {
+        Layout.fillWidth: true
+        Layout.leftMargin: 34
+        Layout.rightMargin: 34
+        title: qsTr("Retention")
+        textColor: panel.textColor
+        mutedTextColor: panel.mutedTextColor
+        dividerColor: panel.dividerColor
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 16
+
+            Label {
+                Layout.preferredWidth: 180
+                text: qsTr("On project close")
+                color: panel.textColor
+                font.pixelSize: 15
+                font.weight: 600
+            }
+
+            AdjustmentCombo {
+                objectName: "maskCacheRetentionControl"
+                controlObjectName: "maskCacheRetentionCombo"
+                Layout.fillWidth: true
+                controlHeight: 36
+                showResetButton: false
+                model: retentionModel
+            }
+        }
+    }
+
+    SettingsSection {
+        Layout.fillWidth: true
+        Layout.leftMargin: 34
+        Layout.rightMargin: 34
+        title: qsTr("Maintenance")
+        textColor: panel.textColor
+        mutedTextColor: panel.mutedTextColor
+        dividerColor: panel.dividerColor
+
+        Label {
+            id: maskCacheClearHint
+            objectName: "maskCacheClearHint"
+            Layout.fillWidth: true
+            text: qsTr("Deletes only this project's disposable Mask coverage files. "
+                       + "Brush strokes, Mask parameters, history, and RAW files are kept; "
+                       + "the cache is rebuilt on next open.")
+            color: panel.mutedTextColor
+            font.pixelSize: appTheme.fontSizeBody
+            wrapMode: Text.WordWrap
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            DialogActionButton {
+                objectName: "maskCacheClearButton"
+                kind: "normal"
+                Layout.fillWidth: true
+                buttonWidth: 188
+                buttonHeight: 42
+                text: qsTr("Clear Mask cache")
+                enabled: panel.hasProject
+                onClicked: {
+                    if (panel.projectModule
+                            && panel.projectModule.ClearMaskCache()) {
+                        panel.messageRequested(qsTr("Mask cache cleared"))
+                    } else if (panel.projectModule) {
+                        panel.messageRequested(
+                                    String(panel.projectModule.maskCacheState.applyError
+                                           || qsTr("Mask cache was not cleared")))
+                    }
+                }
+            }
+
+            DialogActionButton {
+                kind: "normal"
+                Layout.fillWidth: true
+                buttonWidth: 112
+                buttonHeight: 42
+                text: qsTr("Refresh")
+                onClicked: {
+                    if (panel.projectModule)
+                        panel.projectModule.RefreshMaskCacheState()
+                }
+            }
+        }
+    }
+
+    component SettingsSection: ColumnLayout {
+        property string title: ""
+        property color textColor: appTheme.textColor
+        property color mutedTextColor: appTheme.textMutedColor
+        property color dividerColor: appTheme.dividerColor
+
+        spacing: 14
+
+        Label {
+            Layout.fillWidth: true
+            text: title
+            color: textColor
+            font.pixelSize: 18
+            font.weight: 800
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
+            color: dividerColor
+        }
+    }
+
+    component CacheMetric: Rectangle {
+        property string label: ""
+        property string value: ""
+
+        implicitHeight: 84
+        radius: 8
+        color: Qt.rgba(appTheme.bgBaseColor.r, appTheme.bgBaseColor.g,
+                       appTheme.bgBaseColor.b, 0.62)
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 14
+            spacing: 6
+
+            Label {
+                Layout.fillWidth: true
+                text: label
+                color: panel.mutedTextColor
+                font.pixelSize: 12
+                font.weight: 700
+                elide: Text.ElideRight
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: value
+                color: panel.textColor
+                font.family: panel.dataFontFamily
+                font.pixelSize: 18
+                font.weight: 700
+                elide: Text.ElideRight
+            }
+        }
+    }
+}

--- a/alcedo_studio/src/ui/alcedo_main/qml/SettingDialog.qml
+++ b/alcedo_studio/src/ui/alcedo_main/qml/SettingDialog.qml
@@ -58,6 +58,7 @@ Dialog {
     onCurrentCategoryChanged: {
         if (currentCategory === 2) {
             cachePanel.refreshStats()
+            maskCachePanel.reloadPending()
         } else if (currentCategory === 3) {
             appModules.semanticGeneration.RefreshAlbumSummary()
         } else if (currentCategory === 4) {
@@ -74,6 +75,7 @@ Dialog {
         pendingSemanticImportPreference = appModules.semanticGeneration.importPreference
         pendingAcceleratorBackend = appModules.project.acceleratorBackend
         cachePanel.reloadPending()
+        maskCachePanel.reloadPending()
     }
 
     function acceleratorIndexForValue(value) {
@@ -148,6 +150,7 @@ Dialog {
             languageManager.setLanguage(pendingLanguageCode)
         }
         cachePanel.applyPending()
+        maskCachePanel.applyPending()
         if (appModules.semanticGeneration.importPreference !== pendingSemanticImportPreference) {
             appModules.semanticGeneration.SetImportPreference(pendingSemanticImportPreference)
         }
@@ -540,19 +543,40 @@ Dialog {
                             contentWidth: availableWidth
                             clip: true
 
-                            CacheSettingsPanel {
-                                id: cachePanel
+                            ColumnLayout {
                                 width: cacheScroll.availableWidth
-                                libraryModule: appModules.library
-                                projectReady: appModules.project.serviceReady
-                                textColor: dialog.textColor
-                                mutedTextColor: dialog.mutedTextColor
-                                canvasColor: dialog.canvasColor
-                                dividerColor: dialog.dividerColor
-                                dangerColor: dialog.dangerColor
-                                dataFontFamily: dialog.dataFontFamily
-                                onMessageRequested: function(message) {
-                                    dialog.messageRequested(message)
+                                spacing: 0
+
+                                CacheSettingsPanel {
+                                    id: cachePanel
+                                    width: parent.width
+                                    libraryModule: appModules.library
+                                    projectReady: appModules.project.serviceReady
+                                    textColor: dialog.textColor
+                                    mutedTextColor: dialog.mutedTextColor
+                                    canvasColor: dialog.canvasColor
+                                    dividerColor: dialog.dividerColor
+                                    dangerColor: dialog.dangerColor
+                                    dataFontFamily: dialog.dataFontFamily
+                                    onMessageRequested: function(message) {
+                                        dialog.messageRequested(message)
+                                    }
+                                }
+
+                                ProjectMaskCacheSettingsPanel {
+                                    id: maskCachePanel
+                                    width: parent.width
+                                    projectModule: appModules.project
+                                    projectReady: appModules.project.serviceReady
+                                    textColor: dialog.textColor
+                                    mutedTextColor: dialog.mutedTextColor
+                                    dividerColor: dialog.dividerColor
+                                    dangerColor: dialog.dangerColor
+                                    dataFontFamily: dialog.dataFontFamily
+                                    Layout.bottomMargin: 26
+                                    onMessageRequested: function(message) {
+                                        dialog.messageRequested(message)
+                                    }
                                 }
                             }
                         }

--- a/alcedo_studio/src/ui/edit_viewer/mask_edit_geometry.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_edit_geometry.cpp
@@ -4,6 +4,7 @@
 
 #include "ui/edit_viewer/mask_edit_geometry.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 #include <utility>
@@ -183,9 +184,101 @@ auto MaskEditGeometry::Identity(const MaskEditViewMapping& mapping) -> MaskEditM
   return identity;
 }
 
+namespace {
+
+[[nodiscard]] auto AffineFromIdentityComponents(const float components[6]) -> Matrix3x3 {
+  Matrix3x3 matrix = Matrix3x3::Identity();
+  for (int i = 0; i < 6; ++i) {
+    matrix.m[i] = components[i];
+  }
+  return matrix;
+}
+
+[[nodiscard]] auto ViewMappingFromIdentity(const MaskEditMappingIdentity& identity)
+    -> MaskEditViewMapping {
+  MaskEditViewMapping mapping;
+  mapping.widget.widget_width        = identity.widget_width;
+  mapping.widget.widget_height       = identity.widget_height;
+  mapping.widget.device_pixel_ratio  = identity.device_pixel_ratio;
+  mapping.photograph.image_width     = identity.photograph_width;
+  mapping.photograph.image_height    = identity.photograph_height;
+  mapping.zoom                       = identity.zoom;
+  mapping.pan                        = QVector2D(identity.pan_x, identity.pan_y);
+  mapping.presentation               = identity.presentation;
+  mapping.displayed_roi              = FrameRoiRect{identity.roi_x, identity.roi_y, identity.roi_width,
+                                       identity.roi_height};
+  mapping.geometry.full_reference_extent = {identity.full_reference_width,
+                                            identity.full_reference_height};
+  mapping.geometry.render_extent     = {identity.render_width, identity.render_height};
+  mapping.geometry.edit_extent       = mapping.geometry.render_extent;
+  mapping.geometry.decoded_extent    = mapping.geometry.render_extent;
+  mapping.geometry.render_to_reference = AffineFromIdentityComponents(identity.render_to_reference);
+  try {
+    mapping.geometry.reference_to_render = InvertAffine(mapping.geometry.render_to_reference);
+  } catch (const std::runtime_error&) {
+    mapping.geometry.reference_to_render = {};
+  }
+  return mapping;
+}
+
+[[nodiscard]] auto ItemToReferenceShiftLogicalPx(const MaskEditViewMapping& mapping,
+                                                 Vector2                    reference_a,
+                                                 Vector2                    reference_b) -> float {
+  const auto item_a = MaskEditGeometry::MapReferenceToItem(mapping, reference_a);
+  const auto item_b = MaskEditGeometry::MapReferenceToItem(mapping, reference_b);
+  if (item_a.has_value() && item_b.has_value()) {
+    return static_cast<float>(
+        std::hypot(item_a->x() - item_b->x(), item_a->y() - item_b->y()));
+  }
+  return std::hypot(reference_a.x - reference_b.x, reference_a.y - reference_b.y);
+}
+
+}  // namespace
+
 auto MaskEditGeometry::MappingChanged(const MaskEditMappingIdentity& before,
                                       const MaskEditMappingIdentity& after) -> bool {
-  return before != after;
+  if (before.full_reference_width != after.full_reference_width ||
+      before.full_reference_height != after.full_reference_height ||
+      before.presentation != after.presentation || before.widget_width != after.widget_width ||
+      before.widget_height != after.widget_height ||
+      std::fabs(before.device_pixel_ratio - after.device_pixel_ratio) > 1.0e-4f) {
+    return true;
+  }
+  if (before == after) {
+    return false;
+  }
+
+  const auto mapping_before = ViewMappingFromIdentity(before);
+  const auto mapping_after  = ViewMappingFromIdentity(after);
+  if (!IsValid(mapping_before) || !IsValid(mapping_after)) {
+    return true;
+  }
+
+  const qreal width  = static_cast<qreal>(std::max(1, before.widget_width));
+  const qreal height = static_cast<qreal>(std::max(1, before.widget_height));
+  const QPointF probes[] = {
+      QPointF(width * 0.5, height * 0.5),
+      QPointF(1.0, 1.0),
+      QPointF(width - 1.0, height - 1.0),
+      QPointF(width * 0.25, height * 0.75),
+      QPointF(width * 0.80, height * 0.20),
+  };
+  for (const auto& item : probes) {
+    const auto sample_before = MapItemToReference(mapping_before, item, true);
+    const auto sample_after  = MapItemToReference(mapping_after, item, true);
+    if (!sample_before.has_value() && !sample_after.has_value()) {
+      continue;
+    }
+    if (!sample_before.has_value() || !sample_after.has_value()) {
+      return true;
+    }
+    if (ItemToReferenceShiftLogicalPx(mapping_before, sample_before->reference_pixels,
+                                      sample_after->reference_pixels) >
+        kMaskItemRoundTripLogicalPx) {
+      return true;
+    }
+  }
+  return false;
 }
 
 auto MaskEditGeometry::MapItemToReference(const MaskEditViewMapping& mapping, const QPointF& item,

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_geometry.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_geometry.cpp
@@ -302,6 +302,23 @@ void AppendHollowCircle(std::vector<MaskOverlayVertex>& triangles, const QPointF
   AppendRing(triangles, center, inner, outer, aa, color, clip);
 }
 
+void AppendDashedHollowCircle(std::vector<MaskOverlayVertex>& triangles, const QPointF& center,
+                              float radius, float width, float aa, const QColor& color,
+                              const QRectF& clip, float dash_len, float gap_len) {
+  if (radius <= 0.0f || !IsFinitePoint(center)) {
+    return;
+  }
+  const int segments = std::clamp(static_cast<int>(std::ceil(radius * 2.0f)), 24, 128);
+  std::vector<QPointF> ring;
+  ring.reserve(static_cast<std::size_t>(segments));
+  for (int i = 0; i < segments; ++i) {
+    const float a = (static_cast<float>(i) / static_cast<float>(segments)) * 6.28318530718f;
+    ring.emplace_back(center.x() + std::cos(a) * radius, center.y() + std::sin(a) * radius);
+  }
+  AppendDashedPolylineStroke(triangles, ring, /*closed=*/true, width, aa, color, clip, dash_len,
+                             gap_len);
+}
+
 }  // namespace
 
 auto DefaultMaskOverlayStyle() -> MaskOverlayStyle { return {}; }
@@ -332,9 +349,60 @@ auto BuildMaskOverlaySceneGeometry(const MaskOverlayDisplay& display, const Mask
     }
     return handle_r;
   };
+  const auto append_frame_segment = [&](const QPointF& a, const QPointF& b) {
+    AppendClippedStroke(scene.selected_guides, a, b, guide_outer, aa, style.control_fill, clip,
+                        /*round_caps=*/false);
+    AppendClippedStroke(scene.selected_guides, a, b, guide_inner, aa, style.control_outline, clip,
+                        /*round_caps=*/false);
+    ++scene.selected_guide_segment_count;
+  };
 
-  for (const auto& handle : display.handles) {
+  for (std::size_t handle_index = 0; handle_index < display.handles.size(); ++handle_index) {
+    const auto& handle = display.handles[handle_index];
     if (handle.id == MaskOverlayHandleId::None || !IsFinitePoint(handle.item)) {
+      continue;
+    }
+    if (handle.shape == MaskOverlayHandleShape::CornerTick) {
+      // Brush Move frame anchor: two short segments from the corner along the
+      // adjacent frame edges. Edge directions come from the neighbouring
+      // corner handles, so the tick follows the rotated frame.
+      const auto* prev = &handle;
+      const auto* next = &handle;
+      for (std::size_t i = 1; i <= display.handles.size(); ++i) {
+        const auto& candidate =
+            display.handles[(handle_index + display.handles.size() - i) % display.handles.size()];
+        if (candidate.shape == MaskOverlayHandleShape::CornerTick &&
+            IsFinitePoint(candidate.item)) {
+          prev = &candidate;
+          break;
+        }
+      }
+      for (std::size_t i = 1; i <= display.handles.size(); ++i) {
+        const auto& candidate = display.handles[(handle_index + i) % display.handles.size()];
+        if (candidate.shape == MaskOverlayHandleShape::CornerTick &&
+            IsFinitePoint(candidate.item)) {
+          next = &candidate;
+          break;
+        }
+      }
+      const float tick_len = handle_radius(handle.id) * 2.4f;
+      for (const auto* neighbour : {prev, next}) {
+        if (neighbour == &handle) {
+          continue;
+        }
+        const QPointF delta = neighbour->item - handle.item;
+        const double  len   = std::hypot(delta.x(), delta.y());
+        if (len < kMinLength) {
+          continue;
+        }
+        const QPointF end(handle.item.x() + delta.x() / len * tick_len,
+                          handle.item.y() + delta.y() / len * tick_len);
+        AppendClippedStroke(scene.edge_grips, handle.item, end, grip_outer, aa,
+                            style.control_fill, clip, /*round_caps=*/false);
+        AppendClippedStroke(scene.edge_grips, handle.item, end, grip_inner, aa,
+                            style.control_outline, clip, /*round_caps=*/false);
+      }
+      ++scene.handle_count;
       continue;
     }
     const float radius = handle_radius(handle.id);
@@ -351,6 +419,22 @@ auto BuildMaskOverlaySceneGeometry(const MaskOverlayDisplay& display, const Mask
     ++scene.handle_count;
   }
 
+  if (display.move_frame_visible) {
+    // Brush Move frame: closed outline through the ordered CornerTick handles.
+    std::vector<QPointF> frame;
+    for (const auto& handle : display.handles) {
+      if (handle.shape == MaskOverlayHandleShape::CornerTick && IsFinitePoint(handle.item)) {
+        frame.push_back(handle.item);
+      }
+    }
+    for (std::size_t i = 0; i + 1 < frame.size(); ++i) {
+      append_frame_segment(frame[i], frame[i + 1]);
+    }
+    if (frame.size() > 2) {
+      append_frame_segment(frame.back(), frame.front());
+    }
+  }
+
   for (const auto& segment : display.connectors) {
     AppendClippedStroke(scene.connectors, segment.first, segment.second, stroke_w, aa,
                         style.control_fill, clip, /*round_caps=*/true);
@@ -358,8 +442,15 @@ auto BuildMaskOverlaySceneGeometry(const MaskOverlayDisplay& display, const Mask
 
   if (display.cursor_visible && display.cursor_radius_logical_px > 0.0f &&
       IsFinitePoint(display.cursor_center)) {
-    AppendHollowCircle(scene.cursor, display.cursor_center, display.cursor_radius_logical_px,
-                       stroke_w, aa, style.control_fill, clip);
+    if (display.cursor_dashed) {
+      AppendDashedHollowCircle(scene.cursor, display.cursor_center,
+                              display.cursor_radius_logical_px, stroke_w, aa, style.control_fill,
+                              clip, kMaskOverlayDashLengthLogicalPx,
+                              kMaskOverlayDashGapLogicalPx);
+    } else {
+      AppendHollowCircle(scene.cursor, display.cursor_center, display.cursor_radius_logical_px,
+                         stroke_w, aa, style.control_fill, clip);
+    }
   }
 
   if (display.mode == MaskOverlayMode::Creating) {

--- a/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
+++ b/alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp
@@ -5,10 +5,12 @@
 #include "ui/edit_viewer/mask_overlay_layout.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <optional>
 #include <utility>
 
+#include "edit/mask/brush_stroke.hpp"
 #include "ui/edit_viewer/crop_geometry.hpp"
 #include "ui/edit_viewer/viewport_mapper.hpp"
 
@@ -490,6 +492,65 @@ auto MakeBrushExistingOverlayDisplay(const MaskEditViewMapping& mapping,
   return display;
 }
 
+auto BrushPaintSupportReferenceBounds(const BrushMaskSource& source) -> QRectF {
+  QRectF bounds;
+  bool   any = false;
+  for (const auto& stroke : source.strokes) {
+    if (stroke.mode != BrushStrokeMode::Paint || stroke.samples == nullptr) {
+      continue;
+    }
+    for (const auto& sample : *stroke.samples) {
+      if (!(sample.strength > 0.0f) || !std::isfinite(sample.local_x) ||
+          !std::isfinite(sample.local_y) || !(sample.radius > 0.0f)) {
+        continue;
+      }
+      const qreal cx = static_cast<qreal>(sample.local_x + source.placement_translation.x);
+      const qreal cy = static_cast<qreal>(sample.local_y + source.placement_translation.y);
+      const qreal r  = static_cast<qreal>(sample.radius);
+      const QRectF dab(cx - r, cy - r, 2.0 * r, 2.0 * r);
+      bounds = any ? bounds.united(dab) : dab;
+      any    = true;
+    }
+  }
+  return bounds;
+}
+
+auto MakeBrushMoveOverlayDisplay(const MaskEditViewMapping& mapping, const BrushMaskSource& source,
+                                 const QRectF& clip) -> MaskOverlayDisplay {
+  auto bounds = BrushPaintSupportReferenceBounds(source);
+  if (bounds.isEmpty()) {
+    // No painted coverage: keep the single Move anchor at the placement origin.
+    return MakeBrushExistingOverlayDisplay(mapping, source.placement_translation, clip);
+  }
+  const qreal feather = static_cast<qreal>(std::max(0.0f, source.feather_radius));
+  bounds              = bounds.adjusted(-feather, -feather, feather, feather);
+
+  std::array<QPointF, 4> corners;
+  const Vector2          refs[4] = {
+      {static_cast<float>(bounds.left()), static_cast<float>(bounds.top())},
+      {static_cast<float>(bounds.right()), static_cast<float>(bounds.top())},
+      {static_cast<float>(bounds.right()), static_cast<float>(bounds.bottom())},
+      {static_cast<float>(bounds.left()), static_cast<float>(bounds.bottom())},
+  };
+  for (std::size_t i = 0; i < 4; ++i) {
+    const auto item = MaskEditGeometry::MapReferenceToItem(mapping, refs[i]);
+    if (!item) {
+      return MakeBrushExistingOverlayDisplay(mapping, source.placement_translation, clip);
+    }
+    corners[i] = *item;
+  }
+  MaskOverlayDisplay display;
+  display.mode                = MaskOverlayMode::Existing;
+  display.source_kind         = MaskOverlaySourceKind::Brush;
+  display.clip_rect           = EffectiveClip(mapping, clip);
+  display.move_frame_visible  = true;
+  for (const auto& corner : corners) {
+    display.handles.push_back(MaskOverlayHandle{MaskOverlayHandleId::BrushMove, corner,
+                                                MaskOverlayHandleShape::CornerTick});
+  }
+  return display;
+}
+
 auto MakeRadialExistingOverlayDisplay(const MaskEditViewMapping& mapping,
                                       const RadialMaskSource& source, const MaskOverlayStyle& style,
                                       const QRectF& clip) -> MaskOverlayDisplay {
@@ -530,8 +591,8 @@ auto MakeLinearExistingOverlayDisplay(const MaskEditViewMapping&      mapping,
 }
 
 auto MakeBrushCreatingOverlayDisplay(const std::vector<QPointF>& item_path, QPointF cursor_item,
-                                     float cursor_radius_logical_px, const QRectF& clip)
-    -> MaskOverlayDisplay {
+                                     float cursor_radius_logical_px, const QRectF& clip,
+                                     bool erase_cursor) -> MaskOverlayDisplay {
   MaskOverlayDisplay display;
   display.mode           = MaskOverlayMode::Creating;
   display.source_kind    = MaskOverlaySourceKind::Brush;
@@ -541,6 +602,7 @@ auto MakeBrushCreatingOverlayDisplay(const std::vector<QPointF>& item_path, QPoi
                            cursor_radius_logical_px > 0.0f;
   display.cursor_center            = cursor_item;
   display.cursor_radius_logical_px = cursor_radius_logical_px;
+  display.cursor_dashed            = erase_cursor;
   return display;
 }
 
@@ -616,6 +678,44 @@ auto HitTestMaskOverlayHandle(const MaskOverlayDisplay& display, QPointF item,
   }
   if (hit != MaskOverlayHandleId::None) {
     return hit;
+  }
+  if (display.move_frame_visible) {
+    // Brush Move frame: the interior and the frame edges all begin a move.
+    // The mapped quad stays convex (an AABB under an affine map), so a
+    // consistent winding sign marks the interior.
+    std::vector<QPointF> corners;
+    for (const auto& handle : display.handles) {
+      if (handle.shape == MaskOverlayHandleShape::CornerTick) {
+        corners.push_back(handle.item);
+      }
+    }
+    if (corners.size() >= 3) {
+      bool inside     = true;
+      int  first_sign = 0;
+      for (std::size_t i = 0; i < corners.size() && inside; ++i) {
+        const QPointF& a     = corners[i];
+        const QPointF& b     = corners[(i + 1) % corners.size()];
+        const double   cross = (b.x() - a.x()) * (item.y() - a.y()) -
+                             (b.y() - a.y()) * (item.x() - a.x());
+        if (std::abs(cross) < 1.0e-12) {
+          continue;
+        }
+        const int sign = cross > 0.0 ? 1 : -1;
+        if (first_sign == 0) {
+          first_sign = sign;
+        } else if (sign != first_sign) {
+          inside = false;
+        }
+      }
+      bool near_edge = false;
+      for (std::size_t i = 0; i < corners.size() && !near_edge; ++i) {
+        near_edge = DistanceToSegment(item, corners[i], corners[(i + 1) % corners.size()]) <=
+                    hit_radius_logical_px;
+      }
+      if (inside || near_edge) {
+        return MaskOverlayHandleId::BrushMove;
+      }
+    }
   }
   for (const auto& guide : display.selected_guides) {
     if (guide.id == MaskOverlayHandleId::None) {

--- a/alcedo_studio/src/ui/editor_rhi/direct_frame_sink.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/direct_frame_sink.cpp
@@ -412,7 +412,30 @@ void DirectFrameSink::NotifyFrameReady(const FrameCompletionSubmission& submissi
   FramePresentationMode mode       = submission.mode;
   FramePreviewMetadata  metadata   = submission.metadata;
   {
+    // Publish the presented frame's resolved geometry before the slot gate so
+    // zero-copy paths (Metal SubmitMetalFrame) and accepted full frames both
+    // refresh the viewer's Mask mapping reference. RoiFrame/DetailPatch
+    // submissions render a subrect of the same reference space and must not
+    // replace it. Stale request ids never publish.
+    const bool publish_geometry =
+        IsRenderReferenceFrame(mode, metadata.frame_role) &&
+        !submission.geometry.full_reference_extent.Empty() &&
+        !submission.geometry.render_extent.Empty();
     std::lock_guard lock(mutex_);
+    if (publish_geometry &&
+        AcceptSubmissionRequestId(metadata.presentation_request_id) && item_) {
+      const auto connection =
+          (item_->thread() == QThread::currentThread()) ? Qt::DirectConnection
+                                                       : Qt::QueuedConnection;
+      const auto geometry   = submission.geometry;
+      const auto request_id = metadata.presentation_request_id;
+      QMetaObject::invokeMethod(
+          item_,
+          [item = item_, geometry, request_id] {
+            item->NotePresentedMaskGeometry(geometry, request_id);
+          },
+          connection);
+    }
     if (!has_mapped_slot_ || !unmapped_pending_submit_) {
       if (metadata.frame_role == FrameRole::DetailPatch) {
         qCDebug(editorPresentLog) << "[ROI_TRACE][sink-drop] request="

--- a/alcedo_studio/src/ui/editor_rhi/editor_interaction_controller.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_interaction_controller.cpp
@@ -659,7 +659,24 @@ bool EditorInteractionController::isItemPointInsideImage(qreal x, qreal y) const
 }
 
 void EditorInteractionController::setDisplayedMaskGeometry(const ResolvedRenderGeometry& geometry) {
+  const auto& current = displayed_mask_geometry_;
+  const bool  same =
+      current.full_reference_extent == geometry.full_reference_extent &&
+      current.render_extent == geometry.render_extent &&
+      current.edit_extent == geometry.edit_extent &&
+      current.decoded_extent == geometry.decoded_extent &&
+      MatrixApproxEqual(current.render_to_reference, geometry.render_to_reference) &&
+      MatrixApproxEqual(current.reference_to_render, geometry.reference_to_render) &&
+      MatrixApproxEqual(current.reference_to_edit, geometry.reference_to_edit) &&
+      MatrixApproxEqual(current.edit_to_render, geometry.edit_to_render) &&
+      MatrixApproxEqual(current.decoded_to_reference, geometry.decoded_to_reference);
+  if (same) {
+    return;
+  }
   displayed_mask_geometry_ = geometry;
+  // The Mask mapping basis changed with the presented frame; overlays holding
+  // mapped handles must rebuild even before the next pointer event.
+  emit overlayGeometryChanged();
 }
 
 auto EditorInteractionController::maskEditViewMapping() const -> MaskEditViewMapping {

--- a/alcedo_studio/src/ui/editor_rhi/editor_overlay_item.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_overlay_item.cpp
@@ -465,7 +465,10 @@ auto EditorOverlayItem::cropVisible() const -> bool { return last_scene_geometry
 
 void EditorOverlayItem::refreshFromInteraction() {
   rebuildSceneGeometry();
-  rebuildMaskSceneGeometry();
+  // Mask scene geometry is a pure function of (mask_display_, mask_style_);
+  // both owners rebuild it inline in their setters, so interaction signals
+  // alone never change it. Skipping the rebuild here removes one full
+  // contour/handle re-triangulation per interaction-driven refresh.
   ++geometry_revision_;
   ++geometry_rebuild_count_;
   geometry_dirty_ = true;

--- a/alcedo_studio/src/ui/editor_rhi/editor_viewport_item.cpp
+++ b/alcedo_studio/src/ui/editor_rhi/editor_viewport_item.cpp
@@ -158,7 +158,19 @@ void EditorViewportItem::setImageIdentity(qulonglong identity) {
   if (previous == identity) {
     return;
   }
+  presented_mask_geometry_   = {};
+  presented_mask_request_id_ = 0;
   emit ImageIdentityChanged();
+}
+
+void EditorViewportItem::NotePresentedMaskGeometry(const ResolvedRenderGeometry& geometry,
+                                                   qulonglong                    request_id) {
+  if (request_id != 0 && request_id <= presented_mask_request_id_) {
+    return;
+  }
+  presented_mask_geometry_   = geometry;
+  presented_mask_request_id_ = request_id;
+  emit PresentedMaskGeometryChanged();
 }
 
 void EditorViewportItem::setSessionEpoch(qulonglong epoch) {

--- a/alcedo_studio/tests/app/editor_session_command_queue_baseline_test.cpp
+++ b/alcedo_studio/tests/app/editor_session_command_queue_baseline_test.cpp
@@ -629,5 +629,30 @@ TEST_F(EditorSessionCommandQueueBaselineTest,
   EXPECT_EQ(locking->capture_count, 1);
 }
 
+/// Regression: continuous view churn (panel fold, window resize, zoom/pan
+/// drags) submits one RequestViewChange plus one SetPresentationSize per
+/// frame. Frame reuse changes no session-visible state, so these commands
+/// must record results without publishing change notifications — otherwise
+/// every animation frame runs a full backend-changed refresh.
+TEST_F(EditorSessionCommandQueueBaselineTest,
+       FrameReuseAndPresentationSizeDoNotPublishChangeNotifications) {
+  openInteractive(10, 20);
+
+  const auto notifications_before = recorder_->change_notifications;
+  const auto results_before       = recorder_->results.size();
+
+  service_->SetPresentationSize(800, 600);
+  const auto resize_result = service_->RequestViewChange(EditorRenderReason::Resize, std::nullopt);
+  const auto pan_result    = service_->RequestViewChange(EditorRenderReason::ZoomPan, std::nullopt);
+  drainQueue();
+
+  EXPECT_EQ(resize_result.kind, EditorSessionResultKind::Accepted);
+  EXPECT_EQ(pan_result.kind, EditorSessionResultKind::Accepted);
+  EXPECT_EQ(recorder_->change_notifications, notifications_before)
+      << "frame reuse must not publish change notifications";
+  EXPECT_GT(recorder_->results.size(), results_before)
+      << "frame reuse results must still reach the result observer";
+}
+
 }  // namespace
 }  // namespace alcedo

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -362,7 +362,8 @@ alcedo_register_test_target(BrushRegionalReplayTest edit)
 
 # Retained canonical Brush rasters: identity diff, regional replay, and eviction.
 add_executable(ParameterizedBrushReplayCacheTest
-  ${ALCEDO_TEST_ROOT}/edit/mask/parameterized_brush_replay_cache_test.cpp)
+  ${ALCEDO_TEST_ROOT}/edit/mask/parameterized_brush_replay_cache_test.cpp
+  ${ALCEDO_TEST_ROOT}/edit/mask/brush_coverage_update_test.cpp)
 target_include_directories(ParameterizedBrushReplayCacheTest
   PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_ROOT}/edit/mask)
 target_link_libraries(ParameterizedBrushReplayCacheTest
@@ -494,7 +495,8 @@ if(ALCEDO_CUDA_ENABLED)
   add_executable(GpuDagCudaMaskTest
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_mask_test.cpp
     ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_multi_mask_resource_test.cpp
-    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_parameterized_grade_mix_test.cpp)
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_parameterized_grade_mix_test.cpp
+    ${ALCEDO_TEST_ROOT}/edit/runtime/cuda_parameterized_brush_gpu_test.cpp)
   target_include_directories(GpuDagCudaMaskTest PUBLIC ${ALCEDO_INCLUDE_DIR})
   target_link_libraries(GpuDagCudaMaskTest PRIVATE GTest::gtest_main EditRuntimeCuda EditInput)
   gtest_discover_tests(GpuDagCudaMaskTest TEST_PREFIX "GpuDagCudaMaskTest."

--- a/alcedo_studio/tests/edit/CMakeLists.txt
+++ b/alcedo_studio/tests/edit/CMakeLists.txt
@@ -360,6 +360,18 @@ gtest_discover_tests(BrushRegionalReplayTest
   PROPERTIES LABELS "ci_core_flow;edit;mask")
 alcedo_register_test_target(BrushRegionalReplayTest edit)
 
+# Retained canonical Brush rasters: identity diff, regional replay, and eviction.
+add_executable(ParameterizedBrushReplayCacheTest
+  ${ALCEDO_TEST_ROOT}/edit/mask/parameterized_brush_replay_cache_test.cpp)
+target_include_directories(ParameterizedBrushReplayCacheTest
+  PUBLIC ${ALCEDO_INCLUDE_DIR} ${ALCEDO_TEST_ROOT}/edit/mask)
+target_link_libraries(ParameterizedBrushReplayCacheTest
+  PRIVATE GTest::gtest_main EditMaskStore)
+gtest_discover_tests(ParameterizedBrushReplayCacheTest
+  TEST_PREFIX "ParameterizedBrushReplayCacheTest."
+  PROPERTIES LABELS "ci_core_flow;edit;mask")
+alcedo_register_test_target(ParameterizedBrushReplayCacheTest edit)
+
 add_executable(AnalyticMaskEditTest
   ${ALCEDO_TEST_ROOT}/edit/mask/analytic_mask_edit_test.cpp)
 target_include_directories(AnalyticMaskEditTest PUBLIC ${ALCEDO_INCLUDE_DIR})

--- a/alcedo_studio/tests/edit/mask/brush_coverage_update_test.cpp
+++ b/alcedo_studio/tests/edit/mask/brush_coverage_update_test.cpp
@@ -1,0 +1,154 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/brush_coverage_update.hpp"
+
+#include "edit/graph/graph_ids.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/brush_stroke.hpp"
+#include "edit/mask/mask_id.hpp"
+#include "edit/mask/mask_model.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace alcedo {
+namespace {
+
+constexpr Extent2D kFull{96, 64};
+
+auto Paint(std::string_view id, std::vector<BrushCanonicalSample> samples) -> BrushStroke {
+  return MakeBrushStroke(StrokeId{std::string{id}}, BrushStrokeMode::Paint, std::move(samples));
+}
+
+auto MakeBrush(std::vector<BrushStroke> strokes, Vector2 translation = {}) -> BrushMaskSource {
+  BrushMaskSource source;
+  source.strokes               = std::move(strokes);
+  source.placement_translation = translation;
+  return source;
+}
+
+TEST(BrushCoverageUpdate, MissingPreviousReplaysFullRaster) {
+  const auto next = MakeBrush({Paint("a", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}})});
+  const auto raster = CanonicalBrushRasterExtent(kFull);
+  const auto update =
+      DetectBrushCoverageUpdate(nullptr, {}, {}, next, raster, kFull);
+  EXPECT_EQ(update.kind, BrushCoverageUpdateKind::ReplayDirty);
+  EXPECT_EQ(update.dirty, FullTexelRect(raster));
+}
+
+TEST(BrushCoverageUpdate, EqualSourcesAreUnchanged) {
+  const auto source = MakeBrush({Paint("a", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}})});
+  const auto raster = CanonicalBrushRasterExtent(kFull);
+  const auto update =
+      DetectBrushCoverageUpdate(&source, raster, kFull, source, raster, kFull);
+  EXPECT_EQ(update.kind, BrushCoverageUpdateKind::Unchanged);
+  EXPECT_EQ(update.dirty, (RectI{0, 0, 1, 1}));
+}
+
+TEST(BrushCoverageUpdate, GrownDraftStampsOnlyNewSamples) {
+  auto previous = MakeBrush({Paint("draft", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}})});
+  auto next     = previous;
+  next.strokes.back() = Paint("draft", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f},
+                                        {70.0f, 50.0f, 5.0f, 1.0f, 1.0f}});
+  const auto raster = CanonicalBrushRasterExtent(kFull);
+  const auto update =
+      DetectBrushCoverageUpdate(&previous, raster, kFull, next, raster, kFull);
+  EXPECT_EQ(update.kind, BrushCoverageUpdateKind::StampNewSamples);
+  EXPECT_EQ(update.stroke_index, 0u);
+  EXPECT_EQ(update.stroke_end, 1u);
+  EXPECT_EQ(update.sample_begin, 1u);
+  EXPECT_EQ(update.dirty, BrushDabOutputTexelSupport(BrushStrokeSamples(next.strokes[0])[1],
+                                                     next.placement_translation, raster, kFull));
+}
+
+TEST(BrushCoverageUpdate, AppendedStrokeStampsNewStroke) {
+  auto previous = MakeBrush({Paint("a", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}})});
+  auto next     = previous;
+  next.strokes.push_back(Paint("b", {{70.0f, 50.0f, 5.0f, 1.0f, 1.0f}}));
+  const auto raster = CanonicalBrushRasterExtent(kFull);
+  const auto update =
+      DetectBrushCoverageUpdate(&previous, raster, kFull, next, raster, kFull);
+  EXPECT_EQ(update.kind, BrushCoverageUpdateKind::StampNewSamples);
+  EXPECT_EQ(update.stroke_index, 1u);
+  EXPECT_EQ(update.stroke_end, 2u);
+  EXPECT_EQ(update.sample_begin, 0u);
+  EXPECT_EQ(update.dirty, BrushStrokeOutputTexelSupport(next.strokes[1], next.placement_translation,
+                                                        raster, kFull));
+}
+
+TEST(BrushCoverageUpdate, PlacementMoveReplaysOldAndNewBounds) {
+  const auto paint = Paint("a", {{30.0f, 20.0f, 8.0f, 1.0f, 1.0f}});
+  auto       previous = MakeBrush({paint});
+  auto       next     = previous;
+  next.placement_translation = {12.0f, -6.0f};
+  const auto raster = CanonicalBrushRasterExtent(kFull);
+  const auto update =
+      DetectBrushCoverageUpdate(&previous, raster, kFull, next, raster, kFull);
+  EXPECT_EQ(update.kind, BrushCoverageUpdateKind::ReplayDirty);
+  EXPECT_EQ(update.dirty,
+            UnionTexelRect(BrushStrokeOutputTexelSupport(paint, previous.placement_translation,
+                                                         raster, kFull),
+                           BrushStrokeOutputTexelSupport(paint, next.placement_translation, raster,
+                                                         kFull)));
+}
+
+TEST(BrushCoverageUpdate, RemovedStrokeReplaysOldRegion) {
+  auto previous = MakeBrush({Paint("a", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}}),
+                             Paint("b", {{70.0f, 50.0f, 5.0f, 1.0f, 1.0f}})});
+  auto next     = previous;
+  const auto raster = CanonicalBrushRasterExtent(kFull);
+  const auto removed =
+      BrushStrokeOutputTexelSupport(next.strokes.back(), next.placement_translation, raster, kFull);
+  next.strokes.pop_back();
+  const auto update =
+      DetectBrushCoverageUpdate(&previous, raster, kFull, next, raster, kFull);
+  EXPECT_EQ(update.kind, BrushCoverageUpdateKind::ReplayDirty);
+  EXPECT_EQ(update.dirty, removed);
+}
+
+TEST(BrushCoverageUpdate, FeatherRadiusChangeDoesNotStampCoverage) {
+  auto previous = MakeBrush({Paint("a", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}})});
+  auto next     = previous;
+  next.feather_radius = 4.0f;
+  const auto raster  = CanonicalBrushRasterExtent(kFull);
+  const auto update  =
+      DetectBrushCoverageUpdate(&previous, raster, kFull, next, raster, kFull);
+  EXPECT_EQ(update.kind, BrushCoverageUpdateKind::Unchanged);
+}
+
+TEST(BrushCoverageUpdate, EmptyThenFirstStrokeStampsTheNewStroke) {
+  auto previous = MakeBrush({});
+  auto next     = MakeBrush({Paint("a", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}})});
+  const auto raster = CanonicalBrushRasterExtent(kFull);
+  const auto update =
+      DetectBrushCoverageUpdate(&previous, raster, kFull, next, raster, kFull);
+  EXPECT_EQ(update.kind, BrushCoverageUpdateKind::StampNewSamples);
+  EXPECT_EQ(update.stroke_index, 0u);
+  EXPECT_EQ(update.stroke_end, 1u);
+  EXPECT_EQ(update.sample_begin, 0u);
+}
+
+TEST(BrushCoverageCommandJournal, StoreFindAndClearRoundTrip) {
+  BrushCoverageCommandJournal journal;
+  const NodeId grade{"grade.primary"};
+  const MaskId mask{"mask.brush"};
+  const auto   source = MakeBrush({Paint("a", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}})});
+  const auto   raster = CanonicalBrushRasterExtent(kFull);
+  EXPECT_EQ(journal.Find(grade, mask), nullptr);
+  journal.Store(grade, mask, source, raster, kFull);
+  const auto* found = journal.Find(grade, mask);
+  ASSERT_NE(found, nullptr);
+  EXPECT_EQ(found->source, source);
+  EXPECT_EQ(found->raster, raster);
+  EXPECT_EQ(found->full_reference, kFull);
+  journal.Clear();
+  EXPECT_EQ(journal.Find(grade, mask), nullptr);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/mask/parameterized_brush_replay_cache_test.cpp
+++ b/alcedo_studio/tests/edit/mask/parameterized_brush_replay_cache_test.cpp
@@ -1,0 +1,214 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include "edit/mask/parameterized_brush_replay_cache.hpp"
+
+#include "brush_replay_oracle.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_source_geometry.hpp"
+#include "edit/mask/brush_stroke.hpp"
+#include "edit/mask/mask_model.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace alcedo {
+namespace {
+
+constexpr Extent2D kFull{96, 64};
+
+const NodeId kGrade{"grade.primary"};
+const MaskId kMask{"mask.brush"};
+
+void ExpectPixelsMatchOracle(const ActiveRasterMaskInput& input, const BrushMaskSource& source,
+                             Extent2D full_reference) {
+  ASSERT_NE(input.pixels, nullptr);
+  const auto raster = CanonicalBrushRasterExtent(full_reference);
+  ASSERT_EQ(input.pixels->size(),
+            static_cast<std::size_t>(raster.width) * raster.height);
+  const auto expected = brush_replay_oracle::BrushSourceR8(source, raster, full_reference);
+  for (std::uint32_t y = 0; y < raster.height; ++y) {
+    for (std::uint32_t x = 0; x < raster.width; ++x) {
+      const auto i = PackedR8Index(x, y, raster);
+      ASSERT_EQ((*input.pixels)[i], expected[i]) << "texel " << x << "," << y;
+    }
+  }
+}
+
+auto PaintStroke(std::string_view id, std::vector<BrushCanonicalSample> samples) -> BrushStroke {
+  return MakeBrushStroke(StrokeId{std::string{id}}, BrushStrokeMode::Paint, std::move(samples));
+}
+
+auto EraseStroke(std::string_view id, std::vector<BrushCanonicalSample> samples) -> BrushStroke {
+  return MakeBrushStroke(StrokeId{std::string{id}}, BrushStrokeMode::Erase, std::move(samples));
+}
+
+auto MakeBrush(std::vector<BrushStroke> strokes, Vector2 translation = {}, float feather = 0.0f)
+    -> BrushMaskSource {
+  BrushMaskSource source;
+  source.strokes               = std::move(strokes);
+  source.placement_translation = translation;
+  source.feather_radius        = feather;
+  return source;
+}
+
+auto StrokeSupport(const BrushStroke& stroke, Vector2 translation, Extent2D raster,
+                   Extent2D full_reference) -> RectI {
+  return BrushStrokeOutputTexelSupport(stroke, translation, raster, full_reference);
+}
+
+TEST(ParameterizedBrushReplayCache, FirstReplayMatchesFullRasterization) {
+  ParameterizedBrushReplayCache cache;
+  const auto source = MakeBrush({
+      PaintStroke("paint.a", {{12.0f, 10.0f, 6.0f, 1.0f, 1.0f},
+                              {18.0f, 12.0f, 6.0f, 0.75f, 0.5f}}),
+      EraseStroke("erase.b", {{16.0f, 11.0f, 4.0f, 1.0f, 1.0f}}),
+  });
+  const auto input = cache.Replay(kGrade, kMask, source, kFull, 7);
+  EXPECT_EQ(input.content_revision, 7u);
+  EXPECT_EQ(input.descriptor.extent, CanonicalBrushRasterExtent(kFull));
+  EXPECT_EQ(input.dirty_rectangle, FullTexelRect(input.descriptor.extent));
+  ExpectPixelsMatchOracle(input, source, kFull);
+}
+
+TEST(ParameterizedBrushReplayCache, UnchangedSourceReusesPixelsAndSkipsReplay) {
+  ParameterizedBrushReplayCache cache;
+  const auto source =
+      MakeBrush({PaintStroke("paint", {{30.0f, 20.0f, 8.0f, 1.0f, 1.0f}})});
+  const auto first  = cache.Replay(kGrade, kMask, source, kFull, 1);
+  const auto second = cache.Replay(kGrade, kMask, source, kFull, 2);
+  // No dab changed: the retained buffer is returned untouched, so the shared
+  // handle is identical and no rasterization ran.
+  EXPECT_EQ(second.pixels.get(), first.pixels.get());
+  // The upload contract still names a non-empty clipped rectangle.
+  EXPECT_EQ(second.dirty_rectangle, (RectI{0, 0, 1, 1}));
+  EXPECT_EQ(second.content_revision, 2u);
+}
+
+TEST(ParameterizedBrushReplayCache, AppendedStrokeReplaysOnlyItsSupport) {
+  ParameterizedBrushReplayCache cache;
+  auto source = MakeBrush({PaintStroke("paint.a", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}})});
+  (void)cache.Replay(kGrade, kMask, source, kFull, 1);
+
+  const auto added = PaintStroke("paint.b", {{70.0f, 50.0f, 5.0f, 1.0f, 1.0f}});
+  source.strokes.push_back(added);
+  const auto input = cache.Replay(kGrade, kMask, source, kFull, 2);
+  EXPECT_EQ(input.dirty_rectangle,
+            StrokeSupport(added, source.placement_translation, input.descriptor.extent, kFull));
+  ExpectPixelsMatchOracle(input, source, kFull);
+}
+
+TEST(ParameterizedBrushReplayCache, RegrownDraftStrokeReplaysItsGrownSupport) {
+  ParameterizedBrushReplayCache cache;
+  const std::vector<BrushCanonicalSample> first_dabs{{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}};
+  auto source = MakeBrush({PaintStroke("draft", first_dabs)});
+  (void)cache.Replay(kGrade, kMask, source, kFull, 1);
+
+  // A live draft keeps its StrokeId but replaces the shared sample body.
+  std::vector<BrushCanonicalSample> grown = first_dabs;
+  grown.push_back({70.0f, 50.0f, 5.0f, 1.0f, 1.0f});
+  source.strokes.back() =
+      MakeBrushStroke(StrokeId{"draft"}, BrushStrokeMode::Paint, std::move(grown));
+  const auto input = cache.Replay(kGrade, kMask, source, kFull, 2);
+  EXPECT_EQ(input.dirty_rectangle,
+            StrokeSupport(source.strokes.back(), source.placement_translation,
+                          input.descriptor.extent, kFull));
+  ExpectPixelsMatchOracle(input, source, kFull);
+}
+
+TEST(ParameterizedBrushReplayCache, PlacementMoveReplaysOldAndNewBounds) {
+  ParameterizedBrushReplayCache cache;
+  const auto paint = PaintStroke("paint", {{30.0f, 20.0f, 8.0f, 1.0f, 1.0f}});
+  auto       source = MakeBrush({paint});
+  (void)cache.Replay(kGrade, kMask, source, kFull, 1);
+
+  const auto before = StrokeSupport(paint, source.placement_translation,
+                                    CanonicalBrushRasterExtent(kFull), kFull);
+  source.placement_translation = {12.0f, -6.0f};
+  const auto after = StrokeSupport(paint, source.placement_translation,
+                                   CanonicalBrushRasterExtent(kFull), kFull);
+  const auto input = cache.Replay(kGrade, kMask, source, kFull, 2);
+  EXPECT_EQ(input.dirty_rectangle, UnionTexelRect(before, after));
+  ExpectPixelsMatchOracle(input, source, kFull);
+}
+
+TEST(ParameterizedBrushReplayCache, EraseAppendAltersActualCoverage) {
+  ParameterizedBrushReplayCache cache;
+  auto source = MakeBrush({PaintStroke("paint", {{24.0f, 18.0f, 10.0f, 1.0f, 1.0f}})});
+  const auto painted = cache.Replay(kGrade, kMask, source, kFull, 1);
+  const auto center =
+      PackedR8Index(24, 18, CanonicalBrushRasterExtent(kFull));
+  // The retained buffer is shared: capture coverage before the erase replay
+  // mutates it in place.
+  const auto painted_value = (*painted.pixels)[center];
+  ASSERT_GT(painted_value, 0);
+
+  source.strokes.push_back(EraseStroke("erase", {{24.0f, 18.0f, 10.0f, 1.0f, 1.0f}}));
+  const auto erased = cache.Replay(kGrade, kMask, source, kFull, 2);
+  EXPECT_LT((*erased.pixels)[center], painted_value);
+  ExpectPixelsMatchOracle(erased, source, kFull);
+}
+
+TEST(ParameterizedBrushReplayCache, RemovedStrokeReplaysItsOldRegion) {
+  ParameterizedBrushReplayCache cache;
+  auto source = MakeBrush({PaintStroke("a", {{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}}),
+                           PaintStroke("b", {{70.0f, 50.0f, 5.0f, 1.0f, 1.0f}})});
+  (void)cache.Replay(kGrade, kMask, source, kFull, 1);
+
+  const auto removed_support = StrokeSupport(source.strokes.back(), source.placement_translation,
+                                             CanonicalBrushRasterExtent(kFull), kFull);
+  source.strokes.pop_back();
+  const auto input = cache.Replay(kGrade, kMask, source, kFull, 2);
+  EXPECT_EQ(input.dirty_rectangle, removed_support);
+  ExpectPixelsMatchOracle(input, source, kFull);
+}
+
+TEST(ParameterizedBrushReplayCache, GeometryChangeRestartsWithFreshBuffer) {
+  ParameterizedBrushReplayCache cache;
+  const auto source =
+      MakeBrush({PaintStroke("paint", {{30.0f, 20.0f, 8.0f, 1.0f, 1.0f}})});
+  const auto first = cache.Replay(kGrade, kMask, source, kFull, 1);
+  const auto first_bytes = *first.pixels;
+
+  const Extent2D larger{192, 128};
+  const auto     second = cache.Replay(kGrade, kMask, source, larger, 2);
+  EXPECT_EQ(second.descriptor.extent, CanonicalBrushRasterExtent(larger));
+  EXPECT_EQ(second.dirty_rectangle, FullTexelRect(second.descriptor.extent));
+  // The previous handle keeps its old bytes: the retained buffer is replaced,
+  // not mutated under a live consumer.
+  EXPECT_EQ(*first.pixels, first_bytes);
+  ExpectPixelsMatchOracle(second, source, larger);
+}
+
+TEST(ParameterizedBrushReplayCache, EvictedEntryRerasterizesToMatchingPixels) {
+  ParameterizedBrushReplayCache cache;
+  const auto source =
+      MakeBrush({PaintStroke("paint", {{30.0f, 20.0f, 8.0f, 1.0f, 1.0f}})});
+  // Fill past the retained-entry bound so the first key is evicted.
+  for (std::size_t i = 0; i <= ParameterizedBrushReplayCache::kMaxRetainedEntries; ++i) {
+    const MaskId other{std::string{"mask."} + std::to_string(i)};
+    (void)cache.Replay(kGrade, other, source, kFull, 1);
+  }
+  const auto replayed = cache.Replay(kGrade, kMask, source, kFull, 9);
+  ExpectPixelsMatchOracle(replayed, source, kFull);
+  EXPECT_EQ(replayed.dirty_rectangle, FullTexelRect(replayed.descriptor.extent));
+}
+
+TEST(ParameterizedBrushReplayCache, EmptySourceRasterizesZerosAndBadVersionThrows) {
+  ParameterizedBrushReplayCache cache;
+  auto empty = MakeBrush({});
+  const auto zeroed = cache.Replay(kGrade, kMask, empty, kFull, 1);
+  for (const auto texel : *zeroed.pixels) {
+    EXPECT_EQ(texel, 0);
+  }
+  auto bad = MakeBrush({PaintStroke("p", {{8.0f, 8.0f, 4.0f, 1.0f, 1.0f}})});
+  bad.raster_algorithm_version = 99;
+  EXPECT_THROW((void)cache.Replay(kGrade, MaskId{"mask.bad"}, bad, kFull, 1), std::runtime_error);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/edit/mask/parameterized_brush_replay_cache_test.cpp
+++ b/alcedo_studio/tests/edit/mask/parameterized_brush_replay_cache_test.cpp
@@ -102,21 +102,21 @@ TEST(ParameterizedBrushReplayCache, AppendedStrokeReplaysOnlyItsSupport) {
   ExpectPixelsMatchOracle(input, source, kFull);
 }
 
-TEST(ParameterizedBrushReplayCache, RegrownDraftStrokeReplaysItsGrownSupport) {
+TEST(ParameterizedBrushReplayCache, RegrownDraftStrokeStampsOnlyNewDabSupport) {
   ParameterizedBrushReplayCache cache;
   const std::vector<BrushCanonicalSample> first_dabs{{20.0f, 16.0f, 6.0f, 1.0f, 1.0f}};
   auto source = MakeBrush({PaintStroke("draft", first_dabs)});
   (void)cache.Replay(kGrade, kMask, source, kFull, 1);
 
-  // A live draft keeps its StrokeId but replaces the shared sample body.
   std::vector<BrushCanonicalSample> grown = first_dabs;
   grown.push_back({70.0f, 50.0f, 5.0f, 1.0f, 1.0f});
   source.strokes.back() =
       MakeBrushStroke(StrokeId{"draft"}, BrushStrokeMode::Paint, std::move(grown));
   const auto input = cache.Replay(kGrade, kMask, source, kFull, 2);
+  const auto raster = CanonicalBrushRasterExtent(kFull);
   EXPECT_EQ(input.dirty_rectangle,
-            StrokeSupport(source.strokes.back(), source.placement_translation,
-                          input.descriptor.extent, kFull));
+            BrushDabOutputTexelSupport(source.strokes.back().samples->back(),
+                                       source.placement_translation, raster, kFull));
   ExpectPixelsMatchOracle(input, source, kFull);
 }
 

--- a/alcedo_studio/tests/edit/runtime/cuda_parameterized_brush_gpu_test.cpp
+++ b/alcedo_studio/tests/edit/runtime/cuda_parameterized_brush_gpu_test.cpp
@@ -1,0 +1,211 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "../graph/grade_owned_mask_support.hpp"
+#include "../graph/test_camera_profile.hpp"
+#include "../input/prepared_raw_test_support.hpp"
+#include "edit/graph/color_grade_node_model.hpp"
+#include "edit/graph/pipeline_document.hpp"
+#include "edit/input/raw_input_loader.hpp"
+#include "edit/mask/active_raster_mask.hpp"
+#include "edit/mask/brush_raster_encoding.hpp"
+#include "edit/mask/brush_stroke.hpp"
+#include "edit/mask/mask_model.hpp"
+#include "edit/mask/parameterized_brush_raster.hpp"
+#include "edit/runtime/cuda/cuda_mask_pass.hpp"
+#include "edit/runtime/cuda/cuda_render_device.hpp"
+#include "edit/runtime/execution_plan.hpp"
+#include "edit/runtime/graph_compiler.hpp"
+
+namespace alcedo {
+namespace {
+
+auto HasCudaDevice() -> bool {
+  int count = 0;
+  return ::cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+class CudaParameterizedBrushGpuFixture : public ::testing::Test {
+ protected:
+  static const MaskId kMask;
+  static constexpr std::uint32_t kWidth  = 64;
+  static constexpr std::uint32_t kHeight = 48;
+
+  void SetUp() override {
+    if (!HasCudaDevice()) {
+      GTEST_SKIP() << "No CUDA device available.";
+    }
+    prepared_ = RawInputLoader::FromDirectRgb(gpu_dag_test::MakeF32RgbaPlane(kWidth, kHeight),
+                                              gpu_dag_test::FullSensor(kWidth, kHeight));
+    document_ = CreateDefaultPipelineDocument();
+    gpu_dag_test::EnsureTestCameraProfile(document_);
+  }
+
+  void AttachBrush(std::vector<BrushStroke> strokes) {
+    grade_mask_test::AddParameterizedBrushMask(document_, kMask, std::move(strokes));
+    Compile();
+  }
+
+  void ReplaceBrush(BrushMaskSource source) {
+    document_.PrimaryGrade()->ReplaceMaskSource(kMask, MaskSource{std::move(source)});
+  }
+
+  void Compile() {
+    plan_ = GraphCompiler::Compile(document_, prepared_.CompileSource(), {});
+    ASSERT_NE(plan_.FirstGrade(), nullptr);
+  }
+
+  void RenderMask() {
+    device_.BeginRender();
+    (void)ExecuteCudaMask(device_, plan_, document_, nullptr);
+    device_.EndRender();
+    device_.WaitIdle();
+  }
+
+  auto DownloadCanonicalSource() -> std::vector<std::uint8_t> {
+    const auto raster = CanonicalBrushRasterExtent(plan_.geometry.full_reference_extent);
+    auto&      cache  = device_.Workspace().ActiveRasterTextures();
+    const ActiveRasterTextureKey key{document_.PrimaryGrade()->Id(), kMask, 1};
+    EXPECT_TRUE(cache.Contains(key));
+    auto lease = cache.Acquire(key, raster);
+    std::vector<std::uint8_t> pixels(lease.Texture().Bytes());
+    device_.Workspace().Device().DownloadTexture2D(
+        lease.Texture(),
+        std::span<std::byte>(reinterpret_cast<std::byte*>(pixels.data()), pixels.size()),
+        device_.CommandContext());
+    return pixels;
+  }
+
+  PreparedRawInput   prepared_;
+  PipelineDocument   document_;
+  ExecutionPlan      plan_;
+  CudaRenderDevice   device_;
+};
+
+const MaskId CudaParameterizedBrushGpuFixture::kMask{"mask.brush"};
+
+TEST_F(CudaParameterizedBrushGpuFixture, GpuOrderedBrushRasterMatchesCanonicalR8Bytes) {
+  AttachBrush({grade_mask_test::MakePaintStroke("paint.a", 18.0f, 12.0f, 6.0f),
+               MakeBrushStroke(StrokeId{"erase.b"}, BrushStrokeMode::Erase,
+                               {{16.0f, 11.0f, 4.0f, 1.0f, 1.0f}}),
+               MakeBrushStroke(StrokeId{"paint.c"}, BrushStrokeMode::Paint,
+                               {{22.0f, 14.0f, 5.0f, 0.5f, 0.25f}})});
+  RenderMask();
+  const auto* brush = std::get_if<BrushMaskSource>(&document_.PrimaryGrade()->FindMask(kMask)->source);
+  ASSERT_NE(brush, nullptr);
+  const auto expected =
+      RasterizeParameterizedBrushSource(*brush, plan_.geometry.full_reference_extent);
+  const auto actual = DownloadCanonicalSource();
+  ASSERT_EQ(actual.size(), expected.pixels.size());
+  EXPECT_EQ(actual, expected.pixels);
+}
+
+TEST_F(CudaParameterizedBrushGpuFixture, GrowingBrushStampsNewDabsWithoutHostRasterUpload) {
+  AttachBrush({MakeBrushStroke(StrokeId{"draft"}, BrushStrokeMode::Paint,
+                               {{12.0f, 10.0f, 6.0f, 1.0f, 1.0f}})});
+  RenderMask();
+
+  auto* brush = std::get_if<BrushMaskSource>(&document_.PrimaryGrade()->FindMask(kMask)->source);
+  ASSERT_NE(brush, nullptr);
+  auto grown = *brush;
+  grown.strokes[0] = MakeBrushStroke(StrokeId{"draft"}, BrushStrokeMode::Paint,
+                                     {{12.0f, 10.0f, 6.0f, 1.0f, 1.0f},
+                                      {40.0f, 30.0f, 5.0f, 0.75f, 0.5f}});
+  ReplaceBrush(grown);
+
+  auto& backend = device_.Workspace().Device();
+  backend.ResetCounters();
+  backend.NoteHostToDeviceBegin();
+  RenderMask();
+  EXPECT_EQ(backend.HostToDeviceBytes(), 0u);
+
+  brush = std::get_if<BrushMaskSource>(&document_.PrimaryGrade()->FindMask(kMask)->source);
+  ASSERT_NE(brush, nullptr);
+  const auto expected =
+      RasterizeParameterizedBrushSource(*brush, plan_.geometry.full_reference_extent);
+  EXPECT_EQ(DownloadCanonicalSource(), expected.pixels);
+}
+
+TEST_F(CudaParameterizedBrushGpuFixture, EraseAppendStampsWithoutHostRasterUpload) {
+  AttachBrush({grade_mask_test::MakePaintStroke("paint", 20.0f, 16.0f, 10.0f)});
+  RenderMask();
+  auto* brush = std::get_if<BrushMaskSource>(&document_.PrimaryGrade()->FindMask(kMask)->source);
+  ASSERT_NE(brush, nullptr);
+  auto grown = *brush;
+  grown.strokes.push_back(MakeBrushStroke(StrokeId{"erase"}, BrushStrokeMode::Erase,
+                                          {{20.0f, 16.0f, 10.0f, 1.0f, 1.0f}}));
+  ReplaceBrush(grown);
+
+  auto& backend = device_.Workspace().Device();
+  backend.ResetCounters();
+  backend.NoteHostToDeviceBegin();
+  RenderMask();
+  EXPECT_EQ(backend.HostToDeviceBytes(), 0u);
+
+  brush = std::get_if<BrushMaskSource>(&document_.PrimaryGrade()->FindMask(kMask)->source);
+  ASSERT_NE(brush, nullptr);
+  const auto expected =
+      RasterizeParameterizedBrushSource(*brush, plan_.geometry.full_reference_extent);
+  EXPECT_EQ(DownloadCanonicalSource(), expected.pixels);
+}
+
+TEST_F(CudaParameterizedBrushGpuFixture, PlacementMoveReplaysDirtyAndMatchesCanonicalR8) {
+  AttachBrush({grade_mask_test::MakePaintStroke("paint", 20.0f, 16.0f, 8.0f)});
+  RenderMask();
+  auto* brush = std::get_if<BrushMaskSource>(&document_.PrimaryGrade()->FindMask(kMask)->source);
+  ASSERT_NE(brush, nullptr);
+  auto moved                     = *brush;
+  moved.placement_translation    = {12.0f, -4.0f};
+  ReplaceBrush(moved);
+  RenderMask();
+  brush = std::get_if<BrushMaskSource>(&document_.PrimaryGrade()->FindMask(kMask)->source);
+  ASSERT_NE(brush, nullptr);
+  const auto expected =
+      RasterizeParameterizedBrushSource(*brush, plan_.geometry.full_reference_extent);
+  EXPECT_EQ(DownloadCanonicalSource(), expected.pixels);
+}
+
+TEST_F(CudaParameterizedBrushGpuFixture, ReleasedGpuSourceRestampsFromCommands) {
+  AttachBrush({grade_mask_test::MakePaintStroke("paint", 18.0f, 12.0f, 6.0f)});
+  RenderMask();
+  device_.Workspace().ReleaseSessionResources();
+  RenderMask();
+  const auto* brush =
+      std::get_if<BrushMaskSource>(&document_.PrimaryGrade()->FindMask(kMask)->source);
+  ASSERT_NE(brush, nullptr);
+  const auto expected =
+      RasterizeParameterizedBrushSource(*brush, plan_.geometry.full_reference_extent);
+  EXPECT_EQ(DownloadCanonicalSource(), expected.pixels);
+}
+
+TEST_F(CudaParameterizedBrushGpuFixture, FeatherChangeReusesGpuSourceWithoutHostRasterUpload) {
+  AttachBrush({grade_mask_test::MakePaintStroke("paint", 20.0f, 16.0f, 8.0f)});
+  RenderMask();
+  const auto source_before = DownloadCanonicalSource();
+
+  auto* brush = std::get_if<BrushMaskSource>(&document_.PrimaryGrade()->FindMask(kMask)->source);
+  ASSERT_NE(brush, nullptr);
+  auto with_feather          = *brush;
+  with_feather.feather_radius = 4.0f;
+  ReplaceBrush(with_feather);
+
+  auto& backend = device_.Workspace().Device();
+  backend.ResetCounters();
+  backend.NoteHostToDeviceBegin();
+  RenderMask();
+  EXPECT_EQ(backend.HostToDeviceBytes(), 0u);
+  EXPECT_EQ(DownloadCanonicalSource(), source_before);
+}
+
+}  // namespace
+}  // namespace alcedo

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -1257,6 +1257,38 @@ alcedo_ui_gtest_discover_tests(MaskEditGeometryTest
     PROPERTIES LABELS "mask_edit;interaction")
 alcedo_register_test_target(MaskEditGeometryTest ui)
 
+add_executable(EditorBrushInteractionQmlTest
+    ${ALCEDO_TEST_ROOT}/ui/editor_brush_interaction_qml_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/main_qml_test_fixture.cpp
+    ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
+)
+target_include_directories(EditorBrushInteractionQmlTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR}
+)
+target_link_libraries(EditorBrushInteractionQmlTest
+    PRIVATE
+        AlbumBackendLib
+        GTest::gtest
+        Qt6::Core
+        Qt6::Test
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::QuickEffects
+        Qt6::Svg
+        Qt6::Widgets
+)
+target_compile_definitions(EditorBrushInteractionQmlTest
+    PRIVATE ALCEDO_TEST_SRC_DIR="${ALCEDO_SRC_DIR}"
+)
+set_target_properties(EditorBrushInteractionQmlTest PROPERTIES AUTOMOC ON)
+alcedo_ui_gtest_discover_tests(EditorBrushInteractionQmlTest
+    TEST_PREFIX "EditorBrushInteractionQmlTest."
+    PROPERTIES LABELS "workspace_qml;mask_creation")
+alcedo_register_test_target(EditorBrushInteractionQmlTest ui)
+alcedo_link_quickqanava_qml(EditorBrushInteractionQmlTest)
+
 add_executable(MaskOverlayControlTest
     ${ALCEDO_TEST_ROOT}/ui/mask_overlay_control_test.cpp
     ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp

--- a/alcedo_studio/tests/ui/CMakeLists.txt
+++ b/alcedo_studio/tests/ui/CMakeLists.txt
@@ -1072,6 +1072,37 @@ alcedo_ui_gtest_discover_tests(EditorAdjustmentHeaderQmlTest
     PROPERTIES LABELS "workspace_qml;adjustment_header")
 alcedo_register_test_target(EditorAdjustmentHeaderQmlTest ui)
 
+add_executable(ProjectMaskCacheSettingsQmlTest
+    ${ALCEDO_TEST_ROOT}/ui/project_mask_cache_settings_qml_test.cpp
+    ${ALCEDO_TEST_ROOT}/ui/widget_test_main.cpp
+)
+target_include_directories(ProjectMaskCacheSettingsQmlTest
+    PUBLIC ${ALCEDO_INCLUDE_DIR}
+    PRIVATE ${ALCEDO_TEST_DIR}
+)
+target_link_libraries(ProjectMaskCacheSettingsQmlTest
+    PRIVATE
+        AlbumBackendLib
+        GTest::gtest
+        Qt6::Core
+        Qt6::Test
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::QuickDialogs2
+        Qt6::QuickEffects
+        Qt6::Svg
+        Qt6::Widgets
+)
+target_compile_definitions(ProjectMaskCacheSettingsQmlTest
+    PRIVATE ALCEDO_TEST_SRC_DIR="${ALCEDO_SRC_DIR}"
+)
+set_target_properties(ProjectMaskCacheSettingsQmlTest PROPERTIES AUTOMOC ON)
+alcedo_ui_gtest_discover_tests(ProjectMaskCacheSettingsQmlTest
+    TEST_PREFIX "ProjectMaskCacheSettingsQmlTest."
+    PROPERTIES LABELS "workspace_qml;mask_cache_settings")
+alcedo_register_test_target(ProjectMaskCacheSettingsQmlTest ui)
+
 # Display Transform QML snapshot: verifies ODT params populate the
 # Display Transform panel on first bind and method/space/EOTF changes.
 add_executable(EditorDisplayTransformSnapshotQmlTest

--- a/alcedo_studio/tests/ui/accumulating_brush_creation_test.cpp
+++ b/alcedo_studio/tests/ui/accumulating_brush_creation_test.cpp
@@ -400,4 +400,121 @@ TEST(AccumulatingBrushCreationTest, CancelledFirstStrokeLeavesGradeUnchanged) {
   EXPECT_TRUE(harness.controller.selected_mask_id().Empty());
 }
 
+TEST(AccumulatingBrushCreationTest, OneShotMaskFieldEditsPublishTypedHistory) {
+  BrushCreationHarness harness;
+  ASSERT_TRUE(harness.ArmPaint().accepted);
+  const auto first = harness.PaintStroke({0.20f, 0.40f}, {0.28f, 0.42f}, harness.pointer);
+  ASSERT_TRUE(first.accepted);
+  const auto mask_id = first.mask_id;
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), mask_id, harness.session)
+                  .accepted);
+
+  const auto opacity = harness.controller.ApplyMaskFieldValue("opacity", 0.4);
+  ASSERT_TRUE(opacity.accepted);
+  EXPECT_TRUE(opacity.committed);
+  EXPECT_FLOAT_EQ(harness.document.PrimaryGrade()->FindMask(mask_id)->opacity, 0.4f);
+  ASSERT_TRUE(harness.history.working_head().has_value());
+  auto batch = BatchFromCommit(
+      *harness.history.graph()->FindCommit(*harness.history.working_head()));
+  EXPECT_EQ(batch.operation_kind, PipelineEditOperationKind::SetMaskField);
+
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), mask_id, harness.session)
+                  .accepted);
+  const auto invert = harness.controller.ApplyMaskFieldValue("invert", true);
+  ASSERT_TRUE(invert.accepted);
+  EXPECT_TRUE(invert.committed);
+  EXPECT_TRUE(harness.document.PrimaryGrade()->FindMask(mask_id)->invert);
+  batch = BatchFromCommit(
+      *harness.history.graph()->FindCommit(*harness.history.working_head()));
+  EXPECT_EQ(batch.operation_kind, PipelineEditOperationKind::SetMaskField);
+
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), mask_id, harness.session)
+                  .accepted);
+  const auto name =
+      harness.controller.ApplyMaskFieldValue("display_name", std::string{"Sky brush"});
+  ASSERT_TRUE(name.accepted);
+  EXPECT_TRUE(name.committed);
+  EXPECT_EQ(harness.document.PrimaryGrade()->FindMask(mask_id)->display_name, "Sky brush");
+
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), mask_id, harness.session)
+                  .accepted);
+  const auto feather = harness.controller.ApplyMaskFieldValue("brush.feather", 2.5);
+  ASSERT_TRUE(feather.accepted);
+  EXPECT_TRUE(feather.committed);
+  const auto* brush = LiveBrush(harness.document, mask_id);
+  ASSERT_NE(brush, nullptr);
+  EXPECT_FLOAT_EQ(brush->feather_radius, 2.5f);
+  batch = BatchFromCommit(
+      *harness.history.graph()->FindCommit(*harness.history.working_head()));
+  EXPECT_EQ(batch.operation_kind, PipelineEditOperationKind::ReplaceMaskSource);
+}
+
+TEST(AccumulatingBrushCreationTest, MaskFieldDragSettlesOneCommit) {
+  BrushCreationHarness harness;
+  ASSERT_TRUE(harness.ArmPaint().accepted);
+  const auto first = harness.PaintStroke({0.20f, 0.40f}, {0.28f, 0.42f}, harness.pointer);
+  ASSERT_TRUE(first.accepted);
+  const auto mask_id = first.mask_id;
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), mask_id, harness.session)
+                  .accepted);
+
+  ASSERT_TRUE(harness.controller.BeginMaskFieldEdit("opacity").accepted);
+  const auto head_before = harness.history.working_head();
+  const auto mid = harness.controller.ApplyMaskFieldValue("opacity", 0.3);
+  ASSERT_TRUE(mid.accepted);
+  EXPECT_FALSE(mid.committed);
+  EXPECT_TRUE(mid.interactive_preview);
+  EXPECT_FLOAT_EQ(harness.document.PrimaryGrade()->FindMask(mask_id)->opacity, 0.3f);
+  ASSERT_TRUE(harness.controller.ApplyMaskFieldValue("opacity", 0.6).accepted);
+  const auto finish = harness.controller.FinishMaskInput();
+  ASSERT_TRUE(finish.accepted);
+  EXPECT_TRUE(finish.committed);
+  EXPECT_FLOAT_EQ(harness.document.PrimaryGrade()->FindMask(mask_id)->opacity, 0.6f);
+
+  ASSERT_TRUE(harness.history.working_head().has_value());
+  const auto* commit =
+      harness.history.graph()->FindCommit(*harness.history.working_head());
+  ASSERT_NE(commit, nullptr);
+  const auto batch = BatchFromCommit(*commit);
+  EXPECT_EQ(batch.operation_kind, PipelineEditOperationKind::SetMaskField);
+  // Exactly one field commit beyond the AddMask history.
+  EXPECT_NE(harness.history.working_head(), head_before);
+  const auto parent = commit->GetFirstParentHash();
+  ASSERT_TRUE(parent.has_value());
+  const auto* parent_commit = harness.history.graph()->FindCommit(*parent);
+  ASSERT_NE(parent_commit, nullptr);
+  EXPECT_EQ(BatchFromCommit(*parent_commit).operation_kind,
+            PipelineEditOperationKind::AddMask);
+}
+
+TEST(AccumulatingBrushCreationTest, MaskFieldEditCancelRestoresLiveValueWithoutHistory) {
+  BrushCreationHarness harness;
+  ASSERT_TRUE(harness.ArmPaint().accepted);
+  const auto first = harness.PaintStroke({0.20f, 0.40f}, {0.28f, 0.42f}, harness.pointer);
+  ASSERT_TRUE(first.accepted);
+  const auto mask_id = first.mask_id;
+  ASSERT_TRUE(harness.controller
+                  .SelectMask(harness.document.PrimaryGrade()->Id(), mask_id, harness.session)
+                  .accepted);
+
+  const auto head_before = harness.history.working_head();
+  ASSERT_TRUE(harness.controller.BeginMaskFieldEdit("opacity").accepted);
+  ASSERT_TRUE(harness.controller.ApplyMaskFieldValue("opacity", 0.2).accepted);
+  EXPECT_FLOAT_EQ(harness.document.PrimaryGrade()->FindMask(mask_id)->opacity, 0.2f);
+  ASSERT_TRUE(harness.controller.CancelMaskInput().accepted);
+  EXPECT_FLOAT_EQ(harness.document.PrimaryGrade()->FindMask(mask_id)->opacity, 1.0f);
+  EXPECT_EQ(harness.history.working_head(), head_before);
+}
+
+TEST(AccumulatingBrushCreationTest, MaskFieldEditRequiresSelectedMask) {
+  BrushCreationHarness harness;
+  EXPECT_FALSE(harness.controller.ApplyMaskFieldValue("opacity", 0.5).accepted);
+  EXPECT_FALSE(harness.controller.BeginMaskFieldEdit("opacity").accepted);
+}
+
 }  // namespace alcedo

--- a/alcedo_studio/tests/ui/accumulating_brush_creation_test.cpp
+++ b/alcedo_studio/tests/ui/accumulating_brush_creation_test.cpp
@@ -123,7 +123,8 @@ struct BrushCreationHarness {
       -> EditorMaskCreationResult {
     const auto press  = SampleOf(mapping, ItemOf(mapping, from_normalized), false);
     const auto move   = SampleOf(mapping, ItemOf(mapping, to_normalized), true);
-    EXPECT_TRUE(controller.BeginMaskInput(press, identity).accepted);
+    EXPECT_TRUE(
+        controller.BeginMaskInput(press, identity, MaskSourceKind::Brush).accepted);
     EXPECT_TRUE(controller.AppendMaskInput(move, identity).accepted);
     return controller.FinishMaskInput();
   }
@@ -188,7 +189,9 @@ TEST(AccumulatingBrushCreationTest, SizeAndStrengthChangesPersistInStrokeSamples
   BrushCreationHarness harness;
   ASSERT_TRUE(harness.ArmPaint().accepted);
   const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.25f, 0.40f}), false);
-  ASSERT_TRUE(harness.controller.BeginMaskInput(press, harness.pointer).accepted);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskInput(press, harness.pointer, MaskSourceKind::Brush)
+                  .accepted);
   ASSERT_TRUE(harness.controller.SetBrushStrokeParameters(4.0f, 0.5f, 1.0f).accepted);
   const auto move =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.45f, 0.40f}), true);
@@ -230,7 +233,8 @@ TEST(AccumulatingBrushCreationTest, MovingExistingBrushUpdatesInteractivePixels)
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{16.0f / 64.0f, 12.0f / 32.0f}),
                false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::BrushMove, press, harness.pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::BrushMove, press, harness.pointer,
+                                 MaskSourceKind::Brush)
                   .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{40.0f / 64.0f, 20.0f / 32.0f}),
@@ -272,7 +276,8 @@ TEST(AccumulatingBrushCreationTest, BrushMoveDoesNotAppendStroke) {
   ASSERT_TRUE(harness.controller.SetBrushTool(EditorBrushTool::Move).accepted);
   const auto press = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.20f, 0.30f}), false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::BrushMove, press, harness.pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::BrushMove, press, harness.pointer,
+                                 MaskSourceKind::Brush)
                   .accepted);
   const auto moved = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.35f, 0.40f}), true);
   ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
@@ -392,7 +397,9 @@ TEST(AccumulatingBrushCreationTest, CancelledFirstStrokeLeavesGradeUnchanged) {
   ASSERT_TRUE(harness.ArmPaint().accepted);
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.30f, 0.40f}), false);
-  ASSERT_TRUE(harness.controller.BeginMaskInput(press, harness.pointer).accepted);
+  ASSERT_TRUE(harness.controller
+                  .BeginMaskInput(press, harness.pointer, MaskSourceKind::Brush)
+                  .accepted);
   EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 1u);
   ASSERT_TRUE(harness.controller.CancelMaskInput().accepted);
   EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);

--- a/alcedo_studio/tests/ui/analytic_mask_creation_test.cpp
+++ b/alcedo_studio/tests/ui/analytic_mask_creation_test.cpp
@@ -196,7 +196,8 @@ TEST(AnalyticMaskCreationTest, ExistingRadialMoveUpdatesInteractivePixelsBeforeR
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
   ASSERT_TRUE(
-      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer,
+                          MaskSourceKind::Radial)
           .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.28f, 0.62f}), true);
@@ -247,7 +248,8 @@ TEST(AnalyticMaskCreationTest, FinishModeSettlesOnceAndLeavesMaskEditingInactive
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.72f, 0.5f}), false);
   ASSERT_TRUE(
-      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialMajor, press, harness.pointer)
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialMajor, press, harness.pointer,
+                          MaskSourceKind::Radial)
           .accepted);
   const auto moved = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.80f, 0.5f}), true);
   ASSERT_TRUE(harness.controller.AppendMaskInput(moved, harness.pointer).accepted);
@@ -288,7 +290,8 @@ TEST(AnalyticMaskCreationTest, ExistingGradientMovePreservesDirectionAndUpdatesI
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
   ASSERT_TRUE(
-      harness.controller.BeginMaskMove(AnalyticMaskHandle::LinearOrigin, press, harness.pointer)
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::LinearOrigin, press, harness.pointer,
+                          MaskSourceKind::LinearGradient)
           .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.70f, 0.50f}), true);
@@ -341,7 +344,8 @@ TEST(AnalyticMaskCreationTest, RadialFeatherControlsMatchEvaluator) {
                         radial.center_y + std::sin(radial.rotation) * radial.major_radius * 0.55f};
   const auto    press = SampleOf(harness.mapping, ItemOf(harness.mapping, inner_q), false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, press, harness.pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, press, harness.pointer,
+                           MaskSourceKind::Radial)
                   .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(press, harness.pointer).accepted);
 
@@ -356,7 +360,8 @@ TEST(AnalyticMaskCreationTest, RadialFeatherControlsMatchEvaluator) {
   const auto outer_press    = SampleOf(harness.mapping, ItemOf(harness.mapping, outer_q), false);
   outer_pointer.sequence_id = 10;
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer,
+                           MaskSourceKind::Radial)
                   .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(outer_press, outer_pointer).accepted);
 
@@ -388,7 +393,8 @@ TEST(AnalyticMaskCreationTest, DegenerateAnalyticCreationCreatesNoCommit) {
                   .accepted);
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
-  ASSERT_TRUE(harness.controller.BeginMaskInput(press, harness.pointer).accepted);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskInput(press, harness.pointer, MaskSourceKind::Radial).accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(press, harness.pointer).accepted);
   EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
   EXPECT_EQ(harness.preview_count, 0);
@@ -406,7 +412,9 @@ TEST(AnalyticMaskCreationTest, DegenerateAnalyticCreationCreatesNoCommit) {
                   .accepted);
   MaskPointerIdentity linear_pointer = harness.pointer;
   linear_pointer.sequence_id         = 11;
-  ASSERT_TRUE(harness.controller.BeginMaskInput(press, linear_pointer).accepted);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskInput(press, linear_pointer, MaskSourceKind::LinearGradient)
+          .accepted);
   EXPECT_TRUE(harness.controller.FinishMaskInput().accepted);
   EXPECT_EQ(harness.document.PrimaryGrade()->MaskCount(), 0u);
   EXPECT_EQ(harness.history.working_head(), head_before);
@@ -431,7 +439,8 @@ TEST(AnalyticMaskCreationTest, EscapeRestoresAnalyticSourceWithoutCommit) {
   const auto press = SampleOf(
       harness.mapping, ItemOf(harness.mapping, Vector2{radial.center_x, radial.center_y}), false);
   ASSERT_TRUE(
-      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer,
+                          MaskSourceKind::Radial)
           .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.22f, 0.30f}), true);
@@ -460,7 +469,8 @@ TEST(AnalyticMaskCreationTest, ValidRadialCreationCommitsOnceAndKeepsControlOnly
                   .accepted);
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.45f, 0.40f}), false);
-  ASSERT_TRUE(harness.controller.BeginMaskInput(press, harness.pointer).accepted);
+  ASSERT_TRUE(
+      harness.controller.BeginMaskInput(press, harness.pointer, MaskSourceKind::Radial).accepted);
   const auto drag = SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.62f, 0.58f}), true);
   const auto preview = harness.controller.AppendMaskInput(drag, harness.pointer);
   ASSERT_TRUE(preview.accepted);
@@ -504,7 +514,8 @@ TEST(AnalyticMaskCreationTest, RadialFeatherControlsPreserveCenterRadiiAndRotati
   const auto inner_q = RadialNormalizedPoint(radial, 0.55f, 0.0f);
   const auto press   = SampleOf(harness.mapping, ItemOf(harness.mapping, inner_q), false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, press, harness.pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, press, harness.pointer,
+                           MaskSourceKind::Radial)
                   .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(press, harness.pointer).accepted);
   ASSERT_TRUE(harness.controller.FinishMaskInput().accepted);
@@ -517,7 +528,8 @@ TEST(AnalyticMaskCreationTest, RadialFeatherControlsPreserveCenterRadiiAndRotati
   outer_pointer.sequence_id         = 11;
   const auto outer_press = SampleOf(harness.mapping, ItemOf(harness.mapping, outer_q), false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer,
+                           MaskSourceKind::Radial)
                   .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(outer_press, outer_pointer).accepted);
   const auto* live = std::get_if<RadialMaskSource>(
@@ -552,7 +564,8 @@ TEST(AnalyticMaskCreationTest, RadialFeatherDragUpdatesInteractivePixelsBeforeRe
   const auto press = SampleOf(
       harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 1.45f, 0.0f)), false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, press, harness.pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, press, harness.pointer,
+                           MaskSourceKind::Radial)
                   .accepted);
   const auto preview = harness.controller.AppendMaskInput(press, harness.pointer);
   ASSERT_TRUE(preview.accepted);
@@ -618,7 +631,8 @@ TEST(AnalyticMaskCreationTest, SelectedMaskCanBeEditedAfterWorkspaceReentry) {
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
   ASSERT_TRUE(
-      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer,
+                          MaskSourceKind::Radial)
           .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.33f, 0.58f}), true);
@@ -726,7 +740,8 @@ TEST(AnalyticMaskCreationTest, DeletingMaskRejectsQueuedEditsAndDelayedFrames) {
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
   ASSERT_TRUE(
-      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer,
+                          MaskSourceKind::Radial)
           .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.70f, 0.40f}), true);
@@ -772,7 +787,8 @@ TEST(AnalyticMaskCreationTest, GradientBoundaryDragPreservesOriginAndChangesTran
   const Vector2 end{linear.origin_x, linear.origin_y + 0.40f};
   const auto    press = SampleOf(harness.mapping, ItemOf(harness.mapping, end), false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::LinearEndBoundary, press, harness.pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::LinearEndBoundary, press, harness.pointer,
+                           MaskSourceKind::LinearGradient)
                   .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(press, harness.pointer).accepted);
   const auto* live = std::get_if<LinearGradientMaskSource>(
@@ -799,7 +815,8 @@ TEST(AnalyticMaskCreationTest, AnalyticControlCancelRestoresSourceWithoutHistory
   const auto press =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.50f, 0.50f}), false);
   ASSERT_TRUE(
-      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer)
+      harness.controller.BeginMaskMove(AnalyticMaskHandle::RadialCenter, press, harness.pointer,
+                          MaskSourceKind::Radial)
           .accepted);
   const auto moved =
       SampleOf(harness.mapping, ItemOf(harness.mapping, Vector2{0.30f, 0.60f}), true);
@@ -831,7 +848,8 @@ TEST(AnalyticMaskCreationTest, CoincidentRadialBoundariesKeepFeatherControlsReac
       harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 0.70f, 0.0f)), false);
   ASSERT_TRUE(
       harness.controller
-          .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, inner_press, harness.pointer)
+          .BeginMaskMove(AnalyticMaskHandle::RadialInnerFeather, inner_press, harness.pointer,
+                            MaskSourceKind::Radial)
           .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(inner_press, harness.pointer).accepted);
   ASSERT_TRUE(harness.controller.FinishMaskInput().accepted);
@@ -844,7 +862,8 @@ TEST(AnalyticMaskCreationTest, CoincidentRadialBoundariesKeepFeatherControlsReac
   const auto outer_press            = SampleOf(
       harness.mapping, ItemOf(harness.mapping, RadialNormalizedPoint(radial, 1.35f, 0.0f)), false);
   ASSERT_TRUE(harness.controller
-                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer)
+                  .BeginMaskMove(AnalyticMaskHandle::RadialOuterFeather, outer_press, outer_pointer,
+                           MaskSourceKind::Radial)
                   .accepted);
   ASSERT_TRUE(harness.controller.AppendMaskInput(outer_press, outer_pointer).accepted);
   const auto* live = std::get_if<RadialMaskSource>(

--- a/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
@@ -19,6 +19,7 @@
 #include <QQuickStyle>
 #include <QQuickWindow>
 #include <QStringList>
+#include <QTest>
 #include <QTimer>
 #include <QUrl>
 #include <QVariantList>
@@ -50,6 +51,16 @@ class FakeMaskCreation final : public QObject {
   Q_PROPERTY(qreal innerFeatherPercent READ innerFeatherPercent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal outerFeatherPercent READ outerFeatherPercent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal transitionPercent READ transitionPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushRadius READ brushRadius NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushRadiusPercent READ brushRadiusPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushStrengthPercent READ brushStrengthPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(QString brushTool READ brushTool NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushFeatherPercent READ brushFeatherPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool maskEnabled READ maskEnabled NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool maskInvert READ maskInvert NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal maskOpacityPercent READ maskOpacityPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(QString maskName READ maskName NOTIFY maskCreationChanged)
+  Q_PROPERTY(bool maskNudgeAvailable READ maskNudgeAvailable NOTIFY maskCreationChanged)
 
  public:
   auto             bodyVisible() const -> bool { return active_; }
@@ -63,7 +74,25 @@ class FakeMaskCreation final : public QObject {
   auto             innerFeatherPercent() const -> qreal { return 25.0; }
   auto             outerFeatherPercent() const -> qreal { return 20.0; }
   auto             transitionPercent() const -> qreal { return 30.0; }
+  auto             brushRadius() const -> qreal { return brush_radius_; }
+  auto             brushRadiusPercent() const -> qreal { return brush_radius_percent_; }
+  auto             brushStrengthPercent() const -> qreal { return brush_strength_percent_; }
+  auto             brushTool() const -> QString { return brush_tool_; }
+  auto             brushFeatherPercent() const -> qreal { return brush_feather_percent_; }
+  auto             maskEnabled() const -> bool { return mask_enabled_; }
+  auto             maskInvert() const -> bool { return mask_invert_; }
+  auto             maskOpacityPercent() const -> qreal { return mask_opacity_percent_; }
+  auto             maskName() const -> QString { return mask_name_; }
+  auto             maskNudgeAvailable() const -> bool {
+    return !selected_mask_id_.isEmpty() &&
+           (tool_kind_ != QLatin1String("brush") ||
+            brush_tool_ == QLatin1String("move"));
+  }
   auto             finishCount() const -> int { return finish_count_; }
+  auto             nudgeBeginCount() const -> int { return nudge_begin_count_; }
+  auto             nudgeCount() const -> int { return nudge_count_; }
+  auto             nudgeLastDx() const -> qreal { return nudge_last_dx_; }
+  auto             analyticFinishCount() const -> int { return analytic_finish_count_; }
 
   Q_INVOKABLE void beginRadial() { Open(QStringLiteral("radial"), true); }
   Q_INVOKABLE void beginLinear() { Open(QStringLiteral("linear"), true); }
@@ -86,7 +115,42 @@ class FakeMaskCreation final : public QObject {
   Q_INVOKABLE void updateOuterFeather(qreal) {}
   Q_INVOKABLE void beginTransition() {}
   Q_INVOKABLE void updateTransition(qreal) {}
-  Q_INVOKABLE void finishAnalyticControl() {}
+  Q_INVOKABLE void finishAnalyticControl() { ++analytic_finish_count_; }
+
+  Q_INVOKABLE void setBrushTool(const QString& tool) {
+    brush_tool_ = tool;
+    emit maskCreationChanged();
+  }
+  Q_INVOKABLE void setBrushRadius(qreal radius) { brush_radius_ = radius; }
+  Q_INVOKABLE void setBrushRadiusPercent(qreal percent) {
+    brush_radius_percent_ = percent;
+    emit maskCreationChanged();
+  }
+  Q_INVOKABLE void setBrushStrengthPercent(qreal percent) {
+    brush_strength_percent_ = percent;
+    emit maskCreationChanged();
+  }
+  Q_INVOKABLE void setMaskEnabled(bool enabled) { mask_enabled_ = enabled; }
+  Q_INVOKABLE void setMaskInvert(bool invert) { mask_invert_ = invert; }
+  Q_INVOKABLE void setMaskName(const QString& name) { mask_name_ = name; }
+  Q_INVOKABLE void beginMaskOpacity() {}
+  Q_INVOKABLE void updateMaskOpacity(qreal percent) { mask_opacity_percent_ = percent; }
+  Q_INVOKABLE void beginBrushFeather() {}
+  Q_INVOKABLE void updateBrushFeatherPercent(qreal percent) {
+    brush_feather_percent_ = percent;
+  }
+  Q_INVOKABLE bool beginMaskNudge() {
+    if (!maskNudgeAvailable()) {
+      return false;
+    }
+    ++nudge_begin_count_;
+    return true;
+  }
+  Q_INVOKABLE void nudgeMaskBy(qreal dx, qreal dy) {
+    ++nudge_count_;
+    nudge_last_dx_ = dx;
+    nudge_last_dy_ = dy;
+  }
 
   void             SelectExisting(const QString& kind) { Open(kind, false); }
 
@@ -113,7 +177,21 @@ class FakeMaskCreation final : public QObject {
   bool    creating_ = false;
   QString tool_kind_;
   QString selected_mask_id_;
-  int     finish_count_ = 0;
+  int     finish_count_          = 0;
+  int     analytic_finish_count_ = 0;
+  qreal   brush_radius_          = 0.0;
+  qreal   brush_radius_percent_  = 0.0;
+  qreal   brush_strength_percent_ = 100.0;
+  QString brush_tool_;
+  qreal   brush_feather_percent_ = 0.0;
+  bool    mask_enabled_          = true;
+  bool    mask_invert_           = false;
+  qreal   mask_opacity_percent_  = 100.0;
+  QString mask_name_             = QStringLiteral("Mask 1");
+  int     nudge_begin_count_     = 0;
+  int     nudge_count_           = 0;
+  qreal   nudge_last_dx_         = 0.0;
+  qreal   nudge_last_dy_         = 0.0;
 };
 
 class HeaderSession final : public QObject, public IEditorAdjustmentSubmitter {
@@ -380,6 +458,7 @@ class StackHarness {
   }
 
   auto root() const -> QQuickItem* { return root_.get(); }
+  auto window() -> QQuickWindow* { return &window_; }
   auto errors() const -> QString {
     QStringList text;
     for (const auto& error : errors_) {
@@ -777,6 +856,164 @@ TEST(EditorAdjustmentHeaderQmlTest, LutSelectionAndScrollSurviveStackLoadWithout
   EXPECT_EQ(lut_model->selectedPath(), QStringLiteral("D:/fake/lut_12.cube"));
   EXPECT_NEAR(list->property("contentY").toReal(), y_before, 1.5);
   EXPECT_EQ(session.submitCount(), submits);
+}
+
+TEST(EditorAdjustmentHeaderQmlTest, MaskPageBrushSectionRoutesToolSizeStrengthAndFeather) {
+  FakeMaskCreation   mask_creation;
+  HeaderSession      session(&mask_creation);
+  FakeNodeController nodes;
+  StackHarness       harness(&session, &nodes, 320);
+  ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
+
+  mask_creation.SelectExisting(QStringLiteral("brush"));
+  ProcessEvents(40);
+  EXPECT_EQ(session.activeAdjustmentPanel(), QStringLiteral("masks"));
+
+  auto* name    = harness.find(QStringLiteral("editorMasksNameField"));
+  auto* enabled = harness.find(QStringLiteral("editorMasksEnabledCheck"));
+  auto* invert  = harness.find(QStringLiteral("editorMasksInvertCheck"));
+  auto* opacity = harness.find(QStringLiteral("editorMasksOpacitySlider"));
+  auto* nudge   = harness.find(QStringLiteral("editorMasksNudgeArea"));
+  auto* tools   = harness.find(QStringLiteral("editorMasksBrushToolSegments"));
+  auto* size    = harness.find(QStringLiteral("editorMasksBrushSizeSlider"));
+  auto* strength = harness.find(QStringLiteral("editorMasksBrushStrengthSlider"));
+  auto* feather = harness.find(QStringLiteral("editorMasksBrushFeatherSlider"));
+  ASSERT_NE(name, nullptr);
+  ASSERT_NE(enabled, nullptr);
+  ASSERT_NE(invert, nullptr);
+  ASSERT_NE(opacity, nullptr);
+  ASSERT_NE(nudge, nullptr);
+  ASSERT_NE(tools, nullptr);
+  ASSERT_NE(size, nullptr);
+  ASSERT_NE(strength, nullptr);
+  ASSERT_NE(feather, nullptr);
+  EXPECT_TRUE(enabled->isVisible());
+  EXPECT_TRUE(tools->isVisible());
+  EXPECT_TRUE(size->isVisible());
+  EXPECT_TRUE(strength->isVisible());
+  EXPECT_TRUE(feather->isVisible());
+  // Brush keeps the analytic sliders hidden while the Brush tool section shows.
+  auto* major_radius = harness.find(QStringLiteral("editorMasksMajorRadiusSlider"));
+  auto* transition   = harness.find(QStringLiteral("editorMasksTransitionSlider"));
+  ASSERT_NE(major_radius, nullptr);
+  ASSERT_NE(transition, nullptr);
+  EXPECT_FALSE(major_radius->isVisible());
+  EXPECT_FALSE(transition->isVisible());
+  // Move stays disabled until a committed Brush is selected — this fake selects
+  // an existing Mask so the segment is enabled and nudge is available.
+  // Nudge stays hidden while a paint-mode tool is active; arming Move shows it.
+  EXPECT_FALSE(nudge->property("visible").toBool());
+  mask_creation.setBrushTool(QStringLiteral("move"));
+  ProcessEvents(20);
+  EXPECT_TRUE(nudge->property("visible").toBool());
+
+  // Segmented tool select routes through the adapter setter.
+  ASSERT_TRUE(QMetaObject::invokeMethod(tools, "selected",
+                                        Q_ARG(int, 1), Q_ARG(QString, QStringLiteral("erase"))));
+  ProcessEvents(20);
+  EXPECT_EQ(mask_creation.brushTool(), QStringLiteral("erase"));
+
+  // Size/strength one-shot updates route through the adapter setters.
+  QVariantMap step_event;
+  step_event.insert(QStringLiteral("key"), QVariant(Qt::Key_Right));
+  step_event.insert(QStringLiteral("modifiers"), QVariant(int(Qt::NoModifier)));
+  ASSERT_TRUE(QMetaObject::invokeMethod(size, "keyStep",
+                                        Q_ARG(QVariant, QVariant::fromValue(step_event))));
+  ProcessEvents(20);
+  EXPECT_GT(mask_creation.brushRadiusPercent(), 0.0);
+}
+
+TEST(EditorAdjustmentHeaderQmlTest, KeyboardMaskMoveUsesSameInteractiveRoute) {
+  FakeMaskCreation   mask_creation;
+  HeaderSession      session(&mask_creation);
+  FakeNodeController nodes;
+  StackHarness       harness(&session, &nodes, 320);
+  ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
+
+  mask_creation.SelectExisting(QStringLiteral("brush"));
+  ProcessEvents(20);
+  mask_creation.setBrushTool(QStringLiteral("move"));
+  ProcessEvents(20);
+
+  auto* nudge = harness.find(QStringLiteral("editorMasksNudgeArea"));
+  ASSERT_NE(nudge, nullptr);
+  ASSERT_TRUE(nudge->property("visible").toBool());
+  nudge->forceActiveFocus();
+  ProcessEvents(20);
+
+  // Arrow key press opens the nudge op and appends through the same
+  // BeginMove/Append/Finish sequence a pointer drag uses; release settles it.
+  QTest::keyClick(harness.window(), Qt::Key_Right);
+  ProcessEvents(20);
+  EXPECT_EQ(mask_creation.nudgeBeginCount(), 1);
+  EXPECT_GE(mask_creation.nudgeCount(), 1);
+  EXPECT_DOUBLE_EQ(mask_creation.nudgeLastDx(), 1.0);
+  EXPECT_EQ(mask_creation.analyticFinishCount(), 1);
+
+  // Shift steps ten logical pixels through the identical route.
+  QTest::keyClick(harness.window(), Qt::Key_Left, Qt::ShiftModifier);
+  ProcessEvents(20);
+  EXPECT_EQ(mask_creation.nudgeBeginCount(), 2);
+  EXPECT_GE(mask_creation.nudgeCount(), 2);
+  EXPECT_DOUBLE_EQ(mask_creation.nudgeLastDx(), -10.0);
+  EXPECT_EQ(mask_creation.analyticFinishCount(), 2);
+}
+
+TEST(EditorAdjustmentHeaderQmlTest, MaskSelectionDoesNotSubmitOrJumpScroll) {
+  FakeMaskCreation   mask_creation;
+  HeaderSession      session(&mask_creation);
+  FakeNodeController nodes;
+  StackHarness       harness(&session, &nodes, 260);
+  ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
+
+  const int submits = session.submitCount();
+  mask_creation.SelectExisting(QStringLiteral("radial"));
+  ProcessEvents(40);
+  mask_creation.SelectExisting(QStringLiteral("brush"));
+  ProcessEvents(40);
+  mask_creation.SelectExisting(QStringLiteral("linear"));
+  ProcessEvents(40);
+
+  EXPECT_EQ(session.submitCount(), submits);
+  auto* scroll = harness.find(QStringLiteral("editorMasksScroll"));
+  ASSERT_NE(scroll, nullptr);
+  EXPECT_NEAR(scroll->property("contentY").toReal(), 0.0, 0.5);
+}
+
+TEST(EditorAdjustmentHeaderQmlTest, MaskPageLoadsAtPanelWidthsInBothThemesWithoutMotion) {
+  FakeMaskCreation   mask_creation;
+  HeaderSession      session(&mask_creation);
+  FakeNodeController nodes;
+  auto&              theme    = AppTheme::Instance();
+  const int          original = theme.currentThemeIndex();
+  theme.setReduceMotion(true);
+  StackHarness harness(&session, &nodes, 260);
+  ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
+
+  mask_creation.SelectExisting(QStringLiteral("brush"));
+  ProcessEvents(40);
+  auto* panel = harness.find(QStringLiteral("editorAdjustmentPanel_masks"));
+  auto* name  = harness.find(QStringLiteral("editorMasksNameField"));
+  auto* size  = harness.find(QStringLiteral("editorMasksBrushSizeSlider"));
+  auto* nudge = harness.find(QStringLiteral("editorMasksNudgeArea"));
+  ASSERT_NE(panel, nullptr);
+  ASSERT_NE(name, nullptr);
+  ASSERT_NE(size, nullptr);
+  ASSERT_NE(nudge, nullptr);
+
+  for (const int width : {260, 320, 460}) {
+    harness.root()->setWidth(width);
+    ProcessEvents(40);
+    EXPECT_LE(size->width(), static_cast<qreal>(width));
+    EXPECT_GT(size->width(), 0.0);
+    EXPECT_LE(nudge->width(), static_cast<qreal>(width));
+    for (int index = 0; index < 2; ++index) {
+      theme.setCurrentThemeIndex(index);
+      ProcessEvents(40);
+      EXPECT_EQ(name->property("color").value<QColor>(), theme.textColor());
+    }
+  }
+  theme.setCurrentThemeIndex(original);
 }
 
 }  // namespace

--- a/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_adjustment_header_qml_test.cpp
@@ -51,8 +51,8 @@ class FakeMaskCreation final : public QObject {
   Q_PROPERTY(qreal innerFeatherPercent READ innerFeatherPercent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal outerFeatherPercent READ outerFeatherPercent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal transitionPercent READ transitionPercent NOTIFY maskCreationChanged)
-  Q_PROPERTY(qreal brushRadius READ brushRadius NOTIFY maskCreationChanged)
-  Q_PROPERTY(qreal brushRadiusPercent READ brushRadiusPercent NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushDiameter READ brushDiameter NOTIFY maskCreationChanged)
+  Q_PROPERTY(qreal brushDiameterPercent READ brushDiameterPercent NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal brushStrengthPercent READ brushStrengthPercent NOTIFY maskCreationChanged)
   Q_PROPERTY(QString brushTool READ brushTool NOTIFY maskCreationChanged)
   Q_PROPERTY(qreal brushFeatherPercent READ brushFeatherPercent NOTIFY maskCreationChanged)
@@ -74,8 +74,8 @@ class FakeMaskCreation final : public QObject {
   auto             innerFeatherPercent() const -> qreal { return 25.0; }
   auto             outerFeatherPercent() const -> qreal { return 20.0; }
   auto             transitionPercent() const -> qreal { return 30.0; }
-  auto             brushRadius() const -> qreal { return brush_radius_; }
-  auto             brushRadiusPercent() const -> qreal { return brush_radius_percent_; }
+  auto             brushDiameter() const -> qreal { return brush_diameter_; }
+  auto             brushDiameterPercent() const -> qreal { return brush_diameter_percent_; }
   auto             brushStrengthPercent() const -> qreal { return brush_strength_percent_; }
   auto             brushTool() const -> QString { return brush_tool_; }
   auto             brushFeatherPercent() const -> qreal { return brush_feather_percent_; }
@@ -121,9 +121,9 @@ class FakeMaskCreation final : public QObject {
     brush_tool_ = tool;
     emit maskCreationChanged();
   }
-  Q_INVOKABLE void setBrushRadius(qreal radius) { brush_radius_ = radius; }
-  Q_INVOKABLE void setBrushRadiusPercent(qreal percent) {
-    brush_radius_percent_ = percent;
+  Q_INVOKABLE void setBrushDiameter(qreal diameter) { brush_diameter_ = diameter; }
+  Q_INVOKABLE void setBrushDiameterPercent(qreal percent) {
+    brush_diameter_percent_ = percent;
     emit maskCreationChanged();
   }
   Q_INVOKABLE void setBrushStrengthPercent(qreal percent) {
@@ -179,8 +179,8 @@ class FakeMaskCreation final : public QObject {
   QString selected_mask_id_;
   int     finish_count_          = 0;
   int     analytic_finish_count_ = 0;
-  qreal   brush_radius_          = 0.0;
-  qreal   brush_radius_percent_  = 0.0;
+  qreal   brush_diameter_          = 0.0;
+  qreal   brush_diameter_percent_  = 0.0;
   qreal   brush_strength_percent_ = 100.0;
   QString brush_tool_;
   qreal   brush_feather_percent_ = 0.0;
@@ -920,7 +920,7 @@ TEST(EditorAdjustmentHeaderQmlTest, MaskPageBrushSectionRoutesToolSizeStrengthAn
   ASSERT_TRUE(QMetaObject::invokeMethod(size, "keyStep",
                                         Q_ARG(QVariant, QVariant::fromValue(step_event))));
   ProcessEvents(20);
-  EXPECT_GT(mask_creation.brushRadiusPercent(), 0.0);
+  EXPECT_GT(mask_creation.brushDiameterPercent(), 0.0);
 }
 
 TEST(EditorAdjustmentHeaderQmlTest, KeyboardMaskMoveUsesSameInteractiveRoute) {

--- a/alcedo_studio/tests/ui/editor_brush_interaction_qml_test.cpp
+++ b/alcedo_studio/tests/ui/editor_brush_interaction_qml_test.cpp
@@ -1,0 +1,328 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+/// @file editor_brush_interaction_qml_test.cpp
+/// @brief First left-press+drag while Mask owns the left button must forward
+///        the whole pointer path (press, moves, one release) without a prior
+///        click. Handler routing matches EditorWorkspace.qml.
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QPoint>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QQmlError>
+#include <QQuickWindow>
+#include <QStringList>
+#include <QTest>
+#include <QTimer>
+#include <QUrl>
+#include <QVariant>
+
+#include <cmath>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace alcedo::ui::test {
+namespace {
+
+struct PointerSample {
+  qreal x       = 0.0;
+  qreal y       = 0.0;
+  int   buttons = 0;
+};
+
+class RecordingMaskCreation final : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(bool ownsLeftButton READ owns_left_button CONSTANT)
+ public:
+  [[nodiscard]] auto owns_left_button() const -> bool { return true; }
+
+  Q_INVOKABLE bool handlePress(qreal x, qreal y, int button) {
+    presses.push_back({x, y, button});
+    return button == static_cast<int>(Qt::LeftButton);
+  }
+  Q_INVOKABLE bool handleMove(qreal x, qreal y, int buttons) {
+    moves.push_back({x, y, buttons});
+    return true;
+  }
+  Q_INVOKABLE bool handleRelease(qreal x, qreal y, int button) {
+    releases.push_back({x, y, button});
+    return true;
+  }
+  Q_INVOKABLE void handleHover(qreal, qreal) {}
+  Q_INVOKABLE void cancelOpenPointerInput() { ++cancels; }
+
+  std::vector<PointerSample> presses;
+  std::vector<PointerSample> moves;
+  std::vector<PointerSample> releases;
+  int                        cancels = 0;
+};
+
+class RecordingInteraction final : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(bool hasCustomCursor READ has_custom_cursor CONSTANT)
+  Q_PROPERTY(int cursorShape READ cursor_shape CONSTANT)
+ public:
+  [[nodiscard]] auto has_custom_cursor() const -> bool { return false; }
+  [[nodiscard]] auto cursor_shape() const -> int { return static_cast<int>(Qt::ArrowCursor); }
+
+  Q_INVOKABLE void handleHoverMove(qreal, qreal) {}
+  Q_INVOKABLE void handlePress(qreal x, qreal y, int button) { presses.push_back({x, y, button}); }
+  Q_INVOKABLE void handleMove(qreal x, qreal y, int buttons) { moves.push_back({x, y, buttons}); }
+  Q_INVOKABLE void handleRelease(qreal x, qreal y, int button) {
+    releases.push_back({x, y, button});
+  }
+  Q_INVOKABLE void handleDoubleTap(qreal, qreal) { ++double_taps; }
+
+  std::vector<PointerSample> presses;
+  std::vector<PointerSample> moves;
+  std::vector<PointerSample> releases;
+  int                        double_taps = 0;
+};
+
+// Keep this handler block aligned with EditorWorkspace.qml: one PointHandler
+// writer, TapHandler off while Mask owns the left button, last valid point on
+// release, and pointChanged may start the Mask stream before activeChanged.
+constexpr char kFirstDragHarnessQml[] = R"(
+import QtQuick
+import QtQuick.Window
+
+Window {
+    id: root
+    objectName: "brushFirstDragHarness"
+    width: 640
+    height: 480
+    visible: true
+    color: "#202020"
+    title: "brush-first-drag"
+
+    property bool editorControlsEnabled: true
+    property bool maskOwnsLeftButton: true
+    property var maskCreation: null
+    property var editorInteraction: null
+
+    Item {
+        id: viewportSlot
+        objectName: "viewportSlot"
+        anchors.fill: parent
+
+        PointHandler {
+            id: viewportPointer
+            objectName: "editorViewportPointer"
+            enabled: root.editorControlsEnabled
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.TouchScreen | PointerDevice.Stylus
+            acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+            property int _activeButton: Qt.LeftButton
+            property bool _pressed: false
+            property bool _maskStream: false
+            property bool _canceled: false
+            property real _lastX: 0
+            property real _lastY: 0
+            property bool _haveLastItemPos: false
+
+            function rememberItemPos(x, y) {
+                _lastX = x
+                _lastY = y
+                _haveLastItemPos = true
+            }
+            function finishX() {
+                if (_haveLastItemPos && Math.abs(point.position.x) < 1e-6
+                        && Math.abs(point.position.y) < 1e-6)
+                    return _lastX
+                return point.position.x
+            }
+            function finishY() {
+                if (_haveLastItemPos && Math.abs(point.position.x) < 1e-6
+                        && Math.abs(point.position.y) < 1e-6)
+                    return _lastY
+                return point.position.y
+            }
+            function beginMaskOrPan() {
+                _activeButton = (point.pressedButtons & Qt.MiddleButton)
+                        ? Qt.MiddleButton : Qt.LeftButton
+                rememberItemPos(point.position.x, point.position.y)
+                if (_activeButton === Qt.LeftButton
+                        && root.maskOwnsLeftButton
+                        && root.maskCreation
+                        && root.maskCreation.handlePress(
+                               point.position.x, point.position.y, _activeButton)) {
+                    _maskStream = true
+                } else {
+                    _maskStream = false
+                    editorInteraction.handlePress(
+                                point.position.x, point.position.y, _activeButton)
+                }
+            }
+            function finishMaskOrPan() {
+                var x = finishX()
+                var y = finishY()
+                if (_canceled && _maskStream && root.maskCreation
+                        && typeof root.maskCreation.cancelOpenPointerInput === "function") {
+                    root.maskCreation.cancelOpenPointerInput()
+                } else if (_maskStream && root.maskCreation) {
+                    root.maskCreation.handleRelease(x, y, _activeButton)
+                } else {
+                    editorInteraction.handleRelease(x, y, _activeButton)
+                }
+                _pressed = false
+                _maskStream = false
+                _canceled = false
+                _haveLastItemPos = false
+            }
+
+            onCanceled: { _canceled = true }
+            onActiveChanged: {
+                if (active) {
+                    _pressed = true
+                    _canceled = false
+                    beginMaskOrPan()
+                } else if (_pressed) {
+                    finishMaskOrPan()
+                }
+            }
+            onPointChanged: {
+                if (!active) {
+                    return
+                }
+                if (!_pressed) {
+                    _pressed = true
+                    _canceled = false
+                    beginMaskOrPan()
+                }
+                if (point.pressedButtons !== 0) {
+                    rememberItemPos(point.position.x, point.position.y)
+                }
+                if (_maskStream && root.maskCreation) {
+                    root.maskCreation.handleMove(
+                                _haveLastItemPos ? _lastX : point.position.x,
+                                _haveLastItemPos ? _lastY : point.position.y,
+                                point.pressedButtons)
+                } else {
+                    editorInteraction.handleMove(
+                                point.position.x, point.position.y,
+                                point.pressedButtons)
+                }
+            }
+        }
+
+        DragHandler {
+            id: viewportPanDrag
+            objectName: "editorViewportPanDrag"
+            enabled: root.editorControlsEnabled
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.TouchScreen | PointerDevice.Stylus
+            acceptedButtons: root.maskOwnsLeftButton
+                             ? Qt.MiddleButton
+                             : (Qt.LeftButton | Qt.MiddleButton)
+            target: null
+            onActiveChanged: {
+                if (active) {
+                    editorInteraction.handlePress(
+                                centroid.pressPosition.x, centroid.pressPosition.y,
+                                (centroid.pressedButtons & Qt.MiddleButton)
+                                        ? Qt.MiddleButton : Qt.LeftButton)
+                    editorInteraction.handleMove(
+                                centroid.position.x, centroid.position.y,
+                                centroid.pressedButtons)
+                } else {
+                    editorInteraction.handleRelease(
+                                centroid.position.x, centroid.position.y, Qt.LeftButton)
+                }
+            }
+            onTranslationChanged: {
+                if (active) {
+                    editorInteraction.handleMove(
+                                centroid.position.x, centroid.position.y,
+                                centroid.pressedButtons)
+                }
+            }
+        }
+
+        TapHandler {
+            id: viewportDoubleTap
+            objectName: "editorViewportDoubleTap"
+            enabled: root.editorControlsEnabled && !root.maskOwnsLeftButton
+            acceptedButtons: Qt.LeftButton
+            gesturePolicy: TapHandler.DragThreshold
+            onDoubleTapped: function (eventPoint) {
+                editorInteraction.handleDoubleTap(
+                            eventPoint.position.x, eventPoint.position.y)
+            }
+        }
+    }
+}
+)";
+
+void ProcessEventsFor(int ms) {
+  QEventLoop loop;
+  QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+  loop.exec();
+}
+
+void DragBentPath(QQuickWindow* window, const QPoint& origin) {
+  QTest::mousePress(window, Qt::LeftButton, Qt::NoModifier, origin);
+  ProcessEventsFor(16);
+  const QPoint offsets[] = {{24, 4}, {48, 18}, {72, 10}, {104, 36}, {128, 28}};
+  for (const auto& offset : offsets) {
+    QTest::mouseMove(window, origin + offset);
+    ProcessEventsFor(16);
+  }
+  QTest::mouseRelease(window, Qt::LeftButton, Qt::NoModifier, origin + offsets[4]);
+  ProcessEventsFor(30);
+}
+
+}  // namespace
+
+TEST(EditorBrushInteractionQmlTest, FirstBrushDragWithoutPriorClickPaintsWholePath) {
+  ASSERT_TRUE(QCoreApplication::instance());
+
+  RecordingMaskCreation mask;
+  RecordingInteraction  interaction;
+  QQmlApplicationEngine engine;
+  QStringList           warnings;
+  QObject::connect(&engine, &QQmlEngine::warnings, [&](const QList<QQmlError>& emitted) {
+    for (const auto& warning : emitted) {
+      warnings.push_back(warning.toString());
+    }
+  });
+  engine.rootContext()->setContextProperty(QStringLiteral("maskCreation"), &mask);
+  engine.rootContext()->setContextProperty(QStringLiteral("editorInteraction"), &interaction);
+  engine.loadData(QByteArray{kFirstDragHarnessQml},
+                  QUrl(QStringLiteral("file:///brushFirstDragHarness.qml")));
+  ASSERT_FALSE(engine.rootObjects().empty()) << warnings.join('\n').toStdString();
+  auto* window = qobject_cast<QQuickWindow*>(engine.rootObjects().front());
+  ASSERT_NE(window, nullptr);
+  window->setProperty("maskCreation", QVariant::fromValue(static_cast<QObject*>(&mask)));
+  window->setProperty("editorInteraction",
+                      QVariant::fromValue(static_cast<QObject*>(&interaction)));
+  window->show();
+  ASSERT_TRUE(QTest::qWaitForWindowExposed(window));
+  ProcessEventsFor(20);
+
+  auto* tap = window->findChild<QObject*>(QStringLiteral("editorViewportDoubleTap"));
+  ASSERT_NE(tap, nullptr);
+  EXPECT_FALSE(tap->property("enabled").toBool());
+
+  const QPoint origin(180, 140);
+  DragBentPath(window, origin);
+
+  EXPECT_EQ(mask.cancels, 0);
+  ASSERT_EQ(mask.presses.size(), 1u);
+  EXPECT_EQ(mask.presses.front().buttons, static_cast<int>(Qt::LeftButton));
+  EXPECT_GE(mask.moves.size(), 4u) << "first left-drag must forward the path, not a single dab";
+  ASSERT_EQ(mask.releases.size(), 1u);
+  EXPECT_GT(std::hypot(mask.releases.front().x - mask.presses.front().x,
+                       mask.releases.front().y - mask.presses.front().y),
+            40.0);
+  EXPECT_TRUE(interaction.presses.empty()) << "Mask-owned left drag must not start pan";
+  EXPECT_EQ(interaction.double_taps, 0);
+  EXPECT_TRUE(warnings.isEmpty()) << warnings.join('\n').toStdString();
+}
+
+}  // namespace alcedo::ui::test
+
+#include "editor_brush_interaction_qml_test.moc"

--- a/alcedo_studio/tests/ui/mask_edit_geometry_test.cpp
+++ b/alcedo_studio/tests/ui/mask_edit_geometry_test.cpp
@@ -13,6 +13,7 @@
 #include "edit/geometry/render_geometry_resolver.hpp"
 #include "edit/geometry/render_request.hpp"
 #include "edit/geometry/source_geometry.hpp"
+#include "edit/geometry/types.hpp"
 #include "ui/edit_viewer/mask_edit_geometry.hpp"
 #include "ui/edit_viewer/viewport_mapper.hpp"
 #include "ui/editor_rhi/editor_interaction_controller.hpp"
@@ -309,6 +310,54 @@ TEST(MaskEditGeometryTest, CroppedRotatedPhotographUsesResolvedGeometryNotIdenti
   EXPECT_EQ(published.photograph.image_width, static_cast<int>(resolved.edit_extent.width));
   EXPECT_EQ(published.photograph.image_height, static_cast<int>(resolved.edit_extent.height));
   EXPECT_NE(published.geometry.render_to_reference.m[0], identity.render_to_reference.m[0]);
+}
+
+TEST(MaskEditGeometryTest, QualityToInteractiveEquivalentMappingKeepsBrushOpen) {
+  MaskEditViewMapping quality;
+  quality.widget     = {800, 600, 1.0f};
+  quality.photograph = {6000, 4000};
+  quality.zoom       = 1.0f;
+  quality.pan        = QVector2D(0.0f, 0.0f);
+  quality.geometry   = MaskEditGeometry::MakeIdentityPhotographGeometry({6000, 4000});
+  ASSERT_TRUE(MaskEditGeometry::IsValid(quality));
+  const auto before = MaskEditGeometry::Identity(quality);
+
+  auto interactive                         = quality;
+  interactive.photograph                   = {3000, 2000};
+  interactive.geometry.render_extent       = {3000, 2000};
+  interactive.geometry.render_to_reference = Matrix3x3::Scale(2.0f, 2.0f);
+  interactive.geometry.reference_to_render =
+      InvertAffine(interactive.geometry.render_to_reference);
+  ASSERT_TRUE(MaskEditGeometry::IsValid(interactive));
+  const auto after = MaskEditGeometry::Identity(interactive);
+
+  EXPECT_NE(before, after);
+  EXPECT_FALSE(MaskEditGeometry::MappingChanged(before, after));
+
+  auto zoomed = quality;
+  zoomed.zoom = 2.0f;
+  EXPECT_TRUE(MaskEditGeometry::MappingChanged(before, MaskEditGeometry::Identity(zoomed)));
+
+  auto panned = quality;
+  panned.pan  = QVector2D(0.15f, -0.08f);
+  EXPECT_TRUE(MaskEditGeometry::MappingChanged(before, MaskEditGeometry::Identity(panned)));
+}
+
+TEST(MaskEditGeometryTest, SamePhotographInteractiveExtentKeepsItemToReference) {
+  MaskEditViewMapping quality;
+  quality.widget     = {960, 540, 1.25f};
+  quality.photograph = {4000, 3000};
+  quality.zoom       = 1.35f;
+  quality.pan        = QVector2D(0.04f, -0.02f);
+  quality.geometry   = MaskEditGeometry::MakeIdentityPhotographGeometry({4000, 3000});
+  const auto before  = MaskEditGeometry::Identity(quality);
+
+  auto interactive                         = quality;
+  interactive.geometry.render_extent       = {2000, 1500};
+  interactive.geometry.render_to_reference = Matrix3x3::Scale(2.0f, 2.0f);
+  interactive.geometry.reference_to_render =
+      InvertAffine(interactive.geometry.render_to_reference);
+  EXPECT_FALSE(MaskEditGeometry::MappingChanged(before, MaskEditGeometry::Identity(interactive)));
 }
 
 }  // namespace alcedo

--- a/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
+++ b/alcedo_studio/tests/ui/mask_overlay_control_test.cpp
@@ -583,4 +583,105 @@ TEST(MaskOverlayControlTest, GradientControlAxisIsPerpendicularAfterNonSquareMap
   EXPECT_NEAR(dy, source.normal_y, 1.0e-5f);
 }
 
+TEST(MaskOverlayControlTest, MoveFrameEnclosesTranslatedPaintSupportWithFeather) {
+  const auto      mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  BrushMaskSource source;
+  source.placement_translation = {40.0f, 20.0f};
+  source.feather_radius        = 6.0f;
+  source.strokes.push_back(MakeBrushStroke(
+      StrokeId{"paint.a"}, BrushStrokeMode::Paint,
+      {{100.0f, 100.0f, 10.0f, 1.0f, 1.0f}, {140.0f, 110.0f, 10.0f, 0.8f, 0.5f}}));
+  // Zero-strength and Erase samples must not widen the conservative frame.
+  source.strokes.push_back(MakeBrushStroke(StrokeId{"faint"}, BrushStrokeMode::Paint,
+                                           {{300.0f, 200.0f, 30.0f, 0.0f, 1.0f}}));
+  source.strokes.push_back(MakeBrushStroke(StrokeId{"erase.b"}, BrushStrokeMode::Erase,
+                                           {{500.0f, 250.0f, 40.0f, 1.0f, 1.0f}}));
+
+  const auto display = MakeBrushMoveOverlayDisplay(mapping, source, {});
+  EXPECT_EQ(display.mode, MaskOverlayMode::Existing);
+  EXPECT_EQ(display.source_kind, MaskOverlaySourceKind::Brush);
+  EXPECT_TRUE(display.move_frame_visible);
+  ASSERT_EQ(display.handles.size(), 4u);
+  for (const auto& handle : display.handles) {
+    EXPECT_EQ(handle.id, MaskOverlayHandleId::BrushMove);
+    EXPECT_EQ(handle.shape, MaskOverlayHandleShape::CornerTick);
+  }
+
+  // Identity mapping: image and reference pixels coincide. Expected AABB in
+  // reference space: translated Paint supports expanded by feather.
+  const float left   = 100.0f + 40.0f - 10.0f - 6.0f;
+  const float right  = 140.0f + 40.0f + 10.0f + 6.0f;
+  const float top    = 100.0f + 20.0f - 10.0f - 6.0f;
+  const float bottom = 110.0f + 20.0f + 10.0f + 6.0f;
+  EXPECT_NEAR(display.handles[0].item.x(), left, 0.5);
+  EXPECT_NEAR(display.handles[0].item.y(), top, 0.5);
+  EXPECT_NEAR(display.handles[2].item.x(), right, 0.5);
+  EXPECT_NEAR(display.handles[2].item.y(), bottom, 0.5);
+
+  const auto scene = BuildMaskOverlaySceneGeometry(display, DefaultMaskOverlayStyle());
+  EXPECT_FALSE(scene.edge_grips.empty());
+  EXPECT_FALSE(scene.selected_guides.empty());
+  EXPECT_EQ(scene.coverage_fill_vertex_count, 0);
+
+  // Interior and frame edges begin a move; a point outside the painted bounds
+  // does not.
+  const QPointF interior(0.5 * (left + right), 0.5 * (top + bottom));
+  EXPECT_EQ(HitTestMaskOverlayHandle(display, interior, kMaskHandleHitRadiusLogicalPx),
+            MaskOverlayHandleId::BrushMove);
+  const QPointF outside(left - 60.0, top - 60.0);
+  EXPECT_EQ(HitTestMaskOverlayHandle(display, outside, kMaskHandleHitRadiusLogicalPx),
+            MaskOverlayHandleId::None);
+}
+
+TEST(MaskOverlayControlTest, MoveFrameWithoutPaintedCoverageKeepsSingleMoveAnchor) {
+  const auto      mapping = MakeMapping(400, 300, 400, 300, 1.0f, QVector2D(0, 0), 1.0f);
+  BrushMaskSource source;
+  source.placement_translation = {120.0f, 80.0f};
+  source.strokes.push_back(MakeBrushStroke(StrokeId{"erase"}, BrushStrokeMode::Erase,
+                                           {{120.0f, 80.0f, 10.0f, 1.0f, 1.0f}}));
+  const auto display = MakeBrushMoveOverlayDisplay(mapping, source, {});
+  EXPECT_EQ(display.mode, MaskOverlayMode::Existing);
+  EXPECT_FALSE(display.move_frame_visible);
+  ASSERT_EQ(display.handles.size(), 1u);
+  EXPECT_EQ(display.handles.front().id, MaskOverlayHandleId::BrushMove);
+  // Identity mapping: the anchor sits at the placement translation itself.
+  EXPECT_NEAR(display.handles.front().item.x(), 120.0, 0.5);
+  EXPECT_NEAR(display.handles.front().item.y(), 80.0, 0.5);
+}
+
+TEST(MaskOverlayControlTest, PaintAndEraseCursorsStayDistinctFromMoveFrame) {
+  const auto style  = DefaultMaskOverlayStyle();
+  const auto paint  = MakeBrushCreatingOverlayDisplay({QPointF(10, 10), QPointF(20, 20)},
+                                                      QPointF(30, 30), 12.0f, {}, false);
+  const auto erase  = MakeBrushCreatingOverlayDisplay({}, QPointF(30, 30), 12.0f, {}, true);
+  EXPECT_EQ(paint.mode, MaskOverlayMode::Creating);
+  EXPECT_EQ(paint.source_kind, MaskOverlaySourceKind::Brush);
+  EXPECT_TRUE(paint.cursor_visible);
+  EXPECT_FALSE(paint.cursor_dashed);
+  EXPECT_TRUE(erase.cursor_dashed);
+  EXPECT_TRUE(paint.handles.empty());
+  EXPECT_FALSE(paint.move_frame_visible);
+  EXPECT_EQ(paint.creation_path.size(), 2u);
+
+  const auto paint_scene = BuildMaskOverlaySceneGeometry(paint, style);
+  const auto erase_scene = BuildMaskOverlaySceneGeometry(erase, style);
+  EXPECT_FALSE(paint_scene.cursor.empty());
+  EXPECT_FALSE(erase_scene.cursor.empty());
+  // A dashed cursor must leave gaps: some ring samples carry no triangles.
+  int covered = 0;
+  int gapped  = 0;
+  constexpr float kTwoPi = 6.28318530718f;
+  for (int i = 0; i < 360; ++i) {
+    const float   t = (static_cast<float>(i) / 360.0f) * kTwoPi;
+    const QPointF ring(30.0 + 12.0 * std::cos(t), 30.0 + 12.0 * std::sin(t));
+    if (VerticesCoverPoint(erase_scene.cursor, ring)) {
+      ++covered;
+    } else {
+      ++gapped;
+    }
+  }
+  EXPECT_GT(covered, 0);
+  EXPECT_GT(gapped, 0);
+}
+
 }  // namespace alcedo

--- a/alcedo_studio/tests/ui/project_mask_cache_settings_qml_test.cpp
+++ b/alcedo_studio/tests/ui/project_mask_cache_settings_qml_test.cpp
@@ -1,0 +1,256 @@
+//  Copyright 2026 Yurun Zi
+//  SPDX-License-Identifier: GPL-3.0-only
+//  Additional permission under GPLv3 section 7 applies; see the LICENSE file.
+
+/// @file project_mask_cache_settings_qml_test.cpp
+/// @brief Project Mask cache settings panel: project-scoped calls, Clear copy.
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QQmlComponent>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QQmlError>
+#include <QQuickItem>
+#include <QQuickStyle>
+#include <QQuickWindow>
+#include <QSignalSpy>
+#include <QStringList>
+#include <QTimer>
+#include <QUrl>
+#include <QVariantMap>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+
+#include "ui/alcedo_main/app_theme.hpp"
+
+namespace alcedo::ui::test {
+namespace {
+
+class FakeProjectModule final : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(QVariantMap maskCacheState READ maskCacheState NOTIFY MaskCacheStateChanged)
+
+ public:
+  FakeProjectModule() { ResetState(); }
+
+  auto maskCacheState() const -> QVariantMap { return state_; }
+
+  void ResetState() {
+    state_.clear();
+    state_.insert(QStringLiteral("available"), true);
+    state_.insert(QStringLiteral("projectName"), QStringLiteral("Field Session"));
+    state_.insert(QStringLiteral("projectUuid"), QStringLiteral("uuid-field-session"));
+    state_.insert(QStringLiteral("chosenRoot"), QStringLiteral("/projects/field/cache"));
+    state_.insert(QStringLiteral("effectiveRoot"),
+                  QStringLiteral("/projects/field/cache/alcedo-mask-cache/uuid-field-session"));
+    state_.insert(QStringLiteral("retention"), QStringLiteral("keep"));
+    state_.insert(QStringLiteral("fileCount"), 4);
+    state_.insert(QStringLiteral("byteCount"), 8192);
+    state_.insert(QStringLiteral("pendingWrites"), 0);
+    state_.insert(QStringLiteral("dirty"), false);
+    state_.insert(QStringLiteral("lastError"), QString());
+    state_.insert(QStringLiteral("applyError"), QString());
+    emit MaskCacheStateChanged();
+  }
+
+  Q_INVOKABLE bool ApplyMaskCacheRoot(const QString& chosenRoot) {
+    ++apply_root_calls_;
+    last_applied_root_ = chosenRoot;
+    state_.insert(QStringLiteral("chosenRoot"), chosenRoot);
+    emit MaskCacheStateChanged();
+    return true;
+  }
+  Q_INVOKABLE bool ApplyMaskCacheRetention(const QString& retentionKey) {
+    ++apply_retention_calls_;
+    last_applied_retention_ = retentionKey;
+    state_.insert(QStringLiteral("retention"), retentionKey);
+    emit MaskCacheStateChanged();
+    return true;
+  }
+  Q_INVOKABLE bool ClearMaskCache() {
+    ++clear_calls_;
+    state_.insert(QStringLiteral("fileCount"), 0);
+    state_.insert(QStringLiteral("byteCount"), 0);
+    emit MaskCacheStateChanged();
+    return true;
+  }
+  Q_INVOKABLE void RefreshMaskCacheState() {
+    ++refresh_calls_;
+    emit MaskCacheStateChanged();
+  }
+
+  auto    applyRootCalls() const -> int { return apply_root_calls_; }
+  auto    applyRetentionCalls() const -> int { return apply_retention_calls_; }
+  auto    clearCalls() const -> int { return clear_calls_; }
+  auto    refreshCalls() const -> int { return refresh_calls_; }
+  auto    lastAppliedRoot() const -> QString { return last_applied_root_; }
+  auto    lastAppliedRetention() const -> QString { return last_applied_retention_; }
+
+  void SetStateEntry(const QString& key, const QVariant& value) {
+    state_.insert(key, value);
+    emit MaskCacheStateChanged();
+  }
+
+ signals:
+  void MaskCacheStateChanged();
+
+ private:
+  QVariantMap state_;
+  int         apply_root_calls_      = 0;
+  int         apply_retention_calls_ = 0;
+  int         clear_calls_           = 0;
+  int         refresh_calls_         = 0;
+  QString     last_applied_root_;
+  QString     last_applied_retention_;
+};
+
+auto QmlDirectory() -> QString {
+  return QString::fromStdString(
+      (std::filesystem::path(ALCEDO_TEST_SRC_DIR) / "ui" / "alcedo_main" / "qml").string());
+}
+
+void ProcessEvents(int ms) {
+  QEventLoop loop;
+  QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+  loop.exec();
+}
+
+class CachePanelHarness {
+ public:
+  CachePanelHarness(FakeProjectModule* module, int width) {
+    AppTheme::RegisterFonts();
+    AppTheme::Instance().setReduceMotion(true);
+    QQuickStyle::setStyle(QStringLiteral("Basic"));
+
+    engine_.addImportPath(QStringLiteral("qrc:/"));
+    engine_.addImportPath(QmlDirectory());
+    engine_.rootContext()->setContextProperty(QStringLiteral("appTheme"),
+                                              &AppTheme::Instance());
+
+    QQmlComponent component(
+        &engine_, QUrl::fromLocalFile(QmlDirectory() +
+                                      QStringLiteral("/ProjectMaskCacheSettingsPanel.qml")));
+    if (component.isError()) {
+      errors_ = component.errors();
+      return;
+    }
+    QVariantMap initial;
+    initial.insert(QStringLiteral("projectModule"),
+                   QVariant::fromValue(static_cast<QObject*>(module)));
+    initial.insert(QStringLiteral("projectReady"), true);
+    root_.reset(qobject_cast<QQuickItem*>(component.createWithInitialProperties(initial)));
+    if (!root_) {
+      errors_ = component.errors();
+      return;
+    }
+    root_->setWidth(width);
+    root_->setParentItem(window_.contentItem());
+    window_.resize(width, 900);
+    window_.show();
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 200);
+  }
+
+  auto root() const -> QQuickItem* { return root_.get(); }
+  auto errors() const -> QString {
+    QStringList text;
+    for (const auto& error : errors_) {
+      text.push_back(error.toString());
+    }
+    return text.join('\n');
+  }
+
+  template <typename T = QQuickItem>
+  auto find(const QString& name) const -> T* {
+    return root_ ? root_->findChild<T*>(name) : nullptr;
+  }
+
+ private:
+  QQmlEngine                  engine_;
+  QQuickWindow                window_;
+  std::unique_ptr<QQuickItem> root_;
+  QList<QQmlError>            errors_;
+};
+
+TEST(ProjectMaskCacheSettingsQmlTest, CacheSettingsTargetSelectedProjectOnly) {
+  FakeProjectModule  module;
+  CachePanelHarness  harness(&module, 460);
+  ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
+
+  ASSERT_TRUE(QMetaObject::invokeMethod(harness.root(), "reloadPending"));
+  ProcessEvents(20);
+  EXPECT_EQ(harness.root()->property("pendingRoot").toString(),
+            QStringLiteral("/projects/field/cache"));
+
+  // Root change applies through the project module with the pending path only.
+  harness.root()->setProperty("pendingRoot", QStringLiteral("/scratch/other/cache"));
+  auto* warning = harness.find(QStringLiteral("maskCacheRootWarning"));
+  ASSERT_NE(warning, nullptr);
+  EXPECT_TRUE(warning->property("visible").toBool());
+  ASSERT_TRUE(QMetaObject::invokeMethod(harness.root(), "applyPending"));
+  ProcessEvents(20);
+  EXPECT_EQ(module.applyRootCalls(), 1);
+  EXPECT_EQ(module.lastAppliedRoot(), QStringLiteral("/scratch/other/cache"));
+  EXPECT_EQ(module.applyRetentionCalls(), 0);
+
+  // Retention applies through the same project-scoped setter.
+  harness.root()->setProperty("pendingRetention",
+                              QStringLiteral("deleteOnProjectClose"));
+  ASSERT_TRUE(QMetaObject::invokeMethod(harness.root(), "applyPending"));
+  ProcessEvents(20);
+  EXPECT_EQ(module.applyRetentionCalls(), 1);
+  EXPECT_EQ(module.lastAppliedRetention(), QStringLiteral("deleteOnProjectClose"));
+  EXPECT_EQ(module.applyRootCalls(), 1);
+}
+
+TEST(ProjectMaskCacheSettingsQmlTest, ProjectClearExplainsThatBrushHistoryIsRetained) {
+  FakeProjectModule  module;
+  CachePanelHarness  harness(&module, 460);
+  ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
+
+  auto* hint = harness.find(QStringLiteral("maskCacheClearHint"));
+  ASSERT_NE(hint, nullptr);
+  const QString hint_text = hint->property("text").toString();
+  EXPECT_TRUE(hint_text.contains(QStringLiteral("Brush strokes")));
+  EXPECT_TRUE(hint_text.contains(QStringLiteral("history"), Qt::CaseInsensitive));
+  EXPECT_TRUE(hint_text.contains(QStringLiteral("rebuilt"), Qt::CaseInsensitive));
+
+  QSignalSpy messages(harness.root(), SIGNAL(messageRequested(QString)));
+  auto*       clear = harness.find(QStringLiteral("maskCacheClearButton"));
+  ASSERT_NE(clear, nullptr);
+  ASSERT_TRUE(clear->property("enabled").toBool());
+  ASSERT_TRUE(QMetaObject::invokeMethod(clear, "clicked"));
+  ProcessEvents(20);
+  EXPECT_EQ(module.clearCalls(), 1);
+  ASSERT_GE(messages.size(), 1);
+  EXPECT_TRUE(messages.takeFirst().first().toString().contains(
+      QStringLiteral("cleared"), Qt::CaseInsensitive));
+}
+
+TEST(ProjectMaskCacheSettingsQmlTest, ErrorsSurfaceFromProjectModuleState) {
+  FakeProjectModule  module;
+  CachePanelHarness  harness(&module, 320);
+  ASSERT_NE(harness.root(), nullptr) << harness.errors().toStdString();
+  ASSERT_TRUE(QMetaObject::invokeMethod(harness.root(), "reloadPending"));
+  ProcessEvents(20);
+
+  auto* status = harness.find(QStringLiteral("maskCacheStatusLabel"));
+  ASSERT_NE(status, nullptr);
+  EXPECT_FALSE(status->property("visible").toBool());
+
+  module.SetStateEntry(QStringLiteral("applyError"),
+                       QStringLiteral("mask cache folder is not writable"));
+  ProcessEvents(20);
+  EXPECT_TRUE(status->property("visible").toBool());
+  EXPECT_EQ(status->property("text").toString(),
+            QStringLiteral("mask cache folder is not writable"));
+}
+
+}  // namespace
+}  // namespace alcedo::ui::test
+
+#include "project_mask_cache_settings_qml_test.moc"

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -26,6 +26,7 @@ use their own top-level category.
 - [GPU DAG Pipeline Rebuild Phase Plan](alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md)
 - [GPU DAG Metal Migration Phase Plan](alcedo_studio/edit/gpu_dag_metal_migration_phase_plan.md)
 - [Node-aware Pipeline Editing and Mask Authoring Master Plan](alcedo_studio/edit/node_mask_editor_master_plan.md)
+- [Brush Mask Architecture, History, and Raster Materialization Master Plan](alcedo_studio/edit/brush_mask_architecture_master_plan.md)
 
 ## Alcedo Studio — UI
 

--- a/docs/roadmap/alcedo_studio/edit/brush_mask_architecture_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/brush_mask_architecture_master_plan.md
@@ -1,0 +1,613 @@
+# Brush Mask Architecture, History, and Raster Materialization Master Plan
+
+Date: 2026-09-11
+
+Status: planned for the release after the current Node Editor delivery. The current product build
+keeps `ALCEDO_ENABLE_BRUSH_MASK=OFF`. Node Editor NM7.13 establishes the detachable build boundary;
+all implementation and product qualification in this plan happens outside the current release.
+
+Parent context:
+
+- [Node-aware Pipeline Editing and Mask Creation Master Plan](node_mask_editor_master_plan.md)
+- [NM7 Viewer Mask Creation and Editing](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md)
+- [Historical NM7 parameter replay and project-cache design](node_mask_editor/mask_command_replay_and_project_cache_plan.md)
+
+The historical NM7 design and completion records remain evidence for code that exists. They are
+not the target architecture for this plan. This plan replaces parameterized Brush samples embedded
+in JSON, per-dab native dispatch, and render-time reconstruction from the entire stroke list.
+
+---
+
+## 1. Decision and release boundary
+
+Brush is not part of the current Node Editor release. That release delivers:
+
+- Radial Mask creation, selection, editing, history, Version, Paste, reopen, and export;
+- Linear Gradient Mask creation, selection, editing, history, Version, Paste, reopen, and export;
+- multi-Grade and multi-Mask Union execution;
+- NM8 whole-DAG execution performance work with Brush excluded from the build.
+
+The current release must not ship a hidden or unreachable Brush implementation. With
+`ALCEDO_ENABLE_BRUSH_MASK=OFF`, Brush code is absent from the production build graph rather than
+compiled and hidden at runtime. Unsupported Brush data fails at the project/document boundary; it
+does not select Radial, Linear Gradient, CPU evaluation, a lower quality path, or an empty Mask.
+NM7.13 cuts project metadata from `0.6.0` to the Brush-disabled `0.7.0` format. The abandoned
+experimental Brush parameters in `0.6.0` are never an input to this plan and receive no conversion.
+
+The next Brush release starts only after this plan has an execution plan and approved project-format
+cutover. Turning the option on is not itself a release decision.
+
+---
+
+## 2. Problem statement
+
+The current implementation couples four different forms of Brush data:
+
+```text
+pointer input
+  -> canonical dab samples in BrushStroke
+  -> JSON in edit commits and the full PipelineDocument checkpoint
+  -> runtime replay into a canonical R8
+  -> session-local GPU textures and signed-distance data
+```
+
+This produces several independent scaling failures:
+
+1. A long stroke stores thousands or millions of sample objects as JSON.
+2. The current complete PipelineDocument stores the accumulated sample bodies again.
+3. Opening or switching an image parses and copies the full Brush payload on the session owner.
+4. A cold render reconstructs R8 from samples even though a persistent R8 repository exists.
+5. The current CUDA path launches one stamp kernel for each dab.
+6. GUI source equality and overlay-bound calculations can walk every sample.
+7. Whole-image R8 storage per Brush edit would replace CPU/GPU cost with unbounded disk growth.
+
+Sampling-rate reduction alone cannot solve duplicated JSON, history growth, cold raster rebuilds,
+or per-dab dispatch. The persistent model, history representation, raster materialization, native
+execution, UI projection, and garbage collection must be designed together.
+
+---
+
+## 3. Locked product behavior
+
+The following behavior is not negotiable within this plan:
+
+- Brush supports Paint and Erase in exact evaluation order.
+- Brush uses the required source feather behavior; no approximate blur replaces it.
+- Interactive and Quality operate at their specified decode and render quality.
+- Detail ROI changes can recompute effective Mask, Union, Grade, and downstream output.
+- Leaving an image releases its Brush GPU coverage, distance, and effective-Mask allocations.
+- The design does not add a global VRAM cache for inactive images.
+- Opening an image with a valid materialized Brush reads and verifies R8 from project storage; it
+  does not replay the full sample history.
+- Missing, corrupt, stale, or mismatched required Brush materialization reports the real error.
+  Render code does not silently rebuild through a different path.
+- Undo, Redo, Version checkout, branch creation, recovery, Paste, reopen, and export reproduce the
+  same Brush result.
+- A user input sequence produces one settled history operation.
+- No edit commit or complete document JSON embeds the full Brush sample list.
+- Native Brush raster work uses a fixed small number of dispatches per update, not one dispatch per
+  dab.
+
+An explicit project repair operation may regenerate materialized data after validating source
+objects written by this new architecture. A future format upgrade may start only from a supported
+Brush-disabled `0.7.0` project or a released format produced by this plan. Neither operation accepts
+the abandoned `0.6.0` Brush parameters. These operations are not part of ordinary rendering and must
+report their own result.
+
+---
+
+## 4. Target ownership and representations
+
+Brush uses three representations with separate owners and lifetimes.
+
+```text
+BrushModelOwner
+  logical state used by PipelineDocument and Mini-Git
+  ├─ stable MaskId
+  ├─ ordered BrushStrokeRef values
+  ├─ placement
+  ├─ feather and Mask fields
+  ├─ BrushStateHash
+  └─ last Brush mutation commit
+
+BrushStrokeStore
+  project-owned immutable binary objects
+  └─ path/control data or canonical sample data keyed by BrushStrokeBlobKey
+
+BrushRasterStore
+  project-owned verified R8 materialization
+  ├─ BrushStateHash
+  ├─ raster algorithm version
+  ├─ canonical descriptor
+  ├─ R8 tile-tree root
+  └─ independently verified tile/content keys
+
+RenderWorkspace
+  one open image/session
+  ├─ uploaded canonical R8
+  ├─ signed-distance allocations
+  ├─ effective ROI Mask
+  └─ release on image/session exit
+```
+
+The document owner applies changes through focused operations. Callers do not copy the whole Brush,
+edit it, and write it back. Immutable stroke bodies are resolved through the project-owned store with
+a bounded view lifetime. GUI projection reads metadata and stored bounds; it does not load sample
+bodies unless Brush editing requires them.
+
+### 4.1 `BrushStrokeRef`
+
+The logical document stores references instead of bodies:
+
+```cpp
+struct BrushStrokeRef {
+  StrokeId stroke_id;
+  BrushStrokeMode mode;
+  BrushStrokeBlobKey blob_key;
+  NormalizedRect reference_bounds;
+  std::uint32_t point_count;
+};
+```
+
+The exact fields are finalized in BM1 after measuring formats. Bounds and counts are metadata needed
+by ordinary UI, invalidation, reachability, and diagnostics. They are validated against the blob when
+it is first read; they are not an independently editable copy.
+
+### 4.2 `BrushStateHash`
+
+The Brush logical-state identity uses a domain-separated canonical hash over at least:
+
+```text
+source format version
+raster algorithm version
+canonical raster descriptor
+ordered (StrokeId, mode, BrushStrokeBlobKey)
+placement
+coverage-affecting Brush fields
+```
+
+Raw coverage identity excludes downstream-only feather when feather does not modify stored raw R8.
+The final choice is fixed by the exact native evaluation boundary and covered by mutation tests.
+
+The last Brush mutation commit and `BrushStateHash` are stored separately:
+
+- the commit identifies the Mini-Git history position that last changed the Brush;
+- the state hash identifies the logical coverage input;
+- the raster root identifies materialized R8 bytes.
+
+Unrelated node or Grade commits do not invalidate raw Brush R8.
+
+### 4.3 `BrushRasterMaterialization`
+
+```cpp
+struct BrushRasterMaterialization {
+  MaskId mask_id;
+  commit_hash_t last_brush_commit;
+  Hash128 brush_state_hash;
+  std::uint32_t raster_algorithm_version;
+  MaskAssetDescriptor descriptor;
+  BrushRasterRootKey raster_root;
+};
+```
+
+This is the durable relation between history state and raster bytes. It is published only after the
+referenced immutable objects exist. A database row never points to a partially written object.
+
+---
+
+## 5. Binary stroke format
+
+JSON retains only small operation metadata and object keys. Brush path/sample bodies use a versioned,
+canonical binary format suitable for hashing, bounds validation, streaming, and compression.
+
+BM1 must compare at least these representations with fixed real input sequences:
+
+- canonical samples using packed absolute values;
+- first point plus delta-encoded positions;
+- path control points plus deterministic dab expansion;
+- UNORM16 strength/hardness versus float32;
+- float32, fixed-point, or bounded integer coordinate/radius fields;
+- block compression using the project-approved compression dependency, if any.
+
+The selected format must define:
+
+- byte order and exact field widths;
+- finite/range validation;
+- maximum points and decoded bytes per object;
+- stable canonical encoding;
+- version upgrade behavior;
+- deterministic coordinate and pressure reconstruction;
+- reference bounds and point-count verification;
+- hash domain and collision handling;
+- decompression limits before allocation.
+
+Path fitting and lower input density are allowed only when an approved error bound proves that the
+generated canonical dabs preserve the required result. Event frequency must not become persisted
+image semantics. The expansion algorithm is versioned so CPU, CUDA, OpenCL, and Metal receive the
+same ordered canonical input.
+
+---
+
+## 6. Mini-Git integration
+
+Mini-Git commits reference immutable objects. They do not carry sample bodies.
+
+### 6.1 Append
+
+```text
+Finish input
+  -> canonicalize and encode one stroke object
+  -> BrushStrokeStore::Put
+  -> verify returned BrushStrokeBlobKey
+  -> owner AppendBrushStrokeRef(NodeId, MaskId, ref)
+  -> create AppendBrushStrokeRef change
+  -> update BrushStateHash
+  -> update native coverage and durable raster root
+  -> publish history/materialization state
+```
+
+The history change stores `NodeId`, `MaskId`, stable `StrokeId`, evaluation index where required,
+mode, and `BrushStrokeBlobKey`. Its inverse removes that exact reference.
+
+### 6.2 Remove and insert
+
+Removing a stroke records the stable identity, immutable object key, and original evaluation index.
+Undo reinserts the same reference. It does not embed the removed body a second time.
+
+### 6.3 Checkpoint and root state
+
+The complete PipelineDocument stores ordered stroke references and Brush state identities. It does
+not expand them into sample JSON. Pipeline root and image state remain small relative to painted
+content.
+
+### 6.4 Branch, Version, and Paste
+
+Branches and Versions share immutable stroke objects and raster-tree nodes. Paste copies reachable
+objects to the target project store, remaps `NodeId`, `MaskId`, and `StrokeId`, and preserves object
+content keys when the canonical bytes are identical.
+
+### 6.5 Save ordering and recovery
+
+Filesystem objects are published before the DuckDB transaction refers to them. Content-addressed
+orphan objects are safe after a failed database transaction and are removed by reachability cleanup.
+The database transaction atomically advances history, the complete document, and the Brush
+materialization relation. WAL recovery validates every referenced object before accepting the
+recovered head.
+
+---
+
+## 7. Copy-on-write tiled R8 materialization
+
+A complete 4096-long-edge R8 file for every Brush mutation is not acceptable. Canonical coverage is
+stored as immutable tiles with structural sharing.
+
+Initial design values, subject to BM3 measurement:
+
+```text
+pixel format: packed R8 coverage
+tile extent: 256 x 256
+tile identity: Hash(format, tile coordinate/domain, pixel bytes)
+raster identity: root of an immutable tile index
+```
+
+One Brush update computes the exact dirty support and publishes only changed tiles. Unchanged tiles
+keep their prior keys. A persistent radix tree, B-tree, or Merkle tree shares unchanged index nodes
+between history states and branches.
+
+```text
+Raster root A
+  ├─ unchanged tile groups ─────────────┐
+  └─ changed group A                    │
+                                       │ shared
+Raster root B                          │
+  ├─ unchanged tile groups ─────────────┘
+  └─ changed group B
+```
+
+Undo, Redo, and Version checkout select the matching verified raster root. They do not reverse Paint
+or Erase algebra and do not replay every earlier stroke.
+
+The store validates on read:
+
+1. materialization `BrushStateHash` equals the current logical Brush state;
+2. the recorded last Brush commit matches the history relation;
+3. raster algorithm and descriptor match the evaluator;
+4. every loaded index node and tile recomputes to its requested content key;
+5. the complete raster root recomputes to the recorded root.
+
+The project owner provides byte count, object count, path, cleanup, reachability, and integrity
+diagnostics. It does not use a global temporary directory as required product storage.
+
+---
+
+## 8. Native raster execution
+
+The native algorithm preserves ordered Paint/Erase semantics without one launch per dab.
+
+Target chain:
+
+```text
+ordered canonical dabs
+  -> build or update tile-to-dab ranges
+  -> upload packed dabs and tile ranges
+  -> fixed small number of native dispatches
+       one workgroup/block owns one dirty tile
+       one thread owns one or more texels
+       affecting dabs are evaluated in source order
+  -> changed R8 tiles
+  -> exact signed-distance feather
+  -> effective ROI Mask
+  -> Union and Grade Mix
+```
+
+The implementation may use one dispatch for rasterization and separate fixed dispatches for index
+construction or required distance passes. Dispatch count must not grow linearly with dab count.
+
+CUDA, OpenCL, and Metal share:
+
+- canonical packed input;
+- tile coverage and dirty-support rules;
+- Paint/Erase evaluation order;
+- R8 quantization;
+- feather equations and boundary behavior;
+- failure and publication rules.
+
+Backend code owns resource binding and execution mechanics. No backend selects CPU or another GPU
+backend after failure.
+
+---
+
+## 9. Render and GPU lifetime
+
+Disk persistence does not introduce global VRAM retention.
+
+```text
+Open image
+  -> load small document metadata
+  -> resolve current BrushRasterMaterialization
+  -> verify required R8 tiles
+  -> upload canonical coverage into this RenderWorkspace
+  -> build session-local signed-distance data
+
+Leave image
+  -> wait for existing readers/submissions
+  -> release coverage, distance, and effective-Mask GPU resources
+```
+
+Interactive, QualityBase, and Detail ROI obey the existing DAG quality rules. A changed ROI can
+recompute effective Mask, Union, Grade, and downstream output. It does not load stroke bodies or
+reconstruct canonical coverage.
+
+The whole-DAG performance work delivered by Node Editor NM8 is the baseline for this plan. Brush
+must not reintroduce GUI-thread document serialization, whole-parameter hashing, unnecessary static
+plan compilation, or unrelated downstream invalidation.
+
+---
+
+## 10. GUI and editing projection
+
+Ordinary node selection, panel layout, viewport resize, ZoomPan, and filmstrip navigation do not
+read Brush body objects.
+
+The GUI projection exposes only stable and bounded metadata:
+
+- Brush availability and selected `MaskId`;
+- tool state and editable scalar values;
+- stroke count and bounds when the approved UI requires them;
+- current placement and reference mapping;
+- operation/session identity.
+
+Entering Brush editing may acquire the needed immutable stroke/path objects through the owner. The
+adapter keeps handles/views with explicit lifetime; it does not receive a full `MaskSource` by value
+on every backend notification. Overlay bounds come from validated stroke metadata or a maintained
+owner index, not a full sample scan.
+
+---
+
+## 11. Detachable module boundary
+
+Node Editor NM7.13 creates the build boundary before this plan starts. The intended target layout is:
+
+```text
+EditMaskCore
+  MaskId, common Mask fields, Union, range fields, owner operations
+
+EditMaskAnalytic
+  Radial and Linear Gradient model, serialization, history, runtime, UI support
+
+EditMaskBrush       [only when ALCEDO_ENABLE_BRUSH_MASK=ON]
+  Brush model references, stores, history changes, materializer, native passes
+
+EditorMaskAnalytic
+  Radial and Linear Gradient controller/adapter/QML integration
+
+EditorMaskBrush     [only when ALCEDO_ENABLE_BRUSH_MASK=ON]
+  Brush input and editing integration
+```
+
+When disabled:
+
+- no Brush `.cpp`, `.cu`, `.mm`, OpenCL source, QML, SVG, translation, test, or benchmark belongs to
+  a production target;
+- core and analytic public headers do not expose Brush implementation types;
+- Mask creation menus and QML type lists contain only Radial and Linear Gradient;
+- Brush history kinds and JSON readers are unavailable in the current project schema;
+- opening unsupported Brush data fails at the document boundary;
+- package manifests contain no Brush resource;
+- generated dependency/link maps prove the absence of Brush objects and symbols.
+
+After this plan is complete, enabling Brush adds the two optional modules through narrow registration
+interfaces. It must not scatter feature checks through unrelated node, Grade, or rendering code.
+
+---
+
+## 12. Phase summary
+
+| Phase | Status | Result |
+| --- | --- | --- |
+| BM0 — Extracted-boundary audit and format decision | planned | Re-audit the module boundary produced by NM7.13, measure real Brush payloads, select binary/path and tiled-R8 formats, and fix exact project cutover rules. |
+| BM1 — Immutable binary stroke store | planned | Replace sample JSON with validated, bounded, content-addressed binary stroke/path objects and metadata references. |
+| BM2 — Mini-Git, recovery, Version, and Paste integration | planned | Store object references in commits and complete documents; prove branch sharing, recovery ordering, reachability, and target-project transfer. |
+| BM3 — Verified tiled R8 materialization | planned | Add copy-on-write R8 tiles, structural sharing, dual history/content validation, project-owned storage, cleanup, and integrity reporting. |
+| BM4 — Batched three-backend raster execution | planned | Replace per-dab dispatch with ordered tiled raster work on CUDA, OpenCL, and Metal; integrate exact feather and ROI evaluation. |
+| BM5 — Brush authoring and bounded GUI projection | planned | Reconnect input, editing, overlay, node drawer, history, and render pacing without whole-source copies or GUI sample scans. |
+| BM6 — Product qualification and release cutover | planned | Qualify real RAW, long strokes, Undo/Redo, branches, reopen, Paste, package, corruption handling, latency, storage, and all native backends before enabling the product build. |
+
+Each phase gets a dedicated execution plan only when it starts. An execution plan records exact files,
+owner APIs, primary success and failure call chains, tests, fixtures, platform commands, executed
+counts, performance distributions, storage measurements, and remaining gaps.
+
+### 12.1 BM0 — Extracted-boundary audit and format decision
+
+Audit current source after NM7.13 with Brush enabled only in an isolated developer build. Capture:
+
+- real point counts and JSON/binary sizes for short, long, dense, Paint/Erase, and moved Brushes;
+- current commit, WAL, complete-document, load, GUI, CPU, and native costs;
+- the unconditional rejection of `0.6.0` experimental Brush data and the supported `0.7.0`
+  analytic-only input to the next format cut;
+- exact files and symbols that remain outside the optional module;
+- candidate stroke encodings and R8 tile sizes;
+- fixed hash domains and version fields.
+
+Exit when the selected formats have byte-level specifications, bounds, failure behavior, and measured
+evidence. Do not begin persistent schema implementation with unresolved hash or ownership semantics.
+
+### 12.2 BM1 — Immutable binary stroke store
+
+Implement the project-owned store, canonical encoder/decoder, integrity verification, memory limits,
+metadata validation, and owner API. Replace complete sample bodies in the logical document with
+immutable references. Prove identical input produces identical keys and malformed input cannot cause
+unbounded allocation.
+
+### 12.3 BM2 — Mini-Git, recovery, Version, and Paste integration
+
+Replace Brush history payloads with object references. Update root state, complete document, WAL,
+commit hashing, recovery, branch/Version traversal, Paste remapping, package copy, and reachability.
+Prove one stroke object is shared across every referencing state and unavailable objects fail before
+publishing a new head.
+
+### 12.4 BM3 — Verified tiled R8 materialization
+
+Implement immutable R8 tiles, the persistent tile index, structural sharing, materialization rows,
+dual hash validation, atomic publication ordering, crash recovery, cleanup, and storage diagnostics.
+Prove changed bytes and object count are proportional to dirty tiles rather than full canvas area or
+history depth.
+
+### 12.5 BM4 — Batched three-backend raster execution
+
+Implement and qualify ordered tiled rasterization on CUDA, OpenCL, and Metal. Use independent expected
+R8 bytes for Paint/Erase intersections, ordering, hard/soft dabs, quantization boundaries, translation,
+large dirty areas, and exact feather. Record fixed dispatch counts and CPU/GPU timing separately.
+
+### 12.6 BM5 — Brush authoring and bounded GUI projection
+
+Reconnect Brush controls only through the optional module. Prove continuous input, cancellation,
+selection, overlay mapping, node ownership, history settlement, render pacing, and stale-session
+rejection. GUI work during panel resize, ZoomPan, and unrelated backend notification remains bounded
+independently of total Brush points.
+
+### 12.7 BM6 — Product qualification and release cutover
+
+Run the enabled and disabled build matrices. The enabled build must pass real-RAW creation, Paint,
+Erase, move, feather, multiple Masks, 1,000 operations, 1,000 Undo/Redo transitions, branch/Version,
+save/reopen, Paste, export, package, corruption, interrupted publication, storage cleanup, and native
+backend qualification. Only then may the product preset change Brush from disabled to enabled.
+
+---
+
+## 13. Acceptance matrix
+
+| Area | Required evidence |
+| --- | --- |
+| Build boundary | Disabled product configure compiles, links, installs, and packages with no Brush source, symbol, QML, resource, history kind, or test in its build graph. |
+| Stroke format | Byte-level canonical encoding, deterministic key, bounded decoder, metadata verification, version rejection, and measured compression. |
+| History size | Commit and complete-document size remain bounded by references rather than stroke point count; shared objects are stored once. |
+| History behavior | Append/remove/insert/move/feather, Undo/Redo, branch, Version, recovery, and Paste resolve the exact immutable objects. |
+| Raster integrity | Last Brush commit, BrushStateHash, descriptor, algorithm version, tile keys, and raster root are independently verified. |
+| Raster storage | Dirty updates publish only changed tiles/index paths; unchanged history and branches share objects; reachability cleanup preserves every live state. |
+| Native pixels | CUDA/OpenCL/Metal output matches independent expected R8 values and final RGB tolerances without another backend. |
+| Native work | Dispatch count is fixed and small per update; work and upload bytes follow dirty tiles and required feather propagation. |
+| Open/switch | Valid materialized Brush loads from project storage without parsing stroke bodies or replaying samples. |
+| GUI | Filmstrip, panel layout, node selection, ZoomPan, and ordinary Grade edits do not scan or copy Brush bodies. |
+| GPU lifetime | Leaving an image releases Brush GPU allocations; reopen reloads verified disk data without a global VRAM cache. |
+| Failure | Missing/corrupt/mismatched objects, database errors, native errors, stale work, and interrupted publication return precise errors and publish no invalid state. |
+
+---
+
+## 14. Performance and resource targets
+
+BM0 records baselines and BM6 records final evidence on the same RAW, viewport, backend, build type,
+and fixed input sequences. At minimum report p50, p95, maximum, bytes, object counts, and operation
+counts for:
+
+- input event to owner consumption;
+- owner consumption to Interactive photo presentation;
+- release to durable history/materialization publication;
+- image open/switch to first frame and QualityBase;
+- Brush object read/decode and R8 tile read/verification;
+- native bin construction, raster dispatch, feather, Union, Grade, and presentation;
+- GUI panel resize and ZoomPan while a large Brush is selected;
+- current CPU objects, disk objects, native allocations, upload bytes, and released bytes.
+
+No target can be met by lowering decode resolution, changing quality, reducing required feather,
+dropping input, changing Paint/Erase semantics, retaining inactive-image VRAM, or selecting another
+backend.
+
+---
+
+## 15. Main risks
+
+### 15.1 Required R8 becomes an unverifiable cache
+
+Prevent this by storing the explicit history relation and independently recomputing content keys on
+read. A header containing the expected key is not proof that its following pixels match that key.
+
+### 15.2 Every edit publishes a complete R8
+
+Prevent this with dirty-tile publication and structural sharing. Measure physical bytes, not only
+logical object counts.
+
+### 15.3 Binary blobs only move the existing duplication
+
+Prevent this by making commits and documents hold immutable keys, not embedded encoded byte arrays.
+
+### 15.4 Feature checks spread through core code
+
+Prevent this with optional targets and narrow registration seams. The disabled dependency map is an
+acceptance artifact.
+
+### 15.5 Concurrent dab writes change Paint/Erase order
+
+Prevent this by assigning deterministic ordered evaluation to each output texel/tile and comparing
+exact R8 bytes with an independent implementation.
+
+### 15.6 Materialization and history disagree after failure
+
+Publish immutable objects first, then atomically advance database references. Recovery verifies every
+reference before accepting the head. Orphans are safe and later collected.
+
+### 15.7 Old development data silently changes meaning
+
+Use an explicit project-format boundary. Reject `0.6.0` unconditionally; no converter reads its
+embedded experimental sample JSON. Any later verified upgrade starts from a supported released
+format and records the result.
+
+---
+
+## 16. Global completion criteria
+
+- [ ] The optional Brush modules are isolated behind one approved build option and registration seam.
+- [ ] Disabled production builds contain no Brush implementation or product resource.
+- [ ] Brush commits and complete documents contain references, not sample arrays.
+- [ ] Binary stroke/path objects are canonical, versioned, bounded, verified, and content-addressed.
+- [ ] Undo, Redo, branch, Version, recovery, and Paste share immutable objects without body copies.
+- [ ] Project-owned R8 materialization validates last Brush mutation, BrushStateHash, descriptor,
+      algorithm version, raster root, index nodes, and tile bytes.
+- [ ] Changed raster storage grows with dirty tiles, not complete canvas size for every edit.
+- [ ] Opening a valid Brush image reads verified R8 without sample replay.
+- [ ] CUDA, OpenCL, and Metal use fixed-small-count ordered raster dispatch and exact feather behavior.
+- [ ] Ordinary GUI and viewport changes do not load, compare, copy, or scan Brush bodies.
+- [ ] Inactive-image Brush GPU allocations are released; there is no global VRAM cache.
+- [ ] Required errors are explicit and do not select a lower-quality or alternate execution path.
+- [ ] Real-RAW, history, package, integrity, performance, storage, and all native backend evidence is
+      recorded before the product build enables Brush.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/mask_command_replay_and_project_cache_plan.md
@@ -2,7 +2,8 @@
 
 Date: 2026-09-08
 
-Status: NM7.2 parameterized Brush source and Grade owner operations landed; NM7.3 typed
+Status: historical NM7 Brush design, retained as implementation evidence. NM7.2 parameterized
+Brush source and Grade owner operations landed; NM7.3 typed
 stroke/placement history, WAL/Version/Paste remapping, and the Section 8.1 project/schema
 version gate landed. NM7.4 host canonical rasterization, spatial index, and regional Mix
 replay landed. Raster-only Brush JSON is rejected. NM7.5 shared ReferenceSpace mapping and
@@ -10,12 +11,19 @@ Brush placement landed. NM7.6 control-only retained QSG Mask overlay landed. NM7
 and Linear creation plus existing-mask movement landed. Some former NM7.11 UI wiring was
 brought forward for testing. New NM7.8 parameter-mask controls and drawer selection/deletion
 remain planned. Brush UI, Interactive Mix and cache service are now NM7.9–NM7.11; remaining
-full UI is NM7.12 and final qualification ends at NM7.15.
+full UI was NM7.12. The 2026-09-11 release decision stops this design after the historical
+NM7.12RR record. NM7.13 removes Brush from the current product build. The next-version replacement is
+the [Brush Mask Architecture, History, and Raster Materialization Master Plan](../brush_mask_architecture_master_plan.md).
 
 Parent: [NM7 execution plan](phase_nm7_viewer_mask_creation_plan.md).
 This document defines NM7's revised algorithm, data ownership and storage behavior. It replaces
 the earlier NM7 proposal to persist an immutable R8 asset for every completed stroke. Earlier
 NM3/NM4 completion records remain historical implementation evidence, not the new product rule.
+
+The separate Brush Master Plan now supersedes this document as the future target. In particular,
+future Brush work does not embed sample bodies in JSON, does not reconstruct a valid materialized
+Brush during ordinary image open, and does not launch one native kernel per dab. Do not carry the
+remaining work or acceptance items from this file into the Brush-disabled Node Editor release.
 
 ## 1. 用户目标与准确的可逆含义
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,7 +2,9 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.12 complete; NM7.13–NM7.15 planned. This document records the NM7.1 source
+Status: NM7.1–NM7.12 completion records retained; NM7.12R implemented and partially
+verified (release latency, real-adapter QML harness, and Metal still open);
+NM7.13–NM7.15 planned. This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
 shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
@@ -11,7 +13,8 @@ controls, drawer selection/deletion, and crop-style Gradient, NM7.9 accumulating
 Brush paint/erase/move with typed stroke history, NM7.10 serial Interactive Mix
 with one current Grade coverage result, NM7.11 project Mix-cache storage plus
 Keep/DeleteOnProjectClose cleanup, and NM7.12 production Mask controls plus project
-storage UI. NM7.13–NM7.15 acceptance remains outstanding.
+storage UI. The six reported Brush regressions require NM7.12R acceptance before Brush UI
+can be considered qualified. NM7.13–NM7.15 acceptance remains outstanding.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -43,6 +46,13 @@ is specified here as the radial/elliptical range contour and feather boundaries 
 full-ellipse evaluator, without introducing a semicircle coverage algorithm.
 
 ## 1. Purpose and background for the executor
+
+2026-09-10 Brush repair revision: insert **NM7.12R** immediately after NM7.12, without
+renumbering NM7.13–NM7.15. The user requested a repair plan only; this revision does not
+execute implementation, builds, tests, or performance qualification. NM7.12R supersedes
+earlier Brush single-point movement controls and hard-edge creation defaults. Historical
+completion records remain evidence for the tests they actually ran, not proof that the six
+reported viewer problems are resolved.
 
 NM7 makes local adjustment possible directly on the photograph. A user selects a Color Grade,
 creates an area of influence with Brush, Radial, or Linear Gradient, and sees that Grade change
@@ -594,7 +604,8 @@ transitions immediate, and input-following geometry is never animated behind the
 | NM7.10 | Serial Interactive replay and one current Grade R8 result | NM7.7–NM7.9 |
 | NM7.11 | Project-owned cache settings, writeback and cleanup service | NM7.3, NM7.10 |
 | NM7.12 | Production Mask controls and project storage UI | NM7.11 |
-| NM7.13 | Interruptions, late jobs and complete lifecycle | NM7.12 |
+| NM7.12R | Repair Brush tool state, pointer alignment, move frame, erase, drawing cost and default feather | NM7.5–NM7.12 |
+| NM7.13 | Interruptions, late jobs and complete lifecycle | NM7.12, NM7.12R |
 | NM7.14 | Native pixel, persistence, cache bounds and recovery qualification | NM7.13 |
 | NM7.15 | Real viewer/package/performance qualification and NM8 handoff | NM7.14 |
 
@@ -1824,6 +1835,447 @@ native Mix still is not enqueued into the project cache writer from the serial o
 `.r8mask` files and the recent-project list retain their existing KeepFiles behavior.
 Ordinary adjustment Mask writes still fail with the existing “until NM3” text.
 NM6.8–NM6.9 remain planned.
+
+### NM7.12R — 修复 Brush 创建、坐标、移动框、擦除与绘制性能
+
+**Date:** 2026-09-10。**Status:** planned — 本次仅完成代码路径调查、Qt 文档核对和修复方案；
+未修改产品实现，未执行测试或测量，不声称已复现或修复用户报告的六个问题。
+
+**目标：** 点击 Brush 后第一笔就是笔刷；笔尖与实际受影响像素对齐；Paint/Erase 与 Move
+各有明确的输入和控件；擦除对当前 Brush 的真实 coverage 生效；持续绘制保持响应；新建 Brush
+从第一笔起就带默认羽化。六项一起验收，不能只修控件后把实际像素或绘制性能留给 NM7.15。
+
+**边界：** 沿用一组累计笔触对应一个 `MaskId` 的产品语义。Move 移动该 Brush 内所有 Paint/Erase
+笔触，不新增单笔选择、缩放或旋转；也不改其他 Mask 的合成规则。缓存设置 UI 不在本次修复范围。
+本阶段处理这些输入必需的释放、取消和过期回执；NM7.13 保留完整项目生命周期矩阵，NM7.14–NM7.15
+保留全平台恢复和打包资格验证。当前平台上的六项真实 viewer 验收不能依赖后续阶段才能通过。
+
+#### NM7.12R.1 — 代码证据与复现入口
+
+以下是 2026-09-10 工作树的静态调查。用户现象是问题输入；表内实现事实并不等于运行时根因
+已经确认。执行时先记录当前 commit、工作树、Qt 版本、RAW、viewport、DPR、backend 和 build type，
+通过生产 `EditorAdjustmentHeader.qml` 的 Brush 按钮复现，再把原因与测试绑定。
+
+| 问题 | 当前实现事实与调查位置 | 必须确认的运行时证据 |
+| --- | --- | --- |
+| 第一笔出现随鼠标转动的 Gradient | Header 已调用 `beginBrush()`。`EditorMaskCreationAdapter::handlePress` 与 `EnqueueAppendSample` 在通用创建分支中用“Radial，否则 Linear”构造 source；`BeginBrushTool`、`ApplyOwnerSource` 和 `SyncFromSession` 分别改变工具、source 与编辑状态。正常 Brush 分支本来应在此前返回 | 记录从按钮到首次按下、Append、owner consume、回执的 source kind、Brush tool、operation identity。分别断言文档 source、QSG display kind、实际 coverage；区分错误的是控件还是蒙版本身。覆盖先选 Gradient/Radial 再点 Brush，以及 owner 回执延迟 |
+| 笔触出现在笔尖左上方 | `EditorWorkspace.qml` 直接传 `point.position`；`MakeSample` 通过共享 mapper 转 ReferenceSpace。`PublishDisplayedGeometry` 又用 `imageWidth/imageHeight` 与 document crop/rotation 重建 geometry；它不是直接接收当前照片帧的 resolved geometry。`PointHandler.onActiveChanged(false)` 仍读取可能已经清零的位置 | 同时记录事件所属 Item、映射后的 item/reference/local 点、当前帧 geometry identity、实际像素质心。不能只做同一函数的正反变换测试，也不能先认定是 DPR 或固定偏移 |
+| 单点既像把手又像笔尖 | `MakeBrushExistingOverlayDisplay` 只把 `placement_translation` 映射成一个 `BrushMove` 点；该点不是笔触范围中心。`PublishOverlay` 在 Paint/Erase 未按下时也进入这一显示分支；`handleHover` 只更新把手命中，没有独立笔尖跟随。`setBrushTool` 只发状态通知，未立即重建 overlay | 空闲 Paint、绘制中、提交后、Erase、Move 的 production QML/QSG 截图与命中测试；验证状态切换后首帧即正确 |
+| Erase 看起来没用 | owner 已有 `BrushStrokeMode::Erase`，rasterizer 已有 `min(previous, 255-dab)`；按钮存在不等于 mode、目标、dirty 和 native Mix 都正确。其他启用 Mask 的 max 合成也可能覆盖被擦除区域 | 先用单 Brush、enabled=true、invert=false、opacity=1、非恒等 Grade 验证，再加其他 Mask；检查中间 source R8、最终 Grade R8、照片与 history |
+| 绘制卡顿，提交后调参数流畅 | 每条 Append 都先调用 `SetBrushStrokeParameters`，再调用 `AppendMaskInput`；前者即使参数未变化也可能 `ApplyLiveBrushDraft`。`DraftStroke` 复制当前完整 sample 前缀，`ComposeDraftBrush` 复制 strokes 容器；overlay 每次复制整条 item path。native 没有 active override 时经 `ParameterizedBrushActiveRasterForGrade` 完整重放并把 dirty 标成全图 | 分别测事件、GUI 发布、排队、owner 更新、规范重放、上传、羽化、Union/Mix 和显示。session 当前已把一个 consume batch 汇总成一次渲染，不能把每次 draft 更新错误描述为一次 GPU render |
+| 默认无羽化 | `BrushMaskSource::feather_radius` 默认 0；adapter/input hardness 默认 1；`BeginBrushStroke` 新建分支使用空 Brush 默认值，面板 Feather reset 也写 0 | 第一笔按下到释放后的 canonical source、Feather 数值、边缘剖面一致；旧 Brush 的显式 0 不被加载流程改写 |
+
+重点源文件入口：
+[adapter](../../../../../alcedo_studio/src/ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp)、
+[controller](../../../../../alcedo_studio/src/app/editor_mask_creation_controller.cpp)、
+[serial session](../../../../../alcedo_studio/src/app/editor_session_service.cpp)、
+[mapping](../../../../../alcedo_studio/src/ui/edit_viewer/mask_edit_geometry.cpp)、
+[overlay layout](../../../../../alcedo_studio/src/ui/edit_viewer/mask_overlay_layout.cpp)、
+[native replay bridge](../../../../../alcedo_studio/src/include/edit/runtime/compiled_grade_mask.hpp)、
+[full source replay](../../../../../alcedo_studio/src/edit/mask/parameterized_brush_raster.cpp)。
+
+#### NM7.12R.2 — Qt 输入与几何规则
+
+执行只使用 Qt 6.9 已有 API。下列官方在线页可能显示更新版本；不使用其中标注晚于 6.9 的功能。
+
+| Qt 一手文档 | 对本次修复的约束 |
+| --- | --- |
+| [Qt Quick 坐标系统](https://doc.qt.io/qt-6/qtquick-visualcanvas-coordinates.html) 与 [Item 映射](https://doc.qt.io/qt-6/qml-qtquick-item.html#mapToItem-method) | 输入坐标属于具体 Item。边界上用 `mapToItem`/`mapFromItem` 转到 viewer logical coordinates；不能手减侧栏宽度、margin 或标题栏高度 |
+| [handlerPoint](https://doc.qt.io/qt-6/qml-qtquick-handlerpoint.html#details) | `position` 相对 handler 的 parent；释放或由其他 handler 处理后可能归零。必须在有效事件交付中取值，不能在 inactive 回调把 `(0,0)` 当作真实释放点 |
+| [PointHandler](https://doc.qt.io/qt-6/qml-qtquick-pointhandler.html) 与 [PointerHandler](https://doc.qt.io/qt-6/qml-qtquick-pointerhandler.html#signals) | 被动观察不代表独占输入；区分正常 release、`canceled` 和 grab 转移，携带真实 device/point 标识，一条输入只产生一个终止结果 |
+| [DragHandler](https://doc.qt.io/qt-6/qml-qtquick-draghandler.html#target-prop) | `target: null` 让业务层维护位置。Paint 必须从 press 接收输入，不等 drag threshold；Move 不得让 handler 自动移动 QML Item 再把同一个位移应用到 source |
+| [QQuickItem](https://doc.qt.io/qt-6/qquickitem.html#updatePaintNode) 与 [Scene Graph](https://doc.qt.io/qt-6/qtquick-visualcanvas-scenegraph.html) | GUI 修改控件数据后请求 `update()`；QSG 更新与节点复用在同步/渲染边界完成。`updatePaintNode` 执行期间 GUI 被阻塞，因此不能在其中做长路径扫描、重放或 GPU 等待 |
+
+**统一坐标链：** 令 `p_h` 为 handler parent 的逻辑坐标，`p_v` 为 viewport 逻辑坐标，
+`G` 为当前已显示照片对应的 `ResolvedRenderGeometry`，`t` 为 Brush 的参考像素平移。
+
+```text
+p_v = handlerParent.mapToItem(viewportItem, p_h)
+u_d = ViewportMapper::WidgetPointToImageUv(p_v, widget, photograph, zoom, pan)
+u_p = roi.origin + u_d * roi.extent           only for RoiFrame
+u_p = u_d                                   otherwise
+p_render = (u_p.x * G.render_extent.width, u_p.y * G.render_extent.height)
+p_reference = G.render_to_reference * (p_render.x, p_render.y, 1)
+p_local = p_reference - t
+
+display(p_local) = MapReferenceToItem(G, p_local + t)
+```
+
+`ViewportMapper` 已处理内部 DPR 转换；QML 不再乘一次 DPR。RoiFrame 的 ROI 展开、full-frame
+zoom/pan 和 DetailPatch 呈现规则只在共享 mapper 实现一次。ReferenceSpace 始终是完整参考图，
+不能用缩小后的 Interactive 纹理或 DetailPatch 宽高重新定义。Orientation、裁切、旋转、
+expand-to-fit 和取整后的 render extent 必须来自照片实际采用的 geometry。
+上式先展开 ROI，因此 `G.render_extent`/矩阵必须对应整张 photograph；如果帧携带的是 patch
+局部矩阵，则先在现有 geometry owner 转成同一整图表示，不能再把展开后的 UV 乘 patch extent。
+
+修复步骤：
+
+1. 在现有 presentation/session 边界发布已接纳照片帧的 resolved geometry 与 frame identity，
+   供 `EditorInteractionController` 读取；移除 adapter 每次 `PublishOverlay` 重新推导照片几何
+   的职责。只发布映射所需字段，复用现有 geometry 表示，不复制图像或另建可编辑 document。
+2. press 时锁定本次 operation 的 mapping identity；Append/Release 若身份变化则有序取消，
+   不能把一条笔触的前后半段写入不同坐标系。无有效 geometry 的 press 返回明确错误。
+3. 用真实终止事件坐标采样最后一段；若现有 QML 回调无法保证事件仍有效，则在现有 Qt/C++
+   输入边界提取 release，再路由到 adapter。不得用归零点，也不得用“最后 move 点”悄悄丢失
+   release 独有的最后一段。保留独立 hover 点，仅用于控件，不作为已绘制 sample。
+4. 规范 R8 第 `(i,j)` 个像素中心对应 `((i+0.5)*W/Rw, (j+0.5)*H/Rh)`；native 输出像素中心
+   经现有 `MakeRasterMaskSamplingPlan` 采样。不要在输入或显示端补一个经验性半像素偏移。
+5. 笔尖外形从参考像素圆映射：`p_reference + r*(cos(theta), sin(theta))`。仿射映射非等比时是
+   椭圆，不能只映射 x 方向半径再画屏幕圆；映射为等比时可用中心与标量半径的快速路径。
+   控件线宽/命中宽度保持逻辑像素，笔刷半径与 feather 保持参考像素。
+
+独立数值用例：6000×4000 参考图在 900×700 viewer 中 fit，照片矩形为 `(0,50,900,600)`。
+viewer 点 `(225,200)` 必须对应参考点 `(1500,1000)`；同一行列和中心点在 DPR 1、1.25、1.5、2
+下不变。另用有已知裁切与 90° 旋转的手算点验证矩阵顺序；不能以生产 mapper 生成预期值。
+
+#### NM7.12R.3 — 工具状态与两套控件
+
+**状态归属：** owner 决定可接受的工具和 operation；adapter 只持有当前输入及显示所需的最小数据。
+排队成功不等于 owner 已接受。请求/回执至少携带现有 session identity、`NodeId`、`MaskId`、
+sequence 和工具选择修订标识；旧回执不能覆盖用户刚选择的 Brush，也不能把旧 Gradient source
+重新发布到它的 overlay。未产生 `MaskId` 时仍可准备笔刷参数和显示 hover 轮廓。
+
+| 状态 | 可见控件与输入 | 退出与历史 |
+| --- | --- | --- |
+| Paint ready，包含首次新建 | 跟随鼠标的空心笔刷轮廓；可显示羽化外边界；不显示 Move 点/框。已有 Brush 保持原位 | press 立即进入 Painting；单击也产生一个规范 dab |
+| Painting | 只绘制，任何位置按下都不会移动原笔触；平移参数固定；Size/Strength 变化使用明确参数边界 | release 后等待 owner settle；首次有效笔触一个 `AddMask`，之后每笔一个 `AppendBrushStroke`；随后回 Paint ready |
+| Erase ready / Erasing | 与 Paint 同坐标和半径的轮廓，以短划线区分；不复用实体圆点。只对当前已存在 Brush 擦除 | release 提交一个 Erase stroke；随后回 Erase ready。没有已提交 Brush 时禁用 Erase |
+| Settling | 尚未取得提交结果时禁止 Move 和目标切换造成的半完成编辑；笔尖显示仍可跟随 hover | owner 回执决定可用性；失败取消未完成数据并显示具体错误，不虚报提交 |
+| Move ready | 当前累计 Brush 的边界框与四角短线锚点；框内、边框和锚点统一表示整体平移 | press 命中框内或边框才进入 Moving；框外不绘制；不显示缩放/旋转鼠标图标 |
+| Moving | 原框整体随指针移动，照片在 release 前更新；没有笔尖控件 | release 一个 `SetBrushTranslation`；取消恢复原平移；不新增 StrokeId |
+
+Move 是用户明确切换的工具；release 后继续保留 Paint/Erase，方便连续画多笔。只有已提交 Brush
+且没有打开的 stroke/field edit/待确认 settle 时允许 Move。来自 Node drawer 的 Brush 选择进入
+可移动的编辑态；工具栏 Brush 按钮则明确进入 Paint。切换都必须立即重建 overlay 和鼠标形状。
+Paint/Erase 期间隐藏并禁用平移的指针及键盘入口，owner 同时拒绝交错 BeginMove；仅禁用 UI 不够。
+下一笔可作为新 sequence 排在前一笔 Finish 之后；接收新笔不能等待 Quality 帧或缓存落盘。
+owner 的提交回执、照片呈现回执分开处理，旧笔 settle 回执不得清掉已开始的新笔 cursor 或工具。
+
+**删除歧义分支：** 按 `MaskSourceKind` 明确分发 Brush/Radial/Linear；解析型创建函数只接收解析型
+source，错误 kind 直接拒绝。不能把任何“不是 Radial”的情况构造为 Linear。`BeginBrushTool`
+先确定 Paint 再填 command settings，避免 `EnqueueBrushSettings` 用先前的工具值覆盖请求。
+`ApplyOwnerSource` 同步选中 source 时保留或明确恢复当前合法工具，不能无条件改变输入模式。
+
+**边界框几何：** 在 owner 的只读笔触查询上计算参考像素中的保守范围，按 source revision 缓存
+派生 bounds，禁止在每次 hover 扫描整套 strokes。所有 strength>0 的 Paint dab 的圆形支持域
+取包围盒，包含各自 radius，再按 source feather 支持范围与采样边界向外扩展。Erase 不扩大
+这个框；擦除后可以保留保守框，以便移动和 Undo，不能宣称它是实际非零像素的精确轮廓。
+框不受 invert 后的全图 coverage 支持域影响，也不因裁切把源几何永久缩小。
+
+```text
+B_local = AABB(union of positive-strength Paint dab supports)
+B_reference = expand(B_local, feather_support) + placement_translation
+frame_vertices = MapReferenceToItem(each of the four B_reference corners)
+t_after = t_before + (reference_at_current_pointer - reference_at_press)
+```
+
+保留映射后四边形的四个角，图片旋转时框也对应旋转，不把它再压成屏幕轴对齐框。空范围不创建
+伪造中心点；全擦除但仍有 Paint 历史时可保留原保守框。框外不可见时保留面板键盘移动能力。
+命中区域只与 viewport 可见区相交，crop 样式只复用视觉 token 与线段绘制，不复用 crop 的缩放动作。
+拖动包括所有 Erase 记录的整个 Brush；各 sample body 不改写、不重采样。细线、四角锚点、cursor
+内外轮廓全部走现有 retained QSG，不用逐 dab QML Item，不增加覆盖区域填色。
+
+#### NM7.12R.4 — Erase 的真实像素与历史
+
+沿用已持久化的规范算法，不在 UI 修复中更换擦除数学：
+
+```text
+a8 = clamp(floor(255 * DabCoverage(distance, radius, strength, hardness) + 0.5), 0, 255)
+paint: b_next = max(b_previous, a8)
+erase: b_next = min(b_previous, 255 - a8)
+source strokes in order -> source feather -> invert -> opacity -> enabled Mask max -> Grade Mix
+```
+
+满强度中心的 `a8=255` 必须把已画源像素变成 0；半强度 `a8=128` 将 255 限到 127；重复相同
+半强度擦除仍为 127，这不是持续流量式擦除。不得为了“看得见”改成逐帧乘法衰减。先证明
+feather=0 时逐字节结果，再验证默认 feather 下符合已有羽化公式的软边，不把羽化后的数值当作
+原始 Erase R8。平移后的 Brush 必须先减当前 `placement_translation` 再记录擦除点。
+
+Erase 与 Paint 共用 Begin/ordered Append/Finish，但每笔 mode 在 Begin 固定，不能中途被异步
+选择回执改回 Paint。dirty 区域清理并按 stroke 顺序重放；不能只用 max 把结果叠上去。擦除某个
+Mask 后重算其他启用 Mask 的贡献，不能直接清零整个 Grade Mix。单 Brush 测试后增加重叠 Radial，
+断言 Brush 已减少而重叠处最终 Mix 仍由 Radial 决定；面板说明擦除作用于当前 Brush。
+
+取消丢弃未提交 Erase；Undo 移除该记录并重放，Redo 恢复同一记录。strength=0 或确认未改变任何
+规范源像素的笔触不产生历史提交；不能仅凭最终照片没变化判为无效，因为其他 Mask、invert 或
+恒等 Grade 可能隐藏当前 Brush 的变化。无 Brush 时不允许创建空的 Erase-only Mask。
+
+#### NM7.12R.5 — 默认羽化与参数含义
+
+本阶段将新建 Brush 的默认源羽化确定为短边的 **0.5%**：`f0 = 0.005 * min(W,H)`。
+保留现有初始半径 `r0 = 0.01 * min(W,H)`，因此初始羽化半宽为 `r0/2`。这是新增的产品默认值，
+不是从其他 Mask 的不同单位参数直接复制来的数值。6000×4000 图像的初始 radius=40 px、
+diameter=80 px、source feather=20 px。Strength=100%，dab hardness=1 保留，软边由同一个
+source feather 求值，避免同时修改两套软边语义。
+
+- 在 owner 的新建 Brush 操作中设置 `feather_radius`，在首个 provisional dab 发布之前可见，
+  与首个 `AddMask` 一起持久化。不要只改 QML 数值，也不要全局改反序列化默认值。
+- `brush.feather` 是整组累计 Brush 的源参数，单位为参考像素；不是每条笔触的新字段。改变
+  Size 不联动已存在 source 的 feather，追加到旧 Brush 时保留它原本的 feather，包括显式 0。
+- 未创建时面板显示下一次新建 Brush 的 feather，允许设置；创建后显示 owner 值。新建前参数
+  调整不写历史。已有 Brush 的 Feather 拖动使用一个字段编辑和一次 settle；reset 使用 `f0`，
+  用户仍可手动设 0。加载/重进编辑器不触发 setter 提交，不替换旧项目数值。
+- 明确 Size 显示的是直径还是半径。本阶段面向用户显示“笔刷直径”，像素值为 `2r`，百分比与
+  slider 两端也使用直径；adapter 的既有 radius API 仍用半径，只在面板边界转换一次并测试。
+- 显示空心的 dab 半径轮廓与外羽化提示线，不能把提示线承诺为复杂累计 coverage 的精确等值线。
+  默认 feather 必须从绘制中的第一帧使用，释放时不允许突然由硬边换成软边。
+
+#### NM7.12R.6 — 持续绘制性能与所有权修复
+
+**已有快慢差异的解释范围：** settle 后只调 Grade 参数可以复用已有效的 Mask 结果；画笔不断改变
+source，会触发 sample 发布、重放、上传与羽化。两条路径开销不同是合理的，当前实现中的重复工作
+必须去除。`GradeMaskCoverage` 的 host 区域重放测试通过，不证明 `cuda_mask_pass.cu` 等 native
+生产入口已经使用区域重放；必须在真实入口统计调用次数和处理像素数。
+
+按以下顺序实现，各步都保持完整分辨率、现有算法和用户选择的 backend：
+
+1. **事件接收与显示：** GUI 仅做坐标映射、提交最小输入和更新独立 cursor。hover 更新为 O(1)；
+   同一 Qt 帧只发布一次显示几何。创建引导线使用有界的派生显示数据或追加已有几何，禁止每事件
+   复制全部 `brush_item_path_`。显示简化不得删改 canonical samples 或代替真实照片更新。
+2. **有序批处理：** 保留每个 Paint/Erase 输入及真实参数变化边界，按序消费；一个 serial cycle
+   内完成整批采样后发布一次 source 变化/dirty 通知和最多一次 Interactive 请求。Move 可合并
+   最新绝对值，Paint/Erase 不能这样丢掉弯折。Finish/Cancel 不被限速吞掉，也不跨 sequence 合并。
+3. **去除重复 draft 发布：** 参数没变时 `SetBrushStrokeParameters` 完整返回无变化结果；当前
+   sampler 已避免重复参数 sample，但 controller 仍需避免无变化的 source 重组。Append 没有
+   新规范 sample 时只更新 cursor，不发布 source revision。取消 `DraftStroke` 每次复制整个前缀
+   及 `ComposeDraftBrush` 每次复制已提交列表的做法。
+4. **最小 owner 操作：** `BrushMaskInput` 保持唯一未完成 sample 存储，通过有效生命周期内的
+   const view/新增 sample 范围交给串行求值；`ColorGradeNodeModel` 保持唯一已提交 source。
+   在 `WithLockedLiveDocument` 所属安全周期使用 owner 查询和 focused append/finish/cancel
+   操作，不再复制 source、改副本、写回。Finish 一次移动 sample body 到现有 immutable
+   `BrushStroke`，首次原子 AddMask，后续原子 AppendBrushStroke；取消通过丢弃 draft 和参数
+   重放恢复结果，不增加 R8 before-state。跨线程不能保留指向可增长 vector 的 span。
+   首笔在 Begin 分配 provisional `MaskId` 并在 live Grade 插入仅含源元数据的 Brush，草稿
+   samples 仍只由 input owner 持有；同一安全周期以 `DraftSamples()` 和已提交 source 求出
+   对应 active raster，再用现有 `ActiveRasterMaskInput` 按准确 NodeId/MaskId 送入 native
+   Mask pass。这样 compiled Mask 仍能找到目标，预览无需把草稿整个复制进 document。
+   Finish 把该 provisional Mask 的最终参数以一次 AddMask 提交，不能重复插入；Cancel 或
+   首笔确认无效时移除 provisional Mask。之后每笔的 draft 也经同一 active raster 路由。
+   request 持有的 raster 是必要算法输出，必须说明分配、reader、释放和 dirty 的有效内容来源。
+5. **把局部更新接进 native 入口：** 从新增 dab 支持域形成 outward-rounded dirty，使用空间
+   索引查询相交 stroke 并按原顺序重放，重算该区域内所有必要 Mask 的 Union。复用现有
+   `brush_rasterizer`、`brush_spatial_index`、`brush_source_geometry` 和 active raster 入口；
+   改进 `compiled_grade_mask.hpp` / `parameterized_brush_raster.cpp` 的完整重放调用链，不能
+   只优化没有接线的 host helper。索引追加新段，普通 Append 不重新索引全部历史。
+6. **保持单 Grade R8 限制：** 最终 Mix 已经丢失单个 Brush 的源值，不能在 Mix 上直接做 Erase
+   或用它反推出源 coverage。source/feather 中间结果只用 executor 管理的临时 scratch，按需
+   顺序复用；不新增每 Mask/Stroke/Version 的长期全图 R8。若上传资源不是同一合法旧内容，
+   必须先完整初始化；不能给新纹理只上传 dirty 矩形。读者释放前不原地改已发布资源。
+7. **默认羽化必须一起优化：** 现有 signed-distance pass 可能需要全域计算，dirty dab 小不代表
+   distance field 同样局部。优先消除同一 cycle 的重复重放/上传/羽化，复用分配与 pipeline。
+   若进一步做有限半径区域羽化，先从现有距离公式推导 dirty 扩展、读取 halo 与采样边界；
+   对 inside/outside、擦出洞、贴边、全擦除及相邻旧 stroke，与完整羽化逐像素对照。没有证明
+   等价前，不把全域羽化替换成只处理 dab 矩形。不能把 feather 临时设 0 或把 source feather
+   改成另一种 dab 算法来获得性能。
+8. **依赖与调度：** source 变化只失效受影响的 Mask/Union/Mix 和依赖结果，不重复 RAW decode
+   或清掉仍有效的上游 Grade 结果。继续使用现有 serial admission、revision 和 reader 释放
+   边界；磁盘写回不进入 pointer/owner 热路径。积压输入分批排空并保留顺序；容量不足时报告
+   真实错误并取消未完成笔触，不丢样本或切换 backend。
+
+**度量和通过标准：** 在同一 RAW、viewport、backend、构建和笔刷参数上对比修复前后，分别记录
+默认软笔、小硬笔、大软笔、1/100/1000 条已有笔触、冷/暖缓存、单 Mask/重叠多 Mask。固定轨迹
+包括直线、快速折线和圈，另测 125/500/1000 Hz 输入；sample 数、渲染次数和工作量同时报告。
+使用 Release 做时延资格验证，Debug 做诊断，不拿 Debug CUDA 的慢作为改质量理由。
+
+- 本阶段沿用 Section 12 的 16 ms Interactive owner-cycle 目标，并将普通默认笔刷暖态
+  p95 ≤ 16 ms 作为通过条件；给出 p50/p95/max 与完整硬件说明，不能只报平均帧率。
+- GUI 输入处理 p95 ≤ 1 ms；cursor 应在下一个可用 Qt frame 反映最新位置。60 Hz 空闲显示下
+  event-to-cursor p95 ≤ 16.7 ms；故意阻塞 native render 时仍不等待 GPU 或文档锁。
+- 默认笔刷暖态 event-to-photo p95 ≤ 33.4 ms（60 Hz），持续输入结束后积压必须排空；单独
+  记录 source replay、upload bytes、feather、Union/Mix、queue depth 和 release-to-Quality。
+- 同一无参数变化的轨迹分批方式不同，最终 samples/R8 完全一致；源列表发布次数不随原始
+  pointer event 逐次增长；不存在反复复制长度递增前缀造成的累计二次工作量。
+- 大软笔或高重叠的确切最坏成本必须报告；若默认场景未达到目标，状态仍为 partial，并在当前
+  原算法/backend 内继续优化，不能以“其他参数已经流畅”判为通过。
+
+#### NM7.12R.7 — 文件职责与调用链
+
+| 位置 | 修复职责 |
+| --- | --- |
+| `ui/alcedo_main/qml/EditorWorkspace.qml` | 明确事件 parent/viewport 转换；有效 release/cancel；输入设备和单 sequence 路由；工具对应鼠标形状 |
+| `ui/alcedo_main/qml/EditorAdjustmentHeader.qml`、`EditorMasksContextPanel.qml` | 首次 Brush 入口；Paint/Erase/Move 可用性；直径/Strength/Feather 的单位与 reset；source 加载只读 |
+| `ui/alcedo_main/album_backend/editor_mask_creation_adapter.cpp` 及头文件 | typed source 分发；工具选择回执校验；独立 cursor；立即发布工具切换；消费 bounds，不持有可编辑 Brush 镜像 |
+| `ui/editor_rhi/editor_interaction_controller.cpp`、presentation/session 边界 | 当前已显示帧的 geometry 和 identity；共享正反映射；操作中映射变化的取消 |
+| `ui/edit_viewer/mask_overlay_layout.cpp`、`mask_overlay_geometry.cpp`、`ui/editor_rhi/editor_overlay_item.cpp` | Brush 边界四边形、四角锚点、平移命中、空心笔尖与 QSG 节点复用 |
+| `app/editor_mask_creation_controller.cpp`、`brush_mask_input.cpp`、`app/editor_session_service.cpp` | 新建默认羽化；批量输入与一次发布；唯一 draft 生命周期；提交/取消；禁止 Paint 与 Move 交错 |
+| `edit/graph/color_grade_node_model.cpp` 及头文件、`edit/mask/brush_*` | owner 的最小更新/只读查询、不可变已提交 samples、派生范围/索引、确定性重放 |
+| `include/edit/runtime/compiled_grade_mask.hpp`、`edit/mask/parameterized_brush_raster.cpp`、native Mask passes、`PlanExecutor`/`GraphImageCache` | 区域工作接入真实 backend；正确资源初始内容、羽化依赖、单 Grade R8 和 revision/reader 安全 |
+| `alcedo_main/DESIGN.md`、AppTheme | 记录 Brush cursor、移动框和参数含义；复用 crop/Mask 线宽与配色，新增 token 时同步定义 |
+
+上表源路径均相对 `alcedo_studio/src/`。执行前统计完整文件 LOC。adapter/controller 当前已经很大，
+新增 cursor/框范围逻辑应放入对应 geometry 模块；draft 生命周期由已有 `BrushMaskInput` 承担。
+只有状态归属确实分离才抽出新类型，不用拆几个方法文件或新增整包可变 context 假装解耦。
+新 public API 说明线程、owner、view 有效期、失败与原子更新边界；头文件包含类型定义。
+
+**成功调用链（目标）：**
+
+```text
+Header Brush / Mask panel Paint or Erase
+  -> adapter requests exact tool + target -> serial owner accepts -> ready controls
+Qt valid pointer event -> map parent to viewport -> displayed G -> reference/local sample
+  -> ordered input queue -> safe serial consume -> BrushMaskInput canonical sample append
+  -> owner scoped source read + open-stroke view -> dirty replay / native feather / Union
+  -> one current Grade R8 -> native Grade Mix -> accepted Interactive photograph
+Release with valid endpoint -> finish canonical samples -> AddMask or AppendBrushStroke
+  -> one durable history commit -> owner completion -> ready controls -> Quality
+Move frame press -> BeginMove -> current-reference minus press-reference
+  -> SetBrushTranslation live operation -> old/new domain replay -> Interactive pixels
+  -> release -> one SetBrushTranslation history commit -> Move ready
+```
+
+**取消/失败调用链（目标）：**
+
+```text
+grab cancel / mapping identity change / invalid target / rejected command
+  -> fence remaining sequence input -> owner Cancel -> discard open samples or restore translation
+  -> recompute affected current result -> no unfinished history entry -> ready/error UI
+late owner/frame completion -> compare session + target + sequence/revision -> reject stale display
+allocation / native / history failure -> original error -> discard unpublished output
+  -> keep valid committed document/history and prior successful displayed result
+  -> report failed operation; no alternate algorithm, quality, backend, or cache directory
+```
+
+#### NM7.12R.8 — 必须新增或加强的验收
+
+测试名称如下是待实现验收，不是已存在或已通过声明。复用现有 target；生产入口整合测试建议
+新建 `EditorBrushInteractionQmlTest`（`tests/ui/editor_brush_interaction_qml_test.cpp`），加载
+实际 workspace/header/panel + 真 adapter/串行 owner，而不是仅用 fake model 回显按钮值。
+新目标必须注册到 `tests/ui/CMakeLists.txt` 并执行非零测试。
+
+| 行为 | 测试名称 | 层次/目标与核心断言 |
+| --- | --- | --- |
+| 第一笔类型 | `FirstHeaderBrushPressProducesOnlyBrushSource` | 新 QML target；真实按钮后从 press 到 release 均为 Brush，只有规范 dab coverage，没有 Linear source/guide |
+| 异步切换 | `DelayedAnalyticSelectionCannotReplaceArmedBrush` | 新 QML target + `EditorSerialMaskInteractiveTest`；延迟旧选择回执，Brush source/tool/目标不倒退 |
+| 单击与释放 | `BrushClickRecordsOneDabAtReleasePosition`、`BrushReleaseDoesNotAppendResetOrigin` | 新 QML target；无 move 的单击一次提交；release 独有末段不丢，inactive 归零不产生左上拖尾 |
+| viewer 偏移 | `BrushPointerMatchesPhotoPixelsWithOffsetViewport` | 新 QML target；非零父 Item 偏移、面板宽度变化及已知照片点，校验 cursor 与真实像素，不只比 mapper 往返 |
+| 几何矩阵 | `BrushReferenceMappingMatchesIndependentCropRotationPoints` | `MaskEditGeometryTest`；横/竖图、orientation、crop、旋转、fit/100%/zoom/pan、DPR 1/1.25/1.5/2，手算预期点 |
+| 帧几何 | `BrushMappingUsesPresentedFrameAcrossDetailPatch` | `MaskEditGeometryTest` + 新 QML target；完整参考图不被 Interactive cap/ROI extent 替换，几何变更取消未完成笔触 |
+| 笔尖形状 | `BrushCursorMatchesMappedReferenceCircle` | `MaskOverlayControlTest`；非等比仿射下轮廓为正确椭圆；中心误差 ≤ 0.25 logical px，轮廓离散误差 ≤ 0.25 logical px |
+| Paint 锁定平移 | `PaintingOverMoveFrameNeverChangesBrushTranslation` | 新 QML target + `AccumulatingBrushCreationTest`；新增笔触期间 translation 与既有 samples 不变，Move/键盘平移禁用 |
+| 移动框 | `MoveFrameEnclosesTranslatedPaintSupportWithFeather`、`MoveFrameDragTranslatesAllStrokesWithoutScaling` | `MaskOverlayControlTest` + `AccumulatingBrushCreationTest`；四角/边/内部命中；照片 release 前变化；sample body 身份不变；一次平移提交 |
+| 模式显示 | `PaintEraseAndMovePublishDistinctControlsImmediately` | 新 QML target；hover 无按键即可跟随；Paint/Erase 没有 Move 点；Move 没有笔尖；不出现缩放鼠标形状 |
+| Erase 数学 | `EraseStrokeReducesCoverageAtPointerBeforeRelease` | `AccumulatingBrushCreationTest` + `GpuDagCudaMaskTest`；硬边满/半强度的手写 R8 预期、默认软边的独立距离预期，真实照片在 release 前变化 |
+| Union 与平移 | `ErasingMovedBrushPreservesOtherMaskContribution` | `GpuDagCudaMaskTest`；正确 local 坐标、选中 MaskId、重叠 Radial 保留；错误目标像素不变 |
+| 擦除历史 | `EraseUndoRedoRestoresExpectedSourceCoverage`、`ZeroStrengthBrushInputCreatesNoCommit` | `AccumulatingBrushCreationTest` + 现有参数笔触持久化测试；精确 HEAD/次数/重放像素；取消不留空 stroke |
+| 默认软边 | `FirstBrushDabUsesDefaultSourceFeather`、`ExistingZeroFeatherBrushKeepsItsStoredValue` | owner + 新 QML target + native；首帧到 settled 参数/边缘一致；新建、reset、保存重开；旧值 0 保留 |
+| 参数显示 | `BrushDiameterAndFeatherControlsUseReferencePixelUnits` | `EditorAdjustmentHeaderQmlTest` / 新 QML target；40 px radius 显示 80 px diameter，Feather=20 px/0.5%，load-only 零提交 |
+| 批处理 | `OrderedBrushBatchPublishesOneChangedSourceRevision`、`UnchangedBrushParametersDoNotRepublishDraft` | `EditorSerialMaskInteractiveTest`；Append sample 不丢，参数没变不重复发布；每个消费批次最多一个 source 通知/Interactive 请求 |
+| 重放等价 | `PartitionedBrushInputProducesIdenticalCanonicalPixels`、`NativeRegionalBrushUpdateMatchesCompleteReplay` | `BrushCanonicalSamplerTest`、`BrushRegionalReplayTest` + `GpuDagCudaMaskTest`；不同事件分组同样本同 R8，其他 Mask 的幸存贡献一致 |
+| 羽化区域 | `RegionalBrushFeatherMatchesCompleteFeatherAtDirtyBoundary` | host/native；halo、洞、图像边缘、全擦除、不同半径；未实现区域羽化时仍验证完整原算法，不能声称区域优化通过 |
+| 响应与资源 | `BusyNativeRenderDoesNotBlockBrushCursorOrCancel`、`BrushDrawingKeepsOneRetainedGradeCoverage` | 新 QML target + `EditorSerialMaskInteractiveTest` + native；延迟 reader 时 GUI 可动、无同步等待/源竞争，无每笔 R8 文件 |
+
+**比较方法：** 原始 canonical R8 使用手算/独立完整重放，要求逐字节一致；native 插值/羽化结果
+沿用已有容差，通常最多 1 个 R8 code，不能为通过测试放宽。照片用非恒等 Grade 和确定的输入
+像素验证 Mix 公式，并给出最大误差、失败坐标。像素质心比较要计入明确的 R8/native 采样误差，
+不能把亚像素栅格离散误差与系统性坐标偏移混为一谈。几何正反变换是补充，不替代照片像素。
+
+**生产 UI 资格验证：** 在 260/320/460 px 面板宽、两种主题及 reduceMotion 下完成六项场景；
+用真实 Qt 鼠标事件按按钮和绘制，保留 Windows D3D11 overlay 与 CUDA 照片的截图、像素证据
+及 NM7.12R.6 时延记录。没有对应设备的 Metal/OpenCL 项标为未执行，不用另一 backend 代测。
+未来执行时遵守 MSVC wrapper，并从 `ctest -N` 确认实际注册目标；命令和完整结果写回本节。
+
+**实施顺序：** R.1 先加失败复现与工作量计数；R.2/R.3 完成映射和工具隔离；R.4/R.5 完成擦除
+和默认软边；R.6 在默认羽化开启的真实管线上优化；R.8 完成 UI/native/时延证据。编号按本节引用，
+不得进入生产标识符、测试文件或目标名称。
+
+**退出清单（本次全部保持未勾选）：**
+
+- [ ] 第一笔及从解析型 Mask 切换后的第一笔，无 Gradient source/控件串入。
+- [ ] 指针、QSG 笔尖、reference/local samples 与实际照片在完整几何矩阵内对齐。
+- [ ] Paint/Erase 与 Move 输入完全分离；移动框有四角锚点，整体移动而不缩放。
+- [ ] Erase 在 release 前改变当前 Brush 的真实 coverage，Union、取消、Undo/Redo 均正确。
+- [ ] 新 Brush 第一帧即带默认羽化，参数单位/reset 一致，旧项目数值不被重置。
+- [ ] 默认羽化开启时通过绘制时延目标；无完整前缀重复复制，无未授权的质量/backend 替换。
+- [ ] 生产 QML、owner、native 像素和异步测试均有非零执行记录；结果与截图可追溯。
+- [ ] 无新增 source 镜像或未说明必要性的拷贝；只读 view 生命周期、唯一 owner、reader 边界明确。
+- [ ] 同步记录真实修复文件、主要调用链、测试数量、工作量/时延分布及未执行平台。
+
+**本次规划记录：** 阅读相关生产调用链和既有测试入口，核对上列 Qt 官方文档；只修改本计划的
+状态、依赖表与 NM7.12R 节。历史 NM7.12 完成记录不删除，六项修复不标记完成。
+
+##### Phase NM7.12R implementation record (2026-09-10, win_debug, CUDA 12.8)
+
+**Status:** partial — all six regressions have wired implementation and unit/host/GPU
+coverage; release-build latency qualification, the real-adapter QML harness, and Metal
+execution remain open.
+
+**Primary success call chain:**
+
+```text
+Header Brush / panel Paint-Erase -> adapter stamps source_kind + tool + diameter/feather
+  -> queued BeginInput (ordered, identity-fenced)
+  -> EditorSessionService::ApplyMaskCreationCommand (serial, per-batch)
+  -> controller BeginMaskInput(kind fence) -> BeginBrushStroke
+  -> BrushMaskInput canonical samples -> provisional ApplyLiveBrushDraft / AppendBrushStroke
+  -> workspace ParameterizedBrushReplayCache (regional dirty, retained index + shared pixels)
+  -> ActiveRasterMaskInput(content_revision, dirty_rectangle)
+  -> CUDA/OpenCL partial upload -> mask Mix -> presented frame
+Release -> FinishBrushStroke -> AddMask (first stroke) / AppendBrushStroke -> Settling
+Move drag -> BeginMaskMove(BrushMove fence) -> SetBrushTranslation live ops
+  -> release -> one SetBrushTranslation commit
+FramePresent -> submission.geometry = plan.geometry -> DirectFrameSink::NotifyFrameReady
+  -> EditorViewportItem::NotePresentedMaskGeometry (stale-id fence)
+  -> PresentedMaskGeometryChanged -> interaction->setDisplayedMaskGeometry
+  -> maskEditViewMapping().geometry used by adapter MakeSample + overlays
+```
+
+**Primary failure / fencing chain:**
+
+```text
+mapping identity change mid-stroke -> adapter CancelIfMappingChanged
+  -> owner Cancel -> discard open stroke samples -> controls back to armed
+stale pointer identity / wrong source kind -> owner Reject before mutation
+history publish failure -> RestoreLive + Failed state, no half-committed document
+dirty replay throw -> entry invalidated; next call re-rasterizes full
+erase on no mask / Move on no selection / wrong handle kind -> owner Reject
+```
+
+**What was proven (executed tests):**
+
+| Criterion | Target / binary | Result |
+| --- | --- | --- |
+| Brush creation/erase/move/undo/no-commit | `AccumulatingBrushCreationTest` | 14/14 PASS |
+| Analytic fencing, kind separation, handle drag | `AnalyticMaskCreationTest` | 34/34 PASS (mask_creation+edit labels) |
+| Reference/item mapping, presented geometry | `MaskEditGeometryTest` | PASS (mask_edit label, 5/5) |
+| Move frame quad, corner ticks, dashed cursor, hit-test | `MaskOverlayControlTest` (3 new cases) | 16/16 PASS |
+| Regional replay == full evaluation, erase undo, union | `BrushRegionalReplayTest` | 6/6 PASS |
+| Replay cache identity/dirty/eviction | `ParameterizedBrushReplayCacheTest` (new) | 10/10 PASS |
+| Sampler determinism under event grouping | `BrushCanonicalSamplerTest`, `BrushSpatialIndexTest` | PASS |
+| CUDA dirty-rect upload, feather, union | `GpuDagCudaMaskTest` (+ fixtures) | PASS |
+| OpenCL dirty-rect upload, revision fencing | `GpuDagOpenClGradeTest.OpenClMaskFixture` | PASS (50/50 GPU mask tests) |
+| Diameter semantics, Erase gating, tool switcher | `EditorAdjustmentHeaderQmlTest` | PASS (workspace_qml label) |
+
+Commands: `scripts/msvc_env.cmd --build --preset win_debug --parallel 4`;
+`ctest -R <suites> --output-on-failure` from `build/debug`.
+
+**Checklist (honest state):**
+
+- [x] First press creates `BrushMaskSource` only; analytic creation is kind-fenced.
+- [x] Pointer mapping consumes the presented frame's `ResolvedRenderGeometry`; mapping
+      changes cancel open strokes.
+- [x] Paint/Erase/Move are distinct inputs and controls; Move frame uses translated
+      Paint-support bounds with corner ticks and interior hit-test.
+- [x] Erase replays `min(prev, 255-dab)` regionally; verified on host, CUDA, OpenCL.
+- [x] New Brushes apply `0.5%`-of-short-edge default feather from the first dab;
+      existing explicit 0 is preserved.
+- [x] Continuous drawing replays only dirty regions through a retained workspace cache;
+      immutable shared pixel snapshots; CUDA/OpenCL upload dirty rectangles.
+- [ ] `EditorBrushInteractionQmlTest` (real workspace + real adapter + serial owner)
+      — not created; QML coverage is header/panel level.
+- [ ] Release-build p95 ≤ 16 ms drawing latency measurement — not executed.
+- [ ] Metal pass — source updated for the new API; not compiled or executed (no Metal
+      host in this environment).
+- [ ] Production viewer evidence at 260/320/460 px, both themes, real pointer events —
+      not executed.
+
+**LOC note:** largest touched files — `editor_mask_creation_adapter.cpp` (~1500 LOC,
+kept; brush cursor/geometry lives in `mask_overlay_layout`/`mask_overlay_geometry`),
+`editor_mask_creation_controller.cpp` (dispatch + stroke lifecycle), new
+`parameterized_brush_replay_cache.hpp/.cpp` (~200 LOC, workspace-retained).
+
+**Remaining gaps:** latency qualification on a release build, real-adapter QML harness,
+Metal compile/run, and full-viewer pointer evidence remain open and must be reported
+against NM7.12R acceptance rather than assumed.
 
 ### NM7.13 — Complete cancellation and project/session lifecycle
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,17 +2,16 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.11 complete; NM7.12–NM7.15 planned. This document records the NM7.1 source
+Status: NM7.1–NM7.12 complete; NM7.13–NM7.15 planned. This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
 shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
 NM7.7 Radial/Linear creation plus existing-mask movement, NM7.8 parameter-mask
 controls, drawer selection/deletion, and crop-style Gradient, NM7.9 accumulating
 Brush paint/erase/move with typed stroke history, NM7.10 serial Interactive Mix
-with one current Grade coverage result, and NM7.11 project Mix-cache storage plus
-Keep/DeleteOnProjectClose cleanup. Some former NM7.11 UI wiring (now NM7.12) was
-brought forward for Radial/Gradient testing. This is partial wiring of the full UI
-phase. NM7.12–NM7.15 acceptance remains outstanding.
+with one current Grade coverage result, NM7.11 project Mix-cache storage plus
+Keep/DeleteOnProjectClose cleanup, and NM7.12 production Mask controls plus project
+storage UI. NM7.13–NM7.15 acceptance remains outstanding.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -1719,6 +1718,112 @@ controls, focus rules, theme/width/reduced-motion tests and QML registration.
 `ProjectClearExplainsThatBrushHistoryIsRetained`.
 
 **Exit:** production QML at 260/320/460 px in both themes; no unregistered/unused-only implementation.
+
+##### Phase NM7.12 completion record (2026-09-10)
+
+**Status:** complete — Mask value/Brush editing controls on the Mask page, keyboard move,
+and project Mix-cache settings UI on production QML.
+
+**Resolved decisions and actual files/APIs:**
+
+- `EditorMaskCreationCommandKind::{BeginMaskField, SetMaskField}` queue typed Mask value edits;
+  `BeginMaskFieldEdit`/`ApplyMaskFieldValue` live-apply then settle `SetMaskField` for
+  `enabled`/`invert`/`opacity`/`display_name` and `ReplaceMaskSource` for `brush.feather`.
+  `CancelMode`/`RemoveMask` prune queued field commands in `editor_session_service.cpp`.
+- `EditorMaskCreationAdapter` exposes `maskEnabled`/`maskInvert`/`maskOpacityPercent`/`maskName`,
+  `setMaskEnabled`/`setMaskInvert`/`setMaskName`, `beginMaskOpacity`/`updateMaskOpacity`,
+  `beginBrushFeather`/`updateBrushFeatherPercent`, `brushRadiusPercent`/`setBrushRadiusPercent`,
+  `setBrushStrengthPercent`, `setBrushTool`, and `maskNudgeAvailable`/`beginMaskNudge`/`nudgeMaskBy`.
+  Keyboard move reuses the pointer `BeginMove`/`Append`/`Finish` route with a panel-pointer
+  identity and `open_via_panel_`.
+- `EditorMasksContextPanel.qml` adds the Brush section (Paint/Erase/Move segments, Size,
+  Strength, Feather), Mask values (name, enabled, invert, opacity) and a keyboard Position
+  nudge control; existing objectNames for the analytic controls are unchanged.
+- `EditorMonoSlider.qml` gains `activeFocusOnTab`, arrow-key stepping (Shift = 10×), and
+  `Accessible` Slider role/increase/decrease actions; every key step runs
+  `onBegin → onUpdate → onFinish` so one press is one settled edit.
+- `ProjectModule` publishes `maskCacheState` (`available`, `projectName`, `projectUuid`,
+  `chosenRoot`, `effectiveRoot`, `retention`, `fileCount`, `byteCount`, `pendingWrites`,
+  `dirty`, `lastError`, `applyError`) plus `ApplyMaskCacheRoot`/`ApplyMaskCacheRetention`/
+  `ClearMaskCache`/`RefreshMaskCacheState` over `ProjectService`.
+- `ProjectMaskCacheSettingsPanel.qml` is a separate Settings > Cache section with a root
+  FolderDialog, Keep/DeleteOnProjectClose combo, usage rows, revision-aware reload and Clear;
+  thumbnail settings in `CacheSettingsPanel.qml` are untouched. Registered in
+  `alcedo_main/CMakeLists.txt` and hosted by `SettingDialog.qml` with apply-on-OK and reset-on-open.
+
+**Primary success call chain:**
+
+```text
+Mask page control -> EditorMaskCreationAdapter invokable
+  -> EditorMaskCreationCommand{BeginMaskField|SetMaskField|BeginMove|Append|Finish}
+  -> EditorSessionService queue -> EditorMaskCreationController
+  -> live apply (Interactive preview for pixel fields)
+  -> PublishMaskFieldEdit / PublishSettledBatch
+  -> MakeSetMaskFieldBatch | MakeReplaceMaskSourceBatch -> MiniGitWorkingHistory commit
+  -> maskCreationChanged -> panel republish
+Keyboard Arrow on nudge area -> beginMaskNudge -> SelectMask + BeginMove(handle)
+  -> nudgeMaskBy -> Append samples -> Keys.onReleased -> finishAnalyticControl -> Finish
+Settings OK / Apply -> ProjectMaskCacheSettingsPanel.applyPending
+  -> ProjectModule::ApplyMaskCacheRoot / ApplyMaskCacheRetention
+  -> ProjectService::SetMaskCacheRoot / SetMaskCacheRetention -> settings_revision++
+  -> MaskCacheStateChanged -> reloadPending
+```
+
+**Primary cancel/failure call chain:**
+
+```text
+Mask edit rejection -> result.error; queued SetMaskField for a different field while a
+  field edit is open -> rejected; CancelMaskInput restores before_field_value_/source
+  with no commit; removeMask/CancelMode drop queued field commands
+ApplyMaskCacheRoot/Retention failure -> ProjectService error string -> applyError -> visible
+  status row; no temporary-root substitution
+Clear -> ProjectMaskCacheService generation fence -> MaskCacheStateChanged refresh;
+  hint text states Brush strokes/history survive and cache rebuilds
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `MaskPageActivatesOnlyForSelectedOrCreatingMask` | `EditorAdjustmentHeaderQmlTest` | PASS |
+| `MaskSelectionDoesNotSubmitOrJumpScroll` | `EditorAdjustmentHeaderQmlTest` | PASS |
+| `KeyboardMaskMoveUsesSameInteractiveRoute` | `EditorAdjustmentHeaderQmlTest` | PASS |
+| `MaskPageBrushSectionRoutesToolSizeStrengthAndFeather` | `EditorAdjustmentHeaderQmlTest` | PASS |
+| `MaskPageLoadsAtPanelWidthsInBothThemesWithoutMotion` (260/320/460 × 2 themes, reduceMotion) | `EditorAdjustmentHeaderQmlTest` | PASS |
+| `CacheSettingsTargetSelectedProjectOnly` | `ProjectMaskCacheSettingsQmlTest` | PASS |
+| `ProjectClearExplainsThatBrushHistoryIsRetained` | `ProjectMaskCacheSettingsQmlTest` | PASS |
+| `ErrorsSurfaceFromProjectModuleState` | `ProjectMaskCacheSettingsQmlTest` | PASS |
+| Field one-shot/drag/cancel/unselected commits | `AccumulatingBrushCreationTest` (`OneShotMaskFieldEditsPublishTypedHistory`, `MaskFieldDragSettlesOneCommit`, `MaskFieldEditCancelRestoresLiveValueWithoutHistory`, `MaskFieldEditRequiresSelectedMask`) | PASS |
+
+Commands:
+
+```text
+cmake --build build/macos-debug-tests --target EditorAdjustmentHeaderQmlTest \
+    ProjectMaskCacheSettingsQmlTest AccumulatingBrushCreationTest AnalyticMaskCreationTest \
+    EditorAdjustmentControlQmlTest EditorSerialInputBoundaryTest MaskOverlayControlTest -j 8
+QT_QPA_PLATFORM=offscreen ./build/macos-debug-tests/alcedo_studio/tests/ui/<binary>
+```
+
+Suite totals (macOS `macos-debug-tests`, Qt 6.9.2, offscreen QPA): required names 9/9 PASS;
+`AccumulatingBrushCreationTest` 14/14; `AnalyticMaskCreationTest` 20/20;
+`EditorAdjustmentHeaderQmlTest` 16/16; `ProjectMaskCacheSettingsQmlTest` 3/3;
+`EditorAdjustmentControlQmlTest` 8/8; `EditorSerialInputBoundaryTest` 7/7;
+`MaskOverlayControlTest` 13/13. `alcedo_main` links in `macos-debug`.
+
+**Checklist / exit condition:** required tests PASS. Production Mask page loads at
+260/320/460 px under both themes with reduceMotion enabled; Brush tool segments, Size,
+Strength, Feather and Mask name/enabled/invert/opacity all route through the adapter;
+arrow-key nudge takes the same BeginMove/Append/Finish interactive route; project cache
+section is separate from thumbnail cache, applies through `ProjectModule`, surfaces
+`applyError`, and Clear explains that Brush strokes/history are retained.
+
+**Residual gaps:** real-viewer/pointer Brush qualification and packaged D3D11/Metal capture
+are NM7.15. Open-operation cancel on `MappingChanged`, grab cancellation and project-switch
+fencing beyond current hooks are NM7.13. Cacheless reopen rebuild is NM7.14. The settled
+native Mix still is not enqueued into the project cache writer from the serial owner.
+`.r8mask` files and the recent-project list retain their existing KeepFiles behavior.
+Ordinary adjustment Mask writes still fail with the existing “until NM3” text.
+NM6.8–NM6.9 remain planned.
 
 ### NM7.13 — Complete cancellation and project/session lifecycle
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -4,7 +4,9 @@ Date: 2026-09-08
 
 Status: NM7.1–NM7.12 completion records retained; NM7.12R implemented and partially
 verified (release latency, real-adapter QML harness, and Metal still open);
-NM7.12RR planned as one complete repair phase; NM7.13–NM7.15 planned.
+NM7.12RR partial — CUDA GPU stamp (2026-09-11) plus first-drag pointer routing
+and equivalent-mapping keep-open (2026-09-12); erase persistence, parallel EDT,
+and viewer latency remain; NM7.13–NM7.15 planned.
 This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
@@ -2282,7 +2284,7 @@ against NM7.12R acceptance rather than assumed.
 
 ### NM7.12RR — 一次完成连续绘制、擦除稳定性和真实管线性能修复
 
-**Date / source:** 2026-09-10，调查工作树 HEAD `fb95653f`。**Status:** planned。
+**Date / source:** 2026-09-10，调查工作树 HEAD `fb95653f`。**Status:** partial（2026-09-12 first-drag input + CUDA GPU stamp）。
 本次只研究当前实现、核对 Qt/CUDA 一手资料并制定方案；没有重新运行用户的 RAW 绘制过程，
 没有测得各环节耗时。以下区分源码可确认的执行行为、可以数学证明的判断问题和待复现的因果链。
 
@@ -2560,6 +2562,108 @@ Failed GPU work -> invalidate pending content/base -> retain valid published res
 
 本阶段任一条未满足时保持 partial，列出本阶段剩余工作并继续处理；不能再命名一个补修子阶段
 把这些退出条件移走。其他原有 NM7.13–NM7.15 内容仍按原范围保留。
+
+##### Phase NM7.12RR completion record (2026-09-11)
+
+**Status:** partial — CUDA authoring stamps GPU R8 from stroke commands; only new dabs are
+applied on draft growth. Host full-R8 replay is no longer on the CUDA Mask path.
+
+**Primary success call chain:**
+
+```text
+ReplaceMaskSource / live BrushMaskSource
+  -> ExecuteCudaMask (no injected ActiveRasterMaskInput)
+  -> DetectBrushCoverageUpdate vs BrushCoverageCommandJournal
+  -> ApplyParameterizedBrushCuda StampNewSamples | ReplayDirty
+  -> encode coverage from GPU R8 mip 0 (no unused mip fill on the feather path)
+  -> Union / Grade Mix
+```
+
+**Primary failure call chain:**
+
+```text
+unsupported algorithm, empty destination, or CUDA launch error
+  -> ApplyParameterizedBrushCuda / ExecuteCudaMask throw
+  -> no CPU raster substitute; journal and uploaded flag are not treated as success
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `GpuOrderedBrushRasterMatchesCanonicalR8Bytes` | `GpuDagCudaMaskTest` | PASS |
+| `GrowingBrushStampsNewDabsWithoutHostRasterUpload` | `GpuDagCudaMaskTest` | PASS |
+| `EraseAppendStampsWithoutHostRasterUpload` | `GpuDagCudaMaskTest` | PASS |
+| `PlacementMoveReplaysDirtyAndMatchesCanonicalR8` | `GpuDagCudaMaskTest` | PASS |
+| `ReleasedGpuSourceRestampsFromCommands` | `GpuDagCudaMaskTest` | PASS |
+| `FeatherChangeReusesGpuSourceWithoutHostRasterUpload` | `GpuDagCudaMaskTest` | PASS |
+| `RegrownDraftStrokeStampsOnlyNewDabSupport` | `ParameterizedBrushReplayCacheTest` | PASS |
+| `GrownDraftStampsOnlyNewSamples` | `ParameterizedBrushReplayCacheTest` | PASS |
+| `CurrentGradeCoverageHasOneRetainedResult` (Mix vs host coverage) | `GpuDagCudaMaskTest` | PASS |
+
+Commands: `cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target ParameterizedBrushReplayCacheTest --target GpuDagCudaMaskTest` then `ctest --test-dir build/debug -R "ParameterizedBrushReplayCacheTest|GpuDagCudaMaskTest" --output-on-failure`
+
+Suite totals: `56/56` PASS (19 CPU coverage/replay + 37 CUDA mask, including prior mask cases)
+
+**Checklist / exit condition:** GPU ordered raster is on the production CUDA Mask pass and
+matches the CPU oracle byte-for-byte on the executed cases. Remaining NM7.12RR boxes stay
+unchecked: first-drag QML input, erase persistence across Quality/history, parallel exact
+EDT, DraftStroke prefix copy, event-to-photo latency, OpenCL/Metal GPU stamp.
+
+**LOC note (grill-code-review):** `cuda_mask_pass.cu` 620; `brush_coverage_update.cpp` 203;
+`cuda_brush_raster.cu` 193; `brush_rasterizer.cpp` 172; new types stay under 250 LOC each.
+No file crossed 1000.
+
+**Residual gaps:** `BrushMaskInput::DraftStroke` still allocates a new sample body each
+read. OpenCL/Metal still replay through `ParameterizedBrushReplayCache` on the host.
+Regional Mix is not used: `AcquireTextureForWrite` still allocates a new unpublished
+slot, so a partial Mix would leave uninitialized dest texels. Parallel banding EDT still
+launches one thread per row/column. Viewer latency was not measured on this change.
+
+##### Phase NM7.12RR completion record (2026-09-12)
+
+**Status:** partial — first left-press+drag while Brush owns the left button forwards
+the whole pointer path; Quality/Interactive equivalent item→reference mapping no longer
+cancels the open stroke.
+
+**Primary success call chain:**
+
+```text
+EditorWorkspace PointHandler (Mask owns left; double-tap disabled)
+  -> handlePress / handleMove / handleRelease (last valid item point)
+  -> Enqueue BeginInput + ordered Append + Finish
+  -> ConsumePendingMaskCommands -> BeginBrushStroke / UpdateBrushPaint / FinishBrushStroke
+```
+
+**Primary failure call chain:**
+
+```text
+grab cancel (PointHandler canceled)
+  -> cancelOpenPointerInput -> Cancel (stroke only; tool stays armed)
+viewChangeReported with equivalent Quality/Interactive F
+  -> MappingChanged false -> stroke stays open
+real zoom/pan/widget/full-reference change
+  -> CancelIfMappingChanged -> Cancel open stroke
+```
+
+**What was proven (executed tests):**
+
+| Required name / criterion | Target / binary | Result |
+| --- | --- | --- |
+| `FirstBrushDragWithoutPriorClickPaintsWholePath` | `EditorBrushInteractionQmlTest` | PASS (press + ≥4 moves + one release; no pan; double-tap off) |
+| `QualityToInteractiveEquivalentMappingKeepsBrushOpen` | `MaskEditGeometryTest` | PASS |
+| `SamePhotographInteractiveExtentKeepsItemToReference` | `MaskEditGeometryTest` | PASS |
+| MaskEditGeometryTest suite | `MaskEditGeometryTest` | 7/7 PASS |
+
+Commands: `cmd /c scripts\msvc_env.cmd --build --preset win_debug --parallel 4 --target MaskEditGeometryTest --target EditorBrushInteractionQmlTest --target AlcedoMainQml` then `ctest --test-dir build/debug -R MaskEditGeometryTest --output-on-failure` and `ctest --test-dir build/debug -R EditorBrushInteractionQmlTest --output-on-failure`
+
+Suite totals: `7/7` MaskEditGeometryTest PASS; `1/1` EditorBrushInteractionQmlTest PASS
+
+**Checklist / exit condition:** first-drag pointer routing and equivalent-mapping keep-open are implemented and tested. Remaining NM7.12RR boxes stay unchecked: production Main.qml coverage pixels, erase persistence, parallel exact EDT, DraftStroke prefix copy, event-to-photo latency, OpenCL/Metal GPU stamp.
+
+**LOC note (grill-code-review):** `EditorWorkspace.qml` PointHandler block stayed in-file; `mask_edit_geometry.cpp` MappingChanged + reconstruct helpers; adapter gained `cancelOpenPointerInput`. No file crossed 1000.
+
+**Remaining gaps:** Main.qml + RAW e2e for this drag hung/segfaulted under offscreen RHI in this session, so coverage-at-mid/end on a live Grade is not proven here. Rebuild `alcedo_main` to exercise the production workspace. Erase, EDT, and latency work remain in this phase.
 
 ### NM7.13 — Complete cancellation and project/session lifecycle
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -4,7 +4,8 @@ Date: 2026-09-08
 
 Status: NM7.1–NM7.12 completion records retained; NM7.12R implemented and partially
 verified (release latency, real-adapter QML harness, and Metal still open);
-NM7.13–NM7.15 planned. This document records the NM7.1 source
+NM7.12RR planned as one complete repair phase; NM7.13–NM7.15 planned.
+This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
 shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
@@ -14,7 +15,8 @@ Brush paint/erase/move with typed stroke history, NM7.10 serial Interactive Mix
 with one current Grade coverage result, NM7.11 project Mix-cache storage plus
 Keep/DeleteOnProjectClose cleanup, and NM7.12 production Mask controls plus project
 storage UI. The six reported Brush regressions require NM7.12R acceptance before Brush UI
-can be considered qualified. NM7.13–NM7.15 acceptance remains outstanding.
+can be considered qualified. Newly reported second-scale drawing, first-drag input loss,
+and erased-content reappearance are covered by NM7.12RR. NM7.13–NM7.15 acceptance remains outstanding.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
@@ -605,7 +607,8 @@ transitions immediate, and input-following geometry is never animated behind the
 | NM7.11 | Project-owned cache settings, writeback and cleanup service | NM7.3, NM7.10 |
 | NM7.12 | Production Mask controls and project storage UI | NM7.11 |
 | NM7.12R | Repair Brush tool state, pointer alignment, move frame, erase, drawing cost and default feather | NM7.5–NM7.12 |
-| NM7.13 | Interruptions, late jobs and complete lifecycle | NM7.12, NM7.12R |
+| NM7.12RR | Complete continuous Brush input, stable Erase, GPU execution and measured viewer responsiveness in one phase | NM7.12R implementation |
+| NM7.13 | Interruptions, late jobs and complete lifecycle | NM7.12, NM7.12R, NM7.12RR |
 | NM7.14 | Native pixel, persistence, cache bounds and recovery qualification | NM7.13 |
 | NM7.15 | Real viewer/package/performance qualification and NM8 handoff | NM7.14 |
 
@@ -2276,6 +2279,287 @@ kept; brush cursor/geometry lives in `mask_overlay_layout`/`mask_overlay_geometr
 **Remaining gaps:** latency qualification on a release build, real-adapter QML harness,
 Metal compile/run, and full-viewer pointer evidence remain open and must be reported
 against NM7.12R acceptance rather than assumed.
+
+### NM7.12RR — 一次完成连续绘制、擦除稳定性和真实管线性能修复
+
+**Date / source:** 2026-09-10，调查工作树 HEAD `fb95653f`。**Status:** planned。
+本次只研究当前实现、核对 Qt/CUDA 一手资料并制定方案；没有重新运行用户的 RAW 绘制过程，
+没有测得各环节耗时。以下区分源码可确认的执行行为、可以数学证明的判断问题和待复现的因果链。
+
+**本阶段必须交付的整体能力：** Brush/Erase 从第一次 press 起即可连续拖动，不需要先点一下；
+擦除在绘制、释放、Quality 回帧、下一次编辑和 Undo/Redo 后保持正确；默认羽化开启时，实际照片
+随输入连续更新，消除秒级逐帧重绘。Windows CUDA/D3D11 是本次用户问题的直接资格验证路径。
+共享接口改动必须保持 OpenCL/Metal 的既有语义，分别列出编译/执行证据，不能用其他 backend
+替代 CUDA，也不能将未运行的平台说成通过。
+
+**执行约束：** NM7.12RR 只有一个实施范围、一个完成记录和一套退出条件。下文各项是同一阶段
+内必须完成的工作，不再生成 RR.1、RR.2、A/B 或新的补修阶段。输入、擦除、GPU、资源生命周期、
+真实 QML 测试和性能测量都完成才可写 complete；不能再次以“实现已接线，实际拖动/时延以后测”
+作为交付。NM7.12R 的历史记录保留，其未完成的真实 adapter harness 和本机时延验证并入本阶段。
+
+**对“是否每帧生成 R8、是否没有走 GPU”的回答。** 当前路径是 CPU 与 GPU 混合，不是全 CPU，
+也不是已有 GPU 计算就自然足够快：
+
+```text
+Qt input -> adapter -> ordered queue -> serial controller
+  -> DraftStroke copies growing samples -> ComposeDraftBrush -> live source replacement
+  -> ParameterizedBrushReplayCache -> CPU index rebuild / dirty-region rasterization
+  -> shared host R8 -> CUDA active texture acquire -> initial full / later dirty upload
+  -> full mip generation -> full inside/outside distance transform when bytes changed
+  -> feather sampling -> enabled Mask Union -> Grade Mix -> D3D11 photograph presentation
+```
+
+`ParameterizedBrushReplayCache` 已保留 host 像素，`ActiveRasterTextures().Acquire` 也有 GPU
+资源复用，所以**不能说每一帧必然新分配一张纹理**。但源码仍显示下列重复计算，必须分别计时：
+
+| 已确认的执行行为 | 精确位置 | 性能或正确性含义，及尚缺的证据 |
+| --- | --- | --- |
+| 当前 canonical R8 长边上限为 4096，按参考图比例向上取整 | `brush_raster_encoding.cpp::CanonicalBrushRasterExtent` | 6000×4000 参考图产生 4096×2731，约 10.67 MiB R8；不是每次完整 6000×4000 R8，也不能进一步降低上限来掩盖慢 |
+| 增长中的 draft 每次生成新的完整 sample body，source 列表也复制 | `BrushMaskInput::DraftStroke`、`ComposeDraftBrush`、`UpdateBrushPaint` | 无新增 dab 的事件已有早退，但有新 dab 时仍复制旧前缀；一个 batch 的每条有效 Append 仍会发布 source，不能把一批一次 render 当作一批一次 source 更新 |
+| dirty 比较依据 sample body 指针；增长的同一 StrokeId 会计算整条旧/新 stroke 的支持域；每次非空 dirty 重建完整索引 | `parameterized_brush_replay_cache.cpp::BrushReplayDirtyTexels / Replay` | “区域重放”不是“仅新 dab”；长笔划越画越贵，弯曲路径的大包围盒包含大量空白。现有 `RegrownDraftStrokeReplaysItsGrownSupport` 测试正好接受这种扩大行为 |
+| CPU raster 内逐 dab、逐像素计算距离、覆盖与 R8 写入 | `brush_rasterizer.cpp::StampDab / ReplayRegion` | overlap 多时大量重复 host 工作；仅做 GPU 上传局部化没有消除 CPU 栅格化成本 |
+| 每次更高 content revision 上传 dirty 后仍生成完整 mip，并标记 `raster_bytes_changed=true` | `cuda_mask_pass.cu::ExecuteCudaMask` | 只改 feather/invert/opacity 或相同像素的 revision 也要核对是否被当成 source 像素变化；空 dirty 伪造 1×1 上传会触发多余工作 |
+| 源像素变化后，inside/outside 两套 EDT 都扫描完整 canonical raster，再组合距离场 | 同文件 `must_compute`、`ParallelBandHorizontalKernel`、`ParallelBandVerticalKernel` | 羽化不是 CPU 算，但每行/列一个 block，且 launch 的 block size 是 **1**；单线程串行扫描整行/列，不能仅凭函数名把它视为高并行实现 |
+| 纵向 EDT 每个 block 的动态 shared memory 为 `height*(sizeof(int)+sizeof(float))` | 同文件 vertical kernel launch | 4096×2731 源约 21.34 KiB/block，竖图高度 4096 时为 32 KiB/block，却只有一个执行线程；需用 profiler 验证实际占用率、访存与 GPU 时间 |
+| 距离场及 horizontal/inside/outside 共四个源大小 float buffer | 同文件 scratch 分配 | 上述 4096×2731 示例约 170.69 MiB，仅是这四个 buffer；实际峰值还含 R8、mip、Mask outputs 与照片。分清保留分配和逐帧计算，不能靠一个 R8 字节数解释全部成本 |
+| 本地 Debug 的该 `.cu` 实际编译 flags 含 `-G` | `build/debug/build.ninja` 的 `cuda_mask_pass.cu.obj`；根 `CMakeLists.txt` 的 CUDA Debug 选项 | device debug 会抑制优化，是放大器；尚未确认用户运行的 exe/DLL 就是这份 Debug。必须核对进程模块和同 commit Release，不能把换 Release 当成全部修复 |
+
+CPU/GPU、分配/计算、submit/complete 必须分别计时。使用 [CUDA 12.8 性能指南](https://docs.nvidia.com/cuda/archive/12.8.0/cuda-c-best-practices-guide/index.html)
+分析访存、warp 与 shared memory 约束，按 [NVCC 12.8 文档](https://docs.nvidia.com/cuda/archive/12.8.0/cuda-compiler-driver-nvcc/index.html)
+识别 `-G` 与优化配置。GPU launch 的 CPU 返回耗时不是 kernel 耗时；使用同 stream CUDA events，
+需要时间线时使用 [Nsight Systems](https://docs.nvidia.com/nsight-systems/UserGuide/index.html)，
+不能为计时在每个子步骤增加同步而改变原始调度。
+
+**先把三个用户现象放进同一条可追踪输入序列。** 从生产 Header 点击 Brush/Erase，直接 press →
+移动至少 5 个非共线点 → release；不提前点照片、不提前给 adapter 注入选择。对比“先单击后拖动”
+并分别覆盖冷首帧、Quality 已显示、Interactive 已显示、首次创建/已有 Brush、快速连续两笔。
+记录 `device/point/sequence`、按钮、事件阶段、Qt grab、adapter open/tool/target、owner state、
+sample 数、command kind、content revision、frame role、request id 与 terminal reason。
+计数与时间戳写入可开关诊断，临时结果仅存 `build/tmp/brush_continuous_input/`。
+
+重点排查以下路径，取得真实日志或失败测试后在同一阶段修复：
+
+- `EditorWorkspace.qml` 当前仍由 PointHandler 转发，inactive 回调直接当 Release；没有在这里
+  区分正常释放与取消。`handlerPoint` 在释放后可能归零，不能把它作为终点。设备 id/point id
+  也不能由 adapter 固定为 1。Qt 对这些行为的说明见 [handlerPoint](https://doc.qt.io/qt-6/qml-qtquick-handlerpoint.html)。
+- PointHandler 是被动 grab，Qt 文档说明它可继续观察其他独占 grab 期间的移动；不能照抄旧
+  QML 注释就断定 TapHandler 一定吞掉它的 move。实际查 active/point/grab 的交付顺序，见
+  [PointHandler](https://doc.qt.io/qt-6/qml-qtquick-pointhandler.html)。当前 DoubleTap 仍只按
+  `editorControlsEnabled` 开启；Mask 拥有左键时需要隔离双击缩放，防止额外的 view change。
+- `CancelIfMappingChanged` 使用 `MaskEditMappingIdentity` 的逐字段相等；其中包含 render
+  extent、render_to_reference 和呈现模式。Quality/Interactive 换表示时可以字段不同而最终
+  指针映射相同。`ConnectInteraction` 对任何 `viewChangeReported` 都取消也需一并审计。
+  意外 Cancel 会调用 RestoreLive，能造成 draft Erase 的像素重新出现；这条链是高优先级
+  假设，但本次未复现，不能写成用户问题已经定位。
+- `DirectFrameSink::NotifyFrameReady` 在最终 slot gate 之前发送 geometry，
+  `NotePresentedMaskGeometry` 主要按 request id 递增接纳。必须证明 geometry 属于实际已接纳
+  显示的帧，而不是“准备好但未展示”的帧；图像/session identity 也必须参与校验。
+- Erase 回现还要区分四种结果：draft 被 Cancel、Finish 未写入 Erase、host/GPU source 不一致、
+  较旧照片覆盖新照片。逐层读取同一 revision 的 source 字节、effective Mask、Union 和最终帧，
+  不用“有缓存”或“UI 问题”代替具体失败原因。
+
+**输入修复必须保证的行为。** 工具 arm 和第一笔 Begin 保持顺序；在 owner 尚未返回新 `MaskId`
+时也能接收同一 sequence 的后续点。每条有效 move 全部到达规范 sampler；保留弧长插值和参数
+变化边界，不采用仅保存最后坐标的合并。press 立即记录首个 dab，release 使用仍有效的事件终点，
+只产生一个 Finish；cancel/grab loss 只产生一个 Cancel。下一笔排在前一笔 Finish 后即可接收，
+不等待 Quality 或缓存落盘。旧工具/旧笔回执不得清空当前新笔或把 Erase 改回 Paint。
+
+保留单一真实事件写入者。先修现有 PointHandler 的路由和终止语义；若其 QML 回调确实不能在
+当前 Qt 6.9 保证有效 release，则将这套完整 press/move/release/cancel 接收到一个 Qt Quick
+输入 Item，由其持有该设备点的输入；不能再额外加第二个 DragHandler 同时向 owner 写 sample。
+hover 只更新 cursor。pan/crop/双击缩放按工具所有权仲裁；越界释放仍结束原笔，第二触点和
+合成鼠标不能触发重复提交。沿用 [PointerHandler 的取消与 grab 信号](https://doc.qt.io/qt-6/qml-qtquick-pointerhandler.html#signals)。
+
+**用最终几何判断输入是否仍有效。** 把 item → ReferenceSpace 的组合变换作为同一性的基础：
+
+```text
+F = render_to_reference * diag(render_width, render_height, 1)
+    * displayed_uv_to_photograph_uv * item_to_displayed_uv
+
+6000×4000 Quality:     render_to_reference = I,             extent = 6000×4000
+3000×2000 Interactive: render_to_reference = diag(2,2,1),   extent = 3000×2000
+Both give identical F when viewport, crop, orientation, zoom and pan are unchanged.
+```
+
+上述两组 raw fields 不相等，数学上的组合映射却相等；直接按字段取消会把正常换分辨率当作
+坐标变化。对两个 affine `F` 比较有效照片域的角点及测试点，使用明确浮点误差界限，并与原有
+≤0.25 logical px 控件精度一致；image/session、参考图、crop/orientation 语义身份单独校验。
+不把任意近似变化视为相等，更不能整体移除变化校验。等价 Quality/Interactive/ROI 表示切换
+保持笔触；真实缩放/平移/裁切变化按既定策略有序取消，并给出原因。映射发布与呈现 frame 的
+接纳保持同一顺序，修复前后都用独立已知照片点验证，不只做 mapper 自己的往返。
+
+**Erase 的来源、提交和帧发布必须连续一致。** 每条 stroke 的 Paint/Erase mode 在 Begin 固定，
+只作用于准确的 Grade/Mask。继续使用规范 R8 的 `paint=max(b,a8)`、`erase=min(b,255-a8)`；
+GPU 并行不能打乱顺序。满强度擦除后的源像素在没有后续 Paint/Undo 的情况下不得增大。
+该单调性先断言原始 Brush R8；羽化、invert、其他 Mask max 对最终照片的影响另按公式验证。
+
+资源更新以成功完成为准，不能仅以“已排队上传”或较大 revision 判定内容有效：
+
+- 当前 cache 的 `SharedPixels()` 返回 const handle，但其底层 buffer 仍被 rasterizer 原地
+  修改；const shared_ptr 不提供不可变性。明确串行 reader 的持有区间，在所有 CPU/GPU
+  reader 结束前禁止覆盖，测试故意保留 reader。不能为解决它默认每帧复制整张 R8。
+- CPU replay 的 dirty 与 GPU texture 的已完成 base revision 必须匹配。跳过、中断、失败的
+  upload 后，下一次 dirty 若只相对最近 host source，就可能漏掉较早的擦除；按 GPU 实际
+  base 累积变更区域，或在内容未知时从参数执行同一精确重建，不能继续用未初始化旧像素。
+- `SetUploadedPixels`、distance field、effective coverage、Union/Mix 的 pending/completed
+  revision 分开维护，失败使相关未完成结果失效；不得让失败的源更新保留“已上传成功”标签。
+  session/geometry/algorithm/storage identity 改变时清理对应资源，不靠默认 generation=1。
+- 最终照片的接纳除 request 序号外还应验证当前 document/edit revision 与 session。已经显示
+  Erase revision N 后，不得显示未包含该 Erase 的旧 Quality/Interactive 结果，即使其 request
+  编号较大。取消恢复帧应是当前 owner 新的合法状态，不能伪装成陈旧帧绕过校验。
+- Finish 必须提交完整已接受的 Erase sample；无效笔判断不能误丢真实变化。
+  `BrushEraseOverlapsPaint` 当前是 erase×paint dab 的双重遍历，使用空间索引避免 release
+  时另一个长停顿；同时验证无重叠/已擦空/半强度/移动后擦除/下一笔 Paint 的语义。
+- cache 错误注入验证条目原子失效。NM7.12R 记录称 replay throw 会 invalidate，但当前 Replay
+  函数未见对应事务/异常清理；需实测并落实，不能继承记录中的保证。
+
+**性能实现目标：CPU 管输入和有序命令，GPU 管像素。** 本机 CUDA authoring 热路径应去掉
+host 全图 R8 的生成/复制/上传往返。R8 仍是现有 coverage 格式，canonical 分辨率、量化、笔触
+算法版本、source feather 与最终 Mix 语义保持不变；转移计算设备不授权修改图像质量。
+
+同一个 phase 内完成以下整套实现，不能只优化其中一层：
+
+- `BrushMaskInput` 唯一持有可增长 draft，已提交 samples 仍由 document owner 持有现有
+  immutable body。通过安全作用域读取和明确新增 sample 范围消费；一个 serial batch 内
+  接收全部有序点后，仅发布一次 changed source revision/Interactive 请求。取消每事件
+  `DraftStroke` 全前缀复制、`ComposeDraftBrush` 列表复制与 source JSON 往返，Finish 一次
+  移动最终 body 并发布历史。draft/source 不新增平行镜像。
+- 为 GPU 上传新增规范 dab/参数边界和所需 tile 索引，按实际变更上传命令；同一 stroke 的
+  未变前缀不重传。tile 中候选以 stroke/sample 顺序排列，每个输出像素按此序列计算 max/min。
+  不允许 Paint 与 Erase 对同一像素无序原子竞争。与现有 CPU 独立 oracle 比较 canonical R8
+  逐字节相等，包含半值量化、边缘、低强度、半径/硬度变化和重叠；不得用 fast-math 改变边界。
+- dirty 从新增 sample 支持域/实际 owner change 描述生成，索引只追加新增范围。Move、Undo、
+  删除、取消则涵盖 old/new 支持域，并重放所有相交贡献。用 tile 集合表达弯曲路径，避免把
+  整条长笔的包围盒当作每帧 dirty；若 dense/全域变化需要完整求值，明确统计其工作量。
+- 在 `PlanExecutor` 和 `cuda_mask_pass.cu` 的真实生产入口接入 GPU source 求值，不仅新增
+  独立 benchmark kernel。移除本机生产 authoring 对 `ParameterizedBrushReplayCache` host
+  像素缓存的依赖；CPU rasterizer 可作为独立测试 oracle，不作为 GPU 出错时的替代路径。
+- 用真正并行且精确的 Euclidean distance transform 替换当前每 block 单线程行/列扫描。
+  采用分带求解和并行合并的精确方法，可参考作者的 [Parallel Banding Algorithm](https://www.comp.nus.edu.sg/~tants/pba.html)。
+  保留 inside/outside 分类、半像素边界修正、部分 coverage 的距离赋值、双线性距离采样和
+  smoothstep 公式；不是换一个视觉相似的 blur。不能只把 block size 改为 256 后继续让
+  `threadIdx.x != 0` 的线程退出，也不能用未证明等价的近似距离算法代替。
+- 优先完成原分辨率精确 GPU EDT，使默认羽化下的全域必要计算也有效并行。区域距离优化如
+  为达标所需，则同阶段证明读取 halo、dirty 扩展、全擦除/无 inside 或 outside 和纹理边界；
+  特别注意现有路径先插值距离再羽化，不能未经证明先截断距离。没有等价证明就保留精确
+  全域计算并继续优化它，不降低 feather 或先硬边预览、release 再软边。
+- 区分 source-pixel revision、feather 参数和最终 Mask-field revision。source 未变且距离
+  scratch 仍在合法使用期内时，调整 feather 半径复用该距离，invert/opacity 只重算下游。
+  缺少有效中间结果时从规范命令做必要的精确 GPU 求值，并记录重建原因；不能为了声称零重算
+  延长每 Mask 全图 scratch 的有效内容保留期。Grade 自身参数改变应复用仍有效的最终 Mix。
+  未改变内容不再伪造 1×1 上传。soft 路径不生成根本不被读取的 R8 mip；需要 mip 的路径按
+  依赖更新并检查正确采样，不能粗暴删除所有 mip。
+- 当前 replay cache 每 `(Grade,Mask)` 保留一张 host R8（最多四项），已经与原计划“每 Grade
+  一个当前 Mix、source 只作临时 scratch”的要求有差距。此次不扩成每 Mask 的长期 GPU R8
+  副本。继续只保留每 Grade 的当前 Mix；源覆盖、EDT 工作区和 Union 中间结果由 executor
+  scratch 顺序复用，允许池保留分配，但不保留未经授权的多套有效历史内容。冷 cache 从命令
+  精确重建，失败显式返回；不能从最终 Mix 反推单个 Brush 源像素来做 Erase。
+- 新纹理/新 tile 首次使用先初始化完整依赖区域；source buffers、published outputs 和 reader
+  fence 生命周期写在定义处。必须等待的 GPU 边界只发生在 worker 的安全周期，GUI 不等待
+  `WaitIdle`、源重放、history 锁或缓存 I/O。保留有效 RAW/上游 Grade 结果，避免 Mask 编辑
+  重新 decode。照片依然在 press 到 release 之间实际更新，cursor 流畅不能替代照片流畅。
+
+**实施位置与责任。** 路径相对 `alcedo_studio/src/`；新增类型按职责命名，不把 NM 编号写进代码。
+
+| 文件/模块 | 本阶段结束时的责任 |
+| --- | --- |
+| `ui/alcedo_main/qml/EditorWorkspace.qml`、`ui/alcedo_main/album_backend/editor_mask_creation_adapter.*` | 一个输入写入者、真实终止事件、首拖不依赖预点击、模式仲裁与回执身份、独立 cursor |
+| `ui/edit_viewer/mask_edit_geometry.cpp`、`ui/editor_rhi/editor_interaction_controller.cpp` | 比较实际 item→reference 映射；等价表示切换不断笔，真实几何变化明确取消 |
+| `ui/editor_rhi/direct_frame_sink.cpp`、`editor_viewport_item.cpp` 及 presentation queue | geometry 与已接纳照片同序发布；session/edit revision 防止旧擦除前帧覆盖新结果 |
+| `app/editor_mask_creation_controller.cpp`、`brush_mask_input.cpp`、`editor_session_service.cpp`、`edit/graph/color_grade_node_model.*` | 唯一 draft 与 source owner，批量规范采样/一次更新，完整 Finish/Cancel、最小 owner mutation、history |
+| `edit/mask/brush_spatial_index.*`、`brush_source_geometry.*`、`brush_placement.hpp` | 追加索引、精确 dirty、Erase 有效性候选查询；现有 CPU raster 保留独立 oracle 职责 |
+| `edit/mask/parameterized_brush_replay_cache.*`、`include/edit/runtime/compiled_grade_mask.hpp` | 清理 host raster 热路径与源镜像；若其他调用仍使用旧接口，明确 lifetime、invalid-base 和 error 行为并测试 |
+| `edit/runtime/cuda/cuda_mask_pass.cu` 及所需 GPU mask 模块 | GPU 有序 raster、并行精确 EDT、必要采样/Union；避免把更多职责塞进单个 kernel 文件 |
+| `include/edit/runtime/basic_render_workspace.hpp`、active texture/result cache、PlanExecutor | scratch/reader 生命周期，pending/completed revision，实际依赖失效与复用；接口同步检查 OpenCL/Metal |
+| `tests/ui`、`tests/app`、`tests/edit` 的对应测试与 CMake | 真实 production QML 输入整合、异步复现、CPU/GPU oracle、原算法性能统计；必须注册并执行 |
+
+**一套完整验证矩阵。** 以下名称是本阶段新增/加强的验收目标，不是已执行结果。
+必须建立 `EditorBrushInteractionQmlTest`，加载生产 workspace/header/panel、真 adapter、真
+串行 owner；只用 fake mask model 断言按钮调用，不能证明首拖/回现已修复。
+
+| 用户行为或保证 | 必需测试 | 核心断言 |
+| --- | --- | --- |
+| 首次直接画 | `FirstBrushDragWithoutPriorClickPaintsWholePath` | fresh image/工具首次 arm 后直接 Qt press-move-release；非共线路径中段及末段 coverage，准确一次提交，无预点击/预选 MaskId |
+| 首次直接擦 | `FirstEraseDragWithoutPriorClickErasesWholePath` | 切 Erase 后直接拖动；沿路径源像素减少，释放后继续保持；不只断言首个圆 |
+| 连续操作 | `QueuedSecondStrokeSurvivesFirstStrokeCompletion` | owner/render 延迟时快速两笔，点/工具/目标不丢；不能等待 Quality 才接受第二笔 |
+| 等价呈现几何 | `QualityToInteractiveEquivalentMappingKeepsBrushOpen` | 手算等价 F，换 extent/ROI 表示后仍保持同一笔；真实 zoom/crop change 的 Cancel 单独断言 |
+| 事件终止 | `ReleasedBrushUsesValidEndpointAndCommitsExactlyOnce`、`CanceledBrushDoesNotCommit` | 真实 release 末段、归零后的 inactive、越界、重复终止、合成事件、grab cancel；不补原点、不重复提交 |
+| 完成后不回现 | `ErasedCoverageSurvivesReleaseQualityAndNextEdit` | 绘制中、release、settled Quality、下一次 opacity/Grade edit、切页后连续比较 source/Union/photo；非恒等 Grade |
+| 旧帧不能覆盖 | `LatePreEraseFrameCannotReplaceNewerErasePixels` | 延迟旧 Quality/Interactive 的不同到达顺序，含更大 request id 携带旧 edit revision；已显示的新擦除结果不倒退 |
+| base revision 正确 | `FailedOrSkippedUploadPreservesAllPendingEraseRegions` | 两个相离的擦除区 A/B，中断 A 上传后应用 B，两处最终都正确；新纹理初始化、cache eviction、session 重建 |
+| reader 不被改写 | `HeldMaskReaderPreventsRasterMutationUntilRelease` | 故意持有实际 consumer，跨下一次 replay/异常/geometry change；没有同时读写或伪不可变 handle |
+| GPU 像素完全对应 | `GpuOrderedBrushRasterMatchesCanonicalR8Bytes` | 同样规范 samples 的 Paint/Erase 顺序、交叉、不同分批、hard/soft dab、量化边界逐字节相同 |
+| 羽化不降质 | `ParallelGpuDistanceMatchesIndependentEuclideanDistance` | 独立精确 EDT 与 native source/feather；inside/outside 全空、洞、边缘、portrait；沿用既有 ≤1 R8 code 容差，不放宽 |
+| 工作量有界 | `GrowingBrushUpdatesOnlyNewSampleCommandsAndAffectedTiles` | 100/1000 笔与长单笔，命令上传与新增样本相关；不重复复制前缀/重建完整索引/逐次扫完整笔划包围盒 |
+| 参数改变复用正确 | `FeatherOpacityAndGradeEditsReuseValidBrushSourceWork` | Grade 参数改变复用有效 Mix；合法存活的距离不因 feather 参数变化失效；没有 host R8 上传；scratch 已释放时明确计数必要重建 |
+| 历史/合成 | `EraseUndoRedoAndMovedBrushMatchFreshCommandReplay` | 移动后擦除、重叠其他 Mask、Undo/Redo、保存重开；相同参数产生同样 coverage，不依赖旧 cache |
+| 真照片响应 | `BusyMaskRenderKeepsPointerInputAndCancelResponsive`、`ContinuousBrushPresentsIntermediatePhotoFrames` | 压住 native completion 时 GUI 仍接收，松开前至少多个真实照片帧，不允许 cursor-only 通过 |
+
+已有 `AccumulatingBrushCreationTest`、`EditorSerialMaskInteractiveTest`、`MaskEditGeometryTest`、
+`ParameterizedBrushReplayCacheTest`、`BrushCanonicalSamplerTest`、`BrushSpatialIndexTest`、
+`BrushRegionalReplayTest`、`GpuDagCudaMaskTest` 和 frame queue 测试按实际代码复用/扩展。
+保留独立 oracle；不能用同一 GPU/mapper 实现生成 expected 再比较自身。测试发现零案例、只编译
+通过、只做 96×64 小图，均不构成实际绘制资格验证。
+
+**性能验收也必须在这个 phase 完成。** 执行前确认用户运行 exe/DLL 路径、提交和编译 flags，
+保存同 commit Debug 与 Release 对照；Release 实际 flags 不能含 `-G`，profiling 可用正确
+构建中的行号信息。仍保留 Debug 调试用途，不把删掉 Debug 配置作为算法修复。
+参考图至少覆盖 6000×4000 横图、4000×6000 竖图和更大实际 RAW；记录其 canonical extent。
+默认 feather=短边 0.5%，另外测试硬边、大软笔、1/100/1000 strokes、1/5 个 Brush、重叠解析
+Mask、首笔冷缓存和暖态；5 个 Brush 特别检查当前四项 LRU 阈值附近的重复初始化。
+
+同一轨迹至少重复 30 次；鼠标频率 125/500/1000 Hz，60 Hz viewer，fit 与 zoom/pan 都覆盖。
+分开统计 GUI event、queue wait、owner/sample/history、CPU index/replay、命令和像素上传字节、
+GPU raster、mip、EDT 两个方向、feather、Union/Mix、GPU wait 与呈现。所有指标给 p50/p95/max、
+工作量和硬件/软件身份，冷初始化与暖态分列。截图和 traces 保存到 `build/tmp/` 的本任务目录。
+
+- 默认笔刷暖态 GUI 处理 p95 ≤1 ms，cursor 在下一个可用 Qt frame 更新；秒级 native 延迟
+  不阻塞输入或 Cancel。
+- 默认软笔连续 Paint、Erase 和 Move 的完整 Interactive owner-cycle p95 ≤16 ms，
+  event-to-photo p95 ≤33.4 ms，暖态 max <100 ms；不能以跳过中间照片帧或丢弃笔触换平均值。
+- 首笔在既有图像管线暖态但 Brush 资源冷态下，press-to-first-photo ≤100 ms；单独说明 GPU
+  模块首加载与分配成本并在同阶段处理超标，不能要求用户先点一下完成初始化。
+- 长笔划后半段不能出现随完整前缀反复复制导致的累积二次增长；source 未变的参数编辑不走
+  host 像素重放/上传，合法有效结果不因无关 revision 被重复求值。按真实相交样本、像素数
+  和 scratch 失效原因解释必要 GPU 重建、高重叠和大羽化成本，不虚构所有情况 O(1)。
+- 除明确可重建 scratch 和单 Grade 当前 Mix 外，没有每 Mask/Stroke/Version 的长期完整
+  R8 副本。披露 host/device 峰值、资源复用、bytes per update；不通过牺牲 reader 安全达标。
+
+**构建与完成记录。** 通过 `scripts/msvc_env.cmd` 使用 `win_debug`/`win_release`，新 target
+加入 CMake 后配置并构建，`ctest -N` 核对实际注册案例再运行。Windows 每次 configure/build/link
+总等待预算按 AGENTS.md 从 **10–20 分钟起步**，宽目标/CUDA/应用链接优先 20 分钟，仍在编译
+时继续放宽；短工具轮询不是杀进程超时。继续同一个构建 session，不能短超时反复重启。
+本次规划不执行这些构建，不把既有 Debug 测试记录复制为新阶段通过证明。
+
+**目标成功/失败调用链：**
+
+```text
+First real press -> one input owner -> stable item-to-reference mapping -> ordered sequence
+  -> serial canonical sampling -> one batch publication -> GPU ordered tile raster
+  -> exact parallel distance / feather -> Union -> Grade Mix
+  -> accept frame by session + edit revision -> visible intermediate photograph
+Valid release -> finish the same complete stroke -> one history commit -> matching Quality
+
+Equivalent presentation switch -> keep the same stroke and mapping
+Actual geometry change / grab cancel -> one Cancel -> owner restore -> current restore frame
+Stale frame -> reject without replacing newer erased pixels
+Failed GPU work -> invalidate pending content/base -> retain valid published result + real error
+  -> next authorized operation derives exact pixels from current commands; no CPU/quality substitute
+```
+
+**一次性交付清单：**
+
+- [ ] 在未预点击的新图像上，Paint/Erase 第一次直接拖动均覆盖完整轨迹。
+- [ ] Erase 在 release、Quality、下一次编辑、Undo/Redo 与重开后不意外回现。
+- [ ] 已区分并修复真实输入中断、误取消、提交丢失、缓存 base 和旧帧问题；每个实际原因有失败→通过证据。
+- [ ] GPU source raster 与精确并行羽化已接入本机生产链；CPU 前缀复制和重复全域工作已清理。
+- [ ] 实际照片默认软笔达到上述时延，记录冷/暖态、长笔/多 Mask、横/竖图及 Debug/Release 对照。
+- [ ] 真实 workspace QML、owner、GPU、frame queue 和历史测试已注册并非零执行，原有移动框/坐标/默认羽化不回归。
+- [ ] source/reader/资源 revision 生命周期安全，无新源镜像和未授权的长期 R8 多副本。
+- [ ] 完成记录包含 commit、实际文件/API、两个调用链、测试精确命令/数量、像素误差、时延/资源表与平台执行范围。
+
+本阶段任一条未满足时保持 partial，列出本阶段剩余工作并继续处理；不能再命名一个补修子阶段
+把这些退出条件移走。其他原有 NM7.13–NM7.15 内容仍按原范围保留。
 
 ### NM7.13 — Complete cancellation and project/session lifecycle
 

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor/phase_nm7_viewer_mask_creation_plan.md
@@ -2,26 +2,25 @@
 
 Date: 2026-09-08
 
-Status: NM7.1–NM7.12 completion records retained; NM7.12R implemented and partially
-verified (release latency, real-adapter QML harness, and Metal still open);
-NM7.12RR partial — CUDA GPU stamp (2026-09-11) plus first-drag pointer routing
-and equivalent-mapping keep-open (2026-09-12); erase persistence, parallel EDT,
-and viewer latency remain; NM7.13–NM7.15 planned.
+Status: NM7.1–NM7.12 completion records retained; NM7.12R and NM7.12RR remain historical
+partial Brush work. The 2026-09-11 release decision stops Brush delivery in this version.
+NM7.13–NM7.14 are redefined as the disabled-Brush project-format/build cut and complete
+Radial/Linear Gradient qualification. Whole-DAG performance belongs to NM8. All later Node Editor
+work uses `ALCEDO_ENABLE_BRUSH_MASK=OFF`.
 This document records the NM7.1 source
 audit, NM7.2 parameterized Brush owner operations, NM7.3 typed stroke history plus the
 project/schema cutover, NM7.4 canonical rasterization with regional Mix replay, NM7.5
 shared ReferenceSpace mapping with Brush placement, NM7.6 control-only retained QSG,
 NM7.7 Radial/Linear creation plus existing-mask movement, NM7.8 parameter-mask
-controls, drawer selection/deletion, and crop-style Gradient, NM7.9 accumulating
-Brush paint/erase/move with typed stroke history, NM7.10 serial Interactive Mix
-with one current Grade coverage result, NM7.11 project Mix-cache storage plus
-Keep/DeleteOnProjectClose cleanup, and NM7.12 production Mask controls plus project
-storage UI. The six reported Brush regressions require NM7.12R acceptance before Brush UI
-can be considered qualified. Newly reported second-scale drawing, first-drag input loss,
-and erased-content reappearance are covered by NM7.12RR. NM7.13–NM7.15 acceptance remains outstanding.
+controls, drawer selection/deletion, and crop-style Gradient, and the historical
+NM7.9–NM7.12RR Brush implementation records. NM7.13 increments the project format and removes
+Brush from the current product build; NM7.14 completes the two analytic Mask sources.
 
 Parent: [Node-aware Pipeline Editing and Mask Creation](../node_mask_editor_master_plan.md),
 Sections 8–12, 18, 20.3–20.4, 21.8, 23.5, and 24.
+
+Deferred Brush architecture:
+[Brush Mask Architecture, History, and Raster Materialization Master Plan](../brush_mask_architecture_master_plan.md).
 
 Prerequisites: NM1–NM5 ownership, multi-Grade/multi-Mask runtime and typed history,
 and node selection; NM6 serial input consumption, native parameter access, result retention,
@@ -38,8 +37,8 @@ highlighting. This revision supersedes the earlier per-stroke immutable-asset de
 
 Required algorithm/storage design:
 [Parameterized commands, regional replay and project cache](mask_command_replay_and_project_cache_plan.md).
-Read it before implementing NM7.2–NM7.15. It gives equations, inverse operations, replay bounds,
-cache lifecycle, project settings, failure behavior and an initial executable algorithm experiment.
+It governed the historical NM7.2–NM7.12RR work. Do not use it as the target for NM7.13–NM7.14;
+future Brush storage and raster work belongs to the separate Brush Master Plan.
 
 2026-09-08 parameter-mask revision: retain NM7.1–NM7.7 completion records. Insert NM7.8
 for Radial feather/range controls, Node drawer selection/deletion, and Geometry crop-style
@@ -48,6 +47,16 @@ records use the new numbering. Selected analytic boundary lines are required dur
 editing as well as creation; coverage fill remains prohibited. The reported Radial “半圆范围”
 is specified here as the radial/elliptical range contour and feather boundaries of the existing
 full-ellipse evaluator, without introducing a semicircle coverage algorithm.
+
+2026-09-11 current-release revision: Brush is not delivered in this version. Historical NM7.1–
+NM7.12RR implementation and evidence remain recorded below, but they do not define current release
+acceptance. NM7.13 increments the project format, rejects the experimental Brush-bearing format,
+creates a real optional-module boundary, and sets the product default to
+`ALCEDO_ENABLE_BRUSH_MASK=OFF`. NM7.14 qualifies Radial and Linear Gradient as the only shipped Mask
+sources. NM8 owns whole-DAG performance and final product qualification. NM8 and every remaining
+Node Editor plan must configure, build, test, install, package, and profile with Brush disabled. The
+separate Brush Master Plan owns the next-version history, storage, raster, native, UI, and release
+work; no remaining Brush checkbox in this document can block the current version after NM7.13.
 
 ## 1. Purpose and background for the executor
 
@@ -58,8 +67,8 @@ earlier Brush single-point movement controls and hard-edge creation defaults. Hi
 completion records remain evidence for the tests they actually ran, not proof that the six
 reported viewer problems are resolved.
 
-NM7 makes local adjustment possible directly on the photograph. A user selects a Color Grade,
-creates an area of influence with Brush, Radial, or Linear Gradient, and sees that Grade change
+NM7 makes local adjustment possible directly on the photograph. In the current release, a user
+selects a Color Grade, creates an area of influence with Radial or Linear Gradient, and sees that Grade change
 only the covered pixels. Later edits, Undo, Version checkout, reopening, and export must reproduce
 that same area. The drawing is therefore an editing input to the existing image pipeline, not an
 independent illustration layered over an otherwise unchanged photograph.
@@ -588,11 +597,10 @@ transitions immediate, and input-following geometry is never animated behind the
 
 ## 10. Revised ordered implementation phases
 
-本次改变 NM3 source、NM4 history 与 runtime cache，因此先完成数据和重放能力，再开放 viewer。
-保留已完成的 NM7.1–NM7.7，新增 NM7.8 参数蒙版改进；原 NM7.8–NM7.14
-顺延为 NM7.9–NM7.15。原 NM7.11（现 NM7.12）的部分 UI 已为测试提前接线，
-不代表该阶段全部完成。不能把旧的 immutable asset 测试当作新格式验收。
-保持总体 NM1→NM6→NM7→NM8 顺序。
+NM7.1–NM7.12RR 保留原编号和实际完成记录。2026-09-11 决策不重写这些历史提交，但重新定义
+NM7.13–NM7.14：先递增项目格式并从当前产品构建剥离 Brush，再完成两个 analytic Mask。
+整个 DAG 的性能优化与资格验证属于 NM8。保持总体 NM1→NM6→NM7→NM8 顺序；从 NM7.13 起
+所有 Node Editor 构建都关闭 Brush。
 
 | Phase | Result | Dependency |
 | --- | --- | --- |
@@ -610,13 +618,12 @@ transitions immediate, and input-following geometry is never animated behind the
 | NM7.12 | Production Mask controls and project storage UI | NM7.11 |
 | NM7.12R | Repair Brush tool state, pointer alignment, move frame, erase, drawing cost and default feather | NM7.5–NM7.12 |
 | NM7.12RR | Complete continuous Brush input, stable Erase, GPU execution and measured viewer responsiveness in one phase | NM7.12R implementation |
-| NM7.13 | Interruptions, late jobs and complete lifecycle | NM7.12, NM7.12R, NM7.12RR |
-| NM7.14 | Native pixel, persistence, cache bounds and recovery qualification | NM7.13 |
-| NM7.15 | Real viewer/package/performance qualification and NM8 handoff | NM7.14 |
+| NM7.13 | New project-format identity, detachable Brush modules and disabled product build/package | retained NM7.12RR history |
+| NM7.14 | Complete Radial and Linear Gradient lifecycle, native pixels and product qualification | NM7.13 |
 
 Each phase records actual files/APIs, success and failure call chains, commands, executed test
-counts and remaining gaps. Branch names describe the result, e.g. `feature/brush-command-replay`
-or `feature/project-mask-cache`. New names below are proposals, not existing APIs.
+counts and remaining gaps. Branch names describe the result, e.g. `build/detachable-brush-mask`,
+or `feature/analytic-mask-release`. New names below are proposals, not existing APIs.
 
 ### NM7.1 — Audit the revised source and format boundary
 
@@ -2561,7 +2568,8 @@ Failed GPU work -> invalidate pending content/base -> retain valid published res
 - [ ] 完成记录包含 commit、实际文件/API、两个调用链、测试精确命令/数量、像素误差、时延/资源表与平台执行范围。
 
 本阶段任一条未满足时保持 partial，列出本阶段剩余工作并继续处理；不能再命名一个补修子阶段
-把这些退出条件移走。其他原有 NM7.13–NM7.15 内容仍按原范围保留。
+把这些退出条件移走。该句记录 7.12RR 当时的执行要求；2026-09-11 决策已在下文重新定义
+NM7.13–NM7.14，并把未完成 Brush 资格验证移交独立 Master Plan。
 
 ##### Phase NM7.12RR completion record (2026-09-11)
 
@@ -2665,166 +2673,241 @@ Suite totals: `7/7` MaskEditGeometryTest PASS; `1/1` EditorBrushInteractionQmlTe
 
 **Remaining gaps:** Main.qml + RAW e2e for this drag hung/segfaulted under offscreen RHI in this session, so coverage-at-mid/end on a live Grade is not proven here. Rebuild `alcedo_main` to exercise the production workspace. Erase, EDT, and latency work remain in this phase.
 
-### NM7.13 — Complete cancellation and project/session lifecycle
+### NM7.13 — Cut the project format and extract Brush into a disabled optional module
 
-**Purpose:** preserve state when operations terminate without a normal release.
+**Decision:** Brush is removed from the current Node Editor release. The product configure uses
+`ALCEDO_ENABLE_BRUSH_MASK=OFF`. The project metadata version advances from `0.6.0` to `0.7.0`, and
+the accepted minimum and maximum both become `0.7.0`. This is a project-format, compile, and package
+boundary, not a hidden UI flag.
 
-**Work:** route grab cancellation, deactivation, workspace hide, adjustment input, owner deletion,
-Undo/Redo, image/Version/project switch and close through ordered boundaries. Restore unfinished
-commands and rebuild affected results, with no raster before-state. Fence old cache jobs by project
-and storage generation in addition to image/Version/sequence identity. Keep graph actions disabled
-only while creation mode owns input; release resources even when results are rejected.
+**Purpose:** make the current Radial/Linear Gradient delivery incapable of accumulating unreachable
+Brush code or accepting the abandoned experimental Brush parameters. The `0.6.0` project format is
+an experimental dead end: do not read, inspect, migrate, or selectively salvage its Brush state.
+Preserve the existing Brush work only inside a detachable module owned by the separate
+[Brush Mask Architecture Master Plan](../brush_mask_architecture_master_plan.md).
 
-**Files/APIs:** workspace input adapter, controller, session/project lifecycle, node/shortcut gates,
-cache service and frame validation.
+**Work:**
 
-**Primary chain:** interruption → cancel/settle command → owner restore/commit → requested lifecycle
-operation → stale result rejection / old writer retirement.
+- add the cache option `ALCEDO_ENABLE_BRUSH_MASK`, default `OFF` in product presets;
+- change `kProjectFileVersion`, `kMinSupportedProjectFileVersion`, and
+  `kMaxSupportedProjectFileVersion` from `0.6.0` to `0.7.0` in one atomic format cut;
+- reject every `0.6.0` project at the project metadata read boundary before decoding a pipeline
+  document, history row, checkpoint, transfer payload, or Brush parameter body; do not add a
+  `0.6.0` conversion path;
+- write only `0.7.0` metadata from new/save/package paths and update the exact-version tests and
+  user-facing incompatibility error together;
+- split common Mask ownership/Union/range behavior from analytic and Brush implementations;
+- keep Radial and Linear Gradient model, history, native evaluator, application, UI, resources, and
+  tests in the always-built analytic path;
+- move Brush model/reference types, stroke/sample code, history changes, stores, CPU/native raster,
+  application input/controller code, QML actions, icons, translations, tests, and benchmarks behind
+  optional targets;
+- make the disabled `MaskSource`/serializer/history registries contain only current-release source
+  kinds and changes; do not compile Brush branches followed by runtime `if (false)` checks;
+- remove Brush actions and rows from production QML and accessibility trees when disabled;
+- reject a structurally invalid `0.7.0` document that declares a Brush source or Brush history
+  change at its versioned decoder boundary; do not substitute another source or zero coverage;
+- ensure install/package manifests exclude Brush objects, kernels, QML, icons, and translations;
+- add dependency, link-map, QML-resource, and test-registration checks that prove absence;
+- build the isolated `ON` configuration once during extraction to prove that the module boundary is
+  coherent, but do not use it for later Node Editor implementation or qualification.
 
-**Tests:** `GrabCancellationDoesNotCommitBrush`, `DuplicateReleaseCommitsOnce`,
-`VersionCheckoutRejectsOldMaskFrame`, `ProjectSwitchRejectsOldCacheWrite`,
-`MaskDeleteWithViewerFocusDoesNotDeleteGrade`, `WorkspaceHideRestoresUnfinishedMaskMove`.
+**Required target boundary:**
 
-**Exit:** delayed native completion, write jobs and genuine Qt input all obey the same outcome.
+```text
+EditMaskCore
+  -> Mask identity, common fields, Union, ranges, owner operations
 
-### NM7.14 — Qualify native pixels, bounded disk storage and recovery
+EditMaskAnalytic
+  -> Radial + Linear Gradient model/history/runtime
 
-**Purpose:** verify source, command replay and disposable cache as one product path.
+EditMaskBrush                       [ALCEDO_ENABLE_BRUSH_MASK=ON only]
+  -> Brush model/history/storage/raster/native code
 
-**Work:** run the companion acceptance matrix plus main Section 11. Exercise 1,000 strokes,
-1,000 Undo/Redo, many Versions and Clear on multiple projects. Reopen/cacheless package/Paste,
-error injection, crash during atomic replacement and schema rejection. Record native backends
-separately; no CPU/other-backend substitution for unavailable qualification hardware.
+EditorMaskAnalytic
+  -> Radial + Linear Gradient controller/adapter/QML integration
 
-**Files/APIs:** shared native Mask fixtures, history/recovery/project/cache/UI tests and package tests.
-**Primary chain:** actual tool → source commands → clear/save/reopen/Version/Paste → fresh native
-coverage → expected pixels independent of any previous cache.
+EditorMaskBrush                     [ALCEDO_ENABLE_BRUSH_MASK=ON only]
+  -> Brush input/controller/adapter/QML integration
+```
 
-**Tests:** `CachelessProjectRestoresAllMaskVersions`, `NativeMaskReplayMatchesExpectedCoverage`,
-`RepeatedHistoryNavigationKeepsRasterFileCountBounded`, `InterruptedCacheReplaceLeavesNoPartialFile`,
-`PastedBrushUsesTargetProjectStoragePolicy`.
+One generated build configuration header or narrow registration boundary may expose availability.
+Unrelated node, Grade, session, and render files must not accumulate scattered feature checks.
 
-**Exit:** registered tests execute nonzero counts; actual file count/bytes and error cases recorded.
+**Primary disabled-build chain:**
 
-### NM7.15 — Qualify real viewer, packages and performance
+```text
+configure ALCEDO_ENABLE_BRUSH_MASK=OFF
+  -> analytic Mask targets only
+  -> write project_file_version 0.7.0
+  -> current project document accepts Radial / Linear Gradient only
+  -> node drawer and header expose Radial / Linear Gradient
+  -> compiler/runtime contain analytic Mask evaluation only
+  -> install/package contains no Brush implementation or resource
+```
 
-**Purpose:** measure the requested Interactive editing and ensure it ships in installed builds.
+**Primary abandoned-format chain:**
 
-**Work:** real RAW, nonidentity Grade, three sources, existing-source moves, paint/erase, Undo/Redo,
-project cache root/clear/close, packaged reopen. Capture control-only QSG and actual image pixels;
-measure event/queue/replay/feather/Union/Mix/presentation/cache-write costs and memory separately.
-Update completion records and master status only after all required evidence exists.
+```text
+open project_file_version 0.6.0
+  -> project metadata version check
+  -> IncompatibleProjectFormat error before document/history decoding
+  -> project/session remains unopened and unchanged
+```
 
-**Files/APIs:** package/viewer tooling, plan and master completion records; temporary outputs under
-`build/tmp/nm7/`. Preserve the source/owner naming and copy rules of AGENTS.md.
+**Primary invalid-current-document chain:**
 
-**Primary chain:** installed app → real input → Interactive photo → parameter commit → Quality →
-cache clear → reopen/rebuild → same final photo.
+```text
+project_file_version 0.7.0 declares Brush source/change while Brush is disabled
+  -> versioned document/history decoder
+  -> UnsupportedMaskSourceKind error
+  -> project/session remains unopened and unchanged
+```
 
-**Exit:** NM8 receives exact platforms, commands, fixtures, latency distributions, storage bounds,
-and explicitly unexecuted platform checks. No quality reduction or hidden raster-history cache.
+**Tests:** `BrushDisabledBuildExcludesBrushTargets`, `BrushDisabledPackageContainsNoBrushResources`,
+`BrushDisabledQmlExposesOnlyAnalyticMasks`, `BrushDisabledDocumentRejectsBrushSource`,
+`BrushDisabledHistoryRejectsBrushChanges`, `ProjectVersionCutRejectsExperimentalBrushFormat`,
+`ProjectSaveAndPackageWriteOnlyVersion070`, `BrushEnabledIsolationBuildCompiles`.
 
-## 11. Acceptance matrix and independent oracles
+**Exit:** the normal Windows and macOS Node Editor build/install/package commands explicitly use
+`ALCEDO_ENABLE_BRUSH_MASK=OFF`; build dependency and package evidence contain no Brush implementation.
+Every product writer emits `0.7.0`; the minimum and maximum accepted project versions are both
+`0.7.0`; a `0.6.0` project fails before any experimental Brush parameter is decoded. The isolated
+enabled build has no unresolved cross-module ownership, but no Brush product behavior is claimed.
+NM7.14, NM8, and all remaining Node Editor work use only the disabled configuration.
 
-Test implementation and expected outputs must not share the same bug. Use independent analytic
-calculations at chosen sample points and hand-specified R8 dab results, not production geometry
-helpers to generate both sides of a comparison.
+### NM7.14 — Complete and qualify Radial and Linear Gradient delivery
+
+**Purpose:** finish current-release Mask behavior without carrying Brush lifecycle, storage, input,
+or qualification requirements.
+
+**Work:**
+
+- complete cancellation, deactivation, workspace hide, adjustment input, owner deletion,
+  Undo/Redo, image/Version/project switch, close, and stale-session rejection for analytic Masks;
+- qualify Radial center/radii/rotation/feather/range contours and Linear Gradient origin/direction/
+  transition controls against independent equations;
+- qualify the Node drawer selection, deletion, re-editing, stable identity, focus, keyboard,
+  accessibility, two themes, and reduced-motion behavior;
+- qualify real Interactive and Quality pixels before/after release, move, parameter edit, Undo/Redo,
+  Version checkout, save/reopen, Paste, export, and package load;
+- remove current-release project settings or cache UI that exists only for Brush R8;
+- update product copy and format data so the supported Mask list is exactly Radial and Linear
+  Gradient;
+- run CUDA, OpenCL, and Metal qualification separately with no backend substitute.
+
+**Primary chain:**
+
+```text
+header or Node Mask row
+  -> select Radial / Linear Gradient
+  -> viewer ReferenceSpace input
+  -> owner applies provisional analytic parameters
+  -> QSG controls + actual Interactive Mask evaluation
+  -> release/confirm
+  -> one typed history operation
+  -> Quality
+  -> Version/reopen/Paste/export restore the same analytic parameters and pixels
+```
+
+**Primary cancellation chain:**
+
+```text
+Escape / grab cancellation / workspace or identity change
+  -> serial owner cancellation boundary
+  -> restore pre-input analytic fields when provisional values were visible
+  -> no commit
+  -> stale input and frame rejection
+```
+
+**Tests:** `CanceledRadialRestoresFieldsWithoutCommit`,
+`CanceledLinearGradientRestoresFieldsWithoutCommit`,
+`RadialHistoryVersionReopenAndPastePreserveCoverage`,
+`LinearGradientHistoryVersionReopenAndPastePreserveCoverage`,
+`AnalyticMaskDrawerSelectionDeletionAndReeditingUseStableIds`,
+`PackagedEditorExposesOnlyQualifiedAnalyticMasks`.
+
+**Exit:** Radial and Linear Gradient pass Section 11 on the real viewer and installed package. Every
+recorded build uses Brush disabled. No Brush-specific storage setting, action, source kind, history
+change, runtime branch, or product resource remains in the current-release path.
+
+## 11. Current-release acceptance matrix and independent expected results
+
+Test implementation and expected results must not share the same formulas or geometry helper. Brush
+is outside this matrix and must be absent from the build.
 
 | Area | Required cases | Evidence / tolerance |
 | --- | --- | --- |
+| Project-format cut | `0.6.0` project presented to the current product | Rejected at metadata version check before document/history decoding; no migration or partial open; source files unchanged |
+| Build boundary | Windows/macOS product configure, build, install and package at `0.7.0` with Brush disabled | Dependency/link/resource/test manifests show no Brush source, symbol, QML, kernel, icon, translation, history kind, or product test |
+| Unsupported input | Brush source/history data embedded in a structurally invalid `0.7.0` document | Precise versioned decode error; no empty Mask or analytic substitute; session remains unchanged |
 | Mapping | landscape/portrait; crop/rotation/orientation; fit/actual/zoomed; pan; DPR 1/1.25/1.5/2; DetailPatch | Reference and item round-trip tolerances in NM7.5; exact identity preservation |
-| Analytic coverage | Radial center/inside/feather/outside and rotated axes; Linear both ends/midpoint/direction | Independent scalar formulas; R8 error ≤ 1 code value unless existing tests are stricter |
-| Brush pixels | multiple strokes on one MaskId, size/strength changes, click, sparse/dense events, overlaps, duplicates, hard/soft edge, erase, zero changes | Exact R8 bytes for deterministic raster output; different event grouping gives same bytes |
-| Native runtime | CUDA/OpenCL/Metal, one/many Masks, two Grades, invert/opacity/feather, current-cache/fresh-replay | Existing NM3 numerical tolerances; record backend and runtime actually used |
-| Overlay | finite vertices, winding, clipping, alpha seams, constant handle widths, next available Qt frame | Geometry assertions plus accelerated window captures; contour deviation ≤ 0.25 logical px |
-| Parameter-mask UI | selected Radial range/feather lines; crop-style Gradient guides; drawer select/re-edit/delete | NM7.8 production QML input, IDs/history, before-release pixels and captures; no fill |
-| Movement | existing Brush/Radial/Gradient; old/new domains; repeated translation; press/move/release | Interactive pixels update before release; controls only, no coverage fill; one final commit |
-| Project cache | custom root, Clear, close cleanup, two projects, repeated Versions | Stable file count; delete-all-cache restores same history/coverage; no cross-project deletion |
-| Input | press under threshold, outside release, canceled grab, synthesized mouse, second touch, repeated Enter | One source stream and exactly one terminal outcome; no duplicate commit |
-| Ownership | held GPU/request reader, late callback, load/checkout during settle, new image with reused IDs | No simultaneous raster read/write or live mutation/render; no stale publication |
-| History | creation, later edit, delete, cancel, no-op, Undo/Redo, cache corruption, WAL failure | Exact commit counts/HEAD, canonical document values and replayed expected coverage with no prior cache |
-| UI | header/node entry, seven pages with Mask disabled outside editing, stable rows, focus, renamed/missing target, two themes/reduced motion | Production QML load; load-only emits zero commands/renders; actual reachable control path |
-| Persistence | reopen, two Versions, Paste, export | Same settled source-derived coverage; target RAW metadata retained; no overlay in exported pixels |
+| Radial coverage | center/inside/feather/outside, rotated axes, range and feather contours | Independent scalar equations; R8 error ≤ 1 code value unless an existing test is stricter |
+| Linear Gradient coverage | both ends, midpoint, direction, transition distance and reversed direction | Independent scalar equations; R8 error ≤ 1 code value unless an existing test is stricter |
+| Native runtime | CUDA/OpenCL/Metal; one/many analytic Masks; two Grades; invert/opacity/feather | Existing NM3 numerical tolerances; record backend and runtime actually executed |
+| Overlay | finite vertices, clipping, constant handle width and next available Qt frame | Geometry assertions plus accelerated-window captures; contour deviation ≤ 0.25 logical px |
+| UI | header/node entry, selected guides, drawer select/re-edit/delete, stable rows, focus, keyboard, accessibility, themes, reduced motion | Production QML load; load-only path emits zero edits/renders; actual reachable controls |
+| Lifecycle | normal release, Escape, canceled grab, workspace hide, owner deletion, image/Version/project change | One terminal outcome; exact commit counts; provisional values restored or settled once; stale input/frame rejected |
+| History | create/edit/move/delete/no-op, Undo/Redo, WAL recovery and persistence error | Exact HEAD/document values and expected analytic coverage |
+| Persistence | reopen, two Versions, Paste, export and installed package | Same analytic parameters and final pixels; target RAW metadata retained; no overlay in export |
 
-For final RGB comparisons use existing pipeline fixture tolerances and record max/mean error plus
-failure coordinates. Do not loosen tolerances merely because R8 edges make a visual mismatch
-noticeable. Separate contour quantization tolerance from wrong transforms, wrong target or stale data.
+For final RGB comparisons, record maximum and mean error plus failure coordinates. Do not loosen
+tolerances to hide wrong transforms, target identity, stale data, invalidation, or native execution.
 
-No native execution is required for this documentation-only change. During execution, discover
-registered targets with `ctest -N` and inspect CMake before naming exact commands in records.
-Use repository macOS presets and the MSVC wrapper on Windows. New tests must have behavior-specific
-names and be registered; a filter that executes zero tests is not qualification.
+During execution, discover registered targets with `ctest -N` and inspect CMake before recording exact
+commands. Use repository macOS presets and the MSVC wrapper on Windows. A filtered command that runs
+zero tests is not qualification.
 
-## 12. Performance and resource evidence
-
-Preserve NM6's 16 ms total Interactive cycle target, including owner consumption, invalidation,
-Mask work, Grade processing and safe completion. Measure separately:
-
-- Qt event to overlay synchronization/presentation;
-- enqueue to owner consume and queue depth/sample backlog;
-- sample processing/raster update, dirty upload bytes and actual feather work;
-- owner cycle total and Qt photo presentation latency;
-- release to durable parameter commit and Quality presentation; coalesced cache publication separately;
-- current CPU raster bytes, pending sample bytes, QSG vertices/nodes, native allocations/leases.
-
-Run identical fixed sample paths on the same RAW/view/backend/build: one Mask and many Masks;
-small Brush and large soft Brush; cold and warm runtime; first and subsequent parameterized edits. Report
-p50/p95/max and actual operation counts. Do not compare Debug CUDA to Release Metal as a performance
-conclusion. Deliberately hold a render to prove overlay input and cancellation stay responsive.
-
-Expected bounds: no unnecessary full-raster copy/upload for local moves; full-domain changes
-and required feather work are measured explicitly, no R8 history file per stroke, no
-per-frame entire-stroke QML object rebuild, no repeated whole-prefix history copies, no overlapping
-owner cycles, and no valid upstream Interactive-result eviction. Initial texture creation and
-algorithm-required wide feather processing must be reported separately from local source uploads.
-If resources cannot satisfy a complete operation, report the error and restore unfinished work;
-do not drop data, lower quality or switch the backend.
-
-## 13. Failure matrix and completion record template
+## 12. Failure matrix and completion record template
 
 | Failure | Required committed state | Required user/session behavior |
 | --- | --- | --- |
-| Invalid target / transform / fields | Unchanged | Precise rejection; no provisional half-Mask |
+| Brush data in disabled build | Unchanged/unopened | Precise unsupported-format error; no substitute source or coverage |
+| Invalid analytic target / transform / fields | Unchanged | Precise rejection; no provisional partial Mask |
 | Cancel before owner consume | Unchanged | Drop queued sequence; no restore render needed |
-| Cancel after provisional application | Original state restored | Restore frame if pixels changed; no commit |
-| Required R8/scratch allocation failure | Original source remains recoverable | Restore unfinished operation if needed; real error; no lower quality |
-| Cache write failure | Durable parameter HEAD retained | Report I/O error, keep dirty status; no alternate directory or history rollback |
-| Stale cache-job completion | New session untouched | Reject old generation; release temp files/readers through project cache owner |
-| History persistence failure | Existing NM4 durable/restore rules | Never falsely report success; retain real error |
-| GPU failure before/after settle | No invalid output published; valid durable commit retained | Real backend error; no alternate evaluator |
-| Scene graph invalidation | Document/history unchanged | Recreate display geometry on next valid scene |
+| Cancel after provisional analytic apply | Original fields restored | Restore frame if pixels changed; no commit |
+| Image/Version/project identity changes | Requested valid state only | Reject old input and frames; release readers/resources |
+| History persistence failure | Existing NM4 durable/restore rules | Never report success; retain exact error and consistent HEAD |
+| Required native allocation or execution failure | No invalid output published | Real backend error; no CPU or other-backend evaluator |
+| Static-plan or invalidation failure | Prior valid document/result retained where applicable | Report the failing node/value/revision; do not execute an unverified plan |
+| Scene graph invalidation | Document/history unchanged | Recreate analytic display geometry on the next valid scene |
 
-Each executor appends this record under its sub-phase; do not replace planned tests with a vague
+Each executor appends this record under its sub-phase; do not replace planned evidence with a vague
 “tested” line:
 
 ```text
 NM7.x completion record
-Date / commit / platform / Qt version / native backend / build type:
+Date / commit / platform / Qt version / native backend / build type / Brush option:
 Status: planned | in progress | complete
 Resolved decisions and actual files/APIs:
 Primary success call chain:
-Primary cancel/failure call chain:
+Primary cancellation/failure call chain:
 Test name -> registered target -> command -> executed count -> result:
 Reference fixture / expected output / tolerance:
-Resource and latency measurements where applicable:
+Build dependency and package-resource evidence where applicable:
 Source/header ownership and naming checks:
 Remaining gaps and next dependency:
 ```
 
 Global NM7 completion checklist:
 
-- [ ] Section 2 approved decisions are reflected in the master/UI specification and implementation.
-- [ ] All three source types work in the real viewer on the selected exact Color Grade.
-- [ ] QSG input/geometry, actual evaluator and ReferenceSpace agree.
-- [ ] Brush canonical input, parameterized strokes, one current Grade R8 slot, regional replay and reader ownership are proven.
-- [ ] Creation, each edit/stroke, cancellation and deletion have the specified history outcome.
-- [ ] Stale inputs, cache jobs and frames cannot cross image/Version/sequence boundaries.
-- [ ] UI entry points, accessibility, disabled-until-editing Mask page and load-only selection restore are tested.
-- [ ] Native runtime, cacheless persistence/recovery and exported pixels pass the acceptance matrix.
-- [ ] One thousand strokes/Undo/Redo do not create per-step R8 files or pixel history.
-- [ ] Per-project paths, retain/close-cleanup/Clear and stale-writer rejection are qualified.
-- [ ] Resource/performance records include real platform results and no quality substitutions.
+- [ ] `ALCEDO_ENABLE_BRUSH_MASK=OFF` is the default current product configuration.
+- [ ] `kProjectFileVersion`, `kMinSupportedProjectFileVersion`, and
+      `kMaxSupportedProjectFileVersion` are all `0.7.0`; every `0.6.0` project is rejected before
+      document/history decoding and no experimental Brush conversion path exists.
+- [ ] Brush model/history/runtime/application/UI/test/resource code is outside the disabled build and
+      package, not merely hidden at runtime.
+- [ ] Unsupported Brush data fails at the versioned read boundary without changing session state.
+- [ ] All later Node Editor plans, builds, tests, packages, and performance traces explicitly disable
+      Brush.
+- [ ] Radial and Linear Gradient work in the real viewer on the selected exact Color Grade.
+- [ ] QSG input/geometry, analytic evaluator and ReferenceSpace agree.
+- [ ] Creation, editing, cancellation and deletion have the specified history outcome.
+- [ ] Stale inputs and frames cannot cross image/Version/project/sequence boundaries.
+- [ ] UI entry points, accessibility, disabled-until-editing Mask page and load-only selection restore
+      are tested for the two supported sources.
+- [ ] Native runtime, persistence/recovery, Paste, export and installed-package paths pass Section 11.
 - [ ] New headers include defining headers unless a documented include-cycle/PIMPL exception applies.
-- [ ] Added copies have the concrete owner/lifetime/consistency purpose specified in Section 5.1.
+- [ ] Added copies have a concrete owner, lifetime, and consistency need.
 - [ ] Touched first-party names and roadmap text/links satisfy repository terminology rules.
-- [ ] Master NM7 status and NM8 handoff accurately distinguish completion from remaining evidence.
+- [ ] The Node Editor master status and NM8 handoff identify Brush as a separate next-release plan.

--- a/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
+++ b/docs/roadmap/alcedo_studio/edit/node_mask_editor_master_plan.md
@@ -4,8 +4,8 @@ Date: 2026-08-29
 
 Status: NM0, NM2, NM3, NM4, and NM5 complete; NM6.1–NM6.4, NM6.4P, and NM6.P complete
 per execution records; NM6.5–NM6.9 planned; NM1 status retained below;
-NM7.1–NM7.8 complete; NM7.9–NM7.15 and NM8 planned. NML was
-cancelled on 2026-08-30.
+NM7.1–NM7.12RR records retained; NM7.13–NM7.14 and NM8 planned under the
+2026-09-11 Brush-disabled release boundary. NML was cancelled on 2026-08-30.
 
 2026-08-30 简化修订：每张图片只有一个 live document，领域函数原地修改，后台任务共用
 executor；不以整图 candidate 或独立 snapshot executor 实现原子性。History 仍是已提交状态
@@ -20,7 +20,7 @@ disk cache service 拥有写回/失效机制；不在 R 中实施，也不作为
 QuickQanava boundary, and official documentation sources for NM5-NM8 are fixed before NM5 starts.
 See the [NM5 execution plan](node_mask_editor/phase_nm5_nodes_panel_plan.md) for its sub-phases.
 
-2026-09-08 NM7 revised user direction: the
+2026-09-08 historical NM7 direction: the
 [NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md) now has fifteen
 sub-phases and a companion [algorithm/storage design](node_mask_editor/mask_command_replay_and_project_cache_plan.md).
 Brush paths are parameterized; NM4 records reversible stroke/placement commands. R8 is one
@@ -31,9 +31,22 @@ Brush size/strength with paint/erase remain approved. The 2026-09-09 correction 
 seventh Adjustment Stack parameter page that is enabled only during Mask creation or selection;
 the Node drawer remains the sole Mask list.
 This supersedes the earlier immutable-raster-history requirement in Sections 8–12 and NM7.
-NM3/NM4 completion records remain historical evidence; their source/history/cache interfaces
-must be extended inside NM7 before exposing its UI. NM7.1–NM7.8 are complete; NM7.9–NM7.15 remain
-planned.
+NM3/NM4 completion records remain historical evidence. The 2026-09-11 decision below supersedes
+the remaining scope and moves future Brush work out of Node Editor.
+
+2026-09-11 current-release decision: Brush is removed from this Node Editor delivery after the
+historical partial NM7.12RR work. NM7.13 increments the project metadata identity from `0.6.0` to
+`0.7.0`, sets both supported bounds to `0.7.0`, and rejects `0.6.0` before document/history decoding;
+the experimental Brush parameter format is not migrated. The same phase introduces
+`ALCEDO_ENABLE_BRUSH_MASK`, defaults product builds to `OFF`, and extracts Brush
+model/history/runtime/application/UI/test/resource code into optional modules. NM7.14 ships and
+qualifies only Radial and Linear Gradient. NM8 owns whole-DAG performance and final Brush-disabled
+product qualification. NM8 and all remaining Node Editor execution use the disabled configuration.
+Brush history, binary stroke storage, verified tiled R8 materialization,
+batched native rasterization, authoring, and future release qualification move to the separate
+[Brush Mask Architecture Master Plan](brush_mask_architecture_master_plan.md). Earlier Brush sections
+and completion records remain historical evidence only; they do not define current release exit
+criteria or authorize leaving unreachable Brush code in the disabled build.
 
 2026-09-05 NM6 design approval: NM5 is complete. The
 [NM6 execution plan](node_mask_editor/phase_nm6_node_aware_adjustments_plan.md) now defines
@@ -70,6 +83,7 @@ Earlier NM1 status is not re-qualified here.
 - [Phase 6C Mini-Git History and Pipeline Snapshot Plan](../ui/phase_6c_mini_git_history_and_pipeline_snapshot_plan.md)
 - [Editor Single Live Pipeline + WAL + Checkpoint](../ui/editor_single_live_pipeline_wal_checkpoint_plan.md)
 - [Phase 7A History/Versions Recovery and Editor Performance Plan](../ui/phase_7a_history_versions_repair_and_ui_refactor_plan.md)
+- [Brush Mask Architecture, History, and Raster Materialization Master Plan](brush_mask_architecture_master_plan.md)
 - [QuickQanava repository](https://github.com/cneben/QuickQanava)
 - [QuickQanava documentation home](https://cneben.github.io/QuickQanava/index.html)
 - [QuickQanava installation documentation](https://cneben.github.io/QuickQanava/installation.html)
@@ -103,7 +117,7 @@ DRT and Post Processing
 - 在左侧工具轨中打开 Nodes 面板；
 - 使用 QuickQanava 选择节点、创建 Color Grade、删除 Color Grade 和重新连接主链；
 - 选择任意 Color Grade 后，在右侧面板调整属于该节点的参数；
-- 为一个 Color Grade 创建多个 Brush、Radial 或 Linear Gradient 蒙版；
+- 为一个 Color Grade 创建多个 Radial 或 Linear Gradient 蒙版；
 - 在 edit viewer 上直接绘制或修改蒙版，并同时看到实际调色结果预览和 QSG 编辑辅助层；
 - Undo/Redo 节点、参数和蒙版操作；
 - 在历史面板中看清操作目标节点和具体变化；
@@ -184,15 +198,17 @@ NM4 才完成 history 对新图的持久化和重放，不能为填阶段空缺�
 现有 adjustment transfer merge 也以 stage/operator 字段冲突为核心。两个独立图之间没有
 足够自然、稳定的自动合并定义，因此本方案删除新的管线 merge 产品操作，只保留 Paste。
 
-### 2.7 Brush 持久源必须与 R8 缓存分离
+### 2.7 Brush 工作移出当前 Node Editor 发布
 
-NM3/NM4 已实现不可变、内容寻址的 Mask asset 及 key replacement history。这解决了同名文件
-覆盖破坏 Undo 的问题，但每 stroke 持有完整 R8 会使存储随历史快速增长。2026-09-08 用户明确
-更改方向：持久保存参数化 Brush 路径及可逆命令，R8 只缓存当前 Grade Mix 结果。
+NM3/NM4 和 NM7.2–NM7.12RR 留下了 Brush model、历史、runtime、application 和 UI 实现，但其
+参数 JSON、完整 document、磁盘 R8、一 dab 一 dispatch 和 GUI 数据访问不能满足发布要求。
+当前版本不继续修补该路径。NM7.13 把 Brush 整体移动到可选模块并令产品默认构建关闭它；
+Radial 和 Linear Gradient 留在 always-built analytic Mask 路径。
 
-擦除、max/min 和量化不可直接从像素求逆。Undo 在模型层恢复操作，再按原顺序重放影响区域；
-不产生每步栅格或 tile history checkpoint。项目级路径/清理设置只能删除可重建缓存，不能把
-没有参数源的历史原始 asset 当成缓存删除。算法和格式前置条件由 NM7 详细方案负责。
+下一版本的完整 Brush 架构由
+[Brush Mask Architecture Master Plan](brush_mask_architecture_master_plan.md)负责。该方案统一解决
+二进制笔画对象、Mini-Git 引用、可验证的 copy-on-write R8、三后端批量 raster、UI 投影和
+产品资格验证。当前 Node Editor 不把任一未完成 Brush 路径当成发布依赖。
 
 ### 2.8 Viewer 已有正确的扩展位置
 
@@ -228,7 +244,8 @@ EditorOverlayItem              retained QSG 辅助几何
 ### 3.2 蒙版
 
 - **Mask**：属于一个 Color Grade 的局部作用范围。
-- **Mask source**：Brush、Radial 或 Linear Gradient 产生的基础 coverage。
+- **Mask source**：当前发布由 Radial 或 Linear Gradient 产生基础 coverage；Brush 只在独立
+  可选模块和后续 Master Plan 中定义。
 - **Color Range**：直接属于一个 Mask 的可选颜色范围限制。
 - **Luminance Range**：直接属于一个 Mask 的可选明度范围限制。
 - **Union**：同一 Color Grade 内多个启用 Mask 的唯一组合方式。
@@ -259,7 +276,8 @@ Mask 的唯一组合语义是 Union。
 - node-aware adjustment stack；
 - 多 Color Grade compiler 和 CUDA/OpenCL/Metal 执行；
 - 每个 Color Grade 的多 Mask 数据；
-- Brush、Radial、Linear Gradient 绘制和编辑；
+- Radial、Linear Gradient 绘制和编辑；
+- Brush-disabled 编译、安装、打包和 unsupported-format 拒绝边界；
 - QSG mask editing overlay；
 - Color Range/Luminance Range 的数据位置、序列化位置和 typed target 预留；
 - typed pipeline mutation；
@@ -276,6 +294,7 @@ Mask 的唯一组合语义是 Union。
 - Union 以外的 Mask 布尔运算或可配置组合方式；
 - Color Range/Luminance Range 的第一版 UI 和最终选择算法；
 - AI segmentation mask；
+- 当前版本的 Brush 创建、编辑、历史、runtime、项目存储和产品资源；
 - 在节点编辑器中显示内部 GPU pass；
 - detached HEAD；
 - 新的管线 merge 操作；
@@ -475,19 +494,17 @@ ColorGradeNodeModel
 
 ### 8.2 MaskSource
 
-第一版 source variant：
+当前发布的 source variant：
 
 ```cpp
-using MaskSource = std::variant<BrushMaskSource,
-                                RadialMaskSource,
+using MaskSource = std::variant<RadialMaskSource,
                                 LinearGradientMaskSource>;
 ```
 
-Brush 长期保存有序参数化 stroke：稳定 StrokeId、paint/erase、规范采样点、radius/strength/
-hardness、算法版本及 Brush placement。多次 stroke 累积到同一个 Brush Mask，不逐笔创建新 Mask。
-整张 Brush 移动只修改 placement；Undo/Redo 恢复命令/参数后重算，不保留每笔 R8 revision。
 Radial 与 Linear Gradient 保存解析参数，在 ReferenceSpace 中求值。
-每个 Grade 用于 Mix 的最终 R8 是所有启用 Mask 合成后的唯一当前缓存，可从这些参数重建。
+Brush source 仅由 `ALCEDO_ENABLE_BRUSH_MASK=ON` 的可选模块注册；当前产品 schema、历史、UI 和
+runtime 不包含该类型。完整后续模型见
+[Brush Mask Architecture Master Plan](brush_mask_architecture_master_plan.md)。
 
 所有 source 使用稳定的归一化图像空间或现有 ReferenceSpace 约定。viewer zoom、pan、DPR、
 动态渲染分辨率和 ROI 不得改变长期参数含义。
@@ -553,41 +570,39 @@ output = input + node_coverage × (adjusted - input)
 
 ---
 
-## 9. 参数化蒙版、可逆命令与项目 R8 缓存
+## 9. 当前 analytic Mask 持久化与 Brush 模块边界
 
-2026-09-08 修订取代“每 stroke 保存新完整 R8 asset”的原方案。
-完整算法见 [NM7 参数重放与项目缓存](node_mask_editor/mask_command_replay_and_project_cache_plan.md)。
+Radial 和 Linear Gradient 参数直接属于 `ColorGradeNodeModel`。当前 Node Editor 的 typed history、
+WAL、完整 document、Version、Paste 和 reopen 只保存它们的小型解析参数：
 
 ```text
-Brush canonical samples / analytic fields / placement
-  -> typed reversible command in NM4 history
-  -> ordered regional replay + native feather / Union
-  -> one current Grade coverage R8
+Radial / Linear Gradient fields
+  -> typed owner operation
+  -> provisional Interactive evaluation
+  -> one settled NM4 history operation
+  -> Version / checkpoint / Paste references the same analytic fields
+  -> native source evaluation + feather / Union
   -> native Mix -> Interactive / Quality photograph
 ```
 
-### 9.1 可逆对象是命令
+### 9.1 Analytic Mask 的可逆对象
 
-追加笔画的 inverse 是移除该 StrokeId；删除笔画的 inverse 恢复原顺序与 samples；移动恢复
-before translation/center/origin。擦除或 Union 的 Undo 通过重新求值恢复被遮盖的早期贡献，
-不能从最终 R8 相减。空间索引只存 ID/span/bounds，不缓存历史像素。Feather 的完整邻域依赖
-仍必须求值，不能以局部 preview 或近似 blur 替代。
+创建、删除、中心/方向/半径/transition/feather 修改保存准确 before/after 字段和稳定 MaskId。
+Undo/Redo 通过 owner 操作恢复参数，然后按现有 native evaluator 求值。QSG 只显示编辑控件，
+不成为照片 coverage 或历史来源。
 
-### 9.2 当前缓存而非历史文件
+### 9.2 当前发布不包含 Brush 项目缓存 UI
 
-每个 `(ProjectUUID, ImageId, NodeId)` 一个稳定的已发布文件槽。内部 fingerprint、算法版本、
-geometry 与 checksum 验证当前内容；文件名不按 stroke/commit/Version/hash 扩展。
-更新是合并后的原子替换，临时文件和 reader/writer lease 有明确释放，不保留历史栅格。
-参数提交不等待 R8 写回；删光新缓存后，重开、Undo/Redo、Version、Paste 都必须正确。
-QualityBase 继续遵守 NM6 在 RAW Develop 之后的持久结果缓存旁路规则。
+NM7.13 删除或排除仅为 Brush R8 服务的当前发布设置、清理入口和 package 资源。Radial 与 Linear
+Gradient 不创建持久 R8；它们根据小型参数在 native Mask pass 中求值。QualityBase、Detail ROI、
+result lifetime 和 invalidation 继续遵守 NM6 的现有规则，并在 NM8 做整体性能优化和资格验证。
 
-### 9.3 逐项目设置与清理
+### 9.3 Brush 的后续持久化
 
-`ProjectService` 拥有用户选择的 cache root、Keep/DeleteOnProjectClose 策略及管理入口。
-设置页支持按项目查看字节/文件数、Clear、改路径和项目删除时的缓存保留选择。
-新 cache 使用专有 project UUID namespace；项目 A 清理不影响 B、RAW、stroke 参数或 history。
-停止旧写入者并递增 generation 后再清理；旧任务不得复活已删除文件。路径不可用报告原错误，
-不切换全局 temp。当前旧 raster-only asset 没有参数可重建，不得通过新 cache 清理入口删除。
+历史 [NM7 参数重放与项目缓存](node_mask_editor/mask_command_replay_and_project_cache_plan.md)
+保留为已实施代码和旧决策记录，不再指导当前发布。后续 Brush 使用项目级二进制笔画对象、
+Mini-Git 引用和可验证的 copy-on-write tiled R8 materialization；准确 owner、hash、发布、清理和
+三后端要求由 Brush Master Plan 独立验收。
 
 ---
 
@@ -610,7 +625,6 @@ QualityBase 继续遵守 NM6 在 RAW Develop 之后的持久结果缓存旁路�
 蒙版编辑辅助层：
 
 ```text
-Brush cursor / Move handle / temporary initial-creation guides
 Radial center / radii / rotation / feather controls
 Linear Gradient origin / direction / transition controls
   -> EditorOverlayItem retained QSG nodes
@@ -621,13 +635,12 @@ Linear Gradient origin / direction / transition controls
 
 ### 10.2 QSG 只绘制编辑控件
 
-已有 Brush/Radial/Linear Gradient 移动或参数编辑时，QSG 只显示 handles、必要方向线和操作
-连线，不显示受影响区域填充、高亮、heatmap 或已完成 Brush 路径。控件随当前输入定位；
+已有 Radial/Linear Gradient 移动或参数编辑时，QSG 只显示 handles、必要方向线和操作
+连线，不显示受影响区域填充、高亮或 heatmap。控件随当前输入定位；
 实际影响通过同一 pipeline 的 Interactive 照片结果实时呈现，不等 release 才更新。
 
-初次绘制暂定允许随输入变化的 cursor/轮廓/路径创建引导；该细节的澄清记录在 NM7 决策表。
-不以整片蒙版高亮代替照片结果。QSG 与 evaluator 使用同一 ReferenceSpace 映射和参数；
-创建引导若消费笔刷 samples，必须来自同一规范样本序列，不能另行采样原始事件。
+初次创建允许随输入变化的解析轮廓引导；不以整片蒙版高亮代替照片结果。QSG 与 evaluator
+使用同一 ReferenceSpace 映射和参数。
 
 ---
 
@@ -636,7 +649,7 @@ Linear Gradient origin / direction / transition controls
 未来 Color Range 或 Luminance Range 启用后，选中像素取决于该节点上游图像内容。届时可以
 增加 `MaskCoveragePreviewRequest`，把内容相关 coverage texture 交给 viewer 显示。
 
-当前 Brush/Radial/Linear Gradient 阶段不需要通用 `MaskPreviewRequest`。不能为了简单几何
+当前 Radial/Linear Gradient 阶段不需要通用 `MaskPreviewRequest`。不能为了简单几何
 辅助层建立第二条后端 render 通道。
 
 ### 10.4 Overlay 状态规则
@@ -644,9 +657,6 @@ Linear Gradient origin / direction / transition controls
 | 操作 | Mask editing overlay | 实际管线预览 |
 | --- | ---: | ---: |
 | 选中已有 Mask | 仅控件 | 不必立即渲染 |
-| 初次绘制 Brush | 控件与暂时创建引导，无区域填充 | Interactive |
-| 修改已有 Brush placement/source feather | 仅控件，无区域高亮 | Interactive |
-| 修改未来 Brush size/strength | 仅工具控件 | 不改变已有像素；后续 samples 使用新值 |
 | 移动/缩放/旋转 Radial | 仅控件，无区域高亮 | Interactive |
 | 修改 Radial feather | 仅控件 | Interactive |
 | 修改 Linear Gradient | 仅控件，无区域高亮 | Interactive |
@@ -705,10 +715,10 @@ Mask mutation
   AddMask
   RemoveMask
   ReplaceMaskSourceParams
-  AppendBrushStroke
-  RemoveBrushStroke / InsertBrushStroke
-  SetBrushTranslation
 ```
+
+Brush mutation kinds only exist in the optional Brush module and its future project schema. They are
+not registered by the current product build.
 
 Mask 列表 UI 重排和 QuickQanava layout 不属于照片 mutation。
 
@@ -751,8 +761,6 @@ PastedPipelineDocument
 | adjustment slider settled | Quality |
 | Mask transform/feather/opacity provisional | Interactive |
 | Mask transform/feather/opacity settled | Quality |
-| Brush stroke provisional dirty region | Interactive |
-| Settled Brush command / Mask placement | Quality |
 | 添加/删除 Mask | Quality |
 | 添加/删除/重新连接 Color Grade | Quality |
 | Undo/Redo | Quality |
@@ -761,7 +769,7 @@ PastedPipelineDocument
 | node selection / rename | 不渲染；rename 只进 history 与否由 13.4 决定 |
 | graph node layout / pan / zoom | 不渲染 |
 
-结构变化使 static plan key 变化并重新编译。纯参数值、简单 mask 几何参数和 Brush stroke/placement
+结构变化使 static plan key 变化并重新编译。纯参数值和 analytic Mask 几何参数
 变化只更新参数/content key，不应误触发与拓扑无关的 compiler 工作。
 
 ---
@@ -789,7 +797,6 @@ commit hash 对 canonical typed payload 计算。历史回放不能重新推断�
 - Color Grade enabled、mix 和参数修改；
 - Mask 添加、删除；
 - Mask source 参数修改；
-- settled Brush stroke 的规范参数命令，以及 placement 的 before/after 字段；
 - Mask enabled、opacity、invert、feather 等长期参数；
 - 未来 Color Range 和 Luminance Range 修改；
 - 影响导出结果的 Document/Develop/DRT/Post 参数。
@@ -820,7 +827,6 @@ Added Color Grade: Sky
 Removed Color Grade: Background
 Reconnected Color Grade: Skin after Base Grade
 Added Radial Mask: Warm Face
-Brush stroke for Warm Face / Mask 2
 Feather for Warm Face / Radial 1: 24 px → 48 px
 ```
 
@@ -1084,7 +1090,6 @@ Each row shows only the approved source-type icon and localized type label:
 | --- | --- | --- |
 | `MaskSourceKind::LinearGradient` | `Gradient` | `mask_icons/gradient.svg` |
 | `MaskSourceKind::Radial` | `Radial` | `mask_icons/radial.svg` |
-| `MaskSourceKind::Brush` | `Brush` | `mask_icons/brush.svg` |
 
 Do not show Mask name, opacity, enabled state, invert state, ranges, or identity in compact rows.
 The NM7.8 revision requires stable-ID selection and a compact per-row delete action, with
@@ -1111,16 +1116,7 @@ Radial uses Tabler `wash-dryclean`:
 <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
 ```
 
-Brush uses Tabler `brush`:
-
-```svg
-<path d="M3 21v-4a4 4 0 1 1 4 4h-4" />
-<path d="M21 3a16 16 0 0 0 -12.8 10.2" />
-<path d="M21 3a16 16 0 0 1 -10.2 12.8" />
-<path d="M10.6 9a9 9 0 0 1 4.4 4.4" />
-```
-
-Normalize all three files to the shared 24×24 viewBox and white stroke. Keep the user-approved
+Normalize both files to the shared 24×24 viewBox and white stroke. Keep the user-approved
 2 px stroke. The Radial circle is an approved type icon. Do not reuse it as a status dot.
 
 ### 16.8 VI mapping
@@ -1415,9 +1411,9 @@ Creation uses this call chain:
 
 ```text
 select Color Grade
-  -> choose Brush / Radial / Linear Gradient
+  -> choose Radial / Linear Gradient
   -> enter creation mode (no document change yet)
-  -> first valid input applies provisional AddMask, or resumes the existing Brush
+  -> first valid input applies provisional AddMask
   -> viewer input updates provisional source
   -> QSG overlay updates immediately
   -> pipeline Interactive preview
@@ -1437,7 +1433,7 @@ Use these interruption rules:
 ### 18.1 Masks panel
 
 2026-09-09 user correction: Mask is the seventh right-side Adjustment Stack page for the Color
-Grade context. It is disabled until an existing header Brush/Radial/Gradient action or Node Mask
+Grade context. It is disabled until an existing header Radial/Gradient action or Node Mask
 row opens Mask editing. Enter confirms and returns to the previous ordinary page; choosing another
 adjustment page confirms and opens that page. Escape cancels. There are no explicit Done/Cancel
 actions, and the transient Mask page is not persisted as the ordinary panel. Its controls do not
@@ -1446,15 +1442,11 @@ become QuickQanava graph content.
 The panel has this structure:
 
 1. A header shows `Masks`.
-2. The existing header actions enter Brush, Radial, or Linear Gradient creation. Brush resumes
-   the selected Grade's current accumulating Brush Mask if present. It creates no extra row per stroke.
+2. The existing header actions enter Radial or Linear Gradient creation.
 3. The Node drawer is the sole list and management surface for Masks owned by the selected Color
    Grade; the Adjustment Stack page does not repeat those rows.
-4. The Mask page exposes supported source-specific controls for the selected Mask.
-   Brush supports paint/erase and adjustable size/strength; these tool settings affect subsequent
-   samples, while Mask opacity affects the entire accumulated raster. Multiple strokes on a Grade
-   merge into the same current Brush raster and keep its MaskId. Each settled stroke remains
-   independently undoable through parameter commands and regional replay; R8 is only current cache. Radial creation drags from center outward.
+4. The Mask page exposes supported source-specific controls for the selected Mask. Radial creation
+   drags from center outward. Linear Gradient uses its origin, direction, and transition controls.
 5. A range area shows only fields that the product implements.
 
 The Mask list uses the existing recessed list well. A selected row uses
@@ -1519,7 +1511,6 @@ The new `PipelineDocument` schema stores at least:
 - each Color Grade Mask list;
 - each `MaskId`, source, enabled value, and opacity;
 - direct `color_range` and `luminance_range` fields;
-- canonical Brush stroke data, stable StrokeIds, algorithm version and placement;
 - DRT/Post and post-processing parameters.
 
 It does not store:
@@ -1528,12 +1519,13 @@ It does not store:
 - graph selection, hover, or focus;
 - graph pan or zoom;
 - QSG vertices or material instances;
-- a provisional stroke;
+- provisional Mask input;
 - dirty bits, GPU handles, or cache state;
 - a render request;
 - the active panel page.
 
-NM7 extends the NM4 document, history, and project-metadata formats for parameterized Mask data.
+NM7 extends the NM4 document, history, and project-metadata formats for analytic Mask data and a
+Brush-disabled source registry. Unsupported Brush data is rejected at this boundary.
 The existing NM4 format cutover record below describes its earlier implementation. NM4 changed
 the document, history, and project-metadata formats after node, Mask, and history data
 are ready. The new release creates and reads only the new project format. The project-open boundary
@@ -1594,19 +1586,19 @@ Header action selects Radial
   -> SettledMaskEdit Quality render
 ```
 
-### 20.4 Brush stroke
+### 20.4 Edit a Linear Gradient Mask
 
 ```text
-pointer samples
-  -> normalized BrushStroke
-  -> append provisional parameterized stroke
-  -> QSG controls / allowed initial-creation guides
-  -> regional replay into current Grade coverage
+Header action selects Linear Gradient
+  -> viewer creation mode and Mask Adjustment Stack page
+  -> first valid input applies provisional AddMask(NodeId, MaskId, Linear Gradient params)
+  -> pointer input mapped to ReferenceSpace
+  -> provisional origin/direction/transition shared by QSG + pipeline
+  -> QSG overlay next frame
   -> InteractiveMaskEdit render
   -> pointer release
-  -> one AddMask / AppendBrushStroke parameter commit
-  -> Quality render
-  -> coalesced stable project cache write at idle/save/close
+  -> one edit commit
+  -> SettledMaskEdit Quality render
 ```
 
 ### 20.5 Version checkout
@@ -1615,7 +1607,7 @@ pointer samples
 Version selected
   -> finish/cancel provisional input
   -> reset the same live document to initial state and apply first-parent commits
-  -> validate graph / parameterized sources
+  -> validate graph / analytic Mask sources
   -> finish WAL/history head move; failure restores prior state through existing operations
   -> replace node/context/history projections
   -> VersionDocumentChanged Quality render
@@ -1626,8 +1618,8 @@ Version selected
 ```text
 Adjustment Transfer Paste
   -> read target initial state and image metadata
-  -> import transferable grade chain + DRT/Post params + Mask stroke/source parameters
-  -> remap NodeId / MaskId / StrokeId
+  -> import transferable grade chain + DRT/Post params + analytic Mask parameters
+  -> remap NodeId / MaskId
   -> validate local changes and apply to the same live document
   -> create and activate new Version
   -> finish WAL/history operation and use normal persistence
@@ -1655,8 +1647,8 @@ path with a Markdown link when the file exists.
 | NM4 — History, Version, Recovery, and Paste | complete | [node_mask_editor/phase_nm4_history_version_paste_plan.md](node_mask_editor/phase_nm4_history_version_paste_plan.md) | Complete typed history, one DAG per Version, recovery, and Paste-only transfer. |
 | NM5 — QuickQanava Nodes Panel | complete 2026-09-05 | [node_mask_editor/phase_nm5_nodes_panel_plan.md](node_mask_editor/phase_nm5_nodes_panel_plan.md) | Connect the left Nodes panel to the real command, history, and render paths. |
 | NM6 — Node-aware Adjustment Stack | in progress (NM6.1 complete 2026-09-05) | [node_mask_editor/phase_nm6_node_aware_adjustments_plan.md](node_mask_editor/phase_nm6_node_aware_adjustments_plan.md) | Add node-aware panels and EXIF header with serial Interactive input, shared backend execution, and dependency-version caches. |
-| NM7 — Viewer Mask Creation | planned | [NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md) | Parameterized reversible Masks, current project R8 cache, control-only QSG and real Interactive movement. |
-| NM8 — Product Qualification and Cutover | planned | `node_mask_editor/phase_nm8_product_qualification_plan.md` | Qualify all three backends, real RAW files, reopen, Version, Paste, performance, and package behavior. |
+| NM7 — Analytic Viewer Masks and Detachable Brush Boundary | planned after retained NM7.12RR history | [NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md) | Cut project format `0.7.0`, extract and disable Brush, then finish Radial/Linear Gradient. |
+| NM8 — Whole-DAG Performance and Brush-disabled Product Qualification | planned | `node_mask_editor/phase_nm8_product_qualification_plan.md` | Optimize the whole DAG, then qualify the Node Editor, two analytic Mask sources, three backends, real RAW, reopen, Version, Paste, memory, performance, and package behavior with Brush disabled. |
 
 ### 21.1 Phase NM0 — QuickQanava Integration Baseline
 
@@ -1935,34 +1927,30 @@ current-result storage. Runtime/platform evidence is required; this design appro
 
 ### 21.8 Phase NM7 — Viewer Mask Creation
 
-2026-09-08 revision: NM7.2–NM7.4 extend the historical NM3/NM4 source/history interfaces before
-viewer integration; NM7.10–NM7.11 replace per-source/history raster retention with current project
-coverage cache. Historical NM3/NM4 asset tests do not qualify the new parameter format.
+NM7.1–NM7.12RR remain as historical implementation and evidence. They do not require this release to
+complete or expose Brush. The current path begins at NM7.13:
 
-Parameter-mask revision: NM7.1–NM7.7 remain complete. Some former NM7.11 UI wiring was
-brought forward for Radial/Gradient testing. New NM7.8 adds Radial feather controls and selected
-range contours, Node drawer selection/deletion and re-editing, and Gradient controls styled after
-Geometry crop lines/grips. Selected analytic guide lines are required; coverage fill remains
-prohibited. Former NM7.8–NM7.14 shift to NM7.9–NM7.15; remaining full UI is NM7.12.
-Follow the detailed phase for interaction and acceptance requirements.
+```text
+NM7.13 project format 0.7.0 + detachable Brush module + product Brush OFF
+  -> NM7.14 complete Radial and Linear Gradient delivery
+```
 
-
-**Reason for this position:** Viewer creation needs the selected-node context, multi-Mask runtime,
-parameterized source/history extensions, project cache ownership, and Interactive/Quality rendering. A missing dependency
-would produce an edit that cannot restore or preview correctly.
+**Reason for this position:** Viewer creation needs selected-node context, multi-Mask runtime,
+typed history, ReferenceSpace mapping, and Interactive/Quality rendering. This phase fixes the
+shipped Mask set and compile boundary before NM8 measures or optimizes the product DAG.
 
 **Scope:** Follow the [NM7 execution plan](node_mask_editor/phase_nm7_viewer_mask_creation_plan.md).
-Connect the header actions and node Mask rows to the disabled-until-editing Mask Adjustment Stack
-page, keeping the Node drawer as the sole Mask list. Add Brush paint/erase with adjustable size and strength; accumulate
-all strokes for a Color Grade in one current Brush raster. Add center-out Radial creation, Linear
-Gradient creation, viewer input routing, `ReferenceSpace` mapping, QSG Mask-editing overlay, provisional raster dirty rectangle,
-settled parameter commands, project cache settings/cleanup, Escape cancellation, mode interruption, and stale-session fencing. Hide the overlay
-during adjustment input. Use the approved Mask type icons. Do not add an unrequested pill, badge,
-chip, tag, or status dot.
+Advance project metadata from `0.6.0` to `0.7.0`, accept only `0.7.0`, and reject the abandoned
+experimental format before decoding its document or history. Add `ALCEDO_ENABLE_BRUSH_MASK`, default
+it to `OFF`, and place all Brush code/resources/tests in detachable targets. Current product
+model/history/runtime/QML expose only Radial and Linear Gradient. Finish their viewer input,
+controls, QSG guides, owner mutations, history, lifecycle, Version, Paste, reopen, export, and
+package behavior.
 
-**Exit criteria:** Users can edit all three Mask types in the real viewer. QSG and evaluator
-parameters agree. Pointer release creates one commit. A settled edit requests Quality. Escape does
-not create a commit. Image and Version changes reject old results.
+**Exit criteria:** the disabled build and installed package contain no Brush implementation or
+resource; `0.6.0` fails at the project metadata read boundary with no migration, and every current
+writer emits `0.7.0`. Radial and Linear Gradient work in the real viewer, produce correct native
+pixels, and restore through history and persistence.
 
 **Required official QuickQanava documentation:**
 
@@ -1974,20 +1962,30 @@ not create a commit. Image and Version changes reject old results.
 QuickQanava does not own viewer input, the QSG overlay, or Mask coverage. NM7 does not infer these
 features from QuickQanava examples.
 
-### 21.9 Phase NM8 — Product Qualification and Cutover
+### 21.9 Phase NM8 — Whole-DAG Performance and Brush-disabled Product Qualification
 
 **Reason for a separate phase:** Unit and component tests cannot prove that the packaged
-QuickQanava module, real RAW input, all backends, history recovery, parameterized Masks, and final frame use
-one correct product path.
+QuickQanava module, real RAW input, all backends, history recovery, analytic Masks, whole-DAG
+execution, and final frame use one correct product path. Performance work starts only after NM7 has
+fixed the project format, shipped Mask set, and Brush-disabled module boundary.
 
-**Scope:** Run all tests in Section 23 and the real-RAW end-to-end cases. Record evidence for
-Windows/CUDA, OpenCL, macOS/Metal, package load, reopen, Version, Paste, performance, memory, and
-cache behavior. Remove old UI and service paths that an earlier phase explicitly replaced. Update
-this document with the completion record.
+**Scope:** Measure and optimize the whole path from session/context preparation through static-plan
+lookup or justified compilation, dependency invalidation, scheduling, native passes, result
+lifetime, frame sink, and Qt Quick presentation. Cover filmstrip switching, right-panel animation,
+ZoomPan, Detail ROI, parameter input, topology edits, Undo/Redo, Version, Paste, export, and
+background work on fixed real-RAW cases. Preserve required decode size, quality, analytic evaluation,
+and selected backend. Then run all tests in Section 23 and the real-RAW end-to-end cases. Record
+Windows/CUDA, OpenCL, macOS/Metal, package load, reopen, Version, Paste, latency, memory, and package
+evidence. Every configure/build/test/install/package/profile command explicitly uses
+`ALCEDO_ENABLE_BRUSH_MASK=OFF`. Verify again that the package contains no Brush code or resource,
+remove old UI and service paths that an earlier phase explicitly replaced, and append the completion
+record to this document.
 
 **Exit criteria:** All global completion criteria in Section 26 pass. There is no legacy-stage
-write-back, single-primary-Color-Grade product branch, per-stroke raster history, new merge UI, or substitute
-backend or CPU path.
+write-back, single-primary-Color-Grade product branch, compiled Brush implementation, new merge UI,
+or substitute backend or CPU path. Whole-DAG scheduling, invalidation, resource lifetime, frame
+reuse, and latency meet Section 24 with reproducible evidence. Brush enablement remains owned by the
+next-release Brush Master Plan and cannot be inferred from NM8 success.
 
 **Required official QuickQanava documentation:**
 
@@ -2013,8 +2011,8 @@ NM0 QuickQanava baseline
   -> NM4 History, Version, recovery, and Paste
   -> NM5 QuickQanava Nodes panel
   -> NM6 Node-aware adjustment stack
-  -> NM7 Viewer mask creation
-  -> NM8 Product qualification and cutover
+  -> NM7 Analytic viewer masks and detachable Brush boundary
+  -> NM8 Whole-DAG performance and Brush-disabled product qualification
 ```
 
 NML 已取消。NM2 假定已打开的项目带有可用 DAG 文档。没有图的项目不会进入 NM2。后续
@@ -2085,7 +2083,8 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - 中间 Color Grade 无 DRT/Post 专属 adjustment；
 - 多 Mask Union 与 CPU reference 一致；
 - zero masks、all-disabled masks、one/many enabled masks 的边界行为；
-- 参数化 stroke 可重放；每 Grade 一个当前 R8 槽；删除新缓存不破坏 Undo/Redo；
+- disabled build 的 Mask source 和 history registries 只包含 Radial 与 Linear Gradient；
+- Brush project/document/history data 在统一 read boundary 被明确拒绝；
 - 当前受支持格式的 JSON round-trip；旧项目 metadata 在入口被拒绝。
 
 ### 23.2 Runtime/backend tests
@@ -2093,20 +2092,20 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - 两个以上 Color Grade 的顺序影响结果，重新连接后结果按新顺序变化；
 - 每个 node 的参数 Patch 只使该 node 及下游失效；
 - 一个 node 的多个 Mask 在 CUDA/OpenCL/Metal 上等于 Union reference；
-- Radial、Linear Gradient 和 Brush feather 与 reference fixture 一致；
+- Radial、Linear Gradient feather 与独立 expected values 一致；
 - topology change 重新编译 static plan，参数 change 不误编译；
 - endpoint ownership 在 compiler 层拒绝非法 adjustment；
 - backend 失败返回真实错误，不切换 CPU 或其他 backend。
 
 ### 23.3 History/version tests
 
-- Add/Delete/Reconnect/Mask stroke 的一操作一 commit；
+- Add/Delete/Reconnect/analytic Mask edit 的一操作一 commit；
 - Undo 删除恢复完整 NodeId、参数、Mask 和 edges；
 - Redo 恢复相同 document hash；
 - Version checkout 得到对应 DAG，而不是当前全局 graph；
 - root Version 始终得到三节点默认文档；
 - Paste 创建新 Version，保留目标 Develop metadata；
-- Paste remap 后 NodeId/MaskId/StrokeId 无冲突，无缓存仍能重建 coverage；
+- Paste remap 后 NodeId/MaskId 无冲突，analytic coverage 与目标 RAW 坐标一致；
 - 不再创建新的 merge commit；
 - 旧项目拒绝打开，不迁移旧 stage/merge 提交；
 - journal/recovery/reopen 后 checkpoint 的 commit 标签与 history HEAD 对应，document 等于该提交链的重放结果。
@@ -2128,12 +2127,11 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 
 - item/logical -> image UV -> ReferenceSpace 映射在 zoom/pan/DPR 下稳定；
 - QSG Radial/Linear 边界与实际 evaluator 使用相同参数；
-- 初次 Brush 创建引导与 rasterizer 使用同一规范 sample 序列；已有 Mask 不显示影响区高亮；
-- 已有 Brush/Radial/Gradient 移动时仅控件可见，照片 Interactive 实时更新；grade slider 隐藏控件；
+- 已有 Radial/Gradient 移动时仅控件可见，照片 Interactive 实时更新；grade slider 隐藏控件；
 - stale session/result 不污染新 image/Version；
 - pointer release 只产生一次 settled commit；
 - Escape 恢复 before state 且不产生 commit；
-- dirty rectangle 更新不上传整张 raster，除非 feather 传播确实要求全量更新。
+- disabled product QML、resources、registries 和 package 中不存在 Brush。
 
 ### 23.6 Product E2E
 
@@ -2143,15 +2141,16 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 2. 验证 default 三节点和默认 `+1.5 EV` / `+30`；
 3. 新建 Clean Color Grade，验证画面不发生变化；
 4. 修改新节点 Exposure，验证只有该节点参数变化；
-5. 添加 Radial、Linear Gradient 和 Brush Mask；
+5. 添加 Radial 和 Linear Gradient Mask；
 6. 验证多个 Mask 扩展同一节点范围；
-7. 移动已有 Brush/Radial/Gradient 以及修改 feather 时仅显示控件，照片 Interactive 实时改变；
+7. 移动已有 Radial/Gradient 以及修改 feather 时仅显示控件，照片 Interactive 实时改变；
 8. 调整 grade 参数时 overlay 隐藏；
 9. 删除、重新连接节点并 Undo/Redo；
 10. 创建/切换 Version，验证不同 DAG；
 11. Paste 到另一张 RAW 的新 Version，验证目标 RAW metadata 保留；
-12. 保存、关闭、重开，验证 history、Version、DAG、Brush 参数命令和最终帧；清空项目 R8 后仍可恢复；
-13. 在 Windows/CUDA 与 macOS/Metal 执行产品路径；OpenCL 执行对应集成和一致性测试。
+12. 保存、关闭、重开，验证 history、Version、DAG、analytic Mask 参数和最终帧；
+13. 验证 Brush 数据在 disabled build 由统一格式入口拒绝，且 session 保持不变；
+14. 在 Windows/CUDA 与 macOS/Metal 执行产品路径；OpenCL 执行对应集成和一致性测试。
 
 ---
 
@@ -2161,9 +2160,8 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - graph layout/selection 不提交 render intent；
 - parameter-only change 不重建全部 QuickQanava graph；
 - history projection 不监听每帧 render/busy 通知；
-- Brush provisional update 合并 dirty rectangle；
-- settled stroke 仅持久化新增参数命令，不产生新 R8 历史文件；
-- 每项目/图片/Grade 稳定 R8 槽合并写回，千次操作及 Version 切换不增加每步文件；
+- panel resize、连续 ZoomPan 和 node selection 只更新 mapping/projection 并复用当前 frame；
+- Radial/Linear Gradient 参数修改只使 owner node 和下游失效；
 - graph static plan 只在 topology/adjustment structure 改变时重建；
 - 多 Color Grade 会话结果按输出身份、依赖变化版本和表示条件验证；不逐帧序列化或哈希整个节点参数体；
 - UI 滑动只更新局部显示并入队；owner 在帧间消费参数，应用、失效处理与渲染严格串行；
@@ -2172,9 +2170,10 @@ NM0 一直延伸到 NM8 的长期 stacked PR 链。
 - 每个工作区每个输出只保留当前有效结果；不为 Undo 保存旧参数结果，临时 GPU lease 保留单独计量；
 - node deletion/reconnect 允许淘汰不可达 node cache，但必须遵守 GPU submission lease；
 - panel close 后没有残留 Qan delegates 或 QML connection 泄漏；
+- disabled build/link/package manifest 不含 Brush target、symbol、kernel、QML 或 resource；
 - NM8 必须记录同一真实 RAW、同一 viewport、同一 backend 的单节点基线和多节点/多 Mask 数据。
 
-在 N8 之前由现有产品 baseline 确定具体毫秒和内存预算；不能用降低 decode 分辨率、质量或
+在 NM8 之前由现有产品 baseline 确定具体毫秒和内存预算；不能用降低 decode 分辨率、质量或
 切换 backend 的方式达标。
 
 ---
@@ -2204,11 +2203,12 @@ NM1.4 删除整图复制和产品 Apply 的 stage 覆盖，再复用后台 execu
 
 处理：共享坐标、参数和公式；使用有明确容差的参考结果测试同时验证 overlay 输入与 evaluator 输出。
 
-### 25.4 把缓存误当作历史源导致数据丢失或文件膨胀
+### 25.4 Brush 关闭后仍残留在产品构建
 
-处理：NM7 保存参数化 samples 和可逆命令；R8 是可删除的当前缓存。禁止每步 R8 或像素差分
-历史。缓存清理只能作用于新 cache namespace，不能删除不可重建的旧 asset。先完成 schema、
-WAL/Version/Paste 和 cacheless recovery，再暴露 UI。
+处理：NM7.13 在 CMake target、公共 source registry、history、serialization、runtime、应用层、
+QML、resources、tests、install 和 package 各边界排除 Brush。使用 dependency/link/resource
+manifest 证明它没有被编译，而不是只证明用户入口不可见。Brush 的后续架构只由独立 Master
+Plan 接回。
 
 ### 25.5 QuickQanava 变成第二份 graph 状态
 
@@ -2248,8 +2248,15 @@ transfer package 显式列出可转移内容。
 - [ ] node、Mask 和参数操作都能生成准确 history row 并 Undo/Redo。
 - [ ] 每个 Version 对应自己的 DAG，root/new default Version 对应三节点文档。
 - [ ] Adjustment Transfer 只创建 Paste Version，不再创建新的 pipeline merge commit。
-- [ ] Brush source 参数化，Undo/Redo 是可逆命令与重放，不生成每 stroke R8。
-- [ ] 每 Grade 一个当前 Mix R8 槽；项目路径/保留/清理策略与 cacheless recovery 验收通过。
+- [ ] 当前产品只交付 Radial 和 Linear Gradient；两者的创建、编辑、History、Version、Paste、
+      reopen、export 和 native pixels 均已验收。
+- [ ] 项目 metadata、最低支持版本和最高支持版本都从 `0.6.0` 切到 `0.7.0`；`0.6.0` 在读取
+      document/history 前失败，不迁移当前实验性 Brush 参数。
+- [ ] `ALCEDO_ENABLE_BRUSH_MASK=OFF` 是 Node Editor 和 NM8 的产品构建配置。
+- [ ] disabled build/package 不包含 Brush model/history/runtime/application/UI/test/resource code；
+      unsupported Brush data 在统一格式入口真实失败。
+- [ ] whole-DAG 调度、加载、static plan、invalidation、native passes、resource lifetime 和 Qt
+      presentation 已在 NM8 记录并优化。
 - [ ] CUDA、OpenCL、Metal 不使用 CPU 或其他 backend 替代路径。
 - [ ] 旧项目 metadata 在打开入口拒绝；当前格式坏图真实失败；产品路径不使用 stage 镜像。
 - [ ] Windows/macOS package 可加载 QuickQanava QML module 和全部新 panel。

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -39,8 +39,13 @@
 - [ ] Replace the editor image-processing path with the
       [GPU DAG pipeline](alcedo_studio/edit/gpu_dag_pipeline_rebuild_phase_plan.md), delivered as
       a Stacked PR series across CUDA, OpenCL, and Metal.
-- [ ] Add user-facing node-aware pipeline editing and multi-mask authoring; see the
+- [ ] Add user-facing node-aware pipeline editing with Radial and Linear Gradient Mask authoring,
+      a Brush-disabled project-format/build cut in NM7, and whole-DAG performance qualification in
+      NM8; see the
       [Node-aware Pipeline Editing and Mask Authoring master plan](alcedo_studio/edit/node_mask_editor_master_plan.md).
+- [ ] Reintroduce Brush in the following release through binary stroke objects, Mini-Git references,
+      verified tiled R8 materialization, and batched native raster execution; see the
+      [Brush Mask Architecture, History, and Raster Materialization master plan](alcedo_studio/edit/brush_mask_architecture_master_plan.md).
 - [ ] Extend HDR workflow and output.
 - [ ] Continue semantic search and AI-assisted tagging work; see the
       [semantic generation plan](alcedo_studio/ai/semantic_generation_search_plan.md) and


### PR DESCRIPTION
## Summary

NM7.12 — production Mask editing controls and project Mix-cache settings UI.

- Typed Mask value edits: `BeginMaskField`/`SetMaskField` queue kinds drive `enabled`, `invert`, `opacity`, `display_name` (settle as `SetMaskField`) and `brush.feather` (settles as `ReplaceMaskSource`); cancel restores live values, `CancelMode`/`RemoveMask` prune queued field commands.
- `EditorMaskCreationAdapter`: mask field properties, one-shot setters, opacity/brush-feather begin/update, `setBrushRadiusPercent`/`setBrushStrengthPercent`, `setBrushTool`, and `maskNudgeAvailable`/`beginMaskNudge`/`nudgeMaskBy` — keyboard move reuses the pointer `BeginMove`/`Append`/`Finish` route.
- `EditorMasksContextPanel.qml`: Brush section (Paint/Erase/Move segments, Size, Strength, Feather), Mask values (name, enabled, invert, opacity), keyboard Position nudge; `EditorMonoSlider.qml` gains arrow-key stepping and Accessible actions (each key press = one settled edit).
- Project Mix cache settings: `ProjectModule.maskCacheState` + `ApplyMaskCacheRoot`/`ApplyMaskCacheRetention`/`ClearMaskCache`/`RefreshMaskCacheState` over `ProjectService`; new `ProjectMaskCacheSettingsPanel.qml` hosted by `SettingDialog.qml` as a separate section (thumbnail `CacheSettingsPanel` untouched); Clear explains Brush strokes/history are retained.
- NM7.12 completion record written into the phase plan; header status updated to NM7.1–NM7.12 complete.

#### Test plan

- [x] `AccumulatingBrushCreationTest` 14/14 — one-shot/drag/cancel/unselected field commits
- [x] `AnalyticMaskCreationTest` 20/20 — regression
- [x] `EditorAdjustmentHeaderQmlTest` 16/16 — `MaskPageActivatesOnlyForSelectedOrCreatingMask`, `MaskSelectionDoesNotSubmitOrJumpScroll`, `KeyboardMaskMoveUsesSameInteractiveRoute`, Brush-section routing, 260/320/460 px × both themes with reduceMotion
- [x] `ProjectMaskCacheSettingsQmlTest` 3/3 (new) — `CacheSettingsTargetSelectedProjectOnly`, `ProjectClearExplainsThatBrushHistoryIsRetained`, error surfacing
- [x] `EditorAdjustmentControlQmlTest` 8/8, `EditorSerialInputBoundaryTest` 7/7, `MaskOverlayControlTest` 13/13
- [x] `alcedo_main` links on macOS `macos-debug` (Qt 6.9.2)

Generated with [Devin](https://devin.ai)